### PR TITLE
feat: AVL strip-force distributions endpoint

### DIFF
--- a/app/api/v2/endpoints/aeroanalysis.py
+++ b/app/api/v2/endpoints/aeroanalysis.py
@@ -21,6 +21,7 @@ from app.schemas.AeroplaneRequest import AnalysisToolUrlType, AlphaSweepRequest,
 from app.schemas.api_responses import StaticUrlResponse
 from app.schemas.aeroanalysisschema import OperatingPointSchema
 from app.schemas.stability import StabilitySummaryResponse
+from app.schemas.strip_forces import StripForcesResponse
 from app.services import analysis_service
 from app.services import stability_service
 from app.settings import Settings, get_settings
@@ -274,6 +275,30 @@ async def get_streamlines_three_view_url(
             settings=settings,
         )
         return StaticUrlResponse(url=image_url)
+    except ServiceException as exc:
+        _raise_http_from_domain(exc)
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                            detail=f"Unexpected error: {exc}") from exc
+
+
+@router.post(
+    "/aeroplanes/{aeroplane_id}/wings/{wing_name}/strip_forces",
+    response_model=StripForcesResponse,
+    tags=["analysis"],
+    operation_id="get_wing_strip_forces",
+)
+async def get_wing_strip_forces(
+    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
+    wing_name: str = Path(..., description="The name of the wing"),
+    operating_point: OperatingPointSchema = Body(..., description="The operating point"),
+    db: Session = Depends(get_db),
+):
+    """Run AVL analysis and return spanwise strip-force distributions."""
+    try:
+        return await analysis_service.analyze_wing_strip_forces(
+            db, aeroplane_id, wing_name, operating_point
+        )
     except ServiceException as exc:
         _raise_http_from_domain(exc)
     except Exception as exc:  # pragma: no cover - defensive fallback

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -34,3 +34,8 @@ from app.schemas.api_responses import (
     ZipAssetResponse,
     AirplaneConfigurationResponse,
 )
+from app.schemas.strip_forces import (
+    StripForceEntry,
+    SurfaceStripForces,
+    StripForcesResponse,
+)

--- a/app/schemas/strip_forces.py
+++ b/app/schemas/strip_forces.py
@@ -1,0 +1,41 @@
+"""Pydantic schemas for AVL strip-force distribution responses."""
+
+from pydantic import BaseModel, Field
+
+
+class StripForceEntry(BaseModel):
+    j: int = Field(..., description="Strip index")
+    x_le: float = Field(..., alias="Xle", description="Strip leading-edge X (m)")
+    y_le: float = Field(..., alias="Yle", description="Strip leading-edge Y (m)")
+    z_le: float = Field(..., alias="Zle", description="Strip leading-edge Z (m)")
+    chord: float = Field(..., alias="Chord", description="Local chord (m)")
+    area: float = Field(..., alias="Area", description="Strip area (m²)")
+    c_cl: float = Field(..., description="Chord × Cl product")
+    ai: float = Field(..., description="Induced angle of attack (rad)")
+    cl_norm: float = Field(..., description="Normalized Cl (cl × chord / Cref)")
+    cl: float = Field(..., description="Local lift coefficient")
+    cd: float = Field(..., description="Local drag coefficient")
+    cdv: float = Field(..., description="Local viscous drag coefficient")
+    cm_c4: float = Field(..., alias="cm_c/4", description="Moment coefficient at c/4")
+    cm_le: float = Field(..., alias="cm_LE", description="Moment coefficient at LE")
+    cp_xc: float = Field(..., alias="C.P.x/c", description="Center of pressure x/c")
+
+    model_config = {"populate_by_name": True}
+
+
+class SurfaceStripForces(BaseModel):
+    surface_name: str = Field(..., description="AVL surface name")
+    surface_number: int = Field(..., description="AVL surface index")
+    n_chordwise: int = Field(..., description="Number of chordwise panels")
+    n_spanwise: int = Field(..., description="Number of spanwise strips")
+    surface_area: float = Field(..., description="Total surface area (m²)")
+    strips: list[StripForceEntry] = Field(..., description="Per-strip force data")
+
+
+class StripForcesResponse(BaseModel):
+    alpha: float = Field(..., description="Angle of attack (deg)")
+    mach: float = Field(..., description="Mach number")
+    sref: float = Field(..., description="Reference area (m²)")
+    cref: float = Field(..., description="Reference chord (m)")
+    bref: float = Field(..., description="Reference span (m)")
+    surfaces: list[SurfaceStripForces] = Field(..., description="Per-surface strip forces")

--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -28,6 +28,7 @@ from app.db.repository import get_wing_by_name_and_aeroplane_id, get_aeroplane_b
 from app.schemas import AeroplaneSchema
 from app.schemas.AeroplaneRequest import AnalysisToolUrlType, AlphaSweepRequest, SimpleSweepRequest
 from app.schemas.aeroanalysisschema import OperatingPointSchema
+from app.schemas.strip_forces import StripForcesResponse, SurfaceStripForces, StripForceEntry
 
 logger = logging.getLogger(__name__)
 
@@ -989,3 +990,82 @@ async def get_three_view_image(db: Session, aeroplane_uuid) -> bytes:
     except Exception as e:
         logger.error(f"Error generating three-view: {e}")
         raise InternalError(message=f"Error generating diagram: {e}")
+
+
+async def analyze_wing_strip_forces(
+    db: Session,
+    aeroplane_uuid,
+    wing_name: str,
+    operating_point: OperatingPointSchema,
+) -> StripForcesResponse:
+    """Run AVL with strip-force capture for a single wing.
+
+    Returns:
+        StripForcesResponse with per-surface spanwise strip-force distributions.
+
+    Raises:
+        NotFoundError: If the aeroplane or wing does not exist.
+        InternalError: If an analysis error occurs.
+    """
+    from pathlib import Path as _Path
+
+    import aerosandbox as asb
+
+    from app.services.avl_strip_forces import AVLWithStripForces
+
+    plane_schema = await get_wing_schema_or_raise(db, aeroplane_uuid, wing_name)
+
+    try:
+        asb_airplane: Airplane = await aeroplaneSchemaToAsbAirplane_async(plane_schema=plane_schema)
+        asb_airplane.xyz_ref = operating_point.xyz_ref
+        asb_airplane.wings = [w for w in asb_airplane.wings if w.name == wing_name]
+        asb_airplane.fuselages = []
+
+        atmosphere = asb.Atmosphere(altitude=operating_point.altitude)
+        op_point = asb.OperatingPoint(
+            velocity=operating_point.velocity,
+            alpha=operating_point.alpha,
+            beta=operating_point.beta,
+            p=operating_point.p,
+            q=operating_point.q,
+            r=operating_point.r,
+            atmosphere=atmosphere,
+        )
+
+        avl_command = str(
+            _Path(__file__).resolve().parents[2] / "exports" / "avl"
+        )
+
+        avl = AVLWithStripForces(
+            airplane=asb_airplane,
+            op_point=op_point,
+            xyz_ref=operating_point.xyz_ref,
+            avl_command=avl_command,
+            timeout=30,
+        )
+        result = avl.run()
+
+        strip_forces_data = result.get("strip_forces", [])
+        surfaces = []
+        for sf in strip_forces_data:
+            strips = [StripForceEntry.model_validate(s) for s in sf["strips"]]
+            surfaces.append(SurfaceStripForces(
+                surface_name=sf["surface_name"],
+                surface_number=sf["surface_number"],
+                n_chordwise=sf["n_chordwise"],
+                n_spanwise=sf["n_spanwise"],
+                surface_area=sf["surface_area"],
+                strips=strips,
+            ))
+
+        return StripForcesResponse(
+            alpha=result.get("alpha", operating_point.alpha),
+            mach=result.get("mach", 0),
+            sref=result.get("Sref", 0),
+            cref=result.get("Cref", 0),
+            bref=result.get("Bref", 0),
+            surfaces=surfaces,
+        )
+    except Exception as e:
+        logger.error(f"Error analyzing wing strip forces: {e}")
+        raise InternalError(message=f"Strip forces analysis error: {e}")

--- a/app/services/avl_strip_forces.py
+++ b/app/services/avl_strip_forces.py
@@ -7,7 +7,6 @@ import re
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import List
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +87,7 @@ def parse_strip_forces_output(stdout: str) -> list[dict]:
             values = stripped.split()
             if len(values) >= len(_STRIP_COLUMNS):
                 row = {}
-                for col_name, val_str in zip(_STRIP_COLUMNS, values, strict=False):
+                for col_name, val_str in zip(_STRIP_COLUMNS, values, ):
                     row[col_name] = int(val_str) if col_name == "j" else float(val_str)
                 current_surface["strips"].append(row)
             continue
@@ -111,17 +110,7 @@ if HAS_AEROSANDBOX:
         output file for the parent's parser.
         """
 
-        def _default_keystroke_file_contents(self) -> List[str]:
-            """Return parent keystrokes with an ``fs`` marker appended.
-
-            The ``fs`` entry signals that :meth:`run` should inject the
-            strip-forces command into the execution sequence.
-            """
-            ks = super()._default_keystroke_file_contents()
-            ks.append("fs")
-            return ks
-
-        def run(self, run_command: str = None) -> dict:
+        def run(self) -> dict:
             """Run AVL with strip-force capture.
 
             Builds the input file via the inherited :meth:`write_avl`, then
@@ -144,13 +133,7 @@ if HAS_AEROSANDBOX:
                 output_filename = "output.txt"
                 self.write_avl(directory / airplane_file)
 
-                # Build setup keystrokes, removing the "fs" marker we added
-                ks = self._default_keystroke_file_contents()
-                if run_command is not None:
-                    ks.append(run_command)
-                ks = [k for k in ks if k != "fs"]
-
-                # Append execution sequence with strip-force capture
+                ks = super()._default_keystroke_file_contents()
                 ks += [
                     "x",                     # execute analysis
                     "st",                    # stability output ...
@@ -172,9 +155,17 @@ if HAS_AEROSANDBOX:
                     stderr=subprocess.PIPE,
                     cwd=str(directory),
                 )
-                stdout_bytes, _ = proc.communicate(
-                    input=input_text.encode(), timeout=self.timeout,
-                )
+                try:
+                    stdout_bytes, _ = proc.communicate(
+                        input=input_text.encode(), timeout=self.timeout,
+                    )
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.communicate()
+                    raise RuntimeError(
+                        f"AVL timed out after {self.timeout}s. "
+                        "Try increasing the timeout parameter."
+                    )
                 stdout_text = stdout_bytes.decode(errors="replace")
 
                 output_path = directory / output_filename

--- a/app/services/avl_strip_forces.py
+++ b/app/services/avl_strip_forces.py
@@ -1,0 +1,87 @@
+"""AVL utilities for extracting spanwise strip-force distributions."""
+
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+# Column names in AVL's FS (strip forces) output table
+_STRIP_COLUMNS = [
+    "j", "Xle", "Yle", "Zle", "Chord", "Area",
+    "c_cl", "ai", "cl_norm", "cl", "cd", "cdv",
+    "cm_c/4", "cm_LE", "C.P.x/c",
+]
+
+
+def parse_strip_forces_output(stdout: str) -> list[dict]:
+    """Parse AVL's ``FS`` (strip forces) stdout output into structured data.
+
+    Returns a list of dicts, one per surface, each containing:
+    - ``surface_name``: str
+    - ``surface_number``: int
+    - ``n_chordwise``: int
+    - ``n_spanwise``: int
+    - ``surface_area``: float
+    - ``strips``: list of dicts with keys from ``_STRIP_COLUMNS``
+    """
+    surfaces: list[dict] = []
+    current_surface: dict | None = None
+    in_strip_table = False
+
+    for line in stdout.splitlines():
+        stripped = line.strip()
+
+        # Detect surface header: "Surface # 1     Main Wing"
+        m = re.match(r"Surface\s+#\s*(\d+)\s+(.*)", stripped)
+        if m:
+            current_surface = {
+                "surface_number": int(m.group(1)),
+                "surface_name": m.group(2).strip(),
+                "n_chordwise": 0,
+                "n_spanwise": 0,
+                "surface_area": 0.0,
+                "strips": [],
+            }
+            surfaces.append(current_surface)
+            in_strip_table = False
+            continue
+
+        if current_surface is None:
+            continue
+
+        # Parse chordwise/spanwise counts
+        m = re.match(
+            r"#\s*Chordwise\s*=\s*(\d+)\s+#\s*Spanwise\s*=\s*(\d+)",
+            stripped,
+        )
+        if m:
+            current_surface["n_chordwise"] = int(m.group(1))
+            current_surface["n_spanwise"] = int(m.group(2))
+            continue
+
+        # Parse surface area
+        m = re.search(r"Surface area\s+Ssurf\s*=\s*([\d.Ee+-]+)", stripped)
+        if m:
+            current_surface["surface_area"] = float(m.group(1))
+            continue
+
+        # Detect strip table header line
+        if stripped.startswith("j") and "Xle" in stripped and "cl" in stripped:
+            in_strip_table = True
+            continue
+
+        # Parse strip data rows (start with an integer index)
+        if in_strip_table and stripped and stripped[0].isdigit():
+            values = stripped.split()
+            if len(values) >= len(_STRIP_COLUMNS):
+                row = {}
+                for col_name, val_str in zip(_STRIP_COLUMNS, values, strict=False):
+                    row[col_name] = int(val_str) if col_name == "j" else float(val_str)
+                current_surface["strips"].append(row)
+            continue
+
+        # End of strip table (blank line or non-data line after table started)
+        if in_strip_table and not stripped:
+            in_strip_table = False
+
+    return surfaces

--- a/app/services/avl_strip_forces.py
+++ b/app/services/avl_strip_forces.py
@@ -1,9 +1,22 @@
 """AVL utilities for extracting spanwise strip-force distributions."""
 
+from __future__ import annotations
+
 import logging
 import re
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import List
 
 logger = logging.getLogger(__name__)
+
+try:
+    import aerosandbox as asb
+
+    HAS_AEROSANDBOX = True
+except ImportError:
+    HAS_AEROSANDBOX = False
 
 # Column names in AVL's FS (strip forces) output table
 _STRIP_COLUMNS = [
@@ -85,3 +98,170 @@ def parse_strip_forces_output(stdout: str) -> list[dict]:
             in_strip_table = False
 
     return surfaces
+
+
+if HAS_AEROSANDBOX:
+    import numpy as np
+
+    class AVLWithStripForces(asb.AVL):
+        """AVL wrapper that additionally captures strip-force distributions.
+
+        Overrides keystroke generation and run() to capture stdout from the
+        AVL ``FS`` command, while still producing the standard stability
+        output file for the parent's parser.
+        """
+
+        def _default_keystroke_file_contents(self) -> List[str]:
+            """Return parent keystrokes with an ``fs`` marker appended.
+
+            The ``fs`` entry signals that :meth:`run` should inject the
+            strip-forces command into the execution sequence.
+            """
+            ks = super()._default_keystroke_file_contents()
+            ks.append("fs")
+            return ks
+
+        def run(self, run_command: str = None) -> dict:
+            """Run AVL with strip-force capture.
+
+            Builds the input file via the inherited :meth:`write_avl`, then
+            constructs the full command sequence ourselves so that ``fs``
+            appears after ``x`` (execute) to capture strip forces from
+            stdout.  The stability output is still written via ``st`` so
+            that the parent's parser can extract the standard result dict.
+            """
+            if self.working_directory is not None:
+                directory = Path(self.working_directory)
+                directory.mkdir(parents=True, exist_ok=True)
+                cleanup = None
+            else:
+                tmp = tempfile.TemporaryDirectory()
+                directory = Path(tmp.name)
+                cleanup = tmp
+
+            try:
+                airplane_file = "airplane.avl"
+                output_filename = "output.txt"
+                self.write_avl(directory / airplane_file)
+
+                # Build setup keystrokes, removing the "fs" marker we added
+                ks = self._default_keystroke_file_contents()
+                if run_command is not None:
+                    ks.append(run_command)
+                ks = [k for k in ks if k != "fs"]
+
+                # Append execution sequence with strip-force capture
+                ks += [
+                    "x",                     # execute analysis
+                    "st",                    # stability output ...
+                    output_filename,         # ... to file
+                    "o",                     # overwrite if exists
+                    "",
+                    "fs",                    # strip forces to stdout
+                    "",
+                    "",
+                    "quit",
+                ]
+
+                input_text = "\n".join(str(k) for k in ks) + "\n"
+
+                proc = subprocess.Popen(
+                    [self.avl_command, airplane_file],
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    cwd=str(directory),
+                )
+                stdout_bytes, _ = proc.communicate(
+                    input=input_text.encode(), timeout=self.timeout,
+                )
+                stdout_text = stdout_bytes.decode(errors="replace")
+
+                output_path = directory / output_filename
+                if not output_path.exists():
+                    raise FileNotFoundError(
+                        "AVL didn't produce stability output. "
+                        "Check avl_command and input geometry."
+                    )
+                with open(output_path) as f:
+                    raw = f.read()
+
+                result = self.parse_unformatted_data_output(
+                    raw, data_identifier=" =", overwrite=False
+                )
+                result = self._post_process_results(result)
+                result["strip_forces"] = parse_strip_forces_output(stdout_text)
+
+                return result
+            finally:
+                if cleanup is not None:
+                    cleanup.cleanup()
+
+        def _post_process_results(self, result: dict) -> dict:
+            """Apply the same post-processing as the parent's run() method.
+
+            Mirrors the cleanup / derived-quantity logic from
+            ``aerosandbox.AVL.run()`` so callers get an identical result
+            dict (plus the extra ``strip_forces`` key).
+            """
+            op = self.op_point
+
+            # Lowercase canonical keys
+            for key_to_lower in ["Alpha", "Beta", "Mach"]:
+                if key_to_lower in result:
+                    result[key_to_lower.lower()] = result.pop(key_to_lower)
+
+            # Strip "tot" suffix
+            for key in list(result.keys()):
+                if "tot" in key:
+                    result[key.replace("tot", "")] = result.pop(key)
+
+            # Derived quantities
+            q = op.dynamic_pressure()
+            S = self.airplane.s_ref
+            b = self.airplane.b_ref
+            c = self.airplane.c_ref
+
+            result["p"] = result.get("pb/2V", 0) * (2 * op.velocity / b) if b else 0
+            result["q"] = result.get("qc/2V", 0) * (2 * op.velocity / c) if c else 0
+            result["r"] = result.get("rb/2V", 0) * (2 * op.velocity / b) if b else 0
+
+            CL = result.get("CL", 0)
+            CY = result.get("CY", 0)
+            CD = result.get("CD", 0)
+            Cl = result.get("Cl", 0)
+            Cm = result.get("Cm", 0)
+            Cn = result.get("Cn", 0)
+
+            result["L"] = q * S * CL
+            result["Y"] = q * S * CY
+            result["D"] = q * S * CD
+            result["l_b"] = q * S * b * Cl
+            result["m_b"] = q * S * c * Cm
+            result["n_b"] = q * S * b * Cn
+
+            try:
+                Clb = result.get("Clb", 0)
+                Cnr = result.get("Cnr", 0)
+                Clr = result.get("Clr", 0)
+                Cnb = result.get("Cnb", 0)
+                result["Clb Cnr / Clr Cnb"] = Clb * Cnr / (Clr * Cnb)
+            except ZeroDivisionError:
+                result["Clb Cnr / Clr Cnb"] = np.nan
+
+            F_w = [-result["D"], result["Y"], -result["L"]]
+            F_b = op.convert_axes(*F_w, from_axes="wind", to_axes="body")
+            F_g = op.convert_axes(*F_b, from_axes="body", to_axes="geometry")
+
+            M_b = [result["l_b"], result["m_b"], result["n_b"]]
+            M_g = op.convert_axes(*M_b, from_axes="body", to_axes="geometry")
+            M_w = op.convert_axes(*M_b, from_axes="body", to_axes="wind")
+
+            result["F_w"] = F_w
+            result["F_b"] = F_b
+            result["F_g"] = F_g
+            result["M_b"] = M_b
+            result["M_g"] = M_g
+            result["M_w"] = M_w
+
+            return result

--- a/app/tests/test_avl_strip_forces.py
+++ b/app/tests/test_avl_strip_forces.py
@@ -1,0 +1,84 @@
+import pytest
+
+from app.services.avl_strip_forces import parse_strip_forces_output
+
+SAMPLE_FS_OUTPUT = """
+ Surface and Strip Forces by surface
+
+  Sref = 0.25000       Cref = 0.25333       Bref =  1.0000
+  Xref =  0.0000       Yref =  0.0000       Zref =  0.0000
+
+  Surface # 1     Main Wing
+     # Chordwise = 12   # Spanwise = 12     First strip =  1
+     Surface area Ssurf =    0.125000     Ave. chord Cave =    0.250000
+
+ Forces referred to Sref, Cref, Bref about Xref, Yref, Zref
+ Standard axis orientation,  X fwd, Z down
+     CLsurf  =   0.16769     Clsurf  =  -0.03573
+     CYsurf  =  -0.00190     Cmsurf  =  -0.04143
+     CDsurf  =   0.00450     Cnsurf  =  -0.00157
+     CDisurf =   0.00450     CDvsurf =   0.00000
+
+ Forces referred to Ssurf, Cave
+     CLsurf  =   0.33539     CDsurf  =   0.00900
+
+ Strip Forces referred to Strip Area, Chord
+    j     Xle      Yle      Zle      Chord    Area     c_cl     ai     cl_norm    cl       cd       cdv    cm_c/4     cm_LE   C.P.x/c
+     1   0.0001   0.0021   0.0000   0.2996   0.0026   0.1064   0.0563   0.3555   0.3555   0.0117   0.0000   0.0128  -0.0759    0.214
+     2   0.0008   0.0190   0.0000   0.2962   0.0074   0.1063   0.0550   0.3592   0.3592   0.0103   0.0000   0.0130  -0.0766    0.214
+     3   0.0021   0.0517   0.0000   0.2897   0.0115   0.1056   0.0535   0.3649   0.3649   0.0098   0.0000   0.0131  -0.0779    0.214
+
+  Surface # 2     Main Wing (YDUP)
+     # Chordwise = 12   # Spanwise = 12     First strip = 13
+     Surface area Ssurf =    0.125000     Ave. chord Cave =    0.250000
+
+ Forces referred to Sref, Cref, Bref about Xref, Yref, Zref
+ Standard axis orientation,  X fwd, Z down
+     CLsurf  =   0.16769     Clsurf  =   0.03573
+     CYsurf  =   0.00190     Cmsurf  =  -0.04143
+     CDsurf  =   0.00450     Cnsurf  =   0.00157
+     CDisurf =   0.00450     CDvsurf =   0.00000
+
+ Forces referred to Ssurf, Cave
+     CLsurf  =   0.33539     CDsurf  =   0.00900
+
+ Strip Forces referred to Strip Area, Chord
+    j     Xle      Yle      Zle      Chord    Area     c_cl     ai     cl_norm    cl       cd       cdv    cm_c/4     cm_LE   C.P.x/c
+    13   0.0001  -0.0021   0.0000   0.2996   0.0026   0.1064   0.0563   0.3555   0.3555   0.0117   0.0000   0.0128   0.0759    0.214
+    14   0.0008  -0.0190   0.0000   0.2962   0.0074   0.1063   0.0550   0.3592   0.3592   0.0103   0.0000   0.0130   0.0766    0.214
+    15   0.0021  -0.0517   0.0000   0.2897   0.0115   0.1056   0.0535   0.3649   0.3649   0.0098   0.0000   0.0131   0.0779    0.214
+"""
+
+
+class TestParseStripForcesOutput:
+    def test_parses_two_surfaces(self):
+        result = parse_strip_forces_output(SAMPLE_FS_OUTPUT)
+        assert len(result) == 2
+        assert result[0]["surface_name"] == "Main Wing"
+        assert result[1]["surface_name"] == "Main Wing (YDUP)"
+
+    def test_parses_strip_data(self):
+        result = parse_strip_forces_output(SAMPLE_FS_OUTPUT)
+        strips = result[0]["strips"]
+        assert len(strips) == 3
+        assert strips[0]["j"] == 1
+        assert strips[0]["Yle"] == pytest.approx(0.0021)
+        assert strips[0]["Chord"] == pytest.approx(0.2996)
+        assert strips[0]["cl"] == pytest.approx(0.3555)
+        assert strips[0]["cd"] == pytest.approx(0.0117)
+        assert strips[0]["cm_c/4"] == pytest.approx(0.0128)
+        assert strips[0]["C.P.x/c"] == pytest.approx(0.214)
+
+    def test_parses_surface_metadata(self):
+        result = parse_strip_forces_output(SAMPLE_FS_OUTPUT)
+        assert result[0]["n_chordwise"] == 12
+        assert result[0]["n_spanwise"] == 12
+        assert result[0]["surface_area"] == pytest.approx(0.125)
+
+    def test_empty_output(self):
+        result = parse_strip_forces_output("")
+        assert result == []
+
+    def test_output_without_strip_section(self):
+        result = parse_strip_forces_output("Some random AVL output\nwithout strip data")
+        assert result == []

--- a/app/tests/test_avl_strip_forces.py
+++ b/app/tests/test_avl_strip_forces.py
@@ -82,3 +82,40 @@ class TestParseStripForcesOutput:
     def test_output_without_strip_section(self):
         result = parse_strip_forces_output("Some random AVL output\nwithout strip data")
         assert result == []
+
+
+class TestAVLWithStripForcesKeystrokes:
+    def test_keystrokes_contain_fs_command(self):
+        """The extended keystroke sequence must include the FS command."""
+        from app.services.avl_strip_forces import AVLWithStripForces
+        import aerosandbox as asb
+
+        airplane = asb.Airplane(
+            name="test",
+            wings=[asb.Wing(name="W", symmetric=True, xsecs=[
+                asb.WingXSec(xyz_le=[0, 0, 0], chord=0.3, airfoil=asb.Airfoil("naca0012")),
+                asb.WingXSec(xyz_le=[0, 0.5, 0], chord=0.2, airfoil=asb.Airfoil("naca0012")),
+            ])],
+        )
+        op = asb.OperatingPoint(velocity=20, alpha=5)
+        avl = AVLWithStripForces(airplane=airplane, op_point=op)
+        ks = avl._default_keystroke_file_contents()
+        assert "fs" in ks, "FS command must be in keystroke sequence"
+
+    def test_keystrokes_preserve_parent_commands(self):
+        """All parent keystroke commands must still be present."""
+        from app.services.avl_strip_forces import AVLWithStripForces
+        import aerosandbox as asb
+
+        airplane = asb.Airplane(
+            name="test",
+            wings=[asb.Wing(name="W", symmetric=True, xsecs=[
+                asb.WingXSec(xyz_le=[0, 0, 0], chord=0.3, airfoil=asb.Airfoil("naca0012")),
+                asb.WingXSec(xyz_le=[0, 0.5, 0], chord=0.2, airfoil=asb.Airfoil("naca0012")),
+            ])],
+        )
+        op = asb.OperatingPoint(velocity=20, alpha=5)
+        avl = AVLWithStripForces(airplane=airplane, op_point=op)
+        ks = avl._default_keystroke_file_contents()
+        assert "plop" in ks
+        assert "oper" in ks

--- a/app/tests/test_avl_strip_forces.py
+++ b/app/tests/test_avl_strip_forces.py
@@ -85,25 +85,8 @@ class TestParseStripForcesOutput:
 
 
 class TestAVLWithStripForcesKeystrokes:
-    def test_keystrokes_contain_fs_command(self):
-        """The extended keystroke sequence must include the FS command."""
-        from app.services.avl_strip_forces import AVLWithStripForces
-        import aerosandbox as asb
-
-        airplane = asb.Airplane(
-            name="test",
-            wings=[asb.Wing(name="W", symmetric=True, xsecs=[
-                asb.WingXSec(xyz_le=[0, 0, 0], chord=0.3, airfoil=asb.Airfoil("naca0012")),
-                asb.WingXSec(xyz_le=[0, 0.5, 0], chord=0.2, airfoil=asb.Airfoil("naca0012")),
-            ])],
-        )
-        op = asb.OperatingPoint(velocity=20, alpha=5)
-        avl = AVLWithStripForces(airplane=airplane, op_point=op)
-        ks = avl._default_keystroke_file_contents()
-        assert "fs" in ks, "FS command must be in keystroke sequence"
-
-    def test_keystrokes_preserve_parent_commands(self):
-        """All parent keystroke commands must still be present."""
+    def test_subclass_inherits_parent_keystrokes(self):
+        """AVLWithStripForces preserves parent setup keystrokes."""
         from app.services.avl_strip_forces import AVLWithStripForces
         import aerosandbox as asb
 
@@ -119,3 +102,19 @@ class TestAVLWithStripForcesKeystrokes:
         ks = avl._default_keystroke_file_contents()
         assert "plop" in ks
         assert "oper" in ks
+
+    def test_subclass_is_avl_instance(self):
+        """AVLWithStripForces is a proper subclass of asb.AVL."""
+        from app.services.avl_strip_forces import AVLWithStripForces
+        import aerosandbox as asb
+
+        airplane = asb.Airplane(
+            name="test",
+            wings=[asb.Wing(name="W", symmetric=True, xsecs=[
+                asb.WingXSec(xyz_le=[0, 0, 0], chord=0.3, airfoil=asb.Airfoil("naca0012")),
+                asb.WingXSec(xyz_le=[0, 0.5, 0], chord=0.2, airfoil=asb.Airfoil("naca0012")),
+            ])],
+        )
+        op = asb.OperatingPoint(velocity=20, alpha=5)
+        avl = AVLWithStripForces(airplane=airplane, op_point=op)
+        assert isinstance(avl, asb.AVL)

--- a/app/tests/test_avl_strip_forces_integration.py
+++ b/app/tests/test_avl_strip_forces_integration.py
@@ -1,6 +1,6 @@
 """Integration test for AVL strip-force extraction.
 
-Requires the AVL binary at exports/avl and CadQuery.
+Requires the AVL binary at exports/avl.
 """
 import pytest
 from pathlib import Path

--- a/app/tests/test_avl_strip_forces_integration.py
+++ b/app/tests/test_avl_strip_forces_integration.py
@@ -1,0 +1,93 @@
+"""Integration test for AVL strip-force extraction.
+
+Requires the AVL binary at exports/avl and CadQuery.
+"""
+import pytest
+from pathlib import Path
+
+AVL_BINARY = Path(__file__).resolve().parents[2] / "exports" / "avl"
+pytestmark = pytest.mark.slow
+
+
+@pytest.fixture
+def simple_airplane():
+    import aerosandbox as asb
+    return asb.Airplane(
+        name="test_plane",
+        wings=[
+            asb.Wing(
+                name="Main Wing",
+                symmetric=True,
+                xsecs=[
+                    asb.WingXSec(xyz_le=[0, 0, 0], chord=0.3, airfoil=asb.Airfoil("naca0012")),
+                    asb.WingXSec(xyz_le=[0.02, 0.5, 0], chord=0.2, airfoil=asb.Airfoil("naca0012")),
+                ],
+            )
+        ],
+    )
+
+
+@pytest.fixture
+def op_point():
+    import aerosandbox as asb
+    return asb.OperatingPoint(velocity=20, alpha=5)
+
+
+class TestAVLWithStripForcesIntegration:
+    def test_run_returns_strip_forces(self, simple_airplane, op_point):
+        from app.services.avl_strip_forces import AVLWithStripForces
+
+        avl = AVLWithStripForces(
+            airplane=simple_airplane,
+            op_point=op_point,
+            avl_command=str(AVL_BINARY),
+            timeout=15,
+        )
+        result = avl.run()
+
+        # Standard AVL results still present
+        assert "CL" in result
+        assert "CD" in result
+        assert result["CL"] > 0
+
+        # Strip forces present
+        assert "strip_forces" in result
+        surfaces = result["strip_forces"]
+        assert len(surfaces) >= 1
+
+        # Check first surface
+        surface = surfaces[0]
+        assert surface["surface_name"] == "Main Wing"
+        assert len(surface["strips"]) > 0
+
+        # Check strip data is physically plausible
+        for strip in surface["strips"]:
+            assert strip["Chord"] > 0
+            assert strip["cl"] > 0  # positive alpha -> positive lift
+            assert -1 < strip["Yle"] < 1  # within wingspan
+
+    def test_standard_results_match_parent(self, simple_airplane, op_point):
+        """AVLWithStripForces must return the same base results as asb.AVL."""
+        import aerosandbox as asb
+        from app.services.avl_strip_forces import AVLWithStripForces
+
+        parent_avl = asb.AVL(
+            airplane=simple_airplane,
+            op_point=op_point,
+            avl_command=str(AVL_BINARY),
+            timeout=15,
+        )
+        parent_result = parent_avl.run()
+
+        child_avl = AVLWithStripForces(
+            airplane=simple_airplane,
+            op_point=op_point,
+            avl_command=str(AVL_BINARY),
+            timeout=15,
+        )
+        child_result = child_avl.run()
+
+        # Key aerodynamic coefficients must match
+        for key in ["CL", "CD", "Cm", "CLa", "Cma"]:
+            assert child_result[key] == pytest.approx(parent_result[key], rel=1e-4), \
+                f"{key}: {child_result[key]} != {parent_result[key]}"


### PR DESCRIPTION
## Summary
- New `AVLWithStripForces(asb.AVL)` subclass that captures spanwise strip-force data via AVL's `FS` command
- Strip-force parser for AVL's tabular stdout output (15 columns per strip)
- Pydantic schemas: `StripForcesResponse`, `SurfaceStripForces`, `StripForceEntry`
- New endpoint: `POST /aeroplanes/{id}/wings/{name}/strip_forces`
- 9 tests (5 parser unit, 2 keystroke unit, 2 integration)

## How it works
AVL's `FS` command prints strip forces to stdout (not to a file). The subclass overrides `run()` to capture stdout, extract the strip-force section, and add it to the result dict alongside the standard stability derivatives.

Closes #140, #141, #142, #143, #144. Part of #40.

## Test plan
- [x] `poetry run pytest app/tests/test_avl_strip_forces.py -v` — 7 passed
- [x] `poetry run pytest app/tests/test_avl_strip_forces_integration.py -v -m slow` — 2 passed
- [x] `poetry run pytest app/tests/ -m "not slow" -x -q` — 439 passed, no regressions
- [x] `poetry run ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)