### PR TITLE
feat(#108): auto-sync Wings/Fuselages into Component Tree

### DIFF
--- a/app/api/v2/endpoints/aeroplane/fuselages.py
+++ b/app/api/v2/endpoints/aeroplane/fuselages.py
@@ -87,6 +87,10 @@ async def create_aeroplane_fuselage(
             plane.fuselages.append(fuselage)
             db.add(fuselage)
             plane.updated_at = datetime.now()
+
+            # Auto-sync: create group in component tree (gh#108)
+            from app.services.component_tree_service import sync_group_for_fuselage
+            sync_group_for_fuselage(db, str(aeroplane_id), fuselage_name)
         return OperationStatusResponse(status="created", operation="create_aeroplane_fuselage")
     except SQLAlchemyError as e:
         logger.error(f"Database error when creating aeroplane fuselage: {e}")
@@ -203,6 +207,10 @@ async def delete_aeroplane_fuselage(
                 raise HTTPException(status_code=404, detail="Fuselage not found")
             db.delete(fuselage)
             plane.updated_at = datetime.now()
+
+            # Auto-sync: remove fuselage group from component tree (gh#108)
+            from app.services.component_tree_service import delete_synced_nodes
+            delete_synced_nodes(db, str(aeroplane_id), f"fuselage:{fuselage_name}")
         return OperationStatusResponse(status="ok", operation="delete_aeroplane_fuselage")
     except SQLAlchemyError as e:
         logger.error(f"Database error when deleting aeroplane fuselage: {e}")

--- a/app/services/component_tree_service.py
+++ b/app/services/component_tree_service.py
@@ -384,3 +384,116 @@ def _calculate_children_weight(db: Session, aeroplane_id: str, parent_id: int) -
         children_sum = _calculate_children_weight(db, aeroplane_id, child.id)
         total += (own or 0) + children_sum
     return total
+
+
+# ── Auto-Sync (gh#108) ────────────────────────────────────────────
+
+
+def sync_group_for_wing(db: Session, aeroplane_id: str, wing_name: str) -> None:
+    """Ensure a synced group exists in the component tree for a wing."""
+    synced_from = f"wing:{wing_name}"
+    existing = db.query(ComponentTreeNodeModel).filter(
+        ComponentTreeNodeModel.aeroplane_id == aeroplane_id,
+        ComponentTreeNodeModel.synced_from == synced_from,
+    ).first()
+    if existing:
+        return  # already exists
+    node = ComponentTreeNodeModel(
+        aeroplane_id=aeroplane_id,
+        parent_id=None,
+        sort_index=0,
+        node_type="group",
+        name=wing_name,
+        synced_from=synced_from,
+    )
+    db.add(node)
+    db.flush()
+
+
+def sync_group_for_fuselage(db: Session, aeroplane_id: str, fuselage_name: str) -> None:
+    """Ensure a synced group exists in the component tree for a fuselage."""
+    synced_from = f"fuselage:{fuselage_name}"
+    existing = db.query(ComponentTreeNodeModel).filter(
+        ComponentTreeNodeModel.aeroplane_id == aeroplane_id,
+        ComponentTreeNodeModel.synced_from == synced_from,
+    ).first()
+    if existing:
+        return
+    node = ComponentTreeNodeModel(
+        aeroplane_id=aeroplane_id,
+        parent_id=None,
+        sort_index=0,
+        node_type="group",
+        name=fuselage_name,
+        synced_from=synced_from,
+    )
+    db.add(node)
+    db.flush()
+
+
+def delete_synced_nodes(db: Session, aeroplane_id: str, synced_from_prefix: str) -> None:
+    """Delete all synced nodes (and their children) matching a prefix."""
+    nodes = db.query(ComponentTreeNodeModel).filter(
+        ComponentTreeNodeModel.aeroplane_id == aeroplane_id,
+        ComponentTreeNodeModel.synced_from.like(f"{synced_from_prefix}%"),
+    ).all()
+    for node in nodes:
+        _delete_subtree(db, aeroplane_id, node.id)
+        db.delete(node)
+    db.flush()
+
+
+def upsert_synced_servo(
+    db: Session,
+    aeroplane_id: str,
+    wing_name: str,
+    xsec_index: int,
+    component_id: int | None,
+    symmetric: bool = False,
+) -> None:
+    """Create or update a synced servo COTS node under the wing group."""
+    synced_from = f"servo:{wing_name}:{xsec_index}"
+
+    # Find or create the wing group
+    wing_group = db.query(ComponentTreeNodeModel).filter(
+        ComponentTreeNodeModel.aeroplane_id == aeroplane_id,
+        ComponentTreeNodeModel.synced_from == f"wing:{wing_name}",
+    ).first()
+
+    if component_id is None:
+        # Servo removed — delete synced node if it exists
+        existing = db.query(ComponentTreeNodeModel).filter(
+            ComponentTreeNodeModel.aeroplane_id == aeroplane_id,
+            ComponentTreeNodeModel.synced_from == synced_from,
+        ).first()
+        if existing:
+            db.delete(existing)
+            db.flush()
+        return
+
+    # Resolve component name
+    comp = db.query(ComponentModel).filter(ComponentModel.id == component_id).first()
+    comp_name = comp.name if comp else f"Servo #{component_id}"
+
+    existing = db.query(ComponentTreeNodeModel).filter(
+        ComponentTreeNodeModel.aeroplane_id == aeroplane_id,
+        ComponentTreeNodeModel.synced_from == synced_from,
+    ).first()
+
+    if existing:
+        existing.component_id = component_id
+        existing.name = comp_name
+        existing.quantity = 2 if symmetric else 1
+    else:
+        node = ComponentTreeNodeModel(
+            aeroplane_id=aeroplane_id,
+            parent_id=wing_group.id if wing_group else None,
+            sort_index=xsec_index,
+            node_type="cots",
+            name=comp_name,
+            component_id=component_id,
+            quantity=2 if symmetric else 1,
+            synced_from=synced_from,
+        )
+        db.add(node)
+    db.flush()

--- a/app/services/wing_service.py
+++ b/app/services/wing_service.py
@@ -205,6 +205,10 @@ def create_wing(
             plane.wings.append(wing)
             db.add(wing)
             plane.updated_at = datetime.now()
+
+            # Auto-sync: create group in component tree (gh#108)
+            from app.services.component_tree_service import sync_group_for_wing
+            sync_group_for_wing(db, str(aeroplane_uuid), wing_name)
     except (NotFoundError, ValidationError):
         raise
     except SQLAlchemyError as e:
@@ -249,6 +253,10 @@ def create_wing_from_wing_configuration(
             plane.wings.append(wing_model)
             db.add(wing_model)
             plane.updated_at = datetime.now()
+
+            # Auto-sync: create group in component tree (gh#108)
+            from app.services.component_tree_service import sync_group_for_wing
+            sync_group_for_wing(db, str(aeroplane_uuid), wing_name)
     except (NotFoundError, ValidationError):
         raise
     except (ValueError, TypeError) as e:
@@ -359,6 +367,10 @@ def put_wing_as_wingconfig(
             plane.wings.append(wing_model)
             db.add(wing_model)
             plane.updated_at = datetime.now()
+
+            # Auto-sync: ensure group in component tree (gh#108)
+            from app.services.component_tree_service import sync_group_for_wing
+            sync_group_for_wing(db, str(aeroplane_uuid), wing_name)
     except (NotFoundError, ValidationError):
         raise
     except (ValueError, TypeError) as e:
@@ -434,6 +446,11 @@ def delete_wing(db: Session, aeroplane_uuid, wing_name: str) -> None:
             wing = get_wing_or_raise(plane, wing_name)
             db.delete(wing)
             plane.updated_at = datetime.now()
+
+            # Auto-sync: remove wing group + servos from component tree (gh#108)
+            from app.services.component_tree_service import delete_synced_nodes
+            delete_synced_nodes(db, str(aeroplane_uuid), f"wing:{wing_name}")
+            delete_synced_nodes(db, str(aeroplane_uuid), f"servo:{wing_name}:")
     except NotFoundError:
         raise
     except SQLAlchemyError as e:
@@ -1161,6 +1178,18 @@ def patch_control_surface_cad_details_servo_details(
 
             db.add(ted)
             aeroplane.updated_at = datetime.now()
+
+            # Auto-sync: upsert servo node in component tree (gh#108)
+            from app.services.component_tree_service import upsert_synced_servo
+            comp_id = None
+            if not isinstance(servo_payload, int) and ted.servo_data:
+                comp_id = ted.servo_data.component_id
+            upsert_synced_servo(
+                db, str(aeroplane_uuid), wing_name, xsec_index,
+                component_id=comp_id,
+                symmetric=wing.symmetric if hasattr(wing, "symmetric") else False,
+            )
+
             return _control_surface_servo_details_schema_from_ted(ted)
     except (NotFoundError, ValidationError):
         raise

--- a/app/tests/test_auto_sync_component_tree.py
+++ b/app/tests/test_auto_sync_component_tree.py
@@ -1,0 +1,170 @@
+"""Tests for auto-sync of Wings/Fuselages into the Component Tree (gh#108)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+airfoil_path = str(
+    (Path(__file__).resolve().parents[2] / "components" / "airfoils" / "mh32.dat").resolve()
+)
+
+
+@pytest.fixture()
+def client(client_and_db):
+    c, _ = client_and_db
+    yield c
+
+
+def _create_aeroplane(client: TestClient) -> str:
+    resp = client.post("/aeroplanes", params={"name": "sync_test"})
+    assert resp.status_code == 201
+    return resp.json()["id"]
+
+
+def _make_wingconfig() -> dict:
+    return {
+        "segments": [
+            {
+                "root_airfoil": {"airfoil": airfoil_path, "chord": 150.0, "incidence": 0},
+                "tip_airfoil": {"airfoil": airfoil_path, "chord": 120.0, "incidence": 0},
+                "length": 500.0,
+                "sweep": 10.0,
+                "number_interpolation_points": 101,
+            }
+        ],
+        "nose_pnt": [0, 0, 0],
+        "symmetric": True,
+    }
+
+
+def _get_tree(client: TestClient, aero_id: str) -> list:
+    resp = client.get(f"/aeroplanes/{aero_id}/component-tree")
+    assert resp.status_code == 200
+    return resp.json()["root_nodes"]
+
+
+def _find_synced(nodes: list, synced_from: str) -> dict | None:
+    for n in nodes:
+        if n.get("synced_from") == synced_from:
+            return n
+        found = _find_synced(n.get("children", []), synced_from)
+        if found:
+            return found
+    return None
+
+
+class TestWingAutoSync:
+    """Creating/deleting wings auto-syncs groups in the component tree."""
+
+    def test_wing_creates_synced_group(self, client):
+        aero_id = _create_aeroplane(client)
+        resp = client.post(
+            f"/aeroplanes/{aero_id}/wings/main_wing/from-wingconfig",
+            json=_make_wingconfig(),
+        )
+        assert resp.status_code == 201
+
+        nodes = _get_tree(client, aero_id)
+        group = _find_synced(nodes, "wing:main_wing")
+        assert group is not None, "Synced wing group not found"
+        assert group["name"] == "main_wing"
+        assert group["node_type"] == "group"
+
+    def test_wing_group_not_deletable(self, client):
+        aero_id = _create_aeroplane(client)
+        client.post(
+            f"/aeroplanes/{aero_id}/wings/main_wing/from-wingconfig",
+            json=_make_wingconfig(),
+        )
+        nodes = _get_tree(client, aero_id)
+        group = _find_synced(nodes, "wing:main_wing")
+        resp = client.delete(f"/aeroplanes/{aero_id}/component-tree/{group['id']}")
+        assert resp.status_code == 422, "Synced node should not be deletable"
+
+    def test_wing_delete_removes_synced_group(self, client):
+        aero_id = _create_aeroplane(client)
+        client.post(
+            f"/aeroplanes/{aero_id}/wings/main_wing/from-wingconfig",
+            json=_make_wingconfig(),
+        )
+        # Verify group exists
+        assert _find_synced(_get_tree(client, aero_id), "wing:main_wing") is not None
+
+        # Delete the wing
+        resp = client.delete(f"/aeroplanes/{aero_id}/wings/main_wing")
+        assert resp.status_code == 200
+
+        # Group should be gone
+        assert _find_synced(_get_tree(client, aero_id), "wing:main_wing") is None
+
+    def test_duplicate_wing_no_duplicate_group(self, client):
+        aero_id = _create_aeroplane(client)
+        # Create wing twice (PUT semantics — idempotent)
+        client.put(
+            f"/aeroplanes/{aero_id}/wings/main_wing",
+            json={"name": "main_wing", "symmetric": True, "x_secs": [
+                {"xyz_le": [0, 0, 0], "chord": 0.15, "twist": 0, "airfoil": "naca0015"},
+                {"xyz_le": [0, 0.5, 0], "chord": 0.12, "twist": 0, "airfoil": "naca0015"},
+            ]},
+        )
+        client.put(
+            f"/aeroplanes/{aero_id}/wings/main_wing",
+            json={"name": "main_wing", "symmetric": True, "x_secs": [
+                {"xyz_le": [0, 0, 0], "chord": 0.15, "twist": 0, "airfoil": "naca0015"},
+                {"xyz_le": [0, 0.5, 0], "chord": 0.12, "twist": 0, "airfoil": "naca0015"},
+            ]},
+        )
+        nodes = _get_tree(client, aero_id)
+        groups = [n for n in _flatten(nodes) if n.get("synced_from") == "wing:main_wing"]
+        assert len(groups) == 1, f"Expected 1 synced group, got {len(groups)}"
+
+
+class TestFuselageAutoSync:
+    """Creating/deleting fuselages auto-syncs groups."""
+
+    def test_fuselage_creates_synced_group(self, client):
+        aero_id = _create_aeroplane(client)
+        resp = client.put(
+            f"/aeroplanes/{aero_id}/fuselages/fuse_1",
+            json={
+                "name": "fuse_1",
+                "x_secs": [
+                    {"xyz": [0, 0, 0], "a": 0.05, "b": 0.05, "n": 2.0},
+                    {"xyz": [0.3, 0, 0], "a": 0.04, "b": 0.04, "n": 2.0},
+                ],
+            },
+        )
+        assert resp.status_code in (200, 201)
+
+        nodes = _get_tree(client, aero_id)
+        group = _find_synced(nodes, "fuselage:fuse_1")
+        assert group is not None, "Synced fuselage group not found"
+        assert group["name"] == "fuse_1"
+
+    def test_fuselage_delete_removes_synced_group(self, client):
+        aero_id = _create_aeroplane(client)
+        client.put(
+            f"/aeroplanes/{aero_id}/fuselages/fuse_1",
+            json={"name": "fuse_1", "x_secs": [
+                {"xyz": [0, 0, 0], "a": 0.05, "b": 0.05, "n": 2.0},
+                {"xyz": [0.3, 0, 0], "a": 0.04, "b": 0.04, "n": 2.0},
+            ]},
+        )
+        assert _find_synced(_get_tree(client, aero_id), "fuselage:fuse_1") is not None
+
+        resp = client.delete(f"/aeroplanes/{aero_id}/fuselages/fuse_1")
+        assert resp.status_code in (200, 204)
+        assert _find_synced(_get_tree(client, aero_id), "fuselage:fuse_1") is None
+
+
+def _flatten(nodes: list) -> list:
+    """Flatten nested tree to a flat list."""
+    result = []
+    for n in nodes:
+        result.append(n)
+        result.extend(_flatten(n.get("children", [])))
+    return result


### PR DESCRIPTION
## Summary

Wings and fuselages now automatically create synced groups in the Component Tree:

- **Wing create** → group with `synced_from="wing:{name}"` appears
- **Fuselage create** → group with `synced_from="fuselage:{name}"`  
- **Wing/Fuselage delete** → synced group + child nodes removed
- **Servo assign** → COTS node under wing group (qty=2 if symmetric)
- **Synced nodes** are not deletable via UI (existing protection)

No frontend changes needed — nodes appear automatically.

Closes #108

## Test plan
- [x] 6 new integration tests (all pass)
- [x] `poetry run ruff check .` — clean