### PR TITLE
chore(gh-217): use PEP 604 union syntax in schemas

### DIFF
--- a/app/schemas/AeroplaneRequest.py
+++ b/app/schemas/AeroplaneRequest.py
@@ -1,7 +1,7 @@
 import json
 from enum import Enum
 from pathlib import Path
-from typing import Optional, Dict, Any, Union, OrderedDict, List, Literal
+from typing import Optional, Dict, Any, OrderedDict, List, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -599,7 +599,7 @@ class CreateWingLoftRequest(BaseModel):
 
 
 class CreateAeroPlaneRequest(BaseModel):
-    blueprint: Union[Path, Any]
+    blueprint: Path | Any
     wings: Optional[Dict[str, Wing]] = None
     fuselages: Optional[OrderedDict[str, Fuselage]] = None
     settings: Optional[AeroplaneSettings] = None

--- a/app/schemas/aeroanalysisschema.py
+++ b/app/schemas/aeroanalysisschema.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -17,7 +17,7 @@ class OperatingPointSchema(BaseModel):
 
     # Operating point parameters
     velocity: float = Field(10.0, description="Velocity in m/s")
-    alpha: Union[float, List[float]] = Field(0.0, description="Angle of attack in degrees")
+    alpha: float | list[float] = Field(0.0, description="Angle of attack in degrees")
     beta: float = Field(0.0, description="Sideslip angle in degrees")
     p: float = Field(0.0, description="Roll rate in rad/s")
     q: float = Field(0.0, description="Pitch rate in rad/s")

--- a/app/schemas/wing.py
+++ b/app/schemas/wing.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Literal, Union
+from typing import List, Optional, Literal
 from pydantic import AliasChoices, BaseModel, PositiveFloat, NonNegativeFloat, Field
 
 from app.schemas.Servo import Servo
@@ -38,7 +38,7 @@ class TrailingEdgeDevice(BaseModel):
         default=None, 
         description="Spacing from the tip edge of the segment in millimeters"
     )
-    servo: Optional[Union[Servo, int]] = Field(
+    servo: Servo | int | None = Field(
         default=None,
         validation_alias=AliasChoices("servo", "_servo"),
         serialization_alias="servo",


### PR DESCRIPTION
## Summary
- Replace `Union[Path, Any]` with `Path | Any` in `app/schemas/AeroplaneRequest.py:602`
- Replace `Union[float, List[float]]` with `float | list[float]` in `app/schemas/aeroanalysisschema.py:20`
- Replace `Optional[Union[Servo, int]]` with `Servo | int | None` in `app/schemas/wing.py:41`
- Remove unused `Union` imports from all three files

Resolves 3 SonarQube S6546 findings. No logic changes.

Closes #217

## Test plan
- [x] `poetry run ruff check app/schemas/` passes
- [x] `poetry run pytest -m "not slow"` — 613 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)