### PR TITLE
chore(gh-251): Readonly props, nested ternaries, param objects

### DIFF
--- a/frontend/app/workbench/construction-plans/page.tsx
+++ b/frontend/app/workbench/construction-plans/page.tsx
@@ -35,6 +35,16 @@ import {
 
 type RightPanel = "gallery" | "detail" | "params";
 
+function rightPanelHeading(
+  panel: RightPanel,
+  creatorForSelected: unknown,
+  browsingCreator: unknown,
+): string {
+  if (panel === "params" && creatorForSelected) return "Parameters";
+  if (panel === "detail" && browsingCreator) return "Creator Info";
+  return "Creator Catalog";
+}
+
 export default function ConstructionPlansPage() {
   const { aeroplaneId } = useAeroplaneContext();
   const { aeroplanes } = useAeroplanes();
@@ -460,11 +470,7 @@ export default function ConstructionPlansPage() {
           <div className="flex items-center gap-2.5">
             <Hammer className="size-5 text-primary" />
             <h1 className="font-[family-name:var(--font-jetbrains-mono)] text-[20px] text-foreground">
-              {rightPanel === "params" && creatorForSelected
-                ? "Parameters"
-                : rightPanel === "detail" && browsingCreator
-                ? "Creator Info"
-                : "Creator Catalog"}
+              {rightPanelHeading(rightPanel, creatorForSelected, browsingCreator)}
             </h1>
             <span className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-muted-foreground">
               {rightPanel === "gallery" ? `${creators.length} creators` : ""}
@@ -574,22 +580,7 @@ export default function ConstructionPlansPage() {
 
 // ── Extracted dialog components ──────────────────────────────────
 
-function AddStepDialog({
-  open,
-  addingCreator,
-  addCreatorId,
-  addCreatorIdManual,
-  addStepParams,
-  treeJson,
-  creators,
-  selectedStepPath,
-  onClose,
-  onSetAddingCreator,
-  onSetAddCreatorId,
-  onSetAddCreatorIdManual,
-  onSetAddStepParams,
-  onAddCreator,
-}: {
+interface AddStepDialogProps {
   open: boolean;
   addingCreator: CreatorInfo | null;
   addCreatorId: string;
@@ -603,7 +594,23 @@ function AddStepDialog({
   onSetAddCreatorIdManual: (v: boolean) => void;
   onSetAddStepParams: (p: Record<string, unknown>) => void;
   onAddCreator: (creator: CreatorInfo, creatorId?: string) => void;
-}) {
+}
+
+function AddStepDialog({
+  open,
+  addingCreator,
+  addCreatorId,
+  addCreatorIdManual,
+  addStepParams,
+  treeJson,
+  creators,
+  onClose,
+  onSetAddingCreator,
+  onSetAddCreatorId,
+  onSetAddCreatorIdManual,
+  onSetAddStepParams,
+  onAddCreator,
+}: Readonly<AddStepDialogProps>) {
   if (!open) return null;
 
   return (
@@ -727,6 +734,19 @@ function AddStepDialog({
   );
 }
 
+interface NewPlanDialogProps {
+  open: boolean;
+  newPlanName: string;
+  newPlanFromTemplate: boolean;
+  newPlanTemplateId: number | null;
+  templates: Array<{ id: number; name: string; step_count: number; description?: string | null }>;
+  onClose: () => void;
+  onSetNewPlanName: (v: string) => void;
+  onSetNewPlanFromTemplate: (v: boolean) => void;
+  onSetNewPlanTemplateId: (v: number | null) => void;
+  onSubmit: () => void;
+}
+
 function NewPlanDialog({
   open,
   newPlanName,
@@ -738,18 +758,7 @@ function NewPlanDialog({
   onSetNewPlanFromTemplate,
   onSetNewPlanTemplateId,
   onSubmit,
-}: {
-  open: boolean;
-  newPlanName: string;
-  newPlanFromTemplate: boolean;
-  newPlanTemplateId: number | null;
-  templates: Array<{ id: number; name: string; step_count: number; description?: string | null }>;
-  onClose: () => void;
-  onSetNewPlanName: (v: string) => void;
-  onSetNewPlanFromTemplate: (v: boolean) => void;
-  onSetNewPlanTemplateId: (v: number | null) => void;
-  onSubmit: () => void;
-}) {
+}: Readonly<NewPlanDialogProps>) {
   if (!open) return null;
 
   return (
@@ -853,6 +862,17 @@ function NewPlanDialog({
   );
 }
 
+interface ExecuteDialogProps {
+  open: boolean;
+  executeAeroplaneId: string;
+  executing: boolean;
+  executeResult: ExecutionResult | null;
+  aeroplanes: Array<{ id: string; name: string }>;
+  onClose: () => void;
+  onSetExecuteAeroplaneId: (v: string) => void;
+  onExecute: () => void;
+}
+
 function ExecuteDialog({
   open,
   executeAeroplaneId,
@@ -862,16 +882,7 @@ function ExecuteDialog({
   onClose,
   onSetExecuteAeroplaneId,
   onExecute,
-}: {
-  open: boolean;
-  executeAeroplaneId: string;
-  executing: boolean;
-  executeResult: ExecutionResult | null;
-  aeroplanes: Array<{ id: string; name: string }>;
-  onClose: () => void;
-  onSetExecuteAeroplaneId: (v: string) => void;
-  onExecute: () => void;
-}) {
+}: Readonly<ExecuteDialogProps>) {
   if (!open) return null;
 
   return (
@@ -958,6 +969,15 @@ function ExecuteDialog({
   );
 }
 
+interface CadViewerModalProps {
+  open: boolean;
+  fullscreen: boolean;
+  cadViewerData: Record<string, unknown> | null;
+  executeResult: ExecutionResult | null;
+  onClose: () => void;
+  onToggleFullscreen: () => void;
+}
+
 function CadViewerModal({
   open,
   fullscreen,
@@ -965,14 +985,7 @@ function CadViewerModal({
   executeResult,
   onClose,
   onToggleFullscreen,
-}: {
-  open: boolean;
-  fullscreen: boolean;
-  cadViewerData: Record<string, unknown> | null;
-  executeResult: ExecutionResult | null;
-  onClose: () => void;
-  onToggleFullscreen: () => void;
-}) {
+}: Readonly<CadViewerModalProps>) {
   if (!open || !cadViewerData) return null;
 
   return (

--- a/frontend/app/workbench/mission/page.tsx
+++ b/frontend/app/workbench/mission/page.tsx
@@ -32,24 +32,21 @@ function Field({
   value,
   suffix,
   isSelect,
-}: {
+}: Readonly<{
   label: string;
   value: string;
   suffix?: string;
   isSelect?: boolean;
-}) {
+}>) {
   return (
     <div className="flex flex-1 flex-col gap-1">
       <span className="text-[11px] text-muted-foreground">{label}</span>
       <div className="flex items-center gap-2 rounded-xl border border-border bg-input px-3 py-2">
         <span className="text-[13px] text-foreground">{value}</span>
         <span className="flex-1" />
-        {isSelect ? (
-          <ChevronDown className="size-3.5 text-muted-foreground" />
-        ) : (
-          suffix && (
-            <span className="text-[11px] text-muted-foreground">{suffix}</span>
-          )
+        {isSelect && <ChevronDown className="size-3.5 text-muted-foreground" />}
+        {!isSelect && suffix && (
+          <span className="text-[11px] text-muted-foreground">{suffix}</span>
         )}
       </div>
     </div>

--- a/frontend/app/workbench/page.tsx
+++ b/frontend/app/workbench/page.tsx
@@ -274,12 +274,12 @@ function AeroplaneSelector({
   isLoading,
   onSelect,
   onCreate,
-}: {
+}: Readonly<{
   aeroplanes: { id: string; name: string; created_at: string; updated_at: string }[];
   isLoading: boolean;
   onSelect: (id: string) => void;
   onCreate: (name: string) => Promise<void>;
-}) {
+}>) {
   async function handleCreate() {
     const name = prompt("Aeroplane name?");
     if (!name) return;
@@ -293,13 +293,15 @@ function AeroplaneSelector({
           Select Aeroplane
         </h2>
 
-        {isLoading ? (
+        {isLoading && (
           <span className="text-[13px] text-muted-foreground">Loading...</span>
-        ) : aeroplanes.length === 0 ? (
+        )}
+        {!isLoading && aeroplanes.length === 0 && (
           <span className="text-[13px] text-muted-foreground">
             No aeroplanes yet. Create one to get started.
           </span>
-        ) : (
+        )}
+        {!isLoading && aeroplanes.length > 0 && (
           <div className="flex flex-col gap-1">
             {aeroplanes.map((a) => (
               <button

--- a/frontend/components/workbench/AeroplaneTree.tsx
+++ b/frontend/components/workbench/AeroplaneTree.tsx
@@ -370,28 +370,30 @@ function getChipLabel(xsec: XSec): string | undefined {
 
 // ── Build callbacks object — single conditional instead of 18 ternaries ──
 
-function buildCallbacks(
-  isCrossModelView: boolean,
-  selectWing: (n: string | null) => void,
-  selectXsec: (i: number | null) => void,
-  handleDeleteXsec: (wn: string, i: number) => void,
-  handleAddSegment: (wn: string) => void,
-  handleInsertXsec: (wn: string, i: number) => void,
-  setSegAddMenu: (v: { wingName: string; xsecIndex: number; hasTed: boolean; x: number; y: number }) => void,
-  onNodeEdit?: () => void,
-  onEditSpar?: (wingName: string, xsecIndex: number, sparIndex: number, data: Record<string, unknown>) => void,
-  onDeleteSpar?: (wingName: string, xsecIndex: number, sparIndex: number) => void,
-  onEditTed?: (wingName: string, xsecIndex: number, data: Record<string, unknown>) => void,
-  onDeleteTed?: (wingName: string, xsecIndex: number) => void,
-  onAddSpar?: (wingName: string, xsecIndex: number) => void,
-  onAddTed?: (wingName: string, xsecIndex: number) => void,
-): BuildNodeCallbacks {
+interface BuildCallbacksOptions {
+  isCrossModelView: boolean;
+  selectWing: (n: string | null) => void;
+  selectXsec: (i: number | null) => void;
+  handleDeleteXsec: (wn: string, i: number) => void;
+  handleAddSegment: (wn: string) => void;
+  handleInsertXsec: (wn: string, i: number) => void;
+  setSegAddMenu: (v: { wingName: string; xsecIndex: number; hasTed: boolean; x: number; y: number }) => void;
+  onNodeEdit?: () => void;
+  onEditSpar?: (wingName: string, xsecIndex: number, sparIndex: number, data: Record<string, unknown>) => void;
+  onDeleteSpar?: (wingName: string, xsecIndex: number, sparIndex: number) => void;
+  onEditTed?: (wingName: string, xsecIndex: number, data: Record<string, unknown>) => void;
+  onDeleteTed?: (wingName: string, xsecIndex: number) => void;
+  onAddSpar?: (wingName: string, xsecIndex: number) => void;
+  onAddTed?: (wingName: string, xsecIndex: number) => void;
+}
+
+function buildCallbacks(opts: BuildCallbacksOptions): BuildNodeCallbacks {
   const noOp = () => {};
 
-  if (isCrossModelView) {
+  if (opts.isCrossModelView) {
     return {
-      selectWing,
-      selectXsec,
+      selectWing: opts.selectWing,
+      selectXsec: opts.selectXsec,
       onDeleteXsec: noOp,
       onAddSegment: noOp,
       onInsertXsec: noOp,
@@ -399,19 +401,19 @@ function buildCallbacks(
   }
 
   return {
-    selectWing,
-    selectXsec,
-    onDeleteXsec: handleDeleteXsec,
-    onEditNode: onNodeEdit,
-    onEditSpar,
-    onDeleteSpar,
-    onEditTed,
-    onDeleteTed,
-    onAddSpar,
-    onAddTed,
-    onAddMenu: (wn, xi, hasTed, cx, cy) => setSegAddMenu({ wingName: wn, xsecIndex: xi, hasTed, x: cx, y: cy }),
-    onAddSegment: handleAddSegment,
-    onInsertXsec: handleInsertXsec,
+    selectWing: opts.selectWing,
+    selectXsec: opts.selectXsec,
+    onDeleteXsec: opts.handleDeleteXsec,
+    onEditNode: opts.onNodeEdit,
+    onEditSpar: opts.onEditSpar,
+    onDeleteSpar: opts.onDeleteSpar,
+    onEditTed: opts.onEditTed,
+    onDeleteTed: opts.onDeleteTed,
+    onAddSpar: opts.onAddSpar,
+    onAddTed: opts.onAddTed,
+    onAddMenu: (wn, xi, hasTed, cx, cy) => opts.setSegAddMenu({ wingName: wn, xsecIndex: xi, hasTed, x: cx, y: cy }),
+    onAddSegment: opts.handleAddSegment,
+    onInsertXsec: opts.handleInsertXsec,
   };
 }
 
@@ -725,13 +727,13 @@ export function AeroplaneTree(props: Readonly<AeroplaneTreeProps>) {
     (wingDesignModel === "asb" && treeMode === "wingconfig")
   );
 
-  const callbacks = buildCallbacks(
+  const callbacks = buildCallbacks({
     isCrossModelView,
     selectWing, selectXsec,
     handleDeleteXsec, handleAddSegment, handleInsertXsec,
     setSegAddMenu,
     onNodeEdit, onEditSpar, onDeleteSpar, onEditTed, onDeleteTed, onAddSpar, onAddTed,
-  );
+  });
 
   // Build tree data
   const treeData = buildTreeData({
@@ -890,7 +892,7 @@ export function AeroplaneTree(props: Readonly<AeroplaneTreeProps>) {
 
 // ── TreeRow ─────────────────────────────────────────────────────
 
-function TreeRow({ node, onToggle, onNodeEdit: _onNodeEdit }: { node: TreeNode; onToggle: () => void; onNodeEdit?: () => void }) {
+function TreeRow({ node, onToggle, onNodeEdit: _onNodeEdit }: Readonly<{ node: TreeNode; onToggle: () => void; onNodeEdit?: () => void }>) {
   if (node.isInsertPoint) {
     return (
       <div
@@ -994,13 +996,9 @@ function TreeRow({ node, onToggle, onNodeEdit: _onNodeEdit }: { node: TreeNode; 
           }`}
           title={node.previewVisible ? "Hide 3D preview" : "Show 3D preview"}
         >
-          {node.previewLoading ? (
-            <Loader size={12} className="animate-spin" />
-          ) : node.previewVisible ? (
-            <Eye size={12} />
-          ) : (
-            <EyeOff size={12} />
-          )}
+          {node.previewLoading && <Loader size={12} className="animate-spin" />}
+          {!node.previewLoading && node.previewVisible && <Eye size={12} />}
+          {!node.previewLoading && !node.previewVisible && <EyeOff size={12} />}
         </button>
       )}
     </div>

--- a/frontend/components/workbench/CreatorParameterForm.tsx
+++ b/frontend/components/workbench/CreatorParameterForm.tsx
@@ -19,12 +19,12 @@ function ParamInput({
   value,
   onChange,
   availableShapeKeys,
-}: {
+}: Readonly<{
   param: CreatorParam;
   value: unknown;
   onChange: (key: string, value: unknown) => void;
   availableShapeKeys: string[];
-}) {
+}>) {
   const rawValue = value ?? param.default ?? "";
   const strValue = typeof rawValue === "object" ? JSON.stringify(rawValue) : String(rawValue);
 
@@ -150,12 +150,12 @@ function ShapeRefInput({
   onChange,
   shapeKeys,
   required,
-}: {
+}: Readonly<{
   value: string;
   onChange: (v: string) => void;
   shapeKeys: string[];
   required: boolean;
-}) {
+}>) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
 

--- a/frontend/components/workbench/PropertyForm.tsx
+++ b/frontend/components/workbench/PropertyForm.tsx
@@ -133,7 +133,7 @@ function Field({
   onChange,
   readOnly,
   isSelect,
-}: {
+}: Readonly<{
   label: string;
   value: string | number;
   suffix?: string;
@@ -141,7 +141,7 @@ function Field({
   onChange?: (v: string) => void;
   readOnly?: boolean;
   isSelect?: boolean;
-}) {
+}>) {
   const id = useId();
   const [localValue, setLocalValue] = useState(String(value));
   const [editing, setEditing] = useState(false);
@@ -187,6 +187,18 @@ function Field({
 
 // ── WingConfig Fields Sub-Component ────────────────────────────
 
+interface WingConfigFieldsProps {
+  wc: WingConfigState;
+  setWc: (wc: WingConfigState) => void;
+  symmetric: boolean;
+  onSymmetricChange: (checked: boolean) => void;
+  nosePnt: [number, number, number];
+  setNosePnt: (v: [number, number, number]) => void;
+  selectedXsecIndex: number;
+  setDirty: (v: boolean) => void;
+  router: ReturnType<typeof useRouter>;
+}
+
 function WingConfigFields({
   wc,
   setWc,
@@ -197,17 +209,7 @@ function WingConfigFields({
   selectedXsecIndex,
   setDirty,
   router,
-}: {
-  wc: WingConfigState;
-  setWc: (wc: WingConfigState) => void;
-  symmetric: boolean;
-  onSymmetricChange: (checked: boolean) => void;
-  nosePnt: [number, number, number];
-  setNosePnt: (v: [number, number, number]) => void;
-  selectedXsecIndex: number;
-  setDirty: (v: boolean) => void;
-  router: ReturnType<typeof useRouter>;
-}) {
+}: Readonly<WingConfigFieldsProps>) {
   return (
     <>
       {/* Wing-level: symmetric + nose_pnt — only on segment 0 */}
@@ -341,12 +343,12 @@ function AsbFields({
   setAsb,
   xsec,
   setDirty,
-}: {
+}: Readonly<{
   asb: AsbState;
   setAsb: (v: AsbState) => void;
   xsec: XSec;
   setDirty: (v: boolean) => void;
-}) {
+}>) {
   return (
     <>
       {/* ASB mode: airfoil | chord */}
@@ -400,6 +402,24 @@ function AsbFields({
 
 // ── Field Grid Content Helper ──────────────────────────────────
 
+interface FieldGridContentProps {
+  mode: Mode;
+  wc: WingConfigState | null;
+  setWc: (v: WingConfigState) => void;
+  asb: AsbState | null;
+  setAsb: (v: AsbState) => void;
+  xsec: XSec;
+  isReadOnly: boolean;
+  wing: ReturnType<typeof useWing>["wing"];
+  symmetric: boolean;
+  onSymmetricChange: (checked: boolean) => void;
+  nosePnt: [number, number, number];
+  setNosePnt: (v: [number, number, number]) => void;
+  selectedXsecIndex: number;
+  setDirty: (v: boolean) => void;
+  router: ReturnType<typeof useRouter>;
+}
+
 function FieldGridContent({
   mode,
   wc,
@@ -416,23 +436,7 @@ function FieldGridContent({
   selectedXsecIndex,
   setDirty,
   router,
-}: {
-  mode: Mode;
-  wc: WingConfigState | null;
-  setWc: (v: WingConfigState) => void;
-  asb: AsbState | null;
-  setAsb: (v: AsbState) => void;
-  xsec: XSec;
-  isReadOnly: boolean;
-  wing: ReturnType<typeof useWing>["wing"];
-  symmetric: boolean;
-  onSymmetricChange: (checked: boolean) => void;
-  nosePnt: [number, number, number];
-  setNosePnt: (v: [number, number, number]) => void;
-  selectedXsecIndex: number;
-  setDirty: (v: boolean) => void;
-  router: ReturnType<typeof useRouter>;
-}) {
+}: Readonly<FieldGridContentProps>) {
   if (mode === "wingconfig" && wc) {
     return (
       <WingConfigFields
@@ -510,7 +514,7 @@ function buildUpdatedSegments(
 
 // ── Main Component ──────────────────────────────────────────────
 
-export function PropertyForm({ onGeometryChanged }: { onGeometryChanged?: (wingName: string) => void }) {
+export function PropertyForm({ onGeometryChanged }: Readonly<{ onGeometryChanged?: (wingName: string) => void }>) {
   const { aeroplaneId, selectedWing, selectedXsecIndex, selectedFuselage, selectedFuselageXsecIndex, treeMode } =
     useAeroplaneContext();
   const { wing, updateXSec, mutate } = useWing(aeroplaneId, selectedWing);
@@ -724,13 +728,13 @@ function FuselageXSecForm({
   xsecIndex,
   xsec,
   onSave,
-}: {
+}: Readonly<{
   aeroplaneId: string | null;
   fuselageName: string;
   xsecIndex: number;
   xsec: FuselageXSec;
   onSave: (updated: FuselageXSec) => Promise<void>;
-}) {
+}>) {
   const [xyz0, setXyz0] = useState(String(xsec.xyz[0]));
   const [xyz1, setXyz1] = useState(String(xsec.xyz[1]));
   const [xyz2, setXyz2] = useState(String(xsec.xyz[2]));

--- a/frontend/components/workbench/WingOutlineViewer.tsx
+++ b/frontend/components/workbench/WingOutlineViewer.tsx
@@ -810,26 +810,32 @@ function buildPlotlyLayout() {
   };
 }
 
-/** Collect all traces from visible wings and fuselages. */
-async function collectAllTraces(
-  wings: Wing[], fuselages: Fuselage[],
-  visibleWings: Set<string>, visibleFuselages: Set<string>,
-  selectedWing: string | null, selectedXsecIndex: number | null,
-  selectedFuselage: string | null, selectedFuselageXsecIndex: number | null,
-  showQuarterChord: boolean,
-): Promise<PlotlyData[]> {
+/** Options for collecting all traces from visible wings and fuselages. */
+interface CollectTracesOptions {
+  wings: Wing[];
+  fuselages: Fuselage[];
+  visibleWings: Set<string>;
+  visibleFuselages: Set<string>;
+  selectedWing: string | null;
+  selectedXsecIndex: number | null;
+  selectedFuselage: string | null;
+  selectedFuselageXsecIndex: number | null;
+  showQuarterChord: boolean;
+}
+
+async function collectAllTraces(opts: CollectTracesOptions): Promise<PlotlyData[]> {
   const traces: PlotlyData[] = [];
 
-  for (const wing of wings) {
-    if (!visibleWings.has(wing.name)) continue;
-    const selIdx = selectedWing === wing.name ? selectedXsecIndex : null;
-    const wingTraces = await buildAllWingTraces(wing, selIdx, showQuarterChord);
+  for (const wing of opts.wings) {
+    if (!opts.visibleWings.has(wing.name)) continue;
+    const selIdx = opts.selectedWing === wing.name ? opts.selectedXsecIndex : null;
+    const wingTraces = await buildAllWingTraces(wing, selIdx, opts.showQuarterChord);
     traces.push(...wingTraces);
   }
 
-  for (const fuse of fuselages) {
-    if (!visibleFuselages.has(fuse.name)) continue;
-    const fuseSelIdx = selectedFuselage === fuse.name ? selectedFuselageXsecIndex : null;
+  for (const fuse of opts.fuselages) {
+    if (!opts.visibleFuselages.has(fuse.name)) continue;
+    const fuseSelIdx = opts.selectedFuselage === fuse.name ? opts.selectedFuselageXsecIndex : null;
     traces.push(...buildFuselageTraces(fuse, "#3B82F6", fuseSelIdx));
   }
 
@@ -862,12 +868,14 @@ export function WingOutlineViewer({
       if (disposed) return;
       plotlyRef.current = Plotly;
 
-      const traces = await collectAllTraces(
+      const traces = await collectAllTraces({
         wings, fuselages, visibleWings, visibleFuselages,
-        selectedWing ?? null, selectedXsecIndex ?? null,
-        selectedFuselage ?? null, selectedFuselageXsecIndex ?? null,
+        selectedWing: selectedWing ?? null,
+        selectedXsecIndex: selectedXsecIndex ?? null,
+        selectedFuselage: selectedFuselage ?? null,
+        selectedFuselageXsecIndex: selectedFuselageXsecIndex ?? null,
         showQuarterChord,
-      );
+      });
 
       // Guard: empty scene placeholder to avoid Plotly GL crashes
       if (traces.length === 0) {


### PR DESCRIPTION
## Summary

- **S6759**: Added `Readonly<>` to all component props across 7 files (~12 components)
- **S3358**: Replaced nested ternary expressions with conditional rendering patterns (4 locations)
- **S107**: Converted `collectAllTraces` (9 params) and `buildCallbacks` (14 params) to options objects

## Files changed
- `frontend/app/workbench/construction-plans/page.tsx` — Readonly on 4 dialog components, extracted `rightPanelHeading` helper
- `frontend/components/workbench/WingOutlineViewer.tsx` — `CollectTracesOptions` interface
- `frontend/components/workbench/AeroplaneTree.tsx` — `BuildCallbacksOptions` interface, Readonly on TreeRow, ternary fix
- `frontend/components/workbench/PropertyForm.tsx` — Readonly on 5 sub-components, `FieldGridContentProps` interface
- `frontend/components/workbench/CreatorParameterForm.tsx` — Readonly on ParamInput and ShapeRefInput
- `frontend/app/workbench/page.tsx` — Readonly on AeroplaneSelector, nested ternary fix
- `frontend/app/workbench/mission/page.tsx` — Readonly on Field, nested ternary fix

## Test plan
- [x] `npx eslint .` — 0 errors
- [x] `npm run test:unit` — 251 tests pass

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)