### PR TITLE
feat(#126): Template/Plan duality for Construction Plans

### DIFF
--- a/alembic/versions/c4d5e6f7a8b9_add_plan_type_and_aeroplane_id.py
+++ b/alembic/versions/c4d5e6f7a8b9_add_plan_type_and_aeroplane_id.py
@@ -1,0 +1,39 @@
+"""Add plan_type and aeroplane_id to construction_plans
+
+Revision ID: c4d5e6f7a8b9
+Revises: b3e2f1a4c7d9
+Create Date: 2026-04-18
+"""
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "c4d5e6f7a8b9"
+down_revision: Union[str, None] = "b3e2f1a4c7d9"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "construction_plans",
+        sa.Column("plan_type", sa.String(), nullable=False, server_default="template"),
+    )
+    op.add_column(
+        "construction_plans",
+        sa.Column("aeroplane_id", sa.String(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_construction_plans_aeroplane_id",
+        "construction_plans",
+        "aeroplanes",
+        ["aeroplane_id"],
+        ["id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_construction_plans_aeroplane_id", "construction_plans", type_="foreignkey")
+    op.drop_column("construction_plans", "aeroplane_id")
+    op.drop_column("construction_plans", "plan_type")

--- a/alembic/versions/c4d5e6f7a8b9_add_plan_type_and_aeroplane_id.py
+++ b/alembic/versions/c4d5e6f7a8b9_add_plan_type_and_aeroplane_id.py
@@ -16,24 +16,23 @@ depends_on: Union[str, None] = None
 
 
 def upgrade() -> None:
-    op.add_column(
-        "construction_plans",
-        sa.Column("plan_type", sa.String(), nullable=False, server_default="template"),
-    )
-    op.add_column(
-        "construction_plans",
-        sa.Column("aeroplane_id", sa.String(), nullable=True),
-    )
-    op.create_foreign_key(
-        "fk_construction_plans_aeroplane_id",
-        "construction_plans",
-        "aeroplanes",
-        ["aeroplane_id"],
-        ["id"],
-    )
+    with op.batch_alter_table("construction_plans") as batch_op:
+        batch_op.add_column(
+            sa.Column("plan_type", sa.String(), nullable=False, server_default="template"),
+        )
+        batch_op.add_column(
+            sa.Column("aeroplane_id", sa.String(), nullable=True),
+        )
+        batch_op.create_foreign_key(
+            "fk_construction_plans_aeroplane_id",
+            "aeroplanes",
+            ["aeroplane_id"],
+            ["id"],
+        )
 
 
 def downgrade() -> None:
-    op.drop_constraint("fk_construction_plans_aeroplane_id", "construction_plans", type_="foreignkey")
-    op.drop_column("construction_plans", "aeroplane_id")
-    op.drop_column("construction_plans", "plan_type")
+    with op.batch_alter_table("construction_plans") as batch_op:
+        batch_op.drop_constraint("fk_construction_plans_aeroplane_id", type_="foreignkey")
+        batch_op.drop_column("aeroplane_id")
+        batch_op.drop_column("plan_type")

--- a/app/api/v2/endpoints/aeroplane_construction_plans.py
+++ b/app/api/v2/endpoints/aeroplane_construction_plans.py
@@ -1,0 +1,114 @@
+"""REST endpoints for Aeroplane-bound Construction Plans (gh#126)."""
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, Body, Depends, Path
+from fastapi import status
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import ServiceException
+from app.db.session import get_db
+from app.schemas.construction_plan import (
+    ExecuteRequest,
+    ExecutionResult,
+    InstantiateRequest,
+    PlanRead,
+    PlanSummary,
+    ToTemplateRequest,
+)
+from app.services import construction_plan_service as svc
+
+router = APIRouter()
+
+
+def _handle_service_error(exc: ServiceException):
+    from fastapi import HTTPException
+    from app.core.exceptions import NotFoundError, ValidationError, InternalError
+
+    status_map = {
+        NotFoundError: status.HTTP_404_NOT_FOUND,
+        ValidationError: status.HTTP_422_UNPROCESSABLE_ENTITY,
+        InternalError: status.HTTP_500_INTERNAL_SERVER_ERROR,
+    }
+    code = status_map.get(type(exc), status.HTTP_500_INTERNAL_SERVER_ERROR)
+    raise HTTPException(status_code=code, detail=str(exc.message))
+
+
+@router.get(
+    "/aeroplanes/{aeroplane_id}/construction-plans",
+    response_model=List[PlanSummary],
+    tags=["construction-plans"],
+    operation_id="list_aeroplane_construction_plans",
+)
+async def list_aeroplane_plans(
+    aeroplane_id: str = Path(...),
+    db: Session = Depends(get_db),
+) -> List[PlanSummary]:
+    """List construction plans bound to an aeroplane."""
+    try:
+        return svc.list_plans(db, plan_type="plan", aeroplane_id=aeroplane_id)
+    except ServiceException as exc:
+        _handle_service_error(exc)
+
+
+@router.post(
+    "/aeroplanes/{aeroplane_id}/construction-plans/from-template/{template_id}",
+    response_model=PlanRead,
+    status_code=status.HTTP_201_CREATED,
+    tags=["construction-plans"],
+    operation_id="instantiate_construction_template",
+)
+async def instantiate_template(
+    aeroplane_id: str = Path(...),
+    template_id: int = Path(...),
+    request: InstantiateRequest = Body(None),
+    db: Session = Depends(get_db),
+) -> PlanRead:
+    """Create a concrete plan from a template, bound to an aeroplane."""
+    try:
+        return svc.instantiate_template(
+            db,
+            template_id,
+            aeroplane_id,
+            name=request.name if request else None,
+        )
+    except ServiceException as exc:
+        _handle_service_error(exc)
+
+
+@router.post(
+    "/aeroplanes/{aeroplane_id}/construction-plans/{plan_id}/execute",
+    response_model=ExecutionResult,
+    tags=["construction-plans"],
+    operation_id="execute_aeroplane_construction_plan",
+)
+async def execute_plan(
+    aeroplane_id: str = Path(...),
+    plan_id: int = Path(...),
+    db: Session = Depends(get_db),
+) -> ExecutionResult:
+    """Execute a construction plan against an aeroplane configuration."""
+    try:
+        return svc.execute_plan(db, plan_id, ExecuteRequest(aeroplane_id=aeroplane_id))
+    except ServiceException as exc:
+        _handle_service_error(exc)
+
+
+@router.post(
+    "/aeroplanes/{aeroplane_id}/construction-plans/{plan_id}/to-template",
+    response_model=PlanRead,
+    status_code=status.HTTP_201_CREATED,
+    tags=["construction-plans"],
+    operation_id="plan_to_template",
+)
+async def plan_to_template(
+    plan_id: int = Path(...),
+    request: ToTemplateRequest = Body(None),
+    db: Session = Depends(get_db),
+) -> PlanRead:
+    """Create a new template from an existing plan."""
+    try:
+        return svc.to_template(db, plan_id, name=request.name if request else None)
+    except ServiceException as exc:
+        _handle_service_error(exc)

--- a/app/api/v2/endpoints/construction_plans.py
+++ b/app/api/v2/endpoints/construction_plans.py
@@ -68,10 +68,13 @@ async def list_creators() -> List[CreatorInfo]:
     tags=["construction-plans"],
     operation_id="list_construction_plans",
 )
-async def list_plans(db: Session = Depends(get_db)) -> List[PlanSummary]:
-    """List all construction plans."""
+async def list_plans(
+    plan_type: str | None = None,
+    db: Session = Depends(get_db),
+) -> List[PlanSummary]:
+    """List all construction plans, optionally filtered by plan_type."""
     try:
-        return svc.list_plans(db)
+        return svc.list_plans(db, plan_type=plan_type)
     except ServiceException as exc:
         _handle_service_error(exc)
 

--- a/app/api/v2/endpoints/construction_templates.py
+++ b/app/api/v2/endpoints/construction_templates.py
@@ -1,0 +1,66 @@
+"""REST endpoints for Construction Templates (gh#126)."""
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, Body, Depends
+from fastapi import status
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import ServiceException
+from app.db.session import get_db
+from app.schemas.construction_plan import (
+    PlanCreate,
+    PlanRead,
+    PlanSummary,
+)
+from app.services import construction_plan_service as svc
+
+router = APIRouter()
+
+
+def _handle_service_error(exc: ServiceException):
+    from fastapi import HTTPException
+    from app.core.exceptions import NotFoundError, ValidationError, InternalError
+
+    status_map = {
+        NotFoundError: status.HTTP_404_NOT_FOUND,
+        ValidationError: status.HTTP_422_UNPROCESSABLE_ENTITY,
+        InternalError: status.HTTP_500_INTERNAL_SERVER_ERROR,
+    }
+    code = status_map.get(type(exc), status.HTTP_500_INTERNAL_SERVER_ERROR)
+    raise HTTPException(status_code=code, detail=str(exc.message))
+
+
+@router.get(
+    "/construction-templates",
+    response_model=List[PlanSummary],
+    tags=["construction-templates"],
+    operation_id="list_construction_templates",
+)
+async def list_templates(db: Session = Depends(get_db)) -> List[PlanSummary]:
+    """List all construction templates."""
+    try:
+        return svc.list_plans(db, plan_type="template")
+    except ServiceException as exc:
+        _handle_service_error(exc)
+
+
+@router.post(
+    "/construction-templates",
+    response_model=PlanRead,
+    status_code=status.HTTP_201_CREATED,
+    tags=["construction-templates"],
+    operation_id="create_construction_template",
+)
+async def create_template(
+    request: PlanCreate = Body(...),
+    db: Session = Depends(get_db),
+) -> PlanRead:
+    """Create a new construction template."""
+    request.plan_type = "template"
+    request.aeroplane_id = None
+    try:
+        return svc.create_plan(db, request)
+    except ServiceException as exc:
+        _handle_service_error(exc)

--- a/app/main.py
+++ b/app/main.py
@@ -13,7 +13,9 @@ from app.api.v2.endpoints import components
 from app.api.v2.endpoints import component_types
 from app.api.v2.endpoints.aeroplane import component_tree
 from app.api.v2.endpoints.aeroplane import construction_parts
+from app.api.v2.endpoints import aeroplane_construction_plans
 from app.api.v2.endpoints import construction_plans
+from app.api.v2.endpoints import construction_templates
 from app.api.v2.endpoints import flight_profiles
 from app.api.v2.endpoints import fuselage_slice
 from app.api.v2.endpoints import health
@@ -119,7 +121,9 @@ def create_app() -> FastAPI:
     app.include_router(component_types.router, prefix="", tags=["component-types"])
     app.include_router(component_tree.router, prefix="", tags=["component-tree"])
     app.include_router(construction_parts.router, prefix="", tags=["construction-parts"])
+    app.include_router(aeroplane_construction_plans.router, prefix="", tags=["construction-plans"])
     app.include_router(construction_plans.router, prefix="", tags=["construction-plans"])
+    app.include_router(construction_templates.router, prefix="", tags=["construction-templates"])
     app.include_router(flight_profiles.router, prefix="", tags=["flight-profiles"])
     app.include_router(fuselage_slice.router, prefix="", tags=["fuselages"])
     if _cad_router is not None:

--- a/app/models/construction_plan.py
+++ b/app/models/construction_plan.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timezone
 
-from sqlalchemy import Column, String, DateTime, func
+from sqlalchemy import Column, ForeignKey, String, DateTime, func
 from sqlalchemy.types import JSON
 
 from app.db.base import Base
@@ -23,6 +23,8 @@ class ConstructionPlanModel(Base):
     name = Column(String, nullable=False)
     description = Column(String, nullable=True)
     tree_json = Column(JSON, nullable=False)
+    plan_type = Column(String, nullable=False, default="template")
+    aeroplane_id = Column(String, ForeignKey("aeroplanes.id"), nullable=True)
 
     created_at = Column(
         DateTime(timezone=True),

--- a/app/schemas/construction_plan.py
+++ b/app/schemas/construction_plan.py
@@ -50,7 +50,6 @@ class PlanSummary(BaseModel):
 class InstantiateRequest(BaseModel):
     """Request to create a plan from a template."""
 
-    aeroplane_id: str = Field(..., description="Aeroplane to bind the plan to")
     name: Optional[str] = Field(None, description="Optional name override")
 
 

--- a/app/schemas/construction_plan.py
+++ b/app/schemas/construction_plan.py
@@ -16,6 +16,8 @@ class PlanCreate(BaseModel):
         ...,
         description="Serialised ConstructionRootNode tree (GeneralJSONEncoder format)",
     )
+    plan_type: str = Field("template", description="'template' or 'plan'")
+    aeroplane_id: Optional[str] = Field(None, description="Aeroplane ID (required for plan_type='plan')")
 
 
 class PlanRead(PlanCreate):
@@ -35,9 +37,27 @@ class PlanSummary(BaseModel):
     name: str
     description: Optional[str] = None
     step_count: int = Field(0, description="Number of steps in the tree")
+    plan_type: str
+    aeroplane_id: Optional[str] = None
     created_at: datetime
 
     model_config = {"from_attributes": True}
+
+
+# ── Template / Plan duality schemas ─────────────────────────────
+
+
+class InstantiateRequest(BaseModel):
+    """Request to create a plan from a template."""
+
+    aeroplane_id: str = Field(..., description="Aeroplane to bind the plan to")
+    name: Optional[str] = Field(None, description="Optional name override")
+
+
+class ToTemplateRequest(BaseModel):
+    """Request to create a template from a plan."""
+
+    name: Optional[str] = Field(None, description="Optional name override")
 
 
 # ── Creator reflection schemas ──────────────────────────────────

--- a/app/services/construction_plan_service.py
+++ b/app/services/construction_plan_service.py
@@ -54,6 +54,8 @@ def _to_summary(plan: ConstructionPlanModel) -> PlanSummary:
         name=plan.name,
         description=plan.description,
         step_count=_count_steps(plan.tree_json or {}),
+        plan_type=plan.plan_type,
+        aeroplane_id=plan.aeroplane_id,
         created_at=plan.created_at,
     )
 
@@ -74,12 +76,29 @@ def _validate_tree_json(tree_json: dict) -> None:
         )
 
 
+def _get_plan_or_raise(db: Session, plan_id: int) -> ConstructionPlanModel:
+    """Load a plan by ID or raise NotFoundError."""
+    plan = db.get(ConstructionPlanModel, plan_id)
+    if plan is None:
+        raise NotFoundError(entity="Construction plan", resource_id=plan_id)
+    return plan
+
+
 # ── CRUD ────────────────────────────────────────────────────────
 
 
-def list_plans(db: Session) -> list[PlanSummary]:
+def list_plans(
+    db: Session,
+    plan_type: str | None = None,
+    aeroplane_id: str | None = None,
+) -> list[PlanSummary]:
     try:
-        plans = db.query(ConstructionPlanModel).order_by(ConstructionPlanModel.id).all()
+        query = db.query(ConstructionPlanModel)
+        if plan_type:
+            query = query.filter(ConstructionPlanModel.plan_type == plan_type)
+        if aeroplane_id:
+            query = query.filter(ConstructionPlanModel.aeroplane_id == aeroplane_id)
+        plans = query.order_by(ConstructionPlanModel.name).all()
         return [_to_summary(p) for p in plans]
     except SQLAlchemyError as e:
         logger.error("DB error listing plans: %s", e)
@@ -106,6 +125,8 @@ def create_plan(db: Session, data: PlanCreate) -> PlanRead:
             name=data.name,
             description=data.description,
             tree_json=data.tree_json,
+            plan_type=data.plan_type,
+            aeroplane_id=data.aeroplane_id,
         )
         db.add(plan)
         db.commit()
@@ -126,6 +147,8 @@ def update_plan(db: Session, plan_id: int, data: PlanCreate) -> PlanRead:
         plan.name = data.name
         plan.description = data.description
         plan.tree_json = data.tree_json
+        plan.plan_type = data.plan_type
+        plan.aeroplane_id = data.aeroplane_id
         db.commit()
         db.refresh(plan)
         return _to_read(plan)
@@ -150,6 +173,56 @@ def delete_plan(db: Session, plan_id: int) -> None:
         db.rollback()
         logger.error("DB error deleting plan %s: %s", plan_id, e)
         raise InternalError(message=f"Database error: {e}")
+
+
+# ── Template / Plan duality ────────────────────────────────────
+
+
+def instantiate_template(
+    db: Session,
+    template_id: int,
+    aeroplane_id: str,
+    name: str | None = None,
+) -> PlanRead:
+    """Clone a template into a concrete plan bound to an aeroplane."""
+    import copy
+
+    template = _get_plan_or_raise(db, template_id)
+    if template.plan_type != "template":
+        raise ValidationError(message="Only templates can be instantiated")
+
+    # Verify aeroplane exists
+    from app.services.wing_service import get_aeroplane_or_raise
+
+    get_aeroplane_or_raise(db, aeroplane_id)
+
+    plan_data = PlanCreate(
+        name=name or f"{template.name} \u2014 Plan",
+        description=template.description,
+        tree_json=copy.deepcopy(template.tree_json),
+        plan_type="plan",
+        aeroplane_id=aeroplane_id,
+    )
+    return create_plan(db, plan_data)
+
+
+def to_template(
+    db: Session,
+    plan_id: int,
+    name: str | None = None,
+) -> PlanRead:
+    """Create a new template from an existing plan."""
+    import copy
+
+    plan = _get_plan_or_raise(db, plan_id)
+
+    template_data = PlanCreate(
+        name=name or f"{plan.name} \u2014 Template",
+        description=plan.description,
+        tree_json=copy.deepcopy(plan.tree_json),
+        plan_type="template",
+    )
+    return create_plan(db, template_data)
 
 
 # ── Creator Catalog ─────────────────────────────────────────────
@@ -436,12 +509,15 @@ def execute_plan(
     from app.converters.model_schema_converters import wingModelToWingConfig
 
     # Load plan
-    plan = db.get(ConstructionPlanModel, plan_id)
-    if plan is None:
-        raise NotFoundError(entity="Construction plan", resource_id=plan_id)
+    plan = _get_plan_or_raise(db, plan_id)
+    if plan.plan_type == "template":
+        raise ValidationError(
+            message="Templates cannot be executed. Instantiate as a plan first.",
+        )
 
-    # Load aeroplane
-    aeroplane = get_aeroplane_or_raise(db, request.aeroplane_id)
+    # Load aeroplane (prefer stored aeroplane_id, fall back to request)
+    effective_aeroplane_id = plan.aeroplane_id or request.aeroplane_id
+    aeroplane = get_aeroplane_or_raise(db, effective_aeroplane_id)
 
     # Build wing_config map: all wings
     wing_config: dict = {}

--- a/app/tests/test_construction_plans.py
+++ b/app/tests/test_construction_plans.py
@@ -46,11 +46,17 @@ TREE_3_STEPS = {
 }
 
 
-def _create_plan(client: TestClient, name: str, tree: dict = None) -> dict:
-    resp = client.post(
-        "/construction-plans",
-        json={"name": name, "tree_json": tree or SAMPLE_TREE},
-    )
+def _create_plan(
+    client: TestClient,
+    name: str,
+    tree: dict = None,
+    plan_type: str = "template",
+    aeroplane_id: str | None = None,
+) -> dict:
+    body: dict = {"name": name, "tree_json": tree or SAMPLE_TREE, "plan_type": plan_type}
+    if aeroplane_id:
+        body["aeroplane_id"] = aeroplane_id
+    resp = client.post("/construction-plans", json=body)
     assert resp.status_code == 201, resp.text
     return resp.json()
 
@@ -203,12 +209,21 @@ class TestPlanExecution:
 
     def test_execute_nonexistent_aeroplane(self, client):
         """POST execute with unknown aeroplane → 404."""
-        plan = _create_plan(client, "exec_404")
+        plan = _create_plan(client, "exec_404", plan_type="plan")
         resp = client.post(
             f"/construction-plans/{plan['id']}/execute",
             json={"aeroplane_id": "00000000-0000-0000-0000-000000000000"},
         )
         assert resp.status_code == 404
+
+    def test_execute_template_rejected(self, client):
+        """POST execute on a template → 422."""
+        plan = _create_plan(client, "tmpl_no_exec", plan_type="template")
+        resp = client.post(
+            f"/construction-plans/{plan['id']}/execute",
+            json={"aeroplane_id": "00000000-0000-0000-0000-000000000000"},
+        )
+        assert resp.status_code == 422
 
     def test_execute_plan_with_invalid_creator_returns_error(self, client):
         """Plan with unknown creator type → decode error → 422."""
@@ -223,7 +238,7 @@ class TestPlanExecution:
                 }
             },
         }
-        plan = _create_plan(client, "bad_plan", bad_tree)
+        plan = _create_plan(client, "bad_plan", bad_tree, plan_type="plan")
         # Need an aeroplane
         resp = client.post("/aeroplanes", params={"name": "exec_test"})
         assert resp.status_code == 201
@@ -234,6 +249,135 @@ class TestPlanExecution:
             json={"aeroplane_id": aid},
         )
         assert resp.status_code == 422
+
+
+# ── Template / Plan Duality Tests (#126) ───────────────────────
+
+
+def _create_aeroplane(client: TestClient, name: str = "test_plane") -> str:
+    """Create an aeroplane and return its ID."""
+    resp = client.post("/aeroplanes", params={"name": name})
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+class TestTemplatePlanDuality:
+    def test_list_templates_only(self, client):
+        """GET /construction-templates returns only templates."""
+        _create_plan(client, "Tmpl A", plan_type="template")
+        aid = _create_aeroplane(client)
+        _create_plan(client, "Plan A", plan_type="plan", aeroplane_id=aid)
+        resp = client.get("/construction-templates")
+        assert resp.status_code == 200
+        templates = resp.json()
+        assert all(t["plan_type"] == "template" for t in templates)
+        names = {t["name"] for t in templates}
+        assert "Tmpl A" in names
+        assert "Plan A" not in names
+
+    def test_create_template_via_templates_endpoint(self, client):
+        """POST /construction-templates forces plan_type=template."""
+        resp = client.post(
+            "/construction-templates",
+            json={
+                "name": "Forced Template",
+                "tree_json": SAMPLE_TREE,
+                "plan_type": "plan",  # should be overridden
+            },
+        )
+        assert resp.status_code == 201
+        assert resp.json()["plan_type"] == "template"
+        assert resp.json()["aeroplane_id"] is None
+
+    def test_list_plans_filter_by_type(self, client):
+        """GET /construction-plans?plan_type=template filters correctly."""
+        _create_plan(client, "FilterTmpl", plan_type="template")
+        aid = _create_aeroplane(client)
+        _create_plan(client, "FilterPlan", plan_type="plan", aeroplane_id=aid)
+        resp = client.get("/construction-plans", params={"plan_type": "template"})
+        assert resp.status_code == 200
+        assert all(p["plan_type"] == "template" for p in resp.json())
+
+    def test_instantiate_template(self, client):
+        """POST from-template creates a plan bound to aeroplane."""
+        tmpl = _create_plan(client, "Base Template")
+        aid = _create_aeroplane(client)
+        resp = client.post(
+            f"/aeroplanes/{aid}/construction-plans/from-template/{tmpl['id']}",
+        )
+        assert resp.status_code == 201
+        plan = resp.json()
+        assert plan["plan_type"] == "plan"
+        assert plan["aeroplane_id"] == aid
+        assert plan["tree_json"] == SAMPLE_TREE
+
+    def test_instantiate_template_custom_name(self, client):
+        """Instantiate with custom name override."""
+        tmpl = _create_plan(client, "Named Template")
+        aid = _create_aeroplane(client)
+        resp = client.post(
+            f"/aeroplanes/{aid}/construction-plans/from-template/{tmpl['id']}",
+            json={"name": "Custom Plan Name"},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["name"] == "Custom Plan Name"
+
+    def test_instantiate_non_template_rejected(self, client):
+        """Instantiating a plan (not template) returns 422."""
+        aid = _create_aeroplane(client)
+        plan = _create_plan(client, "A Plan", plan_type="plan", aeroplane_id=aid)
+        resp = client.post(
+            f"/aeroplanes/{aid}/construction-plans/from-template/{plan['id']}",
+        )
+        assert resp.status_code == 422
+
+    def test_plan_to_template(self, client):
+        """POST to-template creates a template from a plan."""
+        aid = _create_aeroplane(client)
+        plan = _create_plan(client, "My Plan", plan_type="plan", aeroplane_id=aid)
+        resp = client.post(
+            f"/aeroplanes/{aid}/construction-plans/{plan['id']}/to-template",
+        )
+        assert resp.status_code == 201
+        tmpl = resp.json()
+        assert tmpl["plan_type"] == "template"
+        assert tmpl["aeroplane_id"] is None
+        assert tmpl["tree_json"] == SAMPLE_TREE
+
+    def test_plan_to_template_custom_name(self, client):
+        """to-template with custom name override."""
+        aid = _create_aeroplane(client)
+        plan = _create_plan(client, "Source", plan_type="plan", aeroplane_id=aid)
+        resp = client.post(
+            f"/aeroplanes/{aid}/construction-plans/{plan['id']}/to-template",
+            json={"name": "My Custom Template"},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["name"] == "My Custom Template"
+
+    def test_list_aeroplane_plans(self, client):
+        """GET /aeroplanes/{id}/construction-plans returns plans for that aeroplane."""
+        aid1 = _create_aeroplane(client, "plane1")
+        aid2 = _create_aeroplane(client, "plane2")
+        _create_plan(client, "P1", plan_type="plan", aeroplane_id=aid1)
+        _create_plan(client, "P2", plan_type="plan", aeroplane_id=aid2)
+        resp = client.get(f"/aeroplanes/{aid1}/construction-plans")
+        assert resp.status_code == 200
+        plans = resp.json()
+        assert all(p["aeroplane_id"] == aid1 for p in plans)
+        names = {p["name"] for p in plans}
+        assert "P1" in names
+        assert "P2" not in names
+
+    def test_plan_summary_includes_plan_type(self, client):
+        """PlanSummary includes plan_type and aeroplane_id."""
+        aid = _create_aeroplane(client)
+        _create_plan(client, "Typed Plan", plan_type="plan", aeroplane_id=aid)
+        resp = client.get("/construction-plans")
+        assert resp.status_code == 200
+        plan = next(p for p in resp.json() if p["name"] == "Typed Plan")
+        assert plan["plan_type"] == "plan"
+        assert plan["aeroplane_id"] == aid
 
 
 # ── Printer Settings Seed (#115) ────────────────────────────────

--- a/frontend/__tests__/ConstructionPlansPage.test.tsx
+++ b/frontend/__tests__/ConstructionPlansPage.test.tsx
@@ -10,7 +10,7 @@ vi.mock("lucide-react", () => {
   return {
     Hammer: icon, Plus: icon, Trash2: icon, Play: icon, Loader2: icon,
     Search: icon, ChevronDown: icon, ChevronRight: icon, Pencil: icon,
-    Scale: icon, Info: icon,
+    Scale: icon, Info: icon, BookTemplate: icon, Copy: icon,
   };
 });
 
@@ -26,14 +26,26 @@ const mockExecutePlan = vi.fn().mockResolvedValue({
   duration_ms: 1234,
 });
 
+const mockMutateAeroplanePlans = vi.fn();
+const mockInstantiateTemplate = vi.fn().mockResolvedValue({ id: 10, name: "Instantiated" });
+const mockToTemplate = vi.fn().mockResolvedValue({ id: 11, name: "Saved Template" });
+
 vi.mock("@/hooks/useConstructionPlans", () => ({
   useConstructionPlans: () => ({
     plans: [
-      { id: 1, name: "eHawk Wing", description: null, step_count: 3, created_at: "2026-01-01" },
+      { id: 1, name: "eHawk Wing", description: null, step_count: 3, plan_type: "template", aeroplane_id: null, created_at: "2026-01-01" },
     ],
     error: null,
     isLoading: false,
     mutate: mockMutatePlans,
+  }),
+  useAeroplanePlans: () => ({
+    plans: [
+      { id: 2, name: "eHawk Build", description: null, step_count: 2, plan_type: "plan", aeroplane_id: "aero-1", created_at: "2026-01-01" },
+    ],
+    error: null,
+    isLoading: false,
+    mutate: mockMutateAeroplanePlans,
   }),
   useConstructionPlan: (id: number | null) => ({
     plan: id === 1
@@ -48,6 +60,25 @@ vi.mock("@/hooks/useConstructionPlans", () => ({
               { $TYPE: "VaseModeWingCreator", creator_id: "VaseModeWingCreator", wing_index: "main_wing", successors: [] },
             ],
           },
+          plan_type: "template",
+          aeroplane_id: null,
+          created_at: "2026-01-01",
+          updated_at: "2026-01-01",
+        }
+      : id === 2
+      ? {
+          id: 2,
+          name: "eHawk Build",
+          description: null,
+          tree_json: {
+            $TYPE: "ConstructionRootNode",
+            creator_id: "root",
+            successors: [
+              { $TYPE: "VaseModeWingCreator", creator_id: "VaseModeWingCreator", wing_index: "main_wing", successors: [] },
+            ],
+          },
+          plan_type: "plan",
+          aeroplane_id: "aero-1",
           created_at: "2026-01-01",
           updated_at: "2026-01-01",
         }
@@ -60,6 +91,8 @@ vi.mock("@/hooks/useConstructionPlans", () => ({
   updatePlan: vi.fn().mockResolvedValue({}),
   deletePlan: (...args: unknown[]) => mockDeletePlan(...args),
   executePlan: (...args: unknown[]) => mockExecutePlan(...args),
+  instantiateTemplate: (...args: unknown[]) => mockInstantiateTemplate(...args),
+  toTemplate: (...args: unknown[]) => mockToTemplate(...args),
 }));
 
 vi.mock("@/hooks/useCreators", () => ({
@@ -124,12 +157,18 @@ beforeEach(() => {
 });
 
 describe("ConstructionPlansPage", () => {
-  it("renders the plan selector with existing plans", () => {
+  it("renders the template/plans toggle", () => {
+    render(<ConstructionPlansPage />);
+    expect(screen.getByText("Templates")).toBeDefined();
+    expect(screen.getByText("Plans")).toBeDefined();
+  });
+
+  it("renders the plan selector with templates by default", () => {
     render(<ConstructionPlansPage />);
     expect(screen.getByText("eHawk Wing (3 steps)")).toBeDefined();
   });
 
-  it("shows plan tree when a plan is selected", () => {
+  it("shows plan tree when a template is selected", () => {
     render(<ConstructionPlansPage />);
     const select = screen.getByRole("combobox") as HTMLSelectElement;
     fireEvent.change(select, { target: { value: "1" } });
@@ -138,26 +177,38 @@ describe("ConstructionPlansPage", () => {
     expect(matches.length).toBeGreaterThanOrEqual(2);
   });
 
-  it("shows Execute and Delete buttons when a plan is selected", () => {
+  it("shows Create Plan button (not Execute) in template mode", () => {
     render(<ConstructionPlansPage />);
     fireEvent.change(screen.getByRole("combobox"), { target: { value: "1" } });
+    expect(screen.getByText("Create Plan")).toBeDefined();
+    // Execute should not be visible in template mode
+    const executeButtons = screen.queryAllByText("Execute");
+    // The only "Execute" is inside the dialog trigger which is hidden in template mode
+    expect(executeButtons.length).toBe(0);
+  });
+
+  it("shows Execute button in plans mode", () => {
+    render(<ConstructionPlansPage />);
+    fireEvent.click(screen.getByText("Plans"));
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "2" } });
     expect(screen.getByText("Execute")).toBeDefined();
   });
 
-  it("creates a new plan via prompt", async () => {
+  it("creates a new template via prompt", async () => {
     render(<ConstructionPlansPage />);
-    const buttons = screen.getAllByTitle("New plan");
+    const buttons = screen.getAllByTitle("New template");
     fireEvent.click(buttons[0]);
     await waitFor(() => {
       expect(mockCreatePlan).toHaveBeenCalledWith(
-        expect.objectContaining({ name: "Test Plan" }),
+        expect.objectContaining({ name: "Test Plan", plan_type: "template" }),
       );
     });
   });
 
-  it("opens execute dialog and shows aeroplane selector", () => {
+  it("opens execute dialog and shows aeroplane selector in plans mode", () => {
     render(<ConstructionPlansPage />);
-    fireEvent.change(screen.getByRole("combobox"), { target: { value: "1" } });
+    fireEvent.click(screen.getByText("Plans"));
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "2" } });
     fireEvent.click(screen.getByText("Execute"));
     expect(screen.getByText("Execute Plan")).toBeDefined();
     expect(screen.getByText("eHawk")).toBeDefined();
@@ -166,5 +217,12 @@ describe("ConstructionPlansPage", () => {
   it("shows creator catalog on the right panel", () => {
     render(<ConstructionPlansPage />);
     expect(screen.getByText("Creator Catalog")).toBeDefined();
+  });
+
+  it("shows Save as Template button in plans mode", () => {
+    render(<ConstructionPlansPage />);
+    fireEvent.click(screen.getByText("Plans"));
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "2" } });
+    expect(screen.getByText("Save as Template")).toBeDefined();
   });
 });

--- a/frontend/app/workbench/construction-plans/page.tsx
+++ b/frontend/app/workbench/construction-plans/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback, useRef } from "react";
-import { Hammer, Plus, Trash2, Play, Loader2 } from "lucide-react";
+import { Hammer, Plus, Trash2, Play, Loader2, BookTemplate, Copy } from "lucide-react";
 import { WorkbenchTwoPanel } from "@/components/workbench/WorkbenchTwoPanel";
 import { PlanTree, type PlanStepNode } from "@/components/workbench/PlanTree";
 import { CreatorGallery } from "@/components/workbench/CreatorGallery";
@@ -12,10 +12,13 @@ import { useAeroplanes } from "@/hooks/useAeroplanes";
 import {
   useConstructionPlans,
   useConstructionPlan,
+  useAeroplanePlans,
   createPlan,
   updatePlan,
   deletePlan,
   executePlan,
+  instantiateTemplate,
+  toTemplate,
   type ExecutionResult,
 } from "@/hooks/useConstructionPlans";
 import { useCreators, type CreatorInfo } from "@/hooks/useCreators";
@@ -25,8 +28,13 @@ type RightPanel = "gallery" | "detail" | "params";
 export default function ConstructionPlansPage() {
   const { aeroplaneId } = useAeroplaneContext();
   const { aeroplanes } = useAeroplanes();
-  const { plans, mutate: mutatePlans } = useConstructionPlans();
   const { creators } = useCreators();
+
+  const [viewMode, setViewMode] = useState<"templates" | "plans">("templates");
+  const { plans: templates, mutate: mutateTemplates } = useConstructionPlans("template");
+  const { plans: aeroplanePlans, mutate: mutateAeroplanePlans } = useAeroplanePlans(aeroplaneId);
+  const activePlans = viewMode === "templates" ? templates : aeroplanePlans;
+  const activeMutate = viewMode === "templates" ? mutateTemplates : mutateAeroplanePlans;
 
   const [selectedPlanId, setSelectedPlanId] = useState<number | null>(null);
   const { plan, mutate: mutatePlan } = useConstructionPlan(selectedPlanId);
@@ -106,8 +114,10 @@ export default function ConstructionPlansPage() {
       const created = await createPlan({
         name: name.trim(),
         tree_json: { $TYPE: "ConstructionRootNode", creator_id: "root", successors: [] },
+        plan_type: viewMode === "templates" ? "template" : "plan",
+        aeroplane_id: viewMode === "plans" ? aeroplaneId ?? undefined : undefined,
       });
-      mutatePlans();
+      activeMutate();
       setSelectedPlanId(created.id);
     } catch (err) {
       alert(err instanceof Error ? err.message : "Failed to create plan");
@@ -122,7 +132,7 @@ export default function ConstructionPlansPage() {
       setSelectedPlanId(null);
       setSelectedStepPath(null);
       setSelectedStepNode(null);
-      mutatePlans();
+      activeMutate();
     } catch (err) {
       alert(err instanceof Error ? err.message : "Failed to delete plan");
     }
@@ -171,7 +181,7 @@ export default function ConstructionPlansPage() {
         tree_json: updated as unknown as Record<string, unknown>,
       });
       mutatePlan();
-      mutatePlans();
+      activeMutate();
       if (selectedStepPath === path) {
         setSelectedStepPath(null);
         setSelectedStepNode(null);
@@ -202,7 +212,7 @@ export default function ConstructionPlansPage() {
         tree_json: updatedTree as unknown as Record<string, unknown>,
       });
       mutatePlan();
-      mutatePlans();
+      activeMutate();
       setAddDialogOpen(false);
       setAddingCreator(null);
     } catch (err) {
@@ -306,7 +316,7 @@ export default function ConstructionPlansPage() {
     })
       .then(() => {
         mutatePlan();
-        mutatePlans();
+        activeMutate();
       })
       .catch((err) => alert(err instanceof Error ? err.message : "Failed to reorder"));
   }
@@ -318,7 +328,7 @@ export default function ConstructionPlansPage() {
     setExecuting(true);
     setExecuteResult(null);
     try {
-      const result = await executePlan(selectedPlanId, executeAeroplaneId);
+      const result = await executePlan(executeAeroplaneId, selectedPlanId);
       setExecuteResult(result);
     } catch (err) {
       setExecuteResult({
@@ -333,6 +343,31 @@ export default function ConstructionPlansPage() {
     }
   }
 
+  // ── Template / Plan conversion ──────────────────────────────────
+
+  async function handleInstantiateTemplate() {
+    if (!selectedPlanId || !aeroplaneId) return;
+    try {
+      const created = await instantiateTemplate(aeroplaneId, selectedPlanId);
+      mutateAeroplanePlans();
+      setViewMode("plans");
+      setSelectedPlanId(created.id);
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to create plan");
+    }
+  }
+
+  async function handleSaveAsTemplate() {
+    if (!selectedPlanId || !aeroplaneId) return;
+    try {
+      await toTemplate(aeroplaneId, selectedPlanId);
+      mutateTemplates();
+      alert("Template created successfully");
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to save as template");
+    }
+  }
+
   // ── Render ──────────────────────────────────────────────────────
 
   const treeJson = plan?.tree_json as unknown as PlanStepNode | null;
@@ -344,8 +379,46 @@ export default function ConstructionPlansPage() {
   return (
     <>
       <WorkbenchTwoPanel>
-        {/* Left panel: plan selector + tree */}
+        {/* Left panel: toggle + plan selector + tree */}
         <div className="flex h-full flex-col gap-3 overflow-hidden">
+          {/* Template / Plans toggle */}
+          <div className="flex items-center gap-1 rounded-full border border-border bg-card p-1 self-start">
+            <button
+              onClick={() => {
+                setViewMode("templates");
+                setSelectedPlanId(null);
+                setSelectedStepPath(null);
+                setSelectedStepNode(null);
+                setRightPanel("gallery");
+              }}
+              className={`flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[12px] ${
+                viewMode === "templates"
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              <BookTemplate size={12} />
+              Templates
+            </button>
+            <button
+              onClick={() => {
+                setViewMode("plans");
+                setSelectedPlanId(null);
+                setSelectedStepPath(null);
+                setSelectedStepNode(null);
+                setRightPanel("gallery");
+              }}
+              className={`flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[12px] ${
+                viewMode === "plans"
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              <Hammer size={12} />
+              Plans
+            </button>
+          </div>
+
           {/* Plan selector */}
           <div className="flex items-center gap-2">
             <select
@@ -359,8 +432,10 @@ export default function ConstructionPlansPage() {
               }}
               className="flex-1 rounded-xl border border-border bg-input px-3 py-2 text-[12px] text-foreground"
             >
-              <option value="">Select a plan...</option>
-              {plans.map((p) => (
+              <option value="">
+                {viewMode === "templates" ? "Select a template..." : "Select a plan..."}
+              </option>
+              {activePlans.map((p) => (
                 <option key={p.id} value={p.id}>
                   {p.name} ({p.step_count} steps)
                 </option>
@@ -368,7 +443,7 @@ export default function ConstructionPlansPage() {
             </select>
             <button
               onClick={handleNewPlan}
-              title="New plan"
+              title={viewMode === "templates" ? "New template" : "New plan"}
               className="flex size-8 items-center justify-center rounded-full bg-primary text-primary-foreground hover:opacity-90"
             >
               <Plus size={14} />
@@ -378,22 +453,42 @@ export default function ConstructionPlansPage() {
           {/* Action buttons */}
           {selectedPlanId && plan && (
             <div className="flex items-center gap-2">
-              <button
-                onClick={() => {
-                  setExecuteAeroplaneId(aeroplaneId ?? "");
-                  setExecuteDialogOpen(true);
-                  setExecuteResult(null);
-                }}
-                className="flex items-center gap-1.5 rounded-full bg-primary px-3 py-1.5 text-[12px] text-primary-foreground hover:opacity-90"
-              >
-                <Play size={12} />
-                Execute
-              </button>
+              {viewMode === "plans" && (
+                <button
+                  onClick={() => {
+                    setExecuteAeroplaneId(aeroplaneId ?? "");
+                    setExecuteDialogOpen(true);
+                    setExecuteResult(null);
+                  }}
+                  className="flex items-center gap-1.5 rounded-full bg-primary px-3 py-1.5 text-[12px] text-primary-foreground hover:opacity-90"
+                >
+                  <Play size={12} />
+                  Execute
+                </button>
+              )}
+              {viewMode === "templates" && aeroplaneId && (
+                <button
+                  onClick={handleInstantiateTemplate}
+                  className="flex items-center gap-1.5 rounded-full bg-primary px-3 py-1.5 text-[12px] text-primary-foreground hover:opacity-90"
+                >
+                  <Copy size={12} />
+                  Create Plan
+                </button>
+              )}
+              {viewMode === "plans" && aeroplaneId && (
+                <button
+                  onClick={handleSaveAsTemplate}
+                  className="flex items-center gap-1.5 rounded-full border border-border px-3 py-1.5 text-[12px] text-muted-foreground hover:bg-sidebar-accent"
+                >
+                  <BookTemplate size={12} />
+                  Save as Template
+                </button>
+              )}
               <span className="flex-1" />
               <button
                 onClick={handleDeletePlan}
                 className="flex size-7 items-center justify-center rounded-full border border-border text-destructive hover:bg-destructive/20"
-                title="Delete plan"
+                title={viewMode === "templates" ? "Delete template" : "Delete plan"}
               >
                 <Trash2 size={12} />
               </button>
@@ -415,7 +510,9 @@ export default function ConstructionPlansPage() {
           ) : (
             <div className="flex flex-1 items-center justify-center">
               <p className="text-[13px] text-muted-foreground">
-                Select or create a plan
+                {viewMode === "templates"
+                  ? "Select or create a template"
+                  : "Select or create a plan"}
               </p>
             </div>
           )}
@@ -453,6 +550,18 @@ export default function ConstructionPlansPage() {
                 onChange={handleParamChange}
                 availableShapeKeys={collectAvailableShapeKeys(treeJson, selectedStepPath)}
               />
+              <label className="flex flex-col gap-1 mt-2">
+                <span className="font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-muted-foreground">
+                  Comment
+                </span>
+                <textarea
+                  value={String(selectedStepNode?._comment ?? "")}
+                  onChange={(e) => handleParamChange("_comment", e.target.value)}
+                  placeholder="Notes about this step..."
+                  rows={3}
+                  className="rounded-lg border border-border bg-input px-3 py-1.5 text-[12px] text-foreground outline-none resize-none"
+                />
+              </label>
             </div>
           ) : rightPanel === "detail" && browsingCreator ? (
             <CreatorDetailView

--- a/frontend/hooks/useConstructionPlans.ts
+++ b/frontend/hooks/useConstructionPlans.ts
@@ -8,6 +8,8 @@ export interface PlanSummary {
   name: string;
   description: string | null;
   step_count: number;
+  plan_type: string;
+  aeroplane_id: string | null;
   created_at: string;
 }
 
@@ -16,6 +18,8 @@ export interface PlanRead {
   name: string;
   description: string | null;
   tree_json: Record<string, unknown>;
+  plan_type: string;
+  aeroplane_id: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -28,9 +32,12 @@ export interface ExecutionResult {
   duration_ms: number;
 }
 
-export function useConstructionPlans() {
+export function useConstructionPlans(planType?: string) {
+  const path = planType
+    ? `/construction-plans?plan_type=${planType}`
+    : "/construction-plans";
   const { data, error, isLoading, mutate } = useSWR<PlanSummary[]>(
-    "/construction-plans",
+    path,
     fetcher,
   );
 
@@ -40,6 +47,14 @@ export function useConstructionPlans() {
     isLoading,
     mutate,
   };
+}
+
+export function useAeroplanePlans(aeroplaneId: string | null) {
+  const { data, error, isLoading, mutate } = useSWR<PlanSummary[]>(
+    aeroplaneId ? `/aeroplanes/${aeroplaneId}/construction-plans` : null,
+    fetcher,
+  );
+  return { plans: data ?? [], error, isLoading, mutate };
 }
 
 export function useConstructionPlan(id: number | null) {
@@ -57,7 +72,7 @@ export function useConstructionPlan(id: number | null) {
 }
 
 export async function createPlan(
-  body: { name: string; description?: string; tree_json: Record<string, unknown> },
+  body: { name: string; description?: string; tree_json: Record<string, unknown>; plan_type?: string; aeroplane_id?: string },
 ): Promise<PlanRead> {
   const res = await fetch(`${API_BASE}/construction-plans`, {
     method: "POST",
@@ -98,17 +113,57 @@ export async function deletePlan(id: number): Promise<void> {
 }
 
 export async function executePlan(
-  id: number,
   aeroplaneId: string,
+  planId: number,
 ): Promise<ExecutionResult> {
-  const res = await fetch(`${API_BASE}/construction-plans/${id}/execute`, {
+  const res = await fetch(`${API_BASE}/aeroplanes/${aeroplaneId}/construction-plans/${planId}/execute`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ aeroplane_id: aeroplaneId }),
+    body: "{}",
   });
   if (!res.ok) {
     const detail = await res.text();
     throw new Error(`Execute plan failed: ${res.status} ${detail}`);
+  }
+  return res.json();
+}
+
+export async function instantiateTemplate(
+  aeroplaneId: string,
+  templateId: number,
+  name?: string,
+): Promise<PlanRead> {
+  const res = await fetch(
+    `${API_BASE}/aeroplanes/${aeroplaneId}/construction-plans/from-template/${templateId}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: name ? JSON.stringify({ name }) : "{}",
+    },
+  );
+  if (!res.ok) {
+    const detail = await res.text();
+    throw new Error(`Instantiate failed: ${res.status} ${detail}`);
+  }
+  return res.json();
+}
+
+export async function toTemplate(
+  aeroplaneId: string,
+  planId: number,
+  name?: string,
+): Promise<PlanRead> {
+  const res = await fetch(
+    `${API_BASE}/aeroplanes/${aeroplaneId}/construction-plans/${planId}/to-template`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: name ? JSON.stringify({ name }) : "{}",
+    },
+  );
+  if (!res.ok) {
+    const detail = await res.text();
+    throw new Error(`To template failed: ${res.status} ${detail}`);
   }
   return res.json();
 }


### PR DESCRIPTION
## Summary

Separates Construction Plans into **Templates** (abstract, reusable) and **Plans** (concrete, aeroplane-bound).

### Backend
- **DB migration:** `plan_type` + `aeroplane_id` columns on `construction_plans`
- **`/construction-templates`** — list + create templates (flugzeug-unabhängig)
- **`/aeroplanes/{id}/construction-plans`** — list, instantiate from template, execute, save as template
- **Service:** `instantiate_template`, `to_template`, `plan_type`/`aeroplane_id` filters
- Execute rejects templates with 422
- **31 backend tests** (+11 new for duality)

### Frontend
- Template/Plans toggle in Plans tab
- Templates: no Execute, "Create Plan from Template" button
- Plans: Execute, "Save as Template" button
- Step comments (`_comment` field in tree_json with textarea)
- **230 frontend tests** (+3 new)

### New Endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | `/construction-templates` | List all templates |
| POST | `/construction-templates` | Create template |
| GET | `/aeroplanes/{id}/construction-plans` | Plans for aeroplane |
| POST | `/aeroplanes/{id}/construction-plans/from-template/{tid}` | Instantiate template |
| POST | `/aeroplanes/{id}/construction-plans/{pid}/execute` | Execute plan |
| POST | `/aeroplanes/{id}/construction-plans/{pid}/to-template` | Plan → Template |

Closes #126

## Test plan
- [x] `poetry run pytest app/tests/test_construction_plans.py` — 31 passed
- [x] `npx vitest run` — 230 passed
- [x] `poetry run ruff check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)