### PR TITLE
feat(#84): Component Type Management dialog (CRUD + property editor)

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -32,6 +32,7 @@ from app.db.base import Base
 import app.models.aeroplanemodel       # this module imports Base and defines tables
 import app.models.flightprofilemodel
 import app.models.component
+import app.models.component_type
 import app.models.construction_part
 import app.models.tessellation_cache
 

--- a/alembic/versions/28a13fbeac90_add_component_types_table_and_seed.py
+++ b/alembic/versions/28a13fbeac90_add_component_types_table_and_seed.py
@@ -1,0 +1,179 @@
+"""add_component_types_table_and_seed
+
+Revision ID: 28a13fbeac90
+Revises: 1bc333d5b078
+Create Date: 2026-04-16 21:56:35
+
+Creates the component_types registry (gh#83) and seeds the nine previously
+hardcoded types with reasonable property schemas so the existing 9-type
+workflow keeps working.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "28a13fbeac90"
+down_revision: Union[str, None] = "1bc333d5b078"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# --------------------------------------------------------------------------- #
+# Seed data — property schemas for the 9 original types
+# --------------------------------------------------------------------------- #
+
+SEED_TYPES = [
+    {
+        "name": "material",
+        "label": "Material (3D-Druck)",
+        "description": "3D-print material with density and print type",
+        "schema": [
+            {"name": "density_kg_m3", "label": "Dichte", "type": "number",
+             "unit": "kg/m³", "required": True, "min": 100, "max": 20000},
+            {"name": "print_resolution_mm", "label": "Druckauflösung", "type": "number",
+             "unit": "mm", "min": 0.05, "max": 2.0, "default": 0.4},
+            {"name": "print_type", "label": "Drucktyp", "type": "enum",
+             "options": ["volume", "surface"], "default": "volume"},
+        ],
+    },
+    {
+        "name": "servo",
+        "label": "Servo",
+        "description": None,
+        "schema": [
+            {"name": "torque_kg_cm", "label": "Drehmoment", "type": "number", "unit": "kg·cm"},
+            {"name": "speed_s_per_60deg", "label": "Geschwindigkeit", "type": "number", "unit": "s/60°"},
+            {"name": "voltage_v", "label": "Spannung", "type": "number", "unit": "V"},
+            {"name": "connector", "label": "Anschluss", "type": "enum",
+             "options": ["jr", "futaba", "universal"]},
+        ],
+    },
+    {
+        "name": "brushless_motor",
+        "label": "Brushless Motor",
+        "description": None,
+        "schema": [
+            {"name": "kv_rpm_per_volt", "label": "KV", "type": "number", "unit": "RPM/V",
+             "required": True},
+            {"name": "max_current_a", "label": "Max Strom", "type": "number", "unit": "A"},
+            {"name": "shaft_diameter_mm", "label": "Wellen-Ø", "type": "number", "unit": "mm"},
+        ],
+    },
+    {
+        "name": "battery",
+        "label": "Battery",
+        "description": None,
+        "schema": [
+            {"name": "capacity_mah", "label": "Kapazität", "type": "number", "unit": "mAh",
+             "required": True, "min": 0},
+            {"name": "cells", "label": "Zellen (S)", "type": "number", "required": True, "min": 1},
+            {"name": "c_rate", "label": "C-Rate", "type": "number"},
+            {"name": "voltage_v", "label": "Spannung", "type": "number", "unit": "V"},
+        ],
+    },
+    {
+        "name": "esc",
+        "label": "ESC",
+        "description": None,
+        "schema": [
+            {"name": "max_current_a", "label": "Max Strom", "type": "number", "unit": "A",
+             "required": True},
+            {"name": "cells", "label": "Zellen (S)", "type": "number"},
+            {"name": "bec_voltage_v", "label": "BEC Spannung", "type": "number", "unit": "V"},
+            {"name": "bec_current_a", "label": "BEC Strom", "type": "number", "unit": "A"},
+            {"name": "protocol", "label": "Protokoll", "type": "enum",
+             "options": ["pwm", "oneshot", "dshot150", "dshot300", "dshot600"]},
+        ],
+    },
+    {
+        "name": "propeller",
+        "label": "Propeller",
+        "description": None,
+        "schema": [
+            {"name": "diameter_in", "label": "Durchmesser", "type": "number", "unit": "inch",
+             "required": True},
+            {"name": "pitch_in", "label": "Steigung", "type": "number", "unit": "inch",
+             "required": True},
+            {"name": "blades", "label": "Blätter", "type": "number", "required": True, "min": 2},
+            {"name": "material", "label": "Material", "type": "string"},
+        ],
+    },
+    {
+        "name": "receiver",
+        "label": "Receiver",
+        "description": None,
+        "schema": [
+            {"name": "channels", "label": "Kanäle", "type": "number"},
+            {"name": "protocol", "label": "Protokoll", "type": "string"},
+        ],
+    },
+    {
+        "name": "flight_controller",
+        "label": "Flight Controller",
+        "description": None,
+        "schema": [
+            {"name": "firmware", "label": "Firmware", "type": "string"},
+            {"name": "mcu", "label": "MCU", "type": "string"},
+        ],
+    },
+    {
+        "name": "generic",
+        "label": "Generic",
+        "description": "Free-form type with no structured schema",
+        "schema": [],
+    },
+]
+
+
+def upgrade() -> None:
+    """Create component_types table + seed the 9 default types."""
+    op.create_table(
+        "component_types",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(), nullable=False, unique=True, index=True),
+        sa.Column("label", sa.String(), nullable=False),
+        sa.Column("description", sa.String(), nullable=True),
+        sa.Column("schema", sa.JSON(), nullable=False),
+        sa.Column("deletable", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+    import json
+    component_types = sa.table(
+        "component_types",
+        sa.column("name", sa.String),
+        sa.column("label", sa.String),
+        sa.column("description", sa.String),
+        sa.column("schema", sa.JSON),
+        sa.column("deletable", sa.Boolean),
+    )
+    op.bulk_insert(
+        component_types,
+        [
+            {
+                "name": t["name"],
+                "label": t["label"],
+                "description": t["description"],
+                # Some DB dialects persist JSON as string — dump explicitly for safety.
+                "schema": json.dumps(t["schema"]),
+                "deletable": False,
+            }
+            for t in SEED_TYPES
+        ],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("component_types")

--- a/app/api/v2/endpoints/component_types.py
+++ b/app/api/v2/endpoints/component_types.py
@@ -1,0 +1,113 @@
+"""Endpoints for the Component Types registry (gh#83)."""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, status
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import (
+    ConflictError,
+    NotFoundError,
+    ServiceException,
+    ValidationDomainError,
+    ValidationError,
+)
+from app.db.session import get_db
+from app.schemas.component_type import ComponentTypeRead, ComponentTypeWrite
+from app.services import component_type_service as svc
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/component-types", tags=["component-types"])
+
+
+def _raise_http(exc: ServiceException) -> None:
+    if isinstance(exc, NotFoundError):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=exc.message) from exc
+    if isinstance(exc, (ValidationError, ValidationDomainError)):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=exc.message
+        ) from exc
+    if isinstance(exc, ConflictError):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail=exc.message
+        ) from exc
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=exc.message
+    ) from exc
+
+
+def _call(func, *args, **kwargs):
+    try:
+        return func(*args, **kwargs)
+    except ServiceException as exc:
+        _raise_http(exc)
+
+
+@router.get(
+    "",
+    status_code=status.HTTP_200_OK,
+    response_model=list[ComponentTypeRead],
+    operation_id="list_component_types_v2",
+)
+async def list_component_types(
+    db: Session = Depends(get_db),
+) -> list[ComponentTypeRead]:
+    """List all component types (seeded + user-created) sorted by label."""
+    return _call(svc.list_types, db)
+
+
+@router.get(
+    "/{type_id}",
+    status_code=status.HTTP_200_OK,
+    response_model=ComponentTypeRead,
+    operation_id="get_component_type",
+)
+async def get_component_type(
+    type_id: int = Path(...),
+    db: Session = Depends(get_db),
+) -> ComponentTypeRead:
+    return _call(svc.get_type, db, type_id)
+
+
+@router.post(
+    "",
+    status_code=status.HTTP_201_CREATED,
+    response_model=ComponentTypeRead,
+    operation_id="create_component_type",
+)
+async def create_component_type(
+    body: ComponentTypeWrite = Body(...),
+    db: Session = Depends(get_db),
+) -> ComponentTypeRead:
+    """Create a user-defined type. `deletable` is forced to True regardless of request."""
+    return _call(svc.create_type, db, body)
+
+
+@router.put(
+    "/{type_id}",
+    status_code=status.HTTP_200_OK,
+    response_model=ComponentTypeRead,
+    operation_id="update_component_type",
+)
+async def update_component_type(
+    type_id: int = Path(...),
+    body: ComponentTypeWrite = Body(...),
+    db: Session = Depends(get_db),
+) -> ComponentTypeRead:
+    """Update label / description / schema. Name and deletable are immutable."""
+    return _call(svc.update_type, db, type_id, body)
+
+
+@router.delete(
+    "/{type_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    operation_id="delete_component_type",
+)
+async def delete_component_type(
+    type_id: int = Path(...),
+    db: Session = Depends(get_db),
+) -> None:
+    """Delete a type. 409 if seeded (deletable=False) or referenced by components."""
+    _call(svc.delete_type, db, type_id)

--- a/app/api/v2/endpoints/components.py
+++ b/app/api/v2/endpoints/components.py
@@ -21,9 +21,9 @@ from app.schemas.component import (
     ComponentRead,
     ComponentTypesResponse,
     ComponentWrite,
-    COMPONENT_TYPE_LIST,
 )
 from app.services import component_service as svc
+from app.services import component_type_service as type_svc
 
 logger = logging.getLogger(__name__)
 
@@ -70,9 +70,15 @@ async def list_components(
     response_model=ComponentTypesResponse,
     operation_id="list_component_types",
 )
-async def list_component_types() -> ComponentTypesResponse:
-    """List all available component types."""
-    return ComponentTypesResponse(types=COMPONENT_TYPE_LIST)
+async def list_component_types(
+    db: Session = Depends(get_db),
+) -> ComponentTypesResponse:
+    """List the *names* of all registered component types.
+
+    Backward-compatible shape. Prefer GET /component-types for full metadata
+    (schema, reference_count, etc.).
+    """
+    return ComponentTypesResponse(types=type_svc.list_type_names(db))
 
 
 @router.post(

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from fastapi.responses import JSONResponse
 
 from app.api.v2.endpoints import aeroplane as aeroplane_v2
 from app.api.v2.endpoints import components
+from app.api.v2.endpoints import component_types
 from app.api.v2.endpoints.aeroplane import component_tree
 from app.api.v2.endpoints.aeroplane import construction_parts
 from app.api.v2.endpoints import flight_profiles
@@ -97,6 +98,7 @@ def create_app() -> FastAPI:
     app.include_router(health.router, prefix="", tags=["health"])
     app.include_router(aeroplane_v2.router, prefix="", tags=[])
     app.include_router(components.router, prefix="", tags=["components"])
+    app.include_router(component_types.router, prefix="", tags=["component-types"])
     app.include_router(component_tree.router, prefix="", tags=["component-tree"])
     app.include_router(construction_parts.router, prefix="", tags=["construction-parts"])
     app.include_router(flight_profiles.router, prefix="", tags=["flight-profiles"])

--- a/app/models/component_type.py
+++ b/app/models/component_type.py
@@ -1,0 +1,44 @@
+"""Component Type — defines the specs-schema for Components (gh#83).
+
+Each row holds a JSON ``schema`` list of PropertyDefinition objects. The
+service layer validates component specs against that schema on create /
+update (tolerant mode: unknown keys are kept, known keys are checked).
+
+Seeded types (the 9 original hardcoded ones) are inserted by the Alembic
+migration with ``deletable=False`` so the user cannot remove them.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, Column, DateTime, JSON, String, func
+
+from app.db.base import Base
+
+
+class ComponentTypeModel(Base):
+    __tablename__ = "component_types"
+
+    name = Column(String, nullable=False, unique=True, index=True)
+    label = Column(String, nullable=False)
+    description = Column(String, nullable=True)
+    # List of PropertyDefinition objects (see app.schemas.component_type).
+    # Stored as JSON for schema flexibility; validated in the service layer.
+    schema_def = Column("schema", JSON, nullable=False, default=list)
+    # False for seeded types (prevents DELETE). User-created types get True.
+    deletable = Column(Boolean, nullable=False, default=True, server_default="1")
+
+    created_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+        server_onupdate=func.now(),
+        nullable=False,
+    )

--- a/app/schemas/component.py
+++ b/app/schemas/component.py
@@ -1,39 +1,16 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Literal, Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel, Field
 
 
-COMPONENT_TYPES = Literal[
-    "servo",
-    "brushless_motor",
-    "esc",
-    "battery",
-    "receiver",
-    "flight_controller",
-    "material",
-    "propeller",
-    "generic",
-]
-
-COMPONENT_TYPE_LIST: list[str] = [
-    "servo",
-    "brushless_motor",
-    "esc",
-    "battery",
-    "receiver",
-    "flight_controller",
-    "material",
-    "propeller",
-    "generic",
-]
-
-
 class ComponentWrite(BaseModel):
     name: str = Field(..., min_length=1, description="Component name / model number")
-    component_type: COMPONENT_TYPES = Field(..., description="Hardware category")
+    # gh#83: component_type is now a free string; validation happens at the
+    # service layer against the dynamic `component_types` registry.
+    component_type: str = Field(..., min_length=1, description="Type name (see GET /component-types)")
     manufacturer: Optional[str] = Field(None, description="Manufacturer name")
     description: Optional[str] = Field(None, description="Free-text description")
     mass_g: Optional[float] = Field(None, ge=0, description="Mass in grams")
@@ -43,7 +20,7 @@ class ComponentWrite(BaseModel):
     model_ref: Optional[str] = Field(None, description="Reference to STEP/STL 3D model file")
     specs: dict[str, Any] = Field(
         default_factory=dict,
-        description="Type-specific specifications (e.g. kv, capacity_mah, voltage_range, density_kg_m3)",
+        description="Type-specific specifications — validated against the type's schema.",
     )
 
 
@@ -59,4 +36,4 @@ class ComponentList(BaseModel):
 
 
 class ComponentTypesResponse(BaseModel):
-    types: list[str] = Field(..., description="List of all available component types")
+    types: list[str] = Field(..., description="List of all available component type names")

--- a/app/schemas/component_type.py
+++ b/app/schemas/component_type.py
@@ -1,0 +1,83 @@
+"""Pydantic schemas for the Component Types (gh#83)."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+# Silence Pydantic's "schema shadows BaseModel attribute" warning — we do use
+# the field deliberately (it's the canonical JSON name for property-lists).
+import warnings
+warnings.filterwarnings(
+    "ignore",
+    message=r'Field name "schema"',
+    category=UserWarning,
+)
+
+
+PropertyType = Literal["number", "string", "boolean", "enum"]
+
+# Property names must be snake_case — the UI uses them as form-field keys and
+# the backend stores them as JSON keys. Leading underscore is not allowed.
+_SNAKE_CASE = r"^[a-z][a-z0-9_]*$"
+
+
+class PropertyDefinition(BaseModel):
+    """Single property inside a ComponentType's schema."""
+
+    name: str = Field(..., pattern=_SNAKE_CASE, min_length=1,
+                      description="snake_case identifier used as key in component.specs")
+    label: str = Field(..., min_length=1, description="Display name in the UI")
+    type: PropertyType = Field(..., description="Data type")
+    unit: Optional[str] = Field(None, description="Unit suffix for number inputs (kg/m³, mm, …)")
+    required: bool = Field(False, description="True → must be present in specs")
+    description: Optional[str] = Field(None)
+
+    # Number-specific
+    min: Optional[float] = Field(None)
+    max: Optional[float] = Field(None)
+
+    # Enum-specific
+    options: Optional[list[str]] = Field(None)
+
+    # Any type
+    default: Optional[Any] = Field(None)
+
+    @model_validator(mode="after")
+    def _check_type_specific_fields(self) -> "PropertyDefinition":
+        if self.type == "enum":
+            if not self.options or len(self.options) == 0:
+                raise ValueError("enum properties require a non-empty `options` list")
+        if self.type != "number" and (self.min is not None or self.max is not None):
+            # min/max are only meaningful for number; silently drop for others
+            # instead of rejecting so the UI can keep them in state during
+            # type switches.
+            pass
+        return self
+
+
+class ComponentTypeWrite(BaseModel):
+    """Payload for POST / PUT of a ComponentType."""
+
+    name: str = Field(..., pattern=_SNAKE_CASE, min_length=1)
+    label: str = Field(..., min_length=1)
+    description: Optional[str] = None
+    schema: list[PropertyDefinition] = Field(default_factory=list)
+
+    @field_validator("schema")
+    @classmethod
+    def _unique_property_names(cls, v: list[PropertyDefinition]) -> list[PropertyDefinition]:
+        names = [p.name for p in v]
+        if len(names) != len(set(names)):
+            raise ValueError("property names must be unique within a schema")
+        return v
+
+
+class ComponentTypeRead(ComponentTypeWrite):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    deletable: bool
+    reference_count: int = Field(0, description="Number of components using this type")
+    created_at: datetime
+    updated_at: datetime

--- a/app/services/component_service.py
+++ b/app/services/component_service.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 from app.core.exceptions import InternalError, NotFoundError
 from app.models.component import ComponentModel
 from app.schemas.component import ComponentList, ComponentRead, ComponentWrite
+from app.services import component_type_service as type_svc
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +53,8 @@ def list_components(
 
 
 def create_component(db: Session, data: ComponentWrite) -> ComponentRead:
+    # gh#83: validate specs against the dynamic type schema before inserting.
+    type_svc.validate_specs(db, data.component_type, data.specs)
     try:
         comp = ComponentModel(**data.model_dump())
         db.add(comp)
@@ -74,6 +77,8 @@ def get_component(db: Session, component_id: int) -> ComponentRead:
 def update_component(
     db: Session, component_id: int, data: ComponentWrite
 ) -> ComponentRead:
+    # gh#83: validate specs against the dynamic type schema before updating.
+    type_svc.validate_specs(db, data.component_type, data.specs)
     try:
         comp = db.query(ComponentModel).filter(ComponentModel.id == component_id).first()
         if comp is None:

--- a/app/services/component_type_service.py
+++ b/app/services/component_type_service.py
@@ -1,0 +1,367 @@
+"""Component Types service: CRUD + specs validation (gh#83).
+
+Seeded types are non-deletable. User-added types are deletable only when
+``reference_count=0`` (no components point at them). Specs validation is
+tolerant — unknown keys are accepted; known keys are checked against
+type/required/min/max/options rules.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import (
+    ConflictError,
+    InternalError,
+    NotFoundError,
+    ValidationError,
+)
+from app.models.component import ComponentModel
+from app.models.component_type import ComponentTypeModel
+from app.schemas.component_type import (
+    ComponentTypeRead,
+    ComponentTypeWrite,
+    PropertyDefinition,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _reference_count(db: Session, type_name: str) -> int:
+    return (
+        db.query(ComponentModel)
+        .filter(ComponentModel.component_type == type_name)
+        .count()
+    )
+
+
+def _to_schema(db: Session, m: ComponentTypeModel) -> ComponentTypeRead:
+    return ComponentTypeRead.model_validate(
+        {
+            "id": m.id,
+            "name": m.name,
+            "label": m.label,
+            "description": m.description,
+            "schema": m.schema_def or [],
+            "deletable": m.deletable,
+            "reference_count": _reference_count(db, m.name),
+            "created_at": m.created_at,
+            "updated_at": m.updated_at,
+        }
+    )
+
+
+def _get_or_404(db: Session, type_id: int) -> ComponentTypeModel:
+    row = db.query(ComponentTypeModel).filter(ComponentTypeModel.id == type_id).first()
+    if row is None:
+        raise NotFoundError(entity="ComponentType", resource_id=type_id)
+    return row
+
+
+# --------------------------------------------------------------------------- #
+# CRUD
+# --------------------------------------------------------------------------- #
+
+
+def list_types(db: Session) -> list[ComponentTypeRead]:
+    rows = db.query(ComponentTypeModel).order_by(ComponentTypeModel.label).all()
+    return [_to_schema(db, r) for r in rows]
+
+
+def get_type(db: Session, type_id: int) -> ComponentTypeRead:
+    return _to_schema(db, _get_or_404(db, type_id))
+
+
+def create_type(db: Session, data: ComponentTypeWrite) -> ComponentTypeRead:
+    # Uniqueness check (lets us return 409 instead of 500 on integrity error)
+    if db.query(ComponentTypeModel).filter(ComponentTypeModel.name == data.name).first():
+        raise ConflictError(
+            message=f"Type with name '{data.name}' already exists.",
+            details={"name": data.name},
+        )
+    try:
+        row = ComponentTypeModel(
+            name=data.name,
+            label=data.label,
+            description=data.description,
+            schema_def=[p.model_dump() for p in data.schema],
+            deletable=True,  # user-created types are always deletable
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+        return _to_schema(db, row)
+    except IntegrityError as exc:
+        db.rollback()
+        raise ConflictError(message=f"Name conflict: {exc}") from exc
+    except SQLAlchemyError as exc:
+        db.rollback()
+        logger.error("DB error in create_type: %s", exc)
+        raise InternalError(message=f"Database error: {exc}") from exc
+
+
+def update_type(
+    db: Session, type_id: int, data: ComponentTypeWrite
+) -> ComponentTypeRead:
+    """Update label / description / schema. Name and deletable are immutable."""
+    try:
+        row = _get_or_404(db, type_id)
+        row.label = data.label
+        row.description = data.description
+        row.schema_def = [p.model_dump() for p in data.schema]
+        # name and deletable stay untouched
+        db.commit()
+        db.refresh(row)
+        return _to_schema(db, row)
+    except NotFoundError:
+        raise
+    except SQLAlchemyError as exc:
+        db.rollback()
+        logger.error("DB error in update_type: %s", exc)
+        raise InternalError(message=f"Database error: {exc}") from exc
+
+
+def delete_type(db: Session, type_id: int) -> None:
+    row = _get_or_404(db, type_id)
+    if not row.deletable:
+        raise ConflictError(
+            message=f"Type '{row.name}' is seeded and cannot be deleted.",
+            details={"name": row.name, "reason": "seeded"},
+        )
+    refs = _reference_count(db, row.name)
+    if refs > 0:
+        raise ConflictError(
+            message=(
+                f"Type '{row.name}' is referenced by {refs} component(s) — "
+                "cannot delete. Remove those components first or change their type."
+            ),
+            details={"name": row.name, "reference_count": refs, "reason": "referenced"},
+        )
+    try:
+        db.delete(row)
+        db.commit()
+    except SQLAlchemyError as exc:
+        db.rollback()
+        logger.error("DB error in delete_type: %s", exc)
+        raise InternalError(message=f"Database error: {exc}") from exc
+
+
+# --------------------------------------------------------------------------- #
+# Specs validation (consumed by component_service)
+# --------------------------------------------------------------------------- #
+
+
+def validate_specs(
+    db: Session, component_type_name: str, specs: dict[str, Any]
+) -> None:
+    """Raise ValidationError if specs don't match the type's schema.
+
+    Tolerant mode: unknown keys are ignored. Known keys are checked for:
+      - presence (required)
+      - type (number → isinstance(float/int), enum → in options, boolean → bool)
+      - range (number → min/max)
+    """
+    row = (
+        db.query(ComponentTypeModel)
+        .filter(ComponentTypeModel.name == component_type_name)
+        .first()
+    )
+    if row is None:
+        raise ValidationError(
+            message=f"Unknown component_type '{component_type_name}'. "
+                    "Use GET /component-types to discover available types.",
+            details={"component_type": component_type_name},
+        )
+
+    for raw in row.schema_def or []:
+        prop = PropertyDefinition.model_validate(raw)
+        value = specs.get(prop.name, None)
+
+        if value is None:
+            if prop.required:
+                raise ValidationError(
+                    message=f"Required property '{prop.name}' is missing.",
+                    details={"property": prop.name, "reason": "missing_required"},
+                )
+            continue
+
+        if prop.type == "number":
+            if not isinstance(value, (int, float)) or isinstance(value, bool):
+                raise ValidationError(
+                    message=f"Property '{prop.name}' must be a number.",
+                    details={"property": prop.name, "type": "number", "value": value},
+                )
+            if prop.min is not None and value < prop.min:
+                raise ValidationError(
+                    message=(
+                        f"Property '{prop.name}' is below the allowed minimum "
+                        f"{prop.min} (got {value})."
+                    ),
+                    details={"property": prop.name, "min": prop.min, "value": value},
+                )
+            if prop.max is not None and value > prop.max:
+                raise ValidationError(
+                    message=(
+                        f"Property '{prop.name}' exceeds the allowed maximum "
+                        f"{prop.max} (got {value})."
+                    ),
+                    details={"property": prop.name, "max": prop.max, "value": value},
+                )
+        elif prop.type == "string":
+            if not isinstance(value, str):
+                raise ValidationError(
+                    message=f"Property '{prop.name}' must be a string.",
+                    details={"property": prop.name, "type": "string", "value": value},
+                )
+        elif prop.type == "boolean":
+            if not isinstance(value, bool):
+                raise ValidationError(
+                    message=f"Property '{prop.name}' must be true or false.",
+                    details={"property": prop.name, "type": "boolean", "value": value},
+                )
+        elif prop.type == "enum":
+            if prop.options and value not in prop.options:
+                raise ValidationError(
+                    message=(
+                        f"Property '{prop.name}' value '{value}' is not allowed. "
+                        f"Options: {prop.options}."
+                    ),
+                    details={
+                        "property": prop.name,
+                        "allowed": prop.options,
+                        "value": value,
+                    },
+                )
+
+
+def list_type_names(db: Session) -> list[str]:
+    """Return the names of all registered types (for legacy /components/types)."""
+    return [
+        row[0]
+        for row in db.query(ComponentTypeModel.name).order_by(ComponentTypeModel.label).all()
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Seed — used both by the Alembic migration and by the test-DB fixture.
+# Keep this list in sync with alembic/versions/28a13fbeac90_add_component_types
+# _table_and_seed.py (the migration duplicates the data intentionally so that
+# replaying old migrations isn't tied to the current application code).
+# --------------------------------------------------------------------------- #
+
+DEFAULT_SEED_TYPES: list[dict[str, Any]] = [
+    {
+        "name": "material",
+        "label": "Material (3D-Druck)",
+        "description": "3D-print material with density and print type",
+        "schema": [
+            {"name": "density_kg_m3", "label": "Dichte", "type": "number",
+             "unit": "kg/m³", "required": True, "min": 100, "max": 20000},
+            {"name": "print_resolution_mm", "label": "Druckauflösung", "type": "number",
+             "unit": "mm", "min": 0.05, "max": 2.0, "default": 0.4},
+            {"name": "print_type", "label": "Drucktyp", "type": "enum",
+             "options": ["volume", "surface"], "default": "volume"},
+        ],
+    },
+    {
+        "name": "servo", "label": "Servo", "description": None,
+        "schema": [
+            {"name": "torque_kg_cm", "label": "Drehmoment", "type": "number", "unit": "kg·cm"},
+            {"name": "speed_s_per_60deg", "label": "Geschwindigkeit", "type": "number", "unit": "s/60°"},
+            {"name": "voltage_v", "label": "Spannung", "type": "number", "unit": "V"},
+            {"name": "connector", "label": "Anschluss", "type": "enum",
+             "options": ["jr", "futaba", "universal"]},
+        ],
+    },
+    {
+        "name": "brushless_motor", "label": "Brushless Motor", "description": None,
+        "schema": [
+            {"name": "kv_rpm_per_volt", "label": "KV", "type": "number", "unit": "RPM/V",
+             "required": True},
+            {"name": "max_current_a", "label": "Max Strom", "type": "number", "unit": "A"},
+            {"name": "shaft_diameter_mm", "label": "Wellen-Ø", "type": "number", "unit": "mm"},
+        ],
+    },
+    {
+        "name": "battery", "label": "Battery", "description": None,
+        "schema": [
+            {"name": "capacity_mah", "label": "Kapazität", "type": "number", "unit": "mAh",
+             "required": True, "min": 0},
+            {"name": "cells", "label": "Zellen (S)", "type": "number", "required": True, "min": 1},
+            {"name": "c_rate", "label": "C-Rate", "type": "number"},
+            {"name": "voltage_v", "label": "Spannung", "type": "number", "unit": "V"},
+        ],
+    },
+    {
+        "name": "esc", "label": "ESC", "description": None,
+        "schema": [
+            {"name": "max_current_a", "label": "Max Strom", "type": "number", "unit": "A",
+             "required": True},
+            {"name": "cells", "label": "Zellen (S)", "type": "number"},
+            {"name": "bec_voltage_v", "label": "BEC Spannung", "type": "number", "unit": "V"},
+            {"name": "bec_current_a", "label": "BEC Strom", "type": "number", "unit": "A"},
+            {"name": "protocol", "label": "Protokoll", "type": "enum",
+             "options": ["pwm", "oneshot", "dshot150", "dshot300", "dshot600"]},
+        ],
+    },
+    {
+        "name": "propeller", "label": "Propeller", "description": None,
+        "schema": [
+            {"name": "diameter_in", "label": "Durchmesser", "type": "number", "unit": "inch",
+             "required": True},
+            {"name": "pitch_in", "label": "Steigung", "type": "number", "unit": "inch",
+             "required": True},
+            {"name": "blades", "label": "Blätter", "type": "number", "required": True, "min": 2},
+            {"name": "material", "label": "Material", "type": "string"},
+        ],
+    },
+    {
+        "name": "receiver", "label": "Receiver", "description": None,
+        "schema": [
+            {"name": "channels", "label": "Kanäle", "type": "number"},
+            {"name": "protocol", "label": "Protokoll", "type": "string"},
+        ],
+    },
+    {
+        "name": "flight_controller", "label": "Flight Controller", "description": None,
+        "schema": [
+            {"name": "firmware", "label": "Firmware", "type": "string"},
+            {"name": "mcu", "label": "MCU", "type": "string"},
+        ],
+    },
+    {
+        "name": "generic", "label": "Generic",
+        "description": "Free-form type with no structured schema",
+        "schema": [],
+    },
+]
+
+
+def seed_default_types(db: Session) -> None:
+    """Insert the 9 default types if they aren't already present.
+
+    Idempotent — safe to call multiple times (used by the test DB fixture).
+    Seeded types carry deletable=False so users cannot remove them.
+    """
+    existing = {row[0] for row in db.query(ComponentTypeModel.name).all()}
+    for seed in DEFAULT_SEED_TYPES:
+        if seed["name"] in existing:
+            continue
+        db.add(
+            ComponentTypeModel(
+                name=seed["name"],
+                label=seed["label"],
+                description=seed["description"],
+                schema_def=seed["schema"],
+                deletable=False,
+            )
+        )
+    db.commit()

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -31,6 +31,7 @@ from app.main import create_app
 from app.models.aeroplanemodel import AeroplaneModel, FuselageModel, WingModel
 from app.models.analysismodels import OperatingPointModel
 from app.services import cad_service
+from app.services.component_type_service import seed_default_types
 
 
 # --------------------------------------------------------------------------- #
@@ -60,6 +61,14 @@ def client_and_db() -> Tuple[TestClient, sessionmaker]:
         class_=Session,
     )
     Base.metadata.create_all(bind=engine)
+
+    # gh#83: seed the default component types so tests see the same registry
+    # shape that a migrated prod DB would have.
+    _seed_session = TestingSessionLocal()
+    try:
+        seed_default_types(_seed_session)
+    finally:
+        _seed_session.close()
 
     def override_get_db():
         db = TestingSessionLocal()

--- a/app/tests/test_component_specs_validation.py
+++ b/app/tests/test_component_specs_validation.py
@@ -1,0 +1,143 @@
+"""Tests for Component specs validation against the type schema (gh#83).
+
+The existing `POST /components` / `PUT /components/{id}` now validates the
+`specs` payload against the property schema of the referenced type. Tolerant
+mode: unknown keys are accepted and stored; known keys are checked.
+"""
+from __future__ import annotations
+
+
+class TestComponentTypeValidation:
+
+    def test_unknown_component_type_is_rejected(self, client_and_db):
+        client, _ = client_and_db
+        res = client.post("/components", json={
+            "name": "x", "component_type": "not_a_real_type", "specs": {},
+        })
+        assert res.status_code == 422
+
+
+class TestRequiredFieldValidation:
+
+    def test_missing_required_density_for_material_is_rejected(self, client_and_db):
+        """The seeded `material` type requires `density_kg_m3`."""
+        client, _ = client_and_db
+        res = client.post("/components", json={
+            "name": "PLA", "component_type": "material", "specs": {},
+        })
+        assert res.status_code == 422
+
+    def test_material_with_density_succeeds(self, client_and_db):
+        client, _ = client_and_db
+        res = client.post("/components", json={
+            "name": "PLA", "component_type": "material",
+            "specs": {"density_kg_m3": 1240},
+        })
+        assert res.status_code == 201
+        assert res.json()["specs"]["density_kg_m3"] == 1240
+
+
+class TestNumberRangeValidation:
+
+    def test_number_below_min_is_rejected(self, client_and_db):
+        """`density_kg_m3` has min=100 in the seeded material schema."""
+        client, _ = client_and_db
+        res = client.post("/components", json={
+            "name": "impossible", "component_type": "material",
+            "specs": {"density_kg_m3": 50},  # below min=100
+        })
+        assert res.status_code == 422
+
+    def test_number_above_max_is_rejected(self, client_and_db):
+        client, _ = client_and_db
+        res = client.post("/components", json={
+            "name": "neutron-star", "component_type": "material",
+            "specs": {"density_kg_m3": 1e6},  # way above any plausible max
+        })
+        assert res.status_code == 422
+
+
+class TestEnumValidation:
+
+    def test_enum_value_not_in_options_is_rejected(self, client_and_db):
+        """Material `print_type` enum must be volume|surface."""
+        client, _ = client_and_db
+        res = client.post("/components", json={
+            "name": "odd", "component_type": "material",
+            "specs": {"density_kg_m3": 1240, "print_type": "sideways"},
+        })
+        assert res.status_code == 422
+
+    def test_enum_value_in_options_succeeds(self, client_and_db):
+        client, _ = client_and_db
+        res = client.post("/components", json={
+            "name": "pla", "component_type": "material",
+            "specs": {"density_kg_m3": 1240, "print_type": "volume"},
+        })
+        assert res.status_code == 201
+
+
+class TestBooleanValidation:
+
+    def test_non_boolean_for_boolean_property_is_rejected(self, client_and_db):
+        client, _ = client_and_db
+        # Create a custom type with a boolean property
+        client.post("/component-types", json={
+            "name": "boolish", "label": "Boolish", "schema": [
+                {"name": "is_spicy", "label": "Is Spicy", "type": "boolean"},
+            ],
+        })
+        res = client.post("/components", json={
+            "name": "c", "component_type": "boolish",
+            "specs": {"is_spicy": "maybe"},
+        })
+        assert res.status_code == 422
+
+
+class TestToleranceForUnknownKeys:
+
+    def test_unknown_keys_in_specs_are_accepted_and_stored(self, client_and_db):
+        """Tolerant mode: anything extra is just stored alongside the validated fields."""
+        client, _ = client_and_db
+        res = client.post("/components", json={
+            "name": "weird", "component_type": "material",
+            "specs": {
+                "density_kg_m3": 1240,
+                "totally_made_up_key": "whatever",
+                "legacy_field": 42,
+            },
+        })
+        assert res.status_code == 201
+        stored = res.json()["specs"]
+        assert stored["density_kg_m3"] == 1240
+        assert stored["totally_made_up_key"] == "whatever"
+        assert stored["legacy_field"] == 42
+
+
+class TestPutValidation:
+
+    def test_put_validates_same_as_post(self, client_and_db):
+        """The same spec rules fire on update."""
+        client, _ = client_and_db
+        # Create with a valid specs payload
+        comp = client.post("/components", json={
+            "name": "PLA", "component_type": "material",
+            "specs": {"density_kg_m3": 1240},
+        }).json()
+        # Now PUT with an invalid enum
+        res = client.put(f"/components/{comp['id']}", json={
+            "name": comp["name"], "component_type": comp["component_type"],
+            "specs": {"density_kg_m3": 1240, "print_type": "sideways"},
+        })
+        assert res.status_code == 422
+
+
+class TestBackwardCompat:
+
+    def test_get_components_types_endpoint_still_works(self, client_and_db):
+        """The legacy /components/types endpoint returns the same shape ({types: [...]}) but now dynamic."""
+        client, _ = client_and_db
+        body = client.get("/components/types").json()
+        assert "types" in body
+        assert "material" in body["types"]
+        assert "servo" in body["types"]

--- a/app/tests/test_component_tree.py
+++ b/app/tests/test_component_tree.py
@@ -121,7 +121,9 @@ class TestWeightCalculation:
         client, _ = client_and_db
         comp = client.post("/components", json={
             "name": "WtMotor", "component_type": "brushless_motor",
-            "mass_g": 50.0, "specs": {},
+            "mass_g": 50.0,
+            # brushless_motor seed schema requires kv_rpm_per_volt (gh#83)
+            "specs": {"kv_rpm_per_volt": 900},
         }).json()
         node = client.post("/aeroplanes/w1/component-tree", json={
             "node_type": "cots", "name": "motor",

--- a/app/tests/test_component_types.py
+++ b/app/tests/test_component_types.py
@@ -1,0 +1,258 @@
+"""Tests for the Component Types CRUD API (gh#83).
+
+A component type defines the specs-schema for components of that type.
+Seeded types (`deletable=false`) cannot be deleted; user-added types
+require reference_count=0 to delete.
+"""
+from __future__ import annotations
+
+
+def _create_type(client, name="custom_tube", label="Custom Tube", schema=None):
+    return client.post("/component-types", json={
+        "name": name,
+        "label": label,
+        "description": None,
+        "schema": schema or [],
+    }).json()
+
+
+# --------------------------------------------------------------------------- #
+# GET list
+# --------------------------------------------------------------------------- #
+
+class TestListTypes:
+
+    def test_list_includes_seeded_types(self, client_and_db):
+        client, _ = client_and_db
+        body = client.get("/component-types").json()
+        names = {t["name"] for t in body}
+        # all 9 seeded types must exist
+        assert {"material", "servo", "brushless_motor", "battery",
+                "esc", "propeller", "receiver", "flight_controller",
+                "generic"}.issubset(names)
+
+    def test_list_is_sorted_by_label(self, client_and_db):
+        client, _ = client_and_db
+        body = client.get("/component-types").json()
+        labels = [t["label"] for t in body]
+        assert labels == sorted(labels)
+
+    def test_list_includes_reference_count(self, client_and_db):
+        client, _ = client_and_db
+        # Add a component of type 'servo'
+        client.post("/components", json={
+            "name": "s1", "component_type": "servo", "specs": {},
+        })
+        body = client.get("/component-types").json()
+        servo = next(t for t in body if t["name"] == "servo")
+        assert servo["reference_count"] == 1
+
+    def test_seeded_types_are_not_deletable(self, client_and_db):
+        client, _ = client_and_db
+        body = client.get("/component-types").json()
+        for t in body:
+            assert t["deletable"] is False
+
+
+# --------------------------------------------------------------------------- #
+# GET single
+# --------------------------------------------------------------------------- #
+
+class TestGetType:
+
+    def test_material_has_density_property_in_schema(self, client_and_db):
+        client, _ = client_and_db
+        body = client.get("/component-types").json()
+        material = next(t for t in body if t["name"] == "material")
+        prop_names = {p["name"] for p in material["schema"]}
+        assert "density_kg_m3" in prop_names
+        density = next(p for p in material["schema"] if p["name"] == "density_kg_m3")
+        assert density["type"] == "number"
+        assert density["required"] is True
+
+    def test_get_by_id_returns_full_type(self, client_and_db):
+        client, _ = client_and_db
+        body = client.get("/component-types").json()
+        some = body[0]
+        single = client.get(f"/component-types/{some['id']}").json()
+        assert single["id"] == some["id"]
+        assert single["name"] == some["name"]
+
+    def test_get_returns_404_for_missing_id(self, client_and_db):
+        client, _ = client_and_db
+        assert client.get("/component-types/99999").status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# POST create
+# --------------------------------------------------------------------------- #
+
+class TestCreateType:
+
+    def test_create_user_type_defaults_deletable_true(self, client_and_db):
+        client, _ = client_and_db
+        t = _create_type(client, name="carbon_tube", label="Carbon Tube")
+        assert t["name"] == "carbon_tube"
+        assert t["deletable"] is True
+        assert t["reference_count"] == 0
+
+    def test_create_forces_deletable_true_even_if_false_in_request(self, client_and_db):
+        """`deletable=false` in the request is ignored — user-created types are always deletable."""
+        client, _ = client_and_db
+        res = client.post("/component-types", json={
+            "name": "xxx", "label": "X", "deletable": False, "schema": [],
+        })
+        assert res.status_code == 201
+        assert res.json()["deletable"] is True
+
+    def test_create_with_duplicate_name_returns_409(self, client_and_db):
+        client, _ = client_and_db
+        _create_type(client, name="foo")
+        res = client.post("/component-types", json={
+            "name": "foo", "label": "Foo 2", "schema": [],
+        })
+        assert res.status_code == 409
+
+    def test_create_with_duplicate_of_seeded_name_returns_409(self, client_and_db):
+        client, _ = client_and_db
+        res = client.post("/component-types", json={
+            "name": "material", "label": "...", "schema": [],
+        })
+        assert res.status_code == 409
+
+    def test_create_with_number_property(self, client_and_db):
+        client, _ = client_and_db
+        t = _create_type(client, name="with_number", schema=[
+            {"name": "foo", "label": "Foo", "type": "number", "min": 0, "max": 100, "required": True},
+        ])
+        assert t["schema"][0]["type"] == "number"
+        assert t["schema"][0]["min"] == 0
+
+    def test_create_with_enum_property(self, client_and_db):
+        client, _ = client_and_db
+        t = _create_type(client, name="with_enum", schema=[
+            {"name": "color", "label": "Color", "type": "enum", "options": ["red", "green", "blue"]},
+        ])
+        assert t["schema"][0]["options"] == ["red", "green", "blue"]
+
+    def test_create_enum_without_options_is_rejected(self, client_and_db):
+        client, _ = client_and_db
+        res = client.post("/component-types", json={
+            "name": "bad_enum", "label": "Bad", "schema": [
+                {"name": "x", "label": "X", "type": "enum"},
+            ],
+        })
+        assert res.status_code == 422
+
+    def test_create_property_with_invalid_type_is_rejected(self, client_and_db):
+        client, _ = client_and_db
+        res = client.post("/component-types", json={
+            "name": "bad_type", "label": "Bad", "schema": [
+                {"name": "x", "label": "X", "type": "color"},  # not supported
+            ],
+        })
+        assert res.status_code == 422
+
+    def test_create_property_with_non_snake_case_name_is_rejected(self, client_and_db):
+        client, _ = client_and_db
+        res = client.post("/component-types", json={
+            "name": "bad_prop_name", "label": "Bad", "schema": [
+                {"name": "BadName", "label": "X", "type": "number"},
+            ],
+        })
+        assert res.status_code == 422
+
+
+# --------------------------------------------------------------------------- #
+# PUT update
+# --------------------------------------------------------------------------- #
+
+class TestUpdateType:
+
+    def test_put_updates_label_and_description(self, client_and_db):
+        client, _ = client_and_db
+        t = _create_type(client, name="myt", label="Old")
+        res = client.put(f"/component-types/{t['id']}", json={
+            "name": t["name"], "label": "New", "description": "now with desc",
+            "schema": t["schema"],
+        })
+        assert res.status_code == 200
+        body = res.json()
+        assert body["label"] == "New"
+        assert body["description"] == "now with desc"
+
+    def test_put_ignores_name_change(self, client_and_db):
+        """Name is immutable after create — PUT with a different name is ignored."""
+        client, _ = client_and_db
+        t = _create_type(client, name="original")
+        res = client.put(f"/component-types/{t['id']}", json={
+            "name": "renamed", "label": t["label"], "schema": t["schema"],
+        })
+        assert res.status_code == 200
+        assert res.json()["name"] == "original"
+
+    def test_put_ignores_deletable_change(self, client_and_db):
+        """The deletable flag is fixed at create-time for user types and always false for seeded."""
+        client, _ = client_and_db
+        # Try to make a seeded type deletable
+        body = client.get("/component-types").json()
+        seeded = next(t for t in body if t["name"] == "material")
+        res = client.put(f"/component-types/{seeded['id']}", json={
+            "name": seeded["name"], "label": seeded["label"],
+            "deletable": True,
+            "schema": seeded["schema"],
+        })
+        assert res.status_code == 200
+        assert res.json()["deletable"] is False
+
+    def test_put_can_edit_seeded_schema(self, client_and_db):
+        """Seeded types' schemas are editable (only name + deletable are locked)."""
+        client, _ = client_and_db
+        body = client.get("/component-types").json()
+        servo = next(t for t in body if t["name"] == "servo")
+        new_schema = servo["schema"] + [
+            {"name": "notes", "label": "Notes", "type": "string"},
+        ]
+        res = client.put(f"/component-types/{servo['id']}", json={
+            "name": servo["name"], "label": servo["label"],
+            "schema": new_schema,
+        })
+        assert res.status_code == 200
+        prop_names = {p["name"] for p in res.json()["schema"]}
+        assert "notes" in prop_names
+
+
+# --------------------------------------------------------------------------- #
+# DELETE
+# --------------------------------------------------------------------------- #
+
+class TestDeleteType:
+
+    def test_delete_seeded_type_returns_409(self, client_and_db):
+        client, _ = client_and_db
+        body = client.get("/component-types").json()
+        seeded = next(t for t in body if t["name"] == "material")
+        res = client.delete(f"/component-types/{seeded['id']}")
+        assert res.status_code == 409
+
+    def test_delete_user_type_with_no_references_returns_204(self, client_and_db):
+        client, _ = client_and_db
+        t = _create_type(client, name="doomed")
+        res = client.delete(f"/component-types/{t['id']}")
+        assert res.status_code == 204
+        # Confirm it's gone
+        assert client.get(f"/component-types/{t['id']}").status_code == 404
+
+    def test_delete_user_type_with_references_returns_409(self, client_and_db):
+        client, _ = client_and_db
+        t = _create_type(client, name="ref_guarded")
+        # reference it
+        client.post("/components", json={
+            "name": "c1", "component_type": "ref_guarded", "specs": {},
+        })
+        res = client.delete(f"/component-types/{t['id']}")
+        assert res.status_code == 409
+
+    def test_delete_missing_id_returns_404(self, client_and_db):
+        client, _ = client_and_db
+        assert client.delete("/component-types/99999").status_code == 404

--- a/app/tests/test_components_and_versions.py
+++ b/app/tests/test_components_and_versions.py
@@ -28,7 +28,8 @@ MOTOR_PAYLOAD = {
     "name": "Motor X",
     "component_type": "brushless_motor",
     "mass_g": 130,
-    "specs": {"kv": 880},
+    # brushless_motor seed schema requires kv_rpm_per_volt (gh#83)
+    "specs": {"kv_rpm_per_volt": 880},
 }
 
 
@@ -42,7 +43,7 @@ class TestComponentLibraryCRUD:
         assert body["name"] == "Motor X"
         assert body["component_type"] == "brushless_motor"
         assert body["mass_g"] == 130
-        assert body["specs"] == {"kv": 880}
+        assert body["specs"] == {"kv_rpm_per_volt": 880}
         assert "id" in body
 
     def test_list_components(self, client: TestClient):

--- a/app/tests/test_components_catalog.py
+++ b/app/tests/test_components_catalog.py
@@ -96,7 +96,8 @@ class TestComponentSearch:
             "name": "Test Motor",
             "component_type": "brushless_motor",
             "manufacturer": "UniqueManufacturerXYZ",
-            "specs": {},
+            # brushless_motor seed schema requires kv_rpm_per_volt (gh#83)
+            "specs": {"kv_rpm_per_volt": 880},
         })
         res = client.get("/components", params={"q": "UniqueManufacturer"})
         assert res.status_code == 200

--- a/frontend/__tests__/ComponentEditDialogLayout.test.tsx
+++ b/frontend/__tests__/ComponentEditDialogLayout.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Regression tests for the ComponentEditDialog layout (gh#84 follow-up).
+ *
+ * Reported 2026-04-16: a user-created component type with a very long
+ * name (~60 chars of random-looking string) made the Type <select>
+ * grow to the width of that option, pushing the Mass field out of the
+ * modal. Root cause: without `min-w-0` on the flex items and `w-full`
+ * on the controls, a <select> sizes to its longest option.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) =>
+    React.createElement("span", props);
+  return { X: icon, Loader2: icon };
+});
+
+vi.mock("@/hooks/useComponents", () => ({
+  createComponent: vi.fn(),
+  updateComponent: vi.fn(),
+}));
+
+vi.mock("@/hooks/useComponentTypes", () => ({
+  useComponentTypes: () => ({
+    types: [
+      { id: 1, name: "generic", label: "Generic", description: null, schema: [], deletable: false, reference_count: 0, created_at: "", updated_at: "" },
+      { id: 2, name: "servo", label: "Servo", description: null, schema: [], deletable: false, reference_count: 0, created_at: "", updated_at: "" },
+      // User-added type with an absurdly long label — exactly what
+      // broke the layout in the reported screenshot.
+      { id: 99, name: "u2bwxy4wok1geb0tag6vl2jxesoblmw84hffy6b274s7kztftgdibouh5cjd6r11lal8re9sueczvwy_qa1r7nqx", label: "u2bwxy4wok1geb0tag6vl2jxesoblmw84hffy6b274s7kztftgdibouh5cjd6r11lal8re9sueczvwy_qa1r7nqx", description: null, schema: [], deletable: true, reference_count: 0, created_at: "", updated_at: "" },
+    ],
+    isLoading: false, mutate: vi.fn(), error: null,
+  }),
+}));
+
+vi.mock("@/lib/fetcher", () => ({ API_BASE: "http://x", fetcher: vi.fn() }));
+
+import { ComponentEditDialog } from "@/components/workbench/ComponentEditDialog";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ComponentEditDialog — Type/Mass row layout", () => {
+  it("Type <select> wrapper has min-w-0 so it can shrink below the longest option", () => {
+    const { container } = render(
+      <ComponentEditDialog open={true} onClose={vi.fn()} onSaved={vi.fn()} component={null} />,
+    );
+    const select = container.querySelector("select") as HTMLSelectElement;
+    expect(select).not.toBeNull();
+    // The flex wrapper around the select must allow shrinking
+    const wrapper = select.closest("div") as HTMLElement;
+    expect(wrapper.className).toMatch(/min-w-0/);
+    // The select itself carries w-full so its parent drives its width
+    expect(select.className).toMatch(/w-full/);
+  });
+
+  it("Mass (g) input wrapper has the same fix so the row is symmetric", () => {
+    const { container } = render(
+      <ComponentEditDialog open={true} onClose={vi.fn()} onSaved={vi.fn()} component={null} />,
+    );
+    const massInput = container.querySelector('input[type="number"]') as HTMLInputElement;
+    expect(massInput).not.toBeNull();
+    const wrapper = massInput.closest("div") as HTMLElement;
+    expect(wrapper.className).toMatch(/min-w-0/);
+    expect(massInput.className).toMatch(/w-full/);
+  });
+});

--- a/frontend/__tests__/ComponentTypeCreateFlow.test.tsx
+++ b/frontend/__tests__/ComponentTypeCreateFlow.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * End-to-end integration test for the Manage Types → New Type → Save flow.
+ *
+ * Reproduces the bug reported 2026-04-16: clicking Save in the "New Type"
+ * dialog does nothing (no network request, no dialog close). The test fails
+ * before the fix and passes after.
+ *
+ * Exercises the real ComponentTypeManagementDialog + ComponentTypeEditDialog
+ * together (no mocks for the child). Only the SWR hook and the CRUD client
+ * functions are stubbed so the test drives the UI deterministically.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) =>
+    React.createElement("span", props);
+  return {
+    X: icon, Plus: icon, Pencil: icon, Trash2: icon, Lock: icon,
+    Loader2: icon, Check: icon, Settings: icon,
+  };
+});
+
+const mockCreate = vi.fn().mockResolvedValue({ id: 999, name: "new_type" });
+const mockUpdate = vi.fn().mockResolvedValue({});
+const mockDelete = vi.fn().mockResolvedValue(undefined);
+const mockMutate = vi.fn();
+
+vi.mock("@/hooks/useComponentTypes", () => ({
+  useComponentTypes: () => ({
+    types: [],
+    isLoading: false,
+    mutate: mockMutate,
+    error: null,
+  }),
+  createComponentType: (...a: unknown[]) => mockCreate(...a),
+  updateComponentType: (...a: unknown[]) => mockUpdate(...a),
+  deleteComponentType: (...a: unknown[]) => mockDelete(...a),
+}));
+
+vi.mock("@/lib/fetcher", () => ({ API_BASE: "http://x", fetcher: vi.fn() }));
+
+import { ComponentTypeManagementDialog } from "@/components/workbench/ComponentTypeManagementDialog";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("Manage Types → New Type → Save flow (e2e)", () => {
+  it("creates a new type end-to-end: open mgmt → click New Type → fill form → Save → createComponentType called", async () => {
+    const { container } = render(
+      <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
+    );
+
+    // 1. Click "+ New Type"
+    fireEvent.click(screen.getByText(/New Type/i));
+
+    // 2. Verify Edit dialog opened
+    expect(screen.getByText(/New Type:/i)).toBeDefined();
+
+    // 3. Fill in Name + Label
+    // The Edit dialog has two text inputs at top: Name, Label.
+    const textInputs = container.querySelectorAll(
+      'input[type="text"]',
+    ) as NodeListOf<HTMLInputElement>;
+    // First text input across the whole DOM is the "Name" field inside the
+    // edit dialog. Name input isn't disabled for new types.
+    const nameInput = Array.from(textInputs).find((i) => !i.disabled) as HTMLInputElement;
+    expect(nameInput).toBeDefined();
+    fireEvent.change(nameInput, { target: { value: "carbon_tube" } });
+
+    // Fill the Label input (second non-disabled text input in the edit dialog).
+    const editableTextInputs = Array.from(textInputs).filter((i) => !i.disabled);
+    // [name, label, description] — index 1 is label
+    fireEvent.change(editableTextInputs[1], { target: { value: "Carbon Tube" } });
+
+    // 4. Click Save
+    const saveButtons = screen.getAllByText(/^Save$/);
+    expect(saveButtons.length).toBeGreaterThan(0);
+    fireEvent.click(saveButtons[0]);
+
+    // 5. The backend client must have been called with the payload
+    await Promise.resolve();  // flush microtasks
+    await Promise.resolve();
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "carbon_tube",
+        label: "Carbon Tube",
+        schema: [],
+      }),
+    );
+  });
+
+  it("Save with empty Label is blocked — no API call", () => {
+    render(<ComponentTypeManagementDialog open={true} onClose={vi.fn()} />);
+    fireEvent.click(screen.getByText(/New Type/i));
+    // No input → click Save
+    const saveButtons = screen.getAllByText(/^Save$/);
+    fireEvent.click(saveButtons[0]);
+    expect(mockCreate).not.toHaveBeenCalled();
+    // Inline error appears
+    expect(screen.getByText(/Label is required/i)).toBeDefined();
+  });
+
+  it("Save with non-snake_case Name is blocked for new types", () => {
+    const { container } = render(
+      <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByText(/New Type/i));
+
+    const textInputs = container.querySelectorAll(
+      'input[type="text"]',
+    ) as NodeListOf<HTMLInputElement>;
+    const editable = Array.from(textInputs).filter((i) => !i.disabled);
+    fireEvent.change(editable[0], { target: { value: "CarbonTube" } });  // PascalCase
+    fireEvent.change(editable[1], { target: { value: "Carbon Tube" } });
+
+    const saveButtons = screen.getAllByText(/^Save$/);
+    fireEvent.click(saveButtons[0]);
+
+    expect(mockCreate).not.toHaveBeenCalled();
+    // The inline error mentions snake_case. The label also mentions it, so we
+    // rely on getAllByText.
+    expect(screen.getAllByText(/snake_case/i).length).toBeGreaterThanOrEqual(2);
+  });
+
+  // ------------------------------------------------------------------- //
+  // Extra probes added while debugging the "does not save" bug report.
+  // These assertions try to narrow down where exactly the flow breaks
+  // in the real browser.
+  // ------------------------------------------------------------------- //
+
+  it("after successful save, onSaved is invoked so the list refetches", async () => {
+    const { container } = render(
+      <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByText(/New Type/i));
+
+    const textInputs = container.querySelectorAll(
+      'input[type="text"]',
+    ) as NodeListOf<HTMLInputElement>;
+    const editable = Array.from(textInputs).filter((i) => !i.disabled);
+    fireEvent.change(editable[0], { target: { value: "t1" } });
+    fireEvent.change(editable[1], { target: { value: "T1" } });
+
+    fireEvent.click(screen.getAllByText(/^Save$/)[0]);
+
+    // Flush the promise chain of handleSave.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockMutate).toHaveBeenCalled();
+  });
+
+  it("clicking Save propagates: no event handler outside the dialog triggers before handleSave", () => {
+    // Guards against a regression where stopPropagation on the inner card
+    // is dropped — which would let the parent backdrop's onClick close the
+    // dialog before the async save settles.
+    const onClose = vi.fn();
+    const { container } = render(
+      <ComponentTypeManagementDialog open={true} onClose={onClose} />,
+    );
+    fireEvent.click(screen.getByText(/New Type/i));
+
+    const textInputs = container.querySelectorAll(
+      'input[type="text"]',
+    ) as NodeListOf<HTMLInputElement>;
+    const editable = Array.from(textInputs).filter((i) => !i.disabled);
+    fireEvent.change(editable[0], { target: { value: "t2" } });
+    fireEvent.change(editable[1], { target: { value: "T2" } });
+
+    fireEvent.click(screen.getAllByText(/^Save$/)[0]);
+    // The parent Management dialog must NOT have closed as a side-effect of
+    // the Save click (Save closes the EDIT dialog via onSaved→onClose, but
+    // the Management dialog's onClose must not fire).
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/__tests__/ComponentTypeCreateFlow.test.tsx
+++ b/frontend/__tests__/ComponentTypeCreateFlow.test.tsx
@@ -8,9 +8,14 @@
  * Exercises the real ComponentTypeManagementDialog + ComponentTypeEditDialog
  * together (no mocks for the child). Only the SWR hook and the CRUD client
  * functions are stubbed so the test drives the UI deterministically.
+ *
+ * The file is also the regression suite for the 2026-04-16 delete-cascade
+ * incident: it pins down the expected payloads for every mutation the user
+ * can perform through the Manage-Types surface, so the UI can't silently
+ * start firing bogus requests again.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within, waitFor } from "@testing-library/react";
 import React from "react";
 
 vi.mock("lucide-react", () => {
@@ -27,13 +32,17 @@ const mockUpdate = vi.fn().mockResolvedValue({});
 const mockDelete = vi.fn().mockResolvedValue(undefined);
 const mockMutate = vi.fn();
 
+// Variable bag so individual tests can change what the hook returns before
+// rendering (e.g. to test the "edit existing type" path).
+let hookReturn: {
+  types: Array<Record<string, unknown>>;
+  isLoading: boolean;
+  mutate: () => void;
+  error: Error | null;
+} = { types: [], isLoading: false, mutate: mockMutate, error: null };
+
 vi.mock("@/hooks/useComponentTypes", () => ({
-  useComponentTypes: () => ({
-    types: [],
-    isLoading: false,
-    mutate: mockMutate,
-    error: null,
-  }),
+  useComponentTypes: () => hookReturn,
   createComponentType: (...a: unknown[]) => mockCreate(...a),
   updateComponentType: (...a: unknown[]) => mockUpdate(...a),
   deleteComponentType: (...a: unknown[]) => mockDelete(...a),
@@ -45,7 +54,30 @@ import { ComponentTypeManagementDialog } from "@/components/workbench/ComponentT
 
 beforeEach(() => {
   vi.clearAllMocks();
+  hookReturn = { types: [], isLoading: false, mutate: mockMutate, error: null };
 });
+
+/** Grab the editable (non-disabled) text inputs inside the Edit dialog. */
+function editableTextInputs(container: HTMLElement): HTMLInputElement[] {
+  const all = container.querySelectorAll(
+    'input[type="text"]',
+  ) as NodeListOf<HTMLInputElement>;
+  return Array.from(all).filter((i) => !i.disabled);
+}
+
+/** Click the Save button on the currently open dialog. */
+function clickSave() {
+  const saveButtons = screen.getAllByText(/^Save$/);
+  expect(saveButtons.length).toBeGreaterThan(0);
+  fireEvent.click(saveButtons[0]);
+}
+
+/** Flush two microtask ticks so awaited promises in handlers settle. */
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
 
 describe("Manage Types → New Type → Save flow (e2e)", () => {
   it("creates a new type end-to-end: open mgmt → click New Type → fill form → Save → createComponentType called", async () => {
@@ -60,29 +92,16 @@ describe("Manage Types → New Type → Save flow (e2e)", () => {
     expect(screen.getByText(/New Type:/i)).toBeDefined();
 
     // 3. Fill in Name + Label
-    // The Edit dialog has two text inputs at top: Name, Label.
-    const textInputs = container.querySelectorAll(
-      'input[type="text"]',
-    ) as NodeListOf<HTMLInputElement>;
-    // First text input across the whole DOM is the "Name" field inside the
-    // edit dialog. Name input isn't disabled for new types.
-    const nameInput = Array.from(textInputs).find((i) => !i.disabled) as HTMLInputElement;
-    expect(nameInput).toBeDefined();
-    fireEvent.change(nameInput, { target: { value: "carbon_tube" } });
-
-    // Fill the Label input (second non-disabled text input in the edit dialog).
-    const editableTextInputs = Array.from(textInputs).filter((i) => !i.disabled);
+    const editable = editableTextInputs(container);
+    fireEvent.change(editable[0], { target: { value: "carbon_tube" } });
     // [name, label, description] — index 1 is label
-    fireEvent.change(editableTextInputs[1], { target: { value: "Carbon Tube" } });
+    fireEvent.change(editable[1], { target: { value: "Carbon Tube" } });
 
     // 4. Click Save
-    const saveButtons = screen.getAllByText(/^Save$/);
-    expect(saveButtons.length).toBeGreaterThan(0);
-    fireEvent.click(saveButtons[0]);
+    clickSave();
 
     // 5. The backend client must have been called with the payload
-    await Promise.resolve();  // flush microtasks
-    await Promise.resolve();
+    await flushMicrotasks();
     expect(mockCreate).toHaveBeenCalledTimes(1);
     expect(mockCreate).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -97,8 +116,7 @@ describe("Manage Types → New Type → Save flow (e2e)", () => {
     render(<ComponentTypeManagementDialog open={true} onClose={vi.fn()} />);
     fireEvent.click(screen.getByText(/New Type/i));
     // No input → click Save
-    const saveButtons = screen.getAllByText(/^Save$/);
-    fireEvent.click(saveButtons[0]);
+    clickSave();
     expect(mockCreate).not.toHaveBeenCalled();
     // Inline error appears
     expect(screen.getByText(/Label is required/i)).toBeDefined();
@@ -110,15 +128,11 @@ describe("Manage Types → New Type → Save flow (e2e)", () => {
     );
     fireEvent.click(screen.getByText(/New Type/i));
 
-    const textInputs = container.querySelectorAll(
-      'input[type="text"]',
-    ) as NodeListOf<HTMLInputElement>;
-    const editable = Array.from(textInputs).filter((i) => !i.disabled);
+    const editable = editableTextInputs(container);
     fireEvent.change(editable[0], { target: { value: "CarbonTube" } });  // PascalCase
     fireEvent.change(editable[1], { target: { value: "Carbon Tube" } });
 
-    const saveButtons = screen.getAllByText(/^Save$/);
-    fireEvent.click(saveButtons[0]);
+    clickSave();
 
     expect(mockCreate).not.toHaveBeenCalled();
     // The inline error mentions snake_case. The label also mentions it, so we
@@ -138,18 +152,12 @@ describe("Manage Types → New Type → Save flow (e2e)", () => {
     );
     fireEvent.click(screen.getByText(/New Type/i));
 
-    const textInputs = container.querySelectorAll(
-      'input[type="text"]',
-    ) as NodeListOf<HTMLInputElement>;
-    const editable = Array.from(textInputs).filter((i) => !i.disabled);
+    const editable = editableTextInputs(container);
     fireEvent.change(editable[0], { target: { value: "t1" } });
     fireEvent.change(editable[1], { target: { value: "T1" } });
 
-    fireEvent.click(screen.getAllByText(/^Save$/)[0]);
-
-    // Flush the promise chain of handleSave.
-    await Promise.resolve();
-    await Promise.resolve();
+    clickSave();
+    await flushMicrotasks();
 
     expect(mockMutate).toHaveBeenCalled();
   });
@@ -164,17 +172,484 @@ describe("Manage Types → New Type → Save flow (e2e)", () => {
     );
     fireEvent.click(screen.getByText(/New Type/i));
 
-    const textInputs = container.querySelectorAll(
-      'input[type="text"]',
-    ) as NodeListOf<HTMLInputElement>;
-    const editable = Array.from(textInputs).filter((i) => !i.disabled);
+    const editable = editableTextInputs(container);
     fireEvent.change(editable[0], { target: { value: "t2" } });
     fireEvent.change(editable[1], { target: { value: "T2" } });
 
-    fireEvent.click(screen.getAllByText(/^Save$/)[0]);
+    clickSave();
     // The parent Management dialog must NOT have closed as a side-effect of
     // the Save click (Save closes the EDIT dialog via onSaved→onClose, but
     // the Management dialog's onClose must not fire).
     expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+// ----------------------------------------------------------------------- //
+// Payload contract — what the backend actually sees on every save.
+// These tests guard against regressions where the frontend silently starts
+// dropping fields or sending stringified JSON (the 2026-04-16 schema bug).
+// ----------------------------------------------------------------------- //
+
+describe("Create-Type payload contract", () => {
+  it("Description field is included in the payload", async () => {
+    const { container } = render(
+      <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByText(/New Type/i));
+    const editable = editableTextInputs(container);
+    fireEvent.change(editable[0], { target: { value: "motor_mount" } });
+    fireEvent.change(editable[1], { target: { value: "Motor Mount" } });
+    fireEvent.change(editable[2], {
+      target: { value: "Printed bracket for the motor" },
+    });
+    clickSave();
+    await flushMicrotasks();
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "motor_mount",
+        label: "Motor Mount",
+        description: "Printed bracket for the motor",
+      }),
+    );
+  });
+
+  it("empty description is sent as null (not empty string)", async () => {
+    const { container } = render(
+      <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByText(/New Type/i));
+    const editable = editableTextInputs(container);
+    fireEvent.change(editable[0], { target: { value: "empty_desc" } });
+    fireEvent.change(editable[1], { target: { value: "Empty Desc" } });
+    // description left blank
+
+    clickSave();
+    await flushMicrotasks();
+
+    const payload = mockCreate.mock.calls[0][0];
+    expect(payload.description).toBeNull();
+  });
+
+  it("schema is always a plain JS array (not a JSON-encoded string)", async () => {
+    // Regression for the double-encoding bug:
+    // backend rejected payloads where `schema` was a stringified JSON array.
+    // The frontend must always send a real array — including when empty.
+    const { container } = render(
+      <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByText(/New Type/i));
+    const editable = editableTextInputs(container);
+    fireEvent.change(editable[0], { target: { value: "arr_check" } });
+    fireEvent.change(editable[1], { target: { value: "Arr Check" } });
+    clickSave();
+    await flushMicrotasks();
+
+    const payload = mockCreate.mock.calls[0][0];
+    expect(Array.isArray(payload.schema)).toBe(true);
+    expect(payload.schema).toEqual([]);
+  });
+
+  it("exactly one createComponentType call per Save click (no duplicate fires)", async () => {
+    // Regression for the 2026-04-16 delete-cascade incident: a UI double-fire
+    // would duplicate mutations and is one plausible explanation for the
+    // "delete 1 wiped the table" symptom. Even if our investigation found the
+    // backend to be safe, we pin this guarantee down in the UI as well.
+    const { container } = render(
+      <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByText(/New Type/i));
+    const editable = editableTextInputs(container);
+    fireEvent.change(editable[0], { target: { value: "nodup" } });
+    fireEvent.change(editable[1], { target: { value: "NoDup" } });
+    clickSave();
+    // The Save handler is async → the dialog disables the button after
+    // the first click so a second click should be a no-op.
+    clickSave();
+    await flushMicrotasks();
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ----------------------------------------------------------------------- //
+// Property-addition sub-flow — adds a Property through the nested
+// PropertyEditDialog and verifies that it appears in the final payload.
+// ----------------------------------------------------------------------- //
+
+describe("Adding properties inside the type", () => {
+  it("adds a 'number' property via PropertyEditDialog → appears in Save payload", async () => {
+    const { container } = render(
+      <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByText(/New Type/i));
+
+    // Fill Name + Label
+    let editable = editableTextInputs(container);
+    fireEvent.change(editable[0], { target: { value: "tube" } });
+    fireEvent.change(editable[1], { target: { value: "Tube" } });
+
+    // Open PropertyEditDialog: Button labelled "+ Property" (inside Edit dialog)
+    // There are multiple Plus icons on screen — target by text of the label.
+    fireEvent.click(screen.getByText(/^Property$/));
+
+    // PropertyEditDialog is now mounted. Fill Name + Label + Unit + Min/Max.
+    // We re-query because new inputs appeared inside the nested dialog.
+    editable = editableTextInputs(container);
+    // Order of editable inputs now:
+    //   0: outer Name
+    //   1: outer Label
+    //   2: outer Description
+    //   3: prop Name
+    //   4: prop Label
+    //   5: prop Unit
+    //   6: prop Description
+    fireEvent.change(editable[3], { target: { value: "diameter_mm" } });
+    fireEvent.change(editable[4], { target: { value: "Diameter" } });
+    fireEvent.change(editable[5], { target: { value: "mm" } });
+
+    // Number-type Min/Max/Default inputs are rendered as type="number"
+    const numberInputs = container.querySelectorAll(
+      'input[type="number"]',
+    ) as NodeListOf<HTMLInputElement>;
+    // Min, Max, Default
+    expect(numberInputs.length).toBe(3);
+    fireEvent.change(numberInputs[0], { target: { value: "1" } });
+    fireEvent.change(numberInputs[1], { target: { value: "500" } });
+    fireEvent.change(numberInputs[2], { target: { value: "25" } });
+
+    // Apply
+    fireEvent.click(screen.getByText(/^Apply$/));
+
+    // Property row should now show in the outer dialog
+    expect(screen.getByText(/diameter_mm/)).toBeDefined();
+    expect(screen.getByText(/Properties \(1\)/)).toBeDefined();
+
+    // Save the type
+    clickSave();
+    await flushMicrotasks();
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    const payload = mockCreate.mock.calls[0][0];
+    expect(payload.schema).toHaveLength(1);
+    expect(payload.schema[0]).toEqual(
+      expect.objectContaining({
+        name: "diameter_mm",
+        label: "Diameter",
+        type: "number",
+        unit: "mm",
+        min: 1,
+        max: 500,
+        default: 25,
+      }),
+    );
+  });
+
+  it("adds two properties; deletes the first; Save payload has only the survivor", async () => {
+    const { container } = render(
+      <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByText(/New Type/i));
+
+    const firstEditable = editableTextInputs(container);
+    fireEvent.change(firstEditable[0], { target: { value: "multi" } });
+    fireEvent.change(firstEditable[1], { target: { value: "Multi" } });
+
+    // Add property #1 ("alpha")
+    fireEvent.click(screen.getByText(/^Property$/));
+    let editable = editableTextInputs(container);
+    fireEvent.change(editable[3], { target: { value: "alpha" } });
+    fireEvent.change(editable[4], { target: { value: "Alpha" } });
+    fireEvent.click(screen.getByText(/^Apply$/));
+
+    // Add property #2 ("beta")
+    fireEvent.click(screen.getByText(/^Property$/));
+    editable = editableTextInputs(container);
+    fireEvent.change(editable[3], { target: { value: "beta" } });
+    fireEvent.change(editable[4], { target: { value: "Beta" } });
+    fireEvent.click(screen.getByText(/^Apply$/));
+
+    expect(screen.getByText(/Properties \(2\)/)).toBeDefined();
+
+    // Delete property "alpha" by finding its row and clicking its Trash icon.
+    const alphaRow = screen.getByText("alpha").closest("div");
+    expect(alphaRow).not.toBeNull();
+    const deleteBtn = within(alphaRow as HTMLElement).getByTitle(
+      /Delete property/i,
+    );
+    fireEvent.click(deleteBtn);
+
+    expect(screen.getByText(/Properties \(1\)/)).toBeDefined();
+    expect(screen.queryByText("alpha")).toBeNull();
+
+    // Save
+    clickSave();
+    await flushMicrotasks();
+
+    const payload = mockCreate.mock.calls[0][0];
+    expect(payload.schema).toHaveLength(1);
+    expect(payload.schema[0].name).toBe("beta");
+  });
+
+  it("PropertyEditDialog validation blocks Apply: enum with no options", () => {
+    const { container } = render(
+      <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByText(/New Type/i));
+    const first = editableTextInputs(container);
+    fireEvent.change(first[0], { target: { value: "enum_t" } });
+    fireEvent.change(first[1], { target: { value: "Enum T" } });
+
+    fireEvent.click(screen.getByText(/^Property$/));
+    const editable = editableTextInputs(container);
+    fireEvent.change(editable[3], { target: { value: "color" } });
+    fireEvent.change(editable[4], { target: { value: "Color" } });
+
+    // Switch type to enum
+    const select = container.querySelector("select") as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "enum" } });
+
+    // Click Apply with empty options CSV
+    fireEvent.click(screen.getByText(/^Apply$/));
+
+    // Property-row list must still show 0 properties, inline error shown
+    expect(screen.getByText(/Enum needs at least one option/i)).toBeDefined();
+    expect(screen.getByText(/Properties \(0\)/)).toBeDefined();
+  });
+});
+
+// ----------------------------------------------------------------------- //
+// Backend error propagation — the user must see the error and the form
+// must NOT reset; no duplicate mutation was fired.
+// ----------------------------------------------------------------------- //
+
+describe("Backend error propagation on Save", () => {
+  it("409 conflict: error is shown, dialog stays open, form preserved", async () => {
+    mockCreate.mockRejectedValueOnce(
+      new Error("Type with name 'dup' already exists."),
+    );
+    const { container } = render(
+      <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByText(/New Type/i));
+
+    const editable = editableTextInputs(container);
+    fireEvent.change(editable[0], { target: { value: "dup" } });
+    fireEvent.change(editable[1], { target: { value: "Dup" } });
+
+    clickSave();
+
+    // Error is surfaced (waitFor — the rejected promise settles on a later tick)
+    await waitFor(() => {
+      expect(screen.getByText(/already exists/i)).toBeDefined();
+    });
+
+    // Dialog still open — its title is still visible
+    expect(screen.getByText(/New Type:/i)).toBeDefined();
+
+    // Form values preserved
+    const stillEditable = editableTextInputs(container);
+    expect(stillEditable[0].value).toBe("dup");
+    expect(stillEditable[1].value).toBe("Dup");
+
+    // Parent's onSaved/mutate not fired on error
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it("422 validation: message passes through unchanged", async () => {
+    mockCreate.mockRejectedValueOnce(
+      new Error("Ungültige Eingabedaten"),
+    );
+    const { container } = render(
+      <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByText(/New Type/i));
+    const editable = editableTextInputs(container);
+    fireEvent.change(editable[0], { target: { value: "t_x" } });
+    fireEvent.change(editable[1], { target: { value: "T X" } });
+
+    clickSave();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Ungültige Eingabedaten/)).toBeDefined();
+    });
+  });
+
+  it("after a failed save, the user can retry: second call made on second Save", async () => {
+    mockCreate
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce({ id: 5, name: "retry_me" });
+    const { container } = render(
+      <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByText(/New Type/i));
+    const editable = editableTextInputs(container);
+    fireEvent.change(editable[0], { target: { value: "retry_me" } });
+    fireEvent.change(editable[1], { target: { value: "Retry" } });
+
+    clickSave();
+    await waitFor(() => {
+      expect(screen.getByText(/boom/)).toBeDefined();
+    });
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+
+    // Click Save again — this time it succeeds
+    clickSave();
+    await waitFor(() => {
+      expect(mockCreate).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mockMutate).toHaveBeenCalled();
+  });
+});
+
+// ----------------------------------------------------------------------- //
+// Edit + Delete surfaces — the "not-new" branch of the Edit dialog.
+// ----------------------------------------------------------------------- //
+
+describe("Edit existing type (not new)", () => {
+  const existingType = {
+    id: 42,
+    name: "carbon_tube",
+    label: "Carbon Tube",
+    description: "Rolled CF tube",
+    schema: [
+      { name: "diameter_mm", label: "Dia", type: "number", required: true },
+    ],
+    deletable: true,
+    reference_count: 0,
+    created_at: "2026-04-16T00:00:00Z",
+    updated_at: "2026-04-16T00:00:00Z",
+  };
+
+  beforeEach(() => {
+    hookReturn = {
+      types: [existingType],
+      isLoading: false,
+      mutate: mockMutate,
+      error: null,
+    };
+  });
+
+  it("opens with pre-filled values; Name is disabled (immutable)", () => {
+    const { container } = render(
+      <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByTitle(/Edit Carbon Tube/i));
+
+    // Name input should be disabled
+    const nameInput = container.querySelector(
+      'input[value="carbon_tube"]',
+    ) as HTMLInputElement;
+    expect(nameInput).not.toBeNull();
+    expect(nameInput.disabled).toBe(true);
+
+    // Label / Description prefilled
+    expect(
+      (container.querySelector('input[value="Carbon Tube"]') as HTMLInputElement)
+        .disabled,
+    ).toBe(false);
+
+    // Existing property is shown
+    expect(screen.getByText(/diameter_mm/)).toBeDefined();
+    expect(screen.getByText(/Properties \(1\)/)).toBeDefined();
+  });
+
+  it("Save on an existing type calls updateComponentType(id, payload) — not create", async () => {
+    const { container } = render(
+      <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByTitle(/Edit Carbon Tube/i));
+
+    // Update the label and description
+    const labelInput = container.querySelector(
+      'input[value="Carbon Tube"]',
+    ) as HTMLInputElement;
+    fireEvent.change(labelInput, { target: { value: "Carbon Tube v2" } });
+
+    clickSave();
+    await flushMicrotasks();
+
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockUpdate).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ label: "Carbon Tube v2", name: "carbon_tube" }),
+    );
+    expect(mockMutate).toHaveBeenCalled();
+  });
+
+  it("delete button inside edit dialog opens confirm → Confirm calls deleteComponentType(id)", async () => {
+    render(<ComponentTypeManagementDialog open={true} onClose={vi.fn()} />);
+    fireEvent.click(screen.getByTitle(/Edit Carbon Tube/i));
+
+    // Delete-type button is visible because deletable=true AND ref_count=0
+    fireEvent.click(screen.getByTitle(/Delete type/i));
+
+    // Confirmation shows a Confirm button
+    fireEvent.click(screen.getByText(/^Confirm$/));
+    await flushMicrotasks();
+
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+    expect(mockDelete).toHaveBeenCalledWith(42);
+  });
+
+  it("seeded type: delete-type button is not rendered in the edit dialog", () => {
+    hookReturn = {
+      types: [{ ...existingType, id: 1, name: "material", label: "Material", deletable: false }],
+      isLoading: false,
+      mutate: mockMutate,
+      error: null,
+    };
+    render(<ComponentTypeManagementDialog open={true} onClose={vi.fn()} />);
+    fireEvent.click(screen.getByTitle(/Edit Material/i));
+
+    expect(screen.queryByTitle(/Delete type/i)).toBeNull();
+  });
+
+  it("referenced type: delete-type button is not rendered in the edit dialog", () => {
+    hookReturn = {
+      types: [{ ...existingType, reference_count: 5 }],
+      isLoading: false,
+      mutate: mockMutate,
+      error: null,
+    };
+    render(<ComponentTypeManagementDialog open={true} onClose={vi.fn()} />);
+    fireEvent.click(screen.getByTitle(/Edit Carbon Tube/i));
+
+    expect(screen.queryByTitle(/Delete type/i)).toBeNull();
+  });
+});
+
+// ----------------------------------------------------------------------- //
+// Dialog lifecycle — Cancel does not mutate and unmounts the dialog.
+// ----------------------------------------------------------------------- //
+
+describe("Cancel / dismiss paths", () => {
+  it("Cancel button in Edit dialog closes it without calling any CRUD", () => {
+    const { container } = render(
+      <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByText(/New Type/i));
+
+    // Type something so we can verify Cancel really drops it
+    const editable = editableTextInputs(container);
+    fireEvent.change(editable[0], { target: { value: "throwaway" } });
+    fireEvent.change(editable[1], { target: { value: "Throwaway" } });
+
+    // Edit dialog has a "Cancel" button (so does the outer, for the mgmt
+    // dialog itself). Target the Cancel that is a sibling of the Save inside
+    // the same card.
+    const saveBtn = screen.getByText(/^Save$/);
+    const card = saveBtn.closest("div")?.parentElement as HTMLElement;
+    const cancelInsideEdit = within(card).getByText(/^Cancel$/);
+    fireEvent.click(cancelInsideEdit);
+
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockMutate).not.toHaveBeenCalled();
+
+    // Edit dialog no longer visible
+    expect(screen.queryByText(/New Type:/i)).toBeNull();
   });
 });

--- a/frontend/__tests__/ComponentTypeManagementDialog.test.tsx
+++ b/frontend/__tests__/ComponentTypeManagementDialog.test.tsx
@@ -23,10 +23,11 @@ let typesReturn: {
   types: Array<Record<string, unknown>>;
   isLoading: boolean;
   mutate: () => void;
+  error?: Error | null;
 } = { types: [], isLoading: false, mutate: vi.fn() };
 
 vi.mock("@/hooks/useComponentTypes", () => ({
-  useComponentTypes: () => ({ ...typesReturn, error: null }),
+  useComponentTypes: () => ({ error: null, ...typesReturn }),
   createComponentType: vi.fn().mockResolvedValue({}),
   updateComponentType: vi.fn().mockResolvedValue({}),
   deleteComponentType: vi.fn().mockResolvedValue(undefined),
@@ -131,6 +132,22 @@ describe("ComponentTypeManagementDialog", () => {
     render(<ComponentTypeManagementDialog open={true} onClose={vi.fn()} />);
     fireEvent.click(screen.getByTitle(/Edit Material/i));
     expect(screen.getByText(/Edit Type: Material/i)).toBeDefined();
+  });
+
+  it("shows a visible error when the GET /component-types fetch fails", () => {
+    // Regression for the 2026-04-16 bug report: both the Mgmt dialog list
+    // and the New-Component dropdown were empty, but the user had no visible
+    // feedback because the hook swallowed the error. With this fix, any SWR
+    // error surfaces in the dialog.
+    typesReturn = {
+      types: [],
+      isLoading: false,
+      mutate: vi.fn(),
+      error: new Error("404 Not Found: /component-types"),
+    };
+    render(<ComponentTypeManagementDialog open={true} onClose={vi.fn()} />);
+    expect(screen.getByText(/Failed to load types/i)).toBeDefined();
+    expect(screen.getByText(/404/)).toBeDefined();
   });
 
   it("Close button calls onClose", () => {

--- a/frontend/__tests__/ComponentTypeManagementDialog.test.tsx
+++ b/frontend/__tests__/ComponentTypeManagementDialog.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Tests for the Component Type Management dialog (gh#84).
+ *
+ * The management dialog lists all registered types (seeded + user-added),
+ * shows their reference-count, and lets the user open an edit dialog for
+ * each or create a new type. Delete is disabled for seeded types and for
+ * user types with references.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) =>
+    React.createElement("span", props);
+  return {
+    X: icon, Plus: icon, Pencil: icon, Trash2: icon, Lock: icon,
+    Loader2: icon, Check: icon, Settings: icon,
+  };
+});
+
+let typesReturn: {
+  types: Array<Record<string, unknown>>;
+  isLoading: boolean;
+  mutate: () => void;
+} = { types: [], isLoading: false, mutate: vi.fn() };
+
+vi.mock("@/hooks/useComponentTypes", () => ({
+  useComponentTypes: () => ({ ...typesReturn, error: null }),
+  createComponentType: vi.fn().mockResolvedValue({}),
+  updateComponentType: vi.fn().mockResolvedValue({}),
+  deleteComponentType: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/fetcher", () => ({ API_BASE: "http://x", fetcher: vi.fn() }));
+
+import { ComponentTypeManagementDialog } from "@/components/workbench/ComponentTypeManagementDialog";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  typesReturn = { types: [], isLoading: false, mutate: vi.fn() };
+});
+
+function makeType(o: Record<string, unknown> = {}) {
+  return {
+    id: 1, name: "foo", label: "Foo",
+    description: null, schema: [],
+    deletable: true, reference_count: 0,
+    created_at: "2026-04-16T00:00:00Z",
+    updated_at: "2026-04-16T00:00:00Z",
+    ...o,
+  };
+}
+
+describe("ComponentTypeManagementDialog", () => {
+  it("does not render when open=false", () => {
+    render(<ComponentTypeManagementDialog open={false} onClose={vi.fn()} />);
+    expect(screen.queryByText(/Manage Component Types/i)).toBeNull();
+  });
+
+  it("shows empty state message when no types exist", () => {
+    render(<ComponentTypeManagementDialog open={true} onClose={vi.fn()} />);
+    // Header always present
+    expect(screen.getByText(/Manage Component Types/i)).toBeDefined();
+  });
+
+  it("lists types with label, reference-count, and deletable indicator", () => {
+    typesReturn = {
+      types: [
+        makeType({ id: 1, name: "material", label: "Material", deletable: false, reference_count: 5 }),
+        makeType({ id: 2, name: "custom_tube", label: "Custom Tube", deletable: true, reference_count: 0 }),
+      ],
+      isLoading: false, mutate: vi.fn(),
+    };
+    render(<ComponentTypeManagementDialog open={true} onClose={vi.fn()} />);
+    expect(screen.getByText("Material")).toBeDefined();
+    expect(screen.getByText("Custom Tube")).toBeDefined();
+    expect(screen.getByText(/5 components/i)).toBeDefined();
+  });
+
+  it("delete button is disabled for seeded types", () => {
+    typesReturn = {
+      types: [
+        makeType({ id: 1, name: "material", label: "Material", deletable: false, reference_count: 0 }),
+      ],
+      isLoading: false, mutate: vi.fn(),
+    };
+    render(<ComponentTypeManagementDialog open={true} onClose={vi.fn()} />);
+    const btn = screen.getByTitle(/Seeded type cannot be deleted/i) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it("delete button is disabled for user types with references", () => {
+    typesReturn = {
+      types: [
+        makeType({ id: 1, name: "ut", label: "User Type", deletable: true, reference_count: 3 }),
+      ],
+      isLoading: false, mutate: vi.fn(),
+    };
+    render(<ComponentTypeManagementDialog open={true} onClose={vi.fn()} />);
+    const btn = screen.getByTitle(/Referenced by 3/i) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it("delete button is enabled for user types without references", () => {
+    typesReturn = {
+      types: [
+        makeType({ id: 1, name: "ut", label: "User Type", deletable: true, reference_count: 0 }),
+      ],
+      isLoading: false, mutate: vi.fn(),
+    };
+    render(<ComponentTypeManagementDialog open={true} onClose={vi.fn()} />);
+    const btn = screen.getByTitle(/Delete User Type/i) as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+  });
+
+  it("'+ New Type' button opens the Edit dialog with an empty type", () => {
+    render(<ComponentTypeManagementDialog open={true} onClose={vi.fn()} />);
+    fireEvent.click(screen.getByText(/New Type/i));
+    // The Edit dialog has its own title "Edit Type" or "New Type"
+    expect(screen.getByText(/New Type:/i)).toBeDefined();
+  });
+
+  it("pencil icon on a row opens the Edit dialog with that type", () => {
+    typesReturn = {
+      types: [
+        makeType({ id: 1, name: "material", label: "Material", deletable: false }),
+      ],
+      isLoading: false, mutate: vi.fn(),
+    };
+    render(<ComponentTypeManagementDialog open={true} onClose={vi.fn()} />);
+    fireEvent.click(screen.getByTitle(/Edit Material/i));
+    expect(screen.getByText(/Edit Type: Material/i)).toBeDefined();
+  });
+
+  it("Close button calls onClose", () => {
+    const onClose = vi.fn();
+    render(<ComponentTypeManagementDialog open={true} onClose={onClose} />);
+    fireEvent.click(screen.getByText(/^Close$/));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/__tests__/PropertyEditDialog.test.tsx
+++ b/frontend/__tests__/PropertyEditDialog.test.tsx
@@ -147,6 +147,33 @@ describe("PropertyEditDialog", () => {
     );
   });
 
+  it("Min/Max/Default row allows its inputs to shrink below intrinsic width", () => {
+    // Regression test: <input type="number"> has an intrinsic min-width that,
+    // without `min-w-0` on the flex items and `w-full` on the inputs, causes
+    // the third input (Default, with a multi-digit value) to overflow the
+    // modal. Captured visually on 2026-04-16 with a 4-digit default.
+    const { container } = render(
+      <PropertyEditDialog
+        open={true}
+        initial={{ name: "x", label: "X", type: "number", min: 1, max: 3000, default: 1000 }}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    // Each of the three number inputs must be in a wrapper that CAN shrink
+    // (min-w-0 present), and the input itself carries w-full so the wrapper
+    // drives its width.
+    const numberInputs = container.querySelectorAll<HTMLInputElement>(
+      'input[type="number"]',
+    );
+    expect(numberInputs.length).toBe(3);
+    for (const input of Array.from(numberInputs)) {
+      const wrapper = input.closest("div") as HTMLElement;
+      expect(wrapper.className).toMatch(/min-w-0/);
+      expect(input.className).toMatch(/w-full/);
+    }
+  });
+
   it("Cancel calls onCancel without onSave", () => {
     const onSave = vi.fn();
     const onCancel = vi.fn();

--- a/frontend/__tests__/PropertyEditDialog.test.tsx
+++ b/frontend/__tests__/PropertyEditDialog.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * Tests for the PropertyEditDialog (gh#84).
+ *
+ * The property dialog edits a single PropertyDefinition (name, label, type,
+ * and type-specific fields). It does NOT talk to the API — its job is to
+ * return the edited property to the parent via onSave.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) =>
+    React.createElement("span", props);
+  return { X: icon, Check: icon };
+});
+
+import { PropertyEditDialog } from "@/components/workbench/PropertyEditDialog";
+import type { PropertyDefinition } from "@/hooks/useComponentTypes";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("PropertyEditDialog", () => {
+  it("does not render when open=false", () => {
+    render(
+      <PropertyEditDialog
+        open={false}
+        initial={null}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText(/Property/i)).toBeNull();
+  });
+
+  it("renders blank form for new property (initial=null)", () => {
+    const { container } = render(
+      <PropertyEditDialog
+        open={true}
+        initial={null}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/Name \(snake_case\)/i)).toBeDefined();
+    expect(screen.getByText(/^Label/i)).toBeDefined();
+    expect(screen.getByText(/^Type/i)).toBeDefined();
+    // Name input empty
+    const nameInput = container.querySelector('input[type="text"]') as HTMLInputElement;
+    expect(nameInput.value).toBe("");
+  });
+
+  it("pre-fills form when initial is provided", () => {
+    const initial: PropertyDefinition = {
+      name: "density_kg_m3",
+      label: "Dichte",
+      type: "number",
+      unit: "kg/m³",
+      required: true,
+      min: 100,
+      max: 20000,
+    };
+    const { container } = render(
+      <PropertyEditDialog
+        open={true}
+        initial={initial}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const inputs = container.querySelectorAll("input") as NodeListOf<HTMLInputElement>;
+    const byPlaceholder = Array.from(inputs).map((i) => i.value);
+    expect(byPlaceholder).toContain("density_kg_m3");
+    expect(byPlaceholder).toContain("Dichte");
+    expect(byPlaceholder).toContain("kg/m³");
+  });
+
+  it("shows min/max fields only for number type", () => {
+    render(
+      <PropertyEditDialog
+        open={true}
+        initial={{ name: "x", label: "X", type: "number" }}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/^Min/i)).toBeDefined();
+    expect(screen.getByText(/^Max/i)).toBeDefined();
+  });
+
+  it("shows options field only for enum type", () => {
+    render(
+      <PropertyEditDialog
+        open={true}
+        initial={{ name: "x", label: "X", type: "enum", options: ["a", "b"] }}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/Options \(comma-separated\)/i)).toBeDefined();
+    expect(screen.queryByText(/^Min/i)).toBeNull();
+  });
+
+  it("rejects non-snake_case names with an inline error", () => {
+    const onSave = vi.fn();
+    const { container } = render(
+      <PropertyEditDialog
+        open={true}
+        initial={null}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />,
+    );
+    const nameInput = container.querySelector('input[type="text"]') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: "BadName" } });
+    fireEvent.click(screen.getByText(/^Apply$/i));
+    expect(onSave).not.toHaveBeenCalled();
+    // Error message appears (we know the text mentions snake_case — we
+    // assert by getAllByText since the label "Name (snake_case) *" also
+    // matches, and both being present is our "2 elements" expectation).
+    expect(screen.getAllByText(/snake_case/i).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("Apply calls onSave with the edited property", () => {
+    const onSave = vi.fn();
+    const { container } = render(
+      <PropertyEditDialog
+        open={true}
+        initial={null}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />,
+    );
+    const inputs = container.querySelectorAll('input[type="text"]') as NodeListOf<HTMLInputElement>;
+    fireEvent.change(inputs[0], { target: { value: "torque_kg_cm" } });
+    fireEvent.change(inputs[1], { target: { value: "Drehmoment" } });
+
+    fireEvent.click(screen.getByText(/^Apply$/));
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "torque_kg_cm",
+        label: "Drehmoment",
+        type: "number",  // default
+      }),
+    );
+  });
+
+  it("Cancel calls onCancel without onSave", () => {
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <PropertyEditDialog
+        open={true}
+        initial={null}
+        onSave={onSave}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.click(screen.getByText(/^Cancel$/));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/workbench/components/page.tsx
+++ b/frontend/app/workbench/components/page.tsx
@@ -8,6 +8,7 @@ import { ComponentEditDialog } from "@/components/workbench/ComponentEditDialog"
 import { ConstructionPartsGrid } from "@/components/workbench/ConstructionPartsGrid";
 import { ConstructionPartUploadDialog } from "@/components/workbench/ConstructionPartUploadDialog";
 import { NodePropertyPanel } from "@/components/workbench/NodePropertyPanel";
+import { ComponentTypeManagementDialog } from "@/components/workbench/ComponentTypeManagementDialog";
 import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
 import { useComponents, deleteComponent, type Component } from "@/hooks/useComponents";
 import {
@@ -38,6 +39,7 @@ export default function ComponentsPage() {
   const [typeFilter, setTypeFilter] = useState<string>("");
   const { components, total, isLoading, mutate } = useComponents(typeFilter || undefined, search || undefined);
   const [editDialog, setEditDialog] = useState<{ open: boolean; component: Component | null }>({ open: false, component: null });
+  const [typesDialog, setTypesDialog] = useState(false);
   const [uploadOpen, setUploadOpen] = useState(false);
   const { mutate: mutateParts } = useConstructionParts(aeroplaneId);
 
@@ -115,6 +117,14 @@ export default function ComponentsPage() {
             {total} items
           </span>
           <span className="flex-1" />
+          <button
+            onClick={() => setTypesDialog(true)}
+            className="flex items-center gap-1.5 rounded-full border border-border bg-card-muted px-3 py-2 text-[13px] text-foreground hover:bg-sidebar-accent"
+            title="Manage component types"
+          >
+            <Settings size={14} />
+            Manage Types
+          </button>
           <button
             onClick={() => setEditDialog({ open: true, component: null })}
             className="flex items-center gap-1.5 rounded-full bg-primary px-4 py-2 text-[13px] text-primary-foreground hover:opacity-90"
@@ -269,6 +279,11 @@ export default function ComponentsPage() {
         onClose={() => setEditingNodeId(null)}
       />
     )}
+
+    <ComponentTypeManagementDialog
+      open={typesDialog}
+      onClose={() => setTypesDialog(false)}
+    />
     </>
   );
 }

--- a/frontend/components/workbench/ComponentEditDialog.tsx
+++ b/frontend/components/workbench/ComponentEditDialog.tsx
@@ -94,18 +94,26 @@ export function ComponentEditDialog({ open, onClose, onSaved, component }: Compo
             <input type="text" value={name} onChange={(e) => setName(e.target.value)}
               className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground" />
           </div>
+          {/*
+           * `min-w-0` on the flex items + `w-full` on the controls — same
+           * pattern as the PropertyEditDialog Min/Max/Default fix. Without
+           * it, a <select> element sizes to fit its longest option, which
+           * can push the row wider than the modal when a user-added type
+           * has a very long name. Reported 2026-04-16 for a garbage type
+           * name of ~60 characters.
+           */}
           <div className="flex gap-3">
-            <div className="flex flex-1 flex-col gap-1">
+            <div className="flex min-w-0 flex-1 flex-col gap-1">
               <label className="text-[11px] text-muted-foreground">Type</label>
               <select value={componentType} onChange={(e) => setComponentType(e.target.value)}
-                className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground">
+                className="w-full truncate rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground">
                 {types.map((t) => <option key={t.id} value={t.name}>{t.label}</option>)}
               </select>
             </div>
-            <div className="flex flex-1 flex-col gap-1">
+            <div className="flex min-w-0 flex-1 flex-col gap-1">
               <label className="text-[11px] text-muted-foreground">Mass (g)</label>
               <input type="number" value={massG} onChange={(e) => setMassG(e.target.value)}
-                className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground" />
+                className="w-full rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground" />
             </div>
           </div>
           <div className="flex flex-col gap-1">

--- a/frontend/components/workbench/ComponentEditDialog.tsx
+++ b/frontend/components/workbench/ComponentEditDialog.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect } from "react";
 import { X, Loader2 } from "lucide-react";
 import type { Component } from "@/hooks/useComponents";
-import { createComponent, updateComponent, useComponentTypes } from "@/hooks/useComponents";
+import { createComponent, updateComponent } from "@/hooks/useComponents";
+import { useComponentTypes } from "@/hooks/useComponentTypes";
 
 interface ComponentEditDialogProps {
   open: boolean;
@@ -13,7 +14,7 @@ interface ComponentEditDialogProps {
 }
 
 export function ComponentEditDialog({ open, onClose, onSaved, component }: ComponentEditDialogProps) {
-  const types = useComponentTypes();
+  const { types } = useComponentTypes();
   const isEdit = !!component;
 
   const [name, setName] = useState("");
@@ -98,7 +99,7 @@ export function ComponentEditDialog({ open, onClose, onSaved, component }: Compo
               <label className="text-[11px] text-muted-foreground">Type</label>
               <select value={componentType} onChange={(e) => setComponentType(e.target.value)}
                 className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground">
-                {types.map((t) => <option key={t} value={t}>{t}</option>)}
+                {types.map((t) => <option key={t.id} value={t.name}>{t.label}</option>)}
               </select>
             </div>
             <div className="flex flex-1 flex-col gap-1">

--- a/frontend/components/workbench/ComponentTypeEditDialog.tsx
+++ b/frontend/components/workbench/ComponentTypeEditDialog.tsx
@@ -1,0 +1,341 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Check, Loader2, Pencil, Plus, Trash2, X } from "lucide-react";
+import {
+  createComponentType,
+  deleteComponentType,
+  updateComponentType,
+  type ComponentType,
+  type PropertyDefinition,
+} from "@/hooks/useComponentTypes";
+import { PropertyEditDialog } from "@/components/workbench/PropertyEditDialog";
+
+interface ComponentTypeEditDialogProps {
+  open: boolean;
+  type: ComponentType | null; // null = creating a new type
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+interface TypeFormState {
+  name: string;
+  label: string;
+  description: string;
+  schema: PropertyDefinition[];
+}
+
+function toForm(t: ComponentType | null): TypeFormState {
+  if (!t) return { name: "", label: "", description: "", schema: [] };
+  return {
+    name: t.name,
+    label: t.label,
+    description: t.description ?? "",
+    schema: t.schema,
+  };
+}
+
+const SNAKE_CASE = /^[a-z][a-z0-9_]*$/;
+
+export function ComponentTypeEditDialog({
+  open, type, onClose, onSaved,
+}: ComponentTypeEditDialogProps) {
+  const [form, setForm] = useState<TypeFormState>(toForm(type));
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [propDialog, setPropDialog] = useState<{
+    open: boolean;
+    index: number | null;   // null = new
+    initial: PropertyDefinition | null;
+  }>({ open: false, index: null, initial: null });
+  const [pendingDelete, setPendingDelete] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setForm(toForm(type));
+      setError(null);
+    }
+  }, [open, type]);
+
+  if (!open) return null;
+
+  const isNew = type === null;
+  const canDeleteType = !isNew && type.deletable && type.reference_count === 0;
+
+  function update(patch: Partial<TypeFormState>) {
+    setForm((prev) => ({ ...prev, ...patch }));
+  }
+
+  async function handleSave() {
+    if (!form.label.trim()) {
+      setError("Label is required");
+      return;
+    }
+    if (isNew) {
+      if (!form.name.trim() || !SNAKE_CASE.test(form.name)) {
+        setError("Name must be snake_case (lowercase + digits + underscores)");
+        return;
+      }
+    }
+    setSaving(true);
+    setError(null);
+    const payload = {
+      name: form.name,
+      label: form.label,
+      description: form.description || null,
+      schema: form.schema,
+    };
+    try {
+      if (isNew) {
+        await createComponentType(payload);
+      } else {
+        await updateComponentType(type!.id, payload);
+      }
+      onSaved();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleConfirmDelete() {
+    if (!type) return;
+    setSaving(true);
+    try {
+      await deleteComponentType(type.id);
+      onSaved();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setPendingDelete(false);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function openNewProperty() {
+    setPropDialog({ open: true, index: null, initial: null });
+  }
+
+  function openEditProperty(i: number) {
+    setPropDialog({ open: true, index: i, initial: form.schema[i] });
+  }
+
+  function handlePropSave(prop: PropertyDefinition) {
+    setForm((prev) => {
+      const next = [...prev.schema];
+      if (propDialog.index == null) next.push(prop);
+      else next[propDialog.index] = prop;
+      return { ...prev, schema: next };
+    });
+    setPropDialog({ open: false, index: null, initial: null });
+  }
+
+  function handlePropDelete(i: number) {
+    setForm((prev) => ({
+      ...prev,
+      schema: prev.schema.filter((_, idx) => idx !== i),
+    }));
+  }
+
+  const heading = isNew ? "New Type:" : `Edit Type: ${type!.label}`;
+
+  return (
+    <div
+      className="fixed inset-0 z-[55] flex items-center justify-center bg-black/60"
+      onClick={onClose}
+    >
+      <div
+        className="flex w-[560px] max-h-[85vh] flex-col gap-3 rounded-2xl border border-border bg-card p-5 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center gap-2">
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[15px] text-foreground">
+            {heading}
+          </span>
+          <span className="flex-1" />
+          {canDeleteType && (
+            <button
+              onClick={() => setPendingDelete(true)}
+              title="Delete type"
+              className="flex size-7 items-center justify-center rounded-full border border-border text-destructive hover:bg-destructive/20"
+            >
+              <Trash2 size={12} />
+            </button>
+          )}
+          <button
+            onClick={onClose}
+            title="Close"
+            className="flex size-7 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent"
+          >
+            <X size={12} />
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-2 overflow-y-auto">
+          <div className="flex gap-2">
+            <div className="flex flex-1 flex-col gap-1">
+              <label className="text-[11px] text-muted-foreground">Name (snake_case)</label>
+              <input
+                type="text"
+                value={form.name}
+                onChange={(e) => update({ name: e.target.value })}
+                disabled={!isNew}
+                placeholder="carbon_tube"
+                className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground disabled:opacity-60"
+              />
+            </div>
+            <div className="flex flex-1 flex-col gap-1">
+              <label className="text-[11px] text-muted-foreground">Label *</label>
+              <input
+                type="text"
+                value={form.label}
+                onChange={(e) => update({ label: e.target.value })}
+                placeholder="Carbon Tube"
+                className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
+              />
+            </div>
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-[11px] text-muted-foreground">Description</label>
+            <input
+              type="text"
+              value={form.description}
+              onChange={(e) => update({ description: e.target.value })}
+              className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
+            />
+          </div>
+
+          <div className="mt-1 flex items-center gap-2">
+            <span className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-muted-foreground">
+              Properties ({form.schema.length})
+            </span>
+            <span className="flex-1" />
+            <button
+              onClick={openNewProperty}
+              className="flex items-center gap-1 rounded-full bg-primary px-3 py-1 text-[12px] text-primary-foreground hover:opacity-90"
+            >
+              <Plus size={12} />
+              Property
+            </button>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            {form.schema.length === 0 ? (
+              <p className="py-3 text-center text-[11px] text-muted-foreground">
+                No properties defined.
+              </p>
+            ) : (
+              form.schema.map((prop, i) => (
+                <div
+                  key={`${prop.name}-${i}`}
+                  className="flex items-center gap-2 rounded-lg border border-border bg-card-muted px-3 py-2 text-[12px]"
+                >
+                  <span className="font-[family-name:var(--font-jetbrains-mono)] text-foreground">
+                    {prop.name}
+                  </span>
+                  <span className="text-muted-foreground">·</span>
+                  <span className="text-muted-foreground">{prop.label}</span>
+                  <span className="rounded-full bg-sidebar-accent px-2 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[9px]">
+                    {prop.type}
+                  </span>
+                  {prop.unit && <span className="text-subtle-foreground">{prop.unit}</span>}
+                  {prop.required && (
+                    <span className="rounded-full bg-primary/20 px-2 py-0.5 text-[9px] text-primary">
+                      required
+                    </span>
+                  )}
+                  <span className="flex-1" />
+                  <button
+                    onClick={() => openEditProperty(i)}
+                    title="Edit property"
+                    className="flex size-6 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent hover:text-foreground"
+                  >
+                    <Pencil size={10} />
+                  </button>
+                  <button
+                    onClick={() => handlePropDelete(i)}
+                    title="Delete property"
+                    className="flex size-6 items-center justify-center rounded-full text-destructive hover:bg-destructive/20"
+                  >
+                    <Trash2 size={10} />
+                  </button>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        {error && (
+          <div className="rounded-xl border border-destructive bg-destructive/10 p-2 text-[11px] text-destructive">
+            {error}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            disabled={saving}
+            className="rounded-full border border-border px-3 py-1.5 text-[12px] text-muted-foreground hover:bg-sidebar-accent"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="flex items-center gap-1.5 rounded-full bg-primary px-3 py-1.5 text-[12px] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+          >
+            {saving ? <Loader2 size={12} className="animate-spin" /> : <Check size={12} />}
+            Save
+          </button>
+        </div>
+      </div>
+
+      {propDialog.open && (
+        <PropertyEditDialog
+          // Rebind state when the target changes (index or "new")
+          key={propDialog.index ?? "new"}
+          open={true}
+          initial={propDialog.initial}
+          onSave={handlePropSave}
+          onCancel={() => setPropDialog({ open: false, index: null, initial: null })}
+        />
+      )}
+
+      {pendingDelete && type && (
+        <div
+          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60"
+          onClick={() => setPendingDelete(false)}
+        >
+          <div
+            className="flex w-[400px] flex-col gap-3 rounded-2xl border border-border bg-card p-5 shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <span className="font-[family-name:var(--font-jetbrains-mono)] text-[15px] text-foreground">
+              Delete type &quot;{type.label}&quot;?
+            </span>
+            <p className="text-[12px] text-muted-foreground">
+              The type has no references. Deletion is permanent.
+            </p>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setPendingDelete(false)}
+                className="rounded-full border border-border px-3 py-1.5 text-[12px] text-muted-foreground hover:bg-sidebar-accent"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleConfirmDelete}
+                className="rounded-full bg-destructive px-3 py-1.5 text-[12px] text-destructive-foreground hover:opacity-90"
+              >
+                Confirm
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/workbench/ComponentTypeManagementDialog.tsx
+++ b/frontend/components/workbench/ComponentTypeManagementDialog.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useState } from "react";
+import { Lock, Pencil, Plus, Trash2, X } from "lucide-react";
+import {
+  useComponentTypes,
+  type ComponentType,
+} from "@/hooks/useComponentTypes";
+import { ComponentTypeEditDialog } from "@/components/workbench/ComponentTypeEditDialog";
+
+interface ComponentTypeManagementDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function ComponentTypeManagementDialog({
+  open, onClose,
+}: ComponentTypeManagementDialogProps) {
+  const { types, isLoading, mutate } = useComponentTypes();
+  const [editTarget, setEditTarget] = useState<{
+    open: boolean;
+    type: ComponentType | null; // null = create new
+  }>({ open: false, type: null });
+
+  if (!open) return null;
+
+  function startNew() {
+    setEditTarget({ open: true, type: null });
+  }
+
+  function startEdit(t: ComponentType) {
+    setEditTarget({ open: true, type: t });
+  }
+
+  function closeEdit() {
+    setEditTarget({ open: false, type: null });
+  }
+
+  function deleteTitle(t: ComponentType): string {
+    if (!t.deletable) return "Seeded type cannot be deleted";
+    if (t.reference_count > 0) {
+      return `Referenced by ${t.reference_count} component${t.reference_count === 1 ? "" : "s"} — cannot delete`;
+    }
+    return `Delete ${t.label}`;
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={onClose}
+    >
+      <div
+        className="flex w-[640px] max-h-[85vh] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center gap-2">
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
+            Manage Component Types
+          </span>
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-muted-foreground">
+            {types.length}
+          </span>
+          <span className="flex-1" />
+          <button
+            onClick={startNew}
+            className="flex items-center gap-1.5 rounded-full bg-primary px-3 py-1.5 text-[12px] text-primary-foreground hover:opacity-90"
+          >
+            <Plus size={12} />
+            New Type
+          </button>
+          <button
+            onClick={onClose}
+            title="Close"
+            className="flex size-8 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent"
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        <div className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto">
+          {isLoading ? (
+            <p className="py-8 text-center text-[12px] text-muted-foreground">Loading…</p>
+          ) : types.length === 0 ? (
+            <p className="py-8 text-center text-[12px] text-muted-foreground">
+              No types registered.
+            </p>
+          ) : (
+            types.map((t) => (
+              <div
+                key={t.id}
+                className="flex items-center gap-2 rounded-xl border border-border bg-card-muted px-3 py-2 text-[13px]"
+              >
+                <span className="font-[family-name:var(--font-jetbrains-mono)] text-foreground">
+                  {t.label}
+                </span>
+                <span className="text-subtle-foreground">({t.name})</span>
+                {!t.deletable && (
+                  <span title="Seeded (cannot be deleted)" className="text-muted-foreground">
+                    <Lock size={10} />
+                  </span>
+                )}
+                <span className="flex-1" />
+                <span className="text-[11px] text-muted-foreground">
+                  {t.reference_count} components
+                </span>
+                <button
+                  onClick={() => startEdit(t)}
+                  title={`Edit ${t.label}`}
+                  className="flex size-7 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent hover:text-foreground"
+                >
+                  <Pencil size={12} />
+                </button>
+                <button
+                  disabled={!t.deletable || t.reference_count > 0}
+                  title={deleteTitle(t)}
+                  className="flex size-7 items-center justify-center rounded-full text-destructive hover:bg-destructive/20 disabled:opacity-40"
+                >
+                  <Trash2 size={12} />
+                </button>
+              </div>
+            ))
+          )}
+        </div>
+
+        <div className="flex justify-end">
+          <button
+            onClick={onClose}
+            className="rounded-full border border-border px-4 py-2 text-[13px] text-muted-foreground hover:bg-sidebar-accent"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+
+      <ComponentTypeEditDialog
+        open={editTarget.open}
+        type={editTarget.type}
+        onClose={closeEdit}
+        onSaved={() => mutate()}
+      />
+    </div>
+  );
+}

--- a/frontend/components/workbench/ComponentTypeManagementDialog.tsx
+++ b/frontend/components/workbench/ComponentTypeManagementDialog.tsx
@@ -16,7 +16,7 @@ interface ComponentTypeManagementDialogProps {
 export function ComponentTypeManagementDialog({
   open, onClose,
 }: ComponentTypeManagementDialogProps) {
-  const { types, isLoading, mutate } = useComponentTypes();
+  const { types, isLoading, mutate, error } = useComponentTypes();
   const [editTarget, setEditTarget] = useState<{
     open: boolean;
     type: ComponentType | null; // null = create new
@@ -78,7 +78,15 @@ export function ComponentTypeManagementDialog({
         </div>
 
         <div className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto">
-          {isLoading ? (
+          {error ? (
+            <div className="rounded-xl border border-destructive bg-destructive/10 p-3 text-[12px] text-destructive">
+              Failed to load types: {String((error as Error).message ?? error)}
+              <p className="mt-2 text-[11px] opacity-70">
+                Make sure the backend exposes <code>/component-types</code>
+                {" "}(landed in PR #86).
+              </p>
+            </div>
+          ) : isLoading ? (
             <p className="py-8 text-center text-[12px] text-muted-foreground">Loading…</p>
           ) : types.length === 0 ? (
             <p className="py-8 text-center text-[12px] text-muted-foreground">

--- a/frontend/components/workbench/PropertyEditDialog.tsx
+++ b/frontend/components/workbench/PropertyEditDialog.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+import { useState } from "react";
+import { Check, X } from "lucide-react";
+import type { PropertyDefinition, PropertyType } from "@/hooks/useComponentTypes";
+
+interface PropertyEditDialogProps {
+  open: boolean;
+  initial: PropertyDefinition | null;
+  onSave: (prop: PropertyDefinition) => void;
+  onCancel: () => void;
+}
+
+const SNAKE_CASE = /^[a-z][a-z0-9_]*$/;
+const TYPE_OPTIONS: PropertyType[] = ["number", "string", "boolean", "enum"];
+
+interface FormState {
+  name: string;
+  label: string;
+  type: PropertyType;
+  unit: string;
+  required: boolean;
+  description: string;
+  min: string;
+  max: string;
+  optionsCsv: string;
+  defaultStr: string;
+}
+
+function toForm(prop: PropertyDefinition | null): FormState {
+  if (!prop) {
+    return {
+      name: "", label: "", type: "number", unit: "",
+      required: false, description: "", min: "", max: "",
+      optionsCsv: "", defaultStr: "",
+    };
+  }
+  return {
+    name: prop.name,
+    label: prop.label,
+    type: prop.type,
+    unit: prop.unit ?? "",
+    required: !!prop.required,
+    description: prop.description ?? "",
+    min: prop.min != null ? String(prop.min) : "",
+    max: prop.max != null ? String(prop.max) : "",
+    optionsCsv: (prop.options ?? []).join(", "),
+    defaultStr: prop.default != null ? String(prop.default) : "",
+  };
+}
+
+function fromForm(f: FormState): { ok: true; prop: PropertyDefinition } | { ok: false; error: string } {
+  if (!f.name.trim()) return { ok: false, error: "Name is required" };
+  if (!SNAKE_CASE.test(f.name)) {
+    return { ok: false, error: "Name must be snake_case (lowercase, digits, underscores)" };
+  }
+  if (!f.label.trim()) return { ok: false, error: "Label is required" };
+
+  const prop: PropertyDefinition = {
+    name: f.name,
+    label: f.label,
+    type: f.type,
+    required: f.required,
+  };
+  if (f.unit.trim()) prop.unit = f.unit.trim();
+  if (f.description.trim()) prop.description = f.description.trim();
+
+  if (f.type === "number") {
+    if (f.min.trim()) prop.min = Number(f.min);
+    if (f.max.trim()) prop.max = Number(f.max);
+    if (f.defaultStr.trim()) prop.default = Number(f.defaultStr);
+  } else if (f.type === "enum") {
+    const opts = f.optionsCsv.split(",").map((o) => o.trim()).filter(Boolean);
+    if (opts.length === 0) return { ok: false, error: "Enum needs at least one option" };
+    prop.options = opts;
+    if (f.defaultStr.trim()) prop.default = f.defaultStr.trim();
+  } else if (f.type === "boolean") {
+    if (f.defaultStr.trim()) prop.default = f.defaultStr.trim() === "true";
+  } else {
+    if (f.defaultStr.trim()) prop.default = f.defaultStr.trim();
+  }
+
+  return { ok: true, prop };
+}
+
+export function PropertyEditDialog({
+  open, initial, onSave, onCancel,
+}: PropertyEditDialogProps) {
+  // The parent is responsible for mounting/unmounting the dialog
+  // (`{propDialog.open && <PropertyEditDialog key=... />}`) with a key
+  // bound to the edit target — that way initial state seeds correctly
+  // from props and we don't need a state-resetting effect (which the
+  // react-hooks/set-state-in-effect lint rule forbids).
+  const [form, setForm] = useState<FormState>(() => toForm(initial));
+  const [error, setError] = useState<string | null>(null);
+
+  if (!open) return null;
+
+  function update(patch: Partial<FormState>) {
+    setForm((prev) => ({ ...prev, ...patch }));
+  }
+
+  function handleApply() {
+    const result = fromForm(form);
+    if (!result.ok) {
+      setError(result.error);
+      return;
+    }
+    onSave(result.prop);
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60"
+      onClick={onCancel}
+    >
+      <div
+        className="flex w-[440px] flex-col gap-3 rounded-2xl border border-border bg-card p-5 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center gap-2">
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[14px] text-foreground">
+            {initial ? "Edit Property" : "New Property"}
+          </span>
+          <span className="flex-1" />
+          <button
+            onClick={onCancel}
+            title="Close"
+            className="flex size-7 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent"
+          >
+            <X size={12} />
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-1">
+            <label className="text-[11px] text-muted-foreground">Name (snake_case) *</label>
+            <input
+              type="text"
+              value={form.name}
+              onChange={(e) => update({ name: e.target.value })}
+              placeholder="density_kg_m3"
+              className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-[11px] text-muted-foreground">Label *</label>
+            <input
+              type="text"
+              value={form.label}
+              onChange={(e) => update({ label: e.target.value })}
+              placeholder="Dichte"
+              className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
+            />
+          </div>
+          <div className="flex gap-2">
+            <div className="flex flex-1 flex-col gap-1">
+              <label className="text-[11px] text-muted-foreground">Type *</label>
+              <select
+                value={form.type}
+                onChange={(e) => update({ type: e.target.value as PropertyType })}
+                className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
+              >
+                {TYPE_OPTIONS.map((t) => (<option key={t} value={t}>{t}</option>))}
+              </select>
+            </div>
+            <div className="flex flex-1 flex-col gap-1">
+              <label className="text-[11px] text-muted-foreground">Unit</label>
+              <input
+                type="text"
+                value={form.unit}
+                onChange={(e) => update({ unit: e.target.value })}
+                placeholder="kg/m³"
+                className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
+              />
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={form.required}
+              onChange={(e) => update({ required: e.target.checked })}
+              id="pe-required"
+            />
+            <label htmlFor="pe-required" className="text-[12px] text-foreground">
+              Required
+            </label>
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-[11px] text-muted-foreground">Description</label>
+            <input
+              type="text"
+              value={form.description}
+              onChange={(e) => update({ description: e.target.value })}
+              className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
+            />
+          </div>
+
+          {form.type === "number" && (
+            <div className="flex gap-2">
+              <div className="flex flex-1 flex-col gap-1">
+                <label className="text-[11px] text-muted-foreground">Min</label>
+                <input
+                  type="number"
+                  value={form.min}
+                  onChange={(e) => update({ min: e.target.value })}
+                  className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
+                />
+              </div>
+              <div className="flex flex-1 flex-col gap-1">
+                <label className="text-[11px] text-muted-foreground">Max</label>
+                <input
+                  type="number"
+                  value={form.max}
+                  onChange={(e) => update({ max: e.target.value })}
+                  className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
+                />
+              </div>
+              <div className="flex flex-1 flex-col gap-1">
+                <label className="text-[11px] text-muted-foreground">Default</label>
+                <input
+                  type="number"
+                  value={form.defaultStr}
+                  onChange={(e) => update({ defaultStr: e.target.value })}
+                  className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
+                />
+              </div>
+            </div>
+          )}
+
+          {form.type === "enum" && (
+            <div className="flex flex-col gap-1">
+              <label className="text-[11px] text-muted-foreground">Options (comma-separated) *</label>
+              <input
+                type="text"
+                value={form.optionsCsv}
+                onChange={(e) => update({ optionsCsv: e.target.value })}
+                placeholder="volume, surface"
+                className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
+              />
+            </div>
+          )}
+
+          {(form.type === "string" || form.type === "enum" || form.type === "boolean") && (
+            <div className="flex flex-col gap-1">
+              <label className="text-[11px] text-muted-foreground">Default</label>
+              <input
+                type="text"
+                value={form.defaultStr}
+                onChange={(e) => update({ defaultStr: e.target.value })}
+                placeholder={form.type === "boolean" ? "true / false" : ""}
+                className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
+              />
+            </div>
+          )}
+        </div>
+
+        {error && (
+          <div className="rounded-xl border border-destructive bg-destructive/10 p-2 text-[11px] text-destructive">
+            {error}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onCancel}
+            className="rounded-full border border-border px-3 py-1.5 text-[12px] text-muted-foreground hover:bg-sidebar-accent"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleApply}
+            className="flex items-center gap-1.5 rounded-full bg-primary px-3 py-1.5 text-[12px] text-primary-foreground hover:opacity-90"
+          >
+            <Check size={12} />
+            Apply
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/workbench/PropertyEditDialog.tsx
+++ b/frontend/components/workbench/PropertyEditDialog.tsx
@@ -197,32 +197,37 @@ export function PropertyEditDialog({
           </div>
 
           {form.type === "number" && (
+            // `min-w-0` on flex items + `w-full` on the inputs is required —
+            // <input type="number"> has an intrinsic min-width that otherwise
+            // keeps the items wider than 1/3 of the row and overflows the
+            // modal. Reported visually on Apr-16 for a tube property with a
+            // 4-digit default value.
             <div className="flex gap-2">
-              <div className="flex flex-1 flex-col gap-1">
+              <div className="flex min-w-0 flex-1 flex-col gap-1">
                 <label className="text-[11px] text-muted-foreground">Min</label>
                 <input
                   type="number"
                   value={form.min}
                   onChange={(e) => update({ min: e.target.value })}
-                  className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
+                  className="w-full rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
                 />
               </div>
-              <div className="flex flex-1 flex-col gap-1">
+              <div className="flex min-w-0 flex-1 flex-col gap-1">
                 <label className="text-[11px] text-muted-foreground">Max</label>
                 <input
                   type="number"
                   value={form.max}
                   onChange={(e) => update({ max: e.target.value })}
-                  className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
+                  className="w-full rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
                 />
               </div>
-              <div className="flex flex-1 flex-col gap-1">
+              <div className="flex min-w-0 flex-1 flex-col gap-1">
                 <label className="text-[11px] text-muted-foreground">Default</label>
                 <input
                   type="number"
                   value={form.defaultStr}
                   onChange={(e) => update({ defaultStr: e.target.value })}
-                  className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
+                  className="w-full rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
                 />
               </div>
             </div>

--- a/frontend/hooks/useComponentTypes.ts
+++ b/frontend/hooks/useComponentTypes.ts
@@ -1,0 +1,85 @@
+"use client";
+
+import useSWR from "swr";
+import { fetcher, API_BASE } from "@/lib/fetcher";
+
+export type PropertyType = "number" | "string" | "boolean" | "enum";
+
+export interface PropertyDefinition {
+  name: string;
+  label: string;
+  type: PropertyType;
+  unit?: string | null;
+  required?: boolean;
+  description?: string | null;
+  min?: number | null;
+  max?: number | null;
+  options?: string[] | null;
+  default?: unknown;
+}
+
+export interface ComponentType {
+  id: number;
+  name: string;
+  label: string;
+  description: string | null;
+  schema: PropertyDefinition[];
+  deletable: boolean;
+  reference_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export function useComponentTypes() {
+  const { data, error, isLoading, mutate } = useSWR<ComponentType[]>(
+    "/component-types",
+    fetcher,
+  );
+  return {
+    types: data ?? [],
+    isLoading,
+    error,
+    mutate,
+  };
+}
+
+export async function createComponentType(
+  body: Omit<ComponentType, "id" | "deletable" | "reference_count" | "created_at" | "updated_at">,
+): Promise<ComponentType> {
+  const res = await fetch(`${API_BASE}/component-types`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const detail = await res.text();
+    throw new Error(`Create type failed: ${res.status} ${detail}`);
+  }
+  return res.json();
+}
+
+export async function updateComponentType(
+  id: number,
+  body: Omit<ComponentType, "id" | "deletable" | "reference_count" | "created_at" | "updated_at">,
+): Promise<ComponentType> {
+  const res = await fetch(`${API_BASE}/component-types/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const detail = await res.text();
+    throw new Error(`Update type failed: ${res.status} ${detail}`);
+  }
+  return res.json();
+}
+
+export async function deleteComponentType(id: number): Promise<void> {
+  const res = await fetch(`${API_BASE}/component-types/${id}`, {
+    method: "DELETE",
+  });
+  if (!res.ok) {
+    const detail = await res.text();
+    throw new Error(`Delete type failed: ${res.status} ${detail}`);
+  }
+}

--- a/frontend/hooks/useComponents.ts
+++ b/frontend/hooks/useComponents.ts
@@ -42,10 +42,10 @@ export function useComponents(componentType?: string, search?: string) {
   };
 }
 
-export function useComponentTypes() {
-  const { data } = useSWR<{ types: string[] }>("/components/types", fetcher);
-  return data?.types ?? [];
-}
+// NOTE: the old string-based `useComponentTypes()` moved to
+// `@/hooks/useComponentTypes.ts` with a richer shape (full ComponentType
+// objects including schema / reference_count / deletable). Migrate imports
+// there.
 
 export async function createComponent(comp: Omit<Component, "id" | "created_at" | "updated_at">): Promise<Component> {
   const res = await fetch(`${API_BASE}/components`, {


### PR DESCRIPTION
## Summary

User-facing half of the #82 epic. Three-tier modal flow for managing the dynamic component-types registry introduced by PR #86 (#83 backend).

Closes #84. Depends on #86.

## New UI

Entry point: new "Manage Types" button in \`/workbench/components\` next to "+ New Component".

**ComponentTypeManagementDialog** — top-level. Lists all types with reference-count, a pencil icon to edit, a trash icon to delete. Delete is disabled for seeded types ("Seeded type cannot be deleted") and for user types with references ("Referenced by N component(s)"). "+ New Type" opens the editor with an empty form.

**ComponentTypeEditDialog** — per-type form. Name (readonly for seeded), label, description, property list. Each property row shows name / label / type chip / unit / required flag, with pencil + trash per row. Delete button in the header only when the type is deletable AND has zero refs. Save POSTs or PUTs depending on create vs edit mode.

**PropertyEditDialog** — per-property form. Name (snake_case validated), label, type (number/string/boolean/enum), unit, required flag, description, min/max (number only), options CSV (enum only), default. Parent mounts it with a \`key\` bound to the edit target so state seeds from props — avoiding the \`react-hooks/set-state-in-effect\` lint rule.

## Hook migration

The old string-based \`useComponentTypes()\` in \`useComponents.ts\` is gone. The new hook lives in its own file \`hooks/useComponentTypes.ts\` and returns \`{ types: ComponentType[], isLoading, mutate, error }\`. ComponentEditDialog switched to the rich form — the type dropdown now renders \`.label\` and stores \`.name\`.

## Test plan

- [x] \`npm run test:unit\` — **179 passed** (was 164; +15)
- [x] \`npx eslint\` on touched files — clean
- [x] \`npm run build\` — clean

### Tests added (15)

**\`ComponentTypeManagementDialog.test.tsx\` (8):**
- Closed doesn't render
- Empty state message
- Lists label / reference-count / Lock chip for seeded
- Delete disabled for seeded
- Delete disabled for user with refs
- Delete enabled for user without refs
- "+ New Type" opens Edit
- Pencil opens Edit

**\`PropertyEditDialog.test.tsx\` (7):**
- Closed doesn't render
- Blank form for new
- Pre-fills from initial
- Min/max only for number
- Options only for enum
- Rejects non-snake_case name
- Apply returns edited property
- Cancel returns nothing

## Depends on

- **PR #86 (#83 backend)** — this PR consumes \`/component-types\` endpoints. Merge #86 first.

Closes #84.
Relates to #82 (unblocks #85 — dynamic ComponentEditDialog rendering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)