### PR TITLE
feat: strip-force distribution charts in Analysis tab

### DIFF
--- a/frontend/app/workbench/analysis/page.tsx
+++ b/frontend/app/workbench/analysis/page.tsx
@@ -4,12 +4,14 @@ import { useState } from "react";
 import { Settings, X } from "lucide-react";
 import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
 import { useAnalysis } from "@/hooks/useAnalysis";
+import { useStripForces } from "@/hooks/useStripForces";
 import { AnalysisViewerPanel } from "@/components/workbench/AnalysisViewerPanel";
 import { AnalysisConfigPanel } from "@/components/workbench/AnalysisConfigPanel";
 
 export default function AnalysisPage() {
-  const { aeroplaneId } = useAeroplaneContext();
+  const { aeroplaneId, selectedWing } = useAeroplaneContext();
   const analysis = useAnalysis(aeroplaneId);
+  const stripForces = useStripForces(aeroplaneId);
   const [configOpen, setConfigOpen] = useState(false);
 
   return (
@@ -32,6 +34,8 @@ export default function AnalysisPage() {
             aeroplaneId={aeroplaneId}
             lastRunTime={analysis.lastRunTime}
             lastRunDurationMs={analysis.lastRunDurationMs}
+            stripForces={stripForces.result}
+            stripForcesLoading={stripForces.isRunning}
           />
         </div>
       </div>
@@ -57,7 +61,19 @@ export default function AnalysisPage() {
                 <X size={14} />
               </button>
             </div>
-            <AnalysisConfigPanel analysis={analysis} />
+            <AnalysisConfigPanel
+              analysis={analysis}
+              onRunStripForces={selectedWing ? (params) => {
+                stripForces.run({
+                  wing_name: selectedWing,
+                  velocity: params.velocity_m_s,
+                  alpha: (params.alpha_start_deg + params.alpha_end_deg) / 2,
+                  beta: params.beta_deg,
+                  altitude: 100,
+                  xyz_ref: params.xyz_ref_m,
+                });
+              } : undefined}
+            />
           </div>
         </div>
       )}

--- a/frontend/components/workbench/AnalysisConfigPanel.tsx
+++ b/frontend/components/workbench/AnalysisConfigPanel.tsx
@@ -6,7 +6,9 @@ import type { UseAnalysisReturn } from "@/hooks/useAnalysis";
 
 type Mode = "single" | "sweep";
 
-export function AnalysisConfigPanel({ analysis }: { analysis: UseAnalysisReturn }) {
+import type { AlphaSweepParams } from "@/hooks/useAnalysis";
+
+export function AnalysisConfigPanel({ analysis, onRunStripForces }: { analysis: UseAnalysisReturn; onRunStripForces?: (params: AlphaSweepParams) => void }) {
   const [mode, setMode] = useState<Mode>("sweep");
   const [advancedOpen, setAdvancedOpen] = useState(false);
 
@@ -26,7 +28,7 @@ export function AnalysisConfigPanel({ analysis }: { analysis: UseAnalysisReturn 
       ? xyzParts
       : [0, 0, 0];
 
-    analysis.runAlphaSweep({
+    const params: AlphaSweepParams = {
       analysis_tool: analysisTool,
       velocity_m_s: parseFloat(velocity) || 14.0,
       alpha_start_deg: parseFloat(alphaStart) || -5.0,
@@ -34,7 +36,11 @@ export function AnalysisConfigPanel({ analysis }: { analysis: UseAnalysisReturn 
       alpha_step_deg: parseFloat(alphaStep) || 1.0,
       beta_deg: parseFloat(beta) || 0.0,
       xyz_ref_m: xyz,
-    });
+    };
+    analysis.runAlphaSweep(params);
+    if (analysisTool === "avl" && onRunStripForces) {
+      onRunStripForces(params);
+    }
   };
 
   const handleReset = () => {

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -3,9 +3,10 @@
 import { useState, useMemo } from "react";
 import { Wind, SlidersHorizontal, Activity, Maximize2, Minimize2 } from "lucide-react";
 import type { AnalysisResult } from "@/hooks/useAnalysis";
+import type { StripForcesResult } from "@/hooks/useStripForces";
 import { StreamlinesViewer } from "@/components/workbench/StreamlinesViewer";
 
-const TABS = ["Polar", "Three-View", "Streamlines", "Diagrams"] as const;
+const TABS = ["Polar", "Distributions", "Streamlines", "Three-View"] as const;
 type Tab = (typeof TABS)[number];
 
 interface Props {
@@ -13,6 +14,8 @@ interface Props {
   aeroplaneId: string | null;
   lastRunTime?: Date | null;
   lastRunDurationMs?: number | null;
+  stripForces?: StripForcesResult | null;
+  stripForcesLoading?: boolean;
 }
 
 // ── SVG Line Chart ──────────────────────────────────────────────
@@ -146,7 +149,7 @@ function LineChart({
 
 // ── Main Component ──────────────────────────────────────────────
 
-export function AnalysisViewerPanel({ result, aeroplaneId, lastRunTime, lastRunDurationMs }: Props) {
+export function AnalysisViewerPanel({ result, aeroplaneId, lastRunTime, lastRunDurationMs, stripForces, stripForcesLoading }: Props) {
   const [activeTab, setActiveTab] = useState<Tab>("Polar");
   const [maximizedChart, setMaximizedChart] = useState<string | null>(null);
 
@@ -252,14 +255,77 @@ export function AnalysisViewerPanel({ result, aeroplaneId, lastRunTime, lastRunD
       {activeTab === "Streamlines" && (
         <StreamlinesViewer aeroplaneId={aeroplaneId} />
       )}
-      {activeTab === "Three-View" && (
-        <div className="flex flex-1 items-center justify-center bg-card-muted">
-          <span className="font-[family-name:var(--font-geist-sans)] text-[13px] text-muted-foreground">
-            Coming soon
-          </span>
+      {activeTab === "Distributions" && (
+        <div className="flex flex-1 flex-col gap-4 overflow-auto bg-card-muted p-6">
+          {stripForcesLoading ? (
+            <div className="flex flex-1 items-center justify-center">
+              <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-muted-foreground">
+                Running AVL strip-force analysis...
+              </span>
+            </div>
+          ) : stripForces && stripForces.surfaces.length > 0 ? (
+            (() => {
+              // Merge all non-YDUP surfaces for the distribution plot
+              const primary = stripForces.surfaces.filter((s) => !s.surface_name.includes("YDUP"));
+              const allStrips = primary.flatMap((s) => s.strips);
+              if (allStrips.length === 0) return <span className="text-[12px] text-muted-foreground">No strip data</span>;
+
+              const ySpan = allStrips.map((s) => s.Yle);
+              const cl = allStrips.map((s) => s.cl);
+              const cd = allStrips.map((s) => s.cd);
+              const cCl = allStrips.map((s) => s.c_cl);
+              const cmC4 = allStrips.map((s) => s["cm_c/4"]);
+              const ai = allStrips.map((s) => s.ai);
+              const xFmt = (v: number) => v.toFixed(2);
+
+              const distCharts = [
+                { id: "sf-cl", xData: ySpan, yData: cl, xLabel: "y [m]", yLabel: "Cl", title: "Cl vs span", color: "var(--color-primary)", xFormat: xFmt },
+                { id: "sf-ccl", xData: ySpan, yData: cCl, xLabel: "y [m]", yLabel: "c·Cl", title: "c·Cl vs span", color: "#30A46C", xFormat: xFmt },
+                { id: "sf-cd", xData: ySpan, yData: cd, xLabel: "y [m]", yLabel: "Cd", title: "Cd vs span", color: "var(--color-destructive)", xFormat: xFmt },
+                { id: "sf-cm", xData: ySpan, yData: cmC4, xLabel: "y [m]", yLabel: "Cm c/4", title: "Cm c/4 vs span", color: "#A78BFA", xFormat: xFmt },
+                { id: "sf-ai", xData: ySpan, yData: ai, xLabel: "y [m]", yLabel: "αi [rad]", title: "Induced AoA vs span", color: "#E5484D", xFormat: xFmt },
+              ];
+
+              if (maximizedChart) {
+                const chart = distCharts.find((c) => c.id === maximizedChart);
+                if (!chart) return null;
+                return (
+                  <div className="flex flex-1">
+                    <LineChart {...chart} onToggleMaximize={() => toggleChart(chart.id)} isMaximized />
+                  </div>
+                );
+              }
+              return (
+                <div className="flex flex-col gap-4">
+                  <div className="grid grid-cols-3 gap-4">
+                    {distCharts.slice(0, 3).map((c) => (
+                      <LineChart key={c.id} {...c} onToggleMaximize={() => toggleChart(c.id)} />
+                    ))}
+                  </div>
+                  <div className="grid grid-cols-2 gap-4">
+                    {distCharts.slice(3).map((c) => (
+                      <LineChart key={c.id} {...c} onToggleMaximize={() => toggleChart(c.id)} />
+                    ))}
+                  </div>
+                  <div className="mt-1 text-[11px] text-muted-foreground">
+                    α = {stripForces.alpha.toFixed(1)}° · Mach = {stripForces.mach.toFixed(3)} · Sref = {stripForces.sref.toFixed(4)} m² · {primary.map((s) => s.surface_name).join(", ")}
+                  </div>
+                </div>
+              );
+            })()
+          ) : (
+            <div className="flex flex-1 flex-col items-center justify-center gap-4">
+              <span className="font-[family-name:var(--font-jetbrains-mono)] text-[14px] text-muted-foreground">
+                Run an analysis to see strip-force distributions
+              </span>
+              <span className="text-[12px] text-subtle-foreground">
+                Switch to AVL in the config panel and click {"\u201C"}Run Analysis{"\u201D"}
+              </span>
+            </div>
+          )}
         </div>
       )}
-      {activeTab === "Diagrams" && (
+      {activeTab === "Three-View" && (
         <div className="flex flex-1 items-center justify-center bg-card-muted">
           <span className="font-[family-name:var(--font-geist-sans)] text-[13px] text-muted-foreground">
             Coming soon

--- a/frontend/hooks/useStripForces.ts
+++ b/frontend/hooks/useStripForces.ts
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { API_BASE } from "@/lib/fetcher";
+
+export interface StripForceEntry {
+  j: number;
+  Xle: number;
+  Yle: number;
+  Zle: number;
+  Chord: number;
+  Area: number;
+  c_cl: number;
+  ai: number;
+  cl_norm: number;
+  cl: number;
+  cd: number;
+  cdv: number;
+  "cm_c/4": number;
+  cm_LE: number;
+  "C.P.x/c": number;
+}
+
+export interface SurfaceStripForces {
+  surface_name: string;
+  surface_number: number;
+  n_chordwise: number;
+  n_spanwise: number;
+  surface_area: number;
+  strips: StripForceEntry[];
+}
+
+export interface StripForcesResult {
+  alpha: number;
+  mach: number;
+  sref: number;
+  cref: number;
+  bref: number;
+  surfaces: SurfaceStripForces[];
+}
+
+export interface StripForcesParams {
+  wing_name: string;
+  velocity: number;
+  alpha: number;
+  beta: number;
+  altitude: number;
+  xyz_ref: number[];
+}
+
+export function useStripForces(aeroplaneId: string | null) {
+  const [result, setResult] = useState<StripForcesResult | null>(null);
+  const [isRunning, setIsRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = useCallback(
+    async (params: StripForcesParams) => {
+      if (!aeroplaneId) return;
+      setIsRunning(true);
+      setError(null);
+
+      try {
+        const res = await fetch(
+          `${API_BASE}/aeroplanes/${aeroplaneId}/wings/${encodeURIComponent(params.wing_name)}/strip_forces`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              velocity: params.velocity,
+              alpha: params.alpha,
+              beta: params.beta,
+              altitude: params.altitude,
+              xyz_ref: params.xyz_ref,
+            }),
+          },
+        );
+        if (!res.ok) {
+          const body = await res.text();
+          throw new Error(`Strip forces failed: ${res.status} ${body}`);
+        }
+        const data: StripForcesResult = await res.json();
+        setResult(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setIsRunning(false);
+      }
+    },
+    [aeroplaneId],
+  );
+
+  return { result, isRunning, error, run };
+}


### PR DESCRIPTION
## Summary
- New "Distributions" tab in the Analysis viewer with 5 spanwise charts:
  - Cl vs span, c·Cl vs span, Cd vs span, Cm c/4 vs span, induced AoA vs span
- `useStripForces` hook for the `POST /strip_forces` endpoint
- Auto-triggers strip-force analysis when running AVL (mid-alpha of sweep range)
- Reuses existing SVG LineChart component with maximize/restore toggle

## How it works
When the user runs an AVL alpha sweep, the strip-force endpoint is called in parallel with the mid-alpha operating point. The "Distributions" tab shows the results using the same chart pattern as the Polar tab.

Part of #40.

## Test plan
- [ ] Run AVL analysis → switch to "Distributions" tab → 5 charts visible
- [ ] Charts show physically plausible data (Cl > 0 at positive alpha, Cd > 0)
- [ ] Maximize/restore toggle works on each chart
- [ ] Non-AVL tools (aero_buildup) → "Distributions" shows placeholder message
- [ ] TypeScript: no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)