### PR TITLE
feat(#114,#124): modal config dialogs for Construction + Analysis tabs

### DIFF
--- a/frontend/app/workbench/analysis/page.tsx
+++ b/frontend/app/workbench/analysis/page.tsx
@@ -1,30 +1,66 @@
 "use client";
 
-import { Group, Panel } from "react-resizable-panels";
+import { useState } from "react";
+import { Settings, X } from "lucide-react";
 import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
 import { useAnalysis } from "@/hooks/useAnalysis";
 import { AnalysisViewerPanel } from "@/components/workbench/AnalysisViewerPanel";
 import { AnalysisConfigPanel } from "@/components/workbench/AnalysisConfigPanel";
-import { SplitHandle } from "@/components/workbench/SplitHandle";
 
 export default function AnalysisPage() {
   const { aeroplaneId } = useAeroplaneContext();
   const analysis = useAnalysis(aeroplaneId);
+  const [configOpen, setConfigOpen] = useState(false);
 
   return (
-    <Group orientation="horizontal" className="h-full min-h-0 flex-1">
-      <Panel defaultSize={55} minSize={20}>
-        <AnalysisViewerPanel
-          result={analysis.result}
-          aeroplaneId={aeroplaneId}
-          lastRunTime={analysis.lastRunTime}
-          lastRunDurationMs={analysis.lastRunDurationMs}
-        />
-      </Panel>
-      <SplitHandle />
-      <Panel defaultSize={45} minSize={25}>
-        <AnalysisConfigPanel analysis={analysis} />
-      </Panel>
-    </Group>
+    <>
+      <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
+        {/* Config button */}
+        <div className="flex shrink-0 items-center justify-end px-2 py-1">
+          <button
+            onClick={() => setConfigOpen(true)}
+            className="flex items-center gap-1.5 rounded-full border border-border bg-card-muted px-3 py-1.5 text-[12px] text-foreground hover:bg-sidebar-accent"
+          >
+            <Settings size={12} />
+            Configure & Run
+          </button>
+        </div>
+        {/* Viewer fills remaining space */}
+        <div className="min-h-0 flex-1 overflow-hidden">
+          <AnalysisViewerPanel
+            result={analysis.result}
+            aeroplaneId={aeroplaneId}
+            lastRunTime={analysis.lastRunTime}
+            lastRunDurationMs={analysis.lastRunDurationMs}
+          />
+        </div>
+      </div>
+
+      {/* Config Modal */}
+      {configOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+          onClick={() => setConfigOpen(false)}
+        >
+          <div
+            className="flex max-h-[85vh] w-[480px] flex-col gap-4 overflow-y-auto rounded-2xl border border-border bg-card p-6 shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between">
+              <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
+                Analysis Configuration
+              </h2>
+              <button
+                onClick={() => setConfigOpen(false)}
+                className="flex size-6 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent"
+              >
+                <X size={14} />
+              </button>
+            </div>
+            <AnalysisConfigPanel analysis={analysis} />
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/frontend/app/workbench/page.tsx
+++ b/frontend/app/workbench/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useState } from "react";
+import { X } from "lucide-react";
 import { ViewerPanel } from "@/components/workbench/ViewerPanel";
-import { ConfigPanel } from "@/components/workbench/ConfigPanel";
+import { PropertyForm } from "@/components/workbench/PropertyForm";
+import { ActionRow } from "@/components/workbench/ActionRow";
 import { AeroplaneTree } from "@/components/workbench/AeroplaneTree";
 import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
 import { useAeroplanes } from "@/hooks/useAeroplanes";
@@ -21,6 +23,7 @@ export default function WorkbenchPage() {
 
   const [treeOpen, setTreeOpen] = useState(true);
   const [viewerMaximized, setViewerMaximized] = useState(false);
+  const [configOpen, setConfigOpen] = useState(false);
 
   if (!aeroplaneId) {
     return <AeroplaneSelector
@@ -35,48 +38,72 @@ export default function WorkbenchPage() {
   }
 
   return (
-    <div className="flex h-full min-h-0 flex-1 gap-4 overflow-hidden">
-      {/* Tree Panel — collapsible, fixed width, scrollable */}
-      {treeOpen && !viewerMaximized && (
-        <div className="flex h-full min-h-0 w-[320px] shrink-0 flex-col overflow-hidden">
-          <AeroplaneTree
-            aeroplaneId={aeroplaneId}
-            wingNames={wingNames}
-            fuselageNames={fuselageNames}
-            aeroplaneName={aeroplaneName}
-            isWingVisible={preview.isWingVisible}
-            isWingLoading={(wn) => preview.previews[wn]?.loading ?? false}
-            onTogglePreview={preview.toggleWing}
-            onToggleAllPreview={preview.toggleAllWings}
-            onCollapseTree={() => setTreeOpen(false)}
+    <>
+      <div className="flex h-full min-h-0 flex-1 gap-4 overflow-hidden">
+        {/* Tree Panel — collapsible, fixed width, scrollable */}
+        {treeOpen && !viewerMaximized && (
+          <div className="flex h-full min-h-0 w-[320px] shrink-0 flex-col overflow-hidden">
+            <AeroplaneTree
+              aeroplaneId={aeroplaneId}
+              wingNames={wingNames}
+              fuselageNames={fuselageNames}
+              aeroplaneName={aeroplaneName}
+              isWingVisible={preview.isWingVisible}
+              isWingLoading={(wn) => preview.previews[wn]?.loading ?? false}
+              onTogglePreview={preview.toggleWing}
+              onToggleAllPreview={preview.toggleAllWings}
+              onCollapseTree={() => setTreeOpen(false)}
+              onNodeEdit={() => setConfigOpen(true)}
+              actionSlot={
+                <ActionRow
+                  aeroplaneId={aeroplaneId}
+                  onFuselageSaved={() => mutateFuselages()}
+                />
+              }
+            />
+          </div>
+        )}
+
+        {/* Viewer Panel — fills remaining space */}
+        <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
+          <ViewerPanel
+            visibleParts={preview.visibleParts}
+            isAnyLoading={preview.isAnyLoading}
+            loadingWing={preview.loadingWing}
+            isMaximized={viewerMaximized}
+            onToggleMaximize={() => setViewerMaximized((m) => !m)}
+            isTreeCollapsed={!treeOpen}
+            onExpandTree={() => setTreeOpen(true)}
           />
         </div>
-      )}
-
-      {/* Viewer Panel — fills remaining space */}
-      <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
-        <ViewerPanel
-          visibleParts={preview.visibleParts}
-          isAnyLoading={preview.isAnyLoading}
-          loadingWing={preview.loadingWing}
-          isMaximized={viewerMaximized}
-          onToggleMaximize={() => setViewerMaximized((m) => !m)}
-          isTreeCollapsed={!treeOpen}
-          onExpandTree={() => setTreeOpen(true)}
-        />
       </div>
 
-      {/* Config Panel — shrinks to content, max 420px */}
-      {!viewerMaximized && (
-        <div className="flex h-full min-h-0 w-[340px] shrink-0 flex-col overflow-hidden">
-          <ConfigPanel
-            aeroplaneId={aeroplaneId}
-            onGeometryChanged={preview.invalidateWing}
-            onFuselageSaved={() => mutateFuselages()}
-          />
+      {/* Configuration Modal */}
+      {configOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+          onClick={() => setConfigOpen(false)}
+        >
+          <div
+            className="flex max-h-[85vh] w-[480px] flex-col gap-4 overflow-y-auto rounded-2xl border border-border bg-card p-6 shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between">
+              <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
+                Configuration
+              </h2>
+              <button
+                onClick={() => setConfigOpen(false)}
+                className="flex size-6 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent"
+              >
+                <X size={14} />
+              </button>
+            </div>
+            <PropertyForm onGeometryChanged={preview.invalidateWing} />
+          </div>
         </div>
       )}
-    </div>
+    </>
   );
 }
 

--- a/frontend/components/workbench/AeroplaneTree.tsx
+++ b/frontend/components/workbench/AeroplaneTree.tsx
@@ -255,11 +255,13 @@ interface AeroplaneTreeProps {
   onTogglePreview?: (wingName: string) => void;
   onToggleAllPreview?: (wingNames: string[]) => void;
   onCollapseTree?: () => void;
+  onNodeEdit?: () => void;
+  actionSlot?: React.ReactNode;
 }
 
 // ── Component ───────────────────────────────────────────────────
 
-export function AeroplaneTree({ aeroplaneId, wingNames, fuselageNames = [], aeroplaneName, isWingVisible, isWingLoading, onTogglePreview, onToggleAllPreview, onCollapseTree }: AeroplaneTreeProps) {
+export function AeroplaneTree({ aeroplaneId, wingNames, fuselageNames = [], aeroplaneName, isWingVisible, isWingLoading, onTogglePreview, onToggleAllPreview, onCollapseTree, onNodeEdit, actionSlot }: AeroplaneTreeProps) {
   const { selectedWing, selectedXsecIndex, selectWing, selectXsec, selectedFuselage, selectedFuselageXsecIndex, selectFuselage, selectFuselageXsec, treeMode, setTreeMode } =
     useAeroplaneContext();
   const { wing, isLoading, mutate: mutateWing } = useWing(aeroplaneId, selectedWing);
@@ -500,13 +502,20 @@ export function AeroplaneTree({ aeroplaneId, wingNames, fuselageNames = [], aero
         </button>
       </div>
 
+      {/* Action slot (add wing / fuselage buttons) */}
+      {actionSlot && (
+        <div className="mb-2">
+          {actionSlot}
+        </div>
+      )}
+
       {/* Tree rows */}
       <div className="flex flex-1 flex-col gap-0.5 overflow-y-auto">
         {isLoading && wingNames.length === 0 ? (
           <span className="text-[13px] text-muted-foreground">Loading...</span>
         ) : (
           treeData.map((node) => (
-            <TreeRow key={node.id} node={node} onToggle={() => toggleExpand(node.id)} />
+            <TreeRow key={node.id} node={node} onToggle={() => toggleExpand(node.id)} onNodeEdit={onNodeEdit} />
           ))
         )}
       </div>
@@ -516,7 +525,7 @@ export function AeroplaneTree({ aeroplaneId, wingNames, fuselageNames = [], aero
 
 // ── TreeRow ─────────────────────────────────────────────────────
 
-function TreeRow({ node, onToggle }: { node: TreeNode; onToggle: () => void }) {
+function TreeRow({ node, onToggle, onNodeEdit }: { node: TreeNode; onToggle: () => void; onNodeEdit?: () => void }) {
   if (node.isInsertPoint) {
     return (
       <div
@@ -542,6 +551,7 @@ function TreeRow({ node, onToggle }: { node: TreeNode; onToggle: () => void }) {
   function handleClick() {
     if (!isLeaf) onToggle();
     node.onClick?.();
+    if (node.onClick && onNodeEdit) onNodeEdit();
   }
 
   return (


### PR DESCRIPTION
## Summary

### #114 Construction Tab
- 3-panel → 2-panel layout (Tree | Viewer)
- PropertyForm opens as modal on tree node click
- +Wing/+Fuselage buttons moved to AeroplaneTree header via `actionSlot` prop

### #124 Analysis Tab
- Resizable 2-panel → single full-width Viewer
- "Configure & Run" button opens AnalysisConfigPanel as modal

All tabs now follow the same pattern: content area + modal config.

Closes #114, Closes #124

## Test plan
- [x] `npx vitest run` — 227 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)