### PR TITLE
feat(#96,#97): Spar PUT/DELETE + TED/Servo direct-access routes

### DIFF
--- a/app/api/v2/endpoints/aeroplane/wings.py
+++ b/app/api/v2/endpoints/aeroplane/wings.py
@@ -494,6 +494,164 @@ async def create_aeroplane_wing_cross_section_spar(
     return OperationStatusResponse(status="created", operation="create_wing_cross_section_spar")
 
 
+@router.put(
+    "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/spars/{spar_index}",
+    response_model=OperationStatusResponse,
+    status_code=status.HTTP_200_OK,
+    tags=["spars"],
+    operation_id="update_wing_cross_section_spar",
+)
+async def update_aeroplane_wing_cross_section_spar(
+    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
+    wing_name: str = Path(..., description="The name of the wing"),
+    cross_section_index: int = Path(..., description="The index of the cross section"),
+    spar_index: int = Path(..., description="The index of the spar to replace"),
+    request: schemas.SpareDetailSchema = Body(..., description="Updated spar definition"),
+    db: Session = Depends(get_db),
+) -> OperationStatusResponse:
+    """Replaces the spar at the given index on the selected cross-section."""
+    _call_service(wing_service.update_spare, db, aeroplane_id, wing_name, cross_section_index, spar_index, request)
+    on_wing_changed(db, aeroplane_id, wing_name)
+    return OperationStatusResponse(status="updated", operation="update_wing_cross_section_spar")
+
+
+@router.delete(
+    "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/spars/{spar_index}",
+    response_model=OperationStatusResponse,
+    status_code=status.HTTP_200_OK,
+    tags=["spars"],
+    operation_id="delete_wing_cross_section_spar",
+)
+async def delete_aeroplane_wing_cross_section_spar(
+    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
+    wing_name: str = Path(..., description="The name of the wing"),
+    cross_section_index: int = Path(..., description="The index of the cross section"),
+    spar_index: int = Path(..., description="The index of the spar to delete"),
+    db: Session = Depends(get_db),
+) -> OperationStatusResponse:
+    """Deletes the spar at the given index on the selected cross-section."""
+    _call_service(wing_service.delete_spare, db, aeroplane_id, wing_name, cross_section_index, spar_index)
+    on_wing_changed(db, aeroplane_id, wing_name)
+    return OperationStatusResponse(status="deleted", operation="delete_wing_cross_section_spar")
+
+
+# ── TED direct-access endpoints (gh#97) ─────────────────────────
+# These expose the full TrailingEdgeDeviceDetailSchema, bypassing the
+# ControlSurface ASB-view wrapper. Service functions already existed
+# in wing_service.py but had no HTTP routes until now.
+
+@router.get(
+    "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/trailing_edge_device",
+    response_model=schemas.TrailingEdgeDeviceDetailSchema,
+    status_code=status.HTTP_200_OK,
+    tags=["trailing-edge-devices"],
+    operation_id="get_wing_trailing_edge_device",
+)
+async def get_wing_trailing_edge_device(
+    aeroplane_id: AeroPlaneID = Path(...),
+    wing_name: str = Path(...),
+    cross_section_index: int = Path(...),
+    db: Session = Depends(get_db),
+) -> schemas.TrailingEdgeDeviceDetailSchema:
+    """Returns the full TED with all geometry and spacing fields."""
+    return _call_service(wing_service.get_trailing_edge_device, db, aeroplane_id, wing_name, cross_section_index)
+
+
+@router.patch(
+    "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/trailing_edge_device",
+    response_model=schemas.TrailingEdgeDeviceDetailSchema,
+    status_code=status.HTTP_200_OK,
+    tags=["trailing-edge-devices"],
+    operation_id="patch_wing_trailing_edge_device",
+)
+async def patch_wing_trailing_edge_device(
+    aeroplane_id: AeroPlaneID = Path(...),
+    wing_name: str = Path(...),
+    cross_section_index: int = Path(...),
+    request: schemas.TrailingEdgeDevicePatchSchema = Body(...),
+    db: Session = Depends(get_db),
+) -> schemas.TrailingEdgeDeviceDetailSchema:
+    """Upsert TED fields directly (not through the ControlSurface wrapper)."""
+    result = _call_service(wing_service.patch_trailing_edge_device, db, aeroplane_id, wing_name, cross_section_index, request)
+    on_wing_changed(db, aeroplane_id, wing_name)
+    return result
+
+
+@router.delete(
+    "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/trailing_edge_device",
+    response_model=OperationStatusResponse,
+    status_code=status.HTTP_200_OK,
+    tags=["trailing-edge-devices"],
+    operation_id="delete_wing_trailing_edge_device",
+)
+async def delete_wing_trailing_edge_device(
+    aeroplane_id: AeroPlaneID = Path(...),
+    wing_name: str = Path(...),
+    cross_section_index: int = Path(...),
+    db: Session = Depends(get_db),
+) -> OperationStatusResponse:
+    """Deletes the TED on the selected cross-section."""
+    _call_service(wing_service.delete_trailing_edge_device, db, aeroplane_id, wing_name, cross_section_index)
+    on_wing_changed(db, aeroplane_id, wing_name)
+    return OperationStatusResponse(status="deleted", operation="delete_wing_trailing_edge_device")
+
+
+@router.get(
+    "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/trailing_edge_device/servo",
+    response_model=schemas.ControlSurfaceServoDetailsSchema,
+    status_code=status.HTTP_200_OK,
+    tags=["trailing-edge-devices"],
+    operation_id="get_wing_trailing_edge_servo",
+)
+async def get_wing_trailing_edge_servo(
+    aeroplane_id: AeroPlaneID = Path(...),
+    wing_name: str = Path(...),
+    cross_section_index: int = Path(...),
+    db: Session = Depends(get_db),
+) -> schemas.ControlSurfaceServoDetailsSchema:
+    """Returns the servo assignment on the TED."""
+    return _call_service(wing_service.get_trailing_edge_servo, db, aeroplane_id, wing_name, cross_section_index)
+
+
+@router.patch(
+    "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/trailing_edge_device/servo",
+    response_model=schemas.ControlSurfaceServoDetailsSchema,
+    status_code=status.HTTP_200_OK,
+    tags=["trailing-edge-devices"],
+    operation_id="patch_wing_trailing_edge_servo",
+)
+async def patch_wing_trailing_edge_servo(
+    aeroplane_id: AeroPlaneID = Path(...),
+    wing_name: str = Path(...),
+    cross_section_index: int = Path(...),
+    request: schemas.ControlSurfaceServoDetailsPatchSchema = Body(...),
+    db: Session = Depends(get_db),
+) -> schemas.ControlSurfaceServoDetailsSchema:
+    """Assign or update the servo on the TED."""
+    result = _call_service(wing_service.patch_trailing_edge_servo, db, aeroplane_id, wing_name, cross_section_index, request)
+    on_wing_changed(db, aeroplane_id, wing_name)
+    return result
+
+
+@router.delete(
+    "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/trailing_edge_device/servo",
+    response_model=OperationStatusResponse,
+    status_code=status.HTTP_200_OK,
+    tags=["trailing-edge-devices"],
+    operation_id="delete_wing_trailing_edge_servo",
+)
+async def delete_wing_trailing_edge_servo(
+    aeroplane_id: AeroPlaneID = Path(...),
+    wing_name: str = Path(...),
+    cross_section_index: int = Path(...),
+    db: Session = Depends(get_db),
+) -> OperationStatusResponse:
+    """Remove the servo assignment from the TED."""
+    _call_service(wing_service.delete_trailing_edge_servo, db, aeroplane_id, wing_name, cross_section_index)
+    on_wing_changed(db, aeroplane_id, wing_name)
+    return OperationStatusResponse(status="deleted", operation="delete_wing_trailing_edge_servo")
+
+
 @router.get(
     "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/control_surface",
     response_model=schemas.ControlSurfaceSchema,

--- a/app/services/wing_service.py
+++ b/app/services/wing_service.py
@@ -755,6 +755,70 @@ def create_spare(
         raise InternalError(message=f"Database error: {e}")
 
 
+def update_spare(
+    db: Session,
+    aeroplane_uuid,
+    wing_name: str,
+    xsec_index: int,
+    spar_index: int,
+    spare_data: schemas.SpareDetailSchema,
+) -> None:
+    """Replace a spar at the given index on a wing cross-section."""
+    try:
+        with db.begin():
+            aeroplane = get_aeroplane_or_raise(db, aeroplane_uuid)
+            wing = get_wing_or_raise(aeroplane, wing_name)
+            x_sec = _get_xsec_or_raise(wing, xsec_index)
+            detail = _ensure_segment_detail_or_raise(x_sec, xsec_index, len(wing.x_secs))
+            if spar_index < 0 or spar_index >= len(detail.spares):
+                raise NotFoundError(
+                    message=f"Spar index {spar_index} out of range (0..{len(detail.spares) - 1}).",
+                    details={"spar_index": spar_index},
+                )
+            spare = detail.spares[spar_index]
+            for key, value in spare_data.model_dump().items():
+                setattr(spare, key, value)
+            aeroplane.updated_at = datetime.now()
+    except (NotFoundError, ValidationError):
+        raise
+    except SQLAlchemyError as e:
+        logger.error(f"Database error when updating spar: {e}")
+        raise InternalError(message=f"Database error: {e}")
+
+
+def delete_spare(
+    db: Session,
+    aeroplane_uuid,
+    wing_name: str,
+    xsec_index: int,
+    spar_index: int,
+) -> None:
+    """Delete a spar at the given index on a wing cross-section."""
+    try:
+        with db.begin():
+            aeroplane = get_aeroplane_or_raise(db, aeroplane_uuid)
+            wing = get_wing_or_raise(aeroplane, wing_name)
+            x_sec = _get_xsec_or_raise(wing, xsec_index)
+            detail = _ensure_segment_detail_or_raise(x_sec, xsec_index, len(wing.x_secs))
+            if spar_index < 0 or spar_index >= len(detail.spares):
+                raise NotFoundError(
+                    message=f"Spar index {spar_index} out of range (0..{len(detail.spares) - 1}).",
+                    details={"spar_index": spar_index},
+                )
+            spare = detail.spares[spar_index]
+            db.delete(spare)
+            # Re-index remaining spares
+            for i, s in enumerate(detail.spares):
+                if s is not spare:
+                    s.sort_index = i if i < spar_index else i - 1
+            aeroplane.updated_at = datetime.now()
+    except (NotFoundError, ValidationError):
+        raise
+    except SQLAlchemyError as e:
+        logger.error(f"Database error when deleting spar: {e}")
+        raise InternalError(message=f"Database error: {e}")
+
+
 def get_control_surface(
     db: Session,
     aeroplane_uuid,

--- a/app/tests/test_spar_and_ted_crud.py
+++ b/app/tests/test_spar_and_ted_crud.py
@@ -1,0 +1,252 @@
+"""Tests for spar PUT/DELETE (#96) and TED direct-access endpoints (#97).
+
+Uses the wingconfig API to seed a wing with one segment + one spar + one TED,
+then exercises the new CRUD endpoints.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+airfoil_path = str(
+    (Path(__file__).resolve().parents[2] / "components" / "airfoils" / "mh32.dat").resolve()
+)
+
+
+@pytest.fixture()
+def client(client_and_db):
+    c, _ = client_and_db
+    yield c
+
+
+def _seed_wing(client: TestClient, name: str = "crud_test") -> str:
+    """Create an aeroplane with a wing that has 1 spar + 1 TED on xsec 0."""
+    resp = client.post("/aeroplanes", params={"name": name})
+    assert resp.status_code == 201
+    aeroplane_id = resp.json()["id"]
+
+    wc = {
+        "segments": [
+            {
+                "root_airfoil": {"airfoil": airfoil_path, "chord": 150.0, "incidence": 0},
+                "tip_airfoil": {"airfoil": airfoil_path, "chord": 120.0, "incidence": 0},
+                "length": 500.0,
+                "sweep": 10.0,
+                "number_interpolation_points": 101,
+                "spare_list": [
+                    {
+                        "spare_support_dimension_width": 5.0,
+                        "spare_support_dimension_height": 5.0,
+                        "spare_position_factor": 0.25,
+                        "spare_start": 0.0,
+                        "spare_mode": "standard",
+                        "spare_vector": [0, 1, 0],
+                        "spare_origin": [0, 0, 0],
+                    }
+                ],
+                "trailing_edge_device": {
+                    "name": "aileron",
+                    "rel_chord_root": 0.8,
+                    "rel_chord_tip": 0.8,
+                    "positive_deflection_deg": 25,
+                    "negative_deflection_deg": 25,
+                    "symmetric": False,
+                },
+            }
+        ],
+        "nose_pnt": [0, 0, 0],
+    }
+    resp = client.post(f"/aeroplanes/{aeroplane_id}/wings/w/from-wingconfig", json=wc)
+    assert resp.status_code == 201, resp.text
+    return aeroplane_id
+
+
+# ── Spar CRUD (#96) ────────────────────────────────────────────────
+
+
+class TestSparCrud:
+    def test_get_spars_returns_seeded_spar(self, client):
+        aid = _seed_wing(client, "spar_get")
+        resp = client.get(f"/aeroplanes/{aid}/wings/w/cross_sections/0/spars")
+        assert resp.status_code == 200
+        spars = resp.json()
+        assert len(spars) == 1
+        assert spars[0]["spare_position_factor"] == pytest.approx(0.25)
+
+    def test_put_spar_updates_existing(self, client):
+        aid = _seed_wing(client, "spar_put")
+        updated = {
+            "spare_support_dimension_width": 8.0,
+            "spare_support_dimension_height": 8.0,
+            "spare_position_factor": 0.50,
+            "spare_start": 0.0,
+            "spare_mode": "follow",
+            "spare_vector": [0, 1, 0],
+            "spare_origin": [0, 0, 0],
+        }
+        resp = client.put(f"/aeroplanes/{aid}/wings/w/cross_sections/0/spars/0", json=updated)
+        assert resp.status_code == 200, resp.text
+
+        # Verify update took effect
+        resp = client.get(f"/aeroplanes/{aid}/wings/w/cross_sections/0/spars")
+        spars = resp.json()
+        assert len(spars) == 1
+        assert spars[0]["spare_position_factor"] == pytest.approx(0.50)
+        assert spars[0]["spare_support_dimension_width"] == pytest.approx(8.0)
+        assert spars[0]["spare_mode"] == "follow"
+
+    def test_put_spar_invalid_index_returns_404(self, client):
+        aid = _seed_wing(client, "spar_put_404")
+        updated = {
+            "spare_support_dimension_width": 5.0,
+            "spare_support_dimension_height": 5.0,
+            "spare_position_factor": 0.25,
+            "spare_start": 0.0,
+            "spare_mode": "standard",
+            "spare_vector": [0, 1, 0],
+            "spare_origin": [0, 0, 0],
+        }
+        resp = client.put(f"/aeroplanes/{aid}/wings/w/cross_sections/0/spars/99", json=updated)
+        assert resp.status_code == 404
+
+    def test_delete_spar_removes_it(self, client):
+        aid = _seed_wing(client, "spar_del")
+        resp = client.delete(f"/aeroplanes/{aid}/wings/w/cross_sections/0/spars/0")
+        assert resp.status_code == 200
+
+        # Verify spar is gone
+        resp = client.get(f"/aeroplanes/{aid}/wings/w/cross_sections/0/spars")
+        assert len(resp.json()) == 0
+
+    def test_delete_spar_invalid_index_returns_404(self, client):
+        aid = _seed_wing(client, "spar_del_404")
+        resp = client.delete(f"/aeroplanes/{aid}/wings/w/cross_sections/0/spars/99")
+        assert resp.status_code == 404
+
+    def test_append_then_delete_first_preserves_second(self, client):
+        aid = _seed_wing(client, "spar_order")
+        # Append a second spar
+        second = {
+            "spare_support_dimension_width": 3.0,
+            "spare_support_dimension_height": 3.0,
+            "spare_position_factor": 0.75,
+            "spare_mode": "standard",
+        }
+        resp = client.post(f"/aeroplanes/{aid}/wings/w/cross_sections/0/spars", json=second)
+        assert resp.status_code == 201
+
+        # Delete the first (index 0)
+        resp = client.delete(f"/aeroplanes/{aid}/wings/w/cross_sections/0/spars/0")
+        assert resp.status_code == 200
+
+        # Only the second spar remains
+        resp = client.get(f"/aeroplanes/{aid}/wings/w/cross_sections/0/spars")
+        spars = resp.json()
+        assert len(spars) == 1
+        assert spars[0]["spare_position_factor"] == pytest.approx(0.75)
+
+
+# ── TED direct-access endpoints (#97) ──────────────────────────────
+
+
+class TestTedDirectAccess:
+    def test_get_trailing_edge_device_returns_full_schema(self, client):
+        aid = _seed_wing(client, "ted_get")
+        resp = client.get(f"/aeroplanes/{aid}/wings/w/cross_sections/0/trailing_edge_device")
+        assert resp.status_code == 200
+        ted = resp.json()
+        assert ted["name"] == "aileron"
+        assert ted["symmetric"] is False
+
+    def test_patch_trailing_edge_device_updates_fields(self, client):
+        aid = _seed_wing(client, "ted_patch")
+        patch = {
+            "hinge_spacing": 0.5,
+            "side_spacing_root": 2.0,
+            "side_spacing_tip": 2.0,
+            "hinge_type": "top_simple",
+        }
+        resp = client.patch(
+            f"/aeroplanes/{aid}/wings/w/cross_sections/0/trailing_edge_device",
+            json=patch,
+        )
+        assert resp.status_code == 200, resp.text
+        ted = resp.json()
+        assert ted["hinge_spacing"] == pytest.approx(0.5)
+        assert ted["hinge_type"] == "top_simple"
+
+    def test_delete_trailing_edge_device(self, client):
+        aid = _seed_wing(client, "ted_del")
+        resp = client.delete(f"/aeroplanes/{aid}/wings/w/cross_sections/0/trailing_edge_device")
+        assert resp.status_code == 200
+
+        # Verify it's gone
+        resp = client.get(f"/aeroplanes/{aid}/wings/w/cross_sections/0/trailing_edge_device")
+        assert resp.status_code == 404
+
+    def test_patch_servo_on_ted(self, client):
+        aid = _seed_wing(client, "servo_patch")
+        servo_payload = {
+            "servo": {
+                "length": 23, "width": 12.5, "height": 31.5,
+                "leading_length": 6, "latch_z": 14.5, "latch_x": 7.25,
+                "latch_thickness": 2.6, "latch_length": 6, "cable_z": 26,
+                "screw_hole_lx": 0, "screw_hole_d": 0,
+            }
+        }
+        resp = client.patch(
+            f"/aeroplanes/{aid}/wings/w/cross_sections/0/trailing_edge_device/servo",
+            json=servo_payload,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["servo"]["length"] == pytest.approx(23)
+
+    def test_get_servo_after_patch(self, client):
+        aid = _seed_wing(client, "servo_get")
+        servo_payload = {
+            "servo": {
+                "length": 20, "width": 10, "height": 25,
+                "leading_length": 5, "latch_z": 10, "latch_x": 5,
+                "latch_thickness": 2, "latch_length": 5, "cable_z": 20,
+                "screw_hole_lx": 0, "screw_hole_d": 0,
+            }
+        }
+        client.patch(
+            f"/aeroplanes/{aid}/wings/w/cross_sections/0/trailing_edge_device/servo",
+            json=servo_payload,
+        )
+        resp = client.get(
+            f"/aeroplanes/{aid}/wings/w/cross_sections/0/trailing_edge_device/servo",
+        )
+        assert resp.status_code == 200
+        assert resp.json()["servo"]["width"] == pytest.approx(10)
+
+    def test_delete_servo(self, client):
+        aid = _seed_wing(client, "servo_del")
+        # First assign a servo
+        servo_payload = {
+            "servo": {
+                "length": 20, "width": 10, "height": 25,
+                "leading_length": 5, "latch_z": 10, "latch_x": 5,
+                "latch_thickness": 2, "latch_length": 5, "cable_z": 20,
+                "screw_hole_lx": 0, "screw_hole_d": 0,
+            }
+        }
+        client.patch(
+            f"/aeroplanes/{aid}/wings/w/cross_sections/0/trailing_edge_device/servo",
+            json=servo_payload,
+        )
+        # Delete it
+        resp = client.delete(
+            f"/aeroplanes/{aid}/wings/w/cross_sections/0/trailing_edge_device/servo",
+        )
+        assert resp.status_code == 200
+
+        # Verify it's gone
+        resp = client.get(
+            f"/aeroplanes/{aid}/wings/w/cross_sections/0/trailing_edge_device/servo",
+        )
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- **Spar CRUD** (#96): PUT and DELETE endpoints for individual spars by index
- **TED/Servo routes** (#97): 6 service functions that existed but had no HTTP routes are now exposed

Closes #96, closes #97. Part of epic #92.

## New Endpoints

### Spars (gh#96)

| Method | Path | Description |
|--------|------|-------------|
| PUT | `.../spars/{spar_idx}` | Replace spar at index |
| DELETE | `.../spars/{spar_idx}` | Delete spar at index |

### TED direct-access (gh#97)

| Method | Path | Description |
|--------|------|-------------|
| GET | `.../trailing_edge_device` | Full TED schema (all 15 fields) |
| PATCH | `.../trailing_edge_device` | Update TED fields directly |
| DELETE | `.../trailing_edge_device` | Remove TED |
| GET | `.../trailing_edge_device/servo` | Get servo assignment |
| PATCH | `.../trailing_edge_device/servo` | Assign/update servo |
| DELETE | `.../trailing_edge_device/servo` | Remove servo |

Existing `control_surface` endpoints remain unchanged (backward compat).

## Test plan

- [x] `poetry run ruff check .` — clean
- [x] `poetry run pytest -m "not slow"` — 405 passed (+12 new)
- [x] 6 spar CRUD tests (get, put, put-404, delete, delete-404, order-preservation)
- [x] 6 TED/servo tests (get, patch, delete × TED + servo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)