### PR TITLE
fix(gh-308): remove orphaned setZoomScale call in ImportFuselageDialog

### DIFF
--- a/frontend/__tests__/nextConfigThreeDedup.test.ts
+++ b/frontend/__tests__/nextConfigThreeDedup.test.ts
@@ -27,7 +27,10 @@ describe("next.config three.js deduplication (webpack + turbopack)", () => {
       },
     };
 
-    const result = config.webpack!(fakeWebpackConfig as any, {} as any);
+    const result = config.webpack!(
+      fakeWebpackConfig as Parameters<NonNullable<typeof config.webpack>>[0],
+      {} as Parameters<NonNullable<typeof config.webpack>>[1],
+    );
 
     // The alias for "three" must point to the top-level node_modules/three
     const expectedPath = path.resolve("node_modules", "three");
@@ -45,7 +48,10 @@ describe("next.config three.js deduplication (webpack + turbopack)", () => {
       },
     };
 
-    const result = config.webpack!(fakeWebpackConfig as any, {} as any);
+    const result = config.webpack!(
+      fakeWebpackConfig as Parameters<NonNullable<typeof config.webpack>>[0],
+      {} as Parameters<NonNullable<typeof config.webpack>>[1],
+    );
 
     // Existing alias must still be present
     expect(result.resolve.alias.existing).toBe("/some/path");

--- a/frontend/components/workbench/ImportFuselageDialog.tsx
+++ b/frontend/components/workbench/ImportFuselageDialog.tsx
@@ -809,7 +809,6 @@ export function ImportFuselageDialog({
   const [xsecsMaximized, setXsecsMaximized] = useState(false);
   const [xsecs, setXsecs] = useState<XSec[]>(initialXsecs ?? INITIAL_XSECS);
   const [selectedXsec, setSelectedXsec] = useState<number | null>(initialSelectedIndex ?? (editMode ? 0 : null));
-  // zoomScale state removed — was unused dead code (SonarQube S1854)
   const [file, setFile] = useState<File | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [fidelity, setFidelity] = useState<{ volume_ratio: number; area_ratio: number } | null>(null);
@@ -876,7 +875,6 @@ export function ImportFuselageDialog({
     setFuselageName(initialName ?? "Imported Fuselage");
     setXsecs(initialXsecs ?? INITIAL_XSECS);
     setSelectedXsec(initialSelectedIndex ?? (editMode ? 0 : null));
-    setZoomScale(null);
     setXsecsMaximized(false);
     setViewerMaximized(false);
     setFile(null);


### PR DESCRIPTION
## Summary

- Commit `725e40b` (SonarQube sweep) removed the `zoomScale` `useState` declaration as dead code (S1854) but left a `setZoomScale(null)` call in `handleReset()`, causing a `ReferenceError` crash when clicking Reset in the Import Fuselage dialog.
- Removed the orphaned setter call and the dead-code comment.

## Test plan

- [x] Open the Import Fuselage dialog
- [x] Click the Reset button — no crash, dialog resets correctly
- [x] TypeScript check passes (no new errors)

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)