### PR TITLE
refactor(gh-229): reduce ConstructionPlansPage complexity

### DIFF
--- a/frontend/__tests__/planTreeUtils.test.ts
+++ b/frontend/__tests__/planTreeUtils.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import type { PlanStepNode } from "@/components/workbench/PlanTree";
+import type { CreatorInfo } from "@/hooks/useCreators";
+import {
+  getStepAtPath,
+  deleteStepAtPath,
+  insertStepAtPath,
+  updateNodeAtPath,
+  collectAvailableShapeKeys,
+  resolveIdTemplate,
+  computeReorderTargetPath,
+} from "@/lib/planTreeUtils";
+
+function makeNode(type: string, id: string, successors: PlanStepNode[] = []): PlanStepNode {
+  return { $TYPE: type, creator_id: id, successors };
+}
+
+const root = makeNode("ConstructionRootNode", "root", [
+  makeNode("WingCreator", "wing1"),
+  makeNode("FuselageCreator", "fuse1"),
+  makeNode("ExportCreator", "export1"),
+]);
+
+describe("getStepAtPath", () => {
+  it("returns root for 'root' path", () => {
+    expect(getStepAtPath(root, "root")).toBe(root);
+  });
+
+  it("returns a direct child", () => {
+    expect(getStepAtPath(root, "root.1")).toBe(root.successors![1]);
+  });
+
+  it("returns null for invalid path", () => {
+    expect(getStepAtPath(root, "root.5")).toBeNull();
+  });
+
+  it("navigates nested successors", () => {
+    const nested = makeNode("Root", "root", [
+      makeNode("A", "a", [makeNode("B", "b")]),
+    ]);
+    expect(getStepAtPath(nested, "root.0.0")?.creator_id).toBe("b");
+  });
+});
+
+describe("deleteStepAtPath", () => {
+  it("clears all successors when path is 'root'", () => {
+    const result = deleteStepAtPath(root, "root");
+    expect(result.successors).toEqual([]);
+    // Original unchanged
+    expect(root.successors!.length).toBe(3);
+  });
+
+  it("removes the correct child by index", () => {
+    const result = deleteStepAtPath(root, "root.1");
+    expect(result.successors!.length).toBe(2);
+    expect(result.successors![0].creator_id).toBe("wing1");
+    expect(result.successors![1].creator_id).toBe("export1");
+  });
+});
+
+describe("insertStepAtPath", () => {
+  const newStep = makeNode("NewCreator", "new1");
+
+  it("appends to root when path is 'root'", () => {
+    const result = insertStepAtPath(root, "root", newStep);
+    expect(result.successors!.length).toBe(4);
+    expect(result.successors![3].creator_id).toBe("new1");
+  });
+
+  it("inserts after the specified index", () => {
+    const result = insertStepAtPath(root, "root.0", newStep);
+    expect(result.successors!.length).toBe(4);
+    expect(result.successors![1].creator_id).toBe("new1");
+    expect(result.successors![2].creator_id).toBe("fuse1");
+  });
+});
+
+describe("updateNodeAtPath", () => {
+  it("replaces root when path is 'root'", () => {
+    const replacement = makeNode("X", "x");
+    const result = updateNodeAtPath(root, "root", replacement);
+    expect(result.creator_id).toBe("x");
+  });
+
+  it("replaces a direct child", () => {
+    const replacement = makeNode("Updated", "updated");
+    const result = updateNodeAtPath(root, "root.1", replacement);
+    expect(result.successors![1].creator_id).toBe("updated");
+    expect(result.successors![0].creator_id).toBe("wing1");
+  });
+});
+
+describe("collectAvailableShapeKeys", () => {
+  const creators: CreatorInfo[] = [
+    {
+      class_name: "WingCreator",
+      category: "wing",
+      description: null,
+      parameters: [],
+      outputs: [{ key: "{id}_shape", description: "wing shape" }],
+      suggested_id: null,
+    },
+  ];
+
+  it("returns empty array for null tree", () => {
+    expect(collectAvailableShapeKeys(null, creators)).toEqual([]);
+  });
+
+  it("collects keys from creator outputs", () => {
+    const keys = collectAvailableShapeKeys(root, creators);
+    expect(keys).toContain("wing1_shape");
+  });
+
+  it("stops at stopPath", () => {
+    const keys = collectAvailableShapeKeys(root, creators, "root.0");
+    expect(keys).toEqual([]);
+  });
+
+  it("falls back to stepId when creator has no outputs", () => {
+    const keys = collectAvailableShapeKeys(root, []);
+    expect(keys).toEqual(["wing1", "fuse1", "export1"]);
+  });
+});
+
+describe("resolveIdTemplate", () => {
+  it("replaces placeholders with param values", () => {
+    expect(resolveIdTemplate("{name}_wing", { name: "main" })).toBe("main_wing");
+  });
+
+  it("leaves unresolved placeholders intact", () => {
+    expect(resolveIdTemplate("{name}_wing", {})).toBe("{name}_wing");
+  });
+
+  it("handles empty string params", () => {
+    expect(resolveIdTemplate("{name}_wing", { name: "" })).toBe("{name}_wing");
+  });
+});
+
+describe("computeReorderTargetPath", () => {
+  it("adjusts when dragging forward in same parent", () => {
+    expect(computeReorderTargetPath("root.0", "root.2")).toBe("root.1");
+  });
+
+  it("does not adjust when dragging backward", () => {
+    expect(computeReorderTargetPath("root.2", "root.0")).toBe("root.0");
+  });
+
+  it("does not adjust across different parents", () => {
+    expect(computeReorderTargetPath("root.0", "root.1.0")).toBe("root.1.0");
+  });
+
+  it("returns toPath unchanged for same-index siblings in different depth", () => {
+    expect(computeReorderTargetPath("root.0.1", "root.1")).toBe("root.1");
+  });
+});

--- a/frontend/app/workbench/construction-plans/page.tsx
+++ b/frontend/app/workbench/construction-plans/page.tsx
@@ -23,6 +23,15 @@ import {
   type ExecutionResult,
 } from "@/hooks/useConstructionPlans";
 import { useCreators, type CreatorInfo } from "@/hooks/useCreators";
+import {
+  getStepAtPath,
+  deleteStepAtPath,
+  insertStepAtPath,
+  updateNodeAtPath,
+  collectAvailableShapeKeys,
+  resolveIdTemplate,
+  computeReorderTargetPath,
+} from "@/lib/planTreeUtils";
 
 type RightPanel = "gallery" | "detail" | "params";
 
@@ -72,49 +81,8 @@ export default function ConstructionPlansPage() {
 
   // ── Helpers ─────────────────────────────────────────────────────
 
-  function getStepAtPath(tree: PlanStepNode, path: string): PlanStepNode | null {
-    if (path === "root") return tree;
-    const parts = path.replace("root.", "").split(".");
-    let current: PlanStepNode = tree;
-    for (const part of parts) {
-      const idx = parseInt(part, 10);
-      if (!current.successors || !current.successors[idx]) return null;
-      current = current.successors[idx];
-    }
-    return current;
-  }
-
   function findCreatorForStep(step: PlanStepNode): CreatorInfo | undefined {
     return creators.find((c) => c.class_name === step.creator_id || c.class_name === step.$TYPE);
-  }
-
-  /** Collect shape keys produced by all steps before `stopPath` in the tree. */
-  function collectAvailableShapeKeys(tree: PlanStepNode | null, stopPath?: string | null): string[] {
-    if (!tree) return [];
-    const keys: string[] = [];
-    const successors = tree.successors ?? [];
-    for (let i = 0; i < successors.length; i++) {
-      const stepPath = `root.${i}`;
-      if (stopPath && stepPath === stopPath) break;
-      const step = successors[i];
-      const stepId = step.creator_id ?? step.$TYPE ?? "step";
-      const creator = creators.find((c) => c.class_name === step.$TYPE || c.class_name === step.creator_id);
-      if (creator?.outputs.length) {
-        for (const out of creator.outputs) {
-          keys.push(out.key.replace(/\{id\}/g, stepId));
-        }
-      } else {
-        keys.push(stepId);
-      }
-    }
-    return keys;
-  }
-
-  function resolveIdTemplate(template: string, params: Record<string, unknown>): string {
-    return template.replace(/\{(\w+)\}/g, (match, key) => {
-      const val = params[key];
-      return val != null && val !== "" ? String(val) : match;
-    });
   }
 
   // ── Plan CRUD ───────────────────────────────────────────────────
@@ -193,27 +161,6 @@ export default function ConstructionPlansPage() {
     [],
   );
 
-  function deleteStepAtPath(tree: PlanStepNode, path: string): PlanStepNode {
-    if (path === "root") return { ...tree, successors: [] };
-    const parts = path.replace("root.", "").split(".");
-    const lastIdx = parseInt(parts[parts.length - 1], 10);
-    const parentPath = parts.slice(0, -1);
-
-    function navigate(node: PlanStepNode, remaining: string[]): PlanStepNode {
-      if (remaining.length === 0) {
-        const newSuccessors = [...(node.successors ?? [])];
-        newSuccessors.splice(lastIdx, 1);
-        return { ...node, successors: newSuccessors };
-      }
-      const idx = parseInt(remaining[0], 10);
-      const newSuccessors = [...(node.successors ?? [])];
-      newSuccessors[idx] = navigate(newSuccessors[idx], remaining.slice(1));
-      return { ...node, successors: newSuccessors };
-    }
-
-    return navigate(tree, parentPath);
-  }
-
   async function handleDeleteStep(path: string) {
     if (!plan || !selectedPlanId) return;
     const treeJson = plan.tree_json as unknown as PlanStepNode;
@@ -273,20 +220,7 @@ export default function ConstructionPlansPage() {
     if (paramSaveTimer.current) clearTimeout(paramSaveTimer.current);
     paramSaveTimer.current = setTimeout(() => {
       const treeJson = plan.tree_json as unknown as PlanStepNode;
-
-      function updateNodeAtPath(node: PlanStepNode, path: string): PlanStepNode {
-        if (path === "root") return updatedNode;
-        const parts = path.replace("root.", "").split(".");
-        const idx = parseInt(parts[0], 10);
-        const rest = parts.slice(1).join(".");
-        const newSuccessors = [...(node.successors ?? [])];
-        newSuccessors[idx] = rest
-          ? updateNodeAtPath(newSuccessors[idx], rest)
-          : updatedNode;
-        return { ...node, successors: newSuccessors };
-      }
-
-      const updated = updateNodeAtPath(treeJson, selectedStepPath);
+      const updated = updateNodeAtPath(treeJson, selectedStepPath, updatedNode);
       updatePlan(selectedPlanId, {
         name: plan.name,
         description: plan.description ?? undefined,
@@ -297,60 +231,13 @@ export default function ConstructionPlansPage() {
     }, 400);
   }
 
-  function insertStepAtPath(
-    tree: PlanStepNode,
-    path: string,
-    step: PlanStepNode,
-  ): PlanStepNode {
-    // Insert step after the node at `path` within the same parent
-    if (path === "root") {
-      return { ...tree, successors: [...(tree.successors ?? []), step] };
-    }
-    const parts = path.replace("root.", "").split(".");
-    const insertIdx = parseInt(parts[parts.length - 1], 10) + 1;
-    const parentParts = parts.slice(0, -1);
-
-    function navigate(node: PlanStepNode, remaining: string[]): PlanStepNode {
-      if (remaining.length === 0) {
-        const newSuccessors = [...(node.successors ?? [])];
-        newSuccessors.splice(insertIdx, 0, step);
-        return { ...node, successors: newSuccessors };
-      }
-      const idx = parseInt(remaining[0], 10);
-      const newSuccessors = [...(node.successors ?? [])];
-      newSuccessors[idx] = navigate(newSuccessors[idx], remaining.slice(1));
-      return { ...node, successors: newSuccessors };
-    }
-
-    return navigate(tree, parentParts);
-  }
-
   function handleReorder(fromPath: string, toPath: string) {
     if (!plan || !selectedPlanId) return;
     const treeJson = plan.tree_json as unknown as PlanStepNode;
     const fromNode = getStepAtPath(treeJson, fromPath);
     if (!fromNode) return;
     const withoutFrom = deleteStepAtPath(treeJson, fromPath);
-
-    // Adjust toPath when dragging forward in the same parent:
-    // after removing fromPath, indices shift down by 1
-    let adjustedToPath = toPath;
-    const fromParts = fromPath.replace("root.", "").split(".");
-    const toParts = toPath.replace("root.", "").split(".");
-    if (fromParts.length === toParts.length) {
-      const fromParent = fromParts.slice(0, -1).join(".");
-      const toParent = toParts.slice(0, -1).join(".");
-      if (fromParent === toParent) {
-        const fromIdx = parseInt(fromParts[fromParts.length - 1], 10);
-        const toIdx = parseInt(toParts[toParts.length - 1], 10);
-        if (fromIdx < toIdx) {
-          const adjusted = [...toParts];
-          adjusted[adjusted.length - 1] = String(toIdx - 1);
-          adjustedToPath = "root." + adjusted.join(".");
-        }
-      }
-    }
-
+    const adjustedToPath = computeReorderTargetPath(fromPath, toPath);
     const updated = insertStepAtPath(withoutFrom, adjustedToPath, fromNode);
 
     updatePlan(selectedPlanId, {
@@ -598,7 +485,7 @@ export default function ConstructionPlansPage() {
                 params={creatorForSelected.parameters}
                 values={selectedStepNode as unknown as Record<string, unknown>}
                 onChange={handleParamChange}
-                availableShapeKeys={collectAvailableShapeKeys(treeJson, selectedStepPath)}
+                availableShapeKeys={collectAvailableShapeKeys(treeJson, creators, selectedStepPath)}
               />
               <label className="flex flex-col gap-1 mt-2">
                 <span className="font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-muted-foreground">
@@ -691,7 +578,7 @@ export default function ConstructionPlansPage() {
                         setAddCreatorId(resolveIdTemplate(addingCreator.suggested_id, next));
                       }
                     }}
-                    availableShapeKeys={collectAvailableShapeKeys(treeJson)}
+                    availableShapeKeys={collectAvailableShapeKeys(treeJson, creators)}
                   />
                 )}
                 {/* Creator detail info (collapsed) */}

--- a/frontend/lib/planTreeUtils.ts
+++ b/frontend/lib/planTreeUtils.ts
@@ -1,0 +1,144 @@
+import type { PlanStepNode } from "@/components/workbench/PlanTree";
+import type { CreatorInfo } from "@/hooks/useCreators";
+
+/** Navigate the plan tree to find the node at the given dot-separated path. */
+export function getStepAtPath(tree: PlanStepNode, path: string): PlanStepNode | null {
+  if (path === "root") return tree;
+  const parts = path.replace("root.", "").split(".");
+  let current: PlanStepNode = tree;
+  for (const part of parts) {
+    const idx = parseInt(part, 10);
+    if (!current.successors || !current.successors[idx]) return null;
+    current = current.successors[idx];
+  }
+  return current;
+}
+
+/** Return a new tree with the node at `path` removed. */
+export function deleteStepAtPath(tree: PlanStepNode, path: string): PlanStepNode {
+  if (path === "root") return { ...tree, successors: [] };
+  const parts = path.replace("root.", "").split(".");
+  const lastIdx = parseInt(parts[parts.length - 1], 10);
+  const parentPath = parts.slice(0, -1);
+
+  function navigate(node: PlanStepNode, remaining: string[]): PlanStepNode {
+    if (remaining.length === 0) {
+      const newSuccessors = [...(node.successors ?? [])];
+      newSuccessors.splice(lastIdx, 1);
+      return { ...node, successors: newSuccessors };
+    }
+    const idx = parseInt(remaining[0], 10);
+    const newSuccessors = [...(node.successors ?? [])];
+    newSuccessors[idx] = navigate(newSuccessors[idx], remaining.slice(1));
+    return { ...node, successors: newSuccessors };
+  }
+
+  return navigate(tree, parentPath);
+}
+
+/** Return a new tree with `step` inserted after the node at `path`. */
+export function insertStepAtPath(
+  tree: PlanStepNode,
+  path: string,
+  step: PlanStepNode,
+): PlanStepNode {
+  if (path === "root") {
+    return { ...tree, successors: [...(tree.successors ?? []), step] };
+  }
+  const parts = path.replace("root.", "").split(".");
+  const insertIdx = parseInt(parts[parts.length - 1], 10) + 1;
+  const parentParts = parts.slice(0, -1);
+
+  function navigate(node: PlanStepNode, remaining: string[]): PlanStepNode {
+    if (remaining.length === 0) {
+      const newSuccessors = [...(node.successors ?? [])];
+      newSuccessors.splice(insertIdx, 0, step);
+      return { ...node, successors: newSuccessors };
+    }
+    const idx = parseInt(remaining[0], 10);
+    const newSuccessors = [...(node.successors ?? [])];
+    newSuccessors[idx] = navigate(newSuccessors[idx], remaining.slice(1));
+    return { ...node, successors: newSuccessors };
+  }
+
+  return navigate(tree, parentParts);
+}
+
+/** Return a new tree with `updatedNode` placed at `path`. */
+export function updateNodeAtPath(
+  tree: PlanStepNode,
+  path: string,
+  updatedNode: PlanStepNode,
+): PlanStepNode {
+  if (path === "root") return updatedNode;
+  const parts = path.replace("root.", "").split(".");
+  const idx = parseInt(parts[0], 10);
+  const rest = parts.slice(1).join(".");
+  const newSuccessors = [...(tree.successors ?? [])];
+  newSuccessors[idx] = rest
+    ? updateNodeAtPath(newSuccessors[idx], rest, updatedNode)
+    : updatedNode;
+  return { ...tree, successors: newSuccessors };
+}
+
+/**
+ * Collect shape keys produced by all steps before `stopPath` in the tree.
+ * Uses the creator list to resolve output key templates.
+ */
+export function collectAvailableShapeKeys(
+  tree: PlanStepNode | null,
+  creators: CreatorInfo[],
+  stopPath?: string | null,
+): string[] {
+  if (!tree) return [];
+  const keys: string[] = [];
+  const successors = tree.successors ?? [];
+  for (let i = 0; i < successors.length; i++) {
+    const stepPath = `root.${i}`;
+    if (stopPath && stepPath === stopPath) break;
+    const step = successors[i];
+    const stepId = step.creator_id ?? step.$TYPE ?? "step";
+    const creator = creators.find(
+      (c) => c.class_name === step.$TYPE || c.class_name === step.creator_id,
+    );
+    if (creator?.outputs.length) {
+      for (const out of creator.outputs) {
+        keys.push(out.key.replace(/\{id\}/g, stepId));
+      }
+    } else {
+      keys.push(stepId);
+    }
+  }
+  return keys;
+}
+
+/** Resolve `{param}` placeholders in an ID template using the given params. */
+export function resolveIdTemplate(template: string, params: Record<string, unknown>): string {
+  return template.replace(/\{(\w+)\}/g, (match, key) => {
+    const val = params[key];
+    return val != null && val !== "" ? String(val) : match;
+  });
+}
+
+/**
+ * Compute the adjusted target path when reordering within the same parent.
+ * After removing `fromPath`, indices shift down by 1 for later siblings.
+ */
+export function computeReorderTargetPath(fromPath: string, toPath: string): string {
+  const fromParts = fromPath.replace("root.", "").split(".");
+  const toParts = toPath.replace("root.", "").split(".");
+  if (fromParts.length !== toParts.length) return toPath;
+
+  const fromParent = fromParts.slice(0, -1).join(".");
+  const toParent = toParts.slice(0, -1).join(".");
+  if (fromParent !== toParent) return toPath;
+
+  const fromIdx = parseInt(fromParts[fromParts.length - 1], 10);
+  const toIdx = parseInt(toParts[toParts.length - 1], 10);
+  if (fromIdx < toIdx) {
+    const adjusted = [...toParts];
+    adjusted[adjusted.length - 1] = String(toIdx - 1);
+    return "root." + adjusted.join(".");
+  }
+  return toPath;
+}


### PR DESCRIPTION
## Summary
- Extracted 7 pure tree-manipulation helpers (`getStepAtPath`, `deleteStepAtPath`, `insertStepAtPath`, `updateNodeAtPath`, `collectAvailableShapeKeys`, `resolveIdTemplate`, `computeReorderTargetPath`) from `ConstructionPlansPage` into `frontend/lib/planTreeUtils.ts`
- Reduces cognitive complexity of the main component from 32 to well below the SonarQube S3776 threshold of 15
- Added 21 unit tests for the extracted utilities

## Test plan
- [x] ESLint passes on the refactored page
- [x] All 251 frontend unit tests pass (230 existing + 21 new)
- [x] Pure refactoring — no behavioral changes

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)