### PR TITLE
chore: SonarQube cleanup — S8411, S7503, S1066, S125, S1192 (#180, #182, #183)

### DIFF
--- a/app/api/v2/endpoints/aeroanalysis.py
+++ b/app/api/v2/endpoints/aeroanalysis.py
@@ -30,6 +30,8 @@ from app.settings import Settings, get_settings
 router = APIRouter()
 AeroPlaneID = UUID4
 
+_DESC_AEROPLANE_ID = "The ID of the aeroplane"
+
 logger = logging.getLogger(__name__)
 
 
@@ -75,7 +77,7 @@ def _save_png_and_get_static_url(
     operation_id="get_airplane_strip_forces",
 )
 async def get_airplane_strip_forces(
-    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
     operating_point: Annotated[OperatingPointSchema, Body(..., description="The operating point")],
     db: Annotated[Session, Depends(get_db)],
 ):
@@ -98,7 +100,7 @@ async def get_airplane_strip_forces(
     operation_id="get_wing_strip_forces",
 )
 async def get_wing_strip_forces(
-    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
     wing_name: Annotated[str, Path(..., description="The name of the wing")],
     operating_point: Annotated[OperatingPointSchema, Body(..., description="The operating point")],
     db: Annotated[Session, Depends(get_db)],
@@ -119,7 +121,7 @@ async def get_wing_strip_forces(
              tags=["analysis"],
              operation_id="analyze_wing_aerodynamics")
 async def analyze_wing_post(
-    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
     wing_name: Annotated[str, Path(..., description="The ID of the wing")],
     operating_point: Annotated[OperatingPointSchema, Body(..., description="The operating point of the analysis")],
     analysis_tool: Annotated[AnalysisToolUrlType, Path(..., description="The tool for aerodynamic analysis")],
@@ -141,7 +143,7 @@ async def analyze_wing_post(
              tags=["analysis"],
              operation_id="get_stability_summary")
 async def get_stability_summary(
-    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
     operating_point: Annotated[OperatingPointSchema, Body(..., description="The operating point for the analysis")],
     analysis_tool: Annotated[AnalysisToolUrlType, Path(..., description="The analysis tool to use")],
     db: Annotated[Session, Depends(get_db)]
@@ -162,7 +164,7 @@ async def get_stability_summary(
              tags=["analysis"],
              operation_id="analyze_airplane_at_operating_point")
 async def analyze_airplane_post(
-    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
     operating_point: Annotated[OperatingPointSchema, Body(..., description="The operating point of the analysis")],
     analysis_tool: Annotated[AnalysisToolUrlType, Path(..., description="The tool for aerodynamic analysis")],
     db: Annotated[Session, Depends(get_db)]
@@ -183,7 +185,7 @@ async def analyze_airplane_post(
              tags=["analysis"],
              operation_id="get_streamlines_json")
 async def calculate_streamlines_json(
-    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
     operating_point: Annotated[OperatingPointSchema, Body(..., description="The operating point")],
     db: Annotated[Session, Depends(get_db)],
 ):
@@ -203,7 +205,7 @@ async def calculate_streamlines_json(
              tags=["analysis"],
              operation_id="analyze_alpha_sweep")
 async def analyze_airplane_alpha_sweep(
-    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
     sweep_request: Annotated[AlphaSweepRequest, Body(..., description="Sweep definitions and flight conditions")],
     db: Annotated[Session, Depends(get_db)],
 ):
@@ -220,7 +222,7 @@ async def analyze_airplane_alpha_sweep(
              tags=["analysis"],
              operation_id="analyze_alpha_sweep_diagram")
 async def analyze_airplane_alpha_sweep_diagram(
-    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
     sweep_request: Annotated[AlphaSweepRequest, Body(..., description="Sweep definitions and flight conditions")],
     db: Annotated[Session, Depends(get_db)],
     settings: Annotated[Settings, Depends(get_settings)],
@@ -244,7 +246,7 @@ async def analyze_airplane_alpha_sweep_diagram(
              tags=["analysis"],
              operation_id="analyze_parameter_sweep")
 async def analyze_airplane_simple_sweep(
-    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
     sweep_request: Annotated[SimpleSweepRequest, Body(..., description="Sweep definitions and flight conditions")],
     db: Annotated[Session, Depends(get_db)],
 ):
@@ -274,7 +276,7 @@ async def analyze_airplane_simple_sweep(
          tags=["analysis"],
          operation_id="get_aeroplane_three_view_url")
 async def get_aeroplane_three_view_url(
-    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
     db: Annotated[Session, Depends(get_db)],
     settings: Annotated[Settings, Depends(get_settings)],
     request: Request = None,
@@ -300,7 +302,7 @@ async def get_aeroplane_three_view_url(
              tags=["analysis"],
              operation_id="get_streamlines_three_view_url")
 async def get_streamlines_three_view_url(
-    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
     operating_point: Annotated[OperatingPointSchema, Body(..., description="The operating point of the analysis")],
     db: Annotated[Session, Depends(get_db)],
     settings: Annotated[Settings, Depends(get_settings)],

--- a/app/api/v2/endpoints/aeroplane/wings.py
+++ b/app/api/v2/endpoints/aeroplane/wings.py
@@ -26,6 +26,10 @@ router = APIRouter()
 
 AeroPlaneID = UUID4
 
+_DESC_AEROPLANE_ID = "The ID of the aeroplane"
+_DESC_WING_NAME = "The name of the wing"
+_DESC_XSEC_INDEX = "The index of the cross section"
+
 
 class OperationStatusResponse(BaseModel):
     status: str
@@ -211,7 +215,7 @@ def _call_service(func, *args, **kwargs):
             tags=["wings"],
             operation_id="get_aeroplane_wings")
 async def get_aeroplane_wings(
-        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
         db: Annotated[Session, Depends(get_db)],
 ) -> List[str]:
     """Returns a list of aeroplane's wing names."""
@@ -224,7 +228,7 @@ async def get_aeroplane_wings(
             tags=["wings"],
             operation_id="create_aeroplane_wing")
 async def create_aeroplane_wing(
-        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
         wing_name: Annotated[str, Path(..., description="The ID of the wing")],
         request: Annotated[schemas.AsbWingGeometryWriteSchema, Body(
             ...,
@@ -247,7 +251,7 @@ async def create_aeroplane_wing(
     operation_id="create_aeroplane_wing_from_wingconfig",
 )
 async def create_aeroplane_wing_from_wingconfig(
-    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
     wing_name: Annotated[str, Path(..., description="The ID of the wing")],
     request: Annotated[WingConfigurationSchema, Body(
         ...,
@@ -273,8 +277,8 @@ async def create_aeroplane_wing_from_wingconfig(
     operation_id="get_wing_as_wingconfig",
 )
 async def get_wing_as_wingconfig(
-    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
-    wing_name: Annotated[str, Path(..., description="The name of the wing")],
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
+    wing_name: Annotated[str, Path(..., description=_DESC_WING_NAME)],
     db: Annotated[Session, Depends(get_db)],
 ):
     """Return the wing in WingConfiguration format (segments with root/tip airfoils, length, sweep, dihedral)."""
@@ -289,8 +293,8 @@ async def get_wing_as_wingconfig(
     operation_id="put_wing_as_wingconfig",
 )
 async def put_wing_as_wingconfig(
-    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
-    wing_name: Annotated[str, Path(..., description="The name of the wing")],
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
+    wing_name: Annotated[str, Path(..., description=_DESC_WING_NAME)],
     request: Annotated[WingConfigurationSchema, Body(
         ...,
         description="WingConfiguration JSON (mm). Replaces the existing wing.",
@@ -312,7 +316,7 @@ async def put_wing_as_wingconfig(
     operation_id="update_aeroplane_wing"
 )
 async def update_aeroplane_wing(
-        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
         wing_name: Annotated[str, Path(..., description="The ID of the wing")],
         request: Annotated[schemas.AsbWingGeometryWriteSchema, Body(
             ...,
@@ -331,7 +335,7 @@ async def update_aeroplane_wing(
             tags=["wings"],
             operation_id="get_aeroplane_wing")
 async def get_aeroplane_wing(
-        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
         wing_name: Annotated[str, Path(..., description="The ID of the wing")],
         db: Annotated[Session, Depends(get_db)],
 ) -> schemas.AsbWingReadSchema:
@@ -347,7 +351,7 @@ async def get_aeroplane_wing(
     operation_id="delete_aeroplane_wing"
 )
 async def delete_aeroplane_wing(
-        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
         wing_name: Annotated[str, Path(..., description="The ID of the wing")],
         db: Annotated[Session, Depends(get_db)],
 ):
@@ -367,7 +371,7 @@ async def delete_aeroplane_wing(
     operation_id="get_wing_cross_sections"
 )
 async def get_aeroplane_wing_cross_sections(
-        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
         wing_name: Annotated[str, Path(..., description="The ID of the wing")],
         db: Annotated[Session, Depends(get_db)],
 ) -> List[schemas.WingXSecReadSchema]:
@@ -383,7 +387,7 @@ async def get_aeroplane_wing_cross_sections(
     operation_id="delete_all_wing_cross_sections"
 )
 async def delete_aeroplane_wing_cross_sections(
-        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
         wing_name: Annotated[str, Path(..., description="The ID of the wing")],
         db: Annotated[Session, Depends(get_db)],
 ):
@@ -400,9 +404,9 @@ async def delete_aeroplane_wing_cross_sections(
     operation_id="get_wing_cross_section"
 )
 async def get_aeroplane_wing_cross_section(
-        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
         wing_name: Annotated[str, Path(..., description="The ID of the wing")],
-        cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+        cross_section_index: Annotated[int, Path(..., description=_DESC_XSEC_INDEX)],
         db: Annotated[Session, Depends(get_db)],
 ) -> schemas.WingXSecReadSchema:
     """Returns the aeroplane wing cross-sections as a list of names."""
@@ -417,7 +421,7 @@ async def get_aeroplane_wing_cross_section(
     operation_id="create_wing_cross_section"
 )
 async def create_aeroplane_wing_cross_section(
-        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
         wing_name: Annotated[str, Path(..., description="The ID of the wing")],
         cross_section_index: Annotated[int, Path(...,
                                         description="The index where it will be spliced into the list of cross sections. (-1 is the end of the list, 0 is the start of the list)")],
@@ -442,9 +446,9 @@ async def create_aeroplane_wing_cross_section(
     operation_id="update_wing_cross_section"
 )
 async def update_aeroplane_wing_cross_section(
-        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
         wing_name: Annotated[str, Path(..., description="The ID of the wing")],
-        cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+        cross_section_index: Annotated[int, Path(..., description=_DESC_XSEC_INDEX)],
         request: Annotated[schemas.WingXSecGeometryWriteSchema, Body(
             ...,
             description="Geometry-only wing cross-section definition.",
@@ -464,9 +468,9 @@ async def update_aeroplane_wing_cross_section(
                tags=["cross-sections"],
                operation_id="delete_wing_cross_section")
 async def delete_aeroplane_wing_cross_section(
-        aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+        aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
         wing_name: Annotated[str, Path(..., description="The ID of the wing")],
-        cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+        cross_section_index: Annotated[int, Path(..., description=_DESC_XSEC_INDEX)],
         db: Annotated[Session, Depends(get_db)],
 ):
     """Delete a cross-section."""
@@ -483,9 +487,9 @@ async def delete_aeroplane_wing_cross_section(
     operation_id="get_wing_cross_section_spars",
 )
 async def get_aeroplane_wing_cross_section_spars(
-    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
     wing_name: Annotated[str, Path(..., description="The ID of the wing")],
-    cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+    cross_section_index: Annotated[int, Path(..., description=_DESC_XSEC_INDEX)],
     db: Annotated[Session, Depends(get_db)],
 ) -> List[schemas.SpareDetailSchema]:
     """Returns the spars assigned to the given cross-section."""
@@ -499,9 +503,9 @@ async def get_aeroplane_wing_cross_section_spars(
     operation_id="create_wing_cross_section_spar",
 )
 async def create_aeroplane_wing_cross_section_spar(
-    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
     wing_name: Annotated[str, Path(..., description="The ID of the wing")],
-    cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+    cross_section_index: Annotated[int, Path(..., description=_DESC_XSEC_INDEX)],
     request: Annotated[schemas.SpareDetailSchema, Body(..., description="Spar definition to append")],
     db: Annotated[Session, Depends(get_db)],
 ) -> OperationStatusResponse:
@@ -518,9 +522,9 @@ async def create_aeroplane_wing_cross_section_spar(
     operation_id="update_wing_cross_section_spar",
 )
 async def update_aeroplane_wing_cross_section_spar(
-    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
-    wing_name: Annotated[str, Path(..., description="The name of the wing")],
-    cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
+    wing_name: Annotated[str, Path(..., description=_DESC_WING_NAME)],
+    cross_section_index: Annotated[int, Path(..., description=_DESC_XSEC_INDEX)],
     spar_index: Annotated[int, Path(..., description="The index of the spar to replace")],
     request: Annotated[schemas.SpareDetailSchema, Body(..., description="Updated spar definition")],
     db: Annotated[Session, Depends(get_db)],
@@ -539,9 +543,9 @@ async def update_aeroplane_wing_cross_section_spar(
     operation_id="delete_wing_cross_section_spar",
 )
 async def delete_aeroplane_wing_cross_section_spar(
-    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
-    wing_name: Annotated[str, Path(..., description="The name of the wing")],
-    cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
+    wing_name: Annotated[str, Path(..., description=_DESC_WING_NAME)],
+    cross_section_index: Annotated[int, Path(..., description=_DESC_XSEC_INDEX)],
     spar_index: Annotated[int, Path(..., description="The index of the spar to delete")],
     db: Annotated[Session, Depends(get_db)],
 ) -> OperationStatusResponse:
@@ -674,9 +678,9 @@ async def delete_wing_trailing_edge_servo(
     operation_id="get_wing_cross_section_control_surface",
 )
 async def get_aeroplane_wing_cross_section_control_surface(
-    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
     wing_name: Annotated[str, Path(..., description="The ID of the wing")],
-    cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+    cross_section_index: Annotated[int, Path(..., description=_DESC_XSEC_INDEX)],
     db: Annotated[Session, Depends(get_db)],
 ) -> schemas.ControlSurfaceSchema:
     """Returns the control-surface analysis view projected from the canonical TED."""
@@ -696,9 +700,9 @@ async def get_aeroplane_wing_cross_section_control_surface(
     operation_id="patch_wing_cross_section_control_surface",
 )
 async def patch_aeroplane_wing_cross_section_control_surface(
-    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
     wing_name: Annotated[str, Path(..., description="The ID of the wing")],
-    cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+    cross_section_index: Annotated[int, Path(..., description=_DESC_XSEC_INDEX)],
     request: Annotated[schemas.ControlSurfacePatchSchema, Body(..., description="Control-surface patch payload.")],
     db: Annotated[Session, Depends(get_db)],
 ) -> schemas.ControlSurfaceSchema:
@@ -721,9 +725,9 @@ async def patch_aeroplane_wing_cross_section_control_surface(
     operation_id="delete_wing_cross_section_control_surface",
 )
 async def delete_aeroplane_wing_cross_section_control_surface(
-    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
     wing_name: Annotated[str, Path(..., description="The ID of the wing")],
-    cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+    cross_section_index: Annotated[int, Path(..., description=_DESC_XSEC_INDEX)],
     db: Annotated[Session, Depends(get_db)],
 ) -> OperationStatusResponse:
     """Deletes the canonical TED from which control-surface data is projected."""
@@ -745,9 +749,9 @@ async def delete_aeroplane_wing_cross_section_control_surface(
     operation_id="get_wing_cross_section_control_surface_cad_details",
 )
 async def get_aeroplane_wing_cross_section_control_surface_cad_details(
-    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
     wing_name: Annotated[str, Path(..., description="The ID of the wing")],
-    cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+    cross_section_index: Annotated[int, Path(..., description=_DESC_XSEC_INDEX)],
     db: Annotated[Session, Depends(get_db)],
 ) -> schemas.ControlSurfaceCadDetailsSchema:
     """Returns the CAD detail extension of an existing control surface."""
@@ -767,9 +771,9 @@ async def get_aeroplane_wing_cross_section_control_surface_cad_details(
     operation_id="patch_wing_cross_section_control_surface_cad_details",
 )
 async def patch_aeroplane_wing_cross_section_control_surface_cad_details(
-    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
     wing_name: Annotated[str, Path(..., description="The ID of the wing")],
-    cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+    cross_section_index: Annotated[int, Path(..., description=_DESC_XSEC_INDEX)],
     request: Annotated[schemas.ControlSurfaceCadDetailsPatchSchema, Body(
         ...,
         description="CAD detail patch payload that extends an existing control surface.",
@@ -795,9 +799,9 @@ async def patch_aeroplane_wing_cross_section_control_surface_cad_details(
     operation_id="delete_wing_cross_section_control_surface_cad_details",
 )
 async def delete_aeroplane_wing_cross_section_control_surface_cad_details(
-    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
     wing_name: Annotated[str, Path(..., description="The ID of the wing")],
-    cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+    cross_section_index: Annotated[int, Path(..., description=_DESC_XSEC_INDEX)],
     db: Annotated[Session, Depends(get_db)],
 ) -> OperationStatusResponse:
     """Removes CAD details while keeping the control-surface core definition."""
@@ -819,9 +823,9 @@ async def delete_aeroplane_wing_cross_section_control_surface_cad_details(
     operation_id="get_wing_cross_section_control_surface_cad_details_servo_details",
 )
 async def get_aeroplane_wing_cross_section_control_surface_cad_details_servo_details(
-    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
     wing_name: Annotated[str, Path(..., description="The ID of the wing")],
-    cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+    cross_section_index: Annotated[int, Path(..., description=_DESC_XSEC_INDEX)],
     db: Annotated[Session, Depends(get_db)],
 ) -> schemas.ControlSurfaceServoDetailsSchema:
     """Returns servo details of the control-surface CAD extension."""
@@ -841,9 +845,9 @@ async def get_aeroplane_wing_cross_section_control_surface_cad_details_servo_det
     operation_id="patch_wing_cross_section_control_surface_cad_details_servo_details",
 )
 async def patch_aeroplane_wing_cross_section_control_surface_cad_details_servo_details(
-    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
     wing_name: Annotated[str, Path(..., description="The ID of the wing")],
-    cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+    cross_section_index: Annotated[int, Path(..., description=_DESC_XSEC_INDEX)],
     request: Annotated[schemas.ControlSurfaceServoDetailsPatchSchema, Body(
         ...,
         description="Servo assignment payload (full Servo object or Servo ID reference).",
@@ -869,9 +873,9 @@ async def patch_aeroplane_wing_cross_section_control_surface_cad_details_servo_d
     operation_id="delete_wing_cross_section_control_surface_cad_details_servo_details",
 )
 async def delete_aeroplane_wing_cross_section_control_surface_cad_details_servo_details(
-    aeroplane_id: Annotated[AeroPlaneID, Path(..., description="The ID of the aeroplane")],
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
     wing_name: Annotated[str, Path(..., description="The ID of the wing")],
-    cross_section_index: Annotated[int, Path(..., description="The index of the cross section")],
+    cross_section_index: Annotated[int, Path(..., description=_DESC_XSEC_INDEX)],
     db: Annotated[Session, Depends(get_db)],
 ) -> OperationStatusResponse:
     """Deletes servo details from the control-surface CAD extension."""

--- a/app/api/v2/endpoints/aeroplane_construction_plans.py
+++ b/app/api/v2/endpoints/aeroplane_construction_plans.py
@@ -99,6 +99,7 @@ async def execute_plan(
     operation_id="plan_to_template"
 )
 async def plan_to_template(
+    aeroplane_id: Annotated[str, Path(...)],
     plan_id: Annotated[int, Path(...)],
     db: Annotated[Session, Depends(get_db)],
     request: Annotated[ToTemplateRequest, Body()] = None,

--- a/app/api/v2/endpoints/fuselage_slice.py
+++ b/app/api/v2/endpoints/fuselage_slice.py
@@ -47,7 +47,7 @@ async def slice_step_to_fuselage(
         )
 
     try:
-        return await svc.slice_step_file(
+        return svc.slice_step_file(
             file_content=content,
             filename=file.filename or "upload.step",
             number_of_slices=number_of_slices,

--- a/app/schemas/component_type.py
+++ b/app/schemas/component_type.py
@@ -45,9 +45,8 @@ class PropertyDefinition(BaseModel):
 
     @model_validator(mode="after")
     def _check_type_specific_fields(self) -> "PropertyDefinition":
-        if self.type == "enum":
-            if not self.options or len(self.options) == 0:
-                raise ValueError("enum properties require a non-empty `options` list")
+        if self.type == "enum" and (not self.options or len(self.options) == 0):
+            raise ValueError("enum properties require a non-empty `options` list")
         if self.type != "number" and (self.min is not None or self.max is not None):
             # min/max are only meaningful for number; silently drop for others
             # instead of rejecting so the UI can keep them in state during

--- a/app/services/component_type_service.py
+++ b/app/services/component_type_service.py
@@ -262,8 +262,7 @@ def validate_specs(
                     message=f"Property '{prop.name}' must be true or false.",
                     details={"property": prop.name, "type": "boolean", "value": value},
                 )
-        elif prop.type == "enum":
-            if prop.options and value not in prop.options:
+        elif prop.type == "enum" and prop.options and value not in prop.options:
                 raise ValidationError(
                     message=(
                         f"Property '{prop.name}' value '{value}' is not allowed. "

--- a/app/services/construction_plan_service.py
+++ b/app/services/construction_plan_service.py
@@ -26,6 +26,8 @@ from app.schemas.construction_plan import (
 
 logger = logging.getLogger(__name__)
 
+_ENTITY_CONSTRUCTION_PLAN = "Construction plan"
+
 
 # ── Helpers ─────────────────────────────────────────────────────
 
@@ -80,7 +82,7 @@ def _get_plan_or_raise(db: Session, plan_id: int) -> ConstructionPlanModel:
     """Load a plan by ID or raise NotFoundError."""
     plan = db.get(ConstructionPlanModel, plan_id)
     if plan is None:
-        raise NotFoundError(entity="Construction plan", resource_id=plan_id)
+        raise NotFoundError(entity=_ENTITY_CONSTRUCTION_PLAN, resource_id=plan_id)
     return plan
 
 
@@ -109,7 +111,7 @@ def get_plan(db: Session, plan_id: int) -> PlanRead:
     try:
         plan = db.get(ConstructionPlanModel, plan_id)
         if plan is None:
-            raise NotFoundError(entity="Construction plan", resource_id=plan_id)
+            raise NotFoundError(entity=_ENTITY_CONSTRUCTION_PLAN, resource_id=plan_id)
         return _to_read(plan)
     except NotFoundError:
         raise
@@ -143,7 +145,7 @@ def update_plan(db: Session, plan_id: int, data: PlanCreate) -> PlanRead:
     try:
         plan = db.get(ConstructionPlanModel, plan_id)
         if plan is None:
-            raise NotFoundError(entity="Construction plan", resource_id=plan_id)
+            raise NotFoundError(entity=_ENTITY_CONSTRUCTION_PLAN, resource_id=plan_id)
         plan.name = data.name
         plan.description = data.description
         plan.tree_json = data.tree_json
@@ -164,7 +166,7 @@ def delete_plan(db: Session, plan_id: int) -> None:
     try:
         plan = db.get(ConstructionPlanModel, plan_id)
         if plan is None:
-            raise NotFoundError(entity="Construction plan", resource_id=plan_id)
+            raise NotFoundError(entity=_ENTITY_CONSTRUCTION_PLAN, resource_id=plan_id)
         db.delete(plan)
         db.commit()
     except NotFoundError:
@@ -322,9 +324,8 @@ def _parse_docstring_returns(docstring: str) -> list[CreatorOutput]:
                 key=match.group(1),
                 description=match.group(2).strip(),
             ))
-        elif not stripped:
-            if outputs:
-                break  # Empty line after outputs ends section
+        elif not stripped and outputs:
+            break  # Empty line after outputs ends section
 
     return outputs
 

--- a/app/services/fuselage_slice_service.py
+++ b/app/services/fuselage_slice_service.py
@@ -17,7 +17,7 @@ from app.schemas.fuselage_slice import (
 logger = logging.getLogger(__name__)
 
 
-async def slice_step_file(
+def slice_step_file(
     file_content: bytes,
     filename: str,
     number_of_slices: int = 50,

--- a/app/services/powertrain_sizing_service.py
+++ b/app/services/powertrain_sizing_service.py
@@ -32,7 +32,7 @@ def _air_density(altitude_m: float) -> float:
 def _required_power_w(speed_ms: float, total_mass_kg: float, altitude_m: float) -> float:
     """Estimate power required for level flight at given speed."""
     rho = _air_density(altitude_m)
-    # Drag = 0.5 * rho * v^2 * Cd * S
+    # Parasitic drag: half rho v-squared Cd S
     drag_n = 0.5 * rho * speed_ms**2 * DRAG_COEFF_ESTIMATE * WING_AREA_ESTIMATE_M2
     # Add induced drag (simple)
     cl = (2 * total_mass_kg * 9.81) / (rho * speed_ms**2 * WING_AREA_ESTIMATE_M2)

--- a/app/tests/test_fuselage_slice.py
+++ b/app/tests/test_fuselage_slice.py
@@ -4,7 +4,7 @@ Uses client_and_db fixture for in-memory SQLite isolation.
 """
 
 import io
-from unittest.mock import AsyncMock, patch
+from unittest.mock import MagicMock, patch
 
 from app.schemas.fuselage_slice import FuselageSliceResponse, GeometryProperties, FidelityMetrics
 from app.schemas.aeroplaneschema import FuselageSchema, FuselageXSecSuperEllipseSchema
@@ -31,7 +31,7 @@ class TestFuselageSliceEndpoint:
         client, _ = client_and_db
         with patch(
             "app.services.fuselage_slice_service.slice_step_file",
-            new_callable=AsyncMock,
+            new_callable=MagicMock,
             return_value=MOCK_RESPONSE,
         ):
             res = client.post(
@@ -48,7 +48,7 @@ class TestFuselageSliceEndpoint:
         client, _ = client_and_db
         with patch(
             "app.services.fuselage_slice_service.slice_step_file",
-            new_callable=AsyncMock,
+            new_callable=MagicMock,
             return_value=MOCK_RESPONSE,
         ):
             res = client.post(
@@ -66,7 +66,7 @@ class TestFuselageSliceEndpoint:
         client, _ = client_and_db
         with patch(
             "app.services.fuselage_slice_service.slice_step_file",
-            new_callable=AsyncMock,
+            new_callable=MagicMock,
             return_value=MOCK_RESPONSE,
         ):
             res = client.post(
@@ -87,13 +87,13 @@ class TestFuselageSliceEndpoint:
         # But since the service is async, we need to let it validate
         with patch(
             "app.services.fuselage_slice_service.slice_step_file",
-            new_callable=AsyncMock,
+            new_callable=MagicMock,
             side_effect=Exception("Should not be called"),
         ):
             from app.core.exceptions import ValidationError
             with patch(
                 "app.services.fuselage_slice_service.slice_step_file",
-                new_callable=AsyncMock,
+                new_callable=MagicMock,
                 side_effect=ValidationError(message="Unsupported file type: .pdf"),
             ):
                 res = client.post(
@@ -114,7 +114,7 @@ class TestFuselageSliceEndpoint:
         client, _ = client_and_db
         with patch(
             "app.services.fuselage_slice_service.slice_step_file",
-            new_callable=AsyncMock,
+            new_callable=MagicMock,
             return_value=MOCK_RESPONSE,
         ) as mock_svc:
             client.post(
@@ -138,7 +138,7 @@ class TestFuselageSliceEndpoint:
         client, _ = client_and_db
         with patch(
             "app.services.fuselage_slice_service.slice_step_file",
-            new_callable=AsyncMock,
+            new_callable=MagicMock,
             return_value=MOCK_RESPONSE,
         ) as mock_svc:
             client.post(


### PR DESCRIPTION
## Summary

- **#183 (S8411/S7503):** Add missing `aeroplane_id` path param; remove unnecessary `async` from sync CPU-bound function
- **#182 (S1066/S125):** Merge 3 nested if-statements; replace code-like comment with plain English
- **#180 (S1192):** Extract 62 duplicated string literals into module-level constants across 3 files

## Test plan

- [x] 549 tests pass (`poetry run pytest -m "not slow"`)
- [x] Ruff lint passes
- [ ] CI pipeline passes
- [ ] SonarQube rescan confirms resolved issues

Closes #180, Closes #182, Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)