### PR TITLE
feat(gh#57): Construction-Parts picker dialog for tree-add flow (D4)

### DIFF
--- a/alembic/versions/1bc333d5b078_merge_n1_d2_heads.py
+++ b/alembic/versions/1bc333d5b078_merge_n1_d2_heads.py
@@ -1,0 +1,28 @@
+"""merge_n1_d2_heads
+
+Revision ID: 1bc333d5b078
+Revises: 1a39e098d77e, 7cc3eaf27d6b
+Create Date: 2026-04-16 20:03:29.511945
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '1bc333d5b078'
+down_revision: Union[str, None] = ('1a39e098d77e', '7cc3eaf27d6b')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/app/tests/test_construction_part_fk_migration.py
+++ b/app/tests/test_construction_part_fk_migration.py
@@ -34,7 +34,9 @@ def test_alembic_downgrade_removes_construction_part_id_column(tmp_path):
     alembic_cfg.set_main_option("sqlalchemy.url", db_url)
 
     command.upgrade(alembic_cfg, "head")
-    command.downgrade(alembic_cfg, "-1")
+    # Target the parent of this migration explicitly — `-1` ambiguates once
+    # the history contains merge points.
+    command.downgrade(alembic_cfg, "4a9c81984e86")
 
     engine = create_engine(db_url)
     inspector = inspect(engine)

--- a/app/tests/test_construction_parts_file_api_migration.py
+++ b/app/tests/test_construction_parts_file_api_migration.py
@@ -28,7 +28,9 @@ def test_alembic_downgrade_removes_file_columns(tmp_path):
     alembic_cfg = Config("alembic.ini")
     alembic_cfg.set_main_option("sqlalchemy.url", db_url)
     command.upgrade(alembic_cfg, "head")
-    command.downgrade(alembic_cfg, "-1")
+    # Target the parent of this migration explicitly — `-1` ambiguates once
+    # the history contains merge points.
+    command.downgrade(alembic_cfg, "4a9c81984e86")
 
     engine = create_engine(db_url)
     inspector = inspect(engine)

--- a/frontend/__tests__/ComponentTreeConstructionPartFlow.test.tsx
+++ b/frontend/__tests__/ComponentTreeConstructionPartFlow.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * End-to-end wiring test for the Construction-Part add flow (gh#57-wvg).
+ *
+ * Click (+) on a group → click "Assign Construction Part" → picker opens →
+ * click a part → addTreeNode fires with node_type='cad_shape' and
+ * construction_part_id set (N1 snapshot logic on the backend then fills
+ * volume_mm3 / area_mm2 / material_id).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) =>
+    React.createElement("span", props);
+  return {
+    Plus: icon, Trash2: icon, X: icon, Check: icon,
+    ChevronDown: icon, ChevronRight: icon,
+    FolderPlus: icon, Package: icon, Box: icon,
+    Search: icon, Loader2: icon, Settings: icon, Lock: icon,
+    GripVertical: icon,
+  };
+});
+
+const mockAddTreeNode = vi.fn().mockResolvedValue({});
+const mockMutate = vi.fn();
+
+vi.mock("@/hooks/useComponentTree", () => ({
+  useComponentTree: () => ({
+    tree: [
+      {
+        id: 10, aeroplane_id: "a", parent_id: null, sort_index: 0,
+        node_type: "group", name: "main_wing",
+        component_id: null, quantity: 1, weight_override_g: null,
+        children: [],
+      },
+    ],
+    totalNodes: 1,
+    isLoading: false,
+    error: null,
+    mutate: mockMutate,
+  }),
+  addTreeNode: (...args: unknown[]) => mockAddTreeNode(...args),
+  deleteTreeNode: vi.fn().mockResolvedValue(undefined),
+  moveTreeNode: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("@/hooks/useConstructionParts", () => ({
+  useConstructionParts: () => ({
+    parts: [
+      {
+        id: 77, aeroplane_id: "a", name: "Bulkhead-A",
+        volume_mm3: 5000, area_mm2: 400,
+        bbox_x_mm: 50, bbox_y_mm: 40, bbox_z_mm: 5,
+        material_component_id: null, locked: false,
+        thumbnail_url: null, file_path: "tmp/x.stl", file_format: "stl",
+        created_at: "2026-04-16T00:00:00Z", updated_at: "2026-04-16T00:00:00Z",
+      },
+    ],
+    total: 1,
+    isLoading: false,
+    error: null,
+    mutate: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useComponents", () => ({
+  useComponents: () => ({ components: [], total: 0, isLoading: false, error: null, mutate: vi.fn() }),
+  useComponentTypes: () => ["generic"],
+}));
+
+vi.mock("@/components/workbench/AeroplaneContext", () => ({
+  useAeroplaneContext: () => ({
+    aeroplaneId: "a",
+    selectedWing: null, selectedXsecIndex: null,
+    selectedFuselage: null, selectedFuselageXsecIndex: null,
+    treeMode: "wingconfig",
+    setAeroplaneId: vi.fn(), selectWing: vi.fn(), selectXsec: vi.fn(),
+    selectFuselage: vi.fn(), selectFuselageXsec: vi.fn(), setTreeMode: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/fetcher", () => ({ API_BASE: "http://x", fetcher: vi.fn() }));
+
+import { ComponentTree } from "@/components/workbench/ComponentTree";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ComponentTree — Construction-Part add flow (gh#57-wvg)", () => {
+  it("the 'Assign Construction Part' menu item is enabled", () => {
+    render(<ComponentTree />);
+    fireEvent.click(screen.getByTitle("Add to main_wing"));
+
+    const button = screen.getByText("Assign Construction Part").closest("button");
+    expect(button).not.toBeNull();
+    expect(button?.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("opens the Construction-Part picker on menu click", () => {
+    render(<ComponentTree />);
+    fireEvent.click(screen.getByTitle("Add to main_wing"));
+    fireEvent.click(screen.getByText("Assign Construction Part"));
+
+    expect(screen.getByText(/Assign Construction Part to 'main_wing'/)).toBeDefined();
+    expect(screen.getByText("Bulkhead-A")).toBeDefined();
+  });
+
+  it("creates a cad_shape tree node with construction_part_id on selection", async () => {
+    render(<ComponentTree />);
+    fireEvent.click(screen.getByTitle("Add to main_wing"));
+    fireEvent.click(screen.getByText("Assign Construction Part"));
+    fireEvent.click(screen.getByText("Bulkhead-A"));
+
+    expect(mockAddTreeNode).toHaveBeenCalledWith(
+      "a",
+      expect.objectContaining({
+        parent_id: 10,
+        node_type: "cad_shape",
+        name: "Bulkhead-A",
+        construction_part_id: 77,
+      }),
+    );
+  });
+});

--- a/frontend/__tests__/ConstructionPartPickerDialog.test.tsx
+++ b/frontend/__tests__/ConstructionPartPickerDialog.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * Tests for the Construction-Parts picker (gh#57-wvg).
+ *
+ * Parallel to CotsPickerDialog but sourced from
+ * /aeroplanes/{id}/construction-parts (the D1 endpoint, merged in PR #68).
+ * Selecting a part returns the part object; the caller creates a
+ * `cad_shape` tree node with `construction_part_id` set (N1 wiring).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) =>
+    React.createElement("span", props);
+  return {
+    X: icon, Search: icon, Loader2: icon, Box: icon, Lock: icon,
+  };
+});
+
+let partsReturnValue: {
+  parts: Array<Record<string, unknown>>;
+  total: number;
+  isLoading: boolean;
+} = { parts: [], total: 0, isLoading: false };
+
+vi.mock("@/hooks/useConstructionParts", () => ({
+  useConstructionParts: () => ({
+    ...partsReturnValue,
+    error: null,
+    mutate: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/fetcher", () => ({
+  API_BASE: "http://x",
+  fetcher: vi.fn(),
+}));
+
+import { ConstructionPartPickerDialog } from "@/components/workbench/ConstructionPartPickerDialog";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  partsReturnValue = { parts: [], total: 0, isLoading: false };
+});
+
+describe("ConstructionPartPickerDialog", () => {
+  it("does not render when open=false", () => {
+    render(
+      <ConstructionPartPickerDialog
+        open={false}
+        aeroplaneId="a"
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText(/Construction Part/i)).toBeNull();
+  });
+
+  it("renders with target group name in the header", () => {
+    render(
+      <ConstructionPartPickerDialog
+        open={true}
+        aeroplaneId="a"
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+        targetGroupName="main_wing"
+      />,
+    );
+    expect(screen.getByText(/main_wing/)).toBeDefined();
+  });
+
+  it("shows empty-state when no parts exist", () => {
+    render(
+      <ConstructionPartPickerDialog
+        open={true}
+        aeroplaneId="a"
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/No construction parts/i)).toBeDefined();
+  });
+
+  it("shows loading state", () => {
+    partsReturnValue = { parts: [], total: 0, isLoading: true };
+    render(
+      <ConstructionPartPickerDialog
+        open={true}
+        aeroplaneId="a"
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/Loading/i)).toBeDefined();
+  });
+
+  it("renders a row per part with name and volume", () => {
+    partsReturnValue = {
+      parts: [
+        { id: 1, name: "Bulkhead-A", volume_mm3: 12500, area_mm2: 800, locked: false, material_component_id: null, file_format: "step" },
+        { id: 2, name: "Frame-B", volume_mm3: 25000, area_mm2: 1200, locked: true, material_component_id: null, file_format: "stl" },
+      ],
+      total: 2,
+      isLoading: false,
+    };
+    render(
+      <ConstructionPartPickerDialog
+        open={true}
+        aeroplaneId="a"
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Bulkhead-A")).toBeDefined();
+    expect(screen.getByText("Frame-B")).toBeDefined();
+  });
+
+  it("calls onSelect with the part on row click and closes", () => {
+    partsReturnValue = {
+      parts: [
+        { id: 42, name: "MyPart", volume_mm3: 500, area_mm2: 50, locked: false, material_component_id: null, file_format: "stl" },
+      ],
+      total: 1,
+      isLoading: false,
+    };
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <ConstructionPartPickerDialog
+        open={true}
+        aeroplaneId="a"
+        onClose={onClose}
+        onSelect={onSelect}
+      />,
+    );
+    fireEvent.click(screen.getByText("MyPart"));
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 42, name: "MyPart" }),
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on Cancel", () => {
+    const onClose = vi.fn();
+    render(
+      <ConstructionPartPickerDialog
+        open={true}
+        aeroplaneId="a"
+        onClose={onClose}
+        onSelect={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("filters by search", () => {
+    partsReturnValue = {
+      parts: [
+        { id: 1, name: "Bulkhead", volume_mm3: 100, area_mm2: 10, locked: false, material_component_id: null, file_format: "step" },
+        { id: 2, name: "Frame", volume_mm3: 200, area_mm2: 20, locked: false, material_component_id: null, file_format: "step" },
+      ],
+      total: 2,
+      isLoading: false,
+    };
+    render(
+      <ConstructionPartPickerDialog
+        open={true}
+        aeroplaneId="a"
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+    const input = screen.getByPlaceholderText(/search/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "bulk" } });
+    expect(screen.getByText("Bulkhead")).toBeDefined();
+    expect(screen.queryByText("Frame")).toBeNull();
+  });
+});

--- a/frontend/components/workbench/ComponentTree.tsx
+++ b/frontend/components/workbench/ComponentTree.tsx
@@ -22,7 +22,9 @@ import {
 } from "@/hooks/useComponentTree";
 import { GroupAddMenu } from "@/components/workbench/GroupAddMenu";
 import { CotsPickerDialog } from "@/components/workbench/CotsPickerDialog";
+import { ConstructionPartPickerDialog } from "@/components/workbench/ConstructionPartPickerDialog";
 import type { Component } from "@/hooks/useComponents";
+import type { ConstructionPart } from "@/hooks/useConstructionParts";
 import { computeMoveResult } from "@/lib/treeDnd";
 
 /**
@@ -73,7 +75,8 @@ type AddFlowStage =
   | { kind: "idle" }
   | { kind: "menu"; parentId: number | null; parentName: string }
   | { kind: "newGroup"; parentId: number | null; parentName: string }
-  | { kind: "cotsPicker"; parentId: number | null; parentName: string };
+  | { kind: "cotsPicker"; parentId: number | null; parentName: string }
+  | { kind: "constructionPartsPicker"; parentId: number | null; parentName: string };
 
 function flattenTree(
   nodes: ComponentTreeNode[],
@@ -263,6 +266,28 @@ export function ComponentTree() {
     }
   };
 
+  const handleAssignConstructionPart = async (part: ConstructionPart) => {
+    if (!aeroplaneId) return;
+    const parentId =
+      addFlow.kind === "constructionPartsPicker" ? addFlow.parentId : null;
+    try {
+      // Backend's add_node (N1 snapshot logic) copies volume/area/material
+      // from the referenced part when construction_part_id is set and the
+      // corresponding fields are not explicitly passed.
+      await addTreeNode(aeroplaneId, {
+        parent_id: parentId,
+        node_type: "cad_shape",
+        name: part.name,
+        construction_part_id: part.id,
+      });
+      mutate();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Assign failed");
+    } finally {
+      setAddFlow({ kind: "idle" });
+    }
+  };
+
   const rows = flattenTree(
     tree,
     0,
@@ -333,11 +358,15 @@ export function ComponentTree() {
                   parentName: addFlow.parentName,
                 })
               }
-              onAssignConstructionPart={() => {
-                /* gh#57-wvg: wired when the Construction-Parts picker ships. */
-              }}
+              onAssignConstructionPart={() =>
+                setAddFlow({
+                  kind: "constructionPartsPicker",
+                  parentId: addFlow.parentId,
+                  parentName: addFlow.parentName,
+                })
+              }
               onClose={() => setAddFlow({ kind: "idle" })}
-              constructionPartsEnabled={false}
+              constructionPartsEnabled={true}
             />
           </div>
         </div>
@@ -348,6 +377,16 @@ export function ComponentTree() {
         onClose={() => setAddFlow({ kind: "idle" })}
         onSelect={handleAssignCots}
         targetGroupName={addFlow.kind === "cotsPicker" ? addFlow.parentName : undefined}
+      />
+
+      <ConstructionPartPickerDialog
+        open={addFlow.kind === "constructionPartsPicker"}
+        aeroplaneId={aeroplaneId ?? ""}
+        onClose={() => setAddFlow({ kind: "idle" })}
+        onSelect={handleAssignConstructionPart}
+        targetGroupName={
+          addFlow.kind === "constructionPartsPicker" ? addFlow.parentName : undefined
+        }
       />
     </>
   );

--- a/frontend/components/workbench/ConstructionPartPickerDialog.tsx
+++ b/frontend/components/workbench/ConstructionPartPickerDialog.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState } from "react";
+import { X, Search, Loader2, Box, Lock } from "lucide-react";
+import { useConstructionParts, type ConstructionPart } from "@/hooks/useConstructionParts";
+
+interface ConstructionPartPickerDialogProps {
+  open: boolean;
+  aeroplaneId: string;
+  onClose: () => void;
+  onSelect: (part: ConstructionPart) => void;
+  /** Optional — surfaced in the header so the user knows where the part lands. */
+  targetGroupName?: string;
+}
+
+function formatVolume(volume_mm3: number | null): string {
+  if (volume_mm3 == null) return "— mm³";
+  if (volume_mm3 > 1e6) return `${(volume_mm3 / 1000).toFixed(1)} cm³`;
+  return `${volume_mm3.toFixed(0)} mm³`;
+}
+
+export function ConstructionPartPickerDialog({
+  open,
+  aeroplaneId,
+  onClose,
+  onSelect,
+  targetGroupName,
+}: ConstructionPartPickerDialogProps) {
+  const [search, setSearch] = useState("");
+  const { parts, total, isLoading } = useConstructionParts(open ? aeroplaneId : null);
+
+  if (!open) return null;
+
+  const filtered = search.trim()
+    ? parts.filter((p) => p.name.toLowerCase().includes(search.toLowerCase()))
+    : parts;
+
+  function handlePick(part: ConstructionPart) {
+    onSelect(part);
+    onClose();
+  }
+
+  const heading = targetGroupName
+    ? `Assign Construction Part to '${targetGroupName}'`
+    : "Assign Construction Part";
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={onClose}
+    >
+      <div
+        className="flex max-h-[80vh] w-[560px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-label="Construction-Part picker"
+      >
+        <div className="flex items-center gap-3">
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
+            {heading}
+          </span>
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-muted-foreground">
+            {total} parts
+          </span>
+          <span className="flex-1" />
+          <button
+            onClick={onClose}
+            className="flex size-8 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent"
+            aria-label="Close"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="flex items-center gap-2 rounded-xl border border-border bg-input px-3 py-2">
+          <Search className="size-3.5 text-muted-foreground" />
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search parts..."
+            className="flex-1 bg-transparent text-[12px] text-foreground outline-none placeholder:text-subtle-foreground"
+          />
+        </div>
+
+        <div className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto">
+          {isLoading ? (
+            <div className="flex items-center justify-center gap-2 py-10 text-[13px] text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" />
+              Loading construction parts...
+            </div>
+          ) : filtered.length === 0 ? (
+            <div className="flex flex-col items-center gap-2 py-10 text-[13px] text-muted-foreground">
+              <Box className="size-8 text-subtle-foreground" />
+              <span>
+                {parts.length === 0
+                  ? "No construction parts available"
+                  : "No parts match the filter"}
+              </span>
+            </div>
+          ) : (
+            filtered.map((part) => (
+              <button
+                key={part.id}
+                onClick={() => handlePick(part)}
+                className="flex items-center gap-3 rounded-lg border border-border bg-card px-3 py-2 text-left hover:border-primary hover:bg-sidebar-accent"
+              >
+                <div className="flex flex-1 flex-col gap-0.5">
+                  <div className="flex items-center gap-2">
+                    <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-foreground">
+                      {part.name}
+                    </span>
+                    {part.locked && (
+                      <Lock size={11} className="text-primary" />
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                    {part.file_format && (
+                      <span className="rounded-full bg-sidebar-accent px-2 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[9px]">
+                        {part.file_format.toUpperCase()}
+                      </span>
+                    )}
+                    <span className="font-[family-name:var(--font-jetbrains-mono)]">
+                      {formatVolume(part.volume_mm3)}
+                    </span>
+                  </div>
+                </div>
+              </button>
+            ))
+          )}
+        </div>
+
+        <div className="flex justify-end">
+          <button
+            onClick={onClose}
+            className="rounded-full border border-border px-4 py-2 text-[13px] text-muted-foreground hover:bg-sidebar-accent"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/hooks/useComponentTree.ts
+++ b/frontend/hooks/useComponentTree.ts
@@ -40,7 +40,14 @@ export function useComponentTree(aeroplaneId: string | null) {
 
 export async function addTreeNode(
   aeroplaneId: string,
-  node: { parent_id?: number | null; node_type: string; name: string; component_id?: number; quantity?: number },
+  node: {
+    parent_id?: number | null;
+    node_type: string;
+    name: string;
+    component_id?: number;
+    quantity?: number;
+    construction_part_id?: number;
+  },
 ): Promise<ComponentTreeNode> {
   const res = await fetch(`${API_BASE}/aeroplanes/${aeroplaneId}/component-tree`, {
     method: "POST",

--- a/frontend/hooks/useConstructionParts.ts
+++ b/frontend/hooks/useConstructionParts.ts
@@ -1,0 +1,115 @@
+"use client";
+
+import useSWR from "swr";
+import { fetcher, API_BASE } from "@/lib/fetcher";
+
+export interface ConstructionPart {
+  id: number;
+  aeroplane_id: string;
+  name: string;
+  volume_mm3: number | null;
+  area_mm2: number | null;
+  bbox_x_mm: number | null;
+  bbox_y_mm: number | null;
+  bbox_z_mm: number | null;
+  material_component_id: number | null;
+  locked: boolean;
+  thumbnail_url: string | null;
+  file_path: string | null;
+  file_format: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface ConstructionPartList {
+  aeroplane_id: string;
+  items: ConstructionPart[];
+  total: number;
+}
+
+export function useConstructionParts(aeroplaneId: string | null) {
+  const { data, error, isLoading, mutate } = useSWR<ConstructionPartList>(
+    aeroplaneId ? `/aeroplanes/${aeroplaneId}/construction-parts` : null,
+    fetcher,
+  );
+  return {
+    parts: data?.items ?? [],
+    total: data?.total ?? 0,
+    error,
+    isLoading,
+    mutate,
+  };
+}
+
+export async function uploadConstructionPart(
+  aeroplaneId: string,
+  formData: FormData,
+): Promise<ConstructionPart> {
+  const res = await fetch(`${API_BASE}/aeroplanes/${aeroplaneId}/construction-parts`, {
+    method: "POST",
+    body: formData,
+  });
+  if (!res.ok) {
+    const detail = await res.text();
+    throw new Error(`Upload failed: ${res.status} ${detail}`);
+  }
+  return res.json();
+}
+
+export async function deleteConstructionPart(
+  aeroplaneId: string,
+  partId: number,
+): Promise<void> {
+  const res = await fetch(
+    `${API_BASE}/aeroplanes/${aeroplaneId}/construction-parts/${partId}`,
+    { method: "DELETE" },
+  );
+  if (!res.ok) {
+    const detail = await res.text();
+    throw new Error(`Delete failed: ${res.status} ${detail}`);
+  }
+}
+
+export async function updateConstructionPart(
+  aeroplaneId: string,
+  partId: number,
+  body: { name?: string; material_component_id?: number | null; thumbnail_url?: string | null },
+): Promise<ConstructionPart> {
+  const res = await fetch(
+    `${API_BASE}/aeroplanes/${aeroplaneId}/construction-parts/${partId}`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+  if (!res.ok) {
+    const detail = await res.text();
+    throw new Error(`Update failed: ${res.status} ${detail}`);
+  }
+  return res.json();
+}
+
+export async function lockConstructionPart(
+  aeroplaneId: string,
+  partId: number,
+): Promise<ConstructionPart> {
+  const res = await fetch(
+    `${API_BASE}/aeroplanes/${aeroplaneId}/construction-parts/${partId}/lock`,
+    { method: "PUT" },
+  );
+  if (!res.ok) throw new Error(`Lock failed: ${res.status}`);
+  return res.json();
+}
+
+export async function unlockConstructionPart(
+  aeroplaneId: string,
+  partId: number,
+): Promise<ConstructionPart> {
+  const res = await fetch(
+    `${API_BASE}/aeroplanes/${aeroplaneId}/construction-parts/${partId}/unlock`,
+    { method: "PUT" },
+  );
+  if (!res.ok) throw new Error(`Unlock failed: ${res.status}`);
+  return res.json();
+}


### PR DESCRIPTION
## Summary

Closes the "Assign Construction Part" stub shipped in PR #69 (was a disabled menu entry). A new picker dialog now lets the user assign a previously uploaded construction-part (via D1/D2) to a group in the Component Tree — creating a `cad_shape` node with `construction_part_id` set. The backend's N1 snapshot logic (from PR #71) fills `volume_mm3` / `area_mm2` / `material_id` automatically.

## Frontend

| File | Role |
|------|------|
| `hooks/useConstructionParts.ts` | SWR hook + full client (list, upload, delete, update, lock, unlock). Picker uses list; the rest is wiring for D3 (management panel) next. |
| `components/workbench/ConstructionPartPickerDialog.tsx` | Parallel to `CotsPickerDialog`: search, empty/loading/no-match states, Cancel + outside-click close. Rows show name, file-format chip (STEP/STL), volume, lock icon. |
| `components/workbench/ComponentTree.tsx` | New `AddFlowStage` `"constructionPartsPicker"`. The menu item is now enabled. onSelect fires `addTreeNode({ node_type: 'cad_shape', construction_part_id, name })`. |
| `hooks/useComponentTree.ts` | `addTreeNode` signature accepts `construction_part_id`. |

## Backend housekeeping (fixes double-head)

When PR #71 (N1) and PR #72 (D2) were both merged in parallel, both new migrations had the same parent (`4a9c81984e86`) — this left the Alembic history with two heads, which broke the migration tests on main. This PR adds:

- **`1bc333d5b078_merge_n1_d2_heads.py`** — a no-op merge migration that closes the double-head so `alembic upgrade head` is unambiguous again.
- Two migration downgrade tests updated to target the explicit parent revision (`4a9c81984e86`) instead of `-1`, which became ambiguous.

## Test plan

- [x] `poetry run ruff check .` — clean
- [x] `poetry run pytest -m "not slow" --ignore=.claude` — **318 passed** (merge migration + test fixes)
- [x] `npm run test:unit` — **123 passed** (was 112; +11)
- [x] `npx eslint` on touched files — clean
- [x] `npm run build` — clean

### Test inventory (11 new)

**`ConstructionPartPickerDialog.test.tsx` (8):**
- does not render when `open=false`
- target group name shown in header
- empty-state when no parts
- loading state during fetch
- row per part with name + volume
- onSelect called with part; dialog closes
- Cancel closes
- search filters by name

**`ComponentTreeConstructionPartFlow.test.tsx` (3):**
- "Assign Construction Part" menu entry is enabled
- Picker opens with target group in the header
- Selecting a part calls `addTreeNode` with `node_type='cad_shape'` + `construction_part_id`

## Unblocks

- **D3** (`cad-modelling-service-ggd`) — management panel can reuse `useConstructionParts` and the full hook API (upload, delete, update, lock, unlock)
- **E** (`cad-modelling-service-38x`) — property panel's Lock-Toggle can resolve through `construction_part_id` → `/construction-parts/{partId}/lock|unlock`

Closes \`cad-modelling-service-wvg\`.
Relates to #34 (reopened), #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)