### PR TITLE
chore(gh-190): fix type alias syntax + np.where usage (S8396, S6729)

### DIFF
--- a/app/schemas/AeroplaneRequest.py
+++ b/app/schemas/AeroplaneRequest.py
@@ -28,11 +28,11 @@ class ServoSettings(BaseModel):
     trans_y: float = 0.0
     trans_z: float = 0.0
 
-    servo: Optional[Servo]
+    servo: Optional[Servo] = None
 
 class AeroplaneSettings(BaseModel):
-    printer_settings: Optional[Printer3dSettings]
-    servo_information: Optional[Dict[int, ServoSettings]]
+    printer_settings: Optional[Printer3dSettings] = None
+    servo_information: Optional[Dict[int, ServoSettings]] = None
 
 class CreatorUrlType(str, Enum):
     WING_LOFT = "wing_loft"
@@ -82,8 +82,8 @@ class SimpleSweepRequest(BaseModel):
 
 
 class CreateWingLoftRequest(BaseModel):
-    wings: Optional[Dict[str, Wing]]
-    settings: Optional[AeroplaneSettings]
+    wings: Optional[Dict[str, Wing]] = None
+    settings: Optional[AeroplaneSettings] = None
 
     model_config = ConfigDict(
         json_encoders={
@@ -595,9 +595,9 @@ class CreateWingLoftRequest(BaseModel):
 
 class CreateAeroPlaneRequest(BaseModel):
     blueprint: Union[Path, Any]
-    wings: Optional[Dict[str, Wing]]
-    fuselages: Optional[OrderedDict[str, Fuselage]]
-    settings: Optional[AeroplaneSettings]
+    wings: Optional[Dict[str, Wing]] = None
+    fuselages: Optional[OrderedDict[str, Fuselage]] = None
+    settings: Optional[AeroplaneSettings] = None
 
     model_config = ConfigDict(
         json_encoders={

--- a/app/schemas/flight_profile.py
+++ b/app/schemas/flight_profile.py
@@ -383,4 +383,4 @@ class AircraftFlightProfileAssignmentRead(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     aircraft_id: str
-    flight_profile_id: Optional[int]
+    flight_profile_id: Optional[int] = None

--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -98,7 +98,7 @@ def _compute_alpha_sweep_characteristic_points(
                 "index": i, "alpha_deg": float(alpha[i]), "CL": float(cl[i]), "CD": float(cd[i]), "Cm": None,
             }
 
-            cross = np.where(np.sign(cl[:-1]) != np.sign(cl[1:]))[0]
+            cross = np.nonzero(np.sign(cl[:-1]) != np.sign(cl[1:]))[0]
             if len(cross) > 0:
                 i = int(cross[0])
                 cl0, cl1 = cl[i], cl[i + 1]
@@ -138,7 +138,7 @@ def _compute_alpha_sweep_characteristic_points(
             cm = cm_values[:n]
             alpha = alpha_array[:n]
 
-            cross = np.where(np.sign(cm[:-1]) != np.sign(cm[1:]))[0]
+            cross = np.nonzero(np.sign(cm[:-1]) != np.sign(cm[1:]))[0]
             if len(cross) > 0:
                 i = int(cross[0])
                 cm0, cm1 = cm[i], cm[i + 1]


### PR DESCRIPTION
## Summary
- Add explicit `= None` defaults to 9 `Optional` fields in Pydantic schemas that lacked them (SonarQube S8396)
- Replace 2 `np.where(condition)` calls with `np.nonzero(condition)` in `analysis_service.py` (SonarQube S6729)

Closes #190

## Test plan
- [x] `poetry run pytest -m "not slow"` — 611 passed
- [x] `poetry run ruff check .` — clean
- [ ] SonarQube S8396/S6729 issues resolved after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)