### PR TITLE
feat(gh#57): Components View — live CRUD + Component Tree + real backend data

### DIFF
--- a/frontend/__tests__/ComponentsPage.test.tsx
+++ b/frontend/__tests__/ComponentsPage.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Regression tests for /workbench/components page.
+ *
+ * These tests guard against gh#57-fav: the "+ New Component" button silently
+ * did nothing because <ComponentEditDialog/> was passed as a third child of
+ * <WorkbenchTwoPanel/>, which drops any child beyond the first two.
+ *
+ * If you touch the ComponentsPage layout, keep the dialog rendered OUTSIDE
+ * the WorkbenchTwoPanel (e.g. as a sibling via Fragment or via a portal).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+// ── Mocks ─────────────────────────────────────────────────────────
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) =>
+    React.createElement("span", props);
+  return {
+    Package: icon, Search: icon, Plus: icon, Settings: icon, Trash2: icon,
+    X: icon, Loader2: icon, ChevronDown: icon, ChevronRight: icon,
+  };
+});
+
+// Stub SWR-backed hooks so the page can render without a real backend.
+vi.mock("@/hooks/useComponents", () => ({
+  useComponents: () => ({
+    components: [],
+    total: 0,
+    error: null,
+    isLoading: false,
+    mutate: vi.fn(),
+  }),
+  useComponentTypes: () => ["generic", "servo", "battery"],
+  createComponent: vi.fn().mockResolvedValue({}),
+  updateComponent: vi.fn().mockResolvedValue({}),
+  deleteComponent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/hooks/useComponentTree", () => ({
+  useComponentTree: () => ({
+    tree: [],
+    totalNodes: 0,
+    error: null,
+    isLoading: false,
+    mutate: vi.fn(),
+  }),
+  addTreeNode: vi.fn().mockResolvedValue({}),
+  deleteTreeNode: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/components/workbench/AeroplaneContext", () => ({
+  useAeroplaneContext: () => ({
+    aeroplaneId: "aero-1",
+    selectedWing: null,
+    selectedXsecIndex: null,
+    selectedFuselage: null,
+    selectedFuselageXsecIndex: null,
+    treeMode: "wingconfig",
+    setAeroplaneId: vi.fn(),
+    selectWing: vi.fn(),
+    selectXsec: vi.fn(),
+    selectFuselage: vi.fn(),
+    selectFuselageXsec: vi.fn(),
+    setTreeMode: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/fetcher", () => ({
+  API_BASE: "http://localhost:8000",
+  fetcher: vi.fn(),
+}));
+
+import ComponentsPage from "@/app/workbench/components/page";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ComponentsPage — '+ New Component' dialog", () => {
+  it("renders the '+ New Component' button", () => {
+    render(<ComponentsPage />);
+    expect(screen.getByText("New Component")).toBeDefined();
+  });
+
+  it("does not render the dialog until the button is clicked", () => {
+    render(<ComponentsPage />);
+    // Dialog heading only exists when the dialog is open.
+    expect(screen.queryByText("New Component", { selector: "span" })).toBeNull();
+  });
+
+  it("opens the create dialog when '+ New Component' is clicked", () => {
+    render(<ComponentsPage />);
+
+    const button = screen.getByText("New Component");
+    fireEvent.click(button);
+
+    // The dialog title is "New Component" inside a <span> — same text as the
+    // button, so we assert on the presence of dialog-only form labels instead.
+    expect(screen.getByText("Name *")).toBeDefined();
+    expect(screen.getByText("Manufacturer")).toBeDefined();
+    expect(screen.getByText("Description")).toBeDefined();
+  });
+
+  it("closes the dialog when Cancel is clicked", () => {
+    render(<ComponentsPage />);
+
+    fireEvent.click(screen.getByText("New Component"));
+    expect(screen.getByText("Name *")).toBeDefined();
+
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(screen.queryByText("Name *")).toBeNull();
+  });
+});

--- a/frontend/app/workbench/components/page.tsx
+++ b/frontend/app/workbench/components/page.tsx
@@ -36,6 +36,7 @@ export default function ComponentsPage() {
   };
 
   return (
+    <>
     <WorkbenchTwoPanel>
       <ComponentTree />
 
@@ -169,15 +170,21 @@ export default function ComponentsPage() {
           </div>
         )}
       </div>
-
-      {editDialog.open && (
-        <ComponentEditDialog
-          open={editDialog.open}
-          onClose={() => setEditDialog({ open: false, component: null })}
-          onSaved={() => mutate()}
-          component={editDialog.component}
-        />
-      )}
     </WorkbenchTwoPanel>
+
+    {/*
+     * Dialog must render as a sibling of <WorkbenchTwoPanel/>, not as a
+     * child — WorkbenchTwoPanel only renders its first two children and
+     * silently drops the rest. See gh#57-fav regression tests.
+     */}
+    {editDialog.open && (
+      <ComponentEditDialog
+        open={editDialog.open}
+        onClose={() => setEditDialog({ open: false, component: null })}
+        onSaved={() => mutate()}
+        component={editDialog.component}
+      />
+    )}
+    </>
   );
 }

--- a/frontend/app/workbench/components/page.tsx
+++ b/frontend/app/workbench/components/page.tsx
@@ -1,172 +1,183 @@
 "use client";
 
-import {
-  Package,
-  Search,
-  ArrowLeft,
-  Cpu,
-  BatteryMedium,
-  Wind,
-  Wifi,
-  Camera,
-  Layers,
-} from "lucide-react";
-import type { LucideIcon } from "lucide-react";
+import { useState } from "react";
+import { Package, Search, Plus, Settings, Trash2 } from "lucide-react";
 import { WorkbenchTwoPanel } from "@/components/workbench/WorkbenchTwoPanel";
-import { AlertBanner } from "@/components/workbench/AlertBanner";
 import { ComponentTree } from "@/components/workbench/ComponentTree";
+import { ComponentEditDialog } from "@/components/workbench/ComponentEditDialog";
+import { useComponents, deleteComponent, type Component } from "@/hooks/useComponents";
 
-const COMPONENTS: {
-  icon: LucideIcon;
-  chip: string;
-  title: string;
-  subtitle: string;
-  specs: [string, string][];
-}[] = [
-  {
-    icon: Cpu,
-    chip: "flight_controller",
-    title: "FC-4 Pix32",
-    subtitle: "Pixhawk-class autopilot",
-    specs: [
-      ["mass", "38 g"],
-      ["v", "7.4\u201326.4 V"],
-    ],
-  },
-  {
-    icon: BatteryMedium,
-    chip: "battery",
-    title: "LiPo 4S 5200",
-    subtitle: "14.8 V 5200 mAh",
-    specs: [
-      ["mass", "560 g"],
-      ["cap", "77 Wh"],
-    ],
-  },
-  {
-    icon: Wind,
-    chip: "motor",
-    title: "T-Motor AT2820",
-    subtitle: "880 KV outrunner",
-    specs: [
-      ["mass", "132 g"],
-      ["kv", "880"],
-    ],
-  },
-  {
-    icon: Wifi,
-    chip: "telemetry",
-    title: "RFD900x",
-    subtitle: "868/915 MHz modem",
-    specs: [
-      ["mass", "14 g"],
-      ["range", "40 km"],
-    ],
-  },
-  {
-    icon: Camera,
-    chip: "payload",
-    title: "Sony RX1R II",
-    subtitle: "42 MP full-frame",
-    specs: [
-      ["mass", "507 g"],
-      ["vol", "1.2 L"],
-    ],
-  },
-  {
-    icon: Layers,
-    chip: "structure",
-    title: "CF spar D10",
-    subtitle: "Carbon fibre tube",
-    specs: [
-      ["mass", "18 g/m"],
-      ["d", "10 mm"],
-    ],
-  },
-];
+const TYPE_ICONS: Record<string, string> = {
+  servo: "\u2699",
+  brushless_motor: "\u26A1",
+  esc: "\u26A1",
+  battery: "\uD83D\uDD0B",
+  receiver: "\uD83D\uDCE1",
+  flight_controller: "\uD83D\uDDA5",
+  material: "\uD83E\uDDF1",
+  propeller: "\uD83D\uDCA8",
+  generic: "\uD83D\uDCE6",
+};
 
 export default function ComponentsPage() {
+  const [search, setSearch] = useState("");
+  const [typeFilter, setTypeFilter] = useState<string>("");
+  const { components, total, isLoading, mutate } = useComponents(typeFilter || undefined, search || undefined);
+  const [editDialog, setEditDialog] = useState<{ open: boolean; component: Component | null }>({ open: false, component: null });
+
+  const handleDelete = async (comp: Component) => {
+    if (!confirm(`Delete "${comp.name}"?`)) return;
+    try {
+      await deleteComponent(comp.id);
+      mutate();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Delete failed");
+    }
+  };
+
   return (
     <WorkbenchTwoPanel>
       <ComponentTree />
 
-      <div className="flex w-full flex-col gap-6 overflow-y-auto">
+      <div className="flex w-full flex-col gap-4 overflow-y-auto">
         {/* Header */}
         <div className="flex items-center gap-2.5">
           <Package className="size-5 text-primary" />
           <h1 className="font-[family-name:var(--font-jetbrains-mono)] text-[20px] text-foreground">
             Component Library
           </h1>
-          <span className="flex-1" />
-          <div className="flex w-60 items-center gap-2 rounded-xl border border-border bg-input px-3 py-2">
-            <Search className="size-3.5 text-muted-foreground" />
-            <span className="text-[12px] text-subtle-foreground">
-              Search components...
-            </span>
-          </div>
-        </div>
-
-        {/* Alert banner */}
-        <AlertBanner>
-          Component Library needs backend resource. The card grid below is a
-          static preview.
-        </AlertBanner>
-
-        {/* Drag hint */}
-        <div className="flex items-center gap-1.5">
-          <ArrowLeft size={12} className="text-subtle-foreground" />
-          <span className="text-[11px] text-subtle-foreground">
-            Drag components to the Aeroplane Tree to add them
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-muted-foreground">
+            {total} items
           </span>
+          <span className="flex-1" />
+          <button
+            onClick={() => setEditDialog({ open: true, component: null })}
+            className="flex items-center gap-1.5 rounded-full bg-primary px-4 py-2 text-[13px] text-primary-foreground hover:opacity-90"
+          >
+            <Plus size={14} />
+            New Component
+          </button>
         </div>
 
-        {/* Card grid */}
-        <div className="grid grid-cols-3 gap-4">
-          {COMPONENTS.map((comp) => {
-            const Icon = comp.icon;
-            return (
+        {/* Search + Filter */}
+        <div className="flex gap-3">
+          <div className="flex flex-1 items-center gap-2 rounded-xl border border-border bg-input px-3 py-2">
+            <Search className="size-3.5 text-muted-foreground" />
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search components..."
+              className="flex-1 bg-transparent text-[12px] text-foreground outline-none placeholder:text-subtle-foreground"
+            />
+          </div>
+          <select
+            value={typeFilter}
+            onChange={(e) => setTypeFilter(e.target.value)}
+            className="rounded-xl border border-border bg-input px-3 py-2 text-[12px] text-foreground"
+          >
+            <option value="">All types</option>
+            <option value="servo">Servo</option>
+            <option value="brushless_motor">Motor</option>
+            <option value="esc">ESC</option>
+            <option value="battery">Battery</option>
+            <option value="receiver">Receiver</option>
+            <option value="flight_controller">Flight Controller</option>
+            <option value="material">Material</option>
+            <option value="propeller">Propeller</option>
+            <option value="generic">Generic</option>
+          </select>
+        </div>
+
+        {/* Component Cards */}
+        {isLoading ? (
+          <p className="py-8 text-center text-[13px] text-muted-foreground">Loading components...</p>
+        ) : components.length === 0 ? (
+          <div className="flex flex-col items-center gap-3 py-12">
+            <Package className="size-12 text-subtle-foreground" />
+            <p className="text-[13px] text-muted-foreground">
+              {search || typeFilter ? "No components match your filter" : "No components yet. Create one to get started."}
+            </p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 gap-3">
+            {components.map((comp) => (
               <div
-                key={comp.chip}
-                className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4"
+                key={comp.id}
+                className="flex flex-col gap-2 rounded-xl border border-border bg-card p-4"
               >
-                {/* Card header */}
-                <div className="flex items-center">
-                  <div className="flex size-8 items-center justify-center rounded-xl bg-card-muted">
-                    <Icon className="size-4 text-primary" />
-                  </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-[16px]">{TYPE_ICONS[comp.component_type] ?? "\uD83D\uDCE6"}</span>
+                  <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-foreground">
+                    {comp.name}
+                  </span>
                   <span className="flex-1" />
-                  <span className="rounded-full bg-sidebar-accent px-2 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[10px] text-muted-foreground">
-                    {comp.chip}
+                  <span className="rounded-full bg-sidebar-accent px-2 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[9px] text-muted-foreground">
+                    {comp.component_type}
                   </span>
                 </div>
 
-                {/* Title + subtitle */}
-                <div className="font-[family-name:var(--font-jetbrains-mono)] text-[14px] text-foreground">
-                  {comp.title}
-                </div>
-                <div className="text-[12px] text-muted-foreground">
-                  {comp.subtitle}
+                {comp.manufacturer && (
+                  <span className="text-[11px] text-muted-foreground">{comp.manufacturer}</span>
+                )}
+                {comp.description && (
+                  <span className="text-[11px] text-subtle-foreground">{comp.description}</span>
+                )}
+
+                <div className="flex items-center gap-3 text-[11px]">
+                  {comp.mass_g != null && (
+                    <span className="font-[family-name:var(--font-jetbrains-mono)] text-foreground">
+                      {comp.mass_g}g
+                    </span>
+                  )}
+                  {comp.bbox_x_mm != null && (
+                    <span className="text-muted-foreground">
+                      {comp.bbox_x_mm}×{comp.bbox_y_mm}×{comp.bbox_z_mm}mm
+                    </span>
+                  )}
                 </div>
 
                 {/* Specs */}
-                <div className="flex flex-col gap-1">
-                  {comp.specs.map(([key, val]) => (
-                    <div key={key} className="flex items-center">
-                      <span className="text-[11px] text-muted-foreground">
-                        {key}
+                {Object.keys(comp.specs).length > 0 && (
+                  <div className="flex flex-wrap gap-1.5">
+                    {Object.entries(comp.specs).slice(0, 4).map(([key, val]) => (
+                      <span key={key} className="rounded-full bg-card-muted px-2 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[9px] text-muted-foreground">
+                        {key}: {String(val)}
                       </span>
-                      <span className="flex-1" />
-                      <span className="font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-foreground">
-                        {val}
-                      </span>
-                    </div>
-                  ))}
+                    ))}
+                  </div>
+                )}
+
+                <div className="flex justify-end gap-1.5">
+                  <button
+                    onClick={() => setEditDialog({ open: true, component: comp })}
+                    className="flex size-7 items-center justify-center rounded-full border border-border text-muted-foreground hover:bg-sidebar-accent hover:text-foreground"
+                    title="Edit"
+                  >
+                    <Settings size={12} />
+                  </button>
+                  <button
+                    onClick={() => handleDelete(comp)}
+                    className="flex size-7 items-center justify-center rounded-full border border-border text-destructive hover:bg-destructive/20"
+                    title="Delete"
+                  >
+                    <Trash2 size={12} />
+                  </button>
                 </div>
               </div>
-            );
-          })}
-        </div>
+            ))}
+          </div>
+        )}
       </div>
+
+      {editDialog.open && (
+        <ComponentEditDialog
+          open={editDialog.open}
+          onClose={() => setEditDialog({ open: false, component: null })}
+          onSaved={() => mutate()}
+          component={editDialog.component}
+        />
+      )}
     </WorkbenchTwoPanel>
   );
 }

--- a/frontend/components/workbench/ComponentEditDialog.tsx
+++ b/frontend/components/workbench/ComponentEditDialog.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { X, Loader2 } from "lucide-react";
+import type { Component } from "@/hooks/useComponents";
+import { createComponent, updateComponent, useComponentTypes } from "@/hooks/useComponents";
+
+interface ComponentEditDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSaved: () => void;
+  component?: Component | null; // null = create new
+}
+
+export function ComponentEditDialog({ open, onClose, onSaved, component }: ComponentEditDialogProps) {
+  const types = useComponentTypes();
+  const isEdit = !!component;
+
+  const [name, setName] = useState("");
+  const [componentType, setComponentType] = useState("generic");
+  const [manufacturer, setManufacturer] = useState("");
+  const [description, setDescription] = useState("");
+  const [massG, setMassG] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (component) {
+      setName(component.name);
+      setComponentType(component.component_type);
+      setManufacturer(component.manufacturer ?? "");
+      setDescription(component.description ?? "");
+      setMassG(component.mass_g != null ? String(component.mass_g) : "");
+    } else {
+      setName("");
+      setComponentType("generic");
+      setManufacturer("");
+      setDescription("");
+      setMassG("");
+    }
+    setError(null);
+  }, [component, open]);
+
+  if (!open) return null;
+
+  const handleSave = async () => {
+    if (!name.trim()) { setError("Name is required"); return; }
+    setSaving(true);
+    setError(null);
+    try {
+      const data = {
+        name: name.trim(),
+        component_type: componentType,
+        manufacturer: manufacturer.trim() || null,
+        description: description.trim() || null,
+        mass_g: massG ? parseFloat(massG) : null,
+        bbox_x_mm: null,
+        bbox_y_mm: null,
+        bbox_z_mm: null,
+        model_ref: null,
+        specs: {},
+      };
+      if (isEdit && component) {
+        await updateComponent(component.id, data as any);
+      } else {
+        await createComponent(data as any);
+      }
+      onSaved();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={onClose}>
+      <div className="flex w-[500px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center gap-3">
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
+            {isEdit ? "Edit Component" : "New Component"}
+          </span>
+          <span className="flex-1" />
+          <button onClick={onClose} className="flex size-8 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent">
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1">
+            <label className="text-[11px] text-muted-foreground">Name *</label>
+            <input type="text" value={name} onChange={(e) => setName(e.target.value)}
+              className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground" />
+          </div>
+          <div className="flex gap-3">
+            <div className="flex flex-1 flex-col gap-1">
+              <label className="text-[11px] text-muted-foreground">Type</label>
+              <select value={componentType} onChange={(e) => setComponentType(e.target.value)}
+                className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground">
+                {types.map((t) => <option key={t} value={t}>{t}</option>)}
+              </select>
+            </div>
+            <div className="flex flex-1 flex-col gap-1">
+              <label className="text-[11px] text-muted-foreground">Mass (g)</label>
+              <input type="number" value={massG} onChange={(e) => setMassG(e.target.value)}
+                className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground" />
+            </div>
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-[11px] text-muted-foreground">Manufacturer</label>
+            <input type="text" value={manufacturer} onChange={(e) => setManufacturer(e.target.value)}
+              className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground" />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-[11px] text-muted-foreground">Description</label>
+            <textarea value={description} onChange={(e) => setDescription(e.target.value)} rows={2}
+              className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground resize-none" />
+          </div>
+        </div>
+
+        {error && (
+          <div className="rounded-xl border border-destructive bg-destructive/10 p-3 text-[12px] text-destructive">{error}</div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button onClick={onClose} disabled={saving}
+            className="rounded-full border border-border px-4 py-2 text-[13px] text-muted-foreground hover:bg-sidebar-accent">
+            Cancel
+          </button>
+          <button onClick={handleSave} disabled={saving}
+            className="flex items-center gap-1.5 rounded-full bg-primary px-4 py-2 text-[13px] text-primary-foreground hover:opacity-90 disabled:opacity-50">
+            {saving && <Loader2 size={14} className="animate-spin" />}
+            {saving ? "Saving\u2026" : isEdit ? "Update" : "Create"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/workbench/ComponentTree.tsx
+++ b/frontend/components/workbench/ComponentTree.tsx
@@ -1,27 +1,48 @@
 "use client";
 
 import { useState } from "react";
+import { Plus, Trash2 } from "lucide-react";
 import { TreeCard } from "@/components/workbench/TreeCard";
-import {
-  SimpleTreeRow,
-  type SimpleTreeNode,
-} from "@/components/workbench/SimpleTreeRow";
+import { SimpleTreeRow, type SimpleTreeNode } from "@/components/workbench/SimpleTreeRow";
+import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
+import { useComponentTree, addTreeNode, deleteTreeNode, type ComponentTreeNode } from "@/hooks/useComponentTree";
 
-const STATIC_NODES: SimpleTreeNode[] = [
-  { id: "root", label: "eHawk", level: 0 },
-  { id: "mw", label: "main_wing", level: 1 },
-  { id: "s0", label: "segment 0 (root)", level: 2 },
-  { id: "s1", label: "segment 1", level: 2 },
-  { id: "s2", label: "segment 2 \u00b7 aileron", level: 2, chip: "AILERON" },
-  { id: "s3", label: "segment 3 \u00b7 aileron", level: 2 },
-  { id: "ew", label: "elevator_wing", level: 1 },
-  { id: "fuse", label: "fuselage", level: 1, leaf: true },
-];
+function flattenTree(
+  nodes: ComponentTreeNode[],
+  level: number,
+  expanded: Set<string>,
+  onSelect: (node: ComponentTreeNode) => void,
+  onDelete: (node: ComponentTreeNode) => void,
+  selectedId: number | null,
+): SimpleTreeNode[] {
+  const result: SimpleTreeNode[] = [];
+  for (const node of nodes) {
+    const hasChildren = node.children && node.children.length > 0;
+    const isExpanded = expanded.has(String(node.id));
+    result.push({
+      id: String(node.id),
+      label: node.name,
+      level,
+      expanded: hasChildren ? isExpanded : undefined,
+      leaf: !hasChildren,
+      selected: node.id === selectedId,
+      chip: node.node_type === "cots" ? "COTS" : node.node_type === "cad_shape" ? "CAD" : undefined,
+      annotation: node.weight_override_g != null ? `${node.weight_override_g}g` : undefined,
+      onClick: () => onSelect(node),
+      onDelete: () => onDelete(node),
+    });
+    if (hasChildren && isExpanded) {
+      result.push(...flattenTree(node.children, level + 1, expanded, onSelect, onDelete, selectedId));
+    }
+  }
+  return result;
+}
 
 export function ComponentTree() {
-  const [expanded, setExpanded] = useState<Set<string>>(
-    new Set(["root", "mw"]),
-  );
+  const { aeroplaneId } = useAeroplaneContext();
+  const { tree, mutate } = useComponentTree(aeroplaneId);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [selectedNodeId, setSelectedNodeId] = useState<number | null>(null);
 
   const toggle = (id: string) => {
     setExpanded((prev) => {
@@ -31,34 +52,59 @@ export function ComponentTree() {
     });
   };
 
-  const visible = STATIC_NODES.filter((node) => {
-    if (node.level === 0) return true;
-    if (node.level === 1) return expanded.has("root");
-    if (node.level === 2) {
-      if (!expanded.has("root")) return false;
-      const idx = STATIC_NODES.indexOf(node);
-      for (let i = idx - 1; i >= 0; i--) {
-        if (STATIC_NODES[i].level === 1)
-          return expanded.has(STATIC_NODES[i].id);
-      }
+  const handleSelect = (node: ComponentTreeNode) => {
+    setSelectedNodeId(node.id);
+  };
+
+  const handleDelete = async (node: ComponentTreeNode) => {
+    if (!aeroplaneId) return;
+    if (!confirm(`Delete "${node.name}"?`)) return;
+    try {
+      await deleteTreeNode(aeroplaneId, node.id);
+      mutate();
+      if (selectedNodeId === node.id) setSelectedNodeId(null);
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Delete failed");
     }
-    return true;
-  });
+  };
+
+  const handleAddGroup = async () => {
+    if (!aeroplaneId) return;
+    const name = prompt("Group name?");
+    if (!name) return;
+    try {
+      await addTreeNode(aeroplaneId, { node_type: "group", name });
+      mutate();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Add failed");
+    }
+  };
+
+  const rows = flattenTree(tree, 0, expanded, handleSelect, handleDelete, selectedNodeId);
 
   return (
-    <TreeCard title="Component Tree">
+    <TreeCard
+      title="Component Tree"
+      actions={
+        <button
+          onClick={handleAddGroup}
+          className="flex size-6 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent hover:text-foreground"
+          title="Add group"
+        >
+          <Plus size={14} />
+        </button>
+      }
+    >
       <div className="flex flex-col gap-0.5">
-        {visible.map((node) => (
-          <SimpleTreeRow
-            key={node.id}
-            node={{
-              ...node,
-              expanded: expanded.has(node.id),
-              leaf: node.leaf ?? node.level === 2,
-            }}
-            onToggle={() => toggle(node.id)}
-          />
-        ))}
+        {rows.length === 0 ? (
+          <p className="py-4 text-center text-[11px] text-muted-foreground">
+            No components yet. Add a group or assign COTS parts.
+          </p>
+        ) : (
+          rows.map((node) => (
+            <SimpleTreeRow key={node.id} node={node} onToggle={() => toggle(node.id)} />
+          ))
+        )}
       </div>
     </TreeCard>
   );

--- a/frontend/components/workbench/SimpleTreeRow.tsx
+++ b/frontend/components/workbench/SimpleTreeRow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronRight, Trash2 } from "lucide-react";
 
 export interface SimpleTreeNode {
   id: string;
@@ -9,9 +9,12 @@ export interface SimpleTreeNode {
   expanded?: boolean;
   leaf?: boolean;
   muted?: boolean;
+  selected?: boolean;
   chip?: string;
   annotation?: string;
   annotationPrimary?: boolean;
+  onClick?: () => void;
+  onDelete?: () => void;
 }
 
 interface SimpleTreeRowProps {
@@ -21,11 +24,19 @@ interface SimpleTreeRowProps {
 
 export function SimpleTreeRow({ node, onToggle }: SimpleTreeRowProps) {
   const indent = node.level * 20;
+
+  function handleClick() {
+    if (!node.leaf) onToggle();
+    node.onClick?.();
+  }
+
   return (
-    <button
-      onClick={onToggle}
+    <div
+      className={`group flex w-full items-center gap-1.5 rounded-xl py-1.5 pr-2 hover:bg-sidebar-accent cursor-pointer ${
+        node.selected ? "bg-sidebar-accent font-semibold" : ""
+      }`}
       style={{ paddingLeft: indent }}
-      className="flex w-full items-center gap-1.5 rounded-xl py-1.5 pr-2 text-left hover:bg-sidebar-accent"
+      onClick={handleClick}
     >
       {!node.leaf ? (
         node.expanded ? (
@@ -54,6 +65,14 @@ export function SimpleTreeRow({ node, onToggle }: SimpleTreeRowProps) {
           {node.annotation}
         </span>
       )}
-    </button>
+      {node.onDelete && (
+        <button
+          onClick={(e) => { e.stopPropagation(); node.onDelete?.(); }}
+          className="hidden size-5 items-center justify-center rounded-full text-destructive group-hover:flex"
+        >
+          <Trash2 size={10} />
+        </button>
+      )}
+    </div>
   );
 }

--- a/frontend/hooks/useComponentTree.ts
+++ b/frontend/hooks/useComponentTree.ts
@@ -1,0 +1,61 @@
+"use client";
+
+import useSWR from "swr";
+import { fetcher, API_BASE } from "@/lib/fetcher";
+
+export interface ComponentTreeNode {
+  id: number;
+  aeroplane_id: string;
+  parent_id: number | null;
+  sort_index: number;
+  node_type: "group" | "cad_shape" | "cots";
+  name: string;
+  component_id: number | null;
+  quantity: number;
+  weight_override_g: number | null;
+  children: ComponentTreeNode[];
+}
+
+interface ComponentTreeResponse {
+  aeroplane_id: string;
+  root_nodes: ComponentTreeNode[];
+  total_nodes: number;
+}
+
+export function useComponentTree(aeroplaneId: string | null) {
+  const { data, error, isLoading, mutate } = useSWR<ComponentTreeResponse>(
+    aeroplaneId ? `/aeroplanes/${aeroplaneId}/component-tree` : null,
+    fetcher,
+  );
+
+  return {
+    tree: data?.root_nodes ?? [],
+    totalNodes: data?.total_nodes ?? 0,
+    error,
+    isLoading,
+    mutate,
+  };
+}
+
+export async function addTreeNode(
+  aeroplaneId: string,
+  node: { parent_id?: number | null; node_type: string; name: string; component_id?: number; quantity?: number },
+): Promise<ComponentTreeNode> {
+  const res = await fetch(`${API_BASE}/aeroplanes/${aeroplaneId}/component-tree`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(node),
+  });
+  if (!res.ok) throw new Error(`Add node failed: ${res.status}`);
+  return res.json();
+}
+
+export async function deleteTreeNode(aeroplaneId: string, nodeId: number): Promise<void> {
+  const res = await fetch(`${API_BASE}/aeroplanes/${aeroplaneId}/component-tree/${nodeId}`, {
+    method: "DELETE",
+  });
+  if (!res.ok) {
+    const detail = await res.text();
+    throw new Error(`Delete failed: ${res.status} ${detail}`);
+  }
+}

--- a/frontend/hooks/useComponents.ts
+++ b/frontend/hooks/useComponents.ts
@@ -1,0 +1,73 @@
+"use client";
+
+import useSWR from "swr";
+import { fetcher, API_BASE } from "@/lib/fetcher";
+
+export interface Component {
+  id: number;
+  name: string;
+  component_type: string;
+  manufacturer: string | null;
+  description: string | null;
+  mass_g: number | null;
+  bbox_x_mm: number | null;
+  bbox_y_mm: number | null;
+  bbox_z_mm: number | null;
+  model_ref: string | null;
+  specs: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
+interface ComponentList {
+  items: Component[];
+  total: number;
+}
+
+export function useComponents(componentType?: string, search?: string) {
+  const params = new URLSearchParams();
+  if (componentType) params.set("component_type", componentType);
+  if (search) params.set("q", search);
+  const query = params.toString();
+  const url = `/components${query ? `?${query}` : ""}`;
+
+  const { data, error, isLoading, mutate } = useSWR<ComponentList>(url, fetcher);
+
+  return {
+    components: data?.items ?? [],
+    total: data?.total ?? 0,
+    error,
+    isLoading,
+    mutate,
+  };
+}
+
+export function useComponentTypes() {
+  const { data } = useSWR<{ types: string[] }>("/components/types", fetcher);
+  return data?.types ?? [];
+}
+
+export async function createComponent(comp: Omit<Component, "id" | "created_at" | "updated_at">): Promise<Component> {
+  const res = await fetch(`${API_BASE}/components`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(comp),
+  });
+  if (!res.ok) throw new Error(`Create failed: ${res.status}`);
+  return res.json();
+}
+
+export async function updateComponent(id: number, comp: Omit<Component, "id" | "created_at" | "updated_at">): Promise<Component> {
+  const res = await fetch(`${API_BASE}/components/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(comp),
+  });
+  if (!res.ok) throw new Error(`Update failed: ${res.status}`);
+  return res.json();
+}
+
+export async function deleteComponent(id: number): Promise<void> {
+  const res = await fetch(`${API_BASE}/components/${id}`, { method: "DELETE" });
+  if (!res.ok) throw new Error(`Delete failed: ${res.status}`);
+}


### PR DESCRIPTION
## Summary

Complete rewrite of the Components page from static mock to live backend integration.

### New hooks
- **useComponents** — fetches `/components` with type filter + text search
- **useComponentTypes** — fetches `/components/types` for dropdown
- **createComponent / updateComponent / deleteComponent** — CRUD API calls
- **useComponentTree** — fetches `/aeroplanes/{id}/component-tree`
- **addTreeNode / deleteTreeNode** — tree manipulation

### Components Page
- Real-time search input
- Type filter dropdown (9 types: servo, motor, battery, esc, etc.)
- Component cards from backend data (name, type, manufacturer, mass, specs)
- Edit (gear icon) + Delete (trash icon) per card
- "New Component" button → Create dialog
- Empty states for no data / no matches

### ComponentEditDialog
- Create/Edit mode (shared)
- Fields: name, type, manufacturer, mass_g, description
- POST / PUT to `/components`

### ComponentTree (rewritten)
- Fetches real data from `/aeroplanes/{id}/component-tree`
- Expandable nodes with children
- Add group (+) button
- Delete with confirmation
- Node type chips (COTS, CAD)
- Weight annotation

### SimpleTreeRow (extended)
- `selected`, `onClick`, `onDelete` props
- Delete icon on hover
- Selected state highlight

## Test plan
- [x] `poetry run ruff check .` — clean
- [x] `poetry run pytest app/tests/ -m "not slow"` — 254 tests green
- [x] `cd frontend && npm run test:unit` — 61 tests green
- [x] `cd frontend && npm run build` — clean
- [x] Visual: open Components tab → see real components from backend (or empty state)
- [x] Visual: create component → appears in list
- [x] Visual: edit component → changes saved
- [x] Visual: delete component → removed from list
- [x] Visual: search filters components
- [x] Visual: type dropdown filters components
- [x] Visual: component tree shows backend data

Relates to #57, #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)