### PR TITLE
fix: eye toggle position + gitignore cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -247,3 +247,17 @@ components/constructions/configurator-test-wing.root.json
 # Coverage artifacts
 .coverage
 coverage.xml
+
+# Next.js build output (frontend uses frontend/.next via its own .gitignore)
+/.next/
+
+# Playwright MCP session artifacts
+.playwright-mcp/
+
+# Root-level npm (tooling only — the real frontend is in frontend/)
+/node_modules/
+/package.json
+/package-lock.json
+
+# Claude Code skills lock
+skills-lock.json

--- a/frontend/components/workbench/AeroplaneTree.tsx
+++ b/frontend/components/workbench/AeroplaneTree.tsx
@@ -474,6 +474,15 @@ function TreeRow({ node, onToggle }: { node: TreeNode; onToggle: () => void }) {
 
       <span className="flex-1" />
 
+      {node.onDelete && (
+        <button
+          onClick={(e) => { e.stopPropagation(); node.onDelete?.(); }}
+          className="hidden h-5 w-5 items-center justify-center rounded-[--radius-s] group-hover:flex"
+        >
+          <Trash2 size={12} className="text-destructive" />
+        </button>
+      )}
+
       {node.onPreviewToggle && (
         <button
           onClick={(e) => { e.stopPropagation(); node.onPreviewToggle?.(); }}
@@ -489,15 +498,6 @@ function TreeRow({ node, onToggle }: { node: TreeNode; onToggle: () => void }) {
           ) : (
             <EyeOff size={12} />
           )}
-        </button>
-      )}
-
-      {node.onDelete && (
-        <button
-          onClick={(e) => { e.stopPropagation(); node.onDelete?.(); }}
-          className="hidden h-5 w-5 items-center justify-center rounded-[--radius-s] group-hover:flex"
-        >
-          <Trash2 size={12} className="text-destructive" />
         </button>
       )}
     </div>


### PR DESCRIPTION
## Summary

Two small follow-up changes after merging PR #24.

### fix(gh#35): Eye toggle stays rightmost in tree row
- Swapped render order of delete (trash) and preview (eye) buttons in `TreeRow`
- Delete button now appears to the **left** of the eye on hover
- Eye icon stays at its fixed rightmost position — no accidental deletes

Closes #35

### chore: gitignore root-level tooling artifacts
- `.next/`, `.playwright-mcp/`, root `node_modules/`, `package.json`, `package-lock.json`, `skills-lock.json`
- All are build artifacts or session tooling, not project code

## Test plan
- [x] `npx next build` — compiles
- [x] `poetry run pytest -m "not slow"` — 222 passed
- [x] `poetry run ruff check .` — clean
- [x] `git status` — no untracked files

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)