### PR TITLE
fix(#127,#66): scroll overflow chains + config panel width

### DIFF
--- a/frontend/app/workbench/analysis/page.tsx
+++ b/frontend/app/workbench/analysis/page.tsx
@@ -12,7 +12,7 @@ export default function AnalysisPage() {
   const analysis = useAnalysis(aeroplaneId);
 
   return (
-    <Group orientation="horizontal" className="flex-1">
+    <Group orientation="horizontal" className="h-full min-h-0 flex-1">
       <Panel defaultSize={55} minSize={20}>
         <AnalysisViewerPanel
           result={analysis.result}

--- a/frontend/app/workbench/components/page.tsx
+++ b/frontend/app/workbench/components/page.tsx
@@ -67,7 +67,7 @@ export default function ComponentsPage() {
         onNodeEditRequested={(n: ComponentTreeNode) => setEditingNodeId(n.id)}
       />
 
-      <div className="flex w-full flex-col gap-4 overflow-y-auto">
+      <div className="flex min-h-0 w-full flex-1 flex-col gap-4 overflow-y-auto">
         {/* View Toggle */}
         <div className="flex items-center gap-1 rounded-full border border-border bg-card p-1 self-start">
           <button

--- a/frontend/app/workbench/construction-plans/page.tsx
+++ b/frontend/app/workbench/construction-plans/page.tsx
@@ -422,7 +422,7 @@ export default function ConstructionPlansPage() {
         </div>
 
         {/* Right panel: gallery, detail view, or param editor */}
-        <div className="flex w-full flex-col gap-4 overflow-y-auto">
+        <div className="flex min-h-0 w-full flex-1 flex-col gap-4 overflow-y-auto">
           <div className="flex items-center gap-2.5">
             <Hammer className="size-5 text-primary" />
             <h1 className="font-[family-name:var(--font-jetbrains-mono)] text-[20px] text-foreground">

--- a/frontend/app/workbench/page.tsx
+++ b/frontend/app/workbench/page.tsx
@@ -68,7 +68,7 @@ export default function WorkbenchPage() {
 
       {/* Config Panel — shrinks to content, max 420px */}
       {!viewerMaximized && (
-        <div className="flex h-full min-h-0 w-[380px] shrink-0 flex-col overflow-hidden">
+        <div className="flex h-full min-h-0 w-[340px] shrink-0 flex-col overflow-hidden">
           <ConfigPanel
             aeroplaneId={aeroplaneId}
             onGeometryChanged={preview.invalidateWing}

--- a/frontend/components/workbench/WorkbenchTwoPanel.tsx
+++ b/frontend/components/workbench/WorkbenchTwoPanel.tsx
@@ -9,11 +9,11 @@ interface WorkbenchTwoPanelProps {
 export function WorkbenchTwoPanel({ leftWidth = 360, children, className }: WorkbenchTwoPanelProps) {
   const childArray = React.Children.toArray(children);
   return (
-    <div className={`flex flex-1 gap-4 overflow-hidden${className ? ` ${className}` : ""}`}>
-      <div style={{ width: leftWidth, minWidth: leftWidth }} className="shrink-0 overflow-hidden">
+    <div className={`flex h-full min-h-0 flex-1 gap-4 overflow-hidden${className ? ` ${className}` : ""}`}>
+      <div style={{ width: leftWidth, minWidth: leftWidth }} className="flex min-h-0 shrink-0 flex-col overflow-hidden">
         {childArray[0]}
       </div>
-      <div className="flex-1 overflow-hidden">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         {childArray[1]}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Fix broken flex height chains in 4 files — each panel now scrolls independently
- Reduce config panel width from 380px to 340px
- Header + CopilotStrip stay fixed, content scrolls between them

Closes #127, Closes #66

## Test plan
- [x] `npx vitest run` — 227 passed