### PR TITLE
fix(gh-345): style CAD viewer chrome to match dark theme

### DIFF
--- a/frontend/__tests__/CadViewer.test.tsx
+++ b/frontend/__tests__/CadViewer.test.tsx
@@ -83,7 +83,7 @@ describe("CadViewer", () => {
     mockDispose.mockClear();
   });
 
-  it("passes glass:false and tools:false to Display constructor", async () => {
+  it("passes glass:false and tools:true to Display constructor (gh#345)", async () => {
     await act(async () => {
       render(<CadViewer parts={[SAMPLE_SHAPES as unknown as Record<string, unknown>]} />);
     });
@@ -94,10 +94,12 @@ describe("CadViewer", () => {
 
     expect(lastDisplayOptions).not.toBeNull();
     expect(lastDisplayOptions!.glass).toBe(false);
-    expect(lastDisplayOptions!.tools).toBe(false);
+    // gh#345: tools enabled so the user gets the toolbar (axes/grid
+    // toggles, view-cube, camera presets). Was false (broken UX).
+    expect(lastDisplayOptions!.tools).toBe(true);
   });
 
-  it("passes theme:dark and treeWidth:0 to Display", async () => {
+  it("passes theme:dark and a non-zero treeWidth to Display (gh#345)", async () => {
     await act(async () => {
       render(<CadViewer parts={[SAMPLE_SHAPES as unknown as Record<string, unknown>]} />);
     });
@@ -106,7 +108,9 @@ describe("CadViewer", () => {
     });
 
     expect(lastDisplayOptions!.theme).toBe("dark");
-    expect(lastDisplayOptions!.treeWidth).toBe(0);
+    // gh#345: treeWidth must be > 0 so the Tree/Clipping/Material tabs
+    // are actually rendered. Was 0 (broken UX).
+    expect(lastDisplayOptions!.treeWidth).toBeGreaterThan(0);
   });
 
   it("passes target and up to Viewer constructor", async () => {

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -66,3 +66,43 @@ body {
 *::-webkit-scrollbar-thumb:hover {
   background: var(--color-muted-foreground);
 }
+
+/* gh#345: bind three-cad-viewer's CSS variables to our da3Dalus.pen
+   design tokens so the viewer's toolbar / tabs / tree panel match the
+   app's dark theme regardless of which theme the library defaults to.
+
+   Selector specificity matters here: the library defines its variables
+   under `[data-theme="light"]` / `[data-theme="dark"]` and sets
+   data-theme on both the container (= our .cad-viewer-host) and on
+   document.body. To beat that we match BOTH the container itself and
+   anything inside it where data-theme has been applied, with !important
+   on each var so the cascade order between globals.css and the lib's
+   stylesheet is irrelevant. */
+.cad-viewer-host,
+.cad-viewer-host[data-theme],
+.cad-viewer-host *[data-theme] {
+  --tcv-font-color: var(--color-foreground) !important;
+  --tcv-bg-color: var(--color-card) !important;
+  --tcv-bg-overlay-color: rgba(26, 26, 26, 0.85) !important;
+  --tcv-bg-overlay-rest-color: rgba(26, 26, 26, 0.2) !important;
+  --tcv-bg-highlight-color: var(--color-sidebar-accent) !important;
+  --tcv-bg-pressed-color: var(--color-border) !important;
+  --tcv-bg-pressed-border-color: var(--color-border-strong) !important;
+  --tcv-bg-tooltip-color: var(--color-card-muted) !important;
+  --tcv-theme-blue: var(--color-primary) !important;
+  --tcv-theme-led: var(--color-primary) !important;
+  --tcv-shadow: rgba(0, 0, 0, 0.6) !important;
+  --tcv-menu-shadow: rgba(0, 0, 0, 0.4) !important;
+  --tcv-scrollbar-hover: rgba(255, 255, 255, 0.4) !important;
+  --tcv-scrollbar-active: rgba(255, 255, 255, 0.6) !important;
+  --tcv-scrollbar-thumb: rgba(255, 255, 255, 0.15) !important;
+  --tcv-dropdown-bg: var(--color-card-muted) !important;
+}
+
+/* The library sets data-theme on document.body too which cascades the
+   light defaults to everything outside the viewer. Reset within our
+   viewer container so the lib's body-level vars never leak in. */
+.cad-viewer-host {
+  background: var(--color-card);
+  color: var(--color-foreground);
+}

--- a/frontend/components/workbench/CadViewer.tsx
+++ b/frontend/components/workbench/CadViewer.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+// gh#345: ship the library's own CSS so the toolbar + tabs render
+// as styled controls instead of bare text labels.
+import "three-cad-viewer/css";
 
 interface CadViewerProps {
   /** One or more tessellation results to render. Each is a single-wing
@@ -98,13 +101,18 @@ export function CadViewer({ parts }: Readonly<CadViewerProps>) {
         const w = container.clientWidth || 800;
         const h = container.clientHeight || 500;
 
+        // gh#345: enable the toolbar and tree panel so the user can
+        // toggle axes/grid, switch to perspective/orthographic, change
+        // view presets, and inspect the scene tree. The library's CSS
+        // (imported at the top of this file) handles the layout.
+        const treeWidth = 200;
         const display = new tcv.Display(container, {
-          cadWidth: w,
+          cadWidth: Math.max(0, w - treeWidth),
           height: h,
-          treeWidth: 0,
+          treeWidth,
           theme: "dark",
           glass: false,
-          tools: false,
+          tools: true,
         });
 
         const viewerOptions = { target: [0, 0, 0], up: "Z" };
@@ -181,7 +189,7 @@ export function CadViewer({ parts }: Readonly<CadViewerProps>) {
           </span>
         </div>
       )}
-      <div ref={containerRef} className="h-full w-full" />
+      <div ref={containerRef} className="cad-viewer-host h-full w-full" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- The three-cad-viewer toolbar/tabs/tree previously rendered as raw text labels because the library's stylesheet was never imported — see screenshots in #345.
- Importing the lib's CSS alone gave us the controls but in the lib's default light/grey palette, clashing with the app's dark theme.
- This PR ships the lib's CSS, enables the toolbar (\`tools: true\`) + a 200px tree panel, and binds the lib's \`--tcv-*\` CSS variables to our da3Dalus.pen design tokens so the chrome inherits the app's dark palette + orange accent.

## Changes
- \`CadViewer.tsx\` — \`import "three-cad-viewer/css"\`; \`tools: true\`, \`treeWidth: 200\`; container gets \`cad-viewer-host\` class.
- \`globals.css\` — overrides for all \`--tcv-*\` variables using \`var(--color-card)\`, \`var(--color-foreground)\`, \`var(--color-primary)\`, etc. Selectors cover both \`.cad-viewer-host\` and \`.cad-viewer-host[data-theme]\`/\`*[data-theme]\` descendants with \`!important\` because the library's stylesheet loads after \`globals.css\` (specificity tied at \`(0,1,0)\`).
- \`CadViewer.test.tsx\` — flipped the two assertions that pinned the broken state (\`tools:false\`, \`treeWidth:0\`) to the new contract.

## Test plan
- [x] \`npm run test:unit -- CadViewer\` — 5/5 pass
- [x] \`npm run lint\` — 0 errors (warnings unchanged at 20)
- [x] **Browser smoke** (per CLAUDE.md memory: CadViewer is fragile, real browser verification required) — confirmed by user: toolbar, tabs, tree all render with dark theme + orange accent
- [x] No regressions in other component tests

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)