### PR TITLE
chore: Migrate to Annotated DI + remove redundant response_model (S8410/S8409)

### DIFF
--- a/app/api/v2/endpoints/aeroanalysis.py
+++ b/app/api/v2/endpoints/aeroanalysis.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from typing import Annotated
 from urllib.parse import urljoin
 from uuid import uuid4
 
@@ -74,9 +75,9 @@ def _save_png_and_get_static_url(
     operation_id="get_airplane_strip_forces",
 )
 async def get_airplane_strip_forces(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    operating_point: OperatingPointSchema = Body(..., description="The operating point"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    operating_point: Annotated[OperatingPointSchema, Body(..., description="The operating point")],
+    db: Annotated[Session, Depends(get_db)],
 ):
     """Run AVL analysis for the full airplane and return strip-force distributions for all surfaces."""
     try:
@@ -97,10 +98,10 @@ async def get_airplane_strip_forces(
     operation_id="get_wing_strip_forces",
 )
 async def get_wing_strip_forces(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    wing_name: str = Path(..., description="The name of the wing"),
-    operating_point: OperatingPointSchema = Body(..., description="The operating point"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    wing_name: Annotated[str, Path(..., description="The name of the wing")],
+    operating_point: Annotated[OperatingPointSchema, Body(..., description="The operating point")],
+    db: Annotated[Session, Depends(get_db)],
 ):
     """Run AVL analysis and return spanwise strip-force distributions."""
     try:
@@ -118,11 +119,11 @@ async def get_wing_strip_forces(
              tags=["analysis"],
              operation_id="analyze_wing_aerodynamics")
 async def analyze_wing_post(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    wing_name: str = Path(..., description="The ID of the wing"),
-    operating_point: OperatingPointSchema = Body(..., description="The operating point of the analysis"),
-    analysis_tool: AnalysisToolUrlType = Path(..., description="The tool for aerodynamic analysis"),
-    db: Session = Depends(get_db)
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    wing_name: Annotated[str, Path(..., description="The ID of the wing")],
+    operating_point: Annotated[OperatingPointSchema, Body(..., description="The operating point of the analysis")],
+    analysis_tool: Annotated[AnalysisToolUrlType, Path(..., description="The tool for aerodynamic analysis")],
+    db: Annotated[Session, Depends(get_db)]
 ):
     """Analyze wings using aerobuildup, avl or vortex lattice and return the analysis results."""
     try:
@@ -138,13 +139,12 @@ async def analyze_wing_post(
 
 @router.post("/aeroplanes/{aeroplane_id}/stability_summary/{analysis_tool}",
              tags=["analysis"],
-             operation_id="get_stability_summary",
-             response_model=StabilitySummaryResponse)
+             operation_id="get_stability_summary")
 async def get_stability_summary(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    operating_point: OperatingPointSchema = Body(..., description="The operating point for the analysis"),
-    analysis_tool: AnalysisToolUrlType = Path(..., description="The analysis tool to use"),
-    db: Session = Depends(get_db)
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    operating_point: Annotated[OperatingPointSchema, Body(..., description="The operating point for the analysis")],
+    analysis_tool: Annotated[AnalysisToolUrlType, Path(..., description="The analysis tool to use")],
+    db: Annotated[Session, Depends(get_db)]
 ) -> StabilitySummaryResponse:
     """Get static stability summary (neutral point, static margin, stability derivatives)."""
     try:
@@ -162,10 +162,10 @@ async def get_stability_summary(
              tags=["analysis"],
              operation_id="analyze_airplane_at_operating_point")
 async def analyze_airplane_post(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    operating_point: OperatingPointSchema = Body(..., description="The operating point of the analysis"),
-    analysis_tool: AnalysisToolUrlType = Path(..., description="The tool for aerodynamic analysis"),
-    db: Session = Depends(get_db)
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    operating_point: Annotated[OperatingPointSchema, Body(..., description="The operating point of the analysis")],
+    analysis_tool: Annotated[AnalysisToolUrlType, Path(..., description="The tool for aerodynamic analysis")],
+    db: Annotated[Session, Depends(get_db)]
 ):
     """Analyze an airplane using aerobuildup, avl or vortex lattice and return the analysis results."""
     try:
@@ -183,9 +183,9 @@ async def analyze_airplane_post(
              tags=["analysis"],
              operation_id="get_streamlines_json")
 async def calculate_streamlines_json(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    operating_point: OperatingPointSchema = Body(..., description="The operating point"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    operating_point: Annotated[OperatingPointSchema, Body(..., description="The operating point")],
+    db: Annotated[Session, Depends(get_db)],
 ):
     """Calculate VLM streamlines and return Plotly figure as JSON."""
     try:
@@ -203,9 +203,9 @@ async def calculate_streamlines_json(
              tags=["analysis"],
              operation_id="analyze_alpha_sweep")
 async def analyze_airplane_alpha_sweep(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    sweep_request: AlphaSweepRequest = Body(..., description="Sweep definitions and flight conditions"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    sweep_request: Annotated[AlphaSweepRequest, Body(..., description="Sweep definitions and flight conditions")],
+    db: Annotated[Session, Depends(get_db)],
 ):
     """Performs an angle of attack sweep for a given airplane."""
     try:
@@ -218,14 +218,13 @@ async def analyze_airplane_alpha_sweep(
 
 @router.post("/aeroplanes/{aeroplane_id}/alpha_sweep/diagram",
              tags=["analysis"],
-             response_model=StaticUrlResponse,
              operation_id="analyze_alpha_sweep_diagram")
 async def analyze_airplane_alpha_sweep_diagram(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    sweep_request: AlphaSweepRequest = Body(..., description="Sweep definitions and flight conditions"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    sweep_request: Annotated[AlphaSweepRequest, Body(..., description="Sweep definitions and flight conditions")],
+    db: Annotated[Session, Depends(get_db)],
+    settings: Annotated[Settings, Depends(get_settings)],
     request: Request = None,
-    settings: Settings = Depends(get_settings),
 ) -> StaticUrlResponse:
     """Performs an angle of attack sweep, saves diagram under tmp, and returns its static URL."""
     base_url = _resolve_base_url(request, settings)
@@ -245,9 +244,9 @@ async def analyze_airplane_alpha_sweep_diagram(
              tags=["analysis"],
              operation_id="analyze_parameter_sweep")
 async def analyze_airplane_simple_sweep(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    sweep_request: SimpleSweepRequest = Body(..., description="Sweep definitions and flight conditions"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    sweep_request: Annotated[SimpleSweepRequest, Body(..., description="Sweep definitions and flight conditions")],
+    db: Annotated[Session, Depends(get_db)],
 ):
     """Performs sweep through the given sweep variable for a given airplane."""
     try:
@@ -273,13 +272,12 @@ async def analyze_airplane_simple_sweep(
 
 @router.get("/aeroplanes/{aeroplane_id}/three_view/url",
          tags=["analysis"],
-         response_model=StaticUrlResponse,
          operation_id="get_aeroplane_three_view_url")
 async def get_aeroplane_three_view_url(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    db: Annotated[Session, Depends(get_db)],
+    settings: Annotated[Settings, Depends(get_settings)],
     request: Request = None,
-    settings: Settings = Depends(get_settings),
 ) -> StaticUrlResponse:
     """Generates a three-view diagram, saves it under tmp, and returns its static URL."""
     try:
@@ -300,14 +298,13 @@ async def get_aeroplane_three_view_url(
 
 @router.post("/aeroplanes/{aeroplane_id}/operating_point/vortex_lattice/streamlines/three_view/url",
              tags=["analysis"],
-             response_model=StaticUrlResponse,
              operation_id="get_streamlines_three_view_url")
 async def get_streamlines_three_view_url(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    operating_point: OperatingPointSchema = Body(..., description="The operating point of the analysis"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    operating_point: Annotated[OperatingPointSchema, Body(..., description="The operating point of the analysis")],
+    db: Annotated[Session, Depends(get_db)],
+    settings: Annotated[Settings, Depends(get_settings)],
     request: Request = None,
-    settings: Settings = Depends(get_settings),
 ) -> StaticUrlResponse:
     """Generates streamlines three-view image, saves it under tmp, and returns its static URL."""
     try:

--- a/app/api/v2/endpoints/aeroplane/base.py
+++ b/app/api/v2/endpoints/aeroplane/base.py
@@ -166,8 +166,8 @@ async def get_aeroplane_total_mass_in_kg(
 async def create_aeroplane_total_mass_kg(
         aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
         total_mass_kg: Annotated[AeroplaneMassRequest, Body(..., description="The total mass of the aeroplane in kg")],
+        db: Annotated[Session, Depends(get_db)],
         response: Response = None,
-        db: Annotated[Session, Depends(get_db)] = None,
 ) -> OperationStatusResponse:
     """Set the total mass of the aeroplane in kg. If it already exists, it will be overwritten."""
     try:

--- a/app/api/v2/endpoints/aeroplane/base.py
+++ b/app/api/v2/endpoints/aeroplane/base.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-from typing import List
+from typing import Annotated, List
 
 from fastapi import APIRouter, Path, Depends, Query, Body, Response, HTTPException
 from fastapi import status
@@ -55,11 +55,10 @@ def _raise_http_from_domain(exc: ServiceException) -> None:
 
 
 @router.get("/aeroplanes",
-            response_model=GetAeroplaneResponse,
             status_code=status.HTTP_200_OK,
             tags=["aeroplanes"],
             operation_id="get_all_aeroplanes")
-async def get_aeroplanes(db: Session = Depends(get_db)) -> GetAeroplaneResponse:
+async def get_aeroplanes(db: Annotated[Session, Depends(get_db)]) -> GetAeroplaneResponse:
     """Returns a list of all aeroplanes names with ids alphabetically sorted by the name."""
     try:
         aeroplanes = aeroplane_service.list_all_aeroplanes(db)
@@ -81,13 +80,12 @@ async def get_aeroplanes(db: Session = Depends(get_db)) -> GetAeroplaneResponse:
 
 
 @router.post("/aeroplanes",
-             response_model=CreateAeroplaneResponse,
              status_code=status.HTTP_201_CREATED,
              tags=["aeroplanes"],
              operation_id="create_aeroplane")
 async def create_aeroplane(
-        name: str = Query(..., description="The aeroplanes name.", examples=["RV-7", "eHawk"]),
-        db: Session = Depends(get_db)
+        name: Annotated[str, Query(..., description="The aeroplanes name.", examples=["RV-7", "eHawk"])],
+        db: Annotated[Session, Depends(get_db)],
 ) -> CreateAeroplaneResponse:
     """Create a new aeroplane instance and returns its ID."""
     try:
@@ -102,12 +100,11 @@ async def create_aeroplane(
 
 @router.get("/aeroplanes/{aeroplane_id}",
             status_code=status.HTTP_200_OK,
-            response_model=schemas.AeroplaneSchema,
             tags=["aeroplanes"],
             operation_id="get_aeroplane_by_id")
 async def get_aeroplane(
-        aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-        db: Session = Depends(get_db)
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        db: Annotated[Session, Depends(get_db)],
 ) -> schemas.AeroplaneSchema:
     """Returns the aeroplane definition."""
     try:
@@ -125,8 +122,8 @@ async def get_aeroplane(
                tags=["aeroplanes"],
                operation_id="delete_aeroplane")
 async def delete_aeroplane(
-        aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane to be deleted"),
-        db: Session = Depends(get_db)
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane to be deleted")],
+        db: Annotated[Session, Depends(get_db)],
 ):
     """Deletes the aeroplane."""
     try:
@@ -141,12 +138,11 @@ async def delete_aeroplane(
 
 @router.get("/aeroplanes/{aeroplane_id}/total_mass_kg",
             status_code=status.HTTP_200_OK,
-            response_model=AeroplaneMassRequest,
             tags=["aeroplanes"],
             operation_id="get_aeroplane_total_mass")
 async def get_aeroplane_total_mass_in_kg(
-        aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-        db: Session = Depends(get_db)
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        db: Annotated[Session, Depends(get_db)],
 ) -> AeroplaneMassRequest:
     """Returns the total weight of the aeroplane in kg."""
     try:
@@ -161,7 +157,6 @@ async def get_aeroplane_total_mass_in_kg(
 
 @router.post("/aeroplanes/{aeroplane_id}/total_mass_kg",
              status_code=status.HTTP_201_CREATED,
-             response_model=OperationStatusResponse,
              responses={
                  200: {"model": OperationStatusResponse},
                  201: {"model": OperationStatusResponse},
@@ -169,10 +164,10 @@ async def get_aeroplane_total_mass_in_kg(
              tags=["aeroplanes"],
              operation_id="set_aeroplane_total_mass")
 async def create_aeroplane_total_mass_kg(
-        aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-        total_mass_kg: AeroplaneMassRequest = Body(..., description="The total mass of the aeroplane in kg"),
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        total_mass_kg: Annotated[AeroplaneMassRequest, Body(..., description="The total mass of the aeroplane in kg")],
         response: Response = None,
-        db: Session = Depends(get_db)
+        db: Annotated[Session, Depends(get_db)] = None,
 ) -> OperationStatusResponse:
     """Set the total mass of the aeroplane in kg. If it already exists, it will be overwritten."""
     try:
@@ -195,13 +190,12 @@ async def create_aeroplane_total_mass_kg(
 @router.get(
     "/aeroplanes/{aeroplane_id}/airplane_configuration",
     status_code=status.HTTP_200_OK,
-    response_model=AirplaneConfigurationResponse,
     tags=["aeroplanes"],
     operation_id="get_aeroplane_airplane_configuration",
 )
 async def get_aeroplane_airplane_configuration(
-        aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-        db: Session = Depends(get_db)
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        db: Annotated[Session, Depends(get_db)],
 ) -> AirplaneConfigurationResponse:
     """Returns the full AirplaneConfiguration payload for the aeroplane."""
     try:

--- a/app/api/v2/endpoints/aeroplane/component_tree.py
+++ b/app/api/v2/endpoints/aeroplane/component_tree.py
@@ -1,7 +1,7 @@
 """Endpoints for the per-aeroplane component tree."""
 
 import logging
-from typing import Optional
+from typing import Annotated, Optional
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, status
 from sqlalchemy.orm import Session
@@ -48,12 +48,11 @@ def _call(func, *args, **kwargs):
 @router.get(
     "",
     status_code=status.HTTP_200_OK,
-    response_model=ComponentTreeResponse,
     operation_id="get_component_tree",
 )
 async def get_component_tree(
-    aeroplane_id: str = Path(...),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[str, Path(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> ComponentTreeResponse:
     """Get the full component tree for an aeroplane."""
     return _call(svc.get_tree, db, aeroplane_id)
@@ -62,13 +61,12 @@ async def get_component_tree(
 @router.post(
     "",
     status_code=status.HTTP_201_CREATED,
-    response_model=ComponentTreeNodeRead,
     operation_id="add_tree_node",
 )
 async def add_tree_node(
-    aeroplane_id: str = Path(...),
-    body: ComponentTreeNodeWrite = Body(...),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[str, Path(...)],
+    body: Annotated[ComponentTreeNodeWrite, Body(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> ComponentTreeNodeRead:
     """Add a node to the component tree."""
     return _call(svc.add_node, db, aeroplane_id, body)
@@ -77,14 +75,13 @@ async def add_tree_node(
 @router.put(
     "/{node_id}",
     status_code=status.HTTP_200_OK,
-    response_model=ComponentTreeNodeRead,
     operation_id="update_tree_node",
 )
 async def update_tree_node(
-    aeroplane_id: str = Path(...),
-    node_id: int = Path(...),
-    body: ComponentTreeNodeWrite = Body(...),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[str, Path(...)],
+    node_id: Annotated[int, Path(...)],
+    body: Annotated[ComponentTreeNodeWrite, Body(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> ComponentTreeNodeRead:
     """Update a node in the component tree."""
     return _call(svc.update_node, db, aeroplane_id, node_id, body)
@@ -96,9 +93,9 @@ async def update_tree_node(
     operation_id="delete_tree_node",
 )
 async def delete_tree_node(
-    aeroplane_id: str = Path(...),
-    node_id: int = Path(...),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[str, Path(...)],
+    node_id: Annotated[int, Path(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> None:
     """Delete a node from the tree. Synced nodes cannot be deleted (use move instead)."""
     _call(svc.delete_node, db, aeroplane_id, node_id)
@@ -107,14 +104,13 @@ async def delete_tree_node(
 @router.post(
     "/{node_id}/move",
     status_code=status.HTTP_200_OK,
-    response_model=ComponentTreeNodeRead,
     operation_id="move_tree_node",
 )
 async def move_tree_node(
-    aeroplane_id: str = Path(...),
-    node_id: int = Path(...),
-    body: MoveNodeRequest = Body(...),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[str, Path(...)],
+    node_id: Annotated[int, Path(...)],
+    body: Annotated[MoveNodeRequest, Body(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> ComponentTreeNodeRead:
     """Move a node to a new parent position."""
     return _call(svc.move_node, db, aeroplane_id, node_id, body.new_parent_id, body.sort_index)
@@ -123,13 +119,12 @@ async def move_tree_node(
 @router.get(
     "/{node_id}/weight",
     status_code=status.HTTP_200_OK,
-    response_model=WeightResponse,
     operation_id="get_node_weight",
 )
 async def get_node_weight(
-    aeroplane_id: str = Path(...),
-    node_id: int = Path(...),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[str, Path(...)],
+    node_id: Annotated[int, Path(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> WeightResponse:
     """Calculate the recursive weight for a node (own + all children)."""
     return _call(svc.calculate_weight, db, aeroplane_id, node_id)

--- a/app/api/v2/endpoints/aeroplane/construction_parts.py
+++ b/app/api/v2/endpoints/aeroplane/construction_parts.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional
+from typing import Annotated, Optional
 
 from fastapi import APIRouter, Body, Depends, File, Form, HTTPException, Path, Query, UploadFile, status
 from fastapi.responses import FileResponse
@@ -64,12 +64,11 @@ def _call(func, *args, **kwargs):
 @router.get(
     "",
     status_code=status.HTTP_200_OK,
-    response_model=ConstructionPartList,
     operation_id="list_construction_parts",
 )
 async def list_construction_parts(
-    aeroplane_id: str = Path(...),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[str, Path(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> ConstructionPartList:
     """List all construction parts owned by the given aeroplane."""
     return _call(svc.list_parts, db, aeroplane_id)
@@ -78,13 +77,12 @@ async def list_construction_parts(
 @router.get(
     "/{part_id}",
     status_code=status.HTTP_200_OK,
-    response_model=ConstructionPartRead,
     operation_id="get_construction_part",
 )
 async def get_construction_part(
-    aeroplane_id: str = Path(...),
-    part_id: int = Path(...),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[str, Path(...)],
+    part_id: Annotated[int, Path(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> ConstructionPartRead:
     """Fetch a single construction part scoped to the given aeroplane."""
     return _call(svc.get_part, db, aeroplane_id, part_id)
@@ -93,13 +91,12 @@ async def get_construction_part(
 @router.put(
     "/{part_id}/lock",
     status_code=status.HTTP_200_OK,
-    response_model=ConstructionPartRead,
     operation_id="lock_construction_part",
 )
 async def lock_construction_part(
-    aeroplane_id: str = Path(...),
-    part_id: int = Path(...),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[str, Path(...)],
+    part_id: Annotated[int, Path(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> ConstructionPartRead:
     """Mark the part as locked. Idempotent."""
     return _call(svc.lock_part, db, aeroplane_id, part_id)
@@ -108,13 +105,12 @@ async def lock_construction_part(
 @router.put(
     "/{part_id}/unlock",
     status_code=status.HTTP_200_OK,
-    response_model=ConstructionPartRead,
     operation_id="unlock_construction_part",
 )
 async def unlock_construction_part(
-    aeroplane_id: str = Path(...),
-    part_id: int = Path(...),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[str, Path(...)],
+    part_id: Annotated[int, Path(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> ConstructionPartRead:
     """Mark the part as unlocked. Idempotent."""
     return _call(svc.unlock_part, db, aeroplane_id, part_id)
@@ -126,16 +122,15 @@ async def unlock_construction_part(
 @router.post(
     "",
     status_code=status.HTTP_201_CREATED,
-    response_model=ConstructionPartRead,
     operation_id="upload_construction_part",
 )
 async def upload_construction_part(
-    aeroplane_id: str = Path(...),
-    file: UploadFile = File(..., description="STEP (.step/.stp) or STL (.stl) file"),
-    name: str = Form(..., min_length=1, description="Display name"),
-    material_component_id: Optional[int] = Form(None, description="FK to components (material)"),
-    thumbnail_url: Optional[str] = Form(None, description="Optional preview image URL"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[str, Path(...)],
+    file: Annotated[UploadFile, File(..., description="STEP (.step/.stp) or STL (.stl) file")],
+    name: Annotated[str, Form(..., min_length=1, description="Display name")],
+    db: Annotated[Session, Depends(get_db)],
+    material_component_id: Annotated[Optional[int], Form(description="FK to components (material)")] = None,
+    thumbnail_url: Annotated[Optional[str], Form(description="Optional preview image URL")] = None,
 ) -> ConstructionPartRead:
     """Upload a CAD file and create a new construction-part for this aeroplane.
 
@@ -163,10 +158,10 @@ async def upload_construction_part(
     operation_id="download_construction_part_file",
 )
 async def download_construction_part_file(
-    aeroplane_id: str = Path(...),
-    part_id: int = Path(...),
-    format: str = Query("stl", description="Output format: 'step' or 'stl'"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[str, Path(...)],
+    part_id: Annotated[int, Path(...)],
+    db: Annotated[Session, Depends(get_db)],
+    format: Annotated[str, Query(description="Output format: 'step' or 'stl'")] = "stl",
 ) -> FileResponse:
     """Download the construction-part file in the requested format.
 
@@ -185,14 +180,13 @@ async def download_construction_part_file(
 @router.put(
     "/{part_id}",
     status_code=status.HTTP_200_OK,
-    response_model=ConstructionPartRead,
     operation_id="update_construction_part",
 )
 async def update_construction_part(
-    aeroplane_id: str = Path(...),
-    part_id: int = Path(...),
-    body: ConstructionPartUpdate = Body(...),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[str, Path(...)],
+    part_id: Annotated[int, Path(...)],
+    body: Annotated[ConstructionPartUpdate, Body(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> ConstructionPartRead:
     """Update name / material / thumbnail. File and geometry stay untouched."""
     return _call(svc.update_part, db, aeroplane_id, part_id, body)
@@ -204,9 +198,9 @@ async def update_construction_part(
     operation_id="delete_construction_part",
 )
 async def delete_construction_part(
-    aeroplane_id: str = Path(...),
-    part_id: int = Path(...),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[str, Path(...)],
+    part_id: Annotated[int, Path(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> None:
     """Delete a part and remove its file. Returns 409 if the part is locked."""
     _call(svc.delete_part, db, aeroplane_id, part_id)

--- a/app/api/v2/endpoints/aeroplane/copilot_history.py
+++ b/app/api/v2/endpoints/aeroplane/copilot_history.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Annotated
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, status
 from pydantic import UUID4
@@ -42,13 +43,12 @@ def _call(func, *args, **kwargs):
 @router.get(
     "/aeroplanes/{aeroplane_id}/copilot-history",
     status_code=status.HTTP_200_OK,
-    response_model=CopilotHistory,
     tags=["copilot-history"],
     operation_id="get_copilot_history",
 )
 async def get_copilot_history(
-    aeroplane_id: UUID4 = Path(..., description="The ID of the aeroplane"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> CopilotHistory:
     """Get the full copilot chat history for the aeroplane."""
     return _call(svc.get_history, db, aeroplane_id)
@@ -57,14 +57,13 @@ async def get_copilot_history(
 @router.post(
     "/aeroplanes/{aeroplane_id}/copilot-history",
     status_code=status.HTTP_201_CREATED,
-    response_model=CopilotMessageRead,
     tags=["copilot-history"],
     operation_id="append_copilot_message",
 )
 async def append_copilot_message(
-    aeroplane_id: UUID4 = Path(..., description="The ID of the aeroplane"),
-    body: CopilotMessageWrite = Body(..., description="Message to append"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    body: Annotated[CopilotMessageWrite, Body(..., description="Message to append")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> CopilotMessageRead:
     """Append a new message to the copilot history."""
     return _call(svc.append_message, db, aeroplane_id, body)
@@ -77,8 +76,8 @@ async def append_copilot_message(
     operation_id="clear_copilot_history",
 )
 async def clear_copilot_history(
-    aeroplane_id: UUID4 = Path(..., description="The ID of the aeroplane"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> None:
     """Clear all copilot messages for the aeroplane."""
     _call(svc.clear_history, db, aeroplane_id)
@@ -91,9 +90,9 @@ async def clear_copilot_history(
     operation_id="delete_copilot_message",
 )
 async def delete_copilot_message(
-    aeroplane_id: UUID4 = Path(..., description="The ID of the aeroplane"),
-    message_id: int = Path(..., description="The ID of the message to delete"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    message_id: Annotated[int, Path(..., description="The ID of the message to delete")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> None:
     """Delete a single copilot message."""
     _call(svc.delete_message, db, aeroplane_id, message_id)

--- a/app/api/v2/endpoints/aeroplane/design_versions.py
+++ b/app/api/v2/endpoints/aeroplane/design_versions.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Annotated
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, status
 from pydantic import UUID4
@@ -47,13 +48,12 @@ def _call(func, *args, **kwargs):
 @router.get(
     "/aeroplanes/{aeroplane_id}/design-versions",
     status_code=status.HTTP_200_OK,
-    response_model=list[DesignVersionSummary],
     tags=["design-versions"],
     operation_id="list_design_versions",
 )
 async def list_design_versions(
-    aeroplane_id: UUID4 = Path(..., description="The ID of the aeroplane"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> list[DesignVersionSummary]:
     """List all design version snapshots for the aeroplane."""
     return _call(svc.list_versions, db, aeroplane_id)
@@ -62,14 +62,13 @@ async def list_design_versions(
 @router.post(
     "/aeroplanes/{aeroplane_id}/design-versions",
     status_code=status.HTTP_201_CREATED,
-    response_model=DesignVersionSummary,
     tags=["design-versions"],
     operation_id="create_design_version",
 )
 async def create_design_version(
-    aeroplane_id: UUID4 = Path(..., description="The ID of the aeroplane"),
-    body: DesignVersionCreate = Body(..., description="Version metadata"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    body: Annotated[DesignVersionCreate, Body(..., description="Version metadata")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> DesignVersionSummary:
     """Snapshot the current aeroplane state as a new design version."""
     return _call(svc.create_version, db, aeroplane_id, body)
@@ -78,14 +77,13 @@ async def create_design_version(
 @router.get(
     "/aeroplanes/{aeroplane_id}/design-versions/{version_id}",
     status_code=status.HTTP_200_OK,
-    response_model=DesignVersionRead,
     tags=["design-versions"],
     operation_id="get_design_version",
 )
 async def get_design_version(
-    aeroplane_id: UUID4 = Path(..., description="The ID of the aeroplane"),
-    version_id: int = Path(..., description="The version ID"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    version_id: Annotated[int, Path(..., description="The version ID")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> DesignVersionRead:
     """Read a specific design version including the full snapshot."""
     return _call(svc.get_version, db, aeroplane_id, version_id)
@@ -98,9 +96,9 @@ async def get_design_version(
     operation_id="delete_design_version",
 )
 async def delete_design_version(
-    aeroplane_id: UUID4 = Path(..., description="The ID of the aeroplane"),
-    version_id: int = Path(..., description="The version ID"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    version_id: Annotated[int, Path(..., description="The version ID")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> None:
     """Delete a design version snapshot."""
     _call(svc.delete_version, db, aeroplane_id, version_id)
@@ -109,15 +107,14 @@ async def delete_design_version(
 @router.get(
     "/aeroplanes/{aeroplane_id}/design-versions/{version_a}/diff/{version_b}",
     status_code=status.HTTP_200_OK,
-    response_model=DesignVersionDiff,
     tags=["design-versions"],
     operation_id="diff_design_versions",
 )
 async def diff_design_versions(
-    aeroplane_id: UUID4 = Path(..., description="The ID of the aeroplane"),
-    version_a: int = Path(..., description="First version ID"),
-    version_b: int = Path(..., description="Second version ID"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    version_a: Annotated[int, Path(..., description="First version ID")],
+    version_b: Annotated[int, Path(..., description="Second version ID")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> DesignVersionDiff:
     """Compute a structural diff between two design versions."""
     return _call(svc.diff_versions, db, aeroplane_id, version_a, version_b)

--- a/app/api/v2/endpoints/aeroplane/fuselages.py
+++ b/app/api/v2/endpoints/aeroplane/fuselages.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-from typing import List
+from typing import Annotated, List
 
 from fastapi import APIRouter, Path, Depends, Body, HTTPException
 from fastapi import status
@@ -27,12 +27,11 @@ class OperationStatusResponse(BaseModel):
 # Handle an aeroplane fuselages
 @router.get("/aeroplanes/{aeroplane_id}/fuselages",
             status_code=status.HTTP_200_OK,
-            response_model=List[str],
             tags=["fuselages"],
             operation_id="get_aeroplane_fuselages")
 async def get_aeroplane_fuselages(
-        aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-        db: Session = Depends(get_db)
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        db: Annotated[Session, Depends(get_db)]
 ) -> List[str]:
     """
     Returns a list of aeroplane's fuselage names.
@@ -60,10 +59,10 @@ async def get_aeroplane_fuselages(
             tags=["fuselages"],
             operation_id="create_aeroplane_fuselage")
 async def create_aeroplane_fuselage(
-        aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-        fuselage_name: str = Path(..., description="The ID of the fuselage"),
-        request: schemas.FuselageSchema = Body(..., description="The new fuselage data"),
-        db: Session = Depends(get_db)
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        fuselage_name: Annotated[str, Path(..., description="The ID of the fuselage")],
+        request: Annotated[schemas.FuselageSchema, Body(..., description="The new fuselage data")],
+        db: Annotated[Session, Depends(get_db)]
 ):
     """
     Create the fuselage for the aeroplane.
@@ -110,10 +109,10 @@ async def create_aeroplane_fuselage(
     operation_id="update_aeroplane_fuselage"
 )
 async def update_aeroplane_fuselage(
-        aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-        fuselage_name: str = Path(..., description="The ID of the fuselage"),
-        request: schemas.FuselageSchema = Body(..., description="The new fuselage data"),
-        db: Session = Depends(get_db),
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        fuselage_name: Annotated[str, Path(..., description="The ID of the fuselage")],
+        request: Annotated[schemas.FuselageSchema, Body(..., description="The new fuselage data")],
+        db: Annotated[Session, Depends(get_db)],
 ):
     """
     Overwrite an existing fuselage with the data in the request.
@@ -154,13 +153,12 @@ async def update_aeroplane_fuselage(
 
 
 @router.get("/aeroplanes/{aeroplane_id}/fuselages/{fuselage_name}",
-            response_model=schemas.FuselageSchema,
             tags=["fuselages"],
             operation_id="get_aeroplane_fuselage")
 async def get_aeroplane_fuselage(
-        aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-        fuselage_name: str = Path(..., description="The ID of the fuselage"),
-        db: Session = Depends(get_db)
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        fuselage_name: Annotated[str, Path(..., description="The ID of the fuselage")],
+        db: Annotated[Session, Depends(get_db)]
 ) -> schemas.FuselageSchema:
     """
     Returns the aeroplane fuselage.
@@ -193,9 +191,9 @@ async def get_aeroplane_fuselage(
     operation_id="delete_aeroplane_fuselage"
 )
 async def delete_aeroplane_fuselage(
-        aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-        fuselage_name: str = Path(..., description="The ID of the fuselage"),
-        db: Session = Depends(get_db)
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        fuselage_name: Annotated[str, Path(..., description="The ID of the fuselage")],
+        db: Annotated[Session, Depends(get_db)]
 ):
     """
     Delete a fuselage.
@@ -231,15 +229,14 @@ async def delete_aeroplane_fuselage(
 #########################################
 @router.get(
     "/aeroplanes/{aeroplane_id}/fuselages/{fuselage_name}/cross_sections",
-    response_model=List[schemas.FuselageXSecSuperEllipseSchema],
     status_code=status.HTTP_200_OK,
     tags=["fuselage-cross-sections"],
     operation_id="get_fuselage_cross_sections"
 )
 async def get_aeroplane_fuselage_cross_sections(
-        aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-        fuselage_name: str = Path(..., description="The ID of the fuselage"),
-        db: Session = Depends(get_db)
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        fuselage_name: Annotated[str, Path(..., description="The ID of the fuselage")],
+        db: Annotated[Session, Depends(get_db)]
 ) -> List[schemas.FuselageXSecSuperEllipseSchema]:
     """
     Returns the fuselage's cross-sections as a list.
@@ -274,9 +271,9 @@ async def get_aeroplane_fuselage_cross_sections(
     operation_id="delete_all_fuselage_cross_sections"
 )
 async def delete_aeroplane_fuselage_cross_sections(
-        aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-        fuselage_name: str = Path(..., description="The ID of the fuselage"),
-        db: Session = Depends(get_db)
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        fuselage_name: Annotated[str, Path(..., description="The ID of the fuselage")],
+        db: Annotated[Session, Depends(get_db)]
 ):
     """
     Delete all cross-sections of a fuselage.
@@ -306,16 +303,15 @@ async def delete_aeroplane_fuselage_cross_sections(
 
 @router.get(
     "/aeroplanes/{aeroplane_id}/fuselages/{fuselage_name}/cross_sections/{cross_section_index}",
-    response_model=schemas.FuselageXSecSuperEllipseSchema,
     status_code=status.HTTP_200_OK,
     tags=["fuselage-cross-sections"],
     operation_id="get_fuselage_cross_section"
 )
 async def get_aeroplane_fuselage_cross_section(
-        aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-        fuselage_name: str = Path(..., description="The ID of the fuselage"),
-        cross_section_index: int = Path(..., description="The index of the cross section"),
-        db: Session = Depends(get_db)
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        fuselage_name: Annotated[str, Path(..., description="The ID of the fuselage")],
+        cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+        db: Annotated[Session, Depends(get_db)]
 ) -> schemas.FuselageXSecSuperEllipseSchema:
     """
     Returns the aeroplane fuselage cross-section at the specified index.
@@ -350,12 +346,12 @@ async def get_aeroplane_fuselage_cross_section(
     operation_id="create_fuselage_cross_section"
 )
 async def create_aeroplane_fuselage_cross_section(
-        aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-        fuselage_name: str = Path(..., description="The ID of the fuselage"),
-        cross_section_index: int = Path(...,
-                                        description="The index where it will be spliced into the list of cross sections. (-1 is the end of the list, 0 is the start of the list)"),
-        request: schemas.FuselageXSecSuperEllipseSchema = Body(..., description="Fuselage cross section request"),
-        db: Session = Depends(get_db)
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        fuselage_name: Annotated[str, Path(..., description="The ID of the fuselage")],
+        cross_section_index: Annotated[int, Path(...,
+                                        description="The index where it will be spliced into the list of cross sections. (-1 is the end of the list, 0 is the start of the list)")],
+        request: Annotated[schemas.FuselageXSecSuperEllipseSchema, Body(..., description="Fuselage cross section request")],
+        db: Annotated[Session, Depends(get_db)]
 ) :
     """
     Creates a new cross-section for the fuselage and splice it into the list of cross-sections.
@@ -413,11 +409,11 @@ async def create_aeroplane_fuselage_cross_section(
     operation_id="update_fuselage_cross_section"
 )
 async def update_aeroplane_fuselage_cross_section(
-        aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-        fuselage_name: str = Path(..., description="The ID of the fuselage"),
-        cross_section_index: int = Path(..., description="The index of the cross section"),
-        request: schemas.FuselageXSecSuperEllipseSchema = Body(...),
-        db: Session = Depends(get_db)
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        fuselage_name: Annotated[str, Path(..., description="The ID of the fuselage")],
+        cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+        request: Annotated[schemas.FuselageXSecSuperEllipseSchema, Body(...)],
+        db: Annotated[Session, Depends(get_db)]
 ):
     """
     Updates the cross-section for the fuselage.
@@ -458,10 +454,10 @@ async def update_aeroplane_fuselage_cross_section(
                tags=["fuselage-cross-sections"],
                operation_id="delete_fuselage_cross_section")
 async def delete_aeroplane_fuselage_cross_section(
-        aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-        fuselage_name: str = Path(..., description="The ID of the fuselage"),
-        cross_section_index: int = Path(..., description="The index of the cross section"),
-        db: Session = Depends(get_db)
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        fuselage_name: Annotated[str, Path(..., description="The ID of the fuselage")],
+        cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+        db: Annotated[Session, Depends(get_db)]
 ):
     """
     Delete a cross-section.

--- a/app/api/v2/endpoints/aeroplane/mission_objectives.py
+++ b/app/api/v2/endpoints/aeroplane/mission_objectives.py
@@ -1,3 +1,4 @@
+from typing import Annotated
 import logging
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, status
@@ -43,13 +44,12 @@ def _call(func, *args, **kwargs):
 @router.get(
     "/aeroplanes/{aeroplane_id}/mission-objectives",
     status_code=status.HTTP_200_OK,
-    response_model=MissionObjectivesRead,
     tags=["mission-objectives"],
-    operation_id="get_mission_objectives",
+    operation_id="get_mission_objectives"
 )
 async def get_mission_objectives(
-    aeroplane_id: UUID4 = Path(..., description="The ID of the aeroplane"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> MissionObjectivesRead:
     """Get the mission objectives for the aeroplane."""
     return _call(svc.get_mission_objectives, db, aeroplane_id)
@@ -58,14 +58,13 @@ async def get_mission_objectives(
 @router.put(
     "/aeroplanes/{aeroplane_id}/mission-objectives",
     status_code=status.HTTP_200_OK,
-    response_model=MissionObjectivesRead,
     tags=["mission-objectives"],
-    operation_id="upsert_mission_objectives",
+    operation_id="upsert_mission_objectives"
 )
 async def upsert_mission_objectives(
-    aeroplane_id: UUID4 = Path(..., description="The ID of the aeroplane"),
-    body: MissionObjectivesWrite = Body(..., description="Mission objectives data"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    body: Annotated[MissionObjectivesWrite, Body(..., description="Mission objectives data")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> MissionObjectivesRead:
     """Create or update the mission objectives for the aeroplane."""
     return _call(svc.upsert_mission_objectives, db, aeroplane_id, body)
@@ -78,8 +77,8 @@ async def upsert_mission_objectives(
     operation_id="delete_mission_objectives",
 )
 async def delete_mission_objectives(
-    aeroplane_id: UUID4 = Path(..., description="The ID of the aeroplane"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> None:
     """Delete the mission objectives for the aeroplane."""
     _call(svc.delete_mission_objectives, db, aeroplane_id)

--- a/app/api/v2/endpoints/aeroplane/powertrain_sizing.py
+++ b/app/api/v2/endpoints/aeroplane/powertrain_sizing.py
@@ -1,3 +1,4 @@
+from typing import Annotated
 import logging
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, status
@@ -38,14 +39,13 @@ def _call(func, *args, **kwargs):
 @router.post(
     "/aeroplanes/{aeroplane_id}/powertrain/sizing",
     status_code=status.HTTP_200_OK,
-    response_model=PowertrainSizingResponse,
     tags=["powertrain"],
-    operation_id="size_powertrain",
+    operation_id="size_powertrain"
 )
 async def size_powertrain(
-    aeroplane_id: UUID4 = Path(..., description="The ID of the aeroplane"),
-    body: PowertrainSizingRequest = Body(..., description="Mission parameters for sizing"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    body: Annotated[PowertrainSizingRequest, Body(..., description="Mission parameters for sizing")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> PowertrainSizingResponse:
     """Recommend motor+ESC+battery combos that fit the given mission parameters."""
     return _call(svc.size_powertrain, db, aeroplane_id, body)

--- a/app/api/v2/endpoints/aeroplane/weight_items.py
+++ b/app/api/v2/endpoints/aeroplane/weight_items.py
@@ -1,3 +1,4 @@
+from typing import Annotated
 import logging
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, status
@@ -43,13 +44,12 @@ def _call(func, *args, **kwargs):
 @router.get(
     "/aeroplanes/{aeroplane_id}/weight-items",
     status_code=status.HTTP_200_OK,
-    response_model=WeightSummary,
     tags=["weight-items"],
-    operation_id="list_weight_items",
+    operation_id="list_weight_items"
 )
 async def list_weight_items(
-    aeroplane_id: UUID4 = Path(..., description="The ID of the aeroplane"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> WeightSummary:
     """List all weight items with a total mass summary."""
     return _call(svc.list_weight_items, db, aeroplane_id)
@@ -58,14 +58,13 @@ async def list_weight_items(
 @router.post(
     "/aeroplanes/{aeroplane_id}/weight-items",
     status_code=status.HTTP_201_CREATED,
-    response_model=WeightItemRead,
     tags=["weight-items"],
-    operation_id="create_weight_item",
+    operation_id="create_weight_item"
 )
 async def create_weight_item(
-    aeroplane_id: UUID4 = Path(..., description="The ID of the aeroplane"),
-    body: WeightItemWrite = Body(..., description="Weight item data"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    body: Annotated[WeightItemWrite, Body(..., description="Weight item data")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> WeightItemRead:
     """Add a new weight item to the aeroplane."""
     return _call(svc.create_weight_item, db, aeroplane_id, body)
@@ -74,14 +73,13 @@ async def create_weight_item(
 @router.get(
     "/aeroplanes/{aeroplane_id}/weight-items/{item_id}",
     status_code=status.HTTP_200_OK,
-    response_model=WeightItemRead,
     tags=["weight-items"],
-    operation_id="get_weight_item",
+    operation_id="get_weight_item"
 )
 async def get_weight_item(
-    aeroplane_id: UUID4 = Path(..., description="The ID of the aeroplane"),
-    item_id: int = Path(..., description="The ID of the weight item"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    item_id: Annotated[int, Path(..., description="The ID of the weight item")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> WeightItemRead:
     """Get a single weight item by ID."""
     return _call(svc.get_weight_item, db, aeroplane_id, item_id)
@@ -90,15 +88,14 @@ async def get_weight_item(
 @router.put(
     "/aeroplanes/{aeroplane_id}/weight-items/{item_id}",
     status_code=status.HTTP_200_OK,
-    response_model=WeightItemRead,
     tags=["weight-items"],
-    operation_id="update_weight_item",
+    operation_id="update_weight_item"
 )
 async def update_weight_item(
-    aeroplane_id: UUID4 = Path(..., description="The ID of the aeroplane"),
-    item_id: int = Path(..., description="The ID of the weight item"),
-    body: WeightItemWrite = Body(..., description="Weight item data"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    item_id: Annotated[int, Path(..., description="The ID of the weight item")],
+    body: Annotated[WeightItemWrite, Body(..., description="Weight item data")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> WeightItemRead:
     """Update an existing weight item."""
     return _call(svc.update_weight_item, db, aeroplane_id, item_id, body)
@@ -111,9 +108,9 @@ async def update_weight_item(
     operation_id="delete_weight_item",
 )
 async def delete_weight_item(
-    aeroplane_id: UUID4 = Path(..., description="The ID of the aeroplane"),
-    item_id: int = Path(..., description="The ID of the weight item"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    item_id: Annotated[int, Path(..., description="The ID of the weight item")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> None:
     """Delete a weight item."""
     _call(svc.delete_weight_item, db, aeroplane_id, item_id)

--- a/app/api/v2/endpoints/aeroplane/wings.py
+++ b/app/api/v2/endpoints/aeroplane/wings.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import Annotated, List
 
 from fastapi import APIRouter, Path, Depends, Body, HTTPException
 from fastapi import status
@@ -208,12 +208,11 @@ def _call_service(func, *args, **kwargs):
 
 @router.get("/aeroplanes/{aeroplane_id}/wings",
             status_code=status.HTTP_200_OK,
-            response_model=List[str],
             tags=["wings"],
             operation_id="get_aeroplane_wings")
 async def get_aeroplane_wings(
-        aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-        db: Session = Depends(get_db)
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        db: Annotated[Session, Depends(get_db)],
 ) -> List[str]:
     """Returns a list of aeroplane's wing names."""
     return _call_service(wing_service.list_wing_names, db, aeroplane_id)
@@ -225,13 +224,13 @@ async def get_aeroplane_wings(
             tags=["wings"],
             operation_id="create_aeroplane_wing")
 async def create_aeroplane_wing(
-        aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-        wing_name: str = Path(..., description="The ID of the wing"),
-        request: schemas.AsbWingGeometryWriteSchema = Body(
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        wing_name: Annotated[str, Path(..., description="The ID of the wing")],
+        request: Annotated[schemas.AsbWingGeometryWriteSchema, Body(
             ...,
             description="Geometry-only wing definition (ASB minimum).",
-        ),
-        db: Session = Depends(get_db)
+        )],
+        db: Annotated[Session, Depends(get_db)],
 ):
     """Create the wing for the aeroplane."""
     _assert_design_model(db, aeroplane_id, wing_name, "asb")
@@ -248,17 +247,17 @@ async def create_aeroplane_wing(
     operation_id="create_aeroplane_wing_from_wingconfig",
 )
 async def create_aeroplane_wing_from_wingconfig(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    wing_name: str = Path(..., description="The ID of the wing"),
-    request: WingConfigurationSchema = Body(
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    wing_name: Annotated[str, Path(..., description="The ID of the wing")],
+    request: Annotated[WingConfigurationSchema, Body(
         ...,
         description=(
             "WingConfiguration-JSON (typisch in mm). "
             "Wird intern nach ASB konvertiert und als Wing im Flugzeug gespeichert."
         ),
         examples=[_EHAWK_WINGCONFIG_EXAMPLE],
-    ),
-    db: Session = Depends(get_db),
+    )],
+    db: Annotated[Session, Depends(get_db)],
 ):
     """Create a wing from WingConfiguration JSON and attach it to the aeroplane."""
     _assert_design_model(db, aeroplane_id, wing_name, "wc")
@@ -274,9 +273,9 @@ async def create_aeroplane_wing_from_wingconfig(
     operation_id="get_wing_as_wingconfig",
 )
 async def get_wing_as_wingconfig(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    wing_name: str = Path(..., description="The name of the wing"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    wing_name: Annotated[str, Path(..., description="The name of the wing")],
+    db: Annotated[Session, Depends(get_db)],
 ):
     """Return the wing in WingConfiguration format (segments with root/tip airfoils, length, sweep, dihedral)."""
     return _call_service(wing_service.get_wing_as_wingconfig, db, aeroplane_id, wing_name)
@@ -290,13 +289,13 @@ async def get_wing_as_wingconfig(
     operation_id="put_wing_as_wingconfig",
 )
 async def put_wing_as_wingconfig(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    wing_name: str = Path(..., description="The name of the wing"),
-    request: WingConfigurationSchema = Body(
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    wing_name: Annotated[str, Path(..., description="The name of the wing")],
+    request: Annotated[WingConfigurationSchema, Body(
         ...,
         description="WingConfiguration JSON (mm). Replaces the existing wing.",
-    ),
-    db: Session = Depends(get_db),
+    )],
+    db: Annotated[Session, Depends(get_db)],
 ):
     """Replace a wing from WingConfiguration JSON (idempotent PUT)."""
     _assert_design_model(db, aeroplane_id, wing_name, "wc")
@@ -313,13 +312,13 @@ async def put_wing_as_wingconfig(
     operation_id="update_aeroplane_wing"
 )
 async def update_aeroplane_wing(
-        aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-        wing_name: str = Path(..., description="The ID of the wing"),
-        request: schemas.AsbWingGeometryWriteSchema = Body(
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        wing_name: Annotated[str, Path(..., description="The ID of the wing")],
+        request: Annotated[schemas.AsbWingGeometryWriteSchema, Body(
             ...,
             description="Geometry-only wing definition (ASB minimum).",
-        ),
-        db: Session = Depends(get_db),
+        )],
+        db: Annotated[Session, Depends(get_db)],
 ):
     """Overwrite an existing wing with the data in the request."""
     _assert_design_model(db, aeroplane_id, wing_name, "asb")
@@ -329,13 +328,12 @@ async def update_aeroplane_wing(
 
 
 @router.get("/aeroplanes/{aeroplane_id}/wings/{wing_name}",
-            response_model=schemas.AsbWingReadSchema,
             tags=["wings"],
             operation_id="get_aeroplane_wing")
 async def get_aeroplane_wing(
-        aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-        wing_name: str = Path(..., description="The ID of the wing"),
-        db: Session = Depends(get_db)
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        wing_name: Annotated[str, Path(..., description="The ID of the wing")],
+        db: Annotated[Session, Depends(get_db)],
 ) -> schemas.AsbWingReadSchema:
     """Returns the aeroplane wing."""
     return _call_service(wing_service.get_wing, db, aeroplane_id, wing_name)
@@ -349,9 +347,9 @@ async def get_aeroplane_wing(
     operation_id="delete_aeroplane_wing"
 )
 async def delete_aeroplane_wing(
-        aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-        wing_name: str = Path(..., description="The ID of the wing"),
-        db: Session = Depends(get_db)
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        wing_name: Annotated[str, Path(..., description="The ID of the wing")],
+        db: Annotated[Session, Depends(get_db)],
 ):
     """Delete a wing."""
     _call_service(wing_service.delete_wing, db, aeroplane_id, wing_name)
@@ -364,15 +362,14 @@ async def delete_aeroplane_wing(
 #########################################
 @router.get(
     "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections",
-    response_model=List[schemas.WingXSecReadSchema],
     status_code=status.HTTP_200_OK,
     tags=["cross-sections"],
     operation_id="get_wing_cross_sections"
 )
 async def get_aeroplane_wing_cross_sections(
-        aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-        wing_name: str = Path(..., description="The ID of the wing"),
-        db: Session = Depends(get_db)
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        wing_name: Annotated[str, Path(..., description="The ID of the wing")],
+        db: Annotated[Session, Depends(get_db)],
 ) -> List[schemas.WingXSecReadSchema]:
     """Returns the wing's cross-sections as an ordered list."""
     return _call_service(wing_service.get_wing_cross_sections, db, aeroplane_id, wing_name)
@@ -386,9 +383,9 @@ async def get_aeroplane_wing_cross_sections(
     operation_id="delete_all_wing_cross_sections"
 )
 async def delete_aeroplane_wing_cross_sections(
-        aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-        wing_name: str = Path(..., description="The ID of the wing"),
-        db: Session = Depends(get_db)
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        wing_name: Annotated[str, Path(..., description="The ID of the wing")],
+        db: Annotated[Session, Depends(get_db)],
 ):
     """Delete all cross-sections of a wing."""
     _assert_design_model(db, aeroplane_id, wing_name, "asb")
@@ -398,16 +395,15 @@ async def delete_aeroplane_wing_cross_sections(
 
 @router.get(
     "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}",
-    response_model=schemas.WingXSecReadSchema,
     status_code=status.HTTP_200_OK,
     tags=["cross-sections"],
     operation_id="get_wing_cross_section"
 )
 async def get_aeroplane_wing_cross_section(
-        aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-        wing_name: str = Path(..., description="The ID of the wing"),
-        cross_section_index: int = Path(..., description="The index of the cross section"),
-        db: Session = Depends(get_db)
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        wing_name: Annotated[str, Path(..., description="The ID of the wing")],
+        cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+        db: Annotated[Session, Depends(get_db)],
 ) -> schemas.WingXSecReadSchema:
     """Returns the aeroplane wing cross-sections as a list of names."""
     return _call_service(wing_service.get_cross_section, db, aeroplane_id, wing_name, cross_section_index)
@@ -421,15 +417,15 @@ async def get_aeroplane_wing_cross_section(
     operation_id="create_wing_cross_section"
 )
 async def create_aeroplane_wing_cross_section(
-        aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-        wing_name: str = Path(..., description="The ID of the wing"),
-        cross_section_index: int = Path(...,
-                                        description="The index where it will be spliced into the list of cross sections. (-1 is the end of the list, 0 is the start of the list)"),
-        request: schemas.WingXSecGeometryWriteSchema = Body(
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        wing_name: Annotated[str, Path(..., description="The ID of the wing")],
+        cross_section_index: Annotated[int, Path(...,
+                                        description="The index where it will be spliced into the list of cross sections. (-1 is the end of the list, 0 is the start of the list)")],
+        request: Annotated[schemas.WingXSecGeometryWriteSchema, Body(
             ...,
             description="Geometry-only wing cross-section definition.",
-        ),
-        db: Session = Depends(get_db)
+        )],
+        db: Annotated[Session, Depends(get_db)],
 ):
     """Creates a new cross-section for the wing and splice it into the list of cross-sections."""
     _assert_design_model(db, aeroplane_id, wing_name, "asb")
@@ -446,14 +442,14 @@ async def create_aeroplane_wing_cross_section(
     operation_id="update_wing_cross_section"
 )
 async def update_aeroplane_wing_cross_section(
-        aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-        wing_name: str = Path(..., description="The ID of the wing"),
-        cross_section_index: int = Path(..., description="The index of the cross section"),
-        request: schemas.WingXSecGeometryWriteSchema = Body(
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        wing_name: Annotated[str, Path(..., description="The ID of the wing")],
+        cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+        request: Annotated[schemas.WingXSecGeometryWriteSchema, Body(
             ...,
             description="Geometry-only wing cross-section definition.",
-        ),
-        db: Session = Depends(get_db)
+        )],
+        db: Annotated[Session, Depends(get_db)],
 ):
     """Updates the cross-section for the aeroplane."""
     _assert_design_model(db, aeroplane_id, wing_name, "asb")
@@ -468,10 +464,10 @@ async def update_aeroplane_wing_cross_section(
                tags=["cross-sections"],
                operation_id="delete_wing_cross_section")
 async def delete_aeroplane_wing_cross_section(
-        aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-        wing_name: str = Path(..., description="The ID of the wing"),
-        cross_section_index: int = Path(..., description="The index of the cross section"),
-        db: Session = Depends(get_db)
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        wing_name: Annotated[str, Path(..., description="The ID of the wing")],
+        cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+        db: Annotated[Session, Depends(get_db)],
 ):
     """Delete a cross-section."""
     _assert_design_model(db, aeroplane_id, wing_name, "asb")
@@ -482,16 +478,15 @@ async def delete_aeroplane_wing_cross_section(
 
 @router.get(
     "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/spars",
-    response_model=List[schemas.SpareDetailSchema],
     status_code=status.HTTP_200_OK,
     tags=["spars"],
     operation_id="get_wing_cross_section_spars",
 )
 async def get_aeroplane_wing_cross_section_spars(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    wing_name: str = Path(..., description="The ID of the wing"),
-    cross_section_index: int = Path(..., description="The index of the cross section"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    wing_name: Annotated[str, Path(..., description="The ID of the wing")],
+    cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> List[schemas.SpareDetailSchema]:
     """Returns the spars assigned to the given cross-section."""
     return _call_service(wing_service.get_spares, db, aeroplane_id, wing_name, cross_section_index)
@@ -499,17 +494,16 @@ async def get_aeroplane_wing_cross_section_spars(
 
 @router.post(
     "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/spars",
-    response_model=OperationStatusResponse,
     status_code=status.HTTP_201_CREATED,
     tags=["spars"],
     operation_id="create_wing_cross_section_spar",
 )
 async def create_aeroplane_wing_cross_section_spar(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    wing_name: str = Path(..., description="The ID of the wing"),
-    cross_section_index: int = Path(..., description="The index of the cross section"),
-    request: schemas.SpareDetailSchema = Body(..., description="Spar definition to append"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    wing_name: Annotated[str, Path(..., description="The ID of the wing")],
+    cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+    request: Annotated[schemas.SpareDetailSchema, Body(..., description="Spar definition to append")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> OperationStatusResponse:
     """Creates and appends one spar on the selected cross-section."""
     _assert_design_model(db, aeroplane_id, wing_name, "asb")
@@ -519,18 +513,17 @@ async def create_aeroplane_wing_cross_section_spar(
 
 @router.put(
     "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/spars/{spar_index}",
-    response_model=OperationStatusResponse,
     status_code=status.HTTP_200_OK,
     tags=["spars"],
     operation_id="update_wing_cross_section_spar",
 )
 async def update_aeroplane_wing_cross_section_spar(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    wing_name: str = Path(..., description="The name of the wing"),
-    cross_section_index: int = Path(..., description="The index of the cross section"),
-    spar_index: int = Path(..., description="The index of the spar to replace"),
-    request: schemas.SpareDetailSchema = Body(..., description="Updated spar definition"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    wing_name: Annotated[str, Path(..., description="The name of the wing")],
+    cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+    spar_index: Annotated[int, Path(..., description="The index of the spar to replace")],
+    request: Annotated[schemas.SpareDetailSchema, Body(..., description="Updated spar definition")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> OperationStatusResponse:
     """Replaces the spar at the given index on the selected cross-section."""
     _assert_design_model(db, aeroplane_id, wing_name, "asb")
@@ -541,17 +534,16 @@ async def update_aeroplane_wing_cross_section_spar(
 
 @router.delete(
     "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/spars/{spar_index}",
-    response_model=OperationStatusResponse,
     status_code=status.HTTP_200_OK,
     tags=["spars"],
     operation_id="delete_wing_cross_section_spar",
 )
 async def delete_aeroplane_wing_cross_section_spar(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    wing_name: str = Path(..., description="The name of the wing"),
-    cross_section_index: int = Path(..., description="The index of the cross section"),
-    spar_index: int = Path(..., description="The index of the spar to delete"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    wing_name: Annotated[str, Path(..., description="The name of the wing")],
+    cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+    spar_index: Annotated[int, Path(..., description="The index of the spar to delete")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> OperationStatusResponse:
     """Deletes the spar at the given index on the selected cross-section."""
     _assert_design_model(db, aeroplane_id, wing_name, "asb")
@@ -567,16 +559,15 @@ async def delete_aeroplane_wing_cross_section_spar(
 
 @router.get(
     "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/trailing_edge_device",
-    response_model=schemas.TrailingEdgeDeviceDetailSchema,
     status_code=status.HTTP_200_OK,
     tags=["trailing-edge-devices"],
     operation_id="get_wing_trailing_edge_device",
 )
 async def get_wing_trailing_edge_device(
-    aeroplane_id: AeroPlaneID = Path(...),
-    wing_name: str = Path(...),
-    cross_section_index: int = Path(...),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(...)],
+    wing_name: Annotated[str, Path(...)],
+    cross_section_index: Annotated[int, Path(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> schemas.TrailingEdgeDeviceDetailSchema:
     """Returns the full TED with all geometry and spacing fields."""
     return _call_service(wing_service.get_trailing_edge_device, db, aeroplane_id, wing_name, cross_section_index)
@@ -584,17 +575,16 @@ async def get_wing_trailing_edge_device(
 
 @router.patch(
     "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/trailing_edge_device",
-    response_model=schemas.TrailingEdgeDeviceDetailSchema,
     status_code=status.HTTP_200_OK,
     tags=["trailing-edge-devices"],
     operation_id="patch_wing_trailing_edge_device",
 )
 async def patch_wing_trailing_edge_device(
-    aeroplane_id: AeroPlaneID = Path(...),
-    wing_name: str = Path(...),
-    cross_section_index: int = Path(...),
-    request: schemas.TrailingEdgeDevicePatchSchema = Body(...),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(...)],
+    wing_name: Annotated[str, Path(...)],
+    cross_section_index: Annotated[int, Path(...)],
+    request: Annotated[schemas.TrailingEdgeDevicePatchSchema, Body(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> schemas.TrailingEdgeDeviceDetailSchema:
     """Upsert TED fields directly (not through the ControlSurface wrapper)."""
     _assert_design_model(db, aeroplane_id, wing_name, "asb")
@@ -605,16 +595,15 @@ async def patch_wing_trailing_edge_device(
 
 @router.delete(
     "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/trailing_edge_device",
-    response_model=OperationStatusResponse,
     status_code=status.HTTP_200_OK,
     tags=["trailing-edge-devices"],
     operation_id="delete_wing_trailing_edge_device",
 )
 async def delete_wing_trailing_edge_device(
-    aeroplane_id: AeroPlaneID = Path(...),
-    wing_name: str = Path(...),
-    cross_section_index: int = Path(...),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(...)],
+    wing_name: Annotated[str, Path(...)],
+    cross_section_index: Annotated[int, Path(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> OperationStatusResponse:
     """Deletes the TED on the selected cross-section."""
     _assert_design_model(db, aeroplane_id, wing_name, "asb")
@@ -625,16 +614,15 @@ async def delete_wing_trailing_edge_device(
 
 @router.get(
     "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/trailing_edge_device/servo",
-    response_model=schemas.ControlSurfaceServoDetailsSchema,
     status_code=status.HTTP_200_OK,
     tags=["trailing-edge-devices"],
     operation_id="get_wing_trailing_edge_servo",
 )
 async def get_wing_trailing_edge_servo(
-    aeroplane_id: AeroPlaneID = Path(...),
-    wing_name: str = Path(...),
-    cross_section_index: int = Path(...),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(...)],
+    wing_name: Annotated[str, Path(...)],
+    cross_section_index: Annotated[int, Path(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> schemas.ControlSurfaceServoDetailsSchema:
     """Returns the servo assignment on the TED."""
     return _call_service(wing_service.get_trailing_edge_servo, db, aeroplane_id, wing_name, cross_section_index)
@@ -642,17 +630,16 @@ async def get_wing_trailing_edge_servo(
 
 @router.patch(
     "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/trailing_edge_device/servo",
-    response_model=schemas.ControlSurfaceServoDetailsSchema,
     status_code=status.HTTP_200_OK,
     tags=["trailing-edge-devices"],
     operation_id="patch_wing_trailing_edge_servo",
 )
 async def patch_wing_trailing_edge_servo(
-    aeroplane_id: AeroPlaneID = Path(...),
-    wing_name: str = Path(...),
-    cross_section_index: int = Path(...),
-    request: schemas.ControlSurfaceServoDetailsPatchSchema = Body(...),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(...)],
+    wing_name: Annotated[str, Path(...)],
+    cross_section_index: Annotated[int, Path(...)],
+    request: Annotated[schemas.ControlSurfaceServoDetailsPatchSchema, Body(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> schemas.ControlSurfaceServoDetailsSchema:
     """Assign or update the servo on the TED."""
     _assert_design_model(db, aeroplane_id, wing_name, "asb")
@@ -663,16 +650,15 @@ async def patch_wing_trailing_edge_servo(
 
 @router.delete(
     "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/trailing_edge_device/servo",
-    response_model=OperationStatusResponse,
     status_code=status.HTTP_200_OK,
     tags=["trailing-edge-devices"],
     operation_id="delete_wing_trailing_edge_servo",
 )
 async def delete_wing_trailing_edge_servo(
-    aeroplane_id: AeroPlaneID = Path(...),
-    wing_name: str = Path(...),
-    cross_section_index: int = Path(...),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(...)],
+    wing_name: Annotated[str, Path(...)],
+    cross_section_index: Annotated[int, Path(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> OperationStatusResponse:
     """Remove the servo assignment from the TED."""
     _assert_design_model(db, aeroplane_id, wing_name, "asb")
@@ -683,16 +669,15 @@ async def delete_wing_trailing_edge_servo(
 
 @router.get(
     "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/control_surface",
-    response_model=schemas.ControlSurfaceSchema,
     status_code=status.HTTP_200_OK,
     tags=["control-surfaces"],
     operation_id="get_wing_cross_section_control_surface",
 )
 async def get_aeroplane_wing_cross_section_control_surface(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    wing_name: str = Path(..., description="The ID of the wing"),
-    cross_section_index: int = Path(..., description="The index of the cross section"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    wing_name: Annotated[str, Path(..., description="The ID of the wing")],
+    cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> schemas.ControlSurfaceSchema:
     """Returns the control-surface analysis view projected from the canonical TED."""
     return _call_service(
@@ -706,17 +691,16 @@ async def get_aeroplane_wing_cross_section_control_surface(
 
 @router.patch(
     "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/control_surface",
-    response_model=schemas.ControlSurfaceSchema,
     status_code=status.HTTP_200_OK,
     tags=["control-surfaces"],
     operation_id="patch_wing_cross_section_control_surface",
 )
 async def patch_aeroplane_wing_cross_section_control_surface(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    wing_name: str = Path(..., description="The ID of the wing"),
-    cross_section_index: int = Path(..., description="The index of the cross section"),
-    request: schemas.ControlSurfacePatchSchema = Body(..., description="Control-surface patch payload."),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    wing_name: Annotated[str, Path(..., description="The ID of the wing")],
+    cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+    request: Annotated[schemas.ControlSurfacePatchSchema, Body(..., description="Control-surface patch payload.")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> schemas.ControlSurfaceSchema:
     """Upserts the control-surface analysis view by patching the canonical TED."""
     _assert_design_model(db, aeroplane_id, wing_name, "asb")
@@ -732,16 +716,15 @@ async def patch_aeroplane_wing_cross_section_control_surface(
 
 @router.delete(
     "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/control_surface",
-    response_model=OperationStatusResponse,
     status_code=status.HTTP_200_OK,
     tags=["control-surfaces"],
     operation_id="delete_wing_cross_section_control_surface",
 )
 async def delete_aeroplane_wing_cross_section_control_surface(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    wing_name: str = Path(..., description="The ID of the wing"),
-    cross_section_index: int = Path(..., description="The index of the cross section"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    wing_name: Annotated[str, Path(..., description="The ID of the wing")],
+    cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> OperationStatusResponse:
     """Deletes the canonical TED from which control-surface data is projected."""
     _assert_design_model(db, aeroplane_id, wing_name, "asb")
@@ -757,16 +740,15 @@ async def delete_aeroplane_wing_cross_section_control_surface(
 
 @router.get(
     "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/control_surface/cad_details",
-    response_model=schemas.ControlSurfaceCadDetailsSchema,
     status_code=status.HTTP_200_OK,
     tags=["control-surfaces"],
     operation_id="get_wing_cross_section_control_surface_cad_details",
 )
 async def get_aeroplane_wing_cross_section_control_surface_cad_details(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    wing_name: str = Path(..., description="The ID of the wing"),
-    cross_section_index: int = Path(..., description="The index of the cross section"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    wing_name: Annotated[str, Path(..., description="The ID of the wing")],
+    cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> schemas.ControlSurfaceCadDetailsSchema:
     """Returns the CAD detail extension of an existing control surface."""
     return _call_service(
@@ -780,20 +762,19 @@ async def get_aeroplane_wing_cross_section_control_surface_cad_details(
 
 @router.patch(
     "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/control_surface/cad_details",
-    response_model=schemas.ControlSurfaceCadDetailsSchema,
     status_code=status.HTTP_200_OK,
     tags=["control-surfaces"],
     operation_id="patch_wing_cross_section_control_surface_cad_details",
 )
 async def patch_aeroplane_wing_cross_section_control_surface_cad_details(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    wing_name: str = Path(..., description="The ID of the wing"),
-    cross_section_index: int = Path(..., description="The index of the cross section"),
-    request: schemas.ControlSurfaceCadDetailsPatchSchema = Body(
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    wing_name: Annotated[str, Path(..., description="The ID of the wing")],
+    cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+    request: Annotated[schemas.ControlSurfaceCadDetailsPatchSchema, Body(
         ...,
         description="CAD detail patch payload that extends an existing control surface.",
-    ),
-    db: Session = Depends(get_db),
+    )],
+    db: Annotated[Session, Depends(get_db)],
 ) -> schemas.ControlSurfaceCadDetailsSchema:
     """Patches CAD details on an existing control surface without re-entering control-surface core fields."""
     _assert_design_model(db, aeroplane_id, wing_name, "asb")
@@ -809,16 +790,15 @@ async def patch_aeroplane_wing_cross_section_control_surface_cad_details(
 
 @router.delete(
     "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/control_surface/cad_details",
-    response_model=OperationStatusResponse,
     status_code=status.HTTP_200_OK,
     tags=["control-surfaces"],
     operation_id="delete_wing_cross_section_control_surface_cad_details",
 )
 async def delete_aeroplane_wing_cross_section_control_surface_cad_details(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    wing_name: str = Path(..., description="The ID of the wing"),
-    cross_section_index: int = Path(..., description="The index of the cross section"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    wing_name: Annotated[str, Path(..., description="The ID of the wing")],
+    cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> OperationStatusResponse:
     """Removes CAD details while keeping the control-surface core definition."""
     _assert_design_model(db, aeroplane_id, wing_name, "asb")
@@ -834,16 +814,15 @@ async def delete_aeroplane_wing_cross_section_control_surface_cad_details(
 
 @router.get(
     "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/control_surface/cad_details/servo_details",
-    response_model=schemas.ControlSurfaceServoDetailsSchema,
     status_code=status.HTTP_200_OK,
     tags=["servos"],
     operation_id="get_wing_cross_section_control_surface_cad_details_servo_details",
 )
 async def get_aeroplane_wing_cross_section_control_surface_cad_details_servo_details(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    wing_name: str = Path(..., description="The ID of the wing"),
-    cross_section_index: int = Path(..., description="The index of the cross section"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    wing_name: Annotated[str, Path(..., description="The ID of the wing")],
+    cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> schemas.ControlSurfaceServoDetailsSchema:
     """Returns servo details of the control-surface CAD extension."""
     return _call_service(
@@ -857,20 +836,19 @@ async def get_aeroplane_wing_cross_section_control_surface_cad_details_servo_det
 
 @router.patch(
     "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/control_surface/cad_details/servo_details",
-    response_model=schemas.ControlSurfaceServoDetailsSchema,
     status_code=status.HTTP_200_OK,
     tags=["servos"],
     operation_id="patch_wing_cross_section_control_surface_cad_details_servo_details",
 )
 async def patch_aeroplane_wing_cross_section_control_surface_cad_details_servo_details(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    wing_name: str = Path(..., description="The ID of the wing"),
-    cross_section_index: int = Path(..., description="The index of the cross section"),
-    request: schemas.ControlSurfaceServoDetailsPatchSchema = Body(
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    wing_name: Annotated[str, Path(..., description="The ID of the wing")],
+    cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+    request: Annotated[schemas.ControlSurfaceServoDetailsPatchSchema, Body(
         ...,
         description="Servo assignment payload (full Servo object or Servo ID reference).",
-    ),
-    db: Session = Depends(get_db),
+    )],
+    db: Annotated[Session, Depends(get_db)],
 ) -> schemas.ControlSurfaceServoDetailsSchema:
     """Assigns or updates servo details of the control-surface CAD extension."""
     _assert_design_model(db, aeroplane_id, wing_name, "asb")
@@ -886,16 +864,15 @@ async def patch_aeroplane_wing_cross_section_control_surface_cad_details_servo_d
 
 @router.delete(
     "/aeroplanes/{aeroplane_id}/wings/{wing_name}/cross_sections/{cross_section_index}/control_surface/cad_details/servo_details",
-    response_model=OperationStatusResponse,
     status_code=status.HTTP_200_OK,
     tags=["servos"],
     operation_id="delete_wing_cross_section_control_surface_cad_details_servo_details",
 )
 async def delete_aeroplane_wing_cross_section_control_surface_cad_details_servo_details(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    wing_name: str = Path(..., description="The ID of the wing"),
-    cross_section_index: int = Path(..., description="The index of the cross section"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    wing_name: Annotated[str, Path(..., description="The ID of the wing")],
+    cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> OperationStatusResponse:
     """Deletes servo details from the control-surface CAD extension."""
     _assert_design_model(db, aeroplane_id, wing_name, "asb")

--- a/app/api/v2/endpoints/aeroplane_construction_plans.py
+++ b/app/api/v2/endpoints/aeroplane_construction_plans.py
@@ -1,7 +1,7 @@
 """REST endpoints for Aeroplane-bound Construction Plans (gh#126)."""
 from __future__ import annotations
 
-from typing import List
+from typing import Annotated, List
 
 from fastapi import APIRouter, Body, Depends, Path
 from fastapi import status
@@ -37,13 +37,12 @@ def _handle_service_error(exc: ServiceException):
 
 @router.get(
     "/aeroplanes/{aeroplane_id}/construction-plans",
-    response_model=List[PlanSummary],
     tags=["construction-plans"],
-    operation_id="list_aeroplane_construction_plans",
+    operation_id="list_aeroplane_construction_plans"
 )
 async def list_aeroplane_plans(
-    aeroplane_id: str = Path(...),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[str, Path(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> List[PlanSummary]:
     """List construction plans bound to an aeroplane."""
     try:
@@ -54,16 +53,15 @@ async def list_aeroplane_plans(
 
 @router.post(
     "/aeroplanes/{aeroplane_id}/construction-plans/from-template/{template_id}",
-    response_model=PlanRead,
     status_code=status.HTTP_201_CREATED,
     tags=["construction-plans"],
-    operation_id="instantiate_construction_template",
+    operation_id="instantiate_construction_template"
 )
 async def instantiate_template(
-    aeroplane_id: str = Path(...),
-    template_id: int = Path(...),
-    request: InstantiateRequest = Body(None),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[str, Path(...)],
+    template_id: Annotated[int, Path(...)],
+    db: Annotated[Session, Depends(get_db)],
+    request: Annotated[InstantiateRequest, Body()] = None,
 ) -> PlanRead:
     """Create a concrete plan from a template, bound to an aeroplane."""
     try:
@@ -79,14 +77,13 @@ async def instantiate_template(
 
 @router.post(
     "/aeroplanes/{aeroplane_id}/construction-plans/{plan_id}/execute",
-    response_model=ExecutionResult,
     tags=["construction-plans"],
-    operation_id="execute_aeroplane_construction_plan",
+    operation_id="execute_aeroplane_construction_plan"
 )
 async def execute_plan(
-    aeroplane_id: str = Path(...),
-    plan_id: int = Path(...),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[str, Path(...)],
+    plan_id: Annotated[int, Path(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> ExecutionResult:
     """Execute a construction plan against an aeroplane configuration."""
     try:
@@ -97,15 +94,14 @@ async def execute_plan(
 
 @router.post(
     "/aeroplanes/{aeroplane_id}/construction-plans/{plan_id}/to-template",
-    response_model=PlanRead,
     status_code=status.HTTP_201_CREATED,
     tags=["construction-plans"],
-    operation_id="plan_to_template",
+    operation_id="plan_to_template"
 )
 async def plan_to_template(
-    plan_id: int = Path(...),
-    request: ToTemplateRequest = Body(None),
-    db: Session = Depends(get_db),
+    plan_id: Annotated[int, Path(...)],
+    db: Annotated[Session, Depends(get_db)],
+    request: Annotated[ToTemplateRequest, Body()] = None,
 ) -> PlanRead:
     """Create a new template from an existing plan."""
     try:

--- a/app/api/v2/endpoints/airfoils.py
+++ b/app/api/v2/endpoints/airfoils.py
@@ -1,6 +1,6 @@
 import shutil
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 from urllib.parse import urljoin
 from uuid import uuid4
 
@@ -439,10 +439,9 @@ def _raise_http_from_domain(exc: ServiceException) -> None:
 
 @router.get(
     "/airfoils/{airfoil_name}/known",
-    response_model=AirfoilKnownResponse,
     status_code=status.HTTP_200_OK,
     operation_id="is_airfoil_known",
-    tags=["airfoils"],
+    tags=["airfoils"]
 )
 async def is_airfoil_known(airfoil_name: str) -> AirfoilKnownResponse:
     try:
@@ -473,15 +472,14 @@ async def is_airfoil_known(airfoil_name: str) -> AirfoilKnownResponse:
 
 @router.post(
     "/airfoils/datfile",
-    response_model=AirfoilUploadResponse,
     status_code=status.HTTP_201_CREATED,
     operation_id="upload_airfoil_datfile",
-    tags=["airfoils"],
+    tags=["airfoils"]
 )
 async def upload_airfoil_datfile(
     response: Response,
-    file: UploadFile = File(..., description="DAT-Datei mit Airfoil-Koordinaten."),
-    overwrite: bool = Query(default=False, description="Bestehende Datei überschreiben."),
+    file: Annotated[UploadFile, File(..., description="DAT-Datei mit Airfoil-Koordinaten.")],
+    overwrite: Annotated[bool, Query(description="Bestehende Datei überschreiben.")] = False,
 ) -> AirfoilUploadResponse:
     try:
         raw_name = (file.filename or "").strip()
@@ -507,10 +505,9 @@ async def upload_airfoil_datfile(
 
 @router.get(
     "/airfoils",
-    response_model=AirfoilListResponse,
     status_code=status.HTTP_200_OK,
     operation_id="list_airfoils",
-    tags=["airfoils"],
+    tags=["airfoils"]
 )
 async def list_airfoils() -> AirfoilListResponse:
     try:
@@ -536,15 +533,14 @@ async def list_airfoils() -> AirfoilListResponse:
 
 @router.get(
     "/airfoils/{airfoil_name}/datfile",
-    response_model=AirfoilDatDownloadResponse,
     status_code=status.HTTP_200_OK,
     operation_id="download_airfoil_datfile",
-    tags=["airfoils"],
+    tags=["airfoils"]
 )
 async def download_airfoil_datfile(
     airfoil_name: str,
+    settings: Annotated[Settings, Depends(get_settings)],
     request: Request = None,
-    settings: Settings = Depends(get_settings),
 ) -> AirfoilDatDownloadResponse:
     try:
         file_name, source_path = _resolve_airfoil_file(airfoil_name)
@@ -572,11 +568,10 @@ async def download_airfoil_datfile(
 
 @router.get(
     "/airfoils/{airfoil_name}/geometry-stats",
-    response_model=AirfoilGeometryStatsResponse,
     status_code=status.HTTP_200_OK,
     operation_id="get_airfoil_geometry_stats",
     tags=["airfoils"],
-    summary="Get airfoil geometry statistics (thickness, camber).",
+    summary="Get airfoil geometry statistics (thickness, camber)."
 )
 async def get_airfoil_geometry_stats(airfoil_name: str) -> AirfoilGeometryStatsResponse:
     """Compute max thickness and max camber from the .dat file coordinates."""
@@ -646,14 +641,13 @@ async def get_airfoil_coordinates(airfoil_name: str):
 
 @router.post(
     "/airfoils/{airfoil_name}/neuralfoil/analysis",
-    response_model=AirfoilNeuralFoilAnalysisResponse,
     status_code=status.HTTP_200_OK,
     operation_id="analyze_airfoil_neuralfoil",
-    tags=["airfoils"],
+    tags=["airfoils"]
 )
 async def analyze_airfoil_neuralfoil(
     airfoil_name: str,
-    request: AirfoilNeuralFoilRequest = Body(..., description="NeuralFoil Analyse-Konfiguration."),
+    request: Annotated[AirfoilNeuralFoilRequest, Body(..., description="NeuralFoil Analyse-Konfiguration.")],
 ) -> AirfoilNeuralFoilAnalysisResponse:
     try:
         file_name, file_path = _resolve_airfoil_file(airfoil_name)
@@ -692,16 +686,15 @@ async def analyze_airfoil_neuralfoil(
 
 @router.post(
     "/airfoils/{airfoil_name}/neuralfoil/analysis/diagrams",
-    response_model=AirfoilNeuralFoilDiagramResponse,
     status_code=status.HTTP_200_OK,
     operation_id="analyze_airfoil_neuralfoil_diagrams",
-    tags=["airfoils"],
+    tags=["airfoils"]
 )
 async def analyze_airfoil_neuralfoil_diagrams(
     airfoil_name: str,
-    request: AirfoilNeuralFoilRequest = Body(..., description="NeuralFoil Analyse-Konfiguration."),
+    request: Annotated[AirfoilNeuralFoilRequest, Body(..., description="NeuralFoil Analyse-Konfiguration.")],
+    settings: Annotated[Settings, Depends(get_settings)],
     http_request: Request = None,
-    settings: Settings = Depends(get_settings),
 ) -> AirfoilNeuralFoilDiagramResponse:
     try:
         file_name, file_path = _resolve_airfoil_file(airfoil_name)

--- a/app/api/v2/endpoints/cad.py
+++ b/app/api/v2/endpoints/cad.py
@@ -4,7 +4,7 @@ import os
 import shutil
 from pathlib import Path as FilePath
 
-from typing import Optional
+from typing import Annotated, Optional
 
 from fastapi import APIRouter, Query, Body, Path, Depends, Request, HTTPException
 from fastapi import status
@@ -72,15 +72,14 @@ def _ensure_file_under_tmp(file_path: str, aeroplane_id: str) -> FilePath:
 
 @router.post(
     "/aeroplanes/{aeroplane_id}/wings/{wing_name}/tessellation",
-    response_model=CadTaskAcceptedResponse,
     status_code=http.HTTPStatus.ACCEPTED,
     tags=["cad"],
-    operation_id="start_wing_tessellation",
+    operation_id="start_wing_tessellation"
 )
 async def start_wing_tessellation(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    wing_name: str = Path(..., description="The name of the wing"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    wing_name: Annotated[str, Path(..., description="The name of the wing")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> CadTaskAcceptedResponse:
     """Start async tessellation of a wing for 3D viewer rendering.
 
@@ -119,8 +118,8 @@ async def start_wing_tessellation(
     operation_id="get_aeroplane_tessellation",
 )
 async def get_aeroplane_tessellation(
-    aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    db: Annotated[Session, Depends(get_db)],
 ):
     """Assemble all cached wing/fuselage tessellations into a single three-cad-viewer scene.
 
@@ -224,19 +223,16 @@ async def get_aeroplane_tessellation(
 
 
 @router.post("/aeroplanes/{aeroplane_id}/wings/{wing_name}/{creator_url_type}/{exporter_url_type}",
-         response_model=CadTaskAcceptedResponse,
          status_code=http.HTTPStatus.ACCEPTED,
          operation_id="create_wing_loft_export")
-async def create_wing_loft(aeroplane_id: AeroPlaneID = Path(..., description="The ID of the aeroplane"),
-                           wing_name: str = Path(..., description="The ID of the wing"),
+async def create_wing_loft(aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+                           wing_name: Annotated[str, Path(..., description="The ID of the wing")],
+                           db: Annotated[Session, Depends(get_db)],
+                           leading_edge_offset_factor: Annotated[float, Query(description="only need for vase mode wing")] = 0.1,
+                           trailing_edge_offset_factor: Annotated[float, Query(description="only need for vase mode wing")] = 0.15,
+                           aeroplane_settings: Annotated[Optional[AeroplaneSettings], Body(description="General settings for the construction, not needed for a simple loft")] = None,
                            creator_url_type: CreatorUrlType = CreatorUrlType.WING_LOFT,
-                           exporter_url_type: ExporterUrlType = ExporterUrlType.STL,
-                           leading_edge_offset_factor: float = Query(0.1, description="only need for vase mode wing"),
-                           trailing_edge_offset_factor: float = Query(0.15, description="only need for vase mode wing"),
-                           aeroplane_settings: Optional[AeroplaneSettings] =
-                           Body(None,
-                                description="General settings for the construction, not needed for a simple loft"),
-                           db: Session = Depends(get_db)) -> CadTaskAcceptedResponse:
+                           exporter_url_type: ExporterUrlType = ExporterUrlType.STL) -> CadTaskAcceptedResponse:
     """Create a wing loft export. Business logic delegated to cad_service."""
     try:
         aeroplane_id_str = str(aeroplane_id)
@@ -269,13 +265,12 @@ async def create_wing_loft(aeroplane_id: AeroPlaneID = Path(..., description="Th
 
 
 @router.get("/aeroplanes/{aeroplane_id}/status",
-         response_model=CadTaskStatusResponse,
          response_model_exclude_none=True,
          operation_id="get_aeroplane_task_status")
 async def get_aeroplane_task_status(
     aeroplane_id: str,
-    task_type: Optional[str] = Query(None, description="Task type: 'tessellation' or None for CAD export"),
-    wing_name: Optional[str] = Query(None, description="Wing name (required for tessellation tasks)"),
+    task_type: Annotated[Optional[str], Query(description="Task type: 'tessellation' or None for CAD export")] = None,
+    wing_name: Annotated[Optional[str], Query(description="Wing name (required for tessellation tasks)")] = None,
 ) -> CadTaskStatusResponse:
     """Get the status of an aeroplane export or tessellation task."""
     try:
@@ -315,12 +310,11 @@ async def get_aeroplane_task_status(
 
 
 @router.get("/aeroplanes/{aeroplane_id}/wings/{wing_name}/{creator_url_type}/{exporter_url_type}/zip",
-         response_model=ZipAssetResponse,
          operation_id="download_export_zip")
 async def download_aeroplane_zip(
     aeroplane_id: str,
+    settings: Annotated[Settings, Depends(get_settings)],
     request: Request = None,
-    settings: Settings = Depends(get_settings),
 ) -> ZipAssetResponse:
     """Return the static URL for the completed export zip file."""
     try:

--- a/app/api/v2/endpoints/component_types.py
+++ b/app/api/v2/endpoints/component_types.py
@@ -1,5 +1,6 @@
 """Endpoints for the Component Types registry (gh#83)."""
 from __future__ import annotations
+from typing import Annotated
 
 import logging
 
@@ -48,11 +49,10 @@ def _call(func, *args, **kwargs):
 @router.get(
     "",
     status_code=status.HTTP_200_OK,
-    response_model=list[ComponentTypeRead],
-    operation_id="list_component_types_v2",
+    operation_id="list_component_types_v2"
 )
 async def list_component_types(
-    db: Session = Depends(get_db),
+    db: Annotated[Session, Depends(get_db)],
 ) -> list[ComponentTypeRead]:
     """List all component types (seeded + user-created) sorted by label."""
     return _call(svc.list_types, db)
@@ -61,12 +61,11 @@ async def list_component_types(
 @router.get(
     "/{type_id}",
     status_code=status.HTTP_200_OK,
-    response_model=ComponentTypeRead,
-    operation_id="get_component_type",
+    operation_id="get_component_type"
 )
 async def get_component_type(
-    type_id: int = Path(...),
-    db: Session = Depends(get_db),
+    type_id: Annotated[int, Path(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> ComponentTypeRead:
     return _call(svc.get_type, db, type_id)
 
@@ -74,12 +73,11 @@ async def get_component_type(
 @router.post(
     "",
     status_code=status.HTTP_201_CREATED,
-    response_model=ComponentTypeRead,
-    operation_id="create_component_type",
+    operation_id="create_component_type"
 )
 async def create_component_type(
-    body: ComponentTypeWrite = Body(...),
-    db: Session = Depends(get_db),
+    body: Annotated[ComponentTypeWrite, Body(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> ComponentTypeRead:
     """Create a user-defined type. `deletable` is forced to True regardless of request."""
     return _call(svc.create_type, db, body)
@@ -88,13 +86,12 @@ async def create_component_type(
 @router.put(
     "/{type_id}",
     status_code=status.HTTP_200_OK,
-    response_model=ComponentTypeRead,
-    operation_id="update_component_type",
+    operation_id="update_component_type"
 )
 async def update_component_type(
-    type_id: int = Path(...),
-    body: ComponentTypeWrite = Body(...),
-    db: Session = Depends(get_db),
+    type_id: Annotated[int, Path(...)],
+    body: Annotated[ComponentTypeWrite, Body(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> ComponentTypeRead:
     """Update label / description / schema. Name and deletable are immutable."""
     return _call(svc.update_type, db, type_id, body)
@@ -106,8 +103,8 @@ async def update_component_type(
     operation_id="delete_component_type",
 )
 async def delete_component_type(
-    type_id: int = Path(...),
-    db: Session = Depends(get_db),
+    type_id: Annotated[int, Path(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> None:
     """Delete a type. 409 if seeded (deletable=False) or referenced by components."""
     _call(svc.delete_type, db, type_id)

--- a/app/api/v2/endpoints/components.py
+++ b/app/api/v2/endpoints/components.py
@@ -1,7 +1,7 @@
 import logging
 import shutil
 from pathlib import Path as FilePath
-from typing import Optional
+from typing import Annotated, Optional
 from uuid import uuid4
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, UploadFile, File, status
@@ -52,13 +52,12 @@ def _call(func, *args, **kwargs):
 @router.get(
     "",
     status_code=status.HTTP_200_OK,
-    response_model=ComponentList,
-    operation_id="list_components",
+    operation_id="list_components"
 )
 async def list_components(
-    component_type: Optional[str] = Query(None, description="Filter by component type"),
-    q: Optional[str] = Query(None, description="Search by name"),
-    db: Session = Depends(get_db),
+    db: Annotated[Session, Depends(get_db)],
+    component_type: Annotated[Optional[str], Query(description="Filter by component type")] = None,
+    q: Annotated[Optional[str], Query(description="Search by name")] = None,
 ) -> ComponentList:
     """List all components, optionally filtered by type or name search."""
     return _call(svc.list_components, db, component_type, q)
@@ -67,11 +66,10 @@ async def list_components(
 @router.get(
     "/types",
     status_code=status.HTTP_200_OK,
-    response_model=ComponentTypesResponse,
-    operation_id="list_component_types",
+    operation_id="list_component_types"
 )
 async def list_component_types(
-    db: Session = Depends(get_db),
+    db: Annotated[Session, Depends(get_db)],
 ) -> ComponentTypesResponse:
     """List the *names* of all registered component types.
 
@@ -84,12 +82,11 @@ async def list_component_types(
 @router.post(
     "",
     status_code=status.HTTP_201_CREATED,
-    response_model=ComponentRead,
-    operation_id="create_component",
+    operation_id="create_component"
 )
 async def create_component(
-    body: ComponentWrite = Body(..., description="Component data"),
-    db: Session = Depends(get_db),
+    body: Annotated[ComponentWrite, Body(..., description="Component data")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> ComponentRead:
     """Create a new component in the library."""
     return _call(svc.create_component, db, body)
@@ -98,12 +95,11 @@ async def create_component(
 @router.get(
     "/{component_id}",
     status_code=status.HTTP_200_OK,
-    response_model=ComponentRead,
-    operation_id="get_component",
+    operation_id="get_component"
 )
 async def get_component(
-    component_id: int = Path(..., description="The component ID"),
-    db: Session = Depends(get_db),
+    component_id: Annotated[int, Path(..., description="The component ID")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> ComponentRead:
     """Get a single component by ID."""
     return _call(svc.get_component, db, component_id)
@@ -112,13 +108,12 @@ async def get_component(
 @router.put(
     "/{component_id}",
     status_code=status.HTTP_200_OK,
-    response_model=ComponentRead,
-    operation_id="update_component",
+    operation_id="update_component"
 )
 async def update_component(
-    component_id: int = Path(..., description="The component ID"),
-    body: ComponentWrite = Body(..., description="Component data"),
-    db: Session = Depends(get_db),
+    component_id: Annotated[int, Path(..., description="The component ID")],
+    body: Annotated[ComponentWrite, Body(..., description="Component data")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> ComponentRead:
     """Update an existing component."""
     return _call(svc.update_component, db, component_id, body)
@@ -130,8 +125,8 @@ async def update_component(
     operation_id="delete_component",
 )
 async def delete_component(
-    component_id: int = Path(..., description="The component ID"),
-    db: Session = Depends(get_db),
+    component_id: Annotated[int, Path(..., description="The component ID")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> None:
     """Delete a component from the library."""
     _call(svc.delete_component, db, component_id)
@@ -145,13 +140,12 @@ MODELS_DIR = FilePath("tmp") / "component_models"
 @router.post(
     "/{component_id}/model",
     status_code=status.HTTP_200_OK,
-    response_model=ComponentRead,
-    operation_id="upload_component_model",
+    operation_id="upload_component_model"
 )
 async def upload_component_model(
-    component_id: int = Path(..., description="The component ID"),
-    file: UploadFile = File(..., description="STEP or STL file"),
-    db: Session = Depends(get_db),
+    component_id: Annotated[int, Path(..., description="The component ID")],
+    file: Annotated[UploadFile, File(..., description="STEP or STL file")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> ComponentRead:
     """Upload a STEP or STL 3D model file for a component."""
     comp = _call(svc.get_component, db, component_id)
@@ -188,8 +182,8 @@ async def upload_component_model(
     operation_id="download_component_model",
 )
 async def download_component_model(
-    component_id: int = Path(..., description="The component ID"),
-    db: Session = Depends(get_db),
+    component_id: Annotated[int, Path(..., description="The component ID")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> FileResponse:
     """Download the 3D model file (STEP/STL) for a component."""
     comp = _call(svc.get_component, db, component_id)

--- a/app/api/v2/endpoints/construction_plans.py
+++ b/app/api/v2/endpoints/construction_plans.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from typing import Annotated, List
 
-from fastapi import APIRouter, Body, Depends, Path
+from fastapi import APIRouter, Body, Depends, Path, Query
 from fastapi import status
 from sqlalchemy.orm import Session
 
@@ -68,7 +68,7 @@ async def list_creators() -> List[CreatorInfo]:
 )
 async def list_plans(
     db: Annotated[Session, Depends(get_db)],
-    plan_type: str | None = None,
+    plan_type: Annotated[str | None, Query(description="Filter by plan type")] = None,
 ) -> List[PlanSummary]:
     """List all construction plans, optionally filtered by plan_type."""
     try:

--- a/app/api/v2/endpoints/construction_plans.py
+++ b/app/api/v2/endpoints/construction_plans.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import List
+from typing import Annotated, List
 
 from fastapi import APIRouter, Body, Depends, Path
 from fastapi import status
@@ -48,10 +48,9 @@ def _handle_service_error(exc: ServiceException):
 
 @router.get(
     "/construction-plans/creators",
-    response_model=List[CreatorInfo],
     status_code=status.HTTP_200_OK,
     tags=["construction-plans"],
-    operation_id="list_creators",
+    operation_id="list_creators"
 )
 async def list_creators() -> List[CreatorInfo]:
     """List all available Creator classes with their parameters."""
@@ -63,14 +62,13 @@ async def list_creators() -> List[CreatorInfo]:
 
 @router.get(
     "/construction-plans",
-    response_model=List[PlanSummary],
     status_code=status.HTTP_200_OK,
     tags=["construction-plans"],
-    operation_id="list_construction_plans",
+    operation_id="list_construction_plans"
 )
 async def list_plans(
+    db: Annotated[Session, Depends(get_db)],
     plan_type: str | None = None,
-    db: Session = Depends(get_db),
 ) -> List[PlanSummary]:
     """List all construction plans, optionally filtered by plan_type."""
     try:
@@ -81,14 +79,13 @@ async def list_plans(
 
 @router.post(
     "/construction-plans",
-    response_model=PlanRead,
     status_code=status.HTTP_201_CREATED,
     tags=["construction-plans"],
-    operation_id="create_construction_plan",
+    operation_id="create_construction_plan"
 )
 async def create_plan(
-    request: PlanCreate = Body(...),
-    db: Session = Depends(get_db),
+    request: Annotated[PlanCreate, Body(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> PlanRead:
     """Create a new construction plan."""
     try:
@@ -99,14 +96,13 @@ async def create_plan(
 
 @router.get(
     "/construction-plans/{plan_id}",
-    response_model=PlanRead,
     status_code=status.HTTP_200_OK,
     tags=["construction-plans"],
-    operation_id="get_construction_plan",
+    operation_id="get_construction_plan"
 )
 async def get_plan(
-    plan_id: int = Path(..., description="Construction plan ID"),
-    db: Session = Depends(get_db),
+    plan_id: Annotated[int, Path(..., description="Construction plan ID")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> PlanRead:
     """Get a construction plan by ID."""
     try:
@@ -117,15 +113,14 @@ async def get_plan(
 
 @router.put(
     "/construction-plans/{plan_id}",
-    response_model=PlanRead,
     status_code=status.HTTP_200_OK,
     tags=["construction-plans"],
-    operation_id="update_construction_plan",
+    operation_id="update_construction_plan"
 )
 async def update_plan(
-    plan_id: int = Path(...),
-    request: PlanCreate = Body(...),
-    db: Session = Depends(get_db),
+    plan_id: Annotated[int, Path(...)],
+    request: Annotated[PlanCreate, Body(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> PlanRead:
     """Update an existing construction plan."""
     try:
@@ -141,8 +136,8 @@ async def update_plan(
     operation_id="delete_construction_plan",
 )
 async def delete_plan(
-    plan_id: int = Path(...),
-    db: Session = Depends(get_db),
+    plan_id: Annotated[int, Path(...)],
+    db: Annotated[Session, Depends(get_db)],
 ):
     """Delete a construction plan."""
     try:
@@ -156,15 +151,14 @@ async def delete_plan(
 
 @router.post(
     "/construction-plans/{plan_id}/execute",
-    response_model=ExecutionResult,
     status_code=status.HTTP_200_OK,
     tags=["construction-plans"],
-    operation_id="execute_construction_plan",
+    operation_id="execute_construction_plan"
 )
 async def execute_plan(
-    plan_id: int = Path(...),
-    request: ExecuteRequest = Body(...),
-    db: Session = Depends(get_db),
+    plan_id: Annotated[int, Path(...)],
+    request: Annotated[ExecuteRequest, Body(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> ExecutionResult:
     """Execute a construction plan against an aeroplane configuration."""
     try:

--- a/app/api/v2/endpoints/construction_templates.py
+++ b/app/api/v2/endpoints/construction_templates.py
@@ -1,7 +1,7 @@
 """REST endpoints for Construction Templates (gh#126)."""
 from __future__ import annotations
 
-from typing import List
+from typing import Annotated, List
 
 from fastapi import APIRouter, Body, Depends
 from fastapi import status
@@ -34,11 +34,10 @@ def _handle_service_error(exc: ServiceException):
 
 @router.get(
     "/construction-templates",
-    response_model=List[PlanSummary],
     tags=["construction-templates"],
-    operation_id="list_construction_templates",
+    operation_id="list_construction_templates"
 )
-async def list_templates(db: Session = Depends(get_db)) -> List[PlanSummary]:
+async def list_templates(db: Annotated[Session, Depends(get_db)]) -> List[PlanSummary]:
     """List all construction templates."""
     try:
         return svc.list_plans(db, plan_type="template")
@@ -48,14 +47,13 @@ async def list_templates(db: Session = Depends(get_db)) -> List[PlanSummary]:
 
 @router.post(
     "/construction-templates",
-    response_model=PlanRead,
     status_code=status.HTTP_201_CREATED,
     tags=["construction-templates"],
-    operation_id="create_construction_template",
+    operation_id="create_construction_template"
 )
 async def create_template(
-    request: PlanCreate = Body(...),
-    db: Session = Depends(get_db),
+    request: Annotated[PlanCreate, Body(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> PlanRead:
     """Create a new construction template."""
     request.plan_type = "template"

--- a/app/api/v2/endpoints/flight_profiles.py
+++ b/app/api/v2/endpoints/flight_profiles.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Annotated, Optional
 
 from fastapi import APIRouter, Depends, Path, Query, HTTPException, status
 from pydantic import UUID4, BaseModel
@@ -57,14 +57,13 @@ def _call_service(func, *args, **kwargs):
 
 @router.post(
     "/flight-profiles",
-    response_model=RCFlightProfileRead,
     status_code=status.HTTP_201_CREATED,
     operation_id="create_flight_profile",
-    tags=["flight-profiles"],
+    tags=["flight-profiles"]
 )
 async def create_flight_profile(
     payload: RCFlightProfileCreate,
-    db: Session = Depends(get_db),
+    db: Annotated[Session, Depends(get_db)],
 ) -> RCFlightProfileRead:
     """Erstellt ein neues RC Flight Profile. Dieses Profil beschreibt gewünschte Flugeigenschaften, nicht eine konkrete Flugbahn."""
     return _call_service(flight_profile_service.create_profile, db, payload)
@@ -72,20 +71,18 @@ async def create_flight_profile(
 
 @router.get(
     "/flight-profiles",
-    response_model=list[RCFlightProfileRead],
     status_code=status.HTTP_200_OK,
     operation_id="list_flight_profiles",
-    tags=["flight-profiles"],
+    tags=["flight-profiles"]
 )
 async def list_flight_profiles(
-    profile_type: Optional[FlightProfileType] = Query(
-        default=None,
+    db: Annotated[Session, Depends(get_db)],
+    profile_type: Annotated[Optional[FlightProfileType], Query(
         alias="type",
         description="Optionaler Typfilter, z.B. trainer oder glider.",
-    ),
-    skip: int = Query(default=0, ge=0, description="Wie viele Einträge am Anfang übersprungen werden sollen."),
-    limit: int = Query(default=100, ge=1, le=500, description="Maximale Anzahl zurückgegebener Profile."),
-    db: Session = Depends(get_db),
+    )] = None,
+    skip: Annotated[int, Query(ge=0, description="Wie viele Einträge am Anfang übersprungen werden sollen.")] = 0,
+    limit: Annotated[int, Query(ge=1, le=500, description="Maximale Anzahl zurückgegebener Profile.")] = 100,
 ) -> list[RCFlightProfileRead]:
     """Listet alle Profile auf. Optional kann nach Typ gefiltert und mit skip/limit paginiert werden."""
     return _call_service(
@@ -99,14 +96,13 @@ async def list_flight_profiles(
 
 @router.get(
     "/flight-profiles/{profile_id}",
-    response_model=RCFlightProfileRead,
     status_code=status.HTTP_200_OK,
     operation_id="get_flight_profile",
-    tags=["flight-profiles"],
+    tags=["flight-profiles"]
 )
 async def get_flight_profile(
-    profile_id: int = Path(..., ge=1, description="Interne numerische Profil-ID."),
-    db: Session = Depends(get_db),
+    profile_id: Annotated[int, Path(..., ge=1, description="Interne numerische Profil-ID.")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> RCFlightProfileRead:
     """Gibt ein einzelnes RC Flight Profile zurück."""
     return _call_service(flight_profile_service.get_profile, db, profile_id)
@@ -114,15 +110,14 @@ async def get_flight_profile(
 
 @router.patch(
     "/flight-profiles/{profile_id}",
-    response_model=RCFlightProfileRead,
     status_code=status.HTTP_200_OK,
     operation_id="update_flight_profile",
-    tags=["flight-profiles"],
+    tags=["flight-profiles"]
 )
 async def update_flight_profile(
     payload: RCFlightProfileUpdate,
-    profile_id: int = Path(..., ge=1, description="Interne numerische Profil-ID."),
-    db: Session = Depends(get_db),
+    profile_id: Annotated[int, Path(..., ge=1, description="Interne numerische Profil-ID.")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> RCFlightProfileRead:
     """Teil-Update eines Profils. Nur übergebene Felder werden geändert; alle Validierungsregeln gelten weiterhin."""
     return _call_service(flight_profile_service.update_profile, db, profile_id, payload)
@@ -130,14 +125,13 @@ async def update_flight_profile(
 
 @router.delete(
     "/flight-profiles/{profile_id}",
-    response_model=OperationStatusResponse,
     status_code=status.HTTP_200_OK,
     operation_id="delete_flight_profile",
-    tags=["flight-profiles"],
+    tags=["flight-profiles"]
 )
 async def delete_flight_profile(
-    profile_id: int = Path(..., ge=1, description="Interne numerische Profil-ID."),
-    db: Session = Depends(get_db),
+    profile_id: Annotated[int, Path(..., ge=1, description="Interne numerische Profil-ID.")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> OperationStatusResponse:
     """Löscht ein Profil. Policy: 409 Conflict, solange das Profil noch Aircraft zugewiesen ist."""
     _call_service(flight_profile_service.delete_profile, db, profile_id)
@@ -146,15 +140,14 @@ async def delete_flight_profile(
 
 @router.put(
     "/aeroplanes/{aeroplane_id}/flight-profile/{profile_id}",
-    response_model=AircraftFlightProfileAssignmentRead,
     status_code=status.HTTP_200_OK,
     operation_id="assign_flight_profile_to_aeroplane",
-    tags=["flight-profiles"],
+    tags=["flight-profiles"]
 )
 async def assign_flight_profile_to_aeroplane(
-    aeroplane_id: AircraftID = Path(..., description="UUID des Aeroplanes."),
-    profile_id: int = Path(..., ge=1, description="ID des RC Flight Profiles."),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AircraftID, Path(..., description="UUID des Aeroplanes.")],
+    profile_id: Annotated[int, Path(..., ge=1, description="ID des RC Flight Profiles.")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> AircraftFlightProfileAssignmentRead:
     """Weist einem Aeroplane ein RC Flight Profile zu und überschreibt eine bestehende Zuweisung."""
     return _call_service(flight_profile_service.assign_profile_to_aircraft, db, aeroplane_id, profile_id)
@@ -162,14 +155,13 @@ async def assign_flight_profile_to_aeroplane(
 
 @router.delete(
     "/aeroplanes/{aeroplane_id}/flight-profile",
-    response_model=AircraftFlightProfileAssignmentRead,
     status_code=status.HTTP_200_OK,
     operation_id="detach_flight_profile_from_aeroplane",
-    tags=["flight-profiles"],
+    tags=["flight-profiles"]
 )
 async def detach_flight_profile_from_aeroplane(
-    aeroplane_id: AircraftID = Path(..., description="UUID des Aeroplanes."),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[AircraftID, Path(..., description="UUID des Aeroplanes.")],
+    db: Annotated[Session, Depends(get_db)],
 ) -> AircraftFlightProfileAssignmentRead:
     """Entfernt die Profilzuweisung eines Aeroplanes und setzt flight_profile_id auf NULL."""
     return _call_service(flight_profile_service.detach_profile_from_aircraft, db, aeroplane_id)

--- a/app/api/v2/endpoints/fuselage_slice.py
+++ b/app/api/v2/endpoints/fuselage_slice.py
@@ -1,5 +1,6 @@
 """Endpoint for slicing a STEP file into a fuselage definition."""
 
+from typing import Annotated
 import logging
 
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile, status
@@ -16,16 +17,15 @@ router = APIRouter(prefix="/fuselages", tags=["fuselages"])
 @router.post(
     "/slice",
     status_code=status.HTTP_200_OK,
-    response_model=FuselageSliceResponse,
     operation_id="slice_step_to_fuselage",
-    summary="Slice a STEP file into superellipse cross-sections (asb.Fuselage format)",
+    summary="Slice a STEP file into superellipse cross-sections (asb.Fuselage format)"
 )
 async def slice_step_to_fuselage(
-    file: UploadFile = File(..., description="STEP file (.step or .stp)"),
-    number_of_slices: int = Form(50, ge=2, le=500, description="Number of cross-section slices"),
-    points_per_slice: int = Form(30, ge=10, le=200, description="Points per wire discretization"),
-    slice_axis: str = Form("auto", description="Slice axis: 'x', 'y', 'z', or 'auto' (longest axis)"),
-    fuselage_name: str = Form("Imported Fuselage", description="Name for the resulting fuselage"),
+    file: Annotated[UploadFile, File(..., description="STEP file (.step or .stp)")],
+    number_of_slices: Annotated[int, Form(ge=2, le=500, description="Number of cross-section slices")] = 50,
+    points_per_slice: Annotated[int, Form(ge=10, le=200, description="Points per wire discretization")] = 30,
+    slice_axis: Annotated[str, Form(description="Slice axis: 'x', 'y', 'z', or 'auto' (longest axis)")] = "auto",
+    fuselage_name: Annotated[str, Form(description="Name for the resulting fuselage")] = "Imported Fuselage",
 ) -> FuselageSliceResponse:
     """Upload a STEP file, slice it along the fuselage longitudinal axis,
     fit symmetric superellipses to each cross-section, and return a

--- a/app/api/v2/endpoints/health.py
+++ b/app/api/v2/endpoints/health.py
@@ -8,6 +8,7 @@ linux/aarch64 where the CAD stack is excluded.
 """
 
 from __future__ import annotations
+from typing import Annotated
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
@@ -34,11 +35,10 @@ class HealthResponse(BaseModel):
 
 @router.get(
     "/health",
-    response_model=HealthResponse,
     tags=["health"],
-    summary="Liveness + database ping",
+    summary="Liveness + database ping"
 )
-def get_health(db: Session = Depends(get_db)) -> HealthResponse:
+def get_health(db: Annotated[Session, Depends(get_db)]) -> HealthResponse:
     """Return service status and a DB reachability flag.
 
     A non-reachable database still returns HTTP 200 with

--- a/app/api/v2/endpoints/operating_points.py
+++ b/app/api/v2/endpoints/operating_points.py
@@ -52,15 +52,16 @@ def _resolve_aircraft_pk(db: Session, aircraft_uuid: UUID4) -> Optional[int]:
 )
 async def generate_default_operating_point_set(
     aeroplane_id: Annotated[UUID4, Path(..., description="Aeroplane UUID")],
-    request: Annotated[GenerateOperatingPointSetRequest, Body()],
     db: Annotated[Session, Depends(get_db)],
+    request: Annotated[GenerateOperatingPointSetRequest, Body()] = None,
 ) -> GeneratedOperatingPointSetRead:
     try:
+        req = request or GenerateOperatingPointSetRequest()
         return await operating_point_generator_service.generate_default_set_for_aircraft(
             db=db,
             aircraft_uuid=aeroplane_id,
-            replace_existing=request.replace_existing,
-            profile_id_override=request.profile_id_override,
+            replace_existing=req.replace_existing,
+            profile_id_override=req.profile_id_override,
         )
     except ServiceException as exc:
         _raise_http_from_domain(exc)

--- a/app/api/v2/endpoints/operating_points.py
+++ b/app/api/v2/endpoints/operating_points.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Annotated, Optional
 
 from fastapi import Depends, APIRouter, Query, Path, Body, HTTPException, status
 from pydantic import UUID4
@@ -48,13 +48,12 @@ def _resolve_aircraft_pk(db: Session, aircraft_uuid: UUID4) -> Optional[int]:
 
 @router.post(
     "/aeroplanes/{aeroplane_id}/operating-pointsets/generate-default",
-    response_model=GeneratedOperatingPointSetRead,
-    operation_id="generate_default_operating_point_set",
+    operation_id="generate_default_operating_point_set"
 )
 async def generate_default_operating_point_set(
-    aeroplane_id: UUID4 = Path(..., description="Aeroplane UUID"),
-    request: GenerateOperatingPointSetRequest = Body(default_factory=GenerateOperatingPointSetRequest),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[UUID4, Path(..., description="Aeroplane UUID")],
+    request: Annotated[GenerateOperatingPointSetRequest, Body()],
+    db: Annotated[Session, Depends(get_db)],
 ) -> GeneratedOperatingPointSetRead:
     try:
         return await operating_point_generator_service.generate_default_set_for_aircraft(
@@ -74,13 +73,12 @@ async def generate_default_operating_point_set(
 
 @router.post(
     "/aeroplanes/{aeroplane_id}/operating-points/trim",
-    response_model=TrimmedOperatingPointRead,
-    operation_id="trim_operating_point",
+    operation_id="trim_operating_point"
 )
 async def trim_operating_point(
-    aeroplane_id: UUID4 = Path(..., description="Aeroplane UUID"),
-    request: TrimOperatingPointRequest = Body(...),
-    db: Session = Depends(get_db),
+    aeroplane_id: Annotated[UUID4, Path(..., description="Aeroplane UUID")],
+    request: Annotated[TrimOperatingPointRequest, Body(...)],
+    db: Annotated[Session, Depends(get_db)],
 ) -> TrimmedOperatingPointRead:
     try:
         return await operating_point_generator_service.trim_operating_point_for_aircraft(
@@ -100,7 +98,7 @@ async def trim_operating_point(
 @router.post("/operating_points/", response_model=StoredOperatingPointRead, operation_id="create_operating_point")
 def create_operating_point(
     op_data: StoredOperatingPointCreate,
-    db: Session = Depends(get_db),
+    db: Annotated[Session, Depends(get_db)],
 ):
     op = OperatingPointModel(**op_data.model_dump())
     db.add(op)
@@ -111,10 +109,10 @@ def create_operating_point(
 
 @router.get("/operating_points", response_model=list[StoredOperatingPointRead], operation_id="list_operating_points")
 def list_operating_points(
-    aircraft_id: Optional[UUID4] = Query(default=None, description="Optional aircraft UUID filter"),
-    skip: int = Query(default=0, ge=0),
-    limit: int = Query(default=200, ge=1, le=1000),
-    db: Session = Depends(get_db),
+    db: Annotated[Session, Depends(get_db)],
+    aircraft_id: Annotated[Optional[UUID4], Query(description="Optional aircraft UUID filter")] = None,
+    skip: Annotated[int, Query(ge=0)] = 0,
+    limit: Annotated[int, Query(ge=1, le=1000)] = 200,
 ):
     query = db.query(OperatingPointModel).order_by(OperatingPointModel.id)
     if aircraft_id is not None:
@@ -128,7 +126,7 @@ def list_operating_points(
 @router.get("/operating_points/{op_id}", response_model=StoredOperatingPointRead, operation_id="get_operating_point")
 def read_operating_point(
     op_id: int,
-    db: Session = Depends(get_db),
+    db: Annotated[Session, Depends(get_db)],
 ):
     op = db.query(OperatingPointModel).filter(OperatingPointModel.id == op_id).first()
     if not op:
@@ -140,7 +138,7 @@ def read_operating_point(
 def update_operating_point(
     op_id: int,
     op_data: StoredOperatingPointCreate,
-    db: Session = Depends(get_db),
+    db: Annotated[Session, Depends(get_db)],
 ):
     op = db.query(OperatingPointModel).filter(OperatingPointModel.id == op_id).first()
     if not op:
@@ -153,7 +151,7 @@ def update_operating_point(
 
 
 @router.delete("/operating_points/{op_id}", operation_id="delete_operating_point")
-def delete_operating_point(op_id: int, db: Session = Depends(get_db)):
+def delete_operating_point(op_id: int, db: Annotated[Session, Depends(get_db)]):
     op = db.query(OperatingPointModel).filter(OperatingPointModel.id == op_id).first()
     if not op:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"OperatingPoint {op_id} not found")
@@ -165,7 +163,7 @@ def delete_operating_point(op_id: int, db: Session = Depends(get_db)):
 @router.post("/operating_pointsets/", response_model=OperatingPointSetSchema, operation_id="create_operating_pointset")
 def create_operating_pointset(
     opset_data: OperatingPointSetSchema,
-    db: Session = Depends(get_db),
+    db: Annotated[Session, Depends(get_db)],
 ):
     opset = OperatingPointSetModel(**opset_data.model_dump())
     db.add(opset)
@@ -176,10 +174,10 @@ def create_operating_pointset(
 
 @router.get("/operating_pointsets", response_model=list[OperatingPointSetSchema], operation_id="list_operating_pointsets")
 def list_operating_pointsets(
-    aircraft_id: Optional[UUID4] = Query(default=None, description="Optional aircraft UUID filter"),
-    skip: int = Query(default=0, ge=0),
-    limit: int = Query(default=200, ge=1, le=1000),
-    db: Session = Depends(get_db),
+    db: Annotated[Session, Depends(get_db)],
+    aircraft_id: Annotated[Optional[UUID4], Query(description="Optional aircraft UUID filter")] = None,
+    skip: Annotated[int, Query(ge=0)] = 0,
+    limit: Annotated[int, Query(ge=1, le=1000)] = 200,
 ):
     query = db.query(OperatingPointSetModel).order_by(OperatingPointSetModel.id)
     if aircraft_id is not None:
@@ -191,7 +189,7 @@ def list_operating_pointsets(
 
 
 @router.get("/operating_pointsets/{opset_id}", response_model=OperatingPointSetSchema, operation_id="get_operating_pointset")
-def read_operating_pointset(opset_id: int, db: Session = Depends(get_db)):
+def read_operating_pointset(opset_id: int, db: Annotated[Session, Depends(get_db)]):
     opset = db.query(OperatingPointSetModel).filter(OperatingPointSetModel.id == opset_id).first()
     if not opset:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"OperatingPointSet {opset_id} not found")
@@ -199,7 +197,7 @@ def read_operating_pointset(opset_id: int, db: Session = Depends(get_db)):
 
 
 @router.put("/operating_pointsets/{opset_id}", response_model=OperatingPointSetSchema, operation_id="update_operating_pointset")
-def update_operating_pointset(opset_id: int, opset_data: OperatingPointSetSchema, db: Session = Depends(get_db)):
+def update_operating_pointset(opset_id: int, opset_data: OperatingPointSetSchema, db: Annotated[Session, Depends(get_db)]):
     opset = db.query(OperatingPointSetModel).filter(OperatingPointSetModel.id == opset_id).first()
     if not opset:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"OperatingPointSet {opset_id} not found")
@@ -211,7 +209,7 @@ def update_operating_pointset(opset_id: int, opset_data: OperatingPointSetSchema
 
 
 @router.delete("/operating_pointsets/{opset_id}", operation_id="delete_operating_pointset")
-def delete_operating_pointset(opset_id: int, db: Session = Depends(get_db)):
+def delete_operating_pointset(opset_id: int, db: Annotated[Session, Depends(get_db)]):
     opset = db.query(OperatingPointSetModel).filter(OperatingPointSetModel.id == opset_id).first()
     if not opset:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"OperatingPointSet {opset_id} not found")

--- a/app/tests/test_stability_summary.py
+++ b/app/tests/test_stability_summary.py
@@ -97,7 +97,7 @@ class TestStabilityEndpoint:
             return_value=mock_response,
         ):
             res = client.post(
-                "/aeroplanes/00000000-0000-0000-0000-000000000001/stability_summary/aerobuildup",
+                "/aeroplanes/a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d/stability_summary/aerobuildup",
                 json={"velocity": 14.0, "alpha": 2.0, "beta": 0.0, "altitude": 0},
             )
             assert res.status_code == 200


### PR DESCRIPTION
## Summary

- Migrates all 22 FastAPI endpoint files to `Annotated[Type, Depends(...)]` DI pattern, resolving ~391 SonarQube S8410 BLOCKER issues
- Removes redundant `response_model=X` decorator params where return type annotation matches, resolving ~104 S8409 BLOCKER issues
- Fixes parameter ordering (non-default before default) and extracts positional defaults from Query/Body/Form into `= value` syntax

## Test plan

- [x] All 549 fast tests pass (`poetry run pytest -m "not slow"`)
- [x] Ruff lint passes
- [x] All 23 endpoint files parse correctly
- [x] CI pipeline passes
- [x] SonarQube rescan confirms 0 remaining S8410/S8409 issues

Closes #178, Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)