### PR TITLE
chore(gh-193): fix MINOR SonarQube issues (S7503, S117, S7498, S7500, S7504, S5145, S7493, S1135)

### DIFF
--- a/app/api/utils.py
+++ b/app/api/utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 from typing import Literal
 from urllib.parse import urljoin
@@ -35,9 +36,7 @@ def _build_operating_point(operating_point: OperatingPointSchema) -> asb.Operati
 
 def _run_avl(asb_airplane, op_point, operating_point):
     """Run AVL analysis; raises ValueError for parameter sweeps."""
-    avl = asb.AVL(
-        airplane=asb_airplane, op_point=op_point, xyz_ref=operating_point.xyz_ref
-    )
+    avl = asb.AVL(airplane=asb_airplane, op_point=op_point, xyz_ref=operating_point.xyz_ref)
     if isinstance(operating_point.alpha, (list, tuple, np.ndarray)) or isinstance(
         operating_point.beta, (list, tuple, np.ndarray)
     ):
@@ -50,9 +49,7 @@ def _run_avl(asb_airplane, op_point, operating_point):
 
 def _run_aerobuildup(asb_airplane, op_point, operating_point):
     """Run AeroBuildup analysis."""
-    abu = asb.AeroBuildup(
-        airplane=asb_airplane, op_point=op_point, xyz_ref=operating_point.xyz_ref
-    )
+    abu = asb.AeroBuildup(airplane=asb_airplane, op_point=op_point, xyz_ref=operating_point.xyz_ref)
     return AnalysisModel.from_abu_dict(
         abu.run_with_stability_derivatives(),
         asb_airplan=asb_airplane,
@@ -76,11 +73,13 @@ def _run_vlm(asb_airplane, op_point, operating_point, draw_streamlines, backend)
     ), figure
 
 
-async def analyse_aerodynamics(analysis_tool: AnalysisToolUrlType,
-                               operating_point: OperatingPointSchema,
-                               asb_airplane: Airplane,
-                               draw_streamlines: bool = False,
-                               backend: Literal['plotly','pyvista'] = 'plotly') -> (AnalysisModel, Figure|Plotter):
+def analyse_aerodynamics(
+    analysis_tool: AnalysisToolUrlType,
+    operating_point: OperatingPointSchema,
+    asb_airplane: Airplane,
+    draw_streamlines: bool = False,
+    backend: Literal["plotly", "pyvista"] = "plotly",
+) -> (AnalysisModel, Figure | Plotter):
     """Perform aerodynamic analysis using the specified tool.
 
     Returns (AnalysisModel, Figure | None).
@@ -102,32 +101,39 @@ async def analyse_aerodynamics(analysis_tool: AnalysisToolUrlType,
     )
 
 
-async def compile_four_view_figure(figure):
+def compile_four_view_figure(figure):
     # Create a 2x2 subplot figure
     fig = make_subplots(
-        rows=3, cols=2,
-        specs=[[{'type': 'scene', "rowspan": 2}, {'type': 'scene'}],
-               [None, {'type': 'scene'}],
-               [{'type': 'scene', 'colspan': 2}, None]],
-        subplot_titles=["Side View (y-axis)", "Front View (x-axis)",
-                        "Top View (z-axis)", "Overview from top left"],
+        rows=3,
+        cols=2,
+        specs=[
+            [{"type": "scene", "rowspan": 2}, {"type": "scene"}],
+            [None, {"type": "scene"}],
+            [{"type": "scene", "colspan": 2}, None],
+        ],
+        subplot_titles=[
+            "Side View (y-axis)",
+            "Front View (x-axis)",
+            "Top View (z-axis)",
+            "Overview from top left",
+        ],
         row_heights=[0.2, 0.2, 0.6],
         column_widths=[0.4, 0.6],
         vertical_spacing=0.05,  # reduce space between rows
-        horizontal_spacing=0.05  # reduce space between columns
+        horizontal_spacing=0.05,  # reduce space between columns
     )
     # Calculate the bounding box of all points in the scene
-    x_min, x_max = float('inf'), float('-inf')
-    y_min, y_max = float('inf'), float('-inf')
-    z_min, z_max = float('inf'), float('-inf')
+    x_min, x_max = float("inf"), float("-inf")
+    y_min, y_max = float("inf"), float("-inf")
+    z_min, z_max = float("inf"), float("-inf")
     for trace in figure.data:
-        if hasattr(trace, 'x') and trace.x is not None:
+        if hasattr(trace, "x") and trace.x is not None:
             x_min = min(x_min, min(f for f in trace.x if f is not None))
             x_max = max(x_max, max(f for f in trace.x if f is not None))
-        if hasattr(trace, 'y') and trace.y is not None:
+        if hasattr(trace, "y") and trace.y is not None:
             y_min = min(y_min, min(f for f in trace.y if f is not None))
             y_max = max(y_max, max(f for f in trace.y if f is not None))
-        if hasattr(trace, 'z') and trace.z is not None:
+        if hasattr(trace, "z") and trace.z is not None:
             z_min = min(z_min, min(f for f in trace.z if f is not None))
             z_max = max(z_max, max(f for f in trace.z if f is not None))
     # Calculate the center and size of the bounding box
@@ -151,87 +157,91 @@ async def compile_four_view_figure(figure):
     # Set camera angles for each view and ensure consistent aspect ratio
     # Side view (y-axis)
     fig.update_scenes(
-        camera=dict(
-            eye=dict(x=center_x, y=center_y - camera_distance, z=center_z),
-            up=dict(x=0, y=0, z=1),
-            center=dict(x=center_x, y=center_y, z=center_z)
-        ),
-        aspectmode='data',  # Force equal aspect ratio
-        row=1, col=2
+        camera={
+            "eye": {"x": center_x, "y": center_y - camera_distance, "z": center_z},
+            "up": {"x": 0, "y": 0, "z": 1},
+            "center": {"x": center_x, "y": center_y, "z": center_z},
+        },
+        aspectmode="data",  # Force equal aspect ratio
+        row=1,
+        col=2,
     )
     # Front view (x-axis)
     fig.update_scenes(
-        camera=dict(
-            eye=dict(x=center_x - camera_distance * 2, y=center_y, z=center_z),
-            up=dict(x=0, y=0, z=1),
-            center=dict(x=center_x, y=center_y, z=center_z)
-        ),
-        aspectmode='data',  # Force equal aspect ratio
-        row=2, col=2
+        camera={
+            "eye": {"x": center_x - camera_distance * 2, "y": center_y, "z": center_z},
+            "up": {"x": 0, "y": 0, "z": 1},
+            "center": {"x": center_x, "y": center_y, "z": center_z},
+        },
+        aspectmode="data",  # Force equal aspect ratio
+        row=2,
+        col=2,
     )
     # Top view (z-axis)
     fig.update_scenes(
-        camera=dict(
-            eye=dict(x=center_x, y=center_y, z=center_z + camera_distance * 2.),
-            up=dict(x=0, y=1, z=0),
-            center=dict(x=center_x, y=center_y, z=center_z)
-        ),
-        aspectmode='data',  # Force equal aspect ratio
-        row=1, col=1
+        camera={
+            "eye": {"x": center_x, "y": center_y, "z": center_z + camera_distance * 2.0},
+            "up": {"x": 0, "y": 1, "z": 0},
+            "center": {"x": center_x, "y": center_y, "z": center_z},
+        },
+        aspectmode="data",  # Force equal aspect ratio
+        row=1,
+        col=1,
     )
     # Overview from top left iso-view
     fig.update_scenes(
-        camera=dict(
-            eye=dict(
-                x=center_x - camera_distance * 0.577 * 3,  # 1/sqrt(3) to normalize the vector
-                y=center_y - camera_distance * 0.577 * 3,
-                z=center_z + camera_distance * 0.577 * 3
-            ),
-            up=dict(x=0, y=0, z=1),
-            center=dict(x=center_x, y=center_y, z=center_z)
-        ),
-        aspectmode='data',  # Force equal aspect ratio
-        row=3, col=1
+        camera={
+            "eye": {
+                "x": center_x - camera_distance * 0.577 * 3,  # 1/sqrt(3) to normalize the vector
+                "y": center_y - camera_distance * 0.577 * 3,
+                "z": center_z + camera_distance * 0.577 * 3,
+            },
+            "up": {"x": 0, "y": 0, "z": 1},
+            "center": {"x": center_x, "y": center_y, "z": center_z},
+        },
+        aspectmode="data",  # Force equal aspect ratio
+        row=3,
+        col=1,
     )
     # Update layout
     fig.update_layout(
-        margin=dict(l=20, r=20, t=50, b=20),  # reduce whitespace
+        margin={"l": 20, "r": 20, "t": 50, "b": 20},  # reduce whitespace
         height=1000,
         width=1000,
         title_text="Four Views of Aerodynamic Analysis",
-        showlegend=False
+        showlegend=False,
     )
-    axis_style = dict(
-        showbackground=False,
-        showline=False,
-        zeroline=False,
-        showgrid=False,
-        ticks='',
-        showticklabels=False
-    )
+    axis_style = {
+        "showbackground": False,
+        "showline": False,
+        "zeroline": False,
+        "showgrid": False,
+        "ticks": "",
+        "showticklabels": False,
+    }
     fig.update_layout(
-        scene=dict(
-            xaxis=axis_style,
-            yaxis=axis_style,
-            zaxis=axis_style
-        ),
-        scene2=dict(
-            xaxis=axis_style,
-            yaxis=axis_style,
-            zaxis=axis_style
-        ),
-        scene3=dict(
-            xaxis=axis_style,
-            yaxis=axis_style,
-            zaxis=axis_style
-        ),
-        scene4=dict(
-            xaxis=axis_style,
-            yaxis=axis_style,
-            zaxis=axis_style
-        ),
-        paper_bgcolor='white',
-        plot_bgcolor='white'
+        scene={
+            "xaxis": axis_style,
+            "yaxis": axis_style,
+            "zaxis": axis_style,
+        },
+        scene2={
+            "xaxis": axis_style,
+            "yaxis": axis_style,
+            "zaxis": axis_style,
+        },
+        scene3={
+            "xaxis": axis_style,
+            "yaxis": axis_style,
+            "zaxis": axis_style,
+        },
+        scene4={
+            "xaxis": axis_style,
+            "yaxis": axis_style,
+            "zaxis": axis_style,
+        },
+        paper_bgcolor="white",
+        plot_bgcolor="white",
     )
     return fig
 
@@ -242,9 +252,14 @@ async def save_content_and_get_static_url(aeroplane_id, base_url, content, conte
     os.makedirs(content_dir, exist_ok=True)
     # Save HTML content to file
     file_path = os.path.join(content_dir, filename)
-    with open(file_path, "w") as f:
-        f.write(content)
+    await asyncio.to_thread(_write_file_sync, file_path, content)
     # Return URL to the served HTML file
     relative_url = f"/static/{aeroplane_id}/{content_type}/{filename}"
     full_url = urljoin(base_url, relative_url)
     return full_url
+
+
+def _write_file_sync(file_path: str, content: str) -> None:
+    """Write content to a file synchronously (used via asyncio.to_thread)."""
+    with open(file_path, "w") as f:
+        f.write(content)

--- a/app/api/utils.py
+++ b/app/api/utils.py
@@ -247,19 +247,15 @@ def compile_four_view_figure(figure):
 
 
 async def save_content_and_get_static_url(aeroplane_id, base_url, content, content_type, filename):
-    # Create directory structure
     content_dir = os.path.join("tmp", str(aeroplane_id), content_type)
-    os.makedirs(content_dir, exist_ok=True)
-    # Save HTML content to file
     file_path = os.path.join(content_dir, filename)
-    await asyncio.to_thread(_write_file_sync, file_path, content)
-    # Return URL to the served HTML file
+    await asyncio.to_thread(_write_file_sync, content_dir, file_path, content)
     relative_url = f"/static/{aeroplane_id}/{content_type}/{filename}"
-    full_url = urljoin(base_url, relative_url)
-    return full_url
+    return urljoin(base_url, relative_url)
 
 
-def _write_file_sync(file_path: str, content: str) -> None:
-    """Write content to a file synchronously (used via asyncio.to_thread)."""
+def _write_file_sync(content_dir: str, file_path: str, content: str) -> None:
+    """Create directory and write content (used via asyncio.to_thread)."""
+    os.makedirs(content_dir, exist_ok=True)
     with open(file_path, "w") as f:
         f.write(content)

--- a/app/api/v2/endpoints/cad.py
+++ b/app/api/v2/endpoints/cad.py
@@ -336,7 +336,7 @@ async def get_aeroplane_task_status(
             task_key = f"{aeroplane_id}:{task_type}"
         else:
             task_key = aeroplane_id
-        logger.info("Getting task status for: %s", task_key)
+        logger.info("Getting task status for: %s", task_key.replace("\n", "").replace("\r", ""))
         task_result = cad_service.get_task_result(task_key)
 
         message: str | None = None
@@ -386,7 +386,10 @@ async def download_aeroplane_zip(
 ) -> ZipAssetResponse:
     """Return the static URL for the completed export zip file."""
     try:
-        logger.info("Download request for aeroplane_id: %s", aeroplane_id)
+        logger.info(
+            "Download request for aeroplane_id: %s",
+            str(aeroplane_id).replace("\n", "").replace("\r", ""),
+        )
 
         file_path = cad_service.get_export_file_path(aeroplane_id)
         static_file_path = _ensure_file_under_tmp(file_path, aeroplane_id)

--- a/app/converters/model_schema_converters.py
+++ b/app/converters/model_schema_converters.py
@@ -10,13 +10,21 @@ from app.models import AeroplaneModel, WingModel
 from app.models.aeroplanemodel import FuselageModel
 from app.schemas import AeroplaneSchema
 from app.schemas.Servo import Servo as ServoSchema
-from cad_designer.airplane.aircraft_topology.airplane.AirplaneConfiguration import AirplaneConfiguration
+from cad_designer.airplane.aircraft_topology.airplane.AirplaneConfiguration import (
+    AirplaneConfiguration,
+)
 from cad_designer.airplane.aircraft_topology.components.Servo import Servo as WingServo
-from cad_designer.airplane.aircraft_topology.fuselage.FuselageConfiguration import FuselageConfiguration
-from cad_designer.airplane.aircraft_topology.wing import Spare, TrailingEdgeDevice, WingConfiguration
+from cad_designer.airplane.aircraft_topology.fuselage.FuselageConfiguration import (
+    FuselageConfiguration,
+)
+from cad_designer.airplane.aircraft_topology.wing import (
+    Spare,
+    TrailingEdgeDevice,
+    WingConfiguration,
+)
 
 
-async def aeroplane_model_to_aeroplane_schema_async(plane: AeroplaneModel) -> AeroplaneSchema:
+def aeroplane_model_to_aeroplane_schema_async(plane: AeroplaneModel) -> AeroplaneSchema:
     plane_dict = plane.__dict__.copy()
     plane_dict["wings"] = {w.name: w for w in plane.wings}
     plane_dict["fuselages"] = {f.name: f for f in plane.fuselages}
@@ -82,7 +90,9 @@ def _wing_configuration_sections(wing_config: WingConfiguration):
     if not wing_config.segments:
         return []
 
-    sections = [(wing_config.segments[0].root_airfoil, wing_config.segments[0].trailing_edge_device)]
+    sections = [
+        (wing_config.segments[0].root_airfoil, wing_config.segments[0].trailing_edge_device)
+    ]
     for segment in wing_config.segments:
         sections.append((segment.tip_airfoil, segment.trailing_edge_device))
     return sections
@@ -153,12 +163,18 @@ def _servo_to_wing_servo(servo_value: Any) -> Optional[WingServo | int]:
 
 
 def _spare_to_schema(spare: Spare) -> schemas.SpareDetailSchema:
-    vector = spare.spare_vector.toTuple() if getattr(spare, "spare_vector", None) is not None else None
-    origin = spare.spare_origin.toTuple() if getattr(spare, "spare_origin", None) is not None else None
+    vector = (
+        spare.spare_vector.toTuple() if getattr(spare, "spare_vector", None) is not None else None
+    )
+    origin = (
+        spare.spare_origin.toTuple() if getattr(spare, "spare_origin", None) is not None else None
+    )
     return schemas.SpareDetailSchema(
         spare_support_dimension_width=float(spare.spare_support_dimension_width),
         spare_support_dimension_height=float(spare.spare_support_dimension_height),
-        spare_position_factor=None if spare.spare_position_factor is None else float(spare.spare_position_factor),
+        spare_position_factor=None
+        if spare.spare_position_factor is None
+        else float(spare.spare_position_factor),
         spare_length=None if spare.spare_length is None else float(spare.spare_length),
         spare_start=0.0 if spare.spare_start is None else float(spare.spare_start),
         spare_mode=spare.spare_mode,
@@ -174,13 +190,19 @@ def _spare_schema_to_spare(spare_schema: schemas.SpareDetailSchema) -> Spare:
         spare_position_factor=spare_schema.spare_position_factor,
         spare_length=spare_schema.spare_length,
         spare_start=spare_schema.spare_start,
-        spare_vector=tuple(spare_schema.spare_vector) if spare_schema.spare_vector is not None else None,
-        spare_origin=tuple(spare_schema.spare_origin) if spare_schema.spare_origin is not None else None,
+        spare_vector=tuple(spare_schema.spare_vector)
+        if spare_schema.spare_vector is not None
+        else None,
+        spare_origin=tuple(spare_schema.spare_origin)
+        if spare_schema.spare_origin is not None
+        else None,
         spare_mode=spare_schema.spare_mode or "standard",
     )
 
 
-def _trailing_edge_device_to_schema(ted: TrailingEdgeDevice) -> schemas.TrailingEdgeDeviceDetailSchema:
+def _trailing_edge_device_to_schema(
+    ted: TrailingEdgeDevice,
+) -> schemas.TrailingEdgeDeviceDetailSchema:
     return schemas.TrailingEdgeDeviceDetailSchema(
         name=ted.name,
         rel_chord_root=ted.rel_chord_root,
@@ -215,16 +237,24 @@ def _trailing_edge_device_schema_to_wing_ted(
         servo_placement=ted_schema.servo_placement,
         rel_chord_servo_position=ted_schema.rel_chord_servo_position,
         rel_length_servo_position=ted_schema.rel_length_servo_position,
-        positive_deflection_deg=25.0 if ted_schema.positive_deflection_deg is None else ted_schema.positive_deflection_deg,
-        negative_deflection_deg=25.0 if ted_schema.negative_deflection_deg is None else ted_schema.negative_deflection_deg,
+        positive_deflection_deg=25.0
+        if ted_schema.positive_deflection_deg is None
+        else ted_schema.positive_deflection_deg,
+        negative_deflection_deg=25.0
+        if ted_schema.negative_deflection_deg is None
+        else ted_schema.negative_deflection_deg,
         trailing_edge_offset_factor=(
-            1.0 if ted_schema.trailing_edge_offset_factor is None else ted_schema.trailing_edge_offset_factor
+            1.0
+            if ted_schema.trailing_edge_offset_factor is None
+            else ted_schema.trailing_edge_offset_factor
         ),
         hinge_type="top" if ted_schema.hinge_type is None else ted_schema.hinge_type,
         symmetric=True if ted_schema.symmetric is None else ted_schema.symmetric,
     )
     # CAD type has no dedicated field yet; keep value on instance for roundtrip/export use.
-    ted.deflection_deg = 0.0 if ted_schema.deflection_deg is None else float(ted_schema.deflection_deg)
+    ted.deflection_deg = (
+        0.0 if ted_schema.deflection_deg is None else float(ted_schema.deflection_deg)
+    )
     return ted
 
 
@@ -449,7 +479,7 @@ def _resolve_spare_vectors_and_origins(wing_config: WingConfiguration) -> None:
             _resolve_single_spare(wing_config, segment_index, spare_index, spare)
 
 
-async def aeroplane_schema_to_asb_airplane_async(plane_schema: AeroplaneSchema) -> "asb.Airplane":
+def aeroplane_schema_to_asb_airplane_async(plane_schema: AeroplaneSchema) -> "asb.Airplane":
     """
     Convert an AeroplaneSchema to an Aerosandbox Airplane object.
 
@@ -467,7 +497,7 @@ async def aeroplane_schema_to_asb_airplane_async(plane_schema: AeroplaneSchema) 
             Wing(
                 name=wing_name,
                 symmetric=wing.symmetric,
-                xsecs=[xsec for xsec in _asb_wing_xsecs_from_schema(wing)] if wing.x_secs else None,
+                xsecs=list(_asb_wing_xsecs_from_schema(wing)) if wing.x_secs else None,
             )
             for wing_name, wing in plane_schema.wings.items()
         ]
@@ -488,9 +518,13 @@ async def aeroplane_schema_to_asb_airplane_async(plane_schema: AeroplaneSchema) 
     return asb_airplane
 
 
-async def aeroplane_schema_to_airplane_configuration_async(plane_schema: AeroplaneSchema) -> AirplaneConfiguration:
+def aeroplane_schema_to_airplane_configuration_async(
+    plane_schema: AeroplaneSchema,
+) -> AirplaneConfiguration:
     if plane_schema.total_mass_kg is None:
-        raise ValueError("AeroplaneSchema.total_mass_kg must be set to build AirplaneConfiguration.")
+        raise ValueError(
+            "AeroplaneSchema.total_mass_kg must be set to build AirplaneConfiguration."
+        )
 
     wing_configs: List[WingConfiguration] = []
     for wing in (plane_schema.wings or {}).values():
@@ -532,9 +566,12 @@ def wing_model_to_asb_wing_schema(wing: WingModel) -> schemas.AsbWingSchema:
     # legacy DB rows that have TED/spars on the terminal x-section.
     xsec_dicts = []
     for xs in wing.x_secs:
-        xsec_dicts.append(schemas.WingXSecSchema.model_validate(
-            xs, from_attributes=True,
-        ).model_dump())
+        xsec_dicts.append(
+            schemas.WingXSecSchema.model_validate(
+                xs,
+                from_attributes=True,
+            ).model_dump()
+        )
 
     # Strip segment-specific fields from last x-section
     if xsec_dicts:
@@ -545,11 +582,13 @@ def wing_model_to_asb_wing_schema(wing: WingModel) -> schemas.AsbWingSchema:
         last["tip_type"] = None
         last["number_interpolation_points"] = None
 
-    return schemas.AsbWingSchema.model_validate({
-        "name": wing.name,
-        "symmetric": wing.symmetric,
-        "x_secs": xsec_dicts,
-    })
+    return schemas.AsbWingSchema.model_validate(
+        {
+            "name": wing.name,
+            "symmetric": wing.symmetric,
+            "x_secs": xsec_dicts,
+        }
+    )
 
 
 def asb_wing_schema_to_wing_config(
@@ -615,7 +654,9 @@ def _build_segment_details(segment, control_surface):
         control_surface=control_surface,
     )
     if canonical_ted_payload is not None:
-        trailing_edge_device = schemas.TrailingEdgeDeviceDetailSchema.model_validate(canonical_ted_payload)
+        trailing_edge_device = schemas.TrailingEdgeDeviceDetailSchema.model_validate(
+            canonical_ted_payload
+        )
         control_surface = _control_surface_from_ted(trailing_edge_device, fallback=control_surface)
 
     if segment.spare_list is not None:
@@ -659,8 +700,12 @@ def wing_config_to_asb_wing_schema(
         segment = wing_config.segments[index] if index < len(wing_config.segments) else None
         if segment is not None:
             (
-                trailing_edge_device, spare_list, control_surface,
-                x_sec_type, tip_type, number_interpolation_points,
+                trailing_edge_device,
+                spare_list,
+                control_surface,
+                x_sec_type,
+                tip_type,
+                number_interpolation_points,
             ) = _build_segment_details(segment, control_surface)
 
         x_secs.append(

--- a/app/db/repository.py
+++ b/app/db/repository.py
@@ -12,22 +12,28 @@ from app.schemas import AeroplaneSchema, AsbWingSchema
 
 
 async def get_aeroplane_by_id(aeroplane_id, db) -> AeroplaneSchema:
-    plane: AeroplaneModel = (db.query(AeroplaneModel)
-                             .options(joinedload(AeroplaneModel.wings)
-                                      .joinedload(WingModel.x_secs)
-                                      .joinedload(WingXSecModel.detail)
-                                      .joinedload(WingXSecDetailModel.spares))
-                             .options(joinedload(AeroplaneModel.wings)
-                                      .joinedload(WingModel.x_secs)
-                                      .joinedload(WingXSecModel.detail)
-                                      .joinedload(WingXSecDetailModel.trailing_edge_device)
-                                      .joinedload(WingXSecTrailingEdgeDeviceModel.servo_data))
-                             .options(joinedload(AeroplaneModel.fuselages)
-                                      .joinedload(FuselageModel.x_secs))
-                             .filter(AeroplaneModel.uuid == aeroplane_id).first())
+    plane: AeroplaneModel = (
+        db.query(AeroplaneModel)
+        .options(
+            joinedload(AeroplaneModel.wings)
+            .joinedload(WingModel.x_secs)
+            .joinedload(WingXSecModel.detail)
+            .joinedload(WingXSecDetailModel.spares)
+        )
+        .options(
+            joinedload(AeroplaneModel.wings)
+            .joinedload(WingModel.x_secs)
+            .joinedload(WingXSecModel.detail)
+            .joinedload(WingXSecDetailModel.trailing_edge_device)
+            .joinedload(WingXSecTrailingEdgeDeviceModel.servo_data)
+        )
+        .options(joinedload(AeroplaneModel.fuselages).joinedload(FuselageModel.x_secs))
+        .filter(AeroplaneModel.uuid == aeroplane_id)
+        .first()
+    )
     if not plane:
         raise NotFoundInDbException(f"Aeroplane with the given ID ({aeroplane_id}) not found.")
-    plane_schema: AeroplaneSchema = await aeroplane_model_to_aeroplane_schema_async(plane)
+    plane_schema: AeroplaneSchema = aeroplane_model_to_aeroplane_schema_async(plane)
     return plane_schema
 
 
@@ -35,7 +41,9 @@ async def get_wing_by_name_and_aeroplane_id(aeroplane_id, wing_name, db):
     # Load the parent aeroplane
     plane_schema = await get_aeroplane_by_id(aeroplane_id, db)
     # Find the wing belonging to this aeroplane
-    wing: AsbWingSchema = next((w for w in plane_schema.wings.values() if w.name == wing_name), None)
+    wing: AsbWingSchema = next(
+        (w for w in plane_schema.wings.values() if w.name == wing_name), None
+    )
     if not wing:
         raise NotFoundInDbException(f"Wing '{wing_name}' not found")
     return plane_schema

--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -33,7 +33,9 @@ from app.schemas.strip_forces import StripForcesResponse, SurfaceStripForces, St
 logger = logging.getLogger(__name__)
 
 
-def _extract_alpha_sweep_arrays(result: Any, sweep_request: AlphaSweepRequest) -> tuple[np.ndarray, Optional[np.ndarray], Optional[np.ndarray], Optional[np.ndarray]]:
+def _extract_alpha_sweep_arrays(
+    result: Any, sweep_request: AlphaSweepRequest
+) -> tuple[np.ndarray, Optional[np.ndarray], Optional[np.ndarray], Optional[np.ndarray]]:
     alpha_values = None
     if getattr(result, "flight_condition", None) is not None:
         alpha_values = getattr(result.flight_condition, "alpha", None)
@@ -41,7 +43,7 @@ def _extract_alpha_sweep_arrays(result: Any, sweep_request: AlphaSweepRequest) -
         alpha_values = np.linspace(
             start=sweep_request.alpha_start,
             stop=sweep_request.alpha_end,
-            num=sweep_request.alpha_num
+            num=sweep_request.alpha_num,
         )
     alpha_array = np.atleast_1d(np.asarray(alpha_values, dtype=float))
 
@@ -57,9 +59,7 @@ def _extract_alpha_sweep_arrays(result: Any, sweep_request: AlphaSweepRequest) -
     return alpha_array, cl_values, cd_values, cm_values
 
 
-def _compute_cl_cd_points(
-    alpha: np.ndarray, cl: np.ndarray, cd: np.ndarray, n: int
-) -> dict:
+def _compute_cl_cd_points(alpha: np.ndarray, cl: np.ndarray, cd: np.ndarray, n: int) -> dict:
     """Compute characteristic points from CL and CD arrays."""
     points: dict = {}
 
@@ -68,21 +68,30 @@ def _compute_cl_cd_points(
     if np.isfinite(ld).any():
         i = int(np.nanargmax(ld))
         points["maximum_lift_to_drag_ratio_point"] = {
-            "index": i, "alpha_deg": float(alpha[i]),
-            "CL": float(cl[i]), "CD": float(cd[i]), "Cm": None,
+            "index": i,
+            "alpha_deg": float(alpha[i]),
+            "CL": float(cl[i]),
+            "CD": float(cd[i]),
+            "Cm": None,
             "lift_to_drag_ratio": float(ld[i]),
         }
 
     i = int(np.argmin(cd))
     points["minimum_drag_coefficient_point"] = {
-        "index": i, "alpha_deg": float(alpha[i]),
-        "CL": float(cl[i]), "CD": float(cd[i]), "Cm": None,
+        "index": i,
+        "alpha_deg": float(alpha[i]),
+        "CL": float(cl[i]),
+        "CD": float(cd[i]),
+        "Cm": None,
     }
 
     i = int(np.argmax(cl))
     points["maximum_lift_coefficient_point"] = {
-        "index": i, "alpha_deg": float(alpha[i]),
-        "CL": float(cl[i]), "CD": float(cd[i]), "Cm": None,
+        "index": i,
+        "alpha_deg": float(alpha[i]),
+        "CL": float(cl[i]),
+        "CD": float(cd[i]),
+        "Cm": None,
     }
 
     points["drag_at_zero_lift_point"] = _interpolate_zero_crossing(alpha, cl, cd)
@@ -106,8 +115,11 @@ def _interpolate_zero_crossing(alpha, cl, cd) -> dict:
         }
     i = int(np.argmin(np.abs(cl)))
     return {
-        "index": i, "alpha_deg": float(alpha[i]),
-        "CL": float(cl[i]), "CD": float(cd[i]), "Cm": None,
+        "index": i,
+        "alpha_deg": float(alpha[i]),
+        "CL": float(cl[i]),
+        "CD": float(cd[i]),
+        "Cm": None,
     }
 
 
@@ -123,13 +135,18 @@ def _find_stall_point(alpha, cl, cd, n: int) -> dict:
         else:
             i_stall = min(i_clmax + 1, n - 1)
     return {
-        "index": i_stall, "alpha_deg": float(alpha[i_stall]),
-        "CL": float(cl[i_stall]), "CD": float(cd[i_stall]), "Cm": None,
+        "index": i_stall,
+        "alpha_deg": float(alpha[i_stall]),
+        "CL": float(cl[i_stall]),
+        "CD": float(cd[i_stall]),
+        "Cm": None,
     }
 
 
 def _compute_trim_point(
-    alpha: np.ndarray, cl: np.ndarray, cm: np.ndarray,
+    alpha: np.ndarray,
+    cl: np.ndarray,
+    cm: np.ndarray,
     cd_values: Optional[np.ndarray],
 ) -> dict:
     """Find the trim point where Cm crosses zero."""
@@ -176,16 +193,17 @@ def _compute_alpha_sweep_characteristic_points(
     if cl_values is not None and cd_values is not None:
         n = min(len(cl_values), len(cd_values), len(alpha_array))
         if n > 0:
-            cl_cd_points = _compute_cl_cd_points(
-                alpha_array[:n], cl_values[:n], cd_values[:n], n
-            )
+            cl_cd_points = _compute_cl_cd_points(alpha_array[:n], cl_values[:n], cd_values[:n], n)
             points.update(cl_cd_points)
 
     if cl_values is not None and cm_values is not None:
         n = min(len(cl_values), len(cm_values), len(alpha_array))
         if n > 0:
             points["trim_point_cm_equals_zero"] = _compute_trim_point(
-                alpha_array[:n], cl_values[:n], cm_values[:n], cd_values,
+                alpha_array[:n],
+                cl_values[:n],
+                cm_values[:n],
+                cd_values,
             )
 
     return points
@@ -194,7 +212,7 @@ def _compute_alpha_sweep_characteristic_points(
 async def get_aeroplane_schema_or_raise(db: Session, aeroplane_uuid) -> AeroplaneSchema:
     """
     Get an aeroplane schema by UUID.
-    
+
     Raises:
         NotFoundError: If the aeroplane does not exist.
         InternalError: If a database error occurs.
@@ -202,23 +220,16 @@ async def get_aeroplane_schema_or_raise(db: Session, aeroplane_uuid) -> Aeroplan
     try:
         return await get_aeroplane_by_id(aeroplane_uuid, db)
     except NotFoundInDbException as e:
-        raise NotFoundError(
-            message=str(e),
-            details={"aeroplane_id": str(aeroplane_uuid)}
-        )
+        raise NotFoundError(message=str(e), details={"aeroplane_id": str(aeroplane_uuid)})
     except SQLAlchemyError as e:
         logger.error(f"Database error when getting aeroplane: {e}")
         raise InternalError(message=f"Database error: {e}")
 
 
-async def get_wing_schema_or_raise(
-    db: Session,
-    aeroplane_uuid,
-    wing_name: str
-) -> AeroplaneSchema:
+async def get_wing_schema_or_raise(db: Session, aeroplane_uuid, wing_name: str) -> AeroplaneSchema:
     """
     Get an aeroplane schema with only the specified wing.
-    
+
     Raises:
         NotFoundError: If the aeroplane or wing does not exist.
         InternalError: If a database error occurs.
@@ -227,8 +238,7 @@ async def get_wing_schema_or_raise(
         return await get_wing_by_name_and_aeroplane_id(aeroplane_uuid, wing_name, db)
     except NotFoundInDbException as e:
         raise NotFoundError(
-            message=str(e),
-            details={"aeroplane_id": str(aeroplane_uuid), "wing_name": wing_name}
+            message=str(e), details={"aeroplane_id": str(aeroplane_uuid), "wing_name": wing_name}
         )
     except SQLAlchemyError as e:
         logger.error(f"Database error when getting wing: {e}")
@@ -240,24 +250,24 @@ async def analyze_wing(
     aeroplane_uuid,
     wing_name: str,
     operating_point: OperatingPointSchema,
-    analysis_tool: AnalysisToolUrlType
+    analysis_tool: AnalysisToolUrlType,
 ) -> Any:
     """
     Analyze a single wing using the specified analysis tool.
-    
+
     Raises:
         NotFoundError: If the aeroplane or wing does not exist.
         InternalError: If an analysis error occurs.
     """
     plane_schema = await get_wing_schema_or_raise(db, aeroplane_uuid, wing_name)
-    
+
     try:
-        asb_airplane: Airplane = await aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
+        asb_airplane: Airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
         asb_airplane.xyz_ref = operating_point.xyz_ref
         asb_airplane.wings = [w for w in asb_airplane.wings if w.name == wing_name]
         asb_airplane.fuselages = []
-        
-        result, _ = await analyse_aerodynamics(analysis_tool, operating_point, asb_airplane)
+
+        result, _ = analyse_aerodynamics(analysis_tool, operating_point, asb_airplane)
         return result
     except Exception as e:
         logger.error(f"Error analyzing wing: {e}")
@@ -268,20 +278,20 @@ async def analyze_airplane(
     db: Session,
     aeroplane_uuid,
     operating_point: OperatingPointSchema,
-    analysis_tool: AnalysisToolUrlType
+    analysis_tool: AnalysisToolUrlType,
 ) -> Any:
     """
     Analyze a complete airplane using the specified analysis tool.
-    
+
     Raises:
         NotFoundError: If the aeroplane does not exist.
         InternalError: If an analysis error occurs.
     """
     plane_schema = await get_aeroplane_schema_or_raise(db, aeroplane_uuid)
-    
+
     try:
-        asb_airplane: Airplane = await aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
-        result, _ = await analyse_aerodynamics(analysis_tool, operating_point, asb_airplane)
+        asb_airplane: Airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
+        result, _ = analyse_aerodynamics(analysis_tool, operating_point, asb_airplane)
         return result
     except Exception as e:
         logger.error(f"Error analyzing airplane: {e}")
@@ -307,8 +317,8 @@ async def calculate_streamlines_json(
     plane_schema = await get_aeroplane_schema_or_raise(db, aeroplane_uuid)
 
     try:
-        asb_airplane: Airplane = await aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
-        _, figure = await analyse_aerodynamics(
+        asb_airplane: Airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
+        _, figure = analyse_aerodynamics(
             AnalysisToolUrlType.VORTEX_LATTICE,
             operating_point,
             asb_airplane,
@@ -320,42 +330,40 @@ async def calculate_streamlines_json(
         raise InternalError(message=f"Analysis error: {e}")
 
 
-async def analyze_alpha_sweep(
-    db: Session,
-    aeroplane_uuid,
-    sweep_request: AlphaSweepRequest
-) -> Any:
+async def analyze_alpha_sweep(db: Session, aeroplane_uuid, sweep_request: AlphaSweepRequest) -> Any:
     """
     Perform an angle of attack sweep.
-    
+
     Raises:
         NotFoundError: If the aeroplane does not exist.
         InternalError: If an analysis error occurs.
     """
     plane_schema = await get_aeroplane_schema_or_raise(db, aeroplane_uuid)
-    
+
     try:
-        asb_airplane: Airplane = await aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
-        
+        asb_airplane: Airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
+
         operating_point = OperatingPointSchema(
             altitude=sweep_request.altitude,
             velocity=sweep_request.velocity,
             alpha=np.linspace(
                 start=sweep_request.alpha_start,
                 stop=sweep_request.alpha_end,
-                num=sweep_request.alpha_num
+                num=sweep_request.alpha_num,
             ),
             beta=sweep_request.beta,
             p=sweep_request.p,
             q=sweep_request.q,
             r=sweep_request.r,
-            xyz_ref=sweep_request.xyz_ref
+            xyz_ref=sweep_request.xyz_ref,
         )
-        
-        result, _ = await analyse_aerodynamics(
+
+        result, _ = analyse_aerodynamics(
             AnalysisToolUrlType.AEROBUILDUP, operating_point, asb_airplane
         )
-        alpha_array, cl_values, cd_values, cm_values = _extract_alpha_sweep_arrays(result, sweep_request)
+        alpha_array, cl_values, cd_values, cm_values = _extract_alpha_sweep_arrays(
+            result, sweep_request
+        )
         characteristic_points = _compute_alpha_sweep_characteristic_points(
             alpha_array, cl_values, cd_values, cm_values
         )
@@ -370,10 +378,7 @@ async def analyze_alpha_sweep(
 
 
 async def get_alpha_sweep_diagram_url(
-    db: Session,
-    aeroplane_uuid,
-    sweep_request: AlphaSweepRequest,
-    base_url: str
+    db: Session, aeroplane_uuid, sweep_request: AlphaSweepRequest, base_url: str
 ) -> str:
     """
     Generate an alpha sweep diagram as PNG, save it under tmp, and return its static URL.
@@ -383,7 +388,9 @@ async def get_alpha_sweep_diagram_url(
         result = sweep_data["analysis"]
         characteristic_points = sweep_data["characteristic_points"]
         aircraft_name = sweep_data.get("aircraft_name", str(aeroplane_uuid))
-        alpha_array, cl_values, cd_values, cm_values = _extract_alpha_sweep_arrays(result, sweep_request)
+        alpha_array, cl_values, cd_values, cm_values = _extract_alpha_sweep_arrays(
+            result, sweep_request
+        )
 
         fig, axes = plt.subplots(3, 2, figsize=(18, 16))
         axes = axes.flatten()
@@ -397,7 +404,16 @@ async def get_alpha_sweep_diagram_url(
         def annotate_with_collision_avoidance(ax, points_with_labels):
             used = []
             for x, y, label, color in points_with_labels:
-                candidate_offsets = [(12, 12), (12, -14), (-70, 14), (-70, -14), (36, 26), (36, -26), (-96, 26), (-96, -26)]
+                candidate_offsets = [
+                    (12, 12),
+                    (12, -14),
+                    (-70, 14),
+                    (-70, -14),
+                    (36, 26),
+                    (36, -26),
+                    (-96, 26),
+                    (-96, -26),
+                ]
                 chosen = candidate_offsets[0]
                 for ox, oy in candidate_offsets:
                     if all(abs(ox - uox) > 20 or abs(oy - uoy) > 12 for _, _, uox, uoy in used):
@@ -411,8 +427,19 @@ async def get_alpha_sweep_diagram_url(
                     textcoords="offset points",
                     fontsize=8,
                     color=color,
-                    bbox=dict(boxstyle="round,pad=0.25", facecolor="white", edgecolor=color, linewidth=0.8, alpha=0.9),
-                    arrowprops=dict(arrowstyle="-", linestyle=":", color=color, linewidth=0.9),
+                    bbox={
+                        "boxstyle": "round,pad=0.25",
+                        "facecolor": "white",
+                        "edgecolor": color,
+                        "linewidth": 0.8,
+                        "alpha": 0.9,
+                    },
+                    arrowprops={
+                        "arrowstyle": "-",
+                        "linestyle": ":",
+                        "color": color,
+                        "linewidth": 0.9,
+                    },
                 )
 
         def add_trend_strip(ax, x_vals: np.ndarray, color_vals: list[str], strip_label: str):
@@ -424,7 +451,9 @@ async def get_alpha_sweep_diagram_url(
                 edges = np.array([x[0] - 0.5, x[0] + 0.5], dtype=float)
             else:
                 mids = (x[:-1] + x[1:]) / 2.0
-                edges = np.concatenate(([x[0] - (mids[0] - x[0])], mids, [x[-1] + (x[-1] - mids[-1])]))
+                edges = np.concatenate(
+                    ([x[0] - (mids[0] - x[0])], mids, [x[-1] + (x[-1] - mids[-1])])
+                )
 
             strip_ax = ax.inset_axes([0.06, -0.20, 0.88, 0.07])
             for i in range(n):
@@ -435,7 +464,15 @@ async def get_alpha_sweep_diagram_url(
             strip_ax.set_xticks([])
             for spine in strip_ax.spines.values():
                 spine.set_visible(False)
-            strip_ax.text(0.0, 0.5, strip_label, transform=strip_ax.transAxes, va="center", ha="left", fontsize=8)
+            strip_ax.text(
+                0.0,
+                0.5,
+                strip_label,
+                transform=strip_ax.transAxes,
+                va="center",
+                ha="left",
+                fontsize=8,
+            )
 
         plotted = False
         alpha_point_labels = []
@@ -445,10 +482,16 @@ async def get_alpha_sweep_diagram_url(
         neutral_combined_labels = []
 
         xnp_values = None
-        if getattr(result, "reference", None) is not None and getattr(result.reference, "Xnp", None) is not None:
+        if (
+            getattr(result, "reference", None) is not None
+            and getattr(result.reference, "Xnp", None) is not None
+        ):
             xnp_values = np.atleast_1d(np.asarray(result.reference.Xnp, dtype=float))
         xnp_lat_values = None
-        if getattr(result, "reference", None) is not None and getattr(result.reference, "Xnp_lat", None) is not None:
+        if (
+            getattr(result, "reference", None) is not None
+            and getattr(result.reference, "Xnp_lat", None) is not None
+        ):
             xnp_lat_values = np.atleast_1d(np.asarray(result.reference.Xnp_lat, dtype=float))
 
         lift_values = drag_values = None
@@ -479,7 +522,7 @@ async def get_alpha_sweep_diagram_url(
             if length > 0:
                 cl_polar = cl_values[:length]
                 cd_polar = cd_values[:length]
-                alpha_polar = alpha_array[:min(len(alpha_array), length)]
+                alpha_polar = alpha_array[: min(len(alpha_array), length)]
 
                 ax_polar.plot(cd_polar, cl_polar, linewidth=2, label="Polar Curve")
                 plotted = True
@@ -506,7 +549,10 @@ async def get_alpha_sweep_diagram_url(
                     x_val = point["CD"]
                     y_val = point["CL"]
                     ax_polar.scatter(x_val, y_val, color=marker_style[key], s=35, zorder=5)
-                    if key == "maximum_lift_to_drag_ratio_point" and point.get("lift_to_drag_ratio") is not None:
+                    if (
+                        key == "maximum_lift_to_drag_ratio_point"
+                        and point.get("lift_to_drag_ratio") is not None
+                    ):
                         label = f"{label_name[key]}={point['lift_to_drag_ratio']:.2f}\nCD={x_val:.3f}, CL={y_val:.3f}"
                     elif key == "minimum_drag_coefficient_point":
                         label = f"{label_name[key]}={x_val:.3f}\nCL={y_val:.3f}"
@@ -526,7 +572,7 @@ async def get_alpha_sweep_diagram_url(
                         linestyle="--",
                         linewidth=1.2,
                         color="gray",
-                        alpha=0.8
+                        alpha=0.8,
                     )
 
                 if len(alpha_polar) > 0:
@@ -548,13 +594,22 @@ async def get_alpha_sweep_diagram_url(
                             if y_val is None:
                                 continue
                             ax_coeff.scatter(alpha_val, y_val, color=color, s=25, zorder=5)
-                            alpha_point_labels.append((alpha_val, y_val, f"{text}={y_val:.3f} @ a={alpha_val:.2f}", color))
+                            alpha_point_labels.append(
+                                (alpha_val, y_val, f"{text}={y_val:.3f} @ a={alpha_val:.2f}", color)
+                            )
                         else:
                             y_val = point.get("CL")
                             if y_val is None:
                                 continue
                             ax_coeff.scatter(alpha_val, y_val, color=color, s=25, zorder=5)
-                            alpha_point_labels.append((alpha_val, y_val, f"{text} @ a={alpha_val:.2f}, CL={y_val:.3f}", color))
+                            alpha_point_labels.append(
+                                (
+                                    alpha_val,
+                                    y_val,
+                                    f"{text} @ a={alpha_val:.2f}, CL={y_val:.3f}",
+                                    color,
+                                )
+                            )
 
         if cl_values is not None and cm_values is not None:
             length = min(len(cl_values), len(cm_values))
@@ -582,7 +637,9 @@ async def get_alpha_sweep_diagram_url(
                 if length > 1:
                     points = np.column_stack((cm_curve, cl_curve))
                     segments = np.stack([points[:-1], points[1:]], axis=1)
-                    segment_colors = cm_strip_colors[1:] if len(cm_strip_colors) > 1 else ["#4caf50"]
+                    segment_colors = (
+                        cm_strip_colors[1:] if len(cm_strip_colors) > 1 else ["#4caf50"]
+                    )
                     lc = LineCollection(segments, colors=segment_colors, linewidths=2.2, alpha=0.95)
                     ax_cm.add_collection(lc)
                     ax_cm.autoscale_view()
@@ -604,11 +661,20 @@ async def get_alpha_sweep_diagram_url(
 
                     if alpha_trim is not None:
                         ax_coeff.scatter(alpha_trim, 0.0, color="tab:brown", s=25, zorder=5)
-                        alpha_point_labels.append((alpha_trim, 0.0, f"Trim (Cm=0) @ a={alpha_trim:.2f}", "tab:brown"))
+                        alpha_point_labels.append(
+                            (alpha_trim, 0.0, f"Trim (Cm=0) @ a={alpha_trim:.2f}", "tab:brown")
+                        )
 
                     if cd_trim is not None:
                         ax_polar.scatter(cd_trim, cl_trim, color="tab:brown", s=35, zorder=5)
-                        polar_point_labels.append((cd_trim, cl_trim, f"Trim (Cm=0)\nCD={cd_trim:.3f}, CL={cl_trim:.3f}", "tab:brown"))
+                        polar_point_labels.append(
+                            (
+                                cd_trim,
+                                cl_trim,
+                                f"Trim (Cm=0)\nCD={cd_trim:.3f}, CL={cl_trim:.3f}",
+                                "tab:brown",
+                            )
+                        )
 
                 # Trend strip for longitudinal stability regime based on dCm/dalpha.
                 add_trend_strip(ax_coeff, alpha_cm, cm_strip_colors, "Cm trend")
@@ -624,12 +690,14 @@ async def get_alpha_sweep_diagram_url(
                 if np.isfinite(deviation).any():
                     outlier_idx = int(np.nanargmax(deviation))
                     outlier_alpha = alpha_array[min(outlier_idx, len(alpha_array) - 1)]
-                    neutral_combined_labels.append((
-                        outlier_alpha,
-                        xnp_curve[outlier_idx],
-                        f"Xnp Ausreißer?\na={outlier_alpha:.2f}, Xnp={xnp_curve[outlier_idx]:.3f}",
-                        "tab:red"
-                    ))
+                    neutral_combined_labels.append(
+                        (
+                            outlier_alpha,
+                            xnp_curve[outlier_idx],
+                            f"Xnp Ausreißer?\na={outlier_alpha:.2f}, Xnp={xnp_curve[outlier_idx]:.3f}",
+                            "tab:red",
+                        )
+                    )
 
         if lift_values is not None and drag_values is not None:
             ld_len = min(len(alpha_array), len(lift_values), len(drag_values))
@@ -645,19 +713,25 @@ async def get_alpha_sweep_diagram_url(
 
                 if np.isfinite(ld_curve).any():
                     i_ldmax = int(np.nanargmax(ld_curve))
-                    ax_ld.scatter(alpha_ld[i_ldmax], ld_curve[i_ldmax], color="tab:green", s=35, zorder=5)
-                    ld_point_labels.append((
-                        alpha_ld[i_ldmax],
-                        ld_curve[i_ldmax],
-                        f"Sweet Spot\na={alpha_ld[i_ldmax]:.2f}, L/D={ld_curve[i_ldmax]:.2f}",
-                        "tab:green"
-                    ))
+                    ax_ld.scatter(
+                        alpha_ld[i_ldmax], ld_curve[i_ldmax], color="tab:green", s=35, zorder=5
+                    )
+                    ld_point_labels.append(
+                        (
+                            alpha_ld[i_ldmax],
+                            ld_curve[i_ldmax],
+                            f"Sweet Spot\na={alpha_ld[i_ldmax]:.2f}, L/D={ld_curve[i_ldmax]:.2f}",
+                            "tab:green",
+                        )
+                    )
 
         if xnp_lat_values is not None and len(xnp_lat_values) > 0:
             lat_len = min(len(alpha_array), len(xnp_lat_values))
             if lat_len > 0:
                 x_axis = alpha_array[:lat_len]
-                ax_neutral_combined.plot(x_axis, xnp_lat_values[:lat_len], linewidth=2, color="tab:pink", label="Xnp_lat")
+                ax_neutral_combined.plot(
+                    x_axis, xnp_lat_values[:lat_len], linewidth=2, color="tab:pink", label="Xnp_lat"
+                )
                 plotted = True
 
                 median_lat = float(np.nanmedian(xnp_lat_values[:lat_len]))
@@ -666,12 +740,14 @@ async def get_alpha_sweep_diagram_url(
                     outlier_idx = int(np.nanargmax(deviation_lat))
                     outlier_x = x_axis[outlier_idx]
                     outlier_y = xnp_lat_values[outlier_idx]
-                    neutral_combined_labels.append((
-                        outlier_x,
-                        outlier_y,
-                        f"Xnp_lat Ausreißer?\na={outlier_x:.2f}, Xnp_lat={outlier_y:.3f}",
-                        "tab:red"
-                    ))
+                    neutral_combined_labels.append(
+                        (
+                            outlier_x,
+                            outlier_y,
+                            f"Xnp_lat Ausreißer?\na={outlier_x:.2f}, Xnp_lat={outlier_y:.3f}",
+                            "tab:red",
+                        )
+                    )
 
                 if lat_len > 1:
                     jumps = np.abs(np.diff(xnp_lat_values[:lat_len]))
@@ -679,27 +755,34 @@ async def get_alpha_sweep_diagram_url(
                         jump_idx = int(np.nanargmax(jumps)) + 1
                         jump_x = x_axis[jump_idx]
                         jump_y = xnp_lat_values[jump_idx]
-                        neutral_combined_labels.append((
-                            jump_x,
-                            jump_y,
-                            f"Xnp_lat Sprung\na={jump_x:.2f}",
-                            "tab:orange"
-                        ))
+                        neutral_combined_labels.append(
+                            (jump_x, jump_y, f"Xnp_lat Sprung\na={jump_x:.2f}", "tab:orange")
+                        )
 
         if xnp_values is not None and xnp_lat_values is not None:
             comb_len = min(len(alpha_array), len(xnp_values), len(xnp_lat_values))
             if comb_len > 0:
                 x_axis = alpha_array[:comb_len]
                 xnp_curve = xnp_values[:comb_len]
-                ax_neutral_combined.plot(x_axis, xnp_curve, linewidth=2, color="tab:cyan", label="Xnp")
+                ax_neutral_combined.plot(
+                    x_axis, xnp_curve, linewidth=2, color="tab:cyan", label="Xnp"
+                )
                 plotted = True
                 for x, y, _, color in neutral_combined_labels:
                     ax_neutral_combined.scatter(x, y, color=color, s=30, zorder=5)
 
                 xnp_lat_curve = xnp_lat_values[:comb_len]
                 with np.errstate(divide="ignore", invalid="ignore"):
-                    gx = np.abs(np.gradient(xnp_curve, x_axis)) if comb_len > 1 else np.array([np.nan])
-                    gy = np.abs(np.gradient(xnp_lat_curve, x_axis)) if comb_len > 1 else np.array([np.nan])
+                    gx = (
+                        np.abs(np.gradient(xnp_curve, x_axis))
+                        if comb_len > 1
+                        else np.array([np.nan])
+                    )
+                    gy = (
+                        np.abs(np.gradient(xnp_lat_curve, x_axis))
+                        if comb_len > 1
+                        else np.array([np.nan])
+                    )
                 combined_metric = gx + gy
                 valid = combined_metric[np.isfinite(combined_metric)]
                 if len(valid) > 0:
@@ -721,7 +804,9 @@ async def get_alpha_sweep_diagram_url(
 
         if not plotted:
             plt.close(fig)
-            raise InternalError(message="Alpha sweep results did not contain plottable coefficient data.")
+            raise InternalError(
+                message="Alpha sweep results did not contain plottable coefficient data."
+            )
 
         ax_coeff.set_xlabel("Alpha [deg]")
         ax_coeff.set_ylabel("Coefficient [-]")
@@ -757,7 +842,9 @@ async def get_alpha_sweep_diagram_url(
         ax_neutral_combined.legend()
         annotate_with_collision_avoidance(ax_neutral_combined, neutral_combined_labels)
 
-        def classify_longitudinal_stability(cm_vals: Optional[np.ndarray], alpha_vals: np.ndarray) -> tuple[str, str]:
+        def classify_longitudinal_stability(
+            cm_vals: Optional[np.ndarray], alpha_vals: np.ndarray
+        ) -> tuple[str, str]:
             if cm_vals is None:
                 return "N/A", "gray"
             n = min(len(cm_vals), len(alpha_vals))
@@ -793,32 +880,53 @@ async def get_alpha_sweep_diagram_url(
         generated_at = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         summary_lines.append((f"Aircraft: {aircraft_name}", "black"))
         summary_lines.append((f"Generated: {generated_at}", "black"))
-        summary_lines.append((
-            f"OpPoint: V={sweep_request.velocity:.2f} m/s, h={sweep_request.altitude:.1f} m, "
-            f"beta={sweep_request.beta:.2f} deg",
-            "black",
-        ))
-        summary_lines.append((
-            f"Rates: p={sweep_request.p:.3f}, q={sweep_request.q:.3f}, r={sweep_request.r:.3f} rad/s | "
-            f"xyz_ref={sweep_request.xyz_ref}",
-            "black",
-        ))
+        summary_lines.append(
+            (
+                f"OpPoint: V={sweep_request.velocity:.2f} m/s, h={sweep_request.altitude:.1f} m, "
+                f"beta={sweep_request.beta:.2f} deg",
+                "black",
+            )
+        )
+        summary_lines.append(
+            (
+                f"Rates: p={sweep_request.p:.3f}, q={sweep_request.q:.3f}, r={sweep_request.r:.3f} rad/s | "
+                f"xyz_ref={sweep_request.xyz_ref}",
+                "black",
+            )
+        )
         ldmax = characteristic_points.get("maximum_lift_to_drag_ratio_point")
         cdmin = characteristic_points.get("minimum_drag_coefficient_point")
         clmax = characteristic_points.get("maximum_lift_coefficient_point")
         trim = characteristic_points.get("trim_point_cm_equals_zero")
         stall = characteristic_points.get("stall_point")
 
-        if ldmax and ldmax.get("lift_to_drag_ratio") is not None and ldmax.get("alpha_deg") is not None:
-            summary_lines.append((f"L/D max: {ldmax['lift_to_drag_ratio']:.2f} @ a={ldmax['alpha_deg']:.2f}", "tab:green"))
+        if (
+            ldmax
+            and ldmax.get("lift_to_drag_ratio") is not None
+            and ldmax.get("alpha_deg") is not None
+        ):
+            summary_lines.append(
+                (
+                    f"L/D max: {ldmax['lift_to_drag_ratio']:.2f} @ a={ldmax['alpha_deg']:.2f}",
+                    "tab:green",
+                )
+            )
         if cdmin and cdmin.get("CD") is not None and cdmin.get("alpha_deg") is not None:
-            summary_lines.append((f"CD min: {cdmin['CD']:.3f} @ a={cdmin['alpha_deg']:.2f}", "tab:blue"))
+            summary_lines.append(
+                (f"CD min: {cdmin['CD']:.3f} @ a={cdmin['alpha_deg']:.2f}", "tab:blue")
+            )
         if clmax and clmax.get("CL") is not None and clmax.get("alpha_deg") is not None:
-            summary_lines.append((f"CL max: {clmax['CL']:.3f} @ a={clmax['alpha_deg']:.2f}", "tab:red"))
+            summary_lines.append(
+                (f"CL max: {clmax['CL']:.3f} @ a={clmax['alpha_deg']:.2f}", "tab:red")
+            )
         if trim and trim.get("alpha_deg") is not None and trim.get("CL") is not None:
-            summary_lines.append((f"Trim (Cm=0): a={trim['alpha_deg']:.2f}, CL={trim['CL']:.3f}", "tab:brown"))
+            summary_lines.append(
+                (f"Trim (Cm=0): a={trim['alpha_deg']:.2f}, CL={trim['CL']:.3f}", "tab:brown")
+            )
         if stall and stall.get("alpha_deg") is not None and stall.get("CL") is not None:
-            summary_lines.append((f"Stall-Indiz: a={stall['alpha_deg']:.2f}, CL={stall['CL']:.3f}", "tab:orange"))
+            summary_lines.append(
+                (f"Stall-Indiz: a={stall['alpha_deg']:.2f}, CL={stall['CL']:.3f}", "tab:orange")
+            )
 
         long_text, long_color = classify_longitudinal_stability(cm_values, alpha_array)
         xnp_text, xnp_color = classify_variation(xnp_values, "Xnp trend")
@@ -861,22 +969,20 @@ async def get_alpha_sweep_diagram_url(
 
 
 async def analyze_simple_sweep(
-    db: Session,
-    aeroplane_uuid,
-    sweep_request: SimpleSweepRequest
+    db: Session, aeroplane_uuid, sweep_request: SimpleSweepRequest
 ) -> Any:
     """
     Perform a parameter sweep.
-    
+
     Raises:
         NotFoundError: If the aeroplane does not exist.
         InternalError: If an analysis error occurs.
     """
     plane_schema = await get_aeroplane_schema_or_raise(db, aeroplane_uuid)
-    
+
     try:
-        asb_airplane: Airplane = await aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
-        
+        asb_airplane: Airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
+
         operating_point = OperatingPointSchema(
             name=f"sweep over {sweep_request.sweep_var}",
             description=None,
@@ -887,57 +993,70 @@ async def analyze_simple_sweep(
             p=sweep_request.p,
             q=sweep_request.q,
             r=sweep_request.r,
-            xyz_ref=sweep_request.xyz_ref
+            xyz_ref=sweep_request.xyz_ref,
         )
-        
+
         def vary_index(
-            values: List[float],
-            index: int,
-            start: float,
-            stop: float,
-            num: int
+            values: List[float], index: int, start: float, stop: float, num: int
         ) -> List[List[float]]:
             return [
                 [val if i != index else v for i, val in enumerate(values)]
                 for v in np.linspace(start, stop, num)
             ]
-        
-        if sweep_request.sweep_var in ['alpha', 'velocity', 'beta', 'p', 'q', 'r', 'altitude']:
+
+        if sweep_request.sweep_var in ["alpha", "velocity", "beta", "p", "q", "r", "altitude"]:
             current_val = operating_point.__dict__[sweep_request.sweep_var]
             operating_point.__dict__[sweep_request.sweep_var] = np.linspace(
                 start=current_val,
                 stop=current_val + sweep_request.step_size * sweep_request.num,
-                num=sweep_request.num
+                num=sweep_request.num,
             )
-        elif sweep_request.sweep_var == 'x':
+        elif sweep_request.sweep_var == "x":
             operating_point.xyz_ref = vary_index(
-                operating_point.xyz_ref, 0,
+                operating_point.xyz_ref,
+                0,
                 start=operating_point.xyz_ref[0],
                 stop=operating_point.xyz_ref[0] + sweep_request.step_size * sweep_request.num,
-                num=sweep_request.num
+                num=sweep_request.num,
             )
-        elif sweep_request.sweep_var == 'y':
+        elif sweep_request.sweep_var == "y":
             operating_point.xyz_ref = vary_index(
-                operating_point.xyz_ref, 1,
+                operating_point.xyz_ref,
+                1,
                 start=operating_point.xyz_ref[1],
                 stop=operating_point.xyz_ref[1] + sweep_request.step_size * sweep_request.num,
-                num=sweep_request.num
+                num=sweep_request.num,
             )
-        elif sweep_request.sweep_var == 'z':
+        elif sweep_request.sweep_var == "z":
             operating_point.xyz_ref = vary_index(
-                operating_point.xyz_ref, 2,
+                operating_point.xyz_ref,
+                2,
                 start=operating_point.xyz_ref[2],
                 stop=operating_point.xyz_ref[2] + sweep_request.step_size * sweep_request.num,
-                num=sweep_request.num
+                num=sweep_request.num,
             )
         else:
             from app.core.exceptions import ValidationError
+
             raise ValidationError(
                 message=f"Invalid sweep variable: {sweep_request.sweep_var}",
-                details={"valid_vars": ['alpha', 'velocity', 'beta', 'p', 'q', 'r', 'altitude', 'x', 'y', 'z']}
+                details={
+                    "valid_vars": [
+                        "alpha",
+                        "velocity",
+                        "beta",
+                        "p",
+                        "q",
+                        "r",
+                        "altitude",
+                        "x",
+                        "y",
+                        "z",
+                    ]
+                },
             )
-        
-        result, _ = await analyse_aerodynamics(
+
+        result, _ = analyse_aerodynamics(
             AnalysisToolUrlType.AEROBUILDUP, operating_point, asb_airplane
         )
         return result
@@ -947,34 +1066,32 @@ async def analyze_simple_sweep(
 
 
 async def get_streamlines_three_view_image(
-    db: Session,
-    aeroplane_uuid,
-    operating_point: OperatingPointSchema
+    db: Session, aeroplane_uuid, operating_point: OperatingPointSchema
 ) -> bytes:
     """
     Generate a four-view diagram with streamlines as PNG.
-    
+
     Returns:
         bytes: PNG image data.
-    
+
     Raises:
         NotFoundError: If the aeroplane does not exist.
         InternalError: If an analysis error occurs.
     """
     plane_schema = await get_aeroplane_schema_or_raise(db, aeroplane_uuid)
-    
+
     try:
-        asb_airplane: Airplane = await aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
-        
-        _, figure = await analyse_aerodynamics(
+        asb_airplane: Airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
+
+        _, figure = analyse_aerodynamics(
             AnalysisToolUrlType.VORTEX_LATTICE,
             operating_point,
             asb_airplane,
             draw_streamlines=True,
-            backend='plotly'
+            backend="plotly",
         )
-        
-        fig = await compile_four_view_figure(figure)
+
+        fig = compile_four_view_figure(figure)
         img_bytes = fig.to_image(format="png", width=1000, height=1000, scale=2)
         return img_bytes
     except Exception as e:
@@ -985,27 +1102,27 @@ async def get_streamlines_three_view_image(
 async def get_three_view_image(db: Session, aeroplane_uuid) -> bytes:
     """
     Generate a three-view diagram as PNG.
-    
+
     Returns:
         bytes: PNG image data.
-    
+
     Raises:
         NotFoundError: If the aeroplane does not exist.
         InternalError: If an error occurs.
     """
     plane_schema = await get_aeroplane_schema_or_raise(db, aeroplane_uuid)
-    
+
     try:
-        asb_airplane: Airplane = await aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
-        
+        asb_airplane: Airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
+
         fig = plt.figure(figsize=(10, 10))
         asb_airplane.draw_three_view(show=False)
-        
+
         img_bytes = io.BytesIO()
-        plt.savefig(img_bytes, format='png', dpi=300, bbox_inches='tight')
+        plt.savefig(img_bytes, format="png", dpi=300, bbox_inches="tight")
         img_bytes.seek(0)
         plt.close(fig)
-        
+
         return img_bytes.getvalue()
     except Exception as e:
         logger.error(f"Error generating three-view: {e}")
@@ -1031,7 +1148,7 @@ async def analyze_airplane_strip_forces(
     plane_schema = await get_aeroplane_schema_or_raise(db, aeroplane_uuid)
 
     try:
-        asb_airplane: Airplane = await aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
+        asb_airplane: Airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
         asb_airplane.xyz_ref = operating_point.xyz_ref
 
         atmosphere = asb.Atmosphere(altitude=operating_point.altitude)
@@ -1045,9 +1162,7 @@ async def analyze_airplane_strip_forces(
             atmosphere=atmosphere,
         )
 
-        avl_command = str(
-            _Path(__file__).resolve().parents[2] / "exports" / "avl"
-        )
+        avl_command = str(_Path(__file__).resolve().parents[2] / "exports" / "avl")
 
         avl = AVLWithStripForces(
             airplane=asb_airplane,
@@ -1062,14 +1177,16 @@ async def analyze_airplane_strip_forces(
         surfaces = []
         for sf in strip_forces_data:
             strips = [StripForceEntry.model_validate(s) for s in sf["strips"]]
-            surfaces.append(SurfaceStripForces(
-                surface_name=sf["surface_name"],
-                surface_number=sf["surface_number"],
-                n_chordwise=sf["n_chordwise"],
-                n_spanwise=sf["n_spanwise"],
-                surface_area=sf["surface_area"],
-                strips=strips,
-            ))
+            surfaces.append(
+                SurfaceStripForces(
+                    surface_name=sf["surface_name"],
+                    surface_number=sf["surface_number"],
+                    n_chordwise=sf["n_chordwise"],
+                    n_spanwise=sf["n_spanwise"],
+                    surface_area=sf["surface_area"],
+                    strips=strips,
+                )
+            )
 
         return StripForcesResponse(
             alpha=result.get("alpha", operating_point.alpha),
@@ -1108,7 +1225,7 @@ async def analyze_wing_strip_forces(
     plane_schema = await get_wing_schema_or_raise(db, aeroplane_uuid, wing_name)
 
     try:
-        asb_airplane: Airplane = await aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
+        asb_airplane: Airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
         asb_airplane.xyz_ref = operating_point.xyz_ref
         asb_airplane.wings = [w for w in asb_airplane.wings if w.name == wing_name]
         asb_airplane.fuselages = []
@@ -1124,9 +1241,7 @@ async def analyze_wing_strip_forces(
             atmosphere=atmosphere,
         )
 
-        avl_command = str(
-            _Path(__file__).resolve().parents[2] / "exports" / "avl"
-        )
+        avl_command = str(_Path(__file__).resolve().parents[2] / "exports" / "avl")
 
         avl = AVLWithStripForces(
             airplane=asb_airplane,
@@ -1141,14 +1256,16 @@ async def analyze_wing_strip_forces(
         surfaces = []
         for sf in strip_forces_data:
             strips = [StripForceEntry.model_validate(s) for s in sf["strips"]]
-            surfaces.append(SurfaceStripForces(
-                surface_name=sf["surface_name"],
-                surface_number=sf["surface_number"],
-                n_chordwise=sf["n_chordwise"],
-                n_spanwise=sf["n_spanwise"],
-                surface_area=sf["surface_area"],
-                strips=strips,
-            ))
+            surfaces.append(
+                SurfaceStripForces(
+                    surface_name=sf["surface_name"],
+                    surface_number=sf["surface_number"],
+                    n_chordwise=sf["n_chordwise"],
+                    n_spanwise=sf["n_spanwise"],
+                    surface_area=sf["surface_area"],
+                    strips=strips,
+                )
+            )
 
         return StripForcesResponse(
             alpha=result.get("alpha", operating_point.alpha),

--- a/app/services/avl_strip_forces.py
+++ b/app/services/avl_strip_forces.py
@@ -19,9 +19,21 @@ except ImportError:
 
 # Column names in AVL's FS (strip forces) output table
 _STRIP_COLUMNS = [
-    "j", "Xle", "Yle", "Zle", "Chord", "Area",
-    "c_cl", "ai", "cl_norm", "cl", "cd", "cdv",
-    "cm_c/4", "cm_LE", "C.P.x/c",
+    "j",
+    "Xle",
+    "Yle",
+    "Zle",
+    "Chord",
+    "Area",
+    "c_cl",
+    "ai",
+    "cl_norm",
+    "cl",
+    "cd",
+    "cdv",
+    "cm_c/4",
+    "cm_LE",
+    "C.P.x/c",
 ]
 
 
@@ -177,12 +189,12 @@ if HAS_AEROSANDBOX:
 
                 ks = super()._default_keystroke_file_contents()
                 ks += [
-                    "x",                     # execute analysis
-                    "st",                    # stability output ...
-                    output_filename,         # ... to file
-                    "o",                     # overwrite if exists
+                    "x",  # execute analysis
+                    "st",  # stability output ...
+                    output_filename,  # ... to file
+                    "o",  # overwrite if exists
                     "",
-                    "fs",                    # strip forces to stdout
+                    "fs",  # strip forces to stdout
                     "",
                     "",
                     "quit",
@@ -199,7 +211,8 @@ if HAS_AEROSANDBOX:
                 )
                 try:
                     stdout_bytes, _ = proc.communicate(
-                        input=input_text.encode(), timeout=self.timeout,
+                        input=input_text.encode(),
+                        timeout=self.timeout,
                     )
                 except subprocess.TimeoutExpired:
                     proc.kill()
@@ -213,8 +226,7 @@ if HAS_AEROSANDBOX:
                 output_path = directory / output_filename
                 if not output_path.exists():
                     raise FileNotFoundError(
-                        "AVL didn't produce stability output. "
-                        "Check avl_command and input geometry."
+                        "AVL didn't produce stability output. Check avl_command and input geometry."
                     )
                 with open(output_path) as f:
                     raw = f.read()
@@ -262,9 +274,9 @@ if HAS_AEROSANDBOX:
             CL = result.get("CL", 0)
             CY = result.get("CY", 0)
             CD = result.get("CD", 0)
-            Cl = result.get("Cl", 0)
-            Cm = result.get("Cm", 0)
-            Cn = result.get("Cn", 0)
+            Cl = result.get("Cl", 0)  # noqa: N806 — standard aero coefficient
+            Cm = result.get("Cm", 0)  # noqa: N806 — standard aero coefficient
+            Cn = result.get("Cn", 0)  # noqa: N806 — standard aero coefficient
 
             result["L"] = q * S * CL
             result["Y"] = q * S * CY
@@ -274,21 +286,21 @@ if HAS_AEROSANDBOX:
             result["n_b"] = q * S * b * Cn
 
             try:
-                Clb = result.get("Clb", 0)
-                Cnr = result.get("Cnr", 0)
-                Clr = result.get("Clr", 0)
-                Cnb = result.get("Cnb", 0)
+                Clb = result.get("Clb", 0)  # noqa: N806 — standard aero coefficient
+                Cnr = result.get("Cnr", 0)  # noqa: N806 — standard aero coefficient
+                Clr = result.get("Clr", 0)  # noqa: N806 — standard aero coefficient
+                Cnb = result.get("Cnb", 0)  # noqa: N806 — standard aero coefficient
                 result["Clb Cnr / Clr Cnb"] = Clb * Cnr / (Clr * Cnb)
             except ZeroDivisionError:
                 result["Clb Cnr / Clr Cnb"] = np.nan
 
-            F_w = [-result["D"], result["Y"], -result["L"]]
-            F_b = op.convert_axes(*F_w, from_axes="wind", to_axes="body")
-            F_g = op.convert_axes(*F_b, from_axes="body", to_axes="geometry")
+            F_w = [-result["D"], result["Y"], -result["L"]]  # noqa: N806 — force in wind axes
+            F_b = op.convert_axes(*F_w, from_axes="wind", to_axes="body")  # noqa: N806 — force in body axes
+            F_g = op.convert_axes(*F_b, from_axes="body", to_axes="geometry")  # noqa: N806 — force in geometry axes
 
-            M_b = [result["l_b"], result["m_b"], result["n_b"]]
-            M_g = op.convert_axes(*M_b, from_axes="body", to_axes="geometry")
-            M_w = op.convert_axes(*M_b, from_axes="body", to_axes="wind")
+            M_b = [result["l_b"], result["m_b"], result["n_b"]]  # noqa: N806 — moment in body axes
+            M_g = op.convert_axes(*M_b, from_axes="body", to_axes="geometry")  # noqa: N806 — moment in geometry axes
+            M_w = op.convert_axes(*M_b, from_axes="body", to_axes="wind")  # noqa: N806 — moment in wind axes
 
             result["F_w"] = F_w
             result["F_b"] = F_b

--- a/app/services/copilot_history_service.py
+++ b/app/services/copilot_history_service.py
@@ -13,9 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 def _get_aeroplane(db: Session, aeroplane_uuid) -> AeroplaneModel:
-    aeroplane = db.query(AeroplaneModel).filter(
-        AeroplaneModel.uuid == aeroplane_uuid
-    ).first()
+    aeroplane = db.query(AeroplaneModel).filter(AeroplaneModel.uuid == aeroplane_uuid).first()
     if not aeroplane:
         raise NotFoundError(entity="Aeroplane", resource_id=aeroplane_uuid)
     return aeroplane
@@ -39,9 +37,7 @@ def get_history(db: Session, aeroplane_uuid) -> CopilotHistory:
     return CopilotHistory(messages=messages)
 
 
-def append_message(
-    db: Session, aeroplane_uuid, data: CopilotMessageWrite
-) -> CopilotMessageRead:
+def append_message(db: Session, aeroplane_uuid, data: CopilotMessageWrite) -> CopilotMessageRead:
     try:
         aeroplane = _get_aeroplane(db, aeroplane_uuid)
         next_index = len(aeroplane.copilot_messages)
@@ -69,7 +65,7 @@ def append_message(
 def clear_history(db: Session, aeroplane_uuid) -> None:
     try:
         aeroplane = _get_aeroplane(db, aeroplane_uuid)
-        for msg in list(aeroplane.copilot_messages):
+        for msg in list(aeroplane.copilot_messages):  # list() required: deleting during iteration
             db.delete(msg)
         db.commit()
     except NotFoundError:

--- a/app/services/operating_point_generator_service.py
+++ b/app/services/operating_point_generator_service.py
@@ -8,7 +8,10 @@ import numpy as np
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
-from app.converters.model_schema_converters import aeroplane_model_to_aeroplane_schema_async, aeroplane_schema_to_asb_airplane_async
+from app.converters.model_schema_converters import (
+    aeroplane_model_to_aeroplane_schema_async,
+    aeroplane_schema_to_asb_airplane_async,
+)
 from app.core.exceptions import InternalError, NotFoundError, ValidationError
 from app.models.aeroplanemodel import AeroplaneModel
 from app.models.analysismodels import OperatingPointModel, OperatingPointSetModel
@@ -133,7 +136,9 @@ def _estimate_reference_speeds(profile: dict[str, Any]) -> dict[str, float]:
     }
 
 
-def _build_target_definitions(profile: dict[str, Any], refs: dict[str, float]) -> list[dict[str, Any]]:
+def _build_target_definitions(
+    profile: dict[str, Any], refs: dict[str, float]
+) -> list[dict[str, Any]]:
     goals = profile["goals"]
     altitude = float(profile["environment"].get("altitude_m", 0.0))
 
@@ -146,16 +151,86 @@ def _build_target_definitions(profile: dict[str, Any], refs: dict[str, float]) -
     approach = float(goals.get("approach_speed_margin_vs_ldg", 1.30)) * refs["vs_ldg"]
 
     return [
-        {"name": "stall_near_clean", "config": "clean", "velocity": stall_near, "altitude": altitude, "beta_target_deg": 0.0, "n_target": 1.0},
-        {"name": "takeoff_climb", "config": "takeoff", "velocity": takeoff, "altitude": altitude, "beta_target_deg": 0.0, "n_target": 1.0},
-        {"name": "best_angle_climb_vx", "config": "clean", "velocity": max(1.35 * refs["vs_clean"], cruise * 0.85), "altitude": altitude, "beta_target_deg": 0.0, "n_target": 1.0},
-        {"name": "best_rate_climb_vy", "config": "clean", "velocity": max(1.50 * refs["vs_clean"], cruise * 0.95), "altitude": altitude, "beta_target_deg": 0.0, "n_target": 1.0},
-        {"name": "cruise", "config": "clean", "velocity": cruise, "altitude": altitude, "beta_target_deg": 0.0, "n_target": 1.0},
-        {"name": "loiter_endurance", "config": "clean", "velocity": max(1.15 * refs["vs_clean"], cruise * 0.80), "altitude": altitude, "beta_target_deg": 0.0, "n_target": 1.0},
-        {"name": "max_range", "config": "clean", "velocity": max(1.25 * refs["vs_clean"], cruise * 0.95), "altitude": altitude, "beta_target_deg": 0.0, "n_target": 1.0},
-        {"name": "max_level_speed", "config": "clean", "velocity": v_max_level, "altitude": altitude, "beta_target_deg": 0.0, "n_target": 1.0},
-        {"name": "approach_landing", "config": "landing", "velocity": approach, "altitude": altitude, "beta_target_deg": 0.0, "n_target": 1.0},
-        {"name": "turn_n2", "config": "clean", "velocity": max(cruise, 1.3 * refs["vs_clean"]), "altitude": altitude, "beta_target_deg": 0.0, "n_target": target_turn_n},
+        {
+            "name": "stall_near_clean",
+            "config": "clean",
+            "velocity": stall_near,
+            "altitude": altitude,
+            "beta_target_deg": 0.0,
+            "n_target": 1.0,
+        },
+        {
+            "name": "takeoff_climb",
+            "config": "takeoff",
+            "velocity": takeoff,
+            "altitude": altitude,
+            "beta_target_deg": 0.0,
+            "n_target": 1.0,
+        },
+        {
+            "name": "best_angle_climb_vx",
+            "config": "clean",
+            "velocity": max(1.35 * refs["vs_clean"], cruise * 0.85),
+            "altitude": altitude,
+            "beta_target_deg": 0.0,
+            "n_target": 1.0,
+        },
+        {
+            "name": "best_rate_climb_vy",
+            "config": "clean",
+            "velocity": max(1.50 * refs["vs_clean"], cruise * 0.95),
+            "altitude": altitude,
+            "beta_target_deg": 0.0,
+            "n_target": 1.0,
+        },
+        {
+            "name": "cruise",
+            "config": "clean",
+            "velocity": cruise,
+            "altitude": altitude,
+            "beta_target_deg": 0.0,
+            "n_target": 1.0,
+        },
+        {
+            "name": "loiter_endurance",
+            "config": "clean",
+            "velocity": max(1.15 * refs["vs_clean"], cruise * 0.80),
+            "altitude": altitude,
+            "beta_target_deg": 0.0,
+            "n_target": 1.0,
+        },
+        {
+            "name": "max_range",
+            "config": "clean",
+            "velocity": max(1.25 * refs["vs_clean"], cruise * 0.95),
+            "altitude": altitude,
+            "beta_target_deg": 0.0,
+            "n_target": 1.0,
+        },
+        {
+            "name": "max_level_speed",
+            "config": "clean",
+            "velocity": v_max_level,
+            "altitude": altitude,
+            "beta_target_deg": 0.0,
+            "n_target": 1.0,
+        },
+        {
+            "name": "approach_landing",
+            "config": "landing",
+            "velocity": approach,
+            "altitude": altitude,
+            "beta_target_deg": 0.0,
+            "n_target": 1.0,
+        },
+        {
+            "name": "turn_n2",
+            "config": "clean",
+            "velocity": max(cruise, 1.3 * refs["vs_clean"]),
+            "altitude": altitude,
+            "beta_target_deg": 0.0,
+            "n_target": target_turn_n,
+        },
         {
             "name": "dutch_role_start",
             "config": "clean",
@@ -197,7 +272,9 @@ def _detect_control_capabilities(asb_airplane: asb.Airplane) -> dict[str, Any]:
                     normalized_control_names.add(raw_name.lower())
 
     def _contains_any(tokens: set[str]) -> bool:
-        return any(token in control_name for control_name in normalized_control_names for token in tokens)
+        return any(
+            token in control_name for control_name in normalized_control_names for token in tokens
+        )
 
     return {
         "has_pitch_control": _contains_any({"elevator", "stabilator", "elevon"}),
@@ -215,7 +292,9 @@ def _required_capabilities_for_target(target_name: str) -> set[str]:
     return set()
 
 
-def _validate_target_capability(target: dict[str, Any], capabilities: dict[str, Any]) -> tuple[bool, str]:
+def _validate_target_capability(
+    target: dict[str, Any], capabilities: dict[str, Any]
+) -> tuple[bool, str]:
     target_name = str(target.get("name", ""))
     if target_name == "turn_n2":
         if capabilities.get("has_roll_control") or capabilities.get("has_yaw_control"):
@@ -223,7 +302,9 @@ def _validate_target_capability(target: dict[str, Any], capabilities: dict[str, 
         return False, "has_roll_control|has_yaw_control"
 
     required = _required_capabilities_for_target(target_name)
-    missing = sorted(capability for capability in required if not capabilities.get(capability, False))
+    missing = sorted(
+        capability for capability in required if not capabilities.get(capability, False)
+    )
     if missing:
         return False, ",".join(missing)
     return True, ""
@@ -251,7 +332,9 @@ def _solve_trim_candidate_with_opti(
             upper_bound=alpha_upper,
         )
 
-        available_controls = [str(name).strip() for name in capabilities.get("available_controls", [])]
+        available_controls = [
+            str(name).strip() for name in capabilities.get("available_controls", [])
+        ]
         control_values: dict[str, Any] = {}
         control_variables: dict[str, Any] = {}
 
@@ -260,14 +343,20 @@ def _solve_trim_candidate_with_opti(
         roll_name = _pick_control_name(available_controls, {"aileron", "elevon"})
 
         if pitch_name:
-            control_variables[pitch_name] = opti.variable(init_guess=0.0, lower_bound=-25.0, upper_bound=25.0)
+            control_variables[pitch_name] = opti.variable(
+                init_guess=0.0, lower_bound=-25.0, upper_bound=25.0
+            )
         if target["name"] == "turn_n2" and roll_name:
-            control_variables[roll_name] = opti.variable(init_guess=0.0, lower_bound=-20.0, upper_bound=20.0)
+            control_variables[roll_name] = opti.variable(
+                init_guess=0.0, lower_bound=-20.0, upper_bound=20.0
+            )
         if target["name"] in {"turn_n2", "dutch_role_start"} and yaw_name:
-            control_variables[yaw_name] = opti.variable(init_guess=0.0, lower_bound=-25.0, upper_bound=25.0)
+            control_variables[yaw_name] = opti.variable(
+                init_guess=0.0, lower_bound=-25.0, upper_bound=25.0
+            )
 
         if control_variables:
-            control_values = {name: value for name, value in control_variables.items()}
+            control_values = dict(control_variables.items())
             airplane_for_eval = asb_airplane.with_control_deflections(control_values)
         else:
             airplane_for_eval = asb_airplane
@@ -326,7 +415,7 @@ def _solve_trim_candidate_with_opti(
         return None
 
 
-async def _evaluate_trim_candidate(
+def _evaluate_trim_candidate(
     asb_airplane: asb.Airplane,
     altitude_m: float,
     velocity_mps: float,
@@ -346,7 +435,9 @@ async def _evaluate_trim_candidate(
         atmosphere=atmosphere,
     )
 
-    airplane_for_eval = asb_airplane.with_control_deflections(controls) if controls else asb_airplane
+    airplane_for_eval = (
+        asb_airplane.with_control_deflections(controls) if controls else asb_airplane
+    )
     result = asb.AeroBuildup(
         airplane=airplane_for_eval,
         op_point=op,
@@ -401,7 +492,7 @@ async def _grid_search_trim(
         for beta_deg in beta_candidates:
             for alpha_deg in alpha_candidates:
                 try:
-                    score, _ = await _evaluate_trim_candidate(
+                    score, _ = _evaluate_trim_candidate(
                         asb_airplane=asb_airplane,
                         altitude_m=altitude,
                         velocity_mps=candidate_velocity,
@@ -424,11 +515,16 @@ async def _grid_search_trim(
 
 
 def _apply_limit_warnings(
-    best_alpha: float, best_beta: float, best_score: float,
-    constraints: dict[str, Any], warnings: list[str],
+    best_alpha: float,
+    best_beta: float,
+    best_score: float,
+    constraints: dict[str, Any],
+    warnings: list[str],
 ) -> OperatingPointStatus:
     """Determine trim status and append limit-reached warnings."""
-    trim_status = OperatingPointStatus.TRIMMED if best_score < 0.35 else OperatingPointStatus.NOT_TRIMMED
+    trim_status = (
+        OperatingPointStatus.TRIMMED if best_score < 0.35 else OperatingPointStatus.NOT_TRIMMED
+    )
     if trim_status == OperatingPointStatus.NOT_TRIMMED:
         warnings.append("NOT_TRIMMED")
 
@@ -474,11 +570,14 @@ async def _trim_or_estimate_point(
     best_controls: dict[str, float] = {}
 
     opti_solution = _solve_trim_candidate_with_opti(
-        asb_airplane=asb_airplane, target=target,
-        velocity_mps=velocity, altitude_m=altitude,
+        asb_airplane=asb_airplane,
+        target=target,
+        velocity_mps=velocity,
+        altitude_m=altitude,
         beta_target_deg=float(beta_candidates[0]),
         cl_target=cl_target_fn(velocity),
-        constraints=constraints, capabilities=capabilities,
+        constraints=constraints,
+        capabilities=capabilities,
     )
     if opti_solution and opti_solution["score"] < best_score:
         best_score = float(opti_solution["score"])
@@ -489,10 +588,20 @@ async def _trim_or_estimate_point(
     # Fallback grid-search if opti didn't converge well enough
     if best_score > 0.35:
         gs_score, gs_alpha, gs_beta, gs_velocity, gs_controls = await _grid_search_trim(
-            asb_airplane, target, velocity, altitude, beta_candidates, cl_target_fn,
+            asb_airplane,
+            target,
+            velocity,
+            altitude,
+            beta_candidates,
+            cl_target_fn,
         )
         if gs_score < best_score:
-            best_score, best_alpha, best_beta, best_controls = gs_score, gs_alpha, gs_beta, gs_controls
+            best_score, best_alpha, best_beta, best_controls = (
+                gs_score,
+                gs_alpha,
+                gs_beta,
+                gs_controls,
+            )
             velocity = gs_velocity
 
     trim_status = _apply_limit_warnings(best_alpha, best_beta, best_score, constraints, warnings)
@@ -508,7 +617,9 @@ async def _trim_or_estimate_point(
         altitude=float(altitude),
         alpha_rad=math.radians(best_alpha),
         beta_rad=math.radians(best_beta),
-        p=0.0, q=0.0, r=0.0,
+        p=0.0,
+        q=0.0,
+        r=0.0,
         status=trim_status,
         warnings=warnings,
         controls=best_controls,
@@ -526,9 +637,9 @@ def _persist_point_set(
         db.query(OperatingPointSetModel).filter(
             OperatingPointSetModel.aircraft_id == aircraft.id
         ).delete(synchronize_session=False)
-        db.query(OperatingPointModel).filter(
-            OperatingPointModel.aircraft_id == aircraft.id
-        ).delete(synchronize_session=False)
+        db.query(OperatingPointModel).filter(OperatingPointModel.aircraft_id == aircraft.id).delete(
+            synchronize_session=False
+        )
 
     stored_points: list[OperatingPointModel] = []
     for point in points:
@@ -575,12 +686,14 @@ async def generate_default_set_for_aircraft(
 ) -> GeneratedOperatingPointSetRead:
     try:
         aircraft = _get_aircraft_or_raise(db, aircraft_uuid)
-        profile, source_profile_id = _load_effective_flight_profile(db, aircraft, profile_id_override)
+        profile, source_profile_id = _load_effective_flight_profile(
+            db, aircraft, profile_id_override
+        )
         refs = _estimate_reference_speeds(profile)
         targets = _build_target_definitions(profile, refs)
 
-        plane_schema = await aeroplane_model_to_aeroplane_schema_async(aircraft)
-        asb_airplane = await aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
+        plane_schema = aeroplane_model_to_aeroplane_schema_async(aircraft)
+        asb_airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
         capabilities = _detect_control_capabilities(asb_airplane)
 
         points: list[TrimmedPoint] = []
@@ -634,7 +747,10 @@ async def generate_default_set_for_aircraft(
             description=opset.description,
             aircraft_id=opset.aircraft_id,
             source_flight_profile_id=opset.source_flight_profile_id,
-            operating_points=[StoredOperatingPointRead.model_validate(point, from_attributes=True) for point in stored_points],
+            operating_points=[
+                StoredOperatingPointRead.model_validate(point, from_attributes=True)
+                for point in stored_points
+            ],
         )
     except (NotFoundError, ValidationError):
         raise
@@ -659,8 +775,8 @@ async def trim_operating_point_for_aircraft(
             request.profile_id_override,
         )
 
-        plane_schema = await aeroplane_model_to_aeroplane_schema_async(aircraft)
-        asb_airplane = await aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
+        plane_schema = aeroplane_model_to_aeroplane_schema_async(aircraft)
+        asb_airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
         capabilities = _detect_control_capabilities(asb_airplane)
 
         target = {

--- a/app/services/operating_point_generator_service.py
+++ b/app/services/operating_point_generator_service.py
@@ -469,7 +469,7 @@ def _cl_target_for_velocity(
     return float((total_mass_kg * 9.81 * n_target) / (q_dyn * s_ref))
 
 
-async def _grid_search_trim(
+def _grid_search_trim(
     asb_airplane: asb.Airplane,
     target: dict[str, Any],
     velocity: float,
@@ -587,7 +587,7 @@ async def _trim_or_estimate_point(
 
     # Fallback grid-search if opti didn't converge well enough
     if best_score > 0.35:
-        gs_score, gs_alpha, gs_beta, gs_velocity, gs_controls = await _grid_search_trim(
+        gs_score, gs_alpha, gs_beta, gs_velocity, gs_controls = _grid_search_trim(
             asb_airplane,
             target,
             velocity,

--- a/app/services/stability_service.py
+++ b/app/services/stability_service.py
@@ -58,10 +58,8 @@ async def get_stability_summary(
     plane_schema = await get_aeroplane_schema_or_raise(db, aeroplane_uuid)
 
     try:
-        asb_airplane = await aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
-        result, _ = await analyse_aerodynamics(
-            analysis_tool, operating_point, asb_airplane
-        )
+        asb_airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
+        result, _ = analyse_aerodynamics(analysis_tool, operating_point, asb_airplane)
     except Exception as e:
         logger.error("Error computing stability: %s", e)
         raise InternalError(message=f"Stability analysis error: {e}")

--- a/app/services/tessellation_hooks.py
+++ b/app/services/tessellation_hooks.py
@@ -31,11 +31,7 @@ def on_wing_changed(
     """
     from app.services import tessellation_cache_service as cache_svc
 
-    aeroplane = (
-        db.query(AeroplaneModel)
-        .filter(AeroplaneModel.uuid == str(aeroplane_uuid))
-        .first()
-    )
+    aeroplane = db.query(AeroplaneModel).filter(AeroplaneModel.uuid == str(aeroplane_uuid)).first()
     if aeroplane is None:
         logger.warning(
             "Cannot invalidate tessellation cache — aeroplane %s not found",
@@ -45,14 +41,15 @@ def on_wing_changed(
 
     count = cache_svc.invalidate(db, aeroplane.id, "wing", wing_name)
     if count:
+        safe_wing_name = wing_name.replace("\n", "").replace("\r", "")
         logger.info(
             "Invalidated %d tessellation cache entries for aeroplane=%s wing=%s",
             count,
             aeroplane.id,
-            wing_name,
+            safe_wing_name,
         )
 
-    # TODO: Trigger background re-tessellation.
+    # TODO(gh-202): Trigger background re-tessellation.
     # This requires re-loading the wing schema from the DB, pickling it,
     # and calling tessellation_service.trigger_background_tessellation().
     # Deferred because it needs a separate DB session factory and careful

--- a/app/tests/test_model_schema_converters.py
+++ b/app/tests/test_model_schema_converters.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 
 import pytest
@@ -283,7 +282,7 @@ def test_ted_projection_to_asb_uses_rel_chord_root():
         wings={"main-wing": wing},
     )
 
-    asb_airplane = asyncio.run(aeroplane_schema_to_asb_airplane_async(plane))
+    asb_airplane = aeroplane_schema_to_asb_airplane_async(plane)
     control_surface = asb_airplane.wings[0].xsecs[0].control_surfaces[0]
     assert control_surface.hinge_point == pytest.approx(0.73)
     assert control_surface.deflection == pytest.approx(6.0)
@@ -373,7 +372,7 @@ def test_aeroplane_schema_to_airplane_configuration_requires_mass():
     plane = schemas.AeroplaneSchema(name="test-plane", wings={"main-wing": wing})
 
     with pytest.raises(ValueError):
-        asyncio.run(aeroplane_schema_to_airplane_configuration_async(plane))
+        aeroplane_schema_to_airplane_configuration_async(plane)
 
 
 def test_aeroplane_schema_to_airplane_configuration_preserves_wing_details():
@@ -387,7 +386,7 @@ def test_aeroplane_schema_to_airplane_configuration_preserves_wing_details():
         fuselages={"test-fuselage": fuselage_schema},
     )
 
-    airplane_config = asyncio.run(aeroplane_schema_to_airplane_configuration_async(plane))
+    airplane_config = aeroplane_schema_to_airplane_configuration_async(plane)
 
     assert airplane_config.total_mass == pytest.approx(3.0)
     assert len(airplane_config.wings) == 1


### PR DESCRIPTION
## Summary
- Remove unnecessary `async` keywords from 7 functions that never `await` (S7503), updating all call sites
- Add `noqa: N806` for aerodynamic coefficient variable names like `Cl`, `Cm`, `Cn`, `F_w`, `M_b` (S117)
- Replace `dict()` constructor calls with `{}` dict literals in plotly figure code (S7498)
- Simplify identity comprehensions: `[x for x in iter]` -> `list(iter)`, `{k: v for k, v in d.items()}` -> `dict(d.items())` (S7500)
- Sanitize user-controlled log data by stripping newlines/carriage returns (S5145)
- Use `asyncio.to_thread` for synchronous file I/O in async `save_content_and_get_static_url` (S7493)
- Reference new GH issue #202 in tessellation TODO comment (S1135)
- Document why `list()` is intentionally needed in `copilot_history_service` for mutation-safe iteration (S7504)

Closes #193

## Test plan
- [x] `poetry run pytest -m "not slow"` passes (611 tests)
- [x] `poetry run ruff check .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)