### PR TITLE
fix(gh-273): center native dialog modals with m-auto

### DIFF
--- a/frontend/__tests__/NodePropertyPanel.test.tsx
+++ b/frontend/__tests__/NodePropertyPanel.test.tsx
@@ -248,7 +248,7 @@ describe("NodePropertyPanel — delete", () => {
     fireEvent.click(screen.getByTitle("Delete node"));
     const modalCancel = screen
       .getAllByText("Cancel")
-      .find((el) => el.closest(".fixed") !== null) as HTMLElement;
+      .find((el) => el.closest("dialog") !== null) as HTMLElement;
     expect(modalCancel).toBeDefined();
     fireEvent.click(modalCancel);
     expect(mockDelete).not.toHaveBeenCalled();

--- a/frontend/app/workbench/analysis/page.tsx
+++ b/frontend/app/workbench/analysis/page.tsx
@@ -55,7 +55,7 @@ export default function AnalysisPage() {
       {/* Config Modal */}
       <dialog
         ref={dialogRef}
-        className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+        className="m-auto bg-transparent backdrop:bg-black/60"
         onClose={dialogHandleClose}
         aria-label={modalTitle}
       >

--- a/frontend/app/workbench/construction-plans/page.tsx
+++ b/frontend/app/workbench/construction-plans/page.tsx
@@ -648,7 +648,7 @@ function AddStepDialog({
   return (
     <dialog
       ref={dialogRef}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      className="m-auto bg-transparent backdrop:bg-black/60"
       onClose={handleClose}
       aria-label={addingCreator ? `Add ${addingCreator.class_name}` : "Add Step"}
     >
@@ -792,7 +792,7 @@ function NewPlanDialog({
   return (
     <dialog
       ref={dialogRef}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      className="m-auto bg-transparent backdrop:bg-black/60"
       onClose={handleClose}
       aria-label="New Plan"
     >
@@ -912,7 +912,7 @@ function ExecuteDialog({
   return (
     <dialog
       ref={dialogRef}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      className="m-auto bg-transparent backdrop:bg-black/60"
       onClose={handleClose}
       aria-label="Execute Plan"
     >
@@ -1013,7 +1013,7 @@ function CadViewerModal({
   return (
     <dialog
       ref={dialogRef}
-      className={`fixed inset-0 z-50 flex items-center justify-center bg-transparent ${fullscreen ? "backdrop:bg-transparent" : "backdrop:bg-black/60"}`}
+      className={`m-auto bg-transparent ${fullscreen ? "backdrop:bg-transparent" : "backdrop:bg-black/60"}`}
       onClose={handleClose}
       aria-label="Execution Result"
     >

--- a/frontend/app/workbench/page.tsx
+++ b/frontend/app/workbench/page.tsx
@@ -205,7 +205,7 @@ export default function WorkbenchPage() {
       {/* Configuration Modal — opens via pencil icon on segments/xsecs */}
       <dialog
         ref={configDialogRef}
-        className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+        className="m-auto bg-transparent backdrop:bg-black/60"
         onClose={configHandleClose}
         aria-label="Configuration"
       >

--- a/frontend/components/workbench/ComponentEditDialog.tsx
+++ b/frontend/components/workbench/ComponentEditDialog.tsx
@@ -194,7 +194,7 @@ export function ComponentEditDialog({
   return (
     <dialog
       ref={dialogRef}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      className="m-auto bg-transparent backdrop:bg-black/60"
       onClose={handleClose}
       aria-label={isEdit ? "Edit Component" : "New Component"}
     >

--- a/frontend/components/workbench/ComponentTypeEditDialog.tsx
+++ b/frontend/components/workbench/ComponentTypeEditDialog.tsx
@@ -162,7 +162,7 @@ export function ComponentTypeEditDialog({
     <>
       <dialog
         ref={dialogRef}
-        className="fixed inset-0 z-[55] flex items-center justify-center bg-transparent backdrop:bg-black/60"
+        className="m-auto bg-transparent backdrop:bg-black/60"
         onClose={handleClose}
         aria-label={heading}
       >
@@ -326,7 +326,7 @@ export function ComponentTypeEditDialog({
 
       <dialog
         ref={confirmDialogRef}
-        className="fixed inset-0 z-[60] flex items-center justify-center bg-transparent backdrop:bg-black/60"
+        className="m-auto bg-transparent backdrop:bg-black/60"
         onClose={closeConfirmDialog}
         aria-label="Confirm delete type"
       >

--- a/frontend/components/workbench/ComponentTypeManagementDialog.tsx
+++ b/frontend/components/workbench/ComponentTypeManagementDialog.tsx
@@ -48,7 +48,7 @@ export function ComponentTypeManagementDialog({
     <>
       <dialog
         ref={dialogRef}
-        className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+        className="m-auto bg-transparent backdrop:bg-black/60"
         onClose={handleClose}
         aria-label="Manage Component Types"
       >

--- a/frontend/components/workbench/ConstructionPartPickerDialog.tsx
+++ b/frontend/components/workbench/ConstructionPartPickerDialog.tsx
@@ -47,7 +47,7 @@ export function ConstructionPartPickerDialog({
   return (
     <dialog
       ref={dialogRef}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      className="m-auto bg-transparent backdrop:bg-black/60"
       onClose={handleClose}
       aria-label="Construction-Part picker"
     >

--- a/frontend/components/workbench/ConstructionPartUploadDialog.tsx
+++ b/frontend/components/workbench/ConstructionPartUploadDialog.tsx
@@ -65,7 +65,7 @@ export function ConstructionPartUploadDialog({
   return (
     <dialog
       ref={dialogRef}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      className="m-auto bg-transparent backdrop:bg-black/60"
       onClose={handleClose}
       aria-label="Upload Construction Part"
     >

--- a/frontend/components/workbench/ConstructionPartsGrid.tsx
+++ b/frontend/components/workbench/ConstructionPartsGrid.tsx
@@ -35,7 +35,7 @@ function ConfirmModal({ title, body, onConfirm, onCancel }: Readonly<ConfirmModa
   return (
     <dialog
       ref={dialogRef}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      className="m-auto bg-transparent backdrop:bg-black/60"
       onClose={handleClose}
       aria-label={title}
     >

--- a/frontend/components/workbench/CotsPickerDialog.tsx
+++ b/frontend/components/workbench/CotsPickerDialog.tsx
@@ -52,7 +52,7 @@ export function CotsPickerDialog({
   return (
     <dialog
       ref={dialogRef}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      className="m-auto bg-transparent backdrop:bg-black/60"
       onClose={handleClose}
       aria-label="Component picker"
     >

--- a/frontend/components/workbench/CreateWingDialog.tsx
+++ b/frontend/components/workbench/CreateWingDialog.tsx
@@ -135,7 +135,7 @@ export function CreateWingDialog({
   return (
     <dialog
       ref={dialogRef}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      className="m-auto bg-transparent backdrop:bg-black/60"
       onClose={handleClose}
       aria-label="Create Wing"
     >

--- a/frontend/components/workbench/ImportFuselageDialog.tsx
+++ b/frontend/components/workbench/ImportFuselageDialog.tsx
@@ -888,7 +888,7 @@ export function ImportFuselageDialog({
   return (
     <dialog
       ref={dialogRef}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      className="m-auto bg-transparent backdrop:bg-black/60"
       onClose={dialogHandleClose}
       aria-label="New Fuselage"
     >

--- a/frontend/components/workbench/NodePropertyPanel.tsx
+++ b/frontend/components/workbench/NodePropertyPanel.tsx
@@ -90,7 +90,7 @@ function ConfirmModal({ title, body, onConfirm, onCancel }: Readonly<ConfirmModa
   return (
     <dialog
       ref={dialogRef}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      className="m-auto bg-transparent backdrop:bg-black/60"
       onClose={handleClose}
       aria-label={title}
     >
@@ -324,7 +324,7 @@ export function NodePropertyPanel({
   return (
     <dialog
       ref={dialogRef}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      className="m-auto bg-transparent backdrop:bg-black/60"
       onClose={dialogHandleClose}
       aria-label="Edit tree node"
     >

--- a/frontend/components/workbench/PropertyEditDialog.tsx
+++ b/frontend/components/workbench/PropertyEditDialog.tsx
@@ -134,7 +134,7 @@ export function PropertyEditDialog({
   return (
     <dialog
       ref={dialogRef}
-      className="fixed inset-0 z-[60] flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      className="m-auto bg-transparent backdrop:bg-black/60"
       onClose={handleClose}
       aria-label={initial ? "Edit Property" : "New Property"}
     >

--- a/frontend/components/workbench/SparEditDialog.tsx
+++ b/frontend/components/workbench/SparEditDialog.tsx
@@ -173,7 +173,7 @@ export function SparEditDialog({
   return (
     <dialog
       ref={dialogRef}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      className="m-auto bg-transparent backdrop:bg-black/60"
       onClose={handleClose}
       aria-label={isNew ? "Add Spar" : "Edit Spar"}
     >

--- a/frontend/components/workbench/TedEditDialog.tsx
+++ b/frontend/components/workbench/TedEditDialog.tsx
@@ -195,7 +195,7 @@ export function TedEditDialog({
   return (
     <dialog
       ref={dialogRef}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/60"
+      className="m-auto bg-transparent backdrop:bg-black/60"
       onClose={handleClose}
       aria-label={isNew ? "Add Control Surface" : "Edit Control Surface"}
     >

--- a/frontend/components/workbench/UnsavedChangesModal.tsx
+++ b/frontend/components/workbench/UnsavedChangesModal.tsx
@@ -11,7 +11,7 @@ export function UnsavedChangesModal() {
   return (
     <dialog
       ref={dialogRef}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-transparent backdrop:bg-black/50"
+      className="m-auto bg-transparent backdrop:bg-black/50"
       onClose={handleClose}
     >
       <div className="flex w-[460px] flex-col gap-5 rounded-[16px] border border-border bg-card p-6">


### PR DESCRIPTION
## Summary
Replace `fixed inset-0 flex items-center justify-center` with `m-auto` on all 22 native `<dialog>` elements. Native `<dialog>.showModal()` centers via `margin: auto` — the old Tailwind positioning was overriding this.

## v1 attempt (reverted)
PR #274 removed all positioning classes entirely, which also didn't center because native `<dialog>` needs explicit `margin: auto`.

## Test plan
- [x] 251/251 tests pass
- [ ] Manual: open Configuration dialog — should appear centered

Closes #273