### PR TITLE
feat(gh#57): Construction-Parts file API + metadata CRUD (D2)

### DIFF
--- a/alembic/versions/1a39e098d77e_add_file_path_format_to_construction_.py
+++ b/alembic/versions/1a39e098d77e_add_file_path_format_to_construction_.py
@@ -1,0 +1,32 @@
+"""add_file_path_format_to_construction_parts
+
+Revision ID: 1a39e098d77e
+Revises: 4a9c81984e86
+Create Date: 2026-04-16 19:38:30.843950
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '1a39e098d77e'
+down_revision: Union[str, None] = '4a9c81984e86'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add file_path + file_format columns to construction_parts (gh#57-9uk)."""
+    with op.batch_alter_table('construction_parts', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('file_path', sa.String(), nullable=True))
+        batch_op.add_column(sa.Column('file_format', sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop file_path + file_format from construction_parts."""
+    with op.batch_alter_table('construction_parts', schema=None) as batch_op:
+        batch_op.drop_column('file_format')
+        batch_op.drop_column('file_path')

--- a/app/api/v2/endpoints/aeroplane/construction_parts.py
+++ b/app/api/v2/endpoints/aeroplane/construction_parts.py
@@ -1,19 +1,26 @@
-"""Endpoints for the per-aeroplane Construction-Parts domain (gh#57-g4h)."""
+"""Endpoints for the per-aeroplane Construction-Parts domain (gh#57-g4h + gh#57-9uk)."""
 from __future__ import annotations
 
 import logging
+from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Path, status
+from fastapi import APIRouter, Body, Depends, File, Form, HTTPException, Path, Query, UploadFile, status
+from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
 from app.core.exceptions import (
+    ConflictError,
     NotFoundError,
     ServiceException,
     ValidationDomainError,
     ValidationError,
 )
 from app.db.session import get_db
-from app.schemas.construction_part import ConstructionPartList, ConstructionPartRead
+from app.schemas.construction_part import (
+    ConstructionPartList,
+    ConstructionPartRead,
+    ConstructionPartUpdate,
+)
 from app.services import construction_part_service as svc
 
 logger = logging.getLogger(__name__)
@@ -30,6 +37,17 @@ def _raise_http(exc: ServiceException) -> None:
     if isinstance(exc, (ValidationError, ValidationDomainError)):
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=exc.message
+        ) from exc
+    if isinstance(exc, ConflictError):
+        # File-too-large is signalled via ConflictError with a marker in details
+        # so the upload endpoint can map it to HTTP 413 rather than 409.
+        if exc.details and exc.details.get("reason") == "file_too_large":
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail=exc.message,
+            ) from exc
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail=exc.message
         ) from exc
     raise HTTPException(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=exc.message
@@ -100,3 +118,95 @@ async def unlock_construction_part(
 ) -> ConstructionPartRead:
     """Mark the part as unlocked. Idempotent."""
     return _call(svc.unlock_part, db, aeroplane_id, part_id)
+
+
+# ── D2 (gh#57-9uk): file upload / download / metadata CRUD ──────────────────
+
+
+@router.post(
+    "",
+    status_code=status.HTTP_201_CREATED,
+    response_model=ConstructionPartRead,
+    operation_id="upload_construction_part",
+)
+async def upload_construction_part(
+    aeroplane_id: str = Path(...),
+    file: UploadFile = File(..., description="STEP (.step/.stp) or STL (.stl) file"),
+    name: str = Form(..., min_length=1, description="Display name"),
+    material_component_id: Optional[int] = Form(None, description="FK to components (material)"),
+    thumbnail_url: Optional[str] = Form(None, description="Optional preview image URL"),
+    db: Session = Depends(get_db),
+) -> ConstructionPartRead:
+    """Upload a CAD file and create a new construction-part for this aeroplane.
+
+    The file is stored under ``tmp/construction_parts/{aeroplane_id}/``.
+    Geometry (volume / area / bounding-box) is extracted at upload time via
+    CadQuery; on platforms without CadQuery the row is still created with
+    NULL geometry fields.
+    """
+    content = await file.read()
+    return _call(
+        svc.create_part,
+        db,
+        aeroplane_id,
+        filename=file.filename,
+        content=content,
+        name=name,
+        material_component_id=material_component_id,
+        thumbnail_url=thumbnail_url,
+    )
+
+
+@router.get(
+    "/{part_id}/file",
+    status_code=status.HTTP_200_OK,
+    operation_id="download_construction_part_file",
+)
+async def download_construction_part_file(
+    aeroplane_id: str = Path(...),
+    part_id: int = Path(...),
+    format: str = Query("stl", description="Output format: 'step' or 'stl'"),
+    db: Session = Depends(get_db),
+) -> FileResponse:
+    """Download the construction-part file in the requested format.
+
+    If the source is STEP and the requested format is STL, the STL is
+    regenerated on the fly via CadQuery. Requesting STEP for an STL source
+    returns 422 (the conversion is not lossless).
+    """
+    path, mime = _call(svc.get_part_file, db, aeroplane_id, part_id, format)
+    return FileResponse(
+        path=str(path),
+        media_type=mime,
+        filename=f"construction_part_{part_id}.{format}",
+    )
+
+
+@router.put(
+    "/{part_id}",
+    status_code=status.HTTP_200_OK,
+    response_model=ConstructionPartRead,
+    operation_id="update_construction_part",
+)
+async def update_construction_part(
+    aeroplane_id: str = Path(...),
+    part_id: int = Path(...),
+    body: ConstructionPartUpdate = Body(...),
+    db: Session = Depends(get_db),
+) -> ConstructionPartRead:
+    """Update name / material / thumbnail. File and geometry stay untouched."""
+    return _call(svc.update_part, db, aeroplane_id, part_id, body)
+
+
+@router.delete(
+    "/{part_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    operation_id="delete_construction_part",
+)
+async def delete_construction_part(
+    aeroplane_id: str = Path(...),
+    part_id: int = Path(...),
+    db: Session = Depends(get_db),
+) -> None:
+    """Delete a part and remove its file. Returns 409 if the part is locked."""
+    _call(svc.delete_part, db, aeroplane_id, part_id)

--- a/app/models/construction_part.py
+++ b/app/models/construction_part.py
@@ -45,6 +45,12 @@ class ConstructionPartModel(Base):
 
     thumbnail_url = Column(String, nullable=True)
 
+    # Local storage path for the uploaded CAD file (relative to cwd) and the
+    # source format. Populated by the upload endpoint (gh#57-9uk). NULL until
+    # a file has been uploaded.
+    file_path = Column(String, nullable=True)
+    file_format = Column(String, nullable=True)  # "step" or "stl"
+
     created_at = Column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),

--- a/app/schemas/construction_part.py
+++ b/app/schemas/construction_part.py
@@ -38,8 +38,23 @@ class ConstructionPartRead(BaseModel):
 
     thumbnail_url: Optional[str] = Field(None, description="Optional preview image URL")
 
+    file_path: Optional[str] = Field(
+        None, description="Local storage path of the uploaded CAD file"
+    )
+    file_format: Optional[str] = Field(
+        None, description="Source file format: 'step' or 'stl'"
+    )
+
     created_at: datetime
     updated_at: datetime
+
+
+class ConstructionPartUpdate(BaseModel):
+    """Metadata-only update payload (PUT). File and geometry are untouched."""
+
+    name: Optional[str] = Field(None, min_length=1)
+    material_component_id: Optional[int] = Field(None)
+    thumbnail_url: Optional[str] = Field(None)
 
 
 class ConstructionPartList(BaseModel):

--- a/app/services/construction_part_service.py
+++ b/app/services/construction_part_service.py
@@ -1,20 +1,43 @@
-"""Construction Parts service (gh#57-g4h).
+"""Construction Parts service (gh#57-g4h + gh#57-9uk).
 
-MVP: list, get, lock, unlock. File upload/download and general CRUD
-arrive in gh#57-9uk.
+D1 (g4h): list, get, lock, unlock.
+D2 (9uk): create with multipart upload, file download (with optional
+STEP→STL regeneration), metadata update, lock-protected delete, +
+geometry extraction via CadQuery at upload time.
 """
 from __future__ import annotations
 
 import logging
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Optional
+from uuid import uuid4
 
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
-from app.core.exceptions import InternalError, NotFoundError
+from app.core.exceptions import (
+    ConflictError,
+    InternalError,
+    NotFoundError,
+    ValidationError,
+)
+from app.core.platform import cad_available
 from app.models.construction_part import ConstructionPartModel
-from app.schemas.construction_part import ConstructionPartList, ConstructionPartRead
+from app.schemas.construction_part import (
+    ConstructionPartList,
+    ConstructionPartRead,
+    ConstructionPartUpdate,
+)
 
 logger = logging.getLogger(__name__)
+
+ALLOWED_SUFFIXES = {".step", ".stp", ".stl"}
+MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024  # 50 MB
+ALLOWED_DOWNLOAD_FORMATS = {"step", "stl"}
+STORAGE_ROOT = Path("tmp") / "construction_parts"
 
 
 def _get_part_or_404(
@@ -82,3 +105,257 @@ def lock_part(db: Session, aeroplane_id: str, part_id: int) -> ConstructionPartR
 def unlock_part(db: Session, aeroplane_id: str, part_id: int) -> ConstructionPartRead:
     """Set locked=False. Idempotent when the part is already unlocked."""
     return _set_locked(db, aeroplane_id, part_id, False)
+
+
+# --------------------------------------------------------------------------- #
+# D2 (9uk): Upload, Download, Update, Delete
+# --------------------------------------------------------------------------- #
+
+
+def _validate_upload(filename: Optional[str], content: bytes) -> tuple[str, str]:
+    """Return (suffix_lower, format) or raise ValidationError / ConflictError.
+
+    ValidationError = unsupported / empty.
+    The size check uses ConflictError-mapped HTTP 413 via the endpoint layer.
+    """
+    if not content:
+        raise ValidationError(message="Uploaded file is empty.")
+    if len(content) > MAX_FILE_SIZE_BYTES:
+        # Marker for the endpoint to map to 413.
+        raise ConflictError(
+            message=(
+                f"File exceeds maximum size of {MAX_FILE_SIZE_BYTES // (1024 * 1024)} MB."
+            ),
+            details={"reason": "file_too_large"},
+        )
+    suffix = Path(filename or "upload.unknown").suffix.lower()
+    if suffix not in ALLOWED_SUFFIXES:
+        raise ValidationError(
+            message=(
+                f"Unsupported file extension '{suffix}'. "
+                f"Allowed: {sorted(ALLOWED_SUFFIXES)}"
+            ),
+        )
+    fmt = "stl" if suffix == ".stl" else "step"
+    return suffix, fmt
+
+
+def _store_file(aeroplane_id: str, part_id: int, content: bytes, suffix: str) -> Path:
+    """Persist the uploaded bytes under tmp/construction_parts/{aeroplane}/."""
+    target_dir = STORAGE_ROOT / aeroplane_id
+    target_dir.mkdir(parents=True, exist_ok=True)
+    dest = target_dir / f"{part_id}_{uuid4().hex[:8]}{suffix}"
+    with dest.open("wb") as out:
+        out.write(content)
+    return dest
+
+
+def _extract_geometry(file_path: Path, file_format: str) -> dict[str, Optional[float]]:
+    """Return geometry metadata from the uploaded file via CadQuery.
+
+    Returns a dict with volume_mm3, area_mm2, bbox_x_mm/y/z. Returns all-None
+    when CadQuery is unavailable (linux/aarch64) or extraction fails — the
+    upload still succeeds with NULL geometry fields.
+    """
+    empty = {
+        "volume_mm3": None,
+        "area_mm2": None,
+        "bbox_x_mm": None,
+        "bbox_y_mm": None,
+        "bbox_z_mm": None,
+    }
+    if not cad_available():
+        return empty
+    if file_format != "step":
+        # STL meshes do not give us a watertight solid; computing volume from
+        # a triangle soup needs extra dependencies (numpy-stl etc.). For MVP
+        # we leave STL geometry NULL and document the limitation. Users who
+        # need geometry should upload STEP.
+        logger.info(
+            "Skipping geometry extraction for non-STEP format '%s' on %s",
+            file_format, file_path,
+        )
+        return empty
+    try:
+        import cadquery as cq
+
+        shape = cq.importers.importStep(str(file_path))
+        wp_val = shape.val()
+        try:
+            volume = float(wp_val.Volume())
+        except Exception:  # noqa: BLE001 — degenerate shapes are OK
+            volume = None
+        try:
+            area = float(wp_val.Area())
+        except Exception:  # noqa: BLE001
+            area = None
+        try:
+            bb = wp_val.BoundingBox()
+            bbox = (float(bb.xlen), float(bb.ylen), float(bb.zlen))
+        except Exception:  # noqa: BLE001
+            bbox = (None, None, None)
+        return {
+            "volume_mm3": volume,
+            "area_mm2": area,
+            "bbox_x_mm": bbox[0],
+            "bbox_y_mm": bbox[1],
+            "bbox_z_mm": bbox[2],
+        }
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Geometry extraction failed for %s: %s", file_path, exc)
+        return empty
+
+
+def create_part(
+    db: Session,
+    aeroplane_id: str,
+    *,
+    filename: Optional[str],
+    content: bytes,
+    name: str,
+    material_component_id: Optional[int],
+    thumbnail_url: Optional[str],
+) -> ConstructionPartRead:
+    """Upload a STEP/STL file and persist a new construction-part row.
+
+    Aeroplane-scoped. Geometry is extracted at upload (NULL if CadQuery
+    unavailable). The file is stored under
+    ``tmp/construction_parts/{aeroplane_id}/{part_id}_{uuid8}{ext}``.
+    """
+    suffix, fmt = _validate_upload(filename, content)
+    if not name or not name.strip():
+        raise ValidationError(message="name is required.")
+
+    try:
+        # Two-phase: insert row to get an ID, then store file using the ID.
+        part = ConstructionPartModel(
+            aeroplane_id=aeroplane_id,
+            name=name.strip(),
+            material_component_id=material_component_id,
+            thumbnail_url=thumbnail_url,
+            file_format=fmt,
+            locked=False,
+        )
+        db.add(part)
+        db.flush()  # populate part.id without committing the transaction yet
+        dest = _store_file(aeroplane_id, part.id, content, suffix)
+        part.file_path = str(dest)
+        geom = _extract_geometry(dest, fmt)
+        for key, value in geom.items():
+            setattr(part, key, value)
+        db.commit()
+        db.refresh(part)
+        return ConstructionPartRead.model_validate(part)
+    except ValidationError:
+        db.rollback()
+        raise
+    except SQLAlchemyError as exc:
+        db.rollback()
+        logger.error("DB error in create_part: %s", exc)
+        raise InternalError(message=f"Database error: {exc}") from exc
+
+
+def get_part_file(
+    db: Session, aeroplane_id: str, part_id: int, fmt: str
+) -> tuple[Path, str]:
+    """Return (path_to_serve, mime_type) for the requested format.
+
+    Raises ValidationError when the format is invalid or cannot be produced
+    (e.g. STEP requested but source is STL).
+    """
+    if fmt not in ALLOWED_DOWNLOAD_FORMATS:
+        raise ValidationError(
+            message=f"Invalid format '{fmt}'. Allowed: {sorted(ALLOWED_DOWNLOAD_FORMATS)}",
+        )
+    part = _get_part_or_404(db, aeroplane_id, part_id)
+    if not part.file_path:
+        raise NotFoundError(entity="ConstructionPart file", resource_id=part_id)
+
+    source_path = Path(part.file_path)
+    source_format = part.file_format
+
+    if fmt == source_format:
+        return source_path, ("model/stl" if fmt == "stl" else "model/step")
+
+    if fmt == "stl" and source_format == "step":
+        # Regenerate STL from STEP via CadQuery on the fly.
+        if not cad_available():
+            raise ValidationError(
+                message="STL regeneration requires CadQuery, which is unavailable on this platform.",
+            )
+        import cadquery as cq
+
+        tmp_stl = Path(tempfile.mkstemp(suffix=".stl")[1])
+        try:
+            shape = cq.importers.importStep(str(source_path))
+            cq.exporters.export(shape, str(tmp_stl), exportType="STL")
+            return tmp_stl, "model/stl"
+        except Exception as exc:  # noqa: BLE001
+            logger.error("STL regeneration failed for part %s: %s", part_id, exc)
+            raise InternalError(message=f"STL regeneration failed: {exc}") from exc
+
+    if fmt == "step" and source_format == "stl":
+        raise ValidationError(
+            message="Source is STL — STEP cannot be regenerated from STL.",
+        )
+
+    raise ValidationError(
+        message=f"Cannot serve format '{fmt}' for source format '{source_format}'.",
+    )
+
+
+def update_part(
+    db: Session,
+    aeroplane_id: str,
+    part_id: int,
+    data: ConstructionPartUpdate,
+) -> ConstructionPartRead:
+    """Update name / material / thumbnail. File and geometry are NOT touched."""
+    try:
+        part = _get_part_or_404(db, aeroplane_id, part_id)
+        explicit = data.model_dump(exclude_unset=True)
+        if "name" in explicit and explicit["name"]:
+            part.name = explicit["name"].strip()
+        if "material_component_id" in explicit:
+            part.material_component_id = explicit["material_component_id"]
+        if "thumbnail_url" in explicit:
+            part.thumbnail_url = explicit["thumbnail_url"]
+        db.commit()
+        db.refresh(part)
+        return ConstructionPartRead.model_validate(part)
+    except NotFoundError:
+        raise
+    except SQLAlchemyError as exc:
+        db.rollback()
+        logger.error("DB error in update_part: %s", exc)
+        raise InternalError(message=f"Database error: {exc}") from exc
+
+
+def delete_part(db: Session, aeroplane_id: str, part_id: int) -> None:
+    """Delete a part and remove its file. Blocks with ConflictError if locked."""
+    try:
+        part = _get_part_or_404(db, aeroplane_id, part_id)
+        if part.locked:
+            raise ConflictError(
+                message=(
+                    f"ConstructionPart {part_id} is locked and cannot be deleted. "
+                    "Unlock it first."
+                ),
+                details={"part_id": part_id},
+            )
+        file_path = part.file_path
+        db.delete(part)
+        db.commit()
+        if file_path:
+            try:
+                os.unlink(file_path)
+            except FileNotFoundError:
+                # File already gone — log but don't fail the request, the DB
+                # row deletion is the source of truth.
+                logger.info("File for part %s already missing: %s", part_id, file_path)
+    except (NotFoundError, ConflictError):
+        raise
+    except SQLAlchemyError as exc:
+        db.rollback()
+        logger.error("DB error in delete_part: %s", exc)
+        raise InternalError(message=f"Database error: {exc}") from exc

--- a/app/tests/test_construction_parts_file_api.py
+++ b/app/tests/test_construction_parts_file_api.py
@@ -1,0 +1,310 @@
+"""Tests for the Construction-Parts file API + metadata CRUD (gh#57-9uk).
+
+Covers POST upload, GET file download (with optional STEP→STL regeneration),
+PUT metadata-only update, and DELETE with lock-protection. File storage
+follows the components.py pattern: `tmp/construction_parts/{aeroplane}/...`.
+"""
+from __future__ import annotations
+
+import io
+import os
+from pathlib import Path
+
+import pytest
+
+from app.models.construction_part import ConstructionPartModel
+
+
+# Minimal valid STL (binary header 80 bytes + uint32 triangle count = 0)
+_EMPTY_BINARY_STL = b"\x00" * 80 + b"\x00\x00\x00\x00"
+
+# Minimal valid ASCII STL with one zero-area triangle
+_ASCII_STL_ONE_TRI = (
+    b"solid placeholder\n"
+    b"facet normal 0 0 1\n"
+    b"  outer loop\n"
+    b"    vertex 0 0 0\n"
+    b"    vertex 1 0 0\n"
+    b"    vertex 0 1 0\n"
+    b"  endloop\n"
+    b"endfacet\n"
+    b"endsolid placeholder\n"
+)
+
+
+# --------------------------------------------------------------------------- #
+# UPLOAD  POST /aeroplanes/{id}/construction-parts
+# --------------------------------------------------------------------------- #
+
+class TestUpload:
+
+    def test_upload_stl_creates_part(self, client_and_db):
+        client, _ = client_and_db
+        files = {"file": ("test.stl", _ASCII_STL_ONE_TRI, "application/octet-stream")}
+        data = {"name": "Bracket"}
+
+        res = client.post("/aeroplanes/aero-1/construction-parts", files=files, data=data)
+        assert res.status_code == 201, res.text
+        body = res.json()
+        assert body["name"] == "Bracket"
+        assert body["aeroplane_id"] == "aero-1"
+        assert body["locked"] is False
+        # The file_format/file_path are surfaced for the consumer of the new fields
+        assert body.get("file_format") in ("stl", "step")
+
+    def test_upload_persists_file_to_disk(self, client_and_db):
+        client, sf = client_and_db
+        files = {"file": ("frame.stl", _ASCII_STL_ONE_TRI, "application/octet-stream")}
+        res = client.post("/aeroplanes/aero-x/construction-parts", files=files, data={"name": "Frame"})
+        part_id = res.json()["id"]
+
+        session = sf()
+        try:
+            row = session.get(ConstructionPartModel, part_id)
+            assert row.file_path is not None
+            assert Path(row.file_path).exists(), f"file should exist at {row.file_path}"
+            # File path lives under the per-aeroplane subdir
+            assert "aero-x" in row.file_path
+        finally:
+            session.close()
+            # Cleanup the stored file
+            try:
+                os.unlink(row.file_path)
+            except FileNotFoundError:
+                pass
+
+    def test_upload_with_optional_metadata(self, client_and_db):
+        client, _ = client_and_db
+        material_res = client.post("/components", json={
+            "name": "PLA+", "component_type": "material",
+            "specs": {"density_kg_m3": 1240},
+        })
+        material_id = material_res.json()["id"]
+
+        files = {"file": ("p.stl", _ASCII_STL_ONE_TRI, "application/octet-stream")}
+        data = {
+            "name": "Bulkhead",
+            "material_component_id": str(material_id),
+            "thumbnail_url": "/thumbs/bulkhead.png",
+        }
+        res = client.post("/aeroplanes/aero-1/construction-parts", files=files, data=data)
+        assert res.status_code == 201
+        body = res.json()
+        assert body["material_component_id"] == material_id
+        assert body["thumbnail_url"] == "/thumbs/bulkhead.png"
+
+    def test_upload_rejects_unknown_extension(self, client_and_db):
+        client, _ = client_and_db
+        files = {"file": ("bad.txt", b"not a model", "text/plain")}
+        res = client.post("/aeroplanes/aero-1/construction-parts", files=files, data={"name": "Bad"})
+        assert res.status_code == 422
+
+    def test_upload_rejects_oversized_file(self, client_and_db):
+        client, _ = client_and_db
+        # 60 MB > 50 MB limit
+        big = b"\x00" * (60 * 1024 * 1024)
+        files = {"file": ("big.stl", big, "application/octet-stream")}
+        res = client.post("/aeroplanes/aero-1/construction-parts", files=files, data={"name": "Big"})
+        assert res.status_code == 413
+
+    def test_upload_rejects_empty_file(self, client_and_db):
+        client, _ = client_and_db
+        files = {"file": ("empty.stl", b"", "application/octet-stream")}
+        res = client.post("/aeroplanes/aero-1/construction-parts", files=files, data={"name": "Empty"})
+        assert res.status_code == 422
+
+    def test_upload_records_file_format(self, client_and_db):
+        client, _ = client_and_db
+        files = {"file": ("p.STL", _ASCII_STL_ONE_TRI, "application/octet-stream")}
+        res = client.post("/aeroplanes/a/construction-parts", files=files, data={"name": "P"})
+        assert res.json()["file_format"] == "stl"
+
+
+# --------------------------------------------------------------------------- #
+# DOWNLOAD  GET /aeroplanes/{id}/construction-parts/{partId}/file
+# --------------------------------------------------------------------------- #
+
+class TestDownload:
+
+    def _upload_stl(self, client, aeroplane_id="aero-1", name="Stl"):
+        files = {"file": (f"{name}.stl", _ASCII_STL_ONE_TRI, "application/octet-stream")}
+        return client.post(
+            f"/aeroplanes/{aeroplane_id}/construction-parts",
+            files=files, data={"name": name},
+        ).json()
+
+    def test_download_stl_when_source_is_stl(self, client_and_db):
+        client, _ = client_and_db
+        part = self._upload_stl(client)
+
+        res = client.get(f"/aeroplanes/aero-1/construction-parts/{part['id']}/file?format=stl")
+        assert res.status_code == 200
+        assert res.content == _ASCII_STL_ONE_TRI
+
+    def test_download_returns_404_for_missing_part(self, client_and_db):
+        client, _ = client_and_db
+        res = client.get("/aeroplanes/aero-1/construction-parts/9999/file?format=stl")
+        assert res.status_code == 404
+
+    def test_download_step_from_stl_source_returns_422(self, client_and_db):
+        """STEP cannot be regenerated from STL — 422 with a clear message."""
+        client, _ = client_and_db
+        part = self._upload_stl(client)
+        res = client.get(f"/aeroplanes/aero-1/construction-parts/{part['id']}/file?format=step")
+        assert res.status_code == 422
+
+    def test_download_rejects_invalid_format(self, client_and_db):
+        client, _ = client_and_db
+        part = self._upload_stl(client)
+        res = client.get(f"/aeroplanes/aero-1/construction-parts/{part['id']}/file?format=obj")
+        assert res.status_code == 422
+
+    def test_download_cross_aeroplane_returns_404(self, client_and_db):
+        client, _ = client_and_db
+        part = self._upload_stl(client, aeroplane_id="aero-1")
+        res = client.get(f"/aeroplanes/aero-2/construction-parts/{part['id']}/file?format=stl")
+        assert res.status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# UPDATE  PUT /aeroplanes/{id}/construction-parts/{partId}
+# --------------------------------------------------------------------------- #
+
+class TestUpdateMetadata:
+
+    def _upload(self, client):
+        files = {"file": ("p.stl", _ASCII_STL_ONE_TRI, "application/octet-stream")}
+        return client.post(
+            "/aeroplanes/aero-1/construction-parts",
+            files=files, data={"name": "Original"},
+        ).json()
+
+    def test_put_updates_name(self, client_and_db):
+        client, _ = client_and_db
+        part = self._upload(client)
+        res = client.put(
+            f"/aeroplanes/aero-1/construction-parts/{part['id']}",
+            json={"name": "Renamed", "material_component_id": None, "thumbnail_url": None},
+        )
+        assert res.status_code == 200
+        assert res.json()["name"] == "Renamed"
+
+    def test_put_updates_material_component_id(self, client_and_db):
+        client, _ = client_and_db
+        material = client.post("/components", json={
+            "name": "PETG", "component_type": "material", "specs": {"density_kg_m3": 1270},
+        }).json()
+        part = self._upload(client)
+
+        res = client.put(
+            f"/aeroplanes/aero-1/construction-parts/{part['id']}",
+            json={"name": part["name"], "material_component_id": material["id"], "thumbnail_url": None},
+        )
+        assert res.status_code == 200
+        assert res.json()["material_component_id"] == material["id"]
+
+    def test_put_does_not_touch_geometry_or_file_path(self, client_and_db):
+        client, sf = client_and_db
+        part = self._upload(client)
+        original_path = sf().get(ConstructionPartModel, part["id"]).file_path
+
+        client.put(
+            f"/aeroplanes/aero-1/construction-parts/{part['id']}",
+            json={"name": "Renamed", "material_component_id": None, "thumbnail_url": None},
+        )
+        new_path = sf().get(ConstructionPartModel, part["id"]).file_path
+        assert new_path == original_path
+
+    def test_put_returns_404_for_missing(self, client_and_db):
+        client, _ = client_and_db
+        res = client.put(
+            "/aeroplanes/aero-1/construction-parts/9999",
+            json={"name": "X", "material_component_id": None, "thumbnail_url": None},
+        )
+        assert res.status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# DELETE
+# --------------------------------------------------------------------------- #
+
+class TestDelete:
+
+    def _upload(self, client, name="P"):
+        files = {"file": (f"{name}.stl", _ASCII_STL_ONE_TRI, "application/octet-stream")}
+        return client.post(
+            "/aeroplanes/aero-1/construction-parts",
+            files=files, data={"name": name},
+        ).json()
+
+    def test_delete_unlocked_removes_row_and_file(self, client_and_db):
+        client, sf = client_and_db
+        part = self._upload(client)
+        file_path = sf().get(ConstructionPartModel, part["id"]).file_path
+
+        res = client.delete(f"/aeroplanes/aero-1/construction-parts/{part['id']}")
+        assert res.status_code == 204
+        assert sf().get(ConstructionPartModel, part["id"]) is None
+        assert not Path(file_path).exists()
+
+    def test_delete_locked_returns_409_and_keeps_state(self, client_and_db):
+        client, sf = client_and_db
+        part = self._upload(client)
+        client.put(f"/aeroplanes/aero-1/construction-parts/{part['id']}/lock")
+
+        file_path = sf().get(ConstructionPartModel, part["id"]).file_path
+        res = client.delete(f"/aeroplanes/aero-1/construction-parts/{part['id']}")
+        assert res.status_code == 409
+        # State unchanged
+        assert sf().get(ConstructionPartModel, part["id"]) is not None
+        assert Path(file_path).exists()
+
+    def test_delete_returns_404_for_missing(self, client_and_db):
+        client, _ = client_and_db
+        res = client.delete("/aeroplanes/aero-1/construction-parts/9999")
+        assert res.status_code == 404
+
+    def test_delete_cross_aeroplane_returns_404(self, client_and_db):
+        client, _ = client_and_db
+        part = self._upload(client)
+        res = client.delete(f"/aeroplanes/aero-2/construction-parts/{part['id']}")
+        assert res.status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# Geometry extraction (skipped on platforms without CadQuery)
+# --------------------------------------------------------------------------- #
+
+class TestGeometryExtraction:
+
+    def test_geometry_extraction_skipped_for_stl_uploads(self, client_and_db):
+        """MVP behavior: STL meshes are not analyzed for geometry; STEP is.
+
+        STL gives a triangle soup, not a watertight solid — extracting volume
+        cleanly needs extra deps (numpy-stl). Documented limitation. The
+        upload still succeeds; geometry fields remain NULL.
+        """
+        client, _ = client_and_db
+        files = {"file": ("triangle.stl", _ASCII_STL_ONE_TRI, "application/octet-stream")}
+        res = client.post("/aeroplanes/aero-1/construction-parts", files=files, data={"name": "Tri"})
+        body = res.json()
+        for k in ("volume_mm3", "area_mm2", "bbox_x_mm", "bbox_y_mm", "bbox_z_mm"):
+            assert body[k] is None, f"expected {k} to be NULL for STL upload"
+
+    def test_upload_succeeds_when_cadquery_unavailable(self, client_and_db, monkeypatch):
+        """If CadQuery is unavailable, the row is still created but geometry stays NULL."""
+        from app.core import platform
+        platform.cad_available.cache_clear()
+        monkeypatch.setattr(platform, "cad_available", lambda: False)
+
+        client, _ = client_and_db
+        files = {"file": ("p.stl", _ASCII_STL_ONE_TRI, "application/octet-stream")}
+        res = client.post("/aeroplanes/aero-1/construction-parts", files=files, data={"name": "NoCad"})
+        assert res.status_code == 201
+        body = res.json()
+        # All geometry fields must be NULL
+        assert body["volume_mm3"] is None
+        assert body["area_mm2"] is None
+        assert body["bbox_x_mm"] is None
+        assert body["bbox_y_mm"] is None
+        assert body["bbox_z_mm"] is None

--- a/app/tests/test_construction_parts_file_api_migration.py
+++ b/app/tests/test_construction_parts_file_api_migration.py
@@ -1,0 +1,37 @@
+"""Migration test for file_path + file_format columns on construction_parts (gh#57-9uk)."""
+from __future__ import annotations
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect
+
+
+def test_alembic_upgrade_head_adds_file_columns(tmp_path):
+    db_path = tmp_path / "migration_test.db"
+    db_url = f"sqlite:///{db_path}"
+
+    alembic_cfg = Config("alembic.ini")
+    alembic_cfg.set_main_option("sqlalchemy.url", db_url)
+    command.upgrade(alembic_cfg, "head")
+
+    engine = create_engine(db_url)
+    inspector = inspect(engine)
+    columns = {col["name"] for col in inspector.get_columns("construction_parts")}
+    assert "file_path" in columns
+    assert "file_format" in columns
+
+
+def test_alembic_downgrade_removes_file_columns(tmp_path):
+    db_path = tmp_path / "migration_test.db"
+    db_url = f"sqlite:///{db_path}"
+
+    alembic_cfg = Config("alembic.ini")
+    alembic_cfg.set_main_option("sqlalchemy.url", db_url)
+    command.upgrade(alembic_cfg, "head")
+    command.downgrade(alembic_cfg, "-1")
+
+    engine = create_engine(db_url)
+    inspector = inspect(engine)
+    columns = {col["name"] for col in inspector.get_columns("construction_parts")}
+    assert "file_path" not in columns
+    assert "file_format" not in columns


### PR DESCRIPTION
## Summary

Extends D1 (PR #68) with the file-management endpoints needed by the upcoming Frontend Management Panel (D3) and Picker (D4). Implements ACs from the [#34 reopen comment](https://github.com/szymansk/da3Dalus/issues/34#issuecomment-4262098831).

## New endpoints

Under existing `/aeroplanes/{aeroplane_id}/construction-parts`:

| Method | Path | Behaviour |
|--------|------|-----------|
| POST | `` | multipart upload (STEP/STL); creates row + stores file + extracts geometry (STEP only) |
| GET | `/{partId}/file?format=step\|stl` | download; STL regenerated from STEP via CadQuery if needed |
| PUT | `/{partId}` | metadata only (name / material / thumbnail) |
| DELETE | `/{partId}` | removes file + row; HTTP 409 when `locked=true` |

## Schema extension

```sql
ALTER TABLE construction_parts
  ADD COLUMN file_path     TEXT NULL,    -- local storage path
  ADD COLUMN file_format   TEXT NULL;    -- 'step' or 'stl'
```

Migration `1a39e098d77e` uses `batch_alter_table`; downgrade tested.

## Behavioural decisions

- **Storage:** `tmp/construction_parts/{aeroplane_id}/{part_id}_{uuid8}{ext}` (mirrors `components.py:139` upload pattern from #37)
- **Max file size:** 50 MB → HTTP 413 with explicit message
- **Allowed extensions:** `.step`, `.stp`, `.stl` (422 otherwise)
- **Empty file:** 422
- **Geometry extraction:** STEP only via `cq.importers.importStep` + `Volume()` / `Area()` / `BoundingBox()` (per #33). STL is **skipped** with info log — extracting volume from a triangle soup needs extra deps (`numpy-stl`); not worth it for MVP since 3D-print workflows typically export STEP. Documented in service + test.
- **CadQuery unavailable** (linux/aarch64): row still created, geometry NULL (existing `cad_available()` platform guard)
- **Aeroplane scoping** enforced for ALL endpoints via existing `_get_part_or_404` — cross-aeroplane access returns 404, no leak

## Test plan

- [x] `poetry run ruff check .` — clean
- [x] `poetry run pytest -m "not slow" --ignore=.claude` — **306 passed** (was 282; +24)
- [x] Migration upgrade + downgrade round-trip (in test)

### Test inventory (24 new)

**`test_construction_parts_file_api.py` (22):**
- upload: happy-path, file persisted to disk in per-aeroplane subdir, optional metadata (material+thumbnail), invalid extension → 422, oversized → 413, empty → 422, format detection (case-insensitive)
- download: STL when source is STL, 404 for missing, 422 when STEP requested for STL source, 422 for invalid format, 404 for cross-aeroplane
- update (PUT): name update, material_component_id update, geometry/file untouched, 404 for missing
- delete: unlocked removes row + file, locked → 409 + state untouched, 404 for missing, 404 cross-aeroplane
- geometry: extraction skipped for STL (NULL fields), upload succeeds when CadQuery unavailable

**`test_construction_parts_file_api_migration.py` (2):**
- upgrade adds file_path + file_format columns
- downgrade removes both cleanly

## Unblocks

- D3 (`cad-modelling-service-ggd`) — frontend management panel can now upload, rename, delete construction-parts
- D4 (`cad-modelling-service-wvg`) — picker can show parts that have a backing file (file_path != NULL)

## Notes

- This PR is independent of PR #71 (N1 — adds `construction_part_id` FK to `component_tree`). Both PRs touch different tables (`construction_parts` vs `component_tree`) and can be merged in any order.

Closes \`cad-modelling-service-9uk\`.
Relates to #34 (reopened), #37 (file upload precedent), #33 (geometry extraction), #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)