### PR TITLE
refactor(gh-226): reduce cognitive complexity in 6 SonarQube regressions

### DIFF
--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -640,6 +640,24 @@ def _scatter_characteristic_points(
     return polar_point_labels
 
 
+def _resolve_alpha_marker(
+    point: dict,
+    key: str,
+    alpha_val: float,
+    text: str,
+) -> tuple[float, str] | None:
+    """Return (y_value, label) for a characteristic point on the alpha panel, or None."""
+    if key == "minimum_drag_coefficient_point":
+        y_val = point.get("CD")
+        if y_val is None:
+            return None
+        return y_val, f"{text}={y_val:.3f} @ a={alpha_val:.2f}"
+    y_val = point.get("CL")
+    if y_val is None:
+        return None
+    return y_val, f"{text} @ a={alpha_val:.2f}, CL={y_val:.3f}"
+
+
 def _mirror_markers_to_alpha_panel(
     ax_coeff: Any,
     alpha_polar: np.ndarray,
@@ -662,23 +680,12 @@ def _mirror_markers_to_alpha_panel(
         idx = point.get("index")
         if idx is None or idx >= alpha_len:
             continue
-        alpha_val = alpha_polar[idx]
-        if key == "minimum_drag_coefficient_point":
-            y_val = point.get("CD")
-            if y_val is None:
-                continue
-            ax_coeff.scatter(alpha_val, y_val, color=color, s=25, zorder=5)
-            alpha_point_labels.append(
-                (alpha_val, y_val, f"{text}={y_val:.3f} @ a={alpha_val:.2f}", color)
-            )
-        else:
-            y_val = point.get("CL")
-            if y_val is None:
-                continue
-            ax_coeff.scatter(alpha_val, y_val, color=color, s=25, zorder=5)
-            alpha_point_labels.append(
-                (alpha_val, y_val, f"{text} @ a={alpha_val:.2f}, CL={y_val:.3f}", color)
-            )
+        resolved = _resolve_alpha_marker(point, key, alpha_polar[idx], text)
+        if resolved is None:
+            continue
+        y_val, label = resolved
+        ax_coeff.scatter(alpha_polar[idx], y_val, color=color, s=25, zorder=5)
+        alpha_point_labels.append((alpha_polar[idx], y_val, label, color))
     return alpha_point_labels
 
 

--- a/frontend/app/workbench/construction-plans/page.tsx
+++ b/frontend/app/workbench/construction-plans/page.tsx
@@ -520,358 +520,490 @@ export default function ConstructionPlansPage() {
         </div>
       </WorkbenchTwoPanel>
 
-      {/* Add Step Dialog — Phase 1: pick creator, Phase 2: confirm with creator_id */}
-      {addDialogOpen && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-          onClick={() => { setAddDialogOpen(false); setAddingCreator(null); }}
-        >
-          <div
-            className="flex max-h-[85vh] w-[600px] flex-col gap-4 overflow-y-auto rounded-2xl border border-border bg-card p-6 shadow-2xl"
-            onClick={(e) => e.stopPropagation()}
-          >
-            {addingCreator ? (
-              <>
-                <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
-                  Add {addingCreator.class_name}
-                </h2>
-                {/* Creator ID input with auto-substitution */}
-                <label className="flex flex-col gap-1">
-                  <span className="flex items-center gap-2 font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-muted-foreground">
-                    Step ID (creator_id)
-                    {addCreatorIdManual && addingCreator.suggested_id && (
-                      <button
-                        onClick={() => {
-                          setAddCreatorIdManual(false);
-                          setAddCreatorId(resolveIdTemplate(addingCreator.suggested_id!, addStepParams));
-                        }}
-                        className="text-[9px] text-primary hover:underline"
-                      >
-                        Reset
-                      </button>
-                    )}
-                  </span>
-                  <input
-                    type="text"
-                    value={addCreatorId}
-                    onChange={(e) => {
-                      setAddCreatorId(e.target.value);
-                      setAddCreatorIdManual(true);
-                    }}
-                    placeholder={addingCreator.suggested_id ?? addingCreator.class_name}
-                    className="rounded-lg border border-border bg-input px-3 py-2 font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-foreground outline-none"
-                  />
-                  <span className="text-[9px] text-subtle-foreground">
-                    This ID is used to reference this step&apos;s output shapes in subsequent steps.
-                  </span>
-                </label>
-                {/* Parameter inputs */}
-                {addingCreator.parameters.length > 0 && (
-                  <CreatorParameterForm
-                    creatorName=""
-                    params={addingCreator.parameters}
-                    values={addStepParams}
-                    onChange={(key, value) => {
-                      const next = { ...addStepParams, [key]: value };
-                      setAddStepParams(next);
-                      if (!addCreatorIdManual && addingCreator.suggested_id) {
-                        setAddCreatorId(resolveIdTemplate(addingCreator.suggested_id, next));
-                      }
-                    }}
-                    availableShapeKeys={collectAvailableShapeKeys(treeJson, creators)}
-                  />
-                )}
-                {/* Creator detail info (collapsed) */}
-                <details className="rounded-xl border border-border">
-                  <summary className="cursor-pointer px-3 py-2 font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-muted-foreground">
-                    Creator Info
-                  </summary>
-                  <div className="px-3 pb-3">
-                    <CreatorDetailView
-                      creator={addingCreator}
-                      onBack={() => setAddingCreator(null)}
-                    />
-                  </div>
-                </details>
-                {/* Confirm */}
-                <div className="flex justify-end gap-2">
-                  <button
-                    onClick={() => setAddingCreator(null)}
-                    className="rounded-full border border-border px-4 py-2 text-[12px] text-muted-foreground hover:bg-sidebar-accent"
-                  >
-                    Back
-                  </button>
+      <AddStepDialog
+        open={addDialogOpen}
+        addingCreator={addingCreator}
+        addCreatorId={addCreatorId}
+        addCreatorIdManual={addCreatorIdManual}
+        addStepParams={addStepParams}
+        treeJson={treeJson}
+        creators={creators}
+        onClose={() => { setAddDialogOpen(false); setAddingCreator(null); }}
+        onSetAddingCreator={setAddingCreator}
+        onSetAddCreatorId={setAddCreatorId}
+        onSetAddCreatorIdManual={setAddCreatorIdManual}
+        onSetAddStepParams={setAddStepParams}
+        onAddCreator={handleAddCreator}
+      />
+
+      <NewPlanDialog
+        open={newPlanDialogOpen}
+        newPlanName={newPlanName}
+        newPlanFromTemplate={newPlanFromTemplate}
+        newPlanTemplateId={newPlanTemplateId}
+        templates={templates}
+        onClose={() => setNewPlanDialogOpen(false)}
+        onSetNewPlanName={setNewPlanName}
+        onSetNewPlanFromTemplate={setNewPlanFromTemplate}
+        onSetNewPlanTemplateId={setNewPlanTemplateId}
+        onSubmit={handleNewPlanSubmit}
+      />
+
+      <ExecuteDialog
+        open={executeDialogOpen}
+        executeAeroplaneId={executeAeroplaneId}
+        executing={executing}
+        executeResult={executeResult}
+        aeroplanes={aeroplanes}
+        onClose={() => setExecuteDialogOpen(false)}
+        onSetExecuteAeroplaneId={setExecuteAeroplaneId}
+        onExecute={handleExecute}
+      />
+
+      <CadViewerModal
+        open={cadViewerOpen}
+        fullscreen={cadViewerFullscreen}
+        cadViewerData={cadViewerData}
+        executeResult={executeResult}
+        onClose={() => { setCadViewerOpen(false); setCadViewerFullscreen(false); }}
+        onToggleFullscreen={() => setCadViewerFullscreen((v) => !v)}
+      />
+    </>
+  );
+}
+
+// ── Extracted dialog components ──────────────────────────────────
+
+function AddStepDialog({
+  open,
+  addingCreator,
+  addCreatorId,
+  addCreatorIdManual,
+  addStepParams,
+  treeJson,
+  creators,
+  selectedStepPath,
+  onClose,
+  onSetAddingCreator,
+  onSetAddCreatorId,
+  onSetAddCreatorIdManual,
+  onSetAddStepParams,
+  onAddCreator,
+}: {
+  open: boolean;
+  addingCreator: CreatorInfo | null;
+  addCreatorId: string;
+  addCreatorIdManual: boolean;
+  addStepParams: Record<string, unknown>;
+  treeJson: PlanStepNode | null;
+  creators: CreatorInfo[];
+  onClose: () => void;
+  onSetAddingCreator: (c: CreatorInfo | null) => void;
+  onSetAddCreatorId: (id: string) => void;
+  onSetAddCreatorIdManual: (v: boolean) => void;
+  onSetAddStepParams: (p: Record<string, unknown>) => void;
+  onAddCreator: (creator: CreatorInfo, creatorId?: string) => void;
+}) {
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={onClose}
+    >
+      <div
+        className="flex max-h-[85vh] w-[600px] flex-col gap-4 overflow-y-auto rounded-2xl border border-border bg-card p-6 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {addingCreator ? (
+          <>
+            <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
+              Add {addingCreator.class_name}
+            </h2>
+            <label className="flex flex-col gap-1">
+              <span className="flex items-center gap-2 font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-muted-foreground">
+                Step ID (creator_id)
+                {addCreatorIdManual && addingCreator.suggested_id && (
                   <button
                     onClick={() => {
-                      const id = addCreatorId.trim() || addingCreator.suggested_id || addingCreator.class_name;
-                      handleAddCreator({ ...addingCreator } as CreatorInfo, id);
+                      onSetAddCreatorIdManual(false);
+                      onSetAddCreatorId(resolveIdTemplate(addingCreator.suggested_id!, addStepParams));
                     }}
-                    className="rounded-full bg-primary px-4 py-2 text-[12px] text-primary-foreground hover:opacity-90"
+                    className="text-[9px] text-primary hover:underline"
                   >
-                    Add Step
+                    Reset
                   </button>
-                </div>
+                )}
+              </span>
+              <input
+                type="text"
+                value={addCreatorId}
+                onChange={(e) => {
+                  onSetAddCreatorId(e.target.value);
+                  onSetAddCreatorIdManual(true);
+                }}
+                placeholder={addingCreator.suggested_id ?? addingCreator.class_name}
+                className="rounded-lg border border-border bg-input px-3 py-2 font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-foreground outline-none"
+              />
+              <span className="text-[9px] text-subtle-foreground">
+                This ID is used to reference this step&apos;s output shapes in subsequent steps.
+              </span>
+            </label>
+            {addingCreator.parameters.length > 0 && (
+              <CreatorParameterForm
+                creatorName=""
+                params={addingCreator.parameters}
+                values={addStepParams}
+                onChange={(key, value) => {
+                  const next = { ...addStepParams, [key]: value };
+                  onSetAddStepParams(next);
+                  if (!addCreatorIdManual && addingCreator.suggested_id) {
+                    onSetAddCreatorId(resolveIdTemplate(addingCreator.suggested_id, next));
+                  }
+                }}
+                availableShapeKeys={collectAvailableShapeKeys(treeJson, creators)}
+              />
+            )}
+            <details className="rounded-xl border border-border">
+              <summary className="cursor-pointer px-3 py-2 font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-muted-foreground">
+                Creator Info
+              </summary>
+              <div className="px-3 pb-3">
+                <CreatorDetailView
+                  creator={addingCreator}
+                  onBack={() => onSetAddingCreator(null)}
+                />
+              </div>
+            </details>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => onSetAddingCreator(null)}
+                className="rounded-full border border-border px-4 py-2 text-[12px] text-muted-foreground hover:bg-sidebar-accent"
+              >
+                Back
+              </button>
+              <button
+                onClick={() => {
+                  const id = addCreatorId.trim() || addingCreator.suggested_id || addingCreator.class_name;
+                  onAddCreator({ ...addingCreator } as CreatorInfo, id);
+                }}
+                className="rounded-full bg-primary px-4 py-2 text-[12px] text-primary-foreground hover:opacity-90"
+              >
+                Add Step
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
+              Add Step
+            </h2>
+            <CreatorGallery
+              creators={creators}
+              onSelect={(creator) => {
+                const defaults: Record<string, unknown> = {};
+                for (const p of creator.parameters) {
+                  if (p.default != null) defaults[p.name] = p.default;
+                }
+                onSetAddStepParams(defaults);
+                onSetAddingCreator(creator);
+                onSetAddCreatorIdManual(false);
+                onSetAddCreatorId(
+                  creator.suggested_id
+                    ? resolveIdTemplate(creator.suggested_id, defaults)
+                    : creator.class_name,
+                );
+              }}
+            />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function NewPlanDialog({
+  open,
+  newPlanName,
+  newPlanFromTemplate,
+  newPlanTemplateId,
+  templates,
+  onClose,
+  onSetNewPlanName,
+  onSetNewPlanFromTemplate,
+  onSetNewPlanTemplateId,
+  onSubmit,
+}: {
+  open: boolean;
+  newPlanName: string;
+  newPlanFromTemplate: boolean;
+  newPlanTemplateId: number | null;
+  templates: Array<{ id: number; name: string; step_count: number; description?: string | null }>;
+  onClose: () => void;
+  onSetNewPlanName: (v: string) => void;
+  onSetNewPlanFromTemplate: (v: boolean) => void;
+  onSetNewPlanTemplateId: (v: number | null) => void;
+  onSubmit: () => void;
+}) {
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="New Plan"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={onClose}
+      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
+    >
+      <div
+        className="flex w-[480px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
+        <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
+          New Plan
+        </h2>
+        <label className="flex flex-col gap-1">
+          <span className="text-[12px] text-muted-foreground">Plan name</span>
+          <input
+            type="text"
+            value={newPlanName}
+            onChange={(e) => onSetNewPlanName(e.target.value)}
+            placeholder="Enter plan name..."
+            autoFocus
+            className="rounded-xl border border-border bg-input px-3 py-2 text-[12px] text-foreground outline-none"
+          />
+        </label>
+        <fieldset className="flex flex-col gap-2">
+          <span className="text-[12px] text-muted-foreground">Start from</span>
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="radio"
+              name="newPlanSource"
+              checked={!newPlanFromTemplate}
+              onChange={() => {
+                onSetNewPlanFromTemplate(false);
+                onSetNewPlanTemplateId(null);
+              }}
+              className="accent-[#FF8400]"
+            />
+            <span className="text-[12px] text-foreground">Empty plan</span>
+          </label>
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="radio"
+              name="newPlanSource"
+              checked={newPlanFromTemplate}
+              onChange={() => onSetNewPlanFromTemplate(true)}
+              className="accent-[#FF8400]"
+            />
+            <span className="text-[12px] text-foreground">From template</span>
+          </label>
+        </fieldset>
+        {newPlanFromTemplate && (
+          <div className="flex flex-col gap-2">
+            <select
+              value={newPlanTemplateId ?? ""}
+              onChange={(e) =>
+                onSetNewPlanTemplateId(e.target.value ? Number.parseInt(e.target.value, 10) : null)
+              }
+              className="rounded-xl border border-border bg-input px-3 py-2 text-[12px] text-foreground"
+            >
+              <option value="">Select a template...</option>
+              {templates.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.name} ({t.step_count} steps)
+                </option>
+              ))}
+            </select>
+            {newPlanTemplateId != null &&
+              templates.find((t) => t.id === newPlanTemplateId)?.description && (
+                <p className="text-[11px] text-muted-foreground">
+                  {templates.find((t) => t.id === newPlanTemplateId)?.description}
+                </p>
+              )}
+          </div>
+        )}
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="rounded-full border border-border px-4 py-2 text-[12px] text-muted-foreground hover:bg-sidebar-accent"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onSubmit}
+            disabled={
+              !newPlanName.trim() ||
+              (newPlanFromTemplate && newPlanTemplateId == null)
+            }
+            className="rounded-full bg-primary px-4 py-2 text-[12px] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+          >
+            Create
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ExecuteDialog({
+  open,
+  executeAeroplaneId,
+  executing,
+  executeResult,
+  aeroplanes,
+  onClose,
+  onSetExecuteAeroplaneId,
+  onExecute,
+}: {
+  open: boolean;
+  executeAeroplaneId: string;
+  executing: boolean;
+  executeResult: ExecutionResult | null;
+  aeroplanes: Array<{ id: string; name: string }>;
+  onClose: () => void;
+  onSetExecuteAeroplaneId: (v: string) => void;
+  onExecute: () => void;
+}) {
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={onClose}
+    >
+      <div
+        className="flex w-[480px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
+          Execute Plan
+        </h2>
+        <label className="flex flex-col gap-1">
+          <span className="text-[12px] text-muted-foreground">Aeroplane</span>
+          <select
+            value={executeAeroplaneId}
+            onChange={(e) => onSetExecuteAeroplaneId(e.target.value)}
+            className="rounded-xl border border-border bg-input px-3 py-2 text-[12px] text-foreground"
+          >
+            <option value="">Select aeroplane...</option>
+            {aeroplanes.map((a) => (
+              <option key={a.id} value={a.id}>
+                {a.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {executeResult && (
+          <div
+            className={`rounded-xl border p-3 text-[12px] ${
+              executeResult.status === "success"
+                ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
+                : "border-red-500/30 bg-red-500/10 text-red-400"
+            }`}
+          >
+            <p className="font-semibold">
+              {executeResult.status === "success" ? "Success" : "Error"}
+            </p>
+            {executeResult.error && <p>{executeResult.error}</p>}
+            {executeResult.shape_keys.length > 0 && (
+              <p>Shapes: {executeResult.shape_keys.join(", ")}</p>
+            )}
+            {executeResult.duration_ms > 0 && (
+              <p>Duration: {executeResult.duration_ms}ms</p>
+            )}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="rounded-full border border-border px-4 py-2 text-[12px] text-muted-foreground hover:bg-sidebar-accent"
+          >
+            Close
+          </button>
+          <button
+            onClick={onExecute}
+            disabled={!executeAeroplaneId || executing}
+            className="flex items-center gap-1.5 rounded-full bg-primary px-4 py-2 text-[12px] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+          >
+            {executing ? (
+              <>
+                <Loader2 size={12} className="animate-spin" />
+                Running...
               </>
             ) : (
               <>
-                <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
-                  Add Step
-                </h2>
-                <CreatorGallery
-                  creators={creators}
-                  onSelect={(creator) => {
-                    // Build default params from creator defaults
-                    const defaults: Record<string, unknown> = {};
-                    for (const p of creator.parameters) {
-                      if (p.default != null) defaults[p.name] = p.default;
-                    }
-                    setAddStepParams(defaults);
-                    setAddingCreator(creator);
-                    setAddCreatorIdManual(false);
-                    setAddCreatorId(
-                      creator.suggested_id
-                        ? resolveIdTemplate(creator.suggested_id, defaults)
-                        : creator.class_name,
-                    );
-                  }}
-                />
+                <Play size={12} />
+                Execute
               </>
             )}
-          </div>
+          </button>
         </div>
-      )}
+      </div>
+    </div>
+  );
+}
 
-      {/* New Plan Dialog */}
-      {newPlanDialogOpen && (
-        <div
-          role="dialog"
-          aria-modal="true"
-          aria-label="New Plan"
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-          onClick={() => setNewPlanDialogOpen(false)}
-          onKeyDown={(e) => { if (e.key === "Escape") setNewPlanDialogOpen(false); }}
-        >
-          <div
-            className="flex w-[480px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
-            onClick={(e) => e.stopPropagation()}
-            onKeyDown={(e) => e.stopPropagation()}
+function CadViewerModal({
+  open,
+  fullscreen,
+  cadViewerData,
+  executeResult,
+  onClose,
+  onToggleFullscreen,
+}: {
+  open: boolean;
+  fullscreen: boolean;
+  cadViewerData: Record<string, unknown> | null;
+  executeResult: ExecutionResult | null;
+  onClose: () => void;
+  onToggleFullscreen: () => void;
+}) {
+  if (!open || !cadViewerData) return null;
+
+  return (
+    <div
+      className={`fixed inset-0 z-50 flex items-center justify-center ${fullscreen ? "" : "bg-black/60"}`}
+      onClick={onClose}
+    >
+      <div
+        className={`flex flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-2xl ${
+          fullscreen ? "h-full w-full rounded-none border-0" : "h-[80vh] w-[80vw]"
+        }`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex shrink-0 items-center gap-2 border-b border-border px-4 py-3">
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-foreground">
+            Execution Result
+          </span>
+          {executeResult && (
+            <span className="font-[family-name:var(--font-jetbrains-mono)] text-[10px] text-muted-foreground">
+              {executeResult.shape_keys.length} shapes · {executeResult.duration_ms}ms
+            </span>
+          )}
+          <div className="flex-1" />
+          <button
+            onClick={onToggleFullscreen}
+            className="flex size-7 items-center justify-center rounded-full border border-border text-muted-foreground hover:bg-sidebar-accent"
+            title={fullscreen ? "Exit fullscreen" : "Fullscreen"}
           >
-            <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
-              New Plan
-            </h2>
-
-            {/* Plan name */}
-            <label className="flex flex-col gap-1">
-              <span className="text-[12px] text-muted-foreground">Plan name</span>
-              <input
-                type="text"
-                value={newPlanName}
-                onChange={(e) => setNewPlanName(e.target.value)}
-                placeholder="Enter plan name..."
-                autoFocus
-                className="rounded-xl border border-border bg-input px-3 py-2 text-[12px] text-foreground outline-none"
-              />
-            </label>
-
-            {/* Template selection radio */}
-            <fieldset className="flex flex-col gap-2">
-              <span className="text-[12px] text-muted-foreground">Start from</span>
-              <label className="flex items-center gap-2 cursor-pointer">
-                <input
-                  type="radio"
-                  name="newPlanSource"
-                  checked={!newPlanFromTemplate}
-                  onChange={() => {
-                    setNewPlanFromTemplate(false);
-                    setNewPlanTemplateId(null);
-                  }}
-                  className="accent-[#FF8400]"
-                />
-                <span className="text-[12px] text-foreground">Empty plan</span>
-              </label>
-              <label className="flex items-center gap-2 cursor-pointer">
-                <input
-                  type="radio"
-                  name="newPlanSource"
-                  checked={newPlanFromTemplate}
-                  onChange={() => setNewPlanFromTemplate(true)}
-                  className="accent-[#FF8400]"
-                />
-                <span className="text-[12px] text-foreground">From template</span>
-              </label>
-            </fieldset>
-
-            {/* Template dropdown (visible when "From template" is selected) */}
-            {newPlanFromTemplate && (
-              <div className="flex flex-col gap-2">
-                <select
-                  value={newPlanTemplateId ?? ""}
-                  onChange={(e) =>
-                    setNewPlanTemplateId(e.target.value ? Number.parseInt(e.target.value, 10) : null)
-                  }
-                  className="rounded-xl border border-border bg-input px-3 py-2 text-[12px] text-foreground"
-                >
-                  <option value="">Select a template...</option>
-                  {templates.map((t) => (
-                    <option key={t.id} value={t.id}>
-                      {t.name} ({t.step_count} steps)
-                    </option>
-                  ))}
-                </select>
-                {/* Show description of selected template */}
-                {newPlanTemplateId != null &&
-                  templates.find((t) => t.id === newPlanTemplateId)?.description && (
-                    <p className="text-[11px] text-muted-foreground">
-                      {templates.find((t) => t.id === newPlanTemplateId)?.description}
-                    </p>
-                  )}
-              </div>
-            )}
-
-            {/* Actions */}
-            <div className="flex justify-end gap-2">
-              <button
-                onClick={() => setNewPlanDialogOpen(false)}
-                className="rounded-full border border-border px-4 py-2 text-[12px] text-muted-foreground hover:bg-sidebar-accent"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleNewPlanSubmit}
-                disabled={
-                  !newPlanName.trim() ||
-                  (newPlanFromTemplate && newPlanTemplateId == null)
-                }
-                className="rounded-full bg-primary px-4 py-2 text-[12px] text-primary-foreground hover:opacity-90 disabled:opacity-50"
-              >
-                Create
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Execute Dialog */}
-      {executeDialogOpen && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-          onClick={() => setExecuteDialogOpen(false)}
-        >
-          <div
-            className="flex w-[480px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
-            onClick={(e) => e.stopPropagation()}
+            {fullscreen ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
+          </button>
+          <button
+            onClick={onClose}
+            className="flex size-7 items-center justify-center rounded-full border border-border text-muted-foreground hover:bg-sidebar-accent"
           >
-            <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
-              Execute Plan
-            </h2>
-            <label className="flex flex-col gap-1">
-              <span className="text-[12px] text-muted-foreground">Aeroplane</span>
-              <select
-                value={executeAeroplaneId}
-                onChange={(e) => setExecuteAeroplaneId(e.target.value)}
-                className="rounded-xl border border-border bg-input px-3 py-2 text-[12px] text-foreground"
-              >
-                <option value="">Select aeroplane...</option>
-                {aeroplanes.map((a) => (
-                  <option key={a.id} value={a.id}>
-                    {a.name}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            {executeResult && (
-              <div
-                className={`rounded-xl border p-3 text-[12px] ${
-                  executeResult.status === "success"
-                    ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
-                    : "border-red-500/30 bg-red-500/10 text-red-400"
-                }`}
-              >
-                <p className="font-semibold">
-                  {executeResult.status === "success" ? "Success" : "Error"}
-                </p>
-                {executeResult.error && <p>{executeResult.error}</p>}
-                {executeResult.shape_keys.length > 0 && (
-                  <p>Shapes: {executeResult.shape_keys.join(", ")}</p>
-                )}
-                {executeResult.duration_ms > 0 && (
-                  <p>Duration: {executeResult.duration_ms}ms</p>
-                )}
-              </div>
-            )}
-
-            <div className="flex justify-end gap-2">
-              <button
-                onClick={() => setExecuteDialogOpen(false)}
-                className="rounded-full border border-border px-4 py-2 text-[12px] text-muted-foreground hover:bg-sidebar-accent"
-              >
-                Close
-              </button>
-              <button
-                onClick={handleExecute}
-                disabled={!executeAeroplaneId || executing}
-                className="flex items-center gap-1.5 rounded-full bg-primary px-4 py-2 text-[12px] text-primary-foreground hover:opacity-90 disabled:opacity-50"
-              >
-                {executing ? (
-                  <>
-                    <Loader2 size={12} className="animate-spin" />
-                    Running...
-                  </>
-                ) : (
-                  <>
-                    <Play size={12} />
-                    Execute
-                  </>
-                )}
-              </button>
-            </div>
-          </div>
+            <X size={14} />
+          </button>
         </div>
-      )}
-
-      {/* CadViewer Modal — shows tessellated geometry after Execute */}
-      {cadViewerOpen && cadViewerData && (
-        <div
-          className={`fixed inset-0 z-50 flex items-center justify-center ${cadViewerFullscreen ? "" : "bg-black/60"}`}
-          onClick={() => { setCadViewerOpen(false); setCadViewerFullscreen(false); }}
-        >
-          <div
-            className={`flex flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-2xl ${
-              cadViewerFullscreen ? "h-full w-full rounded-none border-0" : "h-[80vh] w-[80vw]"
-            }`}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="flex shrink-0 items-center gap-2 border-b border-border px-4 py-3">
-              <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-foreground">
-                Execution Result
-              </span>
-              {executeResult && (
-                <span className="font-[family-name:var(--font-jetbrains-mono)] text-[10px] text-muted-foreground">
-                  {executeResult.shape_keys.length} shapes · {executeResult.duration_ms}ms
-                </span>
-              )}
-              <div className="flex-1" />
-              <button
-                onClick={() => setCadViewerFullscreen((v) => !v)}
-                className="flex size-7 items-center justify-center rounded-full border border-border text-muted-foreground hover:bg-sidebar-accent"
-                title={cadViewerFullscreen ? "Exit fullscreen" : "Fullscreen"}
-              >
-                {cadViewerFullscreen ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
-              </button>
-              <button
-                onClick={() => { setCadViewerOpen(false); setCadViewerFullscreen(false); }}
-                className="flex size-7 items-center justify-center rounded-full border border-border text-muted-foreground hover:bg-sidebar-accent"
-              >
-                <X size={14} />
-              </button>
-            </div>
-            <div className="min-h-0 flex-1">
-              <CadViewer parts={[cadViewerData]} />
-            </div>
-          </div>
+        <div className="min-h-0 flex-1">
+          <CadViewer parts={[cadViewerData]} />
         </div>
-      )}
-    </>
+      </div>
+    </div>
   );
 }

--- a/frontend/components/workbench/AeroplaneTree.tsx
+++ b/frontend/components/workbench/AeroplaneTree.tsx
@@ -150,6 +150,41 @@ function buildAddHandler(
   };
 }
 
+/** Build detail rows for an expanded segment (chord, dimensions, TED, spars). */
+function buildExpandedSegmentDetails(
+  segId: string,
+  wingName: string,
+  segIdx: number,
+  root: XSec,
+  tip: XSec,
+  callbacks: BuildNodeCallbacks,
+): TreeNode[] {
+  const nodes: TreeNode[] = [];
+  const rootChord = (root.chord * 1000).toFixed(1);
+  const tipChord = (tip.chord * 1000).toFixed(1);
+  const length = (Math.abs(tip.xyz_le[1] - root.xyz_le[1]) * 1000).toFixed(1);
+  const sweep = ((tip.xyz_le[0] - root.xyz_le[0]) * 1000).toFixed(1);
+
+  nodes.push({
+    id: `${segId}-root`, label: `root: ${airfoilShort(root.airfoil)} · ${rootChord} mm`,
+    level: 3, leaf: true, muted: true,
+  });
+  nodes.push({
+    id: `${segId}-tip`, label: `tip: ${airfoilShort(tip.airfoil)} · ${tipChord} mm`,
+    level: 3, leaf: true, muted: true,
+  });
+  nodes.push({
+    id: `${segId}-dims`, label: `length ${length} mm · sweep ${sweep} mm`,
+    level: 3, leaf: true, muted: true, mono: true,
+  });
+
+  const tedNode = buildTedNode(segId, wingName, segIdx, root, callbacks);
+  if (tedNode) nodes.push(tedNode);
+
+  nodes.push(...buildSparNodes(segId, wingName, segIdx, root, callbacks));
+  return nodes;
+}
+
 // ── Build nodes for WingConfig mode (segments) ──────────────────
 
 function buildSegmentNodes(
@@ -228,28 +263,7 @@ function buildSegmentNodes(
 
     // Expanded segment details
     if (segExpanded) {
-      const rootChord = (root.chord * 1000).toFixed(1);
-      const tipChord = (tip.chord * 1000).toFixed(1);
-      const length = (Math.abs(tip.xyz_le[1] - root.xyz_le[1]) * 1000).toFixed(1);
-      const sweep = ((tip.xyz_le[0] - root.xyz_le[0]) * 1000).toFixed(1);
-
-      nodes.push({
-        id: `${segId}-root`, label: `root: ${airfoilShort(root.airfoil)} · ${rootChord} mm`,
-        level: 3, leaf: true, muted: true,
-      });
-      nodes.push({
-        id: `${segId}-tip`, label: `tip: ${airfoilShort(tip.airfoil)} · ${tipChord} mm`,
-        level: 3, leaf: true, muted: true,
-      });
-      nodes.push({
-        id: `${segId}-dims`, label: `length ${length} mm · sweep ${sweep} mm`,
-        level: 3, leaf: true, muted: true, mono: true,
-      });
-
-      const tedNode = buildTedNode(segId, wingName, i, root, callbacks);
-      if (tedNode) nodes.push(tedNode);
-
-      nodes.push(...buildSparNodes(segId, wingName, i, root, callbacks));
+      nodes.push(...buildExpandedSegmentDetails(segId, wingName, i, root, tip, callbacks));
     }
   }
 

--- a/frontend/components/workbench/ImportFuselageDialog.tsx
+++ b/frontend/components/workbench/ImportFuselageDialog.tsx
@@ -410,6 +410,48 @@ const INITIAL_XSECS: XSec[] = Array.from({ length: 50 }, (_, i) => ({
   n: 2.0 + 0.5 * Math.sin((i / 49) * Math.PI),
 }));
 
+/** Transform raw sliced xsecs by applying scale and optional X-flip. */
+function transformSlicedXsecs(
+  rawXsecs: Array<{ xyz: number[]; a: number; b: number; n: number }>,
+  scaleFactor: number,
+  flipX: boolean,
+): XSec[] {
+  const xFlip = flipX ? -1 : 1;
+  return rawXsecs.map((xs) => ({
+    xyz: xs.xyz.map((v: number, idx: number) => v * scaleFactor * (idx === 0 ? xFlip : 1)),
+    a: xs.a * scaleFactor,
+    b: xs.b * scaleFactor,
+    n: xs.n,
+  }));
+}
+
+/** Save a fuselage via PUT, falling back to POST on 409 conflict. */
+async function saveFuselage(
+  aeroplaneId: string,
+  fuselageName: string,
+  xsecs: XSec[],
+): Promise<void> {
+  const body = JSON.stringify({
+    name: fuselageName,
+    x_secs: xsecs.map((xs) => ({ xyz: xs.xyz, a: xs.a, b: xs.b, n: xs.n })),
+  });
+
+  let res = await fetch(
+    `${API_BASE}/aeroplanes/${aeroplaneId}/fuselages/${encodeURIComponent(fuselageName)}`,
+    { method: "PUT", headers: { "Content-Type": "application/json" }, body },
+  );
+  if (res.status === 409) {
+    res = await fetch(
+      `${API_BASE}/aeroplanes/${aeroplaneId}/fuselages/${encodeURIComponent(fuselageName)}`,
+      { method: "POST", headers: { "Content-Type": "application/json" }, body },
+    );
+  }
+  if (!res.ok) {
+    const detail = await res.text();
+    throw new Error(`Save failed: ${res.status} ${detail}`);
+  }
+}
+
 type Phase = "upload" | "processing" | "preview";
 
 export function ImportFuselageDialog({
@@ -470,13 +512,7 @@ export function ImportFuselageDialog({
       }
       const data = await res.json();
 
-      const xFlip = flipX ? -1 : 1;
-      const newXsecs: XSec[] = (data.fuselage?.x_secs ?? []).map((xs: { xyz: number[]; a: number; b: number; n: number }) => ({
-        xyz: xs.xyz.map((v: number, idx: number) => v * scaleFactor * (idx === 0 ? xFlip : 1)),
-        a: xs.a * scaleFactor,
-        b: xs.b * scaleFactor,
-        n: xs.n,
-      }));
+      const newXsecs = transformSlicedXsecs(data.fuselage?.x_secs ?? [], scaleFactor, flipX);
       setXsecs(newXsecs.length > 0 ? newXsecs : INITIAL_XSECS);
       setFidelity(extractFidelity(data));
       setFuselageName(data.fuselage?.name ?? fuselageName);
@@ -493,26 +529,7 @@ export function ImportFuselageDialog({
     setSaving(true);
     setError(null);
     try {
-      const body = JSON.stringify({
-        name: fuselageName,
-        x_secs: xsecs.map((xs) => ({ xyz: xs.xyz, a: xs.a, b: xs.b, n: xs.n })),
-      });
-
-      // Try PUT (create). If 409 conflict (already exists), try POST (update).
-      let res = await fetch(
-        `${API_BASE}/aeroplanes/${aeroplaneId}/fuselages/${encodeURIComponent(fuselageName)}`,
-        { method: "PUT", headers: { "Content-Type": "application/json" }, body },
-      );
-      if (res.status === 409) {
-        res = await fetch(
-          `${API_BASE}/aeroplanes/${aeroplaneId}/fuselages/${encodeURIComponent(fuselageName)}`,
-          { method: "POST", headers: { "Content-Type": "application/json" }, body },
-        );
-      }
-      if (!res.ok) {
-        const detail = await res.text();
-        throw new Error(`Save failed: ${res.status} ${detail}`);
-      }
+      await saveFuselage(aeroplaneId, fuselageName, xsecs);
       onSaved?.();
       handleReset();
       onClose();

--- a/frontend/components/workbench/PropertyForm.tsx
+++ b/frontend/components/workbench/PropertyForm.tsx
@@ -474,6 +474,38 @@ function FieldGridContent({
   );
 }
 
+/** Build a segment payload from the edited WingConfig state, keeping other segments unchanged. */
+function buildUpdatedSegments(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  segments: any[],
+  editedIndex: number,
+  wc: WingConfigState,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): any[] {
+  return segments.map((seg, i) => {
+    if (i !== editedIndex) return seg;
+    return {
+      ...seg,
+      root_airfoil: {
+        airfoil: wc.root_airfoil,
+        chord: wc.root_chord,
+        dihedral_as_rotation_in_degrees: wc.root_dihedral,
+        incidence: wc.root_incidence,
+      },
+      tip_airfoil: {
+        airfoil: wc.tip_airfoil,
+        chord: wc.tip_chord,
+        dihedral_as_rotation_in_degrees: wc.tip_dihedral,
+        incidence: wc.tip_incidence,
+      },
+      length: wc.length,
+      sweep: wc.sweep,
+      number_interpolation_points: wc.number_interpolation_points,
+      tip_type: wc.tip_type || undefined,
+    };
+  });
+}
+
 // ── Main Component ──────────────────────────────────────────────
 
 export function PropertyForm({ onGeometryChanged }: { onGeometryChanged?: (wingName: string) => void }) {
@@ -600,29 +632,7 @@ export function PropertyForm({ onGeometryChanged }: { onGeometryChanged?: (wingN
     setSaving(true);
     setError(null);
     try {
-      // Build updated WingConfig: replace the edited segment, keep others
-      const updatedSegments = wingConfig.segments.map((seg, i) => {
-        if (i !== selectedXsecIndex) return seg;
-        return {
-          ...seg,
-          root_airfoil: {
-            airfoil: wc.root_airfoil,
-            chord: wc.root_chord,
-            dihedral_as_rotation_in_degrees: wc.root_dihedral,
-            incidence: wc.root_incidence,
-          },
-          tip_airfoil: {
-            airfoil: wc.tip_airfoil,
-            chord: wc.tip_chord,
-            dihedral_as_rotation_in_degrees: wc.tip_dihedral,
-            incidence: wc.tip_incidence,
-          },
-          length: wc.length,
-          sweep: wc.sweep,
-          number_interpolation_points: wc.number_interpolation_points,
-          tip_type: wc.tip_type || undefined,
-        };
-      });
+      const updatedSegments = buildUpdatedSegments(wingConfig.segments, selectedXsecIndex, wc);
 
       await saveWingConfig({
         ...wingConfig,

--- a/frontend/components/workbench/WingOutlineViewer.tsx
+++ b/frontend/components/workbench/WingOutlineViewer.tsx
@@ -508,10 +508,116 @@ function buildSparEdgeLines(
   return traces;
 }
 
+/** Compute spar center points from precise origin/vector or airfoil camber fallback. */
+function computeSparCenters(
+  spar: Record<string, unknown>,
+  posFactor: number,
+  sparStartMm: number,
+  sparLengthMm: number | undefined,
+  segmentSpan: number,
+  startAf: AirfoilCoords | null,
+  endAf: AirfoilCoords | null,
+  startStation: ReturnType<typeof lerpXSec>,
+  endStation: ReturnType<typeof lerpXSec>,
+): { startCenter: { x: number[]; y: number[]; z: number[] } | null; endCenter: { x: number[]; y: number[]; z: number[] } | null } {
+  const sparOrigin = spar.spare_origin as number[] | null | undefined;
+  const sparVector = spar.spare_vector as number[] | null | undefined;
+  const hasPrecise = sparOrigin && sparVector && sparOrigin.length === 3 && sparVector.length === 3;
+
+  if (hasPrecise) {
+    const startDist = sparStartMm * 0.001;
+    const endDist = (sparLengthMm != null ? (sparStartMm + sparLengthMm) * 0.001 : segmentSpan);
+    return {
+      startCenter: {
+        x: [sparOrigin[0] + sparVector[0] * startDist],
+        y: [sparOrigin[1] + sparVector[1] * startDist],
+        z: [sparOrigin[2] + sparVector[2] * startDist],
+      },
+      endCenter: {
+        x: [sparOrigin[0] + sparVector[0] * endDist],
+        y: [sparOrigin[1] + sparVector[1] * endDist],
+        z: [sparOrigin[2] + sparVector[2] * endDist],
+      },
+    };
+  }
+
+  let startCenter: { x: number[]; y: number[]; z: number[] } | null = null;
+  let endCenter: { x: number[]; y: number[]; z: number[] } | null = null;
+  if (startAf) {
+    const camberY = lerpLookup(startAf.camber_x, startAf.camber_y, posFactor);
+    startCenter = transformProfile([posFactor], [camberY], startStation.chord, startStation.twist, startStation.xyz_le, startStation.dihedral);
+  }
+  if (endAf) {
+    const camberY = lerpLookup(endAf.camber_x, endAf.camber_y, posFactor);
+    endCenter = transformProfile([posFactor], [camberY], endStation.chord, endStation.twist, endStation.xyz_le, endStation.dihedral);
+  }
+  return { startCenter, endCenter };
+}
+
+/** Build traces for a single spar within a segment. */
+function buildSingleSparTraces(
+  spar: Record<string, unknown>,
+  segIdx: number,
+  ctx: WingTraceCtx,
+  segmentSpan: number,
+  sparColor: string,
+): PlotlyData[] {
+  const { xsecs, airfoils, dihedrals } = ctx;
+  const traces: PlotlyData[] = [];
+
+  const posFactor = spar.spare_position_factor as number | undefined;
+  if (posFactor == null) return traces;
+
+  const sparW = (spar.spare_support_dimension_width as number ?? 0) * 0.001;
+  const sparH = (spar.spare_support_dimension_height as number ?? 0) * 0.001;
+  const sparStartMm = spar.spare_start as number ?? 0;
+  const sparLengthMm = spar.spare_length as number | undefined;
+
+  const tStart = segmentSpan > 0 ? (sparStartMm * 0.001) / segmentSpan : 0;
+  const tEnd = (sparLengthMm != null && segmentSpan > 0)
+    ? Math.min((sparStartMm + sparLengthMm) * 0.001 / segmentSpan, 1)
+    : 1;
+
+  const startStation = lerpXSec(xsecs, dihedrals, segIdx, segIdx + 1, tStart);
+  const startAf = lerpAf(airfoils, segIdx, segIdx + 1, tStart);
+  const endStation = lerpXSec(xsecs, dihedrals, segIdx, segIdx + 1, tEnd);
+  const endAf = lerpAf(airfoils, segIdx, segIdx + 1, tEnd);
+
+  const { startCenter, endCenter } = computeSparCenters(
+    spar, posFactor, sparStartMm, sparLengthMm, segmentSpan,
+    startAf, endAf, startStation, endStation,
+  );
+
+  // Vertical spar lines + cross-sections
+  traces.push(buildSparVerticalLine(startAf, posFactor, startStation, sparColor));
+  if (startCenter) {
+    const cs = buildSparCrossSection(startCenter, sparW, sparH, startStation.twist, sparColor);
+    if (cs) traces.push(cs);
+  }
+
+  traces.push(buildSparVerticalLine(endAf, posFactor, endStation, sparColor));
+  if (endCenter) {
+    const cs = buildSparCrossSection(endCenter, sparW, sparH, endStation.twist, sparColor);
+    if (cs) traces.push(cs);
+  }
+
+  // Spanwise connection lines
+  if (startAf && endAf) {
+    traces.push(...buildSparSpanwiseLines(startAf, endAf, posFactor, startStation, endStation, sparColor));
+  }
+
+  // Dashed edge lines
+  if (startCenter && endCenter && sparW > 0 && sparH > 0) {
+    traces.push(...buildSparEdgeLines(startCenter, endCenter, sparW, sparH, startStation.twist, endStation.twist, sparColor));
+  }
+
+  return traces;
+}
+
 /** All spar traces for the wing. */
 function buildSparTraces(ctx: WingTraceCtx): PlotlyData[] {
   const traces: PlotlyData[] = [];
-  const { xsecs, airfoils, dihedrals, selectedIdx } = ctx;
+  const { xsecs, selectedIdx } = ctx;
 
   for (let i = 0; i < xsecs.length; i++) {
     const spars = xsecs[i].spare_list as Array<Record<string, unknown>> | undefined;
@@ -525,77 +631,7 @@ function buildSparTraces(ctx: WingTraceCtx): PlotlyData[] {
     const segmentSpan = Math.sqrt(dx * dx + dy * dy + dz * dz);
 
     for (const spar of spars) {
-      const posFactor = spar.spare_position_factor as number | undefined;
-      if (posFactor == null) continue;
-      const sparW = (spar.spare_support_dimension_width as number ?? 0) * 0.001;
-      const sparH = (spar.spare_support_dimension_height as number ?? 0) * 0.001;
-      const sparStartMm = spar.spare_start as number ?? 0;
-      const sparLengthMm = spar.spare_length as number | undefined;
-
-      const tStart = segmentSpan > 0 ? (sparStartMm * 0.001) / segmentSpan : 0;
-      const tEnd = (sparLengthMm != null && segmentSpan > 0)
-        ? Math.min((sparStartMm + sparLengthMm) * 0.001 / segmentSpan, 1)
-        : 1;
-
-      const startStation = lerpXSec(xsecs, dihedrals, i, i + 1, tStart);
-      const startAf = lerpAf(airfoils, i, i + 1, tStart);
-      const endStation = lerpXSec(xsecs, dihedrals, i, i + 1, tEnd);
-      const endAf = lerpAf(airfoils, i, i + 1, tEnd);
-
-      // Compute spar center points
-      const sparOrigin = spar.spare_origin as number[] | null | undefined;
-      const sparVector = spar.spare_vector as number[] | null | undefined;
-      const hasPrecise = sparOrigin && sparVector && sparOrigin.length === 3 && sparVector.length === 3;
-
-      let startCenter: { x: number[]; y: number[]; z: number[] } | null = null;
-      let endCenter: { x: number[]; y: number[]; z: number[] } | null = null;
-
-      if (hasPrecise) {
-        const startDist = sparStartMm * 0.001;
-        const endDist = (sparLengthMm != null ? (sparStartMm + sparLengthMm) * 0.001 : segmentSpan);
-        startCenter = {
-          x: [sparOrigin[0] + sparVector[0] * startDist],
-          y: [sparOrigin[1] + sparVector[1] * startDist],
-          z: [sparOrigin[2] + sparVector[2] * startDist],
-        };
-        endCenter = {
-          x: [sparOrigin[0] + sparVector[0] * endDist],
-          y: [sparOrigin[1] + sparVector[1] * endDist],
-          z: [sparOrigin[2] + sparVector[2] * endDist],
-        };
-      } else {
-        if (startAf) {
-          const camberY = lerpLookup(startAf.camber_x, startAf.camber_y, posFactor);
-          startCenter = transformProfile([posFactor], [camberY], startStation.chord, startStation.twist, startStation.xyz_le, startStation.dihedral);
-        }
-        if (endAf) {
-          const camberY = lerpLookup(endAf.camber_x, endAf.camber_y, posFactor);
-          endCenter = transformProfile([posFactor], [camberY], endStation.chord, endStation.twist, endStation.xyz_le, endStation.dihedral);
-        }
-      }
-
-      // Vertical spar lines + cross-sections
-      traces.push(buildSparVerticalLine(startAf, posFactor, startStation, sparColor));
-      if (startCenter) {
-        const cs = buildSparCrossSection(startCenter, sparW, sparH, startStation.twist, sparColor);
-        if (cs) traces.push(cs);
-      }
-
-      traces.push(buildSparVerticalLine(endAf, posFactor, endStation, sparColor));
-      if (endCenter) {
-        const cs = buildSparCrossSection(endCenter, sparW, sparH, endStation.twist, sparColor);
-        if (cs) traces.push(cs);
-      }
-
-      // Spanwise connection lines
-      if (startAf && endAf) {
-        traces.push(...buildSparSpanwiseLines(startAf, endAf, posFactor, startStation, endStation, sparColor));
-      }
-
-      // Dashed edge lines
-      if (startCenter && endCenter && sparW > 0 && sparH > 0) {
-        traces.push(...buildSparEdgeLines(startCenter, endCenter, sparW, sparH, startStation.twist, endStation.twist, sparColor));
-      }
+      traces.push(...buildSingleSparTraces(spar, i, ctx, segmentSpan, sparColor));
     }
   }
 


### PR DESCRIPTION
## Summary

- Extract helpers from 5 frontend components and 1 backend service to bring cognitive complexity under the SonarQube S3776 threshold (15)
- **WingOutlineViewer.tsx**: `buildSparTraces` (58 -> ~15) via `computeSparCenters` + `buildSingleSparTraces`
- **AeroplaneTree.tsx**: `buildSegmentNodes` (27 -> ~12) via `buildExpandedSegmentDetails`
- **PropertyForm.tsx**: `PropertyForm` (16 -> ~12) via `buildUpdatedSegments`
- **ImportFuselageDialog.tsx**: `ImportFuselageDialog` (19 -> ~12) via `transformSlicedXsecs` + `saveFuselage`
- **construction-plans/page.tsx**: `ConstructionPlansPage` (32 -> ~10) via 4 extracted dialog components
- **analysis_service.py**: `_mirror_markers_to_alpha_panel` (16 -> ~10) via `_resolve_alpha_marker`

Closes #226

## Test plan

- [x] Backend: `poetry run pytest -m "not slow"` — 613 passed
- [x] Frontend: `npm run test:unit` — 251 passed (30 files)
- [x] ESLint: 0 errors (only pre-existing warnings)
- [x] Ruff: all checks passed
- [ ] SonarQube quality gate on PR branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)