### PR TITLE
fix(gh-268): prevent native dialog elements from showing when closed

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,5 +1,10 @@
 @import "tailwindcss";
 
+/* Ensure native <dialog> stays hidden when closed, even with Tailwind positioning classes */
+dialog:not([open]) {
+  display: none !important;
+}
+
 @theme inline {
   /* Colors — mapped 1:1 from pencil da3Dalus.pen design tokens */
   --color-background: #111111;


### PR DESCRIPTION
## Summary
Add `dialog:not([open]) { display: none !important }` to `globals.css` to prevent native `<dialog>` elements from being visible when closed.

## Root Cause
PR #264 converted 18 dialogs to native `<dialog>` elements. Tailwind's `fixed inset-0 flex` classes override the browser-native `dialog:not([open]) { display: none }`, making unconditionally-rendered dialogs (UnsavedChangesModal, ImportFuselageDialog) visible on page load.

## Test plan
- [x] 251/251 frontend tests pass
- [ ] Manual: Open workbench — no dialogs should appear on load
- [ ] Manual: Trigger UnsavedChanges — dialog opens, Escape closes, stays hidden

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)