### PR TITLE
chore(gh-226): fix remaining MEDIUM/LOW SonarQube issues

### DIFF
--- a/frontend/app/workbench/construction-plans/page.tsx
+++ b/frontend/app/workbench/construction-plans/page.tsx
@@ -76,8 +76,12 @@ function rightPanelHeading(
   creatorForSelected: unknown,
   browsingCreator: unknown,
 ): string {
-  if (panel === "params" && creatorForSelected) return "Parameters";
-  if (panel === "detail" && browsingCreator) return "Creator Info";
+  if (panel === "params" && creatorForSelected) {
+    return "Parameters";
+  }
+  if (panel === "detail" && browsingCreator) {
+    return "Creator Info";
+  }
   return "Creator Catalog";
 }
 
@@ -502,7 +506,7 @@ export default function ConstructionPlansPage() {
             </span>
           </div>
 
-          {rightPanel === "params" && selectedStepNode && creatorForSelected ? (
+          {rightPanel === "params" && selectedStepNode && creatorForSelected && (
             <div className="flex flex-col gap-4">
               <button
                 onClick={() => setRightPanel("gallery")}
@@ -531,7 +535,8 @@ export default function ConstructionPlansPage() {
                 />
               </label>
             </div>
-          ) : rightPanel === "detail" && browsingCreator ? (
+          )}
+          {rightPanel === "detail" && browsingCreator && (
             <CreatorDetailView
               creator={browsingCreator}
               onBack={() => {
@@ -539,7 +544,8 @@ export default function ConstructionPlansPage() {
                 setRightPanel("gallery");
               }}
             />
-          ) : (
+          )}
+          {rightPanel === "gallery" && (
             <CreatorGallery
               creators={creators}
               onSelect={(creator) => {

--- a/frontend/components/workbench/AirfoilSelector.tsx
+++ b/frontend/components/workbench/AirfoilSelector.tsx
@@ -88,11 +88,11 @@ export function AirfoilSelector({
 
   return (
     <div ref={containerRef} className="relative flex flex-1 flex-col gap-1">
-      <label htmlFor={`airfoil-${label.toLowerCase().replace(/\s+/g, "-")}`} className="text-[11px] text-muted-foreground">{label}</label>
+      <label htmlFor={`airfoil-${label.toLowerCase().replaceAll(/\s+/g, "-")}`} className="text-[11px] text-muted-foreground">{label}</label>
 
       {/* Trigger */}
       <button
-        id={`airfoil-${label.toLowerCase().replace(/\s+/g, "-")}`}
+        id={`airfoil-${label.toLowerCase().replaceAll(/\s+/g, "-")}`}
         onClick={toggle}
         className={`flex items-center gap-2 rounded-xl px-3 py-2 transition-colors ${
           open ? "border-2 border-primary bg-input" : "border border-border bg-input"

--- a/frontend/components/workbench/AnalysisConfigPanel.tsx
+++ b/frontend/components/workbench/AnalysisConfigPanel.tsx
@@ -129,12 +129,9 @@ export function AnalysisConfigPanel({
 
   const currentError = getCurrentError(activeTab, analysis, stripForcesError, streamlinesError);
 
-  const handleRun =
-    activeTab === "Polar"
-      ? handleRunPolar
-      : activeTab === "Trefftz Plane"
-        ? handleRunStripForces
-        : handleRunStreamlines;
+  let handleRun = handleRunStreamlines;
+  if (activeTab === "Polar") handleRun = handleRunPolar;
+  else if (activeTab === "Trefftz Plane") handleRun = handleRunStripForces;
 
   return (
     <div className="flex w-full flex-col gap-4 overflow-y-auto">

--- a/frontend/components/workbench/ComponentEditDialog.tsx
+++ b/frontend/components/workbench/ComponentEditDialog.tsx
@@ -19,12 +19,8 @@ interface ComponentEditDialogProps {
 /** Default value inserted when a type is selected and specs don't already have the key. */
 function defaultForProp(prop: PropertyDefinition): unknown {
   if (prop.default != null) return prop.default;
-  switch (prop.type) {
-    case "boolean":
-      return false;
-    default:
-      return "";
-  }
+  if (prop.type === "boolean") return false;
+  return "";
 }
 
 /** Parse a user-entered string back into the property's declared type. */
@@ -191,7 +187,9 @@ export function ComponentEditDialog({
     }
   }
 
-  const submitLabel = saving ? "Saving\u2026" : isEdit ? "Update" : "Create";
+  let submitLabel = "Create";
+  if (saving) submitLabel = "Saving\u2026";
+  else if (isEdit) submitLabel = "Update";
 
   return (
     <div

--- a/frontend/components/workbench/ComponentTree.tsx
+++ b/frontend/components/workbench/ComponentTree.tsx
@@ -126,6 +126,13 @@ function aggregateRootStatus(
   return { status: "partial", total };
 }
 
+/** Weight tooltip for the virtual root row. */
+function rootWeightTooltip(status: "valid" | "partial" | "invalid"): string {
+  if (status === "valid") return "All nodes have a valid weight";
+  if (status === "partial") return "Some nodes have no weight and are counted as 0";
+  return "No node in the tree has a valid weight";
+}
+
 /** Weight annotation string for a single tree node. */
 function nodeAnnotation(node: ComponentTreeNode): string | undefined {
   const totalG = node.total_weight_g;
@@ -446,12 +453,7 @@ export function ComponentTree({
     onAdd: openRootAddMenu,
     addTitle: `Add to ${aeroplaneName}`,
     weightStatus: rootAgg.status,
-    weightTooltip:
-      rootAgg.status === "valid"
-        ? "All nodes have a valid weight"
-        : rootAgg.status === "partial"
-        ? "Some nodes have no weight and are counted as 0"
-        : "No node in the tree has a valid weight",
+    weightTooltip: rootWeightTooltip(rootAgg.status),
     annotation:
       rootAgg.total > 0 ? `${rootAgg.total.toFixed(1)}g` : undefined,
     annotationPrimary: true,

--- a/frontend/components/workbench/SimpleTreeRow.tsx
+++ b/frontend/components/workbench/SimpleTreeRow.tsx
@@ -32,6 +32,12 @@ export interface SimpleTreeNode {
   weightTooltip?: string;
 }
 
+function weightStatusColor(status: SimpleTreeWeightStatus | undefined): string {
+  if (status === "valid") return "text-emerald-500";
+  if (status === "partial") return "text-amber-500";
+  return "text-red-500";
+}
+
 interface SimpleTreeRowProps {
   node: SimpleTreeNode;
   onToggle: () => void;
@@ -94,13 +100,7 @@ export function SimpleTreeRow({ node, onToggle }: Readonly<SimpleTreeRowProps>) 
       {node.weightStatus && (
         <span
           title={node.weightTooltip ?? `Weight: ${node.weightStatus}`}
-          className={
-            node.weightStatus === "valid"
-              ? "text-emerald-500"
-              : node.weightStatus === "partial"
-              ? "text-amber-500"
-              : "text-red-500"
-          }
+          className={weightStatusColor(node.weightStatus)}
           data-weight-status={node.weightStatus}
         >
           <Scale size={11} />

--- a/frontend/components/workbench/SparEditDialog.tsx
+++ b/frontend/components/workbench/SparEditDialog.tsx
@@ -166,7 +166,9 @@ export function SparEditDialog({
     }
   }
 
-  const submitLabel = saving ? "Saving..." : isNew ? "Add" : "Save";
+  let submitLabel = "Save";
+  if (saving) submitLabel = "Saving...";
+  else if (isNew) submitLabel = "Add";
 
   return (
     <div

--- a/frontend/components/workbench/TedEditDialog.tsx
+++ b/frontend/components/workbench/TedEditDialog.tsx
@@ -187,7 +187,9 @@ export function TedEditDialog({
   }
 
   const hasTed = !isNew;
-  const submitLabel = saving ? "Saving..." : isNew ? "Add" : "Save";
+  let submitLabel = "Save";
+  if (saving) submitLabel = "Saving...";
+  else if (isNew) submitLabel = "Add";
 
   return (
     <div

--- a/frontend/components/workbench/WingOutlineViewer.tsx
+++ b/frontend/components/workbench/WingOutlineViewer.tsx
@@ -89,21 +89,6 @@ function lerpProfile(
   return { x: xs, y: ys };
 }
 
-/** Interpolate camber lines similarly. */
-function _lerpCamber(
-  a: AirfoilCoords, b: AirfoilCoords, t: number, nPts = 40,
-): { x: number[]; y: number[] } {
-  const xs: number[] = [], ys: number[] = [];
-  for (let i = 0; i <= nPts; i++) {
-    const xNorm = i / nPts;
-    xs.push(xNorm);
-    const ya = lerpLookup(a.camber_x, a.camber_y, xNorm);
-    const yb = lerpLookup(b.camber_x, b.camber_y, xNorm);
-    ys.push(ya * (1 - t) + yb * t);
-  }
-  return { x: xs, y: ys };
-}
-
 /** Linear interpolation lookup in sorted x/y arrays. */
 function lerpLookup(xs: number[], ys: number[], target: number): number {
   if (xs.length === 0) return 0;


### PR DESCRIPTION
## Summary
- **S3358**: Replace nested ternaries with if/else or extracted helpers in 7 files (ComponentEditDialog, SparEditDialog, TedEditDialog, AnalysisConfigPanel, SimpleTreeRow, ComponentTree, construction-plans/page)
- **S7781**: Use `String.replaceAll()` instead of `.replace()` with global regex in AirfoilSelector
- **S1301**: Convert single-case switch to if/else in ComponentEditDialog `defaultForProp`
- **S1854**: Remove unused `_lerpCamber` function in WingOutlineViewer

Relates to EPIC #226

## Test plan
- [x] `npx eslint .` passes (0 errors, pre-existing warnings only)
- [x] `npm run test:unit` passes (251/251 tests)
- [ ] SonarQube quality gate on PR

Generated with [Claude Code](https://claude.com/claude-code)