### PR TITLE
refactor(gh-192): fix naming + ternaries in converters (S1542, S3358, S1244, S5890)

### DIFF
--- a/app/api/v2/endpoints/cad.py
+++ b/app/api/v2/endpoints/cad.py
@@ -99,9 +99,9 @@ async def start_wing_tessellation(
         aeroplane = cad_service.get_aeroplane_with_wings(db, aeroplane_id)
         wing = cad_service.get_wing_from_aeroplane(aeroplane, wing_name)
 
-        from app.converters.model_schema_converters import wingModelToAsbWingSchema
+        from app.converters.model_schema_converters import wing_model_to_asb_wing_schema
 
-        wing_schema = wingModelToAsbWingSchema(wing)
+        wing_schema = wing_model_to_asb_wing_schema(wing)
         wing_schema_pickle = pickle.dumps(wing_schema)
 
         tessellation_service.start_tessellation_task(

--- a/app/converters/model_schema_converters.py
+++ b/app/converters/model_schema_converters.py
@@ -1,3 +1,4 @@
+import math
 import os
 from typing import Any, List, Optional
 
@@ -15,7 +16,7 @@ from cad_designer.airplane.aircraft_topology.fuselage.FuselageConfiguration impo
 from cad_designer.airplane.aircraft_topology.wing import Spare, TrailingEdgeDevice, WingConfiguration
 
 
-async def aeroplaneModelToAeroplaneSchema_async(plane: AeroplaneModel) -> AeroplaneSchema:
+async def aeroplane_model_to_aeroplane_schema_async(plane: AeroplaneModel) -> AeroplaneSchema:
     plane_dict = plane.__dict__.copy()
     plane_dict["wings"] = {w.name: w for w in plane.wings}
     plane_dict["fuselages"] = {f.name: f for f in plane.fuselages}
@@ -231,19 +232,34 @@ def _control_surface_from_ted(
     ted: schemas.TrailingEdgeDeviceDetailSchema,
     fallback: Optional[schemas.ControlSurfaceSchema] = None,
 ) -> schemas.ControlSurfaceSchema:
+    name = ted.name or (fallback.name if fallback else "Control Surface")
+
+    if ted.rel_chord_root is not None:
+        hinge_point = ted.rel_chord_root
+    elif fallback:
+        hinge_point = fallback.hinge_point
+    else:
+        hinge_point = 0.8
+
+    if ted.symmetric is not None:
+        symmetric = ted.symmetric
+    elif fallback:
+        symmetric = fallback.symmetric
+    else:
+        symmetric = True
+
+    if ted.deflection_deg is not None:
+        deflection = float(ted.deflection_deg)
+    elif fallback:
+        deflection = fallback.deflection
+    else:
+        deflection = 0.0
+
     return schemas.ControlSurfaceSchema(
-        name=ted.name or (fallback.name if fallback else "Control Surface"),
-        hinge_point=(
-            ted.rel_chord_root
-            if ted.rel_chord_root is not None
-            else (fallback.hinge_point if fallback else 0.8)
-        ),
-        symmetric=ted.symmetric if ted.symmetric is not None else (fallback.symmetric if fallback else True),
-        deflection=(
-            float(ted.deflection_deg)
-            if ted.deflection_deg is not None
-            else (fallback.deflection if fallback else 0.0)
-        ),
+        name=name,
+        hinge_point=hinge_point,
+        symmetric=symmetric,
+        deflection=deflection,
     )
 
 
@@ -285,7 +301,7 @@ def _scale_asb_wing_geometry_schema(
     wing: schemas.AsbWingSchema,
     scale: float,
 ) -> schemas.AsbWingSchema:
-    if scale == 1.0:
+    if math.isclose(scale, 1.0):
         return wing
 
     scaled_x_secs: List[schemas.WingXSecSchema] = []
@@ -318,7 +334,7 @@ def _asb_fuselage_xsecs_from_schema(
     ]
 
 
-def fuselageSchemaToFuselageConfig(
+def fuselage_schema_to_fuselage_config(
     fuselage: schemas.FuselageSchema,
 ) -> FuselageConfiguration:
     fuselage_config = FuselageConfiguration(name=fuselage.name)
@@ -329,7 +345,7 @@ def fuselageSchemaToFuselageConfig(
     return fuselage_config
 
 
-def fuselageModelToFuselageConfig(
+def fuselage_model_to_fuselage_config(
     fuselage: FuselageModel,
 ) -> FuselageConfiguration:
     fuselage_config = FuselageConfiguration(name=fuselage.name)
@@ -417,7 +433,7 @@ def _resolve_spare_vectors_and_origins(wing_config: WingConfiguration) -> None:
                 wing_config._set_standard_spare_origin_vector(segment_index, spare)
 
 
-async def aeroplaneSchemaToAsbAirplane_async(plane_schema: AeroplaneSchema) -> "asb.Airplane":
+async def aeroplane_schema_to_asb_airplane_async(plane_schema: AeroplaneSchema) -> "asb.Airplane":
     """
     Convert an AeroplaneSchema to an Aerosandbox Airplane object.
 
@@ -456,7 +472,7 @@ async def aeroplaneSchemaToAsbAirplane_async(plane_schema: AeroplaneSchema) -> "
     return asb_airplane
 
 
-async def aeroplaneSchemaToAirplaneConfiguration_async(plane_schema: AeroplaneSchema) -> AirplaneConfiguration:
+async def aeroplane_schema_to_airplane_configuration_async(plane_schema: AeroplaneSchema) -> AirplaneConfiguration:
     if plane_schema.total_mass_kg is None:
         raise ValueError("AeroplaneSchema.total_mass_kg must be set to build AirplaneConfiguration.")
 
@@ -470,7 +486,7 @@ async def aeroplaneSchemaToAirplaneConfiguration_async(plane_schema: AeroplaneSc
     fuselage_configs: Optional[List[FuselageConfiguration]] = None
     if plane_schema.fuselages:
         fuselage_configs = [
-            fuselageSchemaToFuselageConfig(fuselage_schema)
+            fuselage_schema_to_fuselage_config(fuselage_schema)
             for fuselage_schema in plane_schema.fuselages.values()
         ]
 
@@ -482,11 +498,11 @@ async def aeroplaneSchemaToAirplaneConfiguration_async(plane_schema: AeroplaneSc
     )
 
 
-def wingModelToAsbWingSchema(wing: WingModel) -> schemas.AsbWingSchema:
+def wing_model_to_asb_wing_schema(wing: WingModel) -> schemas.AsbWingSchema:
     """Convert a SQLAlchemy ``WingModel`` to its Pydantic
     ``AsbWingSchema`` representation.
 
-    Split out from :func:`wingModelToWingConfig` so that callers that
+    Split out from :func:`wing_model_to_wing_config` so that callers that
     need to cross a process boundary (e.g. the CAD ProcessPoolExecutor
     in ``app.services.cad_service``) can pickle the schema, which is
     picklable, instead of the final :class:`WingConfiguration`, which
@@ -520,13 +536,13 @@ def wingModelToAsbWingSchema(wing: WingModel) -> schemas.AsbWingSchema:
     })
 
 
-def asbWingSchemaToWingConfig(
+def asb_wing_schema_to_wing_config(
     asb_wing: schemas.AsbWingSchema,
     scale: float = 1.0,
 ) -> WingConfiguration:
     """Convert a ``AsbWingSchema`` to a live ``WingConfiguration``.
 
-    This is the second half of :func:`wingModelToWingConfig` and is
+    This is the second half of :func:`wing_model_to_wing_config` and is
     suitable for calling inside a worker process after the schema has
     been transported via pickle.
     """
@@ -537,19 +553,19 @@ def asbWingSchemaToWingConfig(
     return wing_config
 
 
-def wingModelToWingConfig(wing: WingModel, scale: float = 1.0) -> WingConfiguration:
+def wing_model_to_wing_config(wing: WingModel, scale: float = 1.0) -> WingConfiguration:
     """Convert a SQLAlchemy ``WingModel`` to a live ``WingConfiguration``.
 
-    Convenience wrapper around :func:`wingModelToAsbWingSchema` and
-    :func:`asbWingSchemaToWingConfig` for in-process callers. For
+    Convenience wrapper around :func:`wing_model_to_asb_wing_schema` and
+    :func:`asb_wing_schema_to_wing_config` for in-process callers. For
     cross-process transports prefer calling the two halves explicitly
     so the schema (not the config) crosses the process boundary.
     """
-    asb_wing = wingModelToAsbWingSchema(wing)
-    return asbWingSchemaToWingConfig(asb_wing, scale=scale)
+    asb_wing = wing_model_to_asb_wing_schema(wing)
+    return asb_wing_schema_to_wing_config(asb_wing, scale=scale)
 
 
-def wingConfigToAsbWingSchema(
+def wing_config_to_asb_wing_schema(
     wing_config: WingConfiguration,
     wing_name: str,
     scale: float = 1.0,
@@ -641,7 +657,7 @@ def wingConfigToAsbWingSchema(
     )
 
 
-def wingConfigToWingModel(
+def wing_config_to_wing_model(
     wing_config: WingConfiguration,
     wing_name: str,
     scale: float = 1.0,
@@ -654,7 +670,7 @@ def wingConfigToWingModel(
         wing_name: Name to assign to the resulting wing model.
         scale: Scaling used when creating the internal ASB wing (e.g. 0.001 for mm->m).
     """
-    asb_wing_schema = wingConfigToAsbWingSchema(
+    asb_wing_schema = wing_config_to_asb_wing_schema(
         wing_config=wing_config,
         wing_name=wing_name,
         scale=scale,

--- a/app/db/repository.py
+++ b/app/db/repository.py
@@ -1,6 +1,6 @@
 from sqlalchemy.orm import joinedload
 
-from app.converters.model_schema_converters import aeroplaneModelToAeroplaneSchema_async
+from app.converters.model_schema_converters import aeroplane_model_to_aeroplane_schema_async
 from app.db.exceptions import NotFoundInDbException
 from app.models import AeroplaneModel, WingModel, WingXSecModel
 from app.models.aeroplanemodel import (
@@ -27,7 +27,7 @@ async def get_aeroplane_by_id(aeroplane_id, db) -> AeroplaneSchema:
                              .filter(AeroplaneModel.uuid == aeroplane_id).first())
     if not plane:
         raise NotFoundInDbException(f"Aeroplane with the given ID ({aeroplane_id}) not found.")
-    plane_schema: AeroplaneSchema = await aeroplaneModelToAeroplaneSchema_async(plane)
+    plane_schema: AeroplaneSchema = await aeroplane_model_to_aeroplane_schema_async(plane)
     return plane_schema
 
 

--- a/app/schemas/AeroplaneRequest.py
+++ b/app/schemas/AeroplaneRequest.py
@@ -26,7 +26,7 @@ class ServoSettings(BaseModel):
 
     trans_x: float = 0.0
     trans_y: float = 0.0
-    trans_z: float = 0.0,
+    trans_z: float = 0.0
 
     servo: Optional[Servo]
 

--- a/app/services/aeroplane_service.py
+++ b/app/services/aeroplane_service.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import Session
 
 from app import schemas
 from app.core.exceptions import NotFoundError, InternalError, ValidationError
-from app.converters.model_schema_converters import fuselageModelToFuselageConfig, wingModelToWingConfig
+from app.converters.model_schema_converters import fuselage_model_to_fuselage_config, wing_model_to_wing_config
 from app.models.aeroplanemodel import AeroplaneModel
 from cad_designer.airplane.aircraft_topology.airplane.AirplaneConfiguration import AirplaneConfiguration
 
@@ -235,7 +235,7 @@ def get_aeroplane_airplane_configuration(db: Session, aeroplane_uuid) -> dict:
         )
 
     try:
-        wing_configurations = [wingModelToWingConfig(wing) for wing in aeroplane.wings]
+        wing_configurations = [wing_model_to_wing_config(wing) for wing in aeroplane.wings]
     except Exception as exc:
         logger.error("Failed to convert wings for aeroplane %s: %s", aeroplane_uuid, exc)
         raise InternalError(
@@ -243,7 +243,7 @@ def get_aeroplane_airplane_configuration(db: Session, aeroplane_uuid) -> dict:
         )
     try:
         fuselage_configurations = (
-            [fuselageModelToFuselageConfig(fuselage) for fuselage in aeroplane.fuselages]
+            [fuselage_model_to_fuselage_config(fuselage) for fuselage in aeroplane.fuselages]
             if aeroplane.fuselages
             else None
         )

--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -21,7 +21,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from app.api.utils import analyse_aerodynamics, compile_four_view_figure
-from app.converters.model_schema_converters import aeroplaneSchemaToAsbAirplane_async
+from app.converters.model_schema_converters import aeroplane_schema_to_asb_airplane_async
 from app.core.exceptions import NotFoundError, InternalError
 from app.db.exceptions import NotFoundInDbException
 from app.db.repository import get_wing_by_name_and_aeroplane_id, get_aeroplane_by_id
@@ -232,7 +232,7 @@ async def analyze_wing(
     plane_schema = await get_wing_schema_or_raise(db, aeroplane_uuid, wing_name)
     
     try:
-        asb_airplane: Airplane = await aeroplaneSchemaToAsbAirplane_async(plane_schema=plane_schema)
+        asb_airplane: Airplane = await aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
         asb_airplane.xyz_ref = operating_point.xyz_ref
         asb_airplane.wings = [w for w in asb_airplane.wings if w.name == wing_name]
         asb_airplane.fuselages = []
@@ -260,7 +260,7 @@ async def analyze_airplane(
     plane_schema = await get_aeroplane_schema_or_raise(db, aeroplane_uuid)
     
     try:
-        asb_airplane: Airplane = await aeroplaneSchemaToAsbAirplane_async(plane_schema=plane_schema)
+        asb_airplane: Airplane = await aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
         result, _ = await analyse_aerodynamics(analysis_tool, operating_point, asb_airplane)
         return result
     except Exception as e:
@@ -287,7 +287,7 @@ async def calculate_streamlines_json(
     plane_schema = await get_aeroplane_schema_or_raise(db, aeroplane_uuid)
 
     try:
-        asb_airplane: Airplane = await aeroplaneSchemaToAsbAirplane_async(plane_schema=plane_schema)
+        asb_airplane: Airplane = await aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
         _, figure = await analyse_aerodynamics(
             AnalysisToolUrlType.VORTEX_LATTICE,
             operating_point,
@@ -315,7 +315,7 @@ async def analyze_alpha_sweep(
     plane_schema = await get_aeroplane_schema_or_raise(db, aeroplane_uuid)
     
     try:
-        asb_airplane: Airplane = await aeroplaneSchemaToAsbAirplane_async(plane_schema=plane_schema)
+        asb_airplane: Airplane = await aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
         
         operating_point = OperatingPointSchema(
             altitude=sweep_request.altitude,
@@ -855,7 +855,7 @@ async def analyze_simple_sweep(
     plane_schema = await get_aeroplane_schema_or_raise(db, aeroplane_uuid)
     
     try:
-        asb_airplane: Airplane = await aeroplaneSchemaToAsbAirplane_async(plane_schema=plane_schema)
+        asb_airplane: Airplane = await aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
         
         operating_point = OperatingPointSchema(
             name=f"sweep over {sweep_request.sweep_var}",
@@ -944,7 +944,7 @@ async def get_streamlines_three_view_image(
     plane_schema = await get_aeroplane_schema_or_raise(db, aeroplane_uuid)
     
     try:
-        asb_airplane: Airplane = await aeroplaneSchemaToAsbAirplane_async(plane_schema=plane_schema)
+        asb_airplane: Airplane = await aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
         
         _, figure = await analyse_aerodynamics(
             AnalysisToolUrlType.VORTEX_LATTICE,
@@ -976,7 +976,7 @@ async def get_three_view_image(db: Session, aeroplane_uuid) -> bytes:
     plane_schema = await get_aeroplane_schema_or_raise(db, aeroplane_uuid)
     
     try:
-        asb_airplane: Airplane = await aeroplaneSchemaToAsbAirplane_async(plane_schema=plane_schema)
+        asb_airplane: Airplane = await aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
         
         fig = plt.figure(figsize=(10, 10))
         asb_airplane.draw_three_view(show=False)
@@ -1011,7 +1011,7 @@ async def analyze_airplane_strip_forces(
     plane_schema = await get_aeroplane_schema_or_raise(db, aeroplane_uuid)
 
     try:
-        asb_airplane: Airplane = await aeroplaneSchemaToAsbAirplane_async(plane_schema=plane_schema)
+        asb_airplane: Airplane = await aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
         asb_airplane.xyz_ref = operating_point.xyz_ref
 
         atmosphere = asb.Atmosphere(altitude=operating_point.altitude)
@@ -1088,7 +1088,7 @@ async def analyze_wing_strip_forces(
     plane_schema = await get_wing_schema_or_raise(db, aeroplane_uuid, wing_name)
 
     try:
-        asb_airplane: Airplane = await aeroplaneSchemaToAsbAirplane_async(plane_schema=plane_schema)
+        asb_airplane: Airplane = await aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
         asb_airplane.xyz_ref = operating_point.xyz_ref
         asb_airplane.wings = [w for w in asb_airplane.wings if w.name == wing_name]
         asb_airplane.fuselages = []

--- a/app/services/cad_service.py
+++ b/app/services/cad_service.py
@@ -35,8 +35,8 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, joinedload
 
 from app.converters.model_schema_converters import (
-    asbWingSchemaToWingConfig,
-    wingModelToAsbWingSchema,
+    asb_wing_schema_to_wing_config,
+    wing_model_to_asb_wing_schema,
 )
 from app.core.exceptions import NotFoundError, ValidationError, ConflictError, InternalError
 from app.models import AeroplaneModel, WingModel, WingXSecModel
@@ -294,7 +294,7 @@ def _run_construction_worker(
         # cannot be pickled.
         wing_schemas: Dict[str, Any] = pickle.loads(wing_schemas_pickle)
         wing_config: Dict[str, WingConfiguration] = {
-            name: asbWingSchemaToWingConfig(schema, scale=wing_scale)
+            name: asb_wing_schema_to_wing_config(schema, scale=wing_scale)
             for name, schema in wing_schemas.items()
         }
         fuselages: Optional[Dict[str, FuselageSchema]] = (
@@ -417,11 +417,11 @@ def start_wing_export_task(
     # relationship graph, so it must run in the parent process. The
     # final WingModel → WingConfiguration conversion (which creates
     # unpicklable cq.Vector instances) happens in the worker via
-    # asbWingSchemaToWingConfig. Scale metres → millimetres is applied
+    # asb_wing_schema_to_wing_config. Scale metres → millimetres is applied
     # inside the worker, so the scalar factor crosses the boundary too.
     try:
         wing_schemas: Dict[str, Any] = {
-            wing_name: wingModelToAsbWingSchema(wing),
+            wing_name: wing_model_to_asb_wing_schema(wing),
         }
     except Exception as exc:
         logger.error(

--- a/app/services/construction_plan_service.py
+++ b/app/services/construction_plan_service.py
@@ -530,7 +530,7 @@ def execute_plan(
 ) -> ExecutionResult:
     """Execute a plan against an aeroplane configuration."""
     from app.services.wing_service import get_aeroplane_or_raise, get_wing_or_raise
-    from app.converters.model_schema_converters import wingModelToWingConfig
+    from app.converters.model_schema_converters import wing_model_to_wing_config
 
     # Load plan
     plan = _get_plan_or_raise(db, plan_id)
@@ -547,7 +547,7 @@ def execute_plan(
     wing_config: dict = {}
     for wing in aeroplane.wings:
         try:
-            wc = wingModelToWingConfig(wing, scale=1000.0)
+            wc = wing_model_to_wing_config(wing, scale=1000.0)
             wing_config[wing.name] = wc
         except Exception as exc:
             logger.warning("Failed to convert wing '%s': %s", wing.name, exc)

--- a/app/services/operating_point_generator_service.py
+++ b/app/services/operating_point_generator_service.py
@@ -8,7 +8,7 @@ import numpy as np
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
-from app.converters.model_schema_converters import aeroplaneModelToAeroplaneSchema_async, aeroplaneSchemaToAsbAirplane_async
+from app.converters.model_schema_converters import aeroplane_model_to_aeroplane_schema_async, aeroplane_schema_to_asb_airplane_async
 from app.core.exceptions import InternalError, NotFoundError, ValidationError
 from app.models.aeroplanemodel import AeroplaneModel
 from app.models.analysismodels import OperatingPointModel, OperatingPointSetModel
@@ -536,8 +536,8 @@ async def generate_default_set_for_aircraft(
         refs = _estimate_reference_speeds(profile)
         targets = _build_target_definitions(profile, refs)
 
-        plane_schema = await aeroplaneModelToAeroplaneSchema_async(aircraft)
-        asb_airplane = await aeroplaneSchemaToAsbAirplane_async(plane_schema=plane_schema)
+        plane_schema = await aeroplane_model_to_aeroplane_schema_async(aircraft)
+        asb_airplane = await aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
         capabilities = _detect_control_capabilities(asb_airplane)
 
         points: list[TrimmedPoint] = []
@@ -616,8 +616,8 @@ async def trim_operating_point_for_aircraft(
             request.profile_id_override,
         )
 
-        plane_schema = await aeroplaneModelToAeroplaneSchema_async(aircraft)
-        asb_airplane = await aeroplaneSchemaToAsbAirplane_async(plane_schema=plane_schema)
+        plane_schema = await aeroplane_model_to_aeroplane_schema_async(aircraft)
+        asb_airplane = await aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
         capabilities = _detect_control_capabilities(asb_airplane)
 
         target = {

--- a/app/services/stability_service.py
+++ b/app/services/stability_service.py
@@ -32,13 +32,13 @@ async def get_stability_summary(
     """Run an analysis and extract stability summary from the result."""
     # Lazy imports to avoid module-level import errors on platforms
     # where aerosandbox is not available.
-    from app.converters.model_schema_converters import aeroplaneSchemaToAsbAirplane_async
+    from app.converters.model_schema_converters import aeroplane_schema_to_asb_airplane_async
     from app.api.utils import analyse_aerodynamics
 
     plane_schema = await get_aeroplane_schema_or_raise(db, aeroplane_uuid)
 
     try:
-        asb_airplane = await aeroplaneSchemaToAsbAirplane_async(plane_schema=plane_schema)
+        asb_airplane = await aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
         result, _ = await analyse_aerodynamics(
             analysis_tool, operating_point, asb_airplane
         )

--- a/app/services/tessellation_service.py
+++ b/app/services/tessellation_service.py
@@ -72,13 +72,13 @@ def _run_tessellation_worker(
     try:
         _logger.info("Starting tessellation for %s / %s", aeroplane_id, wing_name)
 
-        from app.converters.model_schema_converters import asbWingSchemaToWingConfig
+        from app.converters.model_schema_converters import asb_wing_schema_to_wing_config
         from cad_designer.airplane.creator.wing import WingLoftCreator
         from cadquery import Workplane
 
         # Rebuild WingConfiguration in the worker (CadQuery types not picklable)
         wing_schema = pickle.loads(wing_schema_pickle)
-        wing_config = asbWingSchemaToWingConfig(wing_schema, scale=wing_scale)
+        wing_config = asb_wing_schema_to_wing_config(wing_schema, scale=wing_scale)
 
         # Create the wing loft geometry via WingLoftCreator
         creator = WingLoftCreator(

--- a/app/services/wing_service.py
+++ b/app/services/wing_service.py
@@ -26,7 +26,7 @@ from app.models.aeroplanemodel import (
 from app.schemas.Servo import Servo as ServoSchema
 from app.schemas.wing import Wing as WingConfigurationSchema
 from app.services.create_wing_configuration import create_wing_configuration
-from app.converters.model_schema_converters import wingConfigToWingModel, wingModelToWingConfig
+from app.converters.model_schema_converters import wing_config_to_wing_model, wing_model_to_wing_config
 
 logger = logging.getLogger(__name__)
 
@@ -284,7 +284,7 @@ def create_wing_from_wing_configuration(
                 )
 
             wing_configuration = create_wing_configuration(wing_config_data)
-            wing_model = wingConfigToWingModel(
+            wing_model = wing_config_to_wing_model(
                 wing_config=wing_configuration,
                 wing_name=wing_name,
                 scale=scale,
@@ -309,14 +309,14 @@ def create_wing_from_wing_configuration(
 def get_wing_as_wingconfig(db: Session, aeroplane_uuid, wing_name: str) -> dict:
     """Return the wing converted back to WingConfiguration format.
 
-    Uses the roundtrip converter wingModelToWingConfig to produce
+    Uses the roundtrip converter wing_model_to_wing_config to produce
     the segment-based representation with root/tip airfoils,
     length, sweep, dihedral — without any estimation or loss.
     """
     aeroplane = get_aeroplane_or_raise(db, aeroplane_uuid)
     wing = get_wing_or_raise(aeroplane, wing_name)
     try:
-        wing_config = wingModelToWingConfig(wing, scale=1000.0)
+        wing_config = wing_model_to_wing_config(wing, scale=1000.0)
     except Exception as exc:
         logger.error("Failed to convert wing %s to WingConfig: %s", wing_name, exc)
         raise InternalError(
@@ -397,7 +397,7 @@ def put_wing_as_wingconfig(
                 db.flush()
 
             wing_configuration = create_wing_configuration(wing_config_data)
-            wing_model = wingConfigToWingModel(
+            wing_model = wing_config_to_wing_model(
                 wing_config=wing_configuration,
                 wing_name=wing_name,
                 scale=scale,
@@ -799,7 +799,7 @@ def _recompute_spare_vectors(wing: WingModel) -> None:
     (The CAD call-site uses ``scale=1000.0`` because CadQuery works in mm.)
     """
     try:
-        wing_config = wingModelToWingConfig(wing, scale=1.0)
+        wing_config = wing_model_to_wing_config(wing, scale=1.0)
 
         for seg_idx, segment in enumerate(wing_config.segments or []):
             if seg_idx >= len(wing.x_secs) - 1:

--- a/app/tests/test_ehawk_designer_workflow_integration.py
+++ b/app/tests/test_ehawk_designer_workflow_integration.py
@@ -64,7 +64,7 @@ from zipfile import ZipFile
 import pytest
 from fastapi.testclient import TestClient
 
-from app.converters.model_schema_converters import wingConfigToAsbWingSchema
+from app.converters.model_schema_converters import wing_config_to_asb_wing_schema
 from test.ehawk_workflow_helpers import _build_main_wing
 
 
@@ -342,7 +342,7 @@ def test_ehawk_designer_workflow_stepwise(client: TestClient):
     repo_root = Path(__file__).resolve().parents[2]
     airfoil_path = str((repo_root / "components" / "airfoils" / "mh32.dat").resolve())
     expected_wing_config = _build_main_wing(airfoil_path)
-    asb_wing = wingConfigToAsbWingSchema(
+    asb_wing = wing_config_to_asb_wing_schema(
         wing_config=expected_wing_config,
         wing_name=wing_name,
         scale=0.001,

--- a/app/tests/test_model_schema_converters.py
+++ b/app/tests/test_model_schema_converters.py
@@ -17,12 +17,12 @@ from pydantic import ValidationError  # noqa: E402
 
 from app import schemas  # noqa: E402
 from app.converters.model_schema_converters import (  # noqa: E402
-    aeroplaneSchemaToAirplaneConfiguration_async,
-    aeroplaneSchemaToAsbAirplane_async,
-    fuselageModelToFuselageConfig,
-    wingConfigToAsbWingSchema,
-    wingConfigToWingModel,
-    wingModelToWingConfig,
+    aeroplane_schema_to_airplane_configuration_async,
+    aeroplane_schema_to_asb_airplane_async,
+    fuselage_model_to_fuselage_config,
+    wing_config_to_asb_wing_schema,
+    wing_config_to_wing_model,
+    wing_model_to_wing_config,
 )
 from app.models.aeroplanemodel import FuselageModel, WingModel  # noqa: E402
 from cad_designer.airplane.aircraft_topology.wing import (  # noqa: E402
@@ -99,7 +99,7 @@ def _create_test_fuselage_schema() -> schemas.FuselageSchema:
 def test_wing_config_to_asb_wing_schema():
     wing_config = _create_test_wing_config()
 
-    result = wingConfigToAsbWingSchema(wing_config=wing_config, wing_name="main-wing")
+    result = wing_config_to_asb_wing_schema(wing_config=wing_config, wing_name="main-wing")
 
     assert result.name == "main-wing"
     assert result.symmetric is True
@@ -126,8 +126,8 @@ def test_wing_config_to_asb_wing_schema():
 def test_wing_config_to_wing_model_and_back_preserves_details():
     wing_config = _create_test_wing_config()
 
-    wing_model = wingConfigToWingModel(wing_config=wing_config, wing_name="main-wing")
-    reconstructed = wingModelToWingConfig(wing_model)
+    wing_model = wing_config_to_wing_model(wing_config=wing_config, wing_name="main-wing")
+    reconstructed = wing_model_to_wing_config(wing_model)
 
     assert reconstructed.symmetric is True
     assert len(reconstructed.segments) == 1
@@ -185,7 +185,7 @@ def test_wing_model_to_wing_config_scales_geometry_for_cad():
     )
     wing_model = WingModel.from_dict(name="main-wing", data=wing_schema.model_dump())
 
-    scaled_config = wingModelToWingConfig(wing_model, scale=1000.0)
+    scaled_config = wing_model_to_wing_config(wing_model, scale=1000.0)
 
     assert scaled_config.segments[0].root_airfoil.chord == pytest.approx(200.0)
     assert scaled_config.segments[0].tip_airfoil.chord == pytest.approx(150.0)
@@ -235,7 +235,7 @@ def test_wing_model_to_wing_config_resolves_sparse_vectors_for_standard_and_foll
     )
     wing_model = WingModel.from_dict(name="main-wing", data=wing_schema.model_dump())
 
-    config = wingModelToWingConfig(wing_model, scale=1000.0)
+    config = wing_model_to_wing_config(wing_model, scale=1000.0)
 
     assert config.segments[0].spare_list is not None
     assert config.segments[0].spare_list[0].spare_vector is not None
@@ -283,7 +283,7 @@ def test_ted_projection_to_asb_uses_rel_chord_root():
         wings={"main-wing": wing},
     )
 
-    asb_airplane = asyncio.run(aeroplaneSchemaToAsbAirplane_async(plane))
+    asb_airplane = asyncio.run(aeroplane_schema_to_asb_airplane_async(plane))
     control_surface = asb_airplane.wings[0].xsecs[0].control_surfaces[0]
     assert control_surface.hinge_point == pytest.approx(0.73)
     assert control_surface.deflection == pytest.approx(6.0)
@@ -373,12 +373,12 @@ def test_aeroplane_schema_to_airplane_configuration_requires_mass():
     plane = schemas.AeroplaneSchema(name="test-plane", wings={"main-wing": wing})
 
     with pytest.raises(ValueError):
-        asyncio.run(aeroplaneSchemaToAirplaneConfiguration_async(plane))
+        asyncio.run(aeroplane_schema_to_airplane_configuration_async(plane))
 
 
 def test_aeroplane_schema_to_airplane_configuration_preserves_wing_details():
     wing_config = _create_test_wing_config()
-    wing_schema = wingConfigToAsbWingSchema(wing_config=wing_config, wing_name="main-wing")
+    wing_schema = wing_config_to_asb_wing_schema(wing_config=wing_config, wing_name="main-wing")
     fuselage_schema = _create_test_fuselage_schema()
     plane = schemas.AeroplaneSchema(
         name="test-plane",
@@ -387,7 +387,7 @@ def test_aeroplane_schema_to_airplane_configuration_preserves_wing_details():
         fuselages={"test-fuselage": fuselage_schema},
     )
 
-    airplane_config = asyncio.run(aeroplaneSchemaToAirplaneConfiguration_async(plane))
+    airplane_config = asyncio.run(aeroplane_schema_to_airplane_configuration_async(plane))
 
     assert airplane_config.total_mass == pytest.approx(3.0)
     assert len(airplane_config.wings) == 1
@@ -414,7 +414,7 @@ def test_fuselage_model_to_fuselage_config():
         },
     )
 
-    fuselage_config = fuselageModelToFuselageConfig(fuselage_model)
+    fuselage_config = fuselage_model_to_fuselage_config(fuselage_model)
 
     assert fuselage_config.name == "fuselage-a"
     assert fuselage_config.asb_fuselage is not None

--- a/app/tests/test_operating_point_generator_service.py
+++ b/app/tests/test_operating_point_generator_service.py
@@ -91,8 +91,8 @@ def test_generate_default_set_with_profile_assignment(db_session):
     db_session.commit()
 
     with (
-        patch("app.services.operating_point_generator_service.aeroplaneModelToAeroplaneSchema_async", return_value=SimpleNamespace()),
-        patch("app.services.operating_point_generator_service.aeroplaneSchemaToAsbAirplane_async", return_value=_mock_airplane_with_controls("rudder")),
+        patch("app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async", return_value=SimpleNamespace()),
+        patch("app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async", return_value=_mock_airplane_with_controls("rudder")),
         patch("app.services.operating_point_generator_service._trim_or_estimate_point", side_effect=_fake_trim),
     ):
         result = asyncio.run(generate_default_set_for_aircraft(db_session, aircraft_uuid))
@@ -112,8 +112,8 @@ def test_generate_default_set_without_profile_uses_defaults(db_session):
     db_session.commit()
 
     with (
-        patch("app.services.operating_point_generator_service.aeroplaneModelToAeroplaneSchema_async", return_value=SimpleNamespace()),
-        patch("app.services.operating_point_generator_service.aeroplaneSchemaToAsbAirplane_async", return_value=_mock_airplane_with_controls("rudder")),
+        patch("app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async", return_value=SimpleNamespace()),
+        patch("app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async", return_value=_mock_airplane_with_controls("rudder")),
         patch("app.services.operating_point_generator_service._trim_or_estimate_point", side_effect=_fake_trim),
     ):
         result = asyncio.run(generate_default_set_for_aircraft(db_session, aircraft_uuid))
@@ -129,8 +129,8 @@ def test_generate_replace_existing_replaces_old_rows(db_session):
     db_session.commit()
 
     with (
-        patch("app.services.operating_point_generator_service.aeroplaneModelToAeroplaneSchema_async", return_value=SimpleNamespace()),
-        patch("app.services.operating_point_generator_service.aeroplaneSchemaToAsbAirplane_async", return_value=_mock_airplane_with_controls("rudder")),
+        patch("app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async", return_value=SimpleNamespace()),
+        patch("app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async", return_value=_mock_airplane_with_controls("rudder")),
         patch("app.services.operating_point_generator_service._trim_or_estimate_point", side_effect=_fake_trim),
     ):
         asyncio.run(generate_default_set_for_aircraft(db_session, aircraft_uuid))
@@ -148,8 +148,8 @@ def test_generate_skips_points_when_required_controls_missing(db_session, caplog
     db_session.commit()
 
     with (
-        patch("app.services.operating_point_generator_service.aeroplaneModelToAeroplaneSchema_async", return_value=SimpleNamespace()),
-        patch("app.services.operating_point_generator_service.aeroplaneSchemaToAsbAirplane_async", return_value=_mock_airplane_with_controls()),
+        patch("app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async", return_value=SimpleNamespace()),
+        patch("app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async", return_value=_mock_airplane_with_controls()),
         patch("app.services.operating_point_generator_service._trim_or_estimate_point", side_effect=_fake_trim),
     ):
         result = asyncio.run(generate_default_set_for_aircraft(db_session, aircraft_uuid))
@@ -169,8 +169,8 @@ def test_generate_with_rudder_keeps_dutch_role_point(db_session):
     db_session.commit()
 
     with (
-        patch("app.services.operating_point_generator_service.aeroplaneModelToAeroplaneSchema_async", return_value=SimpleNamespace()),
-        patch("app.services.operating_point_generator_service.aeroplaneSchemaToAsbAirplane_async", return_value=_mock_airplane_with_controls("rudder")),
+        patch("app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async", return_value=SimpleNamespace()),
+        patch("app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async", return_value=_mock_airplane_with_controls("rudder")),
         patch("app.services.operating_point_generator_service._trim_or_estimate_point", side_effect=_fake_trim),
     ):
         result = asyncio.run(generate_default_set_for_aircraft(db_session, aircraft_uuid))
@@ -187,8 +187,8 @@ def test_generate_replace_existing_with_skips_keeps_consistent_rows(db_session):
     db_session.commit()
 
     with (
-        patch("app.services.operating_point_generator_service.aeroplaneModelToAeroplaneSchema_async", return_value=SimpleNamespace()),
-        patch("app.services.operating_point_generator_service.aeroplaneSchemaToAsbAirplane_async", return_value=_mock_airplane_with_controls()),
+        patch("app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async", return_value=SimpleNamespace()),
+        patch("app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async", return_value=_mock_airplane_with_controls()),
         patch("app.services.operating_point_generator_service._trim_or_estimate_point", side_effect=_fake_trim),
     ):
         asyncio.run(generate_default_set_for_aircraft(db_session, aircraft_uuid))
@@ -238,9 +238,9 @@ def test_trim_single_operating_point_for_aircraft(db_session):
     )
 
     with (
-        patch("app.services.operating_point_generator_service.aeroplaneModelToAeroplaneSchema_async", return_value=SimpleNamespace()),
+        patch("app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async", return_value=SimpleNamespace()),
         patch(
-            "app.services.operating_point_generator_service.aeroplaneSchemaToAsbAirplane_async",
+            "app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async",
             return_value=_mock_airplane_with_controls("elevator"),
         ),
         patch("app.services.operating_point_generator_service._trim_or_estimate_point", side_effect=_fake_trim),

--- a/app/tests/test_wingconfig_roundtrip.py
+++ b/app/tests/test_wingconfig_roundtrip.py
@@ -18,8 +18,8 @@ pytest.importorskip("cadquery")
 from app.schemas.wing import Wing, Segment, Airfoil  # noqa: E402
 from app.services.create_wing_configuration import create_wing_configuration  # noqa: E402
 from app.converters.model_schema_converters import (  # noqa: E402
-    wingConfigToAsbWingSchema,
-    asbWingSchemaToWingConfig,
+    wing_config_to_asb_wing_schema,
+    asb_wing_schema_to_wing_config,
 )
 
 AIRFOIL = "naca0015"
@@ -29,8 +29,8 @@ AIRFOIL_ALT = "naca2412"
 def _roundtrip(wing_data: Wing):
     """WingConfig schema → WingConfiguration → ASB schema → WingConfiguration."""
     wc = create_wing_configuration(wing_data)
-    asb_schema = wingConfigToAsbWingSchema(wc, "test", scale=0.001)
-    wc2 = asbWingSchemaToWingConfig(asb_schema, scale=1000.0)
+    asb_schema = wing_config_to_asb_wing_schema(wc, "test", scale=0.001)
+    wc2 = asb_wing_schema_to_wing_config(asb_schema, scale=1000.0)
     return wc, wc2
 
 
@@ -371,8 +371,8 @@ class TestRoundtripDrift:
     def _multi_roundtrip(wing_data: Wing, n: int):
         """Apply the roundtrip n times, return per-iteration snapshots."""
         from app.converters.model_schema_converters import (
-            wingConfigToAsbWingSchema as to_asb,
-            asbWingSchemaToWingConfig as from_asb,
+            wing_config_to_asb_wing_schema as to_asb,
+            asb_wing_schema_to_wing_config as from_asb,
         )
         wc = create_wing_configuration(wing_data)
         snapshots = []

--- a/app/tests/test_wingconfig_vs_theory.py
+++ b/app/tests/test_wingconfig_vs_theory.py
@@ -24,8 +24,8 @@ pytest.importorskip("cadquery")
 from app.schemas.wing import Wing, Segment, Airfoil  # noqa: E402
 from app.services.create_wing_configuration import create_wing_configuration  # noqa: E402
 from app.converters.model_schema_converters import (  # noqa: E402
-    wingConfigToAsbWingSchema,
-    asbWingSchemaToWingConfig,
+    wing_config_to_asb_wing_schema,
+    asb_wing_schema_to_wing_config,
 )
 
 AIRFOIL = "naca0015"
@@ -152,7 +152,7 @@ def _build_and_compare(segments_schemas, segments_params, scale=0.001, tol_pos=0
     """
     wing_data = Wing(nose_pnt=[0, 0, 0], symmetric=True, segments=segments_schemas)
     wc = create_wing_configuration(wing_data)
-    asb_schema = wingConfigToAsbWingSchema(wc, "test", scale=scale)
+    asb_schema = wing_config_to_asb_wing_schema(wc, "test", scale=scale)
 
     expected = compute_expected_xsecs(segments_params)
 


### PR DESCRIPTION
## Summary
- Rename 10 camelCase functions to snake_case in `model_schema_converters.py` + all callers across 16 files (S1542)
- Replace 3 nested ternary expressions with if/elif/else blocks in `_control_surface_from_ted` (S3358)
- Fix float equality comparison `scale == 1.0` with `math.isclose()` (S1244)
- Fix type hint mismatch in `AeroplaneRequest.py`: trailing comma on `trans_z: float = 0.0,` made the default a tuple (S5890)

Closes #192

## Test plan
- [x] `poetry run pytest -m "not slow"` passes (588 passed)
- [x] `poetry run ruff check .` clean
- [x] Grep confirms no remaining camelCase references to renamed functions in `app/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)