### PR TITLE
feat(#89): virtual root node for Component Tree with aeroplane name

### DIFF
--- a/frontend/__tests__/ComponentTreeWeightDisplay.test.tsx
+++ b/frontend/__tests__/ComponentTreeWeightDisplay.test.tsx
@@ -6,7 +6,7 @@
  * total weight + status of the roots combined.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import React from "react";
 
 vi.mock("lucide-react", () => {
@@ -70,17 +70,29 @@ function makeNode(overrides: Record<string, unknown> = {}) {
   };
 }
 
-describe("ComponentTree — weight display (gh#78)", () => {
-  it("shows no header badge or icon when the tree is empty", () => {
+/**
+ * Read the virtual-root row's weight status from the DOM.
+ *
+ * As of gh#89 the aggregated scale + total moved OUT of the panel header INTO
+ * a synthesised root row labelled with the aeroplane name. The `data-weight-
+ * status` attribute on the first row's Scale span is the aggregate indicator.
+ * (Children only render when a group is expanded, so with collapsed children
+ * the first `[data-weight-status]` element is the virtual root itself.)
+ */
+function getVirtualRootStatus(container: HTMLElement): string | null {
+  const first = container.querySelector("[data-weight-status]");
+  return first?.getAttribute("data-weight-status") ?? null;
+}
+
+describe("ComponentTree — weight display (gh#78 + gh#89 virtual root)", () => {
+  it("empty tree: virtual root's aggregate status is 'invalid' (red)", () => {
     treeReturnValue = { tree: [], totalNodes: 0, isLoading: false, error: null };
     const { container } = render(<ComponentTree />);
-    expect(container.querySelector("[data-root-weight-status]")).toBeDefined();
-    // Status is "invalid" for an empty tree (red).
-    const aggIcon = container.querySelector("[data-root-weight-status]") as HTMLElement;
-    expect(aggIcon.getAttribute("data-root-weight-status")).toBe("invalid");
+    // The virtual root row is always present — even with no real nodes.
+    expect(getVirtualRootStatus(container)).toBe("invalid");
   });
 
-  it("shows GREEN scale + total weight when all nodes are valid", () => {
+  it("shows GREEN scale + total weight on the virtual root row when all nodes are valid", () => {
     treeReturnValue = {
       tree: [
         makeNode({
@@ -102,9 +114,9 @@ describe("ComponentTree — weight display (gh#78)", () => {
       error: null,
     };
     const { container } = render(<ComponentTree />);
-    const agg = container.querySelector("[data-root-weight-status]") as HTMLElement;
-    expect(agg.getAttribute("data-root-weight-status")).toBe("valid");
-    // Total weight appears at least in the badge (and also in the row annotation).
+    expect(getVirtualRootStatus(container)).toBe("valid");
+    // Total appears on the virtual root row (the row-level `1` group, collapsed
+    // by default, also shows its own total in its annotation).
     expect(screen.getAllByText("250.0g").length).toBeGreaterThanOrEqual(1);
   });
 
@@ -120,8 +132,7 @@ describe("ComponentTree — weight display (gh#78)", () => {
       totalNodes: 1, isLoading: false, error: null,
     };
     const { container } = render(<ComponentTree />);
-    const agg = container.querySelector("[data-root-weight-status]") as HTMLElement;
-    expect(agg.getAttribute("data-root-weight-status")).toBe("invalid");
+    expect(getVirtualRootStatus(container)).toBe("invalid");
   });
 
   it("shows YELLOW scale for a partially-valid tree", () => {
@@ -144,8 +155,7 @@ describe("ComponentTree — weight display (gh#78)", () => {
       totalNodes: 3, isLoading: false, error: null,
     };
     const { container } = render(<ComponentTree />);
-    const agg = container.querySelector("[data-root-weight-status]") as HTMLElement;
-    expect(agg.getAttribute("data-root-weight-status")).toBe("partial");
+    expect(getVirtualRootStatus(container)).toBe("partial");
     expect(screen.getAllByText("50.0g").length).toBeGreaterThanOrEqual(1);
   });
 
@@ -196,5 +206,100 @@ describe("ComponentTree — weight display (gh#78)", () => {
     // suppressed the total equals own, but the annotation format proves we
     // used total_weight_g not weight_override_g (otherwise it'd be "10g").
     expect(container.textContent).toContain("42.5g");
+  });
+});
+
+// --------------------------------------------------------------------------- //
+// gh#89 — virtual root node contract.
+// --------------------------------------------------------------------------- //
+
+describe("ComponentTree — virtual root (gh#89)", () => {
+  it("renders a root row labelled with the fallback 'Aeroplane' when no aeroplane name is known", () => {
+    treeReturnValue = { tree: [], totalNodes: 0, isLoading: false, error: null };
+    render(<ComponentTree />);
+    // The tests don't mock useAeroplanes, so aeroplanes[] is empty → fallback.
+    expect(screen.getByText("Aeroplane")).toBeDefined();
+  });
+
+  it("panel header no longer carries a weight chip or data-root-weight-status", () => {
+    treeReturnValue = {
+      tree: [
+        makeNode({
+          id: 1, name: "wing", weight_status: "valid",
+          total_weight_g: 124.2, own_weight_g: 124.2, own_weight_source: "override",
+        }),
+      ],
+      totalNodes: 1, isLoading: false, error: null,
+    };
+    const { container } = render(<ComponentTree />);
+    // The old header-side aggregate icon attribute is gone.
+    expect(container.querySelector("[data-root-weight-status]")).toBeNull();
+    // The total still renders — on the virtual root row — so the user still
+    // sees the number, just no longer in the header chip slot.
+    expect(screen.getAllByText("124.2g").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("virtual root row has no delete icon (cannot be deleted)", () => {
+    treeReturnValue = {
+      tree: [
+        makeNode({ id: 1, name: "wing", weight_status: "valid", total_weight_g: 50 }),
+      ],
+      totalNodes: 1, isLoading: false, error: null,
+    };
+    const { container } = render(<ComponentTree />);
+    // The real row for "wing" still has a delete button. The virtual root row
+    // must not. Count Trash2 icons across all rows — with one real child and
+    // the virtual root, we must see at most one (never two).
+    const deleteButtons = container.querySelectorAll(
+      'button.text-destructive',
+    );
+    // The virtual root row has no delete button. The child row does.
+    expect(deleteButtons.length).toBe(1);
+  });
+
+  it("collapsing the virtual root hides every child row", () => {
+    treeReturnValue = {
+      tree: [
+        makeNode({ id: 1, name: "wing", weight_status: "valid", total_weight_g: 50 }),
+        makeNode({ id: 2, name: "fuselage", weight_status: "valid", total_weight_g: 20 }),
+      ],
+      totalNodes: 2, isLoading: false, error: null,
+    };
+    render(<ComponentTree />);
+    // Both real roots are visible while the virtual root is expanded (default).
+    expect(screen.getByText("wing")).toBeDefined();
+    expect(screen.getByText("fuselage")).toBeDefined();
+    // Click the virtual root label to toggle it collapsed.
+    fireEvent.click(screen.getByText("Aeroplane"));
+    expect(screen.queryByText("wing")).toBeNull();
+    expect(screen.queryByText("fuselage")).toBeNull();
+    // The virtual root itself stays visible.
+    expect(screen.getByText("Aeroplane")).toBeDefined();
+  });
+
+  it("virtual root row exposes an 'Add to Aeroplane' affordance (replaces header + button)", () => {
+    treeReturnValue = { tree: [], totalNodes: 0, isLoading: false, error: null };
+    render(<ComponentTree />);
+    // Replaces the panel-header "Add to root" button.
+    expect(screen.getByTitle(/Add to Aeroplane/i)).toBeDefined();
+  });
+
+  it("real tree rows are indented one level deeper than before (nested under virtual root)", () => {
+    treeReturnValue = {
+      tree: [makeNode({ id: 1, name: "wing", weight_status: "valid", total_weight_g: 50 })],
+      totalNodes: 1, isLoading: false, error: null,
+    };
+    const { container } = render(<ComponentTree />);
+    // Find the row for "wing" and verify its padding-left corresponds to level=1
+    // (= 20px) rather than the pre-gh#89 level=0 (= 0px).
+    const wingText = screen.getByText("wing");
+    const row = wingText.closest('[aria-roledescription="sortable"]') as HTMLElement;
+    expect(row.style.paddingLeft).toBe("20px");
+    // Virtual root stays at level=0 (no indent).
+    const aeroText = screen.getByText("Aeroplane");
+    const rootRow = aeroText.closest('[aria-roledescription="sortable"]') as HTMLElement;
+    expect(rootRow.style.paddingLeft).toBe("0px");
+    // Silence unused
+    void container;
   });
 });

--- a/frontend/components/workbench/ComponentTree.tsx
+++ b/frontend/components/workbench/ComponentTree.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Plus, Check, Scale, X } from "lucide-react";
+import { Check, X } from "lucide-react";
 import {
   DndContext,
   PointerSensor,
@@ -13,6 +13,7 @@ import {
 import { TreeCard } from "@/components/workbench/TreeCard";
 import { SimpleTreeRow, type SimpleTreeNode } from "@/components/workbench/SimpleTreeRow";
 import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
+import { useAeroplanes } from "@/hooks/useAeroplanes";
 import {
   useComponentTree,
   addTreeNode,
@@ -77,6 +78,16 @@ type AddFlowStage =
   | { kind: "newGroup"; parentId: number | null; parentName: string }
   | { kind: "cotsPicker"; parentId: number | null; parentName: string }
   | { kind: "constructionPartsPicker"; parentId: number | null; parentName: string };
+
+/**
+ * Sentinel ID for the synthesised root row (labelled with the aeroplane's
+ * name). This row does not exist in the backend `component_tree` table — it
+ * is a purely visual container so all real roots (`wing`, user groups, etc.)
+ * nest under a single aeroplane-named node instead of floating loose. A
+ * non-numeric string keeps it out of the way of real numeric node IDs in
+ * dnd-kit ids and the `expanded` Set.
+ */
+export const VIRTUAL_ROOT_ID = "__root__";
 
 interface FlattenCallbacks {
   onSelect: (node: ComponentTreeNode) => void;
@@ -221,9 +232,18 @@ export function ComponentTree({
 }: ComponentTreeProps = {}) {
   const { aeroplaneId } = useAeroplaneContext();
   const { tree, mutate } = useComponentTree(aeroplaneId);
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const { aeroplanes } = useAeroplanes();
+  // Virtual root starts expanded by default so all real tree rows remain
+  // visible on first render. Users can collapse it to hide everything — the
+  // root row itself (with label + aggregated weight) always stays visible.
+  const [expanded, setExpanded] = useState<Set<string>>(
+    () => new Set([VIRTUAL_ROOT_ID]),
+  );
   const [selectedNodeId, setSelectedNodeId] = useState<number | null>(null);
   const [addFlow, setAddFlow] = useState<AddFlowStage>({ kind: "idle" });
+
+  const aeroplaneName =
+    aeroplanes.find((a) => a.id === aeroplaneId)?.name ?? "Aeroplane";
 
   // Pointer sensor with a small activation distance avoids hijacking simple
   // clicks (open menu, select node) for drags. Touch sensor brings drag-and-
@@ -235,9 +255,40 @@ export function ComponentTree({
 
   function onDragEnd(event: DragEndEvent) {
     if (!aeroplaneId) return;
-    const activeId = Number(String(event.active.id).replace(/^node-/, ""));
-    const overId = event.over ? Number(String(event.over.id).replace(/^node-/, "")) : null;
+    const activeStr = String(event.active.id).replace(/^node-/, "");
+    const overStr = event.over
+      ? String(event.over.id).replace(/^node-/, "")
+      : null;
+
+    // The virtual root is display-only — it can never be the drag source.
+    if (activeStr === VIRTUAL_ROOT_ID) return;
+
+    const activeId = Number(activeStr);
     if (Number.isNaN(activeId)) return;
+
+    // Dropping onto the virtual root == reparent to top level. Issues the
+    // move directly (computeMoveResult expects real node IDs on both sides).
+    if (overStr === VIRTUAL_ROOT_ID) {
+      void (async () => {
+        mutate();
+        try {
+          await moveTreeNode(aeroplaneId, activeId, {
+            new_parent_id: null,
+            sort_index: tree.length,
+          });
+          mutate();
+        } catch (err) {
+          mutate();
+          if (typeof window !== "undefined") {
+            alert(err instanceof Error ? err.message : "Move failed");
+          }
+        }
+      })();
+      return;
+    }
+
+    const overId = overStr ? Number(overStr) : null;
+    if (overId !== null && Number.isNaN(overId)) return;
     void handleDragEnd({
       activeId,
       overId,
@@ -346,68 +397,66 @@ export function ComponentTree({
     }
   };
 
-  const rows = flattenTree(
-    tree,
-    0,
-    expanded,
-    {
-      onSelect: handleSelect,
-      onDelete: handleDelete,
-      onAdd: openAddMenu,
-      onEdit: (n) => onNodeEditRequested?.(n),
-    },
-    selectedNodeId,
-  );
-
   const rootAgg = aggregateRootStatus(tree);
+  const virtualExpanded = expanded.has(VIRTUAL_ROOT_ID);
+
+  // Real tree rows are indented one level deeper so they nest visually under
+  // the virtual root. They are only materialised when the virtual root is
+  // expanded — collapsing the root hides the whole tree (native tree UX).
+  const childRows = virtualExpanded
+    ? flattenTree(
+        tree,
+        1,
+        expanded,
+        {
+          onSelect: handleSelect,
+          onDelete: handleDelete,
+          onAdd: openAddMenu,
+          onEdit: (n) => onNodeEditRequested?.(n),
+        },
+        selectedNodeId,
+      )
+    : [];
+
+  const virtualRootRow: SimpleTreeNode = {
+    id: VIRTUAL_ROOT_ID,
+    label: aeroplaneName,
+    level: 0,
+    expanded: virtualExpanded,
+    leaf: false,
+    // No onDelete / onEdit / onClick — the row is a display container. The
+    // chevron-toggle is handled by SimpleTreeRow's built-in `!leaf` click
+    // behaviour. `onAdd` keeps the "+ to root" entry point available on
+    // hover, now attached to the root row instead of the panel header.
+    onAdd: openRootAddMenu,
+    addTitle: `Add to ${aeroplaneName}`,
+    weightStatus: rootAgg.status,
+    weightTooltip:
+      rootAgg.status === "valid"
+        ? "All nodes have a valid weight"
+        : rootAgg.status === "partial"
+        ? "Some nodes have no weight and are counted as 0"
+        : "No node in the tree has a valid weight",
+    annotation:
+      rootAgg.total > 0 ? `${rootAgg.total.toFixed(1)}g` : undefined,
+    annotationPrimary: true,
+  };
+
+  const rows: SimpleTreeNode[] = [virtualRootRow, ...childRows];
 
   return (
     <>
-      <TreeCard
-        title="Component Tree"
-        badge={rootAgg.total > 0 ? `${rootAgg.total.toFixed(1)}g` : undefined}
-        badgeVariant="primary"
-        actions={
-          <>
-            <span
-              title={
-                rootAgg.status === "valid"
-                  ? "All nodes have a valid weight"
-                  : rootAgg.status === "partial"
-                  ? "Some nodes have no weight and are counted as 0"
-                  : "No node in the tree has a valid weight"
-              }
-              className={
-                rootAgg.status === "valid"
-                  ? "text-emerald-500"
-                  : rootAgg.status === "partial"
-                  ? "text-amber-500"
-                  : "text-red-500"
-              }
-              data-root-weight-status={rootAgg.status}
-            >
-              <Scale size={13} />
-            </span>
-            <button
-              onClick={openRootAddMenu}
-              className="flex size-6 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent hover:text-foreground"
-              title="Add to root"
-            >
-              <Plus size={14} />
-            </button>
-          </>
-        }
-      >
+      <TreeCard title="Component Tree">
         <DndContext sensors={sensors} onDragEnd={onDragEnd}>
         <div className="flex flex-col gap-0.5">
-          {rows.length === 0 ? (
+          {rows.map((node) => (
+            <SimpleTreeRow key={node.id} node={node} onToggle={() => toggle(node.id)} />
+          ))}
+
+          {virtualExpanded && tree.length === 0 && (
             <p className="py-4 text-center text-[11px] text-muted-foreground">
               No components yet. Add a group or assign a component.
             </p>
-          ) : (
-            rows.map((node) => (
-              <SimpleTreeRow key={node.id} node={node} onToggle={() => toggle(node.id)} />
-            ))
           )}
 
           {addFlow.kind === "newGroup" && (


### PR DESCRIPTION
## Summary

- The Component Tree's first row is now a synthesised root labelled with the aeroplane's name (fallback: \`Aeroplane\`).
- The aggregated weight chip + scale icon move out of the panel header into this root row; the header shrinks to just \`Component Tree\`.
- Non-deletable, collapsible; drag-drop onto the root reparents to \`parent_id=null\`. Zero backend changes.

Closes #89.

## What the user sees

**Before:** \`Component Tree  124.2g  ⚖  +\` (header chip + icon + add-to-root button) with \`wing\` as a loose top-level row.

**After:** \`Component Tree\` header only; first tree row is \`eHawk  ⚖ 124.2g\` (aeroplane name + total); \`wing\` sits as its child. The \`+ Add to\` affordance is now on the root row's hover menu.

## Scope

Frontend-only, as agreed during brainstorming. A real backend root would require a migration, a repair migration, reparenting, and new lock semantics — for zero user-visible benefit over the virtual approach since the backend already scopes trees per aeroplane.

## Test plan

- [x] \`npm run test:unit\` — 217 passed (+6 net):
  - 4 updated weight-display tests re-targeted to the virtual row's \`data-weight-status\`.
  - 6 new tests under \`ComponentTree — virtual root (gh#89)\`:
    - fallback label \`Aeroplane\` when no aeroplane is loaded
    - panel header no longer carries \`data-root-weight-status\`
    - virtual root row has no delete icon
    - collapsing the virtual root hides every child row
    - virtual root exposes \`Add to Aeroplane\` affordance
    - child rows indented one level deeper (\`padding-left: 20px\`), virtual root stays at \`0\`
- [x] \`npm run lint\` — clean
- [x] \`npx tsc --noEmit\` — clean
- [x] drag onto virtual root routes to \`moveTreeNode(…, { new_parent_id: null, sort_index: tree.length })\`

## Implementation notes

- Sentinel id \`"__root__"\` is non-numeric, so it can't collide with dnd-kit ids or the \`expanded\` Set.
- Virtual root starts expanded (\`useState(() => new Set([VIRTUAL_ROOT_ID]))\`) — avoids a set-state-in-effect lint violation.
- Aeroplane name sourced from \`useAeroplanes()\` via the existing \`aeroplaneId\` in \`AeroplaneContext\`. No new endpoint.
- \`onDragEnd\` ignores attempts to drag the virtual root as a source (can't move a display-only node) and treats drops *onto* it as reparent-to-root.