### PR TITLE
chore(gh-223): resolve minor SonarQube issues

### DIFF
--- a/frontend/app/workbench/analysis/page.tsx
+++ b/frontend/app/workbench/analysis/page.tsx
@@ -20,12 +20,12 @@ export default function AnalysisPage() {
   const [configOpen, setConfigOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<Tab>("Polar");
 
-  const modalTitle =
-    activeTab === "Polar"
-      ? "Polar Configuration"
-      : activeTab === "Trefftz Plane"
-        ? "Trefftz Plane Configuration"
-        : "Streamlines Configuration";
+  const modalTitleByTab: Record<Tab, string> = {
+    "Polar": "Polar Configuration",
+    "Trefftz Plane": "Trefftz Plane Configuration",
+    "Streamlines": "Streamlines Configuration",
+  };
+  const modalTitle = modalTitleByTab[activeTab];
 
   return (
     <>

--- a/frontend/app/workbench/page.tsx
+++ b/frontend/app/workbench/page.tsx
@@ -9,9 +9,9 @@ import { TedEditDialog } from "@/components/workbench/TedEditDialog";
 import { WingOutlineViewer } from "@/components/workbench/WingOutlineViewer";
 import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
 import { useAeroplanes } from "@/hooks/useAeroplanes";
-import { useWings, useWing, useAllWingData, type Wing } from "@/hooks/useWings";
+import { useWings, useWing, useAllWingData } from "@/hooks/useWings";
 import { useFuselages } from "@/hooks/useFuselages";
-import { useAllFuselageData, type Fuselage } from "@/hooks/useFuselage";
+import { useAllFuselageData } from "@/hooks/useFuselage";
 import { API_BASE } from "@/lib/fetcher";
 
 export default function WorkbenchPage() {

--- a/frontend/components/workbench/SparEditDialog.tsx
+++ b/frontend/components/workbench/SparEditDialog.tsx
@@ -26,6 +26,17 @@ interface SparEditDialogProps {
   onSaved: () => void;
 }
 
+function applyOptionalVec3(
+  vec: number[] | null | undefined,
+  setX: (v: string) => void,
+  setY: (v: string) => void,
+  setZ: (v: string) => void,
+) {
+  setX(vec?.[0] == null ? "" : String(vec[0]));
+  setY(vec?.[1] == null ? "" : String(vec[1]));
+  setZ(vec?.[2] == null ? "" : String(vec[2]));
+}
+
 function num(v: string, fallback = 0): number {
   if (v === "" || v === "-" || v === ".") return fallback;
   const n = parseFloat(v);
@@ -66,13 +77,9 @@ export function SparEditDialog({
       setHeight(String(initialData.spare_support_dimension_height ?? 4.42));
       setSparMode(initialData.spare_mode ?? "standard");
       setSparStart(String(initialData.spare_start ?? 0));
-      setSparLength(initialData.spare_length != null ? String(initialData.spare_length) : "");
-      setVecX(initialData.spare_vector?.[0] != null ? String(initialData.spare_vector[0]) : "");
-      setVecY(initialData.spare_vector?.[1] != null ? String(initialData.spare_vector[1]) : "");
-      setVecZ(initialData.spare_vector?.[2] != null ? String(initialData.spare_vector[2]) : "");
-      setOrigX(initialData.spare_origin?.[0] != null ? String(initialData.spare_origin[0]) : "");
-      setOrigY(initialData.spare_origin?.[1] != null ? String(initialData.spare_origin[1]) : "");
-      setOrigZ(initialData.spare_origin?.[2] != null ? String(initialData.spare_origin[2]) : "");
+      setSparLength(initialData.spare_length == null ? "" : String(initialData.spare_length));
+      applyOptionalVec3(initialData.spare_vector, setVecX, setVecY, setVecZ);
+      applyOptionalVec3(initialData.spare_origin, setOrigX, setOrigY, setOrigZ);
     } else {
       setPosFactor("25");
       setWidth("4.42");
@@ -80,12 +87,8 @@ export function SparEditDialog({
       setSparMode("standard");
       setSparStart("0");
       setSparLength("");
-      setVecX("");
-      setVecY("");
-      setVecZ("");
-      setOrigX("");
-      setOrigY("");
-      setOrigZ("");
+      setVecX(""); setVecY(""); setVecZ("");
+      setOrigX(""); setOrigY(""); setOrigZ("");
     }
     setError(null);
   }, [initialData, open]);


### PR DESCRIPTION
## Summary
- **SparEditDialog.tsx**: Extract `applyOptionalVec3` helper to reduce cognitive complexity (S3776), flip negated null checks to positive form (S7735)
- **analysis/page.tsx**: Replace nested ternary with `Record<Tab, string>` lookup (S3358)
- **workbench/page.tsx**: Remove unused `Wing` and `Fuselage` type imports (S1128)

Closes #223

## Test plan
- [x] `npx eslint .` passes on all changed files (0 errors, 0 warnings)
- [x] `npm run test:unit` — all 251 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)