### PR TITLE
test(gh-294,295): Wave 4 — endpoints, MCP, components, classification

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,7 @@ jobs:
           poetry run pytest -m "not slow" \
             --tb=short \
             --cov=app \
+            --cov=cad_designer \
             --cov-report=term-missing \
             --cov-report=xml \
             --cov-fail-under=70

--- a/app/tests/test_aeroanalysis_endpoint_extended.py
+++ b/app/tests/test_aeroanalysis_endpoint_extended.py
@@ -1,0 +1,519 @@
+"""Extended tests for app/api/v2/endpoints/aeroanalysis.py.
+
+Covers error-handling branches, strip-force endpoints, stability summary,
+and the _raise_http_from_domain helper that were not exercised by the
+original test_aeroanalysis.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException, Request
+
+from app.api.v2.endpoints.aeroanalysis import (
+    _raise_http_from_domain,
+    _resolve_base_url,
+    analyze_airplane_post,
+    analyze_wing_post,
+    calculate_streamlines_json,
+    get_airplane_strip_forces,
+    get_stability_summary,
+    get_wing_strip_forces,
+    get_aeroplane_three_view_url,
+    get_streamlines_three_view_url,
+    analyze_airplane_alpha_sweep,
+    analyze_airplane_simple_sweep,
+)
+from app.core.exceptions import (
+    ConflictError,
+    InternalError,
+    NotFoundError,
+    ServiceException,
+    ValidationDomainError,
+    ValidationError,
+)
+from app.schemas.AeroplaneRequest import (
+    AlphaSweepRequest,
+    AnalysisToolUrlType,
+    SimpleSweepRequest,
+)
+from app.schemas.aeroanalysisschema import OperatingPointSchema
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def plane_id():
+    return uuid.uuid4()
+
+
+@pytest.fixture()
+def operating_point():
+    return OperatingPointSchema.model_construct(
+        velocity=10.0,
+        alpha=5.0,
+        beta=0.0,
+        p=0.0,
+        q=0.0,
+        r=0.0,
+        xyz_ref=[0.0, 0.0, 0.0],
+    )
+
+
+@pytest.fixture()
+def mock_db():
+    return MagicMock()
+
+
+@pytest.fixture()
+def mock_request():
+    req = MagicMock(spec=Request)
+    req.base_url = "http://testserver/"
+    return req
+
+
+@pytest.fixture()
+def mock_settings():
+    s = MagicMock()
+    s.base_url = "http://testserver"
+    return s
+
+
+# ---------------------------------------------------------------------------
+# _raise_http_from_domain — all branches
+# ---------------------------------------------------------------------------
+
+
+class TestRaiseHttpFromDomain:
+    """Cover every isinstance branch in _raise_http_from_domain."""
+
+    def test_not_found_maps_to_404(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_http_from_domain(NotFoundError("gone"))
+        assert exc_info.value.status_code == 404
+        assert "gone" in exc_info.value.detail
+
+    def test_validation_error_maps_to_422(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_http_from_domain(ValidationError("bad input"))
+        assert exc_info.value.status_code == 422
+        assert "bad input" in exc_info.value.detail
+
+    def test_validation_domain_error_maps_to_422(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_http_from_domain(ValidationDomainError("domain issue"))
+        assert exc_info.value.status_code == 422
+        assert "domain issue" in exc_info.value.detail
+
+    def test_conflict_error_maps_to_409(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_http_from_domain(ConflictError("already exists"))
+        assert exc_info.value.status_code == 409
+        assert "already exists" in exc_info.value.detail
+
+    def test_internal_error_maps_to_500(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_http_from_domain(InternalError("boom"))
+        assert exc_info.value.status_code == 500
+        assert "boom" in exc_info.value.detail
+
+    def test_generic_service_exception_maps_to_500(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_http_from_domain(ServiceException("unknown"))
+        assert exc_info.value.status_code == 500
+        assert "unknown" in exc_info.value.detail
+
+
+# ---------------------------------------------------------------------------
+# _resolve_base_url
+# ---------------------------------------------------------------------------
+
+
+class TestResolveBaseUrl:
+    def test_returns_request_base_url_when_available(self, mock_request, mock_settings):
+        result = _resolve_base_url(mock_request, mock_settings)
+        assert result == "http://testserver"
+
+    def test_falls_back_to_settings_when_no_request(self, mock_settings):
+        result = _resolve_base_url(None, mock_settings)
+        assert result == "http://testserver"
+
+    def test_replaces_apiserver_sentinel_with_settings(self, mock_settings):
+        req = MagicMock(spec=Request)
+        req.base_url = "apiserver"
+        mock_settings.base_url = "http://real-server"
+        result = _resolve_base_url(req, mock_settings)
+        assert result == "http://real-server"
+
+
+# ---------------------------------------------------------------------------
+# get_airplane_strip_forces
+# ---------------------------------------------------------------------------
+
+
+class TestGetAirplaneStripForces:
+    def test_success(self, plane_id, operating_point, mock_db):
+        expected = {"surfaces": []}
+        with patch(
+            "app.api.v2.endpoints.aeroanalysis.analysis_service.analyze_airplane_strip_forces",
+            new=AsyncMock(return_value=expected),
+        ) as mock_fn:
+            result = asyncio.run(
+                get_airplane_strip_forces(plane_id, operating_point, mock_db)
+            )
+        assert result == expected
+        mock_fn.assert_awaited_once_with(mock_db, plane_id, operating_point)
+
+    def test_not_found_maps_to_404(self, plane_id, operating_point, mock_db):
+        with patch(
+            "app.api.v2.endpoints.aeroanalysis.analysis_service.analyze_airplane_strip_forces",
+            new=AsyncMock(side_effect=NotFoundError("no plane")),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    get_airplane_strip_forces(plane_id, operating_point, mock_db)
+                )
+        assert exc_info.value.status_code == 404
+
+    def test_conflict_maps_to_409(self, plane_id, operating_point, mock_db):
+        with patch(
+            "app.api.v2.endpoints.aeroanalysis.analysis_service.analyze_airplane_strip_forces",
+            new=AsyncMock(side_effect=ConflictError("locked")),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    get_airplane_strip_forces(plane_id, operating_point, mock_db)
+                )
+        assert exc_info.value.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# get_wing_strip_forces
+# ---------------------------------------------------------------------------
+
+
+class TestGetWingStripForces:
+    def test_success(self, plane_id, operating_point, mock_db):
+        expected = {"surfaces": [{"name": "main"}]}
+        with patch(
+            "app.api.v2.endpoints.aeroanalysis.analysis_service.analyze_wing_strip_forces",
+            new=AsyncMock(return_value=expected),
+        ) as mock_fn:
+            result = asyncio.run(
+                get_wing_strip_forces(plane_id, "main_wing", operating_point, mock_db)
+            )
+        assert result == expected
+        mock_fn.assert_awaited_once_with(
+            mock_db, plane_id, "main_wing", operating_point
+        )
+
+    def test_not_found_maps_to_404(self, plane_id, operating_point, mock_db):
+        with patch(
+            "app.api.v2.endpoints.aeroanalysis.analysis_service.analyze_wing_strip_forces",
+            new=AsyncMock(side_effect=NotFoundError("wing gone")),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    get_wing_strip_forces(plane_id, "no_wing", operating_point, mock_db)
+                )
+        assert exc_info.value.status_code == 404
+
+    def test_validation_error_maps_to_422(self, plane_id, operating_point, mock_db):
+        with patch(
+            "app.api.v2.endpoints.aeroanalysis.analysis_service.analyze_wing_strip_forces",
+            new=AsyncMock(side_effect=ValidationError("bad wing config")),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    get_wing_strip_forces(plane_id, "bad_wing", operating_point, mock_db)
+                )
+        assert exc_info.value.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# get_stability_summary
+# ---------------------------------------------------------------------------
+
+
+class TestGetStabilitySummary:
+    def test_success(self, plane_id, operating_point, mock_db):
+        from app.schemas.stability import StabilitySummaryResponse
+
+        expected = StabilitySummaryResponse(
+            static_margin=0.15,
+            neutral_point_x=0.3,
+            cg_x=0.25,
+            is_statically_stable=True,
+        )
+        with patch(
+            "app.api.v2.endpoints.aeroanalysis.stability_service.get_stability_summary",
+            new=AsyncMock(return_value=expected),
+        ) as mock_fn:
+            result = asyncio.run(
+                get_stability_summary(
+                    plane_id, operating_point, AnalysisToolUrlType.AVL, mock_db
+                )
+            )
+        assert result == expected
+        mock_fn.assert_awaited_once_with(
+            mock_db, plane_id, operating_point, AnalysisToolUrlType.AVL
+        )
+
+    def test_not_found_maps_to_404(self, plane_id, operating_point, mock_db):
+        with patch(
+            "app.api.v2.endpoints.aeroanalysis.stability_service.get_stability_summary",
+            new=AsyncMock(side_effect=NotFoundError("no aeroplane")),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    get_stability_summary(
+                        plane_id, operating_point, AnalysisToolUrlType.AVL, mock_db
+                    )
+                )
+        assert exc_info.value.status_code == 404
+
+    def test_internal_error_maps_to_500(self, plane_id, operating_point, mock_db):
+        with patch(
+            "app.api.v2.endpoints.aeroanalysis.stability_service.get_stability_summary",
+            new=AsyncMock(side_effect=InternalError("solver crashed")),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    get_stability_summary(
+                        plane_id, operating_point, AnalysisToolUrlType.AVL, mock_db
+                    )
+                )
+        assert exc_info.value.status_code == 500
+
+    def test_unexpected_exception_maps_to_500(self, plane_id, operating_point, mock_db):
+        with patch(
+            "app.api.v2.endpoints.aeroanalysis.stability_service.get_stability_summary",
+            new=AsyncMock(side_effect=RuntimeError("surprise")),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    get_stability_summary(
+                        plane_id, operating_point, AnalysisToolUrlType.AVL, mock_db
+                    )
+                )
+        assert exc_info.value.status_code == 500
+        assert "surprise" in exc_info.value.detail
+
+
+# ---------------------------------------------------------------------------
+# calculate_streamlines_json — error path
+# ---------------------------------------------------------------------------
+
+
+class TestStreamlinesJsonErrors:
+    def test_internal_error_maps_to_500(self, plane_id, operating_point, mock_db):
+        with patch(
+            "app.api.v2.endpoints.aeroanalysis.analysis_service.calculate_streamlines_json",
+            new=AsyncMock(side_effect=InternalError("VLM diverged")),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    calculate_streamlines_json(plane_id, operating_point, mock_db)
+                )
+        assert exc_info.value.status_code == 500
+
+    def test_unexpected_exception_maps_to_500(self, plane_id, operating_point, mock_db):
+        with patch(
+            "app.api.v2.endpoints.aeroanalysis.analysis_service.calculate_streamlines_json",
+            new=AsyncMock(side_effect=RuntimeError("oops")),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    calculate_streamlines_json(plane_id, operating_point, mock_db)
+                )
+        assert exc_info.value.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# analyze_wing_post — additional error types
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeWingPostErrors:
+    def test_validation_domain_error_maps_to_422(
+        self, plane_id, operating_point, mock_db
+    ):
+        with patch(
+            "app.api.v2.endpoints.aeroanalysis.analysis_service.analyze_wing",
+            new=AsyncMock(side_effect=ValidationDomainError("chord <= 0")),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    analyze_wing_post(
+                        plane_id,
+                        "wing",
+                        operating_point,
+                        AnalysisToolUrlType.AEROBUILDUP,
+                        mock_db,
+                    )
+                )
+        assert exc_info.value.status_code == 422
+
+    def test_internal_error_maps_to_500(self, plane_id, operating_point, mock_db):
+        with patch(
+            "app.api.v2.endpoints.aeroanalysis.analysis_service.analyze_wing",
+            new=AsyncMock(side_effect=InternalError("solver failed")),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    analyze_wing_post(
+                        plane_id,
+                        "wing",
+                        operating_point,
+                        AnalysisToolUrlType.AEROBUILDUP,
+                        mock_db,
+                    )
+                )
+        assert exc_info.value.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# analyze_airplane_post — additional error types
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeAirplanePostErrors:
+    def test_conflict_error_maps_to_409(self, plane_id, operating_point, mock_db):
+        with patch(
+            "app.api.v2.endpoints.aeroanalysis.analysis_service.analyze_airplane",
+            new=AsyncMock(side_effect=ConflictError("analysis in progress")),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    analyze_airplane_post(
+                        plane_id,
+                        operating_point,
+                        AnalysisToolUrlType.VORTEX_LATTICE,
+                        mock_db,
+                    )
+                )
+        assert exc_info.value.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# alpha_sweep — error path
+# ---------------------------------------------------------------------------
+
+
+class TestAlphaSweepErrors:
+    @pytest.fixture()
+    def sweep_request(self):
+        return AlphaSweepRequest.model_construct(
+            altitude=0.0,
+            velocity=20.0,
+            alpha_start=0.0,
+            alpha_end=10.0,
+            alpha_num=5,
+            beta=0.0,
+            p=0.0,
+            q=0.0,
+            r=0.0,
+            xyz_ref=[0.0, 0.0, 0.0],
+        )
+
+    def test_not_found_maps_to_404(self, plane_id, sweep_request, mock_db):
+        with patch(
+            "app.api.v2.endpoints.aeroanalysis.analysis_service.analyze_alpha_sweep",
+            new=AsyncMock(side_effect=NotFoundError("no plane")),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    analyze_airplane_alpha_sweep(plane_id, sweep_request, mock_db)
+                )
+        assert exc_info.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# simple_sweep — error path
+# ---------------------------------------------------------------------------
+
+
+class TestSimpleSweepErrors:
+    @pytest.fixture()
+    def sweep_request(self):
+        return SimpleSweepRequest.model_construct(
+            sweep_var="velocity",
+            step_size=5.0,
+            num=3,
+            altitude=0.0,
+            velocity=20.0,
+            alpha=5.0,
+            beta=0.0,
+            p=0.0,
+            q=0.0,
+            r=0.0,
+            xyz_ref=[0.0, 0.0, 0.0],
+        )
+
+    def test_not_found_maps_to_404(self, plane_id, sweep_request, mock_db):
+        with patch(
+            "app.api.v2.endpoints.aeroanalysis.analysis_service.analyze_simple_sweep",
+            new=AsyncMock(side_effect=NotFoundError("no aeroplane")),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    analyze_airplane_simple_sweep(plane_id, sweep_request, mock_db)
+                )
+        assert exc_info.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# three_view and streamlines_three_view — error paths
+# ---------------------------------------------------------------------------
+
+
+class TestThreeViewErrors:
+    def test_not_found_maps_to_404(self, plane_id, mock_db, mock_request, mock_settings):
+        with patch(
+            "app.api.v2.endpoints.aeroanalysis.analysis_service.get_three_view_image",
+            new=AsyncMock(side_effect=NotFoundError("no aeroplane")),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    get_aeroplane_three_view_url(
+                        plane_id, mock_db, mock_settings, mock_request
+                    )
+                )
+        assert exc_info.value.status_code == 404
+
+    def test_validation_error_maps_to_422(self, plane_id, mock_db, mock_request, mock_settings):
+        with patch(
+            "app.api.v2.endpoints.aeroanalysis.analysis_service.get_three_view_image",
+            new=AsyncMock(side_effect=ValidationError("incomplete model")),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    get_aeroplane_three_view_url(
+                        plane_id, mock_db, mock_settings, mock_request
+                    )
+                )
+        assert exc_info.value.status_code == 422
+
+
+class TestStreamlinesThreeViewErrors:
+    def test_not_found_maps_to_404(
+        self, plane_id, operating_point, mock_db, mock_request, mock_settings
+    ):
+        with patch(
+            "app.api.v2.endpoints.aeroanalysis.analysis_service.get_streamlines_three_view_image",
+            new=AsyncMock(side_effect=NotFoundError("not found")),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    get_streamlines_three_view_url(
+                        plane_id, operating_point, mock_db, mock_settings, mock_request
+                    )
+                )
+        assert exc_info.value.status_code == 404

--- a/app/tests/test_cad_endpoint_extended.py
+++ b/app/tests/test_cad_endpoint_extended.py
@@ -1,0 +1,786 @@
+"""Extended tests for app/api/v2/endpoints/cad.py.
+
+Covers the helper functions (_raise_http_from_domain, _ensure_file_under_tmp,
+_offset_refs, _expand_bounding_box, _merge_tessellation_entries) and all
+endpoint error-handling branches that were not exercised by existing tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import uuid
+from pathlib import Path as FilePath
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.v2.endpoints.cad import (
+    _ensure_file_under_tmp,
+    _expand_bounding_box,
+    _merge_tessellation_entries,
+    _offset_refs,
+    _raise_http_from_domain,
+    create_wing_loft,
+    download_aeroplane_zip,
+    get_aeroplane_task_status,
+    get_aeroplane_tessellation,
+    start_wing_tessellation,
+)
+from app.core.exceptions import (
+    ConflictError,
+    InternalError,
+    NotFoundError,
+    ServiceException,
+    ValidationDomainError,
+    ValidationError,
+)
+from app.schemas.AeroplaneRequest import CreatorUrlType, ExporterUrlType
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def plane_id():
+    return uuid.uuid4()
+
+
+@pytest.fixture()
+def mock_db():
+    return MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# _raise_http_from_domain — all branches
+# ---------------------------------------------------------------------------
+
+
+class TestRaiseHttpFromDomain:
+    def test_not_found_maps_to_404(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_http_from_domain(NotFoundError("missing"))
+        assert exc_info.value.status_code == 404
+
+    def test_validation_error_maps_to_422(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_http_from_domain(ValidationError("bad"))
+        assert exc_info.value.status_code == 422
+
+    def test_validation_domain_error_maps_to_422(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_http_from_domain(ValidationDomainError("domain"))
+        assert exc_info.value.status_code == 422
+
+    def test_conflict_error_maps_to_409(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_http_from_domain(ConflictError("conflict"))
+        assert exc_info.value.status_code == 409
+
+    def test_internal_error_maps_to_500(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_http_from_domain(InternalError("crash"))
+        assert exc_info.value.status_code == 500
+
+    def test_generic_service_exception_maps_to_500(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_http_from_domain(ServiceException("unknown"))
+        assert exc_info.value.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# _ensure_file_under_tmp
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureFileUnderTmp:
+    def test_file_already_under_tmp(self, tmp_path):
+        """If the file is already under cwd/tmp, it should be returned as-is."""
+        # Create a fake file under a tmp dir inside a temporary cwd
+        fake_cwd = tmp_path / "project"
+        fake_cwd.mkdir()
+        tmp_dir = fake_cwd / "tmp" / "some-id" / "zip"
+        tmp_dir.mkdir(parents=True)
+        target_file = tmp_dir / "export.zip"
+        target_file.write_text("data")
+
+        with patch("app.api.v2.endpoints.cad.FilePath.cwd", return_value=fake_cwd):
+            result = _ensure_file_under_tmp(str(target_file), "some-id")
+
+        assert result == target_file.resolve()
+
+    def test_file_outside_tmp_gets_copied(self, tmp_path):
+        """If the file is outside tmp, it should be copied into tmp."""
+        fake_cwd = tmp_path / "project"
+        fake_cwd.mkdir()
+
+        # Source file is outside tmp
+        source_dir = tmp_path / "elsewhere"
+        source_dir.mkdir()
+        source_file = source_dir / "export.zip"
+        source_file.write_text("zipdata")
+
+        aeroplane_id = "test-plane-123"
+
+        with patch("app.api.v2.endpoints.cad.FilePath.cwd", return_value=fake_cwd):
+            result = _ensure_file_under_tmp(str(source_file), aeroplane_id)
+
+        # Should have been copied under fake_cwd/tmp/<id>/zip/
+        expected_dir = fake_cwd / "tmp" / aeroplane_id / "zip"
+        assert result.parent == expected_dir.resolve()
+        assert result.name == "export.zip"
+        assert result.read_text() == "zipdata"
+
+    def test_relative_path_is_resolved(self, tmp_path):
+        """A relative path should be resolved relative to cwd."""
+        fake_cwd = tmp_path / "project"
+        fake_cwd.mkdir()
+
+        # Create source file at fake_cwd/data/export.zip
+        data_dir = fake_cwd / "data"
+        data_dir.mkdir()
+        source = data_dir / "export.zip"
+        source.write_text("contents")
+
+        with patch("app.api.v2.endpoints.cad.FilePath.cwd", return_value=fake_cwd):
+            result = _ensure_file_under_tmp("data/export.zip", "plane-1")
+
+        expected_dir = fake_cwd / "tmp" / "plane-1" / "zip"
+        assert result.parent == expected_dir.resolve()
+        assert result.read_text() == "contents"
+
+
+# ---------------------------------------------------------------------------
+# _offset_refs
+# ---------------------------------------------------------------------------
+
+
+class TestOffsetRefs:
+    def test_offsets_ref_in_dict(self):
+        node = {"ref": 0, "other": "value"}
+        _offset_refs(node, 5)
+        assert node["ref"] == 5
+
+    def test_offsets_ref_in_nested_dict(self):
+        node = {"child": {"ref": 2}}
+        _offset_refs(node, 10)
+        assert node["child"]["ref"] == 12
+
+    def test_offsets_ref_in_list(self):
+        node = [{"ref": 1}, {"ref": 3}]
+        _offset_refs(node, 100)
+        assert node[0]["ref"] == 101
+        assert node[1]["ref"] == 103
+
+    def test_handles_float_ref(self):
+        node = {"ref": 2.5}
+        _offset_refs(node, 3)
+        assert node["ref"] == 5
+
+    def test_no_ref_key_is_noop(self):
+        node = {"name": "shape", "color": "red"}
+        _offset_refs(node, 10)
+        assert node == {"name": "shape", "color": "red"}
+
+    def test_empty_structures(self):
+        _offset_refs({}, 5)
+        _offset_refs([], 5)
+        _offset_refs("string", 5)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _expand_bounding_box
+# ---------------------------------------------------------------------------
+
+
+class TestExpandBoundingBox:
+    def test_expands_with_valid_bb(self):
+        bb_min = [10.0, 10.0, 10.0]
+        bb_max = [-10.0, -10.0, -10.0]
+        shapes = {"bb": {"min": [1.0, 2.0, 3.0], "max": [4.0, 5.0, 6.0]}}
+        _expand_bounding_box(bb_min, bb_max, shapes)
+        assert bb_min == [1.0, 2.0, 3.0]
+        assert bb_max == [4.0, 5.0, 6.0]
+
+    def test_no_bb_key_is_noop(self):
+        bb_min = [0.0, 0.0, 0.0]
+        bb_max = [1.0, 1.0, 1.0]
+        _expand_bounding_box(bb_min, bb_max, {})
+        assert bb_min == [0.0, 0.0, 0.0]
+        assert bb_max == [1.0, 1.0, 1.0]
+
+    def test_missing_min_in_bb_is_noop(self):
+        bb_min = [0.0, 0.0, 0.0]
+        bb_max = [1.0, 1.0, 1.0]
+        _expand_bounding_box(bb_min, bb_max, {"bb": {"max": [2, 2, 2]}})
+        assert bb_min == [0.0, 0.0, 0.0]
+
+    def test_multiple_expansions_take_extremes(self):
+        bb_min = [float("inf")] * 3
+        bb_max = [float("-inf")] * 3
+        shapes1 = {"bb": {"min": [0.0, 0.0, 0.0], "max": [1.0, 1.0, 1.0]}}
+        shapes2 = {"bb": {"min": [-1.0, -2.0, -3.0], "max": [5.0, 5.0, 5.0]}}
+        _expand_bounding_box(bb_min, bb_max, shapes1)
+        _expand_bounding_box(bb_min, bb_max, shapes2)
+        assert bb_min == [-1.0, -2.0, -3.0]
+        assert bb_max == [5.0, 5.0, 5.0]
+
+
+# ---------------------------------------------------------------------------
+# _merge_tessellation_entries
+# ---------------------------------------------------------------------------
+
+
+class TestMergeTessellationEntries:
+    def _make_entry(
+        self, *, component_type="wing", shapes=None, instances=None, count=1, bb=None
+    ):
+        entry = MagicMock()
+        entry.component_type = component_type
+        entry.is_stale = False
+        data = {}
+        if shapes is not None:
+            data["shapes"] = shapes
+        if instances is not None:
+            data["instances"] = instances
+        if bb is not None and shapes is not None:
+            shapes["bb"] = bb
+        entry.tessellation_json = {"data": data, "count": count}
+        return entry
+
+    def test_empty_entries(self):
+        parts, instances, count, bb = _merge_tessellation_entries([])
+        assert parts == []
+        assert instances == []
+        assert count == 0
+        assert bb == {"min": [0, 0, 0], "max": [0, 0, 0]}
+
+    def test_single_wing_entry(self):
+        entry = self._make_entry(
+            component_type="wing",
+            shapes={"version": 3, "name": "wing"},
+            instances=[{"id": 0}],
+            count=5,
+            bb={"min": [0, 0, 0], "max": [1, 1, 1]},
+        )
+        parts, instances, count, bb = _merge_tessellation_entries([entry])
+        assert len(parts) == 1
+        assert parts[0]["color"] == "#FF8400"  # wing color
+        assert instances == [{"id": 0}]
+        assert count == 5
+        assert bb == {"min": [0, 0, 0], "max": [1, 1, 1]}
+
+    def test_fuselage_gets_grey_color(self):
+        entry = self._make_entry(
+            component_type="fuselage",
+            shapes={"version": 3, "name": "fuse"},
+            instances=[],
+            count=3,
+            bb={"min": [-1, -1, -1], "max": [2, 2, 2]},
+        )
+        parts, _, _, _ = _merge_tessellation_entries([entry])
+        assert parts[0]["color"] == "#888888"
+
+    def test_multiple_entries_merge_instances_and_offset_refs(self):
+        entry1 = self._make_entry(
+            component_type="wing",
+            shapes={"version": 3, "name": "w1", "ref": 0},
+            instances=[{"id": 0}, {"id": 1}],
+            count=2,
+            bb={"min": [0, 0, 0], "max": [1, 1, 1]},
+        )
+        entry2 = self._make_entry(
+            component_type="fuselage",
+            shapes={"version": 3, "name": "f1", "ref": 0},
+            instances=[{"id": 0}],
+            count=3,
+            bb={"min": [-1, -1, -1], "max": [2, 2, 2]},
+        )
+        parts, instances, count, bb = _merge_tessellation_entries([entry1, entry2])
+        assert len(parts) == 2
+        assert len(instances) == 3  # 2 + 1
+        assert count == 5
+        # Second entry's ref should be offset by len(first instances) = 2
+        assert parts[1]["ref"] == 2
+        # BB should be the combined extremes
+        assert bb["min"] == [-1, -1, -1]
+        assert bb["max"] == [2, 2, 2]
+
+    def test_entry_without_shapes_is_skipped(self):
+        entry = self._make_entry(
+            component_type="wing",
+            shapes=None,
+            instances=[{"id": 0}],
+            count=1,
+        )
+        parts, instances, count, bb = _merge_tessellation_entries([entry])
+        assert parts == []
+        assert instances == [{"id": 0}]
+        assert count == 1
+
+
+# ---------------------------------------------------------------------------
+# start_wing_tessellation
+# ---------------------------------------------------------------------------
+
+
+class TestStartWingTessellation:
+    def test_success(self, plane_id, mock_db):
+        mock_aeroplane = MagicMock()
+        mock_wing = MagicMock()
+        mock_wing_schema = MagicMock()
+
+        with (
+            patch(
+                "app.api.v2.endpoints.cad.cad_service.get_aeroplane_with_wings",
+                return_value=mock_aeroplane,
+            ),
+            patch(
+                "app.api.v2.endpoints.cad.cad_service.get_wing_from_aeroplane",
+                return_value=mock_wing,
+            ),
+            patch(
+                "app.converters.model_schema_converters.wing_model_to_asb_wing_schema",
+                return_value=mock_wing_schema,
+            ),
+            patch("pickle.dumps", return_value=b"fake_pickle"),
+            patch(
+                "app.api.v2.endpoints.cad.tessellation_service.start_tessellation_task",
+            ) as mock_start,
+        ):
+            result = asyncio.run(
+                start_wing_tessellation(plane_id, "main_wing", mock_db)
+            )
+
+        assert result.aeroplane_id == str(plane_id)
+        mock_start.assert_called_once()
+
+    def test_not_found_maps_to_404(self, plane_id, mock_db):
+        with patch(
+            "app.api.v2.endpoints.cad.cad_service.get_aeroplane_with_wings",
+            side_effect=NotFoundError("no plane"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    start_wing_tessellation(plane_id, "wing", mock_db)
+                )
+        assert exc_info.value.status_code == 404
+
+    def test_unexpected_error_maps_to_500(self, plane_id, mock_db):
+        with patch(
+            "app.api.v2.endpoints.cad.cad_service.get_aeroplane_with_wings",
+            side_effect=RuntimeError("boom"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    start_wing_tessellation(plane_id, "wing", mock_db)
+                )
+        assert exc_info.value.status_code == 500
+        assert "boom" in exc_info.value.detail
+
+
+# ---------------------------------------------------------------------------
+# get_aeroplane_tessellation
+# ---------------------------------------------------------------------------
+
+
+class TestGetAeroplaneTessellation:
+    def test_success_returns_combined_scene(self, plane_id, mock_db):
+        mock_aeroplane = MagicMock()
+        mock_aeroplane.name = "TestPlane"
+        mock_aeroplane.id = 1
+
+        mock_entry = MagicMock()
+        mock_entry.component_type = "wing"
+        mock_entry.is_stale = False
+        mock_entry.tessellation_json = {
+            "data": {
+                "shapes": {
+                    "version": 3,
+                    "name": "wing",
+                    "bb": {"min": [0, 0, 0], "max": [1, 1, 1]},
+                },
+                "instances": [{"id": 0}],
+            },
+            "count": 5,
+        }
+
+        with (
+            patch(
+                "app.api.v2.endpoints.cad.cad_service.get_aeroplane_with_wings",
+                return_value=mock_aeroplane,
+            ),
+            patch(
+                "app.api.v2.endpoints.cad.tessellation_cache_service.get_all_cached",
+                return_value=[mock_entry],
+            ),
+        ):
+            result = asyncio.run(get_aeroplane_tessellation(plane_id, mock_db))
+
+        assert result["type"] == "data"
+        assert result["count"] == 5
+        assert result["is_stale"] is False
+        assert "data" in result
+        assert "shapes" in result["data"]
+
+    def test_no_cached_entries_returns_404(self, plane_id, mock_db):
+        mock_aeroplane = MagicMock()
+        mock_aeroplane.id = 1
+
+        with (
+            patch(
+                "app.api.v2.endpoints.cad.cad_service.get_aeroplane_with_wings",
+                return_value=mock_aeroplane,
+            ),
+            patch(
+                "app.api.v2.endpoints.cad.tessellation_cache_service.get_all_cached",
+                return_value=[],
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(get_aeroplane_tessellation(plane_id, mock_db))
+
+        assert exc_info.value.status_code == 404
+        assert "No cached tessellations" in exc_info.value.detail
+
+    def test_aeroplane_not_found_maps_to_404(self, plane_id, mock_db):
+        with patch(
+            "app.api.v2.endpoints.cad.cad_service.get_aeroplane_with_wings",
+            side_effect=NotFoundError("no plane"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(get_aeroplane_tessellation(plane_id, mock_db))
+        assert exc_info.value.status_code == 404
+
+    def test_unexpected_error_maps_to_500(self, plane_id, mock_db):
+        with patch(
+            "app.api.v2.endpoints.cad.cad_service.get_aeroplane_with_wings",
+            side_effect=RuntimeError("surprise"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(get_aeroplane_tessellation(plane_id, mock_db))
+        assert exc_info.value.status_code == 500
+
+    def test_is_stale_flag_propagated(self, plane_id, mock_db):
+        mock_aeroplane = MagicMock()
+        mock_aeroplane.name = "Plane"
+        mock_aeroplane.id = 1
+
+        entry1 = MagicMock()
+        entry1.component_type = "wing"
+        entry1.is_stale = False
+        entry1.tessellation_json = {
+            "data": {"shapes": {"version": 3}, "instances": []},
+            "count": 1,
+        }
+        entry2 = MagicMock()
+        entry2.component_type = "fuselage"
+        entry2.is_stale = True
+        entry2.tessellation_json = {
+            "data": {"shapes": {"version": 3}, "instances": []},
+            "count": 1,
+        }
+
+        with (
+            patch(
+                "app.api.v2.endpoints.cad.cad_service.get_aeroplane_with_wings",
+                return_value=mock_aeroplane,
+            ),
+            patch(
+                "app.api.v2.endpoints.cad.tessellation_cache_service.get_all_cached",
+                return_value=[entry1, entry2],
+            ),
+        ):
+            result = asyncio.run(get_aeroplane_tessellation(plane_id, mock_db))
+
+        assert result["is_stale"] is True
+
+
+# ---------------------------------------------------------------------------
+# create_wing_loft
+# ---------------------------------------------------------------------------
+
+
+class TestCreateWingLoft:
+    def test_success(self, plane_id, mock_db):
+        mock_aeroplane = MagicMock()
+        mock_wing = MagicMock()
+
+        with (
+            patch(
+                "app.api.v2.endpoints.cad.cad_service.get_aeroplane_with_wings",
+                return_value=mock_aeroplane,
+            ),
+            patch(
+                "app.api.v2.endpoints.cad.cad_service.get_wing_from_aeroplane",
+                return_value=mock_wing,
+            ),
+            patch(
+                "app.api.v2.endpoints.cad.cad_service.start_wing_export_task",
+            ) as mock_export,
+        ):
+            result = asyncio.run(
+                create_wing_loft(
+                    aeroplane_id=plane_id,
+                    wing_name="main_wing",
+                    db=mock_db,
+                    leading_edge_offset_factor=0.1,
+                    trailing_edge_offset_factor=0.15,
+                    aeroplane_settings=None,
+                    creator_url_type=CreatorUrlType.WING_LOFT,
+                    exporter_url_type=ExporterUrlType.STL,
+                )
+            )
+
+        assert result.aeroplane_id == str(plane_id)
+        mock_export.assert_called_once()
+
+    def test_not_found_maps_to_404(self, plane_id, mock_db):
+        with patch(
+            "app.api.v2.endpoints.cad.cad_service.get_aeroplane_with_wings",
+            side_effect=NotFoundError("no plane"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    create_wing_loft(
+                        plane_id, "wing", mock_db,
+                        creator_url_type=CreatorUrlType.WING_LOFT,
+                        exporter_url_type=ExporterUrlType.STL,
+                    )
+                )
+        assert exc_info.value.status_code == 404
+
+    def test_conflict_error_maps_to_409(self, plane_id, mock_db):
+        mock_aeroplane = MagicMock()
+        with (
+            patch(
+                "app.api.v2.endpoints.cad.cad_service.get_aeroplane_with_wings",
+                return_value=mock_aeroplane,
+            ),
+            patch(
+                "app.api.v2.endpoints.cad.cad_service.get_wing_from_aeroplane",
+                side_effect=ConflictError("export in progress"),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    create_wing_loft(
+                        plane_id, "wing", mock_db,
+                        creator_url_type=CreatorUrlType.WING_LOFT,
+                        exporter_url_type=ExporterUrlType.STL,
+                    )
+                )
+        assert exc_info.value.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# get_aeroplane_task_status
+# ---------------------------------------------------------------------------
+
+
+class TestGetAeroplaneTaskStatus:
+    def test_pending_status(self):
+        with patch(
+            "app.api.v2.endpoints.cad.cad_service.get_task_result",
+            return_value={"status": "PENDING"},
+        ):
+            result = asyncio.run(
+                get_aeroplane_task_status("some-id")
+            )
+        assert result.status == "PENDING"
+        assert result.message == "Task is pending."
+        assert result.result is None
+
+    def test_success_status(self):
+        with patch(
+            "app.api.v2.endpoints.cad.cad_service.get_task_result",
+            return_value={"status": "SUCCESS", "result": {"key": "value"}},
+        ):
+            result = asyncio.run(
+                get_aeroplane_task_status("some-id")
+            )
+        assert result.status == "SUCCESS"
+        assert result.message is None
+        assert result.result == {"key": "value"}
+
+    def test_failure_status(self):
+        with patch(
+            "app.api.v2.endpoints.cad.cad_service.get_task_result",
+            return_value={"status": "FAILURE", "error": "Out of memory"},
+        ):
+            result = asyncio.run(
+                get_aeroplane_task_status("some-id")
+            )
+        assert result.status == "FAILURE"
+        assert result.message == "Out of memory"
+
+    def test_failure_without_error_key(self):
+        with patch(
+            "app.api.v2.endpoints.cad.cad_service.get_task_result",
+            return_value={"status": "FAILURE"},
+        ):
+            result = asyncio.run(
+                get_aeroplane_task_status("some-id")
+            )
+        assert result.message == "An error occurred"
+
+    def test_unknown_status_returns_processing_message(self):
+        with patch(
+            "app.api.v2.endpoints.cad.cad_service.get_task_result",
+            return_value={"status": "RUNNING"},
+        ):
+            result = asyncio.run(
+                get_aeroplane_task_status("some-id")
+            )
+        assert result.status == "RUNNING"
+        assert result.message == "Task is processing."
+
+    def test_tessellation_task_type_builds_correct_key(self):
+        with patch(
+            "app.api.v2.endpoints.cad.cad_service.get_task_result",
+            return_value={"status": "PENDING"},
+        ) as mock_get:
+            asyncio.run(
+                get_aeroplane_task_status(
+                    "plane-1",
+                    task_type="tessellation",
+                    wing_name="main_wing",
+                )
+            )
+        mock_get.assert_called_once_with("plane-1:tessellation:main_wing")
+
+    def test_custom_task_type_builds_correct_key(self):
+        with patch(
+            "app.api.v2.endpoints.cad.cad_service.get_task_result",
+            return_value={"status": "PENDING"},
+        ) as mock_get:
+            asyncio.run(
+                get_aeroplane_task_status("plane-1", task_type="export")
+            )
+        mock_get.assert_called_once_with("plane-1:export")
+
+    def test_no_task_type_uses_aeroplane_id_as_key(self):
+        with patch(
+            "app.api.v2.endpoints.cad.cad_service.get_task_result",
+            return_value={"status": "PENDING"},
+        ) as mock_get:
+            asyncio.run(
+                get_aeroplane_task_status("plane-1")
+            )
+        mock_get.assert_called_once_with("plane-1")
+
+    def test_service_exception_maps_correctly(self):
+        with patch(
+            "app.api.v2.endpoints.cad.cad_service.get_task_result",
+            side_effect=NotFoundError("no task"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(get_aeroplane_task_status("bad-id"))
+        assert exc_info.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# download_aeroplane_zip
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadAeroplaneZip:
+    def test_success(self, tmp_path):
+        # Create a fake file that cad_service would return
+        fake_file = tmp_path / "export.zip"
+        fake_file.write_text("fake_zip")
+
+        mock_settings = MagicMock()
+        mock_settings.base_url = "http://testserver"
+        mock_request = MagicMock()
+        mock_request.base_url = "http://testserver/"
+
+        fake_cwd = tmp_path / "project"
+        fake_cwd.mkdir()
+
+        with (
+            patch(
+                "app.api.v2.endpoints.cad.cad_service.get_export_file_path",
+                return_value=str(fake_file),
+            ),
+            patch(
+                "app.api.v2.endpoints.cad._ensure_file_under_tmp",
+                return_value=fake_cwd / "tmp" / "plane" / "zip" / "export.zip",
+            ),
+            patch(
+                "app.api.v2.endpoints.cad.FilePath.cwd",
+                return_value=fake_cwd,
+            ),
+        ):
+            result = asyncio.run(
+                download_aeroplane_zip(
+                    aeroplane_id="plane-1",
+                    wing_name="main_wing",
+                    creator_url_type="wing_loft",
+                    exporter_url_type="stl",
+                    settings=mock_settings,
+                    request=mock_request,
+                )
+            )
+
+        assert result.filename == "export.zip"
+        assert result.mime_type == "application/zip"
+        assert "static" in result.url
+
+    def test_not_found_maps_to_404(self):
+        mock_settings = MagicMock()
+        mock_settings.base_url = "http://testserver"
+        mock_request = MagicMock()
+        mock_request.base_url = "http://testserver/"
+
+        with patch(
+            "app.api.v2.endpoints.cad.cad_service.get_export_file_path",
+            side_effect=NotFoundError("no export"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    download_aeroplane_zip(
+                        "plane-1", "wing", "wing_loft", "stl",
+                        mock_settings, mock_request,
+                    )
+                )
+        assert exc_info.value.status_code == 404
+
+    def test_apiserver_base_url_falls_back_to_settings(self, tmp_path):
+        fake_file = tmp_path / "export.zip"
+        fake_file.write_text("zip")
+
+        mock_settings = MagicMock()
+        mock_settings.base_url = "http://real-server"
+        mock_request = MagicMock()
+        mock_request.base_url = "apiserver"
+
+        fake_cwd = tmp_path / "project"
+        fake_cwd.mkdir()
+
+        with (
+            patch(
+                "app.api.v2.endpoints.cad.cad_service.get_export_file_path",
+                return_value=str(fake_file),
+            ),
+            patch(
+                "app.api.v2.endpoints.cad._ensure_file_under_tmp",
+                return_value=fake_cwd / "tmp" / "p" / "zip" / "export.zip",
+            ),
+            patch(
+                "app.api.v2.endpoints.cad.FilePath.cwd",
+                return_value=fake_cwd,
+            ),
+        ):
+            result = asyncio.run(
+                download_aeroplane_zip(
+                    "p", "wing", "wing_loft", "stl",
+                    mock_settings, mock_request,
+                )
+            )
+
+        assert "real-server" in result.url

--- a/app/tests/test_component_services_extended.py
+++ b/app/tests/test_component_services_extended.py
@@ -1,0 +1,1300 @@
+"""Extended tests for component_tree_service, component_service,
+component_type_service, and construction_part_service.
+
+Targets coverage gaps identified in GH Issue #294 (app/ Wave 4).
+Focuses on uncovered functions and error/edge-case paths that the
+existing integration tests do not exercise.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import (
+    ConflictError,
+    InternalError,
+    NotFoundError,
+    ValidationError,
+)
+from app.models.component import ComponentModel
+from app.models.component_tree import ComponentTreeNodeModel
+from app.models.construction_part import ConstructionPartModel
+from app.schemas.component_tree import ComponentTreeNodeWrite
+from app.schemas.construction_part import ConstructionPartUpdate
+from app.services import (
+    component_service,
+    component_tree_service,
+    component_type_service,
+    construction_part_service,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture()
+def db(client_and_db):
+    """Yield a plain Session for direct service-layer calls."""
+    _, session_factory = client_and_db
+    session = session_factory()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _make_tree_node(
+    db: Session,
+    aeroplane_id: str = "aero-x",
+    *,
+    parent_id: Optional[int] = None,
+    node_type: str = "group",
+    name: str = "node",
+    sort_index: int = 0,
+    synced_from: Optional[str] = None,
+    component_id: Optional[int] = None,
+    material_id: Optional[int] = None,
+    volume_mm3: Optional[float] = None,
+    area_mm2: Optional[float] = None,
+    weight_override_g: Optional[float] = None,
+    print_type: Optional[str] = None,
+    scale_factor: float = 1.0,
+    quantity: int = 1,
+    construction_part_id: Optional[int] = None,
+) -> ComponentTreeNodeModel:
+    node = ComponentTreeNodeModel(
+        aeroplane_id=aeroplane_id,
+        parent_id=parent_id,
+        node_type=node_type,
+        name=name,
+        sort_index=sort_index,
+        synced_from=synced_from,
+        component_id=component_id,
+        material_id=material_id,
+        volume_mm3=volume_mm3,
+        area_mm2=area_mm2,
+        weight_override_g=weight_override_g,
+        print_type=print_type,
+        scale_factor=scale_factor,
+        quantity=quantity,
+        construction_part_id=construction_part_id,
+    )
+    db.add(node)
+    db.commit()
+    db.refresh(node)
+    return node
+
+
+def _make_component(
+    db: Session,
+    *,
+    name: str = "TestComp",
+    component_type: str = "generic",
+    mass_g: Optional[float] = None,
+    specs: Optional[dict] = None,
+) -> ComponentModel:
+    comp = ComponentModel(
+        name=name,
+        component_type=component_type,
+        mass_g=mass_g,
+        specs=specs or {},
+    )
+    db.add(comp)
+    db.commit()
+    db.refresh(comp)
+    return comp
+
+
+def _make_construction_part(
+    db: Session,
+    aeroplane_id: str = "aero-x",
+    *,
+    name: str = "Part",
+    volume_mm3: Optional[float] = 5000.0,
+    area_mm2: Optional[float] = 200.0,
+    material_component_id: Optional[int] = None,
+    locked: bool = False,
+    file_path: Optional[str] = None,
+    file_format: Optional[str] = None,
+) -> ConstructionPartModel:
+    part = ConstructionPartModel(
+        aeroplane_id=aeroplane_id,
+        name=name,
+        volume_mm3=volume_mm3,
+        area_mm2=area_mm2,
+        material_component_id=material_component_id,
+        locked=locked,
+        file_path=file_path,
+        file_format=file_format,
+    )
+    db.add(part)
+    db.commit()
+    db.refresh(part)
+    return part
+
+
+# =========================================================================== #
+# component_tree_service
+# =========================================================================== #
+
+
+class TestBuildTree:
+    """Test _build_tree and _roll_up_weights helper functions."""
+
+    def test_build_tree_empty(self, db):
+        tree = component_tree_service._build_tree([])
+        assert tree == []
+
+    def test_build_tree_single_root(self, db):
+        node = _make_tree_node(db, name="root")
+        tree = component_tree_service._build_tree([node])
+        assert len(tree) == 1
+        assert tree[0].name == "root"
+        assert tree[0].children == []
+
+    def test_build_tree_parent_child_sorted(self, db):
+        root = _make_tree_node(db, name="root", sort_index=0)
+        child_b = _make_tree_node(
+            db, name="B", parent_id=root.id, sort_index=2
+        )
+        child_a = _make_tree_node(
+            db, name="A", parent_id=root.id, sort_index=1
+        )
+        tree = component_tree_service._build_tree([root, child_b, child_a])
+        assert len(tree) == 1
+        assert [c.name for c in tree[0].children] == ["A", "B"]
+
+    def test_build_tree_orphan_becomes_root(self, db):
+        """A node whose parent_id is not in the list is treated as a root."""
+        node = _make_tree_node(db, name="orphan")
+        # Manually set parent_id to a nonexistent id
+        node.parent_id = 99999
+        tree = component_tree_service._build_tree([node])
+        assert len(tree) == 1
+        assert tree[0].name == "orphan"
+
+
+class TestRollUpWeights:
+    """Test weight rollup logic."""
+
+    def test_leaf_valid_when_has_own_weight(self, db):
+        node = _make_tree_node(db, name="leaf")
+        tree = component_tree_service._build_tree([node])
+        own_weights = {node.id: (10.0, "override")}
+        component_tree_service._roll_up_weights(tree[0], own_weights)
+        assert tree[0].own_weight_g == 10.0
+        assert tree[0].own_weight_source == "override"
+        assert tree[0].weight_status == "valid"
+        assert tree[0].total_weight_g == 10.0
+
+    def test_leaf_invalid_when_no_own_weight(self, db):
+        node = _make_tree_node(db, name="leaf")
+        tree = component_tree_service._build_tree([node])
+        own_weights = {}
+        component_tree_service._roll_up_weights(tree[0], own_weights)
+        assert tree[0].weight_status == "invalid"
+        assert tree[0].own_weight_g is None
+
+    def test_parent_all_children_valid(self, db):
+        root = _make_tree_node(db, name="root", sort_index=0)
+        c1 = _make_tree_node(db, name="c1", parent_id=root.id, sort_index=0)
+        c2 = _make_tree_node(db, name="c2", parent_id=root.id, sort_index=1)
+        tree = component_tree_service._build_tree([root, c1, c2])
+        own_weights = {
+            root.id: (None, "none"),
+            c1.id: (5.0, "calculated"),
+            c2.id: (3.0, "cots"),
+        }
+        component_tree_service._roll_up_weights(tree[0], own_weights)
+        assert tree[0].weight_status == "valid"
+        assert tree[0].total_weight_g == 8.0
+
+    def test_parent_all_children_invalid_no_own(self, db):
+        root = _make_tree_node(db, name="root", sort_index=0)
+        c1 = _make_tree_node(db, name="c1", parent_id=root.id, sort_index=0)
+        tree = component_tree_service._build_tree([root, c1])
+        own_weights = {
+            root.id: (None, "none"),
+            c1.id: (None, "none"),
+        }
+        component_tree_service._roll_up_weights(tree[0], own_weights)
+        assert tree[0].weight_status == "invalid"
+
+    def test_parent_all_children_invalid_with_own(self, db):
+        root = _make_tree_node(db, name="root", sort_index=0)
+        c1 = _make_tree_node(db, name="c1", parent_id=root.id, sort_index=0)
+        tree = component_tree_service._build_tree([root, c1])
+        own_weights = {
+            root.id: (2.0, "override"),
+            c1.id: (None, "none"),
+        }
+        component_tree_service._roll_up_weights(tree[0], own_weights)
+        assert tree[0].weight_status == "partial"
+        assert tree[0].total_weight_g == 2.0
+
+    def test_parent_mixed_children_status(self, db):
+        root = _make_tree_node(db, name="root", sort_index=0)
+        c1 = _make_tree_node(db, name="c1", parent_id=root.id, sort_index=0)
+        c2 = _make_tree_node(db, name="c2", parent_id=root.id, sort_index=1)
+        tree = component_tree_service._build_tree([root, c1, c2])
+        own_weights = {
+            root.id: (None, "none"),
+            c1.id: (5.0, "calculated"),
+            c2.id: (None, "none"),
+        }
+        component_tree_service._roll_up_weights(tree[0], own_weights)
+        assert tree[0].weight_status == "partial"
+
+
+class TestWeightFromCots:
+    """Test _weight_from_cots helper."""
+
+    def test_not_cots_type_returns_none(self, db):
+        node = _make_tree_node(db, node_type="group", name="grp")
+        assert component_tree_service._weight_from_cots(db, node) is None
+
+    def test_cots_no_component_id_returns_none(self, db):
+        node = _make_tree_node(db, node_type="cots", name="cots_no_comp")
+        assert component_tree_service._weight_from_cots(db, node) is None
+
+    def test_cots_component_no_mass_returns_none(self, db):
+        comp = _make_component(db, name="MasslessComp", mass_g=None)
+        node = _make_tree_node(
+            db, node_type="cots", name="cots", component_id=comp.id
+        )
+        assert component_tree_service._weight_from_cots(db, node) is None
+
+    def test_cots_multiplied_by_quantity(self, db):
+        comp = _make_component(db, name="Servo", mass_g=12.0)
+        node = _make_tree_node(
+            db,
+            node_type="cots",
+            name="servos",
+            component_id=comp.id,
+            quantity=3,
+        )
+        assert component_tree_service._weight_from_cots(db, node) == 36.0
+
+
+class TestWeightFromCadShape:
+    """Test _weight_from_cad_shape helper."""
+
+    def test_not_cad_shape_returns_none(self, db):
+        node = _make_tree_node(db, node_type="group", name="g")
+        assert component_tree_service._weight_from_cad_shape(db, node) is None
+
+    def test_no_material_returns_none(self, db):
+        node = _make_tree_node(
+            db, node_type="cad_shape", name="s", volume_mm3=1000.0
+        )
+        assert component_tree_service._weight_from_cad_shape(db, node) is None
+
+    def test_material_no_density_returns_none(self, db):
+        mat = _make_component(
+            db,
+            name="NoDensityMat",
+            component_type="material",
+            specs={},
+        )
+        node = _make_tree_node(
+            db,
+            node_type="cad_shape",
+            name="s",
+            material_id=mat.id,
+            volume_mm3=1000.0,
+        )
+        assert component_tree_service._weight_from_cad_shape(db, node) is None
+
+    def test_volume_calculation(self, db):
+        mat = _make_component(
+            db,
+            name="PLA",
+            component_type="material",
+            specs={"density_kg_m3": 1240},
+        )
+        node = _make_tree_node(
+            db,
+            node_type="cad_shape",
+            name="shell",
+            material_id=mat.id,
+            volume_mm3=10000.0,
+            scale_factor=1.0,
+        )
+        weight = component_tree_service._weight_from_cad_shape(db, node)
+        # 10000 * 1240 / 1e6 = 12.4 grams
+        assert weight is not None
+        assert abs(weight - 12.4) < 0.001
+
+    def test_surface_calculation(self, db):
+        mat = _make_component(
+            db,
+            name="SurfMat",
+            component_type="material",
+            specs={"density_kg_m3": 1000, "print_resolution_mm": 0.5},
+        )
+        node = _make_tree_node(
+            db,
+            node_type="cad_shape",
+            name="skin",
+            material_id=mat.id,
+            area_mm2=2000.0,
+            print_type="surface",
+            scale_factor=1.0,
+        )
+        weight = component_tree_service._weight_from_cad_shape(db, node)
+        # 2000 * 0.5 * 1000 / 1e6 * 1.0 = 1.0 gram
+        assert weight is not None
+        assert abs(weight - 1.0) < 0.001
+
+    def test_surface_uses_default_resolution(self, db):
+        mat = _make_component(
+            db,
+            name="MatNoRes",
+            component_type="material",
+            specs={"density_kg_m3": 1000},
+        )
+        node = _make_tree_node(
+            db,
+            node_type="cad_shape",
+            name="skin",
+            material_id=mat.id,
+            area_mm2=1000.0,
+            print_type="surface",
+            scale_factor=1.0,
+        )
+        weight = component_tree_service._weight_from_cad_shape(db, node)
+        # 1000 * 0.4 * 1000 / 1e6 * 1.0 = 0.4 gram (default resolution 0.4)
+        assert weight is not None
+        assert abs(weight - 0.4) < 0.001
+
+    def test_cad_shape_no_volume_no_area_returns_none(self, db):
+        mat = _make_component(
+            db,
+            name="MatX",
+            component_type="material",
+            specs={"density_kg_m3": 1000},
+        )
+        node = _make_tree_node(
+            db,
+            node_type="cad_shape",
+            name="no_geom",
+            material_id=mat.id,
+        )
+        assert component_tree_service._weight_from_cad_shape(db, node) is None
+
+    def test_material_not_found_returns_none(self, db):
+        node = _make_tree_node(
+            db,
+            node_type="cad_shape",
+            name="no_mat",
+            material_id=99999,
+            volume_mm3=1000.0,
+        )
+        assert component_tree_service._weight_from_cad_shape(db, node) is None
+
+
+class TestCalculateOwnWeight:
+    """Test _calculate_own_weight priority chain."""
+
+    def test_override_wins_over_everything(self, db):
+        comp = _make_component(db, name="Comp", mass_g=50.0)
+        node = _make_tree_node(
+            db,
+            node_type="cots",
+            name="c",
+            component_id=comp.id,
+            weight_override_g=99.0,
+        )
+        weight, source = component_tree_service._calculate_own_weight(db, node)
+        assert weight == 99.0
+        assert source == "override"
+
+    def test_cots_used_when_no_override(self, db):
+        comp = _make_component(db, name="Motor", mass_g=50.0)
+        node = _make_tree_node(
+            db,
+            node_type="cots",
+            name="motor",
+            component_id=comp.id,
+        )
+        weight, source = component_tree_service._calculate_own_weight(db, node)
+        assert weight == 50.0
+        assert source == "cots"
+
+    def test_none_when_no_source(self, db):
+        node = _make_tree_node(db, node_type="group", name="grp")
+        weight, source = component_tree_service._calculate_own_weight(db, node)
+        assert weight is None
+        assert source == "none"
+
+
+class TestAddNodeWithConstructionPart:
+    """Test snapshot behaviour when construction_part_id is set."""
+
+    def test_snapshots_volume_area_material_from_part(self, db):
+        mat = _make_component(db, name="PLAMat", component_type="material")
+        part = _make_construction_part(
+            db,
+            volume_mm3=7777.0,
+            area_mm2=333.0,
+            material_component_id=mat.id,
+        )
+        data = ComponentTreeNodeWrite(
+            node_type="cad_shape",
+            name="from_part",
+            construction_part_id=part.id,
+        )
+        result = component_tree_service.add_node(db, "aero-x", data)
+        assert result.volume_mm3 == 7777.0
+        assert result.area_mm2 == 333.0
+        assert result.material_id == mat.id
+
+    def test_explicit_fields_win_over_snapshot(self, db):
+        part = _make_construction_part(db, volume_mm3=7777.0)
+        data = ComponentTreeNodeWrite(
+            node_type="cad_shape",
+            name="explicit",
+            construction_part_id=part.id,
+            volume_mm3=1111.0,
+        )
+        result = component_tree_service.add_node(db, "aero-x", data)
+        assert result.volume_mm3 == 1111.0
+
+    def test_invalid_construction_part_raises_validation(self, db):
+        data = ComponentTreeNodeWrite(
+            node_type="cad_shape",
+            name="bad_part",
+            construction_part_id=99999,
+        )
+        with pytest.raises(ValidationError, match="construction_part_id"):
+            component_tree_service.add_node(db, "aero-x", data)
+
+    def test_add_node_invalid_parent_raises_not_found(self, db):
+        data = ComponentTreeNodeWrite(
+            node_type="group",
+            name="orphan",
+            parent_id=99999,
+        )
+        with pytest.raises(NotFoundError):
+            component_tree_service.add_node(db, "aero-x", data)
+
+
+class TestUpdateNode:
+
+    def test_update_missing_node_raises_not_found(self, db):
+        data = ComponentTreeNodeWrite(node_type="group", name="x")
+        with pytest.raises(NotFoundError):
+            component_tree_service.update_node(db, "aero-x", 99999, data)
+
+    def test_update_changes_fields(self, db):
+        node = _make_tree_node(db, name="old_name")
+        data = ComponentTreeNodeWrite(node_type="group", name="new_name")
+        result = component_tree_service.update_node(
+            db, "aero-x", node.id, data
+        )
+        assert result.name == "new_name"
+
+
+class TestDeleteNode:
+
+    def test_delete_missing_node_raises_not_found(self, db):
+        with pytest.raises(NotFoundError):
+            component_tree_service.delete_node(db, "aero-x", 99999)
+
+    def test_delete_synced_node_raises_validation(self, db):
+        node = _make_tree_node(
+            db, name="synced", synced_from="wing:main_wing"
+        )
+        with pytest.raises(ValidationError, match="synced"):
+            component_tree_service.delete_node(db, "aero-x", node.id)
+
+    def test_delete_node_with_children(self, db):
+        parent = _make_tree_node(db, name="parent")
+        child = _make_tree_node(db, name="child", parent_id=parent.id)
+        grandchild = _make_tree_node(
+            db, name="grandchild", parent_id=child.id
+        )
+        component_tree_service.delete_node(db, "aero-x", parent.id)
+        # All should be gone
+        assert (
+            db.query(ComponentTreeNodeModel)
+            .filter(ComponentTreeNodeModel.id.in_([parent.id, child.id, grandchild.id]))
+            .count()
+            == 0
+        )
+
+
+class TestMoveNode:
+
+    def test_move_to_nonexistent_parent_raises(self, db):
+        node = _make_tree_node(db, name="move_me")
+        with pytest.raises(NotFoundError):
+            component_tree_service.move_node(db, "aero-x", node.id, 99999, 0)
+
+    def test_move_nonexistent_node_raises(self, db):
+        with pytest.raises(NotFoundError):
+            component_tree_service.move_node(db, "aero-x", 99999, None, 0)
+
+    def test_move_to_own_subtree_raises_validation(self, db):
+        parent = _make_tree_node(db, name="parent")
+        child = _make_tree_node(db, name="child", parent_id=parent.id)
+        with pytest.raises(ValidationError, match="subtree"):
+            component_tree_service.move_node(
+                db, "aero-x", parent.id, child.id, 0
+            )
+
+    def test_move_to_root(self, db):
+        parent = _make_tree_node(db, name="parent")
+        child = _make_tree_node(db, name="child", parent_id=parent.id)
+        result = component_tree_service.move_node(
+            db, "aero-x", child.id, None, 5
+        )
+        assert result.parent_id is None
+        assert result.sort_index == 5
+
+
+class TestCalculateWeight:
+
+    def test_calculate_weight_missing_node_raises(self, db):
+        with pytest.raises(NotFoundError):
+            component_tree_service.calculate_weight(db, "aero-x", 99999)
+
+    def test_calculate_weight_returns_response(self, db):
+        node = _make_tree_node(
+            db, name="weighted", weight_override_g=15.0
+        )
+        result = component_tree_service.calculate_weight(
+            db, "aero-x", node.id
+        )
+        assert result.own_weight_g == 15.0
+        assert result.source == "override"
+        assert result.total_weight_g == 15.0
+
+    def test_calculate_children_weight_recursive(self, db):
+        parent = _make_tree_node(db, name="parent")
+        _make_tree_node(
+            db,
+            name="c1",
+            parent_id=parent.id,
+            weight_override_g=10.0,
+        )
+        child2 = _make_tree_node(
+            db, name="c2", parent_id=parent.id
+        )
+        _make_tree_node(
+            db,
+            name="gc1",
+            parent_id=child2.id,
+            weight_override_g=5.0,
+        )
+        result = component_tree_service.calculate_weight(
+            db, "aero-x", parent.id
+        )
+        assert result.children_weight_g == 15.0
+
+
+class TestSyncGroups:
+
+    def test_sync_group_for_wing_creates_node(self, db):
+        component_tree_service.sync_group_for_wing(db, "aero-x", "main_wing")
+        node = (
+            db.query(ComponentTreeNodeModel)
+            .filter(
+                ComponentTreeNodeModel.aeroplane_id == "aero-x",
+                ComponentTreeNodeModel.synced_from == "wing:main_wing",
+            )
+            .first()
+        )
+        assert node is not None
+        assert node.name == "main_wing"
+        assert node.node_type == "group"
+
+    def test_sync_group_for_wing_idempotent(self, db):
+        component_tree_service.sync_group_for_wing(db, "aero-x", "w1")
+        component_tree_service.sync_group_for_wing(db, "aero-x", "w1")
+        count = (
+            db.query(ComponentTreeNodeModel)
+            .filter(ComponentTreeNodeModel.synced_from == "wing:w1")
+            .count()
+        )
+        assert count == 1
+
+    def test_sync_group_for_fuselage_creates_node(self, db):
+        component_tree_service.sync_group_for_fuselage(
+            db, "aero-x", "fuse_main"
+        )
+        node = (
+            db.query(ComponentTreeNodeModel)
+            .filter(
+                ComponentTreeNodeModel.synced_from == "fuselage:fuse_main",
+            )
+            .first()
+        )
+        assert node is not None
+        assert node.name == "fuse_main"
+
+    def test_sync_group_for_fuselage_idempotent(self, db):
+        component_tree_service.sync_group_for_fuselage(db, "aero-x", "f1")
+        component_tree_service.sync_group_for_fuselage(db, "aero-x", "f1")
+        count = (
+            db.query(ComponentTreeNodeModel)
+            .filter(ComponentTreeNodeModel.synced_from == "fuselage:f1")
+            .count()
+        )
+        assert count == 1
+
+    def test_delete_synced_nodes_by_prefix(self, db):
+        component_tree_service.sync_group_for_wing(db, "aero-x", "w_del")
+        db.commit()
+        # Also add a child under the synced group
+        wing_group = (
+            db.query(ComponentTreeNodeModel)
+            .filter(ComponentTreeNodeModel.synced_from == "wing:w_del")
+            .first()
+        )
+        _make_tree_node(
+            db, name="child_of_synced", parent_id=wing_group.id
+        )
+        component_tree_service.delete_synced_nodes(
+            db, "aero-x", "wing:w_del"
+        )
+        db.commit()
+        remaining = (
+            db.query(ComponentTreeNodeModel)
+            .filter(ComponentTreeNodeModel.synced_from == "wing:w_del")
+            .count()
+        )
+        assert remaining == 0
+
+
+class TestUpsertSyncedServo:
+
+    def test_create_synced_servo(self, db):
+        component_tree_service.sync_group_for_wing(db, "aero-x", "mw")
+        db.commit()
+        comp = _make_component(db, name="TinyServo", mass_g=10.0)
+        component_tree_service.upsert_synced_servo(
+            db, "aero-x", "mw", 0, comp.id, symmetric=False
+        )
+        db.commit()
+        node = (
+            db.query(ComponentTreeNodeModel)
+            .filter(ComponentTreeNodeModel.synced_from == "servo:mw:0")
+            .first()
+        )
+        assert node is not None
+        assert node.component_id == comp.id
+        assert node.quantity == 1
+        assert node.name == "TinyServo"
+
+    def test_update_synced_servo(self, db):
+        component_tree_service.sync_group_for_wing(db, "aero-x", "mw2")
+        db.commit()
+        comp1 = _make_component(db, name="Servo1", mass_g=10.0)
+        comp2 = _make_component(db, name="Servo2", mass_g=15.0)
+        component_tree_service.upsert_synced_servo(
+            db, "aero-x", "mw2", 1, comp1.id, symmetric=False
+        )
+        db.commit()
+        component_tree_service.upsert_synced_servo(
+            db, "aero-x", "mw2", 1, comp2.id, symmetric=True
+        )
+        db.commit()
+        node = (
+            db.query(ComponentTreeNodeModel)
+            .filter(ComponentTreeNodeModel.synced_from == "servo:mw2:1")
+            .first()
+        )
+        assert node.component_id == comp2.id
+        assert node.quantity == 2
+
+    def test_remove_synced_servo(self, db):
+        component_tree_service.sync_group_for_wing(db, "aero-x", "mw3")
+        db.commit()
+        comp = _make_component(db, name="Servo3", mass_g=10.0)
+        component_tree_service.upsert_synced_servo(
+            db, "aero-x", "mw3", 0, comp.id
+        )
+        db.commit()
+        # Remove by passing component_id=None
+        component_tree_service.upsert_synced_servo(
+            db, "aero-x", "mw3", 0, None
+        )
+        db.commit()
+        node = (
+            db.query(ComponentTreeNodeModel)
+            .filter(ComponentTreeNodeModel.synced_from == "servo:mw3:0")
+            .first()
+        )
+        assert node is None
+
+    def test_remove_nonexistent_servo_is_noop(self, db):
+        # Should not raise
+        component_tree_service.upsert_synced_servo(
+            db, "aero-x", "nogroup", 0, None
+        )
+
+    def test_create_servo_without_wing_group(self, db):
+        """When the wing group doesn't exist, parent_id is None."""
+        comp = _make_component(db, name="OrphanServo", mass_g=5.0)
+        component_tree_service.upsert_synced_servo(
+            db, "aero-x", "no_wing", 0, comp.id
+        )
+        db.commit()
+        node = (
+            db.query(ComponentTreeNodeModel)
+            .filter(ComponentTreeNodeModel.synced_from == "servo:no_wing:0")
+            .first()
+        )
+        assert node is not None
+        assert node.parent_id is None
+
+    def test_create_servo_with_missing_component(self, db):
+        """When component is not found, name falls back to default."""
+        component_tree_service.upsert_synced_servo(
+            db, "aero-x", "mw_fallback", 0, 99999
+        )
+        db.commit()
+        node = (
+            db.query(ComponentTreeNodeModel)
+            .filter(
+                ComponentTreeNodeModel.synced_from == "servo:mw_fallback:0"
+            )
+            .first()
+        )
+        assert node is not None
+        assert "Servo #99999" in node.name
+
+
+class TestGetTree:
+    """Test the full get_tree response including weight enrichment."""
+
+    def test_get_tree_enriches_weights(self, db):
+        node = _make_tree_node(
+            db, name="root_node", weight_override_g=42.0
+        )
+        tree_resp = component_tree_service.get_tree(db, "aero-x")
+        assert tree_resp.total_nodes == 1
+        root = tree_resp.root_nodes[0]
+        assert root.own_weight_g == 42.0
+        assert root.own_weight_source == "override"
+        assert root.weight_status == "valid"
+
+
+# =========================================================================== #
+# component_type_service
+# =========================================================================== #
+
+
+class TestNormalizeSchema:
+    """Test _normalize_schema for double-encoded and edge-case inputs."""
+
+    def test_none_returns_empty(self):
+        assert component_type_service._normalize_schema(None) == []
+
+    def test_list_passes_through(self):
+        data = [{"name": "x"}]
+        assert component_type_service._normalize_schema(data) == data
+
+    def test_string_json_list(self):
+        import json
+
+        data = [{"name": "x", "label": "X", "type": "string"}]
+        encoded = json.dumps(data)
+        assert component_type_service._normalize_schema(encoded) == data
+
+    def test_string_non_json(self):
+        assert component_type_service._normalize_schema("not json") == []
+
+    def test_string_json_non_list(self):
+        import json
+
+        assert component_type_service._normalize_schema(json.dumps(42)) == []
+
+    def test_unexpected_type(self):
+        assert component_type_service._normalize_schema(12345) == []
+
+
+class TestValidateSpecs:
+    """Test specs validation against type schemas."""
+
+    def test_unknown_type_raises_validation(self, db):
+        with pytest.raises(ValidationError, match="Unknown component_type"):
+            component_type_service.validate_specs(
+                db, "nonexistent_type", {}
+            )
+
+    def test_missing_required_property_raises(self, db):
+        with pytest.raises(ValidationError, match="missing"):
+            component_type_service.validate_specs(
+                db, "brushless_motor", {}
+            )
+
+    def test_valid_specs_pass(self, db):
+        # Should not raise
+        component_type_service.validate_specs(
+            db, "brushless_motor", {"kv_rpm_per_volt": 1000}
+        )
+
+    def test_number_below_min_raises(self, db):
+        with pytest.raises(ValidationError, match="below"):
+            component_type_service.validate_specs(
+                db, "material", {"density_kg_m3": 50}
+            )
+
+    def test_number_above_max_raises(self, db):
+        with pytest.raises(ValidationError, match="exceeds"):
+            component_type_service.validate_specs(
+                db, "material", {"density_kg_m3": 999999}
+            )
+
+    def test_number_type_with_bool_raises(self, db):
+        with pytest.raises(ValidationError, match="number"):
+            component_type_service.validate_specs(
+                db, "brushless_motor", {"kv_rpm_per_volt": True}
+            )
+
+    def test_number_type_with_string_raises(self, db):
+        with pytest.raises(ValidationError, match="number"):
+            component_type_service.validate_specs(
+                db, "brushless_motor", {"kv_rpm_per_volt": "fast"}
+            )
+
+    def test_string_type_with_int_raises(self, db):
+        with pytest.raises(ValidationError, match="string"):
+            component_type_service.validate_specs(
+                db, "propeller", {"diameter_in": 10, "pitch_in": 5, "blades": 2, "material": 42}
+            )
+
+    def test_boolean_type_with_string_raises(self, db):
+        """Create a custom type with a boolean property and test validation."""
+        from app.models.component_type import ComponentTypeModel
+
+        ct = ComponentTypeModel(
+            name="test_bool_type",
+            label="Test Bool",
+            schema_def=[
+                {"name": "active", "label": "Active", "type": "boolean", "required": True},
+            ],
+            deletable=True,
+        )
+        db.add(ct)
+        db.commit()
+        with pytest.raises(ValidationError, match="true or false"):
+            component_type_service.validate_specs(
+                db, "test_bool_type", {"active": "yes"}
+            )
+
+    def test_enum_invalid_option_raises(self, db):
+        with pytest.raises(ValidationError, match="not allowed"):
+            component_type_service.validate_specs(
+                db, "esc", {"max_current_a": 30, "protocol": "invalid_proto"}
+            )
+
+    def test_enum_valid_option_passes(self, db):
+        component_type_service.validate_specs(
+            db, "esc", {"max_current_a": 30, "protocol": "dshot300"}
+        )
+
+    def test_unknown_keys_ignored(self, db):
+        # generic has empty schema, unknown keys are tolerated
+        component_type_service.validate_specs(
+            db, "generic", {"anything": "goes"}
+        )
+
+
+class TestListTypeNames:
+
+    def test_returns_seeded_names(self, db):
+        names = component_type_service.list_type_names(db)
+        assert "material" in names
+        assert "servo" in names
+        assert "generic" in names
+
+
+class TestComponentTypeCreateDuplicate:
+
+    def test_create_duplicate_name_raises_conflict(self, db):
+        from app.schemas.component_type import ComponentTypeWrite
+
+        data = ComponentTypeWrite(
+            name="dupe_test", label="Dupe", schema=[]
+        )
+        component_type_service.create_type(db, data)
+        with pytest.raises(ConflictError, match="already exists"):
+            component_type_service.create_type(db, data)
+
+
+class TestComponentTypeDeleteProtections:
+
+    def test_delete_seeded_raises_conflict(self, db):
+        from app.models.component_type import ComponentTypeModel
+
+        seeded = (
+            db.query(ComponentTypeModel)
+            .filter(ComponentTypeModel.name == "material")
+            .first()
+        )
+        with pytest.raises(ConflictError, match="seeded"):
+            component_type_service.delete_type(db, seeded.id)
+
+    def test_delete_referenced_raises_conflict(self, db):
+        from app.models.component_type import ComponentTypeModel
+        from app.schemas.component_type import ComponentTypeWrite
+
+        data = ComponentTypeWrite(
+            name="ref_del_test", label="RefDel", schema=[]
+        )
+        ct = component_type_service.create_type(db, data)
+        _make_component(db, name="Referencing", component_type="ref_del_test")
+        with pytest.raises(ConflictError, match="referenced"):
+            component_type_service.delete_type(db, ct.id)
+
+    def test_delete_missing_raises_not_found(self, db):
+        with pytest.raises(NotFoundError):
+            component_type_service.delete_type(db, 99999)
+
+
+class TestComponentTypeUpdate:
+
+    def test_update_missing_raises_not_found(self, db):
+        from app.schemas.component_type import ComponentTypeWrite
+
+        data = ComponentTypeWrite(name="x", label="X", schema=[])
+        with pytest.raises(NotFoundError):
+            component_type_service.update_type(db, 99999, data)
+
+
+# =========================================================================== #
+# component_service
+# =========================================================================== #
+
+
+class TestComponentServiceListFiltering:
+
+    def test_list_with_search_query(self, db):
+        _make_component(db, name="Alpha Motor")
+        _make_component(db, name="Beta Servo")
+        result = component_service.list_components(db, q="Alpha")
+        assert result.total == 1
+        assert result.items[0].name == "Alpha Motor"
+
+    def test_list_with_type_filter(self, db):
+        _make_component(db, name="GenComp", component_type="generic")
+        result = component_service.list_components(
+            db, component_type="generic"
+        )
+        assert result.total >= 1
+        assert all(
+            c.component_type == "generic" for c in result.items
+        )
+
+    def test_list_empty(self, db):
+        result = component_service.list_components(
+            db, component_type="nonexistent_type_xyz"
+        )
+        assert result.total == 0
+
+
+class TestComponentServiceCRUD:
+
+    def test_get_missing_raises_not_found(self, db):
+        with pytest.raises(NotFoundError):
+            component_service.get_component(db, 99999)
+
+    def test_update_missing_raises_not_found(self, db):
+        from app.schemas.component import ComponentWrite
+
+        data = ComponentWrite(
+            name="X",
+            component_type="generic",
+            specs={},
+        )
+        with pytest.raises(NotFoundError):
+            component_service.update_component(db, 99999, data)
+
+    def test_delete_missing_raises_not_found(self, db):
+        with pytest.raises(NotFoundError):
+            component_service.delete_component(db, 99999)
+
+    def test_create_and_delete_round_trip(self, db):
+        from app.schemas.component import ComponentWrite
+
+        data = ComponentWrite(
+            name="Temp",
+            component_type="generic",
+            specs={},
+        )
+        created = component_service.create_component(db, data)
+        assert created.id is not None
+        component_service.delete_component(db, created.id)
+        with pytest.raises(NotFoundError):
+            component_service.get_component(db, created.id)
+
+
+# =========================================================================== #
+# construction_part_service
+# =========================================================================== #
+
+
+class TestValidateUpload:
+
+    def test_empty_content_raises(self):
+        with pytest.raises(ValidationError, match="empty"):
+            construction_part_service._validate_upload("test.step", b"")
+
+    def test_oversized_content_raises(self):
+        huge = b"x" * (construction_part_service.MAX_FILE_SIZE_BYTES + 1)
+        with pytest.raises(ConflictError, match="size"):
+            construction_part_service._validate_upload("test.step", huge)
+
+    def test_unsupported_extension_raises(self):
+        with pytest.raises(ValidationError, match="Unsupported"):
+            construction_part_service._validate_upload("model.obj", b"data")
+
+    def test_step_extension_returns_step(self):
+        suffix, fmt = construction_part_service._validate_upload(
+            "model.step", b"data"
+        )
+        assert suffix == ".step"
+        assert fmt == "step"
+
+    def test_stp_extension_returns_step(self):
+        suffix, fmt = construction_part_service._validate_upload(
+            "model.STP", b"data"
+        )
+        assert suffix == ".stp"
+        assert fmt == "step"
+
+    def test_stl_extension_returns_stl(self):
+        suffix, fmt = construction_part_service._validate_upload(
+            "model.stl", b"data"
+        )
+        assert suffix == ".stl"
+        assert fmt == "stl"
+
+    def test_none_filename_uses_default(self):
+        """No filename defaults to 'upload.unknown' which is unsupported."""
+        with pytest.raises(ValidationError, match="Unsupported"):
+            construction_part_service._validate_upload(None, b"data")
+
+
+class TestStoreFile:
+
+    def test_stores_file_on_disk(self, tmp_path):
+        original_root = construction_part_service.STORAGE_ROOT
+        construction_part_service.STORAGE_ROOT = tmp_path / "parts"
+        try:
+            dest = construction_part_service._store_file(
+                "aero1", 42, b"step data", ".step"
+            )
+            assert dest.exists()
+            assert dest.read_bytes() == b"step data"
+            assert "aero1" in str(dest)
+        finally:
+            construction_part_service.STORAGE_ROOT = original_root
+
+
+class TestCreatePart:
+
+    def test_create_with_valid_step_file(self, db, tmp_path):
+        original_root = construction_part_service.STORAGE_ROOT
+        construction_part_service.STORAGE_ROOT = tmp_path / "parts"
+        try:
+            result = construction_part_service.create_part(
+                db,
+                "aero-x",
+                filename="wing.step",
+                content=b"fake step data",
+                name="Wing Part",
+                material_component_id=None,
+                thumbnail_url=None,
+            )
+            assert result.name == "Wing Part"
+            assert result.file_format == "step"
+            assert result.aeroplane_id == "aero-x"
+        finally:
+            construction_part_service.STORAGE_ROOT = original_root
+
+    def test_create_with_empty_name_raises(self, db):
+        with pytest.raises(ValidationError, match="name"):
+            construction_part_service.create_part(
+                db,
+                "aero-x",
+                filename="wing.step",
+                content=b"data",
+                name="   ",
+                material_component_id=None,
+                thumbnail_url=None,
+            )
+
+
+class TestGetPartFile:
+
+    def test_invalid_format_raises(self, db):
+        part = _make_construction_part(
+            db, file_path="/some/file.step", file_format="step"
+        )
+        with pytest.raises(ValidationError, match="Invalid format"):
+            construction_part_service.get_part_file(
+                db, "aero-x", part.id, "obj"
+            )
+
+    def test_missing_file_path_raises(self, db):
+        part = _make_construction_part(db, file_path=None, file_format="step")
+        with pytest.raises(NotFoundError):
+            construction_part_service.get_part_file(
+                db, "aero-x", part.id, "step"
+            )
+
+    def test_same_format_returns_path_directly(self, db, tmp_path):
+        f = tmp_path / "test.step"
+        f.write_bytes(b"step data")
+        part = _make_construction_part(
+            db, file_path=str(f), file_format="step"
+        )
+        path, mime = construction_part_service.get_part_file(
+            db, "aero-x", part.id, "step"
+        )
+        assert path == f
+        assert mime == "model/step"
+
+    def test_stl_from_stl_source(self, db, tmp_path):
+        f = tmp_path / "test.stl"
+        f.write_bytes(b"stl data")
+        part = _make_construction_part(
+            db, file_path=str(f), file_format="stl"
+        )
+        path, mime = construction_part_service.get_part_file(
+            db, "aero-x", part.id, "stl"
+        )
+        assert path == f
+        assert mime == "model/stl"
+
+    def test_step_from_stl_raises(self, db, tmp_path):
+        f = tmp_path / "test.stl"
+        f.write_bytes(b"stl data")
+        part = _make_construction_part(
+            db, file_path=str(f), file_format="stl"
+        )
+        with pytest.raises(ValidationError, match="cannot be regenerated"):
+            construction_part_service.get_part_file(
+                db, "aero-x", part.id, "step"
+            )
+
+
+class TestUpdatePart:
+
+    def test_update_name(self, db):
+        part = _make_construction_part(db, name="Old Name")
+        data = ConstructionPartUpdate(name="New Name")
+        result = construction_part_service.update_part(
+            db, "aero-x", part.id, data
+        )
+        assert result.name == "New Name"
+
+    def test_update_material(self, db):
+        mat = _make_component(db, name="PLA", component_type="material")
+        part = _make_construction_part(db)
+        data = ConstructionPartUpdate(material_component_id=mat.id)
+        result = construction_part_service.update_part(
+            db, "aero-x", part.id, data
+        )
+        assert result.material_component_id == mat.id
+
+    def test_update_thumbnail(self, db):
+        part = _make_construction_part(db)
+        data = ConstructionPartUpdate(thumbnail_url="/img/thumb.png")
+        result = construction_part_service.update_part(
+            db, "aero-x", part.id, data
+        )
+        assert result.thumbnail_url == "/img/thumb.png"
+
+    def test_update_missing_part_raises(self, db):
+        data = ConstructionPartUpdate(name="X")
+        with pytest.raises(NotFoundError):
+            construction_part_service.update_part(
+                db, "aero-x", 99999, data
+            )
+
+
+class TestDeletePart:
+
+    def test_delete_locked_raises_conflict(self, db):
+        part = _make_construction_part(db, locked=True)
+        with pytest.raises(ConflictError, match="locked"):
+            construction_part_service.delete_part(db, "aero-x", part.id)
+
+    def test_delete_missing_raises_not_found(self, db):
+        with pytest.raises(NotFoundError):
+            construction_part_service.delete_part(db, "aero-x", 99999)
+
+    def test_delete_removes_file(self, db, tmp_path):
+        f = tmp_path / "to_delete.step"
+        f.write_bytes(b"data")
+        part = _make_construction_part(
+            db, file_path=str(f), file_format="step"
+        )
+        construction_part_service.delete_part(db, "aero-x", part.id)
+        assert not f.exists()
+
+    def test_delete_with_missing_file_succeeds(self, db):
+        """If the file is already gone, delete should still succeed."""
+        part = _make_construction_part(
+            db, file_path="/nonexistent/path.step", file_format="step"
+        )
+        # Should not raise
+        construction_part_service.delete_part(db, "aero-x", part.id)
+
+    def test_delete_with_no_file_path(self, db):
+        part = _make_construction_part(db, file_path=None)
+        construction_part_service.delete_part(db, "aero-x", part.id)
+        assert (
+            db.query(ConstructionPartModel)
+            .filter(ConstructionPartModel.id == part.id)
+            .first()
+            is None
+        )
+
+
+class TestExtractGeometry:
+
+    def test_non_step_returns_empty(self, tmp_path):
+        f = tmp_path / "test.stl"
+        f.write_bytes(b"stl data")
+        result = construction_part_service._extract_geometry(f, "stl")
+        assert result["volume_mm3"] is None
+        assert result["area_mm2"] is None
+
+    @patch("app.services.construction_part_service.cad_available", return_value=False)
+    def test_cad_unavailable_returns_empty(self, _mock, tmp_path):
+        f = tmp_path / "test.step"
+        f.write_bytes(b"step data")
+        result = construction_part_service._extract_geometry(f, "step")
+        assert result["volume_mm3"] is None
+
+
+class TestConstructionPartListAndGet:
+
+    def test_list_scoped_to_aeroplane(self, db):
+        _make_construction_part(db, "aero-1", name="P1")
+        _make_construction_part(db, "aero-2", name="P2")
+        result = construction_part_service.list_parts(db, "aero-1")
+        assert result.total == 1
+        assert result.items[0].name == "P1"
+
+    def test_get_part_not_found(self, db):
+        with pytest.raises(NotFoundError):
+            construction_part_service.get_part(db, "aero-x", 99999)
+
+    def test_get_part_wrong_aeroplane(self, db):
+        part = _make_construction_part(db, "aero-1", name="Scoped")
+        with pytest.raises(NotFoundError):
+            construction_part_service.get_part(db, "aero-wrong", part.id)

--- a/app/tests/test_mcp_server_extended.py
+++ b/app/tests/test_mcp_server_extended.py
@@ -1,0 +1,646 @@
+"""Extended tests for app/mcp_server.py — covers utility functions, error paths,
+and edge cases that the existing tool/resource tests do not exercise.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.responses import FileResponse, JSONResponse, Response
+from fastmcp.exceptions import NotFoundError
+
+import app.mcp_server as mcp_server
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def clear_asset_registry():
+    with mcp_server.ASSET_REGISTRY_LOCK:
+        mcp_server.ASSET_REGISTRY.clear()
+    yield
+    with mcp_server.ASSET_REGISTRY_LOCK:
+        mcp_server.ASSET_REGISTRY.clear()
+
+
+@pytest.fixture(autouse=True)
+def stable_base_url(monkeypatch):
+    class DummySettings:
+        base_url = "http://unit.test"
+
+    monkeypatch.setattr(mcp_server, "get_settings", lambda: DummySettings())
+
+
+# ---------------------------------------------------------------------------
+# _normalize_result
+# ---------------------------------------------------------------------------
+
+class TestNormalizeResult:
+    def test_none_returns_status_ok(self):
+        assert mcp_server._normalize_result(None) == {"status": "ok"}
+
+    def test_json_response_with_body(self):
+        body = json.dumps({"key": "value"}).encode("utf-8")
+        resp = JSONResponse(content={"key": "value"}, status_code=200)
+        result = mcp_server._normalize_result(resp)
+        assert result == {"key": "value"}
+
+    def test_json_response_with_null_content(self):
+        resp = JSONResponse(content=None, status_code=204)
+        # JSONResponse with None content produces b"null" which is truthy
+        result = mcp_server._normalize_result(resp)
+        # json.loads(b"null") returns None
+        assert result is None
+
+    def test_json_response_truly_empty(self):
+        resp = JSONResponse(content=None, status_code=204)
+        resp.body = b""
+        result = mcp_server._normalize_result(resp)
+        assert result == {"status_code": 204}
+
+    def test_file_response(self, tmp_path):
+        dummy = tmp_path / "export.stl"
+        dummy.write_text("solid test")
+        resp = FileResponse(
+            path=str(dummy),
+            filename="export.stl",
+            media_type="application/sla",
+        )
+        result = mcp_server._normalize_result(resp)
+        assert result["file_path"] == str(dummy)
+        assert result["filename"] == "export.stl"
+        assert result["media_type"] == "application/sla"
+
+    def test_response_with_image_body(self):
+        image_bytes = b"\x89PNG\r\n\x1a\nfake-image-data"
+        resp = Response(content=image_bytes, media_type="image/png")
+        result = mcp_server._normalize_result(resp)
+        assert result["media_type"] == "image/png"
+        assert result["encoding"] == "base64"
+        import base64
+        assert base64.b64decode(result["data"]) == image_bytes
+
+    def test_response_with_json_body(self):
+        payload = {"items": [1, 2, 3]}
+        resp = Response(
+            content=json.dumps(payload).encode("utf-8"),
+            media_type="application/json",
+        )
+        result = mcp_server._normalize_result(resp)
+        assert result == payload
+
+    def test_response_with_text_body(self):
+        resp = Response(content=b"hello world", media_type="text/plain")
+        result = mcp_server._normalize_result(resp)
+        assert result["media_type"] == "text/plain"
+        assert result["content"] == "hello world"
+
+    def test_response_with_no_body(self):
+        resp = Response(status_code=204)
+        resp.body = b""
+        result = mcp_server._normalize_result(resp)
+        assert result == {"status_code": 204}
+
+    def test_pydantic_encodable_object(self):
+        result = mcp_server._normalize_result({"simple": "dict"})
+        assert result == {"simple": "dict"}
+
+
+# ---------------------------------------------------------------------------
+# _base_url_from_request_url
+# ---------------------------------------------------------------------------
+
+class TestBaseUrlFromRequestUrl:
+    def test_strips_mcp_suffix(self):
+        assert mcp_server._base_url_from_request_url("http://host:8001/mcp") == "http://host:8001"
+
+    def test_strips_nested_mcp_suffix(self):
+        assert mcp_server._base_url_from_request_url("http://host:8001/api/mcp") == "http://host:8001/api"
+
+    def test_returns_none_for_missing_scheme(self):
+        assert mcp_server._base_url_from_request_url("/just/a/path") is None
+
+    def test_returns_none_for_missing_netloc(self):
+        assert mcp_server._base_url_from_request_url("file:///some/path") is None
+
+    def test_no_mcp_suffix(self):
+        result = mcp_server._base_url_from_request_url("http://host:8001/api/v2")
+        assert result == "http://host:8001/api/v2"
+
+
+# ---------------------------------------------------------------------------
+# _base_url_from_context
+# ---------------------------------------------------------------------------
+
+class TestBaseUrlFromContext:
+    def test_none_context_returns_none(self):
+        assert mcp_server._base_url_from_context(None) is None
+
+    def test_context_without_request_context(self):
+        ctx = MagicMock(spec=[])  # no attributes at all
+        assert mcp_server._base_url_from_context(ctx) is None
+
+    def test_context_with_no_request(self):
+        ctx = MagicMock()
+        ctx.request_context = MagicMock(spec=[])  # no .request
+        assert mcp_server._base_url_from_context(ctx) is None
+
+    def test_context_with_no_url(self):
+        ctx = MagicMock()
+        ctx.request_context.request = MagicMock(spec=[])  # no .url
+        assert mcp_server._base_url_from_context(ctx) is None
+
+
+# ---------------------------------------------------------------------------
+# _base_url_from_active_request
+# ---------------------------------------------------------------------------
+
+class TestBaseUrlFromActiveRequest:
+    def test_returns_none_on_runtime_error(self, monkeypatch):
+        monkeypatch.setattr(
+            mcp_server,
+            "get_http_request",
+            MagicMock(side_effect=RuntimeError("no active request")),
+        )
+        assert mcp_server._base_url_from_active_request() is None
+
+    def test_returns_url_when_request_available(self, monkeypatch):
+        mock_request = MagicMock()
+        mock_request.url = "http://agent:9000/mcp"
+        monkeypatch.setattr(mcp_server, "get_http_request", lambda: mock_request)
+        assert mcp_server._base_url_from_active_request() == "http://agent:9000"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_tmp_path_from_static_url
+# ---------------------------------------------------------------------------
+
+class TestResolveTmpPathFromStaticUrl:
+    def test_valid_static_url(self):
+        result = mcp_server._resolve_tmp_path_from_static_url("/static/foo/bar.png")
+        assert result == mcp_server._normalize_file_path(Path("tmp") / "foo" / "bar.png")
+
+    def test_raises_for_non_static_url(self):
+        with pytest.raises(ValueError, match="Unsupported static URL format"):
+            mcp_server._resolve_tmp_path_from_static_url("/other/path.png")
+
+    def test_full_url_with_static_path(self):
+        result = mcp_server._resolve_tmp_path_from_static_url("http://host/static/img.png")
+        assert result == mcp_server._normalize_file_path(Path("tmp") / "img.png")
+
+
+# ---------------------------------------------------------------------------
+# resolve_tmp_path_from_known_output
+# ---------------------------------------------------------------------------
+
+class TestResolveTmpPathFromKnownOutput:
+    def test_dict_with_file_path(self, tmp_path):
+        p = tmp_path / "file.stl"
+        p.write_text("solid")
+        result = mcp_server.resolve_tmp_path_from_known_output({"file_path": str(p)})
+        assert result == p.resolve()
+
+    def test_string_existing_path(self, tmp_path):
+        p = tmp_path / "existing.txt"
+        p.write_text("hello")
+        result = mcp_server.resolve_tmp_path_from_known_output(str(p))
+        assert result == p.resolve()
+
+    def test_dict_with_url_static(self):
+        result = mcp_server.resolve_tmp_path_from_known_output(
+            {"url": "/static/mcp_assets/data/abc.zip"}
+        )
+        assert "mcp_assets" in str(result)
+
+    def test_string_with_static_prefix(self):
+        result = mcp_server.resolve_tmp_path_from_known_output("/static/foo.png")
+        assert "foo.png" in str(result)
+
+    def test_string_starting_with_tmp(self):
+        result = mcp_server.resolve_tmp_path_from_known_output("tmp/some/file.bin")
+        assert "some/file.bin" in str(result) or "some" in str(result)
+
+    def test_string_starting_with_dot_tmp(self):
+        result = mcp_server.resolve_tmp_path_from_known_output("./tmp/some/file.bin")
+        assert "some/file.bin" in str(result) or "some" in str(result)
+
+    def test_http_url_with_static(self):
+        result = mcp_server.resolve_tmp_path_from_known_output(
+            "http://host:8001/static/exports/data.zip"
+        )
+        expected = mcp_server._normalize_file_path(Path("tmp") / "exports" / "data.zip")
+        assert result == expected
+
+    def test_dict_with_url_http(self):
+        result = mcp_server.resolve_tmp_path_from_known_output(
+            {"url": "http://host/static/foo.zip"}
+        )
+        assert "foo.zip" in str(result)
+
+    def test_raises_for_empty_payload(self):
+        with pytest.raises(ValueError, match="Unable to resolve"):
+            mcp_server.resolve_tmp_path_from_known_output({"other": "data"})
+
+    def test_raises_for_unsupported_string(self):
+        with pytest.raises(ValueError, match="Unsupported output payload"):
+            mcp_server.resolve_tmp_path_from_known_output("ftp://nowhere/file")
+
+    def test_raises_for_none(self):
+        with pytest.raises(ValueError, match="Unable to resolve"):
+            mcp_server.resolve_tmp_path_from_known_output(None)
+
+
+# ---------------------------------------------------------------------------
+# _infer_asset_kind
+# ---------------------------------------------------------------------------
+
+class TestInferAssetKind:
+    def test_explicit_kind_takes_priority(self):
+        assert mcp_server._infer_asset_kind("application/zip", explicit_kind="archive") == "archive"
+
+    def test_image_mime(self):
+        assert mcp_server._infer_asset_kind("image/png") == "img"
+        assert mcp_server._infer_asset_kind("image/jpeg") == "img"
+
+    def test_non_image_mime(self):
+        assert mcp_server._infer_asset_kind("application/json") == "data"
+        assert mcp_server._infer_asset_kind("text/html") == "data"
+
+
+# ---------------------------------------------------------------------------
+# register_file_asset
+# ---------------------------------------------------------------------------
+
+class TestRegisterFileAsset:
+    def test_raises_for_nonexistent_file(self):
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            mcp_server.register_file_asset("/no/such/file.png")
+
+    def test_copies_file_outside_tmp(self, tmp_path):
+        source = tmp_path / "external.stl"
+        source.write_text("solid test")
+        entry = mcp_server.register_file_asset(source, mime_type="model/stl")
+        assert entry.kind == "data"
+        assert entry.mime_type == "model/stl"
+        assert entry.file_path.exists()
+        # File was copied under tmp/
+        assert "mcp_assets" in str(entry.file_path)
+        assert "external" in str(entry.file_path)
+
+    def test_file_inside_tmp_not_copied(self):
+        p = mcp_server._normalize_file_path(Path("tmp") / "already_here.png")
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(b"\x89PNGfake")
+        try:
+            entry = mcp_server.register_file_asset(p, mime_type="image/png")
+            assert entry.file_path == p
+            assert entry.kind == "img"
+        finally:
+            p.unlink(missing_ok=True)
+
+    def test_guesses_mime_type(self, tmp_path):
+        source = tmp_path / "readme.txt"
+        source.write_text("hello")
+        entry = mcp_server.register_file_asset(source)
+        assert entry.mime_type == "text/plain"
+
+    def test_falls_back_to_octet_stream(self, tmp_path):
+        source = tmp_path / "mystery.xyz123"
+        source.write_bytes(b"\x00\x01\x02")
+        entry = mcp_server.register_file_asset(source)
+        assert entry.mime_type == "application/octet-stream"
+
+
+# ---------------------------------------------------------------------------
+# register_bytes_asset
+# ---------------------------------------------------------------------------
+
+class TestRegisterBytesAsset:
+    def test_registers_png_bytes(self):
+        entry = mcp_server.register_bytes_asset(
+            b"\x89PNGfake",
+            mime_type="image/png",
+        )
+        assert entry.kind == "img"
+        assert entry.file_path.exists()
+        assert entry.file_path.suffix == ".png"
+        assert entry.file_path.read_bytes() == b"\x89PNGfake"
+
+    def test_registers_binary_bytes(self):
+        entry = mcp_server.register_bytes_asset(
+            b"\x00\x01\x02",
+            mime_type="application/octet-stream",
+        )
+        assert entry.kind == "data"
+        assert entry.file_path.suffix == ".bin"
+
+    def test_custom_filename(self):
+        entry = mcp_server.register_bytes_asset(
+            b"content",
+            mime_type="text/html",
+            filename="report.html",
+        )
+        assert entry.filename == "report.html"
+        assert entry.file_path.name == "report.html"
+
+    def test_custom_kind(self):
+        entry = mcp_server.register_bytes_asset(
+            b"content",
+            mime_type="application/zip",
+            kind="archive",
+        )
+        assert entry.kind == "archive"
+
+    def test_custom_base_url(self):
+        entry = mcp_server.register_bytes_asset(
+            b"content",
+            mime_type="image/png",
+            base_url="http://custom:9999",
+        )
+        assert entry.public_url.startswith("http://custom:9999/static/")
+
+
+# ---------------------------------------------------------------------------
+# _asset_entry_or_raise
+# ---------------------------------------------------------------------------
+
+class TestAssetEntryOrRaise:
+    def test_unknown_id_raises(self):
+        with pytest.raises(NotFoundError, match="Unknown asset"):
+            mcp_server._asset_entry_or_raise("nonexistent", "img")
+
+    def test_wrong_kind_raises(self):
+        entry = mcp_server.register_bytes_asset(b"data", mime_type="application/zip", kind="data")
+        with pytest.raises(NotFoundError, match="registered as 'data'"):
+            mcp_server._asset_entry_or_raise(entry.asset_id, "img")
+
+    def test_missing_file_raises(self, tmp_path):
+        # Register a file, then delete it
+        f = tmp_path / "will_delete.txt"
+        f.write_text("temp")
+        entry = mcp_server.register_file_asset(f)
+        # Now remove the copied file
+        entry.file_path.unlink()
+        with pytest.raises(NotFoundError, match="missing"):
+            mcp_server._asset_entry_or_raise(entry.asset_id, entry.kind)
+
+
+# ---------------------------------------------------------------------------
+# _to_resource_result
+# ---------------------------------------------------------------------------
+
+class TestToResourceResult:
+    def test_text_file_returns_text_content(self):
+        entry = mcp_server.register_bytes_asset(
+            b"hello text",
+            mime_type="text/plain",
+            filename="readme.txt",
+        )
+        result = mcp_server._to_resource_result(entry)
+        assert result.contents[0].mime_type == "text/plain"
+        # ResourceContent stores text in .content as str
+        assert result.contents[0].content == "hello text"
+
+    def test_text_with_unicode_decode_error_falls_back_to_binary(self):
+        # Write invalid UTF-8 bytes but label as text
+        entry = mcp_server.register_bytes_asset(
+            b"\x89\xfe\xff\x00invalid-utf8",
+            mime_type="text/plain",
+            filename="broken.txt",
+        )
+        result = mcp_server._to_resource_result(entry)
+        # Falls back to binary read
+        assert result.contents[0].mime_type == "text/plain"
+        assert result.contents[0].content == b"\x89\xfe\xff\x00invalid-utf8"
+
+    def test_binary_file_returns_bytes(self):
+        data = b"\x89PNG\r\n\x1a\nimage-data"
+        entry = mcp_server.register_bytes_asset(data, mime_type="image/png")
+        result = mcp_server._to_resource_result(entry)
+        assert result.contents[0].content == data
+
+
+# ---------------------------------------------------------------------------
+# _register_image_payload
+# ---------------------------------------------------------------------------
+
+class TestRegisterImagePayload:
+    def test_raises_for_non_dict(self):
+        with pytest.raises(ValueError, match="Expected image payload dict"):
+            mcp_server._register_image_payload("not-a-dict", filename_prefix="test")
+
+    def test_raises_for_missing_base64(self):
+        with pytest.raises(ValueError, match="Expected base64 image payload"):
+            mcp_server._register_image_payload(
+                {"encoding": "raw", "data": "abc"},
+                filename_prefix="test",
+            )
+
+    def test_raises_for_missing_data_key(self):
+        with pytest.raises(ValueError, match="Expected base64 image payload"):
+            mcp_server._register_image_payload(
+                {"encoding": "base64"},
+                filename_prefix="test",
+            )
+
+    def test_successful_registration(self):
+        import base64
+        image_bytes = b"\x89PNGfake"
+        payload = {
+            "encoding": "base64",
+            "data": base64.b64encode(image_bytes).decode("ascii"),
+            "media_type": "image/png",
+        }
+        result = mcp_server._register_image_payload(payload, filename_prefix="sweep")
+        assert "resource_uri" in result
+        assert result["resource_uri"].startswith("img://")
+        assert result["mime_type"] == "image/png"
+
+    def test_defaults_to_png_mime(self):
+        import base64
+        payload = {
+            "encoding": "base64",
+            "data": base64.b64encode(b"data").decode("ascii"),
+        }
+        result = mcp_server._register_image_payload(payload, filename_prefix="test")
+        assert result["mime_type"] == "image/png"
+
+    def test_non_png_uses_bin_suffix(self):
+        import base64
+        payload = {
+            "encoding": "base64",
+            "data": base64.b64encode(b"data").decode("ascii"),
+            "media_type": "image/jpeg",
+        }
+        result = mcp_server._register_image_payload(payload, filename_prefix="test")
+        assert result["mime_type"] == "image/jpeg"
+
+
+# ---------------------------------------------------------------------------
+# _asset_payload
+# ---------------------------------------------------------------------------
+
+class TestAssetPayload:
+    def test_includes_filename_when_present(self):
+        entry = mcp_server.register_bytes_asset(
+            b"data",
+            mime_type="application/zip",
+            filename="export.zip",
+        )
+        payload = mcp_server._asset_payload(entry)
+        assert payload["filename"] == "export.zip"
+
+    def test_omits_filename_when_none(self):
+        entry = mcp_server.AssetEntry(
+            asset_id="abc",
+            kind="data",
+            file_path=mcp_server._normalize_file_path(Path("tmp") / "abc.bin"),
+            mime_type="application/octet-stream",
+            public_url="http://unit.test/static/abc.bin",
+            filename=None,
+        )
+        with mcp_server.ASSET_REGISTRY_LOCK:
+            mcp_server.ASSET_REGISTRY["abc"] = entry
+        payload = mcp_server._asset_payload(entry)
+        assert "filename" not in payload
+
+
+# ---------------------------------------------------------------------------
+# _normalize_file_path
+# ---------------------------------------------------------------------------
+
+class TestNormalizeFilePath:
+    def test_absolute_path_unchanged(self, tmp_path):
+        p = tmp_path / "file.txt"
+        result = mcp_server._normalize_file_path(str(p))
+        assert result == p.resolve()
+
+    def test_relative_path_resolved(self):
+        result = mcp_server._normalize_file_path("tmp/foo.txt")
+        assert result.is_absolute()
+        assert str(result).endswith("tmp/foo.txt")
+
+
+# ---------------------------------------------------------------------------
+# resolve_public_base_url
+# ---------------------------------------------------------------------------
+
+class TestResolvePublicBaseUrl:
+    def test_falls_back_to_settings(self):
+        result = mcp_server.resolve_public_base_url(ctx=None)
+        assert result == "http://unit.test"
+
+    def test_context_takes_priority(self):
+        ctx = MagicMock()
+        ctx.request_context.request.url = "http://agent:9000/mcp"
+        result = mcp_server.resolve_public_base_url(ctx=ctx)
+        assert result == "http://agent:9000"
+
+
+# ---------------------------------------------------------------------------
+# build_public_url_from_tmp_path
+# ---------------------------------------------------------------------------
+
+class TestBuildPublicUrlFromTmpPath:
+    def test_default_base_url(self):
+        file_path = mcp_server._normalize_file_path(Path("tmp") / "foo" / "bar.png")
+        url = mcp_server.build_public_url_from_tmp_path(file_path)
+        assert url == "http://unit.test/static/foo/bar.png"
+
+    def test_custom_base_url(self):
+        file_path = mcp_server._normalize_file_path(Path("tmp") / "export.zip")
+        url = mcp_server.build_public_url_from_tmp_path(file_path, base_url="http://custom:5000/")
+        assert url == "http://custom:5000/static/export.zip"
+
+
+# ---------------------------------------------------------------------------
+# download_export_zip_tool error path
+# ---------------------------------------------------------------------------
+
+class TestDownloadExportZipToolError:
+    def test_raises_for_unexpected_payload(self, monkeypatch):
+        async def fake_download(*, aeroplane_id, request=None, settings=None):
+            return "not-a-dict"
+
+        monkeypatch.setattr(mcp_server.cad, "download_aeroplane_zip", fake_download)
+        with pytest.raises(ValueError, match="Unexpected ZIP payload"):
+            _run(mcp_server.download_export_zip_tool("task-1"))
+
+
+# ---------------------------------------------------------------------------
+# MCPToolSpec and mcp_tool decorator
+# ---------------------------------------------------------------------------
+
+class TestMCPToolSpec:
+    def test_dataclass_fields(self):
+        spec = mcp_server.MCPToolSpec(name="test", description="Test tool.", handler=lambda: None)
+        assert spec.name == "test"
+        assert spec.description == "Test tool."
+        assert callable(spec.handler)
+
+    def test_mcp_tool_decorator_registers_spec(self):
+        original_count = len(mcp_server.TOOL_SPECS)
+        # We won't actually decorate — just verify the existing count is non-zero
+        assert original_count > 0
+
+
+# ---------------------------------------------------------------------------
+# create_mcp_server
+# ---------------------------------------------------------------------------
+
+class TestCreateMcpServer:
+    def test_returns_fastmcp_instance(self):
+        server = mcp_server.create_mcp_server()
+        assert server is not None
+        assert server.name == "da3dalus-cad-tools"
+
+    def test_tools_and_resources_registered(self):
+        server = mcp_server.create_mcp_server()
+        tools = _run(server.list_tools())
+        templates = _run(server.list_resource_templates())
+        assert len(tools) > 0
+        assert len(templates) >= 2
+
+
+# ---------------------------------------------------------------------------
+# _call_endpoint
+# ---------------------------------------------------------------------------
+
+class TestCallEndpoint:
+    def test_sync_endpoint(self):
+        def sync_fn(db, name: str):
+            return {"name": name}
+
+        result = _run(mcp_server._call_endpoint(sync_fn, name="test"))
+        assert result == {"name": "test"}
+
+    def test_async_endpoint(self):
+        async def async_fn(db, x: int):
+            return {"x": x}
+
+        result = _run(mcp_server._call_endpoint(async_fn, x=42))
+        assert result == {"x": 42}
+
+    def test_endpoint_without_db_param(self):
+        def no_db_fn(value: str):
+            return {"value": value}
+
+        result = _run(mcp_server._call_endpoint(no_db_fn, value="hello"))
+        assert result == {"value": "hello"}
+
+    def test_endpoint_returning_none(self):
+        def returns_none(db):
+            return None
+
+        result = _run(mcp_server._call_endpoint(returns_none))
+        assert result == {"status": "ok"}

--- a/cad_designer/tests/test_classification.py
+++ b/cad_designer/tests/test_classification.py
@@ -1,0 +1,216 @@
+"""Tests for cad_designer.aerosandbox.classification module.
+
+Covers all three classification functions with boundary values,
+interior values, and edge cases for each stability tier.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cad_designer.aerosandbox.classification import (
+    classify_Cl_beta,
+    classify_Cm_alpha,
+    classify_Cn_beta,
+)
+from cad_designer.airplane.aircraft_topology.models.analysis_model import (
+    ClBetaClassification,
+    CmAlphaClassification,
+    CnBetaClassification,
+    StabilityLevel,
+)
+
+
+# ---------------------------------------------------------------------------
+# classify_Cm_alpha
+# ---------------------------------------------------------------------------
+# Thresholds (all < comparisons):
+#   < -0.08  -> STRONGLY_STABLE
+#   < -0.04  -> MODERATELY_STABLE
+#   < -0.005 -> MARGINALLY_STABLE
+#   >= -0.005 -> UNSTABLE
+
+class TestClassifyCmAlpha:
+    """Table-driven tests for classify_Cm_alpha."""
+
+    @pytest.mark.parametrize(
+        "value, expected_level",
+        [
+            # Strongly stable — well below -0.08
+            (-0.20, StabilityLevel.STRONGLY_STABLE),
+            (-0.09, StabilityLevel.STRONGLY_STABLE),
+            # Boundary: exactly -0.08 is NOT < -0.08 -> moderately stable
+            (-0.08, StabilityLevel.MODERATELY_STABLE),
+            # Moderately stable interior
+            (-0.06, StabilityLevel.MODERATELY_STABLE),
+            (-0.05, StabilityLevel.MODERATELY_STABLE),
+            # Boundary: exactly -0.04 is NOT < -0.04 -> marginally stable
+            (-0.04, StabilityLevel.MARGINALLY_STABLE),
+            # Marginally stable interior
+            (-0.02, StabilityLevel.MARGINALLY_STABLE),
+            (-0.01, StabilityLevel.MARGINALLY_STABLE),
+            # Boundary: exactly -0.005 is NOT < -0.005 -> unstable
+            (-0.005, StabilityLevel.UNSTABLE),
+            # Unstable
+            (0.0, StabilityLevel.UNSTABLE),
+            (0.05, StabilityLevel.UNSTABLE),
+        ],
+        ids=[
+            "strongly_stable_deep",
+            "strongly_stable_near_boundary",
+            "boundary_strongly_to_moderately",
+            "moderately_stable_interior_1",
+            "moderately_stable_interior_2",
+            "boundary_moderately_to_marginally",
+            "marginally_stable_interior_1",
+            "marginally_stable_interior_2",
+            "boundary_marginally_to_unstable",
+            "unstable_zero",
+            "unstable_positive",
+        ],
+    )
+    def test_classification_level(
+        self, value: float, expected_level: StabilityLevel
+    ) -> None:
+        result = classify_Cm_alpha(value)
+        assert isinstance(result, CmAlphaClassification)
+        assert result.classification == expected_level
+        assert result.value == value
+        assert isinstance(result.comment, str)
+        assert len(result.comment) > 0
+
+
+# ---------------------------------------------------------------------------
+# classify_Cl_beta
+# ---------------------------------------------------------------------------
+# Thresholds (all > comparisons):
+#   > 0.05   -> STRONGLY_STABLE
+#   > 0.02   -> MODERATELY_STABLE
+#   > 0.005  -> MARGINALLY_STABLE
+#   <= 0.005 -> UNSTABLE
+
+class TestClassifyClBeta:
+    """Table-driven tests for classify_Cl_beta."""
+
+    @pytest.mark.parametrize(
+        "value, expected_level",
+        [
+            # Strongly stable
+            (0.10, StabilityLevel.STRONGLY_STABLE),
+            (0.06, StabilityLevel.STRONGLY_STABLE),
+            # Boundary: exactly 0.05 is NOT > 0.05 -> moderately stable
+            (0.05, StabilityLevel.MODERATELY_STABLE),
+            # Moderately stable interior
+            (0.03, StabilityLevel.MODERATELY_STABLE),
+            # Boundary: exactly 0.02 is NOT > 0.02 -> marginally stable
+            (0.02, StabilityLevel.MARGINALLY_STABLE),
+            # Marginally stable interior
+            (0.01, StabilityLevel.MARGINALLY_STABLE),
+            # Boundary: exactly 0.005 is NOT > 0.005 -> unstable
+            (0.005, StabilityLevel.UNSTABLE),
+            # Unstable
+            (0.0, StabilityLevel.UNSTABLE),
+            (-0.05, StabilityLevel.UNSTABLE),
+        ],
+        ids=[
+            "strongly_stable_deep",
+            "strongly_stable_near_boundary",
+            "boundary_strongly_to_moderately",
+            "moderately_stable_interior",
+            "boundary_moderately_to_marginally",
+            "marginally_stable_interior",
+            "boundary_marginally_to_unstable",
+            "unstable_zero",
+            "unstable_negative",
+        ],
+    )
+    def test_classification_level(
+        self, value: float, expected_level: StabilityLevel
+    ) -> None:
+        result = classify_Cl_beta(value)
+        assert isinstance(result, ClBetaClassification)
+        assert result.classification == expected_level
+        assert result.value == value
+        assert isinstance(result.comment, str)
+        assert len(result.comment) > 0
+
+
+# ---------------------------------------------------------------------------
+# classify_Cn_beta
+# ---------------------------------------------------------------------------
+# Thresholds (all > comparisons):
+#   > 0.09   -> STRONGLY_STABLE
+#   > 0.02   -> MODERATELY_STABLE
+#   > 0.0025 -> MARGINALLY_STABLE
+#   <= 0.0025 -> UNSTABLE
+
+class TestClassifyCnBeta:
+    """Table-driven tests for classify_Cn_beta."""
+
+    @pytest.mark.parametrize(
+        "value, expected_level",
+        [
+            # Strongly stable
+            (0.20, StabilityLevel.STRONGLY_STABLE),
+            (0.10, StabilityLevel.STRONGLY_STABLE),
+            # Boundary: exactly 0.09 is NOT > 0.09 -> moderately stable
+            (0.09, StabilityLevel.MODERATELY_STABLE),
+            # Moderately stable interior
+            (0.05, StabilityLevel.MODERATELY_STABLE),
+            # Boundary: exactly 0.02 is NOT > 0.02 -> marginally stable
+            (0.02, StabilityLevel.MARGINALLY_STABLE),
+            # Marginally stable interior
+            (0.01, StabilityLevel.MARGINALLY_STABLE),
+            # Boundary: exactly 0.0025 is NOT > 0.0025 -> unstable
+            (0.0025, StabilityLevel.UNSTABLE),
+            # Unstable
+            (0.0, StabilityLevel.UNSTABLE),
+            (-0.05, StabilityLevel.UNSTABLE),
+        ],
+        ids=[
+            "strongly_stable_deep",
+            "strongly_stable_near_boundary",
+            "boundary_strongly_to_moderately",
+            "moderately_stable_interior",
+            "boundary_moderately_to_marginally",
+            "marginally_stable_interior",
+            "boundary_marginally_to_unstable",
+            "unstable_zero",
+            "unstable_negative",
+        ],
+    )
+    def test_classification_level(
+        self, value: float, expected_level: StabilityLevel
+    ) -> None:
+        result = classify_Cn_beta(value)
+        assert isinstance(result, CnBetaClassification)
+        assert result.classification == expected_level
+        assert result.value == value
+        assert isinstance(result.comment, str)
+        assert len(result.comment) > 0
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting: return-type consistency
+# ---------------------------------------------------------------------------
+
+class TestClassificationReturnTypes:
+    """Verify that all classifiers return Pydantic models with the right fields."""
+
+    def test_cm_alpha_is_pydantic_model(self) -> None:
+        result = classify_Cm_alpha(-0.06)
+        assert hasattr(result, "model_dump")
+        dumped = result.model_dump()
+        assert set(dumped.keys()) == {"value", "classification", "comment"}
+
+    def test_cl_beta_is_pydantic_model(self) -> None:
+        result = classify_Cl_beta(0.03)
+        assert hasattr(result, "model_dump")
+        dumped = result.model_dump()
+        assert set(dumped.keys()) == {"value", "classification", "comment"}
+
+    def test_cn_beta_is_pydantic_model(self) -> None:
+        result = classify_Cn_beta(0.05)
+        assert hasattr(result, "model_dump")
+        dumped = result.model_dump()
+        assert set(dumped.keys()) == {"value", "classification", "comment"}

--- a/cad_designer/tests/test_wing_roundtrip_cases.py
+++ b/cad_designer/tests/test_wing_roundtrip_cases.py
@@ -1,0 +1,161 @@
+"""Tests for cad_designer.aerosandbox.wing_roundtrip_cases module.
+
+Validates the CASE_FACTORIES registry, the get_factory lookup function,
+and each individual factory that can be invoked without heavy external
+dependencies.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cad_designer.aerosandbox.wing_roundtrip_cases import (
+    CASE_FACTORIES,
+    get_factory,
+)
+from cad_designer.airplane.aircraft_topology.wing.WingConfiguration import (
+    WingConfiguration,
+)
+
+
+# ---------------------------------------------------------------------------
+# CASE_FACTORIES registry
+# ---------------------------------------------------------------------------
+
+class TestCaseFactoriesRegistry:
+    """Structural tests for the CASE_FACTORIES list itself."""
+
+    def test_registry_is_non_empty(self) -> None:
+        assert len(CASE_FACTORIES) > 0
+
+    def test_all_entries_are_str_callable_tuples(self) -> None:
+        for entry in CASE_FACTORIES:
+            assert isinstance(entry, tuple), f"Expected tuple, got {type(entry)}"
+            assert len(entry) == 2, f"Expected 2-tuple, got {len(entry)}-tuple"
+            case_id, factory = entry
+            assert isinstance(case_id, str), f"case_id should be str, got {type(case_id)}"
+            assert callable(factory), f"factory for '{case_id}' is not callable"
+
+    def test_case_ids_are_unique(self) -> None:
+        ids = [cid for cid, _ in CASE_FACTORIES]
+        assert len(ids) == len(set(ids)), f"Duplicate case ids: {ids}"
+
+    def test_known_case_ids_present(self) -> None:
+        """Verify that the expected set of case ids is registered."""
+        ids = {cid for cid, _ in CASE_FACTORIES}
+        expected = {
+            "single_segment_flat",
+            "single_segment_with_nose_pnt",
+            "single_segment_with_dihedral",
+            "single_segment_with_twist",
+            "single_segment_with_twist_and_dihedral",
+            "configurator_wing",
+            "ehawk_main_wing",
+        }
+        assert expected.issubset(ids), f"Missing ids: {expected - ids}"
+
+
+# ---------------------------------------------------------------------------
+# get_factory lookup
+# ---------------------------------------------------------------------------
+
+class TestGetFactory:
+    """Tests for the get_factory(case_id) lookup."""
+
+    @pytest.mark.parametrize(
+        "case_id",
+        [cid for cid, _ in CASE_FACTORIES],
+    )
+    def test_returns_callable_for_known_id(self, case_id: str) -> None:
+        factory = get_factory(case_id)
+        assert callable(factory)
+
+    def test_raises_key_error_for_unknown_id(self) -> None:
+        with pytest.raises(KeyError, match="no_such_case"):
+            get_factory("no_such_case")
+
+    def test_raises_key_error_for_empty_string(self) -> None:
+        with pytest.raises(KeyError):
+            get_factory("")
+
+    def test_returned_factory_matches_registry(self) -> None:
+        """get_factory should return the exact same callable that is in the list."""
+        for case_id, expected_factory in CASE_FACTORIES:
+            assert get_factory(case_id) is expected_factory
+
+
+# ---------------------------------------------------------------------------
+# Factory invocations — exclude ehawk_main_wing (pulls heavy CAD deps)
+# ---------------------------------------------------------------------------
+
+# IDs of factories that are safe to call in a fast unit-test context.
+# ehawk_main_wing does a delayed import from test/ehawk_workflow_helpers
+# which may pull in CadQuery / heavy modules; we skip it here.
+_LIGHTWEIGHT_IDS = [
+    cid
+    for cid, _ in CASE_FACTORIES
+    if cid != "ehawk_main_wing"
+]
+
+
+class TestFactoryInvocations:
+    """Call each lightweight factory and verify the returned WingConfiguration."""
+
+    @pytest.mark.parametrize("case_id", _LIGHTWEIGHT_IDS)
+    def test_factory_returns_wing_configuration(self, case_id: str) -> None:
+        factory = get_factory(case_id)
+        wc = factory()
+        assert isinstance(wc, WingConfiguration)
+
+    @pytest.mark.parametrize("case_id", _LIGHTWEIGHT_IDS)
+    def test_wing_configuration_has_segments(self, case_id: str) -> None:
+        """Every WingConfiguration should have at least one segment."""
+        wc = get_factory(case_id)()
+        # WingConfiguration stores segments; the first is built from
+        # root_airfoil + tip_airfoil + length in the constructor.
+        assert hasattr(wc, "segments")
+        assert len(wc.segments) >= 1
+
+    @pytest.mark.parametrize("case_id", _LIGHTWEIGHT_IDS)
+    def test_wing_configuration_is_symmetric(self, case_id: str) -> None:
+        """All test factories create symmetric wings."""
+        wc = get_factory(case_id)()
+        assert wc.symmetric is True
+
+    @pytest.mark.parametrize("case_id", _LIGHTWEIGHT_IDS)
+    def test_wing_configuration_is_relative_mode(self, case_id: str) -> None:
+        """All test factories use 'relative' parameters."""
+        wc = get_factory(case_id)()
+        assert wc.parameters == "relative"
+
+
+class TestSpecificFactories:
+    """Targeted assertions on individual factory outputs."""
+
+    def test_single_segment_flat_zero_dihedral(self) -> None:
+        wc = get_factory("single_segment_flat")()
+        root = wc.segments[0].root_airfoil
+        assert root.dihedral_as_rotation_in_degrees == 0
+        assert root.incidence == 0
+
+    def test_single_segment_with_dihedral_value(self) -> None:
+        wc = get_factory("single_segment_with_dihedral")()
+        root = wc.segments[0].root_airfoil
+        assert root.dihedral_as_rotation_in_degrees == 5
+
+    def test_single_segment_with_nose_pnt(self) -> None:
+        wc = get_factory("single_segment_with_nose_pnt")()
+        assert wc.nose_pnt == (25.0, 50.0, 100.0)
+
+    def test_single_segment_with_twist_tip_incidence(self) -> None:
+        wc = get_factory("single_segment_with_twist")()
+        tip = wc.segments[0].tip_airfoil
+        assert tip.incidence == -10
+
+    def test_configurator_wing_has_three_segments(self) -> None:
+        wc = get_factory("configurator_wing")()
+        assert len(wc.segments) == 3
+
+    def test_configurator_wing_nose_pnt(self) -> None:
+        wc = get_factory("configurator_wing")()
+        assert wc.nose_pnt == (25, 50, 100)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=szymansk_da3Dalus
 sonar.organization=szymansk
 sonar.sources=app,cad_designer,frontend
-sonar.tests=app/tests,frontend/__tests__,frontend/e2e
+sonar.tests=app/tests,cad_designer/tests,frontend/__tests__,frontend/e2e
 sonar.test.inclusions=**/test_*.py,**/*_test.py,**/*.test.ts,**/*.test.tsx,**/*.steps.ts
 sonar.exclusions=frontend/node_modules/**,frontend/.next/**,frontend/.features-gen/**
 sonar.python.coverage.reportPaths=coverage.xml


### PR DESCRIPTION
## Summary
Final coverage wave for both EPICs:

**app/ (#294):** 266 tests
- `aeroanalysis` endpoint: 74% → 100% (29 tests)
- `cad` endpoint: 71% → 100% (47 tests)
- Component services (4 modules): 54% → 85% (113 tests)
- `mcp_server`: 86% → 99% (77 tests)

**cad_designer/ (#295):** 76 tests
- `classification.py`: 32 tests (all stability tiers)
- `wing_roundtrip_cases.py`: 44 tests (factory registry + invocations)

**Config:**
- `sonar-project.properties`: add `cad_designer/tests` to `sonar.tests`
- `.github/workflows/test.yml`: add `--cov=cad_designer` to coverage

No production code modified.

Part of EPICs #278, #283
Closes #294, #295

## Test plan
- [x] All 342 tests pass (8.31s)
- [x] No production code modified
- [x] SonarQube + CI config updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)