### PR TITLE
test(gh-288): cad_designer Wave 2 — topology data models

### DIFF
--- a/cad_designer/tests/test_airfoil.py
+++ b/cad_designer/tests/test_airfoil.py
@@ -1,0 +1,195 @@
+"""Tests for cad_designer.airplane.aircraft_topology.wing.Airfoil."""
+
+import math
+from pathlib import Path
+
+import pytest
+from cadquery import Plane, Vector
+
+from cad_designer.airplane.aircraft_topology.wing.Airfoil import Airfoil
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AIRFOILS_DIR = REPO_ROOT / "components" / "airfoils"
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+class TestAirfoilInit:
+    """Test Airfoil constructor and default values."""
+
+    def test_defaults(self):
+        af = Airfoil()
+        assert af.airfoil is None
+        assert af.chord is None
+        assert af.dihedral_as_rotation_in_degrees == 0
+        assert af.incidence == 0
+        assert af.coordinate_system is None
+
+    def test_all_params(self):
+        af = Airfoil(
+            airfoil="naca2415",
+            chord=200.0,
+            dihedral_as_rotation_in_degrees=5.0,
+            incidence=2.5,
+        )
+        assert af.airfoil == "naca2415"
+        assert af.chord == 200.0
+        assert af.dihedral_as_rotation_in_degrees == 5.0
+        assert af.incidence == 2.5
+
+    @pytest.mark.parametrize(
+        "dihedral",
+        [-180.0, -90.0, 0.0, 45.0, 90.0, 180.0],
+        ids=lambda d: f"dihedral_{d}",
+    )
+    def test_various_dihedral_values(self, dihedral):
+        af = Airfoil(dihedral_as_rotation_in_degrees=dihedral)
+        assert af.dihedral_as_rotation_in_degrees == dihedral
+
+    def test_negative_incidence(self):
+        af = Airfoil(incidence=-3.0)
+        assert af.incidence == -3.0
+
+
+# ---------------------------------------------------------------------------
+# Coordinate system
+# ---------------------------------------------------------------------------
+
+class TestAirfoilCoordinateSystem:
+    """Test set_airfoil_coordinate_system."""
+
+    def test_set_coordinate_system_from_xy_plane(self):
+        af = Airfoil(airfoil="test", chord=100.0)
+        plane = Plane.XY()
+        af.set_airfoil_coordinate_system(plane)
+
+        cs = af.coordinate_system
+        assert cs is not None
+        assert cs.origin == pytest.approx([0.0, 0.0, 0.0])
+        assert cs.xDir == pytest.approx([1.0, 0.0, 0.0])
+        assert cs.yDir == pytest.approx([0.0, 1.0, 0.0])
+        assert cs.zDir == pytest.approx([0.0, 0.0, 1.0])
+
+    def test_set_coordinate_system_from_offset_plane(self):
+        af = Airfoil(airfoil="test", chord=100.0)
+        plane = Plane(origin=(10.0, 20.0, 30.0), xDir=(1, 0, 0), normal=(0, 0, 1))
+        af.set_airfoil_coordinate_system(plane)
+
+        cs = af.coordinate_system
+        assert cs.origin == pytest.approx([10.0, 20.0, 30.0])
+
+    def test_coordinate_system_initially_none(self):
+        af = Airfoil()
+        assert af.coordinate_system is None
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+class TestAirfoilSerialization:
+    """Test __getstate__ and from_json_dict round-trip."""
+
+    def test_getstate_excludes_coordinate_system(self):
+        af = Airfoil(airfoil="naca2415", chord=150.0, incidence=1.5)
+        af.set_airfoil_coordinate_system(Plane.XY())
+
+        state = af.__getstate__()
+        assert "coordinate_system" not in state
+        assert state["airfoil"] == "naca2415"
+        assert state["chord"] == 150.0
+        assert state["incidence"] == 1.5
+        assert state["dihedral_as_rotation_in_degrees"] == 0
+
+    def test_getstate_contains_all_fields_except_cs(self):
+        af = Airfoil(airfoil="rg15", chord=200.0, dihedral_as_rotation_in_degrees=3.0, incidence=-1.0)
+        state = af.__getstate__()
+        expected_keys = {"airfoil", "chord", "dihedral_as_rotation_in_degrees", "incidence"}
+        assert expected_keys == set(state.keys())
+
+    def test_from_json_dict_full(self):
+        data = {
+            "airfoil": "rg15",
+            "chord": 185.0,
+            "dihedral_as_rotation_in_degrees": 5.0,
+            "incidence": 2.0,
+        }
+        af = Airfoil.from_json_dict(data)
+        assert af.airfoil == "rg15"
+        assert af.chord == 185.0
+        assert af.dihedral_as_rotation_in_degrees == 5.0
+        assert af.incidence == 2.0
+        assert af.coordinate_system is None
+
+    def test_from_json_dict_defaults(self):
+        data = {"airfoil": "naca0010"}
+        af = Airfoil.from_json_dict(data)
+        assert af.chord is None
+        assert af.dihedral_as_rotation_in_degrees == 0
+        assert af.incidence == 0
+
+    def test_roundtrip(self):
+        original = Airfoil(airfoil="naca2415", chord=250.0, dihedral_as_rotation_in_degrees=-10.0, incidence=3.5)
+        state = original.__getstate__()
+        restored = Airfoil.from_json_dict(state)
+
+        assert restored.airfoil == original.airfoil
+        assert restored.chord == original.chord
+        assert restored.dihedral_as_rotation_in_degrees == original.dihedral_as_rotation_in_degrees
+        assert restored.incidence == original.incidence
+
+
+# ---------------------------------------------------------------------------
+# repr
+# ---------------------------------------------------------------------------
+
+class TestAirfoilRepr:
+    def test_repr_does_not_raise(self):
+        af = Airfoil(airfoil="naca2415", chord=100.0)
+        result = repr(af)
+        assert "naca2415" in result
+        assert "100.0" in result
+
+
+# ---------------------------------------------------------------------------
+# Airfoil file I/O via cq_plugins (read_airfoil_file)
+# ---------------------------------------------------------------------------
+
+class TestReadAirfoilFile:
+    """Test the read_airfoil_file utility with real .dat files."""
+
+    @pytest.fixture()
+    def reader(self):
+        from cad_designer.cq_plugins.wing.airfoil import read_airfoil_file
+        return read_airfoil_file
+
+    @pytest.mark.parametrize("filename", ["naca2415.dat", "rg15.dat"])
+    def test_read_returns_list_of_tuples(self, reader, filename):
+        path = str(AIRFOILS_DIR / filename)
+        data = reader(path)
+        assert isinstance(data, list)
+        assert len(data) > 10
+        for pt in data:
+            assert len(pt) == 2
+
+    def test_naca2415_starts_near_trailing_edge(self, reader):
+        data = reader(str(AIRFOILS_DIR / "naca2415.dat"))
+        # Selig format: first point is near x=1.0 (trailing edge)
+        assert data[0][0] == pytest.approx(1.0, abs=0.01)
+
+    def test_rg15_starts_near_trailing_edge(self, reader):
+        data = reader(str(AIRFOILS_DIR / "rg15.dat"))
+        assert data[0][0] == pytest.approx(1.0, abs=0.01)
+
+    def test_all_coordinates_in_unit_range(self, reader):
+        """Selig-format airfoil x-coords should be in [0, 1]."""
+        data = reader(str(AIRFOILS_DIR / "naca2415.dat"))
+        xs = [p[0] for p in data]
+        assert min(xs) >= -0.01
+        assert max(xs) <= 1.01
+
+    def test_nonexistent_file_raises(self, reader):
+        with pytest.raises(Exception):
+            reader("/tmp/nonexistent_airfoil_xyz.dat")

--- a/cad_designer/tests/test_airplane_configuration.py
+++ b/cad_designer/tests/test_airplane_configuration.py
@@ -1,0 +1,402 @@
+"""Tests for AirplaneConfiguration data model."""
+from __future__ import annotations
+
+import json
+import os
+import zipfile
+
+import aerosandbox as asb
+import numpy as np
+import pytest
+
+from cad_designer.aerosandbox.wing_roundtrip_cases import (
+    AIRFOIL_PATH,
+    single_segment_flat,
+)
+from cad_designer.airplane.aircraft_topology.airplane.AirplaneConfiguration import (
+    AirplaneConfiguration,
+)
+from cad_designer.airplane.aircraft_topology.fuselage.FuselageConfiguration import (
+    FuselageConfiguration,
+)
+from cad_designer.airplane.aircraft_topology.wing.Airfoil import Airfoil
+from cad_designer.airplane.aircraft_topology.wing.WingConfiguration import (
+    WingConfiguration,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_wing() -> WingConfiguration:
+    """Create a minimal WingConfiguration for testing."""
+    return single_segment_flat()
+
+
+def _make_fuselage() -> FuselageConfiguration:
+    """Create a FuselageConfiguration with an ASB fuselage for testing."""
+    fc = FuselageConfiguration(name="test_body")
+    fc.asb_fuselage = asb.Fuselage(
+        name="body",
+        xsecs=[
+            asb.FuselageXSec(
+                xyz_c=np.array([0.0, 0.0, 0.0]),
+                xyz_normal=np.array([1.0, 0.0, 0.0]),
+                height=0.1,
+                width=0.1,
+            ),
+            asb.FuselageXSec(
+                xyz_c=np.array([1.0, 0.0, 0.0]),
+                xyz_normal=np.array([1.0, 0.0, 0.0]),
+                height=0.05,
+                width=0.05,
+            ),
+        ],
+    )
+    return fc
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def wings_only() -> AirplaneConfiguration:
+    """AirplaneConfiguration with one wing, no fuselages."""
+    return AirplaneConfiguration(
+        name="test_plane",
+        total_mass_kg=2.5,
+        wings=[_make_wing()],
+    )
+
+
+@pytest.fixture
+def wings_and_fuselage() -> AirplaneConfiguration:
+    """AirplaneConfiguration with one wing and one fuselage."""
+    return AirplaneConfiguration(
+        name="full_plane",
+        total_mass_kg=3.0,
+        wings=[_make_wing()],
+        fuselages=[_make_fuselage()],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Constructor tests
+# ---------------------------------------------------------------------------
+
+class TestAirplaneConfigurationInit:
+    """Tests for AirplaneConfiguration.__init__."""
+
+    def test_name_stored(self, wings_only: AirplaneConfiguration) -> None:
+        assert wings_only.name == "test_plane"
+
+    def test_total_mass_stored(self, wings_only: AirplaneConfiguration) -> None:
+        assert wings_only.total_mass == 2.5
+
+    def test_wings_stored(self, wings_only: AirplaneConfiguration) -> None:
+        assert len(wings_only.wings) == 1
+        assert isinstance(wings_only.wings[0], WingConfiguration)
+
+    def test_fuselages_default_none(self, wings_only: AirplaneConfiguration) -> None:
+        assert wings_only.fuselages is None
+
+    def test_fuselages_stored(
+        self, wings_and_fuselage: AirplaneConfiguration
+    ) -> None:
+        assert wings_and_fuselage.fuselages is not None
+        assert len(wings_and_fuselage.fuselages) == 1
+
+    def test_main_wing_index_defaults_to_zero(
+        self, wings_only: AirplaneConfiguration
+    ) -> None:
+        assert wings_only._main_wing_index == 0
+        assert wings_only._main_wing is wings_only.wings[0]
+
+    def test_multiple_wings(self) -> None:
+        ac = AirplaneConfiguration(
+            name="multi",
+            total_mass_kg=5.0,
+            wings=[_make_wing(), _make_wing()],
+        )
+        assert len(ac.wings) == 2
+        assert ac._main_wing is ac.wings[0]
+
+    def test_empty_wings_raises(self) -> None:
+        """An empty wings list should raise IndexError when accessing
+        _main_wing = self.wings[0]."""
+        with pytest.raises(IndexError):
+            AirplaneConfiguration(
+                name="no_wings",
+                total_mass_kg=1.0,
+                wings=[],
+            )
+
+
+# ---------------------------------------------------------------------------
+# Serialization: to_dict
+# ---------------------------------------------------------------------------
+
+class TestAirplaneConfigurationToDict:
+    """Tests for to_dict serialization."""
+
+    def test_contains_required_keys(
+        self, wings_only: AirplaneConfiguration
+    ) -> None:
+        d = wings_only.to_dict()
+        assert "name" in d
+        assert "total_mass_kg" in d
+        assert "wings" in d
+
+    def test_name_and_mass_values(
+        self, wings_only: AirplaneConfiguration
+    ) -> None:
+        d = wings_only.to_dict()
+        assert d["name"] == "test_plane"
+        assert d["total_mass_kg"] == 2.5
+
+    def test_wings_serialized_as_list(
+        self, wings_only: AirplaneConfiguration
+    ) -> None:
+        d = wings_only.to_dict()
+        assert isinstance(d["wings"], list)
+        assert len(d["wings"]) == 1
+
+    def test_no_fuselages_key_when_none(
+        self, wings_only: AirplaneConfiguration
+    ) -> None:
+        d = wings_only.to_dict()
+        assert "fuselages" not in d
+
+    def test_fuselages_included_when_present(
+        self, wings_and_fuselage: AirplaneConfiguration
+    ) -> None:
+        d = wings_and_fuselage.to_dict()
+        assert "fuselages" in d
+        assert len(d["fuselages"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# File I/O: save_to_json / from_json
+# ---------------------------------------------------------------------------
+
+class TestAirplaneConfigurationJsonIO:
+    """Tests for JSON file save/load."""
+
+    def test_save_creates_file(
+        self, wings_only: AirplaneConfiguration, tmp_path
+    ) -> None:
+        path = str(tmp_path / "plane.json")
+        wings_only.save_to_json(path)
+        assert os.path.exists(path)
+
+    def test_saved_file_is_valid_json(
+        self, wings_only: AirplaneConfiguration, tmp_path
+    ) -> None:
+        path = str(tmp_path / "plane.json")
+        wings_only.save_to_json(path)
+        with open(path) as f:
+            data = json.load(f)
+        assert isinstance(data, dict)
+
+    def test_roundtrip_wings_only(
+        self, wings_only: AirplaneConfiguration, tmp_path
+    ) -> None:
+        path = str(tmp_path / "rt.json")
+        wings_only.save_to_json(path)
+        loaded = AirplaneConfiguration.from_json(path)
+        assert loaded.name == wings_only.name
+        assert loaded.total_mass == wings_only.total_mass
+        assert len(loaded.wings) == len(wings_only.wings)
+        assert loaded.fuselages is None
+
+    def test_roundtrip_with_fuselage(
+        self, wings_and_fuselage: AirplaneConfiguration, tmp_path
+    ) -> None:
+        path = str(tmp_path / "rt_fus.json")
+        wings_and_fuselage.save_to_json(path)
+        loaded = AirplaneConfiguration.from_json(path)
+        assert loaded.name == wings_and_fuselage.name
+        assert loaded.fuselages is not None
+        assert len(loaded.fuselages) == 1
+        assert loaded.fuselages[0].name == "test_body"
+
+    def test_from_json_nonexistent_raises(self) -> None:
+        with pytest.raises(FileNotFoundError):
+            AirplaneConfiguration.from_json("/nonexistent/plane.json")
+
+
+# ---------------------------------------------------------------------------
+# Zip I/O: save_to_zip / from_zip
+# ---------------------------------------------------------------------------
+
+class TestAirplaneConfigurationZipIO:
+    """Tests for zip file save/load."""
+
+    def test_save_creates_zip(
+        self, wings_only: AirplaneConfiguration, tmp_path
+    ) -> None:
+        path = str(tmp_path / "plane.zip")
+        wings_only.save_to_zip(path)
+        assert os.path.exists(path)
+        assert zipfile.is_zipfile(path)
+
+    def test_zip_contains_config_and_wings(
+        self, wings_only: AirplaneConfiguration, tmp_path
+    ) -> None:
+        path = str(tmp_path / "plane.zip")
+        wings_only.save_to_zip(path)
+        with zipfile.ZipFile(path, "r") as zf:
+            names = zf.namelist()
+        assert "config.json" in names
+        assert "wings/wing_0.json" in names
+
+    def test_zip_contains_fuselages_when_present(
+        self, wings_and_fuselage: AirplaneConfiguration, tmp_path
+    ) -> None:
+        path = str(tmp_path / "plane.zip")
+        wings_and_fuselage.save_to_zip(path)
+        with zipfile.ZipFile(path, "r") as zf:
+            names = zf.namelist()
+        assert "fuselages/fuselage_0.json" in names
+
+    def test_roundtrip_via_zip(
+        self, wings_and_fuselage: AirplaneConfiguration, tmp_path
+    ) -> None:
+        path = str(tmp_path / "roundtrip.zip")
+        wings_and_fuselage.save_to_zip(path)
+        loaded = AirplaneConfiguration.from_zip(path)
+        assert loaded.name == wings_and_fuselage.name
+        assert loaded.total_mass == wings_and_fuselage.total_mass
+        assert len(loaded.wings) == 1
+        assert loaded.fuselages is not None
+        assert len(loaded.fuselages) == 1
+
+    def test_zip_roundtrip_no_fuselages(
+        self, wings_only: AirplaneConfiguration, tmp_path
+    ) -> None:
+        path = str(tmp_path / "nofus.zip")
+        wings_only.save_to_zip(path)
+        loaded = AirplaneConfiguration.from_zip(path)
+        assert loaded.fuselages is None
+
+    def test_zip_cleans_up_temp_dir(
+        self, wings_only: AirplaneConfiguration, tmp_path
+    ) -> None:
+        path = str(tmp_path / "cleanup.zip")
+        wings_only.save_to_zip(path)
+        temp_dir = tmp_path / "temp_airplane_config"
+        assert not temp_dir.exists(), "Temp directory should be cleaned up after save"
+
+    def test_from_zip_cleans_up_temp_dir(
+        self, wings_only: AirplaneConfiguration, tmp_path
+    ) -> None:
+        path = str(tmp_path / "cleanup2.zip")
+        wings_only.save_to_zip(path)
+        AirplaneConfiguration.from_zip(path)
+        temp_dir = tmp_path / "temp_extract"
+        assert not temp_dir.exists(), "Temp directory should be cleaned up after load"
+
+
+# ---------------------------------------------------------------------------
+# asb_airplane property
+# ---------------------------------------------------------------------------
+
+class TestAirplaneConfigurationAsbAirplane:
+    """Tests for the cached asb_airplane property."""
+
+    def test_returns_asb_airplane(
+        self, wings_only: AirplaneConfiguration
+    ) -> None:
+        airplane = wings_only.asb_airplane
+        assert isinstance(airplane, asb.Airplane)
+
+    def test_airplane_has_correct_name(
+        self, wings_only: AirplaneConfiguration
+    ) -> None:
+        assert wings_only.asb_airplane.name == "test_plane"
+
+    def test_airplane_has_wings(
+        self, wings_only: AirplaneConfiguration
+    ) -> None:
+        assert len(wings_only.asb_airplane.wings) == 1
+
+    def test_airplane_with_fuselage(
+        self, wings_and_fuselage: AirplaneConfiguration
+    ) -> None:
+        airplane = wings_and_fuselage.asb_airplane
+        assert len(airplane.fuselages) == 1
+
+    def test_airplane_no_fuselage_gives_empty_list(
+        self, wings_only: AirplaneConfiguration
+    ) -> None:
+        airplane = wings_only.asb_airplane
+        assert airplane.fuselages == []
+
+    def test_cached_property_returns_same_object(
+        self, wings_only: AirplaneConfiguration
+    ) -> None:
+        a1 = wings_only.asb_airplane
+        a2 = wings_only.asb_airplane
+        assert a1 is a2
+
+    def test_main_wing_set_after_access(
+        self, wings_only: AirplaneConfiguration
+    ) -> None:
+        _ = wings_only.asb_airplane
+        assert wings_only._asb_main_wing is not None
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+class TestAirplaneConfigurationEdgeCases:
+    """Edge case and boundary tests."""
+
+    def test_zero_mass(self) -> None:
+        ac = AirplaneConfiguration(
+            name="zero",
+            total_mass_kg=0.0,
+            wings=[_make_wing()],
+        )
+        assert ac.total_mass == 0.0
+
+    def test_negative_mass_stored(self) -> None:
+        """No validation prevents negative mass at this layer."""
+        ac = AirplaneConfiguration(
+            name="neg",
+            total_mass_kg=-1.0,
+            wings=[_make_wing()],
+        )
+        assert ac.total_mass == -1.0
+
+    def test_multiple_fuselages(self) -> None:
+        ac = AirplaneConfiguration(
+            name="multi_fus",
+            total_mass_kg=5.0,
+            wings=[_make_wing()],
+            fuselages=[_make_fuselage(), _make_fuselage()],
+        )
+        assert len(ac.fuselages) == 2
+
+    def test_to_dict_multiple_wings(self) -> None:
+        ac = AirplaneConfiguration(
+            name="multi_wing",
+            total_mass_kg=4.0,
+            wings=[_make_wing(), _make_wing()],
+        )
+        d = ac.to_dict()
+        assert len(d["wings"]) == 2
+
+    def test_empty_fuselages_list_treated_as_falsy(self) -> None:
+        """An empty fuselage list is falsy, so to_dict omits it."""
+        ac = AirplaneConfiguration(
+            name="empty_fus",
+            total_mass_kg=2.0,
+            wings=[_make_wing()],
+            fuselages=[],
+        )
+        d = ac.to_dict()
+        assert "fuselages" not in d

--- a/cad_designer/tests/test_component_models.py
+++ b/cad_designer/tests/test_component_models.py
@@ -1,0 +1,529 @@
+"""Tests for component information models (Servo, ComponentInformation,
+EngineInformation, ServoInformation).
+
+ComponentInformation, EngineInformation, and ServoInformation import OCP.gp
+at module level, so they require CadQuery. Tests for those classes are
+guarded with requires_cadquery.
+
+Servo imports cadquery at module level (for Workplane/Sketch), so its
+data-model tests are also guarded.
+"""
+
+import pytest
+
+try:
+    from cad_designer.airplane.aircraft_topology.components.Servo import Servo
+
+    HAS_CADQUERY = True
+except ImportError:
+    HAS_CADQUERY = False
+
+requires_cadquery = pytest.mark.skipif(
+    not HAS_CADQUERY, reason="CadQuery / OCP not available"
+)
+
+
+# ---------------------------------------------------------------------------
+# Servo data model
+# ---------------------------------------------------------------------------
+
+@requires_cadquery
+class TestServoConstructor:
+    """Test Servo.__init__ stores all fields correctly."""
+
+    @pytest.fixture
+    def servo(self):
+        return Servo(
+            length=23.0,
+            width=12.5,
+            height=25.0,
+            leading_length=8.0,
+            latch_z=3.0,
+            latch_x=2.0,
+            latch_thickness=1.5,
+            latch_length=4.0,
+            cable_z=10.0,
+            screw_hole_lx=1.0,
+            screw_hole_d=2.0,
+        )
+
+    def test_dimensions(self, servo):
+        assert servo.length == 23.0
+        assert servo.width == 12.5
+        assert servo.height == 25.0
+
+    def test_leading_trailing_length(self, servo):
+        assert servo.leading_length == 8.0
+        assert servo.trailing_length == 23.0 - 8.0  # length - leading
+
+    def test_latch_params(self, servo):
+        assert servo.latch_z == 3.0
+        assert servo.latch_x == 2.0
+        assert servo.latch_thickness == 1.5
+        assert servo.latch_length == 4.0
+
+    def test_cable_and_screws(self, servo):
+        assert servo.cable_z == 10.0
+        assert servo.screw_hole_lx == 1.0
+        assert servo.screw_hole_d == 2.0
+
+    def test_trailing_length_computed(self):
+        servo = Servo(
+            length=30.0,
+            width=10.0,
+            height=20.0,
+            leading_length=12.0,
+            latch_z=0,
+            latch_x=0,
+            latch_thickness=0,
+            latch_length=0,
+            cable_z=0,
+            screw_hole_lx=0,
+            screw_hole_d=0,
+        )
+        assert servo.trailing_length == 18.0
+
+    def test_zero_leading_length(self):
+        """When leading_length is 0, trailing_length equals full length."""
+        servo = Servo(
+            length=20.0,
+            width=10.0,
+            height=15.0,
+            leading_length=0,
+            latch_z=0,
+            latch_x=0,
+            latch_thickness=0,
+            latch_length=0,
+            cable_z=0,
+            screw_hole_lx=0,
+            screw_hole_d=0,
+        )
+        assert servo.trailing_length == 20.0
+
+
+@requires_cadquery
+class TestServoGetState:
+    """Test Servo.__getstate__ serialization."""
+
+    @pytest.fixture
+    def servo(self):
+        return Servo(
+            length=23.0,
+            width=12.5,
+            height=25.0,
+            leading_length=8.0,
+            latch_z=3.0,
+            latch_x=2.0,
+            latch_thickness=1.5,
+            latch_length=4.0,
+            cable_z=10.0,
+            screw_hole_lx=1.0,
+            screw_hole_d=2.0,
+        )
+
+    def test_getstate_keys(self, servo):
+        state = servo.__getstate__()
+        expected_keys = {
+            "model",
+            "length",
+            "width",
+            "height",
+            "leading_length",
+            "latch_z",
+            "latch_x",
+            "latch_thickness",
+            "latch_length",
+            "cable_z",
+            "screw_hole_lx",
+            "screw_hole_d",
+            "trailing_length",
+        }
+        assert set(state.keys()) == expected_keys
+
+    def test_getstate_model_name(self, servo):
+        state = servo.__getstate__()
+        assert state["model"] == "Servo"
+
+    def test_getstate_values(self, servo):
+        state = servo.__getstate__()
+        assert state["length"] == 23.0
+        assert state["width"] == 12.5
+        assert state["height"] == 25.0
+        assert state["trailing_length"] == 15.0
+
+
+@requires_cadquery
+class TestServoFromJsonDict:
+    """Test Servo.from_json_dict deserialization."""
+
+    def test_roundtrip(self):
+        original = Servo(
+            length=23.0,
+            width=12.5,
+            height=25.0,
+            leading_length=8.0,
+            latch_z=3.0,
+            latch_x=2.0,
+            latch_thickness=1.5,
+            latch_length=4.0,
+            cable_z=10.0,
+            screw_hole_lx=1.0,
+            screw_hole_d=2.0,
+        )
+        state = original.__getstate__()
+        restored = Servo.from_json_dict(state)
+
+        assert restored.length == original.length
+        assert restored.width == original.width
+        assert restored.height == original.height
+        assert restored.leading_length == original.leading_length
+        assert restored.latch_z == original.latch_z
+        assert restored.latch_x == original.latch_x
+        assert restored.latch_thickness == original.latch_thickness
+        assert restored.latch_length == original.latch_length
+        assert restored.cable_z == original.cable_z
+        assert restored.screw_hole_lx == original.screw_hole_lx
+        assert restored.screw_hole_d == original.screw_hole_d
+        assert restored.trailing_length == original.trailing_length
+
+    def test_from_json_dict_preserves_trailing_length(self):
+        """When trailing_length is in the dict, it should be set."""
+        data = {
+            "model": "Servo",
+            "length": 30.0,
+            "width": 10.0,
+            "height": 20.0,
+            "leading_length": 10.0,
+            "latch_z": 0,
+            "latch_x": 0,
+            "latch_thickness": 0,
+            "latch_length": 0,
+            "cable_z": 0,
+            "screw_hole_lx": 0,
+            "screw_hole_d": 0,
+            "trailing_length": 20.0,  # length - leading_length
+        }
+        servo = Servo.from_json_dict(data)
+        assert servo.trailing_length == 20.0
+
+    def test_from_json_dict_overrides_computed_trailing_length(self):
+        """trailing_length from JSON overrides the computed value."""
+        data = {
+            "model": "Servo",
+            "length": 30.0,
+            "width": 10.0,
+            "height": 20.0,
+            "leading_length": 10.0,
+            "latch_z": 0,
+            "latch_x": 0,
+            "latch_thickness": 0,
+            "latch_length": 0,
+            "cable_z": 0,
+            "screw_hole_lx": 0,
+            "screw_hole_d": 0,
+            "trailing_length": 99.0,  # intentionally wrong
+        }
+        servo = Servo.from_json_dict(data)
+        # from_json_dict explicitly sets trailing_length from data
+        assert servo.trailing_length == 99.0
+
+
+# ---------------------------------------------------------------------------
+# ComponentInformation
+# ---------------------------------------------------------------------------
+
+@requires_cadquery
+class TestComponentInformation:
+    """Test ComponentInformation data model."""
+
+    def test_constructor_defaults(self):
+        from cad_designer.airplane.aircraft_topology.components.ComponentInformation import (
+            ComponentInformation,
+        )
+
+        ci = ComponentInformation(height=10.0, width=20.0, length=30.0)
+        assert ci.height == 10.0
+        assert ci.width == 20.0
+        assert ci.length == 30.0
+        assert ci.rot_x == 0.0
+        assert ci.rot_y == 0.0
+        assert ci.rot_z == 0.0
+        assert ci.trans_x == 0.0
+        assert ci.trans_y == 0.0
+        assert ci.trans_z == 0.0
+
+    def test_constructor_all_params(self):
+        from cad_designer.airplane.aircraft_topology.components.ComponentInformation import (
+            ComponentInformation,
+        )
+
+        ci = ComponentInformation(
+            height=10.0,
+            width=20.0,
+            length=30.0,
+            rot_x=1.0,
+            rot_y=2.0,
+            rot_z=3.0,
+            trans_x=4.0,
+            trans_y=5.0,
+            trans_z=6.0,
+        )
+        assert ci.rot_x == 1.0
+        assert ci.rot_y == 2.0
+        assert ci.rot_z == 3.0
+        assert ci.trans_x == 4.0
+        assert ci.trans_y == 5.0
+        assert ci.trans_z == 6.0
+
+    def test_get_corner_point(self):
+        from cad_designer.airplane.aircraft_topology.components.ComponentInformation import (
+            ComponentInformation,
+        )
+
+        ci = ComponentInformation(
+            height=10.0, width=20.0, length=30.0,
+            trans_x=1.0, trans_y=2.0, trans_z=3.0,
+        )
+        pt = ci.get_corner_point()
+        assert pt.X() == pytest.approx(1.0)
+        assert pt.Y() == pytest.approx(2.0)
+        assert pt.Z() == pytest.approx(3.0)
+
+
+# ---------------------------------------------------------------------------
+# EngineInformation
+# ---------------------------------------------------------------------------
+
+@requires_cadquery
+class TestEngineInformation:
+    """Test EngineInformation data model."""
+
+    def test_constructor(self):
+        from cad_designer.airplane.aircraft_topology.components.EngineInformation import (
+            EngineInformation,
+        )
+        from cad_designer.airplane.aircraft_topology.Position import Position
+
+        pos = Position(x=10.0, y=20.0, z=30.0)
+        ei = EngineInformation(
+            down_thrust=5.0,
+            side_thrust=2.0,
+            position=pos,
+            length=100.0,
+            width=50.0,
+            height=40.0,
+            screw_hole_circle=15.0,
+            mount_box_length=20.0,
+            screw_din_diameter=3.0,
+            screw_length=10.0,
+        )
+        assert ei.down_thrust == 5.0
+        assert ei.side_thrust == 2.0
+        assert ei.position is pos
+        assert ei.length == 100.0
+        assert ei.width == 50.0
+        assert ei.height == 40.0
+        assert ei.engine_screw_hole_circle == 15.0
+        assert ei.engine_mount_box_length == 20.0
+        assert ei.engine_screw_din_diameter == 3.0
+        assert ei.engine_screw_length == 10.0
+
+    def test_inherits_component_transforms(self):
+        from cad_designer.airplane.aircraft_topology.components.EngineInformation import (
+            EngineInformation,
+        )
+        from cad_designer.airplane.aircraft_topology.Position import Position
+
+        pos = Position(x=10.0, y=20.0, z=30.0)
+        ei = EngineInformation(
+            down_thrust=5.0,
+            side_thrust=2.0,
+            position=pos,
+            length=100.0,
+            width=50.0,
+            height=40.0,
+            screw_hole_circle=15.0,
+            mount_box_length=20.0,
+            screw_din_diameter=3.0,
+            screw_length=10.0,
+        )
+        # super().__init__ maps position coords to trans_* and thrusts to rot_*
+        assert ei.trans_x == 10.0
+        assert ei.trans_y == 20.0
+        assert ei.trans_z == 30.0
+        assert ei.rot_y == 5.0   # down_thrust
+        assert ei.rot_z == 2.0   # side_thrust
+
+    def test_rot_x_default_and_custom(self):
+        from cad_designer.airplane.aircraft_topology.components.EngineInformation import (
+            EngineInformation,
+        )
+        from cad_designer.airplane.aircraft_topology.Position import Position
+
+        pos = Position(x=0, y=0, z=0)
+        defaults = dict(
+            down_thrust=0, side_thrust=0, position=pos,
+            length=10, width=10, height=10,
+            screw_hole_circle=5, mount_box_length=5,
+            screw_din_diameter=2, screw_length=5,
+        )
+        ei_default = EngineInformation(**defaults)
+        assert ei_default.rot_x == 0.0
+
+        ei_custom = EngineInformation(**defaults, rot_x=15.0)
+        assert ei_custom.rot_x == 15.0
+
+
+# ---------------------------------------------------------------------------
+# ServoInformation
+# ---------------------------------------------------------------------------
+
+@requires_cadquery
+class TestServoInformation:
+    """Test ServoInformation data model."""
+
+    def test_constructor_with_servo(self):
+        from cad_designer.airplane.aircraft_topology.components.ServoInformation import (
+            ServoInformation,
+        )
+
+        servo = Servo(
+            length=23.0,
+            width=12.5,
+            height=25.0,
+            leading_length=8.0,
+            latch_z=3.0,
+            latch_x=2.0,
+            latch_thickness=1.5,
+            latch_length=4.0,
+            cable_z=10.0,
+            screw_hole_lx=1.0,
+            screw_hole_d=2.0,
+        )
+        si = ServoInformation(
+            height=25.0,
+            width=12.5,
+            length=23.0,
+            lever_length=5.0,
+            servo=servo,
+        )
+        assert si.lever_length == 5.0
+        assert si.servo is servo
+
+    def test_dimensions_come_from_servo(self):
+        """length, width, height properties delegate to the servo."""
+        from cad_designer.airplane.aircraft_topology.components.ServoInformation import (
+            ServoInformation,
+        )
+
+        servo = Servo(
+            length=23.0,
+            width=12.5,
+            height=25.0,
+            leading_length=8.0,
+            latch_z=3.0,
+            latch_x=2.0,
+            latch_thickness=1.5,
+            latch_length=4.0,
+            cable_z=10.0,
+            screw_hole_lx=1.0,
+            screw_hole_d=2.0,
+        )
+        si = ServoInformation(
+            height=1.0,  # ignored -- property reads from servo
+            width=1.0,
+            length=1.0,
+            lever_length=5.0,
+            servo=servo,
+        )
+        assert si.length == 23.0
+        assert si.width == 12.5
+        assert si.height == 25.0
+
+    def test_auto_created_servo_when_none_provided(self):
+        """When no servo is passed, a default Servo is created from dimensions."""
+        from cad_designer.airplane.aircraft_topology.components.ServoInformation import (
+            ServoInformation,
+        )
+
+        si = ServoInformation(
+            height=25.0,
+            width=12.5,
+            length=23.0,
+            lever_length=5.0,
+        )
+        assert si.servo is not None
+        assert si.servo.length == 23.0
+        assert si.servo.width == 12.5
+        assert si.servo.height == 25.0
+
+    def test_transform_defaults(self):
+        from cad_designer.airplane.aircraft_topology.components.ServoInformation import (
+            ServoInformation,
+        )
+
+        si = ServoInformation(
+            height=25.0, width=12.5, length=23.0, lever_length=5.0,
+        )
+        assert si.trans_x == 0.0
+        assert si.trans_y == 0.0
+        assert si.trans_z == 0.0
+        assert si.rot_x == 0.0
+        assert si.rot_y == 0.0
+        assert si.rot_z == 0.0
+
+    def test_transform_custom(self):
+        from cad_designer.airplane.aircraft_topology.components.ServoInformation import (
+            ServoInformation,
+        )
+
+        si = ServoInformation(
+            height=25.0,
+            width=12.5,
+            length=23.0,
+            lever_length=5.0,
+            trans_x=1.0,
+            trans_y=2.0,
+            trans_z=3.0,
+            rot_x=10.0,
+            rot_y=20.0,
+            rot_z=30.0,
+        )
+        assert si.trans_x == 1.0
+        assert si.trans_y == 2.0
+        assert si.trans_z == 3.0
+        assert si.rot_x == 10.0
+        assert si.rot_y == 20.0
+        assert si.rot_z == 30.0
+
+    def test_dimension_setters_are_noop(self):
+        """The property setters for length/width/height are no-ops."""
+        from cad_designer.airplane.aircraft_topology.components.ServoInformation import (
+            ServoInformation,
+        )
+
+        servo = Servo(
+            length=23.0,
+            width=12.5,
+            height=25.0,
+            leading_length=8.0,
+            latch_z=3.0,
+            latch_x=2.0,
+            latch_thickness=1.5,
+            latch_length=4.0,
+            cable_z=10.0,
+            screw_hole_lx=1.0,
+            screw_hole_d=2.0,
+        )
+        si = ServoInformation(
+            height=25.0, width=12.5, length=23.0,
+            lever_length=5.0, servo=servo,
+        )
+        # Setters are intentionally no-ops
+        si.length = 999.0
+        si.width = 999.0
+        si.height = 999.0
+        # Values unchanged -- backed by servo
+        assert si.length == 23.0
+        assert si.width == 12.5
+        assert si.height == 25.0

--- a/cad_designer/tests/test_fuselage_configuration.py
+++ b/cad_designer/tests/test_fuselage_configuration.py
@@ -1,0 +1,227 @@
+"""Tests for FuselageConfiguration data model."""
+from __future__ import annotations
+
+import json
+import os
+
+import aerosandbox as asb
+import numpy as np
+import pytest
+
+from cad_designer.airplane.aircraft_topology.fuselage.FuselageConfiguration import (
+    FuselageConfiguration,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def simple_fuselage() -> FuselageConfiguration:
+    """A FuselageConfiguration with only a name (no ASB fuselage)."""
+    return FuselageConfiguration(name="test_fuselage")
+
+
+@pytest.fixture
+def fuselage_with_asb() -> FuselageConfiguration:
+    """A FuselageConfiguration populated with an aerosandbox Fuselage."""
+    fc = FuselageConfiguration(name="asb_fuselage")
+    fc.asb_fuselage = asb.Fuselage(
+        name="body",
+        xsecs=[
+            asb.FuselageXSec(
+                xyz_c=np.array([0.0, 0.0, 0.0]),
+                xyz_normal=np.array([1.0, 0.0, 0.0]),
+                height=0.1,
+                width=0.1,
+            ),
+            asb.FuselageXSec(
+                xyz_c=np.array([0.5, 0.0, 0.0]),
+                xyz_normal=np.array([1.0, 0.0, 0.0]),
+                height=0.3,
+                width=0.25,
+            ),
+            asb.FuselageXSec(
+                xyz_c=np.array([1.0, 0.0, 0.0]),
+                xyz_normal=np.array([1.0, 0.0, 0.0]),
+                height=0.05,
+                width=0.05,
+            ),
+        ],
+    )
+    return fc
+
+
+# ---------------------------------------------------------------------------
+# Constructor tests
+# ---------------------------------------------------------------------------
+
+class TestFuselageConfigurationInit:
+    """Tests for FuselageConfiguration.__init__."""
+
+    def test_name_is_stored(self, simple_fuselage: FuselageConfiguration) -> None:
+        assert simple_fuselage.name == "test_fuselage"
+
+    def test_asb_fuselage_defaults_to_none(
+        self, simple_fuselage: FuselageConfiguration
+    ) -> None:
+        assert simple_fuselage.asb_fuselage is None
+
+    def test_private_fields_default_to_none(
+        self, simple_fuselage: FuselageConfiguration
+    ) -> None:
+        assert simple_fuselage._step_file is None
+        assert simple_fuselage._step_scale is None
+        assert simple_fuselage._number_of_slices is None
+
+    def test_empty_name(self) -> None:
+        fc = FuselageConfiguration(name="")
+        assert fc.name == ""
+
+
+# ---------------------------------------------------------------------------
+# Serialization: __getstate__
+# ---------------------------------------------------------------------------
+
+class TestFuselageConfigurationGetState:
+    """Tests for __getstate__ (dict serialization)."""
+
+    def test_minimal_getstate(self, simple_fuselage: FuselageConfiguration) -> None:
+        state = simple_fuselage.__getstate__()
+        assert state["name"] == "test_fuselage"
+        assert state["step_file"] is None
+        assert state["step_scale"] is None
+        assert state["number_of_slices"] is None
+        assert "asb_fuselage" not in state
+
+    def test_getstate_with_asb_fuselage(
+        self, fuselage_with_asb: FuselageConfiguration
+    ) -> None:
+        state = fuselage_with_asb.__getstate__()
+        assert "asb_fuselage" in state
+        asb_data = state["asb_fuselage"]
+        assert asb_data["name"] == "body"
+        assert len(asb_data["xsecs"]) == 3
+
+    def test_getstate_xsec_fields(
+        self, fuselage_with_asb: FuselageConfiguration
+    ) -> None:
+        xsec = fuselage_with_asb.__getstate__()["asb_fuselage"]["xsecs"][1]
+        assert xsec["height"] == 0.3
+        assert xsec["width"] == 0.25
+        np.testing.assert_array_almost_equal(xsec["xyz_c"], [0.5, 0.0, 0.0])
+        np.testing.assert_array_almost_equal(xsec["xyz_normal"], [1.0, 0.0, 0.0])
+
+    def test_getstate_is_json_serializable(
+        self, fuselage_with_asb: FuselageConfiguration
+    ) -> None:
+        """__getstate__ output must be JSON-encodable."""
+        state = fuselage_with_asb.__getstate__()
+        serialized = json.dumps(state)
+        assert isinstance(serialized, str)
+
+
+# ---------------------------------------------------------------------------
+# Deserialization: from_json_dict
+# ---------------------------------------------------------------------------
+
+class TestFuselageConfigurationFromJsonDict:
+    """Tests for the static from_json_dict factory."""
+
+    def test_roundtrip_minimal(self, simple_fuselage: FuselageConfiguration) -> None:
+        state = simple_fuselage.__getstate__()
+        restored = FuselageConfiguration.from_json_dict(state)
+        assert restored.name == simple_fuselage.name
+        assert restored.asb_fuselage is None
+
+    def test_roundtrip_with_asb(
+        self, fuselage_with_asb: FuselageConfiguration
+    ) -> None:
+        state = fuselage_with_asb.__getstate__()
+        restored = FuselageConfiguration.from_json_dict(state)
+        assert restored.name == fuselage_with_asb.name
+        assert restored.asb_fuselage is not None
+        assert len(restored.asb_fuselage.xsecs) == 3
+
+    def test_roundtrip_preserves_xsec_geometry(
+        self, fuselage_with_asb: FuselageConfiguration
+    ) -> None:
+        state = fuselage_with_asb.__getstate__()
+        restored = FuselageConfiguration.from_json_dict(state)
+        original_xsec = fuselage_with_asb.asb_fuselage.xsecs[1]
+        restored_xsec = restored.asb_fuselage.xsecs[1]
+        np.testing.assert_array_almost_equal(
+            restored_xsec.xyz_c, original_xsec.xyz_c
+        )
+        assert restored_xsec.height == original_xsec.height
+        assert restored_xsec.width == original_xsec.width
+
+    def test_missing_name_defaults_to_empty(self) -> None:
+        fc = FuselageConfiguration.from_json_dict({})
+        assert fc.name == ""
+
+    def test_empty_xsecs_list(self) -> None:
+        data = {"name": "empty", "asb_fuselage": {"name": "f", "xsecs": []}}
+        fc = FuselageConfiguration.from_json_dict(data)
+        assert fc.asb_fuselage is not None
+        assert len(fc.asb_fuselage.xsecs) == 0
+
+
+# ---------------------------------------------------------------------------
+# File I/O: save_to_json / from_json
+# ---------------------------------------------------------------------------
+
+class TestFuselageConfigurationFileIO:
+    """Tests for JSON file save/load."""
+
+    def test_save_and_load_minimal(
+        self, simple_fuselage: FuselageConfiguration, tmp_path
+    ) -> None:
+        path = str(tmp_path / "fuselage.json")
+        simple_fuselage.save_to_json(path)
+        assert os.path.exists(path)
+
+        loaded = FuselageConfiguration.from_json(path)
+        assert loaded.name == simple_fuselage.name
+
+    def test_save_and_load_with_asb(
+        self, fuselage_with_asb: FuselageConfiguration, tmp_path
+    ) -> None:
+        path = str(tmp_path / "fuselage_asb.json")
+        fuselage_with_asb.save_to_json(path)
+
+        loaded = FuselageConfiguration.from_json(path)
+        assert loaded.name == fuselage_with_asb.name
+        assert loaded.asb_fuselage is not None
+        assert len(loaded.asb_fuselage.xsecs) == 3
+
+    def test_saved_file_is_valid_json(
+        self, fuselage_with_asb: FuselageConfiguration, tmp_path
+    ) -> None:
+        path = str(tmp_path / "valid.json")
+        fuselage_with_asb.save_to_json(path)
+        with open(path) as f:
+            data = json.load(f)
+        assert isinstance(data, dict)
+        assert data["name"] == "asb_fuselage"
+
+    def test_from_json_nonexistent_file_raises(self) -> None:
+        with pytest.raises(FileNotFoundError):
+            FuselageConfiguration.from_json("/nonexistent/path.json")
+
+
+# ---------------------------------------------------------------------------
+# from_step_file (requires cadquery + real STEP file -- mark as xfail)
+# ---------------------------------------------------------------------------
+
+class TestFuselageConfigurationFromStep:
+    """Tests for from_step_file. These require cadquery and a real STEP file."""
+
+    @pytest.mark.slow
+    def test_from_step_file_missing_file_raises(self) -> None:
+        """from_step_file should raise when the STEP file does not exist."""
+        with pytest.raises(Exception):
+            FuselageConfiguration.from_step_file(
+                step_file="/nonexistent/fuselage.step"
+            )

--- a/cad_designer/tests/test_spare.py
+++ b/cad_designer/tests/test_spare.py
@@ -1,0 +1,184 @@
+"""Tests for cad_designer.airplane.aircraft_topology.wing.Spare."""
+
+import pytest
+from cadquery import Vector
+
+from cad_designer.airplane.aircraft_topology.wing.Spare import Spare, SpareMode
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+class TestSpareInit:
+    """Test Spare constructor and default values."""
+
+    def test_minimal_construction(self):
+        s = Spare(spare_support_dimension_width=10.0, spare_support_dimension_height=5.0)
+        assert s.spare_support_dimension_width == 10.0
+        assert s.spare_support_dimension_height == 5.0
+        assert s.spare_position_factor is None
+        assert s.spare_length is None
+        assert s.spare_start == 0.0
+        assert s.spare_mode == "standard"
+        assert s.spare_vector is None
+        assert s.spare_origin is None
+
+    def test_full_construction(self):
+        s = Spare(
+            spare_support_dimension_width=12.0,
+            spare_support_dimension_height=8.0,
+            spare_position_factor=0.3,
+            spare_length=100.0,
+            spare_start=5.0,
+            spare_vector=(0.0, 1.0, 0.0),
+            spare_origin=(10.0, 20.0, 30.0),
+            spare_mode="follow",
+        )
+        assert s.spare_support_dimension_width == 12.0
+        assert s.spare_support_dimension_height == 8.0
+        assert s.spare_position_factor == 0.3
+        assert s.spare_length == 100.0
+        assert s.spare_start == 5.0
+        assert s.spare_mode == "follow"
+        assert isinstance(s.spare_vector, Vector)
+        assert s.spare_vector.toTuple() == pytest.approx((0.0, 1.0, 0.0))
+        assert isinstance(s.spare_origin, Vector)
+        assert s.spare_origin.toTuple() == pytest.approx((10.0, 20.0, 30.0))
+
+    def test_vector_none_stays_none(self):
+        s = Spare(spare_support_dimension_width=1.0, spare_support_dimension_height=1.0)
+        assert s.spare_vector is None
+        assert s.spare_origin is None
+
+    def test_vector_tuple_converted_to_cadquery_vector(self):
+        s = Spare(
+            spare_support_dimension_width=1.0,
+            spare_support_dimension_height=1.0,
+            spare_vector=(1.0, 2.0, 3.0),
+        )
+        assert isinstance(s.spare_vector, Vector)
+
+    def test_zero_dimensions_allowed(self):
+        s = Spare(spare_support_dimension_width=0.0, spare_support_dimension_height=0.0)
+        assert s.spare_support_dimension_width == 0.0
+        assert s.spare_support_dimension_height == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Spare modes
+# ---------------------------------------------------------------------------
+
+class TestSpareModes:
+    """Test all valid SpareMode values."""
+
+    @pytest.mark.parametrize(
+        "mode",
+        ["normal", "follow", "standard", "standard_backward", "orthogonal_backward"],
+    )
+    def test_valid_modes(self, mode):
+        s = Spare(
+            spare_support_dimension_width=5.0,
+            spare_support_dimension_height=3.0,
+            spare_mode=mode,
+        )
+        assert s.spare_mode == mode
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+class TestSpareSerialization:
+    """Test __getstate__, from_json_dict, and round-trip."""
+
+    def test_getstate_without_vectors(self):
+        s = Spare(spare_support_dimension_width=10.0, spare_support_dimension_height=5.0)
+        state = s.__getstate__()
+        assert state["spare_support_dimension_width"] == 10.0
+        assert state["spare_support_dimension_height"] == 5.0
+        assert state["spare_vector"] is None
+        assert state["spare_origin"] is None
+
+    def test_getstate_with_vectors(self):
+        s = Spare(
+            spare_support_dimension_width=10.0,
+            spare_support_dimension_height=5.0,
+            spare_vector=(1.0, 0.0, 0.0),
+            spare_origin=(5.0, 10.0, 15.0),
+        )
+        state = s.__getstate__()
+        # Vectors should be serialized as tuples, not cadquery.Vector
+        assert isinstance(state["spare_vector"], tuple)
+        assert state["spare_vector"] == pytest.approx((1.0, 0.0, 0.0))
+        assert isinstance(state["spare_origin"], tuple)
+        assert state["spare_origin"] == pytest.approx((5.0, 10.0, 15.0))
+
+    def test_from_json_dict_minimal(self):
+        data = {}
+        s = Spare.from_json_dict(data)
+        assert s.spare_support_dimension_width == 0
+        assert s.spare_support_dimension_height == 0
+        assert s.spare_mode == "standard"
+
+    def test_from_json_dict_full(self):
+        data = {
+            "spare_support_dimension_width": 12.0,
+            "spare_support_dimension_height": 8.0,
+            "spare_position_factor": 0.25,
+            "spare_length": 200.0,
+            "spare_start": 10.0,
+            "spare_vector": (0.0, 1.0, 0.0),
+            "spare_origin": (1.0, 2.0, 3.0),
+            "spare_mode": "follow",
+        }
+        s = Spare.from_json_dict(data)
+        assert s.spare_support_dimension_width == 12.0
+        assert s.spare_support_dimension_height == 8.0
+        assert s.spare_position_factor == 0.25
+        assert s.spare_length == 200.0
+        assert s.spare_start == 10.0
+        assert s.spare_mode == "follow"
+        assert isinstance(s.spare_vector, Vector)
+        assert isinstance(s.spare_origin, Vector)
+
+    def test_roundtrip(self):
+        original = Spare(
+            spare_support_dimension_width=15.0,
+            spare_support_dimension_height=7.5,
+            spare_position_factor=0.4,
+            spare_length=150.0,
+            spare_start=3.0,
+            spare_vector=(0.0, 0.0, 1.0),
+            spare_origin=(10.0, 20.0, 0.0),
+            spare_mode="normal",
+        )
+        state = original.__getstate__()
+        restored = Spare.from_json_dict(state)
+
+        assert restored.spare_support_dimension_width == original.spare_support_dimension_width
+        assert restored.spare_support_dimension_height == original.spare_support_dimension_height
+        assert restored.spare_position_factor == original.spare_position_factor
+        assert restored.spare_length == original.spare_length
+        assert restored.spare_start == original.spare_start
+        assert restored.spare_mode == original.spare_mode
+        assert restored.spare_vector.toTuple() == pytest.approx(original.spare_vector.toTuple())
+        assert restored.spare_origin.toTuple() == pytest.approx(original.spare_origin.toTuple())
+
+    def test_roundtrip_none_vectors(self):
+        original = Spare(spare_support_dimension_width=5.0, spare_support_dimension_height=3.0)
+        state = original.__getstate__()
+        restored = Spare.from_json_dict(state)
+        assert restored.spare_vector is None
+        assert restored.spare_origin is None
+
+
+# ---------------------------------------------------------------------------
+# repr
+# ---------------------------------------------------------------------------
+
+class TestSpareRepr:
+    def test_repr_does_not_raise(self):
+        s = Spare(spare_support_dimension_width=10.0, spare_support_dimension_height=5.0, spare_mode="follow")
+        result = repr(s)
+        assert "follow" in result

--- a/cad_designer/tests/test_trailing_edge_device.py
+++ b/cad_designer/tests/test_trailing_edge_device.py
@@ -1,0 +1,347 @@
+"""Tests for TrailingEdgeDevice topology model."""
+
+import pytest
+
+from cad_designer.airplane.aircraft_topology.wing.TrailingEdgeDevice import (
+    TrailingEdgeDevice,
+    HingeType,
+    ServoPlacement,
+)
+
+try:
+    from cad_designer.airplane.aircraft_topology.components.Servo import Servo
+
+    HAS_CADQUERY = True
+except ImportError:
+    HAS_CADQUERY = False
+
+requires_cadquery = pytest.mark.skipif(
+    not HAS_CADQUERY, reason="CadQuery / OCP not available"
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_servo(**overrides):
+    """Helper to create a Servo with sensible defaults."""
+    defaults = dict(
+        length=23.0,
+        width=12.5,
+        height=25.0,
+        leading_length=8.0,
+        latch_z=3.0,
+        latch_x=2.0,
+        latch_thickness=1.5,
+        latch_length=4.0,
+        cable_z=10.0,
+        screw_hole_lx=1.0,
+        screw_hole_d=2.0,
+    )
+    defaults.update(overrides)
+    return Servo(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Constructor defaults
+# ---------------------------------------------------------------------------
+
+
+class TestTrailingEdgeDeviceDefaults:
+    """Verify default values assigned by the constructor."""
+
+    def test_minimal_construction(self):
+        ted = TrailingEdgeDevice(name="flap")
+        assert ted.name == "flap"
+        assert ted.rel_chord_root == 0.8
+        assert ted.rel_chord_tip == 0.8  # falls back to root when tip is None
+        assert ted.hinge_spacing is None
+        assert ted.side_spacing_root is None
+        assert ted.side_spacing_tip is None
+        assert ted._servo is None
+        assert ted.servo_placement == "top"
+        assert ted.rel_chord_servo_position is None
+        assert ted.rel_length_servo_position is None
+        assert ted.positive_deflection_deg == 25
+        assert ted.negative_deflection_deg == 25
+        assert ted.trailing_edge_offset_factor == 1.0
+        assert ted.hinge_type == "top"
+        assert ted.symmetric is True
+
+
+class TestTrailingEdgeDeviceConstructor:
+    """Verify all constructor parameters are stored correctly."""
+
+    def test_all_parameters(self):
+        ted = TrailingEdgeDevice(
+            name="aileron",
+            rel_chord_root=0.7,
+            rel_chord_tip=0.6,
+            hinge_spacing=5.0,
+            side_spacing_root=2.0,
+            side_spacing_tip=3.0,
+            servo=42,
+            servo_placement="bottom",
+            rel_chord_servo_position=0.5,
+            rel_length_servo_position=0.3,
+            positive_deflection_deg=30,
+            negative_deflection_deg=15,
+            trailing_edge_offset_factor=0.9,
+            hinge_type="middle",
+            symmetric=False,
+        )
+        assert ted.name == "aileron"
+        assert ted.rel_chord_root == 0.7
+        assert ted.rel_chord_tip == 0.6
+        assert ted.hinge_spacing == 5.0
+        assert ted.side_spacing_root == 2.0
+        assert ted.side_spacing_tip == 3.0
+        assert ted._servo == 42
+        assert ted.servo_placement == "bottom"
+        assert ted.rel_chord_servo_position == 0.5
+        assert ted.rel_length_servo_position == 0.3
+        assert ted.positive_deflection_deg == 30
+        assert ted.negative_deflection_deg == 15
+        assert ted.trailing_edge_offset_factor == 0.9
+        assert ted.hinge_type == "middle"
+        assert ted.symmetric is False
+
+    def test_tip_defaults_to_root_when_none(self):
+        ted = TrailingEdgeDevice(name="flap", rel_chord_root=0.65)
+        assert ted.rel_chord_tip == 0.65
+
+    def test_tip_independent_of_root(self):
+        ted = TrailingEdgeDevice(name="flap", rel_chord_root=0.7, rel_chord_tip=0.5)
+        assert ted.rel_chord_root == 0.7
+        assert ted.rel_chord_tip == 0.5
+
+    @requires_cadquery
+    def test_servo_object_stored(self):
+        servo = _make_servo()
+        ted = TrailingEdgeDevice(name="flap", servo=servo)
+        assert ted._servo is servo
+
+    def test_servo_int_id_stored(self):
+        ted = TrailingEdgeDevice(name="flap", servo=99)
+        assert ted._servo == 99
+
+
+# ---------------------------------------------------------------------------
+# Hinge types
+# ---------------------------------------------------------------------------
+
+class TestHingeTypes:
+    """Verify all documented hinge type literals."""
+
+    @pytest.mark.parametrize(
+        "hinge_type",
+        ["middle", "top", "top_simple", "round_inside", "round_outside"],
+    )
+    def test_valid_hinge_types(self, hinge_type):
+        ted = TrailingEdgeDevice(name="flap", hinge_type=hinge_type)
+        assert ted.hinge_type == hinge_type
+
+
+# ---------------------------------------------------------------------------
+# Servo placement
+# ---------------------------------------------------------------------------
+
+class TestServoPlacement:
+    @pytest.mark.parametrize("placement", ["top", "bottom"])
+    def test_valid_placements(self, placement):
+        ted = TrailingEdgeDevice(name="flap", servo_placement=placement)
+        assert ted.servo_placement == placement
+
+
+# ---------------------------------------------------------------------------
+# Deflection angles
+# ---------------------------------------------------------------------------
+
+class TestDeflectionAngles:
+    def test_zero_deflection(self):
+        ted = TrailingEdgeDevice(
+            name="flap", positive_deflection_deg=0, negative_deflection_deg=0
+        )
+        assert ted.positive_deflection_deg == 0
+        assert ted.negative_deflection_deg == 0
+
+    def test_asymmetric_deflection(self):
+        ted = TrailingEdgeDevice(
+            name="aileron",
+            positive_deflection_deg=30,
+            negative_deflection_deg=15,
+            symmetric=False,
+        )
+        assert ted.positive_deflection_deg == 30
+        assert ted.negative_deflection_deg == 15
+        assert ted.symmetric is False
+
+    def test_large_deflection(self):
+        ted = TrailingEdgeDevice(
+            name="flap", positive_deflection_deg=90, negative_deflection_deg=45
+        )
+        assert ted.positive_deflection_deg == 90
+        assert ted.negative_deflection_deg == 45
+
+
+# ---------------------------------------------------------------------------
+# servo() method
+# ---------------------------------------------------------------------------
+
+@requires_cadquery
+class TestServoMethod:
+    """Test the servo() accessor which resolves servo references."""
+
+    def test_servo_none_returns_none(self):
+        ted = TrailingEdgeDevice(name="flap", servo=None)
+        assert ted.servo(servo_information=None) is None
+        assert ted.servo(servo_information={}) is None
+
+    def test_servo_object_returned_directly(self):
+        servo = _make_servo()
+        ted = TrailingEdgeDevice(name="flap", servo=servo)
+        result = ted.servo(servo_information=None)
+        assert result is servo
+
+    def test_servo_object_returned_with_info_dict(self):
+        servo = _make_servo()
+        ted = TrailingEdgeDevice(name="flap", servo=servo)
+        result = ted.servo(servo_information={1: "dummy"})
+        assert result is servo
+
+    def test_servo_int_resolved_from_info(self):
+        from cad_designer.airplane.aircraft_topology.components.ServoInformation import (
+            ServoInformation,
+        )
+
+        servo = _make_servo()
+        info = ServoInformation(
+            height=servo.height,
+            width=servo.width,
+            length=servo.length,
+            lever_length=5.0,
+            servo=servo,
+        )
+        ted = TrailingEdgeDevice(name="flap", servo=42)
+        result = ted.servo(servo_information={42: info})
+        assert result is servo
+
+    def test_servo_int_missing_in_info_raises(self):
+        from cad_designer.airplane.aircraft_topology.components.ServoInformation import (
+            ServoInformation,
+        )
+
+        servo = _make_servo()
+        info = ServoInformation(
+            height=servo.height,
+            width=servo.width,
+            length=servo.length,
+            lever_length=5.0,
+            servo=servo,
+        )
+        ted = TrailingEdgeDevice(name="flap", servo=99)
+        with pytest.raises(ValueError, match="No servo information for servo '99'"):
+            ted.servo(servo_information={42: info})
+
+    def test_servo_int_no_info_dict_raises(self):
+        ted = TrailingEdgeDevice(name="flap", servo=42)
+        with pytest.raises(ValueError, match="No servo information provided"):
+            ted.servo(servo_information=None)
+
+
+# ---------------------------------------------------------------------------
+# __repr__
+# ---------------------------------------------------------------------------
+
+class TestRepr:
+    def test_repr_contains_name(self):
+        ted = TrailingEdgeDevice(name="aileron")
+        r = repr(ted)
+        assert "aileron" in r
+
+
+# ---------------------------------------------------------------------------
+# __getstate__ / serialization
+# ---------------------------------------------------------------------------
+
+class TestSerialization:
+    def test_getstate_contains_all_keys(self):
+        ted = TrailingEdgeDevice(name="flap")
+        state = ted.__getstate__()
+        assert state["name"] == "flap"
+        assert state["rel_chord_root"] == 0.8
+        assert state["hinge_type"] == "top"
+        assert "_servo" in state
+
+    def test_getstate_servo_none(self):
+        ted = TrailingEdgeDevice(name="flap", servo=None)
+        state = ted.__getstate__()
+        assert state["_servo"] is None
+
+    def test_getstate_servo_int(self):
+        ted = TrailingEdgeDevice(name="flap", servo=7)
+        state = ted.__getstate__()
+        assert state["_servo"] == 7
+
+    @requires_cadquery
+    def test_getstate_servo_object_serialized(self):
+        servo = _make_servo()
+        ted = TrailingEdgeDevice(name="flap", servo=servo)
+        state = ted.__getstate__()
+        assert isinstance(state["_servo"], dict)
+        assert state["_servo"]["model"] == "Servo"
+        assert state["_servo"]["length"] == 23.0
+
+
+# ---------------------------------------------------------------------------
+# from_json_dict
+# ---------------------------------------------------------------------------
+
+class TestFromJsonDict:
+    def test_roundtrip_basic(self):
+        ted = TrailingEdgeDevice(
+            name="flap",
+            rel_chord_root=0.75,
+            rel_chord_tip=0.6,
+            hinge_spacing=3.0,
+            positive_deflection_deg=20,
+            negative_deflection_deg=10,
+            hinge_type="middle",
+            servo_placement="bottom",
+            symmetric=False,
+        )
+        state = ted.__getstate__()
+        restored = TrailingEdgeDevice.from_json_dict(state)
+        assert restored.name == "flap"
+        assert restored.rel_chord_root == 0.75
+        assert restored.rel_chord_tip == 0.6
+        assert restored.hinge_spacing == 3.0
+        assert restored.positive_deflection_deg == 20
+        assert restored.negative_deflection_deg == 10
+        assert restored.hinge_type == "middle"
+        assert restored.servo_placement == "bottom"
+        assert restored.symmetric is False
+
+    def test_roundtrip_servo_none(self):
+        ted = TrailingEdgeDevice(name="flap", servo=None)
+        state = ted.__getstate__()
+        restored = TrailingEdgeDevice.from_json_dict(state)
+        assert restored._servo is None
+
+    def test_roundtrip_servo_int(self):
+        ted = TrailingEdgeDevice(name="flap", servo=5)
+        state = ted.__getstate__()
+        restored = TrailingEdgeDevice.from_json_dict(state)
+        assert restored._servo == 5
+
+    @requires_cadquery
+    def test_roundtrip_servo_object(self):
+        servo = _make_servo()
+        ted = TrailingEdgeDevice(name="flap", servo=servo)
+        state = ted.__getstate__()
+        restored = TrailingEdgeDevice.from_json_dict(state)
+        assert isinstance(restored._servo, Servo)
+        assert restored._servo.length == servo.length
+        assert restored._servo.width == servo.width
+        assert restored._servo.height == servo.height

--- a/cad_designer/tests/test_wing_segment.py
+++ b/cad_designer/tests/test_wing_segment.py
@@ -1,0 +1,275 @@
+"""Tests for cad_designer.airplane.aircraft_topology.wing.WingSegment."""
+
+import math
+
+import pytest
+
+from cad_designer.airplane.aircraft_topology.wing.Airfoil import Airfoil
+from cad_designer.airplane.aircraft_topology.wing.Spare import Spare
+from cad_designer.airplane.aircraft_topology.wing.TrailingEdgeDevice import TrailingEdgeDevice
+from cad_designer.airplane.aircraft_topology.wing.WingSegment import WingSegment
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def root_airfoil():
+    return Airfoil(airfoil="naca2415", chord=200.0, dihedral_as_rotation_in_degrees=3.0, incidence=1.0)
+
+
+@pytest.fixture()
+def tip_airfoil():
+    return Airfoil(airfoil="naca2415", chord=150.0, dihedral_as_rotation_in_degrees=0.0, incidence=0.5)
+
+
+@pytest.fixture()
+def sample_spare():
+    return Spare(spare_support_dimension_width=10.0, spare_support_dimension_height=5.0, spare_position_factor=0.3)
+
+
+@pytest.fixture()
+def sample_ted():
+    return TrailingEdgeDevice(name="aileron", rel_chord_root=0.75, rel_chord_tip=0.8)
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+class TestWingSegmentInit:
+    """Test WingSegment constructor and sweep calculations."""
+
+    def test_minimal_construction(self, root_airfoil):
+        ws = WingSegment(root_airfoil=root_airfoil, length=500.0)
+        assert ws.root_airfoil is root_airfoil
+        assert ws.length == 500.0
+        assert ws.sweep == 0.0
+        assert ws.sweep_angle == 0.0
+        assert ws.tip_airfoil is None
+        assert ws.spare_list is None
+        assert ws.trailing_edge_device is None
+        assert ws.number_interpolation_points is None
+        assert ws.tip_type is None
+        assert ws.wing_segment_type == "segment"
+
+    def test_with_all_params(self, root_airfoil, tip_airfoil, sample_spare, sample_ted):
+        ws = WingSegment(
+            root_airfoil=root_airfoil,
+            length=500.0,
+            sweep=50.0,
+            tip_airfoil=tip_airfoil,
+            spare_list=[sample_spare],
+            trailing_edge_device=sample_ted,
+            number_interpolation_points=100,
+            tip_type="round",
+            wing_segment_type="root",
+        )
+        assert ws.tip_airfoil is tip_airfoil
+        assert len(ws.spare_list) == 1
+        assert ws.trailing_edge_device is sample_ted
+        assert ws.number_interpolation_points == 100
+        assert ws.tip_type == "round"
+        assert ws.wing_segment_type == "root"
+
+    def test_wing_segment_types(self, root_airfoil):
+        for seg_type in ("root", "segment", "tip"):
+            ws = WingSegment(root_airfoil=root_airfoil, length=100.0, wing_segment_type=seg_type)
+            assert ws.wing_segment_type == seg_type
+
+
+# ---------------------------------------------------------------------------
+# Sweep calculations
+# ---------------------------------------------------------------------------
+
+class TestSweepCalculation:
+    """Test sweep distance vs. sweep angle conversion."""
+
+    def test_sweep_as_distance(self, root_airfoil):
+        """When sweep_is_angle=False (default), sweep is a distance and angle is derived."""
+        ws = WingSegment(root_airfoil=root_airfoil, length=500.0, sweep=100.0)
+        expected_angle = math.degrees(math.atan(100.0 / 500.0))
+        assert ws.sweep == 100.0
+        assert ws.sweep_angle == pytest.approx(expected_angle)
+
+    def test_sweep_as_angle(self, root_airfoil):
+        """When sweep_is_angle=True, sweep distance is computed from angle and length."""
+        angle_deg = 30.0
+        length = 500.0
+        ws = WingSegment(root_airfoil=root_airfoil, length=length, sweep=angle_deg, sweep_is_angle=True)
+        expected_distance = length * math.tan(math.radians(angle_deg))
+        assert ws.sweep_angle == angle_deg
+        assert ws.sweep == pytest.approx(expected_distance)
+
+    def test_zero_sweep_distance(self, root_airfoil):
+        ws = WingSegment(root_airfoil=root_airfoil, length=500.0, sweep=0.0)
+        assert ws.sweep == 0.0
+        assert ws.sweep_angle == 0.0
+
+    def test_zero_sweep_angle(self, root_airfoil):
+        ws = WingSegment(root_airfoil=root_airfoil, length=500.0, sweep=0.0, sweep_is_angle=True)
+        assert ws.sweep == pytest.approx(0.0)
+        assert ws.sweep_angle == 0.0
+
+    def test_45_degree_sweep_equals_length(self, root_airfoil):
+        """tan(45) = 1, so sweep distance should equal length."""
+        length = 300.0
+        ws = WingSegment(root_airfoil=root_airfoil, length=length, sweep=45.0, sweep_is_angle=True)
+        assert ws.sweep == pytest.approx(length, rel=1e-9)
+
+    def test_sweep_angle_from_distance_small(self, root_airfoil):
+        """Small sweep distance should give small angle."""
+        ws = WingSegment(root_airfoil=root_airfoil, length=1000.0, sweep=1.0)
+        assert ws.sweep_angle == pytest.approx(math.degrees(math.atan(0.001)), rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+class TestWingSegmentSerialization:
+    """Test __getstate__ and from_json_dict."""
+
+    def test_getstate_minimal(self, root_airfoil):
+        ws = WingSegment(root_airfoil=root_airfoil, length=500.0)
+        state = ws.__getstate__()
+        assert state["length"] == 500.0
+        assert state["sweep"] == 0.0
+        assert state["wing_segment_type"] == "segment"
+        # root_airfoil should be serialized as a dict (via Airfoil.__getstate__)
+        assert isinstance(state["root_airfoil"], dict)
+        assert state["root_airfoil"]["airfoil"] == "naca2415"
+        assert state["tip_airfoil"] is None
+        assert state["spare_list"] is None
+        assert state["trailing_edge_device"] is None
+
+    def test_getstate_with_spares(self, root_airfoil, sample_spare):
+        ws = WingSegment(root_airfoil=root_airfoil, length=500.0, spare_list=[sample_spare])
+        state = ws.__getstate__()
+        assert isinstance(state["spare_list"], list)
+        assert len(state["spare_list"]) == 1
+        assert isinstance(state["spare_list"][0], dict)
+
+    def test_getstate_with_ted(self, root_airfoil, sample_ted):
+        ws = WingSegment(root_airfoil=root_airfoil, length=500.0, trailing_edge_device=sample_ted)
+        state = ws.__getstate__()
+        assert isinstance(state["trailing_edge_device"], dict)
+
+    def test_from_json_dict_minimal(self):
+        data = {
+            "root_airfoil": {"airfoil": "rg15", "chord": 180.0},
+            "length": 400.0,
+        }
+        ws = WingSegment.from_json_dict(data)
+        assert ws.root_airfoil.airfoil == "rg15"
+        assert ws.root_airfoil.chord == 180.0
+        assert ws.length == 400.0
+        assert ws.wing_segment_type == "segment"
+
+    def test_from_json_dict_with_spares(self):
+        data = {
+            "root_airfoil": {"airfoil": "naca2415", "chord": 200.0},
+            "length": 500.0,
+            "spare_list": [
+                {"spare_support_dimension_width": 10.0, "spare_support_dimension_height": 5.0},
+                {"spare_support_dimension_width": 8.0, "spare_support_dimension_height": 4.0, "spare_mode": "follow"},
+            ],
+        }
+        ws = WingSegment.from_json_dict(data)
+        assert len(ws.spare_list) == 2
+        assert ws.spare_list[1].spare_mode == "follow"
+
+    def test_from_json_dict_with_tip_airfoil(self):
+        data = {
+            "root_airfoil": {"airfoil": "naca2415", "chord": 200.0},
+            "tip_airfoil": {"airfoil": "naca2415", "chord": 120.0, "incidence": -1.0},
+            "length": 600.0,
+        }
+        ws = WingSegment.from_json_dict(data)
+        assert ws.tip_airfoil is not None
+        assert ws.tip_airfoil.chord == 120.0
+        assert ws.tip_airfoil.incidence == -1.0
+
+    def test_roundtrip(self, root_airfoil, tip_airfoil, sample_spare, sample_ted):
+        original = WingSegment(
+            root_airfoil=root_airfoil,
+            length=500.0,
+            sweep=50.0,
+            tip_airfoil=tip_airfoil,
+            spare_list=[sample_spare],
+            trailing_edge_device=sample_ted,
+            wing_segment_type="root",
+        )
+        state = original.__getstate__()
+        restored = WingSegment.from_json_dict(state)
+
+        assert restored.length == original.length
+        assert restored.sweep == pytest.approx(original.sweep)
+        assert restored.wing_segment_type == original.wing_segment_type
+        assert restored.root_airfoil.airfoil == original.root_airfoil.airfoil
+        assert restored.root_airfoil.chord == original.root_airfoil.chord
+        assert restored.tip_airfoil.airfoil == original.tip_airfoil.airfoil
+        assert restored.tip_airfoil.chord == original.tip_airfoil.chord
+        assert len(restored.spare_list) == 1
+        assert restored.trailing_edge_device is not None
+
+    def test_roundtrip_preserves_sweep_angle(self, root_airfoil):
+        """Roundtrip should preserve sweep distance (angle is re-derived)."""
+        original = WingSegment(root_airfoil=root_airfoil, length=500.0, sweep=75.0)
+        state = original.__getstate__()
+        restored = WingSegment.from_json_dict(state)
+        assert restored.sweep == pytest.approx(original.sweep)
+        assert restored.sweep_angle == pytest.approx(original.sweep_angle)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+class TestWingSegmentEdgeCases:
+    """Test edge cases and boundary conditions."""
+
+    @pytest.mark.xfail(
+        reason="Production bug: __getstate__ treats empty list as falsy, serializes as None instead of []",
+        strict=True,
+    )
+    def test_empty_spare_list(self, root_airfoil):
+        ws = WingSegment(root_airfoil=root_airfoil, length=500.0, spare_list=[])
+        state = ws.__getstate__()
+        # Empty list should serialize as empty list, not None
+        assert state["spare_list"] == []
+
+    def test_from_json_dict_missing_optional_fields(self):
+        data = {
+            "root_airfoil": {"airfoil": "naca0010"},
+            "length": 300.0,
+        }
+        ws = WingSegment.from_json_dict(data)
+        assert ws.tip_airfoil is None
+        assert ws.spare_list is None
+        assert ws.trailing_edge_device is None
+        assert ws.number_interpolation_points is None
+        assert ws.tip_type is None
+
+    def test_from_json_dict_tip_type(self):
+        data = {
+            "root_airfoil": {"airfoil": "naca0010"},
+            "length": 100.0,
+            "tip_type": "round",
+            "wing_segment_type": "tip",
+        }
+        ws = WingSegment.from_json_dict(data)
+        assert ws.tip_type == "round"
+        assert ws.wing_segment_type == "tip"
+
+
+# ---------------------------------------------------------------------------
+# repr
+# ---------------------------------------------------------------------------
+
+class TestWingSegmentRepr:
+    def test_repr_does_not_raise(self, root_airfoil):
+        ws = WingSegment(root_airfoil=root_airfoil, length=500.0, sweep=30.0)
+        result = repr(ws)
+        assert "500.0" in result


### PR DESCRIPTION
## Summary
- Add 172 tests for `cad_designer/` topology data models
- `WingSegment`: 22 tests (sweep calc, serialization roundtrips)
- `Airfoil`: 24 tests (real .dat file parsing, coordinate validation)
- `Spare`: 16 tests (SpareMode enum, vector serialization)
- `TrailingEdgeDevice`: 31 tests (hinge types, deflection, servo resolution)
- Component models: 24 tests (Servo, ComponentInfo, EngineInfo, ServoInfo)
- `FuselageConfiguration`: 18 tests (xsec management, JSON/file I/O)
- `AirplaneConfiguration`: 37 tests (wing/fuselage mgmt, zip I/O, ASB conversion)
- No production code modified
- Bug ticket #290 created for `spare_list` falsy check

Part of EPIC #283

Closes #288

## Test plan
- [x] All 172 tests pass (171 passed, 1 xfailed — 5.65s)
- [x] No production code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)