### PR TITLE
feat(gh-339): enable template execution with ephemeral, downloadable artifacts

### DIFF
--- a/.serena/memories/architecture/api_and_mcp.md
+++ b/.serena/memories/architecture/api_and_mcp.md
@@ -1,0 +1,35 @@
+# API and MCP Architecture
+
+## REST API (v2)
+- Current API version: v2 (`app/api/v2/endpoints/`)
+- v1 is legacy — new endpoints go in v2
+- Endpoints are thin: validate → delegate to service → return Pydantic response
+
+### Key endpoint groups:
+- `aeroplane.py` — Aeroplane CRUD
+- `aeroplane/wings.py` — Wing management (segments, cross-sections, spars, TEDs)
+- `aeroplane/fuselages.py` — Fuselage management
+- `aeroplane/component_tree.py` — Component tree with weight enrichment
+- `aeroplane/construction_parts.py` — Construction part management (STEP files)
+- `aeroplane/design_versions.py` — Design version tracking
+- `aeroplane/weight_items.py` — Weight items
+- `aeroplane/powertrain_sizing.py` — Powertrain sizing
+- `aeroplane/mission_objectives.py` — Mission objectives
+- `aeroanalysis.py` — Aerodynamic analysis (alpha sweep, parameter sweep, operating points)
+- `cad.py` — CAD export (STEP, STL, 3MF)
+- `construction_plans.py` — Construction plan CRUD
+- `construction_templates.py` — Construction templates
+- `operating_points.py` — Operating point management
+- `flight_profiles.py` — Flight profile management
+- `airfoils.py` — Airfoil data management
+- `fuselage_slice.py` — Fuselage cross-section slicing
+- `component_types.py` — Component type catalog (COTS, custom)
+- `components.py` — Component instances
+
+## MCP Server
+- ~80+ MCP tools defined in `app/mcp_server.py`
+- Uses `@mcp_tool` decorator pattern with `MCPToolSpec` dataclass
+- Same host/port as REST API, mounted at `/mcp`
+- FastMCP 3.x (Streamable HTTP transport)
+- Asset registry for serving images/data from MCP responses
+- Tools mirror REST endpoints but tailored for AI agent interaction

--- a/.serena/memories/architecture/cad_engine.md
+++ b/.serena/memories/architecture/cad_engine.md
@@ -1,0 +1,63 @@
+# CAD Engine (`cad_designer/`)
+
+## Overview
+The CAD engine uses CadQuery to generate parametric 3D geometry for aircraft components.
+It follows a construction-tree pattern where shapes are built step-by-step.
+
+## Key Abstractions
+
+### AbstractShapeCreator (`airplane/AbstractShapeCreator.py`)
+Base class for all CAD operations. Subclasses implement `_create_shape()` and define
+`shapes_of_interest_keys` for their outputs. New creators MUST inherit from this.
+
+### ConstructionStepNode / ConstructionRootNode
+Tree structure for CAD construction sequences. Each node wraps a Creator and manages
+input/output shape flow.
+
+### GeneralJSONEncoderDecoder
+Serialization for the construction tree. **READ-ONLY — never modify.**
+
+## Creator Categories
+
+### Wing Creators (`creator/wing/`)
+- `WingLoftCreator` — main wing surface loft from cross-sections
+- `VaseModeWingCreator` — hollow wing for 3D printing
+- `StandWingSegmentOnPrinterCreator` — orient for print bed
+- `ted_sketch_creators` — trailing edge device geometry
+
+### Fuselage Creators (`creator/fuselage/`)
+- `FuselageShellShapeCreator` — main fuselage shell
+- `FuselageReinforcementShapeCreator` — structural reinforcement
+- `EngineMountShapeCreator`, `EngineCapeShapeCreator` — engine integration
+- Various cutout creators for access panels, bolt holes, etc.
+
+### CAD Operations (`creator/cad_operations/`)
+- Boolean ops: Fuse, Cut, Intersect (2-shape and multi-shape variants)
+- `ScaleRotateTranslateCreator` — transform operations
+- `SimpleOffsetShapeCreator` — shell offset
+- `RepairFacesShapeCreator` — topology repair
+
+### Export/Import (`creator/export_import/`)
+- STEP, IGES, STL, 3MF export and STEP/IGES import
+
+### Component Creators (`creator/components/`)
+- `ServoImporterCreator` — import servo STEP models
+- `ComponentImporterCreator` — import generic component STEP models
+
+## Aircraft Topology (`airplane/aircraft_topology/`) — READ-ONLY
+Domain model classes representing aircraft geometry in mm units:
+- `WingConfiguration`, `WingSegment`, `Airfoil`, `Spare`, `TrailingEdgeDevice`
+- `FuselageConfiguration`
+- `AirplaneConfiguration`
+- `Servo`, `ComponentInformation`, `EngineInformation`
+- `Printer3dSettings`, `Position`, `CoordinateSystem`
+
+## Aerosandbox Integration (`aerosandbox/`)
+- `convert2aerosandbox.py` — convert topology to ASB geometry (mm→m)
+- `aerodynamic_calculations.py` — VLM analysis via Aerosandbox
+- `slicing.py` — wing slicing for analysis
+- `classification.py` — airfoil classification
+- `wing_roundtrip.py` — DB ↔ ASB wing roundtrip conversion
+
+## CQ Plugins (`cq_plugins/`)
+CadQuery extension plugins: wing loft, 3D offset, scale XYZ, shape repair, etc.

--- a/.serena/memories/architecture/codebase_structure.md
+++ b/.serena/memories/architecture/codebase_structure.md
@@ -1,0 +1,110 @@
+# Codebase Structure
+
+## Backend (`app/`)
+Layered FastAPI application: **endpoint → service → model/schema/converter**
+
+```
+app/
+├── main.py                  # FastAPI entrypoint, router wiring, exception handlers
+├── mcp_server.py            # FastMCP server with ~80+ MCP tools (same host/port)
+├── settings.py              # App settings
+├── logging_config.py        # Logging setup
+├── api/v2/endpoints/        # REST API v2 (current), grouped by domain
+│   ├── aeroplane.py         # Aeroplane CRUD
+│   ├── aeroplane/           # Sub-endpoints: wings, fuselages, components, etc.
+│   ├── aeroanalysis.py      # Aerodynamic analysis endpoints
+│   ├── cad.py               # CAD export endpoints
+│   ├── construction_plans.py # Construction plan management
+│   ├── construction_templates.py
+│   ├── operating_points.py  # Operating point management
+│   ├── flight_profiles.py
+│   ├── airfoils.py
+│   └── ...
+├── services/                # Business logic, CAD orchestration
+│   ├── wing_service.py      # Wing CRUD + CAD (uses `with db.begin()`)
+│   ├── cad_service.py       # CAD export orchestration
+│   ├── analysis_service.py  # Aero analysis orchestration
+│   ├── stability_service.py # Stability analysis
+│   ├── construction_plan_service.py
+│   ├── tessellation_service.py
+│   └── ~25 more services
+├── models/                  # SQLAlchemy ORM models
+│   ├── aeroplanemodel.py, airfoil.py, component.py, component_tree.py
+│   ├── construction_plan.py, construction_part.py, tessellation_cache.py
+│   └── flightprofilemodel.py, analysismodels.py
+├── schemas/                 # Pydantic request/response DTOs (~24 files)
+├── converters/              # schema ⇄ model ⇄ CAD transforms
+│   └── model_schema_converters.py
+├── core/                    # Config, logging, exceptions, security, platform
+├── db/                      # SQLAlchemy session, engine, repository, exceptions
+└── tests/                   # ~80+ pytest test modules + fixtures/
+```
+
+## CAD Engine (`cad_designer/`)
+```
+cad_designer/
+├── airplane/
+│   ├── AbstractShapeCreator.py      # Base class for all shape creators
+│   ├── ConstructionStepNode.py      # Construction tree node
+│   ├── ConstructionRootNode.py      # Root of construction tree
+│   ├── GeneralJSONEncoderDecoder.py # JSON serialization (READ-ONLY)
+│   ├── creator/                     # Shape creators (subclass AbstractShapeCreator)
+│   │   ├── wing/                    # Wing loft, vase mode, TED sketches
+│   │   ├── fuselage/                # Fuselage shell, reinforcement, cutouts
+│   │   ├── components/              # Servo/component importers
+│   │   ├── cad_operations/          # Boolean ops (fuse, cut, intersect, scale)
+│   │   ├── export_import/           # STEP/IGES/STL/3MF export/import
+│   │   └── _creator_template.py     # Template for new creators
+│   └── aircraft_topology/           # Domain model classes (READ-ONLY)
+│       ├── wing/                    # WingConfig, WingSegment, Airfoil, Spare, TED
+│       ├── fuselage/                # FuselageConfiguration
+│       ├── airplane/                # AirplaneConfiguration
+│       ├── components/              # Servo, ComponentInformation
+│       └── Position.py
+├── aerosandbox/                     # ASB integration, wing roundtrip, slicing
+├── decorators/                      # general_decorators.py
+└── cq_plugins/                      # CadQuery plugins (wing, offset3D, scale, etc.)
+```
+
+**IMPORTANT:** `aircraft_topology/` and `GeneralJSONEncoderDecoder` are read-only. New Creators are allowed.
+
+## Frontend (`frontend/`)
+```
+frontend/
+├── app/                    # Next.js App Router pages
+│   ├── page.tsx            # Landing/project list
+│   ├── layout.tsx          # Root layout
+│   └── workbench/          # Main design workbench
+│       ├── page.tsx        # Wing editor / main view
+│       ├── layout.tsx      # Workbench layout
+│       ├── analysis/       # Aero analysis tab
+│       ├── construction-plans/  # Construction plan management
+│       ├── mission/        # Mission objectives
+│       ├── components/     # Component catalog
+│       └── airfoil-preview/ # Airfoil geometry viewer
+├── components/workbench/   # ~47 UI components
+│   ├── TreeCard.tsx, SimpleTreeRow.tsx    # Reusable tree panels
+│   ├── AirfoilSelector.tsx               # Searchable dropdown
+│   ├── CadViewer.tsx                     # 3D Three.js viewer
+│   ├── AnalysisViewerPanel.tsx           # Analysis results display
+│   ├── ConfigPanel.tsx                   # Wing config editor
+│   ├── ComponentTree.tsx                 # Component tree with DnD
+│   └── ...
+├── hooks/                  # ~20 SWR data hooks
+│   ├── useWings.ts, useWingConfig.ts
+│   ├── useAeroplanes.ts, useFuselages.ts
+│   ├── useAnalysis.ts, useStripForces.ts
+│   ├── useConstructionPlans.ts, useConstructionParts.ts
+│   └── ...
+├── lib/                    # Shared utilities
+├── e2e/                    # Playwright BDD E2E tests
+└── __tests__/              # Vitest unit tests
+```
+
+## Data (`components/`)
+Static data files: airfoils (.dat), servos, lipo specs, brushless motors, CPACS files, test files.
+
+## Other
+- `alembic/` — DB migration scripts
+- `Avl/` — Vendored AVL (Athena Vortex Lattice) source + binary
+- `planning/`, `docs/`, `images/`, `screenshots/` — Documentation assets

--- a/.serena/memories/architecture/domain_model.md
+++ b/.serena/memories/architecture/domain_model.md
@@ -1,0 +1,40 @@
+# Domain Model
+
+## Core Entities (SQLAlchemy models in `app/models/`)
+
+### Aeroplane (`aeroplanemodel.py`)
+Top-level entity. Contains wings, fuselages, flight profiles, weight items, and is associated with analysis results.
+
+### Wing (managed by `wing_service.py`)
+Defined by WingConfiguration topology (from `cad_designer/airplane/aircraft_topology/wing/`):
+- **WingSegment** — individual wing panel with span, sweep, dihedral, taper
+- **Airfoil** — airfoil profile (from .dat files in `components/airfoils/`)
+- **Spare** (spar) — structural spar within a segment
+- **TrailingEdgeDevice** (TED) — flap/aileron with hinge line, deflection
+- **Servo** — servo motor attached to a TED
+- **CoordinateSystem** — wing coordinate frame
+
+### Fuselage
+- **FuselageConfiguration** — fuselage shape defined by cross-sections
+
+### Component System
+- **ComponentType** (`component_type.py`) — catalog of part types (COTS, custom)
+- **Component** (`component.py`) — instances placed in the design
+- **ComponentTree** (`component_tree.py`) — hierarchical assembly tree with weight
+
+### Construction
+- **ConstructionPlan** (`construction_plan.py`) — plan for manufacturing
+- **ConstructionPart** (`construction_part.py`) — individual manufactured part (STEP file)
+
+### Analysis
+- **AnalysisModels** (`analysismodels.py`) — stored analysis results
+- **FlightProfile** (`flightprofilemodel.py`) — mission flight profile
+
+### Other
+- **TessellationCache** (`tessellation_cache.py`) — cached mesh data for 3D viewer
+- **DesignVersion** — version tracking for aeroplane designs
+
+## Converters (`app/converters/model_schema_converters.py`)
+Single file handling all model ↔ schema conversions. Key conversions:
+- Wing DB model ↔ WingConfiguration topology ↔ Pydantic schemas
+- Scale factors: mm→m (0.001) for DB storage, m→mm (1000.0) for topology

--- a/.serena/memories/conventions/style_and_patterns.md
+++ b/.serena/memories/conventions/style_and_patterns.md
@@ -1,0 +1,73 @@
+# Code Style and Conventions
+
+## Python Backend
+
+### Architecture
+- **Layered:** endpoint (thin) → service (business logic) → model/schema/converter
+- Endpoints validate + delegate; no DB queries or CAD calls in endpoints
+- Services hold business logic, CAD orchestration, transactions
+- `wing_service` uses `with db.begin():` for all writes
+
+### Type Hints
+- Type-annotate every public function
+- Use `from __future__ import annotations` for forward refs
+- Prefer `list[str]` / `dict[str, int]` over `List`/`Dict` (Python 3.11+)
+- Use `Optional[X]` or `X | None` consistently within a file
+
+### Pydantic
+- Inherit from `pydantic.BaseModel` (v2)
+- Use `Field(..., description=...)` for API models
+- Validators on the schema, not in endpoints
+
+### SQLAlchemy
+- Query via injected session from `app/db/`
+- Commit in service layer, not endpoints
+- Always add Alembic migration when changing a model
+
+### Style
+- PEP 8, line-length 100 (Ruff)
+- Absolute imports (`app.` or `cad_designer.`), no relative
+- No `print()` — use `logging` module
+- Docstrings: short, focused on *why* not *what*
+
+### Testing
+- Test modules in `app/tests/test_*.py`
+- Use fixtures for TestClient and DB session
+- Markers: unit, integration, slow, requires_cadquery, requires_aerosandbox, requires_avl
+- pytest-timeout: 360s per test, faulthandler at 300s
+- Coverage target: 70–80%
+
+### Security
+- Secrets in `.env`, read via pydantic-settings
+- Never log credentials
+- Sanitize user input before shell commands (no `shell=True` with interpolation)
+- Path safety: always resolve + containment check
+
+## Frontend
+
+### Framework
+- Next.js 16 App Router (NOT Pages Router)
+- React 19, TypeScript
+- All API calls go through the backend (no direct CORS)
+
+### Component Patterns
+- Reuse existing components before creating new ones
+- Key reusable components: TreeCard, SimpleTreeRow, AirfoilSelector, Field, GroupAddMenu
+- Click-dummy for major UI changes before implementing real logic
+- Dark theme with orange accent (#FF8400)
+
+### Data Fetching
+- SWR hooks in `frontend/hooks/`
+- Plotly for all analysis charts (dynamic import `plotly.js-gl3d-dist-min`)
+
+### Testing
+- Vitest for unit tests
+- Playwright + playwright-bdd for E2E
+- dependency-cruiser for architecture checks
+
+## cad_designer Rules
+- `aircraft_topology/` classes are READ-ONLY (never modify)
+- `GeneralJSONEncoderDecoder` is READ-ONLY
+- New Creators (subclasses of AbstractShapeCreator) ARE allowed
+- Use `_creator_template.py` as starting point for new creators
+- Units in topology: millimetres; in DB/ASB: metres

--- a/.serena/memories/conventions/task_completion_checklist.md
+++ b/.serena/memories/conventions/task_completion_checklist.md
@@ -1,0 +1,46 @@
+# Task Completion Checklist
+
+When a coding task is completed, perform the following steps:
+
+## 1. Verify Code Quality
+```bash
+poetry run ruff check .       # Python lint
+poetry run ruff format .      # Python format
+cd frontend && npm run lint   # Frontend lint (if frontend changed)
+```
+
+## 2. Run Tests
+```bash
+poetry run pytest                    # Backend fast tests
+poetry run pytest --cov=app          # With coverage (target 70–80%)
+cd frontend && npm run test:unit     # Frontend unit tests (if changed)
+cd frontend && npm run deps:check   # Dependency architecture (if changed)
+```
+
+## 3. Database Migrations
+If models changed:
+```bash
+alembic revision --autogenerate -m "description"
+alembic upgrade head
+```
+
+## 4. Git Commit
+```bash
+git status
+git add <specific files>
+git commit -m "<type>(<scope>): <description>"
+# Types: feat, fix, refactor, docs, test, chore, perf
+# Branch naming: <type>/gh-<N>-<short-slug>
+```
+
+## 5. Push (if on a feature branch)
+```bash
+git push github <branch>
+```
+
+## Iron Laws
+1. No production code without a failing test first (TDD)
+2. No completion claims without fresh verification evidence
+3. No fixes without root cause investigation
+4. Fix the code, not the tests — NEVER weaken assertions or skip tests
+5. No bug fix without a GH ticket

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -1,0 +1,44 @@
+# da3Dalus — CAD Modelling Service
+
+## Purpose
+da3Dalus is an aircraft design toolchain with a Python backend (FastAPI) and React frontend (Next.js 16).
+It generates parametric aircraft CAD geometry (wings, fuselages, assemblies) using CadQuery, runs aerodynamic
+analysis (vortex lattice method via AVL, stability, operating point sweeps) using Aerosandbox, and persists
+projects via SQLAlchemy + Alembic migrations.
+
+## Tech Stack
+
+### Backend (Python 3.11–3.13, Poetry 2.x)
+- **Framework:** FastAPI
+- **ORM:** SQLAlchemy + Alembic migrations
+- **Schemas:** Pydantic v2
+- **CAD Engine:** CadQuery (parametric 3D geometry)
+- **Aero Analysis:** Aerosandbox (VLM) + vendored AVL binary (`Avl/`)
+- **MCP Server:** FastMCP 3.x (same host/port as REST)
+- **Config:** pydantic-settings (`app/core/config.py`)
+- **Linting:** Ruff (line-length 100, target py311)
+- **Testing:** pytest with markers (unit, integration, slow, requires_cadquery, etc.)
+
+### Frontend (Next.js 16 App Router + React 19)
+- **3D Viewer:** Three.js (`@react-three/fiber`, `three-cad-viewer`)
+- **Charts:** Plotly (`plotly.js-gl3d-dist-min`)
+- **Data Fetching:** SWR
+- **Styling:** Tailwind CSS v4, dark theme with orange accent (#FF8400)
+- **Fonts:** JetBrains Mono + Geist
+- **DnD:** @dnd-kit
+- **Testing:** Vitest (unit), Playwright + playwright-bdd (E2E)
+- **Lint:** ESLint, dependency-cruiser
+
+### Infrastructure
+- Docker + docker-compose (port 8086)
+- Azure Pipelines CI
+- SonarQube (project key: `szymansk_da3Dalus`)
+- Git remote named `github` (not `origin`)
+
+## Units Convention
+- **WingConfig / topology classes:** millimetres (mm)
+- **Database / Aerosandbox:** metres (m)
+- Conversion in converters via `scale=0.001` (mm→m) and `scale=1000.0` (m→mm)
+
+## Platform Guards
+`cadquery` and `aerosandbox` are excluded on `linux/aarch64`. Code importing them must handle `ImportError`.

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -1,0 +1,90 @@
+# Suggested Commands
+
+## Backend Development
+```bash
+# Install dependencies
+poetry install && poetry shell
+
+# Run dev server (hot reload)
+uvicorn app.main:app --host 0.0.0.0 --port 8001 --reload
+
+# Run all fast tests
+poetry run pytest
+
+# Run with coverage
+poetry run pytest --cov=app
+
+# Run only slow CAD/aero tests
+poetry run pytest -m slow
+
+# Run specific test file
+poetry run pytest app/tests/test_wing_service_extended.py -v
+
+# Lint and format
+poetry run ruff check .
+poetry run ruff format .
+
+# Generate Alembic migration
+alembic revision --autogenerate -m "description"
+
+# Apply migrations
+alembic upgrade head
+```
+
+## Frontend Development
+```bash
+cd frontend
+
+# Install dependencies
+npm install
+
+# Run dev server
+npm run dev
+
+# Unit tests
+npm run test:unit
+
+# E2E tests (requires backend running)
+npm run test:e2e
+npm run test:e2e:slow      # includes @slow tests
+npm run test:e2e:headed    # with browser visible
+npm run test:e2e:ui        # Playwright UI mode
+
+# Lint
+npm run lint
+
+# Dependency graph check
+npm run deps:check
+```
+
+## Docker
+```bash
+docker compose build && docker compose up -d   # port 8086
+```
+
+## Git
+```bash
+# Remote is 'github' not 'origin'
+git push github <branch>
+
+# Branch naming: <type>/gh-<N>-<short-slug>
+# e.g. feat/gh-101-construction-plans
+```
+
+## Runtime Endpoints
+| URL | What |
+|-----|------|
+| http://localhost:8001 | REST API |
+| http://localhost:8001/docs | Swagger UI |
+| http://localhost:8001/redoc | ReDoc |
+| http://localhost:8001/openapi.json | OpenAPI schema |
+| http://localhost:8001/mcp | MCP (Streamable HTTP) |
+
+## System Utils (macOS / Darwin)
+```bash
+git status / git diff / git log
+ls / find / grep
+python3 / poetry
+npm / npx
+docker / docker compose
+```

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -28,6 +28,7 @@ project_name: "cad-modelling-service"
 # Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
 languages:
 - python
+- typescript
 
 # the encoding used by text files in the project
 # For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings

--- a/app/api/v2/endpoints/construction_plans.py
+++ b/app/api/v2/endpoints/construction_plans.py
@@ -206,6 +206,30 @@ async def list_artifact_files(
 
 
 @router.get(
+    "/construction-plans/{plan_id}/artifacts/{execution_id}/zip",
+    tags=["construction-plans"],
+    operation_id="download_execution_zip",
+)
+async def download_execution_zip(
+    plan_id: Annotated[int, Path(...)],
+    execution_id: Annotated[str, Path(...)],
+):
+    """Download all artifact files of an execution as a single zip."""
+    from fastapi.responses import FileResponse
+
+    try:
+        zip_path = artifact_service.zip_execution(plan_id, execution_id)
+        filename = f"plan-{plan_id}-{execution_id}.zip"
+        return FileResponse(
+            zip_path,
+            media_type="application/zip",
+            filename=filename,
+        )
+    except ServiceException as exc:
+        _handle_service_error(exc)
+
+
+@router.get(
     "/construction-plans/{plan_id}/artifacts/{execution_id}/{filename:path}",
     tags=["construction-plans"],
     operation_id="download_artifact_file",

--- a/app/api/v2/endpoints/construction_plans.py
+++ b/app/api/v2/endpoints/construction_plans.py
@@ -1,4 +1,5 @@
 """REST endpoints for Construction Plans (gh#101)."""
+
 from __future__ import annotations
 
 import logging
@@ -53,7 +54,7 @@ def _handle_service_error(exc: ServiceException):
     "/construction-plans/creators",
     status_code=status.HTTP_200_OK,
     tags=["construction-plans"],
-    operation_id="list_creators"
+    operation_id="list_creators",
 )
 async def list_creators() -> List[CreatorInfo]:
     """List all available Creator classes with their parameters."""
@@ -67,7 +68,7 @@ async def list_creators() -> List[CreatorInfo]:
     "/construction-plans",
     status_code=status.HTTP_200_OK,
     tags=["construction-plans"],
-    operation_id="list_construction_plans"
+    operation_id="list_construction_plans",
 )
 async def list_plans(
     db: Annotated[Session, Depends(get_db)],
@@ -84,7 +85,7 @@ async def list_plans(
     "/construction-plans",
     status_code=status.HTTP_201_CREATED,
     tags=["construction-plans"],
-    operation_id="create_construction_plan"
+    operation_id="create_construction_plan",
 )
 async def create_plan(
     request: Annotated[PlanCreate, Body(...)],
@@ -101,7 +102,7 @@ async def create_plan(
     "/construction-plans/{plan_id}",
     status_code=status.HTTP_200_OK,
     tags=["construction-plans"],
-    operation_id="get_construction_plan"
+    operation_id="get_construction_plan",
 )
 async def get_plan(
     plan_id: Annotated[int, Path(..., description="Construction plan ID")],
@@ -118,7 +119,7 @@ async def get_plan(
     "/construction-plans/{plan_id}",
     status_code=status.HTTP_200_OK,
     tags=["construction-plans"],
-    operation_id="update_construction_plan"
+    operation_id="update_construction_plan",
 )
 async def update_plan(
     plan_id: Annotated[int, Path(...)],
@@ -156,7 +157,7 @@ async def delete_plan(
     "/construction-plans/{plan_id}/execute",
     status_code=status.HTTP_200_OK,
     tags=["construction-plans"],
-    operation_id="execute_construction_plan"
+    operation_id="execute_construction_plan",
 )
 async def execute_plan(
     plan_id: Annotated[int, Path(...)],

--- a/app/api/v2/endpoints/construction_plans.py
+++ b/app/api/v2/endpoints/construction_plans.py
@@ -198,10 +198,16 @@ async def list_artifact_files(
     plan_id: Annotated[int, Path(...)],
     execution_id: Annotated[str, Path(...)],
     subpath: Annotated[str, Query(description="Subdirectory path within execution dir")] = "",
+    recursive: Annotated[
+        bool,
+        Query(description="If true, return all files recursively as a flat list with relative paths"),
+    ] = False,
 ) -> List[ArtifactFile]:
     """List files in a specific execution's artifact directory (or subdirectory)."""
     try:
-        return artifact_service.list_files(plan_id, execution_id, subpath=subpath)
+        return artifact_service.list_files(
+            plan_id, execution_id, subpath=subpath, recursive=recursive
+        )
     except ServiceException as exc:
         _handle_service_error(exc)
 

--- a/app/schemas/construction_plan.py
+++ b/app/schemas/construction_plan.py
@@ -95,9 +95,17 @@ class CreatorInfo(BaseModel):
 
 
 class ExecuteRequest(BaseModel):
-    """Request body for executing a plan against an aeroplane."""
+    """Request body for executing a plan against an aeroplane.
 
-    aeroplane_id: str = Field(..., description="UUID of the aeroplane to use")
+    `aeroplane_id` is optional in the request body — for stored plans
+    that already have an `aeroplane_id`, the value can be omitted; for
+    templates (no stored aeroplane), the request body must supply it
+    or the service raises a 422.
+    """
+
+    aeroplane_id: Optional[str] = Field(
+        None, description="UUID of the aeroplane to use (required for templates)"
+    )
 
 
 class ExecutionResult(BaseModel):

--- a/app/schemas/construction_plan.py
+++ b/app/schemas/construction_plan.py
@@ -1,4 +1,5 @@
 """Pydantic schemas for Construction Plans (gh#101)."""
+
 from __future__ import annotations
 
 from datetime import datetime
@@ -17,7 +18,9 @@ class PlanCreate(BaseModel):
         description="Serialised ConstructionRootNode tree (GeneralJSONEncoder format)",
     )
     plan_type: str = Field("template", description="'template' or 'plan'")
-    aeroplane_id: Optional[str] = Field(None, description="Aeroplane ID (required for plan_type='plan')")
+    aeroplane_id: Optional[str] = Field(
+        None, description="Aeroplane ID (required for plan_type='plan')"
+    )
 
 
 class PlanRead(PlanCreate):
@@ -84,11 +87,17 @@ class CreatorInfo(BaseModel):
     """Metadata for one AbstractShapeCreator subclass."""
 
     class_name: str
-    category: str = Field(description="Module category: wing, fuselage, cad_operations, export_import, components")
+    category: str = Field(
+        description="Module category: wing, fuselage, cad_operations, export_import, components"
+    )
     description: Optional[str] = None
     parameters: list[CreatorParam]
-    outputs: list[CreatorOutput] = Field(default_factory=list, description="Shape keys this creator produces")
-    suggested_id: Optional[str] = Field(None, description="Template for creator_id, e.g. '{wing_index}.vase_wing'")
+    outputs: list[CreatorOutput] = Field(
+        default_factory=list, description="Shape keys this creator produces"
+    )
+    suggested_id: Optional[str] = Field(
+        None, description="Template for creator_id, e.g. '{wing_index}.vase_wing'"
+    )
 
 
 # ── Execute schemas ─────────────────────────────────────────────
@@ -116,7 +125,9 @@ class ExecutionResult(BaseModel):
     export_paths: list[str] = Field(default_factory=list)
     error: Optional[str] = None
     duration_ms: int = 0
-    tessellation: Optional[dict] = Field(None, description="three-cad-viewer compatible tessellation data")
+    tessellation: Optional[dict] = Field(
+        None, description="three-cad-viewer compatible tessellation data"
+    )
     artifact_dir: Optional[str] = Field(
         None,
         description="Server-side artifact directory for this execution (relative to artifacts base)",

--- a/app/services/artifact_service.py
+++ b/app/services/artifact_service.py
@@ -36,9 +36,26 @@ def _ensure_within_base(path: Path) -> Path:
     return resolved
 
 
+_last_execution_id: str | None = None
+_last_execution_id_suffix: int = 0
+
+
 def new_execution_id() -> str:
-    """Generate a UTC timestamp execution id (e.g. '20260425T120630Z')."""
-    return datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    """Generate a UTC timestamp execution id (e.g. '20260425T120630Z').
+
+    Within the same process, consecutive calls in the same UTC second
+    return distinct ids by appending a numeric suffix
+    (e.g. '20260425T120630Z-1'). This guarantees that callers which
+    treat the id as a unique handle never collide.
+    """
+    global _last_execution_id, _last_execution_id_suffix
+    base_id = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    if base_id == _last_execution_id:
+        _last_execution_id_suffix += 1
+        return f"{base_id}-{_last_execution_id_suffix}"
+    _last_execution_id = base_id
+    _last_execution_id_suffix = 0
+    return base_id
 
 
 def create_execution_dir(aeroplane_id: str, plan_id: int) -> tuple[str, Path]:
@@ -55,6 +72,45 @@ def create_execution_dir(aeroplane_id: str, plan_id: int) -> tuple[str, Path]:
         logger.exception("Failed to create artifact dir %s", abs_path)
         raise InternalError(message=f"Cannot create artifact directory: {exc}") from exc
     logger.info("Created artifact dir: %s", abs_path)
+    return execution_id, abs_path
+
+
+TEMPLATE_RUNS_PREFIX = "_template_runs"
+
+
+def create_template_execution_dir(template_id: int) -> tuple[str, Path]:
+    """Create a fresh artifact directory for a template execution.
+
+    Wipes any previous execution under <base>/_template_runs/<template_id>/
+    so at most one template execution exists per template at any time.
+    Returns (execution_id, absolute_path).
+    """
+    import shutil
+
+    base = settings.ARTIFACTS_BASE_DIR
+    template_root = base / TEMPLATE_RUNS_PREFIX / str(template_id)
+    if template_root.exists():
+        # Validate containment before destructive operation.
+        _ensure_within_base(template_root)
+        try:
+            shutil.rmtree(template_root)
+        except OSError as exc:
+            logger.exception("Failed to wipe template run dir %s", template_root)
+            raise InternalError(
+                message=f"Cannot reset template run directory: {exc}"
+            ) from exc
+
+    execution_id = new_execution_id()
+    abs_path = base / TEMPLATE_RUNS_PREFIX / str(template_id) / execution_id
+    try:
+        abs_path.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        logger.exception("Failed to create template artifact dir %s", abs_path)
+        raise InternalError(
+            message=f"Cannot create template artifact directory: {exc}"
+        ) from exc
+    abs_path = _ensure_within_base(abs_path)
+    logger.info("Created template artifact dir: %s", abs_path)
     return execution_id, abs_path
 
 

--- a/app/services/artifact_service.py
+++ b/app/services/artifact_service.py
@@ -216,12 +216,29 @@ def delete_execution(plan_id: int, execution_id: str) -> None:
 
 
 def _resolve_execution_dir(plan_id: int, execution_id: str) -> Path:
-    """Find and validate the execution directory for plan_id/execution_id."""
+    """Find and validate the execution directory for plan_id/execution_id.
+
+    Searches first under <base>/<aero_id>/<plan_id>/<exec_id> (plan
+    executions). If not found, falls back to
+    <base>/_template_runs/<plan_id>/<exec_id> (template executions).
+    """
     base = settings.ARTIFACTS_BASE_DIR
     if not base.exists():
         raise NotFoundError(message="No artifacts base directory")
+
+    # 1) Search per-aeroplane plan execution dirs (skip the template-runs
+    #    prefix so a template exec_id is not coincidentally returned as
+    #    a plan dir).
     for aero_dir in base.iterdir():
+        if not aero_dir.is_dir() or aero_dir.name == TEMPLATE_RUNS_PREFIX:
+            continue
         candidate = aero_dir / str(plan_id) / execution_id
         if candidate.is_dir():
             return _ensure_within_base(candidate)
+
+    # 2) Fall back to template runs.
+    tpl_candidate = base / TEMPLATE_RUNS_PREFIX / str(plan_id) / execution_id
+    if tpl_candidate.is_dir():
+        return _ensure_within_base(tpl_candidate)
+
     raise NotFoundError(message=f"Execution {execution_id} not found for plan {plan_id}")

--- a/app/services/artifact_service.py
+++ b/app/services/artifact_service.py
@@ -147,8 +147,20 @@ def list_executions(plan_id: int) -> list[ArtifactDirectory]:
         raise InternalError(message="Cannot read artifact directory") from exc
 
 
-def list_files(plan_id: int, execution_id: str, subpath: str = "") -> list[ArtifactFile]:
-    """List files in an execution's artifact directory (or a subdirectory)."""
+def list_files(
+    plan_id: int,
+    execution_id: str,
+    subpath: str = "",
+    recursive: bool = False,
+) -> list[ArtifactFile]:
+    """List files in an execution's artifact directory.
+
+    With ``recursive=True``, returns a flat list of all files under the
+    execution directory (or under ``subpath``) with relative paths in the
+    ``name`` field — directories are omitted. Without it, returns only
+    immediate children (files and subdirectories), matching the original
+    breadcrumb-browser behaviour.
+    """
     exec_dir = _resolve_execution_dir(plan_id, execution_id)
     if subpath:
         target = exec_dir / subpath
@@ -158,16 +170,31 @@ def list_files(plan_id: int, execution_id: str, subpath: str = "") -> list[Artif
         exec_dir = target
     try:
         files: list[ArtifactFile] = []
-        for entry in sorted(exec_dir.iterdir()):
-            stat = entry.stat()
-            files.append(
-                ArtifactFile(
-                    name=entry.name,
-                    is_dir=entry.is_dir(),
-                    size_bytes=stat.st_size if entry.is_file() else 0,
-                    modified=datetime.fromtimestamp(stat.st_mtime, UTC).isoformat(),
+        if recursive:
+            for entry in sorted(exec_dir.rglob("*")):
+                if not entry.is_file():
+                    continue
+                stat = entry.stat()
+                rel_path = entry.relative_to(exec_dir).as_posix()
+                files.append(
+                    ArtifactFile(
+                        name=rel_path,
+                        is_dir=False,
+                        size_bytes=stat.st_size,
+                        modified=datetime.fromtimestamp(stat.st_mtime, UTC).isoformat(),
+                    )
                 )
-            )
+        else:
+            for entry in sorted(exec_dir.iterdir()):
+                stat = entry.stat()
+                files.append(
+                    ArtifactFile(
+                        name=entry.name,
+                        is_dir=entry.is_dir(),
+                        size_bytes=stat.st_size if entry.is_file() else 0,
+                        modified=datetime.fromtimestamp(stat.st_mtime, UTC).isoformat(),
+                    )
+                )
         return files
     except OSError as exc:
         logger.exception("Failed to list files in %s", exec_dir)

--- a/app/services/artifact_service.py
+++ b/app/services/artifact_service.py
@@ -96,9 +96,7 @@ def create_template_execution_dir(template_id: int) -> tuple[str, Path]:
             shutil.rmtree(template_root)
         except OSError as exc:
             logger.exception("Failed to wipe template run dir %s", template_root)
-            raise InternalError(
-                message=f"Cannot reset template run directory: {exc}"
-            ) from exc
+            raise InternalError(message=f"Cannot reset template run directory: {exc}") from exc
 
     execution_id = new_execution_id()
     abs_path = base / TEMPLATE_RUNS_PREFIX / str(template_id) / execution_id
@@ -106,9 +104,7 @@ def create_template_execution_dir(template_id: int) -> tuple[str, Path]:
         abs_path.mkdir(parents=True, exist_ok=True)
     except OSError as exc:
         logger.exception("Failed to create template artifact dir %s", abs_path)
-        raise InternalError(
-            message=f"Cannot create template artifact directory: {exc}"
-        ) from exc
+        raise InternalError(message=f"Cannot create template artifact directory: {exc}") from exc
     abs_path = _ensure_within_base(abs_path)
     logger.info("Created template artifact dir: %s", abs_path)
     return execution_id, abs_path
@@ -228,9 +224,7 @@ def zip_execution(plan_id: int, execution_id: str) -> Path:
 
     exec_dir = _resolve_execution_dir(plan_id, execution_id)
 
-    fd, tmp_name = tempfile.mkstemp(
-        prefix=f"plan{plan_id}-{execution_id}-", suffix=".zip"
-    )
+    fd, tmp_name = tempfile.mkstemp(prefix=f"plan{plan_id}-{execution_id}-", suffix=".zip")
     _os.close(fd)  # we re-open via zipfile
     zip_path = Path(tmp_name)
 
@@ -242,9 +236,7 @@ def zip_execution(plan_id: int, execution_id: str) -> Path:
                 arcname = file_path.relative_to(exec_dir).as_posix()
                 zf.write(file_path, arcname=arcname)
     except OSError as exc:
-        logger.exception(
-            "Failed to build zip for execution %s/%s", plan_id, execution_id
-        )
+        logger.exception("Failed to build zip for execution %s/%s", plan_id, execution_id)
         zip_path.unlink(missing_ok=True)
         raise InternalError(message=f"Cannot build zip: {exc}") from exc
 

--- a/app/services/artifact_service.py
+++ b/app/services/artifact_service.py
@@ -215,6 +215,42 @@ def delete_execution(plan_id: int, execution_id: str) -> None:
     logger.info("Deleted execution dir: %s", exec_dir)
 
 
+def zip_execution(plan_id: int, execution_id: str) -> Path:
+    """Zip an entire execution directory and return the path to the zip file.
+
+    The zip is written to a temp file (auto-cleaned by the OS / next
+    template run). Empty executions yield a valid empty zip (200 OK
+    semantics, not a 404).
+    """
+    import os as _os
+    import tempfile
+    import zipfile
+
+    exec_dir = _resolve_execution_dir(plan_id, execution_id)
+
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f"plan{plan_id}-{execution_id}-", suffix=".zip"
+    )
+    _os.close(fd)  # we re-open via zipfile
+    zip_path = Path(tmp_name)
+
+    try:
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for file_path in sorted(exec_dir.rglob("*")):
+                if not file_path.is_file():
+                    continue
+                arcname = file_path.relative_to(exec_dir).as_posix()
+                zf.write(file_path, arcname=arcname)
+    except OSError as exc:
+        logger.exception(
+            "Failed to build zip for execution %s/%s", plan_id, execution_id
+        )
+        zip_path.unlink(missing_ok=True)
+        raise InternalError(message=f"Cannot build zip: {exc}") from exc
+
+    return zip_path
+
+
 def _resolve_execution_dir(plan_id: int, execution_id: str) -> Path:
     """Find and validate the execution directory for plan_id/execution_id.
 

--- a/app/services/artifact_service.py
+++ b/app/services/artifact_service.py
@@ -147,6 +147,18 @@ def list_executions(plan_id: int) -> list[ArtifactDirectory]:
         raise InternalError(message="Cannot read artifact directory") from exc
 
 
+def _to_artifact_file(entry: Path, name: str) -> ArtifactFile:
+    """Build an ArtifactFile from a filesystem entry."""
+    stat = entry.stat()
+    is_dir = entry.is_dir()
+    return ArtifactFile(
+        name=name,
+        is_dir=is_dir,
+        size_bytes=stat.st_size if not is_dir else 0,
+        modified=datetime.fromtimestamp(stat.st_mtime, UTC).isoformat(),
+    )
+
+
 def list_files(
     plan_id: int,
     execution_id: str,
@@ -169,33 +181,13 @@ def list_files(
             raise NotFoundError(message=f"Directory not found: {subpath}")
         exec_dir = target
     try:
-        files: list[ArtifactFile] = []
         if recursive:
-            for entry in sorted(exec_dir.rglob("*")):
-                if not entry.is_file():
-                    continue
-                stat = entry.stat()
-                rel_path = entry.relative_to(exec_dir).as_posix()
-                files.append(
-                    ArtifactFile(
-                        name=rel_path,
-                        is_dir=False,
-                        size_bytes=stat.st_size,
-                        modified=datetime.fromtimestamp(stat.st_mtime, UTC).isoformat(),
-                    )
-                )
-        else:
-            for entry in sorted(exec_dir.iterdir()):
-                stat = entry.stat()
-                files.append(
-                    ArtifactFile(
-                        name=entry.name,
-                        is_dir=entry.is_dir(),
-                        size_bytes=stat.st_size if entry.is_file() else 0,
-                        modified=datetime.fromtimestamp(stat.st_mtime, UTC).isoformat(),
-                    )
-                )
-        return files
+            return [
+                _to_artifact_file(entry, entry.relative_to(exec_dir).as_posix())
+                for entry in sorted(exec_dir.rglob("*"))
+                if entry.is_file()
+            ]
+        return [_to_artifact_file(entry, entry.name) for entry in sorted(exec_dir.iterdir())]
     except OSError as exc:
         logger.exception("Failed to list files in %s", exec_dir)
         raise InternalError(message="Cannot read artifact files") from exc
@@ -263,7 +255,10 @@ def zip_execution(plan_id: int, execution_id: str) -> Path:
                 arcname = file_path.relative_to(exec_dir).as_posix()
                 zf.write(file_path, arcname=arcname)
     except OSError as exc:
-        logger.exception("Failed to build zip for execution %s/%s", plan_id, execution_id)
+        # Log the validated exec_dir path (sanitised by _ensure_within_base),
+        # not the raw user-supplied execution_id, to avoid log injection
+        # (pythonsecurity:S5145).
+        logger.exception("Failed to build zip for execution at %s", exec_dir)
         zip_path.unlink(missing_ok=True)
         raise InternalError(message=f"Cannot build zip: {exc}") from exc
 

--- a/app/services/construction_plan_service.py
+++ b/app/services/construction_plan_service.py
@@ -1,4 +1,5 @@
 """Service layer for Construction Plans (gh#101)."""
+
 from __future__ import annotations
 
 import inspect
@@ -120,11 +121,14 @@ def _migrate_tree_json(db: Session, plan: ConstructionPlanModel) -> None:
         return
     root_type = tree.get("$TYPE", "")
     if root_type == "ConstructionStepNode":
-        logger.info("Migrating plan %s root from ConstructionStepNode → ConstructionRootNode", plan.id)
+        logger.info(
+            "Migrating plan %s root from ConstructionStepNode → ConstructionRootNode", plan.id
+        )
         tree["$TYPE"] = "ConstructionRootNode"
         # Remove 'creator' key if present (ConstructionRootNode doesn't use it)
         tree.pop("creator", None)
         from sqlalchemy.orm.attributes import flag_modified
+
         flag_modified(plan, "tree_json")
         db.commit()
 
@@ -254,16 +258,23 @@ def to_template(
 
 
 _INTERNAL_PARAMS = {
-    "self", "loglevel", "kwargs",
+    "self",
+    "loglevel",
+    "kwargs",
     "creator_id",
     # Runtime-injected config (passed by GeneralJSONDecoder, not user-facing)
-    "wing_config", "printer_settings", "servo_information",
-    "engine_information", "component_information",
+    "wing_config",
+    "printer_settings",
+    "servo_information",
+    "engine_information",
+    "component_information",
 }
 
 
 def _flush_attribute(
-    result: dict[str, str], name: str | None, desc: list[str],
+    result: dict[str, str],
+    name: str | None,
+    desc: list[str],
 ) -> None:
     """Write accumulated attribute to *result* if *name* and *desc* exist."""
     if name and desc:
@@ -372,16 +383,23 @@ def _parse_docstring_returns(docstring: str) -> list[CreatorOutput]:
             continue
 
         # End on next section header
-        if stripped and not stripped.startswith("{") and stripped.endswith(":") and "(" not in stripped:
+        if (
+            stripped
+            and not stripped.startswith("{")
+            and stripped.endswith(":")
+            and "(" not in stripped
+        ):
             break
 
         # Output line: "{id}.name (type): Description"
         match = re.match(r"(\{[^}]*\}[^\s]*)\s*(?:\([^)]*\))?\s*:\s*(.*)", stripped)
         if match:
-            outputs.append(CreatorOutput(
-                key=match.group(1),
-                description=match.group(2).strip(),
-            ))
+            outputs.append(
+                CreatorOutput(
+                    key=match.group(1),
+                    description=match.group(2).strip(),
+                )
+            )
         elif not stripped and outputs:
             break  # Empty line after outputs ends section
 
@@ -507,28 +525,32 @@ def _collect_creators(cls: type, result: list[CreatorInfo], seen: set[str]) -> N
     for pname, param in sig.parameters.items():
         if pname in _INTERNAL_PARAMS:
             continue
-        params.append(CreatorParam(
-            name=pname,
-            type=_type_to_str(param.annotation),
-            default=param.default if param.default is not inspect.Parameter.empty else None,
-            required=param.default is inspect.Parameter.empty,
-            description=param_descriptions.get(pname),
-            options=_extract_literal_values(param.annotation),
-        ))
+        params.append(
+            CreatorParam(
+                name=pname,
+                type=_type_to_str(param.annotation),
+                default=param.default if param.default is not inspect.Parameter.empty else None,
+                required=param.default is inspect.Parameter.empty,
+                description=param_descriptions.get(pname),
+                options=_extract_literal_values(param.annotation),
+            )
+        )
 
     docstring = (cls.__doc__ or "").strip().split("\n")[0] if cls.__doc__ else None
 
     outputs = _parse_docstring_returns(cls.__doc__ or "")
     suggested_id = getattr(cls, "suggested_creator_id", None)
 
-    result.append(CreatorInfo(
-        class_name=name,
-        category=_get_category(cls),
-        description=docstring,
-        parameters=params,
-        outputs=outputs,
-        suggested_id=suggested_id,
-    ))
+    result.append(
+        CreatorInfo(
+            class_name=name,
+            category=_get_category(cls),
+            description=docstring,
+            parameters=params,
+            outputs=outputs,
+            suggested_id=suggested_id,
+        )
+    )
 
     for sub in cls.__subclasses__():
         _collect_creators(sub, result, seen)
@@ -538,8 +560,10 @@ def _collect_creators(cls: type, result: list[CreatorInfo], seen: set[str]) -> N
 
 
 _EXPORT_CREATOR_TYPES = {
-    "ExportToStlCreator", "ExportToStepCreator",
-    "ExportToIgesCreator", "ExportTo3mfCreator",
+    "ExportToStlCreator",
+    "ExportToStepCreator",
+    "ExportToIgesCreator",
+    "ExportTo3mfCreator",
 }
 
 
@@ -564,14 +588,18 @@ def _rewrite_export_paths(tree_json: dict, artifact_dir) -> dict:
                 fp = creator.get("file_path")
                 if isinstance(fp, str) and not os.path.isabs(fp):
                     abs_path = artifact / fp
-                    abs_path.mkdir(parents=True, exist_ok=True)  # file_path is a directory for exporters
+                    abs_path.mkdir(
+                        parents=True, exist_ok=True
+                    )  # file_path is a directory for exporters
                     creator["file_path"] = str(abs_path)
         # Also check if this node itself is an export creator (flat format)
         if node_type in _EXPORT_CREATOR_TYPES:
             fp = node.get("file_path")
             if isinstance(fp, str) and not os.path.isabs(fp):
                 abs_path = artifact / fp
-                abs_path.mkdir(parents=True, exist_ok=True)  # file_path is a directory for exporters
+                abs_path.mkdir(
+                    parents=True, exist_ok=True
+                )  # file_path is a directory for exporters
                 node["file_path"] = str(abs_path)
         # Recurse into successors
         successors = node.get("successors")
@@ -613,9 +641,7 @@ def execute_plan(
     # Create artifact directory: templates go to a dedicated _template_runs
     # tree with replace-on-next-run; plans go under <aeroplane>/<plan>/.
     if plan.plan_type == "template":
-        execution_id, artifact_dir = artifact_service.create_template_execution_dir(
-            plan_id
-        )
+        execution_id, artifact_dir = artifact_service.create_template_execution_dir(plan_id)
     else:
         execution_id, artifact_dir = artifact_service.create_execution_dir(
             effective_aeroplane_id, plan_id
@@ -656,7 +682,8 @@ def execute_plan(
     except Exception as exc:
         logger.exception(
             "Failed to decode plan tree_json: plan_id=%s execution_id=%s",
-            plan_id, execution_id,
+            plan_id,
+            execution_id,
         )
         raise ValidationError(
             message=f"Failed to decode construction plan: {exc}",
@@ -671,7 +698,9 @@ def execute_plan(
         duration_ms = int((time.monotonic() - t0) * 1000)
         logger.exception(
             "Plan execution failed: plan_id=%s aeroplane_id=%s execution_id=%s",
-            plan_id, effective_aeroplane_id, execution_id,
+            plan_id,
+            effective_aeroplane_id,
+            execution_id,
         )
         return ExecutionResult(
             status="error",
@@ -750,9 +779,7 @@ def execute_plan_streaming(
 
     # Templates: replace-on-next-run; plans: per-aeroplane persistent.
     if plan.plan_type == "template":
-        execution_id, artifact_dir = artifact_service.create_template_execution_dir(
-            plan_id
-        )
+        execution_id, artifact_dir = artifact_service.create_template_execution_dir(plan_id)
     else:
         execution_id, artifact_dir = artifact_service.create_execution_dir(
             effective_aeroplane_id, plan_id
@@ -790,6 +817,7 @@ def execute_plan_streaming(
         shape_queue.put(("shape", name, clean))
 
     from cad_designer.cq_plugins.display.display import set_display_callback
+
     set_display_callback(on_display)
     prev_env = os.environ.get("DISPLAY_CONSTRUCTION_STEP")
     os.environ["DISPLAY_CONSTRUCTION_STEP"] = "1"
@@ -804,22 +832,32 @@ def execute_plan_streaming(
             shape_keys = list(structure.keys()) if isinstance(structure, dict) else []
             # Final tessellation of the complete structure
             tessellation = _tessellate_shapes(structure) if isinstance(structure, dict) else None
-            result_holder.append(("complete", {
-                "duration_ms": duration_ms,
-                "shape_keys": shape_keys,
-                "tessellation": _numpy_to_list(tessellation) if tessellation else None,
-                "artifact_dir": str(artifact_dir),
-                "execution_id": execution_id,
-            }))
+            result_holder.append(
+                (
+                    "complete",
+                    {
+                        "duration_ms": duration_ms,
+                        "shape_keys": shape_keys,
+                        "tessellation": _numpy_to_list(tessellation) if tessellation else None,
+                        "artifact_dir": str(artifact_dir),
+                        "execution_id": execution_id,
+                    },
+                )
+            )
         except Exception as exc:
             duration_ms = int((time.monotonic() - t0) * 1000)
             logger.exception("Plan execution failed: plan_id=%s", plan_id)
-            result_holder.append(("error", {
-                "error": f"{type(exc).__name__}: {exc}",
-                "duration_ms": duration_ms,
-                "artifact_dir": str(artifact_dir),
-                "execution_id": execution_id,
-            }))
+            result_holder.append(
+                (
+                    "error",
+                    {
+                        "error": f"{type(exc).__name__}: {exc}",
+                        "duration_ms": duration_ms,
+                        "artifact_dir": str(artifact_dir),
+                        "execution_id": execution_id,
+                    },
+                )
+            )
         finally:
             shape_queue.put(("done", None, None))
             set_display_callback(None)
@@ -919,7 +957,10 @@ def _tessellate_shapes(structure: dict) -> dict | None:
 
         params = {"deviation": 0.1, "angular_tolerance": 0.2}
         instances, tess_shapes, _mapping = tessellate_group(
-            part_group, instances, params, progress=None,
+            part_group,
+            instances,
+            params,
+            progress=None,
         )
 
         bb = combined_bb(tess_shapes)
@@ -947,6 +988,7 @@ def _load_printer_settings(db: Session):
     """Try to load Printer3dSettings from a component of type 'printer_settings'."""
     try:
         from app.models.component import ComponentModel
+
         comp = (
             db.query(ComponentModel)
             .filter(ComponentModel.component_type == "printer_settings")
@@ -954,6 +996,7 @@ def _load_printer_settings(db: Session):
         )
         if comp and comp.specs:
             from cad_designer.airplane.aircraft_topology.printer3d import Printer3dSettings
+
             return Printer3dSettings(
                 layer_height=float(comp.specs.get("layer_height", 0.24)),
                 wall_thickness=float(comp.specs.get("wall_thickness", 0.42)),
@@ -965,6 +1008,9 @@ def _load_printer_settings(db: Session):
     # Fallback defaults
     try:
         from cad_designer.airplane.aircraft_topology.printer3d import Printer3dSettings
-        return Printer3dSettings(layer_height=0.24, wall_thickness=0.42, rel_gap_wall_thickness=0.075)
+
+        return Printer3dSettings(
+            layer_height=0.24, wall_thickness=0.42, rel_gap_wall_thickness=0.075
+        )
     except ImportError:
         return None

--- a/app/services/construction_plan_service.py
+++ b/app/services/construction_plan_service.py
@@ -595,22 +595,31 @@ def execute_plan(
 ) -> ExecutionResult:
     """Execute a plan against an aeroplane configuration."""
     from app.services.wing_service import get_aeroplane_or_raise, get_wing_or_raise
-    from app.services.artifact_service import create_execution_dir
+    from app.services import artifact_service
     from app.converters.model_schema_converters import wing_model_to_wing_config
 
     # Load plan
     plan = _get_plan_or_raise(db, plan_id)
-    if plan.plan_type == "template":
-        raise ValidationError(
-            message="Templates cannot be executed. Instantiate as a plan first.",
-        )
 
-    # Load aeroplane (prefer stored aeroplane_id, fall back to request)
+    # Resolve aeroplane: prefer stored aeroplane_id (real plans), fall back
+    # to request (templates require it explicitly).
     effective_aeroplane_id = plan.aeroplane_id or request.aeroplane_id
+    if plan.plan_type == "template" and not effective_aeroplane_id:
+        raise ValidationError(
+            message="aeroplane_id required for template execution",
+        )
     aeroplane = get_aeroplane_or_raise(db, effective_aeroplane_id)
 
-    # Create artifact directory for this execution
-    execution_id, artifact_dir = create_execution_dir(effective_aeroplane_id, plan_id)
+    # Create artifact directory: templates go to a dedicated _template_runs
+    # tree with replace-on-next-run; plans go under <aeroplane>/<plan>/.
+    if plan.plan_type == "template":
+        execution_id, artifact_dir = artifact_service.create_template_execution_dir(
+            plan_id
+        )
+    else:
+        execution_id, artifact_dir = artifact_service.create_execution_dir(
+            effective_aeroplane_id, plan_id
+        )
 
     # Build wing_config map: all wings
     wing_config: dict = {}
@@ -704,7 +713,7 @@ def execute_plan_streaming(
     import threading
 
     from app.services.wing_service import get_aeroplane_or_raise
-    from app.services.artifact_service import create_execution_dir
+    from app.services import artifact_service
     from app.converters.model_schema_converters import wing_model_to_wing_config
 
     # Load plan — wrap setup in try/except to yield SSE errors instead of crashing
@@ -713,11 +722,16 @@ def execute_plan_streaming(
     except (NotFoundError, ValidationError) as exc:
         yield f"event: error\ndata: {json.dumps({'error': str(exc)})}\n\n"
         return
-    if plan.plan_type == "template":
-        yield f"event: error\ndata: {json.dumps({'error': 'Templates cannot be executed'})}\n\n"
-        return
 
     effective_aeroplane_id = plan.aeroplane_id or request.aeroplane_id
+    if plan.plan_type == "template" and not effective_aeroplane_id:
+        yield (
+            "event: error\ndata: "
+            f"{json.dumps({'error': 'aeroplane_id required for template execution'})}"
+            "\n\n"
+        )
+        return
+
     try:
         aeroplane = get_aeroplane_or_raise(db, effective_aeroplane_id)
     except NotFoundError as exc:
@@ -733,7 +747,16 @@ def execute_plan_streaming(
             logger.warning("Failed to convert wing '%s': %s", wing.name, exc)
 
     printer_settings = _load_printer_settings(db)
-    execution_id, artifact_dir = create_execution_dir(effective_aeroplane_id, plan_id)
+
+    # Templates: replace-on-next-run; plans: per-aeroplane persistent.
+    if plan.plan_type == "template":
+        execution_id, artifact_dir = artifact_service.create_template_execution_dir(
+            plan_id
+        )
+    else:
+        execution_id, artifact_dir = artifact_service.create_execution_dir(
+            effective_aeroplane_id, plan_id
+        )
 
     # Rewrite export paths for artifact directory
     tree_for_exec = _rewrite_export_paths(plan.tree_json, artifact_dir)

--- a/app/tests/test_artifact_service.py
+++ b/app/tests/test_artifact_service.py
@@ -47,3 +47,46 @@ class TestCreateTemplateExecutionDir:
         assert dir_a.exists()
         assert (dir_a / "a.txt").read_text() == "keep"
         assert dir_b.exists()
+
+
+class TestResolveExecutionDir:
+    def test_resolves_plan_execution_dir(self, tmp_artifacts: Path):
+        # Plan execution lives under <base>/<aero_id>/<plan_id>/<exec_id>/
+        execution_id, plan_dir = artifact_service.create_execution_dir("aero-x", 99)
+
+        resolved = artifact_service._resolve_execution_dir(99, execution_id)
+
+        assert resolved == plan_dir
+
+    def test_resolves_template_execution_dir(self, tmp_artifacts: Path):
+        execution_id, tpl_dir = artifact_service.create_template_execution_dir(55)
+
+        resolved = artifact_service._resolve_execution_dir(55, execution_id)
+
+        assert resolved == tpl_dir
+
+    def test_plan_takes_precedence_over_template_when_id_collides(
+        self, tmp_artifacts: Path
+    ):
+        # Edge case: same id used for both (in real DB they wouldn't collide,
+        # but the resolver must be deterministic).
+        plan_exec_id, plan_dir = artifact_service.create_execution_dir("aero-y", 123)
+        # Manually create a template-run dir with a different exec_id so they
+        # don't both have the same dir name.
+        tpl_root = tmp_artifacts / "_template_runs" / "123"
+        tpl_root.mkdir(parents=True)
+        (tpl_root / "20260101T000000Z").mkdir()
+
+        # Plan exec_id resolves to plan dir
+        assert artifact_service._resolve_execution_dir(123, plan_exec_id) == plan_dir
+        # Template exec_id resolves to template dir
+        assert (
+            artifact_service._resolve_execution_dir(123, "20260101T000000Z")
+            == tpl_root.resolve() / "20260101T000000Z"
+        )
+
+    def test_raises_not_found_for_unknown_execution(self, tmp_artifacts: Path):
+        from app.core.exceptions import NotFoundError
+
+        with pytest.raises(NotFoundError):
+            artifact_service._resolve_execution_dir(404, "nonexistent")

--- a/app/tests/test_artifact_service.py
+++ b/app/tests/test_artifact_service.py
@@ -65,9 +65,7 @@ class TestResolveExecutionDir:
 
         assert resolved == tpl_dir
 
-    def test_plan_takes_precedence_over_template_when_id_collides(
-        self, tmp_artifacts: Path
-    ):
+    def test_plan_takes_precedence_over_template_when_id_collides(self, tmp_artifacts: Path):
         # Edge case: same id used for both (in real DB they wouldn't collide,
         # but the resolver must be deterministic).
         plan_exec_id, plan_dir = artifact_service.create_execution_dir("aero-y", 123)

--- a/app/tests/test_artifact_service.py
+++ b/app/tests/test_artifact_service.py
@@ -1,0 +1,49 @@
+"""Unit tests for artifact_service template-run helpers (gh#339)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.core.config import settings
+from app.services import artifact_service
+
+
+@pytest.fixture()
+def tmp_artifacts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point ARTIFACTS_BASE_DIR at a clean tmp dir for each test."""
+    monkeypatch.setattr(settings, "ARTIFACTS_BASE_DIR", tmp_path)
+    return tmp_path
+
+
+class TestCreateTemplateExecutionDir:
+    def test_creates_directory_under_template_runs(self, tmp_artifacts: Path):
+        execution_id, abs_path = artifact_service.create_template_execution_dir(42)
+
+        assert abs_path.exists()
+        assert abs_path.is_dir()
+        assert abs_path.parent == tmp_artifacts / "_template_runs" / "42"
+        assert abs_path.name == execution_id
+
+    def test_wipes_previous_template_run(self, tmp_artifacts: Path):
+        # First run with a leftover file
+        _, first_dir = artifact_service.create_template_execution_dir(7)
+        (first_dir / "leftover.stl").write_text("old")
+        assert first_dir.exists()
+
+        # Second run must wipe everything under _template_runs/7/
+        _, second_dir = artifact_service.create_template_execution_dir(7)
+
+        assert not first_dir.exists(), "previous execution dir should be wiped"
+        assert second_dir.exists()
+        assert second_dir.parent == tmp_artifacts / "_template_runs" / "7"
+
+    def test_does_not_touch_other_template_runs(self, tmp_artifacts: Path):
+        _, dir_a = artifact_service.create_template_execution_dir(1)
+        (dir_a / "a.txt").write_text("keep")
+        _, dir_b = artifact_service.create_template_execution_dir(2)
+
+        assert dir_a.exists()
+        assert (dir_a / "a.txt").read_text() == "keep"
+        assert dir_b.exists()

--- a/app/tests/test_artifact_service.py
+++ b/app/tests/test_artifact_service.py
@@ -90,3 +90,48 @@ class TestResolveExecutionDir:
 
         with pytest.raises(NotFoundError):
             artifact_service._resolve_execution_dir(404, "nonexistent")
+
+
+class TestZipExecution:
+    def test_zips_all_files_in_execution(self, tmp_artifacts: Path):
+        execution_id, exec_dir = artifact_service.create_execution_dir("aero-z", 11)
+        (exec_dir / "a.stl").write_bytes(b"AAAA")
+        (exec_dir / "b.txt").write_text("hello")
+        sub = exec_dir / "wing"
+        sub.mkdir()
+        (sub / "c.stp").write_bytes(b"CCCC")
+
+        zip_path = artifact_service.zip_execution(11, execution_id)
+
+        import zipfile
+
+        with zipfile.ZipFile(zip_path) as zf:
+            names = sorted(zf.namelist())
+        assert names == ["a.stl", "b.txt", "wing/c.stp"]
+
+    def test_returns_empty_zip_for_empty_execution(self, tmp_artifacts: Path):
+        execution_id, _ = artifact_service.create_execution_dir("aero-z", 12)
+
+        zip_path = artifact_service.zip_execution(12, execution_id)
+
+        import zipfile
+
+        with zipfile.ZipFile(zip_path) as zf:
+            assert zf.namelist() == []
+
+    def test_zips_template_execution(self, tmp_artifacts: Path):
+        execution_id, exec_dir = artifact_service.create_template_execution_dir(33)
+        (exec_dir / "out.stl").write_bytes(b"X")
+
+        zip_path = artifact_service.zip_execution(33, execution_id)
+
+        import zipfile
+
+        with zipfile.ZipFile(zip_path) as zf:
+            assert zf.namelist() == ["out.stl"]
+
+    def test_raises_not_found_for_unknown_execution(self, tmp_artifacts: Path):
+        from app.core.exceptions import NotFoundError
+
+        with pytest.raises(NotFoundError):
+            artifact_service.zip_execution(99, "doesnotexist")

--- a/app/tests/test_artifact_service.py
+++ b/app/tests/test_artifact_service.py
@@ -133,3 +133,51 @@ class TestZipExecution:
 
         with pytest.raises(NotFoundError):
             artifact_service.zip_execution(99, "doesnotexist")
+
+
+class TestListFilesRecursive:
+    """gh#344 — recursive=True returns flat list with relative paths."""
+
+    def test_recursive_returns_files_under_subdirs(self, tmp_artifacts: Path):
+        execution_id, exec_dir = artifact_service.create_execution_dir("aero-rec", 800)
+        (exec_dir / "top.txt").write_text("top")
+        sub = exec_dir / "wing"
+        sub.mkdir()
+        (sub / "wing.stl").write_bytes(b"W")
+        nested = sub / "deeper"
+        nested.mkdir()
+        (nested / "n.stp").write_bytes(b"N")
+
+        files = artifact_service.list_files(800, execution_id, recursive=True)
+
+        names = sorted(f.name for f in files)
+        assert names == ["top.txt", "wing/deeper/n.stp", "wing/wing.stl"]
+        assert all(f.is_dir is False for f in files), "recursive flat list excludes directories"
+
+    def test_non_recursive_unchanged(self, tmp_artifacts: Path):
+        execution_id, exec_dir = artifact_service.create_execution_dir("aero-flat", 801)
+        (exec_dir / "a.txt").write_text("a")
+        (exec_dir / "wing").mkdir()
+
+        files = artifact_service.list_files(801, execution_id)
+
+        names = sorted(f.name for f in files)
+        assert names == ["a.txt", "wing"]
+        # The wing entry must be flagged as a directory in non-recursive mode
+        wing_entry = next(f for f in files if f.name == "wing")
+        assert wing_entry.is_dir is True
+
+    def test_recursive_with_subpath(self, tmp_artifacts: Path):
+        execution_id, exec_dir = artifact_service.create_execution_dir("aero-sub", 802)
+        sub = exec_dir / "wing"
+        sub.mkdir()
+        (sub / "a.stl").write_bytes(b"a")
+        (sub / "deep").mkdir()
+        (sub / "deep" / "b.stl").write_bytes(b"b")
+        # Files outside the subpath should NOT appear
+        (exec_dir / "ignore.txt").write_text("ignore")
+
+        files = artifact_service.list_files(802, execution_id, subpath="wing", recursive=True)
+
+        names = sorted(f.name for f in files)
+        assert names == ["a.stl", "deep/b.stl"]

--- a/app/tests/test_construction_plans.py
+++ b/app/tests/test_construction_plans.py
@@ -3,6 +3,7 @@
 Covers sub-tickets #109 (DB model), #110 (CRUD), #111 (creators), #112 (execute).
 Also: #315 (frontend JSON ↔ backend decoder compatibility).
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -15,6 +16,7 @@ def _can_import_cad() -> bool:
     """Check if cadquery/cad_designer is available (excluded on linux/aarch64)."""
     try:
         from cad_designer.airplane.GeneralJSONEncoderDecoder import GeneralJSONDecoder  # noqa: F401
+
         return True
     except (ImportError, ModuleNotFoundError):
         return False
@@ -191,9 +193,16 @@ class TestCreatorCatalog:
         """Internal and runtime-injected params not in parameters."""
         for c in client.get("/construction-plans/creators").json():
             param_names = {p["name"] for p in c["parameters"]}
-            for internal in ("self", "loglevel", "creator_id", "wing_config",
-                             "printer_settings", "servo_information",
-                             "engine_information", "component_information"):
+            for internal in (
+                "self",
+                "loglevel",
+                "creator_id",
+                "wing_config",
+                "printer_settings",
+                "servo_information",
+                "engine_information",
+                "component_information",
+            ):
                 assert internal not in param_names, f"{c['class_name']} exposes {internal}"
 
     def test_excludes_infrastructure_classes(self, client):
@@ -595,22 +604,16 @@ class TestPrinterSettingsSeed:
 class TestZipDownload:
     """GH#339 — zip download endpoint for an execution dir."""
 
-    def test_zip_endpoint_returns_zip_with_all_files(
-        self, client, tmp_path, monkeypatch
-    ):
+    def test_zip_endpoint_returns_zip_with_all_files(self, client, tmp_path, monkeypatch):
         from app.core.config import settings
         from app.services import artifact_service
 
         monkeypatch.setattr(settings, "ARTIFACTS_BASE_DIR", tmp_path)
-        execution_id, exec_dir = artifact_service.create_execution_dir(
-            "aero-zipper", 501
-        )
+        execution_id, exec_dir = artifact_service.create_execution_dir("aero-zipper", 501)
         (exec_dir / "alpha.stl").write_bytes(b"AAA")
         (exec_dir / "beta.txt").write_text("bb")
 
-        resp = client.get(
-            f"/construction-plans/501/artifacts/{execution_id}/zip"
-        )
+        resp = client.get(f"/construction-plans/501/artifacts/{execution_id}/zip")
 
         assert resp.status_code == 200, resp.text
         assert resp.headers["content-type"] == "application/zip"
@@ -622,9 +625,7 @@ class TestZipDownload:
         with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
             assert sorted(zf.namelist()) == ["alpha.stl", "beta.txt"]
 
-    def test_zip_endpoint_404_for_missing_execution(
-        self, client, tmp_path, monkeypatch
-    ):
+    def test_zip_endpoint_404_for_missing_execution(self, client, tmp_path, monkeypatch):
         from app.core.config import settings
 
         monkeypatch.setattr(settings, "ARTIFACTS_BASE_DIR", tmp_path)
@@ -642,9 +643,7 @@ class TestZipDownload:
         monkeypatch.setattr(settings, "ARTIFACTS_BASE_DIR", tmp_path)
         execution_id, _ = artifact_service.create_execution_dir("aero-empty", 502)
 
-        resp = client.get(
-            f"/construction-plans/502/artifacts/{execution_id}/zip"
-        )
+        resp = client.get(f"/construction-plans/502/artifacts/{execution_id}/zip")
 
         assert resp.status_code == 200
         assert resp.headers["content-type"] == "application/zip"
@@ -662,9 +661,7 @@ class TestTemplateExecution:
     """GH#339 — templates can be executed against a chosen aeroplane."""
 
     @pytest.mark.skipif(not _can_import_cad(), reason="cadquery not available")
-    def test_execute_template_returns_success(
-        self, client, client_and_db, tmp_path, monkeypatch
-    ):
+    def test_execute_template_returns_success(self, client, client_and_db, tmp_path, monkeypatch):
         from app.core.config import settings
 
         monkeypatch.setattr(settings, "ARTIFACTS_BASE_DIR", tmp_path)
@@ -676,9 +673,7 @@ class TestTemplateExecution:
             aero_id = str(aero.uuid)
 
         # Create a template (plan_type defaults to "template" in helper)
-        template = _create_plan(
-            client, "Tpl A", tree=SAMPLE_TREE, plan_type="template"
-        )
+        template = _create_plan(client, "Tpl A", tree=SAMPLE_TREE, plan_type="template")
 
         resp = client.post(
             f"/construction-plans/{template['id']}/execute",
@@ -691,9 +686,7 @@ class TestTemplateExecution:
         assert body["status"] in ("success", "error"), body
 
     def test_execute_template_without_aeroplane_id_returns_422(self, client):
-        template = _create_plan(
-            client, "Tpl B", tree=SAMPLE_TREE, plan_type="template"
-        )
+        template = _create_plan(client, "Tpl B", tree=SAMPLE_TREE, plan_type="template")
 
         resp = client.post(
             f"/construction-plans/{template['id']}/execute",
@@ -717,9 +710,7 @@ class TestTemplateExecution:
             aero = make_aeroplane(session, name="for-replace")
             aero_id = str(aero.uuid)
 
-        template = _create_plan(
-            client, "Tpl C", tree=SAMPLE_TREE, plan_type="template"
-        )
+        template = _create_plan(client, "Tpl C", tree=SAMPLE_TREE, plan_type="template")
 
         # First execute
         resp1 = client.post(
@@ -739,14 +730,10 @@ class TestTemplateExecution:
 
         assert first_exec_id != second_exec_id
         # First execution dir is gone
-        first_dir = (
-            tmp_path / "_template_runs" / str(template["id"]) / first_exec_id
-        )
+        first_dir = tmp_path / "_template_runs" / str(template["id"]) / first_exec_id
         assert not first_dir.exists()
         # Second execution dir exists
-        second_dir = (
-            tmp_path / "_template_runs" / str(template["id"]) / second_exec_id
-        )
+        second_dir = tmp_path / "_template_runs" / str(template["id"]) / second_exec_id
         assert second_dir.is_dir()
 
 
@@ -754,9 +741,7 @@ class TestPlanExecutionPathRegression:
     """Plan executions still write to <aero>/<plan>/<exec> (gh#339)."""
 
     @pytest.mark.skipif(not _can_import_cad(), reason="cadquery not available")
-    def test_plan_execution_path_unchanged(
-        self, client, client_and_db, tmp_path, monkeypatch
-    ):
+    def test_plan_execution_path_unchanged(self, client, client_and_db, tmp_path, monkeypatch):
         from app.core.config import settings
 
         monkeypatch.setattr(settings, "ARTIFACTS_BASE_DIR", tmp_path)

--- a/app/tests/test_construction_plans.py
+++ b/app/tests/test_construction_plans.py
@@ -226,15 +226,6 @@ class TestPlanExecution:
         )
         assert resp.status_code == 404
 
-    def test_execute_template_rejected(self, client):
-        """POST execute on a template → 422."""
-        plan = _create_plan(client, "tmpl_no_exec", plan_type="template")
-        resp = client.post(
-            f"/construction-plans/{plan['id']}/execute",
-            json={"aeroplane_id": "00000000-0000-0000-0000-000000000000"},
-        )
-        assert resp.status_code == 422
-
     def test_execute_plan_with_invalid_creator_returns_error(self, client):
         """Plan with unknown creator type → decode error → 422."""
         bad_tree = {
@@ -662,3 +653,136 @@ class TestZipDownload:
 
         with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
             assert zf.namelist() == []
+
+
+# ── Template execution (gh#339) ─────────────────────────────────
+
+
+class TestTemplateExecution:
+    """GH#339 — templates can be executed against a chosen aeroplane."""
+
+    @pytest.mark.skipif(not _can_import_cad(), reason="cadquery not available")
+    def test_execute_template_returns_success(
+        self, client, client_and_db, tmp_path, monkeypatch
+    ):
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "ARTIFACTS_BASE_DIR", tmp_path)
+        _, SessionLocal = client_and_db
+        from app.tests.conftest import make_aeroplane
+
+        with SessionLocal() as session:
+            aero = make_aeroplane(session, name="for-tpl-exec")
+            aero_id = str(aero.uuid)
+
+        # Create a template (plan_type defaults to "template" in helper)
+        template = _create_plan(
+            client, "Tpl A", tree=SAMPLE_TREE, plan_type="template"
+        )
+
+        resp = client.post(
+            f"/construction-plans/{template['id']}/execute",
+            json={"aeroplane_id": aero_id},
+        )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        # decode may fail (no real Creator) but status code must not be 422
+        assert body["status"] in ("success", "error"), body
+
+    def test_execute_template_without_aeroplane_id_returns_422(self, client):
+        template = _create_plan(
+            client, "Tpl B", tree=SAMPLE_TREE, plan_type="template"
+        )
+
+        resp = client.post(
+            f"/construction-plans/{template['id']}/execute",
+            json={},
+        )
+
+        assert resp.status_code == 422
+        assert "aeroplane_id" in resp.json()["detail"].lower()
+
+    @pytest.mark.skipif(not _can_import_cad(), reason="cadquery not available")
+    def test_template_execution_replaces_previous_run(
+        self, client, client_and_db, tmp_path, monkeypatch
+    ):
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "ARTIFACTS_BASE_DIR", tmp_path)
+        _, SessionLocal = client_and_db
+        from app.tests.conftest import make_aeroplane
+
+        with SessionLocal() as session:
+            aero = make_aeroplane(session, name="for-replace")
+            aero_id = str(aero.uuid)
+
+        template = _create_plan(
+            client, "Tpl C", tree=SAMPLE_TREE, plan_type="template"
+        )
+
+        # First execute
+        resp1 = client.post(
+            f"/construction-plans/{template['id']}/execute",
+            json={"aeroplane_id": aero_id},
+        )
+        assert resp1.status_code == 200
+        first_exec_id = resp1.json()["execution_id"]
+
+        # Second execute
+        resp2 = client.post(
+            f"/construction-plans/{template['id']}/execute",
+            json={"aeroplane_id": aero_id},
+        )
+        assert resp2.status_code == 200
+        second_exec_id = resp2.json()["execution_id"]
+
+        assert first_exec_id != second_exec_id
+        # First execution dir is gone
+        first_dir = (
+            tmp_path / "_template_runs" / str(template["id"]) / first_exec_id
+        )
+        assert not first_dir.exists()
+        # Second execution dir exists
+        second_dir = (
+            tmp_path / "_template_runs" / str(template["id"]) / second_exec_id
+        )
+        assert second_dir.is_dir()
+
+
+class TestPlanExecutionPathRegression:
+    """Plan executions still write to <aero>/<plan>/<exec> (gh#339)."""
+
+    @pytest.mark.skipif(not _can_import_cad(), reason="cadquery not available")
+    def test_plan_execution_path_unchanged(
+        self, client, client_and_db, tmp_path, monkeypatch
+    ):
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "ARTIFACTS_BASE_DIR", tmp_path)
+        _, SessionLocal = client_and_db
+        from app.tests.conftest import make_aeroplane
+
+        with SessionLocal() as session:
+            aero = make_aeroplane(session, name="for-plan")
+            aero_id = str(aero.uuid)
+
+        plan = _create_plan(
+            client,
+            "Real Plan",
+            tree=SAMPLE_TREE,
+            plan_type="plan",
+            aeroplane_id=aero_id,
+        )
+
+        resp = client.post(
+            f"/construction-plans/{plan['id']}/execute",
+            json={"aeroplane_id": aero_id},
+        )
+        assert resp.status_code == 200
+        exec_id = resp.json()["execution_id"]
+
+        # Plan dir under aeroplane root, NOT under _template_runs
+        plan_dir = tmp_path / aero_id / str(plan["id"]) / exec_id
+        assert plan_dir.is_dir()
+        assert not (tmp_path / "_template_runs" / str(plan["id"])).exists()

--- a/app/tests/test_construction_plans.py
+++ b/app/tests/test_construction_plans.py
@@ -737,6 +737,48 @@ class TestTemplateExecution:
         assert second_dir.is_dir()
 
 
+class TestTemplateExecutionViaAeroplaneEndpoint:
+    """GH#343 — templates can be executed via the URL-style endpoint that the
+    frontend uses: POST /aeroplanes/{aero_id}/construction-plans/{template_id}/execute.
+
+    This is a regression guard. The execute-guard removal in svc.execute_plan
+    fixes both this URL endpoint and the body-style /construction-plans/{id}/execute
+    endpoint (they share the service function), but PR #340 originally only
+    covered the body-style endpoint. This class verifies the URL-style path.
+    """
+
+    @pytest.mark.skipif(not _can_import_cad(), reason="cadquery not available")
+    def test_aeroplane_url_endpoint_executes_template(
+        self, client, client_and_db, tmp_path, monkeypatch
+    ):
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "ARTIFACTS_BASE_DIR", tmp_path)
+        _, SessionLocal = client_and_db
+        from app.tests.conftest import make_aeroplane
+
+        with SessionLocal() as session:
+            aero = make_aeroplane(session, name="for-url-tpl-exec")
+            aero_id = str(aero.uuid)
+
+        template = _create_plan(client, "Tpl URL", tree=SAMPLE_TREE, plan_type="template")
+
+        resp = client.post(
+            f"/aeroplanes/{aero_id}/construction-plans/{template['id']}/execute",
+        )
+
+        # Must NOT return 422 with "Templates cannot be executed" — that's the
+        # exact regression #343 reports.
+        assert resp.status_code == 200, resp.text
+        assert "Templates cannot be executed" not in resp.text
+        body = resp.json()
+        assert body["status"] in ("success", "error"), body
+        # Artifacts land under the template-runs tree (replace-on-next-run lifecycle)
+        assert body["execution_id"]
+        tpl_dir = tmp_path / "_template_runs" / str(template["id"]) / body["execution_id"]
+        assert tpl_dir.is_dir()
+
+
 class TestPlanExecutionPathRegression:
     """Plan executions still write to <aero>/<plan>/<exec> (gh#339)."""
 

--- a/app/tests/test_construction_plans.py
+++ b/app/tests/test_construction_plans.py
@@ -596,3 +596,69 @@ class TestPrinterSettingsSeed:
         assert len(ps["schema"]) == 3
         prop_names = {p["name"] for p in ps["schema"]}
         assert prop_names == {"layer_height", "wall_thickness", "rel_gap_wall_thickness"}
+
+
+# ── Zip download (gh#339) ───────────────────────────────────────
+
+
+class TestZipDownload:
+    """GH#339 — zip download endpoint for an execution dir."""
+
+    def test_zip_endpoint_returns_zip_with_all_files(
+        self, client, tmp_path, monkeypatch
+    ):
+        from app.core.config import settings
+        from app.services import artifact_service
+
+        monkeypatch.setattr(settings, "ARTIFACTS_BASE_DIR", tmp_path)
+        execution_id, exec_dir = artifact_service.create_execution_dir(
+            "aero-zipper", 501
+        )
+        (exec_dir / "alpha.stl").write_bytes(b"AAA")
+        (exec_dir / "beta.txt").write_text("bb")
+
+        resp = client.get(
+            f"/construction-plans/501/artifacts/{execution_id}/zip"
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.headers["content-type"] == "application/zip"
+        assert "attachment" in resp.headers.get("content-disposition", "")
+
+        import io
+        import zipfile
+
+        with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+            assert sorted(zf.namelist()) == ["alpha.stl", "beta.txt"]
+
+    def test_zip_endpoint_404_for_missing_execution(
+        self, client, tmp_path, monkeypatch
+    ):
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "ARTIFACTS_BASE_DIR", tmp_path)
+        tmp_path.mkdir(exist_ok=True)
+
+        resp = client.get("/construction-plans/9999/artifacts/missing/zip")
+        assert resp.status_code == 404
+
+    def test_zip_endpoint_returns_empty_zip_for_empty_execution(
+        self, client, tmp_path, monkeypatch
+    ):
+        from app.core.config import settings
+        from app.services import artifact_service
+
+        monkeypatch.setattr(settings, "ARTIFACTS_BASE_DIR", tmp_path)
+        execution_id, _ = artifact_service.create_execution_dir("aero-empty", 502)
+
+        resp = client.get(
+            f"/construction-plans/502/artifacts/{execution_id}/zip"
+        )
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "application/zip"
+        import io
+        import zipfile
+
+        with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+            assert zf.namelist() == []

--- a/app/tests/test_construction_plans.py
+++ b/app/tests/test_construction_plans.py
@@ -813,3 +813,123 @@ class TestPlanExecutionPathRegression:
         plan_dir = tmp_path / aero_id / str(plan["id"]) / exec_id
         assert plan_dir.is_dir()
         assert not (tmp_path / "_template_runs" / str(plan["id"])).exists()
+
+
+class TestExecuteStreaming:
+    """gh#339/gh#344 — coverage for the SSE streaming endpoint setup paths.
+
+    Full streaming execution requires cadquery (skipif elsewhere). These
+    tests cover the early-return error paths and the template-branch wiring,
+    which are pure Python and run on every platform.
+    """
+
+    def _consume_events(self, response_iter) -> str:
+        """Collect SSE chunks from an httpx streaming response into one string."""
+        chunks = []
+        for chunk in response_iter:
+            if isinstance(chunk, bytes):
+                chunks.append(chunk.decode("utf-8"))
+            else:
+                chunks.append(chunk)
+        return "".join(chunks)
+
+    def test_stream_unknown_plan_emits_error_event(self, client):
+        with client.stream(
+            "GET",
+            f"/aeroplanes/aero-x/construction-plans/{99999}/execute-stream",
+        ) as resp:
+            assert resp.status_code == 200
+            assert resp.headers["content-type"].startswith("text/event-stream")
+            body = self._consume_events(resp.iter_bytes())
+
+        assert "event: error" in body
+        # The plan_id is part of the lookup error message
+        assert "99999" in body or "not found" in body.lower()
+
+    def test_stream_template_with_unknown_aeroplane_emits_error_event(
+        self, client, monkeypatch, tmp_path
+    ):
+        """Template + valid-UUID aeroplane_id that's not in DB → SSE error."""
+        import uuid
+
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "ARTIFACTS_BASE_DIR", tmp_path)
+
+        template = _create_plan(client, "Tpl Stream", tree=SAMPLE_TREE, plan_type="template")
+        nonexistent_aero = str(uuid.uuid4())  # valid UUID format, not in DB
+
+        with client.stream(
+            "GET",
+            f"/aeroplanes/{nonexistent_aero}/construction-plans/{template['id']}/execute-stream",
+        ) as resp:
+            assert resp.status_code == 200
+            body = self._consume_events(resp.iter_bytes())
+
+        assert "event: error" in body
+        assert "not found" in body.lower() or "aeroplane" in body.lower()
+
+    def test_stream_template_without_any_aeroplane_emits_error(
+        self, client_and_db, monkeypatch, tmp_path
+    ):
+        """Defensive guard: if execute_plan_streaming is called with no
+        aeroplane_id (neither stored on the plan nor in the request) for a
+        template, it must emit an SSE error rather than crash. This branch
+        is unreachable via the REST URL endpoint (which requires aeroplane_id
+        in the path) so we exercise the service directly.
+        """
+        from app.core.config import settings
+        from app.services import construction_plan_service as svc
+        from app.schemas.construction_plan import ExecuteRequest
+
+        monkeypatch.setattr(settings, "ARTIFACTS_BASE_DIR", tmp_path)
+        client, SessionLocal = client_and_db
+
+        # Create a template via REST so the DB has a row
+        template = _create_plan(
+            client, "Tpl Direct", tree=SAMPLE_TREE, plan_type="template",
+        )
+
+        with SessionLocal() as session:
+            events = list(
+                svc.execute_plan_streaming(
+                    session,
+                    template["id"],
+                    ExecuteRequest(aeroplane_id=None),
+                )
+            )
+
+        assert any("event: error" in e for e in events)
+        assert any("aeroplane_id required for template execution" in e for e in events)
+
+    @pytest.mark.skipif(not _can_import_cad(), reason="cadquery not available")
+    def test_stream_template_branch_creates_template_run_dir(
+        self, client, client_and_db, monkeypatch, tmp_path
+    ):
+        """Pin that the streaming endpoint routes templates to _template_runs/."""
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "ARTIFACTS_BASE_DIR", tmp_path)
+        _, SessionLocal = client_and_db
+        from app.tests.conftest import make_aeroplane
+
+        with SessionLocal() as session:
+            aero = make_aeroplane(session, name="for-stream-tpl")
+            aero_id = str(aero.uuid)
+
+        template = _create_plan(
+            client, "Tpl Stream Real", tree=SAMPLE_TREE, plan_type="template",
+        )
+
+        with client.stream(
+            "GET",
+            f"/aeroplanes/{aero_id}/construction-plans/{template['id']}/execute-stream",
+        ) as resp:
+            assert resp.status_code == 200
+            self._consume_events(resp.iter_bytes())
+
+        # An execution dir exists under _template_runs/<template_id>/
+        tpl_root = tmp_path / "_template_runs" / str(template["id"])
+        assert tpl_root.is_dir()
+        children = list(tpl_root.iterdir())
+        assert len(children) == 1, "exactly one execution dir per template (replace-on-next-run)"

--- a/frontend/__tests__/ExecutionResultDialog.test.tsx
+++ b/frontend/__tests__/ExecutionResultDialog.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for ExecutionResultDialog Generated-files section (gh#339).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+// Mock three-cad-viewer so the dialog body's CadViewer renders without
+// pulling in WebGL/three modules in jsdom.
+vi.mock("three-cad-viewer", () => ({
+  Display: class {
+    constructor() {}
+    dispose() {}
+  },
+  Viewer: class {
+    constructor() {}
+    render() {}
+    dispose() {}
+    resize() {}
+  },
+}));
+
+// Mock useArtifactFiles so the dialog can render without a real backend.
+vi.mock("@/hooks/useConstructionPlans", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/hooks/useConstructionPlans")
+  >("@/hooks/useConstructionPlans");
+  return {
+    ...actual,
+    useArtifactFiles: vi.fn(),
+  };
+});
+
+import { useArtifactFiles } from "@/hooks/useConstructionPlans";
+import { ExecutionResultDialog } from "@/components/workbench/construction-plans/ExecutionResultDialog";
+
+describe("ExecutionResultDialog — Generated files section", () => {
+  beforeEach(() => {
+    vi.mocked(useArtifactFiles).mockReset();
+    // jsdom does not implement HTMLDialogElement APIs by default
+    if (
+      !(HTMLDialogElement.prototype as unknown as { showModal?: () => void })
+        .showModal
+    ) {
+      Object.defineProperty(HTMLDialogElement.prototype, "showModal", {
+        configurable: true,
+        value: function () {
+          this.open = true;
+        },
+      });
+      Object.defineProperty(HTMLDialogElement.prototype, "close", {
+        configurable: true,
+        value: function () {
+          this.open = false;
+        },
+      });
+    }
+  });
+
+  it("renders the file list when files are returned", async () => {
+    vi.mocked(useArtifactFiles).mockReturnValue({
+      files: [
+        { name: "wing.stl", is_dir: false, size_bytes: 1024, modified: "" },
+        { name: "fuselage.stp", is_dir: false, size_bytes: 2048, modified: "" },
+      ],
+      error: null,
+      isLoading: false,
+      mutate: vi.fn(),
+    } as unknown as ReturnType<typeof useArtifactFiles>);
+
+    render(
+      <ExecutionResultDialog
+        open
+        title="Test"
+        planId={42}
+        result={{
+          status: "success",
+          shape_keys: [],
+          export_paths: [],
+          error: null,
+          duration_ms: 100,
+          tessellation: null,
+          artifact_dir: "/tmp/x",
+          execution_id: "exec-1",
+        }}
+        onClose={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("wing.stl")).toBeInTheDocument();
+      expect(screen.getByText("fuselage.stp")).toBeInTheDocument();
+    });
+  });
+
+  it("renders an empty state when no files were generated", async () => {
+    vi.mocked(useArtifactFiles).mockReturnValue({
+      files: [],
+      error: null,
+      isLoading: false,
+      mutate: vi.fn(),
+    } as unknown as ReturnType<typeof useArtifactFiles>);
+
+    render(
+      <ExecutionResultDialog
+        open
+        title="Test"
+        planId={42}
+        result={{
+          status: "success",
+          shape_keys: [],
+          export_paths: [],
+          error: null,
+          duration_ms: 100,
+          tessellation: null,
+          artifact_dir: "/tmp/x",
+          execution_id: "exec-1",
+        }}
+        onClose={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/no files generated/i)).toBeInTheDocument();
+    });
+  });
+
+  it("renders a Download zip link with the correct URL", async () => {
+    vi.mocked(useArtifactFiles).mockReturnValue({
+      files: [{ name: "a.stl", is_dir: false, size_bytes: 4, modified: "" }],
+      error: null,
+      isLoading: false,
+      mutate: vi.fn(),
+    } as unknown as ReturnType<typeof useArtifactFiles>);
+
+    render(
+      <ExecutionResultDialog
+        open
+        title="Test"
+        planId={42}
+        result={{
+          status: "success",
+          shape_keys: [],
+          export_paths: [],
+          error: null,
+          duration_ms: 100,
+          tessellation: null,
+          artifact_dir: "/tmp/x",
+          execution_id: "exec-99",
+        }}
+        onClose={() => {}}
+      />,
+    );
+
+    const zipLink = await screen.findByRole("link", { name: /download zip/i });
+    expect(zipLink.getAttribute("href")).toContain(
+      "/construction-plans/42/artifacts/exec-99/zip",
+    );
+  });
+});

--- a/frontend/__tests__/ExecutionResultDialog.test.tsx
+++ b/frontend/__tests__/ExecutionResultDialog.test.tsx
@@ -157,4 +157,132 @@ describe("ExecutionResultDialog — Generated files section", () => {
       "/construction-plans/42/artifacts/exec-99/zip",
     );
   });
+
+  it("gh#344: shows Download zip even when no files are generated", async () => {
+    vi.mocked(useArtifactFiles).mockReturnValue({
+      files: [],
+      error: null,
+      isLoading: false,
+      mutate: vi.fn(),
+    } as unknown as ReturnType<typeof useArtifactFiles>);
+
+    render(
+      <ExecutionResultDialog
+        open
+        title="Test"
+        planId={42}
+        result={{
+          status: "success",
+          shape_keys: [],
+          export_paths: [],
+          error: null,
+          duration_ms: 100,
+          tessellation: null,
+          artifact_dir: "/tmp/x",
+          execution_id: "exec-empty",
+        }}
+        onClose={() => {}}
+      />,
+    );
+
+    // The zip link MUST be present even when the file list is empty —
+    // the user must always have a download path on a successful execution.
+    const zipLink = await screen.findByRole("link", { name: /download zip/i });
+    expect(zipLink.getAttribute("href")).toContain(
+      "/construction-plans/42/artifacts/exec-empty/zip",
+    );
+  });
+
+  it("gh#344: renders nested file paths returned by the recursive listing", async () => {
+    // Recursive listing puts subdir files in the flat list with relative
+    // path in the `name` field — this is the bug fix from gh#344.
+    vi.mocked(useArtifactFiles).mockReturnValue({
+      files: [
+        {
+          name: "wing/export_stl_main_wing.loft.stl",
+          is_dir: false,
+          size_bytes: 4096,
+          modified: "",
+        },
+        {
+          name: "fuselage/body.stp",
+          is_dir: false,
+          size_bytes: 8192,
+          modified: "",
+        },
+      ],
+      error: null,
+      isLoading: false,
+      mutate: vi.fn(),
+    } as unknown as ReturnType<typeof useArtifactFiles>);
+
+    render(
+      <ExecutionResultDialog
+        open
+        title="Test"
+        planId={42}
+        result={{
+          status: "success",
+          shape_keys: [],
+          export_paths: [],
+          error: null,
+          duration_ms: 100,
+          tessellation: null,
+          artifact_dir: "/tmp/x",
+          execution_id: "exec-nested",
+        }}
+        onClose={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("wing/export_stl_main_wing.loft.stl"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("fuselage/body.stp")).toBeInTheDocument();
+    });
+
+    // Verify the download link preserves the relative path
+    const wingLink = screen.getByText("wing/export_stl_main_wing.loft.stl");
+    expect(wingLink.getAttribute("href")).toContain(
+      "/artifacts/exec-nested/wing/export_stl_main_wing.loft.stl",
+    );
+  });
+
+  it("gh#344: useArtifactFiles is called with recursive=true", async () => {
+    vi.mocked(useArtifactFiles).mockReturnValue({
+      files: [],
+      error: null,
+      isLoading: false,
+      mutate: vi.fn(),
+    } as unknown as ReturnType<typeof useArtifactFiles>);
+
+    render(
+      <ExecutionResultDialog
+        open
+        title="Test"
+        planId={42}
+        result={{
+          status: "success",
+          shape_keys: [],
+          export_paths: [],
+          error: null,
+          duration_ms: 100,
+          tessellation: null,
+          artifact_dir: "/tmp/x",
+          execution_id: "exec-r",
+        }}
+        onClose={() => {}}
+      />,
+    );
+
+    // Pin the contract: the dialog asks the hook for a recursive listing
+    // so files in subdirectories are included.
+    expect(vi.mocked(useArtifactFiles)).toHaveBeenCalledWith(
+      42,
+      "exec-r",
+      "",
+      true,
+    );
+  });
 });

--- a/frontend/__tests__/executePlanHook.test.ts
+++ b/frontend/__tests__/executePlanHook.test.ts
@@ -1,0 +1,71 @@
+/**
+ * GH#343 — regression test for the URL the executePlan hook calls.
+ *
+ * The bug: backend was rejecting template execution with 422
+ * "Templates cannot be executed", because the guard was active in the
+ * shared svc.execute_plan service. The frontend executePlan() hook
+ * targets POST /aeroplanes/{aero_id}/construction-plans/{plan_id}/execute
+ * which delegates to the same service.
+ *
+ * This test pins the exact URL/method/body that the frontend issues so
+ * that any future refactor of the contract is caught immediately, before
+ * a manual click-test reveals it.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { executePlan } from "@/hooks/useConstructionPlans";
+
+describe("executePlan hook (gh#343 regression guard)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("POSTs to /aeroplanes/{aero_id}/construction-plans/{plan_id}/execute with empty body", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: "success",
+          shape_keys: [],
+          duration_ms: 12,
+          tessellation: null,
+          artifact_dir: "/tmp/x",
+          execution_id: "exec-1",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const result = await executePlan("389b5778-54cc-484e-a2db-46f18e448f00", 27);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain(
+      "/aeroplanes/389b5778-54cc-484e-a2db-46f18e448f00/construction-plans/27/execute",
+    );
+    expect(init).toMatchObject({
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+    expect(result.status).toBe("success");
+  });
+
+  it("surfaces a backend 422 (e.g. template-guard regression) as a thrown error", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({ detail: "Templates cannot be executed. Instantiate as a plan first." }),
+        { status: 422, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await expect(executePlan("aero-x", 27)).rejects.toThrow(/422/);
+  });
+
+});

--- a/frontend/__tests__/executePlanHook.test.ts
+++ b/frontend/__tests__/executePlanHook.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { executePlan } from "@/hooks/useConstructionPlans";
+import { executePlan, executionZipUrl } from "@/hooks/useConstructionPlans";
 
 describe("executePlan hook (gh#343 regression guard)", () => {
   let fetchMock: ReturnType<typeof vi.fn>;
@@ -67,5 +67,19 @@ describe("executePlan hook (gh#343 regression guard)", () => {
 
     await expect(executePlan("aero-x", 27)).rejects.toThrow(/422/);
   });
+});
 
+describe("executionZipUrl helper (gh#339)", () => {
+  it("returns the /zip endpoint URL for a plan/execution pair", () => {
+    const url = executionZipUrl(42, "20260426T094402Z");
+
+    expect(url).toContain("/construction-plans/42/artifacts/");
+    expect(url).toContain("/zip");
+    expect(url).toMatch(/\/artifacts\/20260426T094402Z\/zip$/);
+  });
+
+  it("URL-encodes the execution_id", () => {
+    const url = executionZipUrl(7, "exec id with spaces");
+    expect(url).toContain("exec%20id%20with%20spaces");
+  });
 });

--- a/frontend/app/workbench/construction-plans/page.tsx
+++ b/frontend/app/workbench/construction-plans/page.tsx
@@ -113,6 +113,10 @@ export default function ConstructionPlansPage() {
   const [executionTitle, setExecutionTitle] = useState("");
   const [executionDialogOpen, setExecutionDialogOpen] = useState(false);
   const [executionStreamUrl, setExecutionStreamUrl] = useState<string | null>(null);
+  // Plan/template id whose execution is currently displayed in the result
+  // dialog. Used to wire the Generated-files section to the right artifact
+  // endpoints (gh#339).
+  const [executionPlanId, setExecutionPlanId] = useState<number | null>(null);
 
   // Artifact browser state
   const [artifactsPlanId, setArtifactsPlanId] = useState<number | null>(null);
@@ -172,6 +176,7 @@ export default function ConstructionPlansPage() {
       }
       setExecutionTitle(`Execute: ${planName}`);
       setExecutionResult(null);
+      setExecutionPlanId(planId);
       // Use streaming endpoint — viewer opens immediately, shapes appear incrementally
       setExecutionStreamUrl(executeStreamUrl(aeroplaneId, planId));
       setExecutionDialogOpen(true);
@@ -391,6 +396,7 @@ export default function ConstructionPlansPage() {
       }
       setExecutionTitle(`Execute: ${tpl?.name ?? "template"} on ${aero?.name ?? "aeroplane"}`);
       setExecutionResult(null);
+      setExecutionPlanId(executeTemplateId);
       setExecutionDialogOpen(true);
       setExecuteTemplateId(null);
       try {
@@ -563,15 +569,19 @@ export default function ConstructionPlansPage() {
                         if (!aeroplaneId || plans.length === 0) return;
                         setExecutionTitle(`Execute all plans (${plans.length})`);
                         setExecutionResult(null);
+                        setExecutionPlanId(null);
                         setExecutionDialogOpen(true);
                         try {
                           // Execute sequentially; show result of last successful execution
                           let lastResult: ExecutionResult | null = null;
+                          let lastPlanId: number | null = null;
                           for (const p of plans) {
                             lastResult = await executePlan(aeroplaneId, p.id);
+                            lastPlanId = p.id;
                             if (lastResult.status === "error") break;
                           }
                           setExecutionResult(lastResult);
+                          setExecutionPlanId(lastPlanId);
                         } catch (err) {
                           setExecutionResult({
                             status: "error",
@@ -707,10 +717,12 @@ export default function ConstructionPlansPage() {
         title={executionTitle}
         result={executionResult}
         streamUrl={executionStreamUrl}
+        planId={executionPlanId}
         onClose={() => {
           setExecutionDialogOpen(false);
           setExecutionResult(null);
           setExecutionStreamUrl(null);
+          setExecutionPlanId(null);
         }}
       />
 

--- a/frontend/components/workbench/construction-plans/ExecutionResultDialog.tsx
+++ b/frontend/components/workbench/construction-plans/ExecutionResultDialog.tsx
@@ -211,11 +211,12 @@ function GeneratedFilesSection({
   planId,
   executionId,
 }: Readonly<{ planId: number | null; executionId: string | null }>) {
-  const { files, isLoading } = useArtifactFiles(planId, executionId);
+  // Recursive listing — exporters typically write into subdirectories
+  // (e.g. wing/foo.stl), and the post-execution view should show every
+  // generated file flat with its relative path.
+  const { files, isLoading } = useArtifactFiles(planId, executionId, "", true);
 
   if (planId == null || executionId == null) return null;
-
-  const visibleFiles = files.filter((f) => !f.is_dir);
 
   return (
     <div className="border-t border-border px-6 py-4">
@@ -224,23 +225,23 @@ function GeneratedFilesSection({
           Generated files
         </span>
         <span className="flex-1" />
-        {visibleFiles.length > 0 && (
-          <a
-            href={executionZipUrl(planId, executionId)}
-            className="font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-primary hover:underline"
-            download
-          >
-            Download zip
-          </a>
-        )}
+        {/* Always show the zip download on a successful execution; the
+            backend returns an empty zip for empty exec dirs, never 404. */}
+        <a
+          href={executionZipUrl(planId, executionId)}
+          className="font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-primary hover:underline"
+          download
+        >
+          Download zip
+        </a>
       </div>
       {isLoading ? (
         <p className="text-[12px] text-muted-foreground">Loading files...</p>
-      ) : visibleFiles.length === 0 ? (
+      ) : files.length === 0 ? (
         <p className="text-[12px] text-muted-foreground">No files generated.</p>
       ) : (
         <ul className="flex max-h-32 flex-col gap-1 overflow-y-auto">
-          {visibleFiles.map((f) => (
+          {files.map((f) => (
             <li key={f.name} className="flex items-center gap-2 text-[12px]">
               <a
                 href={artifactDownloadUrl(planId, executionId, f.name)}

--- a/frontend/components/workbench/construction-plans/ExecutionResultDialog.tsx
+++ b/frontend/components/workbench/construction-plans/ExecutionResultDialog.tsx
@@ -121,11 +121,14 @@ export function ExecutionResultDialog({
 
   const isStreaming = !!streamUrl;
   const parts = isStreaming ? streamedParts : nonStreamParts;
-  const effectiveStatus = isStreaming ? status : (preResult ? preResult.status : "executing");
+  const preResultStatus = preResult ? preResult.status : "executing";
+  const effectiveStatus = isStreaming ? status : preResultStatus;
   const effectiveError = isStreaming ? error : preResult?.error;
-  const effectiveInfo = isStreaming
-    ? info
-    : (preResult?.status === "success" ? `${preResult.shape_keys?.length ?? 0} shapes · ${preResult.duration_ms} ms` : "");
+  const preResultInfo =
+    preResult?.status === "success"
+      ? `${preResult.shape_keys?.length ?? 0} shapes · ${preResult.duration_ms} ms`
+      : "";
+  const effectiveInfo = isStreaming ? info : preResultInfo;
   const effectiveExecutionId = isStreaming
     ? streamedExecutionId
     : (preResult?.execution_id ?? executionId ?? null);
@@ -235,28 +238,49 @@ function GeneratedFilesSection({
           Download zip
         </a>
       </div>
-      {isLoading ? (
-        <p className="text-[12px] text-muted-foreground">Loading files...</p>
-      ) : files.length === 0 ? (
-        <p className="text-[12px] text-muted-foreground">No files generated.</p>
-      ) : (
-        <ul className="flex max-h-32 flex-col gap-1 overflow-y-auto">
-          {files.map((f) => (
-            <li key={f.name} className="flex items-center gap-2 text-[12px]">
-              <a
-                href={artifactDownloadUrl(planId, executionId, f.name)}
-                className="text-primary hover:underline"
-                download
-              >
-                {f.name}
-              </a>
-              <span className="text-muted-foreground">
-                ({Math.max(1, Math.round(f.size_bytes / 1024))} KB)
-              </span>
-            </li>
-          ))}
-        </ul>
-      )}
+      <FileListBody
+        planId={planId}
+        executionId={executionId}
+        files={files}
+        isLoading={isLoading}
+      />
     </div>
+  );
+}
+
+function FileListBody({
+  planId,
+  executionId,
+  files,
+  isLoading,
+}: Readonly<{
+  planId: number;
+  executionId: string;
+  files: { name: string; size_bytes: number; is_dir: boolean; modified: string }[];
+  isLoading: boolean;
+}>) {
+  if (isLoading) {
+    return <p className="text-[12px] text-muted-foreground">Loading files...</p>;
+  }
+  if (files.length === 0) {
+    return <p className="text-[12px] text-muted-foreground">No files generated.</p>;
+  }
+  return (
+    <ul className="flex max-h-32 flex-col gap-1 overflow-y-auto">
+      {files.map((f) => (
+        <li key={f.name} className="flex items-center gap-2 text-[12px]">
+          <a
+            href={artifactDownloadUrl(planId, executionId, f.name)}
+            className="text-primary hover:underline"
+            download
+          >
+            {f.name}
+          </a>
+          <span className="text-muted-foreground">
+            ({Math.max(1, Math.round(f.size_bytes / 1024))} KB)
+          </span>
+        </li>
+      ))}
+    </ul>
   );
 }

--- a/frontend/components/workbench/construction-plans/ExecutionResultDialog.tsx
+++ b/frontend/components/workbench/construction-plans/ExecutionResultDialog.tsx
@@ -4,6 +4,11 @@ import { useEffect, useState, useRef } from "react";
 import { X } from "lucide-react";
 import { useDialog } from "@/hooks/useDialog";
 import { CadViewer } from "@/components/workbench/CadViewer";
+import {
+  artifactDownloadUrl,
+  executionZipUrl,
+  useArtifactFiles,
+} from "@/hooks/useConstructionPlans";
 import type { ExecutionResult } from "@/hooks/useConstructionPlans";
 
 interface ExecutionResultDialogProps {
@@ -13,6 +18,10 @@ interface ExecutionResultDialogProps {
   result?: ExecutionResult | null;
   /** SSE URL for streaming mode. When set, streams shapes incrementally. */
   streamUrl?: string | null;
+  /** Plan/template id for the artifact endpoints. */
+  planId?: number | null;
+  /** Execution id (resolved from result or streamed 'complete' event). */
+  executionId?: string | null;
   onClose: () => void;
 }
 
@@ -21,6 +30,8 @@ export function ExecutionResultDialog({
   title,
   result: preResult,
   streamUrl,
+  planId,
+  executionId,
   onClose,
 }: Readonly<ExecutionResultDialogProps>) {
   const { dialogRef, handleClose } = useDialog(open, onClose);
@@ -28,6 +39,9 @@ export function ExecutionResultDialog({
   const [status, setStatus] = useState<"executing" | "success" | "error">("executing");
   const [error, setError] = useState<string | null>(null);
   const [info, setInfo] = useState<string>("");
+  const [streamedExecutionId, setStreamedExecutionId] = useState<string | null>(
+    null,
+  );
   const eventSourceRef = useRef<EventSource | null>(null);
 
   // SSE streaming
@@ -37,6 +51,7 @@ export function ExecutionResultDialog({
     setStatus("executing");
     setError(null);
     setInfo("");
+    setStreamedExecutionId(null);
 
     const es = new EventSource(streamUrl);
     eventSourceRef.current = es;
@@ -61,6 +76,7 @@ export function ExecutionResultDialog({
         const data = JSON.parse(e.data);
         setStatus("success");
         setInfo(`${data.shape_keys?.length ?? 0} shapes · ${data.duration_ms} ms`);
+        if (data.execution_id) setStreamedExecutionId(data.execution_id);
         if (data.tessellation) {
           setStreamedParts([data.tessellation]);
         }
@@ -110,6 +126,9 @@ export function ExecutionResultDialog({
   const effectiveInfo = isStreaming
     ? info
     : (preResult?.status === "success" ? `${preResult.shape_keys?.length ?? 0} shapes · ${preResult.duration_ms} ms` : "");
+  const effectiveExecutionId = isStreaming
+    ? streamedExecutionId
+    : (preResult?.execution_id ?? executionId ?? null);
 
   return (
     <dialog
@@ -175,8 +194,68 @@ export function ExecutionResultDialog({
               </div>
             )}
           </div>
+
+          {effectiveStatus === "success" && (
+            <GeneratedFilesSection
+              planId={planId ?? null}
+              executionId={effectiveExecutionId}
+            />
+          )}
         </div>
       )}
     </dialog>
+  );
+}
+
+function GeneratedFilesSection({
+  planId,
+  executionId,
+}: Readonly<{ planId: number | null; executionId: string | null }>) {
+  const { files, isLoading } = useArtifactFiles(planId, executionId);
+
+  if (planId == null || executionId == null) return null;
+
+  const visibleFiles = files.filter((f) => !f.is_dir);
+
+  return (
+    <div className="border-t border-border px-6 py-4">
+      <div className="mb-2 flex items-center gap-3">
+        <span className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-muted-foreground">
+          Generated files
+        </span>
+        <span className="flex-1" />
+        {visibleFiles.length > 0 && (
+          <a
+            href={executionZipUrl(planId, executionId)}
+            className="font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-primary hover:underline"
+            download
+          >
+            Download zip
+          </a>
+        )}
+      </div>
+      {isLoading ? (
+        <p className="text-[12px] text-muted-foreground">Loading files...</p>
+      ) : visibleFiles.length === 0 ? (
+        <p className="text-[12px] text-muted-foreground">No files generated.</p>
+      ) : (
+        <ul className="flex max-h-32 flex-col gap-1 overflow-y-auto">
+          {visibleFiles.map((f) => (
+            <li key={f.name} className="flex items-center gap-2 text-[12px]">
+              <a
+                href={artifactDownloadUrl(planId, executionId, f.name)}
+                className="text-primary hover:underline"
+                download
+              >
+                {f.name}
+              </a>
+              <span className="text-muted-foreground">
+                ({Math.max(1, Math.round(f.size_bytes / 1024))} KB)
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
   );
 }

--- a/frontend/hooks/useConstructionPlans.ts
+++ b/frontend/hooks/useConstructionPlans.ts
@@ -63,8 +63,16 @@ export function usePlanArtifacts(planId: number | null) {
   };
 }
 
-export function useArtifactFiles(planId: number | null, executionId: string | null, subpath: string = "") {
-  const query = subpath ? `?subpath=${encodeURIComponent(subpath)}` : "";
+export function useArtifactFiles(
+  planId: number | null,
+  executionId: string | null,
+  subpath: string = "",
+  recursive: boolean = false,
+) {
+  const params = new URLSearchParams();
+  if (subpath) params.set("subpath", subpath);
+  if (recursive) params.set("recursive", "true");
+  const query = params.toString() ? `?${params.toString()}` : "";
   const { data, error, isLoading, mutate } = useSWR<ArtifactFile[]>(
     planId && executionId
       ? `/construction-plans/${planId}/artifacts/${executionId}${query}`

--- a/frontend/hooks/useConstructionPlans.ts
+++ b/frontend/hooks/useConstructionPlans.ts
@@ -116,6 +116,10 @@ export function artifactDownloadUrl(
   return `${API_BASE}/construction-plans/${planId}/artifacts/${executionId}/${encodedPath}`;
 }
 
+export function executionZipUrl(planId: number, executionId: string): string {
+  return `${API_BASE}/construction-plans/${planId}/artifacts/${encodeURIComponent(executionId)}/zip`;
+}
+
 export function useConstructionPlans(planType?: string) {
   const path = planType
     ? `/construction-plans?plan_type=${planType}`


### PR DESCRIPTION
## Summary
- Removes execute-guards in `execute_plan` / `execute_plan_streaming` (was: `ValidationError("Templates cannot be executed.")`).
- Routes template runs to `<ARTIFACTS_BASE_DIR>/_template_runs/<template_id>/<exec_id>/` with replace-on-next-run lifecycle.
- Adds `GET /construction-plans/{plan_id}/artifacts/{execution_id}/zip` for zip-all download.
- Extends `ExecutionResultDialog` with a Generated-files section (individual download + zip).
- Plan executions are unchanged (regression test included).

Spec: `docs/superpowers/specs/2026-04-26-template-execution-design.md`
Plan: `docs/superpowers/plans/2026-04-26-template-execution.md`

Closes #339

## Test plan
- [x] Backend unit tests for artifact_service helpers
- [x] Backend integration tests for template execute, zip download, plan-path-unchanged
- [x] Frontend unit tests for the Generated-files section (3/3 pass)
- [ ] Manual smoke: template Play → file list → individual + zip download (skipped — see "Deviations")
- [ ] Manual smoke: replace-on-next-run wipes previous template execution dir (skipped — covered by integration test)
- [ ] Manual smoke: plan execution path unchanged (skipped — covered by regression test)

## Implementation deviations from plan
- **`new_execution_id()` was extended with a same-second collision suffix.** The original test `test_wipes_previous_template_run` was logically unsatisfiable when the wipe + recreate happened in the same UTC second (both runs got identical execution_ids). Added a process-local counter so consecutive calls in the same second return distinct ids (`...Z`, `...Z-1`, `...Z-2`).
- **`ExecuteRequest.aeroplane_id` relaxed to `Optional[str]`.** The plan's test `test_execute_template_without_aeroplane_id_returns_422` expected a flat-string `detail` from the service-level guard; FastAPI's auto-422 from required-field validation returns a list, breaking the assertion. Making it Optional pushes validation to the service layer (where the guard already lives) and yields a friendly error message. Backwards-compatible: existing callers that send `aeroplane_id` unchanged.
- **Browser smoke test skipped.** The agent environment does not support running the dev server + browser. The behaviors that the smoke test would validate are covered by the unit tests (file list rendering, empty state, zip URL construction) and the backend integration tests (replace-on-next-run, plan path regression). Recommend a manual smoke test before approving the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)