### PR TITLE
chore(gh-252): minor SonarQube style fixes across frontend

### DIFF
--- a/frontend/components/workbench/ActionRow.tsx
+++ b/frontend/components/workbench/ActionRow.tsx
@@ -13,15 +13,15 @@ interface ActionRowProps {
   onFuselageSaved?: () => void;
 }
 
+function handleDownloadSTEP() {
+  alert("STEP download not yet connected");
+}
+
 export function ActionRow({ aeroplaneId, onWingCreated, onFuselageSaved }: Readonly<ActionRowProps>) {
   const ctx = useAeroplaneContext();
   const { mutate: mutateWings } = useWings(aeroplaneId);
   const [importDialogOpen, setImportDialogOpen] = useState(false);
   const [createWingOpen, setCreateWingOpen] = useState(false);
-
-  function handleDownloadSTEP() {
-    alert("STEP download not yet connected");
-  }
 
   return (
     <div className="flex flex-wrap items-center gap-2">

--- a/frontend/components/workbench/AirfoilPreview.tsx
+++ b/frontend/components/workbench/AirfoilPreview.tsx
@@ -55,7 +55,7 @@ export function AirfoilPreview({ airfoilName, onClose }: Readonly<AirfoilPreview
           </span>
           <div className="rounded-xl border border-border bg-input px-2 py-1">
             <span className="font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-foreground">
-              0.0
+              0
             </span>
           </div>
         </div>

--- a/frontend/components/workbench/ComponentEditDialog.tsx
+++ b/frontend/components/workbench/ComponentEditDialog.tsx
@@ -19,22 +19,28 @@ interface ComponentEditDialogProps {
 /** Default value inserted when a type is selected and specs don't already have the key. */
 function defaultForProp(prop: PropertyDefinition): unknown {
   if (prop.default != null) return prop.default;
-  if (prop.type === "boolean") return false;
-  return "";
+  switch (prop.type) {
+    case "boolean":
+      return false;
+    default:
+      return "";
+  }
 }
 
 /** Parse a user-entered string back into the property's declared type. */
 function parseValue(prop: PropertyDefinition, raw: unknown): unknown {
   if (raw === "" || raw == null) return undefined;
-  if (prop.type === "number") {
-    const n = Number(raw);
-    return Number.isFinite(n) ? n : undefined;
+  switch (prop.type) {
+    case "number": {
+      const n = Number(raw);
+      return Number.isFinite(n) ? n : undefined;
+    }
+    case "boolean":
+      if (typeof raw === "boolean") return raw;
+      return raw === "true" || raw === true;
+    default:
+      return String(raw);
   }
-  if (prop.type === "boolean") {
-    if (typeof raw === "boolean") return raw;
-    return raw === "true" || raw === true;
-  }
-  return String(raw);
 }
 
 type ValidationResult = { ok: true } | { ok: false; property: string; message: string };
@@ -59,13 +65,17 @@ function validateProp(prop: PropertyDefinition, raw: unknown): ValidationResult 
     return fail(prop, `${prop.label} (${prop.name}) is required.`);
   }
   if (parsed === undefined) return null;
-  if (prop.type === "number") {
-    return validateNumberRange(prop, parsed as number);
+  switch (prop.type) {
+    case "number":
+      return validateNumberRange(prop, parsed as number);
+    case "enum":
+      if (prop.options && !prop.options.includes(String(parsed))) {
+        return fail(prop, `${prop.label}: value '${parsed}' is not in ${JSON.stringify(prop.options)}.`);
+      }
+      return null;
+    default:
+      return null;
   }
-  if (prop.type === "enum" && prop.options && !prop.options.includes(String(parsed))) {
-    return fail(prop, `${prop.label}: value '${String(parsed)}' is not in ${JSON.stringify(prop.options)}.`);
-  }
-  return null;
 }
 
 function validate(
@@ -341,58 +351,59 @@ interface SpecFieldProps {
 function SpecField({ prop, value, onChange }: Readonly<SpecFieldProps>) {
   const labelText = `${prop.label}${prop.required ? " *" : ""}${prop.unit ? ` (${prop.unit})` : ""}`;
 
-  if (prop.type === "boolean") {
-    return (
-      <div className="flex items-center gap-2">
-        <input
-          type="checkbox"
-          data-spec={prop.name}
-          checked={!!value}
-          onChange={(e) => onChange(e.target.checked)}
-          id={`spec-${prop.name}`}
-        />
-        <label htmlFor={`spec-${prop.name}`} className="text-[12px] text-foreground">
-          {labelText}
-        </label>
-      </div>
-    );
-  }
+  switch (prop.type) {
+    case "boolean":
+      return (
+        <div className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            data-spec={prop.name}
+            checked={!!value}
+            onChange={(e) => onChange(e.target.checked)}
+            id={`spec-${prop.name}`}
+          />
+          <label htmlFor={`spec-${prop.name}`} className="text-[12px] text-foreground">
+            {labelText}
+          </label>
+        </div>
+      );
 
-  if (prop.type === "enum") {
-    return (
-      <div className="flex flex-col gap-1">
-        <label className="text-[11px] text-muted-foreground">{labelText}</label>
-        <select
-          data-spec={prop.name}
-          value={value == null ? "" : String(value)}
-          onChange={(e) => onChange(e.target.value)}
-          className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
-        >
-          <option value=""></option>
-          {(prop.options ?? []).map((o) => (
-            <option key={o} value={o}>{o}</option>
-          ))}
-        </select>
-      </div>
-    );
-  }
+    case "enum":
+      return (
+        <div className="flex flex-col gap-1">
+          <label className="text-[11px] text-muted-foreground">{labelText}</label>
+          <select
+            data-spec={prop.name}
+            value={value == null ? "" : String(value)}
+            onChange={(e) => onChange(e.target.value)}
+            className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
+          >
+            <option value=""></option>
+            {(prop.options ?? []).map((o) => (
+              <option key={o} value={o}>{o}</option>
+            ))}
+          </select>
+        </div>
+      );
 
-  // number or string
-  return (
-    <div className="flex flex-col gap-1">
-      <label className="text-[11px] text-muted-foreground">{labelText}</label>
-      <input
-        data-spec={prop.name}
-        type={prop.type === "number" ? "number" : "text"}
-        value={value == null ? "" : String(value)}
-        onChange={(e) => onChange(e.target.value)}
-        min={prop.min ?? undefined}
-        max={prop.max ?? undefined}
-        className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
-      />
-      {prop.description && (
-        <span className="text-[10px] text-subtle-foreground">{prop.description}</span>
-      )}
-    </div>
-  );
+    default:
+      // number or string
+      return (
+        <div className="flex flex-col gap-1">
+          <label className="text-[11px] text-muted-foreground">{labelText}</label>
+          <input
+            data-spec={prop.name}
+            type={prop.type === "number" ? "number" : "text"}
+            value={value == null ? "" : String(value)}
+            onChange={(e) => onChange(e.target.value)}
+            min={prop.min ?? undefined}
+            max={prop.max ?? undefined}
+            className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
+          />
+          {prop.description && (
+            <span className="text-[10px] text-subtle-foreground">{prop.description}</span>
+          )}
+        </div>
+      );
+  }
 }

--- a/frontend/components/workbench/CreatorParameterForm.tsx
+++ b/frontend/components/workbench/CreatorParameterForm.tsx
@@ -54,42 +54,44 @@ function ParamInput({
     );
   }
 
-  if (param.type === "bool") {
-    return (
-      <input
-        type="checkbox"
-        checked={Boolean(value ?? param.default ?? false)}
-        onChange={(e) => onChange(param.name, e.target.checked)}
-        className="size-4"
-      />
-    );
-  }
+  switch (param.type) {
+    case "bool":
+      return (
+        <input
+          type="checkbox"
+          checked={Boolean(value ?? param.default ?? false)}
+          onChange={(e) => onChange(param.name, e.target.checked)}
+          className="size-4"
+        />
+      );
 
-  if (param.type === "int" || param.type === "float") {
-    return (
-      <input
-        type="number"
-        value={strValue}
-        onChange={(e) => {
-          const v = param.type === "int"
-            ? Number.parseInt(e.target.value, 10)
-            : Number.parseFloat(e.target.value);
-          onChange(param.name, Number.isNaN(v) ? null : v);
-        }}
-        step={param.type === "float" ? "any" : "1"}
-        className="rounded-lg border border-border bg-input px-3 py-1.5 text-[12px] text-foreground outline-none"
-      />
-    );
-  }
+    case "int":
+    case "float":
+      return (
+        <input
+          type="number"
+          value={strValue}
+          onChange={(e) => {
+            const v = param.type === "int"
+              ? Number.parseInt(e.target.value, 10)
+              : Number.parseFloat(e.target.value);
+            onChange(param.name, Number.isNaN(v) ? null : v);
+          }}
+          step={param.type === "float" ? "any" : "1"}
+          className="rounded-lg border border-border bg-input px-3 py-1.5 text-[12px] text-foreground outline-none"
+        />
+      );
 
-  return (
-    <input
-      type="text"
-      value={strValue}
-      onChange={(e) => onChange(param.name, e.target.value)}
-      className="rounded-lg border border-border bg-input px-3 py-1.5 text-[12px] text-foreground outline-none"
-    />
-  );
+    default:
+      return (
+        <input
+          type="text"
+          value={strValue}
+          onChange={(e) => onChange(param.name, e.target.value)}
+          className="rounded-lg border border-border bg-input px-3 py-1.5 text-[12px] text-foreground outline-none"
+        />
+      );
+  }
 }
 
 export function CreatorParameterForm({

--- a/frontend/components/workbench/NodePropertyPanel.tsx
+++ b/frontend/components/workbench/NodePropertyPanel.tsx
@@ -230,8 +230,8 @@ export function NodePropertyPanel({
   const constructionPartId = node.construction_part_id ?? null;
 
   const original = nodeToForm(node);
-  const dirty = Object.keys(form).some(
-    (k) => form[k as keyof FormState] !== original[k as keyof FormState],
+  const dirty = (Object.keys(form) as (keyof FormState)[]).some(
+    (k) => form[k] !== original[k],
   );
 
   function update(patch: Partial<FormState>) {

--- a/frontend/components/workbench/PropertyForm.tsx
+++ b/frontend/components/workbench/PropertyForm.tsx
@@ -89,40 +89,6 @@ function segmentToWcState(seg: WingConfigSegment): WingConfigState {
   };
 }
 
-/** @deprecated — kept for reference, replaced by segmentToWcState + useWingConfig */
-function xsecsToWingConfig(
-  xsecs: XSec[],
-  segIndex: number,
-): WingConfigState | null {
-  if (segIndex < 0 || segIndex >= xsecs.length - 1) return null;
-  const root = xsecs[segIndex];
-  const tip = xsecs[segIndex + 1];
-  const rootChord = root.chord * 1000;
-  const tipChord = tip.chord * 1000;
-  const dx = (tip.xyz_le[0] - root.xyz_le[0]) * 1000;
-  const dy = (tip.xyz_le[1] - root.xyz_le[1]) * 1000;
-
-  // Estimate dihedral from z-component of leading-edge delta
-  const segLength = Math.hypot(dx, dy);
-  const dz = (tip.xyz_le[2] - root.xyz_le[2]) * 1000;
-  const dihedralDeg = segLength > 0 ? Math.atan2(dz, Math.abs(dy)) * (180 / Math.PI) : 0;
-
-  return {
-    root_airfoil: airfoilShortName(root.airfoil),
-    root_chord: rootChord,
-    root_dihedral: Math.round(dihedralDeg * 100) / 100,
-    root_incidence: root.twist,
-    tip_airfoil: airfoilShortName(tip.airfoil),
-    tip_chord: tipChord,
-    tip_dihedral: Math.round(dihedralDeg * 100) / 100,
-    tip_incidence: tip.twist,
-    length: Math.abs(dy),
-    sweep: dx,
-    number_interpolation_points: root.number_interpolation_points ?? 201,
-    tip_type: root.tip_type ?? "",
-  };
-}
-
 // ── Field Component ─────────────────────────────────────────────
 
 function Field({
@@ -611,8 +577,11 @@ export function PropertyForm({ onGeometryChanged }: Readonly<{ onGeometryChanged
 
   function handleCancel() {
     if (xsec) setAsb(xsecToAsb(xsec));
-    if (wing && selectedXsecIndex !== null)
-      setWc(xsecsToWingConfig(wing.x_secs, selectedXsecIndex));
+    if (wingConfig && selectedXsecIndex !== null && selectedXsecIndex < wingConfig.segments.length) {
+      setWc(segmentToWcState(wingConfig.segments[selectedXsecIndex]));
+    } else {
+      setWc(null);
+    }
     setError(null);
     setDirty(false);
   }

--- a/frontend/hooks/usePreviewState.ts
+++ b/frontend/hooks/usePreviewState.ts
@@ -73,15 +73,18 @@ export function usePreviewState(aeroplaneId: string | null) {
           );
           const s = await r.json();
 
-          if (s.status === "SUCCESS" && s.result?.data) {
-            setPreviews((prev) => ({
-              ...prev,
-              [wingName]: { visible: true, data: s.result, loading: false, error: null },
-            }));
-            return;
-          }
-          if (s.status === "FAILURE") {
-            throw new Error(s.message || "Tessellation failed");
+          switch (s.status) {
+            case "SUCCESS":
+              if (s.result?.data) {
+                setPreviews((prev) => ({
+                  ...prev,
+                  [wingName]: { visible: true, data: s.result, loading: false, error: null },
+                }));
+                return;
+              }
+              break;
+            case "FAILURE":
+              throw new Error(s.message || "Tessellation failed");
           }
           await new Promise((resolve) => setTimeout(resolve, 500));
         }

--- a/frontend/hooks/useStlExport.ts
+++ b/frontend/hooks/useStlExport.ts
@@ -29,9 +29,10 @@ async function pollExportStatus(aeroplaneId: string): Promise<void> {
     if (!statusRes.ok) throw new Error(`Status check failed: ${statusRes.status}`);
     const statusData = await statusRes.json();
 
-    if (statusData.status === "SUCCESS") return;
-    if (statusData.status === "FAILURE") {
-      throw new Error(statusData.message || "Export failed");
+    switch (statusData.status) {
+      case "SUCCESS": return;
+      case "FAILURE":
+        throw new Error(statusData.message || "Export failed");
     }
     await new Promise((r) => setTimeout(r, 500));
   }

--- a/frontend/hooks/useTessellation.ts
+++ b/frontend/hooks/useTessellation.ts
@@ -67,15 +67,16 @@ async function pollTessellation(
     if (!statusRes.ok) throw new Error(`Status check failed: ${statusRes.status}`);
     const statusData = await statusRes.json();
 
-    if (statusData.status === "SUCCESS") {
-      const tessResult = statusData.result;
-      if (!tessResult || !tessResult.data) {
-        throw new Error("Tessellation result has no data");
+    switch (statusData.status) {
+      case "SUCCESS": {
+        const tessResult = statusData.result;
+        if (!tessResult || !tessResult.data) {
+          throw new Error("Tessellation result has no data");
+        }
+        return tessResult;
       }
-      return tessResult;
-    }
-    if (statusData.status === "FAILURE") {
-      throw new Error(statusData.message || "Tessellation failed");
+      case "FAILURE":
+        throw new Error(statusData.message || "Tessellation failed");
     }
     await new Promise((r) => setTimeout(r, 500));
   }


### PR DESCRIPTION
## Summary

- **S7755** — Replace if/else chains with `switch` for type-discriminated checks in `ComponentEditDialog`, `CreatorParameterForm`, `useTessellation`, `useStlExport`, and `usePreviewState`
- **S7721** — Move `handleDownloadSTEP` to module scope in `ActionRow.tsx`
- **S1874** — Remove deprecated `xsecsToWingConfig`, replace its usage with `segmentToWcState` + `useWingConfig` in `PropertyForm.tsx`
- **S7748** — Replace `0.0` with `0` in `AirfoilPreview.tsx`
- **S4624** — Eliminate type assertion in equality comparison in `NodePropertyPanel.tsx`

## Test plan

- [x] `npx eslint .` — 0 errors
- [x] `npm run test:unit` — 251 tests pass

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)