### PR TITLE
chore(gh-226): fix LOW-severity SonarQube issues in frontend

### DIFF
--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -413,7 +413,7 @@ function TrefftzPlaneChart({
       await PlotlyRef.react(node, traces, layout, {
         responsive: true,
         displayModeBar: true,
-        modeBarButtonsToRemove: ["toImage", "sendDataToCloud"] as string[],
+        modeBarButtonsToRemove: ["toImage", "sendDataToCloud"],
       });
     })();
 

--- a/frontend/components/workbench/CadViewer.tsx
+++ b/frontend/components/workbench/CadViewer.tsx
@@ -19,7 +19,7 @@ function resolveRefs(
   if (node.shape && typeof node.shape === "object") {
     const s = node.shape as Record<string, unknown>;
     if ("ref" in s && typeof s.ref === "number") {
-      node.shape = instances[s.ref as number];
+      node.shape = instances[s.ref];
     }
   }
   if (Array.isArray(node.parts)) {

--- a/frontend/components/workbench/ComponentTypeManagementDialog.tsx
+++ b/frontend/components/workbench/ComponentTypeManagementDialog.tsx
@@ -85,7 +85,7 @@ export function ComponentTypeManagementDialog({
         <div className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto">
           {error ? (
             <div className="rounded-xl border border-destructive bg-destructive/10 p-3 text-[12px] text-destructive">
-              Failed to load types: {String((error as Error).message ?? error)}
+              Failed to load types: {error instanceof Error ? error.message : String(error)}
               <p className="mt-2 text-[11px] opacity-70">
                 Make sure the backend exposes <code>/component-types</code>
                 {" "}(landed in PR #86).

--- a/frontend/components/workbench/ConstructionPartUploadDialog.tsx
+++ b/frontend/components/workbench/ConstructionPartUploadDialog.tsx
@@ -141,7 +141,7 @@ export function ConstructionPartUploadDialog({
             >
               <option value="">No material selected</option>
               {materials.map((m) => {
-                const density = (m.specs as Record<string, unknown>)?.["density_kg_m3"];
+                const density = m.specs?.["density_kg_m3"];
                 const label = density
                   ? `${m.name} (${density} kg/m³)`
                   : m.name;

--- a/frontend/components/workbench/ImportFuselageDialog.tsx
+++ b/frontend/components/workbench/ImportFuselageDialog.tsx
@@ -122,7 +122,7 @@ function FuselagePreview3D({ xsecs, selectedXsec }: Readonly<{ xsecs: XSec[]; se
         {
           responsive: true,
           displayModeBar: true,
-          modeBarButtonsToRemove: ["toImage", "sendDataToCloud"] as string[],
+          modeBarButtonsToRemove: ["toImage", "sendDataToCloud"],
         },
       );
 

--- a/frontend/hooks/usePreviewState.ts
+++ b/frontend/hooks/usePreviewState.ts
@@ -73,18 +73,16 @@ export function usePreviewState(aeroplaneId: string | null) {
           );
           const s = await r.json();
 
-          switch (s.status) {
-            case "SUCCESS":
-              if (s.result?.data) {
-                setPreviews((prev) => ({
-                  ...prev,
-                  [wingName]: { visible: true, data: s.result, loading: false, error: null },
-                }));
-                return;
-              }
-              break;
-            case "FAILURE":
-              throw new Error(s.message || "Tessellation failed");
+          if (s.status === "SUCCESS") {
+            if (s.result?.data) {
+              setPreviews((prev) => ({
+                ...prev,
+                [wingName]: { visible: true, data: s.result, loading: false, error: null },
+              }));
+              return;
+            }
+          } else if (s.status === "FAILURE") {
+            throw new Error(s.message || "Tessellation failed");
           }
           await new Promise((resolve) => setTimeout(resolve, 500));
         }

--- a/frontend/hooks/useStlExport.ts
+++ b/frontend/hooks/useStlExport.ts
@@ -29,10 +29,9 @@ async function pollExportStatus(aeroplaneId: string): Promise<void> {
     if (!statusRes.ok) throw new Error(`Status check failed: ${statusRes.status}`);
     const statusData = await statusRes.json();
 
-    switch (statusData.status) {
-      case "SUCCESS": return;
-      case "FAILURE":
-        throw new Error(statusData.message || "Export failed");
+    if (statusData.status === "SUCCESS") return;
+    if (statusData.status === "FAILURE") {
+      throw new Error(statusData.message || "Export failed");
     }
     await new Promise((r) => setTimeout(r, 500));
   }

--- a/frontend/hooks/useTessellation.ts
+++ b/frontend/hooks/useTessellation.ts
@@ -67,16 +67,14 @@ async function pollTessellation(
     if (!statusRes.ok) throw new Error(`Status check failed: ${statusRes.status}`);
     const statusData = await statusRes.json();
 
-    switch (statusData.status) {
-      case "SUCCESS": {
-        const tessResult = statusData.result;
-        if (!tessResult || !tessResult.data) {
-          throw new Error("Tessellation result has no data");
-        }
-        return tessResult;
+    if (statusData.status === "SUCCESS") {
+      const tessResult = statusData.result;
+      if (!tessResult || !tessResult.data) {
+        throw new Error("Tessellation result has no data");
       }
-      case "FAILURE":
-        throw new Error(statusData.message || "Tessellation failed");
+      return tessResult;
+    } else if (statusData.status === "FAILURE") {
+      throw new Error(statusData.message || "Tessellation failed");
     }
     await new Promise((r) => setTimeout(r, 500));
   }


### PR DESCRIPTION
## Summary
- **S4325**: Remove 5 unnecessary type assertions (`as number` after typeof narrowing, redundant `as Record<string, unknown>` on already-typed specs, `as string[]` on inferred array literals, `as Error` replaced with `instanceof` check)
- **S1301**: Convert 3 trivial 2-case switch statements to if/else in status polling hooks (`useTessellation`, `useStlExport`, `usePreviewState`)

Part of EPIC #226.

## Test plan
- [x] `npx eslint .` -- 0 errors (15 pre-existing warnings unchanged)
- [x] `npm run test:unit` -- 251/251 tests pass
- [x] All changes are mechanical (no logic changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)