### PR TITLE
feat(#85): ComponentEditDialog renders specs dynamically from type schema

### DIFF
--- a/frontend/__tests__/ComponentEditDialogDynamic.test.tsx
+++ b/frontend/__tests__/ComponentEditDialogDynamic.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * Tests for the dynamic ComponentEditDialog (gh#85).
+ *
+ * The dialog now renders specs-fields based on the selected type's
+ * schema, validates them on submit, preserves compatible specs across
+ * type changes, and surfaces "Unknown properties" for legacy data.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) =>
+    React.createElement("span", props);
+  return {
+    X: icon, Loader2: icon, ChevronDown: icon, ChevronRight: icon,
+  };
+});
+
+const mockCreate = vi.fn().mockResolvedValue({});
+const mockUpdate = vi.fn().mockResolvedValue({});
+
+vi.mock("@/hooks/useComponents", () => ({
+  createComponent: (...a: unknown[]) => mockCreate(...a),
+  updateComponent: (...a: unknown[]) => mockUpdate(...a),
+}));
+
+vi.mock("@/hooks/useComponentTypes", () => ({
+  useComponentTypes: () => ({
+    types: [
+      {
+        id: 1, name: "generic", label: "Generic",
+        description: null, schema: [], deletable: false, reference_count: 0,
+        created_at: "", updated_at: "",
+      },
+      {
+        id: 2, name: "material", label: "Material", description: null,
+        schema: [
+          { name: "density_kg_m3", label: "Dichte", type: "number",
+            unit: "kg/m³", required: true, min: 100, max: 20000 },
+          { name: "print_type", label: "Drucktyp", type: "enum",
+            options: ["volume", "surface"], default: "volume" },
+        ],
+        deletable: false, reference_count: 0,
+        created_at: "", updated_at: "",
+      },
+      {
+        id: 3, name: "servo", label: "Servo", description: null,
+        schema: [
+          { name: "torque_kg_cm", label: "Drehmoment", type: "number", unit: "kg·cm" },
+          { name: "connector", label: "Anschluss", type: "enum",
+            options: ["jr", "futaba", "universal"] },
+        ],
+        deletable: false, reference_count: 0,
+        created_at: "", updated_at: "",
+      },
+    ],
+    isLoading: false, mutate: vi.fn(), error: null,
+  }),
+}));
+
+import { ComponentEditDialog } from "@/components/workbench/ComponentEditDialog";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ComponentEditDialog — dynamic specs rendering", () => {
+  it("renders number + enum fields for material type", () => {
+    render(
+      <ComponentEditDialog open={true} onClose={vi.fn()} onSaved={vi.fn()}
+        component={null} />,
+    );
+    // Select Material type
+    const select = screen.getAllByRole("combobox")[0] as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "material" } });
+
+    expect(screen.getByText(/Dichte/i)).toBeDefined();
+    expect(screen.getByText(/Drucktyp/i)).toBeDefined();
+  });
+
+  it("required fields are marked with a star", () => {
+    render(
+      <ComponentEditDialog open={true} onClose={vi.fn()} onSaved={vi.fn()}
+        component={null} />,
+    );
+    const select = screen.getAllByRole("combobox")[0] as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "material" } });
+    // The Dichte label should have a * (since required=true)
+    expect(screen.getByText(/Dichte/).textContent).toContain("*");
+  });
+
+  it("type change preserves compatible specs (same name+type)", () => {
+    // Create with a servo, fill torque, switch to a type that also has torque
+    // — servo has torque_kg_cm, material doesn't. Switch servo→material
+    // should drop torque, switching back should restore via user input only.
+    const { container } = render(
+      <ComponentEditDialog open={true} onClose={vi.fn()} onSaved={vi.fn()}
+        component={null} />,
+    );
+
+    const select = screen.getAllByRole("combobox")[0] as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "servo" } });
+    // fill torque
+    const torque = container.querySelector('input[data-spec="torque_kg_cm"]') as HTMLInputElement;
+    expect(torque).toBeDefined();
+    fireEvent.change(torque, { target: { value: "1.8" } });
+    expect(torque.value).toBe("1.8");
+
+    // switch to material — torque field disappears
+    fireEvent.change(select, { target: { value: "material" } });
+    expect(container.querySelector('input[data-spec="torque_kg_cm"]')).toBeNull();
+
+    // switch back to servo — torque field reappears, value preserved
+    fireEvent.change(select, { target: { value: "servo" } });
+    const torqueAgain = container.querySelector('input[data-spec="torque_kg_cm"]') as HTMLInputElement;
+    expect(torqueAgain.value).toBe("1.8");
+  });
+
+  it("blocks submit when a required field is missing", () => {
+    render(
+      <ComponentEditDialog open={true} onClose={vi.fn()} onSaved={vi.fn()}
+        component={null} />,
+    );
+    const nameInput = screen.getAllByRole("textbox")[0] as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: "My Material" } });
+    const select = screen.getAllByRole("combobox")[0] as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "material" } });
+    // Don't fill density
+
+    fireEvent.click(screen.getByText(/^Create$/));
+    expect(mockCreate).not.toHaveBeenCalled();
+    // Error message (inside a destructive-styled box) mentions the missing field.
+    // The label "Dichte" also appears as a regular label — so we filter to the
+    // inline error box.
+    const errors = screen.getAllByText(/Dichte/);
+    const inErrorBox = errors.some((el) =>
+      el.closest("div")?.className.includes("destructive"),
+    );
+    expect(inErrorBox).toBe(true);
+  });
+
+  it("submits specs when all required fields are set", () => {
+    const { container } = render(
+      <ComponentEditDialog open={true} onClose={vi.fn()} onSaved={vi.fn()}
+        component={null} />,
+    );
+    const nameInput = screen.getAllByRole("textbox")[0] as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: "PLA+" } });
+
+    const select = screen.getAllByRole("combobox")[0] as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "material" } });
+
+    const density = container.querySelector('input[data-spec="density_kg_m3"]') as HTMLInputElement;
+    fireEvent.change(density, { target: { value: "1240" } });
+
+    fireEvent.click(screen.getByText(/^Create$/));
+    expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({
+      name: "PLA+",
+      component_type: "material",
+      specs: expect.objectContaining({ density_kg_m3: 1240 }),
+    }));
+  });
+
+  it("shows 'Unknown properties' section when existing specs have extra keys", () => {
+    render(
+      <ComponentEditDialog open={true} onClose={vi.fn()} onSaved={vi.fn()}
+        component={{
+          id: 99, name: "legacy", component_type: "material",
+          manufacturer: null, description: null, mass_g: null,
+          bbox_x_mm: null, bbox_y_mm: null, bbox_z_mm: null, model_ref: null,
+          specs: { density_kg_m3: 1240, legacy_field: "old", some_old_key: 42 },
+          created_at: "", updated_at: "",
+        }} />,
+    );
+    // The unknown-properties section is visible and lists legacy_field + some_old_key
+    expect(screen.getByText(/Unknown properties/i)).toBeDefined();
+  });
+
+  it("number field shows the unit as a hint", () => {
+    const { container } = render(
+      <ComponentEditDialog open={true} onClose={vi.fn()} onSaved={vi.fn()}
+        component={null} />,
+    );
+    const select = screen.getAllByRole("combobox")[0] as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "material" } });
+    // The unit "kg/m³" appears near the density input
+    expect(container.textContent).toContain("kg/m³");
+  });
+});

--- a/frontend/components/workbench/ComponentEditDialog.tsx
+++ b/frontend/components/workbench/ComponentEditDialog.tsx
@@ -1,10 +1,13 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { X, Loader2 } from "lucide-react";
+import { useState } from "react";
+import { ChevronDown, ChevronRight, Loader2, X } from "lucide-react";
 import type { Component } from "@/hooks/useComponents";
 import { createComponent, updateComponent } from "@/hooks/useComponents";
-import { useComponentTypes } from "@/hooks/useComponentTypes";
+import {
+  useComponentTypes,
+  type PropertyDefinition,
+} from "@/hooks/useComponentTypes";
 
 interface ComponentEditDialogProps {
   open: boolean;
@@ -13,39 +16,135 @@ interface ComponentEditDialogProps {
   component?: Component | null; // null = create new
 }
 
-export function ComponentEditDialog({ open, onClose, onSaved, component }: ComponentEditDialogProps) {
+/** Default value inserted when a type is selected and specs don't already have the key. */
+function defaultForProp(prop: PropertyDefinition): unknown {
+  if (prop.default != null) return prop.default;
+  if (prop.type === "boolean") return false;
+  return "";
+}
+
+/** Parse a user-entered string back into the property's declared type. */
+function parseValue(prop: PropertyDefinition, raw: unknown): unknown {
+  if (raw === "" || raw == null) return undefined;
+  if (prop.type === "number") {
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : undefined;
+  }
+  if (prop.type === "boolean") {
+    if (typeof raw === "boolean") return raw;
+    return raw === "true" || raw === true;
+  }
+  return String(raw);
+}
+
+function validate(
+  schema: PropertyDefinition[],
+  specs: Record<string, unknown>,
+): { ok: true } | { ok: false; property: string; message: string } {
+  for (const prop of schema) {
+    const raw = specs[prop.name];
+    const parsed = parseValue(prop, raw);
+    if (prop.required && (parsed === undefined || parsed === "")) {
+      return {
+        ok: false, property: prop.name,
+        message: `${prop.label} (${prop.name}) is required.`,
+      };
+    }
+    if (parsed === undefined) continue;
+    if (prop.type === "number") {
+      const n = parsed as number;
+      if (prop.min != null && n < prop.min) {
+        return {
+          ok: false, property: prop.name,
+          message: `${prop.label}: expected ≥ ${prop.min}, got ${n}.`,
+        };
+      }
+      if (prop.max != null && n > prop.max) {
+        return {
+          ok: false, property: prop.name,
+          message: `${prop.label}: expected ≤ ${prop.max}, got ${n}.`,
+        };
+      }
+    }
+    if (prop.type === "enum" && prop.options && !prop.options.includes(String(parsed))) {
+      return {
+        ok: false, property: prop.name,
+        message: `${prop.label}: value '${parsed}' is not in ${JSON.stringify(prop.options)}.`,
+      };
+    }
+  }
+  return { ok: true };
+}
+
+export function ComponentEditDialog({
+  open, onClose, onSaved, component,
+}: ComponentEditDialogProps) {
   const { types } = useComponentTypes();
   const isEdit = !!component;
 
-  const [name, setName] = useState("");
-  const [componentType, setComponentType] = useState("generic");
-  const [manufacturer, setManufacturer] = useState("");
-  const [description, setDescription] = useState("");
-  const [massG, setMassG] = useState("");
+  // All state is seeded once on mount — parent is responsible for mounting/
+  // unmounting us conditionally so that reopening seeds from fresh props.
+  const [name, setName] = useState(component?.name ?? "");
+  const [componentType, setComponentType] = useState(
+    component?.component_type ?? "generic",
+  );
+  const [manufacturer, setManufacturer] = useState(component?.manufacturer ?? "");
+  const [description, setDescription] = useState(component?.description ?? "");
+  const [massG, setMassG] = useState(
+    component?.mass_g != null ? String(component.mass_g) : "",
+  );
+  const [specs, setSpecs] = useState<Record<string, unknown>>(
+    { ...(component?.specs ?? {}) },
+  );
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (component) {
-      setName(component.name);
-      setComponentType(component.component_type);
-      setManufacturer(component.manufacturer ?? "");
-      setDescription(component.description ?? "");
-      setMassG(component.mass_g != null ? String(component.mass_g) : "");
-    } else {
-      setName("");
-      setComponentType("generic");
-      setManufacturer("");
-      setDescription("");
-      setMassG("");
-    }
-    setError(null);
-  }, [component, open]);
+  const [showUnknown, setShowUnknown] = useState(false);
 
   if (!open) return null;
 
-  const handleSave = async () => {
+  const currentType = types.find((t) => t.name === componentType);
+  const schema: PropertyDefinition[] = currentType?.schema ?? [];
+  const schemaKeys = new Set(schema.map((p) => p.name));
+  const unknownKeys = Object.keys(specs).filter((k) => !schemaKeys.has(k));
+
+  function handleTypeChange(newType: string) {
+    setComponentType(newType);
+    // Defaults for keys that are new in the target schema get seeded from
+    // the property's `default`; keys that were already set stay; keys that
+    // aren't in the new schema remain in `specs` (tolerant mode) but aren't
+    // rendered.
+    const newSchema =
+      types.find((t) => t.name === newType)?.schema ?? [];
+    setSpecs((prev) => {
+      const next = { ...prev };
+      for (const prop of newSchema) {
+        if (!(prop.name in next)) next[prop.name] = defaultForProp(prop);
+      }
+      return next;
+    });
+  }
+
+  function setSpec(propName: string, value: unknown) {
+    setSpecs((prev) => ({ ...prev, [propName]: value }));
+  }
+
+  async function handleSave() {
     if (!name.trim()) { setError("Name is required"); return; }
+    const result = validate(schema, specs);
+    if (!result.ok) {
+      setError(result.message);
+      return;
+    }
+    // Parse known specs to their declared types; keep unknown keys raw.
+    const outSpecs: Record<string, unknown> = {};
+    for (const prop of schema) {
+      const parsed = parseValue(prop, specs[prop.name]);
+      if (parsed !== undefined) outSpecs[prop.name] = parsed;
+    }
+    for (const key of unknownKeys) {
+      outSpecs[key] = specs[key];
+    }
+
     setSaving(true);
     setError(null);
     try {
@@ -59,12 +158,12 @@ export function ComponentEditDialog({ open, onClose, onSaved, component }: Compo
         bbox_y_mm: null,
         bbox_z_mm: null,
         model_ref: null,
-        specs: {},
+        specs: outSpecs,
       };
       if (isEdit && component) {
-        await updateComponent(component.id, data as any);
+        await updateComponent(component.id, data as unknown as Component);
       } else {
-        await createComponent(data as any);
+        await createComponent(data as unknown as Component);
       }
       onSaved();
       onClose();
@@ -73,26 +172,37 @@ export function ComponentEditDialog({ open, onClose, onSaved, component }: Compo
     } finally {
       setSaving(false);
     }
-  };
+  }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={onClose}>
-      <div className="flex w-[500px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl" onClick={(e) => e.stopPropagation()}>
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={onClose}
+    >
+      <div
+        className="flex max-h-[85vh] w-[520px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="flex items-center gap-3">
           <span className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
             {isEdit ? "Edit Component" : "New Component"}
           </span>
           <span className="flex-1" />
-          <button onClick={onClose} className="flex size-8 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent">
+          <button
+            onClick={onClose}
+            className="flex size-8 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent"
+          >
             <X size={16} />
           </button>
         </div>
 
-        <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-3 overflow-y-auto">
           <div className="flex flex-col gap-1">
             <label className="text-[11px] text-muted-foreground">Name *</label>
-            <input type="text" value={name} onChange={(e) => setName(e.target.value)}
-              className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground" />
+            <input
+              type="text" value={name} onChange={(e) => setName(e.target.value)}
+              className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
+            />
           </div>
           {/*
            * `min-w-0` on the flex items + `w-full` on the controls — same
@@ -105,45 +215,172 @@ export function ComponentEditDialog({ open, onClose, onSaved, component }: Compo
           <div className="flex gap-3">
             <div className="flex min-w-0 flex-1 flex-col gap-1">
               <label className="text-[11px] text-muted-foreground">Type</label>
-              <select value={componentType} onChange={(e) => setComponentType(e.target.value)}
-                className="w-full truncate rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground">
-                {types.map((t) => <option key={t.id} value={t.name}>{t.label}</option>)}
+              <select
+                value={componentType}
+                onChange={(e) => handleTypeChange(e.target.value)}
+                className="w-full truncate rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
+              >
+                {types.map((t) => (
+                  <option key={t.id} value={t.name}>{t.label}</option>
+                ))}
               </select>
             </div>
             <div className="flex min-w-0 flex-1 flex-col gap-1">
               <label className="text-[11px] text-muted-foreground">Mass (g)</label>
-              <input type="number" value={massG} onChange={(e) => setMassG(e.target.value)}
-                className="w-full rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground" />
+              <input
+                type="number" value={massG} onChange={(e) => setMassG(e.target.value)}
+                className="w-full rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
+              />
             </div>
           </div>
+
           <div className="flex flex-col gap-1">
             <label className="text-[11px] text-muted-foreground">Manufacturer</label>
-            <input type="text" value={manufacturer} onChange={(e) => setManufacturer(e.target.value)}
-              className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground" />
+            <input
+              type="text" value={manufacturer}
+              onChange={(e) => setManufacturer(e.target.value)}
+              className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
+            />
           </div>
           <div className="flex flex-col gap-1">
             <label className="text-[11px] text-muted-foreground">Description</label>
-            <textarea value={description} onChange={(e) => setDescription(e.target.value)} rows={2}
-              className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground resize-none" />
+            <textarea
+              value={description} onChange={(e) => setDescription(e.target.value)} rows={2}
+              className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground resize-none"
+            />
           </div>
+
+          {schema.length > 0 && (
+            <>
+              <div className="mt-1 flex items-center gap-2">
+                <span className="font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-muted-foreground uppercase tracking-wide">
+                  {currentType?.label} properties
+                </span>
+              </div>
+              {schema.map((prop) => (
+                <SpecField
+                  key={prop.name}
+                  prop={prop}
+                  value={specs[prop.name]}
+                  onChange={(v) => setSpec(prop.name, v)}
+                />
+              ))}
+            </>
+          )}
+
+          {unknownKeys.length > 0 && (
+            <div className="mt-2 rounded-xl border border-border bg-card-muted px-3 py-2">
+              <button
+                onClick={() => setShowUnknown((v) => !v)}
+                className="flex w-full items-center gap-1 text-[11px] text-muted-foreground"
+              >
+                {showUnknown ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                Unknown properties ({unknownKeys.length})
+              </button>
+              {showUnknown && (
+                <ul className="mt-2 flex flex-col gap-1 pl-4">
+                  {unknownKeys.map((k) => (
+                    <li key={k} className="font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-subtle-foreground">
+                      {k}: {String(specs[k])}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
         </div>
 
         {error && (
-          <div className="rounded-xl border border-destructive bg-destructive/10 p-3 text-[12px] text-destructive">{error}</div>
+          <div className="rounded-xl border border-destructive bg-destructive/10 p-3 text-[12px] text-destructive">
+            {error}
+          </div>
         )}
 
         <div className="flex justify-end gap-2">
-          <button onClick={onClose} disabled={saving}
-            className="rounded-full border border-border px-4 py-2 text-[13px] text-muted-foreground hover:bg-sidebar-accent">
+          <button
+            onClick={onClose} disabled={saving}
+            className="rounded-full border border-border px-4 py-2 text-[13px] text-muted-foreground hover:bg-sidebar-accent"
+          >
             Cancel
           </button>
-          <button onClick={handleSave} disabled={saving}
-            className="flex items-center gap-1.5 rounded-full bg-primary px-4 py-2 text-[13px] text-primary-foreground hover:opacity-90 disabled:opacity-50">
+          <button
+            onClick={handleSave} disabled={saving}
+            className="flex items-center gap-1.5 rounded-full bg-primary px-4 py-2 text-[13px] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+          >
             {saving && <Loader2 size={14} className="animate-spin" />}
             {saving ? "Saving\u2026" : isEdit ? "Update" : "Create"}
           </button>
         </div>
       </div>
+    </div>
+  );
+}
+
+// --------------------------------------------------------------------------- //
+// SpecField — renders a single property-schema entry as the right input type.
+// --------------------------------------------------------------------------- //
+
+interface SpecFieldProps {
+  prop: PropertyDefinition;
+  value: unknown;
+  onChange: (v: unknown) => void;
+}
+
+function SpecField({ prop, value, onChange }: SpecFieldProps) {
+  const labelText = `${prop.label}${prop.required ? " *" : ""}${prop.unit ? ` (${prop.unit})` : ""}`;
+
+  if (prop.type === "boolean") {
+    return (
+      <div className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          data-spec={prop.name}
+          checked={!!value}
+          onChange={(e) => onChange(e.target.checked)}
+          id={`spec-${prop.name}`}
+        />
+        <label htmlFor={`spec-${prop.name}`} className="text-[12px] text-foreground">
+          {labelText}
+        </label>
+      </div>
+    );
+  }
+
+  if (prop.type === "enum") {
+    return (
+      <div className="flex flex-col gap-1">
+        <label className="text-[11px] text-muted-foreground">{labelText}</label>
+        <select
+          data-spec={prop.name}
+          value={value == null ? "" : String(value)}
+          onChange={(e) => onChange(e.target.value)}
+          className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
+        >
+          <option value=""></option>
+          {(prop.options ?? []).map((o) => (
+            <option key={o} value={o}>{o}</option>
+          ))}
+        </select>
+      </div>
+    );
+  }
+
+  // number or string
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-[11px] text-muted-foreground">{labelText}</label>
+      <input
+        data-spec={prop.name}
+        type={prop.type === "number" ? "number" : "text"}
+        value={value == null ? "" : String(value)}
+        onChange={(e) => onChange(e.target.value)}
+        min={prop.min ?? undefined}
+        max={prop.max ?? undefined}
+        className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
+      />
+      {prop.description && (
+        <span className="text-[10px] text-subtle-foreground">{prop.description}</span>
+      )}
     </div>
   );
 }

--- a/frontend/e2e/features/component-types.feature
+++ b/frontend/e2e/features/component-types.feature
@@ -1,0 +1,71 @@
+Feature: Dynamic Component Types
+  # BDD coverage for the #82 epic: user-managed types with validated specs.
+  # Each scenario exercises one end-to-end slice through backend + UI.
+
+  Background:
+    Given I am on the workbench with an aeroplane
+    When I click the "Components" step pill
+    Then I see "Component Library" on the page
+
+  Scenario: Seeded Material type exposes the density field
+    When I open the "New Component" dialog
+    And I select type "Material (3D-Druck)"
+    Then I see "Dichte" on the page
+    And I see "kg/m³" on the page
+    And the Dichte input is marked required
+
+  Scenario: Submitting without the required density is blocked
+    When I open the "New Component" dialog
+    And I enter "PLA+" in the Name field
+    And I select type "Material (3D-Druck)"
+    And I click the "Create" button
+    Then the component is NOT saved
+    And the dialog shows a validation error mentioning "Dichte"
+
+  Scenario: A valid material component saves and shows the correct weight via tree
+    When I open the "New Component" dialog
+    And I enter "PLA+" in the Name field
+    And I select type "Material (3D-Druck)"
+    And I enter "1240" in the Dichte field
+    And I click the "Create" button
+    Then the dialog closes
+    And "PLA+" is listed in the Library grid
+
+  Scenario: User creates a custom type and uses it for a component
+    When I click the "Manage Types" button
+    And I click "+ New Type" in the Types dialog
+    And I enter "carbon_tube" in the Name field
+    And I enter "Carbon Tube" in the Label field
+    And I add a number property "outer_diameter_mm" required with unit "mm"
+    And I click "Save" in the Type dialog
+    Then "Carbon Tube" appears in the types list
+    And its reference-count is "0 components"
+    When I close the Types dialog
+    And I open the "New Component" dialog
+    And I select type "Carbon Tube"
+    Then I see an "outer_diameter_mm" input with unit "mm"
+
+  Scenario: Seeded types cannot be deleted
+    When I click the "Manage Types" button
+    Then the delete button for "Material (3D-Druck)" is disabled
+    And its tooltip mentions "Seeded type cannot be deleted"
+
+  Scenario: User type with no references can be deleted
+    Given a custom type "throwaway" exists with no references
+    When I click the "Manage Types" button
+    And I click the delete button for "throwaway"
+    And I confirm the deletion
+    Then "throwaway" is no longer listed
+
+  Scenario: User type with references cannot be deleted
+    Given a custom type "referenced_type" exists with 2 components referencing it
+    When I click the "Manage Types" button
+    Then the delete button for "referenced_type" is disabled
+    And its tooltip mentions "Referenced by 2 components"
+
+  Scenario: Unknown properties on an existing component are surfaced read-only
+    Given a component "legacy" exists of type "Material (3D-Druck)" with unknown keys in its specs
+    When I open the edit dialog for "legacy"
+    Then I see a collapsible "Unknown properties (N)" section
+    When I expand the Unknown properties section
+    Then I see the unknown keys listed as read-only rows


### PR DESCRIPTION
## Summary

Last sub-ticket of the #82 epic. The Component edit dialog now reads the selected type's schema from \`useComponentTypes()\` and renders the right input for each property (number / string / boolean / enum) instead of hard-coding an empty \`specs={}\` payload.

Closes #85. Completes #82.

## Behavior

- **Select Type** → schema loads → type-section renders with labels, units, required stars, min/max constraints on inputs
- **Required fields** are marked with \`*\`
- **Type-change** preserves compatible keys (same name+type across old and new schema stay in \`specs\`; invalid-for-new ones aren't rendered but stay in specs — tolerant mode mirrors the backend)
- **Submit validates client-side**: required / number out-of-range / enum not in options; blocks with inline error
- Backend 422 would surface on top of that (catch → error box)
- **"Unknown properties (N)"** collapsible appears when an edited component has \`specs\` keys that aren't in the current type schema — informative read-only list (tolerant mode keeps them alive)

## Implementation

- pure \`validate(schema, specs)\` helper
- pure \`parseValue(prop, raw)\` coerces form strings back to their declared type before submit
- \`SpecField\` sub-component chooses input element by \`prop.type\`:
  - \`boolean\` → checkbox + label
  - \`enum\` → \`<select>\` with options
  - \`number\` / \`string\` → \`<input>\` with appropriate type, min/max attributes (number)

## Test plan

- [x] \`npm run test:unit\` — **186 passed** (was 179; +7)
- [x] \`npx eslint\` on touched files — clean
- [x] \`npm run build\` — clean

### Tests added (7)

- Renders number + enum fields for material type
- Required fields show \`*\` in label
- Type change preserves compatible specs (servo → material → servo round-trips \`torque_kg_cm\` via user input)
- Blocks submit on missing required (error mentions the field in the destructive-styled error box)
- Submits with specs populated when required field is set
- "Unknown properties" section appears for legacy specs keys
- Unit appears near number fields

## Depends on

- **PR #86** (#83 backend)
- **PR #87** (#84 management dialog — provides the \`useComponentTypes\` hook in its new richer shape)

Merge order: **86 → 87 → this**.

Closes #85. Completes #82 (Epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)