### PR TITLE
refactor(gh-226): reduce S3776 cognitive complexity in 4 frontend components

### DIFF
--- a/frontend/app/workbench/construction-plans/page.tsx
+++ b/frontend/app/workbench/construction-plans/page.tsx
@@ -33,6 +33,42 @@ import {
   computeReorderTargetPath,
 } from "@/lib/planTreeUtils";
 
+/** Build an ExecutionResult for a caught error. */
+function buildErrorResult(err: unknown): ExecutionResult {
+  return {
+    status: "error",
+    shape_keys: [],
+    export_paths: [],
+    error: err instanceof Error ? err.message : "Execution failed",
+    duration_ms: 0,
+    tessellation: null,
+  };
+}
+
+/** Create a new plan — either from a template or from scratch. */
+async function submitNewPlan(
+  name: string,
+  fromTemplate: boolean,
+  templateId: number | null,
+  aeroplaneId: string | null,
+  activeMutate: () => void,
+  mutateAeroplanePlans: () => void,
+): Promise<{ id: number }> {
+  if (fromTemplate && templateId != null && aeroplaneId) {
+    const created = await instantiateTemplate(aeroplaneId, templateId, name);
+    mutateAeroplanePlans();
+    return created;
+  }
+  const created = await createPlan({
+    name,
+    tree_json: { $TYPE: "ConstructionRootNode", creator_id: "root", successors: [] },
+    plan_type: "plan",
+    aeroplane_id: aeroplaneId ?? undefined,
+  });
+  activeMutate();
+  return created;
+}
+
 type RightPanel = "gallery" | "detail" | "params";
 
 function rightPanelHeading(
@@ -99,26 +135,28 @@ export default function ConstructionPlansPage() {
 
   function handleNewPlan() {
     if (viewMode === "plans") {
-      // Open the new plan dialog with template selection
       setNewPlanName("");
       setNewPlanFromTemplate(false);
       setNewPlanTemplateId(null);
       setNewPlanDialogOpen(true);
     } else {
-      // Templates mode: simple prompt (no template-from-template)
-      const name = prompt("Template name:");
-      if (!name?.trim()) return;
-      createPlan({
-        name: name.trim(),
-        tree_json: { $TYPE: "ConstructionRootNode", creator_id: "root", successors: [] },
-        plan_type: "template",
-      })
-        .then((created) => {
-          activeMutate();
-          setSelectedPlanId(created.id);
-        })
-        .catch((err) => alert(err instanceof Error ? err.message : "Failed to create template"));
+      handleNewTemplate();
     }
+  }
+
+  function handleNewTemplate() {
+    const name = prompt("Template name:");
+    if (!name?.trim()) return;
+    createPlan({
+      name: name.trim(),
+      tree_json: { $TYPE: "ConstructionRootNode", creator_id: "root", successors: [] },
+      plan_type: "template",
+    })
+      .then((created) => {
+        activeMutate();
+        setSelectedPlanId(created.id);
+      })
+      .catch((err) => alert(err instanceof Error ? err.message : "Failed to create template"));
   }
 
   async function handleNewPlanSubmit() {
@@ -126,19 +164,10 @@ export default function ConstructionPlansPage() {
     if (!name) return;
     if (newPlanFromTemplate && newPlanTemplateId != null && !aeroplaneId) return;
     try {
-      let created;
-      if (newPlanFromTemplate && newPlanTemplateId != null && aeroplaneId) {
-        created = await instantiateTemplate(aeroplaneId, newPlanTemplateId, name);
-        mutateAeroplanePlans();
-      } else {
-        created = await createPlan({
-          name,
-          tree_json: { $TYPE: "ConstructionRootNode", creator_id: "root", successors: [] },
-          plan_type: "plan",
-          aeroplane_id: aeroplaneId ?? undefined,
-        });
-        activeMutate();
-      }
+      const created = await submitNewPlan(
+        name, newPlanFromTemplate, newPlanTemplateId, aeroplaneId ?? null,
+        activeMutate, mutateAeroplanePlans,
+      );
       setSelectedPlanId(created.id);
       setNewPlanDialogOpen(false);
     } catch (err) {
@@ -271,22 +300,18 @@ export default function ConstructionPlansPage() {
     try {
       const result = await executePlan(executeAeroplaneId, selectedPlanId);
       setExecuteResult(result);
-      // Open CadViewer modal if tessellation data is available
-      if (result.status === "success" && result.tessellation) {
-        setCadViewerData(result.tessellation);
-        setCadViewerOpen(true);
-      }
+      openCadViewerIfSuccess(result);
     } catch (err) {
-      setExecuteResult({
-        status: "error",
-        shape_keys: [],
-        export_paths: [],
-        error: err instanceof Error ? err.message : "Execution failed",
-        duration_ms: 0,
-        tessellation: null,
-      });
+      setExecuteResult(buildErrorResult(err));
     } finally {
       setExecuting(false);
+    }
+  }
+
+  function openCadViewerIfSuccess(result: ExecutionResult) {
+    if (result.status === "success" && result.tessellation) {
+      setCadViewerData(result.tessellation);
+      setCadViewerOpen(true);
     }
   }
 

--- a/frontend/components/workbench/AeroplaneTree.tsx
+++ b/frontend/components/workbench/AeroplaneTree.tsx
@@ -185,6 +185,54 @@ function buildExpandedSegmentDetails(
   return nodes;
 }
 
+// ── Build tree nodes for a single segment (extracted for complexity) ──
+
+function buildSingleSegmentNodes(ctx: BuildNodeContext, i: number): TreeNode[] {
+  const { wingName, wing, selectedWing, selectedXsecIndex, expandedSet, callbacks } = ctx;
+  if (!wing) return [];
+  const root = wing.x_secs[i];
+  const tip = wing.x_secs[i + 1];
+  const segId = `${wingName}-seg${i}`;
+  const isSelected = selectedWing === wingName && selectedXsecIndex === i;
+  const segExpanded = expandedSet.has(segId);
+  const nodes: TreeNode[] = [];
+
+  // Insert point before this segment (except before first)
+  if (i > 0 && callbacks.onInsertXsec) {
+    nodes.push({
+      id: `${wingName}-ins-${i}`,
+      label: "insert",
+      level: 2,
+      isInsertPoint: true,
+      onInsert: () => callbacks.onInsertXsec!(wingName, i),
+    });
+  }
+
+  const chipLabel = getChipLabel(root);
+
+  nodes.push({
+    id: segId,
+    label: i === 0 ? `segment ${i} (root)` : `segment ${i}`,
+    level: 2,
+    expanded: segExpanded,
+    selected: isSelected,
+    chip: chipLabel,
+    onClick: () => { callbacks.selectWing(wingName); callbacks.selectXsec(i); },
+    onEdit: callbacks.onEditNode ? () => { callbacks.selectWing(wingName); callbacks.selectXsec(i); callbacks.onEditNode!(); } : undefined,
+    onDelete: callbacks.onDeleteXsec ? () => {
+      if (confirm(`Delete segment ${i}?`)) callbacks.onDeleteXsec(wingName, i);
+    } : undefined,
+    onAdd: buildAddHandler(wingName, i, root, callbacks),
+  });
+
+  // Expanded segment details
+  if (segExpanded) {
+    nodes.push(...buildExpandedSegmentDetails(segId, wingName, i, root, tip, callbacks));
+  }
+
+  return nodes;
+}
+
 // ── Build nodes for WingConfig mode (segments) ──────────────────
 
 function buildSegmentNodes(
@@ -227,44 +275,7 @@ function buildSegmentNodes(
   // Segments (each segment = pair of consecutive x_secs)
   const segCount = wing.x_secs.length - 1;
   for (let i = 0; i < segCount; i++) {
-    const root = wing.x_secs[i];
-    const tip = wing.x_secs[i + 1];
-    const segId = `${wingName}-seg${i}`;
-    const isSelected = selectedWing === wingName && selectedXsecIndex === i;
-    const segExpanded = expandedSet.has(segId);
-
-    // Insert point before this segment (except before first)
-    if (i > 0 && callbacks.onInsertXsec) {
-      nodes.push({
-        id: `${wingName}-ins-${i}`,
-        label: "insert",
-        level: 2,
-        isInsertPoint: true,
-        onInsert: () => callbacks.onInsertXsec!(wingName, i),
-      });
-    }
-
-    const chipLabel = getChipLabel(root);
-
-    nodes.push({
-      id: segId,
-      label: i === 0 ? `segment ${i} (root)` : `segment ${i}`,
-      level: 2,
-      expanded: segExpanded,
-      selected: isSelected,
-      chip: chipLabel,
-      onClick: () => { callbacks.selectWing(wingName); callbacks.selectXsec(i); },
-      onEdit: callbacks.onEditNode ? () => { callbacks.selectWing(wingName); callbacks.selectXsec(i); callbacks.onEditNode!(); } : undefined,
-      onDelete: callbacks.onDeleteXsec ? () => {
-        if (confirm(`Delete segment ${i}?`)) callbacks.onDeleteXsec(wingName, i);
-      } : undefined,
-      onAdd: buildAddHandler(wingName, i, root, callbacks),
-    });
-
-    // Expanded segment details
-    if (segExpanded) {
-      nodes.push(...buildExpandedSegmentDetails(segId, wingName, i, root, tip, callbacks));
-    }
+    nodes.push(...buildSingleSegmentNodes(ctx, i));
   }
 
   // "+ segment" at the end

--- a/frontend/components/workbench/ImportFuselageDialog.tsx
+++ b/frontend/components/workbench/ImportFuselageDialog.tsx
@@ -452,6 +452,52 @@ async function saveFuselage(
   }
 }
 
+/** Perform the slicing API call and return parsed xsecs + metadata. */
+async function performSlicing(
+  file: File,
+  slices: number,
+  axis: string,
+  fuselageName: string,
+  scaleFactor: number,
+  flipX: boolean,
+): Promise<{ xsecs: XSec[]; fidelity: { volume_ratio: number; area_ratio: number } | null; name: string }> {
+  const formData = new FormData();
+  formData.append("file", file);
+  formData.append("number_of_slices", String(slices));
+  formData.append("points_per_slice", "30");
+  formData.append("slice_axis", axis);
+  formData.append("fuselage_name", fuselageName);
+
+  const res = await fetch(`${API_BASE}/fuselages/slice`, { method: "POST", body: formData });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Slicing failed: ${res.status} ${body}`);
+  }
+  const data = await res.json();
+  const newXsecs = transformSlicedXsecs(data.fuselage?.x_secs ?? [], scaleFactor, flipX);
+  return {
+    xsecs: newXsecs.length > 0 ? newXsecs : INITIAL_XSECS,
+    fidelity: extractFidelity(data),
+    name: data.fuselage?.name ?? fuselageName,
+  };
+}
+
+/** Build default xsecs for the "create empty" flow. */
+function buildDefaultXsecs(scaleFactor: number, flipX: boolean): XSec[] {
+  const raw: XSec[] = [
+    { xyz: [0, 0, 0], a: 0.01, b: 0.01, n: 2.0 },
+    { xyz: [0.1, 0, 0], a: 0.05, b: 0.04, n: 2.0 },
+    { xyz: [0.3, 0, 0], a: 0.05, b: 0.04, n: 2.0 },
+    { xyz: [0.4, 0, 0], a: 0.01, b: 0.01, n: 2.0 },
+  ];
+  return raw.map(xs => ({
+    ...xs,
+    xyz: xs.xyz.map((v, idx) => v * scaleFactor * (idx === 0 && flipX ? -1 : 1)),
+    a: xs.a * scaleFactor,
+    b: xs.b * scaleFactor,
+  }));
+}
+
 type Phase = "upload" | "processing" | "preview";
 
 export function ImportFuselageDialog({
@@ -497,26 +543,11 @@ export function ImportFuselageDialog({
     if (!file) return;
     setPhase("processing");
     setError(null);
-
-    const formData = new FormData();
-    formData.append("file", file);
-    formData.append("number_of_slices", String(slices));
-    formData.append("points_per_slice", "30");
-    formData.append("slice_axis", axis);
-    formData.append("fuselage_name", fuselageName);
-
     try {
-      const res = await fetch(`${API_BASE}/fuselages/slice`, { method: "POST", body: formData });
-      if (!res.ok) {
-        const body = await res.text();
-        throw new Error(`Slicing failed: ${res.status} ${body}`);
-      }
-      const data = await res.json();
-
-      const newXsecs = transformSlicedXsecs(data.fuselage?.x_secs ?? [], scaleFactor, flipX);
-      setXsecs(newXsecs.length > 0 ? newXsecs : INITIAL_XSECS);
-      setFidelity(extractFidelity(data));
-      setFuselageName(data.fuselage?.name ?? fuselageName);
+      const result = await performSlicing(file, slices, axis, fuselageName, scaleFactor, flipX);
+      setXsecs(result.xsecs);
+      setFidelity(result.fidelity);
+      setFuselageName(result.name);
       setSelectedXsec(0);
       setPhase("preview");
     } catch (err) {
@@ -542,18 +573,7 @@ export function ImportFuselageDialog({
   };
 
   const handleCreateEmpty = () => {
-    const defaultXsecs: XSec[] = [
-      { xyz: [0, 0, 0], a: 0.01, b: 0.01, n: 2.0 },
-      { xyz: [0.1, 0, 0], a: 0.05, b: 0.04, n: 2.0 },
-      { xyz: [0.3, 0, 0], a: 0.05, b: 0.04, n: 2.0 },
-      { xyz: [0.4, 0, 0], a: 0.01, b: 0.01, n: 2.0 },
-    ].map(xs => ({
-      ...xs,
-      xyz: xs.xyz.map((v, idx) => v * scaleFactor * (idx === 0 && flipX ? -1 : 1)),
-      a: xs.a * scaleFactor,
-      b: xs.b * scaleFactor,
-    }));
-    setXsecs(defaultXsecs);
+    setXsecs(buildDefaultXsecs(scaleFactor, flipX));
     setFileName(null);
     setFidelity(null);
     setSelectedXsec(0);

--- a/frontend/components/workbench/PropertyForm.tsx
+++ b/frontend/components/workbench/PropertyForm.tsx
@@ -478,6 +478,38 @@ function buildUpdatedSegments(
   });
 }
 
+// ── Fuselage xsec early-return helper (extracted for cognitive complexity) ──
+
+function renderFuselageXsecForm(
+  mode: Mode,
+  selectedFuselage: string | null,
+  selectedFuselageXsecIndex: number | null,
+  fuselage: { x_secs: FuselageXSec[] } | null | undefined,
+  aeroplaneId: string | null,
+  updateFuselageXSec: (idx: number, xsec: FuselageXSec) => Promise<void>,
+  mutateFuselage: () => Promise<unknown>,
+  onGeometryChanged: ((wingName: string) => void) | undefined,
+): React.ReactElement | null {
+  if (mode !== "fuselage" || !selectedFuselage || selectedFuselageXsecIndex === null || !fuselage) {
+    return null;
+  }
+  const fxsec = fuselage.x_secs[selectedFuselageXsecIndex];
+  if (!fxsec) return null;
+  return (
+    <FuselageXSecForm
+      aeroplaneId={aeroplaneId}
+      fuselageName={selectedFuselage}
+      xsecIndex={selectedFuselageXsecIndex}
+      xsec={fxsec}
+      onSave={async (updated) => {
+        await updateFuselageXSec(selectedFuselageXsecIndex, updated);
+        await mutateFuselage();
+        onGeometryChanged?.("");
+      }}
+    />
+  );
+}
+
 // ── Main Component ──────────────────────────────────────────────
 
 export function PropertyForm({ onGeometryChanged }: Readonly<{ onGeometryChanged?: (wingName: string) => void }>) {
@@ -550,25 +582,12 @@ export function PropertyForm({ onGeometryChanged }: Readonly<{ onGeometryChanged
     }
   }, [wingConfig, selectedXsecIndex]);
 
-  // Fuselage xsec mode
-  if (mode === "fuselage" && selectedFuselage && selectedFuselageXsecIndex !== null && fuselage) {
-    const fxsec = fuselage.x_secs[selectedFuselageXsecIndex];
-    if (fxsec) {
-      return (
-        <FuselageXSecForm
-          aeroplaneId={aeroplaneId}
-          fuselageName={selectedFuselage}
-          xsecIndex={selectedFuselageXsecIndex}
-          xsec={fxsec}
-          onSave={async (updated) => {
-            await updateFuselageXSec(selectedFuselageXsecIndex, updated);
-            await mutateFuselage();
-            onGeometryChanged?.("");
-          }}
-        />
-      );
-    }
-  }
+  // Fuselage xsec mode — delegate to dedicated form
+  const fuselageXsecForm = renderFuselageXsecForm(
+    mode, selectedFuselage, selectedFuselageXsecIndex, fuselage,
+    aeroplaneId, updateFuselageXSec, mutateFuselage, onGeometryChanged,
+  );
+  if (fuselageXsecForm) return fuselageXsecForm;
 
   // No segment/xsec selected — nothing to show
   if (selectedXsecIndex === null || !xsec) {


### PR DESCRIPTION
## Summary
- **PropertyForm.tsx** (complexity 16 -> ~12): Extracted `renderFuselageXsecForm()` helper to flatten the nested fuselage early-return block.
- **AeroplaneTree.tsx** (complexity 22 -> ~14): Extracted `buildSingleSegmentNodes()` to move the per-segment loop body (with insert-point, chip, expand logic) into its own function.
- **ImportFuselageDialog.tsx** (complexity 19 -> ~13): Extracted `performSlicing()` (async fetch + transform) and `buildDefaultXsecs()` out of the component.
- **construction-plans/page.tsx** (complexity 18 -> ~13): Extracted `submitNewPlan()`, `buildErrorResult()`, `handleNewTemplate()`, and `openCadViewerIfSuccess()` helpers.

All changes are pure refactoring with identical behavior. 0 eslint errors, 251/251 unit tests pass.

Closes #226

## Test plan
- [x] `npx eslint` on all 4 files: 0 errors (only pre-existing warnings)
- [x] `npm run test:unit`: 251/251 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)