### PR TITLE
feat(gh#57): Construction-Parts backend — listing + lock/unlock

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -32,6 +32,7 @@ from app.db.base import Base
 import app.models.aeroplanemodel       # this module imports Base and defines tables
 import app.models.flightprofilemodel
 import app.models.component
+import app.models.construction_part
 import app.models.tessellation_cache
 
 target_metadata = Base.metadata

--- a/alembic/versions/4a9c81984e86_add_construction_parts_table.py
+++ b/alembic/versions/4a9c81984e86_add_construction_parts_table.py
@@ -1,0 +1,63 @@
+"""add_construction_parts_table
+
+Revision ID: 4a9c81984e86
+Revises: b456b2d255b9
+Create Date: 2026-04-16 08:00:40.241639
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '4a9c81984e86'
+down_revision: Union[str, None] = 'b456b2d255b9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create construction_parts table (gh#57-g4h)."""
+    op.create_table(
+        'construction_parts',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('aeroplane_id', sa.String(), nullable=False, index=True),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('volume_mm3', sa.Float(), nullable=True),
+        sa.Column('area_mm2', sa.Float(), nullable=True),
+        sa.Column('bbox_x_mm', sa.Float(), nullable=True),
+        sa.Column('bbox_y_mm', sa.Float(), nullable=True),
+        sa.Column('bbox_z_mm', sa.Float(), nullable=True),
+        sa.Column(
+            'material_component_id',
+            sa.Integer(),
+            sa.ForeignKey('components.id'),
+            nullable=True,
+        ),
+        sa.Column(
+            'locked',
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text('0'),
+        ),
+        sa.Column('thumbnail_url', sa.String(), nullable=True),
+        sa.Column(
+            'created_at',
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            'updated_at',
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop construction_parts table."""
+    op.drop_table('construction_parts')

--- a/app/api/v2/endpoints/aeroplane/construction_parts.py
+++ b/app/api/v2/endpoints/aeroplane/construction_parts.py
@@ -1,0 +1,102 @@
+"""Endpoints for the per-aeroplane Construction-Parts domain (gh#57-g4h)."""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Path, status
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import (
+    NotFoundError,
+    ServiceException,
+    ValidationDomainError,
+    ValidationError,
+)
+from app.db.session import get_db
+from app.schemas.construction_part import ConstructionPartList, ConstructionPartRead
+from app.services import construction_part_service as svc
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/aeroplanes/{aeroplane_id}/construction-parts",
+    tags=["construction-parts"],
+)
+
+
+def _raise_http(exc: ServiceException) -> None:
+    if isinstance(exc, NotFoundError):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=exc.message) from exc
+    if isinstance(exc, (ValidationError, ValidationDomainError)):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=exc.message
+        ) from exc
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=exc.message
+    ) from exc
+
+
+def _call(func, *args, **kwargs):
+    try:
+        return func(*args, **kwargs)
+    except ServiceException as exc:
+        _raise_http(exc)
+
+
+@router.get(
+    "",
+    status_code=status.HTTP_200_OK,
+    response_model=ConstructionPartList,
+    operation_id="list_construction_parts",
+)
+async def list_construction_parts(
+    aeroplane_id: str = Path(...),
+    db: Session = Depends(get_db),
+) -> ConstructionPartList:
+    """List all construction parts owned by the given aeroplane."""
+    return _call(svc.list_parts, db, aeroplane_id)
+
+
+@router.get(
+    "/{part_id}",
+    status_code=status.HTTP_200_OK,
+    response_model=ConstructionPartRead,
+    operation_id="get_construction_part",
+)
+async def get_construction_part(
+    aeroplane_id: str = Path(...),
+    part_id: int = Path(...),
+    db: Session = Depends(get_db),
+) -> ConstructionPartRead:
+    """Fetch a single construction part scoped to the given aeroplane."""
+    return _call(svc.get_part, db, aeroplane_id, part_id)
+
+
+@router.put(
+    "/{part_id}/lock",
+    status_code=status.HTTP_200_OK,
+    response_model=ConstructionPartRead,
+    operation_id="lock_construction_part",
+)
+async def lock_construction_part(
+    aeroplane_id: str = Path(...),
+    part_id: int = Path(...),
+    db: Session = Depends(get_db),
+) -> ConstructionPartRead:
+    """Mark the part as locked. Idempotent."""
+    return _call(svc.lock_part, db, aeroplane_id, part_id)
+
+
+@router.put(
+    "/{part_id}/unlock",
+    status_code=status.HTTP_200_OK,
+    response_model=ConstructionPartRead,
+    operation_id="unlock_construction_part",
+)
+async def unlock_construction_part(
+    aeroplane_id: str = Path(...),
+    part_id: int = Path(...),
+    db: Session = Depends(get_db),
+) -> ConstructionPartRead:
+    """Mark the part as unlocked. Idempotent."""
+    return _call(svc.unlock_part, db, aeroplane_id, part_id)

--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ from fastapi.responses import JSONResponse
 from app.api.v2.endpoints import aeroplane as aeroplane_v2
 from app.api.v2.endpoints import components
 from app.api.v2.endpoints.aeroplane import component_tree
+from app.api.v2.endpoints.aeroplane import construction_parts
 from app.api.v2.endpoints import flight_profiles
 from app.api.v2.endpoints import fuselage_slice
 from app.api.v2.endpoints import health
@@ -97,6 +98,7 @@ def create_app() -> FastAPI:
     app.include_router(aeroplane_v2.router, prefix="", tags=[])
     app.include_router(components.router, prefix="", tags=["components"])
     app.include_router(component_tree.router, prefix="", tags=["component-tree"])
+    app.include_router(construction_parts.router, prefix="", tags=["construction-parts"])
     app.include_router(flight_profiles.router, prefix="", tags=["flight-profiles"])
     app.include_router(fuselage_slice.router, prefix="", tags=["fuselages"])
     if _cad_router is not None:

--- a/app/models/construction_part.py
+++ b/app/models/construction_part.py
@@ -1,0 +1,61 @@
+"""Construction Part — per-aeroplane CAD bauteil (typically 3D-printed).
+
+Complements the global COTS Component Library (``components`` table).
+The MVP tracks only metadata and the ``locked`` flag that protects the
+part from being overwritten by a future regeneration pipeline (gh#57-qim).
+Actual STEP/STL file storage and full CRUD arrive in a follow-up ticket
+(gh#57-9uk).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Integer, String, func
+
+from app.db.base import Base
+
+
+class ConstructionPartModel(Base):
+    """A CAD part that belongs to a specific aeroplane."""
+
+    __tablename__ = "construction_parts"
+
+    aeroplane_id = Column(String, nullable=False, index=True)
+    name = Column(String, nullable=False)
+
+    # Geometry metadata (populated when the file is uploaded; nullable until then)
+    volume_mm3 = Column(Float, nullable=True)
+    area_mm2 = Column(Float, nullable=True)
+    bbox_x_mm = Column(Float, nullable=True)
+    bbox_y_mm = Column(Float, nullable=True)
+    bbox_z_mm = Column(Float, nullable=True)
+
+    # Reference to a material entry in the generic component library
+    # (components.component_type == 'material'). The service layer does not
+    # enforce the type — the frontend filters the dropdown.
+    material_component_id = Column(
+        Integer,
+        ForeignKey("components.id"),
+        nullable=True,
+    )
+
+    # Lock protects the stored part from being overwritten by a regeneration
+    # pipeline. Tree operations (move, add, remove) are not affected.
+    locked = Column(Boolean, nullable=False, default=False, server_default="0")
+
+    thumbnail_url = Column(String, nullable=True)
+
+    created_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+        server_onupdate=func.now(),
+        nullable=False,
+    )

--- a/app/schemas/construction_part.py
+++ b/app/schemas/construction_part.py
@@ -1,0 +1,50 @@
+"""Pydantic schemas for the construction-parts domain (gh#57-g4h)."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ConstructionPartRead(BaseModel):
+    """Read view of a construction part.
+
+    Write/create schemas will follow in gh#57-9uk (file upload + CRUD).
+    The MVP exposes only read + lock/unlock, which do not need a Write schema.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int = Field(..., description="Construction-Part ID")
+    aeroplane_id: str = Field(..., description="Owning aeroplane ID")
+    name: str = Field(..., description="Display name")
+
+    volume_mm3: Optional[float] = Field(None, ge=0, description="Volume in mm³")
+    area_mm2: Optional[float] = Field(None, ge=0, description="Surface area in mm²")
+    bbox_x_mm: Optional[float] = Field(None, ge=0, description="Bounding box X dimension in mm")
+    bbox_y_mm: Optional[float] = Field(None, ge=0, description="Bounding box Y dimension in mm")
+    bbox_z_mm: Optional[float] = Field(None, ge=0, description="Bounding box Z dimension in mm")
+
+    material_component_id: Optional[int] = Field(
+        None,
+        description="FK to components table; expected to point at a component_type='material' entry",
+    )
+
+    locked: bool = Field(
+        False,
+        description="True if the DB entry is protected from overwrites by a regeneration pipeline",
+    )
+
+    thumbnail_url: Optional[str] = Field(None, description="Optional preview image URL")
+
+    created_at: datetime
+    updated_at: datetime
+
+
+class ConstructionPartList(BaseModel):
+    """Listing response for a specific aeroplane."""
+
+    aeroplane_id: str = Field(..., description="Aeroplane scope of the listing")
+    items: list[ConstructionPartRead] = Field(default_factory=list)
+    total: int = Field(0, description="Total number of parts returned")

--- a/app/services/construction_part_service.py
+++ b/app/services/construction_part_service.py
@@ -1,0 +1,84 @@
+"""Construction Parts service (gh#57-g4h).
+
+MVP: list, get, lock, unlock. File upload/download and general CRUD
+arrive in gh#57-9uk.
+"""
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import InternalError, NotFoundError
+from app.models.construction_part import ConstructionPartModel
+from app.schemas.construction_part import ConstructionPartList, ConstructionPartRead
+
+logger = logging.getLogger(__name__)
+
+
+def _get_part_or_404(
+    db: Session, aeroplane_id: str, part_id: int
+) -> ConstructionPartModel:
+    """Fetch a part by (aeroplane_id, id). Raises NotFoundError if either check fails.
+
+    Aeroplane scoping is enforced here so that callers cannot cross-access a
+    part that belongs to a different aeroplane by guessing its ID.
+    """
+    part = (
+        db.query(ConstructionPartModel)
+        .filter(
+            ConstructionPartModel.id == part_id,
+            ConstructionPartModel.aeroplane_id == aeroplane_id,
+        )
+        .first()
+    )
+    if part is None:
+        raise NotFoundError(entity="ConstructionPart", resource_id=part_id)
+    return part
+
+
+def list_parts(db: Session, aeroplane_id: str) -> ConstructionPartList:
+    rows = (
+        db.query(ConstructionPartModel)
+        .filter(ConstructionPartModel.aeroplane_id == aeroplane_id)
+        .order_by(ConstructionPartModel.name)
+        .all()
+    )
+    return ConstructionPartList(
+        aeroplane_id=aeroplane_id,
+        items=[ConstructionPartRead.model_validate(r) for r in rows],
+        total=len(rows),
+    )
+
+
+def get_part(db: Session, aeroplane_id: str, part_id: int) -> ConstructionPartRead:
+    part = _get_part_or_404(db, aeroplane_id, part_id)
+    return ConstructionPartRead.model_validate(part)
+
+
+def _set_locked(
+    db: Session, aeroplane_id: str, part_id: int, locked: bool
+) -> ConstructionPartRead:
+    try:
+        part = _get_part_or_404(db, aeroplane_id, part_id)
+        part.locked = locked
+        db.commit()
+        db.refresh(part)
+        return ConstructionPartRead.model_validate(part)
+    except NotFoundError:
+        raise
+    except SQLAlchemyError as exc:
+        db.rollback()
+        logger.error("DB error while toggling lock on part %s: %s", part_id, exc)
+        raise InternalError(message=f"Database error: {exc}") from exc
+
+
+def lock_part(db: Session, aeroplane_id: str, part_id: int) -> ConstructionPartRead:
+    """Set locked=True. Idempotent when the part is already locked."""
+    return _set_locked(db, aeroplane_id, part_id, True)
+
+
+def unlock_part(db: Session, aeroplane_id: str, part_id: int) -> ConstructionPartRead:
+    """Set locked=False. Idempotent when the part is already unlocked."""
+    return _set_locked(db, aeroplane_id, part_id, False)

--- a/app/tests/test_construction_parts.py
+++ b/app/tests/test_construction_parts.py
@@ -1,0 +1,261 @@
+"""Tests for the Construction-Parts domain (gh#57-g4h).
+
+Construction-Parts are per-aeroplane CAD bauteile (typically 3D-printed)
+that complement the global COTS Component Library. This MVP covers:
+  - listing parts per aeroplane
+  - fetching a single part
+  - toggling the `locked` flag via lock/unlock endpoints
+
+File upload/download, general CRUD, and lock-aware regeneration are
+future tickets (gh#57-9uk, gh#57-qim).
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from app.models.construction_part import ConstructionPartModel
+
+
+# --------------------------------------------------------------------------- #
+# Test helper: create a ConstructionPart directly in the DB
+# --------------------------------------------------------------------------- #
+
+def _make_part(
+    session_factory,
+    *,
+    aeroplane_id: str,
+    name: str = "BulkheadA",
+    volume_mm3: Optional[float] = 12_345.6,
+    area_mm2: Optional[float] = 987.6,
+    bbox_x_mm: Optional[float] = 50.0,
+    bbox_y_mm: Optional[float] = 40.0,
+    bbox_z_mm: Optional[float] = 5.0,
+    material_component_id: Optional[int] = None,
+    locked: bool = False,
+    thumbnail_url: Optional[str] = None,
+) -> ConstructionPartModel:
+    session = session_factory()
+    try:
+        part = ConstructionPartModel(
+            aeroplane_id=aeroplane_id,
+            name=name,
+            volume_mm3=volume_mm3,
+            area_mm2=area_mm2,
+            bbox_x_mm=bbox_x_mm,
+            bbox_y_mm=bbox_y_mm,
+            bbox_z_mm=bbox_z_mm,
+            material_component_id=material_component_id,
+            locked=locked,
+            thumbnail_url=thumbnail_url,
+        )
+        session.add(part)
+        session.commit()
+        session.refresh(part)
+        return part
+    finally:
+        session.close()
+
+
+# --------------------------------------------------------------------------- #
+# LIST  GET /aeroplanes/{id}/construction-parts
+# --------------------------------------------------------------------------- #
+
+class TestListConstructionParts:
+
+    def test_empty_list(self, client_and_db):
+        client, _ = client_and_db
+        res = client.get("/aeroplanes/aero-empty/construction-parts")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["aeroplane_id"] == "aero-empty"
+        assert body["items"] == []
+        assert body["total"] == 0
+
+    def test_list_returns_parts_for_aeroplane(self, client_and_db):
+        client, sf = client_and_db
+        _make_part(sf, aeroplane_id="aero-1", name="Rib_A")
+        _make_part(sf, aeroplane_id="aero-1", name="Rib_B")
+
+        res = client.get("/aeroplanes/aero-1/construction-parts")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["total"] == 2
+        names = {item["name"] for item in body["items"]}
+        assert names == {"Rib_A", "Rib_B"}
+
+    def test_list_is_scoped_to_aeroplane(self, client_and_db):
+        """A part on aero-1 must not leak into the list for aero-2."""
+        client, sf = client_and_db
+        _make_part(sf, aeroplane_id="aero-1", name="OnlyOnOne")
+        _make_part(sf, aeroplane_id="aero-2", name="OnlyOnTwo")
+
+        res_one = client.get("/aeroplanes/aero-1/construction-parts").json()
+        res_two = client.get("/aeroplanes/aero-2/construction-parts").json()
+
+        assert {i["name"] for i in res_one["items"]} == {"OnlyOnOne"}
+        assert {i["name"] for i in res_two["items"]} == {"OnlyOnTwo"}
+
+    def test_list_is_sorted_by_name(self, client_and_db):
+        client, sf = client_and_db
+        _make_part(sf, aeroplane_id="a", name="Zeta")
+        _make_part(sf, aeroplane_id="a", name="Alpha")
+        _make_part(sf, aeroplane_id="a", name="Mu")
+
+        body = client.get("/aeroplanes/a/construction-parts").json()
+        names = [item["name"] for item in body["items"]]
+        assert names == ["Alpha", "Mu", "Zeta"]
+
+    def test_list_exposes_required_metadata(self, client_and_db):
+        client, sf = client_and_db
+        _make_part(
+            sf,
+            aeroplane_id="a",
+            name="Frame01",
+            volume_mm3=1111.0,
+            area_mm2=222.0,
+            bbox_x_mm=10.0,
+            bbox_y_mm=20.0,
+            bbox_z_mm=30.0,
+            locked=True,
+            thumbnail_url="/thumbs/frame01.png",
+        )
+        body = client.get("/aeroplanes/a/construction-parts").json()
+        item = body["items"][0]
+        assert item["name"] == "Frame01"
+        assert item["volume_mm3"] == 1111.0
+        assert item["area_mm2"] == 222.0
+        assert item["bbox_x_mm"] == 10.0
+        assert item["bbox_y_mm"] == 20.0
+        assert item["bbox_z_mm"] == 30.0
+        assert item["locked"] is True
+        assert item["thumbnail_url"] == "/thumbs/frame01.png"
+        assert "id" in item
+        assert "created_at" in item
+        assert "updated_at" in item
+
+
+# --------------------------------------------------------------------------- #
+# DETAIL  GET /aeroplanes/{id}/construction-parts/{partId}
+# --------------------------------------------------------------------------- #
+
+class TestGetConstructionPart:
+
+    def test_get_returns_part(self, client_and_db):
+        client, sf = client_and_db
+        part = _make_part(sf, aeroplane_id="a", name="X")
+
+        res = client.get(f"/aeroplanes/a/construction-parts/{part.id}")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["id"] == part.id
+        assert body["name"] == "X"
+        assert body["aeroplane_id"] == "a"
+
+    def test_get_returns_404_for_missing(self, client_and_db):
+        client, _ = client_and_db
+        res = client.get("/aeroplanes/a/construction-parts/9999")
+        assert res.status_code == 404
+
+    def test_get_returns_404_when_aeroplane_mismatch(self, client_and_db):
+        """A part on aero-1 must not be retrievable via aero-2."""
+        client, sf = client_and_db
+        part = _make_part(sf, aeroplane_id="aero-1", name="X")
+
+        res = client.get(f"/aeroplanes/aero-2/construction-parts/{part.id}")
+        assert res.status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# LOCK / UNLOCK
+# PUT /aeroplanes/{id}/construction-parts/{partId}/lock
+# PUT /aeroplanes/{id}/construction-parts/{partId}/unlock
+# --------------------------------------------------------------------------- #
+
+class TestLockUnlock:
+
+    def test_lock_sets_flag_true(self, client_and_db):
+        client, sf = client_and_db
+        part = _make_part(sf, aeroplane_id="a", name="P", locked=False)
+
+        res = client.put(f"/aeroplanes/a/construction-parts/{part.id}/lock")
+        assert res.status_code == 200
+        assert res.json()["locked"] is True
+
+        fetched = client.get(f"/aeroplanes/a/construction-parts/{part.id}").json()
+        assert fetched["locked"] is True
+
+    def test_lock_is_idempotent(self, client_and_db):
+        client, sf = client_and_db
+        part = _make_part(sf, aeroplane_id="a", name="P", locked=True)
+
+        res = client.put(f"/aeroplanes/a/construction-parts/{part.id}/lock")
+        assert res.status_code == 200
+        assert res.json()["locked"] is True
+
+    def test_unlock_sets_flag_false(self, client_and_db):
+        client, sf = client_and_db
+        part = _make_part(sf, aeroplane_id="a", name="P", locked=True)
+
+        res = client.put(f"/aeroplanes/a/construction-parts/{part.id}/unlock")
+        assert res.status_code == 200
+        assert res.json()["locked"] is False
+
+        fetched = client.get(f"/aeroplanes/a/construction-parts/{part.id}").json()
+        assert fetched["locked"] is False
+
+    def test_unlock_is_idempotent(self, client_and_db):
+        client, sf = client_and_db
+        part = _make_part(sf, aeroplane_id="a", name="P", locked=False)
+
+        res = client.put(f"/aeroplanes/a/construction-parts/{part.id}/unlock")
+        assert res.status_code == 200
+        assert res.json()["locked"] is False
+
+    def test_lock_missing_part_returns_404(self, client_and_db):
+        client, _ = client_and_db
+        res = client.put("/aeroplanes/a/construction-parts/9999/lock")
+        assert res.status_code == 404
+
+    def test_unlock_missing_part_returns_404(self, client_and_db):
+        client, _ = client_and_db
+        res = client.put("/aeroplanes/a/construction-parts/9999/unlock")
+        assert res.status_code == 404
+
+    def test_lock_rejects_aeroplane_mismatch(self, client_and_db):
+        """Lock via wrong aeroplane path must 404 (not silently flip the flag)."""
+        client, sf = client_and_db
+        part = _make_part(sf, aeroplane_id="aero-1", name="P", locked=False)
+
+        res = client.put(f"/aeroplanes/aero-2/construction-parts/{part.id}/lock")
+        assert res.status_code == 404
+
+        # Original part must remain unlocked.
+        fetched = client.get(f"/aeroplanes/aero-1/construction-parts/{part.id}").json()
+        assert fetched["locked"] is False
+
+
+# --------------------------------------------------------------------------- #
+# Material FK wiring
+# --------------------------------------------------------------------------- #
+
+class TestMaterialLink:
+
+    def test_material_component_id_is_surfaced(self, client_and_db):
+        """material_component_id references a component with type='material'."""
+        client, sf = client_and_db
+        material_res = client.post(
+            "/components",
+            json={
+                "name": "PLA+",
+                "component_type": "material",
+                "manufacturer": "eSUN",
+                "specs": {"density_kg_m3": 1240},
+            },
+        )
+        assert material_res.status_code == 201
+        material_id = material_res.json()["id"]
+
+        _make_part(sf, aeroplane_id="a", name="WithMaterial", material_component_id=material_id)
+
+        body = client.get("/aeroplanes/a/construction-parts").json()
+        assert body["items"][0]["material_component_id"] == material_id

--- a/app/tests/test_construction_parts_migration.py
+++ b/app/tests/test_construction_parts_migration.py
@@ -1,0 +1,47 @@
+"""Migration test for the construction_parts table (gh#57-g4h)."""
+from __future__ import annotations
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect
+
+
+def test_alembic_upgrade_head_creates_construction_parts_table(tmp_path):
+    db_path = tmp_path / "migration_test.db"
+    db_url = f"sqlite:///{db_path}"
+
+    alembic_cfg = Config("alembic.ini")
+    alembic_cfg.set_main_option("sqlalchemy.url", db_url)
+
+    command.upgrade(alembic_cfg, "head")
+
+    engine = create_engine(db_url)
+    inspector = inspect(engine)
+
+    assert "construction_parts" in inspector.get_table_names()
+
+    columns = {col["name"]: col for col in inspector.get_columns("construction_parts")}
+    assert "id" in columns
+    assert "aeroplane_id" in columns
+    assert "name" in columns
+    assert "volume_mm3" in columns
+    assert "area_mm2" in columns
+    assert "bbox_x_mm" in columns
+    assert "bbox_y_mm" in columns
+    assert "bbox_z_mm" in columns
+    assert "material_component_id" in columns
+    assert "locked" in columns
+    assert "thumbnail_url" in columns
+    assert "created_at" in columns
+    assert "updated_at" in columns
+
+    # aeroplane_id must be indexed for the per-aeroplane listing query
+    indexed_cols: set[str] = set()
+    for idx in inspector.get_indexes("construction_parts"):
+        indexed_cols.update(idx["column_names"])
+    assert "aeroplane_id" in indexed_cols
+
+    # FK to components must be present so material_component_id is validated at the DB layer
+    fks = inspector.get_foreign_keys("construction_parts")
+    target_tables = {fk["referred_table"] for fk in fks}
+    assert "components" in target_tables


### PR DESCRIPTION
## Summary

Introduces the per-aeroplane **Construction-Parts** domain — CAD bauteile (typically 3D-printed) that complement the global COTS Component Library. This is the MVP (`cad-modelling-service-g4h`).

**Scope (MVP only):**
- `GET /aeroplanes/{id}/construction-parts` — list scoped to aeroplane, sorted by name
- `GET /aeroplanes/{id}/construction-parts/{partId}` — single part
- `PUT /aeroplanes/{id}/construction-parts/{partId}/lock` — set `locked=true`
- `PUT /aeroplanes/{id}/construction-parts/{partId}/unlock` — set `locked=false`

**Out of scope (follow-up tickets):**
- File upload / download / general CRUD → `cad-modelling-service-9uk` (gh#57-D2)
- Regeneration-pipeline respects the lock → `cad-modelling-service-qim` (gh#57-D5)
- Frontend management panel → `cad-modelling-service-ggd` (gh#57-D3)
- Frontend picker for the component tree → `cad-modelling-service-wvg` (gh#57-D4)

## Data model

New table `construction_parts`:
- `id` · `aeroplane_id` (indexed String — matches existing `component_tree` pattern)
- `name` · `volume_mm3` · `area_mm2` · `bbox_x/y/z_mm`
- `material_component_id` (FK → `components.id`; frontend filters to `component_type='material'`)
- `locked` (bool, default false, `server_default='0'`)
- `thumbnail_url`
- `created_at` / `updated_at`

## Security / scoping

Aeroplane scoping is enforced in `_get_part_or_404` at the service layer: a part belonging to aeroplane A cannot be read or locked via aeroplane B's URL. Covered by `test_get_returns_404_when_aeroplane_mismatch` and `test_lock_rejects_aeroplane_mismatch`.

## Test plan

- [x] `poetry run ruff check .` — clean
- [x] `poetry run pytest -m "not slow" --ignore=.claude` — 282 passed (was 265)
- [x] 17 new tests: 16 API cases + 1 migration schema assertion (columns, index, FK)
- [x] `poetry run alembic upgrade head` applies cleanly on a fresh DB
- [x] `poetry run alembic downgrade -1` reverses cleanly (downgrade defined)

## Verification

- Visual sanity: open Swagger at http://localhost:8000/docs → see new `construction-parts` tag with 4 routes
- Manual: create a part via ORM (factory), hit GET list / detail / lock / unlock

Closes `cad-modelling-service-g4h`.
Relates to #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)