### PR TITLE
fix(gh-226): convert all dialogs to native <dialog> element

### DIFF
--- a/frontend/__tests__/ComponentTreeConstructionPartFlow.test.tsx
+++ b/frontend/__tests__/ComponentTreeConstructionPartFlow.test.tsx
@@ -93,15 +93,18 @@ describe("ComponentTree — Construction-Part add flow (gh#57-wvg)", () => {
     render(<ComponentTree />);
     fireEvent.click(screen.getByTitle("Add to main_wing"));
 
-    const button = screen.getByText("Assign Construction Part").closest("button");
-    expect(button).not.toBeNull();
-    expect(button?.hasAttribute("disabled")).toBe(false);
+    const buttons = screen.getAllByText("Assign Construction Part");
+    const menuButton = buttons.find((el) => el.closest("button"))?.closest("button");
+    expect(menuButton).not.toBeNull();
+    expect(menuButton?.hasAttribute("disabled")).toBe(false);
   });
 
   it("opens the Construction-Part picker on menu click", () => {
     render(<ComponentTree />);
     fireEvent.click(screen.getByTitle("Add to main_wing"));
-    fireEvent.click(screen.getByText("Assign Construction Part"));
+    const buttons = screen.getAllByText("Assign Construction Part");
+    const menuButton = buttons.find((el) => el.closest("button"))?.closest("button");
+    fireEvent.click(menuButton!);
 
     expect(screen.getByText(/Assign Construction Part to 'main_wing'/)).toBeDefined();
     expect(screen.getByText("Bulkhead-A")).toBeDefined();
@@ -110,7 +113,9 @@ describe("ComponentTree — Construction-Part add flow (gh#57-wvg)", () => {
   it("creates a cad_shape tree node with construction_part_id on selection", async () => {
     render(<ComponentTree />);
     fireEvent.click(screen.getByTitle("Add to main_wing"));
-    fireEvent.click(screen.getByText("Assign Construction Part"));
+    const buttons = screen.getAllByText("Assign Construction Part");
+    const menuButton = buttons.find((el) => el.closest("button"))?.closest("button");
+    fireEvent.click(menuButton!);
     fireEvent.click(screen.getByText("Bulkhead-A"));
 
     expect(mockAddTreeNode).toHaveBeenCalledWith(

--- a/frontend/__tests__/ComponentTypeCreateFlow.test.tsx
+++ b/frontend/__tests__/ComponentTypeCreateFlow.test.tsx
@@ -86,7 +86,7 @@ describe("Manage Types → New Type → Save flow (e2e)", () => {
     );
 
     // 1. Click "+ New Type"
-    fireEvent.click(screen.getByText(/New Type/i));
+    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
 
     // 2. Verify Edit dialog opened
     expect(screen.getByText(/New Type:/i)).toBeDefined();
@@ -114,7 +114,7 @@ describe("Manage Types → New Type → Save flow (e2e)", () => {
 
   it("Save with empty Label is blocked — no API call", () => {
     render(<ComponentTypeManagementDialog open={true} onClose={vi.fn()} />);
-    fireEvent.click(screen.getByText(/New Type/i));
+    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
     // No input → click Save
     clickSave();
     expect(mockCreate).not.toHaveBeenCalled();
@@ -126,7 +126,7 @@ describe("Manage Types → New Type → Save flow (e2e)", () => {
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByText(/New Type/i));
+    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
 
     const editable = editableTextInputs(container);
     fireEvent.change(editable[0], { target: { value: "CarbonTube" } });  // PascalCase
@@ -150,7 +150,7 @@ describe("Manage Types → New Type → Save flow (e2e)", () => {
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByText(/New Type/i));
+    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
 
     const editable = editableTextInputs(container);
     fireEvent.change(editable[0], { target: { value: "t1" } });
@@ -170,7 +170,7 @@ describe("Manage Types → New Type → Save flow (e2e)", () => {
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={onClose} />,
     );
-    fireEvent.click(screen.getByText(/New Type/i));
+    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
 
     const editable = editableTextInputs(container);
     fireEvent.change(editable[0], { target: { value: "t2" } });
@@ -195,7 +195,7 @@ describe("Create-Type payload contract", () => {
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByText(/New Type/i));
+    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
     const editable = editableTextInputs(container);
     fireEvent.change(editable[0], { target: { value: "motor_mount" } });
     fireEvent.change(editable[1], { target: { value: "Motor Mount" } });
@@ -218,7 +218,7 @@ describe("Create-Type payload contract", () => {
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByText(/New Type/i));
+    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
     const editable = editableTextInputs(container);
     fireEvent.change(editable[0], { target: { value: "empty_desc" } });
     fireEvent.change(editable[1], { target: { value: "Empty Desc" } });
@@ -238,7 +238,7 @@ describe("Create-Type payload contract", () => {
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByText(/New Type/i));
+    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
     const editable = editableTextInputs(container);
     fireEvent.change(editable[0], { target: { value: "arr_check" } });
     fireEvent.change(editable[1], { target: { value: "Arr Check" } });
@@ -258,7 +258,7 @@ describe("Create-Type payload contract", () => {
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByText(/New Type/i));
+    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
     const editable = editableTextInputs(container);
     fireEvent.change(editable[0], { target: { value: "nodup" } });
     fireEvent.change(editable[1], { target: { value: "NoDup" } });
@@ -282,7 +282,7 @@ describe("Adding properties inside the type", () => {
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByText(/New Type/i));
+    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
 
     // Fill Name + Label
     let editable = editableTextInputs(container);
@@ -349,7 +349,7 @@ describe("Adding properties inside the type", () => {
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByText(/New Type/i));
+    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
 
     const firstEditable = editableTextInputs(container);
     fireEvent.change(firstEditable[0], { target: { value: "multi" } });
@@ -395,7 +395,7 @@ describe("Adding properties inside the type", () => {
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByText(/New Type/i));
+    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
     const first = editableTextInputs(container);
     fireEvent.change(first[0], { target: { value: "enum_t" } });
     fireEvent.change(first[1], { target: { value: "Enum T" } });
@@ -431,7 +431,7 @@ describe("Backend error propagation on Save", () => {
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByText(/New Type/i));
+    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
 
     const editable = editableTextInputs(container);
     fireEvent.change(editable[0], { target: { value: "dup" } });
@@ -463,7 +463,7 @@ describe("Backend error propagation on Save", () => {
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByText(/New Type/i));
+    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
     const editable = editableTextInputs(container);
     fireEvent.change(editable[0], { target: { value: "t_x" } });
     fireEvent.change(editable[1], { target: { value: "T X" } });
@@ -482,7 +482,7 @@ describe("Backend error propagation on Save", () => {
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByText(/New Type/i));
+    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
     const editable = editableTextInputs(container);
     fireEvent.change(editable[0], { target: { value: "retry_me" } });
     fireEvent.change(editable[1], { target: { value: "Retry" } });
@@ -630,7 +630,7 @@ describe("Cancel / dismiss paths", () => {
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByText(/New Type/i));
+    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
 
     // Type something so we can verify Cancel really drops it
     const editable = editableTextInputs(container);
@@ -649,7 +649,10 @@ describe("Cancel / dismiss paths", () => {
     expect(mockUpdate).not.toHaveBeenCalled();
     expect(mockMutate).not.toHaveBeenCalled();
 
-    // Edit dialog no longer visible
-    expect(screen.queryByText(/New Type:/i)).toBeNull();
+    // Edit dialog is closed (not open)
+    const editDialogs = container.querySelectorAll("dialog");
+    // The edit dialog is the second one (first is management dialog)
+    const editDialog = editDialogs[1];
+    expect(editDialog?.hasAttribute("open")).toBe(false);
   });
 });

--- a/frontend/__tests__/ComponentTypeManagementDialog.test.tsx
+++ b/frontend/__tests__/ComponentTypeManagementDialog.test.tsx
@@ -55,8 +55,10 @@ function makeType(o: Record<string, unknown> = {}) {
 
 describe("ComponentTypeManagementDialog", () => {
   it("does not render when open=false", () => {
-    render(<ComponentTypeManagementDialog open={false} onClose={vi.fn()} />);
-    expect(screen.queryByText(/Manage Component Types/i)).toBeNull();
+    const { container } = render(<ComponentTypeManagementDialog open={false} onClose={vi.fn()} />);
+    const dialog = container.querySelector("dialog");
+    expect(dialog).toBeTruthy();
+    expect(dialog?.hasAttribute("open")).toBe(false);
   });
 
   it("shows empty state message when no types exist", () => {
@@ -117,7 +119,7 @@ describe("ComponentTypeManagementDialog", () => {
 
   it("'+ New Type' button opens the Edit dialog with an empty type", () => {
     render(<ComponentTypeManagementDialog open={true} onClose={vi.fn()} />);
-    fireEvent.click(screen.getByText(/New Type/i));
+    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
     // The Edit dialog has its own title "Edit Type" or "New Type"
     expect(screen.getByText(/New Type:/i)).toBeDefined();
   });

--- a/frontend/__tests__/ComponentsPage.test.tsx
+++ b/frontend/__tests__/ComponentsPage.test.tsx
@@ -9,7 +9,7 @@
  * the WorkbenchTwoPanel (e.g. as a sibling via Fragment or via a portal).
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import React from "react";
 
 // ── Mocks ─────────────────────────────────────────────────────────
@@ -109,26 +109,41 @@ describe("ComponentsPage — '+ New Component' dialog", () => {
     expect(screen.queryByText("New Component", { selector: "span" })).toBeNull();
   });
 
-  it("opens the create dialog when '+ New Component' is clicked", () => {
-    render(<ComponentsPage />);
+  it("opens the create dialog when '+ New Component' is clicked", async () => {
+    const { container } = render(<ComponentsPage />);
 
     const button = screen.getByText("New Component");
     fireEvent.click(button);
 
-    // The dialog title is "New Component" inside a <span> — same text as the
-    // button, so we assert on the presence of dialog-only form labels instead.
-    expect(screen.getByText("Name *")).toBeDefined();
-    expect(screen.getByText("Manufacturer")).toBeDefined();
-    expect(screen.getByText("Description")).toBeDefined();
+    // The ComponentEditDialog should now be mounted and open
+    await waitFor(() => {
+      const editDialog = container.querySelector('dialog[aria-label="New Component"]');
+      expect(editDialog).toBeTruthy();
+      expect(editDialog?.hasAttribute("open")).toBe(true);
+    });
   });
 
-  it("closes the dialog when Cancel is clicked", () => {
-    render(<ComponentsPage />);
+  it("closes the dialog when Cancel is clicked", async () => {
+    const { container } = render(<ComponentsPage />);
 
     fireEvent.click(screen.getByText("New Component"));
-    expect(screen.getByText("Name *")).toBeDefined();
 
-    fireEvent.click(screen.getByText("Cancel"));
-    expect(screen.queryByText("Name *")).toBeNull();
+    await waitFor(() => {
+      const editDialog = container.querySelector('dialog[aria-label="New Component"]');
+      expect(editDialog?.hasAttribute("open")).toBe(true);
+    });
+
+    // Cancel buttons exist in the page and dialog; click the one inside the edit dialog
+    const editDialog = container.querySelector('dialog[aria-label="New Component"]');
+    const cancelBtn = editDialog?.querySelector("button");
+    // Find the Cancel button specifically
+    const allBtns = editDialog?.querySelectorAll("button") ?? [];
+    const cancelButton = Array.from(allBtns).find((b) => b.textContent === "Cancel");
+    fireEvent.click(cancelButton!);
+
+    // The dialog should unmount because the parent uses conditional rendering
+    await waitFor(() => {
+      expect(container.querySelector('dialog[aria-label="New Component"]')).toBeNull();
+    });
   });
 });

--- a/frontend/__tests__/ConstructionPartPickerDialog.test.tsx
+++ b/frontend/__tests__/ConstructionPartPickerDialog.test.tsx
@@ -46,7 +46,7 @@ beforeEach(() => {
 
 describe("ConstructionPartPickerDialog", () => {
   it("does not render when open=false", () => {
-    render(
+    const { container } = render(
       <ConstructionPartPickerDialog
         open={false}
         aeroplaneId="a"
@@ -54,7 +54,9 @@ describe("ConstructionPartPickerDialog", () => {
         onSelect={vi.fn()}
       />,
     );
-    expect(screen.queryByText(/Construction Part/i)).toBeNull();
+    const dialog = container.querySelector("dialog");
+    expect(dialog).toBeTruthy();
+    expect(dialog?.hasAttribute("open")).toBe(false);
   });
 
   it("renders with target group name in the header", () => {

--- a/frontend/__tests__/ConstructionPartUploadDialog.test.tsx
+++ b/frontend/__tests__/ConstructionPartUploadDialog.test.tsx
@@ -45,7 +45,7 @@ beforeEach(() => {
 
 describe("ConstructionPartUploadDialog", () => {
   it("does not render when open=false", () => {
-    render(
+    const { container } = render(
       <ConstructionPartUploadDialog
         open={false}
         aeroplaneId="a"
@@ -53,7 +53,9 @@ describe("ConstructionPartUploadDialog", () => {
         onSaved={vi.fn()}
       />,
     );
-    expect(screen.queryByText(/Upload Construction Part/i)).toBeNull();
+    const dialog = container.querySelector("dialog");
+    expect(dialog).toBeTruthy();
+    expect(dialog?.hasAttribute("open")).toBe(false);
   });
 
   it("renders name input, file input, and material dropdown", () => {

--- a/frontend/__tests__/CotsPickerDialog.test.tsx
+++ b/frontend/__tests__/CotsPickerDialog.test.tsx
@@ -44,14 +44,16 @@ beforeEach(() => {
 
 describe("CotsPickerDialog", () => {
   it("does not render when open=false", () => {
-    render(
+    const { container } = render(
       <CotsPickerDialog
         open={false}
         onClose={vi.fn()}
         onSelect={vi.fn()}
       />,
     );
-    expect(screen.queryByText(/Assign Component/i)).toBeNull();
+    const dialog = container.querySelector("dialog");
+    expect(dialog).toBeTruthy();
+    expect(dialog?.hasAttribute("open")).toBe(false);
   });
 
   it("renders the header with target group name when provided", () => {

--- a/frontend/__tests__/FuselageTree.test.tsx
+++ b/frontend/__tests__/FuselageTree.test.tsx
@@ -13,6 +13,8 @@ vi.mock("lucide-react", () => {
   return {
     ChevronDown: icon, ChevronRight: icon, Plus: icon, Trash2: icon,
     Eye: icon, EyeOff: icon, Loader: icon, PanelLeftClose: icon, Pencil: icon,
+    X: icon, Upload: icon, Check: icon, Loader2: icon, Maximize2: icon,
+    Minimize2: icon, Play: icon, Lock: icon,
   };
 });
 

--- a/frontend/__tests__/PropertyEditDialog.test.tsx
+++ b/frontend/__tests__/PropertyEditDialog.test.tsx
@@ -24,7 +24,7 @@ beforeEach(() => {
 
 describe("PropertyEditDialog", () => {
   it("does not render when open=false", () => {
-    render(
+    const { container } = render(
       <PropertyEditDialog
         open={false}
         initial={null}
@@ -32,7 +32,9 @@ describe("PropertyEditDialog", () => {
         onCancel={vi.fn()}
       />,
     );
-    expect(screen.queryByText(/Property/i)).toBeNull();
+    const dialog = container.querySelector("dialog");
+    expect(dialog).toBeTruthy();
+    expect(dialog?.hasAttribute("open")).toBe(false);
   });
 
   it("renders blank form for new property (initial=null)", () => {

--- a/frontend/__tests__/UnsavedChangesModal.test.tsx
+++ b/frontend/__tests__/UnsavedChangesModal.test.tsx
@@ -35,7 +35,9 @@ describe("UnsavedChangesModal", () => {
   it("does not render when pendingHref is null", () => {
     mockUseUnsavedChanges.mockReturnValue(defaultCtx());
     const { container } = render(<UnsavedChangesModal />);
-    expect(container.innerHTML).toBe("");
+    const dialog = container.querySelector("dialog");
+    expect(dialog).toBeTruthy();
+    expect(dialog?.hasAttribute("open")).toBe(false);
   });
 
   it("renders when pendingHref is set", () => {

--- a/frontend/__tests__/setup.ts
+++ b/frontend/__tests__/setup.ts
@@ -1,0 +1,16 @@
+/**
+ * Vitest setup — polyfill HTMLDialogElement for jsdom.
+ *
+ * jsdom does not implement `showModal()` or `close()` on `<dialog>`.
+ * We add minimal stubs so the `useDialog` hook works in unit tests.
+ */
+
+if (typeof HTMLDialogElement !== "undefined") {
+  HTMLDialogElement.prototype.showModal ??= function (this: HTMLDialogElement) {
+    this.setAttribute("open", "");
+  };
+  HTMLDialogElement.prototype.close ??= function (this: HTMLDialogElement) {
+    this.removeAttribute("open");
+    this.dispatchEvent(new Event("close"));
+  };
+}

--- a/frontend/app/workbench/analysis/page.tsx
+++ b/frontend/app/workbench/analysis/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { X } from "lucide-react";
+import { useDialog } from "@/hooks/useDialog";
 import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
 import { useAnalysis } from "@/hooks/useAnalysis";
 import { useStripForces } from "@/hooks/useStripForces";
@@ -19,6 +20,7 @@ export default function AnalysisPage() {
   const { wing } = useWing(aeroplaneId, selectedWing ?? wingNames[0] ?? null);
   const [configOpen, setConfigOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<Tab>("Polar");
+  const { dialogRef, handleClose: dialogHandleClose } = useDialog(configOpen, () => setConfigOpen(false));
 
   const modalTitleByTab: Record<Tab, string> = {
     "Polar": "Polar Configuration",
@@ -51,20 +53,15 @@ export default function AnalysisPage() {
       </div>
 
       {/* Config Modal */}
-      {configOpen && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-          role="dialog"
-          aria-modal="true"
-          aria-label={modalTitle}
-          onClick={() => setConfigOpen(false)}
-          onKeyDown={(e) => { if (e.key === "Escape") setConfigOpen(false); }}
-        >
-          <div
-            className="flex max-h-[85vh] w-[480px] flex-col gap-4 overflow-y-auto rounded-2xl border border-border bg-card p-6 shadow-2xl"
-            onClick={(e) => e.stopPropagation()}
-            onKeyDown={(e) => e.stopPropagation()}
-          >
+      <dialog
+        ref={dialogRef}
+        className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+        onClose={dialogHandleClose}
+        onClick={(e) => { if (e.target === e.currentTarget) dialogHandleClose(); }}
+        aria-label={modalTitle}
+      >
+        {configOpen && (
+          <div className="flex max-h-[85vh] w-[480px] flex-col gap-4 overflow-y-auto rounded-2xl border border-border bg-card p-6 shadow-2xl">
             <div className="flex items-center justify-between">
               <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
                 {modalTitle}
@@ -94,8 +91,8 @@ export default function AnalysisPage() {
               onClose={() => setConfigOpen(false)}
             />
           </div>
-        </div>
-      )}
+        )}
+      </dialog>
     </>
   );
 }

--- a/frontend/app/workbench/construction-plans/page.tsx
+++ b/frontend/app/workbench/construction-plans/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useRef } from "react";
 import { Hammer, Plus, Trash2, Play, Loader2, BookTemplate, Copy, X, Maximize2, Minimize2 } from "lucide-react";
+import { useDialog } from "@/hooks/useDialog";
 import { CadViewer } from "@/components/workbench/CadViewer";
 import { WorkbenchTwoPanel } from "@/components/workbench/WorkbenchTwoPanel";
 import { PlanTree, type PlanStepNode } from "@/components/workbench/PlanTree";
@@ -636,22 +637,18 @@ function AddStepDialog({
   onSetAddStepParams,
   onAddCreator,
 }: Readonly<AddStepDialogProps>) {
-  if (!open) return null;
+  const { dialogRef, handleClose } = useDialog(open, onClose);
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      role="dialog"
-      aria-modal="true"
+    <dialog
+      ref={dialogRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      onClose={handleClose}
+      onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
       aria-label={addingCreator ? `Add ${addingCreator.class_name}` : "Add Step"}
-      onClick={onClose}
-      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
     >
-      <div
-        className="flex max-h-[85vh] w-[600px] flex-col gap-4 overflow-y-auto rounded-2xl border border-border bg-card p-6 shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
+      {open && (
+      <div className="flex max-h-[85vh] w-[600px] flex-col gap-4 overflow-y-auto rounded-2xl border border-border bg-card p-6 shadow-2xl">
         {addingCreator ? (
           <>
             <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
@@ -755,7 +752,8 @@ function AddStepDialog({
           </>
         )}
       </div>
-    </div>
+      )}
+    </dialog>
   );
 }
 
@@ -784,22 +782,18 @@ function NewPlanDialog({
   onSetNewPlanTemplateId,
   onSubmit,
 }: Readonly<NewPlanDialogProps>) {
-  if (!open) return null;
+  const { dialogRef, handleClose } = useDialog(open, onClose);
 
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
+    <dialog
+      ref={dialogRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      onClose={handleClose}
+      onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
       aria-label="New Plan"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      onClick={onClose}
-      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
     >
-      <div
-        className="flex w-[480px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
+      {open && (
+      <div className="flex w-[480px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl">
         <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
           New Plan
         </h2>
@@ -883,7 +877,8 @@ function NewPlanDialog({
           </button>
         </div>
       </div>
-    </div>
+      )}
+    </dialog>
   );
 }
 
@@ -908,22 +903,18 @@ function ExecuteDialog({
   onSetExecuteAeroplaneId,
   onExecute,
 }: Readonly<ExecuteDialogProps>) {
-  if (!open) return null;
+  const { dialogRef, handleClose } = useDialog(open, onClose);
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      role="dialog"
-      aria-modal="true"
+    <dialog
+      ref={dialogRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      onClose={handleClose}
+      onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
       aria-label="Execute Plan"
-      onClick={onClose}
-      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
     >
-      <div
-        className="flex w-[480px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
+      {open && (
+      <div className="flex w-[480px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl">
         <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
           Execute Plan
         </h2>
@@ -990,7 +981,8 @@ function ExecuteDialog({
           </button>
         </div>
       </div>
-    </div>
+      )}
+    </dialog>
   );
 }
 
@@ -1011,23 +1003,22 @@ function CadViewerModal({
   onClose,
   onToggleFullscreen,
 }: Readonly<CadViewerModalProps>) {
+  const { dialogRef, handleClose } = useDialog(open && !!cadViewerData, onClose);
+
   if (!open || !cadViewerData) return null;
 
   return (
-    <div
-      className={`fixed inset-0 z-50 flex items-center justify-center ${fullscreen ? "" : "bg-black/60"}`}
-      role="dialog"
-      aria-modal="true"
+    <dialog
+      ref={dialogRef}
+      className={`fixed inset-0 z-50 flex items-center justify-center bg-transparent ${fullscreen ? "backdrop:bg-transparent" : "backdrop:bg-black/60"}`}
+      onClose={handleClose}
+      onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
       aria-label="Execution Result"
-      onClick={onClose}
-      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
     >
       <div
         className={`flex flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-2xl ${
           fullscreen ? "h-full w-full rounded-none border-0" : "h-[80vh] w-[80vw]"
         }`}
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
       >
         <div className="flex shrink-0 items-center gap-2 border-b border-border px-4 py-3">
           <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-foreground">
@@ -1057,6 +1048,6 @@ function CadViewerModal({
           <CadViewer parts={[cadViewerData]} />
         </div>
       </div>
-    </div>
+    </dialog>
   );
 }

--- a/frontend/app/workbench/page.tsx
+++ b/frontend/app/workbench/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo } from "react";
 import { PanelLeftOpen, Maximize2, Minimize2, X } from "lucide-react";
+import { useDialog } from "@/hooks/useDialog";
 import { PropertyForm } from "@/components/workbench/PropertyForm";
 import { AeroplaneTree } from "@/components/workbench/AeroplaneTree";
 import { SparEditDialog } from "@/components/workbench/SparEditDialog";
@@ -26,6 +27,7 @@ export default function WorkbenchPage() {
   const [treeOpen, setTreeOpen] = useState(true);
   const [viewerMaximized, setViewerMaximized] = useState(false);
   const [configOpen, setConfigOpen] = useState(false);
+  const { dialogRef: configDialogRef, handleClose: configHandleClose } = useDialog(configOpen, () => setConfigOpen(false));
 
   // Spar/TED dialog state
   const [sparDialog, setSparDialog] = useState<{
@@ -201,20 +203,15 @@ export default function WorkbenchPage() {
       </div>
 
       {/* Configuration Modal — opens via pencil icon on segments/xsecs */}
-      {configOpen && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-          role="dialog"
-          aria-modal="true"
-          aria-label="Configuration"
-          onClick={() => setConfigOpen(false)}
-          onKeyDown={(e) => { if (e.key === "Escape") setConfigOpen(false); }}
-        >
-          <div
-            className="flex max-h-[85vh] w-[480px] flex-col gap-4 overflow-y-auto rounded-2xl border border-border bg-card p-6 shadow-2xl"
-            onClick={(e) => e.stopPropagation()}
-            onKeyDown={(e) => e.stopPropagation()}
-          >
+      <dialog
+        ref={configDialogRef}
+        className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+        onClose={configHandleClose}
+        onClick={(e) => { if (e.target === e.currentTarget) configHandleClose(); }}
+        aria-label="Configuration"
+      >
+        {configOpen && (
+          <div className="flex max-h-[85vh] w-[480px] flex-col gap-4 overflow-y-auto rounded-2xl border border-border bg-card p-6 shadow-2xl">
             <div className="flex items-center justify-between">
               <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
                 Configuration
@@ -228,8 +225,8 @@ export default function WorkbenchPage() {
             </div>
             <PropertyForm onGeometryChanged={() => { mutateAllWings(); mutateSelectedWing(); mutateAllFuselages(); }} />
           </div>
-        </div>
-      )}
+        )}
+      </dialog>
 
       {/* Spar Edit/Add Dialog */}
       {sparDialog && aeroplaneId && (

--- a/frontend/components/workbench/AeroplaneTree.tsx
+++ b/frontend/components/workbench/AeroplaneTree.tsx
@@ -831,7 +831,7 @@ export function AeroplaneTree(props: Readonly<AeroplaneTreeProps>) {
         )}
         {addMenuOpen && (
           <>
-            <div className="fixed inset-0 z-30" role="presentation" aria-hidden="true" onClick={() => setAddMenuOpen(false)} onKeyDown={(e) => { if (e.key === "Escape") setAddMenuOpen(false); }} />
+            <div className="fixed inset-0 z-30" aria-hidden="true" onClick={() => setAddMenuOpen(false)} onKeyDown={(e) => { if (e.key === "Escape") setAddMenuOpen(false); }} />
             <div className="absolute right-2 top-1 z-40 w-44 rounded-xl border border-border bg-card shadow-lg">
               <button
                 onClick={() => { setAddMenuOpen(false); handleAddWing(); }}
@@ -855,7 +855,7 @@ export function AeroplaneTree(props: Readonly<AeroplaneTreeProps>) {
       {/* Segment add menu (Spar / Control Surface) — positioned at click location */}
       {segAddMenu && (
         <>
-          <div className="fixed inset-0 z-30" role="presentation" aria-hidden="true" onClick={() => setSegAddMenu(null)} onKeyDown={(e) => { if (e.key === "Escape") setSegAddMenu(null); }} />
+          <div className="fixed inset-0 z-30" aria-hidden="true" onClick={() => setSegAddMenu(null)} onKeyDown={(e) => { if (e.key === "Escape") setSegAddMenu(null); }} />
           <div
             className="fixed z-40 w-52 rounded-xl border border-border bg-card shadow-lg"
             style={{ left: segAddMenu.x, top: segAddMenu.y }}

--- a/frontend/components/workbench/ComponentEditDialog.tsx
+++ b/frontend/components/workbench/ComponentEditDialog.tsx
@@ -8,6 +8,7 @@ import {
   useComponentTypes,
   type PropertyDefinition,
 } from "@/hooks/useComponentTypes";
+import { useDialog } from "@/hooks/useDialog";
 
 interface ComponentEditDialogProps {
   open: boolean;
@@ -94,6 +95,7 @@ export function ComponentEditDialog({
 }: Readonly<ComponentEditDialogProps>) {
   const { types } = useComponentTypes();
   const isEdit = !!component;
+  const { dialogRef, handleClose } = useDialog(open, onClose);
 
   // All state is seeded once on mount — parent is responsible for mounting/
   // unmounting us conditionally so that reopening seeds from fresh props.
@@ -112,8 +114,6 @@ export function ComponentEditDialog({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showUnknown, setShowUnknown] = useState(false);
-
-  if (!open) return null;
 
   const currentType = types.find((t) => t.name === componentType);
   const schema: PropertyDefinition[] = currentType?.schema ?? [];
@@ -194,19 +194,14 @@ export function ComponentEditDialog({
   const submitLabel = saving ? "Saving\u2026" : isEdit ? "Update" : "Create";
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      role="dialog"
-      aria-modal="true"
+    <dialog
+      ref={dialogRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      onClose={handleClose}
+      onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
       aria-label={isEdit ? "Edit Component" : "New Component"}
-      onClick={onClose}
-      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
     >
-      <div
-        className="flex max-h-[85vh] w-[520px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
+      <div className="flex max-h-[85vh] w-[520px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl">
         <div className="flex items-center gap-3">
           <span className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
             {isEdit ? "Edit Component" : "New Component"}
@@ -341,7 +336,7 @@ export function ComponentEditDialog({
           </button>
         </div>
       </div>
-    </div>
+    </dialog>
   );
 }
 

--- a/frontend/components/workbench/ComponentTypeEditDialog.tsx
+++ b/frontend/components/workbench/ComponentTypeEditDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import { Check, Loader2, Pencil, Plus, Trash2, X } from "lucide-react";
 import {
   createComponentType,
@@ -10,6 +10,7 @@ import {
   type PropertyDefinition,
 } from "@/hooks/useComponentTypes";
 import { PropertyEditDialog } from "@/components/workbench/PropertyEditDialog";
+import { useDialog } from "@/hooks/useDialog";
 
 interface ComponentTypeEditDialogProps {
   open: boolean;
@@ -49,6 +50,8 @@ export function ComponentTypeEditDialog({
     initial: PropertyDefinition | null;
   }>({ open: false, index: null, initial: null });
   const [pendingDelete, setPendingDelete] = useState(false);
+  const { dialogRef, handleClose } = useDialog(open, onClose);
+  const confirmDialogRef = useRef<HTMLDialogElement>(null);
 
   useEffect(() => {
     if (open) {
@@ -57,7 +60,20 @@ export function ComponentTypeEditDialog({
     }
   }, [open, type]);
 
-  if (!open) return null;
+  // Manage confirm delete dialog
+  useEffect(() => {
+    const el = confirmDialogRef.current;
+    if (!el) return;
+    if (pendingDelete) {
+      if (!el.open) el.showModal();
+    } else {
+      if (el.open) el.close();
+    }
+  }, [pendingDelete]);
+
+  const closeConfirmDialog = useCallback(() => {
+    setPendingDelete(false);
+  }, []);
 
   const isNew = type === null;
   const canDeleteType = !isNew && type.deletable && type.reference_count === 0;
@@ -143,163 +159,160 @@ export function ComponentTypeEditDialog({
   const heading = isNew ? "New Type:" : `Edit Type: ${type!.label}`;
 
   return (
-    <div
-      className="fixed inset-0 z-[55] flex items-center justify-center bg-black/60"
-      role="dialog"
-      aria-modal="true"
-      aria-label={heading}
-      onClick={onClose}
-      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
-    >
-      <div
-        className="flex w-[560px] max-h-[85vh] flex-col gap-3 rounded-2xl border border-border bg-card p-5 shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
+    <>
+      <dialog
+        ref={dialogRef}
+        className="fixed inset-0 z-[55] flex items-center justify-center bg-transparent backdrop:bg-black/60"
+        onClose={handleClose}
+        onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
+        aria-label={heading}
       >
-        <div className="flex items-center gap-2">
-          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[15px] text-foreground">
-            {heading}
-          </span>
-          <span className="flex-1" />
-          {canDeleteType && (
+        <div className="flex w-[560px] max-h-[85vh] flex-col gap-3 rounded-2xl border border-border bg-card p-5 shadow-2xl">
+          <div className="flex items-center gap-2">
+            <span className="font-[family-name:var(--font-jetbrains-mono)] text-[15px] text-foreground">
+              {heading}
+            </span>
+            <span className="flex-1" />
+            {canDeleteType && (
+              <button
+                onClick={() => setPendingDelete(true)}
+                title="Delete type"
+                className="flex size-7 items-center justify-center rounded-full border border-border text-destructive hover:bg-destructive/20"
+              >
+                <Trash2 size={12} />
+              </button>
+            )}
             <button
-              onClick={() => setPendingDelete(true)}
-              title="Delete type"
-              className="flex size-7 items-center justify-center rounded-full border border-border text-destructive hover:bg-destructive/20"
+              onClick={onClose}
+              title="Close"
+              className="flex size-7 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent"
             >
-              <Trash2 size={12} />
+              <X size={12} />
             </button>
-          )}
-          <button
-            onClick={onClose}
-            title="Close"
-            className="flex size-7 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent"
-          >
-            <X size={12} />
-          </button>
-        </div>
+          </div>
 
-        <div className="flex flex-col gap-2 overflow-y-auto">
-          <div className="flex gap-2">
-            <div className="flex flex-1 flex-col gap-1">
-              <label htmlFor="cte-name" className="text-[11px] text-muted-foreground">Name (snake_case)</label>
-              <input
-                id="cte-name"
-                type="text"
-                value={form.name}
-                onChange={(e) => update({ name: e.target.value })}
-                disabled={!isNew}
-                placeholder="carbon_tube"
-                className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground disabled:opacity-60"
-              />
+          <div className="flex flex-col gap-2 overflow-y-auto">
+            <div className="flex gap-2">
+              <div className="flex flex-1 flex-col gap-1">
+                <label htmlFor="cte-name" className="text-[11px] text-muted-foreground">Name (snake_case)</label>
+                <input
+                  id="cte-name"
+                  type="text"
+                  value={form.name}
+                  onChange={(e) => update({ name: e.target.value })}
+                  disabled={!isNew}
+                  placeholder="carbon_tube"
+                  className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground disabled:opacity-60"
+                />
+              </div>
+              <div className="flex flex-1 flex-col gap-1">
+                <label htmlFor="cte-label" className="text-[11px] text-muted-foreground">Label *</label>
+                <input
+                  id="cte-label"
+                  type="text"
+                  value={form.label}
+                  onChange={(e) => update({ label: e.target.value })}
+                  placeholder="Carbon Tube"
+                  className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
+                />
+              </div>
             </div>
-            <div className="flex flex-1 flex-col gap-1">
-              <label htmlFor="cte-label" className="text-[11px] text-muted-foreground">Label *</label>
+            <div className="flex flex-col gap-1">
+              <label htmlFor="cte-description" className="text-[11px] text-muted-foreground">Description</label>
               <input
-                id="cte-label"
+                id="cte-description"
                 type="text"
-                value={form.label}
-                onChange={(e) => update({ label: e.target.value })}
-                placeholder="Carbon Tube"
+                value={form.description}
+                onChange={(e) => update({ description: e.target.value })}
                 className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
               />
             </div>
-          </div>
-          <div className="flex flex-col gap-1">
-            <label htmlFor="cte-description" className="text-[11px] text-muted-foreground">Description</label>
-            <input
-              id="cte-description"
-              type="text"
-              value={form.description}
-              onChange={(e) => update({ description: e.target.value })}
-              className="rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
-            />
+
+            <div className="mt-1 flex items-center gap-2">
+              <span className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-muted-foreground">
+                Properties ({form.schema.length})
+              </span>
+              <span className="flex-1" />
+              <button
+                onClick={openNewProperty}
+                className="flex items-center gap-1 rounded-full bg-primary px-3 py-1 text-[12px] text-primary-foreground hover:opacity-90"
+              >
+                <Plus size={12} />
+                Property
+              </button>
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              {form.schema.length === 0 ? (
+                <p className="py-3 text-center text-[11px] text-muted-foreground">
+                  No properties defined.
+                </p>
+              ) : (
+                form.schema.map((prop, i) => (
+                  <div
+                    key={`${prop.name}-${i}`}
+                    className="flex items-center gap-2 rounded-lg border border-border bg-card-muted px-3 py-2 text-[12px]"
+                  >
+                    <span className="font-[family-name:var(--font-jetbrains-mono)] text-foreground">
+                      {prop.name}
+                    </span>
+                    <span className="text-muted-foreground">·</span>
+                    <span className="text-muted-foreground">{prop.label}</span>
+                    <span className="rounded-full bg-sidebar-accent px-2 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[9px]">
+                      {prop.type}
+                    </span>
+                    {prop.unit && <span className="text-subtle-foreground">{prop.unit}</span>}
+                    {prop.required && (
+                      <span className="rounded-full bg-primary/20 px-2 py-0.5 text-[9px] text-primary">
+                        required
+                      </span>
+                    )}
+                    <span className="flex-1" />
+                    <button
+                      onClick={() => openEditProperty(i)}
+                      title="Edit property"
+                      className="flex size-6 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent hover:text-foreground"
+                    >
+                      <Pencil size={10} />
+                    </button>
+                    <button
+                      onClick={() => handlePropDelete(i)}
+                      title="Delete property"
+                      className="flex size-6 items-center justify-center rounded-full text-destructive hover:bg-destructive/20"
+                    >
+                      <Trash2 size={10} />
+                    </button>
+                  </div>
+                ))
+              )}
+            </div>
           </div>
 
-          <div className="mt-1 flex items-center gap-2">
-            <span className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-muted-foreground">
-              Properties ({form.schema.length})
-            </span>
-            <span className="flex-1" />
+          {error && (
+            <div className="rounded-xl border border-destructive bg-destructive/10 p-2 text-[11px] text-destructive">
+              {error}
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2">
             <button
-              onClick={openNewProperty}
-              className="flex items-center gap-1 rounded-full bg-primary px-3 py-1 text-[12px] text-primary-foreground hover:opacity-90"
+              onClick={onClose}
+              disabled={saving}
+              className="rounded-full border border-border px-3 py-1.5 text-[12px] text-muted-foreground hover:bg-sidebar-accent"
             >
-              <Plus size={12} />
-              Property
+              Cancel
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={saving}
+              className="flex items-center gap-1.5 rounded-full bg-primary px-3 py-1.5 text-[12px] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+            >
+              {saving ? <Loader2 size={12} className="animate-spin" /> : <Check size={12} />}
+              Save
             </button>
           </div>
-
-          <div className="flex flex-col gap-1.5">
-            {form.schema.length === 0 ? (
-              <p className="py-3 text-center text-[11px] text-muted-foreground">
-                No properties defined.
-              </p>
-            ) : (
-              form.schema.map((prop, i) => (
-                <div
-                  key={`${prop.name}-${i}`}
-                  className="flex items-center gap-2 rounded-lg border border-border bg-card-muted px-3 py-2 text-[12px]"
-                >
-                  <span className="font-[family-name:var(--font-jetbrains-mono)] text-foreground">
-                    {prop.name}
-                  </span>
-                  <span className="text-muted-foreground">·</span>
-                  <span className="text-muted-foreground">{prop.label}</span>
-                  <span className="rounded-full bg-sidebar-accent px-2 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[9px]">
-                    {prop.type}
-                  </span>
-                  {prop.unit && <span className="text-subtle-foreground">{prop.unit}</span>}
-                  {prop.required && (
-                    <span className="rounded-full bg-primary/20 px-2 py-0.5 text-[9px] text-primary">
-                      required
-                    </span>
-                  )}
-                  <span className="flex-1" />
-                  <button
-                    onClick={() => openEditProperty(i)}
-                    title="Edit property"
-                    className="flex size-6 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent hover:text-foreground"
-                  >
-                    <Pencil size={10} />
-                  </button>
-                  <button
-                    onClick={() => handlePropDelete(i)}
-                    title="Delete property"
-                    className="flex size-6 items-center justify-center rounded-full text-destructive hover:bg-destructive/20"
-                  >
-                    <Trash2 size={10} />
-                  </button>
-                </div>
-              ))
-            )}
-          </div>
         </div>
-
-        {error && (
-          <div className="rounded-xl border border-destructive bg-destructive/10 p-2 text-[11px] text-destructive">
-            {error}
-          </div>
-        )}
-
-        <div className="flex justify-end gap-2">
-          <button
-            onClick={onClose}
-            disabled={saving}
-            className="rounded-full border border-border px-3 py-1.5 text-[12px] text-muted-foreground hover:bg-sidebar-accent"
-          >
-            Cancel
-          </button>
-          <button
-            onClick={handleSave}
-            disabled={saving}
-            className="flex items-center gap-1.5 rounded-full bg-primary px-3 py-1.5 text-[12px] text-primary-foreground hover:opacity-90 disabled:opacity-50"
-          >
-            {saving ? <Loader2 size={12} className="animate-spin" /> : <Check size={12} />}
-            Save
-          </button>
-        </div>
-      </div>
+      </dialog>
 
       {propDialog.open && (
         <PropertyEditDialog
@@ -312,20 +325,15 @@ export function ComponentTypeEditDialog({
         />
       )}
 
-      {pendingDelete && type && (
-        <div
-          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60"
-          role="dialog"
-          aria-modal="true"
-          aria-label="Confirm delete type"
-          onClick={() => setPendingDelete(false)}
-          onKeyDown={(e) => { if (e.key === "Escape") setPendingDelete(false); }}
-        >
-          <div
-            className="flex w-[400px] flex-col gap-3 rounded-2xl border border-border bg-card p-5 shadow-2xl"
-            onClick={(e) => e.stopPropagation()}
-            onKeyDown={(e) => e.stopPropagation()}
-          >
+      <dialog
+        ref={confirmDialogRef}
+        className="fixed inset-0 z-[60] flex items-center justify-center bg-transparent backdrop:bg-black/60"
+        onClose={closeConfirmDialog}
+        onClick={(e) => { if (e.target === e.currentTarget) closeConfirmDialog(); }}
+        aria-label="Confirm delete type"
+      >
+        {type && (
+          <div className="flex w-[400px] flex-col gap-3 rounded-2xl border border-border bg-card p-5 shadow-2xl">
             <span className="font-[family-name:var(--font-jetbrains-mono)] text-[15px] text-foreground">
               Delete type &quot;{type.label}&quot;?
             </span>
@@ -347,8 +355,8 @@ export function ComponentTypeEditDialog({
               </button>
             </div>
           </div>
-        </div>
-      )}
-    </div>
+        )}
+      </dialog>
+    </>
   );
 }

--- a/frontend/components/workbench/ComponentTypeManagementDialog.tsx
+++ b/frontend/components/workbench/ComponentTypeManagementDialog.tsx
@@ -7,6 +7,7 @@ import {
   type ComponentType,
 } from "@/hooks/useComponentTypes";
 import { ComponentTypeEditDialog } from "@/components/workbench/ComponentTypeEditDialog";
+import { useDialog } from "@/hooks/useDialog";
 
 interface ComponentTypeManagementDialogProps {
   open: boolean;
@@ -21,8 +22,7 @@ export function ComponentTypeManagementDialog({
     open: boolean;
     type: ComponentType | null; // null = create new
   }>({ open: false, type: null });
-
-  if (!open) return null;
+  const { dialogRef, handleClose } = useDialog(open, onClose);
 
   function startNew() {
     setEditTarget({ open: true, type: null });
@@ -45,105 +45,102 @@ export function ComponentTypeManagementDialog({
   }
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      role="dialog"
-      aria-modal="true"
-      aria-label="Manage Component Types"
-      onClick={onClose}
-      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
-    >
-      <div
-        className="flex w-[640px] max-h-[85vh] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
+    <>
+      <dialog
+        ref={dialogRef}
+        className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+        onClose={handleClose}
+        onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
+        aria-label="Manage Component Types"
       >
-        <div className="flex items-center gap-2">
-          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
-            Manage Component Types
-          </span>
-          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-muted-foreground">
-            {types.length}
-          </span>
-          <span className="flex-1" />
-          <button
-            onClick={startNew}
-            className="flex items-center gap-1.5 rounded-full bg-primary px-3 py-1.5 text-[12px] text-primary-foreground hover:opacity-90"
-          >
-            <Plus size={12} />
-            New Type
-          </button>
-          <button
-            onClick={onClose}
-            title="Close"
-            className="flex size-8 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent"
-          >
-            <X size={14} />
-          </button>
-        </div>
+        <div className="flex w-[640px] max-h-[85vh] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl">
+          <div className="flex items-center gap-2">
+            <span className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
+              Manage Component Types
+            </span>
+            <span className="font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-muted-foreground">
+              {types.length}
+            </span>
+            <span className="flex-1" />
+            <button
+              onClick={startNew}
+              className="flex items-center gap-1.5 rounded-full bg-primary px-3 py-1.5 text-[12px] text-primary-foreground hover:opacity-90"
+            >
+              <Plus size={12} />
+              New Type
+            </button>
+            <button
+              onClick={onClose}
+              title="Close"
+              className="flex size-8 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent"
+            >
+              <X size={14} />
+            </button>
+          </div>
 
-        <div className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto">
-          {error ? (
-            <div className="rounded-xl border border-destructive bg-destructive/10 p-3 text-[12px] text-destructive">
-              Failed to load types: {error instanceof Error ? error.message : String(error)}
-              <p className="mt-2 text-[11px] opacity-70">
-                Make sure the backend exposes <code>/component-types</code>
-                {" "}(landed in PR #86).
-              </p>
-            </div>
-          ) : isLoading ? (
-            <p className="py-8 text-center text-[12px] text-muted-foreground">Loading…</p>
-          ) : types.length === 0 ? (
-            <p className="py-8 text-center text-[12px] text-muted-foreground">
-              No types registered.
-            </p>
-          ) : (
-            types.map((t) => (
-              <div
-                key={t.id}
-                className="flex items-center gap-2 rounded-xl border border-border bg-card-muted px-3 py-2 text-[13px]"
-              >
-                <span className="font-[family-name:var(--font-jetbrains-mono)] text-foreground">
-                  {t.label}
-                </span>
-                <span className="text-subtle-foreground">({t.name})</span>
-                {!t.deletable && (
-                  <span title="Seeded (cannot be deleted)" className="text-muted-foreground">
-                    <Lock size={10} />
-                  </span>
-                )}
-                <span className="flex-1" />
-                <span className="text-[11px] text-muted-foreground">
-                  {t.reference_count} components
-                </span>
-                <button
-                  onClick={() => startEdit(t)}
-                  title={`Edit ${t.label}`}
-                  className="flex size-7 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent hover:text-foreground"
-                >
-                  <Pencil size={12} />
-                </button>
-                <button
-                  disabled={!t.deletable || t.reference_count > 0}
-                  title={deleteTitle(t)}
-                  className="flex size-7 items-center justify-center rounded-full text-destructive hover:bg-destructive/20 disabled:opacity-40"
-                >
-                  <Trash2 size={12} />
-                </button>
+          <div className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto">
+            {error ? (
+              <div className="rounded-xl border border-destructive bg-destructive/10 p-3 text-[12px] text-destructive">
+                Failed to load types: {error instanceof Error ? error.message : String(error)}
+                <p className="mt-2 text-[11px] opacity-70">
+                  Make sure the backend exposes <code>/component-types</code>
+                  {" "}(landed in PR #86).
+                </p>
               </div>
-            ))
-          )}
-        </div>
+            ) : isLoading ? (
+              <p className="py-8 text-center text-[12px] text-muted-foreground">Loading…</p>
+            ) : types.length === 0 ? (
+              <p className="py-8 text-center text-[12px] text-muted-foreground">
+                No types registered.
+              </p>
+            ) : (
+              types.map((t) => (
+                <div
+                  key={t.id}
+                  className="flex items-center gap-2 rounded-xl border border-border bg-card-muted px-3 py-2 text-[13px]"
+                >
+                  <span className="font-[family-name:var(--font-jetbrains-mono)] text-foreground">
+                    {t.label}
+                  </span>
+                  <span className="text-subtle-foreground">({t.name})</span>
+                  {!t.deletable && (
+                    <span title="Seeded (cannot be deleted)" className="text-muted-foreground">
+                      <Lock size={10} />
+                    </span>
+                  )}
+                  <span className="flex-1" />
+                  <span className="text-[11px] text-muted-foreground">
+                    {t.reference_count} components
+                  </span>
+                  <button
+                    onClick={() => startEdit(t)}
+                    title={`Edit ${t.label}`}
+                    className="flex size-7 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent hover:text-foreground"
+                  >
+                    <Pencil size={12} />
+                  </button>
+                  <button
+                    disabled={!t.deletable || t.reference_count > 0}
+                    title={deleteTitle(t)}
+                    className="flex size-7 items-center justify-center rounded-full text-destructive hover:bg-destructive/20 disabled:opacity-40"
+                  >
+                    <Trash2 size={12} />
+                  </button>
+                </div>
+              ))
+            )}
+          </div>
 
-        <div className="flex justify-end">
-          <button
-            onClick={onClose}
-            className="rounded-full border border-border px-4 py-2 text-[13px] text-muted-foreground hover:bg-sidebar-accent"
-          >
-            Close
-          </button>
+          <div className="flex justify-end">
+            <button
+              onClick={onClose}
+              className="rounded-full border border-border px-4 py-2 text-[13px] text-muted-foreground hover:bg-sidebar-accent"
+            >
+              Close
+            </button>
+          </div>
         </div>
-      </div>
+      </dialog>
 
       <ComponentTypeEditDialog
         open={editTarget.open}
@@ -151,6 +148,6 @@ export function ComponentTypeManagementDialog({
         onClose={closeEdit}
         onSaved={() => mutate()}
       />
-    </div>
+    </>
   );
 }

--- a/frontend/components/workbench/ConstructionPartPickerDialog.tsx
+++ b/frontend/components/workbench/ConstructionPartPickerDialog.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { X, Search, Loader2, Box, Lock } from "lucide-react";
 import { useConstructionParts, type ConstructionPart } from "@/hooks/useConstructionParts";
+import { useDialog } from "@/hooks/useDialog";
 
 interface ConstructionPartPickerDialogProps {
   open: boolean;
@@ -28,8 +29,7 @@ export function ConstructionPartPickerDialog({
 }: Readonly<ConstructionPartPickerDialogProps>) {
   const [search, setSearch] = useState("");
   const { parts, total, isLoading } = useConstructionParts(open ? aeroplaneId : null);
-
-  if (!open) return null;
+  const { dialogRef, handleClose } = useDialog(open, onClose);
 
   const filtered = search.trim()
     ? parts.filter((p) => p.name.toLowerCase().includes(search.toLowerCase()))
@@ -45,19 +45,14 @@ export function ConstructionPartPickerDialog({
     : "Assign Construction Part";
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      role="dialog"
-      aria-modal="true"
+    <dialog
+      ref={dialogRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      onClose={handleClose}
+      onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
       aria-label="Construction-Part picker"
-      onClick={onClose}
-      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
     >
-      <div
-        className="flex max-h-[80vh] w-[560px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
+      <div className="flex max-h-[80vh] w-[560px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl">
         <div className="flex items-center gap-3">
           <span className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
             {heading}
@@ -142,6 +137,6 @@ export function ConstructionPartPickerDialog({
           </button>
         </div>
       </div>
-    </div>
+    </dialog>
   );
 }

--- a/frontend/components/workbench/ConstructionPartUploadDialog.tsx
+++ b/frontend/components/workbench/ConstructionPartUploadDialog.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from "react";
 import { X, Loader2, Upload } from "lucide-react";
 import { uploadConstructionPart } from "@/hooks/useConstructionParts";
 import { useComponents } from "@/hooks/useComponents";
+import { useDialog } from "@/hooks/useDialog";
 
 interface ConstructionPartUploadDialogProps {
   open: boolean;
@@ -24,6 +25,7 @@ export function ConstructionPartUploadDialog({
   const [error, setError] = useState<string | null>(null);
   const fileRef = useRef<HTMLInputElement | null>(null);
   const [fileName, setFileName] = useState<string>("");
+  const { dialogRef, handleClose } = useDialog(open, onClose);
 
   // Materials are queried from the existing COTS catalog.
   const { components: materials } = useComponents("material");
@@ -37,8 +39,6 @@ export function ConstructionPartUploadDialog({
       if (fileRef.current) fileRef.current.value = "";
     }
   }, [open]);
-
-  if (!open) return null;
 
   const file = fileRef.current?.files?.[0] ?? null;
   const canSubmit = !!name.trim() && !!fileName && !saving;
@@ -63,19 +63,14 @@ export function ConstructionPartUploadDialog({
   }
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      role="dialog"
-      aria-modal="true"
+    <dialog
+      ref={dialogRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      onClose={handleClose}
+      onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
       aria-label="Upload Construction Part"
-      onClick={onClose}
-      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
     >
-      <div
-        className="flex w-[500px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
+      <div className="flex w-[500px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl">
         <div className="flex items-center gap-3">
           <Upload size={16} className="text-primary" />
           <span className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
@@ -181,6 +176,6 @@ export function ConstructionPartUploadDialog({
           </button>
         </div>
       </div>
-    </div>
+    </dialog>
   );
 }

--- a/frontend/components/workbench/ConstructionPartsGrid.tsx
+++ b/frontend/components/workbench/ConstructionPartsGrid.tsx
@@ -9,6 +9,7 @@ import {
   deleteConstructionPart,
   type ConstructionPart,
 } from "@/hooks/useConstructionParts";
+import { useDialog } from "@/hooks/useDialog";
 
 interface ConstructionPartsGridProps {
   aeroplaneId: string;
@@ -30,20 +31,16 @@ interface ConfirmModalProps {
 }
 
 function ConfirmModal({ title, body, onConfirm, onCancel }: Readonly<ConfirmModalProps>) {
+  const { dialogRef, handleClose } = useDialog(true, onCancel);
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      role="dialog"
-      aria-modal="true"
+    <dialog
+      ref={dialogRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      onClose={handleClose}
+      onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
       aria-label={title}
-      onClick={onCancel}
-      onKeyDown={(e) => { if (e.key === "Escape") onCancel(); }}
     >
-      <div
-        className="flex w-[420px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
+      <div className="flex w-[420px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl">
         <span className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
           {title}
         </span>
@@ -63,7 +60,7 @@ function ConfirmModal({ title, body, onConfirm, onCancel }: Readonly<ConfirmModa
           </button>
         </div>
       </div>
-    </div>
+    </dialog>
   );
 }
 

--- a/frontend/components/workbench/CotsPickerDialog.tsx
+++ b/frontend/components/workbench/CotsPickerDialog.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { X, Search, Loader2, Package } from "lucide-react";
 import { useComponents, type Component } from "@/hooks/useComponents";
+import { useDialog } from "@/hooks/useDialog";
 
 interface CotsPickerDialogProps {
   open: boolean;
@@ -37,8 +38,7 @@ export function CotsPickerDialog({
     typeFilter || undefined,
     search || undefined,
   );
-
-  if (!open) return null;
+  const { dialogRef, handleClose } = useDialog(open, onClose);
 
   function handlePick(comp: Component) {
     onSelect(comp);
@@ -50,19 +50,14 @@ export function CotsPickerDialog({
     : "Assign Component";
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      role="dialog"
-      aria-modal="true"
+    <dialog
+      ref={dialogRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      onClose={handleClose}
+      onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
       aria-label="Component picker"
-      onClick={onClose}
-      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
     >
-      <div
-        className="flex max-h-[80vh] w-[560px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
+      <div className="flex max-h-[80vh] w-[560px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl">
         <div className="flex items-center gap-3">
           <span className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
             {heading}
@@ -154,6 +149,6 @@ export function CotsPickerDialog({
           </button>
         </div>
       </div>
-    </div>
+    </dialog>
   );
 }

--- a/frontend/components/workbench/CreateWingDialog.tsx
+++ b/frontend/components/workbench/CreateWingDialog.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect } from "react";
 import { X } from "lucide-react";
 import { API_BASE } from "@/lib/fetcher";
+import { useDialog } from "@/hooks/useDialog";
 
 type DesignModel = "wc" | "asb";
 
@@ -57,6 +58,7 @@ export function CreateWingDialog({
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const { dialogRef, handleClose } = useDialog(open, onClose);
 
   // Focus the name input when dialog opens
   useEffect(() => {
@@ -69,8 +71,6 @@ export function CreateWingDialog({
       setTimeout(() => inputRef.current?.focus(), 50);
     }
   }, [open]);
-
-  if (!open) return null;
 
   async function handleCreate() {
     const trimmed = name.trim();
@@ -130,27 +130,19 @@ export function CreateWingDialog({
     if (e.key === "Enter" && !creating) {
       handleCreate();
     }
-    if (e.key === "Escape") {
-      onClose();
-    }
   }
 
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
+    <dialog
+      ref={dialogRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      onClose={handleClose}
+      onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
       aria-label="Create Wing"
-      className="fixed inset-0 z-50 flex items-center justify-center"
-      onClick={onClose}
-      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
     >
-      {/* Backdrop */}
-      <div className="absolute inset-0 bg-black/60" />
-
       {/* Dialog */}
       <div
         className="relative z-10 w-full max-w-sm rounded-xl border border-border bg-card p-5 shadow-xl"
-        onClick={(e) => e.stopPropagation()}
         onKeyDown={handleKeyDown}
       >
         {/* Header */}
@@ -272,6 +264,6 @@ export function CreateWingDialog({
           </button>
         </div>
       </div>
-    </div>
+    </dialog>
   );
 }

--- a/frontend/components/workbench/ImportFuselageDialog.tsx
+++ b/frontend/components/workbench/ImportFuselageDialog.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import { Upload, X, Check, Loader2, Maximize2, Minimize2, Plus, Trash2, Play } from "lucide-react";
 import { API_BASE } from "@/lib/fetcher";
+import { useDialog } from "@/hooks/useDialog";
 
 /** Build Plotly Surface3d traces for a fuselage from xsec dicts */
 function buildFuselageSurface(
@@ -814,8 +815,7 @@ export function ImportFuselageDialog({
   const [error, setError] = useState<string | null>(null);
   const [fidelity, setFidelity] = useState<{ volume_ratio: number; area_ratio: number } | null>(null);
   const [saving, setSaving] = useState(false);
-
-  if (!open) return null;
+  const { dialogRef, handleClose: dialogHandleClose } = useDialog(open, () => { handleReset(); onClose(); });
 
   const handleFileSelect = (selectedFile: File) => {
     setFile(selectedFile);
@@ -887,13 +887,12 @@ export function ImportFuselageDialog({
   };
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      role="dialog"
-      aria-modal="true"
+    <dialog
+      ref={dialogRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      onClose={dialogHandleClose}
+      onClick={(e) => { if (e.target === e.currentTarget) dialogHandleClose(); }}
       aria-label="New Fuselage"
-      onClick={() => { handleReset(); onClose(); }}
-      onKeyDown={(e) => { if (e.key === "Escape") { handleReset(); onClose(); } }}
     >
       <div
         className={`flex flex-col rounded-2xl border border-border bg-card shadow-2xl transition-all ${
@@ -901,8 +900,6 @@ export function ImportFuselageDialog({
             ? "fixed inset-4 z-50 w-auto"
             : "w-[900px] h-[80vh]"
         }`}
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
       >
         {/* Header */}
         <div className="flex items-center gap-3 border-b border-border px-6 py-4">
@@ -979,6 +976,6 @@ export function ImportFuselageDialog({
           )}
         </div>
       </div>
-    </div>
+    </dialog>
   );
 }

--- a/frontend/components/workbench/NodePropertyPanel.tsx
+++ b/frontend/components/workbench/NodePropertyPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useId, useState } from "react";
 import { AlertTriangle, Lock, Loader2, Save, Trash2, X } from "lucide-react";
+import { useDialog } from "@/hooks/useDialog";
 import {
   deleteTreeNode,
   updateTreeNode,
@@ -85,20 +86,16 @@ interface ConfirmModalProps {
 }
 
 function ConfirmModal({ title, body, onConfirm, onCancel }: Readonly<ConfirmModalProps>) {
+  const { dialogRef, handleClose } = useDialog(true, onCancel);
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      role="dialog"
-      aria-modal="true"
+    <dialog
+      ref={dialogRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      onClose={handleClose}
+      onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
       aria-label={title}
-      onClick={onCancel}
-      onKeyDown={(e) => { if (e.key === "Escape") onCancel(); }}
     >
-      <div
-        className="flex w-[420px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
+      <div className="flex w-[420px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl">
         <span className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
           {title}
         </span>
@@ -118,7 +115,7 @@ function ConfirmModal({ title, body, onConfirm, onCancel }: Readonly<ConfirmModa
           </button>
         </div>
       </div>
-    </div>
+    </dialog>
   );
 }
 
@@ -218,6 +215,7 @@ export function NodePropertyPanel({
   const [error, setError] = useState<string | null>(null);
   const [pendingDelete, setPendingDelete] = useState(false);
   const [lockBusy, setLockBusy] = useState(false);
+  const { dialogRef, handleClose: dialogHandleClose } = useDialog(!!node, onClose);
 
   const { components: materials } = useComponents("material");
 
@@ -324,18 +322,15 @@ export function NodePropertyPanel({
   const lockTitle = "Lock part";
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      onClick={onClose}
-      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
-      role="dialog"
-      aria-modal="true"
+    <dialog
+      ref={dialogRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      onClose={dialogHandleClose}
+      onClick={(e) => { if (e.target === e.currentTarget) dialogHandleClose(); }}
       aria-label="Edit tree node"
     >
     <div
       className="flex max-h-[85vh] w-[480px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-2xl"
-      onClick={(e) => e.stopPropagation()}
-      onKeyDown={(e) => e.stopPropagation()}
     >
       <div className="flex items-center gap-2">
         <span className="font-[family-name:var(--font-jetbrains-mono)] text-[14px] text-foreground">
@@ -469,6 +464,6 @@ export function NodePropertyPanel({
         />
       )}
     </div>
-    </div>
+    </dialog>
   );
 }

--- a/frontend/components/workbench/PropertyEditDialog.tsx
+++ b/frontend/components/workbench/PropertyEditDialog.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Check, X } from "lucide-react";
 import type { PropertyDefinition, PropertyType } from "@/hooks/useComponentTypes";
+import { useDialog } from "@/hooks/useDialog";
 
 interface PropertyEditDialogProps {
   open: boolean;
@@ -110,8 +111,7 @@ export function PropertyEditDialog({
   // react-hooks/set-state-in-effect lint rule forbids).
   const [form, setForm] = useState<FormState>(() => toForm(initial));
   const [error, setError] = useState<string | null>(null);
-
-  if (!open) return null;
+  const { dialogRef, handleClose } = useDialog(open, onCancel);
 
   function update(patch: Partial<FormState>) {
     setForm((prev) => ({ ...prev, ...patch }));
@@ -127,19 +127,14 @@ export function PropertyEditDialog({
   }
 
   return (
-    <div
-      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60"
-      role="dialog"
-      aria-modal="true"
+    <dialog
+      ref={dialogRef}
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      onClose={handleClose}
+      onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
       aria-label={initial ? "Edit Property" : "New Property"}
-      onClick={onCancel}
-      onKeyDown={(e) => { if (e.key === "Escape") onCancel(); }}
     >
-      <div
-        className="flex w-[440px] flex-col gap-3 rounded-2xl border border-border bg-card p-5 shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
+      <div className="flex w-[440px] flex-col gap-3 rounded-2xl border border-border bg-card p-5 shadow-2xl">
         <div className="flex items-center gap-2">
           <span className="font-[family-name:var(--font-jetbrains-mono)] text-[14px] text-foreground">
             {initial ? "Edit Property" : "New Property"}
@@ -314,6 +309,6 @@ export function PropertyEditDialog({
           </button>
         </div>
       </div>
-    </div>
+    </dialog>
   );
 }

--- a/frontend/components/workbench/SparEditDialog.tsx
+++ b/frontend/components/workbench/SparEditDialog.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useId } from "react";
 import { X } from "lucide-react";
 import { API_BASE } from "@/lib/fetcher";
+import { useDialog } from "@/hooks/useDialog";
 
 const SPAR_MODES = ["standard", "follow", "normal", "standard_backward", "orthogonal_backward"] as const;
 
@@ -69,6 +70,7 @@ export function SparEditDialog({
   const [origZ, setOrigZ] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { dialogRef, handleClose } = useDialog(open, onClose);
 
   useEffect(() => {
     if (initialData) {
@@ -92,8 +94,6 @@ export function SparEditDialog({
     }
     setError(null);
   }, [initialData, open]);
-
-  if (!open) return null;
 
   async function handleSave() {
     setSaving(true);
@@ -169,19 +169,14 @@ export function SparEditDialog({
   const submitLabel = saving ? "Saving..." : isNew ? "Add" : "Save";
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      role="dialog"
-      aria-modal="true"
+    <dialog
+      ref={dialogRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      onClose={handleClose}
+      onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
       aria-label={isNew ? "Add Spar" : "Edit Spar"}
-      onClick={onClose}
-      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
     >
-      <div
-        className="flex max-h-[85vh] w-[420px] flex-col gap-4 overflow-y-auto rounded-2xl border border-border bg-card p-6 shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
+      <div className="flex max-h-[85vh] w-[420px] flex-col gap-4 overflow-y-auto rounded-2xl border border-border bg-card p-6 shadow-2xl">
         {/* Header */}
         <div className="flex items-center justify-between">
           <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
@@ -266,7 +261,7 @@ export function SparEditDialog({
           </button>
         </div>
       </div>
-    </div>
+    </dialog>
   );
 }
 

--- a/frontend/components/workbench/TedEditDialog.tsx
+++ b/frontend/components/workbench/TedEditDialog.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo, useRef, useId } from "react";
 import { X, Check, ChevronDown, ChevronUp, Search, ChevronRight } from "lucide-react";
 import { API_BASE } from "@/lib/fetcher";
 import { useComponents, type Component } from "@/hooks/useComponents";
+import { useDialog } from "@/hooks/useDialog";
 
 const HINGE_TYPES = ["middle", "top", "top_simple", "round_inside", "round_outside"] as const;
 
@@ -63,6 +64,7 @@ export function TedEditDialog({
   const [cadOpen, setCadOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { dialogRef, handleClose } = useDialog(open, onClose);
 
   useEffect(() => {
     if (initialData && typeof initialData === "object") {
@@ -99,8 +101,6 @@ export function TedEditDialog({
     }
     setError(null);
   }, [initialData, open]);
-
-  if (!open) return null;
 
   async function handleSave() {
     if (!name.trim()) {
@@ -190,19 +190,14 @@ export function TedEditDialog({
   const submitLabel = saving ? "Saving..." : isNew ? "Add" : "Save";
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      role="dialog"
-      aria-modal="true"
+    <dialog
+      ref={dialogRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      onClose={handleClose}
+      onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
       aria-label={isNew ? "Add Control Surface" : "Edit Control Surface"}
-      onClick={onClose}
-      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
     >
-      <div
-        className="flex max-h-[85vh] w-[480px] flex-col gap-4 overflow-y-auto rounded-2xl border border-border bg-card p-6 shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
+      <div className="flex max-h-[85vh] w-[480px] flex-col gap-4 overflow-y-auto rounded-2xl border border-border bg-card p-6 shadow-2xl">
         {/* Header */}
         <div className="flex items-center justify-between">
           <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
@@ -337,7 +332,7 @@ export function TedEditDialog({
           </button>
         </div>
       </div>
-    </div>
+    </dialog>
   );
 }
 

--- a/frontend/components/workbench/UnsavedChangesModal.tsx
+++ b/frontend/components/workbench/UnsavedChangesModal.tsx
@@ -2,26 +2,20 @@
 
 import { TriangleAlert } from "lucide-react";
 import { useUnsavedChanges } from "@/components/workbench/UnsavedChangesContext";
+import { useDialog } from "@/hooks/useDialog";
 
 export function UnsavedChangesModal() {
   const { pendingHref, isSaving, confirmDiscard, confirmSave, cancelNavigation } = useUnsavedChanges();
-
-  if (!pendingHref) return null;
+  const { dialogRef, handleClose } = useDialog(!!pendingHref, cancelNavigation);
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-      role="dialog"
-      aria-modal="true"
-      aria-label="Unsaved Changes"
-      onClick={cancelNavigation}
-      onKeyDown={(e) => { if (e.key === "Escape") cancelNavigation(); }}
+    <dialog
+      ref={dialogRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/50"
+      onClose={handleClose}
+      onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
     >
-      <div
-        className="flex w-[460px] flex-col gap-5 rounded-[16px] border border-border bg-card p-6"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
+      <div className="flex w-[460px] flex-col gap-5 rounded-[16px] border border-border bg-card p-6">
         <div className="flex items-center gap-3">
           <TriangleAlert size={24} className="text-primary" />
           <span className="text-[18px] font-semibold text-foreground">
@@ -55,6 +49,6 @@ export function UnsavedChangesModal() {
           </button>
         </div>
       </div>
-    </div>
+    </dialog>
   );
 }

--- a/frontend/hooks/useDialog.ts
+++ b/frontend/hooks/useDialog.ts
@@ -1,0 +1,39 @@
+import { useRef, useEffect, useCallback } from "react";
+
+/**
+ * Manages a native `<dialog>` element's open/close lifecycle via
+ * `.showModal()` and `.close()`.
+ *
+ * Returns a `ref` to attach to the `<dialog>` element and a stable
+ * `handleClose` callback suitable for the `onClose` event handler.
+ *
+ * Usage:
+ * ```tsx
+ * const { dialogRef, handleClose } = useDialog(open, onClose);
+ * return (
+ *   <dialog ref={dialogRef} onClose={handleClose} ...>
+ *     ...
+ *   </dialog>
+ * );
+ * ```
+ */
+export function useDialog(open: boolean, onClose: () => void) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const el = dialogRef.current;
+    if (!el) return;
+
+    if (open) {
+      if (!el.open) el.showModal();
+    } else {
+      if (el.open) el.close();
+    }
+  }, [open]);
+
+  const handleClose = useCallback(() => {
+    onClose();
+  }, [onClose]);
+
+  return { dialogRef, handleClose } as const;
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     globals: true,
+    setupFiles: ["./__tests__/setup.ts"],
     exclude: ["**/node_modules/**", "**/.features-gen/**", "**/e2e/**"],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
## Summary
- Converts all ~20 `<div role="dialog">` patterns to native `<dialog>` elements across the frontend, resolving SonarQube rules S6819, S6847, and S6848 (~53 issues total)
- Introduces a shared `useDialog(open, onClose)` hook that manages the imperative `.showModal()` / `.close()` lifecycle
- Replaces `role="presentation"` with `aria-hidden="true"` on AeroplaneTree overlay divs
- Adds jsdom polyfill for `HTMLDialogElement` in vitest setup and updates 10 test files for the always-present `<dialog>` DOM pattern

## Test plan
- [x] `npx eslint .` -- 0 errors (16 pre-existing warnings)
- [x] `npm run test:unit` -- 251/251 passing
- [x] `npm run deps:check` -- 0 errors (3 pre-existing warnings)
- [ ] Verify dialogs open/close correctly in browser (escape, click-outside, backdrop)
- [ ] Confirm SonarQube issues resolved after CI scan

Part of EPIC #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)