### PR TITLE
fix(gh-353,gh-354): allow negative dihedral + add roundtrip assertions

### DIFF
--- a/app/schemas/wing.py
+++ b/app/schemas/wing.py
@@ -1,5 +1,5 @@
 from typing import List, Optional, Literal
-from pydantic import AliasChoices, BaseModel, PositiveFloat, NonNegativeFloat, Field
+from pydantic import AliasChoices, BaseModel, PositiveFloat, Field
 
 from app.schemas.Servo import Servo
 
@@ -137,9 +137,11 @@ class Airfoil(BaseModel):
     chord: PositiveFloat = Field(
         description="Length of the airfoil chord in millimeters"
     )
-    dihedral_as_rotation_in_degrees: Optional[NonNegativeFloat] = Field(
+    dihedral_as_rotation_in_degrees: Optional[float] = Field(
         default=0,
-        description="Dihedral angle in degrees, representing the upward angle of this cross section. Positive is wingtip upwards."
+        ge=-180.0,
+        le=180.0,
+        description="Dihedral angle in degrees, representing the upward angle of this cross section. Positive is wingtip upwards, negative is anhedral."
     )
     incidence: Optional[float] = Field(
         default=0,

--- a/app/tests/test_negative_dihedral.py
+++ b/app/tests/test_negative_dihedral.py
@@ -1,0 +1,97 @@
+"""Tests for negative dihedral (anhedral) support in wing schema (gh-353).
+
+Verifies that the API accepts negative dihedral values and that they
+survive the WingConfig save/load roundtrip.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+airfoil_path = str(
+    (Path(__file__).resolve().parents[2] / "components" / "airfoils" / "mh32.dat").resolve()
+)
+
+
+@pytest.fixture()
+def client(client_and_db):
+    c, _ = client_and_db
+    yield c
+
+
+def _make_wingconfig(tip_dihedral: float) -> dict:
+    return {
+        "segments": [
+            {
+                "root_airfoil": {"airfoil": airfoil_path, "chord": 150.0, "incidence": 0, "dihedral_as_rotation_in_degrees": 0},
+                "tip_airfoil": {"airfoil": airfoil_path, "chord": 120.0, "incidence": 0, "dihedral_as_rotation_in_degrees": tip_dihedral},
+                "length": 500.0,
+                "sweep": 10.0,
+                "number_interpolation_points": 101,
+            }
+        ],
+        "nose_pnt": [0, 0, 0],
+    }
+
+
+class TestNegativeDihedral:
+
+    def test_negative_dihedral_accepted(self, client):
+        resp = client.post("/aeroplanes", params={"name": "anhedral_test"})
+        assert resp.status_code == 201
+        aid = resp.json()["id"]
+
+        resp = client.post(f"/aeroplanes/{aid}/wings/w/from-wingconfig", json=_make_wingconfig(-5.0))
+        assert resp.status_code == 201, f"Expected 201, got {resp.status_code}: {resp.text}"
+
+    def test_negative_dihedral_roundtrip(self, client):
+        """Interior dihedral survives roundtrip; terminal tip is lossy by design."""
+        resp = client.post("/aeroplanes", params={"name": "anhedral_rt"})
+        aid = resp.json()["id"]
+
+        wc = {
+            "segments": [
+                {
+                    "root_airfoil": {"airfoil": airfoil_path, "chord": 150.0, "incidence": 0, "dihedral_as_rotation_in_degrees": -5.0},
+                    "tip_airfoil": {"airfoil": airfoil_path, "chord": 130.0, "incidence": 0, "dihedral_as_rotation_in_degrees": -3.0},
+                    "length": 500.0, "sweep": 10.0, "number_interpolation_points": 101,
+                },
+                {
+                    "root_airfoil": {"airfoil": airfoil_path, "chord": 130.0, "incidence": 0, "dihedral_as_rotation_in_degrees": -3.0},
+                    "tip_airfoil": {"airfoil": airfoil_path, "chord": 100.0, "incidence": 0, "dihedral_as_rotation_in_degrees": 0},
+                    "length": 300.0, "sweep": 5.0, "number_interpolation_points": 101,
+                },
+            ],
+            "nose_pnt": [0, 0, 0],
+        }
+        resp = client.post(f"/aeroplanes/{aid}/wings/w/from-wingconfig", json=wc)
+        assert resp.status_code == 201
+
+        resp = client.get(f"/aeroplanes/{aid}/wings/w/wingconfig")
+        assert resp.status_code == 200
+        data = resp.json()
+        root_d = data["segments"][0]["root_airfoil"]["dihedral_as_rotation_in_degrees"]
+        assert root_d == pytest.approx(-5.0, abs=0.5)
+
+    def test_boundary_minus_180(self, client):
+        resp = client.post("/aeroplanes", params={"name": "anhedral_180"})
+        aid = resp.json()["id"]
+
+        resp = client.post(f"/aeroplanes/{aid}/wings/w/from-wingconfig", json=_make_wingconfig(-180.0))
+        assert resp.status_code == 201, f"Expected 201, got {resp.status_code}: {resp.text}"
+
+    def test_boundary_plus_180(self, client):
+        resp = client.post("/aeroplanes", params={"name": "dihedral_180"})
+        aid = resp.json()["id"]
+
+        resp = client.post(f"/aeroplanes/{aid}/wings/w/from-wingconfig", json=_make_wingconfig(180.0))
+        assert resp.status_code == 201, f"Expected 201, got {resp.status_code}: {resp.text}"
+
+    def test_out_of_range_rejected(self, client):
+        resp = client.post("/aeroplanes", params={"name": "dihedral_oor"})
+        aid = resp.json()["id"]
+
+        resp = client.post(f"/aeroplanes/{aid}/wings/w/from-wingconfig", json=_make_wingconfig(181.0))
+        assert resp.status_code == 422

--- a/app/tests/test_wingconfig_roundtrip.py
+++ b/app/tests/test_wingconfig_roundtrip.py
@@ -60,14 +60,16 @@ def _wing(*segments: Segment) -> Wing:
     return Wing(nose_pnt=[0, 0, 0], symmetric=True, segments=list(segments))
 
 
-def _assert_airfoil_match(original, roundtripped, label, tol_chord=0.05, tol_angle=0.01):
+def _assert_airfoil_match(
+    original, roundtripped, label,
+    tol_chord=0.05, tol_angle=0.01, is_terminal_tip=False,
+):
     """Assert that airfoil parameters survive the roundtrip within tolerance.
 
-    Documented lossy parameters (see docs/WingConfigRoundtripProof.adoc):
-    - dihedral_as_rotation_in_degrees: preserved after roundtrip
-
-    These change the REPRESENTATION but not the SHAPE — the rebuilt wing
-    renders to the same geometry.
+    Terminal tip dihedral is inherently lossy: the ASB model stores only
+    xyz_le positions, and the last cross-section has no successor segment
+    to derive a dihedral direction from. WingConfiguration.from_asb sets
+    cum_d[n-1] = cum_d[n-2], making the terminal delta always 0.
     """
     assert roundtripped.incidence == pytest.approx(
         original.incidence, abs=tol_angle
@@ -77,15 +79,13 @@ def _assert_airfoil_match(original, roundtripped, label, tol_chord=0.05, tol_ang
         original.chord, abs=tol_chord
     ), f"{label}: chord {roundtripped.chord} != {original.chord}"
 
-    # dihedral_as_rotation_in_degrees is lossy — always 0 after roundtrip
-    # The dihedral effect is preserved via dihedral_as_rotation_in_degrees.
-    # We do NOT assert it matches the original.
-
-    # rotation_point_rel_chord has been removed from the codebase.
-    # The rotation pivot is always at the LE.
+    if not is_terminal_tip:
+        assert roundtripped.dihedral_as_rotation_in_degrees == pytest.approx(
+            original.dihedral_as_rotation_in_degrees, abs=0.1
+        ), f"{label}: dihedral {roundtripped.dihedral_as_rotation_in_degrees} != {original.dihedral_as_rotation_in_degrees}"
 
 
-def _assert_segment_match(orig_seg, rt_seg, seg_idx):
+def _assert_segment_match(orig_seg, rt_seg, seg_idx, *, total_segments=None):
     """Assert that a segment survives the roundtrip.
 
     Compares the WingConfiguration segments (after create_wing_configuration),
@@ -95,11 +95,14 @@ def _assert_segment_match(orig_seg, rt_seg, seg_idx):
     Length and sweep may differ when rc ≠ 0 (documented lossy projection),
     so we use a relaxed tolerance.
     """
+    is_last = total_segments is not None and seg_idx == total_segments - 1
+
     _assert_airfoil_match(
         orig_seg.root_airfoil, rt_seg.root_airfoil, f"seg[{seg_idx}].root"
     )
     _assert_airfoil_match(
-        orig_seg.tip_airfoil, rt_seg.tip_airfoil, f"seg[{seg_idx}].tip"
+        orig_seg.tip_airfoil, rt_seg.tip_airfoil, f"seg[{seg_idx}].tip",
+        is_terminal_tip=is_last,
     )
     # Length/sweep tolerance is relaxed because rc projection changes these
     assert rt_seg.length == pytest.approx(
@@ -122,7 +125,7 @@ class TestBasicRoundtrip:
         wing = _wing(_seg())
         wc, wc2 = _roundtrip(wing)
         assert len(wc2.segments) == 1
-        _assert_segment_match(wing.segments[0], wc2.segments[0], 0)
+        _assert_segment_match(wing.segments[0], wc2.segments[0], 0, total_segments=1)
 
     def test_two_segments_flat(self):
         wing = _wing(
@@ -132,7 +135,7 @@ class TestBasicRoundtrip:
         wc, wc2 = _roundtrip(wing)
         assert len(wc2.segments) == 2
         for i in range(2):
-            _assert_segment_match(wc.segments[i], wc2.segments[i], i)
+            _assert_segment_match(wc.segments[i], wc2.segments[i], i, total_segments=2)
 
     def test_four_segments_flat(self):
         wing = _wing(
@@ -144,7 +147,7 @@ class TestBasicRoundtrip:
         wc, wc2 = _roundtrip(wing)
         assert len(wc2.segments) == 4
         for i in range(4):
-            _assert_segment_match(wc.segments[i], wc2.segments[i], i)
+            _assert_segment_match(wc.segments[i], wc2.segments[i], i, total_segments=4)
 
 
 # ═══════════════════════════════════════════════════════════════════
@@ -163,7 +166,7 @@ class TestIncidenceRoundtrip:
         )
         wc, wc2 = _roundtrip(wing)
         for i in range(2):
-            _assert_segment_match(wc.segments[i], wc2.segments[i], i)
+            _assert_segment_match(wc.segments[i], wc2.segments[i], i, total_segments=2)
 
     def test_washout_classic(self):
         """Root 3°, tip -1° — classic washout."""
@@ -173,7 +176,7 @@ class TestIncidenceRoundtrip:
         )
         wc, wc2 = _roundtrip(wing)
         for i in range(2):
-            _assert_segment_match(wc.segments[i], wc2.segments[i], i)
+            _assert_segment_match(wc.segments[i], wc2.segments[i], i, total_segments=2)
 
     def test_washin(self):
         """Negative root, positive tip — washin."""
@@ -183,7 +186,7 @@ class TestIncidenceRoundtrip:
         )
         wc, wc2 = _roundtrip(wing)
         for i in range(2):
-            _assert_segment_match(wc.segments[i], wc2.segments[i], i)
+            _assert_segment_match(wc.segments[i], wc2.segments[i], i, total_segments=2)
 
     def test_root_incidence_tip_zero(self):
         """Regression: root=-1.5°, tip=0° was corrupted to tip=1.5°."""
@@ -192,8 +195,8 @@ class TestIncidenceRoundtrip:
             _seg(root_incidence=0, tip_incidence=0, length=200),
         )
         wc, wc2 = _roundtrip(wing)
-        _assert_segment_match(wc.segments[0], wc2.segments[0], 0)
-        _assert_segment_match(wc.segments[1], wc2.segments[1], 1)
+        _assert_segment_match(wc.segments[0], wc2.segments[0], 0, total_segments=2)
+        _assert_segment_match(wc.segments[1], wc2.segments[1], 1, total_segments=2)
 
     def test_large_twist_range(self):
         """8° root to -5° tip — large but valid range."""
@@ -204,7 +207,7 @@ class TestIncidenceRoundtrip:
         )
         wc, wc2 = _roundtrip(wing)
         for i in range(3):
-            _assert_segment_match(wc.segments[i], wc2.segments[i], i)
+            _assert_segment_match(wc.segments[i], wc2.segments[i], i, total_segments=3)
 
     def test_nonmonotone_twist(self):
         """Twist increases then decreases — 0°/2°/4°/1°."""
@@ -215,7 +218,7 @@ class TestIncidenceRoundtrip:
         )
         wc, wc2 = _roundtrip(wing)
         for i in range(3):
-            _assert_segment_match(wc.segments[i], wc2.segments[i], i)
+            _assert_segment_match(wc.segments[i], wc2.segments[i], i, total_segments=3)
 
     def test_all_segments_different_incidence(self):
         """Each segment has unique root/tip incidence."""
@@ -227,7 +230,7 @@ class TestIncidenceRoundtrip:
         )
         wc, wc2 = _roundtrip(wing)
         for i in range(4):
-            _assert_segment_match(wc.segments[i], wc2.segments[i], i)
+            _assert_segment_match(wc.segments[i], wc2.segments[i], i, total_segments=4)
 
 
 # ═══════════════════════════════════════════════════════════════════
@@ -244,7 +247,7 @@ class TestDihedralRoundtrip:
         )
         wc, wc2 = _roundtrip(wing)
         for i in range(2):
-            _assert_segment_match(wc.segments[i], wc2.segments[i], i)
+            _assert_segment_match(wc.segments[i], wc2.segments[i], i, total_segments=2)
 
     def test_dihedral_only_root_segment(self):
         wing = _wing(
@@ -254,19 +257,17 @@ class TestDihedralRoundtrip:
         )
         wc, wc2 = _roundtrip(wing)
         for i in range(3):
-            _assert_segment_match(wc.segments[i], wc2.segments[i], i)
+            _assert_segment_match(wc.segments[i], wc2.segments[i], i, total_segments=3)
 
     def test_negative_dihedral_anhedral(self):
         """Anhedral: negative dihedral on a segment."""
-        # Note: dihedral_as_rotation_in_degrees is NonNegativeFloat in schema
-        # Anhedral might not be supported. Test with 0 to be safe.
         wing = _wing(
-            _seg(root_dihedral=0, length=100),
-            _seg(root_dihedral=0, length=200),
+            _seg(root_dihedral=-3, tip_dihedral=-3, length=100),
+            _seg(root_dihedral=-3, tip_dihedral=-3, length=200),
         )
         wc, wc2 = _roundtrip(wing)
         for i in range(2):
-            _assert_segment_match(wc.segments[i], wc2.segments[i], i)
+            _assert_segment_match(wc.segments[i], wc2.segments[i], i, total_segments=2)
 
 
 # ═══════════════════════════════════════════════════════════════════
@@ -294,7 +295,7 @@ class TestCombinedRoundtrip:
         )
         wc, wc2 = _roundtrip(wing)
         for i in range(3):
-            _assert_segment_match(wc.segments[i], wc2.segments[i], i)
+            _assert_segment_match(wc.segments[i], wc2.segments[i], i, total_segments=3)
 
     def test_trapez_wing_full(self):
         """Classic trapezoid wing — 4 segments, taper, washout, dihedral."""
@@ -322,7 +323,7 @@ class TestCombinedRoundtrip:
         )
         wc, wc2 = _roundtrip(wing)
         for i in range(4):
-            _assert_segment_match(wc.segments[i], wc2.segments[i], i)
+            _assert_segment_match(wc.segments[i], wc2.segments[i], i, total_segments=4)
 
 
 # ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- **Closes #353**: Changed `dihedral_as_rotation_in_degrees` schema from `NonNegativeFloat` to `float` with `ge=-180.0, le=180.0`, allowing anhedral (negative dihedral) values
- **Closes #354**: Added dihedral roundtrip assertions to `test_wingconfig_roundtrip.py` across all ~20 test call sites, with a terminal-tip exception (inherently lossy in ASB model)
- Added `test_negative_dihedral.py` with 5 integration tests: acceptance, roundtrip, boundary ±180, and out-of-range rejection

## Test plan
- [x] All 1526 existing tests pass
- [x] New negative dihedral tests pass (acceptance, roundtrip, boundaries, rejection)
- [x] Dihedral roundtrip assertions added to existing wingconfig roundtrip tests
- [x] Terminal tip dihedral correctly excluded from assertions (geometric limitation)
- [x] Lint clean (`ruff check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)