### PR TITLE
chore(gh-249): fix dialog accessibility across frontend

### DIFF
--- a/frontend/app/workbench/analysis/page.tsx
+++ b/frontend/app/workbench/analysis/page.tsx
@@ -54,11 +54,16 @@ export default function AnalysisPage() {
       {configOpen && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+          role="dialog"
+          aria-modal="true"
+          aria-label={modalTitle}
           onClick={() => setConfigOpen(false)}
+          onKeyDown={(e) => { if (e.key === "Escape") setConfigOpen(false); }}
         >
           <div
             className="flex max-h-[85vh] w-[480px] flex-col gap-4 overflow-y-auto rounded-2xl border border-border bg-card p-6 shadow-2xl"
             onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
           >
             <div className="flex items-center justify-between">
               <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">

--- a/frontend/app/workbench/construction-plans/page.tsx
+++ b/frontend/app/workbench/construction-plans/page.tsx
@@ -609,11 +609,16 @@ function AddStepDialog({
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      role="dialog"
+      aria-modal="true"
+      aria-label={addingCreator ? `Add ${addingCreator.class_name}` : "Add Step"}
       onClick={onClose}
+      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
     >
       <div
         className="flex max-h-[85vh] w-[600px] flex-col gap-4 overflow-y-auto rounded-2xl border border-border bg-card p-6 shadow-2xl"
         onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
       >
         {addingCreator ? (
           <>
@@ -872,11 +877,16 @@ function ExecuteDialog({
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Execute Plan"
       onClick={onClose}
+      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
     >
       <div
         className="flex w-[480px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
         onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
       >
         <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
           Execute Plan
@@ -968,13 +978,18 @@ function CadViewerModal({
   return (
     <div
       className={`fixed inset-0 z-50 flex items-center justify-center ${fullscreen ? "" : "bg-black/60"}`}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Execution Result"
       onClick={onClose}
+      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
     >
       <div
         className={`flex flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-2xl ${
           fullscreen ? "h-full w-full rounded-none border-0" : "h-[80vh] w-[80vw]"
         }`}
         onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
       >
         <div className="flex shrink-0 items-center gap-2 border-b border-border px-4 py-3">
           <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-foreground">

--- a/frontend/app/workbench/page.tsx
+++ b/frontend/app/workbench/page.tsx
@@ -204,11 +204,16 @@ export default function WorkbenchPage() {
       {configOpen && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Configuration"
           onClick={() => setConfigOpen(false)}
+          onKeyDown={(e) => { if (e.key === "Escape") setConfigOpen(false); }}
         >
           <div
             className="flex max-h-[85vh] w-[480px] flex-col gap-4 overflow-y-auto rounded-2xl border border-border bg-card p-6 shadow-2xl"
             onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
           >
             <div className="flex items-center justify-between">
               <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">

--- a/frontend/components/workbench/AeroplaneTree.tsx
+++ b/frontend/components/workbench/AeroplaneTree.tsx
@@ -814,7 +814,7 @@ export function AeroplaneTree(props: Readonly<AeroplaneTreeProps>) {
         )}
         {addMenuOpen && (
           <>
-            <div className="fixed inset-0 z-30" onClick={() => setAddMenuOpen(false)} />
+            <div className="fixed inset-0 z-30" role="presentation" aria-hidden="true" onClick={() => setAddMenuOpen(false)} onKeyDown={(e) => { if (e.key === "Escape") setAddMenuOpen(false); }} />
             <div className="absolute right-2 top-1 z-40 w-44 rounded-xl border border-border bg-card shadow-lg">
               <button
                 onClick={() => { setAddMenuOpen(false); handleAddWing(); }}
@@ -838,7 +838,7 @@ export function AeroplaneTree(props: Readonly<AeroplaneTreeProps>) {
       {/* Segment add menu (Spar / Control Surface) — positioned at click location */}
       {segAddMenu && (
         <>
-          <div className="fixed inset-0 z-30" onClick={() => setSegAddMenu(null)} />
+          <div className="fixed inset-0 z-30" role="presentation" aria-hidden="true" onClick={() => setSegAddMenu(null)} onKeyDown={(e) => { if (e.key === "Escape") setSegAddMenu(null); }} />
           <div
             className="fixed z-40 w-52 rounded-xl border border-border bg-card shadow-lg"
             style={{ left: segAddMenu.x, top: segAddMenu.y }}
@@ -924,7 +924,11 @@ function TreeRow({ node, onToggle, onNodeEdit: _onNodeEdit }: { node: TreeNode; 
         node.selected ? "bg-sidebar-accent font-semibold" : ""
       }`}
       style={{ paddingLeft: `${indent}px`, cursor: "pointer" }}
+      role="treeitem"
+      aria-selected={node.selected ?? false}
+      tabIndex={0}
       onClick={handleClick}
+      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); handleClick(); } }}
     >
       {!isLeaf && (
         <span className="flex h-3 w-3 shrink-0 items-center justify-center text-muted-foreground">

--- a/frontend/components/workbench/ComponentEditDialog.tsx
+++ b/frontend/components/workbench/ComponentEditDialog.tsx
@@ -184,11 +184,16 @@ export function ComponentEditDialog({
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      role="dialog"
+      aria-modal="true"
+      aria-label={isEdit ? "Edit Component" : "New Component"}
       onClick={onClose}
+      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
     >
       <div
         className="flex max-h-[85vh] w-[520px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
         onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
       >
         <div className="flex items-center gap-3">
           <span className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">

--- a/frontend/components/workbench/ComponentTypeManagementDialog.tsx
+++ b/frontend/components/workbench/ComponentTypeManagementDialog.tsx
@@ -47,11 +47,16 @@ export function ComponentTypeManagementDialog({
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Manage Component Types"
       onClick={onClose}
+      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
     >
       <div
         className="flex w-[640px] max-h-[85vh] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
         onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
       >
         <div className="flex items-center gap-2">
           <span className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">

--- a/frontend/components/workbench/ConstructionPartPickerDialog.tsx
+++ b/frontend/components/workbench/ConstructionPartPickerDialog.tsx
@@ -47,13 +47,16 @@ export function ConstructionPartPickerDialog({
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Construction-Part picker"
       onClick={onClose}
+      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
     >
       <div
         className="flex max-h-[80vh] w-[560px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
         onClick={(e) => e.stopPropagation()}
-        role="dialog"
-        aria-label="Construction-Part picker"
+        onKeyDown={(e) => e.stopPropagation()}
       >
         <div className="flex items-center gap-3">
           <span className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">

--- a/frontend/components/workbench/ConstructionPartUploadDialog.tsx
+++ b/frontend/components/workbench/ConstructionPartUploadDialog.tsx
@@ -65,13 +65,16 @@ export function ConstructionPartUploadDialog({
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Upload Construction Part"
       onClick={onClose}
+      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
     >
       <div
         className="flex w-[500px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
         onClick={(e) => e.stopPropagation()}
-        role="dialog"
-        aria-label="Upload Construction Part"
+        onKeyDown={(e) => e.stopPropagation()}
       >
         <div className="flex items-center gap-3">
           <Upload size={16} className="text-primary" />
@@ -127,10 +130,11 @@ export function ConstructionPartUploadDialog({
           </div>
 
           <div className="flex flex-col gap-1">
-            <label className="text-[11px] text-muted-foreground">
+            <label htmlFor="upload-part-material" className="text-[11px] text-muted-foreground">
               Material (optional)
             </label>
             <select
+              id="upload-part-material"
               value={materialId}
               onChange={(e) => setMaterialId(e.target.value)}
               className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"

--- a/frontend/components/workbench/ConstructionPartsGrid.tsx
+++ b/frontend/components/workbench/ConstructionPartsGrid.tsx
@@ -33,11 +33,16 @@ function ConfirmModal({ title, body, onConfirm, onCancel }: Readonly<ConfirmModa
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
       onClick={onCancel}
+      onKeyDown={(e) => { if (e.key === "Escape") onCancel(); }}
     >
       <div
         className="flex w-[420px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
         onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
       >
         <span className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
           {title}

--- a/frontend/components/workbench/CotsPickerDialog.tsx
+++ b/frontend/components/workbench/CotsPickerDialog.tsx
@@ -52,13 +52,16 @@ export function CotsPickerDialog({
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Component picker"
       onClick={onClose}
+      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
     >
       <div
         className="flex max-h-[80vh] w-[560px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
         onClick={(e) => e.stopPropagation()}
-        role="dialog"
-        aria-label="Component picker"
+        onKeyDown={(e) => e.stopPropagation()}
       >
         <div className="flex items-center gap-3">
           <span className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">

--- a/frontend/components/workbench/ImportFuselageDialog.tsx
+++ b/frontend/components/workbench/ImportFuselageDialog.tsx
@@ -583,7 +583,11 @@ export function ImportFuselageDialog({
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      role="dialog"
+      aria-modal="true"
+      aria-label="New Fuselage"
       onClick={() => { handleReset(); onClose(); }}
+      onKeyDown={(e) => { if (e.key === "Escape") { handleReset(); onClose(); } }}
     >
       <div
         className={`flex flex-col rounded-2xl border border-border bg-card shadow-2xl transition-all ${
@@ -592,6 +596,7 @@ export function ImportFuselageDialog({
             : "w-[900px] h-[80vh]"
         }`}
         onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
       >
         {/* Header */}
         <div className="flex items-center gap-3 border-b border-border px-6 py-4">
@@ -659,10 +664,11 @@ export function ImportFuselageDialog({
               {/* Parameters */}
               <div className="flex gap-4">
                 <div className="flex flex-1 flex-col gap-1">
-                  <label className="text-[11px] text-muted-foreground">
+                  <label htmlFor="fuselage-name" className="text-[11px] text-muted-foreground">
                     Fuselage Name
                   </label>
                   <input
+                    id="fuselage-name"
                     type="text"
                     value={fuselageName}
                     onChange={(e) => setFuselageName(e.target.value)}
@@ -670,9 +676,10 @@ export function ImportFuselageDialog({
                   />
                 </div>
                 <div className="flex flex-col gap-1">
-                  <label className="text-[11px] text-muted-foreground">Scale Factor</label>
+                  <label htmlFor="fuselage-scale-factor" className="text-[11px] text-muted-foreground">Scale Factor</label>
                   <div className="flex items-center gap-2">
                     <input
+                      id="fuselage-scale-factor"
                       type="text"
                       inputMode="decimal"
                       value={scaleInput}
@@ -713,10 +720,11 @@ export function ImportFuselageDialog({
                   </div>
                 </div>
                 <div className="flex flex-col gap-1">
-                  <label className="text-[11px] text-muted-foreground">
+                  <label htmlFor="fuselage-slices" className="text-[11px] text-muted-foreground">
                     Slices
                   </label>
                   <input
+                    id="fuselage-slices"
                     type="text"
                     inputMode="numeric"
                     value={slicesInput}
@@ -730,10 +738,11 @@ export function ImportFuselageDialog({
                   />
                 </div>
                 <div className="flex flex-col gap-1">
-                  <label className="text-[11px] text-muted-foreground">
+                  <label htmlFor="fuselage-slice-axis" className="text-[11px] text-muted-foreground">
                     Slice Axis
                   </label>
                   <select
+                    id="fuselage-slice-axis"
                     value={axis}
                     onChange={(e) => setAxis(e.target.value)}
                     className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
@@ -845,8 +854,9 @@ export function ImportFuselageDialog({
               {/* Fuselage name (editable) — hidden when either view maximized */}
               {!viewerMaximized && !xsecsMaximized && (
               <div className="flex items-center gap-3">
-                <label className="text-[11px] text-muted-foreground">Save as:</label>
+                <label htmlFor="fuselage-save-as" className="text-[11px] text-muted-foreground">Save as:</label>
                 <input
+                  id="fuselage-save-as"
                   type="text"
                   value={fuselageName}
                   onChange={(e) => setFuselageName(e.target.value)}

--- a/frontend/components/workbench/InfoTooltip.tsx
+++ b/frontend/components/workbench/InfoTooltip.tsx
@@ -15,9 +15,13 @@ export function InfoTooltip({ text, size = 11 }: Readonly<InfoTooltipProps>) {
   return (
     <span
       className="group/tip relative inline-flex shrink-0 text-muted-foreground hover:text-primary"
+      role="img"
+      aria-label={text}
+      tabIndex={0}
       onClick={(e) => e.stopPropagation()}
+      onKeyDown={(e) => e.stopPropagation()}
     >
-      <Info size={size} />
+      <Info size={size} aria-hidden="true" />
       <span className="pointer-events-none absolute bottom-full left-1/2 z-50 mb-1.5 hidden w-max max-w-[240px] -translate-x-1/2 rounded-lg border border-border bg-card px-2.5 py-1.5 text-[10px] font-normal leading-snug text-foreground shadow-lg group-hover/tip:block">
         {text}
       </span>

--- a/frontend/components/workbench/NodePropertyPanel.tsx
+++ b/frontend/components/workbench/NodePropertyPanel.tsx
@@ -88,11 +88,16 @@ function ConfirmModal({ title, body, onConfirm, onCancel }: Readonly<ConfirmModa
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
       onClick={onCancel}
+      onKeyDown={(e) => { if (e.key === "Escape") onCancel(); }}
     >
       <div
         className="flex w-[420px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
         onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
       >
         <span className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
           {title}
@@ -318,12 +323,15 @@ export function NodePropertyPanel({
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
       onClick={onClose}
+      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
       role="dialog"
+      aria-modal="true"
       aria-label="Edit tree node"
     >
     <div
       className="flex max-h-[85vh] w-[480px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
       onClick={(e) => e.stopPropagation()}
+      onKeyDown={(e) => e.stopPropagation()}
     >
       <div className="flex items-center gap-2">
         <span className="font-[family-name:var(--font-jetbrains-mono)] text-[14px] text-foreground">

--- a/frontend/components/workbench/PropertyForm.tsx
+++ b/frontend/components/workbench/PropertyForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useId } from "react";
 import { useRouter } from "next/navigation";
 import { ChevronDown, Eye } from "lucide-react";
 import { AirfoilSelector } from "./AirfoilSelector";
@@ -142,6 +142,7 @@ function Field({
   readOnly?: boolean;
   isSelect?: boolean;
 }) {
+  const id = useId();
   const [localValue, setLocalValue] = useState(String(value));
   const [editing, setEditing] = useState(false);
 
@@ -150,12 +151,13 @@ function Field({
 
   return (
     <div className="flex flex-1 flex-col gap-1">
-      <label className="text-[11px] text-muted-foreground">{label}</label>
+      <label htmlFor={id} className="text-[11px] text-muted-foreground">{label}</label>
       <div className="flex items-center gap-2 rounded-xl border border-border bg-input px-3 py-2">
         {readOnly ? (
-          <span className="text-[13px] text-foreground">{value}</span>
+          <span id={id} className="text-[13px] text-foreground">{value}</span>
         ) : (
           <input
+            id={id}
             type={type}
             step="any"
             value={displayValue}

--- a/frontend/components/workbench/SparEditDialog.tsx
+++ b/frontend/components/workbench/SparEditDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useId } from "react";
 import { X } from "lucide-react";
 import { API_BASE } from "@/lib/fetcher";
 
@@ -169,14 +169,14 @@ export function SparEditDialog({
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      role="presentation"
+      role="dialog"
+      aria-modal="true"
+      aria-label={isNew ? "Add Spar" : "Edit Spar"}
       onClick={onClose}
       onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
     >
       <div
         className="flex max-h-[85vh] w-[420px] flex-col gap-4 overflow-y-auto rounded-2xl border border-border bg-card p-6 shadow-2xl"
-        role="dialog"
-        aria-modal="true"
         onClick={(e) => e.stopPropagation()}
         onKeyDown={(e) => e.stopPropagation()}
       >
@@ -279,11 +279,13 @@ function DialogField({
   suffix?: string;
   onChange: (v: string) => void;
 }>) {
+  const id = useId();
   return (
     <div className="flex flex-1 flex-col gap-1">
-      <label className="text-[11px] text-muted-foreground">{label}</label>
+      <label htmlFor={id} className="text-[11px] text-muted-foreground">{label}</label>
       <div className="flex items-center gap-2 rounded-xl border border-border bg-input px-3 py-2">
         <input
+          id={id}
           type="number"
           step="any"
           value={value}

--- a/frontend/components/workbench/StreamlinesViewer.tsx
+++ b/frontend/components/workbench/StreamlinesViewer.tsx
@@ -61,10 +61,11 @@ export function StreamlinesViewer({ aeroplaneId }: { aeroplaneId: string | null 
       {/* Form + Button row */}
       <div className="flex items-end gap-3 border-b border-border bg-card px-4 py-3">
         <div className="flex flex-col gap-1">
-          <label className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+          <label htmlFor="streamlines-velocity" className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
             Velocity (m/s)
           </label>
           <input
+            id="streamlines-velocity"
             type="number"
             value={params.velocity}
             onChange={(e) => setParams((p) => ({ ...p, velocity: Number.parseFloat(e.target.value) || 0 }))}
@@ -72,10 +73,11 @@ export function StreamlinesViewer({ aeroplaneId }: { aeroplaneId: string | null 
           />
         </div>
         <div className="flex flex-col gap-1">
-          <label className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+          <label htmlFor="streamlines-alpha" className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
             Alpha (&deg;)
           </label>
           <input
+            id="streamlines-alpha"
             type="number"
             value={params.alpha}
             onChange={(e) => setParams((p) => ({ ...p, alpha: Number.parseFloat(e.target.value) || 0 }))}
@@ -83,10 +85,11 @@ export function StreamlinesViewer({ aeroplaneId }: { aeroplaneId: string | null 
           />
         </div>
         <div className="flex flex-col gap-1">
-          <label className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+          <label htmlFor="streamlines-beta" className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
             Beta (&deg;)
           </label>
           <input
+            id="streamlines-beta"
             type="number"
             value={params.beta}
             onChange={(e) => setParams((p) => ({ ...p, beta: Number.parseFloat(e.target.value) || 0 }))}
@@ -94,10 +97,11 @@ export function StreamlinesViewer({ aeroplaneId }: { aeroplaneId: string | null 
           />
         </div>
         <div className="flex flex-col gap-1">
-          <label className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+          <label htmlFor="streamlines-altitude" className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
             Altitude (m)
           </label>
           <input
+            id="streamlines-altitude"
             type="number"
             value={params.altitude}
             onChange={(e) => setParams((p) => ({ ...p, altitude: Number.parseFloat(e.target.value) || 0 }))}

--- a/frontend/components/workbench/TedEditDialog.tsx
+++ b/frontend/components/workbench/TedEditDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo, useRef } from "react";
+import { useState, useEffect, useMemo, useRef, useId } from "react";
 import { X, Check, ChevronDown, ChevronUp, Search, ChevronRight } from "lucide-react";
 import { API_BASE } from "@/lib/fetcher";
 import { useComponents, type Component } from "@/hooks/useComponents";
@@ -184,14 +184,14 @@ export function TedEditDialog({
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      role="presentation"
+      role="dialog"
+      aria-modal="true"
+      aria-label={isNew ? "Add Control Surface" : "Edit Control Surface"}
       onClick={onClose}
       onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
     >
       <div
         className="flex max-h-[85vh] w-[480px] flex-col gap-4 overflow-y-auto rounded-2xl border border-border bg-card p-6 shadow-2xl"
-        role="dialog"
-        aria-modal="true"
         onClick={(e) => e.stopPropagation()}
         onKeyDown={(e) => e.stopPropagation()}
       >
@@ -346,11 +346,13 @@ function TedField({
   type?: "text" | "number";
   onChange: (v: string) => void;
 }>) {
+  const id = useId();
   return (
     <div className="flex flex-1 flex-col gap-1">
-      <label className="text-[11px] text-muted-foreground">{label}</label>
+      <label htmlFor={id} className="text-[11px] text-muted-foreground">{label}</label>
       <div className="flex items-center gap-2 rounded-xl border border-border bg-input px-3 py-2">
         <input
+          id={id}
           type={type}
           step="any"
           value={value}

--- a/frontend/components/workbench/UnsavedChangesModal.tsx
+++ b/frontend/components/workbench/UnsavedChangesModal.tsx
@@ -11,12 +11,16 @@ export function UnsavedChangesModal() {
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Unsaved Changes"
       onClick={cancelNavigation}
+      onKeyDown={(e) => { if (e.key === "Escape") cancelNavigation(); }}
     >
       <div
         className="flex w-[460px] flex-col gap-5 rounded-[16px] border border-border bg-card p-6"
         onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => { if (e.key === "Escape") cancelNavigation(); }}
+        onKeyDown={(e) => e.stopPropagation()}
       >
         <div className="flex items-center gap-3">
           <TriangleAlert size={24} className="text-primary" />


### PR DESCRIPTION
## Summary
- Add `role="dialog"` + `aria-modal="true"` + `aria-label` to all 18 modal backdrop elements across the frontend
- Add `onKeyDown` Escape handler on all backdrops and `stopPropagation` on inner dialog cards
- Add `role="treeitem"` + `aria-selected` + `tabIndex` + keyboard support (Enter/Space) to AeroplaneTree rows
- Associate all `<label>` elements with their `<input>` counterparts via `htmlFor`+`id` (using React `useId`)
- Add `aria-hidden="true"` to decorative info icon SVG in InfoTooltip

Resolves SonarQube rules S6819, S6848, S1082, S6847, S6853.

## Test plan
- [x] `npx eslint .` passes with 0 errors (only pre-existing warnings)
- [x] `npm run test:unit` passes all 251 tests
- [ ] Manual: verify Escape key closes all dialogs
- [ ] Manual: verify Tab + Enter/Space navigates tree items

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)