### PR TITLE
feat(#131): Plotly 3D wireframe preview in Construction tab

### DIFF
--- a/frontend/app/workbench/page.tsx
+++ b/frontend/app/workbench/page.tsx
@@ -1,28 +1,103 @@
 "use client";
 
-import { useState } from "react";
-import { X } from "lucide-react";
-import { ViewerPanel } from "@/components/workbench/ViewerPanel";
+import { useState, useMemo } from "react";
+import { X, PanelLeftOpen, Maximize2, Minimize2 } from "lucide-react";
 import { PropertyForm } from "@/components/workbench/PropertyForm";
 import { AeroplaneTree } from "@/components/workbench/AeroplaneTree";
+import { WingOutlineViewer } from "@/components/workbench/WingOutlineViewer";
 import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
 import { useAeroplanes } from "@/hooks/useAeroplanes";
-import { useWings } from "@/hooks/useWings";
-import { usePreviewState } from "@/hooks/usePreviewState";
+import { useWings, useWing, type Wing } from "@/hooks/useWings";
 import { useFuselages } from "@/hooks/useFuselages";
+import { useFuselage, type Fuselage } from "@/hooks/useFuselage";
 
 export default function WorkbenchPage() {
   const { aeroplaneId, setAeroplaneId } = useAeroplaneContext();
   const { aeroplanes, isLoading, createAeroplane } = useAeroplanes();
   const { wingNames } = useWings(aeroplaneId);
   const { fuselageNames, mutate: mutateFuselages } = useFuselages(aeroplaneId);
-  const preview = usePreviewState(aeroplaneId);
   const aeroplaneName =
     aeroplanes.find((a) => a.id === aeroplaneId)?.name ?? "Aeroplane";
 
   const [treeOpen, setTreeOpen] = useState(true);
   const [viewerMaximized, setViewerMaximized] = useState(false);
   const [configOpen, setConfigOpen] = useState(false);
+
+  // Visibility: all wings/fuselages visible by default
+  const [visibleWings, setVisibleWings] = useState<Set<string>>(new Set());
+  const [visibleFuselages, setVisibleFuselages] = useState<Set<string>>(new Set());
+
+  // Auto-add new wings/fuselages to visible set
+  const effectiveVisibleWings = useMemo(() => {
+    const s = new Set(visibleWings);
+    for (const wn of wingNames) {
+      if (!visibleWings.has(wn) && !visibleWings.has(`_hidden_${wn}`)) s.add(wn);
+    }
+    return s;
+  }, [wingNames, visibleWings]);
+
+  const effectiveVisibleFuselages = useMemo(() => {
+    const s = new Set(visibleFuselages);
+    for (const fn of fuselageNames) {
+      if (!visibleFuselages.has(fn) && !visibleFuselages.has(`_hidden_${fn}`)) s.add(fn);
+    }
+    return s;
+  }, [fuselageNames, visibleFuselages]);
+
+  function toggleWingVisibility(name: string) {
+    setVisibleWings((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) {
+        next.delete(name);
+        next.add(`_hidden_${name}`);
+      } else {
+        next.add(name);
+        next.delete(`_hidden_${name}`);
+      }
+      return next;
+    });
+  }
+
+  function toggleAllWings(names: string[]) {
+    const allVisible = names.every((n) => effectiveVisibleWings.has(n));
+    setVisibleWings((prev) => {
+      const next = new Set(prev);
+      for (const n of names) {
+        if (allVisible) {
+          next.delete(n);
+          next.add(`_hidden_${n}`);
+        } else {
+          next.add(n);
+          next.delete(`_hidden_${n}`);
+        }
+      }
+      return next;
+    });
+  }
+
+  // Load wing/fuselage data for visible items
+  // Note: hooks can't be called conditionally, so we load the first wing/fuselage
+  // For multiple wings, we'd need a bulk hook — for now use the selected wing
+  const { wing: firstWing } = useWing(aeroplaneId, wingNames[0] ?? null);
+  const { wing: secondWing } = useWing(aeroplaneId, wingNames[1] ?? null);
+  const { wing: thirdWing } = useWing(aeroplaneId, wingNames[2] ?? null);
+  const { fuselage: firstFuselage } = useFuselage(aeroplaneId, fuselageNames[0] ?? null);
+  const { fuselage: secondFuselage } = useFuselage(aeroplaneId, fuselageNames[1] ?? null);
+
+  const allWings: Wing[] = useMemo(() => {
+    const wings: Wing[] = [];
+    if (firstWing) wings.push(firstWing);
+    if (secondWing) wings.push(secondWing);
+    if (thirdWing) wings.push(thirdWing);
+    return wings;
+  }, [firstWing, secondWing, thirdWing]);
+
+  const allFuselages: Fuselage[] = useMemo(() => {
+    const fuses: Fuselage[] = [];
+    if (firstFuselage) fuses.push(firstFuselage);
+    if (secondFuselage) fuses.push(secondFuselage);
+    return fuses;
+  }, [firstFuselage, secondFuselage]);
 
   if (!aeroplaneId) {
     return <AeroplaneSelector
@@ -47,10 +122,9 @@ export default function WorkbenchPage() {
               wingNames={wingNames}
               fuselageNames={fuselageNames}
               aeroplaneName={aeroplaneName}
-              isWingVisible={preview.isWingVisible}
-              isWingLoading={(wn) => preview.previews[wn]?.loading ?? false}
-              onTogglePreview={preview.toggleWing}
-              onToggleAllPreview={preview.toggleAllWings}
+              isWingVisible={(wn) => effectiveVisibleWings.has(wn)}
+              onTogglePreview={toggleWingVisibility}
+              onToggleAllPreview={toggleAllWings}
               onCollapseTree={() => setTreeOpen(false)}
               onNodeEdit={() => setConfigOpen(true)}
               onFuselageSaved={() => mutateFuselages()}
@@ -58,17 +132,38 @@ export default function WorkbenchPage() {
           </div>
         )}
 
-        {/* Viewer Panel — fills remaining space */}
-        <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
-          <ViewerPanel
-            visibleParts={preview.visibleParts}
-            isAnyLoading={preview.isAnyLoading}
-            loadingWing={preview.loadingWing}
-            isMaximized={viewerMaximized}
-            onToggleMaximize={() => setViewerMaximized((m) => !m)}
-            isTreeCollapsed={!treeOpen}
-            onExpandTree={() => setTreeOpen(true)}
-          />
+        {/* Plotly Wireframe Viewer — fills remaining space */}
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-xl border border-border">
+          <div className="flex shrink-0 items-center gap-2 border-b border-border bg-card px-4 py-3">
+            {!treeOpen && (
+              <button
+                onClick={() => setTreeOpen(true)}
+                className="flex size-6 items-center justify-center rounded-xl text-muted-foreground hover:bg-sidebar-accent"
+                title="Show tree panel"
+              >
+                <PanelLeftOpen size={14} />
+              </button>
+            )}
+            <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-foreground">
+              Preview
+            </span>
+            <div className="flex-1" />
+            <button
+              onClick={() => setViewerMaximized((m) => !m)}
+              className="flex size-8 items-center justify-center rounded-xl border border-border bg-card-muted text-muted-foreground hover:bg-sidebar-accent"
+              title={viewerMaximized ? "Restore panels" : "Maximize viewer"}
+            >
+              {viewerMaximized ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
+            </button>
+          </div>
+          <div className="min-h-0 flex-1">
+            <WingOutlineViewer
+              wings={allWings}
+              fuselages={allFuselages}
+              visibleWings={effectiveVisibleWings}
+              visibleFuselages={effectiveVisibleFuselages}
+            />
+          </div>
         </div>
       </div>
 
@@ -93,7 +188,7 @@ export default function WorkbenchPage() {
                 <X size={14} />
               </button>
             </div>
-            <PropertyForm onGeometryChanged={preview.invalidateWing} />
+            <PropertyForm />
           </div>
         </div>
       )}

--- a/frontend/components/workbench/WingOutlineViewer.tsx
+++ b/frontend/components/workbench/WingOutlineViewer.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { Wing } from "@/hooks/useWings";
+import type { Fuselage } from "@/hooks/useFuselage";
+
+interface WingOutlineViewerProps {
+  wings: Wing[];
+  fuselages: Fuselage[];
+  visibleWings: Set<string>;
+  visibleFuselages: Set<string>;
+}
+
+/** Build leading/trailing edge + cross-section traces for a wing. */
+function buildWingTraces(wing: Wing, color: string) {
+  const traces: Plotly.Data[] = [];
+  const xsecs = wing.x_secs;
+  if (xsecs.length < 2) return traces;
+
+  // Leading edge line
+  const leX = xsecs.map((xs) => xs.xyz_le[0]);
+  const leY = xsecs.map((xs) => xs.xyz_le[1]);
+  const leZ = xsecs.map((xs) => xs.xyz_le[2]);
+
+  // Trailing edge line (LE + chord along x)
+  const teX = xsecs.map((xs) => xs.xyz_le[0] + xs.chord);
+  const teY = xsecs.map((xs) => xs.xyz_le[1]);
+  const teZ = xsecs.map((xs) => xs.xyz_le[2]);
+
+  // Leading edge
+  traces.push({
+    type: "scatter3d",
+    mode: "lines",
+    x: leX, y: leY, z: leZ,
+    line: { color, width: 3 },
+    name: `${wing.name} LE`,
+    showlegend: false,
+    hoverinfo: "skip",
+  });
+
+  // Trailing edge
+  traces.push({
+    type: "scatter3d",
+    mode: "lines",
+    x: teX, y: teY, z: teZ,
+    line: { color, width: 3 },
+    name: `${wing.name} TE`,
+    showlegend: false,
+    hoverinfo: "skip",
+  });
+
+  // Root chord line
+  traces.push({
+    type: "scatter3d",
+    mode: "lines",
+    x: [leX[0], teX[0]],
+    y: [leY[0], teY[0]],
+    z: [leZ[0], teZ[0]],
+    line: { color, width: 2 },
+    showlegend: false,
+    hoverinfo: "skip",
+  });
+
+  // Tip chord line
+  const last = xsecs.length - 1;
+  traces.push({
+    type: "scatter3d",
+    mode: "lines",
+    x: [leX[last], teX[last]],
+    y: [leY[last], teY[last]],
+    z: [leZ[last], teZ[last]],
+    line: { color, width: 2 },
+    showlegend: false,
+    hoverinfo: "skip",
+  });
+
+  // Cross-section lines at each station
+  for (let i = 1; i < xsecs.length - 1; i++) {
+    traces.push({
+      type: "scatter3d",
+      mode: "lines",
+      x: [leX[i], teX[i]],
+      y: [leY[i], teY[i]],
+      z: [leZ[i], teZ[i]],
+      line: { color, width: 1, dash: "dot" },
+      showlegend: false,
+      hoverinfo: "skip",
+    });
+  }
+
+  // TED hinge lines (colored differently)
+  for (let i = 0; i < xsecs.length; i++) {
+    const ted = xsecs[i].trailing_edge_device ?? xsecs[i].control_surface;
+    if (!ted) continue;
+    const relChord = (ted as Record<string, unknown>).rel_chord_root as number | undefined;
+    if (relChord == null) continue;
+
+    const hingeX = xsecs[i].xyz_le[0] + xsecs[i].chord * (1 - relChord);
+    const teXi = xsecs[i].xyz_le[0] + xsecs[i].chord;
+
+    // Find the next xsec that also has a TED for the hinge line extent
+    const nextI = i + 1 < xsecs.length ? i + 1 : i;
+    const nextTed = xsecs[nextI]?.trailing_edge_device ?? xsecs[nextI]?.control_surface;
+    const nextRelChord = nextTed ? ((nextTed as Record<string, unknown>).rel_chord_tip as number ?? relChord) : relChord;
+    const nextHingeX = xsecs[nextI].xyz_le[0] + xsecs[nextI].chord * (1 - nextRelChord);
+
+    // Hinge line
+    traces.push({
+      type: "scatter3d",
+      mode: "lines",
+      x: [hingeX, nextHingeX],
+      y: [xsecs[i].xyz_le[1], xsecs[nextI].xyz_le[1]],
+      z: [xsecs[i].xyz_le[2], xsecs[nextI].xyz_le[2]],
+      line: { color: "#30A46C", width: 3 },
+      name: `TED`,
+      showlegend: false,
+      hoverinfo: "skip",
+    });
+
+    // TED area (filled between hinge and TE)
+    traces.push({
+      type: "scatter3d",
+      mode: "lines",
+      x: [hingeX, teXi, xsecs[nextI].xyz_le[0] + xsecs[nextI].chord, nextHingeX, hingeX],
+      y: [xsecs[i].xyz_le[1], xsecs[i].xyz_le[1], xsecs[nextI].xyz_le[1], xsecs[nextI].xyz_le[1], xsecs[i].xyz_le[1]],
+      z: [xsecs[i].xyz_le[2], xsecs[i].xyz_le[2], xsecs[nextI].xyz_le[2], xsecs[nextI].xyz_le[2], xsecs[i].xyz_le[2]],
+      line: { color: "#30A46C", width: 1 },
+      showlegend: false,
+      hoverinfo: "skip",
+    });
+  }
+
+  // Mirror if symmetric
+  if (wing.symmetric) {
+    const mirrorTraces = traces.map((t) => ({
+      ...t,
+      y: (t.y as number[]).map((v: number) => -v),
+      name: undefined,
+    }));
+    traces.push(...mirrorTraces);
+  }
+
+  return traces;
+}
+
+/** Build superellipse cross-section traces for a fuselage. */
+function buildFuselageTraces(fuselage: Fuselage, color: string) {
+  const traces: Plotly.Data[] = [];
+  const xsecs = fuselage.x_secs;
+  if (xsecs.length < 2) return traces;
+
+  // Centerline
+  traces.push({
+    type: "scatter3d",
+    mode: "lines",
+    x: xsecs.map((xs) => xs.xyz[0]),
+    y: xsecs.map((xs) => xs.xyz[1]),
+    z: xsecs.map((xs) => xs.xyz[2]),
+    line: { color, width: 2 },
+    showlegend: false,
+    hoverinfo: "skip",
+  });
+
+  // Cross-section outlines
+  const nPts = 32;
+  for (const xs of xsecs) {
+    const cx: number[] = [];
+    const cy: number[] = [];
+    const cz: number[] = [];
+    for (let j = 0; j <= nPts; j++) {
+      const theta = (2 * Math.PI * j) / nPts;
+      const cosT = Math.cos(theta);
+      const sinT = Math.sin(theta);
+      // Superellipse: |y/a|^n + |z/b|^n = 1
+      const r_y = xs.a * Math.sign(cosT) * Math.pow(Math.abs(cosT), 2 / xs.n);
+      const r_z = xs.b * Math.sign(sinT) * Math.pow(Math.abs(sinT), 2 / xs.n);
+      cx.push(xs.xyz[0]);
+      cy.push(xs.xyz[1] + r_y);
+      cz.push(xs.xyz[2] + r_z);
+    }
+    traces.push({
+      type: "scatter3d",
+      mode: "lines",
+      x: cx, y: cy, z: cz,
+      line: { color, width: 1.5 },
+      showlegend: false,
+      hoverinfo: "skip",
+    });
+  }
+
+  // Longitudinal lines (top, bottom, sides)
+  for (const angle of [0, Math.PI / 2, Math.PI, 3 * Math.PI / 2]) {
+    const lx: number[] = [];
+    const ly: number[] = [];
+    const lz: number[] = [];
+    for (const xs of xsecs) {
+      const cosT = Math.cos(angle);
+      const sinT = Math.sin(angle);
+      const r_y = xs.a * Math.sign(cosT) * Math.pow(Math.abs(cosT + 1e-10), 2 / xs.n);
+      const r_z = xs.b * Math.sign(sinT) * Math.pow(Math.abs(sinT + 1e-10), 2 / xs.n);
+      lx.push(xs.xyz[0]);
+      ly.push(xs.xyz[1] + r_y);
+      lz.push(xs.xyz[2] + r_z);
+    }
+    traces.push({
+      type: "scatter3d",
+      mode: "lines",
+      x: lx, y: ly, z: lz,
+      line: { color, width: 1, dash: "dot" },
+      showlegend: false,
+      hoverinfo: "skip",
+    });
+  }
+
+  return traces;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Plotly = any;
+
+export function WingOutlineViewer({ wings, fuselages, visibleWings, visibleFuselages }: WingOutlineViewerProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const plotlyRef = useRef<Plotly>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let disposed = false;
+
+    async function render() {
+      if (!containerRef.current) return;
+      setLoading(true);
+
+      const Plotly = await import("plotly.js-gl3d-dist-min");
+      if (disposed) return;
+      plotlyRef.current = Plotly;
+
+      const traces: Plotly.Data[] = [];
+
+      for (const wing of wings) {
+        if (!visibleWings.has(wing.name)) continue;
+        traces.push(...buildWingTraces(wing, "#FF8400"));
+      }
+
+      for (const fuse of fuselages) {
+        if (!visibleFuselages.has(fuse.name)) continue;
+        traces.push(...buildFuselageTraces(fuse, "#B8B9B6"));
+      }
+
+      const layout = {
+        paper_bgcolor: "#17171A",
+        plot_bgcolor: "#17171A",
+        scene: {
+          xaxis: { showgrid: true, gridcolor: "#2E2E2E", zerolinecolor: "#3A3A3A", color: "#7A7B78", title: "x" },
+          yaxis: { showgrid: true, gridcolor: "#2E2E2E", zerolinecolor: "#3A3A3A", color: "#7A7B78", title: "y" },
+          zaxis: { showgrid: true, gridcolor: "#2E2E2E", zerolinecolor: "#3A3A3A", color: "#7A7B78", title: "z" },
+          aspectmode: "data",
+          bgcolor: "#17171A",
+        },
+        margin: { l: 0, r: 0, t: 0, b: 0 },
+        showlegend: false,
+      };
+
+      const config = { displayModeBar: false, responsive: true };
+
+      await Plotly.newPlot(containerRef.current, traces, layout, config);
+      setLoading(false);
+    }
+
+    render();
+
+    return () => {
+      disposed = true;
+      if (containerRef.current && plotlyRef.current) {
+        try { plotlyRef.current.purge(containerRef.current); } catch { /* ok */ }
+      }
+    };
+  }, [wings, fuselages, visibleWings, visibleFuselages]);
+
+  return (
+    <div className="relative h-full w-full">
+      {loading && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center bg-card-muted/80">
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-muted-foreground">
+            Loading preview…
+          </span>
+        </div>
+      )}
+      <div ref={containerRef} className="h-full w-full" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Replaces the heavy CadViewer (three-cad-viewer + tessellation) with a lightweight Plotly GL3D wireframe preview that renders directly from wing/fuselage configuration data.

### What the wireframe shows
- **Wings:** Leading edge + trailing edge lines, chord lines at each station, section lines (dotted)
- **TEDs:** Hinge lines + area outlines in green
- **Symmetric mirroring:** Automatic for symmetric wings
- **Fuselages:** Superellipse cross-sections + 4 longitudinal guideline

### Key changes
- New `WingOutlineViewer` component using `plotly.js-gl3d-dist-min`
- Replaces `ViewerPanel` + `CadViewer` in Construction tab
- All wings/fuselages visible by default (eye icons control visibility)
- No tessellation pipeline needed — instant rendering from config data
- Dark theme (#17171A) matching workbench

Closes #131

## Test plan
- [x] `npx vitest run` — 230 passed