### PR TITLE
feat(#132): CadViewer modal in Plans tab after Execute

### DIFF
--- a/app/schemas/construction_plan.py
+++ b/app/schemas/construction_plan.py
@@ -109,3 +109,4 @@ class ExecutionResult(BaseModel):
     export_paths: list[str] = Field(default_factory=list)
     error: Optional[str] = None
     duration_ms: int = 0
+    tessellation: Optional[dict] = Field(None, description="three-cad-viewer compatible tessellation data")

--- a/app/services/construction_plan_service.py
+++ b/app/services/construction_plan_service.py
@@ -565,11 +565,93 @@ def execute_plan(
 
     shape_keys = list(structure.keys()) if isinstance(structure, dict) else []
 
+    # Tessellate shapes for 3D viewer (best-effort, non-blocking)
+    tessellation = _tessellate_shapes(structure) if isinstance(structure, dict) else None
+
     return ExecutionResult(
         status="success",
         shape_keys=shape_keys,
         duration_ms=duration_ms,
+        tessellation=tessellation,
     )
+
+
+def _tessellate_shapes(structure: dict) -> dict | None:
+    """Tessellate CadQuery shapes for three-cad-viewer (best-effort)."""
+    try:
+        from ocp_tessellate.convert import to_ocpgroup, tessellate_group, combined_bb
+        import numpy as np
+
+        # Collect CadQuery Workplane objects from the structure
+        shapes = []
+        names = []
+        for key, val in structure.items():
+            if hasattr(val, "val"):  # CadQuery Workplane
+                shapes.append(val)
+                names.append(key)
+
+        if not shapes:
+            return None
+
+        # Use the first shape for tessellation via compound
+        from cadquery import Workplane, Compound
+        solids = []
+        for s in shapes:
+            try:
+                solids.extend(s.val().Solids())
+            except Exception:
+                pass
+
+        if not solids:
+            return None
+
+        compound = Compound.makeCompound(solids)
+        wp = Workplane().newObject([compound])
+
+        part_group, instances = to_ocpgroup(
+            wp,
+            names=["result"],
+            colors=["#FF8400"],
+            alphas=[1.0],
+        )
+
+        params = {"deviation": 0.1, "angular_tolerance": 0.2}
+        instances, tess_shapes, _mapping = tessellate_group(
+            part_group, instances, params, progress=None,
+        )
+
+        bb = combined_bb(tess_shapes)
+        if bb is not None:
+            tess_shapes["bb"] = bb.to_dict()
+
+        def _numpy_to_list(obj):
+            if isinstance(obj, np.ndarray):
+                return obj.tolist()
+            if isinstance(obj, dict):
+                return {k: _numpy_to_list(v) for k, v in obj.items()}
+            if isinstance(obj, (list, tuple)):
+                return [_numpy_to_list(i) for i in obj]
+            if isinstance(obj, np.integer):
+                return int(obj)
+            if isinstance(obj, np.floating):
+                return float(obj)
+            return obj
+
+        return {
+            "data": {
+                "instances": _numpy_to_list(instances),
+                "shapes": _numpy_to_list(tess_shapes),
+            },
+            "type": "data",
+            "config": {"theme": "dark", "control": "orbit"},
+            "count": part_group.count_shapes(),
+        }
+    except ImportError:
+        logger.warning("ocp_tessellate not available — skipping tessellation")
+        return None
+    except Exception as exc:
+        logger.warning("Tessellation failed (non-critical): %s", exc)
+        return None
 
 
 def _load_printer_settings(db: Session):

--- a/frontend/app/workbench/construction-plans/page.tsx
+++ b/frontend/app/workbench/construction-plans/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useCallback, useRef } from "react";
-import { Hammer, Plus, Trash2, Play, Loader2, BookTemplate, Copy } from "lucide-react";
+import { Hammer, Plus, Trash2, Play, Loader2, BookTemplate, Copy, X, Maximize2, Minimize2 } from "lucide-react";
+import { CadViewer } from "@/components/workbench/CadViewer";
 import { WorkbenchTwoPanel } from "@/components/workbench/WorkbenchTwoPanel";
 import { PlanTree, type PlanStepNode } from "@/components/workbench/PlanTree";
 import { CreatorGallery } from "@/components/workbench/CreatorGallery";
@@ -57,6 +58,11 @@ export default function ConstructionPlansPage() {
   const [executeResult, setExecuteResult] = useState<ExecutionResult | null>(null);
   const [executeDialogOpen, setExecuteDialogOpen] = useState(false);
   const [executeAeroplaneId, setExecuteAeroplaneId] = useState<string>("");
+
+  // CadViewer modal state
+  const [cadViewerOpen, setCadViewerOpen] = useState(false);
+  const [cadViewerFullscreen, setCadViewerFullscreen] = useState(false);
+  const [cadViewerData, setCadViewerData] = useState<Record<string, unknown> | null>(null);
 
   // ── Helpers ─────────────────────────────────────────────────────
 
@@ -330,6 +336,11 @@ export default function ConstructionPlansPage() {
     try {
       const result = await executePlan(executeAeroplaneId, selectedPlanId);
       setExecuteResult(result);
+      // Open CadViewer modal if tessellation data is available
+      if (result.status === "success" && result.tessellation) {
+        setCadViewerData(result.tessellation);
+        setCadViewerOpen(true);
+      }
     } catch (err) {
       setExecuteResult({
         status: "error",
@@ -337,6 +348,7 @@ export default function ConstructionPlansPage() {
         export_paths: [],
         error: err instanceof Error ? err.message : "Execution failed",
         duration_ms: 0,
+        tessellation: null,
       });
     } finally {
       setExecuting(false);
@@ -778,6 +790,49 @@ export default function ConstructionPlansPage() {
                   </>
                 )}
               </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* CadViewer Modal — shows tessellated geometry after Execute */}
+      {cadViewerOpen && cadViewerData && (
+        <div
+          className={`fixed inset-0 z-50 flex items-center justify-center ${cadViewerFullscreen ? "" : "bg-black/60"}`}
+          onClick={() => { setCadViewerOpen(false); setCadViewerFullscreen(false); }}
+        >
+          <div
+            className={`flex flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-2xl ${
+              cadViewerFullscreen ? "h-full w-full rounded-none border-0" : "h-[80vh] w-[80vw]"
+            }`}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex shrink-0 items-center gap-2 border-b border-border px-4 py-3">
+              <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-foreground">
+                Execution Result
+              </span>
+              {executeResult && (
+                <span className="font-[family-name:var(--font-jetbrains-mono)] text-[10px] text-muted-foreground">
+                  {executeResult.shape_keys.length} shapes · {executeResult.duration_ms}ms
+                </span>
+              )}
+              <div className="flex-1" />
+              <button
+                onClick={() => setCadViewerFullscreen((v) => !v)}
+                className="flex size-7 items-center justify-center rounded-full border border-border text-muted-foreground hover:bg-sidebar-accent"
+                title={cadViewerFullscreen ? "Exit fullscreen" : "Fullscreen"}
+              >
+                {cadViewerFullscreen ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
+              </button>
+              <button
+                onClick={() => { setCadViewerOpen(false); setCadViewerFullscreen(false); }}
+                className="flex size-7 items-center justify-center rounded-full border border-border text-muted-foreground hover:bg-sidebar-accent"
+              >
+                <X size={14} />
+              </button>
+            </div>
+            <div className="min-h-0 flex-1">
+              <CadViewer parts={[cadViewerData]} />
             </div>
           </div>
         </div>

--- a/frontend/hooks/useConstructionPlans.ts
+++ b/frontend/hooks/useConstructionPlans.ts
@@ -30,6 +30,7 @@ export interface ExecutionResult {
   export_paths: string[];
   error: string | null;
   duration_ms: number;
+  tessellation: Record<string, unknown> | null;
 }
 
 export function useConstructionPlans(planType?: string) {


### PR DESCRIPTION
## Summary

After executing a construction plan, the tessellated 3D geometry is shown in a CadViewer modal.

### Backend
- `_tessellate_shapes()` converts CadQuery Workplane objects to three-cad-viewer JSON inline
- `ExecutionResult.tessellation` field returns the data (best-effort, gracefully fails)

### Frontend  
- CadViewer modal opens automatically on successful execute with tessellation data
- Fullscreen toggle + close via X or backdrop
- Header shows shape count + execution duration

Closes #132

## Test plan
- [x] 31 backend tests passed
- [x] 230 frontend tests passed