### PR TITLE
feat(gh-312,gh-313): add loglevel editing and nested successor steps

### DIFF
--- a/frontend/__tests__/planTreeUtils.test.ts
+++ b/frontend/__tests__/planTreeUtils.test.ts
@@ -11,6 +11,7 @@ import {
   computeReorderTargetPath,
   toBackendTree,
   fromBackendTree,
+  appendChildAtPath,
 } from "@/lib/planTreeUtils";
 
 function makeNode(type: string, id: string, successors: PlanStepNode[] = []): PlanStepNode {
@@ -310,6 +311,58 @@ describe("fromBackendTree", () => {
     const frontend = fromBackendTree(backend);
     expect(frontend.successors![0].successors![0].$TYPE).toBe("ExportCreator");
     expect(frontend.successors![0].successors![0].creator_id).toBe("e1");
+  });
+});
+
+describe("appendChildAtPath", () => {
+  it("appends a child to root's successors when parentPath is 'root'", () => {
+    const tree = makeNode("Root", "root", [makeNode("A", "a")]);
+    const child = makeNode("B", "b");
+    const result = appendChildAtPath(tree, "root", child);
+    expect(result.successors!.length).toBe(2);
+    expect(result.successors![0].creator_id).toBe("a");
+    expect(result.successors![1].creator_id).toBe("b");
+  });
+
+  it("appends a child to a nested node's successors", () => {
+    const tree = makeNode("Root", "root", [
+      makeNode("A", "a", [makeNode("A1", "a1")]),
+      makeNode("B", "b"),
+    ]);
+    const child = makeNode("A2", "a2");
+    const result = appendChildAtPath(tree, "root.0", child);
+    expect(result.successors![0].successors!.length).toBe(2);
+    expect(result.successors![0].successors![0].creator_id).toBe("a1");
+    expect(result.successors![0].successors![1].creator_id).toBe("a2");
+    // Other siblings unchanged
+    expect(result.successors![1].creator_id).toBe("b");
+  });
+
+  it("appends a child to a deeply nested node", () => {
+    const tree = makeNode("Root", "root", [
+      makeNode("A", "a", [
+        makeNode("A1", "a1", [makeNode("A1a", "a1a")]),
+      ]),
+    ]);
+    const child = makeNode("A1b", "a1b");
+    const result = appendChildAtPath(tree, "root.0.0", child);
+    expect(result.successors![0].successors![0].successors!.length).toBe(2);
+    expect(result.successors![0].successors![0].successors![1].creator_id).toBe("a1b");
+  });
+
+  it("appends to a leaf node (creates successors array)", () => {
+    const tree = makeNode("Root", "root", [makeNode("A", "a")]);
+    const child = makeNode("A1", "a1");
+    const result = appendChildAtPath(tree, "root.0", child);
+    expect(result.successors![0].successors!.length).toBe(1);
+    expect(result.successors![0].successors![0].creator_id).toBe("a1");
+  });
+
+  it("does not mutate the original tree", () => {
+    const tree = makeNode("Root", "root", [makeNode("A", "a")]);
+    const child = makeNode("B", "b");
+    appendChildAtPath(tree, "root", child);
+    expect(tree.successors!.length).toBe(1);
   });
 });
 

--- a/frontend/app/workbench/construction-plans/page.tsx
+++ b/frontend/app/workbench/construction-plans/page.tsx
@@ -29,6 +29,7 @@ import {
   deleteStepAtPath,
   insertStepAtPath,
   updateNodeAtPath,
+  appendChildAtPath,
   collectAvailableShapeKeys,
   resolveIdTemplate,
   computeReorderTargetPath,
@@ -111,6 +112,7 @@ export default function ConstructionPlansPage() {
   const [addCreatorId, setAddCreatorId] = useState("");
   const [addCreatorIdManual, setAddCreatorIdManual] = useState(false);
   const [addStepParams, setAddStepParams] = useState<Record<string, unknown>>({});
+  const [addStepParentPath, setAddStepParentPath] = useState<string | null>(null);
 
   // Debounce timer for parameter saves
   const paramSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -238,10 +240,8 @@ export default function ConstructionPlansPage() {
       ...addStepParams,
       successors: [],
     };
-    const updatedTree: PlanStepNode = {
-      ...treeJson,
-      successors: [...(treeJson.successors ?? []), newStep],
-    };
+    const parentPath = addStepParentPath ?? "root";
+    const updatedTree = appendChildAtPath(treeJson, parentPath, newStep);
     try {
       await updatePlan(selectedPlanId, {
         name: plan.name,
@@ -252,6 +252,7 @@ export default function ConstructionPlansPage() {
       activeMutate();
       setAddDialogOpen(false);
       setAddingCreator(null);
+      setAddStepParentPath(null);
     } catch (err) {
       alert(err instanceof Error ? err.message : "Failed to add step");
     }
@@ -485,7 +486,10 @@ export default function ConstructionPlansPage() {
               selectedStepPath={selectedStepPath}
               onSelectStep={handleSelectStep}
               onDeleteStep={handleDeleteStep}
-              onAddStep={() => setAddDialogOpen(true)}
+              onAddStep={(parentPath) => {
+                setAddStepParentPath(parentPath ?? "root");
+                setAddDialogOpen(true);
+              }}
               onReorder={handleReorder}
             />
           ) : (
@@ -570,7 +574,7 @@ export default function ConstructionPlansPage() {
         addStepParams={addStepParams}
         treeJson={treeJson}
         creators={creators}
-        onClose={() => { setAddDialogOpen(false); setAddingCreator(null); }}
+        onClose={() => { setAddDialogOpen(false); setAddingCreator(null); setAddStepParentPath(null); }}
         onSetAddingCreator={setAddingCreator}
         onSetAddCreatorId={setAddCreatorId}
         onSetAddCreatorIdManual={setAddCreatorIdManual}

--- a/frontend/components/workbench/CreatorParameterForm.tsx
+++ b/frontend/components/workbench/CreatorParameterForm.tsx
@@ -94,6 +94,14 @@ function ParamInput({
   }
 }
 
+const LOGLEVEL_OPTIONS = [
+  { value: 10, label: "DEBUG" },
+  { value: 20, label: "INFO" },
+  { value: 30, label: "WARNING" },
+  { value: 40, label: "ERROR" },
+  { value: 50, label: "CRITICAL" },
+] as const;
+
 export function CreatorParameterForm({
   creatorName,
   creatorDescription,
@@ -114,6 +122,22 @@ export function CreatorParameterForm({
           )}
         </div>
       )}
+      {/* Loglevel — universal AbstractShapeCreator parameter */}
+      <label className="flex flex-col gap-1">
+        <span className="flex items-center gap-1 font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-muted-foreground">
+          loglevel
+          <span className="text-[9px] text-subtle-foreground">(int)</span>
+        </span>
+        <select
+          value={Number(values.loglevel ?? 50)}
+          onChange={(e) => onChange("loglevel", Number.parseInt(e.target.value, 10))}
+          className="rounded-lg border border-border bg-input px-3 py-1.5 text-[12px] text-foreground outline-none"
+        >
+          {LOGLEVEL_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>{opt.label} ({opt.value})</option>
+          ))}
+        </select>
+      </label>
       {params.length === 0 ? (
         <p className="text-[12px] text-muted-foreground">No parameters</p>
       ) : (

--- a/frontend/components/workbench/PlanTree.tsx
+++ b/frontend/components/workbench/PlanTree.tsx
@@ -27,7 +27,7 @@ interface PlanTreeProps {
   selectedStepPath: string | null;
   onSelectStep: (path: string, node: PlanStepNode) => void;
   onDeleteStep: (path: string) => void;
-  onAddStep: () => void;
+  onAddStep: (parentPath?: string) => void;
   onReorder: (fromPath: string, toPath: string) => void;
 }
 
@@ -39,6 +39,7 @@ function flattenSteps(
   selectedPath: string | null,
   onSelect: (path: string, node: PlanStepNode) => void,
   onDelete: (path: string) => void,
+  onAddStep: (parentPath?: string) => void,
 ): SimpleTreeNode[] {
   const successors = node.successors ?? [];
   const isLeaf = successors.length === 0;
@@ -53,7 +54,9 @@ function flattenSteps(
     selected: path === selectedPath,
     chip: node.$TYPE?.replace("Creator", ""),
     onClick: () => onSelect(path, node),
-    onDelete: () => onDelete(path),
+    onDelete: path === "root" ? undefined : () => onDelete(path),
+    onAdd: () => onAddStep(path),
+    addTitle: `Add child step to ${node.creator_id ?? node.$TYPE ?? "step"}`,
   };
 
   const rows: SimpleTreeNode[] = [row];
@@ -69,6 +72,7 @@ function flattenSteps(
           selectedPath,
           onSelect,
           onDelete,
+          onAddStep,
         ),
       );
     });
@@ -104,8 +108,9 @@ export function PlanTree({
       selectedStepPath,
       onSelectStep,
       onDeleteStep,
+      onAddStep,
     );
-  }, [treeJson, expanded, selectedStepPath, onSelectStep, onDeleteStep]);
+  }, [treeJson, expanded, selectedStepPath, onSelectStep, onDeleteStep, onAddStep]);
 
   const handleToggle = useCallback(
     (id: string) => {
@@ -133,7 +138,7 @@ export function PlanTree({
       badge={`${stepCount} steps`}
       actions={
         <button
-          onClick={onAddStep}
+          onClick={() => onAddStep()}
           title="Add step"
           className="flex size-6 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent hover:text-foreground"
         >

--- a/frontend/lib/planTreeUtils.ts
+++ b/frontend/lib/planTreeUtils.ts
@@ -146,6 +146,28 @@ export function computeReorderTargetPath(fromPath: string, toPath: string): stri
   return toPath;
 }
 
+/** Return a new tree with `child` appended to the successors of the node at `parentPath`. */
+export function appendChildAtPath(
+  tree: PlanStepNode,
+  parentPath: string,
+  child: PlanStepNode,
+): PlanStepNode {
+  if (parentPath === "root") {
+    return { ...tree, successors: [...(tree.successors ?? []), child] };
+  }
+  const parts = parentPath.replace("root.", "").split(".");
+  const idx = Number.parseInt(parts[0], 10);
+  const rest = parts.slice(1);
+  const newSuccessors = [...(tree.successors ?? [])];
+  if (rest.length === 0) {
+    const target = newSuccessors[idx];
+    newSuccessors[idx] = { ...target, successors: [...(target.successors ?? []), child] };
+  } else {
+    newSuccessors[idx] = appendChildAtPath(newSuccessors[idx], "root." + rest.join("."), child);
+  }
+  return { ...tree, successors: newSuccessors };
+}
+
 /** Default loglevel matching Python's logging.FATAL (50). */
 const DEFAULT_LOGLEVEL = 50;
 


### PR DESCRIPTION
## Summary

- **#312 Loglevel editing**: Added a `loglevel` select dropdown at the top of `CreatorParameterForm`, always visible for every step. Options: DEBUG (10), INFO (20), WARNING (30), ERROR (40), CRITICAL (50). Default: CRITICAL (50). Uses existing `handleParamChange` flow.
- **#313 Nested successor steps**: Added per-row `+` buttons in `PlanTree` using the existing `SimpleTreeRow.onAdd` prop. New `appendChildAtPath` helper in `planTreeUtils.ts` finds the target node by path and appends the new step to its successors. Page state tracks `addStepParentPath` to route the add dialog to the correct parent.

Closes #312
Closes #313

## Test plan
- [x] 5 new tests for `appendChildAtPath` (root, nested, deep, leaf, immutability)
- [x] All 268 frontend tests pass (`npx vitest run`)
- [x] ESLint clean (no new errors)
- [x] Dependency cruiser clean (no new violations)
- [ ] Manual: open construction plans page, select a step, verify loglevel dropdown appears and persists changes
- [ ] Manual: click per-row `+` button, add a nested step, verify it appears as a child in the tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)