### PR TITLE
feat(#101): Construction Plans — CRUD, Creator Catalog, Execute, PrinterSettings

### DIFF
--- a/alembic/versions/b3e2f1a4c7d9_add_construction_plans_table.py
+++ b/alembic/versions/b3e2f1a4c7d9_add_construction_plans_table.py
@@ -1,0 +1,31 @@
+"""Add construction_plans table
+
+Revision ID: b3e2f1a4c7d9
+Revises: a7f1c3d2e5b8
+Create Date: 2026-04-17
+"""
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "b3e2f1a4c7d9"
+down_revision: Union[str, None] = "a7f1c3d2e5b8"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "construction_plans",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("description", sa.String(), nullable=True),
+        sa.Column("tree_json", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("construction_plans")

--- a/app/api/v2/endpoints/construction_plans.py
+++ b/app/api/v2/endpoints/construction_plans.py
@@ -1,0 +1,170 @@
+"""REST endpoints for Construction Plans (gh#101)."""
+from __future__ import annotations
+
+import logging
+from typing import List
+
+from fastapi import APIRouter, Body, Depends, Path
+from fastapi import status
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import (
+    NotFoundError,
+    ValidationError,
+    InternalError,
+    ServiceException,
+)
+from app.db.session import get_db
+from app.schemas.construction_plan import (
+    CreatorInfo,
+    ExecuteRequest,
+    ExecutionResult,
+    PlanCreate,
+    PlanRead,
+    PlanSummary,
+)
+from app.services import construction_plan_service as svc
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _handle_service_error(exc: ServiceException):
+    """Convert domain exceptions to HTTP responses."""
+    from fastapi import HTTPException
+
+    status_map = {
+        NotFoundError: status.HTTP_404_NOT_FOUND,
+        ValidationError: status.HTTP_422_UNPROCESSABLE_ENTITY,
+        InternalError: status.HTTP_500_INTERNAL_SERVER_ERROR,
+    }
+    code = status_map.get(type(exc), status.HTTP_500_INTERNAL_SERVER_ERROR)
+    raise HTTPException(status_code=code, detail=str(exc.message))
+
+
+# ── Creator catalog (MUST be before /{plan_id} to avoid route conflict) ──
+
+
+@router.get(
+    "/construction-plans/creators",
+    response_model=List[CreatorInfo],
+    status_code=status.HTTP_200_OK,
+    tags=["construction-plans"],
+    operation_id="list_creators",
+)
+async def list_creators() -> List[CreatorInfo]:
+    """List all available Creator classes with their parameters."""
+    return svc.list_creators()
+
+
+# ── CRUD ────────────────────────────────────────────────────────
+
+
+@router.get(
+    "/construction-plans",
+    response_model=List[PlanSummary],
+    status_code=status.HTTP_200_OK,
+    tags=["construction-plans"],
+    operation_id="list_construction_plans",
+)
+async def list_plans(db: Session = Depends(get_db)) -> List[PlanSummary]:
+    """List all construction plans."""
+    try:
+        return svc.list_plans(db)
+    except ServiceException as exc:
+        _handle_service_error(exc)
+
+
+@router.post(
+    "/construction-plans",
+    response_model=PlanRead,
+    status_code=status.HTTP_201_CREATED,
+    tags=["construction-plans"],
+    operation_id="create_construction_plan",
+)
+async def create_plan(
+    request: PlanCreate = Body(...),
+    db: Session = Depends(get_db),
+) -> PlanRead:
+    """Create a new construction plan."""
+    try:
+        return svc.create_plan(db, request)
+    except ServiceException as exc:
+        _handle_service_error(exc)
+
+
+@router.get(
+    "/construction-plans/{plan_id}",
+    response_model=PlanRead,
+    status_code=status.HTTP_200_OK,
+    tags=["construction-plans"],
+    operation_id="get_construction_plan",
+)
+async def get_plan(
+    plan_id: int = Path(..., description="Construction plan ID"),
+    db: Session = Depends(get_db),
+) -> PlanRead:
+    """Get a construction plan by ID."""
+    try:
+        return svc.get_plan(db, plan_id)
+    except ServiceException as exc:
+        _handle_service_error(exc)
+
+
+@router.put(
+    "/construction-plans/{plan_id}",
+    response_model=PlanRead,
+    status_code=status.HTTP_200_OK,
+    tags=["construction-plans"],
+    operation_id="update_construction_plan",
+)
+async def update_plan(
+    plan_id: int = Path(...),
+    request: PlanCreate = Body(...),
+    db: Session = Depends(get_db),
+) -> PlanRead:
+    """Update an existing construction plan."""
+    try:
+        return svc.update_plan(db, plan_id, request)
+    except ServiceException as exc:
+        _handle_service_error(exc)
+
+
+@router.delete(
+    "/construction-plans/{plan_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    tags=["construction-plans"],
+    operation_id="delete_construction_plan",
+)
+async def delete_plan(
+    plan_id: int = Path(...),
+    db: Session = Depends(get_db),
+):
+    """Delete a construction plan."""
+    try:
+        svc.delete_plan(db, plan_id)
+    except ServiceException as exc:
+        _handle_service_error(exc)
+
+
+# ── Execute ─────────────────────────────────────────────────────
+
+
+@router.post(
+    "/construction-plans/{plan_id}/execute",
+    response_model=ExecutionResult,
+    status_code=status.HTTP_200_OK,
+    tags=["construction-plans"],
+    operation_id="execute_construction_plan",
+)
+async def execute_plan(
+    plan_id: int = Path(...),
+    request: ExecuteRequest = Body(...),
+    db: Session = Depends(get_db),
+) -> ExecutionResult:
+    """Execute a construction plan against an aeroplane configuration."""
+    try:
+        return svc.execute_plan(db, plan_id, request)
+    except ServiceException as exc:
+        _handle_service_error(exc)

--- a/app/main.py
+++ b/app/main.py
@@ -13,6 +13,7 @@ from app.api.v2.endpoints import components
 from app.api.v2.endpoints import component_types
 from app.api.v2.endpoints.aeroplane import component_tree
 from app.api.v2.endpoints.aeroplane import construction_parts
+from app.api.v2.endpoints import construction_plans
 from app.api.v2.endpoints import flight_profiles
 from app.api.v2.endpoints import fuselage_slice
 from app.api.v2.endpoints import health
@@ -118,6 +119,7 @@ def create_app() -> FastAPI:
     app.include_router(component_types.router, prefix="", tags=["component-types"])
     app.include_router(component_tree.router, prefix="", tags=["component-tree"])
     app.include_router(construction_parts.router, prefix="", tags=["construction-parts"])
+    app.include_router(construction_plans.router, prefix="", tags=["construction-plans"])
     app.include_router(flight_profiles.router, prefix="", tags=["flight-profiles"])
     app.include_router(fuselage_slice.router, prefix="", tags=["fuselages"])
     if _cad_router is not None:

--- a/app/models/construction_plan.py
+++ b/app/models/construction_plan.py
@@ -1,0 +1,40 @@
+"""Construction Plan — JSON-defined build workflows (gh#101)."""
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Column, String, DateTime, func
+from sqlalchemy.types import JSON
+
+from app.db.base import Base
+
+
+class ConstructionPlanModel(Base):
+    """A reusable construction plan stored as a JSON tree.
+
+    The tree_json column holds the serialised ConstructionRootNode /
+    ConstructionStepNode hierarchy produced by GeneralJSONEncoder.
+    Plans are not bound to a specific aeroplane — the aeroplane
+    provides runtime configuration (wing_config, printer_settings)
+    at execution time.
+    """
+
+    __tablename__ = "construction_plans"
+
+    name = Column(String, nullable=False)
+    description = Column(String, nullable=True)
+    tree_json = Column(JSON, nullable=False)
+
+    created_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+        server_onupdate=func.now(),
+        nullable=False,
+    )

--- a/app/schemas/construction_plan.py
+++ b/app/schemas/construction_plan.py
@@ -1,0 +1,80 @@
+"""Pydantic schemas for Construction Plans (gh#101)."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+
+class PlanCreate(BaseModel):
+    """Request body for creating / updating a construction plan."""
+
+    name: str = Field(..., min_length=1, description="Plan display name")
+    description: Optional[str] = Field(None, description="Optional description")
+    tree_json: dict = Field(
+        ...,
+        description="Serialised ConstructionRootNode tree (GeneralJSONEncoder format)",
+    )
+
+
+class PlanRead(PlanCreate):
+    """Full plan including DB metadata."""
+
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class PlanSummary(BaseModel):
+    """Lightweight plan entry for list views."""
+
+    id: int
+    name: str
+    description: Optional[str] = None
+    step_count: int = Field(0, description="Number of steps in the tree")
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+# ── Creator reflection schemas ──────────────────────────────────
+
+
+class CreatorParam(BaseModel):
+    """A single constructor parameter of a Creator class."""
+
+    name: str
+    type: str = Field(description="Python type annotation as string")
+    default: Optional[Any] = None
+    required: bool
+
+
+class CreatorInfo(BaseModel):
+    """Metadata for one AbstractShapeCreator subclass."""
+
+    class_name: str
+    category: str = Field(description="Module category: wing, fuselage, cad_operations, export_import, components")
+    description: Optional[str] = None
+    parameters: list[CreatorParam]
+
+
+# ── Execute schemas ─────────────────────────────────────────────
+
+
+class ExecuteRequest(BaseModel):
+    """Request body for executing a plan against an aeroplane."""
+
+    aeroplane_id: str = Field(..., description="UUID of the aeroplane to use")
+
+
+class ExecutionResult(BaseModel):
+    """Response from plan execution."""
+
+    status: str = Field(description="'success' or 'error'")
+    shape_keys: list[str] = Field(default_factory=list)
+    export_paths: list[str] = Field(default_factory=list)
+    error: Optional[str] = None
+    duration_ms: int = 0

--- a/app/services/component_type_service.py
+++ b/app/services/component_type_service.py
@@ -391,6 +391,18 @@ DEFAULT_SEED_TYPES: list[dict[str, Any]] = [
         ],
     },
     {
+        "name": "printer_settings", "label": "3D-Drucker Einstellungen",
+        "description": "Druckparameter für Vase-Mode-Flügel (VaseModeWingCreator)",
+        "schema": [
+            {"name": "layer_height", "label": "Schichthöhe", "type": "number",
+             "unit": "mm", "required": True, "min": 0.05, "max": 1.0, "default": 0.24},
+            {"name": "wall_thickness", "label": "Wandstärke", "type": "number",
+             "unit": "mm", "required": True, "min": 0.1, "max": 5.0, "default": 0.42},
+            {"name": "rel_gap_wall_thickness", "label": "Spalt-Wandstärke (rel.)", "type": "number",
+             "required": True, "min": 0.01, "max": 0.5, "default": 0.075},
+        ],
+    },
+    {
         "name": "generic", "label": "Generic",
         "description": "Free-form type with no structured schema",
         "schema": [],

--- a/app/services/construction_plan_service.py
+++ b/app/services/construction_plan_service.py
@@ -1,0 +1,332 @@
+"""Service layer for Construction Plans (gh#101)."""
+from __future__ import annotations
+
+import inspect
+import json
+import logging
+import time
+from typing import Any
+
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import InternalError, NotFoundError, ValidationError
+from app.models.construction_plan import ConstructionPlanModel
+from app.schemas.construction_plan import (
+    CreatorInfo,
+    CreatorParam,
+    ExecuteRequest,
+    ExecutionResult,
+    PlanCreate,
+    PlanRead,
+    PlanSummary,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ── Helpers ─────────────────────────────────────────────────────
+
+
+def _count_steps(tree_json: dict) -> int:
+    """Recursively count ConstructionStepNode entries in a tree."""
+    count = 0
+    for node in (tree_json.get("successors") or {}).values():
+        count += 1
+        count += _count_steps(node)
+    return count
+
+
+def _to_summary(plan: ConstructionPlanModel) -> PlanSummary:
+    return PlanSummary(
+        id=plan.id,
+        name=plan.name,
+        description=plan.description,
+        step_count=_count_steps(plan.tree_json or {}),
+        created_at=plan.created_at,
+    )
+
+
+def _to_read(plan: ConstructionPlanModel) -> PlanRead:
+    return PlanRead.model_validate(plan, from_attributes=True)
+
+
+def _validate_tree_json(tree_json: dict) -> None:
+    """Minimal validation: root must have $TYPE and creator_id."""
+    if "$TYPE" not in tree_json:
+        raise ValidationError(
+            message="tree_json must contain a '$TYPE' field at the root level.",
+        )
+    if "creator_id" not in tree_json:
+        raise ValidationError(
+            message="tree_json must contain a 'creator_id' field at the root level.",
+        )
+
+
+# ── CRUD ────────────────────────────────────────────────────────
+
+
+def list_plans(db: Session) -> list[PlanSummary]:
+    try:
+        plans = db.query(ConstructionPlanModel).order_by(ConstructionPlanModel.id).all()
+        return [_to_summary(p) for p in plans]
+    except SQLAlchemyError as e:
+        logger.error("DB error listing plans: %s", e)
+        raise InternalError(message=f"Database error: {e}")
+
+
+def get_plan(db: Session, plan_id: int) -> PlanRead:
+    try:
+        plan = db.get(ConstructionPlanModel, plan_id)
+        if plan is None:
+            raise NotFoundError(entity="Construction plan", resource_id=plan_id)
+        return _to_read(plan)
+    except NotFoundError:
+        raise
+    except SQLAlchemyError as e:
+        logger.error("DB error getting plan %s: %s", plan_id, e)
+        raise InternalError(message=f"Database error: {e}")
+
+
+def create_plan(db: Session, data: PlanCreate) -> PlanRead:
+    _validate_tree_json(data.tree_json)
+    try:
+        plan = ConstructionPlanModel(
+            name=data.name,
+            description=data.description,
+            tree_json=data.tree_json,
+        )
+        db.add(plan)
+        db.commit()
+        db.refresh(plan)
+        return _to_read(plan)
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error("DB error creating plan: %s", e)
+        raise InternalError(message=f"Database error: {e}")
+
+
+def update_plan(db: Session, plan_id: int, data: PlanCreate) -> PlanRead:
+    _validate_tree_json(data.tree_json)
+    try:
+        plan = db.get(ConstructionPlanModel, plan_id)
+        if plan is None:
+            raise NotFoundError(entity="Construction plan", resource_id=plan_id)
+        plan.name = data.name
+        plan.description = data.description
+        plan.tree_json = data.tree_json
+        db.commit()
+        db.refresh(plan)
+        return _to_read(plan)
+    except NotFoundError:
+        raise
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error("DB error updating plan %s: %s", plan_id, e)
+        raise InternalError(message=f"Database error: {e}")
+
+
+def delete_plan(db: Session, plan_id: int) -> None:
+    try:
+        plan = db.get(ConstructionPlanModel, plan_id)
+        if plan is None:
+            raise NotFoundError(entity="Construction plan", resource_id=plan_id)
+        db.delete(plan)
+        db.commit()
+    except NotFoundError:
+        raise
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error("DB error deleting plan %s: %s", plan_id, e)
+        raise InternalError(message=f"Database error: {e}")
+
+
+# ── Creator Catalog ─────────────────────────────────────────────
+
+
+_INTERNAL_PARAMS = {"self", "loglevel", "kwargs"}
+
+_CATEGORY_MAP = {
+    "wing": "wing",
+    "fuselage": "fuselage",
+    "cad_operations": "cad_operations",
+    "export_import": "export_import",
+    "components": "components",
+}
+
+
+def _get_category(cls: type) -> str:
+    module = cls.__module__ or ""
+    for key, category in _CATEGORY_MAP.items():
+        if f".creator.{key}" in module:
+            return category
+    return "other"
+
+
+def _type_to_str(annotation: Any) -> str:
+    if annotation is inspect.Parameter.empty:
+        return "any"
+    if hasattr(annotation, "__name__"):
+        return annotation.__name__
+    return str(annotation).replace("typing.", "")
+
+
+def list_creators() -> list[CreatorInfo]:
+    """Reflect over all AbstractShapeCreator subclasses and return metadata."""
+    try:
+        from cad_designer.airplane.AbstractShapeCreator import AbstractShapeCreator
+    except ImportError:
+        logger.warning("cad_designer not available — returning empty creator list")
+        return []
+
+    # Import creator modules to register all subclasses
+    try:
+        import cad_designer.airplane.creator  # noqa: F401
+    except ImportError:
+        pass
+
+    result: list[CreatorInfo] = []
+    seen: set[str] = set()
+
+    for cls in AbstractShapeCreator.__subclasses__():
+        _collect_creators(cls, result, seen)
+
+    result.sort(key=lambda c: (c.category, c.class_name))
+    return result
+
+
+def _collect_creators(cls: type, result: list[CreatorInfo], seen: set[str]) -> None:
+    """Recursively collect creator classes from the inheritance tree."""
+    name = cls.__name__
+    if name in seen or name in ("ConstructionRootNode", "ConstructionStepNode", "JSONStepNode"):
+        seen.add(name)
+        # Still recurse for subclasses
+        for sub in cls.__subclasses__():
+            _collect_creators(sub, result, seen)
+        return
+
+    seen.add(name)
+
+    sig = inspect.signature(cls.__init__)
+    params: list[CreatorParam] = []
+    for pname, param in sig.parameters.items():
+        if pname in _INTERNAL_PARAMS:
+            continue
+        params.append(CreatorParam(
+            name=pname,
+            type=_type_to_str(param.annotation),
+            default=param.default if param.default is not inspect.Parameter.empty else None,
+            required=param.default is inspect.Parameter.empty,
+        ))
+
+    docstring = (cls.__doc__ or "").strip().split("\n")[0] if cls.__doc__ else None
+
+    result.append(CreatorInfo(
+        class_name=name,
+        category=_get_category(cls),
+        description=docstring,
+        parameters=params,
+    ))
+
+    for sub in cls.__subclasses__():
+        _collect_creators(sub, result, seen)
+
+
+# ── Execute ─────────────────────────────────────────────────────
+
+
+def execute_plan(
+    db: Session,
+    plan_id: int,
+    request: ExecuteRequest,
+) -> ExecutionResult:
+    """Execute a plan against an aeroplane configuration."""
+    from app.services.wing_service import get_aeroplane_or_raise, get_wing_or_raise
+    from app.converters.model_schema_converters import wingModelToWingConfig
+
+    # Load plan
+    plan = db.get(ConstructionPlanModel, plan_id)
+    if plan is None:
+        raise NotFoundError(entity="Construction plan", resource_id=plan_id)
+
+    # Load aeroplane
+    aeroplane = get_aeroplane_or_raise(db, request.aeroplane_id)
+
+    # Build wing_config map: all wings
+    wing_config: dict = {}
+    for wing in aeroplane.wings:
+        try:
+            wc = wingModelToWingConfig(wing, scale=1000.0)
+            wing_config[wing.name] = wc
+        except Exception as exc:
+            logger.warning("Failed to convert wing '%s': %s", wing.name, exc)
+
+    # Load printer_settings from component library (if available)
+    printer_settings = _load_printer_settings(db)
+
+    # Decode tree_json with GeneralJSONDecoder
+    try:
+        from cad_designer.airplane.GeneralJSONEncoderDecoder import GeneralJSONDecoder
+
+        json_string = json.dumps(plan.tree_json)
+        t0 = time.monotonic()
+        root_node = json.loads(
+            json_string,
+            cls=GeneralJSONDecoder,
+            wing_config=wing_config,
+            printer_settings=printer_settings,
+            servo_information={},
+            engine_information=None,
+            component_information=None,
+        )
+    except Exception as exc:
+        raise ValidationError(
+            message=f"Failed to decode construction plan: {exc}",
+        )
+
+    # Execute
+    try:
+        structure = root_node.create_shape()
+        duration_ms = int((time.monotonic() - t0) * 1000)
+    except Exception as exc:
+        duration_ms = int((time.monotonic() - t0) * 1000)
+        return ExecutionResult(
+            status="error",
+            error=str(exc),
+            duration_ms=duration_ms,
+        )
+
+    shape_keys = list(structure.keys()) if isinstance(structure, dict) else []
+
+    return ExecutionResult(
+        status="success",
+        shape_keys=shape_keys,
+        duration_ms=duration_ms,
+    )
+
+
+def _load_printer_settings(db: Session):
+    """Try to load Printer3dSettings from a component of type 'printer_settings'."""
+    try:
+        from app.models.component import ComponentModel
+        comp = (
+            db.query(ComponentModel)
+            .filter(ComponentModel.component_type == "printer_settings")
+            .first()
+        )
+        if comp and comp.specs:
+            from cad_designer.airplane.aircraft_topology.printer3d import Printer3dSettings
+            return Printer3dSettings(
+                layer_height=float(comp.specs.get("layer_height", 0.24)),
+                wall_thickness=float(comp.specs.get("wall_thickness", 0.42)),
+                rel_gap_wall_thickness=float(comp.specs.get("rel_gap_wall_thickness", 0.075)),
+            )
+    except Exception as exc:
+        logger.warning("Could not load printer_settings: %s", exc)
+
+    # Fallback defaults
+    try:
+        from cad_designer.airplane.aircraft_topology.printer3d import Printer3dSettings
+        return Printer3dSettings(layer_height=0.24, wall_thickness=0.42, rel_gap_wall_thickness=0.075)
+    except ImportError:
+        return None

--- a/app/tests/test_component_type_delete_cascade_bug.py
+++ b/app/tests/test_component_type_delete_cascade_bug.py
@@ -20,7 +20,7 @@ class TestDeleteDoesNotCascade:
         # Baseline: 9 seeded types
         before = client.get("/component-types").json()
         seeded_ids = {t["id"] for t in before}
-        assert len(seeded_ids) == 9
+        assert len(seeded_ids) == 10
 
         # Create two user types
         ut1 = client.post("/component-types", json={
@@ -31,7 +31,7 @@ class TestDeleteDoesNotCascade:
         }).json()
 
         mid = client.get("/component-types").json()
-        assert len(mid) == 11
+        assert len(mid) == 12
 
         # Delete the second user type
         res = client.delete(f"/component-types/{ut2['id']}")
@@ -41,8 +41,8 @@ class TestDeleteDoesNotCascade:
         after = client.get("/component-types").json()
         remaining_ids = {t["id"] for t in after}
 
-        assert len(after) == 10, (
-            f"Expected 10 types after deleting one, got {len(after)}. "
+        assert len(after) == 11, (
+            f"Expected 11 types after deleting one, got {len(after)}. "
             f"Remaining: {[t['name'] for t in after]}"
         )
         assert ut1["id"] in remaining_ids

--- a/app/tests/test_component_types_end_to_end.py
+++ b/app/tests/test_component_types_end_to_end.py
@@ -42,7 +42,7 @@ class TestRowCountInvariants:
 
     def test_seed_produces_exactly_9_rows(self, client_and_db):
         _, sf = client_and_db
-        assert _count_types_in_db(sf) == 9
+        assert _count_types_in_db(sf) == 10
 
     def test_create_adds_exactly_one_row(self, client_and_db):
         client, sf = client_and_db
@@ -150,7 +150,7 @@ class TestLifecycleRoundTrip:
         assert client.get(f"/component-types/{created['id']}").status_code == 404
 
         # DB state: 9 seeded types, user type gone
-        assert _count_types_in_db(sf) == 9
+        assert _count_types_in_db(sf) == 10
 
 
 # --------------------------------------------------------------------------- #
@@ -238,7 +238,7 @@ class TestMultipleMutations:
             created_ids.append(r.json()["id"])
 
         before = _count_types_in_db(sf)
-        assert before == 9 + 5
+        assert before == 10 + 5
 
         # Delete just one
         res = client.delete(f"/component-types/{created_ids[2]}")

--- a/app/tests/test_components_catalog.py
+++ b/app/tests/test_components_catalog.py
@@ -17,7 +17,7 @@ class TestComponentTypes:
         assert "material" in types
         assert "propeller" in types
         assert "generic" in types
-        assert len(types) == 9
+        assert len(types) == 10
 
 
 class TestComponentCRUDExtended:

--- a/app/tests/test_construction_plans.py
+++ b/app/tests/test_construction_plans.py
@@ -1,0 +1,250 @@
+"""Tests for Construction Plans CRUD + Creator Catalog + Execute (gh#101).
+
+Covers sub-tickets #109 (DB model), #110 (CRUD), #111 (creators), #112 (execute).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture()
+def client(client_and_db):
+    c, _ = client_and_db
+    yield c
+
+
+SAMPLE_TREE = {
+    "$TYPE": "ConstructionRootNode",
+    "creator_id": "test_root",
+    "successors": {},
+}
+
+TREE_3_STEPS = {
+    "$TYPE": "ConstructionRootNode",
+    "creator_id": "root",
+    "successors": {
+        "step_a": {
+            "$TYPE": "ConstructionStepNode",
+            "creator": {"$TYPE": "Fuse2ShapesCreator", "creator_id": "step_a"},
+            "successors": {
+                "step_b": {
+                    "$TYPE": "ConstructionStepNode",
+                    "creator": {"$TYPE": "Fuse2ShapesCreator", "creator_id": "step_b"},
+                    "successors": {},
+                }
+            },
+        },
+        "step_c": {
+            "$TYPE": "ConstructionStepNode",
+            "creator": {"$TYPE": "ExportToStepCreator", "creator_id": "step_c"},
+            "successors": {},
+        },
+    },
+}
+
+
+def _create_plan(client: TestClient, name: str, tree: dict = None) -> dict:
+    resp = client.post(
+        "/construction-plans",
+        json={"name": name, "tree_json": tree or SAMPLE_TREE},
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+# ── CRUD Tests (#110) ───────────────────────────────────────────
+
+
+class TestConstructionPlansCRUD:
+    def test_create_plan(self, client):
+        """POST → 201 with id."""
+        plan = _create_plan(client, "Build A")
+        assert plan["id"] is not None
+        assert plan["name"] == "Build A"
+        assert plan["tree_json"] == SAMPLE_TREE
+
+    def test_list_plans(self, client):
+        """GET → list with all plans."""
+        _create_plan(client, "Plan A")
+        _create_plan(client, "Plan B")
+        resp = client.get("/construction-plans")
+        assert resp.status_code == 200
+        plans = resp.json()
+        assert len(plans) >= 2
+
+    def test_list_plans_includes_step_count(self, client):
+        """GET list → step_count correctly computed from tree."""
+        _create_plan(client, "ThreeSteps", TREE_3_STEPS)
+        plans = client.get("/construction-plans").json()
+        plan = next(p for p in plans if p["name"] == "ThreeSteps")
+        assert plan["step_count"] == 3
+
+    def test_get_plan_by_id(self, client):
+        """GET /{id} → full tree_json."""
+        plan = _create_plan(client, "Detail")
+        resp = client.get(f"/construction-plans/{plan['id']}")
+        assert resp.status_code == 200
+        assert resp.json()["tree_json"] == SAMPLE_TREE
+
+    def test_update_plan(self, client):
+        """PUT → name + tree_json updated."""
+        plan = _create_plan(client, "Original")
+        updated_tree = {**SAMPLE_TREE, "creator_id": "updated_root"}
+        resp = client.put(
+            f"/construction-plans/{plan['id']}",
+            json={"name": "Updated", "tree_json": updated_tree},
+        )
+        assert resp.status_code == 200
+        reloaded = client.get(f"/construction-plans/{plan['id']}").json()
+        assert reloaded["name"] == "Updated"
+        assert reloaded["tree_json"]["creator_id"] == "updated_root"
+
+    def test_delete_plan(self, client):
+        """DELETE → 204, then GET → 404."""
+        plan = _create_plan(client, "ToDelete")
+        resp = client.delete(f"/construction-plans/{plan['id']}")
+        assert resp.status_code == 204
+        assert client.get(f"/construction-plans/{plan['id']}").status_code == 404
+
+    def test_get_nonexistent_plan(self, client):
+        """GET /999 → 404."""
+        assert client.get("/construction-plans/999").status_code == 404
+
+    def test_create_without_name_fails(self, client):
+        """POST without name → 422."""
+        resp = client.post("/construction-plans", json={"tree_json": SAMPLE_TREE})
+        assert resp.status_code == 422
+
+    def test_create_without_type_fails(self, client):
+        """POST with tree_json missing $TYPE → 422."""
+        resp = client.post(
+            "/construction-plans",
+            json={"name": "bad", "tree_json": {"creator_id": "x"}},
+        )
+        assert resp.status_code == 422
+
+    def test_duplicate_name_allowed(self, client):
+        """Two plans with same name → both 201."""
+        _create_plan(client, "Same")
+        resp = client.post(
+            "/construction-plans",
+            json={"name": "Same", "tree_json": SAMPLE_TREE},
+        )
+        assert resp.status_code == 201
+
+
+# ── Creator Catalog Tests (#111) ────────────────────────────────
+
+
+class TestCreatorCatalog:
+    def test_list_creators_returns_many(self, client):
+        """GET /creators → at least 20 creators."""
+        resp = client.get("/construction-plans/creators")
+        assert resp.status_code == 200
+        creators = resp.json()
+        assert len(creators) >= 20
+
+    def test_known_creators_present(self, client):
+        """Key creators are in the list."""
+        creators = client.get("/construction-plans/creators").json()
+        names = {c["class_name"] for c in creators}
+        assert "VaseModeWingCreator" in names
+        assert "ExportToStepCreator" in names
+        assert "Fuse2ShapesCreator" in names
+        assert "FuselageShellShapeCreator" in names
+
+    def test_creator_has_parameters(self, client):
+        """VaseModeWingCreator has expected parameters."""
+        creators = client.get("/construction-plans/creators").json()
+        vase = next(c for c in creators if c["class_name"] == "VaseModeWingCreator")
+        param_names = {p["name"] for p in vase["parameters"]}
+        assert "creator_id" in param_names
+        assert "wing_index" in param_names
+        assert "leading_edge_offset_factor" in param_names
+
+    def test_creator_categories(self, client):
+        """All 5 categories present."""
+        creators = client.get("/construction-plans/creators").json()
+        categories = {c["category"] for c in creators}
+        assert categories >= {"wing", "fuselage", "cad_operations", "export_import", "components"}
+
+    def test_excludes_internal_params(self, client):
+        """self, loglevel, kwargs not in parameters."""
+        for c in client.get("/construction-plans/creators").json():
+            param_names = {p["name"] for p in c["parameters"]}
+            assert "self" not in param_names
+            assert "loglevel" not in param_names
+
+    def test_excludes_infrastructure_classes(self, client):
+        """ConstructionRootNode, ConstructionStepNode, JSONStepNode not listed."""
+        creators = client.get("/construction-plans/creators").json()
+        names = {c["class_name"] for c in creators}
+        assert "ConstructionRootNode" not in names
+        assert "ConstructionStepNode" not in names
+        assert "JSONStepNode" not in names
+
+
+# ── Execute Tests (#112) ────────────────────────────────────────
+
+
+class TestPlanExecution:
+    def test_execute_nonexistent_plan(self, client):
+        """POST execute on plan 999 → 404."""
+        resp = client.post(
+            "/construction-plans/999/execute",
+            json={"aeroplane_id": "00000000-0000-0000-0000-000000000000"},
+        )
+        assert resp.status_code == 404
+
+    def test_execute_nonexistent_aeroplane(self, client):
+        """POST execute with unknown aeroplane → 404."""
+        plan = _create_plan(client, "exec_404")
+        resp = client.post(
+            f"/construction-plans/{plan['id']}/execute",
+            json={"aeroplane_id": "00000000-0000-0000-0000-000000000000"},
+        )
+        assert resp.status_code == 404
+
+    def test_execute_plan_with_invalid_creator_returns_error(self, client):
+        """Plan with unknown creator type → decode error → 422."""
+        bad_tree = {
+            "$TYPE": "ConstructionRootNode",
+            "creator_id": "root",
+            "successors": {
+                "bad": {
+                    "$TYPE": "NonExistentCreator",
+                    "creator_id": "bad",
+                    "successors": {},
+                }
+            },
+        }
+        plan = _create_plan(client, "bad_plan", bad_tree)
+        # Need an aeroplane
+        resp = client.post("/aeroplanes", params={"name": "exec_test"})
+        assert resp.status_code == 201
+        aid = resp.json()["id"]
+
+        resp = client.post(
+            f"/construction-plans/{plan['id']}/execute",
+            json={"aeroplane_id": aid},
+        )
+        assert resp.status_code == 422
+
+
+# ── Printer Settings Seed (#115) ────────────────────────────────
+
+
+class TestPrinterSettingsSeed:
+    def test_printer_settings_type_seeded(self, client):
+        """GET /component-types contains printer_settings with 3 properties."""
+        resp = client.get("/component-types")
+        assert resp.status_code == 200
+        types = resp.json()
+        ps = next((t for t in types if t["name"] == "printer_settings"), None)
+        assert ps is not None
+        assert len(ps["schema"]) == 3
+        prop_names = {p["name"] for p in ps["schema"]}
+        assert prop_names == {"layer_height", "wall_thickness", "rel_gap_wall_thickness"}


### PR DESCRIPTION
## Summary

Complete backend implementation for JSON-defined construction workflows:

- **CRUD API** for construction plans (5 endpoints)
- **Creator Catalog** reflecting all 29 AbstractShapeCreator subclasses with parameters
- **Execute Endpoint** that runs a plan against an aeroplane configuration
- **PrinterSettings** as new Component Library type for VaseModeWingCreator

Closes #109, #110, #111, #112, #115. Part of epic #101.

## New Endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | `/construction-plans` | List all plans (with step_count) |
| POST | `/construction-plans` | Create a plan |
| GET | `/construction-plans/{id}` | Get plan with full tree_json |
| PUT | `/construction-plans/{id}` | Update plan |
| DELETE | `/construction-plans/{id}` | Delete plan |
| GET | `/construction-plans/creators` | List all 29 Creator classes |
| POST | `/construction-plans/{id}/execute` | Execute plan against aeroplane |

## Test plan

- [x] `poetry run ruff check .` — clean
- [x] `poetry run pytest -m "not slow"` — **426 passed** (+20 new)
- [x] CRUD: 10 tests (create, list, get, update, delete, 404, 422, validation, duplicates, step_count)
- [x] Creators: 6 tests (count, known names, parameters, categories, exclusions)
- [x] Execute: 3 tests (404 plan, 404 aeroplane, invalid creator → 422)
- [x] PrinterSettings: 1 test (seed type with 3 properties)

🤖 Generated with [Claude Code](https://claude.com/claude-code)