### PR TITLE
fix(gh-352): recompute spare_origin to match geometry scale

### DIFF
--- a/app/converters/model_schema_converters.py
+++ b/app/converters/model_schema_converters.py
@@ -476,6 +476,11 @@ def _resolve_single_spare(
 def _resolve_spare_vectors_and_origins(wing_config: WingConfiguration) -> None:
     for segment_index, segment in enumerate(wing_config.segments or []):
         for spare_index, spare in enumerate(segment.spare_list or []):
+            # Always recompute from the current geometry so the result
+            # matches whatever scale the WingConfiguration was built with.
+            # Without this, a DB-cached origin (meters) leaks into a
+            # mm-scale config and produces 1000x-offset spars (gh-352).
+            spare.spare_origin = None
             _resolve_single_spare(wing_config, segment_index, spare_index, spare)
 
 

--- a/app/services/wing_service.py
+++ b/app/services/wing_service.py
@@ -798,9 +798,10 @@ def _recompute_spare_vectors(wing: WingModel) -> None:
     """Rebuild WingConfiguration to compute spare_vector/spare_origin for all spars,
     then persist the computed values back to the DB spar records.
 
-    Uses ``scale=1.0`` intentionally — the DB stores metres and the frontend
-    consumes metres, so the computed origin coordinates must stay in metres.
-    (The CAD call-site uses ``scale=1000.0`` because CadQuery works in mm.)
+    Uses ``scale=1.0`` because the DB stores metres — the computed origin
+    coordinates stay in metres.  The CAD call-site rebuilds with
+    ``scale=1000.0``; ``_resolve_spare_vectors_and_origins`` forces
+    recomputation so the origin always matches the active geometry scale.
     """
     try:
         wing_config = wing_model_to_wing_config(wing, scale=1.0)

--- a/app/tests/test_model_schema_converters.py
+++ b/app/tests/test_model_schema_converters.py
@@ -244,6 +244,51 @@ def test_wing_model_to_wing_config_resolves_sparse_vectors_for_standard_and_foll
     assert config.segments[1].spare_list[0].spare_origin is not None
 
 
+def test_spare_origin_recomputed_when_scaled_gh352():
+    """Regression for gh-352: spare_origin from DB (meters) must not leak into mm context.
+
+    When _recompute_spare_vectors stores origin in meters and the CAD path
+    rebuilds with scale=1000.0, the origin must be recomputed from mm-scale
+    geometry — not used as-is from the DB.
+    """
+    wing_schema = schemas.AsbWingSchema(
+        name="test-wing",
+        symmetric=True,
+        x_secs=[
+            schemas.WingXSecSchema(
+                xyz_le=[0.0, 0.0, 0.0],
+                chord=0.2,
+                twist=0.0,
+                airfoil="./components/airfoils/mh32.dat",
+                spare_list=[
+                    schemas.SpareDetailSchema(
+                        spare_support_dimension_width=4.42,
+                        spare_support_dimension_height=4.42,
+                        spare_position_factor=0.25,
+                        spare_mode="standard",
+                        spare_origin=[0.05, 0.0, 0.003],
+                    )
+                ],
+            ),
+            schemas.WingXSecSchema(
+                xyz_le=[0.0, 0.5, 0.0],
+                chord=0.15,
+                twist=0.0,
+                airfoil="./components/airfoils/mh32.dat",
+            ),
+        ],
+    )
+    wing_model = WingModel.from_dict(name="test-wing", data=wing_schema.model_dump())
+
+    config_mm = wing_model_to_wing_config(wing_model, scale=1000.0)
+    spare = config_mm.segments[0].spare_list[0]
+
+    assert spare.spare_origin is not None
+    assert abs(spare.spare_origin.x) > 1.0, (
+        f"spare_origin.x={spare.spare_origin.x} looks like meters, expected mm"
+    )
+
+
 def test_ted_projection_to_asb_uses_rel_chord_root():
     wing = schemas.AsbWingSchema(
         name="main-wing",

--- a/frontend/components/workbench/SparEditDialog.tsx
+++ b/frontend/components/workbench/SparEditDialog.tsx
@@ -223,7 +223,7 @@ export function SparEditDialog({
             <DialogField label="Y" value={vecY} onChange={setVecY} />
             <DialogField label="Z" value={vecZ} onChange={setVecZ} />
           </div>
-          <span className="pt-1 text-[11px] text-muted-foreground">Origin (opt.)</span>
+          <span className="pt-1 text-[11px] text-muted-foreground">Origin (opt.) mm</span>
           <div className="flex gap-3">
             <DialogField label="X" value={origX} onChange={setOrigX} />
             <DialogField label="Y" value={origY} onChange={setOrigY} />

--- a/frontend/components/workbench/SparEditDialog.tsx
+++ b/frontend/components/workbench/SparEditDialog.tsx
@@ -81,7 +81,10 @@ export function SparEditDialog({
       setSparStart(String(initialData.spare_start ?? 0));
       setSparLength(initialData.spare_length == null ? "" : String(initialData.spare_length));
       applyOptionalVec3(initialData.spare_vector, setVecX, setVecY, setVecZ);
-      applyOptionalVec3(initialData.spare_origin, setOrigX, setOrigY, setOrigZ);
+      applyOptionalVec3(
+        initialData.spare_origin?.map((v: number) => v * 1000) ?? null,
+        setOrigX, setOrigY, setOrigZ,
+      );
     } else {
       setPosFactor("25");
       setWidth("4.42");
@@ -115,7 +118,7 @@ export function SparEditDialog({
         payload.spare_vector = null;
       }
       if (origX.trim() && origY.trim() && origZ.trim()) {
-        payload.spare_origin = [num(origX), num(origY), num(origZ)];
+        payload.spare_origin = [num(origX) / 1000, num(origY) / 1000, num(origZ) / 1000];
       } else {
         payload.spare_origin = null;
       }


### PR DESCRIPTION
## Summary

- Force recomputation of `spare_origin` in `_resolve_spare_vectors_and_origins` so the origin always matches the active geometry scale (mm for CadQuery, meters for DB)
- Previously, meter-scale origin cached in DB leaked into mm-scale WingConfiguration, producing spars offset by 1000x in VaseModeWingCreator
- Add "mm" unit label to Origin fields in SparEditDialog
- Fix misleading comment in `_recompute_spare_vectors`

## Test plan

- [x] Regression test `test_spare_origin_recomputed_when_scaled_gh352` — verifies origin is in mm (not meters) when scale=1000.0
- [x] All 11 converter tests pass
- [x] 607 cad_designer tests pass
- [x] 823 app tests pass (1 pre-existing failure unrelated to this change)

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)