### PR TITLE
test(gh-287): Wave 2 — cover medium-gap services

### DIFF
--- a/app/tests/test_design_version_service.py
+++ b/app/tests/test_design_version_service.py
@@ -1,0 +1,620 @@
+"""Tests for app.services.design_version_service.
+
+Covers all public CRUD functions, internal helpers (_compute_diff,
+_diff_lists, serialization), and error paths (NotFoundError, DB errors).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.core.exceptions import InternalError, NotFoundError
+from app.models.aeroplanemodel import (
+    AeroplaneModel,
+    DesignVersionModel,
+    MissionObjectivesModel,
+    WeightItemModel,
+)
+from app.schemas.design_version import (
+    DesignVersionCreate,
+    DesignVersionDiff,
+    DesignVersionRead,
+    DesignVersionSummary,
+)
+from app.services.design_version_service import (
+    _build_snapshot,
+    _compute_diff,
+    _diff_lists,
+    _get_aeroplane,
+    _get_version,
+    _serialize_fuselage,
+    _serialize_mission_objectives,
+    _serialize_weight_items,
+    _serialize_wing,
+    create_version,
+    delete_version,
+    diff_versions,
+    get_version,
+    list_versions,
+)
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────
+
+
+def _make_mock_aeroplane(
+    *,
+    aeroplane_id: int = 1,
+    aeroplane_uuid: uuid.UUID | None = None,
+    name: str = "test-plane",
+    total_mass_kg: float | None = 5.0,
+    xyz_ref: list[float] | None = None,
+    wings: list | None = None,
+    fuselages: list | None = None,
+    mission_objectives: Any = None,
+    weight_items: list | None = None,
+    design_versions: list | None = None,
+) -> MagicMock:
+    ap = MagicMock(spec=AeroplaneModel)
+    ap.id = aeroplane_id
+    ap.uuid = aeroplane_uuid or uuid.uuid4()
+    ap.name = name
+    ap.total_mass_kg = total_mass_kg
+    ap.xyz_ref = xyz_ref or [0.0, 0.0, 0.0]
+    ap.wings = wings or []
+    ap.fuselages = fuselages or []
+    ap.mission_objectives = mission_objectives
+    ap.weight_items = weight_items or []
+    ap.design_versions = design_versions or []
+    return ap
+
+
+def _make_mock_version(
+    *,
+    version_id: int = 10,
+    label: str = "v1",
+    description: str | None = None,
+    parent_version_id: int | None = None,
+    snapshot: dict | None = None,
+    created_at: datetime | None = None,
+) -> MagicMock:
+    ver = MagicMock(spec=DesignVersionModel)
+    ver.id = version_id
+    ver.label = label
+    ver.description = description
+    ver.parent_version_id = parent_version_id
+    ver.snapshot = snapshot or {"name": "test"}
+    ver.created_at = created_at or datetime.now(timezone.utc)
+    return ver
+
+
+def _make_mock_xsec(columns: dict[str, Any], wing_id: int = 1) -> MagicMock:
+    """Create a mock cross-section with __table__.columns support."""
+    xsec = MagicMock()
+    xsec.sort_index = columns.get("sort_index", 0)
+
+    # Build mock columns
+    mock_cols = []
+    for col_name in columns:
+        col = MagicMock()
+        col.name = col_name
+        mock_cols.append(col)
+    # Add the excluded columns so the filter logic is exercised
+    for excluded in ("id", "wing_id"):
+        col = MagicMock()
+        col.name = excluded
+        mock_cols.append(col)
+
+    xsec.__table__ = MagicMock()
+    xsec.__table__.columns = mock_cols
+
+    # Make getattr work for each column
+    for col_name, val in columns.items():
+        setattr(xsec, col_name, val)
+    xsec.id = 99
+    xsec.wing_id = wing_id
+    return xsec
+
+
+def _make_mock_fuselage_xsec(columns: dict[str, Any], fuselage_id: int = 1) -> MagicMock:
+    xsec = MagicMock()
+    xsec.sort_index = columns.get("sort_index", 0)
+
+    mock_cols = []
+    for col_name in columns:
+        col = MagicMock()
+        col.name = col_name
+        mock_cols.append(col)
+    for excluded in ("id", "fuselage_id"):
+        col = MagicMock()
+        col.name = excluded
+        mock_cols.append(col)
+
+    xsec.__table__ = MagicMock()
+    xsec.__table__.columns = mock_cols
+
+    for col_name, val in columns.items():
+        setattr(xsec, col_name, val)
+    xsec.id = 99
+    xsec.fuselage_id = fuselage_id
+    return xsec
+
+
+# ── _get_aeroplane ─────────────────────────────────────────────────────
+
+
+class TestGetAeroplane:
+    def test_found(self):
+        mock_db = MagicMock()
+        ap = _make_mock_aeroplane()
+        mock_db.query.return_value.filter.return_value.first.return_value = ap
+        result = _get_aeroplane(mock_db, ap.uuid)
+        assert result is ap
+
+    def test_not_found_raises(self):
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+        with pytest.raises(NotFoundError) as exc_info:
+            _get_aeroplane(mock_db, uuid.uuid4())
+        assert "Aeroplane" in str(exc_info.value)
+
+
+# ── _get_version ────────────────────────────────────────────────────────
+
+
+class TestGetVersion:
+    def test_found(self):
+        v1 = _make_mock_version(version_id=1)
+        v2 = _make_mock_version(version_id=2)
+        ap = _make_mock_aeroplane(design_versions=[v1, v2])
+        assert _get_version(ap, 2) is v2
+
+    def test_not_found_raises(self):
+        ap = _make_mock_aeroplane(design_versions=[])
+        with pytest.raises(NotFoundError) as exc_info:
+            _get_version(ap, 999)
+        assert "DesignVersion" in str(exc_info.value)
+
+
+# ── Serialization helpers ──────────────────────────────────────────────
+
+
+class TestSerializeWing:
+    def test_basic_wing(self):
+        xsec = _make_mock_xsec({
+            "sort_index": 0,
+            "chord": 0.3,
+            "twist": 2.0,
+            "airfoil": "naca0012",
+        })
+        wing = MagicMock()
+        wing.name = "main_wing"
+        wing.symmetric = True
+        wing.x_secs = [xsec]
+
+        result = _serialize_wing(wing)
+        assert result["name"] == "main_wing"
+        assert result["symmetric"] is True
+        assert len(result["x_secs"]) == 1
+        xs = result["x_secs"][0]
+        assert xs["sort_index"] == 0
+        assert xs["chord"] == 0.3
+        assert xs["twist"] == 2.0
+        assert xs["airfoil"] == "naca0012"
+        # Excluded columns must not appear
+        assert "id" not in xs
+        assert "wing_id" not in xs
+
+    def test_empty_xsecs(self):
+        wing = MagicMock()
+        wing.name = "bare_wing"
+        wing.symmetric = False
+        wing.x_secs = []
+        result = _serialize_wing(wing)
+        assert result["x_secs"] == []
+
+
+class TestSerializeFuselage:
+    def test_basic_fuselage(self):
+        xsec = _make_mock_fuselage_xsec({
+            "sort_index": 0,
+            "radius": 0.1,
+        })
+        fus = MagicMock()
+        fus.name = "main_fus"
+        fus.x_secs = [xsec]
+
+        result = _serialize_fuselage(fus)
+        assert result["name"] == "main_fus"
+        assert len(result["x_secs"]) == 1
+        assert "id" not in result["x_secs"][0]
+        assert "fuselage_id" not in result["x_secs"][0]
+
+
+class TestSerializeMissionObjectives:
+    def test_none_returns_none(self):
+        assert _serialize_mission_objectives(None) is None
+
+    def test_with_objectives(self):
+        obj = MagicMock(spec=MissionObjectivesModel)
+        col_payload = MagicMock()
+        col_payload.name = "payload_kg"
+        col_id = MagicMock()
+        col_id.name = "id"
+        col_ap = MagicMock()
+        col_ap.name = "aeroplane_id"
+        obj.__table__ = MagicMock()
+        obj.__table__.columns = [col_id, col_ap, col_payload]
+        obj.payload_kg = 2.5
+
+        result = _serialize_mission_objectives(obj)
+        assert result == {"payload_kg": 2.5}
+        assert "id" not in result
+        assert "aeroplane_id" not in result
+
+
+class TestSerializeWeightItems:
+    def test_empty_list(self):
+        assert _serialize_weight_items([]) == []
+
+    def test_with_items(self):
+        item = MagicMock(spec=WeightItemModel)
+        col_id = MagicMock()
+        col_id.name = "id"
+        col_ap = MagicMock()
+        col_ap.name = "aeroplane_id"
+        col_name = MagicMock()
+        col_name.name = "name"
+        col_mass = MagicMock()
+        col_mass.name = "mass_kg"
+        item.__table__ = MagicMock()
+        item.__table__.columns = [col_id, col_ap, col_name, col_mass]
+        item.name = "battery"
+        item.mass_kg = 0.5
+
+        result = _serialize_weight_items([item])
+        assert len(result) == 1
+        assert result[0] == {"name": "battery", "mass_kg": 0.5}
+
+
+class TestBuildSnapshot:
+    def test_full_snapshot(self):
+        wing = MagicMock()
+        wing.name = "w1"
+        wing.symmetric = True
+        wing.x_secs = []
+
+        fus = MagicMock()
+        fus.name = "f1"
+        fus.x_secs = []
+
+        ap = _make_mock_aeroplane(
+            name="my-plane",
+            total_mass_kg=3.0,
+            xyz_ref=[0.1, 0.2, 0.3],
+            wings=[wing],
+            fuselages=[fus],
+            mission_objectives=None,
+            weight_items=[],
+        )
+
+        result = _build_snapshot(ap)
+        assert result["name"] == "my-plane"
+        assert result["total_mass_kg"] == 3.0
+        assert result["xyz_ref"] == [0.1, 0.2, 0.3]
+        assert len(result["wings"]) == 1
+        assert len(result["fuselages"]) == 1
+        assert result["mission_objectives"] is None
+        assert result["weight_items"] == []
+
+
+# ── list_versions ──────────────────────────────────────────────────────
+
+
+class TestListVersions:
+    def test_returns_summaries(self):
+        mock_db = MagicMock()
+        now = datetime.now(timezone.utc)
+        v1 = _make_mock_version(version_id=1, label="v1", created_at=now)
+        v2 = _make_mock_version(version_id=2, label="v2", created_at=now)
+        ap = _make_mock_aeroplane(design_versions=[v1, v2])
+        mock_db.query.return_value.filter.return_value.first.return_value = ap
+
+        result = list_versions(mock_db, ap.uuid)
+        assert len(result) == 2
+        assert all(isinstance(s, DesignVersionSummary) for s in result)
+        assert result[0].label == "v1"
+        assert result[1].label == "v2"
+
+    def test_empty_list(self):
+        mock_db = MagicMock()
+        ap = _make_mock_aeroplane(design_versions=[])
+        mock_db.query.return_value.filter.return_value.first.return_value = ap
+
+        result = list_versions(mock_db, ap.uuid)
+        assert result == []
+
+    def test_aeroplane_not_found(self):
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+        with pytest.raises(NotFoundError):
+            list_versions(mock_db, uuid.uuid4())
+
+
+# ── create_version ─────────────────────────────────────────────────────
+
+
+class TestCreateVersion:
+    def test_success(self):
+        mock_db = MagicMock()
+        now = datetime.now(timezone.utc)
+        ap = _make_mock_aeroplane(
+            wings=[], fuselages=[], weight_items=[], mission_objectives=None
+        )
+        mock_db.query.return_value.filter.return_value.first.return_value = ap
+
+        # After commit + refresh, the version object should have an id and created_at
+        def fake_refresh(obj):
+            obj.id = 42
+            obj.created_at = now
+            obj.parent_version_id = None
+
+        mock_db.refresh.side_effect = fake_refresh
+
+        data = DesignVersionCreate(label="snapshot-1", description="first version")
+        result = create_version(mock_db, ap.uuid, data)
+
+        assert isinstance(result, DesignVersionSummary)
+        assert result.id == 42
+        assert result.label == "snapshot-1"
+        assert result.description == "first version"
+        mock_db.add.assert_called_once()
+        mock_db.commit.assert_called_once()
+
+    def test_aeroplane_not_found(self):
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+        data = DesignVersionCreate(label="x")
+        with pytest.raises(NotFoundError):
+            create_version(mock_db, uuid.uuid4(), data)
+
+    def test_db_error_rolls_back(self):
+        mock_db = MagicMock()
+        ap = _make_mock_aeroplane(
+            wings=[], fuselages=[], weight_items=[], mission_objectives=None
+        )
+        mock_db.query.return_value.filter.return_value.first.return_value = ap
+        mock_db.commit.side_effect = SQLAlchemyError("disk full")
+
+        data = DesignVersionCreate(label="boom")
+        with pytest.raises(InternalError, match="Database error"):
+            create_version(mock_db, ap.uuid, data)
+        mock_db.rollback.assert_called_once()
+
+
+# ── get_version ─────────────────────────────────────────────────────────
+
+
+class TestGetVersion:
+    def test_success(self):
+        mock_db = MagicMock()
+        now = datetime.now(timezone.utc)
+        snap = {"name": "plane", "wings": []}
+        ver = _make_mock_version(version_id=5, label="v5", snapshot=snap, created_at=now)
+        ap = _make_mock_aeroplane(design_versions=[ver])
+        mock_db.query.return_value.filter.return_value.first.return_value = ap
+
+        result = get_version(mock_db, ap.uuid, 5)
+        assert isinstance(result, DesignVersionRead)
+        assert result.id == 5
+        assert result.snapshot == snap
+
+    def test_aeroplane_not_found(self):
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+        with pytest.raises(NotFoundError):
+            get_version(mock_db, uuid.uuid4(), 1)
+
+    def test_version_not_found(self):
+        mock_db = MagicMock()
+        ap = _make_mock_aeroplane(design_versions=[])
+        mock_db.query.return_value.filter.return_value.first.return_value = ap
+        with pytest.raises(NotFoundError):
+            get_version(mock_db, ap.uuid, 999)
+
+
+# ── delete_version ──────────────────────────────────────────────────────
+
+
+class TestDeleteVersion:
+    def test_success(self):
+        mock_db = MagicMock()
+        ver = _make_mock_version(version_id=7)
+        ap = _make_mock_aeroplane(design_versions=[ver])
+        mock_db.query.return_value.filter.return_value.first.return_value = ap
+
+        delete_version(mock_db, ap.uuid, 7)
+        mock_db.delete.assert_called_once_with(ver)
+        mock_db.commit.assert_called_once()
+
+    def test_aeroplane_not_found(self):
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+        with pytest.raises(NotFoundError):
+            delete_version(mock_db, uuid.uuid4(), 1)
+
+    def test_version_not_found(self):
+        mock_db = MagicMock()
+        ap = _make_mock_aeroplane(design_versions=[])
+        mock_db.query.return_value.filter.return_value.first.return_value = ap
+        with pytest.raises(NotFoundError):
+            delete_version(mock_db, ap.uuid, 1)
+
+    def test_db_error_rolls_back(self):
+        mock_db = MagicMock()
+        ver = _make_mock_version(version_id=7)
+        ap = _make_mock_aeroplane(design_versions=[ver])
+        mock_db.query.return_value.filter.return_value.first.return_value = ap
+        mock_db.commit.side_effect = SQLAlchemyError("lock timeout")
+
+        with pytest.raises(InternalError, match="Database error"):
+            delete_version(mock_db, ap.uuid, 7)
+        mock_db.rollback.assert_called_once()
+
+
+# ── diff_versions ──────────────────────────────────────────────────────
+
+
+class TestDiffVersions:
+    def test_identical_snapshots(self):
+        mock_db = MagicMock()
+        snap = {"name": "same", "mass": 5.0}
+        v1 = _make_mock_version(version_id=1, snapshot=snap)
+        v2 = _make_mock_version(version_id=2, snapshot=dict(snap))  # copy
+        ap = _make_mock_aeroplane(design_versions=[v1, v2])
+        mock_db.query.return_value.filter.return_value.first.return_value = ap
+
+        result = diff_versions(mock_db, ap.uuid, 1, 2)
+        assert isinstance(result, DesignVersionDiff)
+        assert result.version_a == 1
+        assert result.version_b == 2
+        assert result.changes == []
+
+    def test_with_changes(self):
+        mock_db = MagicMock()
+        snap_a = {"name": "old", "mass": 5.0}
+        snap_b = {"name": "new", "mass": 5.0}
+        v1 = _make_mock_version(version_id=1, snapshot=snap_a)
+        v2 = _make_mock_version(version_id=2, snapshot=snap_b)
+        ap = _make_mock_aeroplane(design_versions=[v1, v2])
+        mock_db.query.return_value.filter.return_value.first.return_value = ap
+
+        result = diff_versions(mock_db, ap.uuid, 1, 2)
+        assert len(result.changes) == 1
+        assert result.changes[0]["path"] == "name"
+        assert result.changes[0]["type"] == "changed"
+
+    def test_version_not_found(self):
+        mock_db = MagicMock()
+        v1 = _make_mock_version(version_id=1)
+        ap = _make_mock_aeroplane(design_versions=[v1])
+        mock_db.query.return_value.filter.return_value.first.return_value = ap
+        with pytest.raises(NotFoundError):
+            diff_versions(mock_db, ap.uuid, 1, 999)
+
+
+# ── _compute_diff ──────────────────────────────────────────────────────
+
+
+class TestComputeDiff:
+    def test_no_changes(self):
+        assert _compute_diff({"a": 1}, {"a": 1}) == []
+
+    def test_changed_value(self):
+        changes = _compute_diff({"x": 1}, {"x": 2})
+        assert len(changes) == 1
+        assert changes[0] == {"path": "x", "type": "changed", "old": 1, "new": 2}
+
+    def test_added_key(self):
+        changes = _compute_diff({}, {"new_key": 42})
+        assert len(changes) == 1
+        assert changes[0] == {"path": "new_key", "type": "added", "value": 42}
+
+    def test_removed_key(self):
+        changes = _compute_diff({"old_key": 42}, {})
+        assert len(changes) == 1
+        assert changes[0] == {"path": "old_key", "type": "removed", "value": 42}
+
+    def test_nested_dict_diff(self):
+        a = {"outer": {"inner": 1}}
+        b = {"outer": {"inner": 2}}
+        changes = _compute_diff(a, b)
+        assert len(changes) == 1
+        assert changes[0]["path"] == "outer.inner"
+        assert changes[0]["type"] == "changed"
+
+    def test_nested_list_diff(self):
+        a = {"items": [1, 2]}
+        b = {"items": [1, 3]}
+        changes = _compute_diff(a, b)
+        assert len(changes) == 1
+        assert changes[0]["path"] == "items[1]"
+        assert changes[0]["old"] == 2
+        assert changes[0]["new"] == 3
+
+    def test_multiple_changes_sorted_by_key(self):
+        a = {"b": 1, "a": 2}
+        b = {"b": 10, "a": 20}
+        changes = _compute_diff(a, b)
+        assert len(changes) == 2
+        # Keys are sorted: "a" before "b"
+        assert changes[0]["path"] == "a"
+        assert changes[1]["path"] == "b"
+
+    def test_prefix_propagation(self):
+        changes = _compute_diff({"k": 1}, {"k": 2}, prefix="root")
+        assert changes[0]["path"] == "root.k"
+
+    def test_none_to_value_is_added(self):
+        changes = _compute_diff({"k": None}, {"k": 42})
+        assert changes[0]["type"] == "added"
+        assert changes[0]["value"] == 42
+
+    def test_value_to_none_is_removed(self):
+        changes = _compute_diff({"k": 42}, {"k": None})
+        assert changes[0]["type"] == "removed"
+        assert changes[0]["value"] == 42
+
+    def test_both_none_no_change(self):
+        assert _compute_diff({"k": None}, {"k": None}) == []
+
+
+# ── _diff_lists ─────────────────────────────────────────────────────────
+
+
+class TestDiffLists:
+    def test_identical_lists(self):
+        assert _diff_lists([1, 2, 3], [1, 2, 3], "items") == []
+
+    def test_changed_element(self):
+        changes = _diff_lists([1], [2], "arr")
+        assert changes == [{"path": "arr[0]", "type": "changed", "old": 1, "new": 2}]
+
+    def test_added_element(self):
+        changes = _diff_lists([], [99], "arr")
+        assert changes == [{"path": "arr[0]", "type": "added", "value": 99}]
+
+    def test_removed_element(self):
+        changes = _diff_lists([99], [], "arr")
+        assert changes == [{"path": "arr[0]", "type": "removed", "value": 99}]
+
+    def test_nested_dict_in_list(self):
+        a = [{"x": 1}]
+        b = [{"x": 2}]
+        changes = _diff_lists(a, b, "items")
+        assert len(changes) == 1
+        assert changes[0]["path"] == "items[0].x"
+
+    def test_mixed_lengths(self):
+        a = [10, 20]
+        b = [10, 20, 30, 40]
+        changes = _diff_lists(a, b, "arr")
+        assert len(changes) == 2
+        assert changes[0]["path"] == "arr[2]"
+        assert changes[0]["type"] == "added"
+        assert changes[1]["path"] == "arr[3]"
+
+    def test_both_empty(self):
+        assert _diff_lists([], [], "arr") == []
+
+    def test_longer_a_than_b(self):
+        changes = _diff_lists([1, 2, 3], [1], "arr")
+        assert len(changes) == 2
+        assert changes[0] == {"path": "arr[1]", "type": "removed", "value": 2}
+        assert changes[1] == {"path": "arr[2]", "type": "removed", "value": 3}

--- a/app/tests/test_fuselage_endpoints_extended.py
+++ b/app/tests/test_fuselage_endpoints_extended.py
@@ -1,0 +1,787 @@
+"""Extended integration tests for fuselage and fuselage cross-section endpoints.
+
+Covers paths not exercised by the existing unit-mock tests in
+test_aeroplane_fuselage_endpoints.py and
+test_aeroplane_fuselage_cross_section_endpoints.py.
+
+Uses the shared ``client_and_db`` fixture so requests flow through the
+full FastAPI stack (routing, validation, DB) rather than calling
+endpoint functions directly with mock objects.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.tests.conftest import make_aeroplane, make_fuselage
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _xsec(xyz=None, a=0.5, b=0.4, n=2.0):
+    """Return a valid FuselageXSecSuperEllipseSchema dict."""
+    return {"xyz": xyz or [0.0, 0.0, 0.0], "a": a, "b": b, "n": n}
+
+
+def _fuselage_body(name="fus", x_secs=None):
+    """Return a valid FuselageSchema dict (min 2 cross-sections)."""
+    if x_secs is None:
+        x_secs = [
+            _xsec([0.0, 0.0, 0.0]),
+            _xsec([0.0, 1.0, 0.0]),
+        ]
+    return {"name": name, "x_secs": x_secs}
+
+
+# ---------------------------------------------------------------------------
+# GET /aeroplanes/{id}/fuselages  (list fuselage names)
+# ---------------------------------------------------------------------------
+
+class TestGetAeroplaneFuselages:
+    """Cover get_aeroplane_fuselages endpoint."""
+
+    def test_list_fuselages_empty(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        resp = client.get(f"/aeroplanes/{ap_uuid}/fuselages")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_list_fuselages_returns_names(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+            make_fuselage(s, aeroplane_id=ap.id, name="fus_a")
+            make_fuselage(s, aeroplane_id=ap.id, name="fus_b")
+
+        resp = client.get(f"/aeroplanes/{ap_uuid}/fuselages")
+        assert resp.status_code == 200
+        names = resp.json()
+        assert set(names) == {"fus_a", "fus_b"}
+
+    def test_list_fuselages_aeroplane_not_found(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.get(f"/aeroplanes/{uuid.uuid4()}/fuselages")
+        assert resp.status_code == 404
+
+    def test_list_fuselages_invalid_uuid(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.get("/aeroplanes/not-a-uuid/fuselages")
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# PUT /aeroplanes/{id}/fuselages/{name}  (create)
+# ---------------------------------------------------------------------------
+
+class TestCreateFuselage:
+    """Cover create_aeroplane_fuselage endpoint."""
+
+    def test_create_fuselage_success(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        body = _fuselage_body("new_fus")
+        resp = client.put(f"/aeroplanes/{ap_uuid}/fuselages/new_fus", json=body)
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["status"] == "created"
+        assert data["operation"] == "create_aeroplane_fuselage"
+
+        # Verify it shows up in the list
+        list_resp = client.get(f"/aeroplanes/{ap_uuid}/fuselages")
+        assert "new_fus" in list_resp.json()
+
+    def test_create_fuselage_aeroplane_not_found(self, client_and_db):
+        client, _ = client_and_db
+        body = _fuselage_body("fus")
+        resp = client.put(f"/aeroplanes/{uuid.uuid4()}/fuselages/fus", json=body)
+        assert resp.status_code == 404
+
+    def test_create_fuselage_duplicate_name_conflict(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        body = _fuselage_body("dup")
+        resp1 = client.put(f"/aeroplanes/{ap_uuid}/fuselages/dup", json=body)
+        assert resp1.status_code == 201
+
+        # Second create with same name -> 409
+        resp2 = client.put(f"/aeroplanes/{ap_uuid}/fuselages/dup", json=body)
+        assert resp2.status_code == 409
+
+    def test_create_fuselage_invalid_body(self, client_and_db):
+        """Missing required x_secs field -> 422."""
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        resp = client.put(f"/aeroplanes/{ap_uuid}/fuselages/fus", json={"name": "fus"})
+        assert resp.status_code == 422
+
+    def test_create_fuselage_too_few_xsecs(self, client_and_db):
+        """x_secs has min_length=2, sending 1 should fail validation."""
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        body = _fuselage_body("fus", x_secs=[_xsec()])
+        resp = client.put(f"/aeroplanes/{ap_uuid}/fuselages/fus", json=body)
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# POST /aeroplanes/{id}/fuselages/{name}  (update)
+# ---------------------------------------------------------------------------
+
+class TestUpdateFuselage:
+    """Cover update_aeroplane_fuselage endpoint."""
+
+    def test_update_fuselage_success(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        body = _fuselage_body("upd")
+        client.put(f"/aeroplanes/{ap_uuid}/fuselages/upd", json=body)
+
+        updated_body = _fuselage_body("upd", x_secs=[
+            _xsec([0, 0, 0], a=1.0),
+            _xsec([0, 2, 0], a=1.5),
+        ])
+        resp = client.post(f"/aeroplanes/{ap_uuid}/fuselages/upd", json=updated_body)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["operation"] == "update_aeroplane_fuselage"
+
+    def test_update_fuselage_aeroplane_not_found(self, client_and_db):
+        client, _ = client_and_db
+        body = _fuselage_body("fus")
+        resp = client.post(f"/aeroplanes/{uuid.uuid4()}/fuselages/fus", json=body)
+        assert resp.status_code == 404
+
+    def test_update_fuselage_fuselage_not_found(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        body = _fuselage_body("ghost")
+        resp = client.post(f"/aeroplanes/{ap_uuid}/fuselages/ghost", json=body)
+        assert resp.status_code == 404
+
+    def test_update_fuselage_invalid_body(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        resp = client.post(f"/aeroplanes/{ap_uuid}/fuselages/x", json={})
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /aeroplanes/{id}/fuselages/{name}  (get single)
+# ---------------------------------------------------------------------------
+
+class TestGetFuselage:
+    """Cover get_aeroplane_fuselage endpoint."""
+
+    def test_get_fuselage_success(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        body = _fuselage_body("read_me")
+        client.put(f"/aeroplanes/{ap_uuid}/fuselages/read_me", json=body)
+
+        resp = client.get(f"/aeroplanes/{ap_uuid}/fuselages/read_me")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "read_me"
+        assert len(data["x_secs"]) == 2
+
+    def test_get_fuselage_aeroplane_not_found(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.get(f"/aeroplanes/{uuid.uuid4()}/fuselages/any")
+        assert resp.status_code == 404
+
+    def test_get_fuselage_fuselage_not_found(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        resp = client.get(f"/aeroplanes/{ap_uuid}/fuselages/nonexistent")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /aeroplanes/{id}/fuselages/{name}
+# ---------------------------------------------------------------------------
+
+class TestDeleteFuselage:
+    """Cover delete_aeroplane_fuselage endpoint."""
+
+    def test_delete_fuselage_success(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        body = _fuselage_body("del_me")
+        client.put(f"/aeroplanes/{ap_uuid}/fuselages/del_me", json=body)
+
+        resp = client.delete(f"/aeroplanes/{ap_uuid}/fuselages/del_me")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+
+        # Confirm it's gone
+        list_resp = client.get(f"/aeroplanes/{ap_uuid}/fuselages")
+        assert "del_me" not in list_resp.json()
+
+    def test_delete_fuselage_aeroplane_not_found(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.delete(f"/aeroplanes/{uuid.uuid4()}/fuselages/any")
+        assert resp.status_code == 404
+
+    def test_delete_fuselage_fuselage_not_found(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        resp = client.delete(f"/aeroplanes/{ap_uuid}/fuselages/nonexistent")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /aeroplanes/{id}/fuselages/{name}/cross_sections  (list)
+# ---------------------------------------------------------------------------
+
+class TestGetFuselageCrossSections:
+    """Cover get_aeroplane_fuselage_cross_sections via HTTP."""
+
+    def test_list_cross_sections_success(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        body = _fuselage_body("cs_list")
+        client.put(f"/aeroplanes/{ap_uuid}/fuselages/cs_list", json=body)
+
+        resp = client.get(f"/aeroplanes/{ap_uuid}/fuselages/cs_list/cross_sections")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+        assert "a" in data[0]
+        assert "b" in data[0]
+
+    def test_list_cross_sections_aeroplane_not_found(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.get(f"/aeroplanes/{uuid.uuid4()}/fuselages/x/cross_sections")
+        assert resp.status_code == 404
+
+    def test_list_cross_sections_fuselage_not_found(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        resp = client.get(f"/aeroplanes/{ap_uuid}/fuselages/nope/cross_sections")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /aeroplanes/{id}/fuselages/{name}/cross_sections  (delete all)
+# ---------------------------------------------------------------------------
+
+class TestDeleteAllCrossSections:
+    """Cover delete_aeroplane_fuselage_cross_sections via HTTP."""
+
+    def test_delete_all_cross_sections_success(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        body = _fuselage_body("cs_del_all")
+        client.put(f"/aeroplanes/{ap_uuid}/fuselages/cs_del_all", json=body)
+
+        resp = client.delete(f"/aeroplanes/{ap_uuid}/fuselages/cs_del_all/cross_sections")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+        # Verify they're gone
+        list_resp = client.get(f"/aeroplanes/{ap_uuid}/fuselages/cs_del_all/cross_sections")
+        assert list_resp.status_code == 200
+        assert list_resp.json() == []
+
+    def test_delete_all_cross_sections_aeroplane_not_found(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.delete(f"/aeroplanes/{uuid.uuid4()}/fuselages/x/cross_sections")
+        assert resp.status_code == 404
+
+    def test_delete_all_cross_sections_fuselage_not_found(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        resp = client.delete(f"/aeroplanes/{ap_uuid}/fuselages/nope/cross_sections")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET .../cross_sections/{index}  (get single)
+# ---------------------------------------------------------------------------
+
+class TestGetSingleCrossSection:
+    """Cover get_aeroplane_fuselage_cross_section via HTTP."""
+
+    def test_get_cross_section_by_index(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        body = _fuselage_body("cs_get", x_secs=[
+            _xsec([0, 0, 0], a=0.1),
+            _xsec([0, 1, 0], a=0.2),
+        ])
+        client.put(f"/aeroplanes/{ap_uuid}/fuselages/cs_get", json=body)
+
+        resp = client.get(f"/aeroplanes/{ap_uuid}/fuselages/cs_get/cross_sections/0")
+        assert resp.status_code == 200
+        assert resp.json()["a"] == pytest.approx(0.1)
+
+        resp1 = client.get(f"/aeroplanes/{ap_uuid}/fuselages/cs_get/cross_sections/1")
+        assert resp1.status_code == 200
+        assert resp1.json()["a"] == pytest.approx(0.2)
+
+    def test_get_cross_section_index_out_of_range(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        body = _fuselage_body("cs_oor")
+        client.put(f"/aeroplanes/{ap_uuid}/fuselages/cs_oor", json=body)
+
+        resp = client.get(f"/aeroplanes/{ap_uuid}/fuselages/cs_oor/cross_sections/99")
+        assert resp.status_code == 404
+
+    def test_get_cross_section_negative_index(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        body = _fuselage_body("cs_neg")
+        client.put(f"/aeroplanes/{ap_uuid}/fuselages/cs_neg", json=body)
+
+        resp = client.get(f"/aeroplanes/{ap_uuid}/fuselages/cs_neg/cross_sections/-1")
+        assert resp.status_code == 404
+
+    def test_get_cross_section_aeroplane_not_found(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.get(f"/aeroplanes/{uuid.uuid4()}/fuselages/x/cross_sections/0")
+        assert resp.status_code == 404
+
+    def test_get_cross_section_fuselage_not_found(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        resp = client.get(f"/aeroplanes/{ap_uuid}/fuselages/nope/cross_sections/0")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST .../cross_sections/{index}  (create / splice)
+# ---------------------------------------------------------------------------
+
+class TestCreateCrossSection:
+    """Cover create_aeroplane_fuselage_cross_section via HTTP."""
+
+    def test_create_cross_section_append(self, client_and_db):
+        """Index -1 appends to the end."""
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        body = _fuselage_body("cs_app")
+        client.put(f"/aeroplanes/{ap_uuid}/fuselages/cs_app", json=body)
+
+        new_xs = _xsec([0, 5, 0], a=0.9)
+        resp = client.post(
+            f"/aeroplanes/{ap_uuid}/fuselages/cs_app/cross_sections/-1",
+            json=new_xs,
+        )
+        assert resp.status_code == 201
+        assert resp.json()["status"] == "created"
+
+        # Confirm 3 cross-sections now
+        list_resp = client.get(f"/aeroplanes/{ap_uuid}/fuselages/cs_app/cross_sections")
+        assert len(list_resp.json()) == 3
+
+    def test_create_cross_section_insert_at_start(self, client_and_db):
+        """Index 0 inserts at the beginning."""
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        body = _fuselage_body("cs_ins0")
+        client.put(f"/aeroplanes/{ap_uuid}/fuselages/cs_ins0", json=body)
+
+        new_xs = _xsec([0, -1, 0], a=0.01)
+        resp = client.post(
+            f"/aeroplanes/{ap_uuid}/fuselages/cs_ins0/cross_sections/0",
+            json=new_xs,
+        )
+        assert resp.status_code == 201
+
+        # The new xsec should be at index 0
+        get_resp = client.get(f"/aeroplanes/{ap_uuid}/fuselages/cs_ins0/cross_sections/0")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["a"] == pytest.approx(0.01)
+
+    def test_create_cross_section_insert_at_middle(self, client_and_db):
+        """Index 1 inserts between existing 0 and 1."""
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        body = _fuselage_body("cs_mid", x_secs=[
+            _xsec([0, 0, 0], a=0.1),
+            _xsec([0, 2, 0], a=0.3),
+        ])
+        client.put(f"/aeroplanes/{ap_uuid}/fuselages/cs_mid", json=body)
+
+        new_xs = _xsec([0, 1, 0], a=0.2)
+        resp = client.post(
+            f"/aeroplanes/{ap_uuid}/fuselages/cs_mid/cross_sections/1",
+            json=new_xs,
+        )
+        assert resp.status_code == 201
+
+        # 3 xsecs total, middle one has a=0.2
+        list_resp = client.get(f"/aeroplanes/{ap_uuid}/fuselages/cs_mid/cross_sections")
+        xsecs = list_resp.json()
+        assert len(xsecs) == 3
+        assert xsecs[1]["a"] == pytest.approx(0.2)
+
+    def test_create_cross_section_beyond_end(self, client_and_db):
+        """Index >= len(existing) appends (same as -1)."""
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        body = _fuselage_body("cs_big")
+        client.put(f"/aeroplanes/{ap_uuid}/fuselages/cs_big", json=body)
+
+        new_xs = _xsec([0, 99, 0], a=9.9)
+        resp = client.post(
+            f"/aeroplanes/{ap_uuid}/fuselages/cs_big/cross_sections/999",
+            json=new_xs,
+        )
+        assert resp.status_code == 201
+
+        list_resp = client.get(f"/aeroplanes/{ap_uuid}/fuselages/cs_big/cross_sections")
+        assert len(list_resp.json()) == 3
+
+    def test_create_cross_section_aeroplane_not_found(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.post(
+            f"/aeroplanes/{uuid.uuid4()}/fuselages/x/cross_sections/0",
+            json=_xsec(),
+        )
+        assert resp.status_code == 404
+
+    def test_create_cross_section_fuselage_not_found(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        resp = client.post(
+            f"/aeroplanes/{ap_uuid}/fuselages/nope/cross_sections/0",
+            json=_xsec(),
+        )
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# PUT .../cross_sections/{index}  (update single)
+# ---------------------------------------------------------------------------
+
+class TestUpdateCrossSection:
+    """Cover update_aeroplane_fuselage_cross_section via HTTP."""
+
+    def test_update_cross_section_success(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        body = _fuselage_body("cs_upd")
+        client.put(f"/aeroplanes/{ap_uuid}/fuselages/cs_upd", json=body)
+
+        updated = _xsec([0, 0, 0], a=9.9, b=8.8, n=3.0)
+        resp = client.put(
+            f"/aeroplanes/{ap_uuid}/fuselages/cs_upd/cross_sections/0",
+            json=updated,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+        # Verify the update took effect
+        get_resp = client.get(f"/aeroplanes/{ap_uuid}/fuselages/cs_upd/cross_sections/0")
+        assert get_resp.json()["a"] == pytest.approx(9.9)
+
+    def test_update_cross_section_index_out_of_range(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        body = _fuselage_body("cs_upd_oor")
+        client.put(f"/aeroplanes/{ap_uuid}/fuselages/cs_upd_oor", json=body)
+
+        resp = client.put(
+            f"/aeroplanes/{ap_uuid}/fuselages/cs_upd_oor/cross_sections/99",
+            json=_xsec(),
+        )
+        assert resp.status_code == 404
+
+    def test_update_cross_section_negative_index(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        body = _fuselage_body("cs_upd_neg")
+        client.put(f"/aeroplanes/{ap_uuid}/fuselages/cs_upd_neg", json=body)
+
+        resp = client.put(
+            f"/aeroplanes/{ap_uuid}/fuselages/cs_upd_neg/cross_sections/-1",
+            json=_xsec(),
+        )
+        assert resp.status_code == 404
+
+    def test_update_cross_section_aeroplane_not_found(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.put(
+            f"/aeroplanes/{uuid.uuid4()}/fuselages/x/cross_sections/0",
+            json=_xsec(),
+        )
+        assert resp.status_code == 404
+
+    def test_update_cross_section_fuselage_not_found(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        resp = client.put(
+            f"/aeroplanes/{ap_uuid}/fuselages/nope/cross_sections/0",
+            json=_xsec(),
+        )
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE .../cross_sections/{index}  (delete single)
+# ---------------------------------------------------------------------------
+
+class TestDeleteSingleCrossSection:
+    """Cover delete_aeroplane_fuselage_cross_section via HTTP."""
+
+    def test_delete_cross_section_success(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        body = _fuselage_body("cs_del", x_secs=[
+            _xsec([0, 0, 0], a=0.1),
+            _xsec([0, 1, 0], a=0.2),
+            _xsec([0, 2, 0], a=0.3),
+        ])
+        client.put(f"/aeroplanes/{ap_uuid}/fuselages/cs_del", json=body)
+
+        # Delete the middle one (index 1)
+        resp = client.delete(f"/aeroplanes/{ap_uuid}/fuselages/cs_del/cross_sections/1")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+        # Verify 2 remain and sort_index is contiguous
+        list_resp = client.get(f"/aeroplanes/{ap_uuid}/fuselages/cs_del/cross_sections")
+        xsecs = list_resp.json()
+        assert len(xsecs) == 2
+        assert xsecs[0]["a"] == pytest.approx(0.1)
+        assert xsecs[1]["a"] == pytest.approx(0.3)
+
+    def test_delete_cross_section_first(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        body = _fuselage_body("cs_del0", x_secs=[
+            _xsec([0, 0, 0], a=0.1),
+            _xsec([0, 1, 0], a=0.2),
+            _xsec([0, 2, 0], a=0.3),
+        ])
+        client.put(f"/aeroplanes/{ap_uuid}/fuselages/cs_del0", json=body)
+
+        resp = client.delete(f"/aeroplanes/{ap_uuid}/fuselages/cs_del0/cross_sections/0")
+        assert resp.status_code == 200
+
+        list_resp = client.get(f"/aeroplanes/{ap_uuid}/fuselages/cs_del0/cross_sections")
+        xsecs = list_resp.json()
+        assert len(xsecs) == 2
+        assert xsecs[0]["a"] == pytest.approx(0.2)
+
+    def test_delete_cross_section_last(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        body = _fuselage_body("cs_del_last", x_secs=[
+            _xsec([0, 0, 0], a=0.1),
+            _xsec([0, 1, 0], a=0.2),
+            _xsec([0, 2, 0], a=0.3),
+        ])
+        client.put(f"/aeroplanes/{ap_uuid}/fuselages/cs_del_last", json=body)
+
+        resp = client.delete(f"/aeroplanes/{ap_uuid}/fuselages/cs_del_last/cross_sections/2")
+        assert resp.status_code == 200
+
+        list_resp = client.get(f"/aeroplanes/{ap_uuid}/fuselages/cs_del_last/cross_sections")
+        xsecs = list_resp.json()
+        assert len(xsecs) == 2
+        assert xsecs[1]["a"] == pytest.approx(0.2)
+
+    def test_delete_cross_section_index_out_of_range(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        body = _fuselage_body("cs_del_oor")
+        client.put(f"/aeroplanes/{ap_uuid}/fuselages/cs_del_oor", json=body)
+
+        resp = client.delete(f"/aeroplanes/{ap_uuid}/fuselages/cs_del_oor/cross_sections/99")
+        assert resp.status_code == 404
+
+    def test_delete_cross_section_negative_index(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        body = _fuselage_body("cs_del_neg")
+        client.put(f"/aeroplanes/{ap_uuid}/fuselages/cs_del_neg", json=body)
+
+        resp = client.delete(f"/aeroplanes/{ap_uuid}/fuselages/cs_del_neg/cross_sections/-1")
+        assert resp.status_code == 404
+
+    def test_delete_cross_section_aeroplane_not_found(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.delete(f"/aeroplanes/{uuid.uuid4()}/fuselages/x/cross_sections/0")
+        assert resp.status_code == 404
+
+    def test_delete_cross_section_fuselage_not_found(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        resp = client.delete(f"/aeroplanes/{ap_uuid}/fuselages/nope/cross_sections/0")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# End-to-end CRUD sequence
+# ---------------------------------------------------------------------------
+
+class TestFuselageCrudSequence:
+    """Full CRUD lifecycle in a single test to verify state transitions."""
+
+    def test_full_lifecycle(self, client_and_db):
+        client, Session = client_and_db
+        with Session() as s:
+            ap = make_aeroplane(s)
+            ap_uuid = str(ap.uuid)
+
+        # 1. Create
+        body = _fuselage_body("lifecycle", x_secs=[
+            _xsec([0, 0, 0], a=0.5),
+            _xsec([0, 1, 0], a=0.6),
+        ])
+        create_resp = client.put(f"/aeroplanes/{ap_uuid}/fuselages/lifecycle", json=body)
+        assert create_resp.status_code == 201
+
+        # 2. Read back
+        get_resp = client.get(f"/aeroplanes/{ap_uuid}/fuselages/lifecycle")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["name"] == "lifecycle"
+
+        # 3. Update
+        updated = _fuselage_body("lifecycle", x_secs=[
+            _xsec([0, 0, 0], a=1.0),
+            _xsec([0, 2, 0], a=1.5),
+        ])
+        update_resp = client.post(f"/aeroplanes/{ap_uuid}/fuselages/lifecycle", json=updated)
+        assert update_resp.status_code == 200
+
+        # 4. Verify update
+        get2 = client.get(f"/aeroplanes/{ap_uuid}/fuselages/lifecycle")
+        assert get2.json()["x_secs"][0]["a"] == pytest.approx(1.0)
+
+        # 5. Add a cross-section
+        add_resp = client.post(
+            f"/aeroplanes/{ap_uuid}/fuselages/lifecycle/cross_sections/-1",
+            json=_xsec([0, 3, 0], a=2.0),
+        )
+        assert add_resp.status_code == 201
+
+        # 6. Delete a cross-section
+        del_xs_resp = client.delete(
+            f"/aeroplanes/{ap_uuid}/fuselages/lifecycle/cross_sections/0",
+        )
+        assert del_xs_resp.status_code == 200
+
+        # 7. Delete the fuselage
+        del_resp = client.delete(f"/aeroplanes/{ap_uuid}/fuselages/lifecycle")
+        assert del_resp.status_code == 200
+
+        # 8. Confirm it's gone
+        gone_resp = client.get(f"/aeroplanes/{ap_uuid}/fuselages/lifecycle")
+        assert gone_resp.status_code == 404

--- a/app/tests/test_operating_point_generator_service_extended.py
+++ b/app/tests/test_operating_point_generator_service_extended.py
@@ -1,0 +1,1155 @@
+"""Extended tests for operating_point_generator_service.
+
+Covers the pure/utility functions and internal helpers that the existing
+test module does not exercise (lines 49-56, 60-63, 86, 93, 103-104,
+247-259, 289, 323-541, 551-609, 755-762, 794, 832-837).
+"""
+
+import math
+import uuid
+from types import SimpleNamespace
+from typing import Any, Optional
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.core.exceptions import InternalError, NotFoundError, ValidationError
+from app.db.base import Base
+from app.models.aeroplanemodel import AeroplaneModel
+from app.models.flightprofilemodel import RCFlightProfileModel
+from app.schemas.aeroanalysisschema import (
+    OperatingPointStatus,
+    TrimOperatingPointRequest,
+)
+from app.services.operating_point_generator_service import (
+    TrimmedPoint,
+    _apply_limit_warnings,
+    _build_target_definitions,
+    _cl_target_for_velocity,
+    _compute_trim_score,
+    _default_profile,
+    _detect_control_capabilities,
+    _estimate_reference_speeds,
+    _evaluate_trim_candidate,
+    _fallback_speeds,
+    _get_aircraft_or_raise,
+    _get_profile_or_raise,
+    _grid_search_trim,
+    _load_effective_flight_profile,
+    _pick_control_name,
+    _required_capabilities_for_target,
+    _safe_coeff,
+    _solve_trim_candidate_with_opti,
+    _trim_or_estimate_point,
+    _validate_target_capability,
+    generate_default_set_for_aircraft,
+    trim_operating_point_for_aircraft,
+)
+
+
+# ------------------------------------------------------------------ #
+# Fixtures
+# ------------------------------------------------------------------ #
+
+@pytest.fixture()
+def db_session():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(
+        bind=engine, autocommit=False, autoflush=False, class_=Session
+    )
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+def _make_profile(db: Session, **overrides) -> RCFlightProfileModel:
+    defaults = dict(
+        name="test_profile",
+        type="trainer",
+        environment={"altitude_m": 0, "wind_mps": 0},
+        goals={
+            "cruise_speed_mps": 18,
+            "max_level_speed_mps": 28,
+            "min_speed_margin_vs_clean": 1.20,
+            "takeoff_speed_margin_vs_to": 1.25,
+            "approach_speed_margin_vs_ldg": 1.30,
+            "target_turn_n": 2.0,
+            "loiter_s": 600,
+        },
+        handling={},
+        constraints={"max_alpha_deg": 25, "max_beta_deg": 30},
+    )
+    defaults.update(overrides)
+    profile = RCFlightProfileModel(**defaults)
+    db.add(profile)
+    db.flush()
+    return profile
+
+
+def _make_aircraft(
+    db: Session,
+    *,
+    flight_profile_id: Optional[int] = None,
+    total_mass_kg: Optional[float] = None,
+) -> AeroplaneModel:
+    aircraft = AeroplaneModel(
+        name="test-plane",
+        uuid=uuid.uuid4(),
+        flight_profile_id=flight_profile_id,
+        total_mass_kg=total_mass_kg,
+    )
+    db.add(aircraft)
+    db.commit()
+    return aircraft
+
+
+def _mock_airplane_with_controls(*control_names: str) -> SimpleNamespace:
+    control_surfaces = [SimpleNamespace(name=n) for n in control_names]
+    return SimpleNamespace(
+        xyz_ref=[0, 0, 0],
+        s_ref=1.0,
+        wings=[SimpleNamespace(xsecs=[SimpleNamespace(control_surfaces=control_surfaces)])],
+    )
+
+
+def _fake_trim(*_, target, **__):
+    return TrimmedPoint(
+        name=target["name"],
+        description=f"mocked {target['name']}",
+        config=target["config"],
+        velocity=float(target["velocity"]),
+        altitude=float(target["altitude"]),
+        alpha_rad=0.05,
+        beta_rad=0.0,
+        p=0.0,
+        q=0.0,
+        r=0.0,
+        status=OperatingPointStatus.TRIMMED,
+        warnings=[],
+        controls={},
+    )
+
+
+# ================================================================== #
+# _safe_coeff  (lines 49-56)
+# ================================================================== #
+
+
+class TestSafeCoeff:
+    def test_none_value_returns_default(self):
+        assert _safe_coeff({"x": None}, "x") == 0.0
+        assert _safe_coeff({"x": None}, "x", default=5.0) == 5.0
+
+    def test_missing_key_returns_default(self):
+        assert _safe_coeff({}, "x") == 0.0
+        assert _safe_coeff({}, "x", default=-1.0) == -1.0
+
+    def test_scalar_float(self):
+        assert _safe_coeff({"CL": 1.23}, "CL") == pytest.approx(1.23)
+
+    def test_scalar_int(self):
+        assert _safe_coeff({"CL": 3}, "CL") == pytest.approx(3.0)
+
+    def test_numpy_scalar(self):
+        assert _safe_coeff({"CL": np.float64(2.5)}, "CL") == pytest.approx(2.5)
+
+    def test_numpy_1d_array(self):
+        assert _safe_coeff({"CL": np.array([4.2, 5.0])}, "CL") == pytest.approx(4.2)
+
+    def test_numpy_empty_array_returns_default(self):
+        assert _safe_coeff({"CL": np.array([])}, "CL") == 0.0
+        assert _safe_coeff({"CL": np.array([])}, "CL", default=9.9) == pytest.approx(9.9)
+
+    def test_numpy_2d_array_ravel(self):
+        arr = np.array([[7.7, 8.8]])
+        assert _safe_coeff({"x": arr}, "x") == pytest.approx(7.7)
+
+
+# ================================================================== #
+# _compute_trim_score  (lines 60-63)
+# ================================================================== #
+
+
+class TestComputeTrimScore:
+    def test_no_cl_target(self):
+        score = _compute_trim_score(cm=0.1, cy=0.2, cl=0.5, cl_target=None)
+        assert score == pytest.approx(abs(0.1) + 0.5 * abs(0.2))
+
+    def test_with_cl_target(self):
+        score = _compute_trim_score(cm=0.0, cy=0.0, cl=1.0, cl_target=0.8)
+        assert score == pytest.approx(0.3 * abs(1.0 - 0.8))
+
+    def test_all_zero(self):
+        assert _compute_trim_score(0, 0, 0, 0) == pytest.approx(0.0)
+
+
+# ================================================================== #
+# _get_aircraft_or_raise / _get_profile_or_raise  (lines 83-94)
+# ================================================================== #
+
+
+class TestGetOrRaise:
+    def test_aircraft_found(self, db_session):
+        aircraft = _make_aircraft(db_session)
+        result = _get_aircraft_or_raise(db_session, aircraft.uuid)
+        assert result.id == aircraft.id
+
+    def test_aircraft_not_found_raises(self, db_session):
+        with pytest.raises(NotFoundError):
+            _get_aircraft_or_raise(db_session, uuid.uuid4())
+
+    def test_profile_found(self, db_session):
+        profile = _make_profile(db_session)
+        result = _get_profile_or_raise(db_session, profile.id)
+        assert result.id == profile.id
+
+    def test_profile_not_found_raises(self, db_session):
+        with pytest.raises(NotFoundError):
+            _get_profile_or_raise(db_session, 99999)
+
+
+# ================================================================== #
+# _load_effective_flight_profile  (lines 97-120)
+# ================================================================== #
+
+
+class TestLoadEffectiveFlightProfile:
+    def test_profile_override(self, db_session):
+        profile = _make_profile(db_session, name="override_profile")
+        aircraft = _make_aircraft(db_session)
+        data, pid = _load_effective_flight_profile(db_session, aircraft, profile.id)
+        assert pid == profile.id
+        assert data["name"] == "override_profile"
+
+    def test_aircraft_assigned_profile(self, db_session):
+        profile = _make_profile(db_session, name="assigned")
+        aircraft = _make_aircraft(db_session, flight_profile_id=profile.id)
+        data, pid = _load_effective_flight_profile(db_session, aircraft)
+        assert pid == profile.id
+        assert data["name"] == "assigned"
+
+    def test_default_profile_fallback(self, db_session):
+        aircraft = _make_aircraft(db_session)
+        data, pid = _load_effective_flight_profile(db_session, aircraft)
+        assert pid is None
+        assert data["name"] == "default_profile"
+
+
+# ================================================================== #
+# _fallback_speeds  (lines 247-251)
+# ================================================================== #
+
+
+class TestFallbackSpeeds:
+    def test_max_level_speed_decreasing_factors(self):
+        speeds = _fallback_speeds("max_level_speed", 20.0)
+        assert len(speeds) == 4
+        assert speeds[0] == pytest.approx(20.0)
+        assert speeds[1] == pytest.approx(19.0)
+        assert speeds[2] == pytest.approx(18.0)
+        assert speeds[3] == pytest.approx(17.0)
+
+    def test_other_name_increasing_factors(self):
+        speeds = _fallback_speeds("cruise", 10.0)
+        assert len(speeds) == 4
+        assert speeds[0] == pytest.approx(10.0)
+        assert speeds[1] == pytest.approx(10.5)
+        assert speeds[2] == pytest.approx(11.0)
+        assert speeds[3] == pytest.approx(11.5)
+
+    def test_minimum_speed_clamp(self):
+        speeds = _fallback_speeds("stall_near_clean", 1.0)
+        # All should be >= 2.0
+        for s in speeds:
+            assert s >= 2.0
+
+
+# ================================================================== #
+# _pick_control_name  (lines 255-259)
+# ================================================================== #
+
+
+class TestPickControlName:
+    def test_finds_matching_control(self):
+        assert _pick_control_name(["Elevator_Main"], {"elevator"}) == "Elevator_Main"
+
+    def test_returns_none_when_no_match(self):
+        assert _pick_control_name(["Flap_Left"], {"elevator"}) is None
+
+    def test_case_insensitive(self):
+        assert _pick_control_name(["RUDDER_1"], {"rudder"}) == "RUDDER_1"
+
+    def test_empty_list(self):
+        assert _pick_control_name([], {"elevator"}) is None
+
+    def test_first_match_wins(self):
+        result = _pick_control_name(["elevon_left", "elevator_right"], {"elevon", "elevator"})
+        assert result == "elevon_left"
+
+
+# ================================================================== #
+# _detect_control_capabilities  (lines 262-284)
+# ================================================================== #
+
+
+class TestDetectControlCapabilities:
+    def test_with_elevator(self):
+        airplane = _mock_airplane_with_controls("elevator")
+        caps = _detect_control_capabilities(airplane)
+        assert caps["has_pitch_control"] is True
+        assert caps["has_roll_control"] is False
+        assert caps["has_yaw_control"] is False
+        assert "elevator" in caps["available_controls"]
+
+    def test_with_aileron_and_rudder(self):
+        airplane = _mock_airplane_with_controls("aileron", "rudder")
+        caps = _detect_control_capabilities(airplane)
+        assert caps["has_pitch_control"] is False
+        assert caps["has_roll_control"] is True
+        assert caps["has_yaw_control"] is True
+
+    def test_with_elevon(self):
+        airplane = _mock_airplane_with_controls("elevon_left")
+        caps = _detect_control_capabilities(airplane)
+        assert caps["has_pitch_control"] is True
+        assert caps["has_roll_control"] is True
+
+    def test_no_controls(self):
+        airplane = _mock_airplane_with_controls()
+        caps = _detect_control_capabilities(airplane)
+        assert caps["has_pitch_control"] is False
+        assert caps["has_roll_control"] is False
+        assert caps["has_yaw_control"] is False
+        assert caps["available_controls"] == []
+
+    def test_no_wings(self):
+        airplane = SimpleNamespace(wings=[])
+        caps = _detect_control_capabilities(airplane)
+        assert caps["available_controls"] == []
+
+    def test_no_xsecs(self):
+        airplane = SimpleNamespace(wings=[SimpleNamespace(xsecs=[])])
+        caps = _detect_control_capabilities(airplane)
+        assert caps["available_controls"] == []
+
+    def test_empty_name_skipped(self):
+        airplane = SimpleNamespace(
+            wings=[SimpleNamespace(xsecs=[SimpleNamespace(control_surfaces=[SimpleNamespace(name="")])])]
+        )
+        caps = _detect_control_capabilities(airplane)
+        assert caps["available_controls"] == []
+
+    def test_wings_attr_none(self):
+        airplane = SimpleNamespace(wings=None)
+        caps = _detect_control_capabilities(airplane)
+        assert caps["available_controls"] == []
+
+
+# ================================================================== #
+# _required_capabilities_for_target  (line 289)
+# ================================================================== #
+
+
+class TestRequiredCapabilitiesForTarget:
+    def test_turn_n2(self):
+        assert _required_capabilities_for_target("turn_n2") == {"has_roll_control|has_yaw_control"}
+
+    def test_dutch_role_start(self):
+        assert _required_capabilities_for_target("dutch_role_start") == {"has_yaw_control"}
+
+    def test_cruise_empty(self):
+        assert _required_capabilities_for_target("cruise") == set()
+
+    def test_unknown_empty(self):
+        assert _required_capabilities_for_target("something_else") == set()
+
+
+# ================================================================== #
+# _validate_target_capability  (lines 295-310)
+# ================================================================== #
+
+
+class TestValidateTargetCapability:
+    def test_turn_n2_with_roll_control(self):
+        ok, missing = _validate_target_capability(
+            {"name": "turn_n2"},
+            {"has_roll_control": True, "has_yaw_control": False},
+        )
+        assert ok is True
+        assert missing == ""
+
+    def test_turn_n2_with_yaw_control(self):
+        ok, missing = _validate_target_capability(
+            {"name": "turn_n2"},
+            {"has_roll_control": False, "has_yaw_control": True},
+        )
+        assert ok is True
+
+    def test_turn_n2_without_controls(self):
+        ok, missing = _validate_target_capability(
+            {"name": "turn_n2"},
+            {"has_roll_control": False, "has_yaw_control": False},
+        )
+        assert ok is False
+        assert "has_roll_control|has_yaw_control" in missing
+
+    def test_dutch_role_without_yaw(self):
+        ok, missing = _validate_target_capability(
+            {"name": "dutch_role_start"},
+            {"has_yaw_control": False},
+        )
+        assert ok is False
+        assert "has_yaw_control" in missing
+
+    def test_dutch_role_with_yaw(self):
+        ok, _ = _validate_target_capability(
+            {"name": "dutch_role_start"},
+            {"has_yaw_control": True},
+        )
+        assert ok is True
+
+    def test_cruise_always_valid(self):
+        ok, _ = _validate_target_capability({"name": "cruise"}, {})
+        assert ok is True
+
+
+# ================================================================== #
+# _cl_target_for_velocity  (lines 464-469)
+# ================================================================== #
+
+
+class TestClTargetForVelocity:
+    def test_valid_computation(self):
+        result = _cl_target_for_velocity(
+            candidate_velocity_mps=20.0,
+            total_mass_kg=5.0,
+            s_ref=0.5,
+            rho=1.225,
+            n_target=1.0,
+        )
+        q_dyn = 0.5 * 1.225 * 20.0**2
+        expected = (5.0 * 9.81 * 1.0) / (q_dyn * 0.5)
+        assert result == pytest.approx(expected)
+
+    def test_no_mass_returns_none(self):
+        assert _cl_target_for_velocity(20.0, None, 0.5, 1.225, 1.0) is None
+        assert _cl_target_for_velocity(20.0, 0.0, 0.5, 1.225, 1.0) is None
+
+    def test_zero_s_ref_returns_none(self):
+        assert _cl_target_for_velocity(20.0, 5.0, 0.0, 1.225, 1.0) is None
+        assert _cl_target_for_velocity(20.0, 5.0, -1.0, 1.225, 1.0) is None
+
+    def test_n_target_scaling(self):
+        r1 = _cl_target_for_velocity(20.0, 5.0, 0.5, 1.225, 1.0)
+        r2 = _cl_target_for_velocity(20.0, 5.0, 0.5, 1.225, 2.0)
+        assert r2 == pytest.approx(2.0 * r1)
+
+
+# ================================================================== #
+# _apply_limit_warnings  (lines 525-541)
+# ================================================================== #
+
+
+class TestApplyLimitWarnings:
+    def test_trimmed(self):
+        warnings: list[str] = []
+        status = _apply_limit_warnings(5.0, 0.0, 0.1, {"max_alpha_deg": 25}, warnings)
+        assert status == OperatingPointStatus.TRIMMED
+        assert warnings == []
+
+    def test_not_trimmed(self):
+        warnings: list[str] = []
+        status = _apply_limit_warnings(5.0, 0.0, 0.5, {}, warnings)
+        assert status == OperatingPointStatus.NOT_TRIMMED
+        assert "NOT_TRIMMED" in warnings
+
+    def test_alpha_limit_reached(self):
+        warnings: list[str] = []
+        status = _apply_limit_warnings(30.0, 0.0, 0.1, {"max_alpha_deg": 25}, warnings)
+        assert status == OperatingPointStatus.LIMIT_REACHED
+        assert "ALPHA_LIMIT_REACHED" in warnings
+
+    def test_beta_limit_reached(self):
+        warnings: list[str] = []
+        status = _apply_limit_warnings(5.0, 35.0, 0.1, {"max_beta_deg": 30}, warnings)
+        assert status == OperatingPointStatus.LIMIT_REACHED
+        assert "BETA_LIMIT_REACHED" in warnings
+
+    def test_both_limits_reached(self):
+        warnings: list[str] = []
+        status = _apply_limit_warnings(
+            30.0, 35.0, 0.5,
+            {"max_alpha_deg": 25, "max_beta_deg": 30},
+            warnings,
+        )
+        assert status == OperatingPointStatus.LIMIT_REACHED
+        assert "NOT_TRIMMED" in warnings
+        assert "ALPHA_LIMIT_REACHED" in warnings
+        assert "BETA_LIMIT_REACHED" in warnings
+
+    def test_no_constraint_keys(self):
+        warnings: list[str] = []
+        status = _apply_limit_warnings(30.0, 35.0, 0.1, {}, warnings)
+        assert status == OperatingPointStatus.TRIMMED
+
+
+# ================================================================== #
+# _estimate_reference_speeds
+# ================================================================== #
+
+
+class TestEstimateReferenceSpeeds:
+    def test_default_profile(self):
+        profile = _default_profile()
+        refs = _estimate_reference_speeds(profile)
+        assert refs["vs_clean"] >= 3.0
+        assert refs["vs_to"] >= 2.5
+        assert refs["vs_ldg"] >= 2.0
+
+    def test_low_margin_clamped(self):
+        profile = _default_profile()
+        profile["goals"]["min_speed_margin_vs_clean"] = 0.5  # below 1.05
+        refs = _estimate_reference_speeds(profile)
+        # min_margin_clean should be clamped to 1.05
+        cruise = 18.0
+        assert refs["vs_clean"] == pytest.approx(max(3.0, cruise / 1.05))
+
+
+# ================================================================== #
+# _build_target_definitions
+# ================================================================== #
+
+
+class TestBuildTargetDefinitions:
+    def test_returns_11_targets(self):
+        profile = _default_profile()
+        refs = _estimate_reference_speeds(profile)
+        targets = _build_target_definitions(profile, refs)
+        assert len(targets) == 11
+        names = [t["name"] for t in targets]
+        assert "cruise" in names
+        assert "dutch_role_start" in names
+        assert "turn_n2" in names
+
+    def test_altitude_propagated(self):
+        profile = _default_profile()
+        profile["environment"]["altitude_m"] = 500.0
+        refs = _estimate_reference_speeds(profile)
+        targets = _build_target_definitions(profile, refs)
+        for t in targets:
+            assert t["altitude"] == 500.0
+
+    def test_max_level_speed_fallback(self):
+        profile = _default_profile()
+        profile["goals"]["max_level_speed_mps"] = None
+        refs = _estimate_reference_speeds(profile)
+        targets = _build_target_definitions(profile, refs)
+        mls = next(t for t in targets if t["name"] == "max_level_speed")
+        cruise = 18.0
+        expected = max(1.35 * cruise, cruise + 8.0)
+        assert mls["velocity"] == pytest.approx(expected)
+
+
+# ================================================================== #
+# generate_default_set_for_aircraft — error paths (lines 755-762)
+# ================================================================== #
+
+
+class TestGenerateDefaultSetErrors:
+    def test_aircraft_not_found_raises(self, db_session):
+        with pytest.raises(NotFoundError):
+            generate_default_set_for_aircraft(db_session, uuid.uuid4())
+
+    def test_sqlalchemy_error_raises_internal(self, db_session):
+        aircraft = _make_aircraft(db_session)
+        with (
+            patch(
+                "app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async",
+                side_effect=SQLAlchemyError("db boom"),
+            ),
+        ):
+            with pytest.raises(InternalError, match="Database error"):
+                generate_default_set_for_aircraft(db_session, aircraft.uuid)
+
+    def test_generic_exception_raises_internal(self, db_session):
+        aircraft = _make_aircraft(db_session)
+        with (
+            patch(
+                "app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async",
+                side_effect=RuntimeError("unexpected"),
+            ),
+        ):
+            with pytest.raises(InternalError, match="Operating-point generation error"):
+                generate_default_set_for_aircraft(db_session, aircraft.uuid)
+
+    def test_profile_override_not_found_raises(self, db_session):
+        aircraft = _make_aircraft(db_session)
+        with pytest.raises(NotFoundError):
+            generate_default_set_for_aircraft(
+                db_session, aircraft.uuid, profile_id_override=99999
+            )
+
+
+# ================================================================== #
+# trim_operating_point_for_aircraft — error paths (lines 794, 832-837)
+# ================================================================== #
+
+
+class TestTrimOperatingPointErrors:
+    def _make_request(self, **overrides) -> TrimOperatingPointRequest:
+        defaults = dict(
+            name="test_trim",
+            config="clean",
+            velocity=20.0,
+            altitude=0.0,
+            beta_target_deg=0.0,
+            n_target=1.0,
+        )
+        defaults.update(overrides)
+        return TrimOperatingPointRequest(**defaults)
+
+    def test_aircraft_not_found(self, db_session):
+        request = self._make_request()
+        with pytest.raises(NotFoundError):
+            trim_operating_point_for_aircraft(db_session, uuid.uuid4(), request)
+
+    def test_missing_controls_raises_validation_error(self, db_session):
+        aircraft = _make_aircraft(db_session)
+        request = self._make_request(name="turn_n2")
+        with (
+            patch(
+                "app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async",
+                return_value=SimpleNamespace(),
+            ),
+            patch(
+                "app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async",
+                return_value=_mock_airplane_with_controls(),  # no controls
+            ),
+        ):
+            with pytest.raises(ValidationError, match="cannot be trimmed"):
+                trim_operating_point_for_aircraft(db_session, aircraft.uuid, request)
+
+    def test_sqlalchemy_error(self, db_session):
+        aircraft = _make_aircraft(db_session)
+        request = self._make_request()
+        with (
+            patch(
+                "app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async",
+                side_effect=SQLAlchemyError("db error"),
+            ),
+        ):
+            with pytest.raises(InternalError, match="Database error"):
+                trim_operating_point_for_aircraft(db_session, aircraft.uuid, request)
+
+    def test_generic_exception(self, db_session):
+        aircraft = _make_aircraft(db_session)
+        request = self._make_request()
+        with (
+            patch(
+                "app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            with pytest.raises(InternalError, match="Operating-point trim error"):
+                trim_operating_point_for_aircraft(db_session, aircraft.uuid, request)
+
+    def test_successful_trim_returns_result(self, db_session):
+        profile = _make_profile(db_session)
+        aircraft = _make_aircraft(db_session, flight_profile_id=profile.id)
+        request = self._make_request()
+        with (
+            patch(
+                "app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async",
+                return_value=SimpleNamespace(),
+            ),
+            patch(
+                "app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async",
+                return_value=_mock_airplane_with_controls("elevator"),
+            ),
+            patch(
+                "app.services.operating_point_generator_service._trim_or_estimate_point",
+                side_effect=_fake_trim,
+            ),
+        ):
+            result = trim_operating_point_for_aircraft(db_session, aircraft.uuid, request)
+
+        assert result.source_flight_profile_id == profile.id
+        assert result.point.name == "test_trim"
+        assert result.point.velocity == pytest.approx(20.0)
+
+
+# ================================================================== #
+# _default_profile
+# ================================================================== #
+
+
+class TestDefaultProfile:
+    def test_structure(self):
+        p = _default_profile()
+        assert p["name"] == "default_profile"
+        assert "environment" in p
+        assert "goals" in p
+        assert "constraints" in p
+        assert p["goals"]["cruise_speed_mps"] == 18.0
+
+
+# ================================================================== #
+# TrimmedPoint dataclass
+# ================================================================== #
+
+
+class TestTrimmedPoint:
+    def test_construction(self):
+        tp = TrimmedPoint(
+            name="test",
+            description="desc",
+            config="clean",
+            velocity=20.0,
+            altitude=0.0,
+            alpha_rad=0.1,
+            beta_rad=0.0,
+            p=0.0,
+            q=0.0,
+            r=0.0,
+            status=OperatingPointStatus.TRIMMED,
+            warnings=[],
+            controls={"elevator": 2.5},
+        )
+        assert tp.name == "test"
+        assert tp.controls == {"elevator": 2.5}
+
+
+# ================================================================== #
+# _solve_trim_candidate_with_opti  (lines 323-415)
+# ================================================================== #
+
+
+class TestSolveTrimCandidateWithOpti:
+    """Tests for the Opti-based trim solver.
+
+    These mock the aerosandbox Opti/AeroBuildup internals to test
+    the function's logic without running real aero computations.
+    """
+
+    def _make_target(self, name: str = "cruise") -> dict[str, Any]:
+        return {
+            "name": name,
+            "config": "clean",
+            "velocity": 20.0,
+            "altitude": 0.0,
+            "beta_target_deg": 0.0,
+            "n_target": 1.0,
+        }
+
+    def test_returns_none_on_exception(self):
+        """When anything inside raises, should return None (catch-all)."""
+        mock_airplane = MagicMock()
+        # Make with_control_deflections raise to trigger the except branch
+        mock_airplane.with_control_deflections.side_effect = RuntimeError("boom")
+
+        result = _solve_trim_candidate_with_opti(
+            asb_airplane=mock_airplane,
+            target=self._make_target(),
+            velocity_mps=20.0,
+            altitude_m=0.0,
+            beta_target_deg=0.0,
+            cl_target=0.5,
+            constraints={"max_alpha_deg": 25},
+            capabilities={"available_controls": ["elevator"]},
+        )
+        assert result is None
+
+    def test_returns_none_no_controls_and_aero_fails(self):
+        """With no controls, if AeroBuildup fails, returns None."""
+        mock_airplane = MagicMock()
+        mock_airplane.xyz_ref = [0, 0, 0]
+
+        with patch("app.services.operating_point_generator_service.asb") as mock_asb:
+            mock_asb.Opti.return_value = MagicMock()
+            mock_asb.Atmosphere.return_value = MagicMock()
+            mock_asb.OperatingPoint.return_value = MagicMock()
+            mock_asb.AeroBuildup.return_value.run_with_stability_derivatives.side_effect = (
+                RuntimeError("aero failure")
+            )
+            result = _solve_trim_candidate_with_opti(
+                asb_airplane=mock_airplane,
+                target=self._make_target(),
+                velocity_mps=20.0,
+                altitude_m=0.0,
+                beta_target_deg=0.0,
+                cl_target=None,
+                constraints={},
+                capabilities={"available_controls": []},
+            )
+        assert result is None
+
+
+# ================================================================== #
+# _evaluate_trim_candidate  (lines 427-453)
+# ================================================================== #
+
+
+class TestEvaluateTrimCandidate:
+    """Tests for the trim evaluation function using mocked ASB."""
+
+    def test_basic_evaluation(self):
+        mock_airplane = MagicMock()
+        mock_airplane.xyz_ref = [0, 0, 0]
+
+        with patch("app.services.operating_point_generator_service.asb") as mock_asb:
+            mock_asb.Atmosphere.return_value = MagicMock()
+            mock_asb.OperatingPoint.return_value = MagicMock()
+            mock_buildup = MagicMock()
+            mock_buildup.run_with_stability_derivatives.return_value = {
+                "Cm": 0.01,
+                "CL": 0.5,
+                "CY": 0.02,
+            }
+            mock_asb.AeroBuildup.return_value = mock_buildup
+
+            score, metrics = _evaluate_trim_candidate(
+                asb_airplane=mock_airplane,
+                altitude_m=0.0,
+                velocity_mps=20.0,
+                alpha_deg=5.0,
+                beta_deg=0.0,
+                cl_target=0.5,
+            )
+
+        assert isinstance(score, float)
+        assert metrics["cm"] == pytest.approx(0.01)
+        assert metrics["cl"] == pytest.approx(0.5)
+        assert metrics["cy"] == pytest.approx(0.02)
+
+    def test_with_controls(self):
+        mock_airplane = MagicMock()
+        mock_airplane.xyz_ref = [0, 0, 0]
+        mock_deflected = MagicMock()
+        mock_deflected.xyz_ref = [0, 0, 0]
+        mock_airplane.with_control_deflections.return_value = mock_deflected
+
+        with patch("app.services.operating_point_generator_service.asb") as mock_asb:
+            mock_asb.Atmosphere.return_value = MagicMock()
+            mock_asb.OperatingPoint.return_value = MagicMock()
+            mock_buildup = MagicMock()
+            mock_buildup.run_with_stability_derivatives.return_value = {
+                "Cm": 0.0,
+                "CL": 0.4,
+                "CY": 0.0,
+            }
+            mock_asb.AeroBuildup.return_value = mock_buildup
+
+            score, metrics = _evaluate_trim_candidate(
+                asb_airplane=mock_airplane,
+                altitude_m=100.0,
+                velocity_mps=25.0,
+                alpha_deg=3.0,
+                beta_deg=1.0,
+                cl_target=0.4,
+                controls={"elevator": 2.0},
+            )
+
+        mock_airplane.with_control_deflections.assert_called_once_with({"elevator": 2.0})
+        assert score == pytest.approx(0.0)
+
+    def test_no_cl_target(self):
+        mock_airplane = MagicMock()
+        mock_airplane.xyz_ref = [0, 0, 0]
+
+        with patch("app.services.operating_point_generator_service.asb") as mock_asb:
+            mock_asb.Atmosphere.return_value = MagicMock()
+            mock_asb.OperatingPoint.return_value = MagicMock()
+            mock_buildup = MagicMock()
+            mock_buildup.run_with_stability_derivatives.return_value = {
+                "Cm": 0.1,
+                "CL": 0.5,
+                "CY": 0.2,
+            }
+            mock_asb.AeroBuildup.return_value = mock_buildup
+
+            score, _ = _evaluate_trim_candidate(
+                asb_airplane=mock_airplane,
+                altitude_m=0.0,
+                velocity_mps=20.0,
+                alpha_deg=5.0,
+                beta_deg=0.0,
+                cl_target=None,
+            )
+
+        # score = abs(cm) + 0.5*abs(cy) = 0.1 + 0.1 = 0.2
+        assert score == pytest.approx(0.2)
+
+
+# ================================================================== #
+# _grid_search_trim  (lines 484-514)
+# ================================================================== #
+
+
+class TestGridSearchTrim:
+    def test_finds_best_score(self):
+        """Grid search should call _evaluate_trim_candidate and track the best."""
+        call_count = {"n": 0}
+
+        def mock_evaluate(*, asb_airplane, altitude_m, velocity_mps, alpha_deg, beta_deg, cl_target):
+            call_count["n"] += 1
+            # Return a low score for alpha near 4.0
+            score = abs(alpha_deg - 4.0) * 0.1 + 0.01
+            return score, {"cm": 0.01, "cl": 0.5, "cy": 0.0}
+
+        mock_airplane = MagicMock()
+        target = {"name": "cruise", "velocity": 20.0, "altitude": 0.0}
+
+        with patch(
+            "app.services.operating_point_generator_service._evaluate_trim_candidate",
+            side_effect=lambda **kw: mock_evaluate(**kw),
+        ):
+            best_score, best_alpha, best_beta, best_vel, best_controls = _grid_search_trim(
+                asb_airplane=mock_airplane,
+                target=target,
+                velocity=20.0,
+                altitude=0.0,
+                beta_candidates=[0.0],
+                cl_target_fn=lambda v: 0.5,
+            )
+
+        assert best_score < float("inf")
+        assert call_count["n"] > 0
+        assert best_controls == {}
+
+    def test_handles_exception_in_evaluate(self):
+        """If _evaluate_trim_candidate raises, grid search should skip."""
+        mock_airplane = MagicMock()
+        target = {"name": "cruise", "velocity": 20.0, "altitude": 0.0}
+
+        with patch(
+            "app.services.operating_point_generator_service._evaluate_trim_candidate",
+            side_effect=RuntimeError("eval failed"),
+        ):
+            best_score, best_alpha, best_beta, best_vel, best_controls = _grid_search_trim(
+                asb_airplane=mock_airplane,
+                target=target,
+                velocity=20.0,
+                altitude=0.0,
+                beta_candidates=[0.0],
+                cl_target_fn=lambda v: None,
+            )
+
+        assert best_score == float("inf")
+
+
+# ================================================================== #
+# _trim_or_estimate_point  (lines 551-609)
+# ================================================================== #
+
+
+class TestTrimOrEstimatePoint:
+    def _make_target(self, name: str = "cruise") -> dict[str, Any]:
+        return {
+            "name": name,
+            "config": "clean",
+            "velocity": 20.0,
+            "altitude": 0.0,
+            "beta_target_deg": 0.0,
+            "n_target": 1.0,
+        }
+
+    def test_opti_converges_well(self):
+        """When opti returns a good score (<0.35), grid search is skipped."""
+        mock_airplane = MagicMock()
+        mock_airplane.s_ref = 0.5
+        aircraft = MagicMock()
+        aircraft.total_mass_kg = 5.0
+
+        opti_result = {
+            "alpha_deg": 3.0,
+            "beta_deg": 0.0,
+            "score": 0.05,
+            "controls": {"elevator": 1.5},
+            "metrics": {"cm": 0.001, "cy": 0.0, "cl": 0.5},
+        }
+
+        with (
+            patch("app.services.operating_point_generator_service.asb") as mock_asb,
+            patch(
+                "app.services.operating_point_generator_service._solve_trim_candidate_with_opti",
+                return_value=opti_result,
+            ),
+            patch(
+                "app.services.operating_point_generator_service._grid_search_trim",
+            ) as mock_grid,
+        ):
+            mock_asb.Atmosphere.return_value.density.return_value = 1.225
+
+            result = _trim_or_estimate_point(
+                asb_airplane=mock_airplane,
+                aircraft=aircraft,
+                target=self._make_target(),
+                constraints={"max_alpha_deg": 25},
+                capabilities={"available_controls": ["elevator"]},
+            )
+
+        mock_grid.assert_not_called()
+        assert result.name == "cruise"
+        assert result.alpha_rad == pytest.approx(math.radians(3.0))
+        assert result.controls == {"elevator": 1.5}
+        assert result.status == OperatingPointStatus.TRIMMED
+
+    def test_opti_fails_falls_back_to_grid(self):
+        """When opti returns None, grid search is used."""
+        mock_airplane = MagicMock()
+        mock_airplane.s_ref = 0.5
+        aircraft = MagicMock()
+        aircraft.total_mass_kg = 5.0
+
+        with (
+            patch("app.services.operating_point_generator_service.asb") as mock_asb,
+            patch(
+                "app.services.operating_point_generator_service._solve_trim_candidate_with_opti",
+                return_value=None,
+            ),
+            patch(
+                "app.services.operating_point_generator_service._grid_search_trim",
+                return_value=(0.1, 5.0, 0.0, 20.0, {}),
+            ) as mock_grid,
+        ):
+            mock_asb.Atmosphere.return_value.density.return_value = 1.225
+
+            result = _trim_or_estimate_point(
+                asb_airplane=mock_airplane,
+                aircraft=aircraft,
+                target=self._make_target(),
+                constraints={"max_alpha_deg": 25},
+                capabilities={"available_controls": []},
+            )
+
+        mock_grid.assert_called_once()
+        assert result.alpha_rad == pytest.approx(math.radians(5.0))
+        assert result.status == OperatingPointStatus.TRIMMED
+
+    def test_opti_poor_score_triggers_grid(self):
+        """When opti score > 0.35, grid search is attempted."""
+        mock_airplane = MagicMock()
+        mock_airplane.s_ref = 0.5
+        aircraft = MagicMock()
+        aircraft.total_mass_kg = 5.0
+
+        opti_result = {
+            "alpha_deg": 10.0,
+            "beta_deg": 0.0,
+            "score": 0.5,
+            "controls": {},
+            "metrics": {"cm": 0.3, "cy": 0.0, "cl": 0.5},
+        }
+
+        with (
+            patch("app.services.operating_point_generator_service.asb") as mock_asb,
+            patch(
+                "app.services.operating_point_generator_service._solve_trim_candidate_with_opti",
+                return_value=opti_result,
+            ),
+            patch(
+                "app.services.operating_point_generator_service._grid_search_trim",
+                return_value=(0.2, 4.0, 0.0, 20.0, {}),
+            ),
+        ):
+            mock_asb.Atmosphere.return_value.density.return_value = 1.225
+
+            result = _trim_or_estimate_point(
+                asb_airplane=mock_airplane,
+                aircraft=aircraft,
+                target=self._make_target(),
+                constraints={"max_alpha_deg": 25},
+                capabilities={"available_controls": []},
+            )
+
+        # Grid search found better score (0.2 < 0.5), so grid result is used
+        assert result.alpha_rad == pytest.approx(math.radians(4.0))
+        assert result.status == OperatingPointStatus.TRIMMED
+
+    def test_dutch_role_extra_beta_candidates(self):
+        """dutch_role_start target should produce 3 beta candidates."""
+        mock_airplane = MagicMock()
+        mock_airplane.s_ref = 0.5
+        aircraft = MagicMock()
+        aircraft.total_mass_kg = 5.0
+
+        target = self._make_target("dutch_role_start")
+        target["beta_target_deg"] = 2.0
+        target["warnings"] = ["NO_CONTROL_TRIM_MVP"]
+
+        with (
+            patch("app.services.operating_point_generator_service.asb") as mock_asb,
+            patch(
+                "app.services.operating_point_generator_service._solve_trim_candidate_with_opti",
+                return_value=None,
+            ),
+            patch(
+                "app.services.operating_point_generator_service._grid_search_trim",
+                return_value=(0.1, 3.0, 2.0, 20.0, {}),
+            ) as mock_grid,
+        ):
+            mock_asb.Atmosphere.return_value.density.return_value = 1.225
+
+            result = _trim_or_estimate_point(
+                asb_airplane=mock_airplane,
+                aircraft=aircraft,
+                target=target,
+                constraints={},
+                capabilities={"available_controls": []},
+            )
+
+        # Verify beta_candidates passed to grid_search_trim includes [2.0, 0.0, -2.0]
+        call_args = mock_grid.call_args
+        beta_candidates = call_args.kwargs.get("beta_candidates") or call_args[0][4]
+        assert 2.0 in beta_candidates
+        assert 0.0 in beta_candidates
+        assert -2.0 in beta_candidates
+        # Warnings should include the original warning
+        assert "NO_CONTROL_TRIM_MVP" in result.warnings
+
+    def test_warnings_from_target_propagated(self):
+        """Pre-existing warnings on the target are carried through."""
+        mock_airplane = MagicMock()
+        mock_airplane.s_ref = 0.5
+        aircraft = MagicMock()
+        aircraft.total_mass_kg = None
+
+        target = self._make_target()
+        target["warnings"] = ["CUSTOM_WARNING"]
+
+        with (
+            patch("app.services.operating_point_generator_service.asb") as mock_asb,
+            patch(
+                "app.services.operating_point_generator_service._solve_trim_candidate_with_opti",
+                return_value=None,
+            ),
+            patch(
+                "app.services.operating_point_generator_service._grid_search_trim",
+                return_value=(0.5, 8.0, 0.0, 20.0, {}),
+            ),
+        ):
+            mock_asb.Atmosphere.return_value.density.return_value = 1.225
+
+            result = _trim_or_estimate_point(
+                asb_airplane=mock_airplane,
+                aircraft=aircraft,
+                target=target,
+                constraints={},
+                capabilities={"available_controls": []},
+            )
+
+        assert "CUSTOM_WARNING" in result.warnings
+        assert result.status == OperatingPointStatus.NOT_TRIMMED

--- a/app/tests/test_operating_points_endpoint.py
+++ b/app/tests/test_operating_points_endpoint.py
@@ -1,0 +1,643 @@
+"""Tests for app/api/v2/endpoints/operating_points.py.
+
+Covers CRUD for operating points and operating point sets, plus the
+generate-default and trim endpoints (mocked at the service layer).
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from app.core.exceptions import (
+    ConflictError,
+    InternalError,
+    NotFoundError,
+    ValidationDomainError,
+    ValidationError,
+)
+from app.core.platform import aerosandbox_available
+from app.schemas.aeroanalysisschema import (
+    GeneratedOperatingPointSetRead,
+    OperatingPointStatus,
+    StoredOperatingPointRead,
+    TrimmedOperatingPointRead,
+    StoredOperatingPointCreate,
+)
+from app.models.analysismodels import OperatingPointModel
+from app.tests.conftest import make_aeroplane
+
+# The operating_points router is only registered when aerosandbox is available.
+pytestmark = pytest.mark.skipif(
+    not aerosandbox_available(),
+    reason="operating_points router requires aerosandbox",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _op_payload(**overrides) -> dict:
+    """Return a valid StoredOperatingPointCreate payload dict."""
+    base = dict(
+        name="cruise",
+        description="Cruise flight",
+        velocity=25.0,
+        alpha=0.05,
+        beta=0.0,
+        p=0.0,
+        q=0.0,
+        r=0.0,
+        altitude=100.0,
+        config="clean",
+        status="NOT_TRIMMED",
+        warnings=[],
+        controls={},
+        xyz_ref=[0.0, 0.0, 0.0],
+    )
+    base.update(overrides)
+    return base
+
+
+def _make_aeroplane_detached(SessionLocal, name="test-plane"):
+    """Create an aeroplane and return (uuid_str, pk) without a live session."""
+    db = SessionLocal()
+    try:
+        aeroplane = make_aeroplane(db, name=name)
+        return str(aeroplane.uuid), aeroplane.id
+    finally:
+        db.close()
+
+
+def _opset_payload(**overrides) -> dict:
+    """Return a valid OperatingPointSetSchema payload dict."""
+    base = dict(
+        name="default_set",
+        description="Default operating point set",
+        operating_points=[1, 2, 3],
+    )
+    base.update(overrides)
+    return base
+
+
+# =========================================================================
+# Operating Point CRUD
+# =========================================================================
+
+
+class TestCreateOperatingPoint:
+    def test_success(self, client_and_db):
+        client, _ = client_and_db
+        payload = _op_payload()
+        resp = client.post("/operating_points/", json=payload)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "cruise"
+        assert data["velocity"] == 25.0
+        assert "id" in data
+
+    def test_missing_required_field(self, client_and_db):
+        client, _ = client_and_db
+        payload = _op_payload()
+        del payload["velocity"]
+        resp = client.post("/operating_points/", json=payload)
+        assert resp.status_code == 422
+
+    def test_empty_body(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.post("/operating_points/", json={})
+        assert resp.status_code == 422
+
+
+class TestListOperatingPoints:
+    def test_empty_list(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.get("/operating_points")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_returns_created_points(self, client_and_db):
+        client, _ = client_and_db
+        client.post("/operating_points/", json=_op_payload(name="op1"))
+        client.post("/operating_points/", json=_op_payload(name="op2"))
+        resp = client.get("/operating_points")
+        assert resp.status_code == 200
+        names = [op["name"] for op in resp.json()]
+        assert "op1" in names
+        assert "op2" in names
+
+    def test_filter_by_aircraft_id(self, client_and_db):
+        client, SessionLocal = client_and_db
+        db = SessionLocal()
+        try:
+            aeroplane = make_aeroplane(db, name="filter-test")
+            aircraft_uuid = str(aeroplane.uuid)
+            op = OperatingPointModel(
+                name="linked_op",
+                description="linked op desc",
+                aircraft_id=aeroplane.id,
+                velocity=20.0,
+                alpha=0.05,
+                beta=0.0,
+                p=0.0,
+                q=0.0,
+                r=0.0,
+                altitude=0.0,
+                config="clean",
+                status="TRIMMED",
+                warnings=[],
+                controls={},
+                xyz_ref=[0.0, 0.0, 0.0],
+            )
+            db.add(op)
+            db.commit()
+        finally:
+            db.close()
+
+        # Filter by existing aircraft UUID
+        resp = client.get(f"/operating_points?aircraft_id={aircraft_uuid}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) >= 1
+        assert any(o["name"] == "linked_op" for o in data)
+
+    def test_filter_by_nonexistent_aircraft_returns_empty(self, client_and_db):
+        client, _ = client_and_db
+        fake_uuid = str(uuid.uuid4())
+        resp = client.get(f"/operating_points?aircraft_id={fake_uuid}")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_pagination_skip_and_limit(self, client_and_db):
+        client, _ = client_and_db
+        for i in range(5):
+            client.post("/operating_points/", json=_op_payload(name=f"op_{i}"))
+        resp = client.get("/operating_points?skip=2&limit=2")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+
+    def test_invalid_skip_negative(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.get("/operating_points?skip=-1")
+        assert resp.status_code == 422
+
+    def test_invalid_limit_zero(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.get("/operating_points?limit=0")
+        assert resp.status_code == 422
+
+
+class TestReadOperatingPoint:
+    def test_success(self, client_and_db):
+        client, _ = client_and_db
+        create_resp = client.post("/operating_points/", json=_op_payload())
+        op_id = create_resp.json()["id"]
+        resp = client.get(f"/operating_points/{op_id}")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == op_id
+
+    def test_not_found(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.get("/operating_points/99999")
+        assert resp.status_code == 404
+        assert "not found" in resp.json()["detail"].lower()
+
+
+class TestUpdateOperatingPoint:
+    def test_success(self, client_and_db):
+        client, _ = client_and_db
+        create_resp = client.post("/operating_points/", json=_op_payload())
+        op_id = create_resp.json()["id"]
+        updated = _op_payload(name="updated_cruise", velocity=30.0)
+        resp = client.put(f"/operating_points/{op_id}", json=updated)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "updated_cruise"
+        assert data["velocity"] == 30.0
+
+    def test_not_found(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.put("/operating_points/99999", json=_op_payload())
+        assert resp.status_code == 404
+
+    def test_invalid_body(self, client_and_db):
+        client, _ = client_and_db
+        create_resp = client.post("/operating_points/", json=_op_payload())
+        op_id = create_resp.json()["id"]
+        resp = client.put(f"/operating_points/{op_id}", json={"name": "no_velocity"})
+        assert resp.status_code == 422
+
+
+class TestDeleteOperatingPoint:
+    def test_success(self, client_and_db):
+        client, _ = client_and_db
+        create_resp = client.post("/operating_points/", json=_op_payload())
+        op_id = create_resp.json()["id"]
+        resp = client.delete(f"/operating_points/{op_id}")
+        assert resp.status_code == 200
+        assert "deleted" in resp.json()["detail"].lower()
+        # Verify it is gone
+        get_resp = client.get(f"/operating_points/{op_id}")
+        assert get_resp.status_code == 404
+
+    def test_not_found(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.delete("/operating_points/99999")
+        assert resp.status_code == 404
+
+
+# =========================================================================
+# Operating Point Set CRUD
+# =========================================================================
+
+
+class TestCreateOperatingPointSet:
+    def test_success(self, client_and_db):
+        client, _ = client_and_db
+        payload = _opset_payload()
+        resp = client.post("/operating_pointsets/", json=payload)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "default_set"
+        assert data["operating_points"] == [1, 2, 3]
+
+    def test_missing_required_field(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.post("/operating_pointsets/", json={"name": "no_desc"})
+        assert resp.status_code == 422
+
+
+class TestListOperatingPointSets:
+    def test_empty(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.get("/operating_pointsets")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_returns_created_sets(self, client_and_db):
+        client, _ = client_and_db
+        client.post("/operating_pointsets/", json=_opset_payload(name="set1"))
+        client.post("/operating_pointsets/", json=_opset_payload(name="set2"))
+        resp = client.get("/operating_pointsets")
+        assert resp.status_code == 200
+        names = [s["name"] for s in resp.json()]
+        assert "set1" in names
+        assert "set2" in names
+
+    def test_filter_by_nonexistent_aircraft_returns_empty(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.get(f"/operating_pointsets?aircraft_id={uuid.uuid4()}")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_pagination(self, client_and_db):
+        client, _ = client_and_db
+        for i in range(4):
+            client.post("/operating_pointsets/", json=_opset_payload(name=f"set_{i}"))
+        resp = client.get("/operating_pointsets?skip=1&limit=2")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+
+
+class TestReadOperatingPointSet:
+    def _create_opset_and_get_id(self, client, SessionLocal):
+        """Create an opset via API and resolve its DB id via ORM."""
+        from app.models.analysismodels import OperatingPointSetModel
+
+        client.post("/operating_pointsets/", json=_opset_payload())
+        db = SessionLocal()
+        try:
+            opset = db.query(OperatingPointSetModel).order_by(
+                OperatingPointSetModel.id.desc()
+            ).first()
+            return opset.id
+        finally:
+            db.close()
+
+    def test_success(self, client_and_db):
+        client, SessionLocal = client_and_db
+        opset_id = self._create_opset_and_get_id(client, SessionLocal)
+        resp = client.get(f"/operating_pointsets/{opset_id}")
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "default_set"
+
+    def test_not_found(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.get("/operating_pointsets/99999")
+        assert resp.status_code == 404
+
+
+class TestUpdateOperatingPointSet:
+    def _create_opset_and_get_id(self, client, SessionLocal):
+        from app.models.analysismodels import OperatingPointSetModel
+
+        client.post("/operating_pointsets/", json=_opset_payload())
+        db = SessionLocal()
+        try:
+            opset = db.query(OperatingPointSetModel).order_by(
+                OperatingPointSetModel.id.desc()
+            ).first()
+            return opset.id
+        finally:
+            db.close()
+
+    def test_success(self, client_and_db):
+        client, SessionLocal = client_and_db
+        opset_id = self._create_opset_and_get_id(client, SessionLocal)
+        updated = _opset_payload(name="renamed_set", operating_points=[10, 20])
+        resp = client.put(f"/operating_pointsets/{opset_id}", json=updated)
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "renamed_set"
+        assert resp.json()["operating_points"] == [10, 20]
+
+    def test_not_found(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.put("/operating_pointsets/99999", json=_opset_payload())
+        assert resp.status_code == 404
+
+
+class TestDeleteOperatingPointSet:
+    def _create_opset_and_get_id(self, client, SessionLocal):
+        from app.models.analysismodels import OperatingPointSetModel
+
+        client.post("/operating_pointsets/", json=_opset_payload())
+        db = SessionLocal()
+        try:
+            opset = db.query(OperatingPointSetModel).order_by(
+                OperatingPointSetModel.id.desc()
+            ).first()
+            return opset.id
+        finally:
+            db.close()
+
+    def test_success(self, client_and_db):
+        client, SessionLocal = client_and_db
+        opset_id = self._create_opset_and_get_id(client, SessionLocal)
+        resp = client.delete(f"/operating_pointsets/{opset_id}")
+        assert resp.status_code == 200
+        assert "deleted" in resp.json()["detail"].lower()
+        get_resp = client.get(f"/operating_pointsets/{opset_id}")
+        assert get_resp.status_code == 404
+
+    def test_not_found(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.delete("/operating_pointsets/99999")
+        assert resp.status_code == 404
+
+
+# =========================================================================
+# Generate default operating point set (service-mocked)
+# =========================================================================
+
+
+class TestGenerateDefaultOperatingPointSet:
+    _SERVICE = "app.api.v2.endpoints.operating_points.operating_point_generator_service"
+
+    def test_success_default_request(self, client_and_db):
+        client, SessionLocal = client_and_db
+        aircraft_uuid, aircraft_pk = _make_aeroplane_detached(SessionLocal, "gen-test")
+
+        mock_return = GeneratedOperatingPointSetRead(
+            id=1,
+            name="auto_set",
+            description="Generated set",
+            aircraft_id=aircraft_pk,
+            source_flight_profile_id=None,
+            operating_points=[
+                StoredOperatingPointRead(
+                    id=1, name="op1", description="desc", velocity=20.0,
+                    alpha=0.05, beta=0.0, p=0.0, q=0.0, r=0.0,
+                    altitude=0.0, config="clean",
+                    status=OperatingPointStatus.TRIMMED,
+                    warnings=[], controls={}, xyz_ref=[0, 0, 0],
+                ),
+            ],
+        )
+        with patch(
+            f"{self._SERVICE}.generate_default_set_for_aircraft",
+            return_value=mock_return,
+        ) as mock_gen:
+            resp = client.post(
+                f"/aeroplanes/{aircraft_uuid}/operating-pointsets/generate-default",
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["name"] == "auto_set"
+            assert len(data["operating_points"]) == 1
+            mock_gen.assert_called_once()
+
+    def test_with_explicit_request_body(self, client_and_db):
+        client, SessionLocal = client_and_db
+        aircraft_uuid, aircraft_pk = _make_aeroplane_detached(SessionLocal, "gen-body-test")
+
+        mock_return = GeneratedOperatingPointSetRead(
+            id=2, name="custom_set", description="desc",
+            operating_points=[], aircraft_id=aircraft_pk,
+        )
+        with patch(
+            f"{self._SERVICE}.generate_default_set_for_aircraft",
+            return_value=mock_return,
+        ) as mock_gen:
+            resp = client.post(
+                f"/aeroplanes/{aircraft_uuid}/operating-pointsets/generate-default",
+                json={"replace_existing": True, "profile_id_override": 42},
+            )
+            assert resp.status_code == 200
+            call_kwargs = mock_gen.call_args.kwargs
+            assert call_kwargs["replace_existing"] is True
+            assert call_kwargs["profile_id_override"] == 42
+
+    def test_not_found_error(self, client_and_db):
+        client, _ = client_and_db
+        fake_uuid = uuid.uuid4()
+        with patch(
+            f"{self._SERVICE}.generate_default_set_for_aircraft",
+            side_effect=NotFoundError("Aircraft not found"),
+        ):
+            resp = client.post(
+                f"/aeroplanes/{fake_uuid}/operating-pointsets/generate-default",
+            )
+            assert resp.status_code == 404
+
+    def test_validation_error(self, client_and_db):
+        client, SessionLocal = client_and_db
+        aircraft_uuid, _ = _make_aeroplane_detached(SessionLocal, "val-err-test")
+
+        with patch(
+            f"{self._SERVICE}.generate_default_set_for_aircraft",
+            side_effect=ValidationError("Invalid config"),
+        ):
+            resp = client.post(
+                f"/aeroplanes/{aircraft_uuid}/operating-pointsets/generate-default",
+            )
+            assert resp.status_code == 422
+
+    def test_validation_domain_error(self, client_and_db):
+        client, SessionLocal = client_and_db
+        aircraft_uuid, _ = _make_aeroplane_detached(SessionLocal, "domain-err-test")
+
+        with patch(
+            f"{self._SERVICE}.generate_default_set_for_aircraft",
+            side_effect=ValidationDomainError("Domain rule violated"),
+        ):
+            resp = client.post(
+                f"/aeroplanes/{aircraft_uuid}/operating-pointsets/generate-default",
+            )
+            assert resp.status_code == 422
+
+    def test_conflict_error(self, client_and_db):
+        client, SessionLocal = client_and_db
+        aircraft_uuid, _ = _make_aeroplane_detached(SessionLocal, "conflict-test")
+
+        with patch(
+            f"{self._SERVICE}.generate_default_set_for_aircraft",
+            side_effect=ConflictError("Already exists"),
+        ):
+            resp = client.post(
+                f"/aeroplanes/{aircraft_uuid}/operating-pointsets/generate-default",
+            )
+            assert resp.status_code == 409
+
+    def test_internal_error(self, client_and_db):
+        client, SessionLocal = client_and_db
+        aircraft_uuid, _ = _make_aeroplane_detached(SessionLocal, "internal-err-test")
+
+        with patch(
+            f"{self._SERVICE}.generate_default_set_for_aircraft",
+            side_effect=InternalError("Something broke"),
+        ):
+            resp = client.post(
+                f"/aeroplanes/{aircraft_uuid}/operating-pointsets/generate-default",
+            )
+            assert resp.status_code == 500
+
+    def test_invalid_uuid_path(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.post(
+            "/aeroplanes/not-a-uuid/operating-pointsets/generate-default",
+        )
+        assert resp.status_code == 422
+
+
+# =========================================================================
+# Trim operating point (service-mocked)
+# =========================================================================
+
+
+class TestTrimOperatingPoint:
+    _SERVICE = "app.api.v2.endpoints.operating_points.operating_point_generator_service"
+
+    def test_success(self, client_and_db):
+        client, SessionLocal = client_and_db
+        aircraft_uuid, _ = _make_aeroplane_detached(SessionLocal, "trim-test")
+
+        mock_return = TrimmedOperatingPointRead(
+            source_flight_profile_id=None,
+            point=StoredOperatingPointCreate(
+                name="trimmed_pt", description="desc",
+                velocity=20.0, alpha=0.05, beta=0.0,
+                p=0.0, q=0.0, r=0.0, altitude=0.0,
+                config="clean", status=OperatingPointStatus.TRIMMED,
+                warnings=[], controls={"elevator": -0.02},
+                xyz_ref=[0, 0, 0],
+            ),
+        )
+        with patch(
+            f"{self._SERVICE}.trim_operating_point_for_aircraft",
+            return_value=mock_return,
+        ) as mock_trim:
+            resp = client.post(
+                f"/aeroplanes/{aircraft_uuid}/operating-points/trim",
+                json={
+                    "name": "custom_trim",
+                    "config": "clean",
+                    "velocity": 20.0,
+                    "altitude": 0.0,
+                    "beta_target_deg": 0.0,
+                    "n_target": 1.0,
+                },
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["point"]["name"] == "trimmed_pt"
+            assert data["point"]["controls"]["elevator"] == -0.02
+            mock_trim.assert_called_once()
+
+    def test_missing_velocity(self, client_and_db):
+        client, SessionLocal = client_and_db
+        aircraft_uuid, _ = _make_aeroplane_detached(SessionLocal, "trim-missing")
+
+        resp = client.post(
+            f"/aeroplanes/{aircraft_uuid}/operating-points/trim",
+            json={"name": "bad_trim", "config": "clean"},
+        )
+        assert resp.status_code == 422
+
+    def test_velocity_must_be_positive(self, client_and_db):
+        client, SessionLocal = client_and_db
+        aircraft_uuid, _ = _make_aeroplane_detached(SessionLocal, "trim-negative-v")
+
+        resp = client.post(
+            f"/aeroplanes/{aircraft_uuid}/operating-points/trim",
+            json={"velocity": 0.0, "n_target": 1.0},
+        )
+        assert resp.status_code == 422
+
+    def test_not_found_error(self, client_and_db):
+        client, _ = client_and_db
+        fake_uuid = uuid.uuid4()
+        with patch(
+            f"{self._SERVICE}.trim_operating_point_for_aircraft",
+            side_effect=NotFoundError("Aircraft not found"),
+        ):
+            resp = client.post(
+                f"/aeroplanes/{fake_uuid}/operating-points/trim",
+                json={"velocity": 20.0, "n_target": 1.0},
+            )
+            assert resp.status_code == 404
+
+    def test_conflict_error(self, client_and_db):
+        client, SessionLocal = client_and_db
+        aircraft_uuid, _ = _make_aeroplane_detached(SessionLocal, "trim-conflict")
+
+        with patch(
+            f"{self._SERVICE}.trim_operating_point_for_aircraft",
+            side_effect=ConflictError("Trim conflict"),
+        ):
+            resp = client.post(
+                f"/aeroplanes/{aircraft_uuid}/operating-points/trim",
+                json={"velocity": 20.0, "n_target": 1.0},
+            )
+            assert resp.status_code == 409
+
+    def test_empty_body(self, client_and_db):
+        client, SessionLocal = client_and_db
+        aircraft_uuid, _ = _make_aeroplane_detached(SessionLocal, "trim-empty")
+
+        resp = client.post(
+            f"/aeroplanes/{aircraft_uuid}/operating-points/trim",
+            json={},
+        )
+        assert resp.status_code == 422
+
+
+# =========================================================================
+# _raise_http_from_domain helper (unit-level)
+# =========================================================================
+
+
+class TestRaiseHttpFromDomain:
+    """Direct unit tests for the error-mapping helper."""
+
+    def test_generic_service_exception_maps_to_500(self):
+        from fastapi import HTTPException
+
+        from app.api.v2.endpoints.operating_points import _raise_http_from_domain
+        from app.core.exceptions import ServiceException
+
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_http_from_domain(ServiceException("generic error"))
+        assert exc_info.value.status_code == 500


### PR DESCRIPTION
## Summary
- Add 220 tests for four medium-coverage modules (30-55% → 85-93%)
- `design_version_service`: 43% → ~90% (45 tests)
- `operating_points` endpoint: 45% → ~85% (44 tests)
- `operating_point_generator_service`: 49% → 93% (82 tests)
- `fuselages` endpoint: 54% → ~85% (49 tests)
- No production code modified

Part of EPIC #278

Closes #287

## Test plan
- [x] All 220 new tests pass (9.04s)
- [x] No production code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)