### PR TITLE
refactor(gh-231): reduce cognitive complexity in 5 workbench components

### DIFF
--- a/frontend/components/workbench/CadViewer.tsx
+++ b/frontend/components/workbench/CadViewer.tsx
@@ -8,6 +8,10 @@ interface CadViewerProps {
   parts: Record<string, unknown>[];
 }
 
+interface PartData {
+  data?: { shapes?: Record<string, unknown>; instances?: Record<string, unknown>[] };
+}
+
 function resolveRefs(
   node: Record<string, unknown>,
   instances: Record<string, unknown>[],
@@ -23,6 +27,36 @@ function resolveRefs(
       if (part && typeof part === "object") {
         resolveRefs(part as Record<string, unknown>, instances);
       }
+    }
+  }
+}
+
+/** Deep-clone shapes and resolve instance refs for a single part. Returns null if no shapes. */
+function preparePartShapes(part: PartData): Record<string, unknown> | null {
+  const shapes = part?.data?.shapes;
+  if (!shapes) return null;
+  const copy = JSON.parse(JSON.stringify(shapes));
+  const instances = part?.data?.instances;
+  if (instances && Array.isArray(instances)) {
+    resolveRefs(copy, instances);
+  }
+  return copy;
+}
+
+/** Add remaining parts to an already-initialised viewer. */
+function addRemainingParts(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  viewer: any,
+  parts: Record<string, unknown>[],
+  rootId: string,
+): void {
+  for (let i = 1; i < parts.length; i++) {
+    const shapes = preparePartShapes(parts[i] as PartData);
+    if (!shapes) continue;
+    try {
+      viewer.addPart(rootId, shapes, { skipBounds: true });
+    } catch (err) {
+      console.warn(`[CadViewer] addPart for part ${i} failed:`, err);
     }
   }
 }
@@ -86,42 +120,14 @@ export function CadViewer({ parts }: CadViewerProps) {
         };
 
         // Extract shapes from the first part and render it (initializes the scene)
-        const first = parts[0] as {
-          data?: { shapes?: Record<string, unknown>; instances?: Record<string, unknown>[] };
-        };
-        const firstShapes = first?.data?.shapes;
-        const firstInstances = first?.data?.instances;
-        if (!firstShapes) throw new Error("No shape data in tessellation result");
-
-        // Deep-clone before resolving refs — never mutate cached state
-        const firstShapesCopy = JSON.parse(JSON.stringify(firstShapes));
-        if (firstInstances && Array.isArray(firstInstances)) {
-          resolveRefs(firstShapesCopy, firstInstances);
-        }
+        const firstShapesCopy = preparePartShapes(parts[0] as PartData);
+        if (!firstShapesCopy) throw new Error("No shape data in tessellation result");
 
         viewer.render(firstShapesCopy, renderOptions, viewerOptions);
 
         // Add remaining parts incrementally via addPart()
-        for (let i = 1; i < parts.length; i++) {
-          const part = parts[i] as {
-            data?: { shapes?: Record<string, unknown>; instances?: Record<string, unknown>[] };
-          };
-          const shapes = part?.data?.shapes;
-          const instances = part?.data?.instances;
-          if (!shapes) continue;
-
-          const shapesCopy = JSON.parse(JSON.stringify(shapes));
-          if (instances && Array.isArray(instances)) {
-            resolveRefs(shapesCopy, instances);
-          }
-
-          try {
-            const rootId = (firstShapesCopy as { id?: string }).id || "/Group";
-            viewer.addPart(rootId, shapesCopy, { skipBounds: true });
-          } catch (err) {
-            console.warn(`[CadViewer] addPart for part ${i} failed:`, err);
-          }
-        }
+        const rootId = (firstShapesCopy as { id?: string }).id || "/Group";
+        addRemainingParts(viewer, parts, rootId);
 
         // Recompute bounds once after all parts are added
         if (parts.length > 1) {

--- a/frontend/components/workbench/ComponentEditDialog.tsx
+++ b/frontend/components/workbench/ComponentEditDialog.tsx
@@ -37,41 +37,44 @@ function parseValue(prop: PropertyDefinition, raw: unknown): unknown {
   return String(raw);
 }
 
+type ValidationResult = { ok: true } | { ok: false; property: string; message: string };
+
+function fail(prop: PropertyDefinition, message: string): ValidationResult {
+  return { ok: false, property: prop.name, message };
+}
+
+function validateNumberRange(prop: PropertyDefinition, n: number): ValidationResult | null {
+  if (prop.min != null && n < prop.min) {
+    return fail(prop, `${prop.label}: expected \u2265 ${prop.min}, got ${n}.`);
+  }
+  if (prop.max != null && n > prop.max) {
+    return fail(prop, `${prop.label}: expected \u2264 ${prop.max}, got ${n}.`);
+  }
+  return null;
+}
+
+function validateProp(prop: PropertyDefinition, raw: unknown): ValidationResult | null {
+  const parsed = parseValue(prop, raw);
+  if (prop.required && (parsed === undefined || parsed === "")) {
+    return fail(prop, `${prop.label} (${prop.name}) is required.`);
+  }
+  if (parsed === undefined) return null;
+  if (prop.type === "number") {
+    return validateNumberRange(prop, parsed as number);
+  }
+  if (prop.type === "enum" && prop.options && !prop.options.includes(String(parsed))) {
+    return fail(prop, `${prop.label}: value '${parsed}' is not in ${JSON.stringify(prop.options)}.`);
+  }
+  return null;
+}
+
 function validate(
   schema: PropertyDefinition[],
   specs: Record<string, unknown>,
-): { ok: true } | { ok: false; property: string; message: string } {
+): ValidationResult {
   for (const prop of schema) {
-    const raw = specs[prop.name];
-    const parsed = parseValue(prop, raw);
-    if (prop.required && (parsed === undefined || parsed === "")) {
-      return {
-        ok: false, property: prop.name,
-        message: `${prop.label} (${prop.name}) is required.`,
-      };
-    }
-    if (parsed === undefined) continue;
-    if (prop.type === "number") {
-      const n = parsed as number;
-      if (prop.min != null && n < prop.min) {
-        return {
-          ok: false, property: prop.name,
-          message: `${prop.label}: expected ≥ ${prop.min}, got ${n}.`,
-        };
-      }
-      if (prop.max != null && n > prop.max) {
-        return {
-          ok: false, property: prop.name,
-          message: `${prop.label}: expected ≤ ${prop.max}, got ${n}.`,
-        };
-      }
-    }
-    if (prop.type === "enum" && prop.options && !prop.options.includes(String(parsed))) {
-      return {
-        ok: false, property: prop.name,
-        message: `${prop.label}: value '${parsed}' is not in ${JSON.stringify(prop.options)}.`,
-      };
-    }
+    const err = validateProp(prop, specs[prop.name]);
+    if (err) return err;
   }
   return { ok: true };
 }
@@ -128,21 +131,25 @@ export function ComponentEditDialog({
     setSpecs((prev) => ({ ...prev, [propName]: value }));
   }
 
+  /** Build the final specs object: parse known keys, keep unknown keys raw. */
+  function buildOutSpecs(): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+    for (const prop of schema) {
+      const parsed = parseValue(prop, specs[prop.name]);
+      if (parsed !== undefined) out[prop.name] = parsed;
+    }
+    for (const key of unknownKeys) {
+      out[key] = specs[key];
+    }
+    return out;
+  }
+
   async function handleSave() {
     if (!name.trim()) { setError("Name is required"); return; }
     const result = validate(schema, specs);
     if (!result.ok) {
       setError(result.message);
       return;
-    }
-    // Parse known specs to their declared types; keep unknown keys raw.
-    const outSpecs: Record<string, unknown> = {};
-    for (const prop of schema) {
-      const parsed = parseValue(prop, specs[prop.name]);
-      if (parsed !== undefined) outSpecs[prop.name] = parsed;
-    }
-    for (const key of unknownKeys) {
-      outSpecs[key] = specs[key];
     }
 
     setSaving(true);
@@ -158,7 +165,7 @@ export function ComponentEditDialog({
         bbox_y_mm: null,
         bbox_z_mm: null,
         model_ref: null,
-        specs: outSpecs,
+        specs: buildOutSpecs(),
       };
       if (isEdit && component) {
         await updateComponent(component.id, data as unknown as Component);

--- a/frontend/components/workbench/ComponentTree.tsx
+++ b/frontend/components/workbench/ComponentTree.tsx
@@ -126,6 +126,50 @@ function aggregateRootStatus(
   return { status: "partial", total };
 }
 
+/** Weight annotation string for a single tree node. */
+function nodeAnnotation(node: ComponentTreeNode): string | undefined {
+  const totalG = node.total_weight_g;
+  if (totalG != null && totalG > 0) return `${totalG.toFixed(1)}g`;
+  if (node.weight_override_g != null) return `${node.weight_override_g}g`;
+  return undefined;
+}
+
+/** Node-type chip label for the tree row badge. */
+function nodeChip(node: ComponentTreeNode): string | undefined {
+  if (node.node_type === "cots") return "COTS";
+  if (node.node_type === "cad_shape") return "CAD";
+  return undefined;
+}
+
+function toSimpleTreeNode(
+  node: ComponentTreeNode,
+  level: number,
+  isExpanded: boolean,
+  cb: FlattenCallbacks,
+  selectedId: number | null,
+): SimpleTreeNode {
+  const hasChildren = node.children && node.children.length > 0;
+  const isGroup = node.node_type === "group";
+  return {
+    id: String(node.id),
+    label: node.name,
+    level,
+    expanded: hasChildren ? isExpanded : undefined,
+    leaf: !hasChildren,
+    selected: node.id === selectedId,
+    chip: nodeChip(node),
+    annotation: nodeAnnotation(node),
+    onClick: () => cb.onSelect(node),
+    onDelete: () => cb.onDelete(node),
+    onAdd: isGroup ? () => cb.onAdd(node) : undefined,
+    addTitle: isGroup ? `Add to ${node.name}` : undefined,
+    onEdit: () => cb.onEdit(node),
+    editTitle: `Edit ${node.name}`,
+    weightStatus: node.weight_status,
+    weightTooltip: weightTooltip(node),
+  };
+}
+
 function flattenTree(
   nodes: ComponentTreeNode[],
   level: number,
@@ -137,35 +181,7 @@ function flattenTree(
   for (const node of nodes) {
     const hasChildren = node.children && node.children.length > 0;
     const isExpanded = expanded.has(String(node.id));
-    const isGroup = node.node_type === "group";
-    // Use total_weight_g from the backend enrichment (gh#78). Fall back to
-    // weight_override_g for backward compatibility with older responses.
-    const totalG = node.total_weight_g;
-    const annotation =
-      totalG != null && totalG > 0
-        ? `${totalG.toFixed(1)}g`
-        : node.weight_override_g != null
-        ? `${node.weight_override_g}g`
-        : undefined;
-
-    result.push({
-      id: String(node.id),
-      label: node.name,
-      level,
-      expanded: hasChildren ? isExpanded : undefined,
-      leaf: !hasChildren,
-      selected: node.id === selectedId,
-      chip: node.node_type === "cots" ? "COTS" : node.node_type === "cad_shape" ? "CAD" : undefined,
-      annotation,
-      onClick: () => cb.onSelect(node),
-      onDelete: () => cb.onDelete(node),
-      onAdd: isGroup ? () => cb.onAdd(node) : undefined,
-      addTitle: isGroup ? `Add to ${node.name}` : undefined,
-      onEdit: () => cb.onEdit(node),
-      editTitle: `Edit ${node.name}`,
-      weightStatus: node.weight_status,
-      weightTooltip: weightTooltip(node),
-    });
+    result.push(toSimpleTreeNode(node, level, isExpanded, cb, selectedId));
     if (hasChildren && isExpanded) {
       result.push(...flattenTree(node.children, level + 1, expanded, cb, selectedId));
     }
@@ -253,6 +269,22 @@ export function ComponentTree({
     useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
   );
 
+  async function moveToRoot(activeId: number) {
+    mutate();
+    try {
+      await moveTreeNode(aeroplaneId, activeId, {
+        new_parent_id: null,
+        sort_index: tree.length,
+      });
+      mutate();
+    } catch (err) {
+      mutate();
+      if (typeof window !== "undefined") {
+        alert(err instanceof Error ? err.message : "Move failed");
+      }
+    }
+  }
+
   function onDragEnd(event: DragEndEvent) {
     if (!aeroplaneId) return;
     const activeStr = String(event.active.id).replace(/^node-/, "");
@@ -260,30 +292,13 @@ export function ComponentTree({
       ? String(event.over.id).replace(/^node-/, "")
       : null;
 
-    // The virtual root is display-only — it can never be the drag source.
     if (activeStr === VIRTUAL_ROOT_ID) return;
 
     const activeId = Number(activeStr);
     if (Number.isNaN(activeId)) return;
 
-    // Dropping onto the virtual root == reparent to top level. Issues the
-    // move directly (computeMoveResult expects real node IDs on both sides).
     if (overStr === VIRTUAL_ROOT_ID) {
-      void (async () => {
-        mutate();
-        try {
-          await moveTreeNode(aeroplaneId, activeId, {
-            new_parent_id: null,
-            sort_index: tree.length,
-          });
-          mutate();
-        } catch (err) {
-          mutate();
-          if (typeof window !== "undefined") {
-            alert(err instanceof Error ? err.message : "Move failed");
-          }
-        }
-      })();
+      void moveToRoot(activeId);
       return;
     }
 

--- a/frontend/components/workbench/CreatorParameterForm.tsx
+++ b/frontend/components/workbench/CreatorParameterForm.tsx
@@ -13,6 +13,84 @@ interface CreatorParameterFormProps {
   availableShapeKeys?: string[];
 }
 
+/** Renders the appropriate input control for a single creator parameter. */
+function ParamInput({
+  param,
+  value,
+  onChange,
+  availableShapeKeys,
+}: {
+  param: CreatorParam;
+  value: unknown;
+  onChange: (key: string, value: unknown) => void;
+  availableShapeKeys: string[];
+}) {
+  const strValue = String(value ?? param.default ?? "");
+
+  if (param.is_shape_ref && availableShapeKeys.length > 0) {
+    return (
+      <ShapeRefInput
+        value={strValue}
+        onChange={(v) => onChange(param.name, v)}
+        shapeKeys={availableShapeKeys}
+        required={param.required}
+      />
+    );
+  }
+
+  if (param.options && param.options.length > 0) {
+    return (
+      <select
+        value={strValue}
+        onChange={(e) => onChange(param.name, e.target.value)}
+        className="rounded-lg border border-border bg-input px-3 py-1.5 text-[12px] text-foreground outline-none"
+      >
+        {!param.required && <option value="">—</option>}
+        {param.options.map((opt) => (
+          <option key={opt} value={opt}>{opt}</option>
+        ))}
+      </select>
+    );
+  }
+
+  if (param.type === "bool") {
+    return (
+      <input
+        type="checkbox"
+        checked={Boolean(value ?? param.default ?? false)}
+        onChange={(e) => onChange(param.name, e.target.checked)}
+        className="size-4"
+      />
+    );
+  }
+
+  if (param.type === "int" || param.type === "float") {
+    return (
+      <input
+        type="number"
+        value={strValue}
+        onChange={(e) => {
+          const v = param.type === "int"
+            ? parseInt(e.target.value, 10)
+            : parseFloat(e.target.value);
+          onChange(param.name, isNaN(v) ? null : v);
+        }}
+        step={param.type === "float" ? "any" : "1"}
+        className="rounded-lg border border-border bg-input px-3 py-1.5 text-[12px] text-foreground outline-none"
+      />
+    );
+  }
+
+  return (
+    <input
+      type="text"
+      value={strValue}
+      onChange={(e) => onChange(param.name, e.target.value)}
+      className="rounded-lg border border-border bg-input px-3 py-1.5 text-[12px] text-foreground outline-none"
+    />
+  );
+}
+
 export function CreatorParameterForm({
   creatorName,
   creatorDescription,
@@ -48,52 +126,12 @@ export function CreatorParameterForm({
                 <InfoTooltip text={param.description} size={10} />
               )}
             </span>
-            {param.is_shape_ref && availableShapeKeys.length > 0 ? (
-              <ShapeRefInput
-                value={String(values[param.name] ?? param.default ?? "")}
-                onChange={(v) => onChange(param.name, v)}
-                shapeKeys={availableShapeKeys}
-                required={param.required}
-              />
-            ) : param.options && param.options.length > 0 ? (
-              <select
-                value={String(values[param.name] ?? param.default ?? "")}
-                onChange={(e) => onChange(param.name, e.target.value)}
-                className="rounded-lg border border-border bg-input px-3 py-1.5 text-[12px] text-foreground outline-none"
-              >
-                {!param.required && <option value="">—</option>}
-                {param.options.map((opt) => (
-                  <option key={opt} value={opt}>{opt}</option>
-                ))}
-              </select>
-            ) : param.type === "bool" ? (
-              <input
-                type="checkbox"
-                checked={Boolean(values[param.name] ?? param.default ?? false)}
-                onChange={(e) => onChange(param.name, e.target.checked)}
-                className="size-4"
-              />
-            ) : param.type === "int" || param.type === "float" ? (
-              <input
-                type="number"
-                value={String(values[param.name] ?? param.default ?? "")}
-                onChange={(e) => {
-                  const v = param.type === "int"
-                    ? parseInt(e.target.value, 10)
-                    : parseFloat(e.target.value);
-                  onChange(param.name, isNaN(v) ? null : v);
-                }}
-                step={param.type === "float" ? "any" : "1"}
-                className="rounded-lg border border-border bg-input px-3 py-1.5 text-[12px] text-foreground outline-none"
-              />
-            ) : (
-              <input
-                type="text"
-                value={String(values[param.name] ?? param.default ?? "")}
-                onChange={(e) => onChange(param.name, e.target.value)}
-                className="rounded-lg border border-border bg-input px-3 py-1.5 text-[12px] text-foreground outline-none"
-              />
-            )}
+            <ParamInput
+              param={param}
+              value={values[param.name]}
+              onChange={onChange}
+              availableShapeKeys={availableShapeKeys}
+            />
           </label>
         ))
       )}

--- a/frontend/components/workbench/PropertyEditDialog.tsx
+++ b/frontend/components/workbench/PropertyEditDialog.tsx
@@ -49,7 +49,36 @@ function toForm(prop: PropertyDefinition | null): FormState {
   };
 }
 
-function fromForm(f: FormState): { ok: true; prop: PropertyDefinition } | { ok: false; error: string } {
+type FromFormResult = { ok: true; prop: PropertyDefinition } | { ok: false; error: string };
+
+/** Apply type-specific fields (min/max, options, default) to a partially built prop. */
+function applyTypeFields(
+  prop: PropertyDefinition,
+  f: FormState,
+): string | null {
+  switch (f.type) {
+    case "number":
+      if (f.min.trim()) prop.min = Number(f.min);
+      if (f.max.trim()) prop.max = Number(f.max);
+      if (f.defaultStr.trim()) prop.default = Number(f.defaultStr);
+      return null;
+    case "enum": {
+      const opts = f.optionsCsv.split(",").map((o) => o.trim()).filter(Boolean);
+      if (opts.length === 0) return "Enum needs at least one option";
+      prop.options = opts;
+      if (f.defaultStr.trim()) prop.default = f.defaultStr.trim();
+      return null;
+    }
+    case "boolean":
+      if (f.defaultStr.trim()) prop.default = f.defaultStr.trim() === "true";
+      return null;
+    default:
+      if (f.defaultStr.trim()) prop.default = f.defaultStr.trim();
+      return null;
+  }
+}
+
+function fromForm(f: FormState): FromFormResult {
   if (!f.name.trim()) return { ok: false, error: "Name is required" };
   if (!SNAKE_CASE.test(f.name)) {
     return { ok: false, error: "Name must be snake_case (lowercase, digits, underscores)" };
@@ -65,20 +94,8 @@ function fromForm(f: FormState): { ok: true; prop: PropertyDefinition } | { ok: 
   if (f.unit.trim()) prop.unit = f.unit.trim();
   if (f.description.trim()) prop.description = f.description.trim();
 
-  if (f.type === "number") {
-    if (f.min.trim()) prop.min = Number(f.min);
-    if (f.max.trim()) prop.max = Number(f.max);
-    if (f.defaultStr.trim()) prop.default = Number(f.defaultStr);
-  } else if (f.type === "enum") {
-    const opts = f.optionsCsv.split(",").map((o) => o.trim()).filter(Boolean);
-    if (opts.length === 0) return { ok: false, error: "Enum needs at least one option" };
-    prop.options = opts;
-    if (f.defaultStr.trim()) prop.default = f.defaultStr.trim();
-  } else if (f.type === "boolean") {
-    if (f.defaultStr.trim()) prop.default = f.defaultStr.trim() === "true";
-  } else {
-    if (f.defaultStr.trim()) prop.default = f.defaultStr.trim();
-  }
+  const typeError = applyTypeFields(prop, f);
+  if (typeError) return { ok: false, error: typeError };
 
   return { ok: true, prop };
 }


### PR DESCRIPTION
## Summary
- Extract helper functions from deeply nested logic in 5 frontend workbench components to bring cognitive complexity below SonarQube threshold (15)
- **CadViewer.tsx**: preparePartShapes() and addRemainingParts() extracted from init() (import pattern unchanged per project memory)
- **ComponentTree.tsx**: nodeAnnotation(), nodeChip(), toSimpleTreeNode(), moveToRoot() extracted from flattenTree and onDragEnd
- **ComponentEditDialog.tsx**: validateProp(), validateNumberRange(), buildOutSpecs() extracted from validate and handleSave
- **PropertyEditDialog.tsx**: applyTypeFields() with switch/case replaces chained if/else in fromForm
- **CreatorParameterForm.tsx**: ParamInput component extracted from nested ternary chain

## Test plan
- [x] ESLint passes (0 errors, 1 pre-existing warning)
- [x] All 230 frontend unit tests pass
- [ ] CI pipeline green

Closes #231