### PR TITLE
feat(gh-321): add structured GH issue tracking to supercycle commands

### DIFF
--- a/.claude/commands/supercycle/bug.md
+++ b/.claude/commands/supercycle/bug.md
@@ -232,6 +232,52 @@ poetry run pytest -m "not slow"   # Full suite green
 
 ---
 
+## GH Issue Tracking
+
+**Reference:** See `tracking.md` in this directory for the label
+catalog, comment template, and helper commands.
+
+### At Phase 2 start (root cause investigation):
+
+Rotate status to `status:brainstorming`.
+
+### After Phase 2c (root cause identified):
+
+1. Post a comment with header `## 🏷️ has-root-cause` containing the
+   full bug analysis (error, root cause, introducing commit, severity,
+   affected features, proposed fix)
+2. Add label `has-root-cause`
+
+**Note:** If the bug input was free-text, the GH Issue may not exist
+yet at this point. In that case, post the root-cause comment AFTER
+Phase 3 (ticket creation).
+
+### After Phase 4b (failing test written — TDD RED):
+
+1. Post a comment with header `## 🏷️ has-reproduction` containing
+   the test name, file path, test code, and failing output
+2. Add label `has-reproduction`
+3. Rotate status to `status:implementing`
+
+### After Phase 4f (PR created):
+
+1. Post a comment with header `## 🏷️ has-pr` containing PR number
+   and link, root cause summary, test name, fix description
+2. Add label `has-pr`
+
+### After Phase 5a (review dispatched):
+
+Rotate status to `status:in-review`.
+
+### After Phase 5b (merged):
+
+Rotate status to `status:merged`.
+
+**IMPORTANT:** Always post the comment FIRST, then add the label.
+Always ensure the label exists before adding it (idempotent create).
+
+---
+
 ## Supercycle Position
 
 ```

--- a/.claude/commands/supercycle/bug.md
+++ b/.claude/commands/supercycle/bug.md
@@ -265,9 +265,12 @@ Phase 3 (ticket creation).
    and link, root cause summary, test name, fix description
 2. Add label `has-pr`
 
-### After Phase 5a (review dispatched):
+### After Phase 5a (review complete):
 
-Rotate status to `status:in-review`.
+1. Post a comment with header `## 🏷️ has-review` containing the
+   review verdict, findings summary, and next steps
+2. Add label `has-review`
+3. Rotate status to `status:in-review`
 
 ### After Phase 5b (merged):
 

--- a/.claude/commands/supercycle/fix.md
+++ b/.claude/commands/supercycle/fix.md
@@ -94,6 +94,30 @@ git push github <branch>
 
 ---
 
+## GH Issue Tracking
+
+**Reference:** See `tracking.md` in this directory for the label
+catalog, comment template, and helper commands.
+
+### At Phase 1 start (identifying findings):
+
+For each linked issue (from `Closes #N` in PR body), rotate status
+to `status:fixing`.
+
+### After Phase 3 (report):
+
+For each linked issue:
+
+1. Post a comment with header `## 🏷️ has-fix` containing the full
+   fix report (findings fixed with file:line references, findings
+   skipped as false positives with rationale)
+2. Add label `has-fix`
+
+**IMPORTANT:** Always post the comment FIRST, then add the label.
+Always ensure the label exists before adding it (idempotent create).
+
+---
+
 ## Supercycle Position
 
 ```

--- a/.claude/commands/supercycle/implement.md
+++ b/.claude/commands/supercycle/implement.md
@@ -84,6 +84,31 @@ Next steps:
 
 ---
 
+## GH Issue Tracking
+
+**Reference:** See `tracking.md` in this directory for the label
+catalog, comment template, and helper commands.
+
+### At Phase 1 start (loading issues):
+
+For each issue, rotate status to `status:implementing`.
+
+### After Phase 3 (PRs created):
+
+For each issue that got a PR:
+
+1. Post a comment with header `## 🏷️ has-pr` containing:
+   - PR number and link
+   - Branch name
+   - Summary of changes (files modified, tests added)
+   - Quality gate results
+2. Add label `has-pr`
+
+**IMPORTANT:** Always post the comment FIRST, then add the label.
+Always ensure the label exists before adding it (idempotent create).
+
+---
+
 ## Supercycle Position
 
 ```

--- a/.claude/commands/supercycle/merge.md
+++ b/.claude/commands/supercycle/merge.md
@@ -111,6 +111,25 @@ Report:
 
 ---
 
+## GH Issue Tracking
+
+**Reference:** See `tracking.md` in this directory for the label
+catalog, comment template, and helper commands.
+
+### At Phase 1 start (CI status check):
+
+For each linked issue (from `Closes #N` in PR body), rotate status
+to `status:merging`.
+
+### After Phase 4 (post-merge verification):
+
+For each linked issue, rotate status to `status:merged`.
+
+No `has-*` label is set — the merged status and the closed issue
+(via `Closes #N`) are sufficient.
+
+---
+
 ## Supercycle Position
 
 ```

--- a/.claude/commands/supercycle/review.md
+++ b/.claude/commands/supercycle/review.md
@@ -185,6 +185,30 @@ After all agents return, consolidate into a single report:
 
 ---
 
+## GH Issue Tracking
+
+**Reference:** See `tracking.md` in this directory for the label
+catalog, comment template, and helper commands.
+
+### At Phase 1 start (loading PRs):
+
+For each linked issue (from `Closes #N` in PR body), rotate status
+to `status:in-review`.
+
+### After Phase 5 (review consolidated):
+
+For each linked issue:
+
+1. Post a comment with header `## 🏷️ has-review` containing the
+   full consolidated review report (verdict, findings, task
+   completeness, must-fix vs should-fix, next steps)
+2. Add label `has-review`
+
+**IMPORTANT:** Always post the comment FIRST, then add the label.
+Always ensure the label exists before adding it (idempotent create).
+
+---
+
 ## Supercycle Position
 
 ```

--- a/.claude/commands/supercycle/tracking.md
+++ b/.claude/commands/supercycle/tracking.md
@@ -1,0 +1,183 @@
+---
+description: >
+  Shared reference for supercycle GH Issue tracking — label catalog,
+  comment templates, and reusable gh command snippets. This is NOT a
+  user-invocable command; it is imported by other supercycle skills.
+---
+
+# Supercycle Tracking Reference
+
+All supercycle skills post structured comments and apply labels to the
+GH Issue at each lifecycle step. This document is the single source of
+truth for label names, colors, comment format, and helper commands.
+
+---
+
+## Label Catalog
+
+### Step Labels (`has-*`)
+
+Applied once when a step artifact is produced. They accumulate — an issue
+may carry several `has-*` labels at once.
+
+| Label | Color | Meaning |
+|---|---|---|
+| `has-spec` | `#0E8A16` | Acceptance criteria / spec written |
+| `has-plan` | `#1D76DB` | Implementation plan attached |
+| `has-pr` | `#6F42C1` | Pull request opened |
+| `has-review` | `#E4A221` | Code review comment posted |
+| `has-fix` | `#FBCA04` | Review findings addressed |
+| `has-root-cause` | `#D93F0B` | Root cause identified (bug flow) |
+| `has-reproduction` | `#B60205` | Reproduction test added (bug flow) |
+
+### Status Labels (`status:*`)
+
+Only ONE `status:*` label is active at a time. Each skill removes the
+previous one and adds the next.
+
+| Label | Color | Meaning |
+|---|---|---|
+| `status:brainstorming` | `#C2E0C6` | In active brainstorming / design discussion |
+| `status:planning` | `#BFD4F2` | Implementation plan being written |
+| `status:implementing` | `#6F42C1` | Code being written in worktrees |
+| `status:in-review` | `#E4A221` | PR under automated + human review |
+| `status:fixing` | `#FBCA04` | Review findings being addressed |
+| `status:merging` | `#0E8A16` | CI passing, merge in progress |
+| `status:merged` | `#333333` | Issue closed, PR merged |
+
+---
+
+## Comment Template
+
+Every tracking comment follows this structure so they are easy to scan in
+the GH Issue timeline:
+
+```
+## 🏷️ <label-name>
+
+> Label `<label-name>` added by **supercycle/<skill-name>** · <ISO-8601 date>
+
+---
+
+<human-readable summary of what happened at this step, 2-5 sentences>
+
+<optional: bullet list of artifacts, links, or decisions>
+```
+
+### Examples
+
+```markdown
+## 🏷️ has-plan
+
+> Label `has-plan` added by **supercycle/work** · 2026-04-25
+
+---
+
+Implementation plan finalised. Three tasks identified; no file overlaps
+detected, so parallel worktree agents will be dispatched.
+
+- Task 1: add `tracking.md` shared reference
+- Task 2: instrument `work.md` with tracking calls
+- Task 3: instrument remaining skills
+```
+
+```markdown
+## 🏷️ status:in-review
+
+> Label `status:in-review` added by **supercycle/review** · 2026-04-25
+
+---
+
+PR #322 opened and dispatched to automated review agents.
+Checklist completeness: 3/3 tasks confirmed in diff.
+```
+
+---
+
+## Helper Commands
+
+### Idempotent label creation
+
+Run once per repo to ensure all labels exist. Safe to re-run.
+
+```bash
+gh label create "has-spec"         --description "Acceptance criteria written"      --color "0E8A16" 2>/dev/null || true
+gh label create "has-plan"         --description "Implementation plan attached"      --color "1D76DB" 2>/dev/null || true
+gh label create "has-pr"           --description "Pull request opened"               --color "6F42C1" 2>/dev/null || true
+gh label create "has-review"       --description "Code review comment posted"        --color "E4A221" 2>/dev/null || true
+gh label create "has-fix"          --description "Review findings addressed"         --color "FBCA04" 2>/dev/null || true
+gh label create "has-root-cause"   --description "Root cause identified"             --color "D93F0B" 2>/dev/null || true
+gh label create "has-reproduction" --description "Reproduction test added"           --color "B60205" 2>/dev/null || true
+
+gh label create "status:brainstorming" --description "Active brainstorming"          --color "C2E0C6" 2>/dev/null || true
+gh label create "status:planning"      --description "Implementation plan in progress" --color "BFD4F2" 2>/dev/null || true
+gh label create "status:implementing"  --description "Code being written"            --color "6F42C1" 2>/dev/null || true
+gh label create "status:in-review"     --description "PR under review"               --color "E4A221" 2>/dev/null || true
+gh label create "status:fixing"        --description "Review findings being fixed"   --color "FBCA04" 2>/dev/null || true
+gh label create "status:merging"       --description "CI passing, merging"           --color "0E8A16" 2>/dev/null || true
+gh label create "status:merged"        --description "Issue closed, PR merged"       --color "333333" 2>/dev/null || true
+```
+
+### Post comment then add label
+
+**Always post the comment first, then apply the label.** This preserves
+chronological order in the GH Issue timeline.
+
+```bash
+# 1. Post the comment
+gh issue comment <issue-number> --body "$(cat <<'BODY'
+## 🏷️ <label-name>
+
+> Label `<label-name>` added by **supercycle/<skill>** · $(date -u +%Y-%m-%d)
+
+---
+
+<summary>
+BODY
+)"
+
+# 2. Add the step label
+gh issue edit <issue-number> --add-label "<label-name>"
+```
+
+### Status rotation
+
+Remove all current `status:*` labels, then apply the new one.
+
+```bash
+ISSUE=<issue-number>
+NEW_STATUS="status:implementing"   # change as appropriate
+
+# Collect existing status labels
+CURRENT=$(gh issue view "$ISSUE" --json labels \
+  --jq '.labels[].name | select(startswith("status:"))' \
+  | tr '\n' ',' | sed 's/,$//')
+
+# Remove old status labels (if any)
+if [ -n "$CURRENT" ]; then
+  gh issue edit "$ISSUE" --remove-label "$CURRENT"
+fi
+
+# Apply new status label
+gh issue edit "$ISSUE" --add-label "$NEW_STATUS"
+```
+
+---
+
+## Tracking Points per Skill
+
+| Skill | Step label(s) applied | Status transition |
+|---|---|---|
+| `work.md` — brainstorm phase | — | `→ status:brainstorming` |
+| `work.md` — spec written | `has-spec` | `→ status:planning` |
+| `work.md` — plan written | `has-plan` | `→ status:implementing` |
+| `implement.md` — PRs created | `has-pr` | `→ status:implementing` |
+| `review.md` — review complete | `has-review` | `→ status:in-review` |
+| `fix.md` — fixes applied | `has-fix` | `→ status:fixing` |
+| `merge.md` — merge started | — | `→ status:merging` |
+| `merge.md` — merge complete | — | `→ status:merged` |
+| `bug.md` — root cause found | `has-root-cause` | — |
+| `bug.md` — reproduction added | `has-reproduction` | `→ status:implementing` |
+| `bug.md` — PR created | `has-pr` | — |
+| `bug.md` — review done | — | `→ status:in-review` |
+| `bug.md` — merged | — | `→ status:merged` |

--- a/.claude/commands/supercycle/work.md
+++ b/.claude/commands/supercycle/work.md
@@ -142,6 +142,32 @@ The agent prompt MUST include:
 
 ---
 
+## GH Issue Tracking
+
+**Reference:** See `tracking.md` in this directory for the label
+catalog, comment template, and helper commands.
+
+### At Phase 2 start (brainstorming begins):
+
+Rotate status to `status:brainstorming`.
+
+### After Phase 2c (spec/design finalized):
+
+1. Post the full design spec as a comment with header `## 🏷️ has-spec`
+2. Add label `has-spec`
+3. Rotate status to `status:planning`
+
+### After writing plans (before handing off to work-orchestrator):
+
+1. Post the full implementation plan as a comment with header `## 🏷️ has-plan`
+2. Add label `has-plan`
+3. Rotate status to `status:implementing`
+
+**IMPORTANT:** Always post the comment FIRST, then add the label.
+Always ensure the label exists before adding it (idempotent create).
+
+---
+
 ## Supercycle Overview
 
 ```

--- a/.claude/hooks/post-command/validate-issue-tracking.sh
+++ b/.claude/hooks/post-command/validate-issue-tracking.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Post-command hook: Validate GH issue tracking label comments.
+#
+# Fires after every Bash tool use. If the command was a `gh issue edit --add-label "has-*"`
+# call, checks that the most recent comment on that issue contains the matching 🏷️ header.
+# Advisory only — always exits 0.
+
+set -euo pipefail
+
+# Read the hook payload from stdin (JSON with tool_name, tool_input, etc.)
+INPUT=$(cat)
+
+# Extract the bash command that was executed
+BASH_CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null) || BASH_CMD=""
+
+# Only act on `gh issue edit ... --add-label "has-` commands
+if ! printf '%s' "$BASH_CMD" | grep -qE 'gh issue edit.*--add-label.*"has-'; then
+    exit 0
+fi
+
+# Extract the issue number (first numeric argument after `gh issue edit`)
+ISSUE_NUMBER=$(printf '%s' "$BASH_CMD" \
+    | grep -oE 'gh issue edit [0-9]+' \
+    | grep -oE '[0-9]+$') || ISSUE_NUMBER=""
+
+if [ -z "$ISSUE_NUMBER" ]; then
+    exit 0
+fi
+
+# Extract the label name from --add-label "has-..."
+LABEL_NAME=$(printf '%s' "$BASH_CMD" \
+    | grep -oE '"has-[^"]*"' \
+    | head -1 \
+    | tr -d '"') || LABEL_NAME=""
+
+if [ -z "$LABEL_NAME" ]; then
+    exit 0
+fi
+
+# Fetch the latest comment body on the issue
+LATEST_COMMENT=$(gh issue view "$ISSUE_NUMBER" --json comments \
+    --jq '.comments[-1].body // ""' 2>/dev/null) || LATEST_COMMENT=""
+
+# Check whether it contains the expected 🏷️ header
+if ! printf '%s' "$LATEST_COMMENT" | grep -qF "🏷️ ${LABEL_NAME}"; then
+    echo "⚠️  [validate-issue-tracking] Warning: label '${LABEL_NAME}' was added to issue #${ISSUE_NUMBER}" >&2
+    echo "   but the most recent comment does not contain a '🏷️ ${LABEL_NAME}' header." >&2
+    echo "   Consider adding a tracking comment to document why this label was applied." >&2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,10 @@
           {
             "type": "command",
             "command": "bash -c \"./.claude/hooks/post-command/log-tool-result.sh 2>/dev/null || true\""
+          },
+          {
+            "type": "command",
+            "command": "bash -c \"./.claude/hooks/post-command/validate-issue-tracking.sh 2>/dev/null || true\""
           }
         ]
       },


### PR DESCRIPTION
## Summary

- Adds structured comments and labels to GH Issues at each supercycle step
- Each step posts a comment with `## 🏷️ <label>` header, then applies the label
- Step labels (`has-*`) accumulate; status labels (`status:*`) rotate (one active)
- Validation hook warns when labels are added without matching comments

## Changes

- **New:** `.claude/commands/supercycle/tracking.md` — shared label catalog, comment template, helper commands
- **Modified:** All 6 supercycle skills (`work`, `implement`, `review`, `fix`, `merge`, `bug`) — added "GH Issue Tracking" section
- **New:** `.claude/hooks/post-command/validate-issue-tracking.sh` — advisory PostToolUse hook
- **Modified:** `.claude/settings.json` — registered validation hook

## Test plan

- [ ] Run `/supercycle:work` on a test issue — verify `has-spec`, `has-plan` comments + labels appear
- [ ] Run `/supercycle:implement` — verify `has-pr` comment + label
- [ ] Run `/supercycle:review` — verify `has-review` comment + label
- [ ] Verify status labels rotate correctly (only one `status:*` at a time)
- [ ] Verify validation hook warns when label is added without comment

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)