### PR TITLE
chore(gh-232): resolve ~77 mechanical SonarQube issues in cad_designer/

### DIFF
--- a/cad_designer/aerosandbox/convert2aerosandbox.py
+++ b/cad_designer/aerosandbox/convert2aerosandbox.py
@@ -1,11 +1,10 @@
+from __future__ import annotations
+
 import logging
-from typing import Any, Tuple, List
 
 import numpy as np
 import aerosandbox as asb
 from cadquery import Workplane, CQ
-
-import logging
 
 from cad_designer.aerosandbox.slicing import compute_shape_properties, slice_model_along_x, fit_shape_area_superellipse, \
     plot_superellipse_fit, load_step_model
@@ -16,7 +15,7 @@ logger = logging.getLogger(__name__)
 from pathlib import Path
 
 def asb_mesh_to_stl(
-    data: Tuple[np.ndarray, np.ndarray],
+    data: tuple[np.ndarray, np.ndarray],
     output_path: str,
     scale: float = 1.0,
     correct_normals: bool = True
@@ -27,7 +26,7 @@ def asb_mesh_to_stl(
     cavets: The normal direction of the STL file may not be correct.
 
     Args:
-        data (Tuple[np.ndarray, np.ndarray]): A tuple containing:
+        data (tuple[np.ndarray, np.ndarray]): A tuple containing:
             - vertices (np.ndarray): An array of vertex coordinates (Nx3).
             - triangles (np.ndarray): An array of triangle indices (Mx3).
         output_path (str): The file path where the STL file will be saved.
@@ -139,14 +138,12 @@ def convert_solid_to_asb_fuselage(shape: Workplane, number_of_slices=100, spacin
                 plot_superellipse_fit(points_3d= np.array(points), fit_result=result, num_samples = 200)
             result['center'] = np.array([points[0][0], result['center'][0], result['center'][1]])
             ellipse_slices.append(result)
-            #break # only take one wire per slice
             prev_params = result
 
     # convert ellipse_slices to FuselageXSec
     fuselage_xsecs = []
     for i, ellipse in enumerate(ellipse_slices):
         fuselage_xsec = asb.FuselageXSec(
-            #xyz_c = ellipse['center'],
             xyz_normal = np.array([1.0, 0.0, 0.0]),
             radius = None,
             width = 2. * ellipse['a'],
@@ -160,8 +157,8 @@ def convert_solid_to_asb_fuselage(shape: Workplane, number_of_slices=100, spacin
     asb_fuselage = asb.Fuselage(
         name="Fuselage",
         xsecs=fuselage_xsecs,
-        color = None, #: Optional[Union[str, Tuple[float]]] = None,
-        analysis_specific_options = None #: Optional[Dict[type, Dict[str, Any]]] = None,
+        color=None,
+        analysis_specific_options=None,
     )
 
     if plot:
@@ -170,7 +167,7 @@ def convert_solid_to_asb_fuselage(shape: Workplane, number_of_slices=100, spacin
                 f"Fuselage volume       >> initial: {surface_volume['volume']}; transformed: {asb_fuselage.volume()}; transformed/initial = {surface_volume['volume']/asb_fuselage.volume()}")
     return asb_fuselage
 
-def convert_step_to_asb_fuselage(step_file: str, number_of_slices=100, spacing=None, plot: bool = False, scale:float=1.0) -> List[asb.Fuselage]:
+def convert_step_to_asb_fuselage(step_file: str, number_of_slices=100, spacing=None, plot: bool = False, scale:float=1.0) -> list[asb.Fuselage]:
     """
     Converts a STEP file containing 3D CAD models into a list of AeroSandbox fuselage objects.
 

--- a/cad_designer/airplane/AbstractShapeCreator.py
+++ b/cad_designer/airplane/AbstractShapeCreator.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import abc
 import logging
-from typing import Union
 
 from cadquery import Workplane
 
@@ -8,9 +9,9 @@ class AbstractShapeCreator(metaclass=abc.ABCMeta):
     """
     Base class for shape creating/modifying nodes.
     """
-    def __init__(self, creator_id: str, shapes_of_interest_keys: Union[list[str], None], loglevel:int=logging.FATAL):
+    def __init__(self, creator_id: str, shapes_of_interest_keys: list[str] | None, loglevel:int=logging.FATAL):
         self.loglevel: int = loglevel
-        self._shapes_of_interest_keys: Union[list[str], None] = shapes_of_interest_keys
+        self._shapes_of_interest_keys: list[str] | None = shapes_of_interest_keys
         self.creator_id: str = creator_id
 
     @property
@@ -21,14 +22,13 @@ class AbstractShapeCreator(metaclass=abc.ABCMeta):
         :return: identifier as name of this shape. If used several times the shape will be overwritten in future steps.
         """
         return self.creator_id
-        pass
 
     @property
     def shapes_of_interest_keys(self) -> list[str]:
         return self._shapes_of_interest_keys
 
     @abc.abstractmethod
-    def _create_shape(self, shapes_of_interest: Union[list[str], None], input_shapes: dict[str, Workplane],
+    def _create_shape(self, shapes_of_interest: list[str] | None, input_shapes: dict[str, Workplane],
                       **kwargs) -> dict[str, Workplane]:
         """
         This method will create a shape. The shape can depend on shapes of previous steps. All previous steps
@@ -66,8 +66,8 @@ class AbstractShapeCreator(metaclass=abc.ABCMeta):
         """
         shapes = {}
         if needed_shapes is not None:
-            shapes = {k: kwargs[k] for k in kwargs.keys() & needed_shapes}
-            missing = {(k if k not in kwargs.keys() else None) for k in needed_shapes}  # check what is missing
+            shapes = {k: kwargs[k] for k in kwargs & needed_shapes}
+            missing = {(k if k not in kwargs else None) for k in needed_shapes}  # check what is missing
             missing = [i for i in missing if i is not None]  # remove all Nones
             if len(missing) > 0:
                 raise KeyError(f"shapes are missing in step '{self.identifier}': {missing}")

--- a/cad_designer/airplane/ConstructionRootNode.py
+++ b/cad_designer/airplane/ConstructionRootNode.py
@@ -1,4 +1,6 @@
-from typing import MutableMapping, Union
+from __future__ import annotations
+
+from typing import MutableMapping
 from collections import OrderedDict
 
 from cadquery import Workplane
@@ -42,8 +44,8 @@ class ConstructionRootNode(AbstractShapeCreator, MutableMapping):
         """
         self.update({value.creator.identifier: value})
 
-    def _create_shape(self, shapes_of_interest: Union[list[str], None], input_shapes: dict[str, Workplane], **kwargs) \
-            -> dict[str, Union[object, Workplane]]:
+    def _create_shape(self, shapes_of_interest: list[str] | None, input_shapes: dict[str, Workplane], **kwargs) \
+            -> dict[str, object | Workplane]:
         """
         Executes the construction of all shapes based on the defined workflow structure.
         :param input_shapes: the shapes that have been constructed in the predecessor step

--- a/cad_designer/airplane/ConstructionStepNode.py
+++ b/cad_designer/airplane/ConstructionStepNode.py
@@ -1,4 +1,6 @@
-from typing import MutableMapping, Union, TypeVar
+from __future__ import annotations
+
+from typing import MutableMapping, TypeVar
 from collections import OrderedDict
 from cadquery import Workplane
 
@@ -42,8 +44,8 @@ class ConstructionStepNode(AbstractShapeCreator, MutableMapping):
         """
         self.update({value.creator.identifier: value})
 
-    def _create_shape(self, shapes_of_interest: Union[list[str], None], input_shapes: dict[str, Workplane], **kwargs) \
-            -> dict[str, Union[object, Workplane]]:
+    def _create_shape(self, shapes_of_interest: list[str] | None, input_shapes: dict[str, Workplane], **kwargs) \
+            -> dict[str, object | Workplane]:
         """
         Executes the construction of all shapes based on the defined workflow structure.
         :param shapes_of_interest: 
@@ -70,5 +72,4 @@ class ConstructionStepNode(AbstractShapeCreator, MutableMapping):
         kwargs.update(output_shapes.copy())
         for key in self.successors:
             kwargs.update(self.successors.get(key).create_shape(_input_shapes, **kwargs))
-        # del _input_shapes  # deleting this list
         return kwargs

--- a/cad_designer/airplane/JSONStepNode.py
+++ b/cad_designer/airplane/JSONStepNode.py
@@ -17,9 +17,8 @@ class JSONStepNode(ConstructionStepNode):
                                                   cls=GeneralJSONDecoder,
                                                   **self._to_be_injected)
         _json_file.close()
-        if "successors" in kwargs.keys():
+        if "successors" in kwargs:
             kwargs.pop("successors")
-        if "creator" in kwargs.keys():
+        if "creator" in kwargs:
             kwargs.pop("creator")
         super().__init__(creator=creator.creator, successors=creator.successors, **kwargs)
-        pass

--- a/cad_designer/airplane/aircraft_topology/airplane/AirplaneConfiguration.py
+++ b/cad_designer/airplane/aircraft_topology/airplane/AirplaneConfiguration.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from functools import cached_property
-from typing import List, Optional, Dict, Any
+from typing import Any
 import json
 import os
 import zipfile
@@ -19,19 +21,18 @@ class AirplaneConfiguration:
     def __init__(self,
                  name: str,
                  total_mass_kg: float,
-                 wings: List[WingConfiguration],
-                 fuselages: Optional[List[FuselageConfiguration]] = None,
+                 wings: list[WingConfiguration],
+                 fuselages: list[FuselageConfiguration] | None = None,
                  ):
         self.name: str = name
         self.total_mass: float = total_mass_kg
-        self.wings: List[WingConfiguration] = wings
-        self.fuselages: Optional[List[FuselageConfiguration]] = fuselages
+        self.wings: list[WingConfiguration] = wings
+        self.fuselages: list[FuselageConfiguration] | None = fuselages
 
         self._main_wing_index = 0
         self._main_wing = self.wings[self._main_wing_index]
-        pass
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert the AirplaneConfiguration to a dictionary for JSON serialization."""
         data = {
             "name": self.name,
@@ -175,9 +176,9 @@ class AirplaneConfiguration:
             fuselages=fuselages,
             propulsors=None,
             analysis_specific_options={
-                asb.AVL: dict(
-                    profile_drag_coefficient=0.,
-                )
+                asb.AVL: {
+                    "profile_drag_coefficient": 0.,
+                }
             }
         )
 

--- a/cad_designer/airplane/aircraft_topology/components/ServoInformation.py
+++ b/cad_designer/airplane/aircraft_topology/components/ServoInformation.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 from OCP.gp import *
 from pydantic import PositiveFloat
@@ -16,7 +16,7 @@ class ServoInformation(ComponentInformation):
 
     @length.setter
     def length(self, value):
-        pass
+        pass  # Read-only property backed by self.servo
 
     @property
     def width(self):
@@ -24,7 +24,7 @@ class ServoInformation(ComponentInformation):
 
     @width.setter
     def width(self, value):
-        pass
+        pass  # Read-only property backed by self.servo
 
     @property
     def height(self):
@@ -32,14 +32,14 @@ class ServoInformation(ComponentInformation):
 
     @height.setter
     def height(self, value):
-        pass
+        pass  # Read-only property backed by self.servo
 
     def __init__(self,
                  height: PositiveFloat, width: PositiveFloat, length: PositiveFloat,
                  lever_length: NonNegativeFloat,
                  rot_x: float = 0.0, rot_y: float = 0.0, rot_z: float = 0.0,
                  trans_x: float = 0.0, trans_y: float = 0.0, trans_z: float = 0.0,
-                 servo: Optional[Servo] = None):
+                 servo: Servo | None = None):
         self.lever_length = lever_length
         self.servo: Servo = servo if servo is not None \
             else Servo(length, width, height, 0, 0, 0, 0, 0, 0, 0, 0)

--- a/cad_designer/airplane/aircraft_topology/fuselage/FuselageConfiguration.py
+++ b/cad_designer/airplane/aircraft_topology/fuselage/FuselageConfiguration.py
@@ -1,4 +1,5 @@
-from typing import Optional
+from __future__ import annotations
+
 import logging
 logger = logging.getLogger(__name__)
 
@@ -12,11 +13,10 @@ class FuselageConfiguration:
     def __init__(self,
                  name: str):
         self.name: str = name
-        self.asb_fuselage: Optional[asb.Fuselage] = None
-        self._step_file: Optional[str] = None
-        self._step_scale: Optional[float] = None
-        self._number_of_slices: Optional[int] = None
-        pass
+        self.asb_fuselage: asb.Fuselage | None = None
+        self._step_file: str | None = None
+        self._step_scale: float | None = None
+        self._number_of_slices: int | None = None
 
     def __getstate__(self):
         """Return a dictionary of serializable attributes for JSON serialization."""
@@ -120,7 +120,7 @@ class FuselageConfiguration:
             number_of_slices=number_of_slices,
             scale=scale*MM_TO_M,
         )
-        fuselage.analysis_specific_options= {
+        fuselage.analysis_specific_options = {
                 dict(panel_resolution=24, panel_spacing="cosine")
             }
 

--- a/cad_designer/airplane/aircraft_topology/models/analysis_model.py
+++ b/cad_designer/airplane/aircraft_topology/models/analysis_model.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 from enum import Enum
 
 import math
 import numpy as np
 from pydantic import BaseModel, Field, field_validator
-from typing import List, Literal, Tuple, Union
-from typing import Optional
+from typing import Literal
 
 import aerosandbox as asb
 
@@ -17,7 +18,7 @@ class AircraftModel(BaseModel):
     wing_chord_m: float = Field(..., title="Mean Geometric Chord", description="Mean geometric chord of the wing [m]")
     MAC_m: float = Field(..., title="Mean Aerodynamic Chord", description="Mean aerodynamic chord [m]")
     static_margin_in_percent_MAC: float = Field(..., title="Static Margin", description="Static margin as % of MAC [%]")
-    NP_m: List[float] = Field(..., title="Neutral Point", description="Neutral point coordinates [m]")
+    NP_m: list[float] = Field(..., title="Neutral Point", description="Neutral point coordinates [m]")
     airfoil_root: str = Field(..., title="Root Airfoil", description="Root airfoil name [string]")
     airfoil_tip: str = Field(..., title="Tip Airfoil", description="Tip airfoil name [string]")
 
@@ -47,31 +48,31 @@ class WingGeometryModel(BaseModel):
 
 
 class AerodynamicsModel(BaseModel):
-    alpha_range_deg: List[float] = Field(..., title="Angle of Attack Range", description="Angle of attack values [deg]")
-    F_g_curve_alpha: List[List[float]] = Field(..., title="Geometry Axes Forces", description="Forces in geometry axes [N]")
-    F_b_curve_alpha: List[List[float]] = Field(..., title="Body Axes Forces", description="Forces in body axes [N]")
-    F_w_curve_alpha: List[List[float]] = Field(..., title="Wind Axes Forces", description="Forces in wind axes [N]")
-    M_g_curve_alpha: List[List[float]] = Field(..., title="Geometry Moments", description="Moments about geometry axes [Nm]")
-    M_b_curve_alpha: List[List[float]] = Field(..., title="Body Moments", description="Moments about body axes [Nm]")
-    M_w_curve_alpha: List[List[float]] = Field(..., title="Wind Moments", description="Moments about wind axes [Nm]")
-    L_lift_force_N_curve_alpha: List[float] = Field(..., title="Lift Force", description="Lift force [N]")
-    Y_side_force_N_curve_alpha: List[float] = Field(..., title="Side Force", description="Side force [N]")
-    D_drag_force_N_curve_alpha: List[float] = Field(..., title="Drag Force", description="Drag force [N]")
-    l_b_rolling_moment_Nm_curve_alpha: List[float] = Field(..., title="Rolling Moment", description="Rolling moment [Nm]")
-    m_b_pitching_moment_Nm_curve_alpha: List[float] = Field(..., title="Pitching Moment", description="Pitching moment [Nm]")
-    n_b_yawing_moment_Nm_curve_alpha: List[float] = Field(..., title="Yawing Moment", description="Yawing moment [Nm]")
-    CL_lift_coefficient_curve_alpha: List[float] = Field(..., title="Lift Coefficient", description="Lift coefficient [-]: wind axes")
-    CY_sideforce_coefficient_curve_alpha: List[float] = Field(..., title="Sideforce Coefficient", description="Sideforce coefficient [-]: wind axes")
-    CD_drag_coefficient_curve_alpha: List[float] = Field(..., title="Drag Coefficient", description="Drag coefficient [-]: wind axes")
-    Cl_rolling_moment_curve_alpha: List[float] = Field(..., title="Rolling Coefficient", description="Rolling coefficient [-]: body axes")
-    Cm_pitching_moment_curve_alpha: List[float] = Field(..., title="Pitching Coefficient", description="Pitching coefficient [-]: body axes")
-    Cn_yawing_moment_curve_alpha: List[float] = Field(..., title="Yawing Coefficient", description="Yawing coefficient [-]: body axes")
+    alpha_range_deg: list[float] = Field(..., title="Angle of Attack Range", description="Angle of attack values [deg]")
+    F_g_curve_alpha: list[list[float]] = Field(..., title="Geometry Axes Forces", description="Forces in geometry axes [N]")
+    F_b_curve_alpha: list[list[float]] = Field(..., title="Body Axes Forces", description="Forces in body axes [N]")
+    F_w_curve_alpha: list[list[float]] = Field(..., title="Wind Axes Forces", description="Forces in wind axes [N]")
+    M_g_curve_alpha: list[list[float]] = Field(..., title="Geometry Moments", description="Moments about geometry axes [Nm]")
+    M_b_curve_alpha: list[list[float]] = Field(..., title="Body Moments", description="Moments about body axes [Nm]")
+    M_w_curve_alpha: list[list[float]] = Field(..., title="Wind Moments", description="Moments about wind axes [Nm]")
+    L_lift_force_N_curve_alpha: list[float] = Field(..., title="Lift Force", description="Lift force [N]")
+    Y_side_force_N_curve_alpha: list[float] = Field(..., title="Side Force", description="Side force [N]")
+    D_drag_force_N_curve_alpha: list[float] = Field(..., title="Drag Force", description="Drag force [N]")
+    l_b_rolling_moment_Nm_curve_alpha: list[float] = Field(..., title="Rolling Moment", description="Rolling moment [Nm]")
+    m_b_pitching_moment_Nm_curve_alpha: list[float] = Field(..., title="Pitching Moment", description="Pitching moment [Nm]")
+    n_b_yawing_moment_Nm_curve_alpha: list[float] = Field(..., title="Yawing Moment", description="Yawing moment [Nm]")
+    CL_lift_coefficient_curve_alpha: list[float] = Field(..., title="Lift Coefficient", description="Lift coefficient [-]: wind axes")
+    CY_sideforce_coefficient_curve_alpha: list[float] = Field(..., title="Sideforce Coefficient", description="Sideforce coefficient [-]: wind axes")
+    CD_drag_coefficient_curve_alpha: list[float] = Field(..., title="Drag Coefficient", description="Drag coefficient [-]: wind axes")
+    Cl_rolling_moment_curve_alpha: list[float] = Field(..., title="Rolling Coefficient", description="Rolling coefficient [-]: body axes")
+    Cm_pitching_moment_curve_alpha: list[float] = Field(..., title="Pitching Coefficient", description="Pitching coefficient [-]: body axes")
+    Cn_yawing_moment_curve_alpha: list[float] = Field(..., title="Yawing Coefficient", description="Yawing coefficient [-]: body axes")
 
 
 class EfficiencyModel(BaseModel):
-    masses_kg: List[float] = Field(..., title="Masses", description="List of mass configurations [kg]")
-    stall_velocity_m_per_s_curve_masses_kg: List[float] = Field(..., title="Stall Velocities", description="Stall velocity per mass [m/s]")
-    travel_velocity_m_per_s_curve_masses_kg: List[float] = Field(..., title="Travel Velocities", description="Travel velocity per mass [m/s]")
+    masses_kg: list[float] = Field(..., title="Masses", description="List of mass configurations [kg]")
+    stall_velocity_m_per_s_curve_masses_kg: list[float] = Field(..., title="Stall Velocities", description="Stall velocity per mass [m/s]")
+    travel_velocity_m_per_s_curve_masses_kg: list[float] = Field(..., title="Travel Velocities", description="Travel velocity per mass [m/s]")
     stall_velocity_m_per_s: float = Field(..., title="Stall Velocity", description="Stall speed at current mass [m/s]")
     travel_velocity_m_per_s: float = Field(..., title="Travel Velocity", description="Optimal travel speed [m/s]")
     alpha_at_stall_deg: float = Field(..., title="Stall AoA", description="Angle of attack at stall [deg]")
@@ -108,79 +109,79 @@ class StabilityModel(BaseModel):
     static_directional_stability_best_alpha: CnBetaClassification = Field(..., title="Lateral Stability", description="Static directional stability present")
 
 class AvlReferenceModel(BaseModel):
-    Bref: Optional[float] = Field(None, title="Reference Span", description="Reference span [m]")
-    Cref: Optional[float] = Field(None, title="Reference Chord", description="Reference chord [m]")
-    Sref: Optional[float] = Field(None, title="Reference Area", description="Reference area [m²]")
-    Xref: Optional[float] = Field(None, title="X Reference", description="X reference location [m]")
-    Yref: Optional[float] = Field(None, title="Y Reference", description="Y reference location [m]")
-    Zref: Optional[float] = Field(None, title="Z Reference", description="Z reference location [m]")
-    Xnp: Optional[List[float]] = Field(None, title="Neutral Point", description="Neutral point location [m]")
-    Xnp_lat: Optional[List[float]] = Field(None, title="Lateral Neutral Point", description="Lateral Neutral point location [m]")
-    Strips: Optional[float] = Field(None, title="Strip Count", description="Number of strips in the model [-]")
-    Surfaces: Optional[float] = Field(None, title="Surface Count", description="Number of surfaces in the model [-]")
-    Vortices: Optional[float] = Field(None, title="Vortex Count", description="Number of vortices in the model [-]")
+    Bref: float | None = Field(None, title="Reference Span", description="Reference span [m]")
+    Cref: float | None = Field(None, title="Reference Chord", description="Reference chord [m]")
+    Sref: float | None = Field(None, title="Reference Area", description="Reference area [m²]")
+    Xref: float | None = Field(None, title="X Reference", description="X reference location [m]")
+    Yref: float | None = Field(None, title="Y Reference", description="Y reference location [m]")
+    Zref: float | None = Field(None, title="Z Reference", description="Z reference location [m]")
+    Xnp: list[float] | None = Field(None, title="Neutral Point", description="Neutral point location [m]")
+    Xnp_lat: list[float] | None = Field(None, title="Lateral Neutral Point", description="Lateral Neutral point location [m]")
+    Strips: float | None = Field(None, title="Strip Count", description="Number of strips in the model [-]")
+    Surfaces: float | None = Field(None, title="Surface Count", description="Number of surfaces in the model [-]")
+    Vortices: float | None = Field(None, title="Vortex Count", description="Number of vortices in the model [-]")
 
 class AvlForceModel(BaseModel):
-    F_b: Optional[List[Tuple[float, float, float]]] = Field(None, title="Body Axes Forces", description="List of forces in body axes for each alpha [N]")
-    F_g: Optional[List[Tuple[float, float, float]]] = Field(None, title="Geometry Axes Forces", description="List of forces in geometry axes for each alpha [N]")
-    F_w: Optional[List[List[float]]] = Field(None, title="Wind Axes Forces", description="List of forces in wind axes for each alpha [N]")
-    L: Optional[List[float]] = Field(None, title="Lift Force", description="List of lift force for each alpha [N]")
-    D: Optional[List[float]] = Field(None, title="Drag Force", description="List of drag force for each alpha [N]")
-    Y: Optional[List[float]] = Field(None, title="Side Force", description="List of side force for each alpha [N]")
+    F_b: list[tuple[float, float, float]] | None = Field(None, title="Body Axes Forces", description="List of forces in body axes for each alpha [N]")
+    F_g: list[tuple[float, float, float]] | None = Field(None, title="Geometry Axes Forces", description="List of forces in geometry axes for each alpha [N]")
+    F_w: list[list[float]] | None = Field(None, title="Wind Axes Forces", description="List of forces in wind axes for each alpha [N]")
+    L: list[float] | None = Field(None, title="Lift Force", description="List of lift force for each alpha [N]")
+    D: list[float] | None = Field(None, title="Drag Force", description="List of drag force for each alpha [N]")
+    Y: list[float] | None = Field(None, title="Side Force", description="List of side force for each alpha [N]")
 
 class AvlMomentModel(BaseModel):
-    M_b: Optional[List[List[float]]] = Field(None, title="Body Moments", description="List of moments about body axes for each alpha [Nm]")
-    M_g: Optional[List[Tuple[float, float, float]]] = Field(None, title="Geometry Moments", description="List of moments about geometry axes for each alpha [Nm]")
-    M_w: Optional[List[List[float]]] = Field(None, title="Wind Moments", description="List of moments about wind axes for each alpha [Nm]")
-    l_b: Optional[List[float]] = Field(None, title="Body Roll Moment", description="List of roll moment in body axes for each alpha [Nm]")
-    m_b: Optional[List[float]] = Field(None, title="Body Pitch Moment", description="List of pitch moment in body axes for each alpha [Nm]")
-    n_b: Optional[List[float]] = Field(None, title="Body Yaw Moment", description="List of yaw moment in body axes for each alpha [Nm]")
+    M_b: list[list[float]] | None = Field(None, title="Body Moments", description="List of moments about body axes for each alpha [Nm]")
+    M_g: list[tuple[float, float, float]] | None = Field(None, title="Geometry Moments", description="List of moments about geometry axes for each alpha [Nm]")
+    M_w: list[list[float]] | None = Field(None, title="Wind Moments", description="List of moments about wind axes for each alpha [Nm]")
+    l_b: list[float] | None = Field(None, title="Body Roll Moment", description="List of roll moment in body axes for each alpha [Nm]")
+    m_b: list[float] | None = Field(None, title="Body Pitch Moment", description="List of pitch moment in body axes for each alpha [Nm]")
+    n_b: list[float] | None = Field(None, title="Body Yaw Moment", description="List of yaw moment in body axes for each alpha [Nm]")
 
 class AvlCoefficientsModel(BaseModel):
-    CL: Optional[List[float]] = Field(None, title="Lift Coefficient", description="List of lift coefficient for each alpha [-]")
-    CD: Optional[List[float]] = Field(None, title="Drag Coefficient", description="List of drag coefficient for each alpha [-]")
-    CY: Optional[List[float]] = Field(None, title="Y-Force Coefficient", description="List of y-axis force coefficient for each alpha [-]")
-    CZ: Optional[List[float]] = Field(None, title="Z-Force Coefficient", description="List of z-axis force coefficient for each alpha [-]")
-    CX: Optional[List[float]] = Field(None, title="X-Force Coefficient", description="List of x-axis force coefficient for each alpha [-]")
-    Cl: Optional[List[float]] = Field(None, title="Roll Moment Coefficient", description="List of roll moment coefficient for each alpha [-]")
-    Cl_prime: Optional[List[float]] = Field(None, title="Roll Moment Prime", description="List of roll moment coefficient prime for each alpha [-]")#, alias="Cl'")
-    Cm: Optional[List[float]] = Field(None, title="Pitch Moment Coefficient", description="List of pitch moment coefficient for each alpha [-]")
-    Cn: Optional[List[float]] = Field(None, title="Yaw Moment Coefficient", description="List of yaw moment coefficient for each alpha [-]")
-    Cn_prime: Optional[List[float]] = Field(None, title="Yaw Moment Prime", description="List of yaw moment coefficient prime for each alpha [-]")#, alias="Cn'")
-    CDff: Optional[List[float]] = Field(None, title="Drag in Trefftz Plane", description="List ofTrefftz Plane drag coefficient for each alpha [-]")
-    CDind: Optional[List[float]] = Field(None, title="Induced Drag", description="List of induced drag coefficient for each alpha [-]")
-    CDvis: Optional[List[float]] = Field(None, title="Viscous Drag", description="List of viscous drag coefficient for each alpha [-]")
-    CLff: Optional[List[float]] = Field(None, title="Lift in Trefftz Plane", description="List of Trefftz Plane lift coefficient for each alpha [-]")
-    CYff: Optional[List[float]] = Field(None, title="Trefftz Plane Side Force", description="List of Trefftz Plane side force coefficient for each alpha [-]")
-    e: Optional[List[float]] = Field(None, title="Oswald Efficiency", description="List of Oswald efficiency factor for each alpha [-]")
+    CL: list[float] | None = Field(None, title="Lift Coefficient", description="List of lift coefficient for each alpha [-]")
+    CD: list[float] | None = Field(None, title="Drag Coefficient", description="List of drag coefficient for each alpha [-]")
+    CY: list[float] | None = Field(None, title="Y-Force Coefficient", description="List of y-axis force coefficient for each alpha [-]")
+    CZ: list[float] | None = Field(None, title="Z-Force Coefficient", description="List of z-axis force coefficient for each alpha [-]")
+    CX: list[float] | None = Field(None, title="X-Force Coefficient", description="List of x-axis force coefficient for each alpha [-]")
+    Cl: list[float] | None = Field(None, title="Roll Moment Coefficient", description="List of roll moment coefficient for each alpha [-]")
+    Cl_prime: list[float] | None = Field(None, title="Roll Moment Prime", description="List of roll moment coefficient prime for each alpha [-]")
+    Cm: list[float] | None = Field(None, title="Pitch Moment Coefficient", description="List of pitch moment coefficient for each alpha [-]")
+    Cn: list[float] | None = Field(None, title="Yaw Moment Coefficient", description="List of yaw moment coefficient for each alpha [-]")
+    Cn_prime: list[float] | None = Field(None, title="Yaw Moment Prime", description="List of yaw moment coefficient prime for each alpha [-]")
+    CDff: list[float] | None = Field(None, title="Drag in Trefftz Plane", description="List ofTrefftz Plane drag coefficient for each alpha [-]")
+    CDind: list[float] | None = Field(None, title="Induced Drag", description="List of induced drag coefficient for each alpha [-]")
+    CDvis: list[float] | None = Field(None, title="Viscous Drag", description="List of viscous drag coefficient for each alpha [-]")
+    CLff: list[float] | None = Field(None, title="Lift in Trefftz Plane", description="List of Trefftz Plane lift coefficient for each alpha [-]")
+    CYff: list[float] | None = Field(None, title="Trefftz Plane Side Force", description="List of Trefftz Plane side force coefficient for each alpha [-]")
+    e: list[float] | None = Field(None, title="Oswald Efficiency", description="List of Oswald efficiency factor for each alpha [-]")
 
 class AvlDerivativesModel(BaseModel):
-    CLa: Optional[List[Optional[float]]] = Field(None, title="Lift Curve Slope", description="List of lift curve slope for each alpha [1/rad]")
-    CLb: Optional[List[Optional[float]]] = Field(None, title="Lift-Sideslip Derivative", description="List of lift coefficient derivative with sideslip for each alpha [1/rad]")
-    CLp: Optional[List[Optional[float]]] = Field(None, title="Roll Damping", description="List of roll damping derivative for each alpha [1/rad]")
-    CLq: Optional[List[Optional[float]]] = Field(None, title="Pitch Rate Lift", description="List of pitch rate lift derivative for each alpha [1/rad]")
-    CLr: Optional[List[Optional[float]]] = Field(None, title="Yaw Rate Lift", description="List of yaw rate lift derivative for each alpha [1/rad]")
-    CYa: Optional[List[Optional[float]]] = Field(None, title="Side Force-Alpha", description="List of side force derivative with alpha for each alpha [1/rad]")
-    CYb: Optional[List[Optional[float]]] = Field(None, title="Side Force-Beta", description="List of side force derivative with beta for each alpha [1/rad]")
-    CYp: Optional[List[Optional[float]]] = Field(None, title="Roll Rate Side Force", description="List of roll rate side force derivative for each alpha [1/rad]")
-    CYq: Optional[List[Optional[float]]] = Field(None, title="Pitch Rate Side Force", description="List of pitch rate side force derivative for each alpha [1/rad]")
-    CYr: Optional[List[Optional[float]]] = Field(None, title="Yaw Rate Side Force", description="List of yaw rate side force derivative for each alpha [1/rad]")
-    Cla: Optional[List[Optional[float]]] = Field(None, title="Roll-Alpha Derivative", description="List of roll moment derivative with alpha for each alpha [1/rad]")
-    Clb: Optional[List[Optional[float]]] = Field(None, title="Roll-Beta Derivative", description="List of roll moment derivative with beta for each alpha [1/rad]")
-    Clp: Optional[List[Optional[float]]] = Field(None, title="Roll Damping", description="List of roll damping derivative for each alpha [1/rad]")
-    Clq: Optional[List[Optional[float]]] = Field(None, title="Pitch Rate Roll", description="List of pitch rate roll derivative for each alpha [1/rad]")
-    Clr: Optional[List[Optional[float]]] = Field(None, title="Yaw Rate Roll", description="List of yaw rate roll derivative for each alpha [1/rad]")
-    Cma: Optional[List[Optional[float]]] = Field(None, title="Pitch-Alpha Derivative", description="List of pitch moment derivative with alpha for each alpha [1/rad]")
-    Cmb: Optional[List[Optional[float]]] = Field(None, title="Pitch-Beta Derivative", description="List of pitch moment derivative with beta for each alpha [1/rad]")
-    Cmp: Optional[List[Optional[float]]] = Field(None, title="Roll Rate Pitch", description="List of roll rate pitch derivative for each alpha [1/rad]")
-    Cmq: Optional[List[Optional[float]]] = Field(None, title="Pitch Damping", description="List of pitch damping derivative for each alpha [1/rad]")
-    Cmr: Optional[List[Optional[float]]] = Field(None, title="Yaw Rate Pitch", description="List of yaw rate pitch derivative for each alpha [1/rad]")
-    Cna: Optional[List[Optional[float]]] = Field(None, title="Yaw-Alpha Derivative", description="List of yaw moment derivative with alpha for each alpha [1/rad]")
-    Cnb: Optional[List[Optional[float]]] = Field(None, title="Yaw-Beta Derivative", description="List of yaw moment derivative with beta for each alpha [1/rad]")
-    Cnp: Optional[List[Optional[float]]] = Field(None, title="Roll Rate Yaw", description="List of roll rate yaw derivative for each alpha [1/rad]")
-    Cnq: Optional[List[Optional[float]]] = Field(None, title="Pitch Rate Yaw", description="List of pitch rate yaw derivative for each alpha [1/rad]")
-    Cnr: Optional[List[Optional[float]]] = Field(None, title="Yaw Damping", description="List of yaw damping derivative for each alpha [1/rad]")
-    Clb_Cnr_div_Clr_Cnb: Optional[List[Optional[float]]] = Field(None, title="Roll-Yaw Coupling", description="List of roll-yaw coupling parameter for each alpha [-]")#, alias="Clb Cnr / Clr Cnb")
+    CLa: list[float | None] | None = Field(None, title="Lift Curve Slope", description="List of lift curve slope for each alpha [1/rad]")
+    CLb: list[float | None] | None = Field(None, title="Lift-Sideslip Derivative", description="List of lift coefficient derivative with sideslip for each alpha [1/rad]")
+    CLp: list[float | None] | None = Field(None, title="Roll Damping", description="List of roll damping derivative for each alpha [1/rad]")
+    CLq: list[float | None] | None = Field(None, title="Pitch Rate Lift", description="List of pitch rate lift derivative for each alpha [1/rad]")
+    CLr: list[float | None] | None = Field(None, title="Yaw Rate Lift", description="List of yaw rate lift derivative for each alpha [1/rad]")
+    CYa: list[float | None] | None = Field(None, title="Side Force-Alpha", description="List of side force derivative with alpha for each alpha [1/rad]")
+    CYb: list[float | None] | None = Field(None, title="Side Force-Beta", description="List of side force derivative with beta for each alpha [1/rad]")
+    CYp: list[float | None] | None = Field(None, title="Roll Rate Side Force", description="List of roll rate side force derivative for each alpha [1/rad]")
+    CYq: list[float | None] | None = Field(None, title="Pitch Rate Side Force", description="List of pitch rate side force derivative for each alpha [1/rad]")
+    CYr: list[float | None] | None = Field(None, title="Yaw Rate Side Force", description="List of yaw rate side force derivative for each alpha [1/rad]")
+    Cla: list[float | None] | None = Field(None, title="Roll-Alpha Derivative", description="List of roll moment derivative with alpha for each alpha [1/rad]")
+    Clb: list[float | None] | None = Field(None, title="Roll-Beta Derivative", description="List of roll moment derivative with beta for each alpha [1/rad]")
+    Clp: list[float | None] | None = Field(None, title="Roll Damping", description="List of roll damping derivative for each alpha [1/rad]")
+    Clq: list[float | None] | None = Field(None, title="Pitch Rate Roll", description="List of pitch rate roll derivative for each alpha [1/rad]")
+    Clr: list[float | None] | None = Field(None, title="Yaw Rate Roll", description="List of yaw rate roll derivative for each alpha [1/rad]")
+    Cma: list[float | None] | None = Field(None, title="Pitch-Alpha Derivative", description="List of pitch moment derivative with alpha for each alpha [1/rad]")
+    Cmb: list[float | None] | None = Field(None, title="Pitch-Beta Derivative", description="List of pitch moment derivative with beta for each alpha [1/rad]")
+    Cmp: list[float | None] | None = Field(None, title="Roll Rate Pitch", description="List of roll rate pitch derivative for each alpha [1/rad]")
+    Cmq: list[float | None] | None = Field(None, title="Pitch Damping", description="List of pitch damping derivative for each alpha [1/rad]")
+    Cmr: list[float | None] | None = Field(None, title="Yaw Rate Pitch", description="List of yaw rate pitch derivative for each alpha [1/rad]")
+    Cna: list[float | None] | None = Field(None, title="Yaw-Alpha Derivative", description="List of yaw moment derivative with alpha for each alpha [1/rad]")
+    Cnb: list[float | None] | None = Field(None, title="Yaw-Beta Derivative", description="List of yaw moment derivative with beta for each alpha [1/rad]")
+    Cnp: list[float | None] | None = Field(None, title="Roll Rate Yaw", description="List of roll rate yaw derivative for each alpha [1/rad]")
+    Cnq: list[float | None] | None = Field(None, title="Pitch Rate Yaw", description="List of pitch rate yaw derivative for each alpha [1/rad]")
+    Cnr: list[float | None] | None = Field(None, title="Yaw Damping", description="List of yaw damping derivative for each alpha [1/rad]")
+    Clb_Cnr_div_Clr_Cnb: list[float | None] | None = Field(None, title="Roll-Yaw Coupling", description="List of roll-yaw coupling parameter for each alpha [-]")
 
     @field_validator('*', mode='before')
     @classmethod
@@ -190,18 +191,18 @@ class AvlDerivativesModel(BaseModel):
         return v
 
 class AvlSingleControlSurfaceModel(BaseModel):
-    name: Optional[str] = Field(None, title="Control Surface Name", description="Name of the control surface")
-    ed: Optional[List[float]] = Field(None, title="Control Surface Efficiency", description="List of control surface efficiency for each alpha [-]")
-    CDff: Optional[List[float]] = Field(None, title="Control Surface Drag", description="List of control surface drag contribution for each alpha [-]")
-    CLd: Optional[List[float]] = Field(None, title="Control Surface Lift", description="List of control surface lift contribution for each alpha [-]")
-    CYd: Optional[List[float]] = Field(None, title="Control Surface Side Force", description="List of control surface side force contribution for each alpha [-]")
-    Cld: Optional[List[float]] = Field(None, title="Control Surface Roll", description="List of control surface roll contribution for each alpha [-]")
-    Cmd: Optional[List[float]] = Field(None, title="Control Surface Pitch", description="List of control surface pitch contribution for each alpha [-]")
-    Cnd: Optional[List[float]] = Field(None, title="Control Surface Yaw", description="List of control surface yaw contribution for each alpha [-]")
-    deflection: Optional[List[float]] = Field(None, title="Control Surface Deflection", description="List of control surface deflection angle for each alpha [deg]")
+    name: str | None = Field(None, title="Control Surface Name", description="Name of the control surface")
+    ed: list[float] | None = Field(None, title="Control Surface Efficiency", description="List of control surface efficiency for each alpha [-]")
+    CDff: list[float] | None = Field(None, title="Control Surface Drag", description="List of control surface drag contribution for each alpha [-]")
+    CLd: list[float] | None = Field(None, title="Control Surface Lift", description="List of control surface lift contribution for each alpha [-]")
+    CYd: list[float] | None = Field(None, title="Control Surface Side Force", description="List of control surface side force contribution for each alpha [-]")
+    Cld: list[float] | None = Field(None, title="Control Surface Roll", description="List of control surface roll contribution for each alpha [-]")
+    Cmd: list[float] | None = Field(None, title="Control Surface Pitch", description="List of control surface pitch contribution for each alpha [-]")
+    Cnd: list[float] | None = Field(None, title="Control Surface Yaw", description="List of control surface yaw contribution for each alpha [-]")
+    deflection: list[float] | None = Field(None, title="Control Surface Deflection", description="List of control surface deflection angle for each alpha [deg]")
 
 class AvlControlSurfaceModel(BaseModel):
-    control_surfaces: Optional[List[AvlSingleControlSurfaceModel]] = Field(None, title="Control Surfaces", description="List of control surfaces")
+    control_surfaces: list[AvlSingleControlSurfaceModel] | None = Field(None, title="Control Surfaces", description="List of control surfaces")
 
     def _deflection_by_name(self, name: str):
         for control_surface in self.control_surfaces or []:
@@ -226,17 +227,17 @@ class AvlControlSurfaceModel(BaseModel):
         return self._deflection_by_name("rudder")
 
 class AvlFlightConditionModel(BaseModel):
-    alpha: Optional[Union[float,List[float]]] = Field(None, title="Angle of Attack", description="List of angle of attack for each alpha [deg]")
-    beta: Optional[Union[float,List[float]]] = Field(None, title="Sideslip Angle", description="Sideslip angle [deg]")
-    mach: Optional[Union[float,List[float]]] = Field(None, title="Mach Number", description="Mach number [-]")
-    p: Optional[Union[float,List[float]]] = Field(None, title="Roll Rate", description="Roll rate [rad/s]")
-    q: Optional[Union[float,List[float]]] = Field(None, title="Pitch Rate", description="Pitch rate [rad/s]")
-    r: Optional[Union[float,List[float]]] = Field(None, title="Yaw Rate", description="Yaw rate [rad/s]")
-    p_prime_b_div_2V: Optional[float] = Field(None, title="Normalized Roll Acceleration", description="Normalized roll acceleration [-]")#, alias="p'b/2V"
-    pb_div_2V: Optional[float] = Field(None, title="Normalized Roll Rate", description="Normalized roll rate [-]")#, alias="pb/2V"
-    qc_div_2V: Optional[float] = Field(None, title="Normalized Pitch Rate", description="Normalized pitch rate [-]")#, alias="qc/2V"
-    r_prime_b_div_2V: Optional[float] = Field(None, title="Normalized Yaw Acceleration", description="Normalized yaw acceleration [-]")#, alias="r'b/2V"
-    rb_div_2V: Optional[float] = Field(None, title="Normalized Yaw Rate", description="Normalized yaw rate [-]")#, alias="rb/2V"
+    alpha: float | list[float] | None = Field(None, title="Angle of Attack", description="List of angle of attack for each alpha [deg]")
+    beta: float | list[float] | None = Field(None, title="Sideslip Angle", description="Sideslip angle [deg]")
+    mach: float | list[float] | None = Field(None, title="Mach Number", description="Mach number [-]")
+    p: float | list[float] | None = Field(None, title="Roll Rate", description="Roll rate [rad/s]")
+    q: float | list[float] | None = Field(None, title="Pitch Rate", description="Pitch rate [rad/s]")
+    r: float | list[float] | None = Field(None, title="Yaw Rate", description="Yaw rate [rad/s]")
+    p_prime_b_div_2V: float | None = Field(None, title="Normalized Roll Acceleration", description="Normalized roll acceleration [-]")
+    pb_div_2V: float | None = Field(None, title="Normalized Roll Rate", description="Normalized roll rate [-]")
+    qc_div_2V: float | None = Field(None, title="Normalized Pitch Rate", description="Normalized pitch rate [-]")
+    r_prime_b_div_2V: float | None = Field(None, title="Normalized Yaw Acceleration", description="Normalized yaw acceleration [-]")
+    rb_div_2V: float | None = Field(None, title="Normalized Yaw Rate", description="Normalized yaw rate [-]")
 
 class AnalysisModel(BaseModel):
     method: Literal['avl', 'aerobuildup', 'vortex_lattice'] = Field(..., title="Analysis Method", description="Method used for analysis: 'avl', 'aerobuildup', or 'vortex_lattice'")
@@ -621,7 +622,7 @@ class AnalysisModel(BaseModel):
             Cnp=to_list(data.get('Cnp')),
             Cnq=to_list(data.get('Cnq')),
             Cnr=to_list(data.get('Cnr')),
-            Clb_Cnr_div_Clr_Cnb=None#[(data['Clb']*data['Cnr']) / (data['Clr']/data['Cnb'])]
+            Clb_Cnr_div_Clr_Cnb=None
         )
         # Control Surfaces
         control_surfaces = AvlControlSurfaceModel(control_surfaces=None)

--- a/cad_designer/airplane/aircraft_topology/wing/WingConfiguration.py
+++ b/cad_designer/airplane/aircraft_topology/wing/WingConfiguration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from types import SimpleNamespace
 
@@ -8,7 +10,7 @@ logger = logging.getLogger(__name__)
 from functools import cached_property, cache
 
 import math
-from typing import TypeVar, Any, List, Tuple, Union, Optional, Literal
+from typing import TypeVar, Any, Literal
 
 import numpy as np
 import aerosandbox as asb
@@ -70,13 +72,13 @@ class WingConfiguration:
                  length: PositiveFloat,
                  sweep: NonNegativeFloat = 0,
                  sweep_is_angle: bool = False,
-                 tip_airfoil: Optional[Airfoil] = None,
-                 number_interpolation_points: Optional[PositiveInt] = None,
-                 spare_list: Optional[List[Spare]] = None,
-                 trailing_edge_device: Optional[TrailingEdgeDevice] = None,
+                 tip_airfoil: Airfoil | None = None,
+                 number_interpolation_points: PositiveInt | None = None,
+                 spare_list: list[Spare] | None = None,
+                 trailing_edge_device: TrailingEdgeDevice | None = None,
                  symmetric: bool = True,
                  parameters: Literal["relative", "aerosandbox"] = "relative") -> T:
-        self.segments: Union[list[WingSegment], None] = None
+        self.segments: list[WingSegment] | None = None
         self.nose_pnt: tuple[float, float, float] = nose_pnt
         self.parameters: Literal["relative", "aerosandbox"] = parameters
 
@@ -93,12 +95,12 @@ class WingConfiguration:
                                    number_interpolation_points=number_interpolation_points, wing_segment_type='root')
 
         self.segments: list[WingSegment] = [root_segment]
-        self._wing_workplanes: dict[Tuple[int, bool], Workplane] = {}
+        self._wing_workplanes: dict[tuple[int, bool], Workplane] = {}
         self._wing_workplanes[(0, False)] = self.get_wing_workplane(0)
         self.segments[0].root_airfoil.set_airfoil_coordinate_system((self._wing_workplanes[(0, False)].plane))
 
         self._scaled_point_list: dict[str, list[tuple[float, float]]] = {}
-        self._asb_wing: Optional[asb.Wing] = None
+        self._asb_wing: asb.Wing | None = None
 
         self.symmetric: bool = symmetric
 
@@ -184,8 +186,8 @@ class WingConfiguration:
                         tip_type: TipType,
                         length: PositiveFloat,
                         sweep: NonNegativeFloat = 0,
-                        tip_airfoil: Optional[Airfoil] = None,
-                        number_interpolation_points: Optional[PositiveInt] = None
+                        tip_airfoil: Airfoil | None = None,
+                        number_interpolation_points: PositiveInt | None = None
                         ) -> T:
         """
         Adds a tip segment to the wing configuration.
@@ -194,8 +196,8 @@ class WingConfiguration:
             tip_type (TipType): The type of the tip ('flat', 'round').
             length (PositiveFloat): The length of the tip segment.
             sweep (NonNegativeFloat): The sweep of the tip segment.
-            tip_airfoil (Optional[Airfoil]): The airfoil at the tip of the segment.
-            number_interpolation_points (Optional[PositiveInt]): Number of points for airfoil interpolation.
+            tip_airfoil (Airfoil | None): The airfoil at the tip of the segment.
+            number_interpolation_points (PositiveInt | None): Number of points for airfoil interpolation.
 
         Returns:
             WingConfiguration: The updated WingConfiguration instance.
@@ -233,10 +235,10 @@ class WingConfiguration:
                     length: PositiveFloat,
                     sweep: NonNegativeFloat = 0,
                     sweep_is_angle=False,
-                    tip_airfoil: Optional[Airfoil] = None,
-                    number_interpolation_points: Optional[PositiveInt] = None,
-                    spare_list: Optional[List[Spare]] = None,
-                    trailing_edge_device: Optional[TrailingEdgeDevice] = None
+                    tip_airfoil: Airfoil | None = None,
+                    number_interpolation_points: PositiveInt | None = None,
+                    spare_list: list[Spare] | None = None,
+                    trailing_edge_device: TrailingEdgeDevice | None = None
                     ) -> T:
         """
         Adds a new segment to the wing configuration.
@@ -245,10 +247,10 @@ class WingConfiguration:
             length (PositiveFloat): The length of the segment.
             sweep (NonNegativeFloat): The sweep of the segment.
             sweep_is_angle (bool): If True, sweep is interpreted as an angle.
-            tip_airfoil (Optional[Airfoil]): The airfoil at the tip of the segment.
-            number_interpolation_points (Optional[PositiveInt]): Number of points for airfoil interpolation.
-            spare_list (Optional[List[Spare]]): List of spares for the segment.
-            trailing_edge_device (Optional[TrailingEdgeDevice]): Trailing edge device for the segment.
+            tip_airfoil (Airfoil | None): The airfoil at the tip of the segment.
+            number_interpolation_points (PositiveInt | None): Number of points for airfoil interpolation.
+            spare_list (list[Spare] | None): List of spares for the segment.
+            trailing_edge_device (TrailingEdgeDevice | None): Trailing edge device for the segment.
 
         Returns:
             WingConfiguration: The updated WingConfiguration instance.
@@ -319,7 +321,6 @@ class WingConfiguration:
                         follows_spare = self.segments[seg_num].spare_list[spare_idx]
                         self._set_follow_spare_origin_vector(seg_num, follows_spare, spare_idx)
 
-                    pass
 
                 elif spare.spare_mode == "standard":
                     self._set_standard_spare_origin_vector(segment_number, spare)
@@ -337,7 +338,6 @@ class WingConfiguration:
                                     self.segments[segment_number].root_airfoil.chord * spare.spare_position_factor)
                     else:
                         spare.spare_origin = seg_plane.origin + spare.spare_origin
-                    pass
         return self
 
     def _set_follow_spare_origin_vector(self, segment_number, spare, spare_idx):
@@ -380,9 +380,6 @@ class WingConfiguration:
         Note:
             The workplane is aligned with the segment's geometry and cached for performance.
         """
-
-        #if (segment, ignore_nose_point) in self._wing_workplanes.keys():
-        #    return self._wing_workplanes[(segment, ignore_nose_point)]
 
         if self.parameters == "aerosandbox":
             all_trans = self._get_absolute_segment_coordinate_system(segment, ignore_nose_point)
@@ -523,7 +520,7 @@ class WingConfiguration:
         return self._scaled_point_list[key]
 
     def get_camber_y_at_rel_chord(self: T, segment: NonNegativeInt, relative_chord: Factor,
-                                  relative_length: float = 0.) -> Tuple[float, float]:
+                                  relative_length: float = 0.) -> tuple[float, float]:
         """
         Calculates the camber height and offset at a given relative chord position for a segment.
 
@@ -533,7 +530,7 @@ class WingConfiguration:
             relative_length (float): Relative position along the segment length (0 to 1).
 
         Returns:
-            Tuple[float, float]: (camber height, offset from lower surface to chord).
+            tuple[float, float]: (camber height, offset from lower surface to chord).
         """
         upper, lower = self.get_points_on_surface(segment, relative_chord=relative_chord,
                                                   relative_length=relative_length)
@@ -564,7 +561,7 @@ class WingConfiguration:
             end_segment (NonNegativeInt): Index of the ending segment.
 
         Returns:
-            Tuple[Plane, Plane]: Planes at the root and tip for the trailing edge device.
+            tuple[Plane, Plane]: Planes at the root and tip for the trailing edge device.
 
         Note:
             Returns (None, None) if no trailing edge device is present.
@@ -648,19 +645,19 @@ class WingConfiguration:
                     twist=incidence_angle,
                     control_surfaces=[control_surface] if control_surface is not None else None,
                     analysis_specific_options={
-                        asb.AVL: dict(
-                            spanwise_resolution=12,
-                            spanwise_spacing="cosine",
-                            cl_alpha_factor=None,  # This is a float
-                            drag_polar=dict(
-                                CL1=0,
-                                CD1=0,
-                                CL2=0,
-                                CD2=0,
-                                CL3=0,
-                                CD3=0,
-                            ),
-                        )},
+                        asb.AVL: {
+                            "spanwise_resolution": 12,
+                            "spanwise_spacing": "cosine",
+                            "cl_alpha_factor": None,  # This is a float
+                            "drag_polar": {
+                                "CL1": 0,
+                                "CD1": 0,
+                                "CL2": 0,
+                                "CD2": 0,
+                                "CL3": 0,
+                                "CD3": 0,
+                            },
+                        }},
                 ).translate([root_origin.x * scale, root_origin.y * scale, root_origin.z * scale])
                 sections.append(root_section)
                 is_root = False
@@ -689,35 +686,34 @@ class WingConfiguration:
             ).translate([tip_origin.x * scale, tip_origin.y * scale, tip_origin.z * scale])
 
             sections.append(tip_section)
-            pass
 
         # create the aerosandbox wing
         self._asb_wing = (asb.Wing(xsecs=sections,
                                    symmetric=self.symmetric,
                                    color=None,
                                    analysis_specific_options={
-                                       asb.AVL: dict(
-                                           wing_level_spanwise_spacing=True,
-                                           spanwise_resolution=int(round(tip_origin.y * scale * 50)),
-                                           spanwise_spacing="cosine",
-                                           chordwise_resolution=12,
-                                           chordwise_spacing="cosine",
-                                           component=None,  # This is an int
-                                           no_wake=False,
-                                           no_alpha_beta=False,
-                                           no_load=False,
-                                           drag_polar=dict(
-                                               CL1=0,
-                                               CD1=0,
-                                               CL2=0,
-                                               CD2=0,
-                                               CL3=0,
-                                               CD3=0,
-                                           ),
-                                       )}
+                                       asb.AVL: {
+                                           "wing_level_spanwise_spacing": True,
+                                           "spanwise_resolution": int(round(tip_origin.y * scale * 50)),
+                                           "spanwise_spacing": "cosine",
+                                           "chordwise_resolution": 12,
+                                           "chordwise_spacing": "cosine",
+                                           "component": None,  # This is an int
+                                           "no_wake": False,
+                                           "no_alpha_beta": False,
+                                           "no_load": False,
+                                           "drag_polar": {
+                                               "CL1": 0,
+                                               "CD1": 0,
+                                               "CL2": 0,
+                                               "CD2": 0,
+                                               "CL3": 0,
+                                               "CD3": 0,
+                                           },
+                                       }}
                                    )
                           # translate the wing to the nose point
-                          .translate([x * scale for x in list(self.nose_pnt)]))
+                          .translate([x * scale for x in self.nose_pnt]))
         return self._asb_wing
 
     @staticmethod
@@ -735,7 +731,7 @@ class WingConfiguration:
                               coordinate_system: CoordinateSystemBase = "world",
                               x_offset: float = .0,
                               z_offset: float = .0
-                              ) -> Tuple[Vector, Vector]:
+                              ) -> tuple[Vector, Vector]:
         """
         Returns the points on the surface (top, bottom) in the airfoil coordinate system.
         x points along the airfoil's center line, y points to the top, and z points along the nose
@@ -793,7 +789,7 @@ class WingConfiguration:
             logger.critical(f"unknown coordinate system {coordinate_system}")
             raise ValueError(f"unknown coordinate system {coordinate_system}")
 
-    def _interpolate_y_at_x(self, points, x, reverse=False) -> Tuple[float, float]:
+    def _interpolate_y_at_x(self, points, x, reverse=False) -> tuple[float, float]:
         # Extrahiere x- und y-Werte aus den Punkten
         if not reverse:
             x_values = [point[0] for point in points[:math.ceil(len(points) / 2)]]
@@ -902,7 +898,7 @@ class WingConfiguration:
             json.dump(self.__getstate__(), f, indent=4)
 
     @staticmethod
-    def from_asb(xsecs: List[asb.WingXSec], symmetric: bool = True) -> 'WingConfiguration':
+    def from_asb(xsecs: list[asb.WingXSec], symmetric: bool = True) -> 'WingConfiguration':
         """Create a WingConfiguration from a list of Aerosandbox WingXSecs.
 
         Decoupled reconstruction: with rc=0 and the decoupled frame
@@ -937,7 +933,7 @@ class WingConfiguration:
             )
 
         # Per-segment deltas in global frame.
-        deltas: List[ndarray] = []
+        deltas: list[ndarray] = []
         for i in range(n - 1):
             delta = (
                 np.asarray(asb_wing.xsecs[i + 1].xyz_le, dtype=float)
@@ -953,13 +949,13 @@ class WingConfiguration:
         )
 
         # Per-xsec cumulative twist (absolute, as stored by asb).
-        cum_twists: List[float] = [float(asb_wing.xsecs[k].twist) for k in range(n)]
+        cum_twists: list[float] = [float(asb_wing.xsecs[k].twist) for k in range(n)]
 
         # Per-xsec cumulative dihedral angle, extracted from deltas.
         # With decoupled frame, delta = R_x(cum_d) . [sweep, length, 0],
         # so cum_d = atan2(delta.z, delta.y). Always extractable
         # because twist does not contaminate positions.
-        cum_d: List[float] = [0.0] * n
+        cum_d: list[float] = [0.0] * n
         for k in range(n - 1):
             delta_y = float(deltas[k][1])
             delta_z = float(deltas[k][2])
@@ -974,7 +970,7 @@ class WingConfiguration:
         root_i = cum_twists[0]
         root_d = cum_d[0]
 
-        def _airfoil_name(xsec: asb.WingXSec) -> Optional[str]:
+        def _airfoil_name(xsec: asb.WingXSec) -> str | None:
             af = xsec.airfoil
             return af.name if af is not None else None
 

--- a/cad_designer/airplane/creator/_creator_template.py
+++ b/cad_designer/airplane/creator/_creator_template.py
@@ -55,8 +55,9 @@ Documentation (frontend integration):
             \"\"\"
 """
 
+from __future__ import annotations
+
 import logging
-from typing import Optional, Union
 
 from cadquery import Workplane
 
@@ -82,7 +83,7 @@ class MyCreator(AbstractShapeCreator):
         # ── Shape references (upstream shapes this creator needs) ──
         # Use str keys that reference output of previous steps.
         # Default to None to allow positional pipeline resolution.
-        input_shape: Optional[str] = None,
+        input_shape: str | None = None,
         #
         # ── Runtime-injected config (optional) ─────────────────
         # These are passed by GeneralJSONDecoder at decode time.
@@ -113,7 +114,7 @@ class MyCreator(AbstractShapeCreator):
         shapes_of_interest: dict[str, Workplane],
         input_shapes: dict[str, Workplane],
         **kwargs,
-    ) -> dict[str, Union[object, Workplane]]:
+    ) -> dict[str, object | Workplane]:
         """
         Implement your shape creation logic here.
 

--- a/cad_designer/airplane/creator/cad_operations/AddMultipleShapesCreator.py
+++ b/cad_designer/airplane/creator/cad_operations/AddMultipleShapesCreator.py
@@ -29,7 +29,7 @@ class AddMultipleShapesCreator(AbstractShapeCreator):
         shape = shape_list[0]
         for shp in shape_list[1:]:
             shape.add(shp)
-        _shape = shape.combine()
+        shape.combine()
         _shape = shape.combine() # I am not sure, why this only works after the second call...
 
         _shape.display(self.identifier, logging.DEBUG)

--- a/cad_designer/airplane/creator/cad_operations/ScaleRotateTranslateCreator.py
+++ b/cad_designer/airplane/creator/cad_operations/ScaleRotateTranslateCreator.py
@@ -80,18 +80,4 @@ class ScaleRotateTranslateCreator(AbstractShapeCreator):
             .rotate((0,0,0),(0,0,1),rot_z)\
             .translate((trans_x, trans_y, trans_z)))
 
-        # trafo = tgl_geom.CTiglTransformation()
-        # trafo.add_scaling(scale_x, scale_y, scale_z)
-        # trafo.add_rotation_x(rot_x)
-        # trafo.add_rotation_y(rot_y)
-        # trafo.add_rotation_z(rot_z)
-        # trafo.add_translation(trans_x, trans_y, trans_z)
-
-        # if mirroring == "xy":
-        #     trafo.add_mirroring_at_xyplane()
-        # elif mirroring == "xz":
-        #     trafo.add_mirroring_at_xzplane()
-        # elif mirroring == "yz":
-        #     trafo.add_projection_on_yzplane()
-
         return shape

--- a/cad_designer/airplane/creator/export_import/ExportTo3mfCreator.py
+++ b/cad_designer/airplane/creator/export_import/ExportTo3mfCreator.py
@@ -38,13 +38,11 @@ class ExportTo3mfCreator(AbstractShapeCreator):
         logging.info(f"converting shapes '{', '.join(shapes_of_interest.keys())}' to .3mf")
 
         from cadquery import exporters
-        #ass = cq.Assembly()
         for name, shape in shapes_of_interest.items():
             step_path = os.path.join(self.file_path, f"{self.identifier}_{name}.3mf")
             logging.debug(f"writing model to '{step_path}'")
             exporters.export(shape, step_path,
                              tolerance=self.tolerance, angularTolerance=self.angular_tolerance)
-            #ass.add(shape)
 
         import gc
         del exporters

--- a/cad_designer/airplane/creator/export_import/ExportToStepCreator.py
+++ b/cad_designer/airplane/creator/export_import/ExportToStepCreator.py
@@ -63,23 +63,7 @@ class ExportToStepCreator(AbstractShapeCreator):
     def _generateStepWriter(self):
         # ===============
         from OCP.STEPControl import STEPControl_Controller, STEPControl_Writer
-        st = STEPControl_Controller()
-        # st.Init()
+        _st = STEPControl_Controller()
         step_writer = STEPControl_Writer()
-        dd = step_writer.WS().TransferWriter().FinderProcess()
-        # from OCP.Interface_Static import Interface_Static_SetCVal, Interface_Static_SetIVal
-        # defines the version of schema used for the output STEP file:
-        # 1 or AP214CD (default): AP214, CD version (dated 26 November 1996),
-        # 2 or AP214DIS: AP214, DIS version (dated 15 September 1998).
-        # 3 or AP203: AP203, possibly with modular extensions (depending on data written to a file).
-        # 4 or AP214IS: AP214, IS version (dated 2002)
-        # 5 or AP242DIS: AP242, DIS version.
-        # Interface_Static_SetCVal("write.step.schema", "AP214CD")
-        # 0 (Off) : (default) writes STEP files without assemblies.
-        # 1 (On) : writes all shapes in the form of STEP assemblies.
-        # 2 (Auto) : writes shapes having a structure of (possibly nested) TopoDS_Compounds in the form of STEP
-        #    assemblies, single shapes are written without assembly structures.
-        # Interface_Static_SetIVal("write.step.assembly", 0)
-        # Interface_Static_SetCVal("write.step.unit", "")
-        # Interface_Static_SetIVal("write.precision.mode", 0)
+        _dd = step_writer.WS().TransferWriter().FinderProcess()
         return step_writer

--- a/cad_designer/airplane/creator/export_import/ExportToStlCreator.py
+++ b/cad_designer/airplane/creator/export_import/ExportToStlCreator.py
@@ -36,13 +36,11 @@ class ExportToStlCreator(AbstractShapeCreator):
         logging.info(f"exporting stl model '{', '.join(shapes_of_interest.keys())}' --> '{self.file_path}'")
 
         from cadquery import exporters
-        #ass = cq.Assembly()
         for name, shape in shapes_of_interest.items():
             step_path = os.path.join(self.file_path, f"{self.identifier}_{name}.stl")
             logging.debug(f"writing model to '{step_path}'")
             exporters.export(shape, step_path,
                              tolerance=self.tolerance, angularTolerance=self.angular_tolerance)
-            #ass.add(shape)
 
         import gc
         del exporters

--- a/cad_designer/airplane/creator/fuselage/WingReinforcementShapeCreator.py
+++ b/cad_designer/airplane/creator/fuselage/WingReinforcementShapeCreator.py
@@ -51,8 +51,6 @@ class WingReinforcementShapeCreator(AbstractShapeCreator):
         wing_center = wing.findSolid().CenterOfBoundBox()
 
         root_section = wing.faces('<Y').display(name="root", severity=logging.NOTSET)
-        #tip_section = cq.Workplane('XZ', origin=(wing_center.x, wing_bbox.ymin + wing_bbox.ylen * tip_end_in_length_percent, wing_center.z))\
-        #    .add(wing).section().display(name="tip", severity=logging.NOTSET)
         tip_section = wing.faces('>Y').display(name="tip", severity=logging.NOTSET)
 
         ribs = self.construct_ribs(wing, rib_quantity, rib_width, wing_rib_angle_roll, wing_rib_angle_yaw)
@@ -139,15 +137,6 @@ class WingReinforcementShapeCreator(AbstractShapeCreator):
                 .loft() \
                 .display(name="pipe", severity=logging.NOTSET)
 
-        # beam = (cq.Workplane('XZ')
-        #              .copyWorkplane(root_section.workplane(invert=True, origin=root_bbox.center))
-        #              .moveTo(root_bbox.xlen * (chord_beam_position - 1 / 2), 0)
-        #              .rect(pipe_diameter + (4 * printer_resolution), root_bbox.zlen, True)
-        #              .copyWorkplane(tip_section.workplane(invert=True, origin=tip_bbox.center))
-        #              .moveTo(tip_bbox.xlen * (chord_beam_position - 1 / 2), 0)
-        #              .rect(pipe_diameter + 4 * printer_resolution, tip_bbox.zlen, True)
-        #              .loft().faces('<Y or >Y').shell(2*printer_resolution) ).intersect(intersect)
-
         beam = (cq.Workplane('XZ')
                      .copyWorkplane(root_section.workplane(invert=True, origin=root_bbox.center))
                      .moveTo(root_bbox.xlen * (chord_beam_position - 1 / 2) , 0)
@@ -156,15 +145,6 @@ class WingReinforcementShapeCreator(AbstractShapeCreator):
                      .moveTo(tip_bbox.xlen * (chord_beam_position - 1 / 2), 0)
                      .rect(2 * printer_resolution , tip_bbox.zlen, True)
                      .loft()).intersect(intersect)
-
-        # beam = beam + (cq.Workplane('XZ')
-        #         .copyWorkplane(root_section.workplane(invert=True, origin=root_bbox.center))
-        #         .moveTo(root_bbox.xlen * (chord_beam_position - 1 / 2) + (pipe_diameter / 2 + (2 * printer_resolution)),0)
-        #         .rect((2 * printer_resolution), root_bbox.zlen, True)
-        #         .copyWorkplane(tip_section.workplane(invert=True, origin=tip_bbox.center))
-        #         .moveTo(tip_bbox.xlen * (chord_beam_position - 1 / 2) + (pipe_diameter / 2 + (2 * printer_resolution)),0)
-        #         .rect(2 * printer_resolution, tip_bbox.zlen, True)
-        #         .loft()).intersect(intersect)
 
         if beam_with_pipe:
             beam = (beam + pipe) \

--- a/cad_designer/airplane/creator/wing/StandWingSegmentOnPrinterCreator.py
+++ b/cad_designer/airplane/creator/wing/StandWingSegmentOnPrinterCreator.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import logging
-from typing import Union
 
 import math
 import numpy as np
@@ -24,11 +25,11 @@ class StandWingSegmentOnPrinterCreator(AbstractShapeCreator):
 
     def __init__(self, creator_id: str,
                  shape_dict: dict[NonNegativeInt, str],
-                 wing_index: Union[str, NonNegativeInt],
+                 wing_index: str | NonNegativeInt,
                  wing_config: dict[NonNegativeInt, WingConfiguration] = None,
                  loglevel=logging.INFO):
         self.shape_dict: dict[NonNegativeInt, str] = shape_dict
-        self.wing_index: Union[str, NonNegativeInt] = wing_index
+        self.wing_index: str | NonNegativeInt = wing_index
         self._wing_config: dict[NonNegativeInt, WingConfiguration] = wing_config
         super().__init__(creator_id, shapes_of_interest_keys=[*shape_dict.values()], loglevel=loglevel)
 

--- a/cad_designer/airplane/creator/wing/VaseModeWingCreator.py
+++ b/cad_designer/airplane/creator/wing/VaseModeWingCreator.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import logging
 
 import math
 
 import numpy as np
 
-from typing import Union, Literal, Tuple, cast as tcast, Optional, Annotated
+from typing import Literal, Tuple, cast as tcast, Annotated
 from pydantic import Field, NonNegativeInt
 
 from math import cos, asin, degrees, radians
@@ -37,7 +39,7 @@ class VaseModeWingCreator(AbstractShapeCreator):
         trailing_edge_offset_factor (float): Factor to determine the offset of the trailing edge.
         minimum_rib_angle (float): Minimum angle for ribs to ensure printability (default is 45°).
         wing_side (Literal["LEFT", "RIGHT", "BOTH"]): Specifies which side of the wing to create.
-        wing_index (Union[str, int]): Index or identifier of the wing.
+        wing_index (str | int): Index or identifier of the wing.
         _wing_config (dict[int, WingConfiguration]): Configuration of the wing segments.
         _printer_settings (Printer3dSettings): Printer settings for 3D printing.
         _servo_information (dict[int, ServoInformation]): Information about servo placements.
@@ -68,25 +70,25 @@ class VaseModeWingCreator(AbstractShapeCreator):
 
     suggested_creator_id = "{wing_index}.vase_wing"
 
-    def __init__(self, creator_id: str, wing_index: Union[str, NonNegativeInt], leading_edge_offset_factor: Factor,
+    def __init__(self, creator_id: str, wing_index: str | NonNegativeInt, leading_edge_offset_factor: Factor,
                  trailing_edge_offset_factor: Factor,
                  minimum_rib_angle: Annotated[float, Field(ge=45.0, default=45)] = 45,
-                 wing_config: Optional[dict[NonNegativeInt, WingConfiguration]] = None,
-                 printer_settings: Optional[Printer3dSettings] = None,
-                 servo_information: Optional[dict[NonNegativeInt, ServoInformation]] = None,
-                 wing_side: Optional[WingSides] = None, symmetric: bool = True, connected:bool=True, loglevel: int = logging.INFO,
+                 wing_config: dict[NonNegativeInt, WingConfiguration] | None = None,
+                 printer_settings: Printer3dSettings | None = None,
+                 servo_information: dict[NonNegativeInt, ServoInformation] | None = None,
+                 wing_side: WingSides | None = None, symmetric: bool = True, connected:bool=True, loglevel: int = logging.INFO,
                  ):
         """
         Initializes the VaseModeWingCreator class with the required parameters.
 
         Parameters:
             creator_id (str): Identifier for the wing creator.
-            wing_index (Union[str, NonNegativeInt]): Index or identifier of the wing.
+            wing_index (str | NonNegativeInt): Index or identifier of the wing.
             leading_edge_offset_factor (Factor): Factor to determine the offset of the leading edge.
             trailing_edge_offset_factor (Factor): Factor to determine the offset of the trailing edge.
             minimum_rib_angle (float): Minimum angle for ribs to ensure printability (default is 45°).
             wing_config (Optional[dict[int, WingConfiguration]]): Configuration of the wing segments.
-            printer_settings (Optional[Printer3dSettings]): Printer settings for 3D printing.
+            printer_settings (Printer3dSettings | None): Printer settings for 3D printing.
             servo_information (Optional[dict[int, ServoInformation]]): Information about servo placements.
             wing_side (Literal["LEFT", "RIGHT", "BOTH"]): Specifies which side of the wing to create.
             loglevel (int): Logging level for the class (default is logging.INFO).
@@ -95,7 +97,7 @@ class VaseModeWingCreator(AbstractShapeCreator):
         self.trailing_edge_offset_factor: float = trailing_edge_offset_factor
         self.minimum_rib_angle: float = minimum_rib_angle
         self.wing_side: WingSides = wing_side
-        self.wing_index: Union[str, int] = wing_index
+        self.wing_index: str | int = wing_index
         self._wing_config: dict[int, WingConfiguration] = wing_config
         self._printer_settings: Printer3dSettings = printer_settings
         self._servo_information: dict[int, ServoInformation] = servo_information
@@ -190,7 +192,6 @@ class VaseModeWingCreator(AbstractShapeCreator):
                 segment=segment,
                 wing_config=wing_config,
                 spare_idx=spare_idx)
-            pass
             right_wing_spare = right_wing_spare.add(spare_shape)
 
         # create root segment ribs
@@ -221,7 +222,6 @@ class VaseModeWingCreator(AbstractShapeCreator):
                                                                                                  end_segment= segment,
                                                                                                  wing_config= wing_config)
             teds[f"{wing_config.segments[segment].trailing_edge_device.name}[{segment}]"] = ted_shape
-            pass
 
         logging.info(f"==> combining shapes --> '{self.identifier}[{segment}]'")
         final_right_segments[segment] = (right_wing_hull
@@ -272,8 +272,6 @@ class VaseModeWingCreator(AbstractShapeCreator):
                 logging.info(f"==> creating main spare shape for '{self.identifier}[{segment}]'")
                 raw_spare, spare_plane = self._create_spare_shape(current=current_2xpwt_offset, segment=segment,
                                                                   wing_config=wing_config, spare_idx=0)
-                #right_wing_spare = right_wing_spare.add(raw_spare)
-
                 # create the cut out for the ribs in an hour glass like shape
                 # the cut out is created in a way that the main spare fits into it nicely
                 logging.info(f"==> creating rib shapes for '{self.identifier}[{segment}]'")
@@ -317,7 +315,7 @@ class VaseModeWingCreator(AbstractShapeCreator):
                         wing_config.segments[ind].trailing_edge_device.rel_chord_tip = (
                             wing_config.segments[same_teds_indx[0]].trailing_edge_device.rel_chord_tip)
                         if ind != last_ind+1:
-                            raise ValueError(f"same ted names should be in a sequence no segments in between")
+                            raise ValueError("same ted names should be in a sequence no segments in between")
                         last_ind = ind
 
                     if ted.servo(self._servo_information) is not None:
@@ -373,17 +371,13 @@ class VaseModeWingCreator(AbstractShapeCreator):
                     .union(raw_ribs)
                     .cut(right_wing_slot)
                     .combine())
-                    #.fix_shape())
 
             right_wing_pwt_offset.add(current_pwt_offset)
-            pass
 
         # we combine everything and try to fix the shape
         final_right_wing = Workplane()
         for wing_seg in final_right_segments:
             final_right_wing = final_right_wing.add(wing_seg)
-        #final_right_wing = final_right_wing.fix_shape()
-
         # now we decide if we need the left, right or both wings for the wing
         # for the vertical stabilizer with the rudder we do only need one side
         if self.wing_side == "LEFT":
@@ -399,7 +393,7 @@ class VaseModeWingCreator(AbstractShapeCreator):
                 _teds[f"{k}*"] = v.mirror("XZ")
             teds = _teds
 
-        final_right_wing = final_right_wing.combine()#.fix_shape().combine()
+        final_right_wing = final_right_wing.combine()
 
         # append main shapes
         final_dict: dict[str, Workplane] = {self.identifier: final_right_wing}
@@ -572,17 +566,6 @@ class VaseModeWingCreator(AbstractShapeCreator):
         cover = cover.union(toUnion=cover_small, clean=True, glue=False, tol=1.0e-3)
         updated_hull = updated_hull.union(toUnion=cover)
 
-        #cover.display("cover", 500)
-        #current_hull.display("hull", 500)
-        #updated_hull.display("hull", 500)
-        #servo_mount.display("servo_mount", 500)
-
-        # box=Workplane().box(3,1,12, centered=False)
-        # box = (Workplane(box.findSolid().mirror(mirrorPlane="YZ")
-        #                   .rotate((0, 0, 0), (0, 1, 0), servo_orientation_deg).located(plane.location)))
-        # trans = plane.xDir * so.x + plane.yDir * so.y + plane.zDir * (so.z - (so.z - sob.z) * 0.15)
-        # box = box.translate(trans).display("box",24234)
-
         glue_in_mount = ted.servo(self._servo_information).create_laying_glue_in_mount(base_thickness=MOUNT_PLATE_THICKNESS, placement='bottom')
         glue_in_mount = mirror_and_rotate(glue_in_mount)
         glue_in_mount = glue_in_mount.translate(trans_mount)
@@ -644,7 +627,6 @@ class VaseModeWingCreator(AbstractShapeCreator):
                     top_min = top_lc.z
                 if bottom_max < bottom_lc.z:
                     bottom_max = bottom_lc.z
-                pass
 
         return bottom_max, top_min
 
@@ -822,7 +804,6 @@ class VaseModeWingCreator(AbstractShapeCreator):
             )
         except:
             logging.warning(f"could not create segment: {segment}!")
-        pass
         return raw_ribs, leading_edge_start, trailing_edge_start, spare_vector_origin, lower_part
 
     @staticmethod

--- a/cad_designer/airplane/creator/wing/WingLoftCreator.py
+++ b/cad_designer/airplane/creator/wing/WingLoftCreator.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import logging
-from typing import Union, Literal, Optional
 
 from cadquery import Workplane
 from pydantic import NonNegativeInt
@@ -13,7 +14,7 @@ class WingLoftCreator(AbstractShapeCreator):
     """Creates a solid loft shape of the full wing from wing configuration segments.
 
     Attributes:
-        wing_index (Union[str, int]): Index or identifier of the wing in the configuration.
+        wing_index (str | int): Index or identifier of the wing in the configuration.
         offset (float): Inward offset applied to the wing surface in mm.
         wing_side (str): Which side to create: LEFT, RIGHT, or BOTH.
         connected (bool): Whether to fill the gap between wing halves when dihedral is non-zero.
@@ -24,9 +25,9 @@ class WingLoftCreator(AbstractShapeCreator):
 
     suggested_creator_id = "{wing_index}.loft"
 
-    def __init__(self, creator_id: str, wing_index: Union[str, int], offset: float = 0,
-                 wing_config: Optional[dict[NonNegativeInt, WingConfiguration]] = None,
-                 wing_side: Optional[WingSides] = None, connected:bool=True, loglevel=logging.INFO):
+    def __init__(self, creator_id: str, wing_index: str | int, offset: float = 0,
+                 wing_config: dict[NonNegativeInt, WingConfiguration] | None = None,
+                 wing_side: WingSides | None = None, connected:bool=True, loglevel=logging.INFO):
         self.wing_side: WingSides = wing_side
         self.wing_index = wing_index
         self.offset = offset
@@ -87,10 +88,6 @@ class WingLoftCreator(AbstractShapeCreator):
                 tip_plane=tip_plane
             )
             right_wing.add(current)
-
-        #bb_right = right_wing.findSolid().BoundingBox(tolerance=1e-3)
-        #right_wing = right_wing.translate((0,-abs(bb_right.ymin)-1, 0))
-        #right_wing = right_wing.fix_shape()
 
         if self.wing_side == "LEFT":
             right_wing = right_wing.mirror("XZ")

--- a/cad_designer/cq_plugins/offest3D/offset3D.py
+++ b/cad_designer/cq_plugins/offest3D/offset3D.py
@@ -14,7 +14,6 @@ def offset3D(self: Workplane, offset: float, tol=1e-3, join_mode: Literal["arc",
 
     if perform_simple:
         maker.PerformBySimple(solid.wrapped, offset)
-        of_shape = maker.Shape()
     else:
         jm = GeomAbs_Arc
         if join_mode == "intersection":

--- a/cad_designer/cq_plugins/segmentToEdge/segmentToEdge.py
+++ b/cad_designer/cq_plugins/segmentToEdge/segmentToEdge.py
@@ -1,4 +1,6 @@
-from typing import Tuple, TypeVar, Optional, Literal, Union, cast as tcast
+from __future__ import annotations
+
+from typing import TypeVar, Literal, cast as tcast
 from multimethod import multimethod
 
 from cadquery.occ_impl.shapes import Edge
@@ -8,7 +10,7 @@ from scipy.spatial.transform import Rotation as R
 
 T = TypeVar("T", bound="Sketch")
 Modes = Literal["a", "s", "i", "c"]  # add, subtract, intersect, construct
-Point = Union[Vector, Tuple[Union[int, float], Union[int, float]]]
+Point = Vector | tuple[int | float, int | float]
 
 def _line(p1, p2):
     A = (p1[1] - p2[1])
@@ -41,7 +43,7 @@ def _line_segments_intersection(edge: Edge, v1: Point, v2: Point) -> Edge:
     return Edge.makeLine(v1, Vector(I))
 
 
-def _intersect_to_edge(self: T, v1: Vector, v2: Vector, edge: Edge, tag: Optional[str], forConstruction: bool) -> T:
+def _intersect_to_edge(self: T, v1: Vector, v2: Vector, edge: Edge, tag: str | None, forConstruction: bool) -> T:
     """Shared intersection logic for all segmentToEdge overloads."""
     if edge.geomType() == "LINE":
         val = _line_segments_intersection(edge, v1, v2)
@@ -52,7 +54,7 @@ def _intersect_to_edge(self: T, v1: Vector, v2: Vector, edge: Edge, tag: Optiona
     return self.edge(val, tag, forConstruction)
 
 
-def _angle_to_direction(angle: Union[float, int], v1: Vector) -> Vector:
+def _angle_to_direction(angle: float | int, v1: Vector) -> Vector:
     """Convert an angle (degrees from +x) to a target vector relative to v1."""
     r = R.from_euler("z", angle, degrees=True)
     direction = Vector(tuple(r.apply((10.0, 0.0, 0.0))))
@@ -60,7 +62,7 @@ def _angle_to_direction(angle: Union[float, int], v1: Vector) -> Vector:
 
 
 @multimethod
-def segmentToEdge(self: T, point: Point, direction: Point, end_tag: str, tag: Optional[str] = None, forConstruction: bool = False) -> T:
+def segmentToEdge(self: T, point: Point, direction: Point, end_tag: str, tag: str | None = None, forConstruction: bool = False) -> T:
     """
     Construction of a segment that stops at the given tagged end edge.
     Starting at the given point.
@@ -77,7 +79,7 @@ def segmentToEdge(self: T, point: Point, direction: Point, end_tag: str, tag: Op
     return _intersect_to_edge(self, v1, v2, edge, tag, forConstruction)
 
 @segmentToEdge.register
-def segmentToEdge(self: T, point: Point, angle: Union[float, int], end_tag: str, tag: Optional[str] = None,
+def segmentToEdge(self: T, point: Point, angle: float | int, end_tag: str, tag: str | None = None,
                      forConstruction: bool = False
                      ) -> T:
     """
@@ -97,7 +99,7 @@ def segmentToEdge(self: T, point: Point, angle: Union[float, int], end_tag: str,
 
 @segmentToEdge.register
 def segmentToEdge(
-        self: T, direction: Point, end_tag: str, tag: Optional[str] = None, forConstruction: bool = False
+        self: T, direction: Point, end_tag: str, tag: str | None = None, forConstruction: bool = False
 ) -> T:
     """
     Construction of a segment that stops at the given tagged end edge.
@@ -115,7 +117,7 @@ def segmentToEdge(
 
 @segmentToEdge.register
 def segmentToEdge(
-        self: T, start_tag: str, direction: Point, end_tag: str, tag: Optional[str] = None,
+        self: T, start_tag: str, direction: Point, end_tag: str, tag: str | None = None,
         forConstruction: bool = False) -> T:
     """
     Construction of a segment that stops at the given tagged end edge.
@@ -135,7 +137,7 @@ def segmentToEdge(
 
 @segmentToEdge.register
 def segmentToEdge(
-        self: T, angle: Union[float, int], end_tag: str, tag: Optional[str] = None, forConstruction: bool = False) -> T:
+        self: T, angle: float | int, end_tag: str, tag: str | None = None, forConstruction: bool = False) -> T:
     """
     Construction of a segment that stops at the given tagged end edge.
     Starting at the end point of the last edge.
@@ -152,7 +154,7 @@ def segmentToEdge(
 
 @segmentToEdge.register
 def segmentToEdge(
-        self: T, start_tag: str, angle: Union[float, int], end_tag: str, tag: Optional[str] = None,
+        self: T, start_tag: str, angle: float | int, end_tag: str, tag: str | None = None,
         forConstruction: bool = False
 ) -> T:
     """
@@ -172,7 +174,7 @@ def segmentToEdge(
 
 @segmentToEdge.register
 def segmentToEdge(
-        self: T, start_tag: str, r: Union[float, int], end_tag: str, s: Union[float, int], tag: Optional[str] = None,
+        self: T, start_tag: str, r: float | int, end_tag: str, s: float | int, tag: str | None = None,
         forConstruction: bool = False) -> T:
     """
     Construction of a segment between two edges.
@@ -197,7 +199,7 @@ def segmentToEdge(
     return self.edge(val, tag, forConstruction)
 
 @segmentToEdge.register
-def segmentToEdge(self: T, end_tag: str, s: Union[float, int], point: Point, tag: Optional[str] = None, forConstruction: bool = False) -> T:
+def segmentToEdge(self: T, end_tag: str, s: float | int, point: Point, tag: str | None = None, forConstruction: bool = False) -> T:
     """
     Construction of a segment between the point and a point on an edge segment defined by end_tag and s as
     the path parameter.

--- a/cad_designer/cq_plugins/sew_fix_shape/sew_fix_shape.py
+++ b/cad_designer/cq_plugins/sew_fix_shape/sew_fix_shape.py
@@ -13,7 +13,6 @@ def sewAndFixShape(self: Workplane) -> Workplane:
 
     exp_shell = TopExp_Explorer()
     make_solid = BRepBuilderAPI_MakeSolid()
-    # make_solid = TopOpeBRepBuild_ShellToSolid()
 
     exp_shell.Init(sewed_shape, TopAbs_SHELL)
     while exp_shell.More():

--- a/cad_designer/cq_plugins/wing/airfoil.py
+++ b/cad_designer/cq_plugins/wing/airfoil.py
@@ -1,7 +1,5 @@
 from io import StringIO
 
-#import numpy as np
-#import aerosandbox.numpy as np
 import numpy as np
 import matplotlib.pyplot as plt
 import requests
@@ -32,57 +30,6 @@ def reparameterize_airfoil(airfoil_data, M):
     complete = list(reversed(_upper)) + _lower[1:]
     return [ (p.x, p.y) for p in complete]
 
-from typing import Callable
-from scipy import interpolate
-
-# def _reparameterize_airfoil(
-#     airfoil_data: list[tuple[float, float]],
-#     n_points_per_side: int = 100,
-#     spacing_function_per_side: Callable[[float, float, int], np.ndarray] = np.cosspace,
-# ) -> list[tuple[float, float]]:
-#     airfoil_data = np.array(airfoil_data)
-#     unique_array = np.array(list({tuple(row): None for row in map(tuple, airfoil_data)}.keys()))
-#     amin = int(np.argmin(unique_array[:, 0]))  # Leading Edge = min x
-#
-#     upper = unique_array[: amin + 1][::-1]  # reverse to go from TE -> LE
-#     lower = unique_array[amin:]            # LE -> TE
-#
-#     def resample_side(points: np.ndarray, spacing_fn: Callable, side: str) -> np.ndarray:
-#         distances = np.linalg.norm(np.diff(points, axis=0), axis=1)
-#         cumulative_distances = np.concatenate(([0], np.cumsum(distances)))
-#
-#         bc_type_a = (2, (0, 0)) if side == "upper" else (1, (0, -1))
-#         bc_type_b = (1, (0, -1)) if side == "upper" else (2, (0, 0))
-#
-#         try:
-#             spline = interpolate.CubicSpline(
-#                 x=cumulative_distances,
-#                 y=points,
-#                 axis=0,
-#                 bc_type=(bc_type_a, bc_type_b)
-#             )
-#
-#             resampled = spline(spacing_fn(0, cumulative_distances[-1], n_points_per_side))
-#         except ValueError as e:
-#             if not (
-#                     (np.all(np.diff(cumulative_distances)) > 0)
-#             ):
-#                 raise ValueError(
-#                     f"It looks like your Airfoil has a duplicate point at the '{side}' side. Try removing the duplicate point and "
-#                     "re-running Airfoil.repanel()."
-#                 )
-#             else:
-#                 raise e
-#
-#         return resampled, cumulative_distances
-#
-#     upper_resampled, uppder_cd = resample_side(upper, spacing_function_per_side, "upper")
-#     lower_resampled, lower_cd = resample_side(lower, spacing_function_per_side, "lower")
-#
-#     # Remove duplicate LE point from lower
-#     combined = np.vstack([upper_resampled, lower_resampled[1:]])
-#     return [tuple(p) for p in combined]
-
 def plot_airfoil(original_points, scaled_points, offset_points, normals, scaled_normals):
     original_points = np.array(original_points)
     scaled_points = np.array(scaled_points)
@@ -93,10 +40,6 @@ def plot_airfoil(original_points, scaled_points, offset_points, normals, scaled_
     fig, axs = plt.subplots(2, 1, figsize=(40, 10))
 
     axs[0].plot(original_points[:, 0], original_points[:, 1], 'bo-', label="Original Airfoil", markersize=5)
-    #axs[0].plot(offset_points[:, 0], offset_points[:, 1], 'r*-', label="Offset Airfoil", markersize=4)
-    #axs[0].quiver(original_points[:, 0], original_points[:, 1],
-    #              -normals[:, 0]*0.1, -normals[:, 1]*0.1,
-    #              angles='xy', scale_units='xy', scale=1, color='g', label="Normals")
     axs[0].set_aspect('equal', adjustable='box')
     axs[0].legend(loc='center left', bbox_to_anchor=(1, 0.5))
     axs[0].set_xlabel("x")
@@ -132,8 +75,6 @@ def airfoil(self: cq.Workplane, selig_file: str, chord: float, offset: float = 0
 
     if number_interpolation_points is not None:
         scaled_points = reparameterize_airfoil(scaled_points, number_interpolation_points)
-
-    #plot_airfoil(af_point_list, scale_points(point_list, chord), scaled_points, None, None)
 
     plane = self.plane
     new_plane = cq.Plane(xDir=plane.xDir, origin=(0, 0, 0), normal=plane.zDir)
@@ -199,9 +140,6 @@ if __name__ == "__main__":
                    offset=0.42,
                    number_interpolation_points = 201,
                    forConstruction= True)
-    # Run the tests
-    #unittest.main(argv=['first-arg-is-ignored'], exit=False)
-
     chord = 185
     # Visualize the airfoil with the increased offset using rg15 data
     original_points = rg15_data
@@ -217,8 +155,6 @@ if __name__ == "__main__":
     scaled_points = scale_points(reparameterized_points, chord)
     scaled_normals = calculate_normals(scaled_points)
 
-    #offset_points = apply_offset(reparameterized_points, normals, 0.42/chord)
-    #offset_points = repair_offset_profile(offset_points, reparameterized_points)
     scaled_offset_points = scale_points(offset_points, chord)
 
 


### PR DESCRIPTION
## Summary

- Resolves ~77 mechanical SonarQube issues across 24 files in `cad_designer/`
- Zero logic changes -- purely syntactic/stylistic cleanup
- All 613 fast tests pass with no regressions

### Rules fixed

| Rule | Count | Description |
|------|-------|-------------|
| S6546 | ~20 | `Optional[X]` / `Union[X,Y]` -> `X \| None` / `X \| Y` with `from __future__ import annotations` |
| S125 | ~15 | Removed commented-out code blocks |
| S1481 | 2 | Prefixed unused locals with `_` |
| S2772 | ~12 | Removed unneeded `pass` statements |
| S7498 | 5 | `dict(key=val)` -> `{"key": val}` literals |
| S8521 | 2 | Removed unnecessary `.keys()` calls |
| S7504 | 1 | Removed unnecessary `list()` wrapper |
| S1854 | 2 | Removed dead assignments |
| S3457 | 1 | Removed `f` prefix from f-string without placeholders |
| S1186 | 3 | Added comments to empty setter methods |

### Files changed (24)

All in `cad_designer/` -- topology classes, creators, CQ plugins, and aerosandbox converters.

## Test plan

- [x] `poetry run pytest -m "not slow" --tb=no -q` -- 613 passed, 0 failures
- [ ] SonarQube quality gate on PR branch

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)