### PR TITLE
fix(gh-212): remove stale await on analyse_aerodynamics / compile_four_view_figure

### DIFF
--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -307,7 +307,7 @@ async def analyze_wing(
         asb_airplane.wings = [w for w in asb_airplane.wings if w.name == wing_name]
         asb_airplane.fuselages = []
 
-        result, _ = await analyse_aerodynamics(analysis_tool, operating_point, asb_airplane)
+        result, _ = analyse_aerodynamics(analysis_tool, operating_point, asb_airplane)
         return result
     except Exception as e:
         logger.error(f"Error analyzing wing: {e}")
@@ -333,7 +333,7 @@ async def analyze_airplane(
         asb_airplane: Airplane = aeroplane_schema_to_asb_airplane_async(
             plane_schema=plane_schema
         )
-        result, _ = await analyse_aerodynamics(analysis_tool, operating_point, asb_airplane)
+        result, _ = analyse_aerodynamics(analysis_tool, operating_point, asb_airplane)
         return result
     except Exception as e:
         logger.error(f"Error analyzing airplane: {e}")
@@ -362,7 +362,7 @@ async def calculate_streamlines_json(
         asb_airplane: Airplane = aeroplane_schema_to_asb_airplane_async(
             plane_schema=plane_schema
         )
-        _, figure = await analyse_aerodynamics(
+        _, figure = analyse_aerodynamics(
             AnalysisToolUrlType.VORTEX_LATTICE,
             operating_point,
             asb_airplane,
@@ -404,7 +404,7 @@ async def analyze_alpha_sweep(db: Session, aeroplane_uuid, sweep_request: AlphaS
             xyz_ref=sweep_request.xyz_ref,
         )
 
-        result, _ = await analyse_aerodynamics(
+        result, _ = analyse_aerodynamics(
             AnalysisToolUrlType.AEROBUILDUP, operating_point, asb_airplane
         )
         alpha_array, cl_values, cd_values, cm_values = _extract_alpha_sweep_arrays(
@@ -1276,7 +1276,7 @@ async def analyze_simple_sweep(
                 },
             )
 
-        result, _ = await analyse_aerodynamics(
+        result, _ = analyse_aerodynamics(
             AnalysisToolUrlType.AEROBUILDUP, operating_point, asb_airplane
         )
         return result
@@ -1305,7 +1305,7 @@ async def get_streamlines_three_view_image(
             plane_schema=plane_schema
         )
 
-        _, figure = await analyse_aerodynamics(
+        _, figure = analyse_aerodynamics(
             AnalysisToolUrlType.VORTEX_LATTICE,
             operating_point,
             asb_airplane,
@@ -1313,7 +1313,7 @@ async def get_streamlines_three_view_image(
             backend="plotly",
         )
 
-        fig = await compile_four_view_figure(figure)
+        fig = compile_four_view_figure(figure)
         img_bytes = fig.to_image(format="png", width=1000, height=1000, scale=2)
         return img_bytes
     except Exception as e:

--- a/app/tests/test_aeroanalysis.py
+++ b/app/tests/test_aeroanalysis.py
@@ -343,5 +343,99 @@ class TestAeroanalysis(unittest.TestCase):
         self.assertIn("Aeroplane not found", str(ctx.exception.detail))
 
 
+class TestAnalysisServiceAwaitContract(unittest.TestCase):
+    """Service-level tests that verify sync helper functions are NOT awaited.
+
+    These tests call the async service functions directly (not the endpoint
+    layer) with MagicMock (not AsyncMock) for the sync dependencies. If a
+    sync function is incorrectly awaited, asyncio will raise TypeError.
+    """
+
+    def setUp(self):
+        self.test_plane_id = uuid.uuid4()
+        self.mock_db = MagicMock()
+        self.mock_plane_schema = MagicMock()
+        self.mock_plane_schema.name = "TestPlane"
+        self.mock_plane_schema.wings = {}
+        self.test_operating_point = OperatingPointSchema.model_construct(
+            velocity=10.0, alpha=5.0, beta=0.0,
+            p=0.0, q=0.0, r=0.0, xyz_ref=[0.0, 0.0, 0.0],
+        )
+
+    def _make_mock_result(self):
+        """Build a mock analysis result with the minimum attributes."""
+        result = MagicMock()
+        result.flight_condition.alpha = [0.0, 2.0, 4.0]
+        result.coefficients.CL = [0.0, 0.2, 0.4]
+        result.coefficients.CD = [0.01, 0.02, 0.04]
+        result.coefficients.Cm = [-0.05, -0.03, -0.01]
+        result.reference.Xnp = None
+        result.reference.Xnp_lat = None
+        result.forces.L = None
+        result.forces.D = None
+        return result
+
+    def test_analyze_alpha_sweep_does_not_await_sync_functions(self):
+        """analyse_aerodynamics is sync — awaiting it raises TypeError."""
+        from app.services.analysis_service import analyze_alpha_sweep
+
+        mock_result = self._make_mock_result()
+        sweep_request = AlphaSweepRequest.model_construct(
+            altitude=1000.0, velocity=30.0,
+            alpha_start=-5, alpha_end=15, alpha_num=3,
+            beta=0.0, p=0.0, q=0.0, r=0.0, xyz_ref=[0, 0, 0],
+        )
+
+        with (
+            patch(
+                "app.services.analysis_service.get_aeroplane_schema_or_raise",
+                return_value=self.mock_plane_schema,
+            ),
+            patch(
+                "app.services.analysis_service.aeroplane_schema_to_asb_airplane_async",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "app.services.analysis_service.analyse_aerodynamics",
+                return_value=(mock_result, None),
+            ),
+        ):
+            result = asyncio.run(
+                analyze_alpha_sweep(self.mock_db, self.test_plane_id, sweep_request)
+            )
+
+        self.assertIn("analysis", result)
+        self.assertIn("characteristic_points", result)
+
+    def test_analyze_airplane_does_not_await_sync_functions(self):
+        """analyse_aerodynamics is sync — awaiting it raises TypeError."""
+        from app.services.analysis_service import analyze_airplane
+
+        mock_result = MagicMock()
+
+        with (
+            patch(
+                "app.services.analysis_service.get_aeroplane_schema_or_raise",
+                return_value=self.mock_plane_schema,
+            ),
+            patch(
+                "app.services.analysis_service.aeroplane_schema_to_asb_airplane_async",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "app.services.analysis_service.analyse_aerodynamics",
+                return_value=(mock_result, None),
+            ),
+        ):
+            result = asyncio.run(
+                analyze_airplane(
+                    self.mock_db, self.test_plane_id,
+                    self.test_operating_point, AnalysisToolUrlType.AEROBUILDUP,
+                )
+            )
+
+        self.assertEqual(result, mock_result)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Remove `await` from 6 calls to `analyse_aerodynamics` and 1 call to `compile_four_view_figure` in `analysis_service.py`
- Same regression as #210 — these sync functions had `async` removed in `4a9f0b0` (S7503), but PR #209 reintroduced stale `await` calls

## Root Cause
PR #209 (complexity refactoring) was branched before commit `4a9f0b0` which de-async'd utility functions. On merge, the stale `await` calls were reintroduced. #210 caught only `aeroplane_schema_to_asb_airplane_async` — this fixes the remaining 7 call sites.

## Test plan
- [x] 2 new service-level tests (`TestAnalysisServiceAwaitContract`) that use `MagicMock` (not `AsyncMock`) to catch stale `await` on sync functions
- [x] Tests FAIL before fix (RED), PASS after (GREEN)
- [x] 613/613 fast tests pass (11 existing + 2 new)
- [x] ruff check clean
- [ ] Manual: `POST /aeroplanes/{id}/alpha_sweep` returns 200

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)