### PR TITLE
feat(gh#34): Component Tree — hierarchical assembly structure per aeroplane

### DIFF
--- a/alembic/versions/0e7ea09c363d_extend_components_table_bbox_model_ref.py
+++ b/alembic/versions/0e7ea09c363d_extend_components_table_bbox_model_ref.py
@@ -1,0 +1,34 @@
+"""extend_components_table_bbox_model_ref
+
+Revision ID: 0e7ea09c363d
+Revises: 04b8c856eab9
+Create Date: 2026-04-14 23:06:53.789992
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '0e7ea09c363d'
+down_revision: Union[str, None] = '04b8c856eab9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add bbox and model_ref columns to components table."""
+    op.add_column('components', sa.Column('bbox_x_mm', sa.Float(), nullable=True))
+    op.add_column('components', sa.Column('bbox_y_mm', sa.Float(), nullable=True))
+    op.add_column('components', sa.Column('bbox_z_mm', sa.Float(), nullable=True))
+    op.add_column('components', sa.Column('model_ref', sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    """Remove bbox and model_ref columns from components table."""
+    op.drop_column('components', 'model_ref')
+    op.drop_column('components', 'bbox_z_mm')
+    op.drop_column('components', 'bbox_y_mm')
+    op.drop_column('components', 'bbox_x_mm')

--- a/alembic/versions/b456b2d255b9_add_component_tree_table.py
+++ b/alembic/versions/b456b2d255b9_add_component_tree_table.py
@@ -1,0 +1,55 @@
+"""add_component_tree_table
+
+Revision ID: b456b2d255b9
+Revises: 0e7ea09c363d
+Create Date: 2026-04-14 23:13:57.506937
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b456b2d255b9'
+down_revision: Union[str, None] = '0e7ea09c363d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create component_tree table."""
+    op.create_table(
+        'component_tree',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('aeroplane_id', sa.String(), nullable=False, index=True),
+        sa.Column('parent_id', sa.Integer(), sa.ForeignKey('component_tree.id'), nullable=True),
+        sa.Column('sort_index', sa.Integer(), default=0),
+        sa.Column('node_type', sa.String(), nullable=False),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('shape_key', sa.String(), nullable=True),
+        sa.Column('shape_hash', sa.String(), nullable=True),
+        sa.Column('volume_mm3', sa.Float(), nullable=True),
+        sa.Column('area_mm2', sa.Float(), nullable=True),
+        sa.Column('component_id', sa.Integer(), sa.ForeignKey('components.id'), nullable=True),
+        sa.Column('quantity', sa.Integer(), default=1),
+        sa.Column('pos_x', sa.Float(), default=0),
+        sa.Column('pos_y', sa.Float(), default=0),
+        sa.Column('pos_z', sa.Float(), default=0),
+        sa.Column('rot_x', sa.Float(), default=0),
+        sa.Column('rot_y', sa.Float(), default=0),
+        sa.Column('rot_z', sa.Float(), default=0),
+        sa.Column('material_id', sa.Integer(), sa.ForeignKey('components.id'), nullable=True),
+        sa.Column('weight_override_g', sa.Float(), nullable=True),
+        sa.Column('print_type', sa.String(), nullable=True),
+        sa.Column('scale_factor', sa.Float(), default=1.0),
+        sa.Column('synced_from', sa.String(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Drop component_tree table."""
+    op.drop_table('component_tree')

--- a/app/api/v2/endpoints/aeroplane/component_tree.py
+++ b/app/api/v2/endpoints/aeroplane/component_tree.py
@@ -1,0 +1,135 @@
+"""Endpoints for the per-aeroplane component tree."""
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, status
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import (
+    NotFoundError,
+    ServiceException,
+    ValidationDomainError,
+    ValidationError,
+)
+from app.db.session import get_db
+from app.schemas.component_tree import (
+    ComponentTreeNodeRead,
+    ComponentTreeNodeWrite,
+    ComponentTreeResponse,
+    MoveNodeRequest,
+    WeightResponse,
+)
+from app.services import component_tree_service as svc
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/aeroplanes/{aeroplane_id}/component-tree",
+    tags=["component-tree"],
+)
+
+
+def _raise_http(exc: ServiceException) -> None:
+    if isinstance(exc, NotFoundError):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=exc.message) from exc
+    if isinstance(exc, (ValidationError, ValidationDomainError)):
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=exc.message) from exc
+    raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=exc.message) from exc
+
+
+def _call(func, *args, **kwargs):
+    try:
+        return func(*args, **kwargs)
+    except ServiceException as exc:
+        _raise_http(exc)
+
+
+@router.get(
+    "",
+    status_code=status.HTTP_200_OK,
+    response_model=ComponentTreeResponse,
+    operation_id="get_component_tree",
+)
+async def get_component_tree(
+    aeroplane_id: str = Path(...),
+    db: Session = Depends(get_db),
+) -> ComponentTreeResponse:
+    """Get the full component tree for an aeroplane."""
+    return _call(svc.get_tree, db, aeroplane_id)
+
+
+@router.post(
+    "",
+    status_code=status.HTTP_201_CREATED,
+    response_model=ComponentTreeNodeRead,
+    operation_id="add_tree_node",
+)
+async def add_tree_node(
+    aeroplane_id: str = Path(...),
+    body: ComponentTreeNodeWrite = Body(...),
+    db: Session = Depends(get_db),
+) -> ComponentTreeNodeRead:
+    """Add a node to the component tree."""
+    return _call(svc.add_node, db, aeroplane_id, body)
+
+
+@router.put(
+    "/{node_id}",
+    status_code=status.HTTP_200_OK,
+    response_model=ComponentTreeNodeRead,
+    operation_id="update_tree_node",
+)
+async def update_tree_node(
+    aeroplane_id: str = Path(...),
+    node_id: int = Path(...),
+    body: ComponentTreeNodeWrite = Body(...),
+    db: Session = Depends(get_db),
+) -> ComponentTreeNodeRead:
+    """Update a node in the component tree."""
+    return _call(svc.update_node, db, aeroplane_id, node_id, body)
+
+
+@router.delete(
+    "/{node_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    operation_id="delete_tree_node",
+)
+async def delete_tree_node(
+    aeroplane_id: str = Path(...),
+    node_id: int = Path(...),
+    db: Session = Depends(get_db),
+) -> None:
+    """Delete a node from the tree. Synced nodes cannot be deleted (use move instead)."""
+    _call(svc.delete_node, db, aeroplane_id, node_id)
+
+
+@router.post(
+    "/{node_id}/move",
+    status_code=status.HTTP_200_OK,
+    response_model=ComponentTreeNodeRead,
+    operation_id="move_tree_node",
+)
+async def move_tree_node(
+    aeroplane_id: str = Path(...),
+    node_id: int = Path(...),
+    body: MoveNodeRequest = Body(...),
+    db: Session = Depends(get_db),
+) -> ComponentTreeNodeRead:
+    """Move a node to a new parent position."""
+    return _call(svc.move_node, db, aeroplane_id, node_id, body.new_parent_id, body.sort_index)
+
+
+@router.get(
+    "/{node_id}/weight",
+    status_code=status.HTTP_200_OK,
+    response_model=WeightResponse,
+    operation_id="get_node_weight",
+)
+async def get_node_weight(
+    aeroplane_id: str = Path(...),
+    node_id: int = Path(...),
+    db: Session = Depends(get_db),
+) -> WeightResponse:
+    """Calculate the recursive weight for a node (own + all children)."""
+    return _call(svc.calculate_weight, db, aeroplane_id, node_id)

--- a/app/api/v2/endpoints/components.py
+++ b/app/api/v2/endpoints/components.py
@@ -1,7 +1,11 @@
 import logging
+import shutil
+from pathlib import Path as FilePath
 from typing import Optional
+from uuid import uuid4
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, status
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, UploadFile, File, status
+from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
 from app.core.exceptions import (
@@ -12,7 +16,13 @@ from app.core.exceptions import (
     ValidationError,
 )
 from app.db.session import get_db
-from app.schemas.component import ComponentList, ComponentRead, ComponentWrite
+from app.schemas.component import (
+    ComponentList,
+    ComponentRead,
+    ComponentTypesResponse,
+    ComponentWrite,
+    COMPONENT_TYPE_LIST,
+)
 from app.services import component_service as svc
 
 logger = logging.getLogger(__name__)
@@ -52,6 +62,17 @@ async def list_components(
 ) -> ComponentList:
     """List all components, optionally filtered by type or name search."""
     return _call(svc.list_components, db, component_type, q)
+
+
+@router.get(
+    "/types",
+    status_code=status.HTTP_200_OK,
+    response_model=ComponentTypesResponse,
+    operation_id="list_component_types",
+)
+async def list_component_types() -> ComponentTypesResponse:
+    """List all available component types."""
+    return ComponentTypesResponse(types=COMPONENT_TYPE_LIST)
 
 
 @router.post(
@@ -108,3 +129,74 @@ async def delete_component(
 ) -> None:
     """Delete a component from the library."""
     _call(svc.delete_component, db, component_id)
+
+
+# ── 3D Model Upload / Download ──────────────────────────────────
+
+MODELS_DIR = FilePath("tmp") / "component_models"
+
+
+@router.post(
+    "/{component_id}/model",
+    status_code=status.HTTP_200_OK,
+    response_model=ComponentRead,
+    operation_id="upload_component_model",
+)
+async def upload_component_model(
+    component_id: int = Path(..., description="The component ID"),
+    file: UploadFile = File(..., description="STEP or STL file"),
+    db: Session = Depends(get_db),
+) -> ComponentRead:
+    """Upload a STEP or STL 3D model file for a component."""
+    comp = _call(svc.get_component, db, component_id)
+
+    suffix = FilePath(file.filename or "model.step").suffix.lower()
+    if suffix not in (".step", ".stp", ".stl"):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Unsupported file type: {suffix}. Must be .step, .stp, or .stl",
+        )
+
+    MODELS_DIR.mkdir(parents=True, exist_ok=True)
+    dest = MODELS_DIR / f"{component_id}_{uuid4().hex[:8]}{suffix}"
+    with dest.open("wb") as out:
+        shutil.copyfileobj(file.file, out)
+
+    return _call(svc.update_component, db, component_id, ComponentWrite(
+        name=comp.name,
+        component_type=comp.component_type,
+        manufacturer=comp.manufacturer,
+        description=comp.description,
+        mass_g=comp.mass_g,
+        bbox_x_mm=comp.bbox_x_mm,
+        bbox_y_mm=comp.bbox_y_mm,
+        bbox_z_mm=comp.bbox_z_mm,
+        model_ref=str(dest),
+        specs=comp.specs,
+    ))
+
+
+@router.get(
+    "/{component_id}/model",
+    status_code=status.HTTP_200_OK,
+    operation_id="download_component_model",
+)
+async def download_component_model(
+    component_id: int = Path(..., description="The component ID"),
+    db: Session = Depends(get_db),
+) -> FileResponse:
+    """Download the 3D model file (STEP/STL) for a component."""
+    comp = _call(svc.get_component, db, component_id)
+    if not comp.model_ref:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Component {component_id} has no 3D model uploaded",
+        )
+    path = FilePath(comp.model_ref)
+    if not path.is_file():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Model file not found on disk: {path.name}",
+        )
+    media_type = "application/sla" if path.suffix.lower() == ".stl" else "application/step"
+    return FileResponse(path, media_type=media_type, filename=path.name)

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from fastapi.responses import JSONResponse
 
 from app.api.v2.endpoints import aeroplane as aeroplane_v2
 from app.api.v2.endpoints import components
+from app.api.v2.endpoints.aeroplane import component_tree
 from app.api.v2.endpoints import flight_profiles
 from app.api.v2.endpoints import health
 from app.core.platform import aerosandbox_available, cad_available
@@ -94,6 +95,7 @@ def create_app() -> FastAPI:
     app.include_router(health.router, prefix="", tags=["health"])
     app.include_router(aeroplane_v2.router, prefix="", tags=[])
     app.include_router(components.router, prefix="", tags=["components"])
+    app.include_router(component_tree.router, prefix="", tags=["component-tree"])
     app.include_router(flight_profiles.router, prefix="", tags=["flight-profiles"])
     if _cad_router is not None:
         app.include_router(_cad_router, prefix="", tags=["cad"])

--- a/app/models/component.py
+++ b/app/models/component.py
@@ -19,6 +19,10 @@ class ComponentModel(Base):
     manufacturer = Column(String, nullable=True)
     description = Column(String, nullable=True)
     mass_g = Column(Float, nullable=True)
+    bbox_x_mm = Column(Float, nullable=True)
+    bbox_y_mm = Column(Float, nullable=True)
+    bbox_z_mm = Column(Float, nullable=True)
+    model_ref = Column(String, nullable=True)
     specs = Column(JSON, nullable=False, default=dict)
     created_at = Column(
         DateTime(timezone=True),

--- a/app/models/component_tree.py
+++ b/app/models/component_tree.py
@@ -1,0 +1,67 @@
+"""Component Tree — hierarchical assembly structure per aeroplane."""
+
+from sqlalchemy import Column, Integer, String, Float, ForeignKey, DateTime, func
+from datetime import datetime, timezone
+
+from app.db.base import Base
+
+
+class ComponentTreeNodeModel(Base):
+    """A node in the component tree.
+
+    Three node types:
+    - "group": structural grouping (e.g. "main_wing", "electronics")
+    - "cad_shape": reference to a CadQuery shape from the Creator pipeline
+    - "cots": reference to a COTS component in the components catalog
+    """
+    __tablename__ = "component_tree"
+
+    aeroplane_id = Column(String, nullable=False, index=True)
+    parent_id = Column(Integer, ForeignKey("component_tree.id"), nullable=True)
+    sort_index = Column(Integer, default=0)
+
+    # Node identity
+    node_type = Column(String, nullable=False)  # "group", "cad_shape", "cots"
+    name = Column(String, nullable=False)
+
+    # For node_type = "cad_shape"
+    shape_key = Column(String, nullable=True)
+    shape_hash = Column(String, nullable=True)
+    volume_mm3 = Column(Float, nullable=True)
+    area_mm2 = Column(Float, nullable=True)
+
+    # For node_type = "cots"
+    component_id = Column(Integer, ForeignKey("components.id"), nullable=True)
+    quantity = Column(Integer, default=1)
+
+    # Position / Orientation (6-DOF)
+    pos_x = Column(Float, default=0)
+    pos_y = Column(Float, default=0)
+    pos_z = Column(Float, default=0)
+    rot_x = Column(Float, default=0)
+    rot_y = Column(Float, default=0)
+    rot_z = Column(Float, default=0)
+
+    # Weight
+    material_id = Column(Integer, ForeignKey("components.id"), nullable=True)
+    weight_override_g = Column(Float, nullable=True)
+    print_type = Column(String, nullable=True)  # "volume" or "surface"
+    scale_factor = Column(Float, default=1.0)
+
+    # Sync protection
+    synced_from = Column(String, nullable=True)  # e.g. "wing:main_wing" or "segment:main_wing:0"
+
+    created_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+        server_onupdate=func.now(),
+        nullable=False,
+    )

--- a/app/schemas/component.py
+++ b/app/schemas/component.py
@@ -13,6 +13,21 @@ COMPONENT_TYPES = Literal[
     "battery",
     "receiver",
     "flight_controller",
+    "material",
+    "propeller",
+    "generic",
+]
+
+COMPONENT_TYPE_LIST: list[str] = [
+    "servo",
+    "brushless_motor",
+    "esc",
+    "battery",
+    "receiver",
+    "flight_controller",
+    "material",
+    "propeller",
+    "generic",
 ]
 
 
@@ -22,9 +37,13 @@ class ComponentWrite(BaseModel):
     manufacturer: Optional[str] = Field(None, description="Manufacturer name")
     description: Optional[str] = Field(None, description="Free-text description")
     mass_g: Optional[float] = Field(None, ge=0, description="Mass in grams")
+    bbox_x_mm: Optional[float] = Field(None, ge=0, description="Bounding box X dimension in mm")
+    bbox_y_mm: Optional[float] = Field(None, ge=0, description="Bounding box Y dimension in mm")
+    bbox_z_mm: Optional[float] = Field(None, ge=0, description="Bounding box Z dimension in mm")
+    model_ref: Optional[str] = Field(None, description="Reference to STEP/STL 3D model file")
     specs: dict[str, Any] = Field(
         default_factory=dict,
-        description="Type-specific specifications (e.g. kv, capacity_mah, voltage_range)",
+        description="Type-specific specifications (e.g. kv, capacity_mah, voltage_range, density_kg_m3)",
     )
 
 
@@ -37,3 +56,7 @@ class ComponentRead(ComponentWrite):
 class ComponentList(BaseModel):
     items: list[ComponentRead] = Field(default_factory=list)
     total: int = Field(0, description="Total number of matching components")
+
+
+class ComponentTypesResponse(BaseModel):
+    types: list[str] = Field(..., description="List of all available component types")

--- a/app/schemas/component_tree.py
+++ b/app/schemas/component_tree.py
@@ -1,0 +1,76 @@
+"""Pydantic schemas for the component tree."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+NODE_TYPES = Literal["group", "cad_shape", "cots"]
+
+
+class ComponentTreeNodeWrite(BaseModel):
+    parent_id: Optional[int] = Field(None, description="Parent node ID, null for root")
+    sort_index: int = Field(0, description="Sort order among siblings")
+    node_type: NODE_TYPES = Field(..., description="Node type: group, cad_shape, or cots")
+    name: str = Field(..., min_length=1, description="Display name")
+
+    # cad_shape fields
+    shape_key: Optional[str] = Field(None, description="Key from create_shape() dict")
+    shape_hash: Optional[str] = Field(None, description="Hash of the Workplane object")
+    volume_mm3: Optional[float] = Field(None, ge=0, description="Volume in mm³")
+    area_mm2: Optional[float] = Field(None, ge=0, description="Surface area in mm²")
+
+    # cots fields
+    component_id: Optional[int] = Field(None, description="Reference to components table")
+    quantity: int = Field(1, ge=1, description="Quantity of this component")
+
+    # Position / Orientation
+    pos_x: float = Field(0, description="X position in mm")
+    pos_y: float = Field(0, description="Y position in mm")
+    pos_z: float = Field(0, description="Z position in mm")
+    rot_x: float = Field(0, description="Rotation around X in degrees")
+    rot_y: float = Field(0, description="Rotation around Y in degrees")
+    rot_z: float = Field(0, description="Rotation around Z in degrees")
+
+    # Weight
+    material_id: Optional[int] = Field(None, description="Material component ID (for print weight calc)")
+    weight_override_g: Optional[float] = Field(None, ge=0, description="Manual weight override in grams")
+    print_type: Optional[str] = Field(None, description="'volume' or 'surface' for 3D print weight calc")
+    scale_factor: float = Field(1.0, gt=0, description="Weight scaling factor (empirical)")
+
+
+class ComponentTreeNodeRead(ComponentTreeNodeWrite):
+    id: int
+    aeroplane_id: str
+    synced_from: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class ComponentTreeNodeWithChildren(ComponentTreeNodeRead):
+    """Node with nested children for tree response."""
+    children: list[ComponentTreeNodeWithChildren] = Field(default_factory=list)
+
+
+class ComponentTreeResponse(BaseModel):
+    """Full component tree for an aeroplane."""
+    aeroplane_id: str
+    root_nodes: list[ComponentTreeNodeWithChildren] = Field(default_factory=list)
+    total_nodes: int = 0
+
+
+class MoveNodeRequest(BaseModel):
+    new_parent_id: Optional[int] = Field(None, description="New parent node ID, null for root")
+    sort_index: int = Field(0, description="New sort index")
+
+
+class WeightResponse(BaseModel):
+    node_id: int
+    name: str
+    own_weight_g: Optional[float] = Field(None, description="This node's weight in grams")
+    children_weight_g: float = Field(0, description="Sum of children weights")
+    total_weight_g: float = Field(0, description="own + children")
+    source: str = Field("none", description="Weight source: calculated, override, cots, or none")

--- a/app/services/component_service.py
+++ b/app/services/component_service.py
@@ -21,6 +21,10 @@ def _to_schema(m: ComponentModel) -> ComponentRead:
         manufacturer=m.manufacturer,
         description=m.description,
         mass_g=m.mass_g,
+        bbox_x_mm=m.bbox_x_mm,
+        bbox_y_mm=m.bbox_y_mm,
+        bbox_z_mm=m.bbox_z_mm,
+        model_ref=m.model_ref,
         specs=m.specs or {},
         created_at=m.created_at,
         updated_at=m.updated_at,
@@ -36,7 +40,9 @@ def list_components(
     if component_type:
         query = query.filter(ComponentModel.component_type == component_type)
     if q:
-        query = query.filter(ComponentModel.name.ilike(f"%{q}%"))
+        query = query.filter(
+            ComponentModel.name.ilike(f"%{q}%") | ComponentModel.manufacturer.ilike(f"%{q}%")
+        )
     query = query.order_by(ComponentModel.component_type, ComponentModel.name)
     rows = query.all()
     return ComponentList(

--- a/app/services/component_tree_service.py
+++ b/app/services/component_tree_service.py
@@ -1,0 +1,304 @@
+"""Component Tree Service — CRUD + weight calculation for the assembly tree."""
+
+import logging
+from typing import Optional
+
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import InternalError, NotFoundError, ValidationError
+from app.models.component_tree import ComponentTreeNodeModel
+from app.models.component import ComponentModel
+from app.schemas.component_tree import (
+    ComponentTreeNodeRead,
+    ComponentTreeNodeWithChildren,
+    ComponentTreeNodeWrite,
+    ComponentTreeResponse,
+    WeightResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _to_schema(m: ComponentTreeNodeModel) -> ComponentTreeNodeRead:
+    return ComponentTreeNodeRead(
+        id=m.id,
+        aeroplane_id=m.aeroplane_id,
+        parent_id=m.parent_id,
+        sort_index=m.sort_index,
+        node_type=m.node_type,
+        name=m.name,
+        shape_key=m.shape_key,
+        shape_hash=m.shape_hash,
+        volume_mm3=m.volume_mm3,
+        area_mm2=m.area_mm2,
+        component_id=m.component_id,
+        quantity=m.quantity,
+        pos_x=m.pos_x,
+        pos_y=m.pos_y,
+        pos_z=m.pos_z,
+        rot_x=m.rot_x,
+        rot_y=m.rot_y,
+        rot_z=m.rot_z,
+        material_id=m.material_id,
+        weight_override_g=m.weight_override_g,
+        print_type=m.print_type,
+        scale_factor=m.scale_factor,
+        synced_from=m.synced_from,
+        created_at=m.created_at,
+        updated_at=m.updated_at,
+    )
+
+
+def _build_tree(
+    nodes: list[ComponentTreeNodeModel],
+) -> list[ComponentTreeNodeWithChildren]:
+    """Build nested tree from flat list of nodes."""
+    node_map: dict[int, ComponentTreeNodeWithChildren] = {}
+    for n in nodes:
+        node_map[n.id] = ComponentTreeNodeWithChildren(**_to_schema(n).model_dump(), children=[])
+
+    roots: list[ComponentTreeNodeWithChildren] = []
+    for n in nodes:
+        child = node_map[n.id]
+        if n.parent_id and n.parent_id in node_map:
+            node_map[n.parent_id].children.append(child)
+        else:
+            roots.append(child)
+
+    # Sort children by sort_index
+    for node in node_map.values():
+        node.children.sort(key=lambda c: c.sort_index)
+    roots.sort(key=lambda c: c.sort_index)
+
+    return roots
+
+
+def get_tree(db: Session, aeroplane_id: str) -> ComponentTreeResponse:
+    """Get the full component tree for an aeroplane."""
+    nodes = (
+        db.query(ComponentTreeNodeModel)
+        .filter(ComponentTreeNodeModel.aeroplane_id == aeroplane_id)
+        .order_by(ComponentTreeNodeModel.sort_index)
+        .all()
+    )
+    tree = _build_tree(nodes)
+    return ComponentTreeResponse(
+        aeroplane_id=aeroplane_id,
+        root_nodes=tree,
+        total_nodes=len(nodes),
+    )
+
+
+def add_node(
+    db: Session, aeroplane_id: str, data: ComponentTreeNodeWrite
+) -> ComponentTreeNodeRead:
+    """Add a node to the tree."""
+    try:
+        if data.parent_id:
+            parent = db.query(ComponentTreeNodeModel).filter(
+                ComponentTreeNodeModel.id == data.parent_id,
+                ComponentTreeNodeModel.aeroplane_id == aeroplane_id,
+            ).first()
+            if not parent:
+                raise NotFoundError(entity="Parent node", resource_id=data.parent_id)
+
+        node = ComponentTreeNodeModel(
+            aeroplane_id=aeroplane_id,
+            **data.model_dump(),
+        )
+        db.add(node)
+        db.commit()
+        db.refresh(node)
+        return _to_schema(node)
+    except NotFoundError:
+        raise
+    except SQLAlchemyError as exc:
+        db.rollback()
+        logger.error("DB error in add_node: %s", exc)
+        raise InternalError(message=f"Database error: {exc}") from exc
+
+
+def update_node(
+    db: Session, aeroplane_id: str, node_id: int, data: ComponentTreeNodeWrite
+) -> ComponentTreeNodeRead:
+    """Update a node in the tree."""
+    try:
+        node = db.query(ComponentTreeNodeModel).filter(
+            ComponentTreeNodeModel.id == node_id,
+            ComponentTreeNodeModel.aeroplane_id == aeroplane_id,
+        ).first()
+        if not node:
+            raise NotFoundError(entity="Component tree node", resource_id=node_id)
+
+        for key, value in data.model_dump().items():
+            setattr(node, key, value)
+        db.commit()
+        db.refresh(node)
+        return _to_schema(node)
+    except NotFoundError:
+        raise
+    except SQLAlchemyError as exc:
+        db.rollback()
+        logger.error("DB error in update_node: %s", exc)
+        raise InternalError(message=f"Database error: {exc}") from exc
+
+
+def delete_node(db: Session, aeroplane_id: str, node_id: int) -> None:
+    """Delete a node (and its children) from the tree."""
+    try:
+        node = db.query(ComponentTreeNodeModel).filter(
+            ComponentTreeNodeModel.id == node_id,
+            ComponentTreeNodeModel.aeroplane_id == aeroplane_id,
+        ).first()
+        if not node:
+            raise NotFoundError(entity="Component tree node", resource_id=node_id)
+
+        if node.synced_from:
+            raise ValidationError(
+                message=f"Cannot delete synced node '{node.name}' (synced from {node.synced_from}). "
+                        "Use move instead.",
+            )
+
+        # Delete children recursively
+        _delete_subtree(db, aeroplane_id, node_id)
+        db.delete(node)
+        db.commit()
+    except (NotFoundError, ValidationError):
+        raise
+    except SQLAlchemyError as exc:
+        db.rollback()
+        logger.error("DB error in delete_node: %s", exc)
+        raise InternalError(message=f"Database error: {exc}") from exc
+
+
+def _delete_subtree(db: Session, aeroplane_id: str, parent_id: int) -> None:
+    """Recursively delete all children of a node."""
+    children = db.query(ComponentTreeNodeModel).filter(
+        ComponentTreeNodeModel.aeroplane_id == aeroplane_id,
+        ComponentTreeNodeModel.parent_id == parent_id,
+    ).all()
+    for child in children:
+        _delete_subtree(db, aeroplane_id, child.id)
+        db.delete(child)
+
+
+def move_node(
+    db: Session, aeroplane_id: str, node_id: int, new_parent_id: Optional[int], sort_index: int
+) -> ComponentTreeNodeRead:
+    """Move a node to a new parent."""
+    try:
+        node = db.query(ComponentTreeNodeModel).filter(
+            ComponentTreeNodeModel.id == node_id,
+            ComponentTreeNodeModel.aeroplane_id == aeroplane_id,
+        ).first()
+        if not node:
+            raise NotFoundError(entity="Component tree node", resource_id=node_id)
+
+        if new_parent_id:
+            parent = db.query(ComponentTreeNodeModel).filter(
+                ComponentTreeNodeModel.id == new_parent_id,
+                ComponentTreeNodeModel.aeroplane_id == aeroplane_id,
+            ).first()
+            if not parent:
+                raise NotFoundError(entity="New parent node", resource_id=new_parent_id)
+            # Prevent moving to own descendant
+            if _is_descendant(db, aeroplane_id, new_parent_id, node_id):
+                raise ValidationError(message="Cannot move a node under its own subtree.")
+
+        node.parent_id = new_parent_id
+        node.sort_index = sort_index
+        db.commit()
+        db.refresh(node)
+        return _to_schema(node)
+    except (NotFoundError, ValidationError):
+        raise
+    except SQLAlchemyError as exc:
+        db.rollback()
+        logger.error("DB error in move_node: %s", exc)
+        raise InternalError(message=f"Database error: {exc}") from exc
+
+
+def _is_descendant(db: Session, aeroplane_id: str, candidate_id: int, ancestor_id: int) -> bool:
+    """Check if candidate is a descendant of ancestor."""
+    current = db.query(ComponentTreeNodeModel).filter(
+        ComponentTreeNodeModel.id == candidate_id,
+        ComponentTreeNodeModel.aeroplane_id == aeroplane_id,
+    ).first()
+    while current and current.parent_id:
+        if current.parent_id == ancestor_id:
+            return True
+        current = db.query(ComponentTreeNodeModel).filter(
+            ComponentTreeNodeModel.id == current.parent_id,
+        ).first()
+    return False
+
+
+def calculate_weight(db: Session, aeroplane_id: str, node_id: int) -> WeightResponse:
+    """Calculate recursive weight for a node."""
+    node = db.query(ComponentTreeNodeModel).filter(
+        ComponentTreeNodeModel.id == node_id,
+        ComponentTreeNodeModel.aeroplane_id == aeroplane_id,
+    ).first()
+    if not node:
+        raise NotFoundError(entity="Component tree node", resource_id=node_id)
+
+    own_weight, source = _calculate_own_weight(db, node)
+    children_weight = _calculate_children_weight(db, aeroplane_id, node_id)
+
+    return WeightResponse(
+        node_id=node_id,
+        name=node.name,
+        own_weight_g=own_weight,
+        children_weight_g=children_weight,
+        total_weight_g=(own_weight or 0) + children_weight,
+        source=source,
+    )
+
+
+def _calculate_own_weight(
+    db: Session, node: ComponentTreeNodeModel
+) -> tuple[Optional[float], str]:
+    """Calculate a single node's own weight."""
+    # Manual override takes precedence
+    if node.weight_override_g is not None:
+        return node.weight_override_g, "override"
+
+    # COTS component: use mass_g from catalog
+    if node.node_type == "cots" and node.component_id:
+        comp = db.query(ComponentModel).filter(ComponentModel.id == node.component_id).first()
+        if comp and comp.mass_g is not None:
+            return comp.mass_g * (node.quantity or 1), "cots"
+
+    # CAD shape: calculate from volume/area + material
+    if node.node_type == "cad_shape" and node.material_id:
+        material = db.query(ComponentModel).filter(ComponentModel.id == node.material_id).first()
+        if material:
+            specs = material.specs or {}
+            density = specs.get("density_kg_m3")
+            if density:
+                if node.print_type == "surface" and node.area_mm2 is not None:
+                    resolution = specs.get("print_resolution_mm", 0.4)
+                    # area_mm2 * resolution_mm * density_kg_m3 / 1e9 → kg, * 1000 → g
+                    weight_g = node.area_mm2 * resolution * density / 1e6 * node.scale_factor
+                    return weight_g, "calculated"
+                elif node.volume_mm3 is not None:
+                    # volume_mm3 * density_kg_m3 / 1e9 → kg, * 1000 → g
+                    weight_g = node.volume_mm3 * density / 1e6 * node.scale_factor
+                    return weight_g, "calculated"
+
+    return None, "none"
+
+
+def _calculate_children_weight(db: Session, aeroplane_id: str, parent_id: int) -> float:
+    """Recursively sum children weights."""
+    children = db.query(ComponentTreeNodeModel).filter(
+        ComponentTreeNodeModel.aeroplane_id == aeroplane_id,
+        ComponentTreeNodeModel.parent_id == parent_id,
+    ).all()
+    total = 0.0
+    for child in children:
+        own, _ = _calculate_own_weight(db, child)
+        children_sum = _calculate_children_weight(db, aeroplane_id, child.id)
+        total += (own or 0) + children_sum
+    return total

--- a/app/tests/test_component_tree.py
+++ b/app/tests/test_component_tree.py
@@ -1,0 +1,182 @@
+"""Tests for the component tree (GH#34)."""
+
+import uuid
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def _uid():
+    return f"test-{uuid.uuid4().hex[:8]}"
+
+
+class TestComponentTreeCRUD:
+
+    def test_get_empty_tree(self):
+        aero = _uid()
+        res = client.get(f"/aeroplanes/{aero}/component-tree")
+        assert res.status_code == 200
+        data = res.json()
+        assert data["root_nodes"] == []
+        assert data["total_nodes"] == 0
+
+    def test_add_root_group_node(self):
+        aero = _uid()
+        res = client.post(f"/aeroplanes/{aero}/component-tree", json={
+            "node_type": "group", "name": "eHawk",
+        })
+        assert res.status_code == 201
+        assert res.json()["node_type"] == "group"
+        assert res.json()["parent_id"] is None
+
+    def test_add_child_node(self):
+        aero = _uid()
+        parent = client.post(f"/aeroplanes/{aero}/component-tree", json={
+            "node_type": "group", "name": "main_wing",
+        }).json()
+        child = client.post(f"/aeroplanes/{aero}/component-tree", json={
+            "parent_id": parent["id"],
+            "node_type": "cad_shape", "name": "segment 0",
+            "shape_key": "seg0_shell",
+        }).json()
+        assert child["parent_id"] == parent["id"]
+
+    def test_add_cots_node(self):
+        aero = _uid()
+        comp = client.post("/components", json={
+            "name": "TreeTestServo", "component_type": "servo",
+            "mass_g": 14.0, "specs": {},
+        }).json()
+        node = client.post(f"/aeroplanes/{aero}/component-tree", json={
+            "node_type": "cots", "name": "Servo",
+            "component_id": comp["id"], "quantity": 2,
+        }).json()
+        assert node["component_id"] == comp["id"]
+        assert node["quantity"] == 2
+
+    def test_get_tree_nested(self):
+        aero = _uid()
+        root = client.post(f"/aeroplanes/{aero}/component-tree", json={
+            "node_type": "group", "name": "root",
+        }).json()
+        client.post(f"/aeroplanes/{aero}/component-tree", json={
+            "parent_id": root["id"],
+            "node_type": "group", "name": "wing",
+        })
+        tree = client.get(f"/aeroplanes/{aero}/component-tree").json()
+        assert tree["total_nodes"] == 2
+        assert tree["root_nodes"][0]["children"][0]["name"] == "wing"
+
+    def test_update_node(self):
+        aero = _uid()
+        node = client.post(f"/aeroplanes/{aero}/component-tree", json={
+            "node_type": "group", "name": "old",
+        }).json()
+        res = client.put(f"/aeroplanes/{aero}/component-tree/{node['id']}", json={
+            "node_type": "group", "name": "new",
+        })
+        assert res.status_code == 200
+        assert res.json()["name"] == "new"
+
+    def test_delete_node(self):
+        aero = _uid()
+        node = client.post(f"/aeroplanes/{aero}/component-tree", json={
+            "node_type": "group", "name": "delete_me",
+        }).json()
+        res = client.delete(f"/aeroplanes/{aero}/component-tree/{node['id']}")
+        assert res.status_code == 204
+
+    def test_delete_synced_node_rejected(self):
+        aero = _uid()
+        from app.db.session import get_db
+        from app.models.component_tree import ComponentTreeNodeModel
+        db = next(get_db())
+        node = ComponentTreeNodeModel(
+            aeroplane_id=aero, node_type="group", name="synced",
+            synced_from="wing:main_wing",
+        )
+        db.add(node)
+        db.commit()
+        db.refresh(node)
+        res = client.delete(f"/aeroplanes/{aero}/component-tree/{node.id}")
+        assert res.status_code == 422
+
+
+class TestMoveNode:
+
+    def test_move_node(self):
+        aero = _uid()
+        p1 = client.post(f"/aeroplanes/{aero}/component-tree", json={
+            "node_type": "group", "name": "p1",
+        }).json()
+        p2 = client.post(f"/aeroplanes/{aero}/component-tree", json={
+            "node_type": "group", "name": "p2",
+        }).json()
+        child = client.post(f"/aeroplanes/{aero}/component-tree", json={
+            "parent_id": p1["id"], "node_type": "group", "name": "child",
+        }).json()
+        res = client.post(f"/aeroplanes/{aero}/component-tree/{child['id']}/move", json={
+            "new_parent_id": p2["id"], "sort_index": 0,
+        })
+        assert res.json()["parent_id"] == p2["id"]
+
+
+class TestWeightCalculation:
+
+    def test_cots_weight(self):
+        aero = _uid()
+        comp = client.post("/components", json={
+            "name": "WtMotor", "component_type": "brushless_motor",
+            "mass_g": 50.0, "specs": {},
+        }).json()
+        node = client.post(f"/aeroplanes/{aero}/component-tree", json={
+            "node_type": "cots", "name": "motor",
+            "component_id": comp["id"],
+        }).json()
+        wt = client.get(f"/aeroplanes/{aero}/component-tree/{node['id']}/weight").json()
+        assert wt["own_weight_g"] == 50.0
+        assert wt["source"] == "cots"
+
+    def test_override_weight(self):
+        aero = _uid()
+        node = client.post(f"/aeroplanes/{aero}/component-tree", json={
+            "node_type": "cad_shape", "name": "shell",
+            "weight_override_g": 25.5,
+        }).json()
+        wt = client.get(f"/aeroplanes/{aero}/component-tree/{node['id']}/weight").json()
+        assert wt["own_weight_g"] == 25.5
+        assert wt["source"] == "override"
+
+    def test_recursive_weight(self):
+        aero = _uid()
+        parent = client.post(f"/aeroplanes/{aero}/component-tree", json={
+            "node_type": "group", "name": "assembly",
+        }).json()
+        client.post(f"/aeroplanes/{aero}/component-tree", json={
+            "parent_id": parent["id"],
+            "node_type": "cad_shape", "name": "a", "weight_override_g": 10.0,
+        })
+        client.post(f"/aeroplanes/{aero}/component-tree", json={
+            "parent_id": parent["id"],
+            "node_type": "cad_shape", "name": "b", "weight_override_g": 20.0,
+        })
+        wt = client.get(f"/aeroplanes/{aero}/component-tree/{parent['id']}/weight").json()
+        assert wt["children_weight_g"] == 30.0
+        assert wt["total_weight_g"] == 30.0
+
+    def test_calculated_volume_weight(self):
+        aero = _uid()
+        mat = client.post("/components", json={
+            "name": "PLA", "component_type": "material",
+            "specs": {"density_kg_m3": 1240},
+        }).json()
+        node = client.post(f"/aeroplanes/{aero}/component-tree", json={
+            "node_type": "cad_shape", "name": "wing_shell",
+            "volume_mm3": 10000, "material_id": mat["id"],
+            "print_type": "volume", "scale_factor": 1.0,
+        }).json()
+        wt = client.get(f"/aeroplanes/{aero}/component-tree/{node['id']}/weight").json()
+        assert wt["source"] == "calculated"
+        assert abs(wt["own_weight_g"] - 12.4) < 0.1

--- a/app/tests/test_component_tree.py
+++ b/app/tests/test_component_tree.py
@@ -1,123 +1,115 @@
-"""Tests for the component tree (GH#34)."""
+"""Tests for the component tree (GH#34).
 
-import uuid
-from fastapi.testclient import TestClient
+Uses the client_and_db fixture for in-memory SQLite isolation.
+"""
 
-from app.main import app
-
-client = TestClient(app)
-
-
-def _uid():
-    return f"test-{uuid.uuid4().hex[:8]}"
+from app.models.component_tree import ComponentTreeNodeModel
 
 
 class TestComponentTreeCRUD:
 
-    def test_get_empty_tree(self):
-        aero = _uid()
-        res = client.get(f"/aeroplanes/{aero}/component-tree")
+    def test_get_empty_tree(self, client_and_db):
+        client, _ = client_and_db
+        res = client.get("/aeroplanes/empty-aero/component-tree")
         assert res.status_code == 200
-        data = res.json()
-        assert data["root_nodes"] == []
-        assert data["total_nodes"] == 0
+        assert res.json()["root_nodes"] == []
+        assert res.json()["total_nodes"] == 0
 
-    def test_add_root_group_node(self):
-        aero = _uid()
-        res = client.post(f"/aeroplanes/{aero}/component-tree", json={
+    def test_add_root_group_node(self, client_and_db):
+        client, _ = client_and_db
+        res = client.post("/aeroplanes/a1/component-tree", json={
             "node_type": "group", "name": "eHawk",
         })
         assert res.status_code == 201
         assert res.json()["node_type"] == "group"
         assert res.json()["parent_id"] is None
 
-    def test_add_child_node(self):
-        aero = _uid()
-        parent = client.post(f"/aeroplanes/{aero}/component-tree", json={
+    def test_add_child_node(self, client_and_db):
+        client, _ = client_and_db
+        parent = client.post("/aeroplanes/a2/component-tree", json={
             "node_type": "group", "name": "main_wing",
         }).json()
-        child = client.post(f"/aeroplanes/{aero}/component-tree", json={
+        child = client.post("/aeroplanes/a2/component-tree", json={
             "parent_id": parent["id"],
             "node_type": "cad_shape", "name": "segment 0",
             "shape_key": "seg0_shell",
         }).json()
         assert child["parent_id"] == parent["id"]
 
-    def test_add_cots_node(self):
-        aero = _uid()
+    def test_add_cots_node(self, client_and_db):
+        client, _ = client_and_db
         comp = client.post("/components", json={
-            "name": "TreeTestServo", "component_type": "servo",
+            "name": "TreeServo", "component_type": "servo",
             "mass_g": 14.0, "specs": {},
         }).json()
-        node = client.post(f"/aeroplanes/{aero}/component-tree", json={
+        node = client.post("/aeroplanes/a3/component-tree", json={
             "node_type": "cots", "name": "Servo",
             "component_id": comp["id"], "quantity": 2,
         }).json()
         assert node["component_id"] == comp["id"]
         assert node["quantity"] == 2
 
-    def test_get_tree_nested(self):
-        aero = _uid()
-        root = client.post(f"/aeroplanes/{aero}/component-tree", json={
+    def test_get_tree_nested(self, client_and_db):
+        client, _ = client_and_db
+        root = client.post("/aeroplanes/a4/component-tree", json={
             "node_type": "group", "name": "root",
         }).json()
-        client.post(f"/aeroplanes/{aero}/component-tree", json={
+        client.post("/aeroplanes/a4/component-tree", json={
             "parent_id": root["id"],
             "node_type": "group", "name": "wing",
         })
-        tree = client.get(f"/aeroplanes/{aero}/component-tree").json()
+        tree = client.get("/aeroplanes/a4/component-tree").json()
         assert tree["total_nodes"] == 2
         assert tree["root_nodes"][0]["children"][0]["name"] == "wing"
 
-    def test_update_node(self):
-        aero = _uid()
-        node = client.post(f"/aeroplanes/{aero}/component-tree", json={
+    def test_update_node(self, client_and_db):
+        client, _ = client_and_db
+        node = client.post("/aeroplanes/a5/component-tree", json={
             "node_type": "group", "name": "old",
         }).json()
-        res = client.put(f"/aeroplanes/{aero}/component-tree/{node['id']}", json={
+        res = client.put(f"/aeroplanes/a5/component-tree/{node['id']}", json={
             "node_type": "group", "name": "new",
         })
         assert res.status_code == 200
         assert res.json()["name"] == "new"
 
-    def test_delete_node(self):
-        aero = _uid()
-        node = client.post(f"/aeroplanes/{aero}/component-tree", json={
+    def test_delete_node(self, client_and_db):
+        client, _ = client_and_db
+        node = client.post("/aeroplanes/a6/component-tree", json={
             "node_type": "group", "name": "delete_me",
         }).json()
-        res = client.delete(f"/aeroplanes/{aero}/component-tree/{node['id']}")
+        res = client.delete(f"/aeroplanes/a6/component-tree/{node['id']}")
         assert res.status_code == 204
 
-    def test_delete_synced_node_rejected(self):
-        aero = _uid()
-        from app.db.session import get_db
-        from app.models.component_tree import ComponentTreeNodeModel
-        db = next(get_db())
+    def test_delete_synced_node_rejected(self, client_and_db):
+        client, session_factory = client_and_db
+        db = session_factory()
         node = ComponentTreeNodeModel(
-            aeroplane_id=aero, node_type="group", name="synced",
+            aeroplane_id="a7", node_type="group", name="synced",
             synced_from="wing:main_wing",
         )
         db.add(node)
         db.commit()
         db.refresh(node)
-        res = client.delete(f"/aeroplanes/{aero}/component-tree/{node.id}")
+        res = client.delete(f"/aeroplanes/a7/component-tree/{node.id}")
         assert res.status_code == 422
+        db.close()
 
 
 class TestMoveNode:
 
-    def test_move_node(self):
-        aero = _uid()
-        p1 = client.post(f"/aeroplanes/{aero}/component-tree", json={
+    def test_move_node(self, client_and_db):
+        client, _ = client_and_db
+        p1 = client.post("/aeroplanes/m1/component-tree", json={
             "node_type": "group", "name": "p1",
         }).json()
-        p2 = client.post(f"/aeroplanes/{aero}/component-tree", json={
+        p2 = client.post("/aeroplanes/m1/component-tree", json={
             "node_type": "group", "name": "p2",
         }).json()
-        child = client.post(f"/aeroplanes/{aero}/component-tree", json={
+        child = client.post("/aeroplanes/m1/component-tree", json={
             "parent_id": p1["id"], "node_type": "group", "name": "child",
         }).json()
-        res = client.post(f"/aeroplanes/{aero}/component-tree/{child['id']}/move", json={
+        res = client.post(f"/aeroplanes/m1/component-tree/{child['id']}/move", json={
             "new_parent_id": p2["id"], "sort_index": 0,
         })
         assert res.json()["parent_id"] == p2["id"]
@@ -125,58 +117,58 @@ class TestMoveNode:
 
 class TestWeightCalculation:
 
-    def test_cots_weight(self):
-        aero = _uid()
+    def test_cots_weight(self, client_and_db):
+        client, _ = client_and_db
         comp = client.post("/components", json={
             "name": "WtMotor", "component_type": "brushless_motor",
             "mass_g": 50.0, "specs": {},
         }).json()
-        node = client.post(f"/aeroplanes/{aero}/component-tree", json={
+        node = client.post("/aeroplanes/w1/component-tree", json={
             "node_type": "cots", "name": "motor",
             "component_id": comp["id"],
         }).json()
-        wt = client.get(f"/aeroplanes/{aero}/component-tree/{node['id']}/weight").json()
+        wt = client.get(f"/aeroplanes/w1/component-tree/{node['id']}/weight").json()
         assert wt["own_weight_g"] == 50.0
         assert wt["source"] == "cots"
 
-    def test_override_weight(self):
-        aero = _uid()
-        node = client.post(f"/aeroplanes/{aero}/component-tree", json={
+    def test_override_weight(self, client_and_db):
+        client, _ = client_and_db
+        node = client.post("/aeroplanes/w2/component-tree", json={
             "node_type": "cad_shape", "name": "shell",
             "weight_override_g": 25.5,
         }).json()
-        wt = client.get(f"/aeroplanes/{aero}/component-tree/{node['id']}/weight").json()
+        wt = client.get(f"/aeroplanes/w2/component-tree/{node['id']}/weight").json()
         assert wt["own_weight_g"] == 25.5
         assert wt["source"] == "override"
 
-    def test_recursive_weight(self):
-        aero = _uid()
-        parent = client.post(f"/aeroplanes/{aero}/component-tree", json={
+    def test_recursive_weight(self, client_and_db):
+        client, _ = client_and_db
+        parent = client.post("/aeroplanes/w3/component-tree", json={
             "node_type": "group", "name": "assembly",
         }).json()
-        client.post(f"/aeroplanes/{aero}/component-tree", json={
+        client.post("/aeroplanes/w3/component-tree", json={
             "parent_id": parent["id"],
             "node_type": "cad_shape", "name": "a", "weight_override_g": 10.0,
         })
-        client.post(f"/aeroplanes/{aero}/component-tree", json={
+        client.post("/aeroplanes/w3/component-tree", json={
             "parent_id": parent["id"],
             "node_type": "cad_shape", "name": "b", "weight_override_g": 20.0,
         })
-        wt = client.get(f"/aeroplanes/{aero}/component-tree/{parent['id']}/weight").json()
+        wt = client.get(f"/aeroplanes/w3/component-tree/{parent['id']}/weight").json()
         assert wt["children_weight_g"] == 30.0
         assert wt["total_weight_g"] == 30.0
 
-    def test_calculated_volume_weight(self):
-        aero = _uid()
+    def test_calculated_volume_weight(self, client_and_db):
+        client, _ = client_and_db
         mat = client.post("/components", json={
             "name": "PLA", "component_type": "material",
             "specs": {"density_kg_m3": 1240},
         }).json()
-        node = client.post(f"/aeroplanes/{aero}/component-tree", json={
+        node = client.post("/aeroplanes/w4/component-tree", json={
             "node_type": "cad_shape", "name": "wing_shell",
             "volume_mm3": 10000, "material_id": mat["id"],
             "print_type": "volume", "scale_factor": 1.0,
         }).json()
-        wt = client.get(f"/aeroplanes/{aero}/component-tree/{node['id']}/weight").json()
+        wt = client.get(f"/aeroplanes/w4/component-tree/{node['id']}/weight").json()
         assert wt["source"] == "calculated"
         assert abs(wt["own_weight_g"] - 12.4) < 0.1

--- a/app/tests/test_components_catalog.py
+++ b/app/tests/test_components_catalog.py
@@ -1,0 +1,187 @@
+"""Tests for the extended components catalog (GH#37)."""
+
+import io
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+class TestComponentTypes:
+    """GET /components/types"""
+
+    def test_returns_all_types(self):
+        res = client.get("/components/types")
+        assert res.status_code == 200
+        data = res.json()
+        assert "types" in data
+        types = data["types"]
+        assert "servo" in types
+        assert "brushless_motor" in types
+        assert "material" in types
+        assert "propeller" in types
+        assert "generic" in types
+        assert len(types) == 9
+
+
+class TestComponentCRUDExtended:
+    """Test new fields (bbox, model_ref) and new types."""
+
+    def test_create_material_component(self):
+        res = client.post("/components", json={
+            "name": "PLA+",
+            "component_type": "material",
+            "manufacturer": "eSUN",
+            "mass_g": None,
+            "specs": {
+                "density_kg_m3": 1240,
+                "print_resolution_mm": 0.4,
+                "print_type": "volume",
+            },
+        })
+        assert res.status_code == 201
+        data = res.json()
+        assert data["component_type"] == "material"
+        assert data["specs"]["density_kg_m3"] == 1240
+
+    def test_create_propeller_component(self):
+        res = client.post("/components", json={
+            "name": "APC 10x5",
+            "component_type": "propeller",
+            "manufacturer": "APC",
+            "mass_g": 15,
+            "specs": {
+                "diameter_in": 10,
+                "pitch_in": 5,
+                "blades": 2,
+                "material": "glass-filled nylon",
+            },
+        })
+        assert res.status_code == 201
+        assert res.json()["component_type"] == "propeller"
+
+    def test_create_generic_component(self):
+        res = client.post("/components", json={
+            "name": "M3x10 Screw Pack",
+            "component_type": "generic",
+            "mass_g": 2.5,
+            "specs": {"quantity": 50, "material": "stainless steel"},
+        })
+        assert res.status_code == 201
+        assert res.json()["component_type"] == "generic"
+
+    def test_create_with_bbox(self):
+        res = client.post("/components", json={
+            "name": "Savox SH-0257MG",
+            "component_type": "servo",
+            "manufacturer": "Savox",
+            "mass_g": 14.2,
+            "bbox_x_mm": 22.8,
+            "bbox_y_mm": 12.0,
+            "bbox_z_mm": 25.4,
+            "specs": {"torque_kgcm": 2.2, "speed_s_60deg": 0.09, "voltage_v": 6.0},
+        })
+        assert res.status_code == 201
+        data = res.json()
+        assert data["bbox_x_mm"] == 22.8
+        assert data["bbox_y_mm"] == 12.0
+        assert data["bbox_z_mm"] == 25.4
+
+    def test_bbox_fields_default_to_none(self):
+        res = client.post("/components", json={
+            "name": "Simple Part",
+            "component_type": "generic",
+            "specs": {},
+        })
+        assert res.status_code == 201
+        data = res.json()
+        assert data["bbox_x_mm"] is None
+        assert data["bbox_y_mm"] is None
+        assert data["bbox_z_mm"] is None
+        assert data["model_ref"] is None
+
+
+class TestComponentSearch:
+    """Test search by name and manufacturer."""
+
+    def test_search_by_manufacturer(self):
+        # Create component with known manufacturer
+        client.post("/components", json={
+            "name": "Test Motor",
+            "component_type": "brushless_motor",
+            "manufacturer": "UniqueManufacturerXYZ",
+            "specs": {},
+        })
+        res = client.get("/components", params={"q": "UniqueManufacturer"})
+        assert res.status_code == 200
+        items = res.json()["items"]
+        assert any(c["manufacturer"] == "UniqueManufacturerXYZ" for c in items)
+
+
+class TestModelUploadDownload:
+    """Test STEP/STL file upload and download."""
+
+    def test_upload_step_file(self):
+        # Create component first
+        create_res = client.post("/components", json={
+            "name": "Upload Test Part",
+            "component_type": "generic",
+            "specs": {},
+        })
+        comp_id = create_res.json()["id"]
+
+        # Upload a fake STEP file
+        step_content = b"ISO-10303-21; (fake step content for testing)"
+        res = client.post(
+            f"/components/{comp_id}/model",
+            files={"file": ("test_part.step", io.BytesIO(step_content), "application/step")},
+        )
+        assert res.status_code == 200
+        data = res.json()
+        assert data["model_ref"] is not None
+        assert "step" in data["model_ref"]
+
+    def test_download_model_file(self):
+        # Create + upload
+        create_res = client.post("/components", json={
+            "name": "Download Test Part",
+            "component_type": "generic",
+            "specs": {},
+        })
+        comp_id = create_res.json()["id"]
+
+        step_content = b"ISO-10303-21; (fake step content for download test)"
+        client.post(
+            f"/components/{comp_id}/model",
+            files={"file": ("download_test.step", io.BytesIO(step_content), "application/step")},
+        )
+
+        # Download
+        res = client.get(f"/components/{comp_id}/model")
+        assert res.status_code == 200
+        assert b"ISO-10303-21" in res.content
+
+    def test_download_without_model_returns_404(self):
+        create_res = client.post("/components", json={
+            "name": "No Model Part",
+            "component_type": "generic",
+            "specs": {},
+        })
+        comp_id = create_res.json()["id"]
+        res = client.get(f"/components/{comp_id}/model")
+        assert res.status_code == 404
+
+    def test_upload_unsupported_format_rejected(self):
+        create_res = client.post("/components", json={
+            "name": "Bad Upload Part",
+            "component_type": "generic",
+            "specs": {},
+        })
+        comp_id = create_res.json()["id"]
+        res = client.post(
+            f"/components/{comp_id}/model",
+            files={"file": ("bad.pdf", io.BytesIO(b"pdf content"), "application/pdf")},
+        )
+        assert res.status_code == 422

--- a/app/tests/test_components_catalog.py
+++ b/app/tests/test_components_catalog.py
@@ -1,25 +1,19 @@
-"""Tests for the extended components catalog (GH#37)."""
+"""Tests for the extended components catalog (GH#37).
+
+Uses the client_and_db fixture for in-memory SQLite isolation.
+"""
 
 import io
-import pytest
-from fastapi.testclient import TestClient
-
-from app.main import app
-
-client = TestClient(app)
 
 
 class TestComponentTypes:
-    """GET /components/types"""
 
-    def test_returns_all_types(self):
+    def test_returns_all_types(self, client_and_db):
+        client, _ = client_and_db
         res = client.get("/components/types")
         assert res.status_code == 200
-        data = res.json()
-        assert "types" in data
-        types = data["types"]
+        types = res.json()["types"]
         assert "servo" in types
-        assert "brushless_motor" in types
         assert "material" in types
         assert "propeller" in types
         assert "generic" in types
@@ -27,52 +21,44 @@ class TestComponentTypes:
 
 
 class TestComponentCRUDExtended:
-    """Test new fields (bbox, model_ref) and new types."""
 
-    def test_create_material_component(self):
+    def test_create_material_component(self, client_and_db):
+        client, _ = client_and_db
         res = client.post("/components", json={
             "name": "PLA+",
             "component_type": "material",
             "manufacturer": "eSUN",
-            "mass_g": None,
-            "specs": {
-                "density_kg_m3": 1240,
-                "print_resolution_mm": 0.4,
-                "print_type": "volume",
-            },
+            "specs": {"density_kg_m3": 1240, "print_resolution_mm": 0.4, "print_type": "volume"},
         })
         assert res.status_code == 201
-        data = res.json()
-        assert data["component_type"] == "material"
-        assert data["specs"]["density_kg_m3"] == 1240
+        assert res.json()["component_type"] == "material"
+        assert res.json()["specs"]["density_kg_m3"] == 1240
 
-    def test_create_propeller_component(self):
+    def test_create_propeller_component(self, client_and_db):
+        client, _ = client_and_db
         res = client.post("/components", json={
             "name": "APC 10x5",
             "component_type": "propeller",
             "manufacturer": "APC",
             "mass_g": 15,
-            "specs": {
-                "diameter_in": 10,
-                "pitch_in": 5,
-                "blades": 2,
-                "material": "glass-filled nylon",
-            },
+            "specs": {"diameter_in": 10, "pitch_in": 5, "blades": 2},
         })
         assert res.status_code == 201
         assert res.json()["component_type"] == "propeller"
 
-    def test_create_generic_component(self):
+    def test_create_generic_component(self, client_and_db):
+        client, _ = client_and_db
         res = client.post("/components", json={
             "name": "M3x10 Screw Pack",
             "component_type": "generic",
             "mass_g": 2.5,
-            "specs": {"quantity": 50, "material": "stainless steel"},
+            "specs": {"quantity": 50},
         })
         assert res.status_code == 201
         assert res.json()["component_type"] == "generic"
 
-    def test_create_with_bbox(self):
+    def test_create_with_bbox(self, client_and_db):
+        client, _ = client_and_db
         res = client.post("/components", json={
             "name": "Savox SH-0257MG",
             "component_type": "servo",
@@ -81,7 +67,7 @@ class TestComponentCRUDExtended:
             "bbox_x_mm": 22.8,
             "bbox_y_mm": 12.0,
             "bbox_z_mm": 25.4,
-            "specs": {"torque_kgcm": 2.2, "speed_s_60deg": 0.09, "voltage_v": 6.0},
+            "specs": {"torque_kgcm": 2.2},
         })
         assert res.status_code == 201
         data = res.json()
@@ -89,7 +75,8 @@ class TestComponentCRUDExtended:
         assert data["bbox_y_mm"] == 12.0
         assert data["bbox_z_mm"] == 25.4
 
-    def test_bbox_fields_default_to_none(self):
+    def test_bbox_fields_default_to_none(self, client_and_db):
+        client, _ = client_and_db
         res = client.post("/components", json={
             "name": "Simple Part",
             "component_type": "generic",
@@ -98,16 +85,13 @@ class TestComponentCRUDExtended:
         assert res.status_code == 201
         data = res.json()
         assert data["bbox_x_mm"] is None
-        assert data["bbox_y_mm"] is None
-        assert data["bbox_z_mm"] is None
         assert data["model_ref"] is None
 
 
 class TestComponentSearch:
-    """Test search by name and manufacturer."""
 
-    def test_search_by_manufacturer(self):
-        # Create component with known manufacturer
+    def test_search_by_manufacturer(self, client_and_db):
+        client, _ = client_and_db
         client.post("/components", json={
             "name": "Test Motor",
             "component_type": "brushless_motor",
@@ -116,72 +100,51 @@ class TestComponentSearch:
         })
         res = client.get("/components", params={"q": "UniqueManufacturer"})
         assert res.status_code == 200
-        items = res.json()["items"]
-        assert any(c["manufacturer"] == "UniqueManufacturerXYZ" for c in items)
+        assert any(c["manufacturer"] == "UniqueManufacturerXYZ" for c in res.json()["items"])
 
 
 class TestModelUploadDownload:
-    """Test STEP/STL file upload and download."""
 
-    def test_upload_step_file(self):
-        # Create component first
-        create_res = client.post("/components", json={
-            "name": "Upload Test Part",
-            "component_type": "generic",
-            "specs": {},
-        })
-        comp_id = create_res.json()["id"]
-
-        # Upload a fake STEP file
-        step_content = b"ISO-10303-21; (fake step content for testing)"
+    def test_upload_step_file(self, client_and_db):
+        client, _ = client_and_db
+        comp = client.post("/components", json={
+            "name": "Upload Test", "component_type": "generic", "specs": {},
+        }).json()
         res = client.post(
-            f"/components/{comp_id}/model",
-            files={"file": ("test_part.step", io.BytesIO(step_content), "application/step")},
+            f"/components/{comp['id']}/model",
+            files={"file": ("test.step", io.BytesIO(b"ISO-10303-21;"), "application/step")},
         )
         assert res.status_code == 200
-        data = res.json()
-        assert data["model_ref"] is not None
-        assert "step" in data["model_ref"]
+        assert res.json()["model_ref"] is not None
 
-    def test_download_model_file(self):
-        # Create + upload
-        create_res = client.post("/components", json={
-            "name": "Download Test Part",
-            "component_type": "generic",
-            "specs": {},
-        })
-        comp_id = create_res.json()["id"]
-
-        step_content = b"ISO-10303-21; (fake step content for download test)"
+    def test_download_model_file(self, client_and_db):
+        client, _ = client_and_db
+        comp = client.post("/components", json={
+            "name": "Download Test", "component_type": "generic", "specs": {},
+        }).json()
         client.post(
-            f"/components/{comp_id}/model",
-            files={"file": ("download_test.step", io.BytesIO(step_content), "application/step")},
+            f"/components/{comp['id']}/model",
+            files={"file": ("dl.step", io.BytesIO(b"ISO-10303-21; content"), "application/step")},
         )
-
-        # Download
-        res = client.get(f"/components/{comp_id}/model")
+        res = client.get(f"/components/{comp['id']}/model")
         assert res.status_code == 200
         assert b"ISO-10303-21" in res.content
 
-    def test_download_without_model_returns_404(self):
-        create_res = client.post("/components", json={
-            "name": "No Model Part",
-            "component_type": "generic",
-            "specs": {},
-        })
-        comp_id = create_res.json()["id"]
-        res = client.get(f"/components/{comp_id}/model")
+    def test_download_without_model_returns_404(self, client_and_db):
+        client, _ = client_and_db
+        comp = client.post("/components", json={
+            "name": "No Model", "component_type": "generic", "specs": {},
+        }).json()
+        res = client.get(f"/components/{comp['id']}/model")
         assert res.status_code == 404
 
-    def test_upload_unsupported_format_rejected(self):
-        create_res = client.post("/components", json={
-            "name": "Bad Upload Part",
-            "component_type": "generic",
-            "specs": {},
-        })
-        comp_id = create_res.json()["id"]
+    def test_upload_unsupported_format_rejected(self, client_and_db):
+        client, _ = client_and_db
+        comp = client.post("/components", json={
+            "name": "Bad Upload", "component_type": "generic", "specs": {},
+        }).json()
         res = client.post(
-            f"/components/{comp_id}/model",
-            files={"file": ("bad.pdf", io.BytesIO(b"pdf content"), "application/pdf")},
+            f"/components/{comp['id']}/model",
+            files={"file": ("bad.pdf", io.BytesIO(b"pdf"), "application/pdf")},
         )
         assert res.status_code == 422


### PR DESCRIPTION
## Summary

New `component_tree` table with adjacency list structure for per-aeroplane assembly hierarchy:

- **3 node types:** group (structural), cad_shape (CAD geometry ref), cots (catalog component ref)
- **6-DOF positioning** per node (pos_x/y/z, rot_x/y/z)
- **Weight calculation:** Volume×Density, Area×Resolution×Density, manual override, recursive aggregation
- **Material assignment** per node (links to material components from catalog)
- **Sync protection:** nodes with `synced_from` cannot be deleted (only moved)
- **Move operation:** reparent nodes with cycle detection

### API

| Method | Endpoint | Purpose |
|--------|----------|---------|
| GET | `/aeroplanes/{id}/component-tree` | Full nested tree |
| POST | `/aeroplanes/{id}/component-tree` | Add node |
| PUT | `/aeroplanes/{id}/component-tree/{node_id}` | Update node |
| DELETE | `/aeroplanes/{id}/component-tree/{node_id}` | Delete node |
| POST | `/aeroplanes/{id}/component-tree/{node_id}/move` | Reparent node |
| GET | `/aeroplanes/{id}/component-tree/{node_id}/weight` | Recursive weight |

## Test plan

- [ ] `poetry run ruff check .` — clean
- [ ] `poetry run pytest app/tests/ -m "not slow"` — 241+ tests green
- [ ] `poetry run pytest app/tests/test_component_tree.py -v` — 13 tests

Depends on #55 (GH#37 components catalog extension).
Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)