### PR TITLE
feat: Frontend Wireframe Redesign — shared components + screen refactors (GH#44)

### DIFF
--- a/frontend/__tests__/AlertBanner.test.tsx
+++ b/frontend/__tests__/AlertBanner.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => ({
+  Info: (props: Record<string, unknown>) => (
+    <svg data-testid="info-icon" {...props} />
+  ),
+}));
+
+import { AlertBanner } from "../components/workbench/AlertBanner";
+
+describe("AlertBanner", () => {
+  it("renders default title and children text", () => {
+    render(<AlertBanner>Some body text here</AlertBanner>);
+
+    expect(
+      screen.getByText("Coming soon \u2014 backend wiring in progress"),
+    ).toBeDefined();
+    expect(screen.getByText("Some body text here")).toBeDefined();
+  });
+
+  it("renders custom title when provided", () => {
+    render(<AlertBanner title="Custom title">Body content</AlertBanner>);
+
+    expect(screen.getByText("Custom title")).toBeDefined();
+    expect(screen.getByText("Body content")).toBeDefined();
+  });
+
+  it("renders the Info icon", () => {
+    render(<AlertBanner>Content</AlertBanner>);
+
+    expect(screen.getByTestId("info-icon")).toBeDefined();
+  });
+});

--- a/frontend/__tests__/RadarChart.test.tsx
+++ b/frontend/__tests__/RadarChart.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RadarChart, polarToCartesian, buildPolygonPoints } from "@/components/workbench/RadarChart";
+
+const AXES = [
+  { key: "payload", label: "Payload" },
+  { key: "flight_time", label: "Flight Time" },
+  { key: "speed", label: "Cruise Speed" },
+  { key: "range", label: "Range" },
+  { key: "ceiling", label: "Ceiling" },
+];
+
+const TARGET = { payload: 0.5, flight_time: 0.7, speed: 0.6, range: 0.4, ceiling: 0.8 };
+const ANALYSIS = { payload: 0.3, flight_time: 0.5, speed: 0.8, range: 0.6, ceiling: 0.4 };
+
+describe("RadarChart", () => {
+  it("renders all 5 axis labels", () => {
+    render(<RadarChart axes={AXES} target={TARGET} />);
+    for (const axis of AXES) {
+      expect(screen.getByText(axis.label)).toBeDefined();
+    }
+  });
+
+  it("renders grid rings", () => {
+    render(<RadarChart axes={AXES} target={TARGET} />);
+    const rings = screen.getAllByTestId("grid-ring");
+    expect(rings.length).toBe(3);
+  });
+
+  it("renders target polygon", () => {
+    render(<RadarChart axes={AXES} target={TARGET} />);
+    const poly = screen.getByTestId("target-polygon");
+    expect(poly.getAttribute("stroke")).toBe("var(--color-primary)");
+    expect(poly.getAttribute("fill")).toBe("#FF840030");
+  });
+
+  it("does not render analysis polygon when null", () => {
+    render(<RadarChart axes={AXES} target={TARGET} analysis={null} />);
+    expect(screen.queryByTestId("analysis-polygon")).toBeNull();
+  });
+
+  it("renders analysis polygon when provided", () => {
+    render(<RadarChart axes={AXES} target={TARGET} analysis={ANALYSIS} />);
+    const poly = screen.getByTestId("analysis-polygon");
+    expect(poly.getAttribute("stroke")).toBe("var(--color-success)");
+    expect(poly.getAttribute("fill")).toBe("#30A46C30");
+  });
+
+  it("handles all-zero target values", () => {
+    const zeros = { payload: 0, flight_time: 0, speed: 0, range: 0, ceiling: 0 };
+    expect(() => render(<RadarChart axes={AXES} target={zeros} />)).not.toThrow();
+  });
+
+  it("handles all-max target values", () => {
+    const maxes = { payload: 1, flight_time: 1, speed: 1, range: 1, ceiling: 1 };
+    expect(() => render(<RadarChart axes={AXES} target={maxes} />)).not.toThrow();
+  });
+
+  it("uses custom size in viewBox", () => {
+    render(<RadarChart axes={AXES} target={TARGET} size={300} />);
+    const svg = screen.getByTestId("radar-chart");
+    expect(svg.getAttribute("viewBox")).toContain("300");
+  });
+});
+
+describe("polarToCartesian", () => {
+  it("returns center at r=0", () => {
+    const pt = polarToCartesian(100, 100, 0, Math.PI);
+    expect(pt.x).toBeCloseTo(100);
+    expect(pt.y).toBeCloseTo(100);
+  });
+});
+
+describe("buildPolygonPoints", () => {
+  it("returns space-separated coordinate pairs", () => {
+    const angles = [0, Math.PI / 2];
+    const result = buildPolygonPoints(0, 0, 10, [1, 1], angles);
+    expect(result.split(" ").length).toBe(2);
+    expect(result).toContain(",");
+  });
+});

--- a/frontend/__tests__/SplitHandle.test.tsx
+++ b/frontend/__tests__/SplitHandle.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+vi.mock("react-resizable-panels", () => ({
+  Separator: ({ children, className, ...props }: any) => (
+    <div data-testid="separator" className={className} {...props}>
+      {typeof children === "function" ? children() : children}
+    </div>
+  ),
+}));
+
+vi.mock("lucide-react", () => ({
+  ChevronRight: ({ className, ...props }: any) => (
+    <svg data-testid="chevron" className={className} {...props} />
+  ),
+}));
+
+import { SplitHandle } from "@/components/workbench/SplitHandle";
+
+describe("SplitHandle", () => {
+  it("renders 3 grip dots", () => {
+    const { container } = render(<SplitHandle />);
+    const dots = container.querySelectorAll(".rounded-full");
+    expect(dots).toHaveLength(3);
+  });
+
+  it("renders collapse button when onCollapse provided", () => {
+    render(<SplitHandle onCollapse={() => {}} />);
+    const button = screen.getByRole("button");
+    expect(button).toBeDefined();
+  });
+
+  it("does not render collapse button without onCollapse", () => {
+    render(<SplitHandle />);
+    const button = screen.queryByRole("button");
+    expect(button).toBeNull();
+  });
+
+  it("chevron has rotate-180 class when collapsed=false", () => {
+    render(<SplitHandle onCollapse={() => {}} collapsed={false} />);
+    const chevron = screen.getByTestId("chevron");
+    expect(chevron.getAttribute("class")).toContain("rotate-180");
+  });
+
+  it("calls onCollapse when collapse button is clicked", () => {
+    const onCollapse = vi.fn();
+    render(<SplitHandle onCollapse={onCollapse} collapsed={false} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onCollapse).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/__tests__/TreeCard.test.tsx
+++ b/frontend/__tests__/TreeCard.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for the TreeCard shared component.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+import { TreeCard } from "../components/workbench/TreeCard";
+
+describe("TreeCard", () => {
+  it("renders title text", () => {
+    render(<TreeCard title="Weight Tree">body</TreeCard>);
+
+    expect(screen.getByText("Weight Tree")).toBeDefined();
+  });
+
+  it("renders badge with muted variant class by default", () => {
+    render(
+      <TreeCard title="Weight" badge="1.177 kg">
+        body
+      </TreeCard>,
+    );
+
+    const badge = screen.getByText("1.177 kg");
+    expect(badge).toBeDefined();
+    expect(badge.className).toContain("text-muted-foreground");
+    expect(badge.className).not.toContain("text-primary");
+  });
+
+  it("renders badge with primary variant class when specified", () => {
+    render(
+      <TreeCard title="Weight" badge="1.177 kg" badgeVariant="primary">
+        body
+      </TreeCard>,
+    );
+
+    const badge = screen.getByText("1.177 kg");
+    expect(badge.className).toContain("text-primary");
+  });
+
+  it("renders actions slot content", () => {
+    render(
+      <TreeCard
+        title="Tree"
+        actions={<button data-testid="action-btn">Add</button>}
+      >
+        body
+      </TreeCard>,
+    );
+
+    expect(screen.getByTestId("action-btn")).toBeDefined();
+    expect(screen.getByText("Add")).toBeDefined();
+  });
+
+  it("body container has overflow-y-auto class", () => {
+    render(
+      <TreeCard title="Tree">
+        <span data-testid="child">content</span>
+      </TreeCard>,
+    );
+
+    const child = screen.getByTestId("child");
+    const body = child.parentElement!;
+    expect(body.className).toContain("overflow-y-auto");
+  });
+});

--- a/frontend/__tests__/UnsavedChangesModal.test.tsx
+++ b/frontend/__tests__/UnsavedChangesModal.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => ({
+  TriangleAlert: (props: Record<string, unknown>) => (
+    <svg data-testid="triangle-alert-icon" {...props} />
+  ),
+}));
+
+const mockUseUnsavedChanges = vi.fn();
+
+vi.mock("@/components/workbench/UnsavedChangesContext", () => ({
+  useUnsavedChanges: () => mockUseUnsavedChanges(),
+}));
+
+import { UnsavedChangesModal } from "../components/workbench/UnsavedChangesModal";
+
+function defaultCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    pendingHref: null,
+    isSaving: false,
+    confirmDiscard: vi.fn(),
+    confirmSave: vi.fn(),
+    cancelNavigation: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("UnsavedChangesModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not render when pendingHref is null", () => {
+    mockUseUnsavedChanges.mockReturnValue(defaultCtx());
+    const { container } = render(<UnsavedChangesModal />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders when pendingHref is set", () => {
+    mockUseUnsavedChanges.mockReturnValue(
+      defaultCtx({ pendingHref: "/workbench/analysis" }),
+    );
+    render(<UnsavedChangesModal />);
+    expect(screen.getByText("Unsaved Changes")).toBeDefined();
+    expect(
+      screen.getByText("You have unsaved changes. Do you want to save before leaving?"),
+    ).toBeDefined();
+  });
+
+  it("Discard button calls confirmDiscard", () => {
+    const ctx = defaultCtx({ pendingHref: "/workbench/analysis" });
+    mockUseUnsavedChanges.mockReturnValue(ctx);
+    render(<UnsavedChangesModal />);
+
+    fireEvent.click(screen.getByText("Discard"));
+    expect(ctx.confirmDiscard).toHaveBeenCalledOnce();
+  });
+
+  it("Cancel button calls cancelNavigation", () => {
+    const ctx = defaultCtx({ pendingHref: "/workbench/analysis" });
+    mockUseUnsavedChanges.mockReturnValue(ctx);
+    render(<UnsavedChangesModal />);
+
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(ctx.cancelNavigation).toHaveBeenCalledOnce();
+  });
+
+  it("Save & Continue button calls confirmSave", () => {
+    const ctx = defaultCtx({ pendingHref: "/workbench/analysis" });
+    mockUseUnsavedChanges.mockReturnValue(ctx);
+    render(<UnsavedChangesModal />);
+
+    fireEvent.click(screen.getByText("Save & Continue"));
+    expect(ctx.confirmSave).toHaveBeenCalledOnce();
+  });
+
+  it('shows "Saving..." when isSaving is true', () => {
+    mockUseUnsavedChanges.mockReturnValue(
+      defaultCtx({ pendingHref: "/workbench/analysis", isSaving: true }),
+    );
+    render(<UnsavedChangesModal />);
+    expect(screen.getByText("Saving\u2026")).toBeDefined();
+  });
+});

--- a/frontend/__tests__/WorkbenchTwoPanel.test.tsx
+++ b/frontend/__tests__/WorkbenchTwoPanel.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+import { WorkbenchTwoPanel } from "../components/workbench/WorkbenchTwoPanel";
+
+describe("WorkbenchTwoPanel", () => {
+  it("renders two children side by side", () => {
+    render(
+      <WorkbenchTwoPanel>
+        <div data-testid="left">Left</div>
+        <div data-testid="right">Right</div>
+      </WorkbenchTwoPanel>,
+    );
+    expect(screen.getByTestId("left")).toBeTruthy();
+    expect(screen.getByTestId("right")).toBeTruthy();
+  });
+
+  it("left panel has correct default width of 360px", () => {
+    render(
+      <WorkbenchTwoPanel>
+        <div data-testid="left">Left</div>
+        <div data-testid="right">Right</div>
+      </WorkbenchTwoPanel>,
+    );
+    const leftPanel = screen.getByTestId("left").parentElement!;
+    expect(leftPanel.style.width).toBe("360px");
+    expect(leftPanel.style.minWidth).toBe("360px");
+  });
+
+  it("applies custom leftWidth prop", () => {
+    render(
+      <WorkbenchTwoPanel leftWidth={480}>
+        <div data-testid="left">Left</div>
+        <div data-testid="right">Right</div>
+      </WorkbenchTwoPanel>,
+    );
+    const leftPanel = screen.getByTestId("left").parentElement!;
+    expect(leftPanel.style.width).toBe("480px");
+    expect(leftPanel.style.minWidth).toBe("480px");
+  });
+
+  it("renders gracefully with a single child", () => {
+    render(
+      <WorkbenchTwoPanel>
+        <div data-testid="only">Only child</div>
+      </WorkbenchTwoPanel>,
+    );
+    expect(screen.getByTestId("only")).toBeTruthy();
+    // Right panel exists but is empty — no crash
+    const container = screen.getByTestId("only").parentElement!.parentElement!;
+    expect(container.children).toHaveLength(2);
+  });
+});

--- a/frontend/app/workbench/analysis/page.tsx
+++ b/frontend/app/workbench/analysis/page.tsx
@@ -1,18 +1,30 @@
 "use client";
 
+import { Group, Panel } from "react-resizable-panels";
 import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
 import { useAnalysis } from "@/hooks/useAnalysis";
 import { AnalysisViewerPanel } from "@/components/workbench/AnalysisViewerPanel";
 import { AnalysisConfigPanel } from "@/components/workbench/AnalysisConfigPanel";
+import { SplitHandle } from "@/components/workbench/SplitHandle";
 
 export default function AnalysisPage() {
   const { aeroplaneId } = useAeroplaneContext();
   const analysis = useAnalysis(aeroplaneId);
 
   return (
-    <>
-      <AnalysisViewerPanel result={analysis.result} aeroplaneId={aeroplaneId} />
-      <AnalysisConfigPanel analysis={analysis} />
-    </>
+    <Group orientation="horizontal" className="flex-1">
+      <Panel defaultSize={55} minSize={20}>
+        <AnalysisViewerPanel
+          result={analysis.result}
+          aeroplaneId={aeroplaneId}
+          lastRunTime={analysis.lastRunTime}
+          lastRunDurationMs={analysis.lastRunDurationMs}
+        />
+      </Panel>
+      <SplitHandle />
+      <Panel defaultSize={45} minSize={25}>
+        <AnalysisConfigPanel analysis={analysis} />
+      </Panel>
+    </Group>
   );
 }

--- a/frontend/app/workbench/components/page.tsx
+++ b/frontend/app/workbench/components/page.tsx
@@ -1,7 +1,9 @@
+"use client";
+
 import {
   Package,
   Search,
-  Info,
+  ArrowLeft,
   Cpu,
   BatteryMedium,
   Wind,
@@ -10,6 +12,9 @@ import {
   Layers,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
+import { WorkbenchTwoPanel } from "@/components/workbench/WorkbenchTwoPanel";
+import { AlertBanner } from "@/components/workbench/AlertBanner";
+import { ComponentTree } from "@/components/workbench/ComponentTree";
 
 const COMPONENTS: {
   icon: LucideIcon;
@@ -82,82 +87,86 @@ const COMPONENTS: {
 
 export default function ComponentsPage() {
   return (
-    <div className="flex w-full flex-col gap-6">
-      {/* Header */}
-      <div className="flex items-center gap-2.5">
-        <Package className="size-5 text-primary" />
-        <h1 className="font-[family-name:var(--font-jetbrains-mono)] text-[20px] text-foreground">
-          Component Library
-        </h1>
-        <span className="flex-1" />
-        <div className="flex w-60 items-center gap-2 rounded-[--radius-s] border border-border bg-input px-3 py-2">
-          <Search className="size-3.5 text-muted-foreground" />
-          <span className="text-[12px] text-subtle-foreground">
-            Search components...
+    <WorkbenchTwoPanel>
+      <ComponentTree />
+
+      <div className="flex w-full flex-col gap-6 overflow-y-auto">
+        {/* Header */}
+        <div className="flex items-center gap-2.5">
+          <Package className="size-5 text-primary" />
+          <h1 className="font-[family-name:var(--font-jetbrains-mono)] text-[20px] text-foreground">
+            Component Library
+          </h1>
+          <span className="flex-1" />
+          <div className="flex w-60 items-center gap-2 rounded-[--radius-s] border border-border bg-input px-3 py-2">
+            <Search className="size-3.5 text-muted-foreground" />
+            <span className="text-[12px] text-subtle-foreground">
+              Search components...
+            </span>
+          </div>
+        </div>
+
+        {/* Alert banner */}
+        <AlertBanner>
+          Component Library needs backend resource. The card grid below is a
+          static preview.
+        </AlertBanner>
+
+        {/* Drag hint */}
+        <div className="flex items-center gap-1.5">
+          <ArrowLeft size={12} className="text-subtle-foreground" />
+          <span className="text-[11px] text-subtle-foreground">
+            Drag components to the Aeroplane Tree to add them
           </span>
         </div>
-      </div>
 
-      {/* Alert banner */}
-      <div className="flex items-start gap-3 rounded-[--radius-s] border border-primary bg-[#2A1F10] p-4">
-        <Info className="size-4 shrink-0 text-primary" />
-        <div className="flex flex-col gap-0.5">
-          <span className="text-[13px] font-semibold text-foreground">
-            Coming soon — backend wiring in progress
-          </span>
-          <span className="text-[12px] text-muted-foreground">
-            Component Library needs backend resource. The card grid below is a
-            static preview.
-          </span>
-        </div>
-      </div>
-
-      {/* Card grid */}
-      <div className="grid grid-cols-3 gap-4">
-        {COMPONENTS.map((comp) => {
-          const Icon = comp.icon;
-          return (
-            <div
-              key={comp.chip}
-              className="flex flex-col gap-3 rounded-[--radius-m] border border-border bg-card p-4"
-            >
-              {/* Card header */}
-              <div className="flex items-center">
-                <div className="flex size-8 items-center justify-center rounded-[--radius-s] bg-card-muted">
-                  <Icon className="size-4 text-primary" />
-                </div>
-                <span className="flex-1" />
-                <span className="rounded-[--radius-pill] bg-sidebar-accent px-2 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[10px] text-muted-foreground">
-                  {comp.chip}
-                </span>
-              </div>
-
-              {/* Title + subtitle */}
-              <div className="font-[family-name:var(--font-jetbrains-mono)] text-[14px] text-foreground">
-                {comp.title}
-              </div>
-              <div className="text-[12px] text-muted-foreground">
-                {comp.subtitle}
-              </div>
-
-              {/* Specs */}
-              <div className="flex flex-col gap-1">
-                {comp.specs.map(([key, val]) => (
-                  <div key={key} className="flex items-center">
-                    <span className="text-[11px] text-muted-foreground">
-                      {key}
-                    </span>
-                    <span className="flex-1" />
-                    <span className="font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-foreground">
-                      {val}
-                    </span>
+        {/* Card grid */}
+        <div className="grid grid-cols-3 gap-4">
+          {COMPONENTS.map((comp) => {
+            const Icon = comp.icon;
+            return (
+              <div
+                key={comp.chip}
+                className="flex flex-col gap-3 rounded-[--radius-m] border border-border bg-card p-4"
+              >
+                {/* Card header */}
+                <div className="flex items-center">
+                  <div className="flex size-8 items-center justify-center rounded-[--radius-s] bg-card-muted">
+                    <Icon className="size-4 text-primary" />
                   </div>
-                ))}
+                  <span className="flex-1" />
+                  <span className="rounded-[--radius-pill] bg-sidebar-accent px-2 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[10px] text-muted-foreground">
+                    {comp.chip}
+                  </span>
+                </div>
+
+                {/* Title + subtitle */}
+                <div className="font-[family-name:var(--font-jetbrains-mono)] text-[14px] text-foreground">
+                  {comp.title}
+                </div>
+                <div className="text-[12px] text-muted-foreground">
+                  {comp.subtitle}
+                </div>
+
+                {/* Specs */}
+                <div className="flex flex-col gap-1">
+                  {comp.specs.map(([key, val]) => (
+                    <div key={key} className="flex items-center">
+                      <span className="text-[11px] text-muted-foreground">
+                        {key}
+                      </span>
+                      <span className="flex-1" />
+                      <span className="font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-foreground">
+                        {val}
+                      </span>
+                    </div>
+                  ))}
+                </div>
               </div>
-            </div>
-          );
-        })}
+            );
+          })}
+        </div>
       </div>
-    </div>
+    </WorkbenchTwoPanel>
   );
 }

--- a/frontend/app/workbench/layout.tsx
+++ b/frontend/app/workbench/layout.tsx
@@ -2,6 +2,8 @@ import { Suspense } from "react";
 import { Header } from "@/components/workbench/Header";
 import { CopilotStrip } from "@/components/workbench/CopilotStrip";
 import { AeroplaneProvider } from "@/components/workbench/AeroplaneContext";
+import { UnsavedChangesProvider } from "@/components/workbench/UnsavedChangesContext";
+import { UnsavedChangesModal } from "@/components/workbench/UnsavedChangesModal";
 
 export default function WorkbenchLayout({
   children,
@@ -11,13 +13,16 @@ export default function WorkbenchLayout({
   return (
     <Suspense>
       <AeroplaneProvider>
-        <div className="flex h-full flex-col bg-background text-foreground font-[family-name:var(--font-geist-sans)]">
-          <Header />
-          <main className="flex flex-1 overflow-hidden p-4 gap-4">
-            {children}
-          </main>
-          <CopilotStrip />
-        </div>
+        <UnsavedChangesProvider>
+          <div className="flex h-full flex-col bg-background text-foreground font-[family-name:var(--font-geist-sans)]">
+            <Header />
+            <main className="flex flex-1 overflow-hidden p-4 gap-4">
+              {children}
+            </main>
+            <CopilotStrip />
+          </div>
+          <UnsavedChangesModal />
+        </UnsavedChangesProvider>
       </AeroplaneProvider>
     </Suspense>
   );

--- a/frontend/app/workbench/mission/page.tsx
+++ b/frontend/app/workbench/mission/page.tsx
@@ -1,4 +1,31 @@
-import { Target, Info, ChevronDown } from "lucide-react";
+import { Target, Radar, ChevronDown } from "lucide-react";
+import { WorkbenchTwoPanel } from "@/components/workbench/WorkbenchTwoPanel";
+import { AlertBanner } from "@/components/workbench/AlertBanner";
+import { RadarChart } from "@/components/workbench/RadarChart";
+
+const MISSION_AXES = [
+  { key: "payload_mass", label: "Payload", max: 10 },
+  { key: "flight_time", label: "Flight Time", max: 120 },
+  { key: "cruise_speed", label: "Cruise Speed", max: 30 },
+  { key: "range", label: "Range", max: 50 },
+  { key: "ceiling", label: "Ceiling", max: 2000 },
+];
+
+const FORM_VALUES: Record<string, number> = {
+  payload_mass: 2.5,
+  flight_time: 45,
+  cruise_speed: 14,
+  range: 12,
+  ceiling: 400,
+};
+
+function normalize(raw: Record<string, number>) {
+  const result: Record<string, number> = {};
+  for (const axis of MISSION_AXES) {
+    result[axis.key] = Math.min(1, Math.max(0, (raw[axis.key] ?? 0) / axis.max));
+  }
+  return result;
+}
 
 function Field({
   label,
@@ -30,55 +57,79 @@ function Field({
 }
 
 export default function MissionPage() {
+  const targetValues = normalize(FORM_VALUES);
+
   return (
-    <div className="mx-auto flex w-full max-w-[960px] flex-col gap-6 rounded-[--radius-l] border border-border bg-card p-6">
-      {/* Header */}
-      <div className="flex items-center gap-2.5">
-        <Target className="size-5 text-primary" />
-        <h1 className="font-[family-name:var(--font-jetbrains-mono)] text-[20px] text-foreground">
-          Mission Objectives
-        </h1>
-      </div>
-
-      {/* Alert banner */}
-      <div className="flex items-start gap-3 rounded-[--radius-s] border border-primary bg-[#2A1F10] p-4">
-        <Info className="size-4 shrink-0 text-primary" />
-        <div className="flex flex-col gap-0.5">
-          <span className="text-[13px] font-semibold text-foreground">
-            Coming soon — backend wiring in progress
-          </span>
-          <span className="text-[12px] text-muted-foreground">
-            Mission Objectives is waiting on backend resource. The form below
-            renders but saving is disabled.
+    <WorkbenchTwoPanel leftWidth={480}>
+      {/* Left: Radar Chart Card */}
+      <div className="flex h-full flex-col gap-4 rounded-[--radius-l] border border-border bg-card p-6">
+        <div className="flex items-center gap-3">
+          <Radar className="size-5 text-primary" />
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[18px] text-foreground">
+            Mission Compliance
           </span>
         </div>
+        <div className="flex-1">
+          <RadarChart
+            axes={MISSION_AXES.map((a) => ({ key: a.key, label: a.label }))}
+            target={targetValues}
+            analysis={null}
+          />
+        </div>
+        <div className="flex items-center justify-center gap-5">
+          <div className="flex items-center gap-1.5">
+            <div className="size-2.5 rounded-[2px] bg-primary" />
+            <span className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+              Target
+            </span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <div className="size-2.5 rounded-[2px] bg-success" />
+            <span className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+              Analysis
+            </span>
+          </div>
+        </div>
       </div>
 
-      {/* Form grid */}
-      <div className="flex flex-col gap-3 opacity-60">
-        <div className="flex gap-3">
-          <Field label="payload_mass" value="2.5" suffix="kg" />
-          <Field label="flight_time" value="45" suffix="min" />
+      {/* Right: Mission Objectives Card */}
+      <div className="flex flex-col gap-6 rounded-[--radius-l] border border-border bg-card p-8">
+        <div className="flex items-center gap-3">
+          <Target className="size-5 text-primary" />
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[20px] text-foreground">
+            Mission Objectives
+          </span>
         </div>
-        <div className="flex gap-3">
-          <Field label="cruise_speed" value="14" suffix="m/s" />
-          <Field label="range" value="12" suffix="km" />
-        </div>
-        <div className="flex gap-3">
-          <Field label="ceiling" value="400" suffix="m" />
-          <Field label="mission_type" value="surveillance" isSelect />
-        </div>
-      </div>
 
-      {/* Actions */}
-      <div className="flex justify-end gap-2">
-        <button className="rounded-[--radius-pill] border border-border-strong bg-background px-3.5 py-2 text-[13px] text-muted-foreground">
-          Cancel
-        </button>
-        <button className="rounded-[--radius-pill] border border-border bg-card-muted px-4 py-2 text-[13px] text-subtle-foreground">
-          Save
-        </button>
+        <AlertBanner>
+          Mission Objectives is waiting on backend resource. The form below
+          renders but saving is disabled.
+        </AlertBanner>
+
+        <div className="flex flex-col gap-4 opacity-60">
+          <div className="flex gap-4">
+            <Field label="payload_mass" value="2.5" suffix="kg" />
+            <Field label="flight_time" value="45" suffix="min" />
+          </div>
+          <div className="flex gap-4">
+            <Field label="cruise_speed" value="14" suffix="m/s" />
+            <Field label="range" value="12" suffix="km" />
+          </div>
+          <div className="flex gap-4">
+            <Field label="ceiling" value="400" suffix="m" />
+            <Field label="mission_type" value="surveillance" isSelect />
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-2">
+          <button className="rounded-[--radius-pill] border border-border-strong bg-background px-3.5 py-2 text-[13px] text-muted-foreground">
+            Cancel
+          </button>
+          <button className="rounded-[--radius-pill] border border-border bg-card-muted px-4 py-2 text-[13px] text-subtle-foreground">
+            Save
+          </button>
+        </div>
       </div>
-    </div>
+    </WorkbenchTwoPanel>
   );
 }

--- a/frontend/app/workbench/page.tsx
+++ b/frontend/app/workbench/page.tsx
@@ -1,16 +1,22 @@
 "use client";
 
-import { Group, Panel, Separator } from "react-resizable-panels";
+import { Group, Panel } from "react-resizable-panels";
 import { ViewerPanel } from "@/components/workbench/ViewerPanel";
 import { ConfigPanel } from "@/components/workbench/ConfigPanel";
+import { AeroplaneTree } from "@/components/workbench/AeroplaneTree";
+import { SplitHandle } from "@/components/workbench/SplitHandle";
 import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
 import { useAeroplanes } from "@/hooks/useAeroplanes";
+import { useWings } from "@/hooks/useWings";
 import { usePreviewState } from "@/hooks/usePreviewState";
 
 export default function WorkbenchPage() {
   const { aeroplaneId, setAeroplaneId } = useAeroplaneContext();
   const { aeroplanes, isLoading, createAeroplane } = useAeroplanes();
+  const { wingNames } = useWings(aeroplaneId);
   const preview = usePreviewState(aeroplaneId);
+  const aeroplaneName =
+    aeroplanes.find((a) => a.id === aeroplaneId)?.name ?? "Aeroplane";
 
   if (!aeroplaneId) {
     return <AeroplaneSelector
@@ -26,21 +32,31 @@ export default function WorkbenchPage() {
 
   return (
     <Group orientation="horizontal" className="flex-1">
-      <Panel defaultSize={55} minSize={20}>
+      <Panel defaultSize={20} minSize={15} maxSize={30}>
+        <div className="h-full overflow-y-auto p-4">
+          <AeroplaneTree
+            aeroplaneId={aeroplaneId}
+            wingNames={wingNames}
+            aeroplaneName={aeroplaneName}
+            isWingVisible={preview.isWingVisible}
+            isWingLoading={(wn) => preview.previews[wn]?.loading ?? false}
+            onTogglePreview={preview.toggleWing}
+            onToggleAllPreview={preview.toggleAllWings}
+          />
+        </div>
+      </Panel>
+      <SplitHandle />
+      <Panel defaultSize={45} minSize={20}>
         <ViewerPanel
           visibleParts={preview.visibleParts}
           isAnyLoading={preview.isAnyLoading}
           loadingWing={preview.loadingWing}
         />
       </Panel>
-      <Separator className="w-1.5 bg-border hover:bg-primary/50 transition-colors cursor-col-resize" />
-      <Panel defaultSize={45} minSize={30}>
+      <SplitHandle />
+      <Panel defaultSize={35} minSize={20}>
         <ConfigPanel
           aeroplaneId={aeroplaneId}
-          isWingVisible={preview.isWingVisible}
-          isWingLoading={(wn) => preview.previews[wn]?.loading ?? false}
-          onTogglePreview={preview.toggleWing}
-          onToggleAllPreview={preview.toggleAllWings}
           onGeometryChanged={preview.invalidateWing}
         />
       </Panel>

--- a/frontend/app/workbench/page.tsx
+++ b/frontend/app/workbench/page.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { Group, Panel } from "react-resizable-panels";
+import { useState } from "react";
 import { ViewerPanel } from "@/components/workbench/ViewerPanel";
 import { ConfigPanel } from "@/components/workbench/ConfigPanel";
 import { AeroplaneTree } from "@/components/workbench/AeroplaneTree";
-import { SplitHandle } from "@/components/workbench/SplitHandle";
 import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
 import { useAeroplanes } from "@/hooks/useAeroplanes";
 import { useWings } from "@/hooks/useWings";
@@ -17,6 +16,9 @@ export default function WorkbenchPage() {
   const preview = usePreviewState(aeroplaneId);
   const aeroplaneName =
     aeroplanes.find((a) => a.id === aeroplaneId)?.name ?? "Aeroplane";
+
+  const [treeOpen, setTreeOpen] = useState(true);
+  const [viewerMaximized, setViewerMaximized] = useState(false);
 
   if (!aeroplaneId) {
     return <AeroplaneSelector
@@ -31,9 +33,10 @@ export default function WorkbenchPage() {
   }
 
   return (
-    <Group orientation="horizontal" className="flex-1">
-      <Panel defaultSize={20} minSize={15} maxSize={30}>
-        <div className="h-full overflow-y-auto p-4">
+    <div className="flex flex-1 gap-4 overflow-hidden">
+      {/* Tree Panel — collapsible */}
+      {treeOpen && !viewerMaximized && (
+        <div className="h-full shrink-0 overflow-y-auto" style={{ width: 320 }}>
           <AeroplaneTree
             aeroplaneId={aeroplaneId}
             wingNames={wingNames}
@@ -42,25 +45,34 @@ export default function WorkbenchPage() {
             isWingLoading={(wn) => preview.previews[wn]?.loading ?? false}
             onTogglePreview={preview.toggleWing}
             onToggleAllPreview={preview.toggleAllWings}
+            onCollapseTree={() => setTreeOpen(false)}
           />
         </div>
-      </Panel>
-      <SplitHandle />
-      <Panel defaultSize={45} minSize={20}>
+      )}
+
+      {/* Viewer Panel — can maximize to fill all space */}
+      <div className="flex-1 overflow-hidden">
         <ViewerPanel
           visibleParts={preview.visibleParts}
           isAnyLoading={preview.isAnyLoading}
           loadingWing={preview.loadingWing}
+          isMaximized={viewerMaximized}
+          onToggleMaximize={() => setViewerMaximized((m) => !m)}
+          isTreeCollapsed={!treeOpen}
+          onExpandTree={() => setTreeOpen(true)}
         />
-      </Panel>
-      <SplitHandle />
-      <Panel defaultSize={35} minSize={20}>
-        <ConfigPanel
-          aeroplaneId={aeroplaneId}
-          onGeometryChanged={preview.invalidateWing}
-        />
-      </Panel>
-    </Group>
+      </div>
+
+      {/* Config Panel — hidden when viewer maximized */}
+      {!viewerMaximized && (
+        <div className="h-full shrink-0 overflow-hidden" style={{ width: 556 }}>
+          <ConfigPanel
+            aeroplaneId={aeroplaneId}
+            onGeometryChanged={preview.invalidateWing}
+          />
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/frontend/app/workbench/weight/page.tsx
+++ b/frontend/app/workbench/weight/page.tsx
@@ -1,4 +1,9 @@
-import { Scale, Plus, Info, Settings, X } from "lucide-react";
+"use client";
+
+import { Scale, Plus, Settings, X } from "lucide-react";
+import { WorkbenchTwoPanel } from "@/components/workbench/WorkbenchTwoPanel";
+import { AlertBanner } from "@/components/workbench/AlertBanner";
+import { WeightTree } from "@/components/workbench/WeightTree";
 
 const WEIGHT_ITEMS = [
   {
@@ -35,103 +40,105 @@ const WEIGHT_ITEMS = [
   },
 ];
 
-const COLUMN_HEADERS = ["NAME", "MASS_KG", "X [M]", "Y [M]", "Z [M]", "ACTIONS"];
+const COLUMN_HEADERS = [
+  "NAME",
+  "MASS_KG",
+  "X [M]",
+  "Y [M]",
+  "Z [M]",
+  "ACTIONS",
+];
 
 export default function WeightPage() {
   return (
-    <div className="flex w-full flex-col gap-6">
-      {/* Header */}
-      <div className="flex items-center gap-2.5">
-        <Scale className="size-5 text-primary" />
-        <h1 className="font-[family-name:var(--font-jetbrains-mono)] text-[20px] text-foreground">
-          Weight Items
-        </h1>
-        <span className="flex-1" />
-        <button className="flex items-center gap-1.5 rounded-[--radius-pill] bg-primary px-3.5 py-2 text-[13px] text-primary-foreground">
-          <Plus className="size-3.5" />
-          + Item
-        </button>
-      </div>
+    <WorkbenchTwoPanel>
+      <WeightTree />
 
-      {/* Alert banner */}
-      <div className="flex items-start gap-3 rounded-[--radius-s] border border-primary bg-[#2A1F10] p-4">
-        <Info className="size-4 shrink-0 text-primary" />
-        <div className="flex flex-col gap-0.5">
-          <span className="text-[13px] font-semibold text-foreground">
-            Coming soon — backend wiring in progress
-          </span>
-          <span className="text-[12px] text-muted-foreground">
-            Weight Items needs backend resource. The table below writes to
-            browser state until the resource lands.
-          </span>
+      <div className="flex w-full flex-col gap-6 overflow-y-auto">
+        {/* Header */}
+        <div className="flex items-center gap-2.5">
+          <Scale className="size-5 text-primary" />
+          <h1 className="font-[family-name:var(--font-jetbrains-mono)] text-[20px] text-foreground">
+            Weight Items
+          </h1>
+          <span className="flex-1" />
+          <button className="flex items-center gap-1.5 rounded-[--radius-pill] bg-primary px-3.5 py-2 text-[13px] text-primary-foreground">
+            <Plus className="size-3.5" />+ Item
+          </button>
         </div>
-      </div>
 
-      {/* Weight table */}
-      <div className="overflow-hidden rounded-[--radius-m] border border-border bg-card">
-        {/* Header row */}
-        <div className="flex items-center rounded-t-[--radius-m] border-b border-border bg-card-muted px-4 py-3">
-          <span className="flex-1 font-[family-name:var(--font-jetbrains-mono)] text-[11px] uppercase tracking-wide text-muted-foreground">
-            {COLUMN_HEADERS[0]}
-          </span>
-          {COLUMN_HEADERS.slice(1, 5).map((h) => (
-            <span
-              key={h}
-              className="w-24 text-right font-[family-name:var(--font-jetbrains-mono)] text-[11px] uppercase tracking-wide text-muted-foreground"
-            >
-              {h}
+        {/* Alert banner */}
+        <AlertBanner>
+          Weight Items needs backend resource. The table below writes to browser
+          state until the resource lands.
+        </AlertBanner>
+
+        {/* Weight table */}
+        <div className="overflow-hidden rounded-[--radius-m] border border-border bg-card">
+          {/* Header row */}
+          <div className="flex items-center rounded-t-[--radius-m] border-b border-border bg-card-muted px-4 py-3">
+            <span className="flex-1 font-[family-name:var(--font-jetbrains-mono)] text-[11px] uppercase tracking-wide text-muted-foreground">
+              {COLUMN_HEADERS[0]}
             </span>
-          ))}
-          <span className="w-16 text-right font-[family-name:var(--font-jetbrains-mono)] text-[11px] uppercase tracking-wide text-muted-foreground">
-            {COLUMN_HEADERS[5]}
-          </span>
-        </div>
-
-        {/* Data rows */}
-        {WEIGHT_ITEMS.map((item) => (
-          <div
-            key={item.name}
-            className="flex items-center border-t border-border px-4 py-3"
-          >
-            <div className="flex flex-1 flex-col">
-              <span className="text-[13px] text-foreground">{item.name}</span>
-              <span className="text-[11px] text-muted-foreground">
-                {item.category}
-              </span>
-            </div>
-            {[item.mass, item.x, item.y, item.z].map((val, i) => (
+            {COLUMN_HEADERS.slice(1, 5).map((h) => (
               <span
-                key={i}
-                className="w-24 text-right font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-foreground"
+                key={h}
+                className="w-24 text-right font-[family-name:var(--font-jetbrains-mono)] text-[11px] uppercase tracking-wide text-muted-foreground"
               >
-                {val}
+                {h}
               </span>
             ))}
-            <div className="flex w-16 justify-end gap-1.5">
-              <button className="flex size-6 items-center justify-center rounded-[--radius-s] border border-border bg-card-muted">
-                <Settings className="size-3 text-muted-foreground" />
-              </button>
-              <button className="flex size-6 items-center justify-center rounded-[--radius-s] border border-border bg-card-muted">
-                <X className="size-3 text-muted-foreground" />
-              </button>
-            </div>
+            <span className="w-16 text-right font-[family-name:var(--font-jetbrains-mono)] text-[11px] uppercase tracking-wide text-muted-foreground">
+              {COLUMN_HEADERS[5]}
+            </span>
           </div>
-        ))}
 
-        {/* Totals row */}
-        <div className="flex items-center rounded-b-[--radius-m] border-t border-border bg-sidebar-accent px-4 py-3">
-          <span className="flex-1 font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-muted-foreground">
-            {"\u03A3"} TOTAL
-          </span>
-          <span className="w-24 text-right font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-primary">
-            1.177
-          </span>
-          <span className="w-24" />
-          <span className="w-24" />
-          <span className="w-24" />
-          <span className="w-16" />
+          {/* Data rows */}
+          {WEIGHT_ITEMS.map((item) => (
+            <div
+              key={item.name}
+              className="flex items-center border-t border-border px-4 py-3"
+            >
+              <div className="flex flex-1 flex-col">
+                <span className="text-[13px] text-foreground">{item.name}</span>
+                <span className="text-[11px] text-muted-foreground">
+                  {item.category}
+                </span>
+              </div>
+              {[item.mass, item.x, item.y, item.z].map((val, i) => (
+                <span
+                  key={i}
+                  className="w-24 text-right font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-foreground"
+                >
+                  {val}
+                </span>
+              ))}
+              <div className="flex w-16 justify-end gap-1.5">
+                <button className="flex size-6 items-center justify-center rounded-[--radius-s] border border-border bg-card-muted">
+                  <Settings className="size-3 text-muted-foreground" />
+                </button>
+                <button className="flex size-6 items-center justify-center rounded-[--radius-s] border border-border bg-card-muted">
+                  <X className="size-3 text-muted-foreground" />
+                </button>
+              </div>
+            </div>
+          ))}
+
+          {/* Totals row */}
+          <div className="flex items-center rounded-b-[--radius-m] border-t border-border bg-sidebar-accent px-4 py-3">
+            <span className="flex-1 font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-muted-foreground">
+              {"\u03A3"} TOTAL
+            </span>
+            <span className="w-24 text-right font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-primary">
+              1.177
+            </span>
+            <span className="w-24" />
+            <span className="w-24" />
+            <span className="w-24" />
+            <span className="w-16" />
+          </div>
         </div>
       </div>
-    </div>
+    </WorkbenchTwoPanel>
   );
 }

--- a/frontend/components/workbench/AeroplaneTree.tsx
+++ b/frontend/components/workbench/AeroplaneTree.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronDown, ChevronRight, Plus, Trash2, Eye, EyeOff, Loader } from "lucide-react";
+import { ChevronDown, ChevronRight, Plus, Trash2, Eye, EyeOff, Loader, PanelLeftClose } from "lucide-react";
 import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
 import { useWing } from "@/hooks/useWings";
 import type { XSec } from "@/hooks/useWings";
@@ -248,11 +248,12 @@ interface AeroplaneTreeProps {
   isWingLoading?: (wingName: string) => boolean;
   onTogglePreview?: (wingName: string) => void;
   onToggleAllPreview?: (wingNames: string[]) => void;
+  onCollapseTree?: () => void;
 }
 
 // ── Component ───────────────────────────────────────────────────
 
-export function AeroplaneTree({ aeroplaneId, wingNames, aeroplaneName, isWingVisible, isWingLoading, onTogglePreview, onToggleAllPreview }: AeroplaneTreeProps) {
+export function AeroplaneTree({ aeroplaneId, wingNames, aeroplaneName, isWingVisible, isWingLoading, onTogglePreview, onToggleAllPreview, onCollapseTree }: AeroplaneTreeProps) {
   const { selectedWing, selectedXsecIndex, selectWing, selectXsec, treeMode, setTreeMode } =
     useAeroplaneContext();
   const { wing, isLoading, mutate: mutateWing } = useWing(aeroplaneId, selectedWing);
@@ -368,8 +369,17 @@ export function AeroplaneTree({ aeroplaneId, wingNames, aeroplaneName, isWingVis
 
   return (
     <div className="rounded-[--radius-m] border border-border bg-card p-3 px-4">
-      {/* Header with mode toggle */}
+      {/* Header with collapse + mode toggle */}
       <div className="mb-2 flex items-center gap-2">
+        {onCollapseTree && (
+          <button
+            onClick={onCollapseTree}
+            className="flex size-6 items-center justify-center rounded-[--radius-s] text-muted-foreground hover:bg-sidebar-accent"
+            title="Collapse tree panel"
+          >
+            <PanelLeftClose size={14} />
+          </button>
+        )}
         <span className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-muted-foreground">
           Aeroplane Tree
         </span>

--- a/frontend/components/workbench/AlertBanner.tsx
+++ b/frontend/components/workbench/AlertBanner.tsx
@@ -1,0 +1,23 @@
+import { Info } from "lucide-react";
+
+interface AlertBannerProps {
+  title?: string;
+  children: React.ReactNode;
+}
+
+export function AlertBanner({
+  title = "Coming soon \u2014 backend wiring in progress",
+  children,
+}: AlertBannerProps) {
+  return (
+    <div className="flex items-start gap-3 rounded-[--radius-s] border border-primary bg-[#2A1F10] p-4">
+      <Info className="size-4 shrink-0 text-primary" />
+      <div className="flex flex-col gap-0.5">
+        <span className="text-[13px] font-semibold text-foreground">
+          {title}
+        </span>
+        <span className="text-[12px] text-muted-foreground">{children}</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/workbench/AnalysisConfigPanel.tsx
+++ b/frontend/components/workbench/AnalysisConfigPanel.tsx
@@ -2,18 +2,11 @@
 
 import { useState } from "react";
 import { Play, RefreshCw, ChevronDown, ChevronRight, Loader2 } from "lucide-react";
-import type { AnalysisResult, AlphaSweepParams } from "@/hooks/useAnalysis";
+import type { UseAnalysisReturn } from "@/hooks/useAnalysis";
 
 type Mode = "single" | "sweep";
 
-interface AnalysisHandle {
-  result: AnalysisResult | null;
-  isRunning: boolean;
-  error: string | null;
-  runAlphaSweep: (params: AlphaSweepParams) => Promise<void>;
-}
-
-export function AnalysisConfigPanel({ analysis }: { analysis: AnalysisHandle }) {
+export function AnalysisConfigPanel({ analysis }: { analysis: UseAnalysisReturn }) {
   const [mode, setMode] = useState<Mode>("sweep");
   const [advancedOpen, setAdvancedOpen] = useState(false);
 
@@ -56,7 +49,7 @@ export function AnalysisConfigPanel({ analysis }: { analysis: AnalysisHandle }) 
   };
 
   return (
-    <div className="flex w-[556px] shrink-0 flex-col gap-4 overflow-y-auto">
+    <div className="flex w-full flex-col gap-4 overflow-y-auto">
       {/* ── Action Row ── */}
       <div className="flex items-center gap-2">
         <button
@@ -76,7 +69,10 @@ export function AnalysisConfigPanel({ analysis }: { analysis: AnalysisHandle }) 
           <RefreshCw size={14} />
           Clear Results
         </button>
-        <button className="rounded-[--radius-pill] border border-border-strong bg-background px-3.5 py-2.5 font-[family-name:var(--font-geist-sans)] text-[13px] text-foreground transition-colors hover:bg-sidebar-accent">
+        <button
+          disabled
+          className="rounded-[--radius-pill] border border-border-strong bg-background px-3.5 py-2.5 font-[family-name:var(--font-geist-sans)] text-[13px] text-foreground transition-colors hover:bg-sidebar-accent disabled:opacity-40 disabled:cursor-not-allowed"
+        >
           Load OP set&hellip;
         </button>
         <div className="flex-1" />

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -11,6 +11,8 @@ type Tab = (typeof TABS)[number];
 interface Props {
   result: AnalysisResult | null;
   aeroplaneId: string | null;
+  lastRunTime?: Date | null;
+  lastRunDurationMs?: number | null;
 }
 
 // ── SVG Line Chart ──────────────────────────────────────────────
@@ -133,7 +135,7 @@ function LineChart({
 
 // ── Main Component ──────────────────────────────────────────────
 
-export function AnalysisViewerPanel({ result, aeroplaneId }: Props) {
+export function AnalysisViewerPanel({ result, aeroplaneId, lastRunTime, lastRunDurationMs }: Props) {
   const [activeTab, setActiveTab] = useState<Tab>("Polar");
 
   const charts = useMemo(() => {
@@ -268,6 +270,9 @@ export function AnalysisViewerPanel({ result, aeroplaneId }: Props) {
         <div className="flex-1" />
         <span className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
           {charts ? `${charts.alpha.length} points` : "No data"}
+          {lastRunTime && lastRunDurationMs != null && (
+            <> &middot; Last run: {lastRunTime.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false })} &middot; {lastRunDurationMs} ms</>
+          )}
         </span>
       </div>
     </div>

--- a/frontend/components/workbench/ComponentTree.tsx
+++ b/frontend/components/workbench/ComponentTree.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState } from "react";
+import { TreeCard } from "@/components/workbench/TreeCard";
+import {
+  SimpleTreeRow,
+  type SimpleTreeNode,
+} from "@/components/workbench/SimpleTreeRow";
+
+const STATIC_NODES: SimpleTreeNode[] = [
+  { id: "root", label: "eHawk", level: 0 },
+  { id: "mw", label: "main_wing", level: 1 },
+  { id: "s0", label: "segment 0 (root)", level: 2 },
+  { id: "s1", label: "segment 1", level: 2 },
+  { id: "s2", label: "segment 2 \u00b7 aileron", level: 2, chip: "AILERON" },
+  { id: "s3", label: "segment 3 \u00b7 aileron", level: 2 },
+  { id: "ew", label: "elevator_wing", level: 1 },
+  { id: "fuse", label: "fuselage", level: 1, leaf: true },
+];
+
+export function ComponentTree() {
+  const [expanded, setExpanded] = useState<Set<string>>(
+    new Set(["root", "mw"]),
+  );
+
+  const toggle = (id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  };
+
+  const visible = STATIC_NODES.filter((node) => {
+    if (node.level === 0) return true;
+    if (node.level === 1) return expanded.has("root");
+    if (node.level === 2) {
+      if (!expanded.has("root")) return false;
+      const idx = STATIC_NODES.indexOf(node);
+      for (let i = idx - 1; i >= 0; i--) {
+        if (STATIC_NODES[i].level === 1)
+          return expanded.has(STATIC_NODES[i].id);
+      }
+    }
+    return true;
+  });
+
+  return (
+    <TreeCard title="Component Tree">
+      <div className="flex flex-col gap-0.5">
+        {visible.map((node) => (
+          <SimpleTreeRow
+            key={node.id}
+            node={{
+              ...node,
+              expanded: expanded.has(node.id),
+              leaf: node.leaf ?? node.level === 2,
+            }}
+            onToggle={() => toggle(node.id)}
+          />
+        ))}
+      </div>
+    </TreeCard>
+  );
+}

--- a/frontend/components/workbench/ConfigPanel.tsx
+++ b/frontend/components/workbench/ConfigPanel.tsx
@@ -1,41 +1,21 @@
 "use client";
 
 import { ActionRow } from "./ActionRow";
-import { AeroplaneTree } from "./AeroplaneTree";
 import { PropertyForm } from "./PropertyForm";
 import { useWings } from "@/hooks/useWings";
-import { useAeroplanes } from "@/hooks/useAeroplanes";
 
 interface ConfigPanelProps {
   aeroplaneId: string;
-  isWingVisible?: (wingName: string) => boolean;
-  isWingLoading?: (wingName: string) => boolean;
-  onTogglePreview?: (wingName: string) => void;
-  onToggleAllPreview?: (wingNames: string[]) => void;
   onGeometryChanged?: (wingName: string) => void;
 }
 
-export function ConfigPanel({ aeroplaneId, isWingVisible, isWingLoading, onTogglePreview, onToggleAllPreview, onGeometryChanged }: ConfigPanelProps) {
-  const { wingNames, mutate: mutateWings } = useWings(aeroplaneId);
-  const { aeroplanes } = useAeroplanes();
-  const aeroplaneName =
-    aeroplanes.find((a) => a.id === aeroplaneId)?.name ?? "Aeroplane";
+export function ConfigPanel({ aeroplaneId, onGeometryChanged }: ConfigPanelProps) {
+  const { mutate: mutateWings } = useWings(aeroplaneId);
 
   return (
     <aside className="flex h-full flex-col gap-4 p-4">
       <ActionRow aeroplaneId={aeroplaneId} onWingCreated={() => mutateWings()} />
       <div className="min-h-0 flex-1 overflow-y-auto">
-        <AeroplaneTree
-          aeroplaneId={aeroplaneId}
-          wingNames={wingNames}
-          aeroplaneName={aeroplaneName}
-          isWingVisible={isWingVisible}
-          isWingLoading={isWingLoading}
-          onTogglePreview={onTogglePreview}
-          onToggleAllPreview={onToggleAllPreview}
-        />
-      </div>
-      <div className="shrink-0">
         <PropertyForm onGeometryChanged={onGeometryChanged} />
       </div>
     </aside>

--- a/frontend/components/workbench/GuardedLink.tsx
+++ b/frontend/components/workbench/GuardedLink.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import Link from "next/link";
+import { useUnsavedChanges } from "@/components/workbench/UnsavedChangesContext";
+import type { ComponentProps } from "react";
+
+export function GuardedLink(props: ComponentProps<typeof Link>) {
+  const { isDirty, requestNavigation } = useUnsavedChanges();
+  const href = typeof props.href === "string" ? props.href : props.href.pathname ?? "/";
+
+  return (
+    <Link
+      {...props}
+      onClick={(e) => {
+        if (isDirty) {
+          e.preventDefault();
+          requestNavigation(href);
+        }
+        props.onClick?.(e);
+      }}
+    />
+  );
+}

--- a/frontend/components/workbench/Header.tsx
+++ b/frontend/components/workbench/Header.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { GuardedLink } from "./GuardedLink";
 import {
   History,
   ChevronDown,
@@ -52,7 +52,7 @@ export function Header() {
         {STEPS.map((step) => {
           const active = isActive(step.href, pathname);
           return (
-            <Link
+            <GuardedLink
               key={step.num}
               href={step.href}
               className={`flex items-center gap-2 rounded-[--radius-pill] px-4 py-2 text-[13px] transition-colors ${
@@ -67,7 +67,7 @@ export function Header() {
               <span className="font-[family-name:var(--font-geist-sans)]">
                 {step.label}
               </span>
-            </Link>
+            </GuardedLink>
           );
         })}
       </nav>

--- a/frontend/components/workbench/PropertyForm.tsx
+++ b/frontend/components/workbench/PropertyForm.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { AirfoilSelector } from "./AirfoilSelector";
 import { useAeroplaneContext } from "./AeroplaneContext";
+import { useUnsavedChanges } from "./UnsavedChangesContext";
 import { useWing, type XSec } from "@/hooks/useWings";
 import { useWingConfig } from "@/hooks/useWingConfig";
 import type { WingConfigSegment } from "@/hooks/useWingConfig";
@@ -200,6 +201,8 @@ export function PropertyForm({ onGeometryChanged }: { onGeometryChanged?: (wingN
     treeMode === "wingconfig" ? selectedWing : null,
   );
 
+  const { setDirty } = useUnsavedChanges();
+
   // Mode is driven by tree toggle, not local state
   const mode: Mode = treeMode;
   const [saving, setSaving] = useState(false);
@@ -257,6 +260,7 @@ export function PropertyForm({ onGeometryChanged }: { onGeometryChanged?: (wingN
     if (wing && selectedXsecIndex !== null)
       setWc(xsecsToWingConfig(wing.x_secs, selectedXsecIndex));
     setError(null);
+    setDirty(false);
   }
 
   async function handleSaveAsb() {
@@ -267,6 +271,7 @@ export function PropertyForm({ onGeometryChanged }: { onGeometryChanged?: (wingN
       await updateXSec(selectedXsecIndex!, asbToPayload(asb));
       await mutate();
       if (selectedWing) onGeometryChanged?.(selectedWing);
+      setDirty(false);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Save failed");
     } finally {
@@ -313,6 +318,7 @@ export function PropertyForm({ onGeometryChanged }: { onGeometryChanged?: (wingN
       await mutate();
       await mutateWc();
       if (selectedWing) onGeometryChanged?.(selectedWing);
+      setDirty(false);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Save failed");
     } finally {
@@ -339,11 +345,11 @@ export function PropertyForm({ onGeometryChanged }: { onGeometryChanged?: (wingN
             {selectedXsecIndex === 0 && (
               <div className="flex gap-3">
                 <Field label="nose x" value={nosePnt[0]} suffix="mm"
-                  onChange={(v) => setNosePnt([num(v), nosePnt[1], nosePnt[2]])} />
+                  onChange={(v) => { setDirty(true); setNosePnt([num(v), nosePnt[1], nosePnt[2]]); }} />
                 <Field label="nose y" value={nosePnt[1]} suffix="mm"
-                  onChange={(v) => setNosePnt([nosePnt[0], num(v), nosePnt[2]])} />
+                  onChange={(v) => { setDirty(true); setNosePnt([nosePnt[0], num(v), nosePnt[2]]); }} />
                 <Field label="nose z" value={nosePnt[2]} suffix="mm"
-                  onChange={(v) => setNosePnt([nosePnt[0], nosePnt[1], num(v)])} />
+                  onChange={(v) => { setDirty(true); setNosePnt([nosePnt[0], nosePnt[1], num(v)]); }} />
               </div>
             )}
             {/* Row 1: root_airfoil | tip_airfoil */}
@@ -351,12 +357,12 @@ export function PropertyForm({ onGeometryChanged }: { onGeometryChanged?: (wingN
               <AirfoilSelector
                 label="root_airfoil"
                 value={wc.root_airfoil}
-                onChange={(v) => setWc({ ...wc, root_airfoil: v })}
+                onChange={(v) => { setDirty(true); setWc({ ...wc, root_airfoil: v }); }}
               />
               <AirfoilSelector
                 label="tip_airfoil"
                 value={wc.tip_airfoil}
-                onChange={(v) => setWc({ ...wc, tip_airfoil: v })}
+                onChange={(v) => { setDirty(true); setWc({ ...wc, tip_airfoil: v }); }}
               />
             </div>
             {/* Row 2: root_chord | tip_chord */}
@@ -365,13 +371,13 @@ export function PropertyForm({ onGeometryChanged }: { onGeometryChanged?: (wingN
                 label="root_chord"
                 value={wc.root_chord}
                 suffix="mm"
-                onChange={(v) => setWc({ ...wc, root_chord: num(v) })}
+                onChange={(v) => { setDirty(true); setWc({ ...wc, root_chord: num(v) }); }}
               />
               <Field
                 label="tip_chord"
                 value={wc.tip_chord}
                 suffix="mm"
-                onChange={(v) => setWc({ ...wc, tip_chord: num(v) })}
+                onChange={(v) => { setDirty(true); setWc({ ...wc, tip_chord: num(v) }); }}
               />
             </div>
             {/* Row 3: length | sweep */}
@@ -380,13 +386,13 @@ export function PropertyForm({ onGeometryChanged }: { onGeometryChanged?: (wingN
                 label="length"
                 value={wc.length}
                 suffix="mm"
-                onChange={(v) => setWc({ ...wc, length: num(v) })}
+                onChange={(v) => { setDirty(true); setWc({ ...wc, length: num(v) }); }}
               />
               <Field
                 label="sweep"
                 value={wc.sweep}
                 suffix="mm"
-                onChange={(v) => setWc({ ...wc, sweep: num(v) })}
+                onChange={(v) => { setDirty(true); setWc({ ...wc, sweep: num(v) }); }}
               />
             </div>
             {/* Row 4: dihedral | incidence */}
@@ -395,13 +401,13 @@ export function PropertyForm({ onGeometryChanged }: { onGeometryChanged?: (wingN
                 label="dihedral"
                 value={wc.root_dihedral}
                 suffix="°"
-                onChange={(v) => setWc({ ...wc, root_dihedral: num(v) })}
+                onChange={(v) => { setDirty(true); setWc({ ...wc, root_dihedral: num(v) }); }}
               />
               <Field
                 label="incidence"
                 value={wc.root_incidence}
                 suffix="°"
-                onChange={(v) => setWc({ ...wc, root_incidence: num(v) })}
+                onChange={(v) => { setDirty(true); setWc({ ...wc, root_incidence: num(v) }); }}
               />
             </div>
             {/* Row 5: rotation_point | interpolation_pts */}
@@ -409,12 +415,12 @@ export function PropertyForm({ onGeometryChanged }: { onGeometryChanged?: (wingN
               <Field
                 label="rotation_point"
                 value={wc.root_rotation_point}
-                onChange={(v) => setWc({ ...wc, root_rotation_point: num(v, 0.25) })}
+                onChange={(v) => { setDirty(true); setWc({ ...wc, root_rotation_point: num(v, 0.25) }); }}
               />
               <Field
                 label="interpolation_pts"
                 value={wc.number_interpolation_points}
-                onChange={(v) => setWc({ ...wc, number_interpolation_points: num(v, 201) })}
+                onChange={(v) => { setDirty(true); setWc({ ...wc, number_interpolation_points: num(v, 201) }); }}
               />
             </div>
           </>
@@ -425,13 +431,13 @@ export function PropertyForm({ onGeometryChanged }: { onGeometryChanged?: (wingN
               <AirfoilSelector
                 label="airfoil"
                 value={asb.airfoil}
-                onChange={(v) => setAsb({ ...asb, airfoil: v })}
+                onChange={(v) => { setDirty(true); setAsb({ ...asb, airfoil: v }); }}
               />
               <Field
                 label="chord"
                 value={asb.chord}
                 suffix="mm"
-                onChange={(v) => setAsb({ ...asb, chord: num(v) })}
+                onChange={(v) => { setDirty(true); setAsb({ ...asb, chord: num(v) }); }}
               />
             </div>
             {/* twist | x_sec_type */}
@@ -440,7 +446,7 @@ export function PropertyForm({ onGeometryChanged }: { onGeometryChanged?: (wingN
                 label="twist"
                 value={asb.twist}
                 suffix="°"
-                onChange={(v) => setAsb({ ...asb, twist: num(v) })}
+                onChange={(v) => { setDirty(true); setAsb({ ...asb, twist: num(v) }); }}
               />
               <Field
                 label="x_sec_type"
@@ -457,6 +463,7 @@ export function PropertyForm({ onGeometryChanged }: { onGeometryChanged?: (wingN
                   value={asb.xyz_le[i]}
                   suffix="m"
                   onChange={(v) => {
+                    setDirty(true);
                     const next: [number, number, number] = [...asb.xyz_le];
                     next[i] = num(v);
                     setAsb({ ...asb, xyz_le: next });

--- a/frontend/components/workbench/RadarChart.tsx
+++ b/frontend/components/workbench/RadarChart.tsx
@@ -1,0 +1,133 @@
+interface RadarChartAxis {
+  key: string;
+  label: string;
+}
+
+interface RadarChartProps {
+  axes: RadarChartAxis[];
+  target: Record<string, number>;
+  analysis?: Record<string, number> | null;
+  size?: number;
+}
+
+export function polarToCartesian(
+  cx: number,
+  cy: number,
+  r: number,
+  angle: number,
+): { x: number; y: number } {
+  return { x: cx + r * Math.cos(angle), y: cy + r * Math.sin(angle) };
+}
+
+export function buildPolygonPoints(
+  cx: number,
+  cy: number,
+  R: number,
+  values: number[],
+  angles: number[],
+): string {
+  return values
+    .map((v, i) => {
+      const pt = polarToCartesian(cx, cy, R * v, angles[i]);
+      return `${pt.x.toFixed(1)},${pt.y.toFixed(1)}`;
+    })
+    .join(" ");
+}
+
+export function RadarChart({
+  axes,
+  target,
+  analysis = null,
+  size = 420,
+}: RadarChartProps) {
+  const height = Math.round(size * 0.81);
+  const cx = size / 2;
+  const cy = height / 2;
+  const R = Math.min(size, height) * 0.35;
+  const n = axes.length;
+  const angles = axes.map((_, i) => -Math.PI / 2 + (2 * Math.PI * i) / n);
+  const levels = [0.33, 0.67, 1.0];
+
+  const targetValues = axes.map((a) => target[a.key] ?? 0);
+  const analysisValues = analysis
+    ? axes.map((a) => analysis[a.key] ?? 0)
+    : null;
+
+  return (
+    <svg
+      data-testid="radar-chart"
+      viewBox={`0 0 ${size} ${height}`}
+      className="h-full w-full"
+      preserveAspectRatio="xMidYMid meet"
+    >
+      {/* Grid: concentric pentagons */}
+      {levels.map((lv) => (
+        <polygon
+          key={`grid-${lv}`}
+          data-testid="grid-ring"
+          points={buildPolygonPoints(
+            cx, cy, R * lv, Array(n).fill(1), angles,
+          )}
+          fill="none"
+          stroke="var(--color-border)"
+          strokeWidth="1"
+        />
+      ))}
+
+      {/* Grid: axis spokes */}
+      {angles.map((angle, i) => {
+        const outer = polarToCartesian(cx, cy, R, angle);
+        return (
+          <line
+            key={`spoke-${i}`}
+            x1={cx} y1={cy} x2={outer.x} y2={outer.y}
+            stroke="var(--color-border)" strokeWidth="1"
+          />
+        );
+      })}
+
+      {/* Target polygon */}
+      <polygon
+        data-testid="target-polygon"
+        points={buildPolygonPoints(cx, cy, R, targetValues, angles)}
+        fill="#FF840030"
+        stroke="var(--color-primary)"
+        strokeWidth="2"
+      />
+
+      {/* Analysis polygon */}
+      {analysisValues && (
+        <polygon
+          data-testid="analysis-polygon"
+          points={buildPolygonPoints(cx, cy, R, analysisValues, angles)}
+          fill="#30A46C30"
+          stroke="var(--color-success)"
+          strokeWidth="2"
+        />
+      )}
+
+      {/* Axis labels */}
+      {axes.map((axis, i) => {
+        const labelR = R + 25;
+        const pt = polarToCartesian(cx, cy, labelR, angles[i]);
+        const cosA = Math.cos(angles[i]);
+        let anchor: "middle" | "start" | "end" = "middle";
+        if (cosA > 0.3) anchor = "start";
+        else if (cosA < -0.3) anchor = "end";
+
+        return (
+          <text
+            key={axis.key}
+            x={pt.x} y={pt.y + 4}
+            textAnchor={anchor}
+            fontSize="11"
+            fill="var(--color-muted-foreground)"
+            fontFamily="var(--font-geist-sans)"
+          >
+            {axis.label}
+          </text>
+        );
+      })}
+    </svg>
+  );
+}

--- a/frontend/components/workbench/SimpleTreeRow.tsx
+++ b/frontend/components/workbench/SimpleTreeRow.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { ChevronDown, ChevronRight } from "lucide-react";
+
+export interface SimpleTreeNode {
+  id: string;
+  label: string;
+  level: number;
+  expanded?: boolean;
+  leaf?: boolean;
+  muted?: boolean;
+  chip?: string;
+  annotation?: string;
+  annotationPrimary?: boolean;
+}
+
+interface SimpleTreeRowProps {
+  node: SimpleTreeNode;
+  onToggle: () => void;
+}
+
+export function SimpleTreeRow({ node, onToggle }: SimpleTreeRowProps) {
+  const indent = node.level * 20;
+  return (
+    <button
+      onClick={onToggle}
+      style={{ paddingLeft: indent }}
+      className="flex w-full items-center gap-1.5 rounded-[--radius-s] py-1.5 pr-2 text-left hover:bg-sidebar-accent"
+    >
+      {!node.leaf ? (
+        node.expanded ? (
+          <ChevronDown size={12} className="shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronRight size={12} className="shrink-0 text-muted-foreground" />
+        )
+      ) : (
+        <span className="w-3 shrink-0" />
+      )}
+      <span
+        className={`truncate ${node.muted ? "text-[12px] text-muted-foreground" : "font-[family-name:var(--font-geist-sans)] text-[13px] text-foreground"}`}
+      >
+        {node.label}
+      </span>
+      {node.chip && (
+        <span className="rounded bg-card-muted px-1.5 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[10px] text-primary">
+          {node.chip}
+        </span>
+      )}
+      <span className="flex-1" />
+      {node.annotation && (
+        <span
+          className={`font-[family-name:var(--font-jetbrains-mono)] text-[11px] ${node.annotationPrimary ? "text-primary" : "text-muted-foreground"}`}
+        >
+          {node.annotation}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/frontend/components/workbench/SplitHandle.tsx
+++ b/frontend/components/workbench/SplitHandle.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Separator } from "react-resizable-panels";
+import { ChevronRight } from "lucide-react";
+
+interface SplitHandleProps {
+  onCollapse?: () => void;
+  collapsed?: boolean;
+}
+
+export function SplitHandle({ onCollapse, collapsed }: SplitHandleProps) {
+  return (
+    <Separator className="group relative flex w-1 items-center justify-center bg-border transition-colors hover:bg-primary/50 data-[resize-handle-active]:bg-primary/50">
+      {/* Grip dots */}
+      <div className="flex flex-col gap-1">
+        {[0, 1, 2].map((i) => (
+          <div key={i} className="size-[3px] rounded-full bg-muted-foreground opacity-50" />
+        ))}
+      </div>
+      {/* Collapse chevron */}
+      {onCollapse && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onCollapse(); }}
+          className="absolute -left-1.5 top-1/2 flex w-4 h-6 -translate-y-1/2 items-center justify-center rounded-[4px] border border-border bg-card-muted"
+        >
+          <ChevronRight
+            size={12}
+            className={`text-muted-foreground transition-transform ${!collapsed ? "rotate-180" : ""}`}
+          />
+        </button>
+      )}
+    </Separator>
+  );
+}

--- a/frontend/components/workbench/TreeCard.tsx
+++ b/frontend/components/workbench/TreeCard.tsx
@@ -1,0 +1,49 @@
+/**
+ * TreeCard — visual card shell for tree panels.
+ *
+ * Provides a consistent header (title, optional badge, optional actions slot)
+ * and a scrollable body for tree content. Extracted from AeroplaneTree.tsx
+ * to be reused by Weight Tree and other tree panels.
+ */
+
+interface TreeCardProps {
+  title: string;
+  badge?: string;
+  badgeVariant?: "primary" | "muted";
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function TreeCard({
+  title,
+  badge,
+  badgeVariant = "muted",
+  actions,
+  children,
+  className,
+}: TreeCardProps) {
+  return (
+    <div
+      className={`rounded-[--radius-m] border border-border bg-card overflow-hidden flex flex-col${className ? ` ${className}` : ""}`}
+    >
+      {/* Header */}
+      <div className="flex items-center gap-2 px-4 py-3">
+        <span className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-muted-foreground">
+          {title}
+        </span>
+        {badge && (
+          <span
+            className={`font-[family-name:var(--font-jetbrains-mono)] text-[11px] ${badgeVariant === "primary" ? "text-primary" : "text-muted-foreground"}`}
+          >
+            {badge}
+          </span>
+        )}
+        <div className="flex-1" />
+        {actions}
+      </div>
+      {/* Scrollable body */}
+      <div className="flex-1 overflow-y-auto px-4 pb-3">{children}</div>
+    </div>
+  );
+}

--- a/frontend/components/workbench/UnsavedChangesContext.tsx
+++ b/frontend/components/workbench/UnsavedChangesContext.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { createContext, useContext, useState, useCallback, useEffect, type ReactNode } from "react";
+import { useRouter } from "next/navigation";
+
+interface UnsavedChangesContextValue {
+  isDirty: boolean;
+  setDirty: (dirty: boolean) => void;
+  registerSave: (fn: () => Promise<void>) => void;
+  pendingHref: string | null;
+  requestNavigation: (href: string) => void;
+  confirmDiscard: () => void;
+  confirmSave: () => void;
+  cancelNavigation: () => void;
+  isSaving: boolean;
+}
+
+const UnsavedChangesContext = createContext<UnsavedChangesContextValue | null>(null);
+
+export function UnsavedChangesProvider({ children }: { children: ReactNode }) {
+  const router = useRouter();
+  const [isDirty, setDirty] = useState(false);
+  const [pendingHref, setPendingHref] = useState<string | null>(null);
+  const [saveFn, setSaveFn] = useState<(() => Promise<void>) | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const registerSave = useCallback((fn: () => Promise<void>) => {
+    setSaveFn(() => fn);
+  }, []);
+
+  const requestNavigation = useCallback((href: string) => {
+    if (isDirty) {
+      setPendingHref(href);
+    } else {
+      router.push(href);
+    }
+  }, [isDirty, router]);
+
+  const confirmDiscard = useCallback(() => {
+    const href = pendingHref;
+    setDirty(false);
+    setPendingHref(null);
+    if (href) router.push(href);
+  }, [pendingHref, router]);
+
+  const confirmSave = useCallback(async () => {
+    if (!saveFn) return;
+    setIsSaving(true);
+    try {
+      await saveFn();
+      const href = pendingHref;
+      setDirty(false);
+      setPendingHref(null);
+      if (href) router.push(href);
+    } finally {
+      setIsSaving(false);
+    }
+  }, [saveFn, pendingHref, router]);
+
+  const cancelNavigation = useCallback(() => {
+    setPendingHref(null);
+  }, []);
+
+  // Browser beforeunload
+  useEffect(() => {
+    if (!isDirty) return;
+    const handler = (e: BeforeUnloadEvent) => { e.preventDefault(); };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [isDirty]);
+
+  return (
+    <UnsavedChangesContext.Provider value={{
+      isDirty, setDirty, registerSave, pendingHref,
+      requestNavigation, confirmDiscard, confirmSave, cancelNavigation, isSaving,
+    }}>
+      {children}
+    </UnsavedChangesContext.Provider>
+  );
+}
+
+export function useUnsavedChanges() {
+  const ctx = useContext(UnsavedChangesContext);
+  if (!ctx) throw new Error("useUnsavedChanges must be inside UnsavedChangesProvider");
+  return ctx;
+}

--- a/frontend/components/workbench/UnsavedChangesModal.tsx
+++ b/frontend/components/workbench/UnsavedChangesModal.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { TriangleAlert } from "lucide-react";
+import { useUnsavedChanges } from "@/components/workbench/UnsavedChangesContext";
+
+export function UnsavedChangesModal() {
+  const { pendingHref, isSaving, confirmDiscard, confirmSave, cancelNavigation } = useUnsavedChanges();
+
+  if (!pendingHref) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={cancelNavigation}
+    >
+      <div
+        className="flex w-[460px] flex-col gap-5 rounded-[16px] border border-border bg-card p-6"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => { if (e.key === "Escape") cancelNavigation(); }}
+      >
+        <div className="flex items-center gap-3">
+          <TriangleAlert size={24} className="text-primary" />
+          <span className="text-[18px] font-semibold text-foreground">
+            Unsaved Changes
+          </span>
+        </div>
+        <p className="text-[14px] leading-relaxed text-muted-foreground">
+          You have unsaved changes. Do you want to save before leaving?
+        </p>
+        <div className="flex justify-end gap-3">
+          <button
+            onClick={confirmDiscard}
+            disabled={isSaving}
+            className="rounded-[--radius-s] border border-destructive px-5 py-2.5 text-[14px] font-medium text-destructive disabled:opacity-50"
+          >
+            Discard
+          </button>
+          <button
+            onClick={cancelNavigation}
+            disabled={isSaving}
+            className="rounded-[--radius-s] bg-sidebar-accent px-5 py-2.5 text-[14px] font-medium text-muted-foreground disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={confirmSave}
+            disabled={isSaving}
+            className="rounded-[--radius-s] bg-primary px-5 py-2.5 text-[14px] font-medium text-primary-foreground disabled:opacity-50"
+          >
+            {isSaving ? "Saving\u2026" : "Save & Continue"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/workbench/ViewerPanel.tsx
+++ b/frontend/components/workbench/ViewerPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Box, Loader } from "lucide-react";
+import { Box, Loader, Maximize2, Minimize2, PanelLeftOpen } from "lucide-react";
 import { CadViewer } from "./CadViewer";
 
 const STAGES = ["Bare Aero", "+TEDs", "+Spars", "Final Print"] as const;
@@ -11,15 +11,29 @@ interface ViewerPanelProps {
   visibleParts: Record<string, unknown>[];
   isAnyLoading: boolean;
   loadingWing: string | null;
+  isMaximized?: boolean;
+  onToggleMaximize?: () => void;
+  isTreeCollapsed?: boolean;
+  onExpandTree?: () => void;
 }
 
-export function ViewerPanel({ visibleParts, isAnyLoading, loadingWing }: ViewerPanelProps) {
+export function ViewerPanel({ visibleParts, isAnyLoading, loadingWing, isMaximized, onToggleMaximize, isTreeCollapsed, onExpandTree }: ViewerPanelProps) {
   const [activeStage, setActiveStage] = useState<Stage>("Bare Aero");
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden rounded-[--radius-m] border border-border">
       {/* Header */}
       <div className="flex items-center gap-2 border-b border-border bg-card px-4 py-3">
+        {/* Tree expand button — shown when tree is collapsed */}
+        {isTreeCollapsed && onExpandTree && (
+          <button
+            onClick={onExpandTree}
+            className="flex size-6 items-center justify-center rounded-[--radius-s] text-muted-foreground hover:bg-sidebar-accent"
+            title="Show tree panel"
+          >
+            <PanelLeftOpen size={14} />
+          </button>
+        )}
         <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-foreground">
           CAD Viewer
         </span>
@@ -39,6 +53,16 @@ export function ViewerPanel({ visibleParts, isAnyLoading, loadingWing }: ViewerP
             </button>
           ))}
         </div>
+        {/* Maximize/minimize button */}
+        {onToggleMaximize && (
+          <button
+            onClick={onToggleMaximize}
+            className="flex size-8 items-center justify-center rounded-[--radius-s] border border-border bg-card-muted text-muted-foreground hover:bg-sidebar-accent"
+            title={isMaximized ? "Restore panels" : "Maximize viewer"}
+          >
+            {isMaximized ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
+          </button>
+        )}
       </div>
 
       {/* Viewer Body */}

--- a/frontend/components/workbench/WeightTree.tsx
+++ b/frontend/components/workbench/WeightTree.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+import { TreeCard } from "@/components/workbench/TreeCard";
+import {
+  SimpleTreeRow,
+  type SimpleTreeNode,
+} from "@/components/workbench/SimpleTreeRow";
+
+const STATIC_NODES: SimpleTreeNode[] = [
+  {
+    id: "root",
+    label: "eHawk",
+    level: 0,
+    annotation: "1.177 kg",
+    annotationPrimary: true,
+  },
+  { id: "mw", label: "main_wing", level: 1, annotation: "0.985 kg" },
+  { id: "s0", label: "segment 0 (root)", level: 2 },
+  { id: "s1", label: "segment 1", level: 2 },
+  { id: "s2", label: "segment 2 \u00b7 aileron", level: 2, chip: "AILERON" },
+  { id: "s3", label: "segment 3 \u00b7 aileron", level: 2 },
+  { id: "ew", label: "elevator_wing", level: 1, annotation: "0.120 kg" },
+  {
+    id: "fuse",
+    label: "fuselage",
+    level: 1,
+    leaf: true,
+    annotation: "0.072 kg",
+  },
+];
+
+export function WeightTree() {
+  const [expanded, setExpanded] = useState<Set<string>>(
+    new Set(["root", "mw"]),
+  );
+
+  const toggle = (id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  };
+
+  const visible = STATIC_NODES.filter((node) => {
+    if (node.level === 0) return true;
+    if (node.level === 1) return expanded.has("root");
+    if (node.level === 2) {
+      if (!expanded.has("root")) return false;
+      const idx = STATIC_NODES.indexOf(node);
+      for (let i = idx - 1; i >= 0; i--) {
+        if (STATIC_NODES[i].level === 1)
+          return expanded.has(STATIC_NODES[i].id);
+      }
+    }
+    return true;
+  });
+
+  return (
+    <TreeCard title="Weight Tree" badge="1.177 kg" badgeVariant="primary">
+      <div className="flex flex-col gap-0.5">
+        {visible.map((node) => (
+          <SimpleTreeRow
+            key={node.id}
+            node={{
+              ...node,
+              expanded: expanded.has(node.id),
+              leaf: node.leaf ?? node.level === 2,
+            }}
+            onToggle={() => toggle(node.id)}
+          />
+        ))}
+      </div>
+    </TreeCard>
+  );
+}

--- a/frontend/components/workbench/WorkbenchTwoPanel.tsx
+++ b/frontend/components/workbench/WorkbenchTwoPanel.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+interface WorkbenchTwoPanelProps {
+  leftWidth?: number;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function WorkbenchTwoPanel({ leftWidth = 360, children, className }: WorkbenchTwoPanelProps) {
+  const childArray = React.Children.toArray(children);
+  return (
+    <div className={`flex flex-1 gap-4 overflow-hidden${className ? ` ${className}` : ""}`}>
+      <div style={{ width: leftWidth, minWidth: leftWidth }} className="shrink-0 overflow-hidden">
+        {childArray[0]}
+      </div>
+      <div className="flex-1 overflow-hidden">
+        {childArray[1]}
+      </div>
+    </div>
+  );
+}

--- a/frontend/hooks/useAnalysis.ts
+++ b/frontend/hooks/useAnalysis.ts
@@ -37,16 +37,28 @@ function extractResult(data: Record<string, unknown>): AnalysisResult {
   };
 }
 
-export function useAnalysis(aeroplaneId: string | null) {
+export interface UseAnalysisReturn {
+  result: AnalysisResult | null;
+  isRunning: boolean;
+  error: string | null;
+  lastRunTime: Date | null;
+  lastRunDurationMs: number | null;
+  runAlphaSweep: (params: AlphaSweepParams) => Promise<void>;
+}
+
+export function useAnalysis(aeroplaneId: string | null): UseAnalysisReturn {
   const [result, setResult] = useState<AnalysisResult | null>(null);
   const [isRunning, setIsRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [lastRunTime, setLastRunTime] = useState<Date | null>(null);
+  const [lastRunDurationMs, setLastRunDurationMs] = useState<number | null>(null);
 
   const runAlphaSweep = useCallback(
     async (params: AlphaSweepParams) => {
       if (!aeroplaneId) return;
       setIsRunning(true);
       setError(null);
+      const t0 = Date.now();
 
       try {
         const res = await fetch(
@@ -63,6 +75,8 @@ export function useAnalysis(aeroplaneId: string | null) {
         }
         const data = await res.json();
         setResult(extractResult(data));
+        setLastRunTime(new Date());
+        setLastRunDurationMs(Date.now() - t0);
       } catch (err) {
         setError(err instanceof Error ? err.message : String(err));
       } finally {
@@ -72,5 +86,5 @@ export function useAnalysis(aeroplaneId: string | null) {
     [aeroplaneId],
   );
 
-  return { result, isRunning, error, runAlphaSweep };
+  return { result, isRunning, error, lastRunTime, lastRunDurationMs, runAlphaSweep };
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test:unit": "vitest run",
     "test:e2e": "rm -f e2e/.cleanup-done && npx -p playwright-bdd bddgen && npx playwright test --grep-invert @slow; rm -f e2e/.cleanup-done",
     "test:e2e:slow": "rm -f e2e/.cleanup-done && npx -p playwright-bdd bddgen && npx playwright test; rm -f e2e/.cleanup-done",
     "test:e2e:ui": "npx -p playwright-bdd bddgen && npx playwright test --ui",

--- a/planning/gh-45-shared-workbench-components/implementation-plan.md
+++ b/planning/gh-45-shared-workbench-components/implementation-plan.md
@@ -1,0 +1,339 @@
+# Implementation Plan: GH #45 — Shared Workbench Layout-Komponenten
+
+## Context
+
+**Problem:** 5 von 6 Workbench-Screens nutzen identische Layout-Patterns (Two-Panel, Tree-Card-Shell, Alert-Banner). Aktuell ist jede Page einzeln strukturiert, was zu Duplikation (3x identischer Alert-Block) und inkonsistenter Umsetzung führt.
+
+**Desired Outcome:** 4 shared Komponenten (`TreeCard`, `WorkbenchTwoPanel`, `AlertBanner`, `SplitHandle`) als Grundlage für alle Screen-Refactors in Epic #44.
+
+**Wireframe-Referenz:** `da3Dalus.pen` — Pattern sichtbar in `screen-1-mission`, `screen-3-analysis`, `screen-4-components`, `screen-5-weight`
+
+**Part of:** Epic #44 (Frontend Wireframe Redesign)
+**Blocks:** #47, #48, #49, #50, #51
+
+---
+
+## Scope
+
+### In Scope (Acceptance Criteria aus GH #45)
+1. `TreeCard` rendert Header + scrollbaren Body, akzeptiert `title` + `children`
+2. `WorkbenchTwoPanel` erzeugt Two-Panel-Layout mit konfigurierbarer linker Breite
+3. `AlertBanner` ersetzt die 3 duplizierten Alert-Blocks in Mission/Components/Weight
+4. `SplitHandle` zeigt Grip-Dots und Collapse-Chevron, funktioniert mit `react-resizable-panels`
+5. Alle Komponenten haben Unit Tests
+6. `npm run build` fehlerfrei
+
+### Out of Scope
+- Einbau in bestehende Pages (eigene Issues #47–#51)
+- Resizable Variante von TwoPanel
+- Backend-Änderungen
+
+---
+
+## Architecture Constraints
+
+| Constraint | Specification | Source |
+|-----------|--------------|--------|
+| React 19 | `react@19.2.5`, `react-dom@19.2.5` | `package.json` |
+| Next.js Canary | `next@16.2.1-canary.33`, App Router | `package.json`, `CLAUDE.md` |
+| Dark Theme | Orange accent `#FF8400`, JetBrains Mono + Geist | `frontend/CLAUDE.md` |
+| Tailwind 4 | `tailwindcss@4`, CSS variables for tokens | `package.json` |
+| Pencil First | All UI changes must match `da3Dalus.pen` wireframe | `CLAUDE.md` |
+| react-resizable-panels | `v4.10.0`, imports `Group`, `Panel`, `Separator` | `package.json` |
+| Test Framework | vitest 4.1.4 + @testing-library/react 16.3 | `package.json` |
+
+---
+
+## Key Design Decisions
+
+### Decision 1: TreeCard als reine Shell, nicht als generalisierter Tree
+
+**Decision:** `TreeCard` ist nur die visuelle Card-Hülle (Header + scrollbarer Body). Die Tree-Logik (Expand/Collapse, Daten) bleibt in den jeweiligen Tree-Komponenten.
+
+**Rationale:** Der bestehende `AeroplaneTree.tsx` (505 LOC) hat hochspezifische Logik (WingConfig vs ASB modes, segment CRUD). Diese zu generalisieren wäre riskant und ein Breaking Change. TreeCard extrahiert nur das visuelle Pattern, das in der Wireframe-`component/AeroplaneTree` Node identisch wiederverwendet wird.
+
+### Decision 2: WorkbenchTwoPanel ohne Resize
+
+**Decision:** `WorkbenchTwoPanel` ist ein einfacher Flex-Container mit fixer linker Breite. Kein `react-resizable-panels`.
+
+**Rationale:** Construction + Analysis brauchen Resize (User zieht CAD Viewer größer). Mission, Components, Weight haben statische Layouts wo Resize keinen Wert hat. Zwei verschiedene Layout-Mechanismen statt einen zu überladen.
+
+### Decision 3: SplitHandle als PanelResizeHandle-Wrapper
+
+**Decision:** `SplitHandle` implementiert die `react-resizable-panels` `PanelResizeHandle`-API (ersetzt `<Separator>`), nicht eine eigene Drag-Logik.
+
+**Rationale:** `react-resizable-panels` v4 unterstützt custom children in `PanelResizeHandle`. Eigene Drag-Logik wäre redundant und fehleranfällig. Die Collapse-Funktion nutzt die `Panel.collapse()`/`expand()` API via imperative handle.
+
+### Decision 4: AlertBanner mit title + children statt title + body
+
+**Decision:** `AlertBanner` Props: `{ title: string; children: ReactNode }` statt `{ title: string; body: string }`.
+
+**Rationale:** Die Wireframes zeigen teilweise Beads-Issue-Referenzen im Body-Text (`cad-modelling-service-yu9`). Mit `children` kann der Konsument beliebige Inhalte (Links, Code) einbetten. Die 3 aktuellen Anwendungsfälle sind trivial (`<AlertBanner title="...">text</AlertBanner>`).
+
+---
+
+## Project Structure
+
+```
+frontend/
+├── components/workbench/
+│   ├── TreeCard.tsx              NEW — Card-Shell für Tree-Panels
+│   ├── WorkbenchTwoPanel.tsx     NEW — Two-Panel Layout ohne Resize
+│   ├── AlertBanner.tsx           NEW — Shared Alert Banner
+│   ├── SplitHandle.tsx           NEW — Custom Split Handle
+│   ├── AeroplaneTree.tsx         EXISTING — wird TreeCard konsumieren (späteres Issue)
+│   ├── AnalysisConfigPanel.tsx   EXISTING — konsumiert SplitHandle (späteres Issue)
+│   └── ...
+├── __tests__/
+│   ├── TreeCard.test.tsx         NEW
+│   ├── WorkbenchTwoPanel.test.tsx NEW
+│   ├── AlertBanner.test.tsx      NEW
+│   └── SplitHandle.test.tsx      NEW
+└── package.json                  EXISTING — keine Änderungen nötig
+```
+
+---
+
+## Module Specifications
+
+### 1. TreeCard
+
+**Datei:** `frontend/components/workbench/TreeCard.tsx`
+**Verantwortung:** Visuelle Card-Shell für Tree-Panels mit Header und scrollbarem Body.
+
+```tsx
+// Props
+interface TreeCardProps {
+  title: string;
+  badge?: string;              // z.B. "1.177 kg" im Weight Tree
+  badgeVariant?: "primary" | "muted";
+  actions?: React.ReactNode;   // z.B. Mode-Toggle, Plus-Button
+  children: React.ReactNode;   // Tree-Content
+  className?: string;
+}
+
+// Sketch
+export function TreeCard({ title, badge, badgeVariant, actions, children, className }: TreeCardProps) {
+  return (
+    <div className={cn("rounded-[--radius-m] border border-border bg-card overflow-hidden flex flex-col", className)}>
+      {/* Header */}
+      <div className="flex items-center gap-2 px-4 py-3">
+        <span className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-muted-foreground">
+          {title}
+        </span>
+        {badge && <span className={cn("...", badgeVariant)}>{badge}</span>}
+        <div className="flex-1" />
+        {actions}
+      </div>
+      {/* Scrollable body */}
+      <div className="flex-1 overflow-y-auto px-4 pb-3">
+        {children}
+      </div>
+    </div>
+  );
+}
+```
+
+**Design Points:**
+- Spiegelt das Pattern aus `AeroplaneTree.tsx` Zeile 369-415 (outer div)
+- Wireframe `component/AeroplaneTree` Node `k7wab`: `cornerRadius: --radius-m`, `fill: --card`, `stroke: --border`, `padding: [12,16]`, `gap: 4`, `clip: true`
+- `overflow-y-auto` auf Body für scrollbare Trees
+- `actions` Slot für mode-toggle (AeroplaneTree) oder add-buttons (WeightTree)
+
+**Tests:** 4 Tests
+- Rendert Titel
+- Rendert Badge mit korrektem Variant
+- Rendert Actions-Slot
+- Scrollbar bei Overflow
+
+### 2. WorkbenchTwoPanel
+
+**Datei:** `frontend/components/workbench/WorkbenchTwoPanel.tsx`
+**Verantwortung:** Einfaches Two-Panel-Layout mit fixer linker Breite.
+
+```tsx
+interface WorkbenchTwoPanelProps {
+  leftWidth?: number;           // default 360
+  children: React.ReactNode;    // erwartet genau 2 Kinder
+  className?: string;
+}
+
+// Sketch
+export function WorkbenchTwoPanel({ leftWidth = 360, children, className }: WorkbenchTwoPanelProps) {
+  const [left, right] = React.Children.toArray(children);
+  return (
+    <div className={cn("flex flex-1 gap-4 overflow-hidden", className)}>
+      <div style={{ width: leftWidth, minWidth: leftWidth }} className="shrink-0 overflow-hidden">
+        {left}
+      </div>
+      <div className="flex-1 overflow-hidden">
+        {right}
+      </div>
+    </div>
+  );
+}
+```
+
+**Design Points:**
+- Wireframe zeigt konsistent: linkes Panel 360px, gap 16px (Tailwind `gap-4`), rechtes Panel `fill_container`
+- Workbench Layout (`layout.tsx`) setzt `p-4 gap-4` auf `<main>` — TwoPanel muss `flex-1 overflow-hidden` sein
+- Kein `react-resizable-panels` — bewusst einfach gehalten
+- `shrink-0` auf links verhindert Quetschung
+
+**Tests:** 4 Tests
+- Rendert zwei Kinder nebeneinander
+- Linkes Panel hat korrekte Breite (default 360)
+- Custom leftWidth wird übernommen
+- Overflow wird auf beiden Panels gehidden
+
+### 3. AlertBanner
+
+**Datei:** `frontend/components/workbench/AlertBanner.tsx`
+**Verantwortung:** Orange Alert-Banner für "Coming soon"-Hinweise.
+
+```tsx
+interface AlertBannerProps {
+  title?: string;               // default "Coming soon — backend wiring in progress"
+  children: React.ReactNode;    // Body-Text
+}
+
+// Sketch
+export function AlertBanner({ title = "Coming soon — backend wiring in progress", children }: AlertBannerProps) {
+  return (
+    <div className="flex items-start gap-3 rounded-[--radius-s] border border-primary bg-[#2A1F10] p-4">
+      <Info className="size-4 shrink-0 text-primary" />
+      <div className="flex flex-col gap-0.5">
+        <span className="text-[13px] font-semibold text-foreground">
+          {title}
+        </span>
+        <span className="text-[12px] text-muted-foreground">
+          {children}
+        </span>
+      </div>
+    </div>
+  );
+}
+```
+
+**Design Points:**
+- Exakt das duplizierte Pattern aus Mission/Components/Weight (identische Klassen)
+- Default-Title deckt den häufigsten Fall ab
+- `children` statt `body: string` für Flexibilität (Links, Beads-Referenzen)
+
+**Tests:** 3 Tests
+- Rendert Default-Title + children
+- Rendert Custom-Title
+- Info-Icon ist sichtbar
+
+### 4. SplitHandle
+
+**Datei:** `frontend/components/workbench/SplitHandle.tsx`
+**Verantwortung:** Custom Split Handle für `react-resizable-panels` mit Grip-Dots und Collapse-Button.
+
+```tsx
+import { PanelResizeHandle } from "react-resizable-panels";
+
+interface SplitHandleProps {
+  onCollapse?: () => void;
+  collapsed?: boolean;
+}
+
+// Sketch
+export function SplitHandle({ onCollapse, collapsed }: SplitHandleProps) {
+  return (
+    <PanelResizeHandle className="group relative flex w-1 items-center justify-center bg-border transition-colors hover:bg-primary/50">
+      {/* Grip dots */}
+      <div className="flex flex-col gap-1">
+        {[0, 1, 2].map((i) => (
+          <div key={i} className="size-[3px] rounded-full bg-muted-foreground opacity-50" />
+        ))}
+      </div>
+      {/* Collapse chevron */}
+      {onCollapse && (
+        <button
+          onClick={onCollapse}
+          className="absolute -left-1.5 top-1/2 flex w-4 h-6 -translate-y-1/2 items-center justify-center rounded-[--radius-xs] border border-border bg-card-muted"
+        >
+          <ChevronRight size={12} className={cn("text-muted-foreground transition-transform", !collapsed && "rotate-180")} />
+        </button>
+      )}
+    </PanelResizeHandle>
+  );
+}
+```
+
+**Design Points:**
+- Wireframe Node `9fOlp`/`PWy49`: `width: 4`, `fill: --border`, 3 Grip-Dots (`ellipse 3×3`, `opacity: 0.5`), Chevron-Button (`16×24`, `cornerRadius: 4`, `absolute position x:-6`)
+- `PanelResizeHandle` ersetzt `<Separator>` — Drop-in Replacement in bestehenden Pages
+- Collapse-Button ist optional (`onCollapse` prop) — nicht alle Panels brauchen Collapse
+- `collapsed` steuert Chevron-Richtung (rechts = expand, links = collapse)
+
+**Tests:** 5 Tests
+- Rendert 3 Grip-Dots
+- Rendert Collapse-Button wenn `onCollapse` übergeben
+- Kein Collapse-Button ohne `onCollapse`
+- Chevron rotiert bei `collapsed=true`
+- Click auf Collapse ruft `onCollapse` auf
+
+---
+
+## Test Strategy
+
+**Coverage Target:** >90% für alle 4 neuen Komponenten
+
+**Test Framework:** vitest + @testing-library/react (bestehendes Pattern)
+
+| Modul | Unit Tests | Gesamt |
+|-------|-----------|--------|
+| TreeCard | 4 | 4 |
+| WorkbenchTwoPanel | 4 | 4 |
+| AlertBanner | 3 | 3 |
+| SplitHandle | 5 | 5 |
+| **Total** | **16** | **16** |
+
+**Mock Patterns:**
+- `react-resizable-panels`: Mock `PanelResizeHandle` als `div` mit `onMouseDown`
+- `lucide-react`: Mock Icons als simple SVG-Placeholder (Pattern aus `StreamlinesViewer.test.tsx`)
+
+**Quality Gates:**
+1. `npx vitest run` — alle 16 Tests grün
+2. `npm run build` — keine TypeScript-Errors
+3. Visueller Vergleich gegen `da3Dalus.pen` Screenshots
+
+---
+
+## Verification
+
+| AC | Test/Evidence |
+|----|---------------|
+| TreeCard rendert Header + scrollbaren Body | `TreeCard.test.tsx` — Render + overflow test |
+| WorkbenchTwoPanel mit konfigurierbarer Breite | `WorkbenchTwoPanel.test.tsx` — Default + custom width |
+| AlertBanner ersetzt duplizierte Blocks | `AlertBanner.test.tsx` — Render mit default/custom title |
+| SplitHandle mit Grip-Dots + Collapse | `SplitHandle.test.tsx` — Dots, button, rotation, click |
+| Alle Komponenten haben Tests | 16 Tests über 4 Dateien |
+| `npm run build` fehlerfrei | CI build step |
+
+---
+
+## Forward Compatibility
+
+| Downstream Issue | Readiness | Integration Point |
+|-----------------|-----------|-------------------|
+| #47 Mission Radar | TreeCard nicht benötigt, WorkbenchTwoPanel + AlertBanner | TwoPanel links=RadarChart, rechts=Form |
+| #48 Components Tree | TreeCard + WorkbenchTwoPanel + AlertBanner | TreeCard wraps ComponentTree |
+| #49 Weight Tree | TreeCard + WorkbenchTwoPanel + AlertBanner | TreeCard wraps WeightTree mit badge |
+| #50 Airfoil Preview | WorkbenchTwoPanel-Pattern (aber mit Resize) | Ggf. eigenes Layout, nicht TwoPanel |
+| #51 Analysis Handle | SplitHandle | Drop-in für `<Separator>` |
+
+---
+
+## Key References
+
+| Document | Path | Relevance |
+|----------|------|-----------|
+| GH Issue #45 | github.com/szymansk/da3Dalus/issues/45 | Epic specification |
+| Wireframe | `da3Dalus.pen` | Visual spec für alle Komponenten |
+| AeroplaneTree | `frontend/components/workbench/AeroplaneTree.tsx:369-415` | TreeCard Shell-Pattern |
+| Alert duplication | `mission/page.tsx:44`, `components/page.tsx:101`, `weight/page.tsx:57` | AlertBanner Extraktion |
+| Analysis Separator | `workbench/page.tsx:36` | SplitHandle Replace-Target |
+| Test patterns | `frontend/__tests__/StreamlinesViewer.test.tsx` | Component test Pattern |


### PR DESCRIPTION
## Summary

- **GH#45**: 4 shared layout components (TreeCard, WorkbenchTwoPanel, AlertBanner, SplitHandle) + `test:unit` script
- **GH#51**: Analysis screen — SplitHandle between panels, Load OP set disabled, Reset to defaults, last-run timestamp
- **GH#47**: Mission screen — SVG RadarChart (5-axis spider) + two-column layout with WorkbenchTwoPanel
- **GH#48+49**: Components + Weight screens — SimpleTreeRow, ComponentTree, WeightTree + two-panel layouts
- **GH#46**: Unsaved Changes Guard — context/hook, modal (Discard/Cancel/Save & Continue), GuardedLink in Header
- **GH#52**: Construction screen — AeroplaneTree as own left panel with collapse/expand toggle, Viewer maximize button

## Metrics

- **55 unit tests** (vitest) — all green
- **210 backend tests** (pytest) — all green
- **Ruff** — clean
- **Build** — clean (TypeScript, Next.js static generation)
- **~1,700 LOC** new code across 22 new files + 8 modified

## Wireframe reference

All screens match `da3Dalus.pen` wireframes:
- `screen-1-mission` (epqpi) — RadarChart + two-column
- `screen-2-construction` (pN0io) — 3-panel with toggle buttons
- `screen-3-analysis` (pdzFr) — SplitHandle + action buttons
- `screen-4-components` (TkfUz) — ComponentTree + two-panel
- `screen-5-weight` (godpv) — WeightTree + two-panel

## Not included

- **GH#50** (Airfoil Preview dedicated screen) — deferred to separate PR (new route + hook + config panel)

## Test plan

- [ ] `cd frontend && npm run test:unit` — 55 tests green
- [ ] `cd frontend && npm run build` — no errors
- [ ] `poetry run ruff check .` — clean
- [ ] `poetry run pytest app/tests/ -m "not slow"` — 210 tests green
- [ ] Visual comparison: each screen against `da3Dalus.pen` wireframes
- [ ] Navigation: step pills trigger unsaved changes modal when form is dirty
- [ ] Construction: tree collapse/expand + viewer maximize work correctly

Closes #45, #51, #47, #48, #49, #46, #52
Part of #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)