### PR TITLE
feat(gh#57): tree add-menu — (+) per group with COTS picker + inline group

### DIFF
--- a/frontend/__tests__/ComponentTreeAddFlow.test.tsx
+++ b/frontend/__tests__/ComponentTreeAddFlow.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * Integration tests for the Component Tree's new add-flow (gh#57-40g):
+ *   - per-group (+) button
+ *   - inline input for creating sub-groups (replaces window.prompt())
+ *   - COTS picker wiring — clicking a component creates a cots tree node
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) =>
+    React.createElement("span", props);
+  return {
+    Plus: icon, Trash2: icon, X: icon, Check: icon,
+    ChevronDown: icon, ChevronRight: icon,
+    FolderPlus: icon, Package: icon, Box: icon,
+    Search: icon, Loader2: icon, Settings: icon,
+  };
+});
+
+const mockAddTreeNode = vi.fn().mockResolvedValue({});
+const mockMutate = vi.fn();
+let treeReturnValue: Record<string, unknown> = {
+  tree: [
+    {
+      id: 10,
+      aeroplane_id: "aero-1",
+      parent_id: null,
+      node_type: "group",
+      name: "eHawk",
+      children: [
+        {
+          id: 11,
+          aeroplane_id: "aero-1",
+          parent_id: 10,
+          node_type: "group",
+          name: "main_wing",
+          children: [],
+        },
+      ],
+    },
+  ],
+  totalNodes: 2,
+  isLoading: false,
+  error: null,
+};
+
+vi.mock("@/hooks/useComponentTree", () => ({
+  useComponentTree: () => ({ ...treeReturnValue, mutate: mockMutate }),
+  addTreeNode: (...args: unknown[]) => mockAddTreeNode(...args),
+  deleteTreeNode: vi.fn().mockResolvedValue(undefined),
+}));
+
+let componentsList: Array<Record<string, unknown>> = [
+  { id: 77, name: "KST X08", component_type: "servo", manufacturer: "KST", mass_g: 7, specs: {} },
+];
+vi.mock("@/hooks/useComponents", () => ({
+  useComponents: () => ({
+    components: componentsList,
+    total: componentsList.length,
+    error: null,
+    isLoading: false,
+    mutate: vi.fn(),
+  }),
+  useComponentTypes: () => ["generic", "servo", "battery"],
+}));
+
+vi.mock("@/components/workbench/AeroplaneContext", () => ({
+  useAeroplaneContext: () => ({
+    aeroplaneId: "aero-1",
+    selectedWing: null,
+    selectedXsecIndex: null,
+    selectedFuselage: null,
+    selectedFuselageXsecIndex: null,
+    treeMode: "wingconfig",
+    setAeroplaneId: vi.fn(),
+    selectWing: vi.fn(),
+    selectXsec: vi.fn(),
+    selectFuselage: vi.fn(),
+    selectFuselageXsec: vi.fn(),
+    setTreeMode: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/fetcher", () => ({
+  API_BASE: "http://localhost:8000",
+  fetcher: vi.fn(),
+}));
+
+import { ComponentTree } from "@/components/workbench/ComponentTree";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  componentsList = [
+    { id: 77, name: "KST X08", component_type: "servo", manufacturer: "KST", mass_g: 7, specs: {} },
+  ];
+  treeReturnValue = {
+    tree: [
+      {
+        id: 10,
+        aeroplane_id: "aero-1",
+        parent_id: null,
+        node_type: "group",
+        name: "eHawk",
+        children: [
+          {
+            id: 11,
+            aeroplane_id: "aero-1",
+            parent_id: 10,
+            node_type: "group",
+            name: "main_wing",
+            children: [],
+          },
+        ],
+      },
+    ],
+    totalNodes: 2,
+    isLoading: false,
+    error: null,
+  };
+});
+
+describe("ComponentTree — per-group add flow", () => {
+  it("renders an add button for each group node (root + nested)", () => {
+    const { container } = render(<ComponentTree />);
+    // Expand the root group so the nested group is visible.
+    fireEvent.click(screen.getByText("eHawk"));
+
+    // Expect one add button per group row; root (tree header) + 2 groups = 3 '+' affordances.
+    // We query by title since buttons use an empty <span> icon.
+    const addButtons = container.querySelectorAll('[title^="Add to"]');
+    expect(addButtons.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("opens the popover when a group's (+) is clicked", () => {
+    render(<ComponentTree />);
+    // Click the (+) on the root group eHawk.
+    const rootAddBtn = screen.getByTitle("Add to eHawk");
+    fireEvent.click(rootAddBtn);
+
+    expect(screen.getByText("New Group")).toBeDefined();
+    expect(screen.getByText("Assign COTS Component")).toBeDefined();
+  });
+
+  it("opens an inline input for 'New Group' and submits to create a sub-group", async () => {
+    render(<ComponentTree />);
+    fireEvent.click(screen.getByTitle("Add to eHawk"));
+    fireEvent.click(screen.getByText("New Group"));
+
+    // Inline input appears — we look for a text input placeholder
+    const input = screen.getByPlaceholderText(/group name/i) as HTMLInputElement;
+    expect(input).toBeDefined();
+    fireEvent.change(input, { target: { value: "electronics" } });
+
+    // Submit by pressing Enter
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+    expect(mockAddTreeNode).toHaveBeenCalledWith(
+      "aero-1",
+      expect.objectContaining({
+        parent_id: 10,
+        node_type: "group",
+        name: "electronics",
+      }),
+    );
+  });
+
+  it("cancels the inline input on Escape without calling the API", () => {
+    render(<ComponentTree />);
+    fireEvent.click(screen.getByTitle("Add to eHawk"));
+    fireEvent.click(screen.getByText("New Group"));
+
+    const input = screen.getByPlaceholderText(/group name/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "not-saved" } });
+    fireEvent.keyDown(input, { key: "Escape", code: "Escape" });
+
+    expect(mockAddTreeNode).not.toHaveBeenCalled();
+    expect(screen.queryByPlaceholderText(/group name/i)).toBeNull();
+  });
+
+  it("does not submit an empty group name", () => {
+    render(<ComponentTree />);
+    fireEvent.click(screen.getByTitle("Add to eHawk"));
+    fireEvent.click(screen.getByText("New Group"));
+
+    const input = screen.getByPlaceholderText(/group name/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+    expect(mockAddTreeNode).not.toHaveBeenCalled();
+  });
+
+  it("opens the COTS picker and creates a cots node on selection", async () => {
+    render(<ComponentTree />);
+    fireEvent.click(screen.getByTitle("Add to eHawk"));
+    fireEvent.click(screen.getByText("Assign COTS Component"));
+
+    // The picker dialog is open, library component is listed
+    const pickRow = screen.getByText("KST X08");
+    fireEvent.click(pickRow);
+
+    expect(mockAddTreeNode).toHaveBeenCalledWith(
+      "aero-1",
+      expect.objectContaining({
+        parent_id: 10,
+        node_type: "cots",
+        component_id: 77,
+        name: "KST X08",
+      }),
+    );
+  });
+});

--- a/frontend/__tests__/ComponentsPage.test.tsx
+++ b/frontend/__tests__/ComponentsPage.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Regression tests for /workbench/components page.
+ *
+ * These tests guard against gh#57-fav: the "+ New Component" button silently
+ * did nothing because <ComponentEditDialog/> was passed as a third child of
+ * <WorkbenchTwoPanel/>, which drops any child beyond the first two.
+ *
+ * If you touch the ComponentsPage layout, keep the dialog rendered OUTSIDE
+ * the WorkbenchTwoPanel (e.g. as a sibling via Fragment or via a portal).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+// ── Mocks ─────────────────────────────────────────────────────────
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) =>
+    React.createElement("span", props);
+  return {
+    Package: icon, Search: icon, Plus: icon, Settings: icon, Trash2: icon,
+    X: icon, Loader2: icon, ChevronDown: icon, ChevronRight: icon,
+  };
+});
+
+// Stub SWR-backed hooks so the page can render without a real backend.
+vi.mock("@/hooks/useComponents", () => ({
+  useComponents: () => ({
+    components: [],
+    total: 0,
+    error: null,
+    isLoading: false,
+    mutate: vi.fn(),
+  }),
+  useComponentTypes: () => ["generic", "servo", "battery"],
+  createComponent: vi.fn().mockResolvedValue({}),
+  updateComponent: vi.fn().mockResolvedValue({}),
+  deleteComponent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/hooks/useComponentTree", () => ({
+  useComponentTree: () => ({
+    tree: [],
+    totalNodes: 0,
+    error: null,
+    isLoading: false,
+    mutate: vi.fn(),
+  }),
+  addTreeNode: vi.fn().mockResolvedValue({}),
+  deleteTreeNode: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/components/workbench/AeroplaneContext", () => ({
+  useAeroplaneContext: () => ({
+    aeroplaneId: "aero-1",
+    selectedWing: null,
+    selectedXsecIndex: null,
+    selectedFuselage: null,
+    selectedFuselageXsecIndex: null,
+    treeMode: "wingconfig",
+    setAeroplaneId: vi.fn(),
+    selectWing: vi.fn(),
+    selectXsec: vi.fn(),
+    selectFuselage: vi.fn(),
+    selectFuselageXsec: vi.fn(),
+    setTreeMode: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/fetcher", () => ({
+  API_BASE: "http://localhost:8000",
+  fetcher: vi.fn(),
+}));
+
+import ComponentsPage from "@/app/workbench/components/page";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ComponentsPage — '+ New Component' dialog", () => {
+  it("renders the '+ New Component' button", () => {
+    render(<ComponentsPage />);
+    expect(screen.getByText("New Component")).toBeDefined();
+  });
+
+  it("does not render the dialog until the button is clicked", () => {
+    render(<ComponentsPage />);
+    // Dialog heading only exists when the dialog is open.
+    expect(screen.queryByText("New Component", { selector: "span" })).toBeNull();
+  });
+
+  it("opens the create dialog when '+ New Component' is clicked", () => {
+    render(<ComponentsPage />);
+
+    const button = screen.getByText("New Component");
+    fireEvent.click(button);
+
+    // The dialog title is "New Component" inside a <span> — same text as the
+    // button, so we assert on the presence of dialog-only form labels instead.
+    expect(screen.getByText("Name *")).toBeDefined();
+    expect(screen.getByText("Manufacturer")).toBeDefined();
+    expect(screen.getByText("Description")).toBeDefined();
+  });
+
+  it("closes the dialog when Cancel is clicked", () => {
+    render(<ComponentsPage />);
+
+    fireEvent.click(screen.getByText("New Component"));
+    expect(screen.getByText("Name *")).toBeDefined();
+
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(screen.queryByText("Name *")).toBeNull();
+  });
+});

--- a/frontend/__tests__/CotsPickerDialog.test.tsx
+++ b/frontend/__tests__/CotsPickerDialog.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * Tests for the picker dialog that selects an existing COTS component from
+ * the Component Library and reports the chosen ID back (gh#57-40g).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) =>
+    React.createElement("span", props);
+  return {
+    X: icon, Search: icon, Loader2: icon, Package: icon,
+    Plus: icon, Check: icon,
+  };
+});
+
+let componentsReturnValue: {
+  components: Array<Record<string, unknown>>;
+  total: number;
+  isLoading: boolean;
+} = { components: [], total: 0, isLoading: false };
+
+vi.mock("@/hooks/useComponents", () => ({
+  useComponents: () => ({
+    ...componentsReturnValue,
+    error: null,
+    mutate: vi.fn(),
+  }),
+  useComponentTypes: () => ["generic", "servo", "battery", "material"],
+}));
+
+vi.mock("@/lib/fetcher", () => ({
+  API_BASE: "http://localhost:8000",
+  fetcher: vi.fn(),
+}));
+
+import { CotsPickerDialog } from "@/components/workbench/CotsPickerDialog";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  componentsReturnValue = { components: [], total: 0, isLoading: false };
+});
+
+describe("CotsPickerDialog", () => {
+  it("does not render when open=false", () => {
+    render(
+      <CotsPickerDialog
+        open={false}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText(/Assign Component/i)).toBeNull();
+  });
+
+  it("renders the header with target group name when provided", () => {
+    render(
+      <CotsPickerDialog
+        open={true}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+        targetGroupName="main_wing"
+      />,
+    );
+    expect(screen.getByText(/main_wing/)).toBeDefined();
+  });
+
+  it("shows empty-state text when no components exist", () => {
+    render(
+      <CotsPickerDialog
+        open={true}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/No components/i)).toBeDefined();
+  });
+
+  it("renders a row per component returned by useComponents", () => {
+    componentsReturnValue = {
+      components: [
+        { id: 1, name: "KST X08", component_type: "servo", manufacturer: "KST", mass_g: 7, specs: {} },
+        { id: 2, name: "Sunnysky A2212", component_type: "brushless_motor", manufacturer: "Sunnysky", mass_g: 55, specs: {} },
+      ],
+      total: 2,
+      isLoading: false,
+    };
+
+    render(
+      <CotsPickerDialog
+        open={true}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("KST X08")).toBeDefined();
+    expect(screen.getByText("Sunnysky A2212")).toBeDefined();
+  });
+
+  it("calls onSelect with the component ID and closes on pick", () => {
+    componentsReturnValue = {
+      components: [
+        { id: 42, name: "KST X08", component_type: "servo", manufacturer: "KST", mass_g: 7, specs: {} },
+      ],
+      total: 1,
+      isLoading: false,
+    };
+
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <CotsPickerDialog
+        open={true}
+        onClose={onClose}
+        onSelect={onSelect}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("KST X08"));
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 42, name: "KST X08" }),
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on Cancel click", () => {
+    const onClose = vi.fn();
+    render(
+      <CotsPickerDialog
+        open={true}
+        onClose={onClose}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a loading state while the library is loading", () => {
+    componentsReturnValue = { components: [], total: 0, isLoading: true };
+
+    render(
+      <CotsPickerDialog
+        open={true}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/Loading/i)).toBeDefined();
+  });
+});

--- a/frontend/__tests__/GroupAddMenu.test.tsx
+++ b/frontend/__tests__/GroupAddMenu.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * Tests for the popover-style add menu attached to each group row
+ * in the Component Tree (gh#57-40g).
+ *
+ * The menu surfaces three options:
+ *   1. "New Group"                — opens an inline input
+ *   2. "Assign COTS Component"    — opens CotsPickerDialog
+ *   3. "Assign Construction Part" — disabled until gh#57-wvg (D4) ships
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) =>
+    React.createElement("span", props);
+  return {
+    FolderPlus: icon, Package: icon, Box: icon,
+    Plus: icon, X: icon, Check: icon,
+  };
+});
+
+import { GroupAddMenu } from "@/components/workbench/GroupAddMenu";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GroupAddMenu", () => {
+  it("shows all three options", () => {
+    render(
+      <GroupAddMenu
+        groupName="main_wing"
+        onNewGroup={vi.fn()}
+        onAssignCots={vi.fn()}
+        onAssignConstructionPart={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("New Group")).toBeDefined();
+    expect(screen.getByText("Assign COTS Component")).toBeDefined();
+    expect(screen.getByText("Assign Construction Part")).toBeDefined();
+  });
+
+  it("shows the group name as context in the header", () => {
+    render(
+      <GroupAddMenu
+        groupName="avionics"
+        onNewGroup={vi.fn()}
+        onAssignCots={vi.fn()}
+        onAssignConstructionPart={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    // The group name appears somewhere (e.g. "Add to avionics")
+    expect(screen.getByText(/avionics/)).toBeDefined();
+  });
+
+  it("calls onNewGroup (but not onClose) when 'New Group' is clicked", () => {
+    const onNewGroup = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <GroupAddMenu
+        groupName="main_wing"
+        onNewGroup={onNewGroup}
+        onAssignCots={vi.fn()}
+        onAssignConstructionPart={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("New Group"));
+
+    // The parent is responsible for dismissing the menu (typically by
+    // transitioning into another state); GroupAddMenu must NOT auto-close.
+    expect(onNewGroup).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("calls onAssignCots (but not onClose) when 'Assign COTS Component' is clicked", () => {
+    const onAssignCots = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <GroupAddMenu
+        groupName="main_wing"
+        onNewGroup={vi.fn()}
+        onAssignCots={onAssignCots}
+        onAssignConstructionPart={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Assign COTS Component"));
+
+    expect(onAssignCots).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("disables 'Assign Construction Part' when constructionPartsEnabled=false", () => {
+    const onAssign = vi.fn();
+    render(
+      <GroupAddMenu
+        groupName="main_wing"
+        onNewGroup={vi.fn()}
+        onAssignCots={vi.fn()}
+        onAssignConstructionPart={onAssign}
+        onClose={vi.fn()}
+        constructionPartsEnabled={false}
+      />,
+    );
+
+    // Clicking the disabled item must not fire the callback
+    fireEvent.click(screen.getByText("Assign Construction Part"));
+    expect(onAssign).not.toHaveBeenCalled();
+  });
+
+  it("calls onClose when the Escape key is pressed", () => {
+    const onClose = vi.fn();
+    render(
+      <GroupAddMenu
+        groupName="main_wing"
+        onNewGroup={vi.fn()}
+        onAssignCots={vi.fn()}
+        onAssignConstructionPart={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.keyDown(window, { key: "Escape", code: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("enables 'Assign Construction Part' when constructionPartsEnabled=true", () => {
+    const onAssign = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <GroupAddMenu
+        groupName="main_wing"
+        onNewGroup={vi.fn()}
+        onAssignCots={vi.fn()}
+        onAssignConstructionPart={onAssign}
+        onClose={onClose}
+        constructionPartsEnabled={true}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Assign Construction Part"));
+    expect(onAssign).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/workbench/components/page.tsx
+++ b/frontend/app/workbench/components/page.tsx
@@ -36,6 +36,7 @@ export default function ComponentsPage() {
   };
 
   return (
+    <>
     <WorkbenchTwoPanel>
       <ComponentTree />
 
@@ -169,15 +170,21 @@ export default function ComponentsPage() {
           </div>
         )}
       </div>
-
-      {editDialog.open && (
-        <ComponentEditDialog
-          open={editDialog.open}
-          onClose={() => setEditDialog({ open: false, component: null })}
-          onSaved={() => mutate()}
-          component={editDialog.component}
-        />
-      )}
     </WorkbenchTwoPanel>
+
+    {/*
+     * Dialog must render as a sibling of <WorkbenchTwoPanel/>, not as a
+     * child — WorkbenchTwoPanel only renders its first two children and
+     * silently drops the rest. See gh#57-fav regression tests.
+     */}
+    {editDialog.open && (
+      <ComponentEditDialog
+        open={editDialog.open}
+        onClose={() => setEditDialog({ open: false, component: null })}
+        onSaved={() => mutate()}
+        component={editDialog.component}
+      />
+    )}
+    </>
   );
 }

--- a/frontend/app/workbench/components/page.tsx
+++ b/frontend/app/workbench/components/page.tsx
@@ -1,172 +1,183 @@
 "use client";
 
-import {
-  Package,
-  Search,
-  ArrowLeft,
-  Cpu,
-  BatteryMedium,
-  Wind,
-  Wifi,
-  Camera,
-  Layers,
-} from "lucide-react";
-import type { LucideIcon } from "lucide-react";
+import { useState } from "react";
+import { Package, Search, Plus, Settings, Trash2 } from "lucide-react";
 import { WorkbenchTwoPanel } from "@/components/workbench/WorkbenchTwoPanel";
-import { AlertBanner } from "@/components/workbench/AlertBanner";
 import { ComponentTree } from "@/components/workbench/ComponentTree";
+import { ComponentEditDialog } from "@/components/workbench/ComponentEditDialog";
+import { useComponents, deleteComponent, type Component } from "@/hooks/useComponents";
 
-const COMPONENTS: {
-  icon: LucideIcon;
-  chip: string;
-  title: string;
-  subtitle: string;
-  specs: [string, string][];
-}[] = [
-  {
-    icon: Cpu,
-    chip: "flight_controller",
-    title: "FC-4 Pix32",
-    subtitle: "Pixhawk-class autopilot",
-    specs: [
-      ["mass", "38 g"],
-      ["v", "7.4\u201326.4 V"],
-    ],
-  },
-  {
-    icon: BatteryMedium,
-    chip: "battery",
-    title: "LiPo 4S 5200",
-    subtitle: "14.8 V 5200 mAh",
-    specs: [
-      ["mass", "560 g"],
-      ["cap", "77 Wh"],
-    ],
-  },
-  {
-    icon: Wind,
-    chip: "motor",
-    title: "T-Motor AT2820",
-    subtitle: "880 KV outrunner",
-    specs: [
-      ["mass", "132 g"],
-      ["kv", "880"],
-    ],
-  },
-  {
-    icon: Wifi,
-    chip: "telemetry",
-    title: "RFD900x",
-    subtitle: "868/915 MHz modem",
-    specs: [
-      ["mass", "14 g"],
-      ["range", "40 km"],
-    ],
-  },
-  {
-    icon: Camera,
-    chip: "payload",
-    title: "Sony RX1R II",
-    subtitle: "42 MP full-frame",
-    specs: [
-      ["mass", "507 g"],
-      ["vol", "1.2 L"],
-    ],
-  },
-  {
-    icon: Layers,
-    chip: "structure",
-    title: "CF spar D10",
-    subtitle: "Carbon fibre tube",
-    specs: [
-      ["mass", "18 g/m"],
-      ["d", "10 mm"],
-    ],
-  },
-];
+const TYPE_ICONS: Record<string, string> = {
+  servo: "\u2699",
+  brushless_motor: "\u26A1",
+  esc: "\u26A1",
+  battery: "\uD83D\uDD0B",
+  receiver: "\uD83D\uDCE1",
+  flight_controller: "\uD83D\uDDA5",
+  material: "\uD83E\uDDF1",
+  propeller: "\uD83D\uDCA8",
+  generic: "\uD83D\uDCE6",
+};
 
 export default function ComponentsPage() {
+  const [search, setSearch] = useState("");
+  const [typeFilter, setTypeFilter] = useState<string>("");
+  const { components, total, isLoading, mutate } = useComponents(typeFilter || undefined, search || undefined);
+  const [editDialog, setEditDialog] = useState<{ open: boolean; component: Component | null }>({ open: false, component: null });
+
+  const handleDelete = async (comp: Component) => {
+    if (!confirm(`Delete "${comp.name}"?`)) return;
+    try {
+      await deleteComponent(comp.id);
+      mutate();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Delete failed");
+    }
+  };
+
   return (
     <WorkbenchTwoPanel>
       <ComponentTree />
 
-      <div className="flex w-full flex-col gap-6 overflow-y-auto">
+      <div className="flex w-full flex-col gap-4 overflow-y-auto">
         {/* Header */}
         <div className="flex items-center gap-2.5">
           <Package className="size-5 text-primary" />
           <h1 className="font-[family-name:var(--font-jetbrains-mono)] text-[20px] text-foreground">
             Component Library
           </h1>
-          <span className="flex-1" />
-          <div className="flex w-60 items-center gap-2 rounded-xl border border-border bg-input px-3 py-2">
-            <Search className="size-3.5 text-muted-foreground" />
-            <span className="text-[12px] text-subtle-foreground">
-              Search components...
-            </span>
-          </div>
-        </div>
-
-        {/* Alert banner */}
-        <AlertBanner>
-          Component Library needs backend resource. The card grid below is a
-          static preview.
-        </AlertBanner>
-
-        {/* Drag hint */}
-        <div className="flex items-center gap-1.5">
-          <ArrowLeft size={12} className="text-subtle-foreground" />
-          <span className="text-[11px] text-subtle-foreground">
-            Drag components to the Aeroplane Tree to add them
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-muted-foreground">
+            {total} items
           </span>
+          <span className="flex-1" />
+          <button
+            onClick={() => setEditDialog({ open: true, component: null })}
+            className="flex items-center gap-1.5 rounded-full bg-primary px-4 py-2 text-[13px] text-primary-foreground hover:opacity-90"
+          >
+            <Plus size={14} />
+            New Component
+          </button>
         </div>
 
-        {/* Card grid */}
-        <div className="grid grid-cols-3 gap-4">
-          {COMPONENTS.map((comp) => {
-            const Icon = comp.icon;
-            return (
+        {/* Search + Filter */}
+        <div className="flex gap-3">
+          <div className="flex flex-1 items-center gap-2 rounded-xl border border-border bg-input px-3 py-2">
+            <Search className="size-3.5 text-muted-foreground" />
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search components..."
+              className="flex-1 bg-transparent text-[12px] text-foreground outline-none placeholder:text-subtle-foreground"
+            />
+          </div>
+          <select
+            value={typeFilter}
+            onChange={(e) => setTypeFilter(e.target.value)}
+            className="rounded-xl border border-border bg-input px-3 py-2 text-[12px] text-foreground"
+          >
+            <option value="">All types</option>
+            <option value="servo">Servo</option>
+            <option value="brushless_motor">Motor</option>
+            <option value="esc">ESC</option>
+            <option value="battery">Battery</option>
+            <option value="receiver">Receiver</option>
+            <option value="flight_controller">Flight Controller</option>
+            <option value="material">Material</option>
+            <option value="propeller">Propeller</option>
+            <option value="generic">Generic</option>
+          </select>
+        </div>
+
+        {/* Component Cards */}
+        {isLoading ? (
+          <p className="py-8 text-center text-[13px] text-muted-foreground">Loading components...</p>
+        ) : components.length === 0 ? (
+          <div className="flex flex-col items-center gap-3 py-12">
+            <Package className="size-12 text-subtle-foreground" />
+            <p className="text-[13px] text-muted-foreground">
+              {search || typeFilter ? "No components match your filter" : "No components yet. Create one to get started."}
+            </p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 gap-3">
+            {components.map((comp) => (
               <div
-                key={comp.chip}
-                className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4"
+                key={comp.id}
+                className="flex flex-col gap-2 rounded-xl border border-border bg-card p-4"
               >
-                {/* Card header */}
-                <div className="flex items-center">
-                  <div className="flex size-8 items-center justify-center rounded-xl bg-card-muted">
-                    <Icon className="size-4 text-primary" />
-                  </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-[16px]">{TYPE_ICONS[comp.component_type] ?? "\uD83D\uDCE6"}</span>
+                  <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-foreground">
+                    {comp.name}
+                  </span>
                   <span className="flex-1" />
-                  <span className="rounded-full bg-sidebar-accent px-2 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[10px] text-muted-foreground">
-                    {comp.chip}
+                  <span className="rounded-full bg-sidebar-accent px-2 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[9px] text-muted-foreground">
+                    {comp.component_type}
                   </span>
                 </div>
 
-                {/* Title + subtitle */}
-                <div className="font-[family-name:var(--font-jetbrains-mono)] text-[14px] text-foreground">
-                  {comp.title}
-                </div>
-                <div className="text-[12px] text-muted-foreground">
-                  {comp.subtitle}
+                {comp.manufacturer && (
+                  <span className="text-[11px] text-muted-foreground">{comp.manufacturer}</span>
+                )}
+                {comp.description && (
+                  <span className="text-[11px] text-subtle-foreground">{comp.description}</span>
+                )}
+
+                <div className="flex items-center gap-3 text-[11px]">
+                  {comp.mass_g != null && (
+                    <span className="font-[family-name:var(--font-jetbrains-mono)] text-foreground">
+                      {comp.mass_g}g
+                    </span>
+                  )}
+                  {comp.bbox_x_mm != null && (
+                    <span className="text-muted-foreground">
+                      {comp.bbox_x_mm}×{comp.bbox_y_mm}×{comp.bbox_z_mm}mm
+                    </span>
+                  )}
                 </div>
 
                 {/* Specs */}
-                <div className="flex flex-col gap-1">
-                  {comp.specs.map(([key, val]) => (
-                    <div key={key} className="flex items-center">
-                      <span className="text-[11px] text-muted-foreground">
-                        {key}
+                {Object.keys(comp.specs).length > 0 && (
+                  <div className="flex flex-wrap gap-1.5">
+                    {Object.entries(comp.specs).slice(0, 4).map(([key, val]) => (
+                      <span key={key} className="rounded-full bg-card-muted px-2 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[9px] text-muted-foreground">
+                        {key}: {String(val)}
                       </span>
-                      <span className="flex-1" />
-                      <span className="font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-foreground">
-                        {val}
-                      </span>
-                    </div>
-                  ))}
+                    ))}
+                  </div>
+                )}
+
+                <div className="flex justify-end gap-1.5">
+                  <button
+                    onClick={() => setEditDialog({ open: true, component: comp })}
+                    className="flex size-7 items-center justify-center rounded-full border border-border text-muted-foreground hover:bg-sidebar-accent hover:text-foreground"
+                    title="Edit"
+                  >
+                    <Settings size={12} />
+                  </button>
+                  <button
+                    onClick={() => handleDelete(comp)}
+                    className="flex size-7 items-center justify-center rounded-full border border-border text-destructive hover:bg-destructive/20"
+                    title="Delete"
+                  >
+                    <Trash2 size={12} />
+                  </button>
                 </div>
               </div>
-            );
-          })}
-        </div>
+            ))}
+          </div>
+        )}
       </div>
+
+      {editDialog.open && (
+        <ComponentEditDialog
+          open={editDialog.open}
+          onClose={() => setEditDialog({ open: false, component: null })}
+          onSaved={() => mutate()}
+          component={editDialog.component}
+        />
+      )}
     </WorkbenchTwoPanel>
   );
 }

--- a/frontend/components/workbench/ComponentEditDialog.tsx
+++ b/frontend/components/workbench/ComponentEditDialog.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { X, Loader2 } from "lucide-react";
+import type { Component } from "@/hooks/useComponents";
+import { createComponent, updateComponent, useComponentTypes } from "@/hooks/useComponents";
+
+interface ComponentEditDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSaved: () => void;
+  component?: Component | null; // null = create new
+}
+
+export function ComponentEditDialog({ open, onClose, onSaved, component }: ComponentEditDialogProps) {
+  const types = useComponentTypes();
+  const isEdit = !!component;
+
+  const [name, setName] = useState("");
+  const [componentType, setComponentType] = useState("generic");
+  const [manufacturer, setManufacturer] = useState("");
+  const [description, setDescription] = useState("");
+  const [massG, setMassG] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (component) {
+      setName(component.name);
+      setComponentType(component.component_type);
+      setManufacturer(component.manufacturer ?? "");
+      setDescription(component.description ?? "");
+      setMassG(component.mass_g != null ? String(component.mass_g) : "");
+    } else {
+      setName("");
+      setComponentType("generic");
+      setManufacturer("");
+      setDescription("");
+      setMassG("");
+    }
+    setError(null);
+  }, [component, open]);
+
+  if (!open) return null;
+
+  const handleSave = async () => {
+    if (!name.trim()) { setError("Name is required"); return; }
+    setSaving(true);
+    setError(null);
+    try {
+      const data = {
+        name: name.trim(),
+        component_type: componentType,
+        manufacturer: manufacturer.trim() || null,
+        description: description.trim() || null,
+        mass_g: massG ? parseFloat(massG) : null,
+        bbox_x_mm: null,
+        bbox_y_mm: null,
+        bbox_z_mm: null,
+        model_ref: null,
+        specs: {},
+      };
+      if (isEdit && component) {
+        await updateComponent(component.id, data as any);
+      } else {
+        await createComponent(data as any);
+      }
+      onSaved();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={onClose}>
+      <div className="flex w-[500px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center gap-3">
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
+            {isEdit ? "Edit Component" : "New Component"}
+          </span>
+          <span className="flex-1" />
+          <button onClick={onClose} className="flex size-8 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent">
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1">
+            <label className="text-[11px] text-muted-foreground">Name *</label>
+            <input type="text" value={name} onChange={(e) => setName(e.target.value)}
+              className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground" />
+          </div>
+          <div className="flex gap-3">
+            <div className="flex flex-1 flex-col gap-1">
+              <label className="text-[11px] text-muted-foreground">Type</label>
+              <select value={componentType} onChange={(e) => setComponentType(e.target.value)}
+                className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground">
+                {types.map((t) => <option key={t} value={t}>{t}</option>)}
+              </select>
+            </div>
+            <div className="flex flex-1 flex-col gap-1">
+              <label className="text-[11px] text-muted-foreground">Mass (g)</label>
+              <input type="number" value={massG} onChange={(e) => setMassG(e.target.value)}
+                className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground" />
+            </div>
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-[11px] text-muted-foreground">Manufacturer</label>
+            <input type="text" value={manufacturer} onChange={(e) => setManufacturer(e.target.value)}
+              className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground" />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-[11px] text-muted-foreground">Description</label>
+            <textarea value={description} onChange={(e) => setDescription(e.target.value)} rows={2}
+              className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground resize-none" />
+          </div>
+        </div>
+
+        {error && (
+          <div className="rounded-xl border border-destructive bg-destructive/10 p-3 text-[12px] text-destructive">{error}</div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button onClick={onClose} disabled={saving}
+            className="rounded-full border border-border px-4 py-2 text-[13px] text-muted-foreground hover:bg-sidebar-accent">
+            Cancel
+          </button>
+          <button onClick={handleSave} disabled={saving}
+            className="flex items-center gap-1.5 rounded-full bg-primary px-4 py-2 text-[13px] text-primary-foreground hover:opacity-90 disabled:opacity-50">
+            {saving && <Loader2 size={14} className="animate-spin" />}
+            {saving ? "Saving\u2026" : isEdit ? "Update" : "Create"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/workbench/ComponentTree.tsx
+++ b/frontend/components/workbench/ComponentTree.tsx
@@ -1,27 +1,48 @@
 "use client";
 
 import { useState } from "react";
+import { Plus, Trash2 } from "lucide-react";
 import { TreeCard } from "@/components/workbench/TreeCard";
-import {
-  SimpleTreeRow,
-  type SimpleTreeNode,
-} from "@/components/workbench/SimpleTreeRow";
+import { SimpleTreeRow, type SimpleTreeNode } from "@/components/workbench/SimpleTreeRow";
+import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
+import { useComponentTree, addTreeNode, deleteTreeNode, type ComponentTreeNode } from "@/hooks/useComponentTree";
 
-const STATIC_NODES: SimpleTreeNode[] = [
-  { id: "root", label: "eHawk", level: 0 },
-  { id: "mw", label: "main_wing", level: 1 },
-  { id: "s0", label: "segment 0 (root)", level: 2 },
-  { id: "s1", label: "segment 1", level: 2 },
-  { id: "s2", label: "segment 2 \u00b7 aileron", level: 2, chip: "AILERON" },
-  { id: "s3", label: "segment 3 \u00b7 aileron", level: 2 },
-  { id: "ew", label: "elevator_wing", level: 1 },
-  { id: "fuse", label: "fuselage", level: 1, leaf: true },
-];
+function flattenTree(
+  nodes: ComponentTreeNode[],
+  level: number,
+  expanded: Set<string>,
+  onSelect: (node: ComponentTreeNode) => void,
+  onDelete: (node: ComponentTreeNode) => void,
+  selectedId: number | null,
+): SimpleTreeNode[] {
+  const result: SimpleTreeNode[] = [];
+  for (const node of nodes) {
+    const hasChildren = node.children && node.children.length > 0;
+    const isExpanded = expanded.has(String(node.id));
+    result.push({
+      id: String(node.id),
+      label: node.name,
+      level,
+      expanded: hasChildren ? isExpanded : undefined,
+      leaf: !hasChildren,
+      selected: node.id === selectedId,
+      chip: node.node_type === "cots" ? "COTS" : node.node_type === "cad_shape" ? "CAD" : undefined,
+      annotation: node.weight_override_g != null ? `${node.weight_override_g}g` : undefined,
+      onClick: () => onSelect(node),
+      onDelete: () => onDelete(node),
+    });
+    if (hasChildren && isExpanded) {
+      result.push(...flattenTree(node.children, level + 1, expanded, onSelect, onDelete, selectedId));
+    }
+  }
+  return result;
+}
 
 export function ComponentTree() {
-  const [expanded, setExpanded] = useState<Set<string>>(
-    new Set(["root", "mw"]),
-  );
+  const { aeroplaneId } = useAeroplaneContext();
+  const { tree, mutate } = useComponentTree(aeroplaneId);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [selectedNodeId, setSelectedNodeId] = useState<number | null>(null);
 
   const toggle = (id: string) => {
     setExpanded((prev) => {
@@ -31,34 +52,59 @@ export function ComponentTree() {
     });
   };
 
-  const visible = STATIC_NODES.filter((node) => {
-    if (node.level === 0) return true;
-    if (node.level === 1) return expanded.has("root");
-    if (node.level === 2) {
-      if (!expanded.has("root")) return false;
-      const idx = STATIC_NODES.indexOf(node);
-      for (let i = idx - 1; i >= 0; i--) {
-        if (STATIC_NODES[i].level === 1)
-          return expanded.has(STATIC_NODES[i].id);
-      }
+  const handleSelect = (node: ComponentTreeNode) => {
+    setSelectedNodeId(node.id);
+  };
+
+  const handleDelete = async (node: ComponentTreeNode) => {
+    if (!aeroplaneId) return;
+    if (!confirm(`Delete "${node.name}"?`)) return;
+    try {
+      await deleteTreeNode(aeroplaneId, node.id);
+      mutate();
+      if (selectedNodeId === node.id) setSelectedNodeId(null);
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Delete failed");
     }
-    return true;
-  });
+  };
+
+  const handleAddGroup = async () => {
+    if (!aeroplaneId) return;
+    const name = prompt("Group name?");
+    if (!name) return;
+    try {
+      await addTreeNode(aeroplaneId, { node_type: "group", name });
+      mutate();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Add failed");
+    }
+  };
+
+  const rows = flattenTree(tree, 0, expanded, handleSelect, handleDelete, selectedNodeId);
 
   return (
-    <TreeCard title="Component Tree">
+    <TreeCard
+      title="Component Tree"
+      actions={
+        <button
+          onClick={handleAddGroup}
+          className="flex size-6 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent hover:text-foreground"
+          title="Add group"
+        >
+          <Plus size={14} />
+        </button>
+      }
+    >
       <div className="flex flex-col gap-0.5">
-        {visible.map((node) => (
-          <SimpleTreeRow
-            key={node.id}
-            node={{
-              ...node,
-              expanded: expanded.has(node.id),
-              leaf: node.leaf ?? node.level === 2,
-            }}
-            onToggle={() => toggle(node.id)}
-          />
-        ))}
+        {rows.length === 0 ? (
+          <p className="py-4 text-center text-[11px] text-muted-foreground">
+            No components yet. Add a group or assign COTS parts.
+          </p>
+        ) : (
+          rows.map((node) => (
+            <SimpleTreeRow key={node.id} node={node} onToggle={() => toggle(node.id)} />
+          ))
+        )}
       </div>
     </TreeCard>
   );

--- a/frontend/components/workbench/ComponentTree.tsx
+++ b/frontend/components/workbench/ComponentTree.tsx
@@ -1,11 +1,25 @@
 "use client";
 
 import { useState } from "react";
-import { Plus, Trash2 } from "lucide-react";
+import { Plus, Check, X } from "lucide-react";
 import { TreeCard } from "@/components/workbench/TreeCard";
 import { SimpleTreeRow, type SimpleTreeNode } from "@/components/workbench/SimpleTreeRow";
 import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
-import { useComponentTree, addTreeNode, deleteTreeNode, type ComponentTreeNode } from "@/hooks/useComponentTree";
+import {
+  useComponentTree,
+  addTreeNode,
+  deleteTreeNode,
+  type ComponentTreeNode,
+} from "@/hooks/useComponentTree";
+import { GroupAddMenu } from "@/components/workbench/GroupAddMenu";
+import { CotsPickerDialog } from "@/components/workbench/CotsPickerDialog";
+import type { Component } from "@/hooks/useComponents";
+
+type AddFlowStage =
+  | { kind: "idle" }
+  | { kind: "menu"; parentId: number | null; parentName: string }
+  | { kind: "newGroup"; parentId: number | null; parentName: string }
+  | { kind: "cotsPicker"; parentId: number | null; parentName: string };
 
 function flattenTree(
   nodes: ComponentTreeNode[],
@@ -13,12 +27,14 @@ function flattenTree(
   expanded: Set<string>,
   onSelect: (node: ComponentTreeNode) => void,
   onDelete: (node: ComponentTreeNode) => void,
+  onAdd: (node: ComponentTreeNode) => void,
   selectedId: number | null,
 ): SimpleTreeNode[] {
   const result: SimpleTreeNode[] = [];
   for (const node of nodes) {
     const hasChildren = node.children && node.children.length > 0;
     const isExpanded = expanded.has(String(node.id));
+    const isGroup = node.node_type === "group";
     result.push({
       id: String(node.id),
       label: node.name,
@@ -30,12 +46,62 @@ function flattenTree(
       annotation: node.weight_override_g != null ? `${node.weight_override_g}g` : undefined,
       onClick: () => onSelect(node),
       onDelete: () => onDelete(node),
+      onAdd: isGroup ? () => onAdd(node) : undefined,
+      addTitle: isGroup ? `Add to ${node.name}` : undefined,
     });
     if (hasChildren && isExpanded) {
-      result.push(...flattenTree(node.children, level + 1, expanded, onSelect, onDelete, selectedId));
+      result.push(
+        ...flattenTree(node.children, level + 1, expanded, onSelect, onDelete, onAdd, selectedId),
+      );
     }
   }
   return result;
+}
+
+interface NewGroupInputProps {
+  onSubmit: (name: string) => void;
+  onCancel: () => void;
+}
+
+function NewGroupInput({ onSubmit, onCancel }: NewGroupInputProps) {
+  const [value, setValue] = useState("");
+
+  function trySubmit() {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    onSubmit(trimmed);
+  }
+
+  return (
+    <div className="flex items-center gap-1.5 rounded-xl border border-primary bg-card px-2 py-1.5">
+      <input
+        autoFocus
+        type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") trySubmit();
+          if (e.key === "Escape") onCancel();
+        }}
+        placeholder="Group name..."
+        className="flex-1 bg-transparent text-[12px] text-foreground outline-none placeholder:text-subtle-foreground"
+      />
+      <button
+        onClick={trySubmit}
+        className="flex size-5 items-center justify-center rounded-full text-primary hover:bg-sidebar-accent"
+        aria-label="Create group"
+      >
+        <Check size={12} />
+      </button>
+      <button
+        onClick={onCancel}
+        className="flex size-5 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent"
+        aria-label="Cancel"
+      >
+        <X size={12} />
+      </button>
+    </div>
+  );
 }
 
 export function ComponentTree() {
@@ -43,11 +109,13 @@ export function ComponentTree() {
   const { tree, mutate } = useComponentTree(aeroplaneId);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [selectedNodeId, setSelectedNodeId] = useState<number | null>(null);
+  const [addFlow, setAddFlow] = useState<AddFlowStage>({ kind: "idle" });
 
   const toggle = (id: string) => {
     setExpanded((prev) => {
       const next = new Set(prev);
-      next.has(id) ? next.delete(id) : next.add(id);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
       return next;
     });
   };
@@ -68,44 +136,140 @@ export function ComponentTree() {
     }
   };
 
-  const handleAddGroup = async () => {
+  const openAddMenu = (node: ComponentTreeNode) => {
+    // Auto-expand the target group so a newly created child is visible right away.
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      next.add(String(node.id));
+      return next;
+    });
+    setAddFlow({ kind: "menu", parentId: node.id, parentName: node.name });
+  };
+
+  const openRootAddMenu = () => {
+    setAddFlow({ kind: "menu", parentId: null, parentName: "root" });
+  };
+
+  const handleCreateGroup = async (name: string) => {
     if (!aeroplaneId) return;
-    const name = prompt("Group name?");
-    if (!name) return;
+    const parentId = addFlow.kind === "newGroup" ? addFlow.parentId : null;
     try {
-      await addTreeNode(aeroplaneId, { node_type: "group", name });
+      await addTreeNode(aeroplaneId, {
+        parent_id: parentId,
+        node_type: "group",
+        name,
+      });
       mutate();
     } catch (err) {
       alert(err instanceof Error ? err.message : "Add failed");
+    } finally {
+      setAddFlow({ kind: "idle" });
     }
   };
 
-  const rows = flattenTree(tree, 0, expanded, handleSelect, handleDelete, selectedNodeId);
+  const handleAssignCots = async (component: Component) => {
+    if (!aeroplaneId) return;
+    const parentId = addFlow.kind === "cotsPicker" ? addFlow.parentId : null;
+    try {
+      await addTreeNode(aeroplaneId, {
+        parent_id: parentId,
+        node_type: "cots",
+        name: component.name,
+        component_id: component.id,
+        quantity: 1,
+      });
+      mutate();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Assign failed");
+    } finally {
+      setAddFlow({ kind: "idle" });
+    }
+  };
+
+  const rows = flattenTree(
+    tree,
+    0,
+    expanded,
+    handleSelect,
+    handleDelete,
+    openAddMenu,
+    selectedNodeId,
+  );
 
   return (
-    <TreeCard
-      title="Component Tree"
-      actions={
-        <button
-          onClick={handleAddGroup}
-          className="flex size-6 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent hover:text-foreground"
-          title="Add group"
+    <>
+      <TreeCard
+        title="Component Tree"
+        actions={
+          <button
+            onClick={openRootAddMenu}
+            className="flex size-6 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent hover:text-foreground"
+            title="Add to root"
+          >
+            <Plus size={14} />
+          </button>
+        }
+      >
+        <div className="flex flex-col gap-0.5">
+          {rows.length === 0 ? (
+            <p className="py-4 text-center text-[11px] text-muted-foreground">
+              No components yet. Add a group or assign a component.
+            </p>
+          ) : (
+            rows.map((node) => (
+              <SimpleTreeRow key={node.id} node={node} onToggle={() => toggle(node.id)} />
+            ))
+          )}
+
+          {addFlow.kind === "newGroup" && (
+            <div className="px-1 py-1">
+              <NewGroupInput
+                onSubmit={handleCreateGroup}
+                onCancel={() => setAddFlow({ kind: "idle" })}
+              />
+            </div>
+          )}
+        </div>
+      </TreeCard>
+
+      {addFlow.kind === "menu" && (
+        <div
+          className="fixed inset-0 z-40 bg-black/40"
+          onClick={() => setAddFlow({ kind: "idle" })}
         >
-          <Plus size={14} />
-        </button>
-      }
-    >
-      <div className="flex flex-col gap-0.5">
-        {rows.length === 0 ? (
-          <p className="py-4 text-center text-[11px] text-muted-foreground">
-            No components yet. Add a group or assign COTS parts.
-          </p>
-        ) : (
-          rows.map((node) => (
-            <SimpleTreeRow key={node.id} node={node} onToggle={() => toggle(node.id)} />
-          ))
-        )}
-      </div>
-    </TreeCard>
+          <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+            <GroupAddMenu
+              groupName={addFlow.parentName}
+              onNewGroup={() =>
+                setAddFlow({
+                  kind: "newGroup",
+                  parentId: addFlow.parentId,
+                  parentName: addFlow.parentName,
+                })
+              }
+              onAssignCots={() =>
+                setAddFlow({
+                  kind: "cotsPicker",
+                  parentId: addFlow.parentId,
+                  parentName: addFlow.parentName,
+                })
+              }
+              onAssignConstructionPart={() => {
+                /* gh#57-wvg: wired when the Construction-Parts picker ships. */
+              }}
+              onClose={() => setAddFlow({ kind: "idle" })}
+              constructionPartsEnabled={false}
+            />
+          </div>
+        </div>
+      )}
+
+      <CotsPickerDialog
+        open={addFlow.kind === "cotsPicker"}
+        onClose={() => setAddFlow({ kind: "idle" })}
+        onSelect={handleAssignCots}
+        targetGroupName={addFlow.kind === "cotsPicker" ? addFlow.parentName : undefined}
+      />
+    </>
   );
 }

--- a/frontend/components/workbench/CotsPickerDialog.tsx
+++ b/frontend/components/workbench/CotsPickerDialog.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState } from "react";
+import { X, Search, Loader2, Package } from "lucide-react";
+import { useComponents, type Component } from "@/hooks/useComponents";
+
+interface CotsPickerDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSelect: (component: Component) => void;
+  /** Optional — shown in the header to give the user context. */
+  targetGroupName?: string;
+}
+
+const TYPE_FILTER_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
+  { value: "", label: "All types" },
+  { value: "servo", label: "Servo" },
+  { value: "brushless_motor", label: "Motor" },
+  { value: "esc", label: "ESC" },
+  { value: "battery", label: "Battery" },
+  { value: "receiver", label: "Receiver" },
+  { value: "flight_controller", label: "Flight Controller" },
+  { value: "material", label: "Material" },
+  { value: "propeller", label: "Propeller" },
+  { value: "generic", label: "Generic" },
+];
+
+export function CotsPickerDialog({
+  open,
+  onClose,
+  onSelect,
+  targetGroupName,
+}: CotsPickerDialogProps) {
+  const [search, setSearch] = useState("");
+  const [typeFilter, setTypeFilter] = useState<string>("");
+  const { components, total, isLoading } = useComponents(
+    typeFilter || undefined,
+    search || undefined,
+  );
+
+  if (!open) return null;
+
+  function handlePick(comp: Component) {
+    onSelect(comp);
+    onClose();
+  }
+
+  const heading = targetGroupName
+    ? `Assign Component to '${targetGroupName}'`
+    : "Assign Component";
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={onClose}
+    >
+      <div
+        className="flex max-h-[80vh] w-[560px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-label="Component picker"
+      >
+        <div className="flex items-center gap-3">
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
+            {heading}
+          </span>
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-muted-foreground">
+            {total} items
+          </span>
+          <span className="flex-1" />
+          <button
+            onClick={onClose}
+            className="flex size-8 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent"
+            aria-label="Close"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="flex gap-3">
+          <div className="flex flex-1 items-center gap-2 rounded-xl border border-border bg-input px-3 py-2">
+            <Search className="size-3.5 text-muted-foreground" />
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search components..."
+              className="flex-1 bg-transparent text-[12px] text-foreground outline-none placeholder:text-subtle-foreground"
+            />
+          </div>
+          <select
+            value={typeFilter}
+            onChange={(e) => setTypeFilter(e.target.value)}
+            className="rounded-xl border border-border bg-input px-3 py-2 text-[12px] text-foreground"
+          >
+            {TYPE_FILTER_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto">
+          {isLoading ? (
+            <div className="flex items-center justify-center gap-2 py-10 text-[13px] text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" />
+              Loading components...
+            </div>
+          ) : components.length === 0 ? (
+            <div className="flex flex-col items-center gap-2 py-10 text-[13px] text-muted-foreground">
+              <Package className="size-8 text-subtle-foreground" />
+              <span>
+                {search || typeFilter
+                  ? "No components match the filter"
+                  : "No components available"}
+              </span>
+            </div>
+          ) : (
+            components.map((comp) => (
+              <button
+                key={comp.id}
+                onClick={() => handlePick(comp)}
+                className="flex items-center gap-3 rounded-lg border border-border bg-card px-3 py-2 text-left hover:border-primary hover:bg-sidebar-accent"
+              >
+                <div className="flex flex-1 flex-col gap-0.5">
+                  <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-foreground">
+                    {comp.name}
+                  </span>
+                  <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                    <span className="rounded-full bg-sidebar-accent px-2 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[9px]">
+                      {comp.component_type}
+                    </span>
+                    {comp.manufacturer && <span>{comp.manufacturer}</span>}
+                    {comp.mass_g != null && (
+                      <span className="font-[family-name:var(--font-jetbrains-mono)] text-foreground">
+                        {comp.mass_g}g
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </button>
+            ))
+          )}
+        </div>
+
+        <div className="flex justify-end">
+          <button
+            onClick={onClose}
+            className="rounded-full border border-border px-4 py-2 text-[13px] text-muted-foreground hover:bg-sidebar-accent"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/workbench/GroupAddMenu.tsx
+++ b/frontend/components/workbench/GroupAddMenu.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useEffect } from "react";
+import { FolderPlus, Package, Box } from "lucide-react";
+
+interface GroupAddMenuProps {
+  groupName: string;
+  /**
+   * Action handlers are responsible for dismissing/transitioning the menu
+   * themselves — picking an action does NOT auto-call onClose. onClose is
+   * only invoked on outside click / escape key / explicit close button,
+   * never as a consequence of an action pick.
+   */
+  onNewGroup: () => void;
+  onAssignCots: () => void;
+  onAssignConstructionPart: () => void;
+  onClose: () => void;
+  /**
+   * Enables the "Assign Construction Part" option. Until gh#57-wvg lands
+   * the Construction-Parts picker is not implemented, so the caller sets
+   * this to false and the option renders as disabled.
+   */
+  constructionPartsEnabled?: boolean;
+}
+
+interface MenuItemProps {
+  icon: React.ReactNode;
+  label: string;
+  hint?: string;
+  disabled?: boolean;
+  onClick: () => void;
+}
+
+function MenuItem({ icon, label, hint, disabled, onClick }: MenuItemProps) {
+  return (
+    <button
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
+      className={`flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2 text-left text-[13px] ${
+        disabled
+          ? "cursor-not-allowed opacity-40 text-foreground"
+          : "text-foreground hover:bg-sidebar-accent"
+      }`}
+    >
+      <span className="flex size-4 shrink-0 items-center justify-center text-muted-foreground">
+        {icon}
+      </span>
+      <span className="flex-1 truncate">{label}</span>
+      {hint && (
+        <span className="font-[family-name:var(--font-jetbrains-mono)] text-[10px] text-subtle-foreground">
+          {hint}
+        </span>
+      )}
+    </button>
+  );
+}
+
+export function GroupAddMenu({
+  groupName,
+  onNewGroup,
+  onAssignCots,
+  onAssignConstructionPart,
+  onClose,
+  constructionPartsEnabled = false,
+}: GroupAddMenuProps) {
+  // Picking an action does not also close the menu — the parent is
+  // expected to transition state, which implicitly unmounts this menu.
+  // The menu closes on Escape via this effect.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  return (
+    <div
+      className="flex w-64 flex-col gap-0.5 rounded-xl border border-border bg-card p-1.5 shadow-2xl"
+      onClick={(e) => e.stopPropagation()}
+      role="menu"
+    >
+      <div className="px-2.5 pb-1 pt-1">
+        <span className="font-[family-name:var(--font-jetbrains-mono)] text-[10px] text-muted-foreground">
+          Add to &lsquo;{groupName}&rsquo;
+        </span>
+      </div>
+      <div className="my-0.5 h-px w-full bg-border" />
+      <MenuItem
+        icon={<FolderPlus size={14} />}
+        label="New Group"
+        hint="inline"
+        onClick={onNewGroup}
+      />
+      <MenuItem
+        icon={<Package size={14} />}
+        label="Assign COTS Component"
+        hint="picker"
+        onClick={onAssignCots}
+      />
+      <MenuItem
+        icon={<Box size={14} />}
+        label="Assign Construction Part"
+        hint={constructionPartsEnabled ? "picker" : "soon"}
+        disabled={!constructionPartsEnabled}
+        onClick={onAssignConstructionPart}
+      />
+    </div>
+  );
+}

--- a/frontend/components/workbench/SimpleTreeRow.tsx
+++ b/frontend/components/workbench/SimpleTreeRow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronRight, Trash2 } from "lucide-react";
 
 export interface SimpleTreeNode {
   id: string;
@@ -9,9 +9,12 @@ export interface SimpleTreeNode {
   expanded?: boolean;
   leaf?: boolean;
   muted?: boolean;
+  selected?: boolean;
   chip?: string;
   annotation?: string;
   annotationPrimary?: boolean;
+  onClick?: () => void;
+  onDelete?: () => void;
 }
 
 interface SimpleTreeRowProps {
@@ -21,11 +24,19 @@ interface SimpleTreeRowProps {
 
 export function SimpleTreeRow({ node, onToggle }: SimpleTreeRowProps) {
   const indent = node.level * 20;
+
+  function handleClick() {
+    if (!node.leaf) onToggle();
+    node.onClick?.();
+  }
+
   return (
-    <button
-      onClick={onToggle}
+    <div
+      className={`group flex w-full items-center gap-1.5 rounded-xl py-1.5 pr-2 hover:bg-sidebar-accent cursor-pointer ${
+        node.selected ? "bg-sidebar-accent font-semibold" : ""
+      }`}
       style={{ paddingLeft: indent }}
-      className="flex w-full items-center gap-1.5 rounded-xl py-1.5 pr-2 text-left hover:bg-sidebar-accent"
+      onClick={handleClick}
     >
       {!node.leaf ? (
         node.expanded ? (
@@ -54,6 +65,14 @@ export function SimpleTreeRow({ node, onToggle }: SimpleTreeRowProps) {
           {node.annotation}
         </span>
       )}
-    </button>
+      {node.onDelete && (
+        <button
+          onClick={(e) => { e.stopPropagation(); node.onDelete?.(); }}
+          className="hidden size-5 items-center justify-center rounded-full text-destructive group-hover:flex"
+        >
+          <Trash2 size={10} />
+        </button>
+      )}
+    </div>
   );
 }

--- a/frontend/components/workbench/SimpleTreeRow.tsx
+++ b/frontend/components/workbench/SimpleTreeRow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronDown, ChevronRight, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronRight, Plus, Trash2 } from "lucide-react";
 
 export interface SimpleTreeNode {
   id: string;
@@ -15,6 +15,10 @@ export interface SimpleTreeNode {
   annotationPrimary?: boolean;
   onClick?: () => void;
   onDelete?: () => void;
+  /** Optional per-row add action. Rendered only when provided (typically group rows only). */
+  onAdd?: () => void;
+  /** Tooltip for the add button; also used as a test hook via title="…". */
+  addTitle?: string;
 }
 
 interface SimpleTreeRowProps {
@@ -64,6 +68,15 @@ export function SimpleTreeRow({ node, onToggle }: SimpleTreeRowProps) {
         >
           {node.annotation}
         </span>
+      )}
+      {node.onAdd && (
+        <button
+          onClick={(e) => { e.stopPropagation(); node.onAdd?.(); }}
+          title={node.addTitle ?? "Add"}
+          className="hidden size-5 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent hover:text-foreground group-hover:flex"
+        >
+          <Plus size={10} />
+        </button>
       )}
       {node.onDelete && (
         <button

--- a/frontend/hooks/useComponentTree.ts
+++ b/frontend/hooks/useComponentTree.ts
@@ -1,0 +1,61 @@
+"use client";
+
+import useSWR from "swr";
+import { fetcher, API_BASE } from "@/lib/fetcher";
+
+export interface ComponentTreeNode {
+  id: number;
+  aeroplane_id: string;
+  parent_id: number | null;
+  sort_index: number;
+  node_type: "group" | "cad_shape" | "cots";
+  name: string;
+  component_id: number | null;
+  quantity: number;
+  weight_override_g: number | null;
+  children: ComponentTreeNode[];
+}
+
+interface ComponentTreeResponse {
+  aeroplane_id: string;
+  root_nodes: ComponentTreeNode[];
+  total_nodes: number;
+}
+
+export function useComponentTree(aeroplaneId: string | null) {
+  const { data, error, isLoading, mutate } = useSWR<ComponentTreeResponse>(
+    aeroplaneId ? `/aeroplanes/${aeroplaneId}/component-tree` : null,
+    fetcher,
+  );
+
+  return {
+    tree: data?.root_nodes ?? [],
+    totalNodes: data?.total_nodes ?? 0,
+    error,
+    isLoading,
+    mutate,
+  };
+}
+
+export async function addTreeNode(
+  aeroplaneId: string,
+  node: { parent_id?: number | null; node_type: string; name: string; component_id?: number; quantity?: number },
+): Promise<ComponentTreeNode> {
+  const res = await fetch(`${API_BASE}/aeroplanes/${aeroplaneId}/component-tree`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(node),
+  });
+  if (!res.ok) throw new Error(`Add node failed: ${res.status}`);
+  return res.json();
+}
+
+export async function deleteTreeNode(aeroplaneId: string, nodeId: number): Promise<void> {
+  const res = await fetch(`${API_BASE}/aeroplanes/${aeroplaneId}/component-tree/${nodeId}`, {
+    method: "DELETE",
+  });
+  if (!res.ok) {
+    const detail = await res.text();
+    throw new Error(`Delete failed: ${res.status} ${detail}`);
+  }
+}

--- a/frontend/hooks/useComponents.ts
+++ b/frontend/hooks/useComponents.ts
@@ -1,0 +1,73 @@
+"use client";
+
+import useSWR from "swr";
+import { fetcher, API_BASE } from "@/lib/fetcher";
+
+export interface Component {
+  id: number;
+  name: string;
+  component_type: string;
+  manufacturer: string | null;
+  description: string | null;
+  mass_g: number | null;
+  bbox_x_mm: number | null;
+  bbox_y_mm: number | null;
+  bbox_z_mm: number | null;
+  model_ref: string | null;
+  specs: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
+interface ComponentList {
+  items: Component[];
+  total: number;
+}
+
+export function useComponents(componentType?: string, search?: string) {
+  const params = new URLSearchParams();
+  if (componentType) params.set("component_type", componentType);
+  if (search) params.set("q", search);
+  const query = params.toString();
+  const url = `/components${query ? `?${query}` : ""}`;
+
+  const { data, error, isLoading, mutate } = useSWR<ComponentList>(url, fetcher);
+
+  return {
+    components: data?.items ?? [],
+    total: data?.total ?? 0,
+    error,
+    isLoading,
+    mutate,
+  };
+}
+
+export function useComponentTypes() {
+  const { data } = useSWR<{ types: string[] }>("/components/types", fetcher);
+  return data?.types ?? [];
+}
+
+export async function createComponent(comp: Omit<Component, "id" | "created_at" | "updated_at">): Promise<Component> {
+  const res = await fetch(`${API_BASE}/components`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(comp),
+  });
+  if (!res.ok) throw new Error(`Create failed: ${res.status}`);
+  return res.json();
+}
+
+export async function updateComponent(id: number, comp: Omit<Component, "id" | "created_at" | "updated_at">): Promise<Component> {
+  const res = await fetch(`${API_BASE}/components/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(comp),
+  });
+  if (!res.ok) throw new Error(`Update failed: ${res.status}`);
+  return res.json();
+}
+
+export async function deleteComponent(id: number): Promise<void> {
+  const res = await fetch(`${API_BASE}/components/${id}`, { method: "DELETE" });
+  if (!res.ok) throw new Error(`Delete failed: ${res.status}`);
+}


### PR DESCRIPTION
## Summary

Replaces the tree's root-only Plus button + `window.prompt()` with a per-group (+) affordance that opens a popover with three options:

1. **New Group** — opens an inline input in the tree (Enter submits, Escape cancels, empty names rejected). Creates a sub-group via `POST /aeroplanes/{id}/component-tree` with `parent_id` set to the target group.
2. **Assign COTS Component** — opens a picker dialog over the Component Library (reuses `useComponents` hook for search + type filter). Selecting a component creates a `cots` tree node.
3. **Assign Construction Part** — disabled until `cad-modelling-service-wvg` (D4) ships. The option is visible so users know it is coming.

## New components

- **`GroupAddMenu.tsx`** — popover. Closes on Escape (via a window-level `keydown` listener that is cleaned up on unmount). **Picking an action does NOT auto-close** — the parent is expected to transition state; closing would race with the parent's own state update.
- **`CotsPickerDialog.tsx`** — fixed-position modal with search + type filter. Renders empty-state, loading-state, and matched-list states.

## Changed

- **`ComponentTree.tsx`** — state machine with four stages: `idle` → `menu` → `newGroup` or `cotsPicker` → `idle`. Auto-expands the target group on (+) click so the new child is immediately visible.
- **`SimpleTreeRow.tsx`** — optional `onAdd` slot with a Plus button shown on row hover (alongside the existing Trash2). `addTitle` serves as both tooltip and stable test hook (`title=\"Add to <group>\"`).

## Depends on

- **PR #67** (BUG-A: Dialog-Rendering fix) — this branch is stacked on \`feat/gh-57-components-frontend\`. The \`+ New Component\` dialog fix from PR #67 is required for the COTS-Picker to render (same \`WorkbenchTwoPanel\` pattern).
- Merge order: merge PR #67 first, then this PR.

## Pencil wireframe

Detail frame added: \`screen-4-components-tree-add-detail\` — shows the (+) affordance next to a group row and the popover with all three options (construction-part dimmed).

## Test plan

- [x] \`npm run test:unit\` — 85 green (was 65; +20 new across 3 new test files)
  - 7× GroupAddMenu — rendering, action wiring, disabled construction-part, Escape-closes
  - 7× CotsPickerDialog — empty / loading / matched states, select callback shape, Cancel
  - 6× ComponentTreeAddFlow — per-group (+), popover opens, inline input submit/cancel/empty-reject, COTS picker creates cots node
- [x] \`npx eslint\` on touched files — clean
- [x] \`npm run build\` — clean
- [x] \`poetry run ruff check .\` + \`poetry run pytest -m \"not slow\"\` — 265 green (backend untouched)

## Out of scope

- Drag-&-Drop reordering → \`cad-modelling-service-wak\` (gh#57-C)
- Construction-Parts picker integration → \`cad-modelling-service-wvg\` (gh#57-D4)
- Per-node property panel → \`cad-modelling-service-38x\` (gh#57-E)

Closes \`cad-modelling-service-40g\`.
Relates to #57.
Depends on #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)