### PR TITLE
chore: update supercycle commands to use SonarQube skills

### DIFF
--- a/.claude/commands/supercycle/bug.md
+++ b/.claude/commands/supercycle/bug.md
@@ -1,7 +1,7 @@
 ---
 description: "Bug intake: investigate root cause, create GH ticket, fix, review, and merge — all in one flow"
 argument-hint: "<error log, description, or GH issue number>"
-allowed-tools: Bash, Read, Edit, Write, Glob, Grep, Agent, WebSearch
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep, Agent, WebSearch, Skill
 ---
 
 # /supercycle:bug — Bug Intake & Fix
@@ -27,7 +27,8 @@ gh issue view <number> --json number,title,body,labels,state
 ```
 
 Read the issue. If it references external systems (SonarQube, Sentry),
-fetch current data NOW.
+fetch current data NOW. For SonarQube references, use
+`/sonarqube:sonar-list-issues` and `/sonarqube:sonar-analyze`.
 
 ### If free-text (error log / description):
 

--- a/.claude/commands/supercycle/fix.md
+++ b/.claude/commands/supercycle/fix.md
@@ -1,7 +1,7 @@
 ---
 description: "Fix review findings on PR branches — switch to branch, apply fixes, run quality gates, push"
 argument-hint: "<PR numbers, comma-separated: 200, 201>"
-allowed-tools: Bash, Read, Edit, Write, Glob, Grep
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep, Skill
 ---
 
 # /supercycle:fix — Fix Review Findings

--- a/.claude/commands/supercycle/implement.md
+++ b/.claude/commands/supercycle/implement.md
@@ -1,7 +1,7 @@
 ---
 description: "Skip brainstorming — go straight to parallel implementation of one or more GH issues via worktree agents"
 argument-hint: "<GH issue numbers, comma-separated: #188, #190>"
-allowed-tools: Bash, Read, Glob, Grep, Agent, WebSearch
+allowed-tools: Bash, Read, Glob, Grep, Agent, WebSearch, Skill
 ---
 
 # /supercycle:implement — Direct Implementation
@@ -23,7 +23,9 @@ gh issue view <N> --json number,title,body,labels
 ```
 
 If any issue references an external system (SonarQube, Sentry, etc.),
-fetch current data NOW.
+fetch current data NOW. For SonarQube issues, use
+`/sonarqube:sonar-list-issues` to get current line numbers and
+`/sonarqube:sonar-analyze` for deeper analysis of affected files.
 
 ---
 

--- a/.claude/commands/supercycle/init.md
+++ b/.claude/commands/supercycle/init.md
@@ -1,7 +1,7 @@
 ---
 description: "Check and install all tools, dependencies, and services required by the supercycle workflow"
 argument-hint: ""
-allowed-tools: Bash, Read, Glob, Grep
+allowed-tools: Bash, Read, Glob, Grep, Skill
 ---
 
 # /supercycle:init — Toolchain Setup & Verification
@@ -91,17 +91,19 @@ npx playwright --version 2>/dev/null || echo "INFO: Playwright not installed —
 ## Phase 4 — External Services
 
 ### 4.1 — SonarQube / SonarCloud
+
+Run `/sonarqube:sonar-integrate` to ensure `sonarqube-cli` is
+installed and up-to-date, authentication is valid, and the MCP
+server + secrets-scanning hooks are wired into Claude Code.
+
+The skill handles everything: install, self-update, auth check,
+and `sonar integrate claude`. It will prompt the user only when
+interactive input is required (auth login, scope selection).
+
+After the skill completes, verify the project config:
 ```bash
-# Check if sonar-project.properties exists
 test -f sonar-project.properties && echo "SonarQube configured" || echo "MISSING: sonar-project.properties"
-
-# Check MCP server
-# SonarQube MCP should be available — verify by trying to list projects
 ```
-
-Use `mcp__sonarqube__search_my_sonarqube_projects` to verify the
-SonarQube MCP connection works. If it fails, suggest running
-`/sonarqube:integrate`.
 
 ### 4.2 — GitHub Actions
 ```bash
@@ -161,6 +163,7 @@ npm run test:unit -- --run 2>&1 | tail -3          # vitest (fast)
 | Frontend | vitest | X.Y.Z | ✓ (N tests pass) |
 | Frontend | dep-cruiser | X.Y.Z | ✓ (N violations) |
 | Frontend | playwright | X.Y.Z | ✓ / not installed |
+| Service | sonarqube-cli | X.Y.Z | ✓ / not installed |
 | Service | SonarCloud | — | ✓ connected / ✗ not configured |
 | Service | GitHub Actions | — | ✓ workflow exists |
 | Commands | supercycle/* | — | ✓ all 7 present |

--- a/.claude/commands/supercycle/merge.md
+++ b/.claude/commands/supercycle/merge.md
@@ -1,7 +1,7 @@
 ---
 description: "Check CI, analyse quality gates, and merge one or more PRs sequentially with rebase conflict resolution"
 argument-hint: "<PR numbers, comma-separated: 200, 201>"
-allowed-tools: Bash, Read, Glob, Grep
+allowed-tools: Bash, Read, Glob, Grep, Skill
 ---
 
 # /supercycle:merge — CI Check & Merge
@@ -39,20 +39,20 @@ Tests failing on PR #N. Options:
 
 ## Phase 2 — SonarQube Quality Gate Analysis
 
-If SonarCloud Quality Gate is failing:
-
-```
-mcp__sonarqube__get_project_quality_gate_status(projectKey, pullRequest=<N>)
-```
+If SonarCloud Quality Gate is failing, use `/sonarqube:sonar-quality-gate`
+to get the detailed status for the PR.
 
 For each failed condition:
 - **Security / Reliability / Maintainability:** Must fix before merge.
-  Report the specific issues.
+  Use `/sonarqube:sonar-list-issues` to get the specific issues on
+  the PR branch and `/sonarqube:sonar-analyze` for deeper analysis.
 - **Coverage on new code:** Analyse if acceptable:
   - Refactoring/chore PRs: coverage gaps on renamed/moved code are expected
-  - Feature PRs: new code should have tests — flag if missing
-- **Duplication:** Check if duplication is from mechanical changes (e.g.
-  repeated `responses={}` patterns) or real copy-paste.
+  - Feature PRs: new code should have tests — flag if missing.
+    Use `/sonarqube:sonar-coverage` to inspect uncovered lines.
+- **Duplication:** Use `/sonarqube:sonar-duplication` to check if
+  duplication is from mechanical changes (e.g. repeated `responses={}`
+  patterns) or real copy-paste.
 
 Report the analysis and a merge recommendation for each PR.
 

--- a/.claude/commands/supercycle/review.md
+++ b/.claude/commands/supercycle/review.md
@@ -1,7 +1,7 @@
 ---
 description: "Run parallel code review agents on one or more open PRs — dispatches code-reviewer + conditional specialized reviewers"
 argument-hint: "<PR numbers, comma-separated: 200, 201>"
-allowed-tools: Bash, Read, Glob, Grep, Agent
+allowed-tools: Bash, Read, Glob, Grep, Agent, Skill
 ---
 
 # /supercycle:review — Parallel PR Review

--- a/.claude/commands/supercycle/status.md
+++ b/.claude/commands/supercycle/status.md
@@ -1,7 +1,7 @@
 ---
 description: "Project health dashboard — GH issues, SonarQube status, dependency graph, and next-phase recommendations"
 argument-hint: ""
-allowed-tools: Bash, Read, Glob, Grep, Agent, WebSearch
+allowed-tools: Bash, Read, Glob, Grep, Agent, WebSearch, Skill
 ---
 
 # /supercycle:status — Project Health Dashboard
@@ -73,8 +73,8 @@ gh pr list --state open --json number,title,headRefName,additions,deletions
 
 ### 2a — Quality Gate Status
 
-Use `mcp__sonarqube__get_project_quality_gate_status` for the
-overall project quality gate.
+Use `/sonarqube:sonar-quality-gate` for the overall project
+quality gate.
 
 Present:
 ```
@@ -84,8 +84,7 @@ Present:
 
 ### 2b — Issue Distribution
 
-Use `mcp__sonarqube__search_sonar_issues_in_projects` with
-`ps=1` for each severity to get counts:
+Use `/sonarqube:sonar-list-issues` to get issues by severity:
 
 ```
 | Severity | Count | Trend |
@@ -99,8 +98,8 @@ Use `mcp__sonarqube__search_sonar_issues_in_projects` with
 
 ### 2c — Top Rules
 
-Fetch page 1 (100 issues) and count by rule to identify the
-most frequent issue types:
+From the `/sonarqube:sonar-list-issues` output, count by rule
+to identify the most frequent issue types:
 
 ```
 | Rule | Count | Description |
@@ -109,7 +108,7 @@ most frequent issue types:
 
 ### 2d — Top Files
 
-From the same page 1 data, count by file:
+From the same data, count by file:
 
 ```
 | File | Issues | Top Rule |

--- a/.claude/commands/supercycle/work.md
+++ b/.claude/commands/supercycle/work.md
@@ -1,7 +1,7 @@
 ---
 description: "Full supercycle: brainstorm GH issue/feature with user, refine ticket, then orchestrate implementation through to merged PR"
 argument-hint: "<GH issue number> OR <feature description>"
-allowed-tools: Bash, Read, Glob, Grep, Agent, WebSearch
+allowed-tools: Bash, Read, Glob, Grep, Agent, WebSearch, Skill
 ---
 
 # /supercycle:work — Full Development Cycle
@@ -36,8 +36,8 @@ that system NOW — issue descriptions go stale.
 
 **SonarQube example:**
 - If the issue body mentions `S1234` or links to sonarcloud.io →
-  use `sonarqube:list-issues` to get current line numbers and rule details
-- Use `sonarqube:show-rule` for the official fix recommendation
+  use `/sonarqube:sonar-list-issues` to get current line numbers and rule details
+- Use `/sonarqube:sonar-analyze` on the affected file for deeper analysis
 
 ### If free-text (feature description):
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c \"./.claude/hooks/post-command/log-tool-result.sh 2\u003e/dev/null || true\""
+            "command": "bash -c \"./.claude/hooks/post-command/log-tool-result.sh 2>/dev/null || true\""
           }
         ]
       },
@@ -15,11 +15,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c \"./.claude/hooks/post-command/format-code.sh 2\u003e/dev/null || true\""
+            "command": "bash -c \"./.claude/hooks/post-command/format-code.sh 2>/dev/null || true\""
           },
           {
             "type": "command",
-            "command": "bash -c \"./.claude/hooks/post-command/lint-code.sh 2\u003e/dev/null || true\""
+            "command": "bash -c \"./.claude/hooks/post-command/lint-code.sh 2>/dev/null || true\""
           }
         ]
       },
@@ -28,11 +28,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c \"./.claude/hooks/post-command/format-code.sh 2\u003e/dev/null || true\""
+            "command": "bash -c \"./.claude/hooks/post-command/format-code.sh 2>/dev/null || true\""
           },
           {
             "type": "command",
-            "command": "bash -c \"./.claude/hooks/post-command/lint-code.sh 2\u003e/dev/null || true\""
+            "command": "bash -c \"./.claude/hooks/post-command/lint-code.sh 2>/dev/null || true\""
           }
         ]
       }
@@ -53,7 +53,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c \"./.claude/hooks/pre-command/log-tool-use.sh 2\u003e/dev/null || true\""
+            "command": "bash -c \"./.claude/hooks/pre-command/log-tool-use.sh 2>/dev/null || true\""
           }
         ]
       },
@@ -74,6 +74,16 @@
             "command": "bash ./.claude/hooks/pre-command/check-sensitive-path.sh"
           }
         ]
+      },
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/sonar-secrets/build-scripts/pretool-secrets.sh",
+            "timeout": 60
+          }
+        ]
       }
     ],
     "SessionStart": [
@@ -81,11 +91,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c \"if [ -d .beads ]; then bd prime 2\u003e/dev/null || true; fi\""
+            "command": "bash -c \"if [ -d .beads ]; then bd prime 2>/dev/null || true; fi\""
           },
           {
             "type": "command",
-            "command": "bash -c \"./.claude/hooks/pre-command/check-toolchain.sh 2\u003e/dev/null || true\""
+            "command": "bash -c \"./.claude/hooks/pre-command/check-toolchain.sh 2>/dev/null || true\""
           }
         ]
       }
@@ -95,7 +105,19 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c \"if [ -d .beads ]; then bd sync 2\u003e/dev/null || true; fi\""
+            "command": "bash -c \"if [ -d .beads ]; then bd sync 2>/dev/null || true; fi\""
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/sonar-secrets/build-scripts/prompt-secrets.sh",
+            "timeout": 60
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Add `Skill` to `allowed-tools` in all supercycle commands so they can invoke SonarQube skills
- Replace raw MCP tool calls (`mcp__sonarqube__*`) with `/sonarqube:sonar-*` skill invocations across all commands
- Delegate SonarQube setup in `init.md` to `/sonarqube:sonar-integrate` skill
- Add sonar-secrets pre-tool and prompt hooks to `settings.json`
- Fix unicode escapes (`\u003e` → `>`) in hook commands

## Test plan
- [ ] Run `/supercycle:init` and verify SonarQube integration step works
- [ ] Run `/supercycle:status` and verify SonarQube dashboard section renders
- [ ] Verify hooks fire correctly on session start

🤖 Generated with [Claude Code](https://claude.com/claude-code)