### PR TITLE
fix(#93): Wing.symmetric in schema + Servo required fields

### DIFF
--- a/app/schemas/Servo.py
+++ b/app/schemas/Servo.py
@@ -1,16 +1,37 @@
-from typing import Optional
+from pydantic import BaseModel, NonNegativeFloat, PositiveFloat, Field
 
-from pydantic import BaseModel
 
 class Servo(BaseModel):
-    length: Optional[float] = None
-    width: Optional[float] = None
-    height: Optional[float] = None
-    leading_length: Optional[float] = None
-    latch_z: Optional[float] = None
-    latch_x: Optional[float] = None
-    latch_thickness: Optional[float] = None
-    latch_length: Optional[float] = None
-    cable_z: Optional[float] = None
-    screw_hole_lx: Optional[float] = None
-    screw_hole_d: Optional[float] = None
+    """Physical dimensions of a servo actuator.
+
+    All fields are required — they describe the mechanical envelope that the
+    CAD modeller needs to cut a servo pocket into the wing skin.
+    """
+
+    length: PositiveFloat = Field(description="X-dimension of the servo body (mm)")
+    width: PositiveFloat = Field(description="Y-dimension of the servo body (mm)")
+    height: PositiveFloat = Field(description="Z-dimension of the servo body (mm)")
+    leading_length: NonNegativeFloat = Field(
+        description="X from the front edge to the rotation axis (mm)"
+    )
+    latch_z: NonNegativeFloat = Field(
+        description="Z-position of the lower edge of the latch (mm)"
+    )
+    latch_x: NonNegativeFloat = Field(
+        description="X-dimension of the latch (mm)"
+    )
+    latch_thickness: NonNegativeFloat = Field(
+        description="Thickness of the latch (mm)"
+    )
+    latch_length: NonNegativeFloat = Field(
+        description="Length of the latch (mm)"
+    )
+    cable_z: NonNegativeFloat = Field(
+        description="Z-position of the cable exit (mm)"
+    )
+    screw_hole_lx: NonNegativeFloat = Field(
+        description="X-distance of the screw hole from the leading edge (mm)"
+    )
+    screw_hole_d: NonNegativeFloat = Field(
+        description="Diameter of the screw hole (mm)"
+    )

--- a/app/schemas/wing.py
+++ b/app/schemas/wing.py
@@ -230,6 +230,10 @@ class Wing(BaseModel):
     nose_pnt: List[float] = Field(
         description="3D coordinates [x, y, z] of the wing's nose point in the aircraft coordinate system"
     )
+    symmetric: bool = Field(
+        default=True,
+        description="Whether the wing is mirrored along the aircraft's symmetry plane",
+    )
 
     model_config = {
         "json_schema_extra": {

--- a/app/services/create_wing_configuration.py
+++ b/app/services/create_wing_configuration.py
@@ -161,6 +161,7 @@ def create_root_segment(wing_model: WingModel) -> dict:
         wing_model.nose_pnt[1],
         wing_model.nose_pnt[2]
     )
+    initialization_dict['symmetric'] = getattr(wing_model, 'symmetric', True)
     initialization_dict['sweep_is_angle'] = False
     initialization_dict['root_airfoil'] = create_airfoil(root_segment.root_airfoil)
     initialization_dict['tip_airfoil'] = create_airfoil(root_segment.tip_airfoil)

--- a/app/tests/test_wingconfig_endpoint.py
+++ b/app/tests/test_wingconfig_endpoint.py
@@ -92,3 +92,94 @@ def test_put_wingconfig_updates_configuration(client):
 
     body = resp.json()
     assert body["segments"][0]["root_airfoil"]["chord"] == pytest.approx(200.0)
+
+
+# --------------------------------------------------------------------------- #
+# gh#93 — symmetric roundtrip + Servo schema validation
+# --------------------------------------------------------------------------- #
+
+
+def test_symmetric_false_roundtrip(client):
+    """POST with symmetric=false → GET returns symmetric=false."""
+    wc = _make_wingconfig()
+    wc["symmetric"] = False
+    aeroplane_id = _create_aeroplane_and_wing(client, wc)
+
+    resp = client.get(f"/aeroplanes/{aeroplane_id}/wings/test_wing/wingconfig")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["symmetric"] is False
+
+
+def test_symmetric_defaults_to_true_when_omitted(client):
+    """POST without 'symmetric' key → defaults to True (backward compat)."""
+    wc = _make_wingconfig()
+    wc.pop("symmetric", None)
+    aeroplane_id = _create_aeroplane_and_wing(client, wc)
+
+    resp = client.get(f"/aeroplanes/{aeroplane_id}/wings/test_wing/wingconfig")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["symmetric"] is True
+
+
+def test_servo_with_missing_required_field_returns_422(client):
+    """POST a TED with a Servo missing a required field → HTTP 422, not 500."""
+    wc = _make_wingconfig()
+    wc["segments"][0]["trailing_edge_device"] = {
+        "name": "aileron",
+        "rel_chord_root": 0.8,
+        "servo": {
+            "length": 23,
+            "width": 12.5,
+            # height is missing — required field
+            "leading_length": 6,
+            "latch_z": 14.5,
+            "latch_x": 7.25,
+            "latch_thickness": 2.6,
+            "latch_length": 6,
+            "cable_z": 26,
+            "screw_hole_lx": 0,
+            "screw_hole_d": 0,
+        },
+    }
+    resp = client.post("/aeroplanes", params={"name": "servo_test"})
+    assert resp.status_code == 201
+    aeroplane_id = resp.json()["id"]
+
+    resp = client.post(
+        f"/aeroplanes/{aeroplane_id}/wings/test_wing/from-wingconfig",
+        json=wc,
+    )
+    assert resp.status_code == 422, (
+        f"Expected 422 for missing Servo.height, got {resp.status_code}: {resp.text}"
+    )
+
+
+def test_servo_with_all_fields_accepted(client):
+    """POST a TED with a complete Servo → HTTP 201."""
+    wc = _make_wingconfig()
+    wc["segments"][0]["trailing_edge_device"] = {
+        "name": "flap",
+        "rel_chord_root": 0.7,
+        "servo": {
+            "length": 23,
+            "width": 12.5,
+            "height": 31.5,
+            "leading_length": 6,
+            "latch_z": 14.5,
+            "latch_x": 7.25,
+            "latch_thickness": 2.6,
+            "latch_length": 6,
+            "cable_z": 26,
+            "screw_hole_lx": 0,
+            "screw_hole_d": 0,
+        },
+    }
+    resp = client.post("/aeroplanes", params={"name": "servo_ok"})
+    assert resp.status_code == 201
+    aeroplane_id = resp.json()["id"]
+
+    resp = client.post(
+        f"/aeroplanes/{aeroplane_id}/wings/test_wing/from-wingconfig",
+        json=wc,
+    )
+    assert resp.status_code == 201, resp.text


### PR DESCRIPTION
## Summary

- `Wing` schema gains `symmetric: bool = True` — POST/PUT can now create asymmetric wings
- `Servo` schema: all 11 fields changed from `Optional[float]=None` to required (`PositiveFloat`/`NonNegativeFloat`) — prevents crash when None reaches the topology constructor

Closes #93. Part of epic #92.

## Changes

| File | What |
|------|------|
| `app/schemas/wing.py` | Added `symmetric: bool = True` to `Wing` model |
| `app/schemas/Servo.py` | All fields → required with proper Pydantic types |
| `app/services/create_wing_configuration.py` | `create_root_segment` passes `symmetric` to `WingConfiguration.__init__` |
| `app/tests/test_wingconfig_endpoint.py` | 4 new tests |

## Test plan

- [x] `poetry run ruff check .` — clean
- [x] `poetry run pytest -m "not slow"` — 393 passed (+4 new)
- [x] `symmetric=false` roundtrip: POST → GET → assert false
- [x] `symmetric` omitted → defaults to `true` (backward compat)
- [x] Servo with missing required field → HTTP 422 (not 500)
- [x] Servo with all fields → HTTP 201

🤖 Generated with [Claude Code](https://claude.com/claude-code)