### PR TITLE
fix(gh-155): add "New Plan" dialog with template selection

### DIFF
--- a/frontend/app/workbench/construction-plans/page.tsx
+++ b/frontend/app/workbench/construction-plans/page.tsx
@@ -59,6 +59,12 @@ export default function ConstructionPlansPage() {
   const [executeDialogOpen, setExecuteDialogOpen] = useState(false);
   const [executeAeroplaneId, setExecuteAeroplaneId] = useState<string>("");
 
+  // New Plan dialog state
+  const [newPlanDialogOpen, setNewPlanDialogOpen] = useState(false);
+  const [newPlanName, setNewPlanName] = useState("");
+  const [newPlanFromTemplate, setNewPlanFromTemplate] = useState(false);
+  const [newPlanTemplateId, setNewPlanTemplateId] = useState<number | null>(null);
+
   // CadViewer modal state
   const [cadViewerOpen, setCadViewerOpen] = useState(false);
   const [cadViewerFullscreen, setCadViewerFullscreen] = useState(false);
@@ -113,18 +119,49 @@ export default function ConstructionPlansPage() {
 
   // ── Plan CRUD ───────────────────────────────────────────────────
 
-  async function handleNewPlan() {
-    const name = prompt("Plan name:");
-    if (!name?.trim()) return;
-    try {
-      const created = await createPlan({
+  function handleNewPlan() {
+    if (viewMode === "plans") {
+      // Open the new plan dialog with template selection
+      setNewPlanName("");
+      setNewPlanFromTemplate(false);
+      setNewPlanTemplateId(null);
+      setNewPlanDialogOpen(true);
+    } else {
+      // Templates mode: simple prompt (no template-from-template)
+      const name = prompt("Template name:");
+      if (!name?.trim()) return;
+      createPlan({
         name: name.trim(),
         tree_json: { $TYPE: "ConstructionRootNode", creator_id: "root", successors: [] },
-        plan_type: viewMode === "templates" ? "template" : "plan",
-        aeroplane_id: viewMode === "plans" ? aeroplaneId ?? undefined : undefined,
-      });
-      activeMutate();
+        plan_type: "template",
+      })
+        .then((created) => {
+          activeMutate();
+          setSelectedPlanId(created.id);
+        })
+        .catch((err) => alert(err instanceof Error ? err.message : "Failed to create template"));
+    }
+  }
+
+  async function handleNewPlanSubmit() {
+    const name = newPlanName.trim();
+    if (!name) return;
+    try {
+      let created;
+      if (newPlanFromTemplate && newPlanTemplateId != null) {
+        created = await instantiateTemplate(aeroplaneId!, newPlanTemplateId, name);
+        mutateAeroplanePlans();
+      } else {
+        created = await createPlan({
+          name,
+          tree_json: { $TYPE: "ConstructionRootNode", creator_id: "root", successors: [] },
+          plan_type: "plan",
+          aeroplane_id: aeroplaneId ?? undefined,
+        });
+        activeMutate();
+      }
       setSelectedPlanId(created.id);
+      setNewPlanDialogOpen(false);
     } catch (err) {
       alert(err instanceof Error ? err.message : "Failed to create plan");
     }
@@ -712,6 +749,111 @@ export default function ConstructionPlansPage() {
                 />
               </>
             )}
+          </div>
+        </div>
+      )}
+
+      {/* New Plan Dialog */}
+      {newPlanDialogOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+          onClick={() => setNewPlanDialogOpen(false)}
+        >
+          <div
+            className="flex w-[480px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
+              New Plan
+            </h2>
+
+            {/* Plan name */}
+            <label className="flex flex-col gap-1">
+              <span className="text-[12px] text-muted-foreground">Plan name</span>
+              <input
+                type="text"
+                value={newPlanName}
+                onChange={(e) => setNewPlanName(e.target.value)}
+                placeholder="Enter plan name..."
+                autoFocus
+                className="rounded-xl border border-border bg-input px-3 py-2 text-[12px] text-foreground outline-none"
+              />
+            </label>
+
+            {/* Template selection radio */}
+            <fieldset className="flex flex-col gap-2">
+              <span className="text-[12px] text-muted-foreground">Start from</span>
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name="newPlanSource"
+                  checked={!newPlanFromTemplate}
+                  onChange={() => {
+                    setNewPlanFromTemplate(false);
+                    setNewPlanTemplateId(null);
+                  }}
+                  className="accent-[#FF8400]"
+                />
+                <span className="text-[12px] text-foreground">Empty plan</span>
+              </label>
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name="newPlanSource"
+                  checked={newPlanFromTemplate}
+                  onChange={() => setNewPlanFromTemplate(true)}
+                  className="accent-[#FF8400]"
+                />
+                <span className="text-[12px] text-foreground">From template</span>
+              </label>
+            </fieldset>
+
+            {/* Template dropdown (visible when "From template" is selected) */}
+            {newPlanFromTemplate && (
+              <div className="flex flex-col gap-2">
+                <select
+                  value={newPlanTemplateId ?? ""}
+                  onChange={(e) =>
+                    setNewPlanTemplateId(e.target.value ? parseInt(e.target.value, 10) : null)
+                  }
+                  className="rounded-xl border border-border bg-input px-3 py-2 text-[12px] text-foreground"
+                >
+                  <option value="">Select a template...</option>
+                  {templates.map((t) => (
+                    <option key={t.id} value={t.id}>
+                      {t.name} ({t.step_count} steps)
+                    </option>
+                  ))}
+                </select>
+                {/* Show description of selected template */}
+                {newPlanTemplateId != null && (() => {
+                  const selected = templates.find((t) => t.id === newPlanTemplateId);
+                  return selected?.description ? (
+                    <p className="text-[11px] text-muted-foreground">{selected.description}</p>
+                  ) : null;
+                })()}
+              </div>
+            )}
+
+            {/* Actions */}
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setNewPlanDialogOpen(false)}
+                className="rounded-full border border-border px-4 py-2 text-[12px] text-muted-foreground hover:bg-sidebar-accent"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleNewPlanSubmit}
+                disabled={
+                  !newPlanName.trim() ||
+                  (newPlanFromTemplate && newPlanTemplateId == null)
+                }
+                className="rounded-full bg-primary px-4 py-2 text-[12px] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+              >
+                Create
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/frontend/app/workbench/construction-plans/page.tsx
+++ b/frontend/app/workbench/construction-plans/page.tsx
@@ -146,10 +146,11 @@ export default function ConstructionPlansPage() {
   async function handleNewPlanSubmit() {
     const name = newPlanName.trim();
     if (!name) return;
+    if (newPlanFromTemplate && newPlanTemplateId != null && !aeroplaneId) return;
     try {
       let created;
-      if (newPlanFromTemplate && newPlanTemplateId != null) {
-        created = await instantiateTemplate(aeroplaneId!, newPlanTemplateId, name);
+      if (newPlanFromTemplate && newPlanTemplateId != null && aeroplaneId) {
+        created = await instantiateTemplate(aeroplaneId, newPlanTemplateId, name);
         mutateAeroplanePlans();
       } else {
         created = await createPlan({
@@ -758,6 +759,7 @@ export default function ConstructionPlansPage() {
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
           onClick={() => setNewPlanDialogOpen(false)}
+          onKeyDown={(e) => { if (e.key === "Escape") setNewPlanDialogOpen(false); }}
         >
           <div
             className="flex w-[480px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
@@ -826,12 +828,12 @@ export default function ConstructionPlansPage() {
                   ))}
                 </select>
                 {/* Show description of selected template */}
-                {newPlanTemplateId != null && (() => {
-                  const selected = templates.find((t) => t.id === newPlanTemplateId);
-                  return selected?.description ? (
-                    <p className="text-[11px] text-muted-foreground">{selected.description}</p>
-                  ) : null;
-                })()}
+                {newPlanTemplateId != null &&
+                  templates.find((t) => t.id === newPlanTemplateId)?.description && (
+                    <p className="text-[11px] text-muted-foreground">
+                      {templates.find((t) => t.id === newPlanTemplateId)?.description}
+                    </p>
+                  )}
               </div>
             )}
 

--- a/frontend/app/workbench/construction-plans/page.tsx
+++ b/frontend/app/workbench/construction-plans/page.tsx
@@ -757,6 +757,9 @@ export default function ConstructionPlansPage() {
       {/* New Plan Dialog */}
       {newPlanDialogOpen && (
         <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="New Plan"
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
           onClick={() => setNewPlanDialogOpen(false)}
           onKeyDown={(e) => { if (e.key === "Escape") setNewPlanDialogOpen(false); }}
@@ -764,6 +767,7 @@ export default function ConstructionPlansPage() {
           <div
             className="flex w-[480px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
             onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
           >
             <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
               New Plan
@@ -816,7 +820,7 @@ export default function ConstructionPlansPage() {
                 <select
                   value={newPlanTemplateId ?? ""}
                   onChange={(e) =>
-                    setNewPlanTemplateId(e.target.value ? parseInt(e.target.value, 10) : null)
+                    setNewPlanTemplateId(e.target.value ? Number.parseInt(e.target.value, 10) : null)
                   }
                   className="rounded-xl border border-border bg-input px-3 py-2 text-[12px] text-foreground"
                 >


### PR DESCRIPTION
## Summary

- Replace browser `prompt()` in `handleNewPlan()` with a proper modal dialog when creating plans
- Dialog offers plan name input, "Empty plan" / "From template" radio toggle, and template dropdown with step count and description preview
- Submit is disabled when name is empty or template mode is selected but no template is chosen
- Templates view mode retains the simple `prompt()` since template-from-template is not needed

Closes #155

## Test plan

- [ ] Open Construction Plans page, switch to "Plans" view
- [ ] Click "+" to create a new plan -- verify the dialog opens (not a browser prompt)
- [ ] Verify "Empty plan" is selected by default
- [ ] Enter a name and click "Create" -- verify an empty plan is created
- [ ] Open dialog again, select "From template", pick a template -- verify description and step count shown
- [ ] Click "Create" -- verify a plan is created from the template
- [ ] Verify submit button is disabled when name is empty or no template selected (in template mode)
- [ ] Switch to "Templates" view, click "+" -- verify the old prompt() behavior still works
- [ ] `npx eslint app/workbench/construction-plans/page.tsx` -- 0 errors
- [ ] `npm run test:unit` -- all 230 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)