### PR TITLE
refactor: Reduce cognitive complexity in 5 service functions (S3776)

### DIFF
--- a/app/services/avl_strip_forces.py
+++ b/app/services/avl_strip_forces.py
@@ -25,6 +25,61 @@ _STRIP_COLUMNS = [
 ]
 
 
+def _parse_surface_header(stripped: str) -> dict | None:
+    """Detect and parse a "Surface # N Name" header line.
+
+    Returns a new surface dict if matched, or ``None``.
+    """
+    m = re.match(r"Surface\s+#\s*(\d+)\s+(.*)", stripped)
+    if not m:
+        return None
+    return {
+        "surface_number": int(m.group(1)),
+        "surface_name": m.group(2).strip(),
+        "n_chordwise": 0,
+        "n_spanwise": 0,
+        "surface_area": 0.0,
+        "strips": [],
+    }
+
+
+def _parse_strip_row(values: list[str], columns: list[str]) -> dict | None:
+    """Convert raw split values to a strip row dict.
+
+    Returns a dict keyed by *columns* or ``None`` if *values* has
+    fewer elements than *columns*.
+    """
+    if len(values) < len(columns):
+        return None
+    return {
+        col: int(val) if col == "j" else float(val)
+        for col, val in zip(columns, values, strict=False)
+    }
+
+
+def _try_parse_metadata(stripped: str, surface: dict) -> bool:
+    """Try to parse chordwise/spanwise/area metadata from *stripped*.
+
+    Mutates *surface* in place and returns ``True`` if any field
+    matched, ``False`` otherwise.
+    """
+    m = re.match(
+        r"#\s*Chordwise\s*=\s*(\d+)\s+#\s*Spanwise\s*=\s*(\d+)",
+        stripped,
+    )
+    if m:
+        surface["n_chordwise"] = int(m.group(1))
+        surface["n_spanwise"] = int(m.group(2))
+        return True
+
+    m = re.search(r"Surface area\s+Ssurf\s*=\s*([\d.Ee+-]+)", stripped)
+    if m:
+        surface["surface_area"] = float(m.group(1))
+        return True
+
+    return False
+
+
 def parse_strip_forces_output(stdout: str) -> list[dict]:
     """Parse AVL's ``FS`` (strip forces) stdout output into structured data.
 
@@ -43,17 +98,9 @@ def parse_strip_forces_output(stdout: str) -> list[dict]:
     for line in stdout.splitlines():
         stripped = line.strip()
 
-        # Detect surface header: "Surface # 1     Main Wing"
-        m = re.match(r"Surface\s+#\s*(\d+)\s+(.*)", stripped)
-        if m:
-            current_surface = {
-                "surface_number": int(m.group(1)),
-                "surface_name": m.group(2).strip(),
-                "n_chordwise": 0,
-                "n_spanwise": 0,
-                "surface_area": 0.0,
-                "strips": [],
-            }
+        header = _parse_surface_header(stripped)
+        if header is not None:
+            current_surface = header
             surfaces.append(current_surface)
             in_strip_table = False
             continue
@@ -61,20 +108,7 @@ def parse_strip_forces_output(stdout: str) -> list[dict]:
         if current_surface is None:
             continue
 
-        # Parse chordwise/spanwise counts
-        m = re.match(
-            r"#\s*Chordwise\s*=\s*(\d+)\s+#\s*Spanwise\s*=\s*(\d+)",
-            stripped,
-        )
-        if m:
-            current_surface["n_chordwise"] = int(m.group(1))
-            current_surface["n_spanwise"] = int(m.group(2))
-            continue
-
-        # Parse surface area
-        m = re.search(r"Surface area\s+Ssurf\s*=\s*([\d.Ee+-]+)", stripped)
-        if m:
-            current_surface["surface_area"] = float(m.group(1))
+        if _try_parse_metadata(stripped, current_surface):
             continue
 
         # Detect strip table header line
@@ -84,11 +118,8 @@ def parse_strip_forces_output(stdout: str) -> list[dict]:
 
         # Parse strip data rows (start with an integer index)
         if in_strip_table and stripped and stripped[0].isdigit():
-            values = stripped.split()
-            if len(values) >= len(_STRIP_COLUMNS):
-                row = {}
-                for col_name, val_str in zip(_STRIP_COLUMNS, values, strict=False):
-                    row[col_name] = int(val_str) if col_name == "j" else float(val_str)
+            row = _parse_strip_row(stripped.split(), _STRIP_COLUMNS)
+            if row is not None:
                 current_surface["strips"].append(row)
             continue
 

--- a/app/services/construction_plan_service.py
+++ b/app/services/construction_plan_service.py
@@ -602,7 +602,10 @@ def execute_plan(
 
 def _numpy_to_list(obj: Any) -> Any:
     """Recursively convert numpy arrays and scalars to plain Python types."""
-    import numpy as np
+    try:
+        import numpy as np
+    except ImportError:
+        return obj
 
     if isinstance(obj, np.ndarray):
         return obj.tolist()

--- a/app/services/construction_plan_service.py
+++ b/app/services/construction_plan_service.py
@@ -239,6 +239,32 @@ _INTERNAL_PARAMS = {
 }
 
 
+def _flush_attribute(
+    result: dict[str, str], name: str | None, desc: list[str],
+) -> None:
+    """Write accumulated attribute to *result* if *name* and *desc* exist."""
+    if name and desc:
+        result[name] = " ".join(desc).strip()
+
+
+def _is_section_header(stripped: str) -> bool:
+    """Detect the start of a new docstring section (e.g. ``Returns:``)."""
+    return (
+        bool(stripped)
+        and not stripped.startswith("_")
+        and stripped.endswith(":")
+        and "(" not in stripped
+    )
+
+
+def _parse_attribute_line(stripped: str) -> tuple[str, str] | None:
+    """Match ``name (type): desc`` and return *(name, desc_start)* or *None*."""
+    match = re.match(r"(\w+)\s*\([^)]*\)\s*:\s*(.*)", stripped)
+    if match:
+        return match.group(1), match.group(2)
+    return None
+
+
 def _parse_docstring_attributes(docstring: str) -> dict[str, str]:
     """Extract parameter descriptions from a docstring's Attributes section.
 
@@ -262,33 +288,27 @@ def _parse_docstring_attributes(docstring: str) -> dict[str, str]:
             continue
 
         # End of Attributes section on next section header
-        if stripped and not stripped.startswith("_") and stripped.endswith(":") and "(" not in stripped:
-            # Flush last param
-            if current_name and current_desc:
-                result[current_name] = " ".join(current_desc).strip()
+        if _is_section_header(stripped):
+            _flush_attribute(result, current_name, current_desc)
             break
 
         # New attribute line: "name (type): description"
-        match = re.match(r"(\w+)\s*\([^)]*\)\s*:\s*(.*)", stripped)
-        if match:
-            # Flush previous
-            if current_name and current_desc:
-                result[current_name] = " ".join(current_desc).strip()
-            current_name = match.group(1)
-            current_desc = [match.group(2)] if match.group(2) else []
+        parsed = _parse_attribute_line(stripped)
+        if parsed:
+            _flush_attribute(result, current_name, current_desc)
+            current_name, desc_start = parsed
+            current_desc = [desc_start] if desc_start else []
         elif current_name and stripped:
             # Continuation line
             current_desc.append(stripped)
         elif not stripped and current_name:
             # Empty line ends current param
-            if current_desc:
-                result[current_name] = " ".join(current_desc).strip()
+            _flush_attribute(result, current_name, current_desc)
             current_name = None
             current_desc = []
 
     # Flush final param
-    if current_name and current_desc:
-        result[current_name] = " ".join(current_desc).strip()
+    _flush_attribute(result, current_name, current_desc)
 
     return result
 
@@ -355,6 +375,17 @@ def _type_to_str(annotation: Any) -> str:
     return str(annotation).replace("typing.", "")
 
 
+def _find_literal_in_args(args: tuple) -> list[str] | None:
+    """Iterate over type *args*, skip NoneType, and return the first Literal values found."""
+    for arg in args:
+        if arg is type(None):
+            continue
+        vals = _extract_literal_values(arg)
+        if vals:
+            return vals
+    return None
+
+
 def _extract_literal_values(annotation: Any) -> list[str] | None:
     """Extract allowed values from Literal type annotations.
 
@@ -374,24 +405,16 @@ def _extract_literal_values(annotation: Any) -> list[str] | None:
 
     # Union / Optional — check each branch
     if origin is typing.Union:
-        for arg in annotation.__args__:
-            if arg is type(None):
-                continue
-            vals = _extract_literal_values(arg)
-            if vals:
-                return vals
+        return _find_literal_in_args(annotation.__args__)
 
     # Annotated — unwrap and recurse
     if hasattr(annotation, "__metadata__") and hasattr(annotation, "__origin__"):
         return _extract_literal_values(annotation.__origin__)
 
     # Nested args (e.g. Optional[Annotated[Literal[...], ...]])
-    for arg in getattr(annotation, "__args__", ()):
-        if arg is type(None):
-            continue
-        vals = _extract_literal_values(arg)
-        if vals:
-            return vals
+    args = getattr(annotation, "__args__", None)
+    if args:
+        return _find_literal_in_args(args)
 
     return None
 
@@ -577,32 +600,57 @@ def execute_plan(
     )
 
 
+def _numpy_to_list(obj: Any) -> Any:
+    """Recursively convert numpy arrays and scalars to plain Python types."""
+    import numpy as np
+
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    if isinstance(obj, dict):
+        return {k: _numpy_to_list(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_numpy_to_list(i) for i in obj]
+    if isinstance(obj, np.integer):
+        return int(obj)
+    if isinstance(obj, np.floating):
+        return float(obj)
+    return obj
+
+
+def _collect_shapes(structure: dict) -> tuple[list, list[str]]:
+    """Extract CadQuery Workplane objects and their keys from *structure*."""
+    shapes = []
+    names = []
+    for key, val in structure.items():
+        if hasattr(val, "val"):  # CadQuery Workplane
+            shapes.append(val)
+            names.append(key)
+    return shapes, names
+
+
+def _extract_solids(shapes: list) -> list:
+    """Safely extract solids from each shape, skipping failures."""
+    solids = []
+    for s in shapes:
+        try:
+            solids.extend(s.val().Solids())
+        except Exception:
+            pass
+    return solids
+
+
 def _tessellate_shapes(structure: dict) -> dict | None:
     """Tessellate CadQuery shapes for three-cad-viewer (best-effort)."""
     try:
         from ocp_tessellate.convert import to_ocpgroup, tessellate_group, combined_bb
-        import numpy as np
 
-        # Collect CadQuery Workplane objects from the structure
-        shapes = []
-        names = []
-        for key, val in structure.items():
-            if hasattr(val, "val"):  # CadQuery Workplane
-                shapes.append(val)
-                names.append(key)
-
+        shapes, _names = _collect_shapes(structure)
         if not shapes:
             return None
 
-        # Use the first shape for tessellation via compound
         from cadquery import Workplane, Compound
-        solids = []
-        for s in shapes:
-            try:
-                solids.extend(s.val().Solids())
-            except Exception:
-                pass
 
+        solids = _extract_solids(shapes)
         if not solids:
             return None
 
@@ -624,19 +672,6 @@ def _tessellate_shapes(structure: dict) -> dict | None:
         bb = combined_bb(tess_shapes)
         if bb is not None:
             tess_shapes["bb"] = bb.to_dict()
-
-        def _numpy_to_list(obj):
-            if isinstance(obj, np.ndarray):
-                return obj.tolist()
-            if isinstance(obj, dict):
-                return {k: _numpy_to_list(v) for k, v in obj.items()}
-            if isinstance(obj, (list, tuple)):
-                return [_numpy_to_list(i) for i in obj]
-            if isinstance(obj, np.integer):
-                return int(obj)
-            if isinstance(obj, np.floating):
-                return float(obj)
-            return obj
 
         return {
             "data": {

--- a/app/services/wing_service.py
+++ b/app/services/wing_service.py
@@ -775,6 +775,21 @@ def delete_cross_section(
         raise InternalError(message=f"Database error: {e}")
 
 
+def _sync_spares_for_xsec(db_xsec, segment) -> None:
+    """Copy computed spare_vector/spare_origin from a WingConfiguration segment
+    back to the corresponding DB cross-section's spar records."""
+    for spare_idx, spare in enumerate(segment.spare_list or []):
+        if spare_idx >= len(db_xsec.detail.spares):
+            break
+        db_spare = db_xsec.detail.spares[spare_idx]
+        if spare.spare_vector is not None:
+            vec = spare.spare_vector.toTuple() if hasattr(spare.spare_vector, "toTuple") else spare.spare_vector
+            db_spare.spare_vector = [float(v) for v in vec]
+        if spare.spare_origin is not None:
+            orig = spare.spare_origin.toTuple() if hasattr(spare.spare_origin, "toTuple") else spare.spare_origin
+            db_spare.spare_origin = [float(v) for v in orig]
+
+
 def _recompute_spare_vectors(wing: WingModel) -> None:
     """Rebuild WingConfiguration to compute spare_vector/spare_origin for all spars,
     then persist the computed values back to the DB spar records.
@@ -792,16 +807,7 @@ def _recompute_spare_vectors(wing: WingModel) -> None:
             db_xsec = wing.x_secs[seg_idx]
             if db_xsec.detail is None:
                 continue
-            for spare_idx, spare in enumerate(segment.spare_list or []):
-                if spare_idx >= len(db_xsec.detail.spares):
-                    break
-                db_spare = db_xsec.detail.spares[spare_idx]
-                if spare.spare_vector is not None:
-                    vec = spare.spare_vector.toTuple() if hasattr(spare.spare_vector, "toTuple") else spare.spare_vector
-                    db_spare.spare_vector = [float(v) for v in vec]
-                if spare.spare_origin is not None:
-                    orig = spare.spare_origin.toTuple() if hasattr(spare.spare_origin, "toTuple") else spare.spare_origin
-                    db_spare.spare_origin = [float(v) for v in orig]
+            _sync_spares_for_xsec(db_xsec, segment)
     except ImportError:
         logger.debug("CadQuery not available — skipping spare vector computation")
 

--- a/app/tests/test_construction_plan_helpers.py
+++ b/app/tests/test_construction_plan_helpers.py
@@ -1,0 +1,246 @@
+"""Unit tests for helper functions extracted in GH#181 (S3776 refactoring)."""
+
+from __future__ import annotations
+
+import typing
+from typing import Annotated, Literal, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.construction_plan_service import (
+    _collect_shapes,
+    _extract_literal_values,
+    _extract_solids,
+    _find_literal_in_args,
+    _flush_attribute,
+    _is_section_header,
+    _numpy_to_list,
+    _parse_attribute_line,
+    _parse_docstring_attributes,
+)
+
+
+# ── _flush_attribute ──────────────────────────────────────────────
+
+
+class TestFlushAttribute:
+    def test_writes_when_name_and_desc(self):
+        result = {}
+        _flush_attribute(result, "param", ["Some", "description"])
+        assert result == {"param": "Some description"}
+
+    def test_skips_when_no_name(self):
+        result = {}
+        _flush_attribute(result, None, ["text"])
+        assert result == {}
+
+    def test_skips_when_empty_desc(self):
+        result = {}
+        _flush_attribute(result, "param", [])
+        assert result == {}
+
+    def test_strips_whitespace(self):
+        result = {}
+        _flush_attribute(result, "x", ["  hello  ", "  world  "])
+        assert result == {"x": "hello     world"}
+
+
+# ── _is_section_header ───────────────────────────────────────────
+
+
+class TestIsSectionHeader:
+    def test_returns_section(self):
+        assert _is_section_header("Returns:") is True
+
+    def test_attributes_section(self):
+        assert _is_section_header("Attributes:") is True
+
+    def test_empty_string(self):
+        assert _is_section_header("") is False
+
+    def test_private_attr(self):
+        assert _is_section_header("_private:") is False
+
+    def test_function_call(self):
+        assert _is_section_header("func(arg):") is False
+
+    def test_no_colon(self):
+        assert _is_section_header("Returns") is False
+
+
+# ── _parse_attribute_line ─────────────────────────────────────────
+
+
+class TestParseAttributeLine:
+    def test_standard_attribute(self):
+        result = _parse_attribute_line("name (str): A description.")
+        assert result == ("name", "A description.")
+
+    def test_no_description(self):
+        result = _parse_attribute_line("name (int):")
+        assert result == ("name", "")
+
+    def test_no_match(self):
+        assert _parse_attribute_line("just some text") is None
+
+    def test_complex_type(self):
+        result = _parse_attribute_line("param (list[str]): Items")
+        assert result == ("param", "Items")
+
+
+# ── _parse_docstring_attributes ───────────────────────────────────
+
+
+class TestParseDocstringAttributes:
+    def test_basic_docstring(self):
+        doc = """Summary line.
+
+        Attributes:
+            name (str): The name.
+            age (int): The age.
+        """
+        result = _parse_docstring_attributes(doc)
+        assert result == {"name": "The name.", "age": "The age."}
+
+    def test_multiline_description(self):
+        doc = """Summary.
+
+        Attributes:
+            name (str): First line.
+                Second line.
+        """
+        result = _parse_docstring_attributes(doc)
+        assert result == {"name": "First line. Second line."}
+
+    def test_section_ends_at_next_header(self):
+        doc = """Summary.
+
+        Attributes:
+            x (int): Value.
+
+        Returns:
+            Something.
+        """
+        result = _parse_docstring_attributes(doc)
+        assert result == {"x": "Value."}
+
+    def test_no_attributes_section(self):
+        doc = """Just a simple docstring."""
+        assert _parse_docstring_attributes(doc) == {}
+
+    def test_empty_docstring(self):
+        assert _parse_docstring_attributes("") == {}
+
+
+# ── _find_literal_in_args / _extract_literal_values ───────────────
+
+
+class TestExtractLiteralValues:
+    def test_direct_literal(self):
+        result = _extract_literal_values(Literal["a", "b", "c"])
+        assert result == ["a", "b", "c"]
+
+    def test_optional_literal(self):
+        result = _extract_literal_values(Optional[Literal["x", "y"]])
+        assert result == ["x", "y"]
+
+    def test_annotated_literal(self):
+        result = _extract_literal_values(Annotated[Literal["p", "q"], "meta"])
+        assert result == ["p", "q"]
+
+    def test_not_literal(self):
+        assert _extract_literal_values(str) is None
+
+    def test_none_type(self):
+        assert _extract_literal_values(type(None)) is None
+
+    def test_empty_param(self):
+        import inspect
+        assert _extract_literal_values(inspect.Parameter.empty) is None
+
+
+class TestFindLiteralInArgs:
+    def test_finds_literal(self):
+        result = _find_literal_in_args((type(None), Literal["a"]))
+        assert result == ["a"]
+
+    def test_no_literal(self):
+        assert _find_literal_in_args((str, int)) is None
+
+    def test_empty_args(self):
+        assert _find_literal_in_args(()) is None
+
+
+# ── _numpy_to_list ────────────────────────────────────────────────
+
+
+class TestNumpyToList:
+    def test_plain_value_passthrough(self):
+        assert _numpy_to_list(42) == 42
+        assert _numpy_to_list("hello") == "hello"
+
+    def test_dict_recursion(self):
+        result = _numpy_to_list({"a": 1, "b": [2, 3]})
+        assert result == {"a": 1, "b": [2, 3]}
+
+    def test_list_recursion(self):
+        result = _numpy_to_list([1, [2, 3]])
+        assert result == [1, [2, 3]]
+
+    def test_numpy_array(self):
+        np = pytest.importorskip("numpy")
+        arr = np.array([1.0, 2.0, 3.0])
+        assert _numpy_to_list(arr) == [1.0, 2.0, 3.0]
+
+    def test_numpy_integer(self):
+        np = pytest.importorskip("numpy")
+        val = np.int64(42)
+        result = _numpy_to_list(val)
+        assert result == 42
+        assert type(result) is int
+
+    def test_numpy_float(self):
+        np = pytest.importorskip("numpy")
+        val = np.float64(3.14)
+        result = _numpy_to_list(val)
+        assert result == pytest.approx(3.14)
+        assert type(result) is float
+
+
+# ── _collect_shapes / _extract_solids ─────────────────────────────
+
+
+class TestCollectShapes:
+    def test_collects_workplane_objects(self):
+        wp = MagicMock()
+        wp.val = MagicMock()  # has .val attribute
+        plain = "not a workplane"
+        structure = {"wing": wp, "name": plain}
+        shapes, names = _collect_shapes(structure)
+        assert shapes == [wp]
+        assert names == ["wing"]
+
+    def test_empty_structure(self):
+        shapes, names = _collect_shapes({})
+        assert shapes == []
+        assert names == []
+
+
+class TestExtractSolids:
+    def test_extracts_solids(self):
+        shape = MagicMock()
+        shape.val.return_value.Solids.return_value = ["solid1", "solid2"]
+        result = _extract_solids([shape])
+        assert result == ["solid1", "solid2"]
+
+    def test_skips_failing_shapes(self):
+        good = MagicMock()
+        good.val.return_value.Solids.return_value = ["solid1"]
+        bad = MagicMock()
+        bad.val.side_effect = Exception("broken")
+        result = _extract_solids([bad, good])
+        assert result == ["solid1"]
+
+    def test_empty_list(self):
+        assert _extract_solids([]) == []


### PR DESCRIPTION
## Summary

- Extract helper functions to reduce Cognitive Complexity below 15 in all 5 flagged functions
- `parse_strip_forces_output` (30→~12): 3 parsing helpers extracted
- `_recompute_spare_vectors` (27→~7): inner spare loop extracted + guard clauses
- `_parse_docstring_attributes` (30→~12): 3 state-machine helpers extracted
- `_extract_literal_values` (18→~10): shared args loop extracted
- `_tessellate_shapes` (21→~10): nested function moved to module level + 2 helpers

## Test plan

- [x] 588 tests pass (`poetry run pytest -m "not slow"`)
- [x] Ruff lint passes
- [x] CI pipeline passes (fast 3.11 ✓, fast 3.12 ✓, SonarCloud ✓)
- [x] SonarQube rescan confirms 0 S3776 issues on PR, Quality Gate OK (coverage 88.4%)

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)