### PR TITLE
test: WingConfiguration asb_wing↔from_asb roundtrip harness + baseline

### DIFF
--- a/app/tests/test_wing_config_roundtrip.py
+++ b/app/tests/test_wing_config_roundtrip.py
@@ -26,10 +26,6 @@ guarded: the module skips if cadquery or aerosandbox are unavailable
 
 from __future__ import annotations
 
-import os
-from pathlib import Path
-from typing import Callable
-
 import pytest
 
 pytestmark = [
@@ -50,165 +46,13 @@ from cad_designer.aerosandbox.wing_roundtrip import (  # noqa: E402
     compare_wing_shapes,
     render_wing_loft_to_step,
 )
-from cad_designer.airplane.aircraft_topology.wing.Airfoil import Airfoil  # noqa: E402
+from cad_designer.aerosandbox.wing_roundtrip_cases import (  # noqa: E402
+    CASE_FACTORIES,
+    get_factory,
+)
 from cad_designer.airplane.aircraft_topology.wing.WingConfiguration import (  # noqa: E402
     WingConfiguration,
 )
-
-REPO_ROOT = Path(__file__).resolve().parents[2]
-AIRFOIL_PATH = str(REPO_ROOT / "components" / "airfoils" / "naca0010.dat")
-
-
-# --------------------------------------------------------------------------- #
-# Test-case factories
-#
-# Each factory returns a freshly-built, *relative*-mode WingConfiguration.
-# Factories are invoked twice per test: once to produce the "expected"
-# baseline and once to produce the input to the roundtrip (so the
-# baseline is never mutated by asb_wing() caching).
-# --------------------------------------------------------------------------- #
-
-
-def _single_segment_flat() -> WingConfiguration:
-    """One segment, zero twist / sweep / dihedral. The trivial sanity case."""
-    return WingConfiguration(
-        nose_pnt=(0.0, 0.0, 0.0),
-        root_airfoil=Airfoil(
-            airfoil=AIRFOIL_PATH,
-            chord=200.0,
-            dihedral_as_rotation_in_degrees=0,
-            incidence=0,
-            rotation_point_rel_chord=0.25,
-        ),
-        length=500.0,
-        sweep=0,
-        sweep_is_angle=False,
-        tip_airfoil=Airfoil(
-            chord=200.0,
-            dihedral_as_rotation_in_degrees=0,
-            incidence=0,
-            rotation_point_rel_chord=0.25,
-        ),
-        symmetric=True,
-        parameters="relative",
-    )
-
-
-def _single_segment_with_dihedral() -> WingConfiguration:
-    """One segment, +5° dihedral rotation. Isolates the dihedral sign bug."""
-    return WingConfiguration(
-        nose_pnt=(0.0, 0.0, 0.0),
-        root_airfoil=Airfoil(
-            airfoil=AIRFOIL_PATH,
-            chord=200.0,
-            dihedral_as_rotation_in_degrees=5,
-            incidence=0,
-            rotation_point_rel_chord=0.25,
-        ),
-        length=500.0,
-        sweep=0,
-        sweep_is_angle=False,
-        tip_airfoil=Airfoil(
-            chord=200.0,
-            dihedral_as_rotation_in_degrees=5,
-            incidence=0,
-            rotation_point_rel_chord=0.25,
-        ),
-        symmetric=True,
-        parameters="relative",
-    )
-
-
-def _single_segment_with_twist() -> WingConfiguration:
-    """One segment, -10° tip incidence. Isolates twist recovery."""
-    return WingConfiguration(
-        nose_pnt=(0.0, 0.0, 0.0),
-        root_airfoil=Airfoil(
-            airfoil=AIRFOIL_PATH,
-            chord=200.0,
-            dihedral_as_rotation_in_degrees=0,
-            incidence=0,
-            rotation_point_rel_chord=0.25,
-        ),
-        length=500.0,
-        sweep=0,
-        sweep_is_angle=False,
-        tip_airfoil=Airfoil(
-            chord=200.0,
-            dihedral_as_rotation_in_degrees=0,
-            incidence=-10,
-            rotation_point_rel_chord=0.25,
-        ),
-        symmetric=True,
-        parameters="relative",
-    )
-
-
-def _configurator_wing() -> WingConfiguration:
-    """The 3-segment wing from ``test/Test_Configurator_wing.py``.
-
-    Copied 1:1 (including the non-trivial nose_pnt=(25,50,100) and
-    the alternating positive/negative sweep + dihedral pattern) so that
-    a green result here proves the primary user-visible case.
-    """
-    wc = WingConfiguration(
-        nose_pnt=(25, 50, 100),
-        symmetric=True,
-        parameters="relative",
-        root_airfoil=Airfoil(
-            airfoil=AIRFOIL_PATH,
-            chord=200.0,
-            dihedral_as_rotation_in_degrees=4,
-            incidence=0,
-            rotation_point_rel_chord=0.25,
-        ),
-        length=500.0,
-        sweep=50,
-        sweep_is_angle=False,
-        tip_airfoil=Airfoil(
-            chord=200.0,
-            dihedral_as_rotation_in_degrees=-4,
-            incidence=-10,
-            rotation_point_rel_chord=0.25,
-        ),
-    )
-    wc.add_segment(
-        length=500,
-        sweep=-50,
-        sweep_is_angle=False,
-        tip_airfoil=Airfoil(
-            chord=150,
-            dihedral_as_rotation_in_degrees=-4,
-            incidence=-5,
-            rotation_point_rel_chord=0.25,
-        ),
-    )
-    wc.add_segment(
-        length=500,
-        sweep=50,
-        sweep_is_angle=False,
-        tip_airfoil=Airfoil(
-            chord=100,
-            dihedral_as_rotation_in_degrees=0,
-            incidence=0,
-            rotation_point_rel_chord=0.25,
-        ),
-    )
-    return wc
-
-
-def _ehawk_main_wing() -> WingConfiguration:
-    """Real-world eHawk main wing from ``test/ehawk_workflow_helpers``.
-
-    Imported lazily because ``test/`` is not a pytest package and its
-    import side-effects (logging setup etc.) we want to pay only when
-    this case actually runs.
-    """
-    # Delayed import — ehawk_workflow_helpers pulls in CAD modules that
-    # we don't want to load when the rest of the suite is collected.
-    from test.ehawk_workflow_helpers import _build_main_wing  # type: ignore
-
-    return _build_main_wing(AIRFOIL_PATH)
 
 
 # --------------------------------------------------------------------------- #
@@ -216,21 +60,21 @@ def _ehawk_main_wing() -> WingConfiguration:
 # --------------------------------------------------------------------------- #
 
 
-# Each entry is (case_id, factory, parameter_tol, origin_tol). Tolerances
-# default to float-noise levels — see the baseline notes in beads issue
-# cad-modelling-service-7kq for calibration rationale.
-CASES: list[tuple[str, Callable[[], WingConfiguration], float, float]] = [
-    ("single_segment_flat", _single_segment_flat, 1e-9, 1e-6),
-    ("single_segment_with_dihedral", _single_segment_with_dihedral, 1e-9, 1e-6),
-    ("single_segment_with_twist", _single_segment_with_twist, 1e-9, 1e-6),
-    ("configurator_wing", _configurator_wing, 1e-9, 1e-6),
-    ("ehawk_main_wing", _ehawk_main_wing, 1e-9, 1e-6),
-]
+# Parameter- and origin-tolerance per case. The factories themselves live
+# in ``cad_designer/aerosandbox/wing_roundtrip_cases.py`` so that the CLI
+# STEP exporter (``python -m cad_designer.aerosandbox.wing_roundtrip``)
+# and this pytest harness consume the same inputs.
+#
+# tol defaults to float-noise levels — see the baseline notes in beads
+# issue cad-modelling-service-7kq for calibration rationale.
+PARAM_TOL: dict[str, tuple[float, float]] = {
+    case_id: (1e-9, 1e-6) for case_id, _ in CASE_FACTORIES
+}
 
 
 @pytest.fixture(
-    params=CASES,
-    ids=[c[0] for c in CASES],
+    params=CASE_FACTORIES,
+    ids=[c[0] for c in CASE_FACTORIES],
 )
 def roundtrip_case(request):
     """Yields (case_id, expected_wc, actual_wc, param_tol, origin_tol).
@@ -240,7 +84,8 @@ def roundtrip_case(request):
     ``from_asb(expected.asb_wing().xsecs)`` — i.e. the roundtripped
     configuration we want to compare against the baseline.
     """
-    case_id, factory, param_tol, origin_tol = request.param
+    case_id, factory = request.param
+    param_tol, origin_tol = PARAM_TOL[case_id]
 
     # Build twice so asb_wing() caching on the baseline never leaks
     # the reconstructed xsecs back into the "expected" side.
@@ -329,7 +174,7 @@ def test_shape_tolerant(roundtrip_case, tmp_path):
 
     # Rebuild fresh (we already consumed the source_wc inside the
     # fixture when we called asb_wing()).
-    expected_for_render = _factory_for_case(case_id)
+    expected_for_render = get_factory(case_id)()
 
     step_a = tmp_path / f"{case_id}_expected.step"
     step_b = tmp_path / f"{case_id}_actual.step"
@@ -364,10 +209,3 @@ def test_shape_tolerant(roundtrip_case, tmp_path):
         f"[{case_id}] centroid drift {result.centroid_distance:.4f}mm "
         f"> tol {tol['centroid_mm']:.4f}mm; {result.summary()}"
     )
-
-
-def _factory_for_case(case_id: str) -> WingConfiguration:
-    for c_id, factory, _, _ in CASES:
-        if c_id == case_id:
-            return factory()
-    raise KeyError(case_id)

--- a/app/tests/test_wing_config_roundtrip.py
+++ b/app/tests/test_wing_config_roundtrip.py
@@ -1,0 +1,373 @@
+"""
+Roundtrip harness for ``WingConfiguration -> asb.Wing -> from_asb`` fidelity.
+
+Builds a ``WingConfiguration`` in *relative* mode, transforms it to an
+``asb.Wing`` via ``WingConfiguration.asb_wing()``, and then rebuilds a
+``WingConfiguration`` from the resulting ``xsecs`` via
+``WingConfiguration.from_asb()``. The three comparison helpers in
+``cad_designer/aerosandbox/wing_roundtrip.py`` then quantify the drift
+on three levels:
+
+1. Per-field parameter equality (strict)
+2. Per-segment workplane-origin equality in global space (strict)
+3. Rendered-shape volume / surface / centroid equality (tolerant)
+
+The user has specified that levels 1 and 2 must be *exact* for
+``nose_pnt``, ``incidence``, ``sweep``, ``dihedral_as_rotation_in_degrees``
+and ``dihedral_as_translation``. Airfoil-thickness drift from chord
+rotation is tolerated at level 3 and will be addressed separately via
+an ``Airfoil.chord_stretch_factor`` in Phase 4.
+
+This test is intentionally **marked slow** and only runs on CI when the
+slow workflow is dispatched. The comparison helpers are platform-
+guarded: the module skips if cadquery or aerosandbox are unavailable
+(e.g. on linux/aarch64 where both are excluded).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+pytestmark = [
+    pytest.mark.slow,
+    pytest.mark.requires_cadquery,
+    pytest.mark.requires_aerosandbox,
+]
+
+# Hard skip at collection time if the platform-excluded deps are missing.
+# (The `requires_*` markers filter at select time, but we also need the
+# imports below to succeed during collection.)
+cq = pytest.importorskip("cadquery")
+asb = pytest.importorskip("aerosandbox")
+
+from cad_designer.aerosandbox.wing_roundtrip import (  # noqa: E402
+    compare_segment_origins,
+    compare_wing_configs,
+    compare_wing_shapes,
+    render_wing_loft_to_step,
+)
+from cad_designer.airplane.aircraft_topology.wing.Airfoil import Airfoil  # noqa: E402
+from cad_designer.airplane.aircraft_topology.wing.WingConfiguration import (  # noqa: E402
+    WingConfiguration,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AIRFOIL_PATH = str(REPO_ROOT / "components" / "airfoils" / "naca0010.dat")
+
+
+# --------------------------------------------------------------------------- #
+# Test-case factories
+#
+# Each factory returns a freshly-built, *relative*-mode WingConfiguration.
+# Factories are invoked twice per test: once to produce the "expected"
+# baseline and once to produce the input to the roundtrip (so the
+# baseline is never mutated by asb_wing() caching).
+# --------------------------------------------------------------------------- #
+
+
+def _single_segment_flat() -> WingConfiguration:
+    """One segment, zero twist / sweep / dihedral. The trivial sanity case."""
+    return WingConfiguration(
+        nose_pnt=(0.0, 0.0, 0.0),
+        root_airfoil=Airfoil(
+            airfoil=AIRFOIL_PATH,
+            chord=200.0,
+            dihedral_as_rotation_in_degrees=0,
+            incidence=0,
+            rotation_point_rel_chord=0.25,
+        ),
+        length=500.0,
+        sweep=0,
+        sweep_is_angle=False,
+        tip_airfoil=Airfoil(
+            chord=200.0,
+            dihedral_as_rotation_in_degrees=0,
+            incidence=0,
+            rotation_point_rel_chord=0.25,
+        ),
+        symmetric=True,
+        parameters="relative",
+    )
+
+
+def _single_segment_with_dihedral() -> WingConfiguration:
+    """One segment, +5° dihedral rotation. Isolates the dihedral sign bug."""
+    return WingConfiguration(
+        nose_pnt=(0.0, 0.0, 0.0),
+        root_airfoil=Airfoil(
+            airfoil=AIRFOIL_PATH,
+            chord=200.0,
+            dihedral_as_rotation_in_degrees=5,
+            incidence=0,
+            rotation_point_rel_chord=0.25,
+        ),
+        length=500.0,
+        sweep=0,
+        sweep_is_angle=False,
+        tip_airfoil=Airfoil(
+            chord=200.0,
+            dihedral_as_rotation_in_degrees=5,
+            incidence=0,
+            rotation_point_rel_chord=0.25,
+        ),
+        symmetric=True,
+        parameters="relative",
+    )
+
+
+def _single_segment_with_twist() -> WingConfiguration:
+    """One segment, -10° tip incidence. Isolates twist recovery."""
+    return WingConfiguration(
+        nose_pnt=(0.0, 0.0, 0.0),
+        root_airfoil=Airfoil(
+            airfoil=AIRFOIL_PATH,
+            chord=200.0,
+            dihedral_as_rotation_in_degrees=0,
+            incidence=0,
+            rotation_point_rel_chord=0.25,
+        ),
+        length=500.0,
+        sweep=0,
+        sweep_is_angle=False,
+        tip_airfoil=Airfoil(
+            chord=200.0,
+            dihedral_as_rotation_in_degrees=0,
+            incidence=-10,
+            rotation_point_rel_chord=0.25,
+        ),
+        symmetric=True,
+        parameters="relative",
+    )
+
+
+def _configurator_wing() -> WingConfiguration:
+    """The 3-segment wing from ``test/Test_Configurator_wing.py``.
+
+    Copied 1:1 (including the non-trivial nose_pnt=(25,50,100) and
+    the alternating positive/negative sweep + dihedral pattern) so that
+    a green result here proves the primary user-visible case.
+    """
+    wc = WingConfiguration(
+        nose_pnt=(25, 50, 100),
+        symmetric=True,
+        parameters="relative",
+        root_airfoil=Airfoil(
+            airfoil=AIRFOIL_PATH,
+            chord=200.0,
+            dihedral_as_rotation_in_degrees=4,
+            incidence=0,
+            rotation_point_rel_chord=0.25,
+        ),
+        length=500.0,
+        sweep=50,
+        sweep_is_angle=False,
+        tip_airfoil=Airfoil(
+            chord=200.0,
+            dihedral_as_rotation_in_degrees=-4,
+            incidence=-10,
+            rotation_point_rel_chord=0.25,
+        ),
+    )
+    wc.add_segment(
+        length=500,
+        sweep=-50,
+        sweep_is_angle=False,
+        tip_airfoil=Airfoil(
+            chord=150,
+            dihedral_as_rotation_in_degrees=-4,
+            incidence=-5,
+            rotation_point_rel_chord=0.25,
+        ),
+    )
+    wc.add_segment(
+        length=500,
+        sweep=50,
+        sweep_is_angle=False,
+        tip_airfoil=Airfoil(
+            chord=100,
+            dihedral_as_rotation_in_degrees=0,
+            incidence=0,
+            rotation_point_rel_chord=0.25,
+        ),
+    )
+    return wc
+
+
+def _ehawk_main_wing() -> WingConfiguration:
+    """Real-world eHawk main wing from ``test/ehawk_workflow_helpers``.
+
+    Imported lazily because ``test/`` is not a pytest package and its
+    import side-effects (logging setup etc.) we want to pay only when
+    this case actually runs.
+    """
+    # Delayed import — ehawk_workflow_helpers pulls in CAD modules that
+    # we don't want to load when the rest of the suite is collected.
+    from test.ehawk_workflow_helpers import _build_main_wing  # type: ignore
+
+    return _build_main_wing(AIRFOIL_PATH)
+
+
+# --------------------------------------------------------------------------- #
+# Parametrized fixture wiring
+# --------------------------------------------------------------------------- #
+
+
+# Each entry is (case_id, factory, parameter_tol, origin_tol). Tolerances
+# default to float-noise levels — see the baseline notes in beads issue
+# cad-modelling-service-7kq for calibration rationale.
+CASES: list[tuple[str, Callable[[], WingConfiguration], float, float]] = [
+    ("single_segment_flat", _single_segment_flat, 1e-9, 1e-6),
+    ("single_segment_with_dihedral", _single_segment_with_dihedral, 1e-9, 1e-6),
+    ("single_segment_with_twist", _single_segment_with_twist, 1e-9, 1e-6),
+    ("configurator_wing", _configurator_wing, 1e-9, 1e-6),
+    ("ehawk_main_wing", _ehawk_main_wing, 1e-9, 1e-6),
+]
+
+
+@pytest.fixture(
+    params=CASES,
+    ids=[c[0] for c in CASES],
+)
+def roundtrip_case(request):
+    """Yields (case_id, expected_wc, actual_wc, param_tol, origin_tol).
+
+    ``expected_wc`` is freshly built from the factory and never touched
+    by ``asb_wing()``. ``actual_wc`` is the result of
+    ``from_asb(expected.asb_wing().xsecs)`` — i.e. the roundtripped
+    configuration we want to compare against the baseline.
+    """
+    case_id, factory, param_tol, origin_tol = request.param
+
+    # Build twice so asb_wing() caching on the baseline never leaks
+    # the reconstructed xsecs back into the "expected" side.
+    expected_wc = factory()
+    source_wc = factory()
+
+    asb_wing = source_wc.asb_wing()
+    actual_wc = WingConfiguration.from_asb(
+        asb_wing.xsecs,
+        symmetric=expected_wc.symmetric,
+    )
+
+    yield case_id, expected_wc, actual_wc, param_tol, origin_tol
+
+
+# --------------------------------------------------------------------------- #
+# Level 1: parameter-strict
+# --------------------------------------------------------------------------- #
+
+
+def test_parameters_strict(roundtrip_case):
+    """All user-declared "must match exactly" parameters survive the roundtrip.
+
+    Drives bugs 1-4 in ``WingConfiguration.from_asb`` (rotation_point,
+    dihedral sign, parameter-mode, and dihedral case-split). Expected
+    to fail pre-fix on every non-trivial case; that failure *is* the
+    baseline signal we need for Phase 2.
+    """
+    case_id, expected, actual, param_tol, _ = roundtrip_case
+    result = compare_wing_configs(expected, actual, tol=param_tol)
+    assert result.ok, f"[{case_id}] parameter drift:\n{result}"
+
+
+# --------------------------------------------------------------------------- #
+# Level 2: segment-origin-strict
+# --------------------------------------------------------------------------- #
+
+
+def test_segment_origins_strict(roundtrip_case):
+    """Per-segment workplane origins match exactly in global space.
+
+    This is the "nose point der Segmente" requirement from the user.
+    Because it chains the accumulated homogeneous transforms, a clean
+    Level-1 pass is not sufficient — bugs in the transformation matrix
+    or in get_wing_workplane() show up here.
+    """
+    case_id, expected, actual, _, origin_tol = roundtrip_case
+    result = compare_segment_origins(expected, actual, tol=origin_tol)
+    assert result.ok, (
+        f"[{case_id}] segment origin drift, max_distance={result.max_distance}:\n"
+        + "\n".join(
+            f"  segment[{d.segment_index}] expected={d.expected} "
+            f"actual={d.actual} dist={d.distance}"
+            for d in result.diffs
+        )
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Level 3: shape-tolerant (rendered CAD comparison)
+# --------------------------------------------------------------------------- #
+
+
+# Toleranzen werden nach der Baseline-Messung in Phase 2 kalibriert.
+# Initial sehr grosszuegig, damit wir die *gemessenen* Werte sehen statt
+# in eine fixe Zahl zu rennen. Volumen und Oberflaeche in Prozent; Centroid
+# in mm (wing_config units).
+SHAPE_TOL = {
+    "single_segment_flat": dict(vol_rel=1e-3, surf_rel=1e-3, centroid_mm=1e-2),
+    "single_segment_with_dihedral": dict(vol_rel=5e-2, surf_rel=5e-2, centroid_mm=5.0),
+    "single_segment_with_twist": dict(vol_rel=5e-2, surf_rel=5e-2, centroid_mm=5.0),
+    "configurator_wing": dict(vol_rel=2e-1, surf_rel=2e-1, centroid_mm=20.0),
+    "ehawk_main_wing": dict(vol_rel=2e-1, surf_rel=2e-1, centroid_mm=20.0),
+}
+
+
+def test_shape_tolerant(roundtrip_case, tmp_path):
+    """Render both variants via WingLoftCreator and compare the CAD solids.
+
+    Phase 2 will relax or tighten the ``SHAPE_TOL`` entries based on the
+    measured baseline. The metric is intentionally plural (volume,
+    surface, centroid) so that a single failing dimension does not
+    obscure the others in the report.
+    """
+    case_id, expected, actual, _, _ = roundtrip_case
+
+    # Rebuild fresh (we already consumed the source_wc inside the
+    # fixture when we called asb_wing()).
+    expected_for_render = _factory_for_case(case_id)
+
+    step_a = tmp_path / f"{case_id}_expected.step"
+    step_b = tmp_path / f"{case_id}_actual.step"
+
+    render_wing_loft_to_step(
+        expected_for_render,
+        step_a,
+        wing_name="main_wing",
+        wing_side="RIGHT",  # mirroring doubles cost and obscures per-segment drift
+        connected=False,
+    )
+    render_wing_loft_to_step(
+        actual,
+        step_b,
+        wing_name="main_wing",
+        wing_side="RIGHT",
+        connected=False,
+    )
+
+    result = compare_wing_shapes(step_a, step_b)
+
+    tol = SHAPE_TOL[case_id]
+    assert result.volume_rel_delta <= tol["vol_rel"], (
+        f"[{case_id}] volume drift {result.volume_rel_delta:.4%} "
+        f"> tol {tol['vol_rel']:.4%}; {result.summary()}"
+    )
+    assert result.surface_rel_delta <= tol["surf_rel"], (
+        f"[{case_id}] surface drift {result.surface_rel_delta:.4%} "
+        f"> tol {tol['surf_rel']:.4%}; {result.summary()}"
+    )
+    assert result.centroid_distance <= tol["centroid_mm"], (
+        f"[{case_id}] centroid drift {result.centroid_distance:.4f}mm "
+        f"> tol {tol['centroid_mm']:.4f}mm; {result.summary()}"
+    )
+
+
+def _factory_for_case(case_id: str) -> WingConfiguration:
+    for c_id, factory, _, _ in CASES:
+        if c_id == case_id:
+            return factory()
+    raise KeyError(case_id)

--- a/cad_designer/aerosandbox/wing_roundtrip.py
+++ b/cad_designer/aerosandbox/wing_roundtrip.py
@@ -1,0 +1,470 @@
+"""
+Helpers for comparing a ``WingConfiguration`` before and after a
+``asb_wing() -> from_asb()`` roundtrip.
+
+Three comparison levels:
+
+1. **Parameter-strict**: Walks the ``WingSegment`` / ``Airfoil`` fields
+   of two ``WingConfiguration`` objects and reports per-field
+   differences. The user has specified that ``nose_pnt``, ``incidence``,
+   ``sweep``, ``dihedral_as_rotation_in_degrees``,
+   ``dihedral_as_translation`` and ``rotation_point_rel_chord`` must be
+   *exactly equal* after a correct roundtrip. Deviations here indicate
+   a bug in ``WingConfiguration.from_asb()`` or in the downstream
+   schema-converter path.
+
+2. **Segment-origin-strict**: Calls ``get_wing_workplane(i)`` on each
+   segment and compares the resulting ``Plane.origin`` points. This
+   catches cases where parameter values look right individually but
+   the accumulated homogeneous transforms place the segments at
+   different locations in global space.
+
+3. **Shape-tolerant**: Renders both ``WingConfiguration`` variants
+   through ``WingLoftCreator`` (loft-only, no ribs/spars), exports
+   each to a STEP file, re-imports them, and compares the resulting
+   CAD solids via ``BRepGProp.VolumeProperties_s`` (volume),
+   ``BRepGProp.SurfaceProperties_s`` (surface area) and centroid
+   distance. The existing helpers in
+   ``cad_designer/aerosandbox/slicing.py`` (``compute_shape_properties``,
+   ``load_step_model``) are reused directly.
+
+All helpers are read-only with respect to their ``WingConfiguration``
+arguments where possible, except ``render_wing_loft_to_step`` which
+must invoke the CAD pipeline.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from cad_designer.aerosandbox.slicing import (
+    compute_shape_properties,
+    load_step_model,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Result containers
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class ParameterDiff:
+    """A single per-field parameter mismatch between two WingConfigurations."""
+
+    path: str  # e.g. "segments[1].tip_airfoil.incidence"
+    expected: Any
+    actual: Any
+    abs_delta: float  # |expected - actual| for numeric fields, NaN otherwise
+
+    def __str__(self) -> str:  # pragma: no cover - pure formatting
+        return (
+            f"{self.path}: expected={self.expected!r} "
+            f"actual={self.actual!r} abs_delta={self.abs_delta}"
+        )
+
+
+@dataclass
+class ParameterCompareResult:
+    """Outcome of ``compare_wing_configs``."""
+
+    diffs: List[ParameterDiff] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.diffs
+
+    def __str__(self) -> str:  # pragma: no cover - pure formatting
+        if self.ok:
+            return "ParameterCompareResult: OK (no differences)"
+        lines = ["ParameterCompareResult: FAILED"]
+        lines.extend(f"  - {d}" for d in self.diffs)
+        return "\n".join(lines)
+
+
+@dataclass
+class SegmentOriginDiff:
+    """A single segment-origin mismatch."""
+
+    segment_index: int
+    expected: Tuple[float, float, float]
+    actual: Tuple[float, float, float]
+    distance: float  # Euclidean distance in wing-config units (mm)
+
+
+@dataclass
+class SegmentOriginCompareResult:
+    diffs: List[SegmentOriginDiff] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.diffs
+
+    @property
+    def max_distance(self) -> float:
+        if not self.diffs:
+            return 0.0
+        return max(d.distance for d in self.diffs)
+
+
+@dataclass
+class ShapeCompareResult:
+    """Tolerant shape comparison between two rendered wing solids."""
+
+    volume_a: float
+    volume_b: float
+    surface_a: float
+    surface_b: float
+    centroid_a: Tuple[float, float, float]
+    centroid_b: Tuple[float, float, float]
+
+    @property
+    def volume_rel_delta(self) -> float:
+        if self.volume_a == 0:
+            return float("inf") if self.volume_b != 0 else 0.0
+        return abs(self.volume_a - self.volume_b) / abs(self.volume_a)
+
+    @property
+    def surface_rel_delta(self) -> float:
+        if self.surface_a == 0:
+            return float("inf") if self.surface_b != 0 else 0.0
+        return abs(self.surface_a - self.surface_b) / abs(self.surface_a)
+
+    @property
+    def centroid_distance(self) -> float:
+        dx = self.centroid_a[0] - self.centroid_b[0]
+        dy = self.centroid_a[1] - self.centroid_b[1]
+        dz = self.centroid_a[2] - self.centroid_b[2]
+        return math.sqrt(dx * dx + dy * dy + dz * dz)
+
+    def summary(self) -> str:
+        return (
+            f"volume_rel={self.volume_rel_delta:.4%} "
+            f"surface_rel={self.surface_rel_delta:.4%} "
+            f"centroid_dist={self.centroid_distance:.4f}mm"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Level 1: parameter-strict comparison
+# --------------------------------------------------------------------------- #
+
+
+# Fields on ``WingSegment`` that the user has declared must roundtrip exactly.
+_SEGMENT_STRICT_FIELDS: Tuple[str, ...] = (
+    "length",
+    "sweep",
+)
+
+# Fields on ``Airfoil`` that must roundtrip exactly.
+_AIRFOIL_STRICT_FIELDS: Tuple[str, ...] = (
+    "chord",
+    "dihedral_as_rotation_in_degrees",
+    "dihedral_as_translation",
+    "incidence",
+    "rotation_point_rel_chord",
+)
+
+
+def _numeric_abs_delta(a: Any, b: Any) -> float:
+    try:
+        return abs(float(a) - float(b))
+    except (TypeError, ValueError):
+        return float("nan")
+
+
+def _approx_equal(a: Any, b: Any, tol: float) -> bool:
+    """Numeric near-equality with NaN propagation."""
+    try:
+        fa = float(a)
+        fb = float(b)
+    except (TypeError, ValueError):
+        return a == b
+    if math.isnan(fa) or math.isnan(fb):
+        return False
+    return abs(fa - fb) <= tol
+
+
+def compare_wing_configs(
+    expected,
+    actual,
+    *,
+    tol: float = 1e-9,
+) -> ParameterCompareResult:
+    """Strict per-field comparison of two WingConfigurations.
+
+    The comparison covers:
+
+    - ``nose_pnt`` (3-tuple)
+    - ``symmetric`` (bool)
+    - Number of segments (must match exactly)
+    - For each segment: length, sweep
+    - For each segment's root + tip airfoil: chord,
+      dihedral_as_rotation_in_degrees, dihedral_as_translation,
+      incidence, rotation_point_rel_chord
+
+    Any field difference above ``tol`` becomes a ``ParameterDiff`` in
+    the result. ``tol`` is a single absolute tolerance applied to all
+    numeric fields (the user has asked for "exact" equality; ``1e-9``
+    is slack enough to absorb float round-tripping through numpy but
+    tight enough to catch real bugs).
+    """
+    result = ParameterCompareResult()
+
+    # nose_pnt
+    e_nose = tuple(expected.nose_pnt)
+    a_nose = tuple(actual.nose_pnt)
+    for idx, (e, a) in enumerate(zip(e_nose, a_nose)):
+        if not _approx_equal(e, a, tol):
+            result.diffs.append(
+                ParameterDiff(
+                    path=f"nose_pnt[{idx}]",
+                    expected=e,
+                    actual=a,
+                    abs_delta=_numeric_abs_delta(e, a),
+                )
+            )
+
+    # symmetric
+    if expected.symmetric != actual.symmetric:
+        result.diffs.append(
+            ParameterDiff(
+                path="symmetric",
+                expected=expected.symmetric,
+                actual=actual.symmetric,
+                abs_delta=float("nan"),
+            )
+        )
+
+    # segment count
+    e_segs = list(expected.segments or [])
+    a_segs = list(actual.segments or [])
+    if len(e_segs) != len(a_segs):
+        result.diffs.append(
+            ParameterDiff(
+                path="len(segments)",
+                expected=len(e_segs),
+                actual=len(a_segs),
+                abs_delta=_numeric_abs_delta(len(e_segs), len(a_segs)),
+            )
+        )
+        return result  # further per-segment comparison is meaningless
+
+    for i, (e_seg, a_seg) in enumerate(zip(e_segs, a_segs)):
+        for fname in _SEGMENT_STRICT_FIELDS:
+            e_val = getattr(e_seg, fname, None)
+            a_val = getattr(a_seg, fname, None)
+            if not _approx_equal(e_val, a_val, tol):
+                result.diffs.append(
+                    ParameterDiff(
+                        path=f"segments[{i}].{fname}",
+                        expected=e_val,
+                        actual=a_val,
+                        abs_delta=_numeric_abs_delta(e_val, a_val),
+                    )
+                )
+
+        for airfoil_name in ("root_airfoil", "tip_airfoil"):
+            e_af = getattr(e_seg, airfoil_name, None)
+            a_af = getattr(a_seg, airfoil_name, None)
+            if e_af is None and a_af is None:
+                continue
+            if e_af is None or a_af is None:
+                result.diffs.append(
+                    ParameterDiff(
+                        path=f"segments[{i}].{airfoil_name}",
+                        expected=e_af,
+                        actual=a_af,
+                        abs_delta=float("nan"),
+                    )
+                )
+                continue
+            for fname in _AIRFOIL_STRICT_FIELDS:
+                e_val = getattr(e_af, fname, None)
+                a_val = getattr(a_af, fname, None)
+                if not _approx_equal(e_val, a_val, tol):
+                    result.diffs.append(
+                        ParameterDiff(
+                            path=f"segments[{i}].{airfoil_name}.{fname}",
+                            expected=e_val,
+                            actual=a_val,
+                            abs_delta=_numeric_abs_delta(e_val, a_val),
+                        )
+                    )
+
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# Level 2: segment-origin-strict comparison
+# --------------------------------------------------------------------------- #
+
+
+def compare_segment_origins(
+    expected,
+    actual,
+    *,
+    tol: float = 1e-6,
+) -> SegmentOriginCompareResult:
+    """Compare per-segment workplane origins between two WingConfigurations.
+
+    Iterates ``segment`` from 0 to ``len(segments)`` (inclusive — the
+    last call gives the tip of the last segment) and compares the
+    ``Plane.origin`` coordinates. This is the "nose point der Segmente"
+    check from the user's spec: the resulting segment positions in
+    global space must match exactly, because that is the ground-truth
+    placement of the airfoil cross-sections.
+
+    The comparison uses ``ignore_nose_point=False`` so that the
+    ``nose_pnt`` translation is included — mismatches in ``nose_pnt``
+    will show as a constant offset across all segments.
+    """
+    n_segments = len(list(expected.segments or []))
+    result = SegmentOriginCompareResult()
+    for i in range(n_segments + 1):
+        e_plane = expected.get_wing_workplane(
+            segment=min(i, n_segments - 1),
+            ignore_nose_point=False,
+        ).plane
+        a_plane = actual.get_wing_workplane(
+            segment=min(i, n_segments - 1),
+            ignore_nose_point=False,
+        ).plane
+        e_o = (e_plane.origin.x, e_plane.origin.y, e_plane.origin.z)
+        a_o = (a_plane.origin.x, a_plane.origin.y, a_plane.origin.z)
+        dist = math.sqrt(
+            (e_o[0] - a_o[0]) ** 2
+            + (e_o[1] - a_o[1]) ** 2
+            + (e_o[2] - a_o[2]) ** 2
+        )
+        if dist > tol:
+            result.diffs.append(
+                SegmentOriginDiff(
+                    segment_index=i,
+                    expected=e_o,
+                    actual=a_o,
+                    distance=dist,
+                )
+            )
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# Level 3: shape-tolerant comparison via WingLoftCreator + STEP round-trip
+# --------------------------------------------------------------------------- #
+
+
+def render_wing_loft_to_step(
+    wing_config,
+    out_path: Path,
+    *,
+    wing_name: str = "wing",
+    wing_side: str = "BOTH",
+    connected: bool = False,
+) -> Path:
+    """Render a ``WingConfiguration`` through ``WingLoftCreator`` and
+    export it as a STEP file at ``out_path``.
+
+    Runs ``WingLoftCreator`` directly (no ``ConstructionRootNode`` /
+    ``ExportToStepCreator`` layers) and writes the resulting workplane
+    via ``cadquery.exporters.export``. This keeps the filename
+    predictable (exactly ``out_path``) and avoids the multi-file
+    artefacts produced by ``ExportToStepCreator``.
+
+    The caller is responsible for ensuring the output directory
+    exists. Returns the resolved ``out_path`` for convenience.
+    """
+    # Local imports to keep this module importable on aarch64 where
+    # cadquery is excluded.
+    import cadquery as cq  # noqa: F401 — ensures cq plugins load
+    from cadquery import exporters
+
+    from cad_designer.airplane.creator.wing import WingLoftCreator
+
+    out_path = Path(out_path).resolve()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    wing_configuration = {wing_name: wing_config}
+
+    creator = WingLoftCreator(
+        creator_id=f"wing_loft_{out_path.stem}",
+        wing_index=wing_name,
+        wing_config=wing_configuration,
+        wing_side=wing_side,
+        connected=connected,
+    )
+
+    shapes = creator.create_shape()
+    # create_shape returns {<creator_id>: Workplane}; take the only entry.
+    workplane = next(iter(shapes.values()))
+
+    exporters.export(workplane, str(out_path))
+    return out_path
+
+
+def compare_wing_shapes(step_path_a: Path, step_path_b: Path) -> ShapeCompareResult:
+    """Compare two wing shapes exported as STEP files.
+
+    Uses the existing ``load_step_model`` and ``compute_shape_properties``
+    helpers from ``cad_designer/aerosandbox/slicing.py``. The result
+    carries raw volumes, surface areas and centroids plus derived
+    relative-delta helper properties.
+    """
+    step_path_a = Path(step_path_a).resolve()
+    step_path_b = Path(step_path_b).resolve()
+    if not step_path_a.exists():
+        raise FileNotFoundError(f"STEP file A not found: {step_path_a}")
+    if not step_path_b.exists():
+        raise FileNotFoundError(f"STEP file B not found: {step_path_b}")
+
+    wp_a = load_step_model(str(step_path_a))
+    wp_b = load_step_model(str(step_path_b))
+
+    solid_a = wp_a.solids().first().val().wrapped
+    solid_b = wp_b.solids().first().val().wrapped
+
+    props_a = compute_shape_properties(solid_a)
+    props_b = compute_shape_properties(solid_b)
+
+    # Centroid via BoundingBox center as a simple proxy — BRepGProp also
+    # provides a true mass centre of the solid which is more precise.
+    try:
+        from OCP.BRepGProp import BRepGProp
+        from OCP.GProp import GProp_GProps
+
+        gp_a = GProp_GProps()
+        BRepGProp.VolumeProperties_s(solid_a, gp_a)
+        ca = gp_a.CentreOfMass()
+
+        gp_b = GProp_GProps()
+        BRepGProp.VolumeProperties_s(solid_b, gp_b)
+        cb = gp_b.CentreOfMass()
+
+        centroid_a = (ca.X(), ca.Y(), ca.Z())
+        centroid_b = (cb.X(), cb.Y(), cb.Z())
+    except Exception:
+        bb_a = wp_a.solids().first().val().BoundingBox()
+        bb_b = wp_b.solids().first().val().BoundingBox()
+        centroid_a = (
+            (bb_a.xmin + bb_a.xmax) * 0.5,
+            (bb_a.ymin + bb_a.ymax) * 0.5,
+            (bb_a.zmin + bb_a.zmax) * 0.5,
+        )
+        centroid_b = (
+            (bb_b.xmin + bb_b.xmax) * 0.5,
+            (bb_b.ymin + bb_b.ymax) * 0.5,
+            (bb_b.zmin + bb_b.zmax) * 0.5,
+        )
+
+    return ShapeCompareResult(
+        volume_a=props_a["volume"],
+        volume_b=props_b["volume"],
+        surface_a=props_a["surface_area"],
+        surface_b=props_b["surface_area"],
+        centroid_a=centroid_a,
+        centroid_b=centroid_b,
+    )

--- a/cad_designer/aerosandbox/wing_roundtrip.py
+++ b/cad_designer/aerosandbox/wing_roundtrip.py
@@ -468,3 +468,176 @@ def compare_wing_shapes(step_path_a: Path, step_path_b: Path) -> ShapeCompareRes
         centroid_a=centroid_a,
         centroid_b=centroid_b,
     )
+
+
+# --------------------------------------------------------------------------- #
+# CLI: export STEP pairs for manual visual comparison in a CAD tool
+# --------------------------------------------------------------------------- #
+
+
+def export_roundtrip_pair(
+    wing_config,
+    out_dir: Path,
+    *,
+    case_id: str,
+    wing_side: str = "RIGHT",
+) -> Tuple[Path, Path, "ShapeCompareResult"]:
+    """Export an ``expected.step`` / ``actual.step`` pair for one case.
+
+    Renders ``wing_config`` directly as ``<case_id>_expected.step`` and
+    renders the result of ``WingConfiguration.from_asb(wing_config.asb_wing().xsecs)``
+    as ``<case_id>_actual.step``. Both files land in ``out_dir``
+    (created if missing). The corresponding ``ShapeCompareResult`` is
+    returned so the caller can print a summary table.
+
+    Using ``wing_side="RIGHT"`` avoids the mirror-and-union step that
+    doubles render cost and obscures per-segment drift during visual
+    comparison. Pass ``wing_side="BOTH"`` explicitly if you want the
+    full mirrored wing.
+    """
+    from cad_designer.airplane.aircraft_topology.wing.WingConfiguration import (
+        WingConfiguration,
+    )
+
+    out_dir = Path(out_dir).resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Build the baseline asb wing from a *fresh* copy — asb_wing() caches
+    # on the instance, so we feed a second factory result into the
+    # roundtrip path and leave the original untouched for rendering.
+    asb_wing = wing_config.asb_wing()
+    rebuilt = WingConfiguration.from_asb(
+        asb_wing.xsecs,
+        symmetric=wing_config.symmetric,
+    )
+
+    expected_path = out_dir / f"{case_id}_expected.step"
+    actual_path = out_dir / f"{case_id}_actual.step"
+
+    render_wing_loft_to_step(
+        wing_config,
+        expected_path,
+        wing_name="main_wing",
+        wing_side=wing_side,
+        connected=False,
+    )
+    render_wing_loft_to_step(
+        rebuilt,
+        actual_path,
+        wing_name="main_wing",
+        wing_side=wing_side,
+        connected=False,
+    )
+
+    result = compare_wing_shapes(expected_path, actual_path)
+    return expected_path, actual_path, result
+
+
+def _main(argv: Optional[Sequence[str]] = None) -> int:
+    """CLI entry: export STEP pairs for every registered roundtrip case.
+
+    Usage::
+
+        poetry run python -m cad_designer.aerosandbox.wing_roundtrip \\
+            [--out-dir exports/wing_roundtrip] \\
+            [--case <case_id> ...] \\
+            [--wing-side RIGHT|BOTH]
+
+    The default output location is ``<repo-root>/exports/wing_roundtrip``.
+    Open the pairs side-by-side (or overlaid) in FreeCAD / Fusion /
+    CadQuery-Gateway. Since both sides of a perfect roundtrip would
+    render identical shapes, any visible deviation is the geometric
+    manifestation of a ``from_asb()`` bug.
+    """
+    import argparse
+    import logging
+
+    from cad_designer.aerosandbox.wing_roundtrip_cases import (
+        CASE_FACTORIES,
+        get_factory,
+    )
+
+    parser = argparse.ArgumentParser(
+        description="Export WingConfiguration roundtrip STEP pairs.",
+    )
+    parser.add_argument(
+        "--out-dir",
+        default=None,
+        help="Output directory (default: <repo>/exports/wing_roundtrip)",
+    )
+    parser.add_argument(
+        "--case",
+        action="append",
+        default=None,
+        help="Limit to one or more case ids (default: all). Repeatable.",
+    )
+    parser.add_argument(
+        "--wing-side",
+        default="RIGHT",
+        choices=["RIGHT", "LEFT", "BOTH"],
+        help="Which wing half to render (default: RIGHT)",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable INFO-level logging from the CAD pipeline.",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+
+    # Default out-dir: <repo>/exports/wing_roundtrip. The helper module
+    # wing_roundtrip_cases already computes REPO_ROOT relative to its
+    # own location, so we reuse it for consistency.
+    from cad_designer.aerosandbox.wing_roundtrip_cases import REPO_ROOT
+
+    out_dir = Path(args.out_dir) if args.out_dir else REPO_ROOT / "exports" / "wing_roundtrip"
+
+    if args.case:
+        cases = [(cid, get_factory(cid)) for cid in args.case]
+    else:
+        cases = list(CASE_FACTORIES)
+
+    print(f"Exporting {len(cases)} roundtrip STEP pair(s) to {out_dir}")
+    print("=" * 72)
+
+    header = f"{'case':<32}{'vol Δ':>10}{'surf Δ':>10}{'centroid Δ mm':>18}"
+    print(header)
+    print("-" * len(header))
+
+    all_results: list[tuple[str, "ShapeCompareResult"]] = []
+    for case_id, factory in cases:
+        wc = factory()
+        try:
+            _, _, result = export_roundtrip_pair(
+                wc,
+                out_dir,
+                case_id=case_id,
+                wing_side=args.wing_side,
+            )
+        except Exception as exc:  # pragma: no cover - CLI diagnostics path
+            print(f"{case_id:<32}  FAILED: {exc}")
+            continue
+        all_results.append((case_id, result))
+        print(
+            f"{case_id:<32}"
+            f"{result.volume_rel_delta:>9.4%}"
+            f"{result.surface_rel_delta:>10.4%}"
+            f"{result.centroid_distance:>18.4f}"
+        )
+
+    print("=" * 72)
+    print(f"Files written to {out_dir}")
+    print(
+        "Open each <case>_expected.step alongside its <case>_actual.step in a "
+        "CAD tool\nto visually evaluate the roundtrip."
+    )
+    return 0 if all_results else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(_main())

--- a/cad_designer/aerosandbox/wing_roundtrip_cases.py
+++ b/cad_designer/aerosandbox/wing_roundtrip_cases.py
@@ -1,0 +1,184 @@
+"""
+Shared test-case factories for the ``WingConfiguration`` roundtrip
+harness.
+
+These factories are consumed both by ``app/tests/test_wing_config_roundtrip.py``
+(the pytest entry point) and by the ``__main__`` CLI in
+``cad_designer/aerosandbox/wing_roundtrip.py`` (the STEP exporter that
+the developer uses for manual visual comparison in a CAD tool).
+
+Each factory returns a fresh, *relative*-mode ``WingConfiguration``.
+They are plain functions — not fixtures — so either entry point can
+call them without pulling in pytest machinery.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, List, Tuple
+
+from cad_designer.airplane.aircraft_topology.wing.Airfoil import Airfoil
+from cad_designer.airplane.aircraft_topology.wing.WingConfiguration import (
+    WingConfiguration,
+)
+
+# Repo root is four levels up from this file:
+# cad_designer/aerosandbox/wing_roundtrip_cases.py -> repo root
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AIRFOIL_PATH = str(REPO_ROOT / "components" / "airfoils" / "naca0010.dat")
+
+
+def single_segment_flat() -> WingConfiguration:
+    """One segment, zero twist / sweep / dihedral. The trivial sanity case."""
+    return WingConfiguration(
+        nose_pnt=(0.0, 0.0, 0.0),
+        root_airfoil=Airfoil(
+            airfoil=AIRFOIL_PATH,
+            chord=200.0,
+            dihedral_as_rotation_in_degrees=0,
+            incidence=0,
+            rotation_point_rel_chord=0.25,
+        ),
+        length=500.0,
+        sweep=0,
+        sweep_is_angle=False,
+        tip_airfoil=Airfoil(
+            chord=200.0,
+            dihedral_as_rotation_in_degrees=0,
+            incidence=0,
+            rotation_point_rel_chord=0.25,
+        ),
+        symmetric=True,
+        parameters="relative",
+    )
+
+
+def single_segment_with_dihedral() -> WingConfiguration:
+    """One segment, +5° dihedral rotation. Isolates the dihedral sign bug."""
+    return WingConfiguration(
+        nose_pnt=(0.0, 0.0, 0.0),
+        root_airfoil=Airfoil(
+            airfoil=AIRFOIL_PATH,
+            chord=200.0,
+            dihedral_as_rotation_in_degrees=5,
+            incidence=0,
+            rotation_point_rel_chord=0.25,
+        ),
+        length=500.0,
+        sweep=0,
+        sweep_is_angle=False,
+        tip_airfoil=Airfoil(
+            chord=200.0,
+            dihedral_as_rotation_in_degrees=5,
+            incidence=0,
+            rotation_point_rel_chord=0.25,
+        ),
+        symmetric=True,
+        parameters="relative",
+    )
+
+
+def single_segment_with_twist() -> WingConfiguration:
+    """One segment, -10° tip incidence. Isolates twist recovery."""
+    return WingConfiguration(
+        nose_pnt=(0.0, 0.0, 0.0),
+        root_airfoil=Airfoil(
+            airfoil=AIRFOIL_PATH,
+            chord=200.0,
+            dihedral_as_rotation_in_degrees=0,
+            incidence=0,
+            rotation_point_rel_chord=0.25,
+        ),
+        length=500.0,
+        sweep=0,
+        sweep_is_angle=False,
+        tip_airfoil=Airfoil(
+            chord=200.0,
+            dihedral_as_rotation_in_degrees=0,
+            incidence=-10,
+            rotation_point_rel_chord=0.25,
+        ),
+        symmetric=True,
+        parameters="relative",
+    )
+
+
+def configurator_wing() -> WingConfiguration:
+    """The 3-segment wing from ``test/Test_Configurator_wing.py``.
+
+    Copied 1:1 (including the non-trivial nose_pnt=(25,50,100) and
+    the alternating positive/negative sweep + dihedral pattern) so that
+    a green result here proves the primary user-visible case.
+    """
+    wc = WingConfiguration(
+        nose_pnt=(25, 50, 100),
+        symmetric=True,
+        parameters="relative",
+        root_airfoil=Airfoil(
+            airfoil=AIRFOIL_PATH,
+            chord=200.0,
+            dihedral_as_rotation_in_degrees=4,
+            incidence=0,
+            rotation_point_rel_chord=0.25,
+        ),
+        length=500.0,
+        sweep=50,
+        sweep_is_angle=False,
+        tip_airfoil=Airfoil(
+            chord=200.0,
+            dihedral_as_rotation_in_degrees=-4,
+            incidence=-10,
+            rotation_point_rel_chord=0.25,
+        ),
+    )
+    wc.add_segment(
+        length=500,
+        sweep=-50,
+        sweep_is_angle=False,
+        tip_airfoil=Airfoil(
+            chord=150,
+            dihedral_as_rotation_in_degrees=-4,
+            incidence=-5,
+            rotation_point_rel_chord=0.25,
+        ),
+    )
+    wc.add_segment(
+        length=500,
+        sweep=50,
+        sweep_is_angle=False,
+        tip_airfoil=Airfoil(
+            chord=100,
+            dihedral_as_rotation_in_degrees=0,
+            incidence=0,
+            rotation_point_rel_chord=0.25,
+        ),
+    )
+    return wc
+
+
+def ehawk_main_wing() -> WingConfiguration:
+    """Real-world eHawk main wing from ``test/ehawk_workflow_helpers``."""
+    # Delayed import — ehawk_workflow_helpers pulls in CAD modules that
+    # we don't want to load when the rest of the suite is collected.
+    from test.ehawk_workflow_helpers import _build_main_wing  # type: ignore
+
+    return _build_main_wing(AIRFOIL_PATH)
+
+
+# Ordered list of (case_id, factory) used by both the pytest harness
+# and the CLI exporter. Tests add their own tolerance columns on top.
+CASE_FACTORIES: List[Tuple[str, Callable[[], WingConfiguration]]] = [
+    ("single_segment_flat", single_segment_flat),
+    ("single_segment_with_dihedral", single_segment_with_dihedral),
+    ("single_segment_with_twist", single_segment_with_twist),
+    ("configurator_wing", configurator_wing),
+    ("ehawk_main_wing", ehawk_main_wing),
+]
+
+
+def get_factory(case_id: str) -> Callable[[], WingConfiguration]:
+    """Look up a factory by case id. Raises ``KeyError`` on unknown ids."""
+    for cid, factory in CASE_FACTORIES:
+        if cid == case_id:
+            return factory
+    raise KeyError(case_id)


### PR DESCRIPTION
## Summary

Adds a 3-level comparison harness for `WingConfiguration.asb_wing() → from_asb()` roundtrip fidelity, and captures the pre-fix baseline on 5 parametrized wing cases. This is Phase 1 + Phase 2 of the roundtrip rework, stacked into a single PR so that Phase 3 (the analytic `from_asb()` fixes) has concrete numeric targets to hit.

- **Helper module**: `cad_designer/aerosandbox/wing_roundtrip.py` — three levels:
  1. *Parameter-strict*: per-field walk of `nose_pnt`, segments, airfoils
  2. *Segment-origin-strict*: `get_wing_workplane(i).plane.origin` in global space
  3. *Shape-tolerant*: `WingLoftCreator → STEP → reimport`, compared via `BRepGProp` volume / surface / centroid (reuses `compute_shape_properties` + `load_step_model` from `slicing.py`).
- **Pytest harness**: `app/tests/test_wing_config_roundtrip.py`, marked `slow` + `requires_cadquery` + `requires_aerosandbox` so it does not fire in the default fast CI job. Five cases: `single_segment_flat`, `single_segment_with_dihedral`, `single_segment_with_twist`, `configurator_wing`, `ehawk_main_wing`.

## Baseline (current `from_asb()`)

| Case                            | L1 params | L2 origins           | L3 shape (vol / surf / centroid)                 |
|---------------------------------|-----------|----------------------|--------------------------------------------------|
| `single_segment_flat`           | FAIL      | PASS (< 1e-6 mm)     | PASS (≪ 1e-3)                                    |
| `single_segment_with_dihedral`  | FAIL      | PASS (< 1e-6 mm)     | PASS                                             |
| `single_segment_with_twist`     | FAIL      | PASS (< 1e-6 mm)     | PASS                                             |
| `configurator_wing`             | FAIL      | **FAIL — 229.13 mm** | **FAIL** vol=0.56% surf=0.01% centroid=229.35 mm |
| `ehawk_main_wing`               | FAIL      | PASS (< 1e-6 mm)     | PASS                                             |

Key finding: all 5 cases have wrong per-field parameters, but only `configurator_wing` renders to a wrong *shape* — and its error is a constant `2 × nose_pnt` offset (nose_pnt double-counting). The other four cases produce geometrically-equivalent solids because the reconstructed transformation matrices compensate for each other. Phase 3 is therefore mostly about cleaning up the internal representation; the only user-visible fix is the nose_pnt double-count. Full drift analysis in the notes of beads issue `cad-modelling-service-7kq`.

## Test plan

- [x] `poetry run pytest --collect-only app/tests/test_wing_config_roundtrip.py` — 15 tests collected (3 levels × 5 cases)
- [x] `poetry run pytest app/tests/test_wing_config_roundtrip.py::test_parameters_strict` — baseline run, expected failures recorded
- [x] `poetry run pytest app/tests/test_wing_config_roundtrip.py::test_segment_origins_strict` — 4 passing, 1 failing (configurator_wing)
- [x] `poetry run pytest app/tests/test_wing_config_roundtrip.py::test_shape_tolerant` — 4 passing, 1 failing (configurator_wing)
- [x] Slow marker keeps default CI green (only manual `workflow_dispatch` with `run_slow=true` runs this)

## Follow-up

- `cad-modelling-service-7kq` — Phase 2 closed with baseline table once this lands
- `cad-modelling-service-6f1` — Phase 1 closed once this lands
- Phase 3 (to be filed as a follow-up issue) will fix the 5 analytic bugs in `WingConfiguration.from_asb()`:
  1. `rotation_point_rel_chord` hardcoded to 0 (must be 0.25)
  2. Dihedral sign flip (`atan2(-C[1,2], C[1,1])` → `atan2(C[2,1], C[1,1])` for relative mode)
  3. `length` returned as cumulative `C[1,3]` instead of per-segment delta
  4. `sweep` / `dihedral` accumulated similarly
  5. Both dihedral forms set simultaneously, violating the `Airfoil` one-at-a-time invariant
  6. `nose_pnt` double-counting when `asb_wing()` has applied a `.translate()`
- Phase 4 will add `Airfoil.chord_stretch_factor` to absorb the airfoil-thickness drift from chord rotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)