### PR TITLE
fix(tda): drop nose_pnt double-count in relative-mode wing workplane

### DIFF
--- a/app/tests/test_wing_config_roundtrip.py
+++ b/app/tests/test_wing_config_roundtrip.py
@@ -155,6 +155,7 @@ def test_segment_origins_strict(roundtrip_case):
 # in mm (wing_config units).
 SHAPE_TOL = {
     "single_segment_flat": dict(vol_rel=1e-3, surf_rel=1e-3, centroid_mm=1e-2),
+    "single_segment_with_nose_pnt": dict(vol_rel=1e-3, surf_rel=1e-3, centroid_mm=1e-2),
     "single_segment_with_dihedral": dict(vol_rel=5e-2, surf_rel=5e-2, centroid_mm=5.0),
     "single_segment_with_twist": dict(vol_rel=5e-2, surf_rel=5e-2, centroid_mm=5.0),
     "configurator_wing": dict(vol_rel=2e-1, surf_rel=2e-1, centroid_mm=20.0),

--- a/cad_designer/aerosandbox/wing_roundtrip_cases.py
+++ b/cad_designer/aerosandbox/wing_roundtrip_cases.py
@@ -78,6 +78,37 @@ def single_segment_with_dihedral() -> WingConfiguration:
     )
 
 
+def single_segment_with_nose_pnt() -> WingConfiguration:
+    """One segment at non-zero ``nose_pnt``. Guards against regression
+    of the ``_get_relative_segment_coordinate_system`` inverted-``if``
+    bug (cad-modelling-service-tda): a 1-segment wing is the simplest
+    topology that still surfaces the nose_pnt double-counting, and
+    avoids the other parameter-drift noise that multi-segment cases
+    add on top of it.
+    """
+    return WingConfiguration(
+        nose_pnt=(25.0, 50.0, 100.0),
+        root_airfoil=Airfoil(
+            airfoil=AIRFOIL_PATH,
+            chord=200.0,
+            dihedral_as_rotation_in_degrees=0,
+            incidence=0,
+            rotation_point_rel_chord=0.25,
+        ),
+        length=500.0,
+        sweep=0,
+        sweep_is_angle=False,
+        tip_airfoil=Airfoil(
+            chord=200.0,
+            dihedral_as_rotation_in_degrees=0,
+            incidence=0,
+            rotation_point_rel_chord=0.25,
+        ),
+        symmetric=True,
+        parameters="relative",
+    )
+
+
 def single_segment_with_twist() -> WingConfiguration:
     """One segment, -10° tip incidence. Isolates twist recovery."""
     return WingConfiguration(
@@ -169,6 +200,7 @@ def ehawk_main_wing() -> WingConfiguration:
 # and the CLI exporter. Tests add their own tolerance columns on top.
 CASE_FACTORIES: List[Tuple[str, Callable[[], WingConfiguration]]] = [
     ("single_segment_flat", single_segment_flat),
+    ("single_segment_with_nose_pnt", single_segment_with_nose_pnt),
     ("single_segment_with_dihedral", single_segment_with_dihedral),
     ("single_segment_with_twist", single_segment_with_twist),
     ("configurator_wing", configurator_wing),

--- a/cad_designer/airplane/aircraft_topology/wing/WingConfiguration.py
+++ b/cad_designer/airplane/aircraft_topology/wing/WingConfiguration.py
@@ -447,8 +447,17 @@ class WingConfiguration:
         r_neg_rel_chord[0, 3] = -self.segments[seg].root_airfoil.rotation_point_rel_chord * self.segments[
             seg].root_airfoil.chord
 
+        # ``ignore_nose_point=True`` means "give me the segment frame WITHOUT
+        # the nose_pnt offset"; the absolute branch just below already
+        # follows this convention and asb_wing() relies on it (it passes
+        # ignore_nose_point=True and then applies .translate(nose_pnt)
+        # itself). The condition here was historically inverted, which
+        # caused nose_pnt to leak into asb_wing()'s per-segment frames and
+        # then be applied a second time by .translate(), producing a
+        # 2 × nose_pnt offset in the from_asb() roundtrip. See issue
+        # cad-modelling-service-tda.
         nose_point_trans = np.eye(4)
-        if ignore_nose_point:
+        if not ignore_nose_point:
             nose_point_trans[:3, 3] = self.nose_pnt
 
         # apply the transformations in reverse order


### PR DESCRIPTION
## Summary

Fixes `cad-modelling-service-tda` — the `asb_wing() → from_asb()` roundtrip applied `nose_pnt` twice for any `WingConfiguration` with non-zero nose. Root cause was *not* in `from_asb()` (as the bug ticket initially suspected) but in `_get_relative_segment_coordinate_system`, which had an inverted `if ignore_nose_point` guard.

## Root cause

`cad_designer/airplane/aircraft_topology/wing/WingConfiguration.py:450-452` was:

```python
nose_point_trans = np.eye(4)
if ignore_nose_point:               # ← inverted!
    nose_point_trans[:3, 3] = self.nose_pnt
```

The sibling absolute branch at line 496-498 has the correct form (`if not ignore_nose_point`). The relative branch applied `nose_pnt` exactly when the caller asked to *skip* it.

Chain of the double-count:

1. `asb_wing()` calls `get_wing_workplane(i, ignore_nose_point=True)` intending to receive nose-excluded local frames. Due to the inverted `if`, it got frames with `nose_pnt` already folded in.
2. `asb_wing()` then applies `.translate([*nose_pnt])` at line 736 — adding `nose_pnt` a second time.
3. `from_asb()` faithfully read `xyz_le[0] = 2 × nose_pnt` and stored it into the rebuilt configuration — the roundtrip rendered at a constant offset of 2× nose.

Baseline caught this on `configurator_wing` (nose_pnt=(25,50,100)): L2 origin drift 229.13 mm, L3 centroid distance 229.35 mm. The four other Phase 1 cases had `nose_pnt=(0,0,0)` so the double-offset collapsed to zero.

## Fix

One-line flip to `if not ignore_nose_point`, aligning with the absolute branch. Surrounding comment documents the incident for future readers.

## Blast radius

`grep 'nose_pnt=\(.*[1-9]'` across the repo identified the call sites that pass a non-zero `nose_pnt` to a *relative*-mode `WingConfiguration`:

- `test/ehawk_workflow_helpers.py:392` — `(650, 0, 0)` elevator
- `test/Test_Wing_Alternative_CS.py:167,306,362,405`
- `test/Test_RV7ConstructionSteps_V2.py:418,441,450`
- `test/Construction_eHawk_wing.py:380`

**All** are under the `test/` legacy script folder (not pytest, not under `app/`, not touched by REST or MCP). None of them specify `parameters=`, so they all defaulted to `"relative"`, which means every one of them has been silently rendering its wing at `(0,0,0)` regardless of the configured `nose_pnt`. The fix shifts them to their configured positions — which is the behaviour the scripts always intended.

No fast-suite test fails after the fix: `poetry run pytest -m "not slow"` → **183 passed**.

## New regression test

`cad_designer/aerosandbox/wing_roundtrip_cases.py::single_segment_with_nose_pnt` — a 1-segment flat wing at `nose_pnt=(25, 50, 100)`. The simplest topology that still surfaces the bug; without it the harness only catches the double-count when a multi-segment case happens to have a non-zero nose.

## Verification

```
$ poetry run pytest app/tests/test_wing_config_roundtrip.py::test_segment_origins_strict
6 passed

$ poetry run pytest app/tests/test_wing_config_roundtrip.py::test_shape_tolerant
6 passed

$ poetry run python -m cad_designer.aerosandbox.wing_roundtrip \
      --case configurator_wing --case single_segment_with_nose_pnt
  configurator_wing                 vol=0.5572%  surf=0.0111%  centroid=0.4411 mm
  single_segment_with_nose_pnt      vol=0.0000%  surf=0.0000%  centroid=0.0000 mm
```

Bounding boxes of the re-exported STEP files confirm both wings now sit at their configured `nose_pnt`:

```
configurator_wing_expected           x=[ 25.00, 272.76]  y=[ 49.30, 548.78]  z=[ 90.02, 161.13]
configurator_wing_actual             x=[ 25.00, 272.75]  y=[ 49.48, 548.93]  z=[ 90.01, 161.16]
single_segment_with_nose_pnt_expected x=[ 25.00, 225.00]  y=[ 50.00, 550.00]  z=[ 90.00, 110.00]
single_segment_with_nose_pnt_actual   x=[ 25.00, 225.00]  y=[ 50.00, 550.00]  z=[ 90.00, 110.00]
```

Level 3 centroid on `configurator_wing` drops from **229.35 mm → 0.44 mm**. The 0.44 mm residual is Level-1 parameter drift (Phase 3 scope), not nose-related.

## Test plan

- [x] `poetry run pytest -m "not slow"` — fast suite clean (183 passed)
- [x] `poetry run pytest app/tests/test_wing_config_roundtrip.py::test_segment_origins_strict` — 6 passed
- [x] `poetry run pytest app/tests/test_wing_config_roundtrip.py::test_shape_tolerant` — 6 passed
- [x] `poetry run pytest app/tests/test_wing_config_roundtrip.py::test_parameters_strict` — 6 failed as expected (Phase 3 scope)
- [x] Visual: re-exported STEP pairs overlay cleanly in FreeCAD for both affected cases
- [ ] Spot-check a legacy aircraft script (e.g. `Construction_eHawk_wing.py`) renders the expected assembly layout — recommended before merging, since those scripts will see their wings move for the first time

## Follow-up

- `cad-modelling-service-tda` closes when this merges
- `cad-modelling-service-7em` (REST E2E xfail) may now be reviewable — the double-count was one of the symptoms that pushed the E2E test to xfail; worth re-running after merge
- Phase 3 (Level 1 parameter drift in `from_asb()`) remains open under epic `cad-modelling-service-6b0`

Closes #tda

🤖 Generated with [Claude Code](https://claude.com/claude-code)