### PR TITLE
feat(gh#57): drag-and-drop reordering in Component Tree (C)

### DIFF
--- a/frontend/__tests__/ComponentTreeDnd.test.tsx
+++ b/frontend/__tests__/ComponentTreeDnd.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * Integration tests for the Component Tree drag-and-drop wiring (gh#57-wak).
+ *
+ * The pure drop-resolution logic is exhaustively covered in `treeDnd.test.ts`.
+ * Here we verify the React glue: the row exposes draggable attributes, and
+ * the exported `handleDragEnd` callback wires through to `moveTreeNode` /
+ * `mutate()` with optimistic-rollback semantics.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) =>
+    React.createElement("span", props);
+  return {
+    Plus: icon, Trash2: icon, X: icon, Check: icon,
+    ChevronDown: icon, ChevronRight: icon,
+    FolderPlus: icon, Package: icon, Box: icon,
+    Search: icon, Loader2: icon, GripVertical: icon,
+  };
+});
+
+const mockMoveTreeNode = vi.fn().mockResolvedValue({});
+const mockMutate = vi.fn();
+
+vi.mock("@/hooks/useComponentTree", () => ({
+  useComponentTree: () => ({
+    tree: [
+      {
+        id: 10, aeroplane_id: "a", parent_id: null, sort_index: 0,
+        node_type: "group", name: "eHawk",
+        component_id: null, quantity: 1, weight_override_g: null,
+        children: [
+          {
+            id: 20, aeroplane_id: "a", parent_id: 10, sort_index: 0,
+            node_type: "group", name: "main_wing",
+            component_id: null, quantity: 1, weight_override_g: null,
+            children: [],
+          },
+        ],
+      },
+    ],
+    totalNodes: 2,
+    isLoading: false,
+    error: null,
+    mutate: mockMutate,
+  }),
+  addTreeNode: vi.fn().mockResolvedValue({}),
+  deleteTreeNode: vi.fn().mockResolvedValue(undefined),
+  moveTreeNode: (...args: unknown[]) => mockMoveTreeNode(...args),
+}));
+
+vi.mock("@/hooks/useComponents", () => ({
+  useComponents: () => ({ components: [], total: 0, isLoading: false, error: null, mutate: vi.fn() }),
+  useComponentTypes: () => ["generic"],
+}));
+
+vi.mock("@/components/workbench/AeroplaneContext", () => ({
+  useAeroplaneContext: () => ({
+    aeroplaneId: "a",
+    selectedWing: null, selectedXsecIndex: null,
+    selectedFuselage: null, selectedFuselageXsecIndex: null,
+    treeMode: "wingconfig",
+    setAeroplaneId: vi.fn(), selectWing: vi.fn(), selectXsec: vi.fn(),
+    selectFuselage: vi.fn(), selectFuselageXsec: vi.fn(), setTreeMode: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/fetcher", () => ({ API_BASE: "http://x", fetcher: vi.fn() }));
+
+import { ComponentTree } from "@/components/workbench/ComponentTree";
+import { handleDragEnd } from "@/components/workbench/ComponentTree";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ComponentTree — drag-and-drop wiring", () => {
+  it("renders without crashing under a DndContext-equipped tree", () => {
+    render(<ComponentTree />);
+    expect(screen.getByText("eHawk")).toBeDefined();
+  });
+
+  it("rows expose a draggable attribute (data-dnd-handle or aria-roledescription)", () => {
+    const { container } = render(<ComponentTree />);
+    const draggables = container.querySelectorAll(
+      '[aria-roledescription="sortable"], [data-dnd-handle="true"]',
+    );
+    expect(draggables.length).toBeGreaterThan(0);
+  });
+});
+
+// --------------------------------------------------------------------------- //
+// Pure handleDragEnd unit tests
+// --------------------------------------------------------------------------- //
+
+const treeFixture = [
+  {
+    id: 10, aeroplane_id: "a", parent_id: null, sort_index: 0,
+    node_type: "group" as const, name: "eHawk",
+    component_id: null, quantity: 1, weight_override_g: null,
+    children: [
+      {
+        id: 20, aeroplane_id: "a", parent_id: 10, sort_index: 0,
+        node_type: "group" as const, name: "main_wing",
+        component_id: null, quantity: 1, weight_override_g: null,
+        children: [
+          {
+            id: 100, aeroplane_id: "a", parent_id: 20, sort_index: 0,
+            node_type: "cots" as const, name: "servo",
+            component_id: 7, quantity: 1, weight_override_g: null,
+            children: [],
+          },
+        ],
+      },
+      {
+        id: 30, aeroplane_id: "a", parent_id: 10, sort_index: 1,
+        node_type: "group" as const, name: "v_tail",
+        component_id: null, quantity: 1, weight_override_g: null,
+        children: [],
+      },
+    ],
+  },
+];
+
+describe("handleDragEnd", () => {
+  it("calls moveTreeNode + mutate when the drop is valid", async () => {
+    await handleDragEnd({
+      activeId: 100,
+      overId: 30,
+      tree: treeFixture,
+      aeroplaneId: "a",
+      moveFn: mockMoveTreeNode,
+      mutateFn: mockMutate,
+    });
+    expect(mockMoveTreeNode).toHaveBeenCalledWith(
+      "a",
+      100,
+      { new_parent_id: 30, sort_index: 0 },
+    );
+    expect(mockMutate).toHaveBeenCalled();
+  });
+
+  it("does not call moveTreeNode when activeId == overId (drop on self)", async () => {
+    await handleDragEnd({
+      activeId: 20, overId: 20, tree: treeFixture,
+      aeroplaneId: "a", moveFn: mockMoveTreeNode, mutateFn: mockMutate,
+    });
+    expect(mockMoveTreeNode).not.toHaveBeenCalled();
+  });
+
+  it("does not call moveTreeNode when target is a descendant of source (cycle)", async () => {
+    await handleDragEnd({
+      activeId: 10, overId: 100, tree: treeFixture,
+      aeroplaneId: "a", moveFn: mockMoveTreeNode, mutateFn: mockMutate,
+    });
+    expect(mockMoveTreeNode).not.toHaveBeenCalled();
+  });
+
+  it("does not call moveTreeNode when overId is null (drop outside)", async () => {
+    await handleDragEnd({
+      activeId: 100, overId: null, tree: treeFixture,
+      aeroplaneId: "a", moveFn: mockMoveTreeNode, mutateFn: mockMutate,
+    });
+    expect(mockMoveTreeNode).not.toHaveBeenCalled();
+  });
+
+  it("triggers mutate even when the move API rejects (rollback)", async () => {
+    const reject = vi.fn().mockRejectedValue(new Error("network"));
+    await handleDragEnd({
+      activeId: 100, overId: 30, tree: treeFixture,
+      aeroplaneId: "a", moveFn: reject, mutateFn: mockMutate,
+    }).catch(() => undefined);
+    // mutate is called BEFORE the API call (optimistic) AND after error to
+    // trigger a rollback refetch.
+    expect(mockMutate).toHaveBeenCalled();
+  });
+
+  it("drops on a leaf (cots) do nothing — leaves are not 'into' targets", async () => {
+    await handleDragEnd({
+      activeId: 30, overId: 100, tree: treeFixture,
+      aeroplaneId: "a", moveFn: mockMoveTreeNode, mutateFn: mockMutate,
+    });
+    expect(mockMoveTreeNode).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/__tests__/treeDnd.test.ts
+++ b/frontend/__tests__/treeDnd.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Pure-logic tests for the tree drag-and-drop helpers (gh#57-wak).
+ *
+ * The interactive @dnd-kit wiring lives in <ComponentTree>; these helpers
+ * compute the API call (or null) given a drop event description. Keeping the
+ * pure logic separate means we can cover all corner cases (cycles, root
+ * drops, sibling reorder) without simulating mouse events.
+ */
+import { describe, it, expect } from "vitest";
+import type { ComponentTreeNode } from "@/hooks/useComponentTree";
+import {
+  findNode,
+  isDescendantOf,
+  computeMoveResult,
+  type DropPosition,
+} from "@/lib/treeDnd";
+
+const fixture = (): ComponentTreeNode[] => [
+  {
+    id: 1, aeroplane_id: "a", parent_id: null, sort_index: 0,
+    node_type: "group", name: "eHawk",
+    component_id: null, quantity: 1, weight_override_g: null,
+    children: [
+      {
+        id: 10, aeroplane_id: "a", parent_id: 1, sort_index: 0,
+        node_type: "group", name: "main_wing",
+        component_id: null, quantity: 1, weight_override_g: null,
+        children: [
+          {
+            id: 100, aeroplane_id: "a", parent_id: 10, sort_index: 0,
+            node_type: "cots", name: "servo",
+            component_id: 7, quantity: 1, weight_override_g: null,
+            children: [],
+          },
+          {
+            id: 101, aeroplane_id: "a", parent_id: 10, sort_index: 1,
+            node_type: "cad_shape", name: "rib",
+            component_id: null, quantity: 1, weight_override_g: null,
+            children: [],
+          },
+        ],
+      },
+      {
+        id: 20, aeroplane_id: "a", parent_id: 1, sort_index: 1,
+        node_type: "group", name: "v_tail",
+        component_id: null, quantity: 1, weight_override_g: null,
+        children: [],
+      },
+    ],
+  },
+];
+
+describe("findNode", () => {
+  it("returns the node at root", () => {
+    expect(findNode(fixture(), 1)?.name).toBe("eHawk");
+  });
+  it("returns a deeply nested node", () => {
+    expect(findNode(fixture(), 100)?.name).toBe("servo");
+  });
+  it("returns null for an unknown ID", () => {
+    expect(findNode(fixture(), 999)).toBeNull();
+  });
+});
+
+describe("isDescendantOf", () => {
+  it("identifies a direct child", () => {
+    expect(isDescendantOf(fixture(), 1, 10)).toBe(true);
+  });
+  it("identifies a deep grandchild", () => {
+    expect(isDescendantOf(fixture(), 1, 100)).toBe(true);
+  });
+  it("returns false for a sibling", () => {
+    expect(isDescendantOf(fixture(), 10, 20)).toBe(false);
+  });
+  it("returns false for an ancestor", () => {
+    expect(isDescendantOf(fixture(), 100, 1)).toBe(false);
+  });
+  it("returns false for the same node", () => {
+    expect(isDescendantOf(fixture(), 10, 10)).toBe(false);
+  });
+});
+
+describe("computeMoveResult", () => {
+  it("'into' a group makes the source a child of that group", () => {
+    const result = computeMoveResult(fixture(), 100, 20, "into" as DropPosition);
+    expect(result).toEqual({ newParentId: 20, sortIndex: 0 });
+  });
+
+  it("'into' an empty group → sortIndex = 0", () => {
+    const result = computeMoveResult(fixture(), 100, 20, "into" as DropPosition);
+    expect(result?.sortIndex).toBe(0);
+  });
+
+  it("'into' a group with existing children → sortIndex = end of children", () => {
+    const result = computeMoveResult(fixture(), 100, 10, "into" as DropPosition);
+    // moving 100 into group 10 (its current parent, but treat as fresh):
+    // group 10 has children [100, 101]; moving "into" appends → sortIndex = 2
+    expect(result?.sortIndex).toBe(2);
+  });
+
+  it("'before' a sibling reorders within the same parent", () => {
+    // move 101 before 100 within group 10
+    const result = computeMoveResult(fixture(), 101, 100, "before" as DropPosition);
+    expect(result).toEqual({ newParentId: 10, sortIndex: 0 });
+  });
+
+  it("'after' a sibling reorders within the same parent", () => {
+    // move 100 after 101 within group 10
+    const result = computeMoveResult(fixture(), 100, 101, "after" as DropPosition);
+    expect(result).toEqual({ newParentId: 10, sortIndex: 2 });
+  });
+
+  it("'before' a node in a different parent moves AND reorders", () => {
+    // move 100 (in group 10) before 20 (in root group 1)
+    const result = computeMoveResult(fixture(), 100, 20, "before" as DropPosition);
+    expect(result).toEqual({ newParentId: 1, sortIndex: 1 });
+  });
+
+  it("returns null when dropping a node onto itself ('into')", () => {
+    expect(computeMoveResult(fixture(), 10, 10, "into" as DropPosition)).toBeNull();
+  });
+
+  it("returns null when dropping a node onto its descendant", () => {
+    // can't move 1 into 100 (cycle)
+    expect(computeMoveResult(fixture(), 1, 100, "into" as DropPosition)).toBeNull();
+    // can't drop 1 before 100 either
+    expect(computeMoveResult(fixture(), 1, 100, "before" as DropPosition)).toBeNull();
+  });
+
+  it("returns null when source or target is unknown", () => {
+    expect(computeMoveResult(fixture(), 999, 10, "into" as DropPosition)).toBeNull();
+    expect(computeMoveResult(fixture(), 10, 999, "into" as DropPosition)).toBeNull();
+  });
+
+  it("'into' a leaf node is rejected (only groups accept 'into')", () => {
+    // 100 is a cots leaf; cannot drop INTO a leaf
+    expect(computeMoveResult(fixture(), 101, 100, "into" as DropPosition)).toBeNull();
+  });
+
+  it("dropping a node where it already lives is a no-op (returns null)", () => {
+    // 100 is already child[0] of 10; "before" 100 with self → null
+    expect(computeMoveResult(fixture(), 100, 100, "before" as DropPosition)).toBeNull();
+  });
+});

--- a/frontend/components/workbench/ComponentTree.tsx
+++ b/frontend/components/workbench/ComponentTree.tsx
@@ -2,6 +2,14 @@
 
 import { useState } from "react";
 import { Plus, Check, X } from "lucide-react";
+import {
+  DndContext,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
 import { TreeCard } from "@/components/workbench/TreeCard";
 import { SimpleTreeRow, type SimpleTreeNode } from "@/components/workbench/SimpleTreeRow";
 import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
@@ -9,11 +17,57 @@ import {
   useComponentTree,
   addTreeNode,
   deleteTreeNode,
+  moveTreeNode,
   type ComponentTreeNode,
 } from "@/hooks/useComponentTree";
 import { GroupAddMenu } from "@/components/workbench/GroupAddMenu";
 import { CotsPickerDialog } from "@/components/workbench/CotsPickerDialog";
 import type { Component } from "@/hooks/useComponents";
+import { computeMoveResult } from "@/lib/treeDnd";
+
+/**
+ * Pure drop handler — separated so it can be unit-tested without simulating
+ * mouse events. Returns silently on invalid drops (cycle, leaf-as-target,
+ * drop-on-self, drop-outside). On success: optimistic mutate + API call +
+ * rollback mutate on failure.
+ */
+export interface HandleDragEndArgs {
+  activeId: number;
+  overId: number | null;
+  tree: ComponentTreeNode[];
+  aeroplaneId: string;
+  moveFn: typeof moveTreeNode;
+  mutateFn: () => void;
+}
+
+export async function handleDragEnd({
+  activeId,
+  overId,
+  tree,
+  aeroplaneId,
+  moveFn,
+  mutateFn,
+}: HandleDragEndArgs): Promise<void> {
+  if (overId == null) return;
+  const result = computeMoveResult(tree, activeId, overId, "into");
+  if (!result) return;
+
+  // Optimistic refetch trigger (UI updates after the server confirms).
+  mutateFn();
+  try {
+    await moveFn(aeroplaneId, activeId, {
+      new_parent_id: result.newParentId,
+      sort_index: result.sortIndex,
+    });
+    mutateFn();
+  } catch (err) {
+    // Rollback: refetch from server to discard any client-side optimistic state.
+    mutateFn();
+    if (typeof window !== "undefined") {
+      alert(err instanceof Error ? err.message : "Move failed");
+    }
+  }
+}
 
 type AddFlowStage =
   | { kind: "idle" }
@@ -110,6 +164,29 @@ export function ComponentTree() {
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [selectedNodeId, setSelectedNodeId] = useState<number | null>(null);
   const [addFlow, setAddFlow] = useState<AddFlowStage>({ kind: "idle" });
+
+  // Pointer sensor with a small activation distance avoids hijacking simple
+  // clicks (open menu, select node) for drags. Touch sensor brings drag-and-
+  // drop to mobile.
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
+  );
+
+  function onDragEnd(event: DragEndEvent) {
+    if (!aeroplaneId) return;
+    const activeId = Number(String(event.active.id).replace(/^node-/, ""));
+    const overId = event.over ? Number(String(event.over.id).replace(/^node-/, "")) : null;
+    if (Number.isNaN(activeId)) return;
+    void handleDragEnd({
+      activeId,
+      overId,
+      tree,
+      aeroplaneId,
+      moveFn: moveTreeNode,
+      mutateFn: mutate,
+    });
+  }
 
   const toggle = (id: string) => {
     setExpanded((prev) => {
@@ -210,6 +287,7 @@ export function ComponentTree() {
           </button>
         }
       >
+        <DndContext sensors={sensors} onDragEnd={onDragEnd}>
         <div className="flex flex-col gap-0.5">
           {rows.length === 0 ? (
             <p className="py-4 text-center text-[11px] text-muted-foreground">
@@ -230,6 +308,7 @@ export function ComponentTree() {
             </div>
           )}
         </div>
+        </DndContext>
       </TreeCard>
 
       {addFlow.kind === "menu" && (

--- a/frontend/components/workbench/SimpleTreeRow.tsx
+++ b/frontend/components/workbench/SimpleTreeRow.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useDraggable, useDroppable } from "@dnd-kit/core";
 import { ChevronDown, ChevronRight, Plus, Trash2 } from "lucide-react";
 
 export interface SimpleTreeNode {
@@ -29,6 +30,20 @@ interface SimpleTreeRowProps {
 export function SimpleTreeRow({ node, onToggle }: SimpleTreeRowProps) {
   const indent = node.level * 20;
 
+  // dnd-kit hooks: each row is BOTH draggable (source) and droppable (target).
+  // We share the same id space so the parent's onDragEnd can resolve the move
+  // through the existing tree data.
+  const dndId = `node-${node.id}`;
+  const { attributes, listeners, setNodeRef: setDragRef, isDragging } = useDraggable({
+    id: dndId,
+  });
+  const { setNodeRef: setDropRef, isOver } = useDroppable({ id: dndId });
+
+  function setRefs(el: HTMLDivElement | null) {
+    setDragRef(el);
+    setDropRef(el);
+  }
+
   function handleClick() {
     if (!node.leaf) onToggle();
     node.onClick?.();
@@ -36,9 +51,13 @@ export function SimpleTreeRow({ node, onToggle }: SimpleTreeRowProps) {
 
   return (
     <div
+      ref={setRefs}
+      {...attributes}
+      {...listeners}
+      aria-roledescription="sortable"
       className={`group flex w-full items-center gap-1.5 rounded-xl py-1.5 pr-2 hover:bg-sidebar-accent cursor-pointer ${
         node.selected ? "bg-sidebar-accent font-semibold" : ""
-      }`}
+      } ${isOver ? "ring-2 ring-primary" : ""} ${isDragging ? "opacity-40" : ""}`}
       style={{ paddingLeft: indent }}
       onClick={handleClick}
     >

--- a/frontend/hooks/useComponentTree.ts
+++ b/frontend/hooks/useComponentTree.ts
@@ -13,6 +13,7 @@ export interface ComponentTreeNode {
   component_id: number | null;
   quantity: number;
   weight_override_g: number | null;
+  synced_from?: string | null;
   children: ComponentTreeNode[];
 }
 
@@ -58,4 +59,24 @@ export async function deleteTreeNode(aeroplaneId: string, nodeId: number): Promi
     const detail = await res.text();
     throw new Error(`Delete failed: ${res.status} ${detail}`);
   }
+}
+
+export async function moveTreeNode(
+  aeroplaneId: string,
+  nodeId: number,
+  body: { new_parent_id: number | null; sort_index: number },
+): Promise<ComponentTreeNode> {
+  const res = await fetch(
+    `${API_BASE}/aeroplanes/${aeroplaneId}/component-tree/${nodeId}/move`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+  if (!res.ok) {
+    const detail = await res.text();
+    throw new Error(`Move failed: ${res.status} ${detail}`);
+  }
+  return res.json();
 }

--- a/frontend/lib/treeDnd.ts
+++ b/frontend/lib/treeDnd.ts
@@ -1,0 +1,116 @@
+/**
+ * Pure helpers for the Component Tree drag-and-drop flow (gh#57-wak).
+ *
+ * Kept separate from the React component so the cycle-prevention and
+ * sort-index math can be exhaustively unit-tested without simulating mouse
+ * events. The component layer wires these into @dnd-kit's onDragEnd.
+ */
+import type { ComponentTreeNode } from "@/hooks/useComponentTree";
+
+export type DropPosition = "before" | "after" | "into";
+
+export interface MoveResult {
+  newParentId: number | null;
+  sortIndex: number;
+}
+
+/** Recursive lookup. Returns null if the ID is not in the tree. */
+export function findNode(
+  tree: ComponentTreeNode[],
+  id: number,
+): ComponentTreeNode | null {
+  for (const node of tree) {
+    if (node.id === id) return node;
+    const inside = findNode(node.children, id);
+    if (inside) return inside;
+  }
+  return null;
+}
+
+/**
+ * True if `candidateId` is anywhere inside the subtree of `ancestorId`.
+ * `ancestorId === candidateId` returns false (a node is not its own descendant).
+ */
+export function isDescendantOf(
+  tree: ComponentTreeNode[],
+  ancestorId: number,
+  candidateId: number,
+): boolean {
+  const ancestor = findNode(tree, ancestorId);
+  if (!ancestor) return false;
+  return findNode(ancestor.children, candidateId) !== null;
+}
+
+/** Find the immediate parent + the source list a node lives in. */
+function locateParent(
+  tree: ComponentTreeNode[],
+  childId: number,
+): { parent: ComponentTreeNode | null; siblings: ComponentTreeNode[] } | null {
+  // Root level
+  if (tree.some((n) => n.id === childId)) {
+    return { parent: null, siblings: tree };
+  }
+  for (const node of tree) {
+    if (node.children.some((c) => c.id === childId)) {
+      return { parent: node, siblings: node.children };
+    }
+    const recursed = locateParent(node.children, childId);
+    if (recursed) return recursed;
+  }
+  return null;
+}
+
+/**
+ * Translate an active-over-position drop into a backend move payload.
+ *
+ * Returns `null` when the drop is invalid:
+ *   - source equals target
+ *   - source is dropped on a descendant (cycle)
+ *   - source/target node IDs are unknown
+ *   - "into" is requested on a non-group leaf
+ *   - the resulting position is identical to the current position (no-op)
+ *
+ * Sort-index semantics:
+ *   - "before X" → X.sortIndex (X and later siblings shift down by 1 server-side)
+ *   - "after X"  → X.sortIndex + 1
+ *   - "into G"   → end of G.children (length)
+ */
+export function computeMoveResult(
+  tree: ComponentTreeNode[],
+  activeId: number,
+  overId: number,
+  position: DropPosition,
+): MoveResult | null {
+  if (activeId === overId) return null;
+
+  const active = findNode(tree, activeId);
+  const over = findNode(tree, overId);
+  if (!active || !over) return null;
+
+  // Cycle prevention: source cannot be moved under one of its descendants.
+  if (isDescendantOf(tree, activeId, overId)) return null;
+
+  if (position === "into") {
+    if (over.node_type !== "group") return null;
+    return { newParentId: over.id, sortIndex: over.children.length };
+  }
+
+  // "before" / "after": determine the parent and sort_index relative to over.
+  const overParent = locateParent(tree, overId);
+  if (!overParent) return null;
+
+  const newParentId = overParent.parent ? overParent.parent.id : null;
+  const sortIndex = position === "before" ? over.sort_index : over.sort_index + 1;
+
+  // No-op detection: if the active is already at exactly that slot, return null.
+  const activeParent = locateParent(tree, activeId);
+  if (
+    activeParent &&
+    ((activeParent.parent?.id ?? null) === newParentId) &&
+    active.sort_index === sortIndex
+  ) {
+    return null;
+  }
+
+  return { newParentId, sortIndex };
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,9 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@types/three": "^0.183.1",
         "@zip.js/zip.js": "^2.8.26",
         "lucide-react": "^1.8.0",
@@ -670,6 +673,59 @@
       "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.9.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,9 @@
     "test:e2e:headed": "npx -p playwright-bdd bddgen && npx playwright test --headed --grep-invert @slow"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@types/three": "^0.183.1",
     "@zip.js/zip.js": "^2.8.26",
     "lucide-react": "^1.8.0",


### PR DESCRIPTION
## Summary

Closes the explicit out-of-scope of gh#34 (*"Drag & Drop im Frontend (nur API)"*). Backend `POST /component-tree/{id}/move` was already in place from PR #56 — this PR wires it to the React tree via `@dnd-kit`.

## Architecture

| File | Role |
|------|------|
| `frontend/lib/treeDnd.ts` | Pure helpers (`findNode`, `isDescendantOf`, `computeMoveResult`). Zero React deps. |
| `frontend/hooks/useComponentTree.ts` | Adds `moveTreeNode()` API call + `synced_from?` field. |
| `frontend/components/workbench/ComponentTree.tsx` | Wraps row list in `DndContext`. Pointer (4 px activation) + Touch (200 ms delay) sensors. Exports a pure `handleDragEnd(args)` that resolves the move via `computeMoveResult`, optimistically `mutate()`s, calls `moveTreeNode`, and `mutate()`s again on error to roll back. |
| `frontend/components/workbench/SimpleTreeRow.tsx` | Each row is now both `useDraggable` source and `useDroppable` target (same id). Active drag dims the source (`opacity-40`); hover highlights the target (`ring-2 ring-primary`). |

## MVP scope decisions (honest disclosure)

- **Drop position is `into` only.** Reorder-between-siblings has full pure-logic support in `computeMoveResult` (covers `before`/`after`), but the @dnd-kit wiring resolves every drop as `into` for now. Adding positional indicators (top-edge / bottom-edge collision detection) is a follow-up if needed.
- **AC C-2** (visual feedback distinguishing into-group vs between-siblings): **partially satisfied** — hover-ring on group target is present; line-between-siblings is not (since reorder isn't wired yet).
- **Synced nodes** (`synced_from != null`): can be moved by drag-and-drop. Backend permits move on synced nodes — only delete is blocked. No special UI treatment, matching the gh#34 contract.
- **Optimistic update**: `mutate()` is triggered before AND after the API call; on failure, `mutate()` forces a refetch which acts as the rollback. A non-blocking `alert()` surfaces the error.

## Test plan

- [x] `npm run test:unit` — **112 passed** (was 85; +27)
- [x] `npx eslint` on touched files — clean
- [x] `npm run build` — clean
- [x] `poetry run ruff check .` + `pytest -m "not slow"` — 282 passed (backend untouched)

### Test inventory (27 new)

**`treeDnd.test.ts` (19):**
- `findNode` — root / nested / unknown
- `isDescendantOf` — direct child, deep grandchild, sibling, ancestor, self
- `computeMoveResult` — `into` empty group / `into` populated group / `before` / `after` / cross-parent reorder / cycle rejection / drop-on-self / drop-on-leaf rejection / unknown ID / no-op detection

**`ComponentTreeDnd.test.tsx` (8):**
- Renders without crash under `DndContext`
- Rows expose sortable role
- `handleDragEnd` happy path → calls `moveTreeNode` + `mutate`
- Drop-on-self → no API call
- Cycle (target is descendant) → no API call
- Drop outside (`overId=null`) → no API call
- Rollback: API rejects → `mutate` still called
- Drop on leaf → no API call

## New dependencies

```json
"@dnd-kit/core": "^6.3.1",
"@dnd-kit/sortable": "^10.0.0",
"@dnd-kit/utilities": "^3.2.2"
```

## Out of scope (potential follow-ups)

- Between-sibling line indicators + reorder UX (pure logic is ready in `computeMoveResult`)
- DragOverlay / custom drag preview (currently the source row stays in place dimmed)
- Pencil wireframe of drop indicators (skipped; the visual is too motion-driven for a useful static sketch)

Closes \`cad-modelling-service-wak\`.
Relates to #34 (reopened), #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)