### PR TITLE
chore(gh-221): resolve SonarQube issues in AnalysisConfigPanel

### DIFF
--- a/frontend/components/workbench/AnalysisConfigPanel.tsx
+++ b/frontend/components/workbench/AnalysisConfigPanel.tsx
@@ -10,21 +10,33 @@ import type { Tab } from "@/components/workbench/AnalysisViewerPanel";
 type Mode = "single" | "sweep";
 
 interface AnalysisConfigPanelProps {
-  activeTab: Tab;
+  readonly activeTab: Tab;
   // Polar
-  analysis: UseAnalysisReturn;
+  readonly analysis: UseAnalysisReturn;
   // Trefftz Plane
-  wingNames: string[];
-  selectedWing: string | null;
-  onRunStripForces?: (params: StripForcesAllParams) => void;
-  stripForcesRunning?: boolean;
-  stripForcesError?: string | null;
+  readonly wingNames: string[];
+  readonly selectedWing: string | null;
+  readonly onRunStripForces?: (params: StripForcesAllParams) => void;
+  readonly stripForcesRunning?: boolean;
+  readonly stripForcesError?: string | null;
   // Streamlines
-  onRunStreamlines?: (params: StreamlinesParams) => void;
-  streamlinesRunning?: boolean;
-  streamlinesError?: string | null;
+  readonly onRunStreamlines?: (params: StreamlinesParams) => void;
+  readonly streamlinesRunning?: boolean;
+  readonly streamlinesError?: string | null;
   // Modal close
-  onClose?: () => void;
+  readonly onClose?: () => void;
+}
+
+function getIsRunning(activeTab: Tab, analysis: UseAnalysisReturn, stripForcesRunning: boolean | undefined, streamlinesRunning: boolean | undefined): boolean {
+  if (activeTab === "Polar") return analysis.isRunning;
+  if (activeTab === "Trefftz Plane") return stripForcesRunning ?? false;
+  return streamlinesRunning ?? false;
+}
+
+function getCurrentError(activeTab: Tab, analysis: UseAnalysisReturn, stripForcesError: string | null | undefined, streamlinesError: string | null | undefined): string | null {
+  if (activeTab === "Polar") return analysis.error;
+  if (activeTab === "Trefftz Plane") return stripForcesError ?? null;
+  return streamlinesError ?? null;
 }
 
 export function AnalysisConfigPanel({
@@ -39,26 +51,26 @@ export function AnalysisConfigPanel({
   streamlinesRunning,
   streamlinesError,
   onClose,
-}: AnalysisConfigPanelProps) {
+}: Readonly<AnalysisConfigPanelProps>) {
   const [mode, setMode] = useState<Mode>("sweep");
   const [advancedOpen, setAdvancedOpen] = useState(false);
 
   // Shared form state
-  const [alphaStart, setAlphaStart] = useState("-5.0");
-  const [alphaEnd, setAlphaEnd] = useState("15.0");
-  const [alphaStep, setAlphaStep] = useState("1.0");
-  const [velocity, setVelocity] = useState("14.0");
+  const [alphaStart, setAlphaStart] = useState("-5");
+  const [alphaEnd, setAlphaEnd] = useState("15");
+  const [alphaStep, setAlphaStep] = useState("1");
+  const [velocity, setVelocity] = useState("14");
   const [altitude, setAltitude] = useState("100");
-  const [beta, setBeta] = useState("0.0");
+  const [beta, setBeta] = useState("0");
   const [analysisTool, setAnalysisTool] = useState("aero_buildup");
-  const [xyzRef, setXyzRef] = useState("0.0, 0.0, 0.0");
+  const [xyzRef, setXyzRef] = useState("0, 0, 0");
 
   // Trefftz-specific state
-  const [trefftzAlpha, setTrefftzAlpha] = useState("5.0");
+  const [trefftzAlpha, setTrefftzAlpha] = useState("5");
 
   const parseXyzRef = (): number[] => {
-    const parts = xyzRef.split(",").map((s) => parseFloat(s.trim()));
-    return parts.length === 3 && parts.every((n) => !isNaN(n))
+    const parts = xyzRef.split(",").map((s) => Number.parseFloat(s.trim()));
+    return parts.length === 3 && parts.every((n) => !Number.isNaN(n))
       ? parts
       : [0, 0, 0];
   };
@@ -67,11 +79,11 @@ export function AnalysisConfigPanel({
   const handleRunPolar = () => {
     analysis.runAlphaSweep({
       analysis_tool: analysisTool,
-      velocity_m_s: parseFloat(velocity) || 14.0,
-      alpha_start_deg: parseFloat(alphaStart) || -5.0,
-      alpha_end_deg: parseFloat(alphaEnd) || 15.0,
-      alpha_step_deg: parseFloat(alphaStep) || 1.0,
-      beta_deg: parseFloat(beta) || 0.0,
+      velocity_m_s: Number.parseFloat(velocity) || 14,
+      alpha_start_deg: Number.parseFloat(alphaStart) || -5,
+      alpha_end_deg: Number.parseFloat(alphaEnd) || 15,
+      alpha_step_deg: Number.parseFloat(alphaStep) || 1,
+      beta_deg: Number.parseFloat(beta) || 0,
       xyz_ref_m: parseXyzRef(),
     });
     onClose?.();
@@ -80,10 +92,10 @@ export function AnalysisConfigPanel({
   // ── Trefftz Plane handlers ──
   const handleRunStripForces = () => {
     onRunStripForces?.({
-      velocity: parseFloat(velocity) || 14.0,
-      alpha: parseFloat(trefftzAlpha) || 5.0,
-      beta: parseFloat(beta) || 0.0,
-      altitude: parseFloat(altitude) || 100,
+      velocity: Number.parseFloat(velocity) || 14,
+      alpha: Number.parseFloat(trefftzAlpha) || 5,
+      beta: Number.parseFloat(beta) || 0,
+      altitude: Number.parseFloat(altitude) || 100,
       xyz_ref: parseXyzRef(),
     });
     onClose?.();
@@ -92,40 +104,30 @@ export function AnalysisConfigPanel({
   // ── Streamlines handlers ──
   const handleRunStreamlines = () => {
     onRunStreamlines?.({
-      velocity: parseFloat(velocity) || 14.0,
-      alpha: parseFloat(trefftzAlpha) || 5.0,
-      beta: parseFloat(beta) || 0.0,
-      altitude: parseFloat(altitude) || 100,
+      velocity: Number.parseFloat(velocity) || 14,
+      alpha: Number.parseFloat(trefftzAlpha) || 5,
+      beta: Number.parseFloat(beta) || 0,
+      altitude: Number.parseFloat(altitude) || 100,
     });
     onClose?.();
   };
 
   const handleReset = () => {
-    setAlphaStart("-5.0");
-    setAlphaEnd("15.0");
-    setAlphaStep("1.0");
-    setVelocity("14.0");
+    setAlphaStart("-5");
+    setAlphaEnd("15");
+    setAlphaStep("1");
+    setVelocity("14");
     setAltitude("100");
-    setBeta("0.0");
+    setBeta("0");
     setAnalysisTool("aero_buildup");
-    setXyzRef("0.0, 0.0, 0.0");
-    setTrefftzAlpha("5.0");
+    setXyzRef("0, 0, 0");
+    setTrefftzAlpha("5");
   };
 
   // Determine running/error state for active tab
-  const isRunning =
-    activeTab === "Polar"
-      ? analysis.isRunning
-      : activeTab === "Trefftz Plane"
-        ? stripForcesRunning ?? false
-        : streamlinesRunning ?? false;
+  const isRunning = getIsRunning(activeTab, analysis, stripForcesRunning, streamlinesRunning);
 
-  const currentError =
-    activeTab === "Polar"
-      ? analysis.error
-      : activeTab === "Trefftz Plane"
-        ? stripForcesError ?? null
-        : streamlinesError ?? null;
+  const currentError = getCurrentError(activeTab, analysis, stripForcesError, streamlinesError);
 
   const handleRun =
     activeTab === "Polar"
@@ -223,11 +225,11 @@ export function AnalysisConfigPanel({
               <div className="flex flex-col gap-3">
                 {/* sweep_var */}
                 <div className="flex flex-col gap-1">
-                  <label className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+                  <label htmlFor="sweep-var-select" className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
                     sweep_var
                   </label>
                   <div className="relative">
-                    <select className="w-full appearance-none rounded-xl border border-border bg-input px-3 py-2 pr-8 font-[family-name:var(--font-geist-sans)] text-[13px] text-foreground">
+                    <select id="sweep-var-select" className="w-full appearance-none rounded-xl border border-border bg-input px-3 py-2 pr-8 font-[family-name:var(--font-geist-sans)] text-[13px] text-foreground">
                       <option>alpha</option>
                       <option>beta</option>
                       <option>velocity</option>
@@ -242,10 +244,11 @@ export function AnalysisConfigPanel({
                 {/* Range row */}
                 <div className="grid grid-cols-3 gap-3">
                   <div className="flex flex-col gap-1">
-                    <label className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+                    <label htmlFor="sweep-start" className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
                       start
                     </label>
                     <input
+                      id="sweep-start"
                       type="text"
                       value={alphaStart}
                       onChange={(e) => setAlphaStart(e.target.value)}
@@ -253,10 +256,11 @@ export function AnalysisConfigPanel({
                     />
                   </div>
                   <div className="flex flex-col gap-1">
-                    <label className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+                    <label htmlFor="sweep-end" className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
                       end
                     </label>
                     <input
+                      id="sweep-end"
                       type="text"
                       value={alphaEnd}
                       onChange={(e) => setAlphaEnd(e.target.value)}
@@ -264,10 +268,11 @@ export function AnalysisConfigPanel({
                     />
                   </div>
                   <div className="flex flex-col gap-1">
-                    <label className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+                    <label htmlFor="sweep-step" className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
                       step
                     </label>
                     <input
+                      id="sweep-step"
                       type="text"
                       value={alphaStep}
                       onChange={(e) => setAlphaStep(e.target.value)}
@@ -288,11 +293,12 @@ export function AnalysisConfigPanel({
                 {/* Fixed row 1 */}
                 <div className="grid grid-cols-2 gap-3">
                   <div className="flex flex-col gap-1">
-                    <label className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+                    <label htmlFor="polar-velocity" className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
                       velocity
                     </label>
                     <div className="relative">
                       <input
+                        id="polar-velocity"
                         type="text"
                         value={velocity}
                         onChange={(e) => setVelocity(e.target.value)}
@@ -304,11 +310,12 @@ export function AnalysisConfigPanel({
                     </div>
                   </div>
                   <div className="flex flex-col gap-1">
-                    <label className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+                    <label htmlFor="polar-altitude" className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
                       altitude
                     </label>
                     <div className="relative">
                       <input
+                        id="polar-altitude"
                         type="text"
                         value={altitude}
                         onChange={(e) => setAltitude(e.target.value)}
@@ -323,11 +330,12 @@ export function AnalysisConfigPanel({
 
                 {/* Fixed row 2 */}
                 <div className="flex flex-col gap-1">
-                  <label className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+                  <label htmlFor="polar-beta" className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
                     beta
                   </label>
                   <div className="relative">
                     <input
+                      id="polar-beta"
                       type="text"
                       value={beta}
                       onChange={(e) => setBeta(e.target.value)}
@@ -358,13 +366,14 @@ export function AnalysisConfigPanel({
                       <div className="grid grid-cols-3 gap-3">
                         {["p", "q", "r"].map((label) => (
                           <div key={label} className="flex flex-col gap-1">
-                            <label className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+                            <label htmlFor={`advanced-${label}`} className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
                               {label}
                             </label>
                             <div className="relative">
                               <input
+                                id={`advanced-${label}`}
                                 type="text"
-                                defaultValue="0.0"
+                                defaultValue="0"
                                 className="w-full rounded-xl border border-border bg-input px-3 py-2 pr-12 font-[family-name:var(--font-geist-sans)] text-[13px] text-foreground"
                               />
                               <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
@@ -376,11 +385,12 @@ export function AnalysisConfigPanel({
                       </div>
                       {/* xyz_ref row */}
                       <div className="flex flex-col gap-1">
-                        <label className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+                        <label htmlFor="polar-xyz-ref" className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
                           xyz_ref
                         </label>
                         <div className="relative">
                           <input
+                            id="polar-xyz-ref"
                             type="text"
                             value={xyzRef}
                             onChange={(e) => setXyzRef(e.target.value)}
@@ -433,11 +443,11 @@ export function AnalysisConfigPanel({
 
             {/* Flight profile */}
             <div className="flex flex-col gap-1">
-              <label className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+              <label htmlFor="flight-profile-select" className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
                 Flight profile
               </label>
               <div className="relative">
-                <select className="w-full appearance-none rounded-xl border border-border bg-input px-3 py-2 pr-8 font-[family-name:var(--font-geist-sans)] text-[13px] text-foreground">
+                <select id="flight-profile-select" className="w-full appearance-none rounded-xl border border-border bg-input px-3 py-2 pr-8 font-[family-name:var(--font-geist-sans)] text-[13px] text-foreground">
                   <option>cruise</option>
                   <option>takeoff</option>
                   <option>landing</option>
@@ -468,11 +478,12 @@ export function AnalysisConfigPanel({
 
           {/* Alpha (single) */}
           <div className="flex flex-col gap-1">
-            <label className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+            <label htmlFor="trefftz-alpha" className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
               alpha
             </label>
             <div className="relative">
               <input
+                id="trefftz-alpha"
                 type="text"
                 value={trefftzAlpha}
                 onChange={(e) => setTrefftzAlpha(e.target.value)}
@@ -487,11 +498,12 @@ export function AnalysisConfigPanel({
           {/* Velocity + Altitude */}
           <div className="grid grid-cols-2 gap-3">
             <div className="flex flex-col gap-1">
-              <label className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+              <label htmlFor="trefftz-velocity" className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
                 velocity
               </label>
               <div className="relative">
                 <input
+                  id="trefftz-velocity"
                   type="text"
                   value={velocity}
                   onChange={(e) => setVelocity(e.target.value)}
@@ -503,11 +515,12 @@ export function AnalysisConfigPanel({
               </div>
             </div>
             <div className="flex flex-col gap-1">
-              <label className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+              <label htmlFor="trefftz-altitude" className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
                 altitude
               </label>
               <div className="relative">
                 <input
+                  id="trefftz-altitude"
                   type="text"
                   value={altitude}
                   onChange={(e) => setAltitude(e.target.value)}
@@ -522,11 +535,12 @@ export function AnalysisConfigPanel({
 
           {/* Beta */}
           <div className="flex flex-col gap-1">
-            <label className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+            <label htmlFor="trefftz-beta" className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
               beta
             </label>
             <div className="relative">
               <input
+                id="trefftz-beta"
                 type="text"
                 value={beta}
                 onChange={(e) => setBeta(e.target.value)}
@@ -554,11 +568,12 @@ export function AnalysisConfigPanel({
             {advancedOpen && (
               <div className="flex flex-col gap-3 opacity-60">
                 <div className="flex flex-col gap-1">
-                  <label className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+                  <label htmlFor="trefftz-xyz-ref" className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
                     xyz_ref
                   </label>
                   <div className="relative">
                     <input
+                      id="trefftz-xyz-ref"
                       type="text"
                       value={xyzRef}
                       onChange={(e) => setXyzRef(e.target.value)}
@@ -586,11 +601,12 @@ export function AnalysisConfigPanel({
 
           {/* Alpha (single) */}
           <div className="flex flex-col gap-1">
-            <label className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+            <label htmlFor="streamlines-alpha" className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
               alpha
             </label>
             <div className="relative">
               <input
+                id="streamlines-alpha"
                 type="text"
                 value={trefftzAlpha}
                 onChange={(e) => setTrefftzAlpha(e.target.value)}
@@ -605,11 +621,12 @@ export function AnalysisConfigPanel({
           {/* Velocity + Altitude */}
           <div className="grid grid-cols-2 gap-3">
             <div className="flex flex-col gap-1">
-              <label className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+              <label htmlFor="streamlines-velocity" className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
                 velocity
               </label>
               <div className="relative">
                 <input
+                  id="streamlines-velocity"
                   type="text"
                   value={velocity}
                   onChange={(e) => setVelocity(e.target.value)}
@@ -621,11 +638,12 @@ export function AnalysisConfigPanel({
               </div>
             </div>
             <div className="flex flex-col gap-1">
-              <label className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+              <label htmlFor="streamlines-altitude" className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
                 altitude
               </label>
               <div className="relative">
                 <input
+                  id="streamlines-altitude"
                   type="text"
                   value={altitude}
                   onChange={(e) => setAltitude(e.target.value)}
@@ -640,11 +658,12 @@ export function AnalysisConfigPanel({
 
           {/* Beta */}
           <div className="flex flex-col gap-1">
-            <label className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+            <label htmlFor="streamlines-beta" className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
               beta
             </label>
             <div className="relative">
               <input
+                id="streamlines-beta"
                 type="text"
                 value={beta}
                 onChange={(e) => setBeta(e.target.value)}


### PR DESCRIPTION
## Summary

- **S6853** (9x): Associate form labels with controls using `htmlFor`+`id` pairs
- **S3358** (3x): Extract nested ternary operations into `getIsRunning()` and `getCurrentError()` helper functions
- **S7773** (8x): Replace global `parseFloat`/`isNaN` with `Number.parseFloat`/`Number.isNaN`
- **S7748** (6x): Remove unnecessary zero fractions (`0.0` -> `0`, `14.0` -> `14`, etc.)
- **S6759**: Mark all props as `readonly` via `Readonly<>` wrapper and individual `readonly` modifiers

Pure refactoring — identical runtime behavior.

Closes #221

## Test plan

- [x] `npx eslint components/workbench/AnalysisConfigPanel.tsx` — 0 errors
- [x] `npm run test:unit` — 251 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)