### PR TITLE
fix(gh-349): allow cross-section CRUD on WC wings

### DIFF
--- a/app/api/v2/endpoints/aeroplane/wings.py
+++ b/app/api/v2/endpoints/aeroplane/wings.py
@@ -393,7 +393,6 @@ async def delete_aeroplane_wing_cross_sections(
         db: Annotated[Session, Depends(get_db)],
 ):
     """Delete all cross-sections of a wing."""
-    _assert_design_model(db, aeroplane_id, wing_name, "asb")
     _call_service(wing_service.delete_all_cross_sections, db, aeroplane_id, wing_name)
     return OperationStatusResponse(status="ok", operation="delete_all_wing_cross_sections")
 
@@ -433,7 +432,6 @@ async def create_aeroplane_wing_cross_section(
         db: Annotated[Session, Depends(get_db)],
 ):
     """Creates a new cross-section for the wing and splice it into the list of cross-sections."""
-    _assert_design_model(db, aeroplane_id, wing_name, "asb")
     _call_service(wing_service.create_cross_section, db, aeroplane_id, wing_name, cross_section_index, request)
     on_wing_changed(db, aeroplane_id, wing_name)
     return OperationStatusResponse(status="created", operation="create_wing_cross_section")
@@ -457,7 +455,6 @@ async def update_aeroplane_wing_cross_section(
         db: Annotated[Session, Depends(get_db)],
 ):
     """Updates the cross-section for the aeroplane."""
-    _assert_design_model(db, aeroplane_id, wing_name, "asb")
     _call_service(wing_service.update_cross_section, db, aeroplane_id, wing_name, cross_section_index, request)
     on_wing_changed(db, aeroplane_id, wing_name)
     return OperationStatusResponse(status="ok", operation="update_wing_cross_section")
@@ -475,7 +472,6 @@ async def delete_aeroplane_wing_cross_section(
         db: Annotated[Session, Depends(get_db)],
 ):
     """Delete a cross-section."""
-    _assert_design_model(db, aeroplane_id, wing_name, "asb")
     _call_service(wing_service.delete_cross_section, db, aeroplane_id, wing_name, cross_section_index)
     on_wing_changed(db, aeroplane_id, wing_name)
     return OperationStatusResponse(status="ok", operation="delete_wing_cross_section")

--- a/app/tests/test_design_model_guards.py
+++ b/app/tests/test_design_model_guards.py
@@ -91,12 +91,12 @@ class TestWcWingGuards:
         assert resp.status_code == 409
         assert "design_model='wc'" in resp.json()["detail"]
 
-    def test_wc_wing_rejects_cross_section_create(self, client):
+    def test_wc_wing_allows_cross_section_create(self, client):
         aid = _create_aeroplane(client, "wc_guard_xsec")
         _create_wc_wing(client, aid)
         xsec = {"xyz_le": [0, 0.3, 0], "chord": 0.1, "twist": 0, "airfoil": "naca0012"}
         resp = client.post(f"/aeroplanes/{aid}/wings/w/cross_sections/0", json=xsec)
-        assert resp.status_code == 409
+        assert resp.status_code == 201
 
     def test_wc_wing_allows_wingconfig_put(self, client):
         aid = _create_aeroplane(client, "wc_guard_wc_put")

--- a/app/tests/test_wc_wing_xsec_crud.py
+++ b/app/tests/test_wc_wing_xsec_crud.py
@@ -1,0 +1,105 @@
+"""Tests for cross-section CRUD on WC-mode wings (gh-349).
+
+Verifies that adding, deleting, and bulk-deleting cross-sections works
+on wings with design_model='wc', not just 'asb'.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+airfoil_path = str(
+    (Path(__file__).resolve().parents[2] / "components" / "airfoils" / "mh32.dat").resolve()
+)
+
+
+@pytest.fixture()
+def client(client_and_db):
+    c, _ = client_and_db
+    yield c
+
+
+def _seed_wc_wing(client: TestClient, name: str = "wc_test") -> str:
+    """Create an aeroplane with a WC wing (design_model='wc')."""
+    resp = client.post("/aeroplanes", params={"name": name})
+    assert resp.status_code == 201
+    aeroplane_id = resp.json()["id"]
+
+    wc = {
+        "segments": [
+            {
+                "root_airfoil": {"airfoil": airfoil_path, "chord": 150.0, "incidence": 0},
+                "tip_airfoil": {"airfoil": airfoil_path, "chord": 120.0, "incidence": 0},
+                "length": 500.0,
+                "sweep": 10.0,
+                "number_interpolation_points": 101,
+                "spare_list": [],
+            }
+        ],
+        "nose_pnt": [0, 0, 0],
+    }
+    resp = client.post(f"/aeroplanes/{aeroplane_id}/wings/w/from-wingconfig", json=wc)
+    assert resp.status_code == 201, resp.text
+    return aeroplane_id
+
+
+class TestWcWingXsecCrud:
+
+    def test_add_cross_section_to_wc_wing(self, client):
+        aid = _seed_wc_wing(client, "wc_add")
+        new_xsec = {
+            "xyz_le": [0, 0.6, 0],
+            "chord": 0.1,
+            "twist": 0,
+            "airfoil": "naca0012",
+        }
+        resp = client.post(f"/aeroplanes/{aid}/wings/w/cross_sections/2", json=new_xsec)
+        assert resp.status_code == 201, f"Expected 201, got {resp.status_code}: {resp.text}"
+
+        resp = client.get(f"/aeroplanes/{aid}/wings/w/cross_sections")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 3
+
+    def test_delete_cross_section_from_wc_wing(self, client):
+        aid = _seed_wc_wing(client, "wc_del")
+        resp = client.get(f"/aeroplanes/{aid}/wings/w/cross_sections")
+        assert len(resp.json()) == 2
+
+        resp = client.delete(f"/aeroplanes/{aid}/wings/w/cross_sections/1")
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+
+        resp = client.get(f"/aeroplanes/{aid}/wings/w/cross_sections")
+        assert len(resp.json()) == 1
+
+    def test_delete_all_cross_sections_from_wc_wing(self, client):
+        aid = _seed_wc_wing(client, "wc_del_all")
+        resp = client.delete(f"/aeroplanes/{aid}/wings/w/cross_sections")
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+
+    def test_update_cross_section_on_wc_wing(self, client):
+        aid = _seed_wc_wing(client, "wc_update")
+        updated_xsec = {
+            "xyz_le": [0, 0, 0],
+            "chord": 0.2,
+            "twist": 2.0,
+            "airfoil": "naca2412",
+        }
+        resp = client.put(f"/aeroplanes/{aid}/wings/w/cross_sections/0", json=updated_xsec)
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+
+    def test_insert_cross_section_into_wc_wing(self, client):
+        aid = _seed_wc_wing(client, "wc_insert")
+        new_xsec = {
+            "xyz_le": [0, 0.25, 0],
+            "chord": 0.135,
+            "twist": 0,
+            "airfoil": "naca0012",
+        }
+        resp = client.post(f"/aeroplanes/{aid}/wings/w/cross_sections/1", json=new_xsec)
+        assert resp.status_code == 201, f"Expected 201, got {resp.status_code}: {resp.text}"
+
+        resp = client.get(f"/aeroplanes/{aid}/wings/w/cross_sections")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 3


### PR DESCRIPTION
## Summary

- Remove `_assert_design_model("asb")` guard from 3 cross-section topology endpoints (create, delete, delete-all) — the service layer is model-agnostic, same as spar/TED CRUD (fixed in gh-276)
- Add 4 integration tests verifying add/insert/delete/delete-all on WC wings
- Update existing guard test that was asserting the buggy 409 behavior

## Root Cause

`POST /wings/{name}/cross_sections/{index}` called `_assert_design_model(..."asb")`, rejecting WC wings with 409 Conflict. The frontend's WC tree mode shows a "+ segment" button that calls this endpoint.

## Test plan

- [x] `test_add_cross_section_to_wc_wing` — POST xsec on WC wing returns 201
- [x] `test_insert_cross_section_into_wc_wing` — POST at middle index returns 201
- [x] `test_delete_cross_section_from_wc_wing` — DELETE single xsec returns 200
- [x] `test_delete_all_cross_sections_from_wc_wing` — DELETE all xsecs returns 200
- [x] Full suite: 1525 passed, 0 failed

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)