### PR TITLE
feat(gh-359): add segment paginator to Configuration dialog

### DIFF
--- a/docs/superpowers/plans/2026-04-27-segment-paginator.md
+++ b/docs/superpowers/plans/2026-04-27-segment-paginator.md
@@ -1,0 +1,691 @@
+# Segment Paginator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an inline segment/cross-section paginator to the Configuration dialog so users can navigate between segments without closing the dialog, with auto-save on navigation.
+
+**Architecture:** A pure presentational `SegmentPaginator` component renders page indices with ellipsis truncation. It sits in the dialog header in `page.tsx`, which owns the save-then-navigate callback. PropertyForm exposes an imperative `save()` handle via `forwardRef`/`useImperativeHandle` so the parent can trigger saves before switching segments.
+
+**Tech Stack:** React 19, TypeScript, Lucide icons, Tailwind CSS, vitest + @testing-library/react
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `frontend/components/workbench/SegmentPaginator.tsx` | Presentational paginator with ellipsis logic |
+| Create | `frontend/__tests__/SegmentPaginator.test.tsx` | Unit tests for paginator |
+| Modify | `frontend/components/workbench/PropertyForm.tsx:519` | Add `forwardRef` + `useImperativeHandle` for save handle |
+| Modify | `frontend/app/workbench/page.tsx:19,206-228` | Add hooks, paginator, save-then-navigate handler |
+
+---
+
+### Task 1: SegmentPaginator — ellipsis logic + rendering (TDD)
+
+**Files:**
+- Create: `frontend/__tests__/SegmentPaginator.test.tsx`
+- Create: `frontend/components/workbench/SegmentPaginator.tsx`
+
+- [ ] **Step 1: Write failing tests for the paginator**
+
+```tsx
+// frontend/__tests__/SegmentPaginator.test.tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) =>
+    React.createElement("span", { ...props, "data-testid": props["data-testid"] || "icon" });
+  return { ChevronLeft: icon, ChevronRight: icon };
+});
+
+import { SegmentPaginator } from "@/components/workbench/SegmentPaginator";
+
+describe("SegmentPaginator", () => {
+  const onChange = vi.fn<(n: number) => Promise<void>>().mockResolvedValue(undefined);
+
+  beforeEach(() => vi.clearAllMocks());
+
+  describe("few segments (total <= 5)", () => {
+    it("renders all indices for total=4", () => {
+      render(<SegmentPaginator current={0} total={4} onChange={onChange} />);
+      expect(screen.getByRole("button", { name: "0" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "1" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "2" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "3" })).toBeInTheDocument();
+      expect(screen.queryByText("…")).not.toBeInTheDocument();
+    });
+
+    it("renders single index for total=1", () => {
+      render(<SegmentPaginator current={0} total={1} onChange={onChange} />);
+      expect(screen.getByRole("button", { name: "0" })).toBeInTheDocument();
+    });
+  });
+
+  describe("many segments (total > 5) — ellipsis", () => {
+    it("current=0: shows 0 1 … 10", () => {
+      render(<SegmentPaginator current={0} total={11} onChange={onChange} />);
+      expect(screen.getByRole("button", { name: "0" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "1" })).toBeInTheDocument();
+      expect(screen.getByText("…")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "10" })).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "2" })).not.toBeInTheDocument();
+    });
+
+    it("current=5: shows 0 … 4 5 6 … 10", () => {
+      render(<SegmentPaginator current={5} total={11} onChange={onChange} />);
+      expect(screen.getByRole("button", { name: "0" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "4" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "5" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "6" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "10" })).toBeInTheDocument();
+      expect(screen.getAllByText("…")).toHaveLength(2);
+    });
+
+    it("current=10: shows 0 … 9 10", () => {
+      render(<SegmentPaginator current={10} total={11} onChange={onChange} />);
+      expect(screen.getByRole("button", { name: "0" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "9" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "10" })).toBeInTheDocument();
+      expect(screen.getAllByText("…")).toHaveLength(1);
+    });
+
+    it("current=1: shows 0 1 2 … 10", () => {
+      render(<SegmentPaginator current={1} total={11} onChange={onChange} />);
+      expect(screen.getByRole("button", { name: "0" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "1" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "2" })).toBeInTheDocument();
+      expect(screen.getAllByText("…")).toHaveLength(1);
+      expect(screen.getByRole("button", { name: "10" })).toBeInTheDocument();
+    });
+
+    it("current=9: shows 0 … 8 9 10", () => {
+      render(<SegmentPaginator current={9} total={11} onChange={onChange} />);
+      expect(screen.getByRole("button", { name: "0" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "8" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "9" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "10" })).toBeInTheDocument();
+      expect(screen.getAllByText("…")).toHaveLength(1);
+    });
+  });
+
+  describe("current highlight", () => {
+    it("highlights current index with accent style", () => {
+      render(<SegmentPaginator current={2} total={4} onChange={onChange} />);
+      const btn = screen.getByRole("button", { name: "2" });
+      expect(btn.className).toMatch(/bg-primary|bg-\[#FF8400\]/);
+    });
+  });
+
+  describe("arrow buttons", () => {
+    it("prev arrow disabled at index 0", () => {
+      render(<SegmentPaginator current={0} total={4} onChange={onChange} />);
+      const prev = screen.getByLabelText("Previous segment");
+      expect(prev).toBeDisabled();
+    });
+
+    it("next arrow disabled at last index", () => {
+      render(<SegmentPaginator current={3} total={4} onChange={onChange} />);
+      const next = screen.getByLabelText("Next segment");
+      expect(next).toBeDisabled();
+    });
+
+    it("prev arrow calls onChange(current - 1)", async () => {
+      render(<SegmentPaginator current={2} total={4} onChange={onChange} />);
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText("Previous segment"));
+      });
+      expect(onChange).toHaveBeenCalledWith(1);
+    });
+
+    it("next arrow calls onChange(current + 1)", async () => {
+      render(<SegmentPaginator current={1} total={4} onChange={onChange} />);
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText("Next segment"));
+      });
+      expect(onChange).toHaveBeenCalledWith(2);
+    });
+  });
+
+  describe("index click", () => {
+    it("calls onChange with clicked index", async () => {
+      render(<SegmentPaginator current={0} total={4} onChange={onChange} />);
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "3" }));
+      });
+      expect(onChange).toHaveBeenCalledWith(3);
+    });
+
+    it("does not call onChange when clicking current index", async () => {
+      render(<SegmentPaginator current={2} total={4} onChange={onChange} />);
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "2" }));
+      });
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("disabled states", () => {
+    it("all buttons disabled when disabled prop is true", () => {
+      render(<SegmentPaginator current={1} total={4} onChange={onChange} disabled />);
+      const buttons = screen.getAllByRole("button");
+      buttons.forEach((btn) => expect(btn).toBeDisabled());
+    });
+
+    it("all buttons disabled while onChange is in flight", async () => {
+      let resolveOnChange: () => void;
+      const slowChange = vi.fn<(n: number) => Promise<void>>(
+        () => new Promise((r) => { resolveOnChange = r; }),
+      );
+      render(<SegmentPaginator current={1} total={4} onChange={slowChange} />);
+
+      // Click next — should start loading
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText("Next segment"));
+      });
+
+      // All buttons should be disabled while in flight
+      const buttons = screen.getAllByRole("button");
+      buttons.forEach((btn) => expect(btn).toBeDisabled());
+
+      // Resolve the promise
+      await act(async () => { resolveOnChange!(); });
+
+      // Buttons should be re-enabled
+      expect(screen.getByLabelText("Next segment")).not.toBeDisabled();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npm run test:unit -- --run __tests__/SegmentPaginator.test.tsx`
+Expected: FAIL — module `@/components/workbench/SegmentPaginator` not found.
+
+- [ ] **Step 3: Implement the SegmentPaginator component**
+
+```tsx
+// frontend/components/workbench/SegmentPaginator.tsx
+"use client";
+
+import { useState, useCallback } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+interface SegmentPaginatorProps {
+  current: number;
+  total: number;
+  onChange: (index: number) => Promise<void>;
+  disabled?: boolean;
+}
+
+function buildPageIndices(current: number, total: number): (number | "ellipsis")[] {
+  if (total <= 5) {
+    return Array.from({ length: total }, (_, i) => i);
+  }
+  const pages = new Set<number>();
+  pages.add(0);
+  pages.add(total - 1);
+  for (let i = current - 1; i <= current + 1; i++) {
+    if (i >= 0 && i < total) pages.add(i);
+  }
+  const sorted = [...pages].sort((a, b) => a - b);
+  const result: (number | "ellipsis")[] = [];
+  for (let i = 0; i < sorted.length; i++) {
+    if (i > 0 && sorted[i] - sorted[i - 1] > 1) {
+      result.push("ellipsis");
+    }
+    result.push(sorted[i]);
+  }
+  return result;
+}
+
+export function SegmentPaginator({ current, total, onChange, disabled }: Readonly<SegmentPaginatorProps>) {
+  const [loading, setLoading] = useState(false);
+  const isDisabled = disabled || loading;
+
+  const handleClick = useCallback(async (index: number) => {
+    if (index === current) return;
+    setLoading(true);
+    try {
+      await onChange(index);
+    } finally {
+      setLoading(false);
+    }
+  }, [current, onChange]);
+
+  const pages = buildPageIndices(current, total);
+
+  return (
+    <div className="flex items-center gap-1">
+      <button
+        aria-label="Previous segment"
+        disabled={isDisabled || current === 0}
+        onClick={() => handleClick(current - 1)}
+        className="flex size-6 items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed"
+      >
+        <ChevronLeft size={14} />
+      </button>
+
+      {pages.map((page, i) =>
+        page === "ellipsis" ? (
+          <span key={`ellipsis-${i}`} className="px-0.5 text-[12px] text-muted-foreground">
+            …
+          </span>
+        ) : (
+          <button
+            key={page}
+            disabled={isDisabled}
+            onClick={() => handleClick(page)}
+            className={`flex size-6 items-center justify-center rounded font-[family-name:var(--font-jetbrains-mono)] text-[11px] ${
+              page === current
+                ? "bg-primary text-primary-foreground font-bold"
+                : "border border-border text-muted-foreground hover:bg-sidebar-accent"
+            } disabled:opacity-30 disabled:cursor-not-allowed`}
+          >
+            {page}
+          </button>
+        ),
+      )}
+
+      <button
+        aria-label="Next segment"
+        disabled={isDisabled || current === total - 1}
+        onClick={() => handleClick(current + 1)}
+        className="flex size-6 items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed"
+      >
+        <ChevronRight size={14} />
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npm run test:unit -- --run __tests__/SegmentPaginator.test.tsx`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/components/workbench/SegmentPaginator.tsx frontend/__tests__/SegmentPaginator.test.tsx
+git commit -m "feat(gh-359): add SegmentPaginator component with ellipsis logic"
+```
+
+---
+
+### Task 2: PropertyForm — expose imperative save handle
+
+**Files:**
+- Modify: `frontend/components/workbench/PropertyForm.tsx:1-3,519`
+
+- [ ] **Step 1: Write failing test for the imperative handle**
+
+Add to an existing or new test file. Since PropertyForm depends on many hooks and context, we test the handle pattern in isolation via a thin wrapper:
+
+```tsx
+// frontend/__tests__/PropertyFormHandle.test.tsx
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, act } from "@testing-library/react";
+import React, { useRef, useImperativeHandle, forwardRef, useState } from "react";
+
+// This tests the save handle pattern in isolation,
+// matching the contract PropertyForm will expose.
+interface SaveHandle {
+  save(): Promise<void>;
+}
+
+const MockForm = forwardRef<SaveHandle, { onSave: () => Promise<void>; dirty: boolean }>(
+  function MockForm({ onSave, dirty }, ref) {
+    useImperativeHandle(ref, () => ({
+      async save() {
+        if (!dirty) return;
+        await onSave();
+      },
+    }), [dirty, onSave]);
+    return <div>form</div>;
+  },
+);
+
+function Harness({ onSave, dirty }: { onSave: () => Promise<void>; dirty: boolean }) {
+  const ref = useRef<SaveHandle>(null);
+  return (
+    <>
+      <MockForm ref={ref} onSave={onSave} dirty={dirty} />
+      <button onClick={() => ref.current?.save()}>trigger-save</button>
+    </>
+  );
+}
+
+describe("imperative save handle", () => {
+  it("calls onSave when dirty", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const { getByText } = render(<Harness onSave={onSave} dirty={true} />);
+    await act(async () => { getByText("trigger-save").click(); });
+    expect(onSave).toHaveBeenCalledOnce();
+  });
+
+  it("skips save when not dirty", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const { getByText } = render(<Harness onSave={onSave} dirty={false} />);
+    await act(async () => { getByText("trigger-save").click(); });
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("re-throws on save failure", async () => {
+    const onSave = vi.fn().mockRejectedValue(new Error("fail"));
+    const { getByText } = render(<Harness onSave={onSave} dirty={true} />);
+    await expect(
+      act(async () => { await (document.querySelector("button") as HTMLElement).click(); }),
+    ).rejects.toThrow;
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it passes (pattern validation only)**
+
+Run: `cd frontend && npm run test:unit -- --run __tests__/PropertyFormHandle.test.tsx`
+Expected: PASS — this validates the pattern before we apply it to PropertyForm.
+
+- [ ] **Step 3: Modify PropertyForm to expose the save handle**
+
+In `frontend/components/workbench/PropertyForm.tsx`, make these changes:
+
+**a) Update imports (line 3):**
+
+Change:
+```tsx
+import { useEffect, useState, useId } from "react";
+```
+To:
+```tsx
+import { useEffect, useState, useId, forwardRef, useImperativeHandle } from "react";
+```
+
+**b) Export the handle type (after line 24, the `Mode` type):**
+
+```tsx
+export interface PropertyFormHandle {
+  save(): Promise<void>;
+}
+```
+
+**c) Convert `PropertyForm` to use `forwardRef` (line 519):**
+
+Change:
+```tsx
+export function PropertyForm({ onGeometryChanged }: Readonly<{ onGeometryChanged?: (wingName: string) => void }>) {
+```
+To:
+```tsx
+export const PropertyForm = forwardRef<PropertyFormHandle, Readonly<{ onGeometryChanged?: (wingName: string) => void }>>(
+  function PropertyForm({ onGeometryChanged }, ref) {
+```
+
+**d) Add `useImperativeHandle` after the `useUnsavedChanges()` call (after line 544):**
+
+```tsx
+  const { isDirty, setDirty } = useUnsavedChanges();
+
+  useImperativeHandle(ref, () => ({
+    async save() {
+      if (!isDirty) return;
+      const saveFn = mode === "wingconfig" ? handleSaveWingConfig
+        : mode === "fuselage" ? handleSaveFuselage
+        : handleSaveAsb;
+      await saveFn();
+    },
+  }));
+```
+
+Note: `handleSaveWingConfig` and `handleSaveAsb` are defined later in the function body (lines 612, 628). They currently catch errors and set state. We need them to also re-throw so the caller can detect failure.
+
+**e) Make save handlers re-throw on error:**
+
+In `handleSaveAsb` (line 612), after `setError(...)`, add `throw err;`:
+
+```tsx
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Save failed");
+      throw err;
+    } finally {
+```
+
+In `handleSaveWingConfig` (line 628), same pattern:
+
+```tsx
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Save failed");
+      throw err;
+    } finally {
+```
+
+**f) Handle fuselage save — extract `handleSaveFuselage`:**
+
+The fuselage save is currently an inline `onSave` callback in `renderFuselageXsecForm` (line 508). The imperative handle can't reach it. We need a `handleSaveFuselage` in the main component body.
+
+Add after the existing save handlers (after line 649):
+
+```tsx
+  async function handleSaveFuselage() {
+    if (mode !== "fuselage" || !selectedFuselage || selectedFuselageXsecIndex === null || !fuselage) return;
+    const fxsec = fuselage.x_secs[selectedFuselageXsecIndex];
+    if (!fxsec) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await updateFuselageXSec(selectedFuselageXsecIndex, fxsec);
+      await mutateFuselage();
+      onGeometryChanged?.("");
+      setDirty(false);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Save failed");
+      throw err;
+    } finally {
+      setSaving(false);
+    }
+  }
+```
+
+Note: The `FuselageXSecForm` sub-component manages its own local state (xyz, a, b, n). The imperative save from the parent will save the *current server state* of the fuselage x_sec. This is acceptable because the FuselageXSecForm re-syncs from props via `useEffect` when the xsec/index changes. For full local-state save, the FuselageXSecForm would also need a `forwardRef` — but that's a deeper refactor. For this ticket, the pattern works because unsaved fuselage edits are visible in the form's error state, and the save-on-navigate triggers the parent-level save which persists the last-saved state.
+
+**g) Close the `forwardRef` at the end of the component (after the closing `}` of the function, before the `FuselageXSecForm` definition):**
+
+```tsx
+  );  // end forwardRef
+```
+
+- [ ] **Step 4: Run existing tests to verify no regressions**
+
+Run: `cd frontend && npm run test:unit -- --run`
+Expected: All existing tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/components/workbench/PropertyForm.tsx frontend/__tests__/PropertyFormHandle.test.tsx
+git commit -m "feat(gh-359): expose imperative save handle on PropertyForm"
+```
+
+---
+
+### Task 3: Integrate paginator into the dialog header
+
+**Files:**
+- Modify: `frontend/app/workbench/page.tsx:1-20,206-228`
+
+- [ ] **Step 1: Add imports and hooks to `page.tsx`**
+
+Add these imports (near the top of the file, with the existing imports):
+
+```tsx
+import { useCallback, useRef } from "react";
+import { SegmentPaginator } from "@/components/workbench/SegmentPaginator";
+import { type PropertyFormHandle } from "@/components/workbench/PropertyForm";
+import { useWing } from "@/hooks/useWings";
+import { useWingConfig } from "@/hooks/useWingConfig";
+import { useFuselage } from "@/hooks/useFuselage";
+```
+
+In the component body, add `treeMode` to the existing `useAeroplaneContext()` destructure (line 19):
+
+Change:
+```tsx
+const { aeroplaneId, setAeroplaneId, selectedWing, selectedXsecIndex, selectedFuselage, selectedFuselageXsecIndex } = useAeroplaneContext();
+```
+To:
+```tsx
+const { aeroplaneId, setAeroplaneId, selectedWing, selectedXsecIndex, selectXsec, selectedFuselage, selectedFuselageXsecIndex, selectFuselageXsec, treeMode } = useAeroplaneContext();
+```
+
+Add the data hooks and derived state (after the context destructure):
+
+```tsx
+const { wing } = useWing(aeroplaneId, selectedWing);
+const { wingConfig } = useWingConfig(aeroplaneId, treeMode === "wingconfig" ? selectedWing : null);
+const { fuselage } = useFuselage(aeroplaneId, treeMode === "fuselage" ? selectedFuselage : null);
+
+const mode = treeMode === "fuselage" ? "fuselage" : treeMode;
+
+const paginatorCurrent = mode === "fuselage"
+  ? selectedFuselageXsecIndex
+  : selectedXsecIndex;
+
+const paginatorTotal = mode === "fuselage"
+  ? fuselage?.x_secs?.length
+  : mode === "wingconfig"
+    ? wingConfig?.segments?.length
+    : wing?.x_secs?.length;
+
+const formRef = useRef<PropertyFormHandle>(null);
+
+const handleSegmentChange = useCallback(async (newIndex: number) => {
+  try {
+    await formRef.current?.save();
+  } catch {
+    return;
+  }
+  if (mode === "fuselage") {
+    selectFuselageXsec(newIndex);
+  } else {
+    selectXsec(newIndex);
+  }
+}, [mode, selectXsec, selectFuselageXsec]);
+```
+
+- [ ] **Step 2: Add paginator to dialog header and ref to PropertyForm**
+
+In the dialog section (lines 214-225), change the header to include the paginator:
+
+Change:
+```tsx
+            <div className="flex items-center justify-between">
+              <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
+                Configuration
+              </h2>
+              <button
+                onClick={() => setConfigOpen(false)}
+                className="flex size-6 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent"
+              >
+                <X size={14} />
+              </button>
+            </div>
+            <PropertyForm onGeometryChanged={() => { mutateAllWings(); mutateSelectedWing(); mutateAllFuselages(); }} />
+```
+
+To:
+```tsx
+            <div className="flex items-center justify-between">
+              <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
+                Configuration
+              </h2>
+              {paginatorCurrent !== null && paginatorTotal != null && paginatorTotal > 1 && (
+                <SegmentPaginator
+                  current={paginatorCurrent}
+                  total={paginatorTotal}
+                  onChange={handleSegmentChange}
+                />
+              )}
+              <button
+                onClick={() => setConfigOpen(false)}
+                className="flex size-6 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent"
+              >
+                <X size={14} />
+              </button>
+            </div>
+            <PropertyForm ref={formRef} onGeometryChanged={() => { mutateAllWings(); mutateSelectedWing(); mutateAllFuselages(); }} />
+```
+
+- [ ] **Step 3: Check that `useRef` and `useCallback` are imported**
+
+Verify the imports at the top of `page.tsx` include `useRef` and `useCallback` from React. If they're already imported via another path, don't duplicate.
+
+- [ ] **Step 4: Run all frontend tests**
+
+Run: `cd frontend && npm run test:unit -- --run`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/app/workbench/page.tsx
+git commit -m "feat(gh-359): integrate SegmentPaginator into Configuration dialog"
+```
+
+---
+
+### Task 4: Manual browser test
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Start the dev servers**
+
+Run (in separate terminals or background):
+```bash
+# Backend
+poetry run uvicorn app.main:app --host 0.0.0.0 --port 8001 --reload
+
+# Frontend
+cd frontend && npm run dev
+```
+
+- [ ] **Step 2: Test wingconfig mode**
+
+1. Open `http://localhost:3000/workbench`
+2. Select an aeroplane with a wing that has 3+ segments
+3. Click the pencil icon on any segment to open the Configuration dialog
+4. Verify: paginator appears in header between "Configuration" and ✕
+5. Click a different segment number — verify form updates without dialog closing
+6. Edit a field, then click a different segment — verify auto-save (no data loss)
+7. Test prev/next arrows at boundaries (disabled at 0 and last)
+
+- [ ] **Step 3: Test ASB mode**
+
+1. Switch tree mode to ASB
+2. Open Configuration dialog on a wing cross-section
+3. Verify paginator shows correct x_sec count
+4. Navigate between x_secs via paginator
+
+- [ ] **Step 4: Test fuselage mode**
+
+1. Switch tree mode to Fuselage
+2. Open Configuration dialog on a fuselage cross-section
+3. Verify paginator shows correct fuselage x_sec count
+4. Navigate between x_secs via paginator
+
+- [ ] **Step 5: Test edge cases**
+
+1. Wing with 1 segment — verify paginator is hidden
+2. Wing with 6+ segments — verify ellipsis pagination renders correctly
+3. Edit a field, introduce a validation error, try to navigate — verify navigation is blocked and error is shown
+
+- [ ] **Step 6: Commit any fixes**
+
+If any issues found, fix and commit:
+```bash
+git add -A
+git commit -m "fix(gh-359): address issues found in manual testing"
+```

--- a/docs/superpowers/specs/2026-04-27-segment-paginator-design.md
+++ b/docs/superpowers/specs/2026-04-27-segment-paginator-design.md
@@ -1,0 +1,175 @@
+# Segment Paginator — Design Spec
+
+**Issue:** GH#359  
+**Status:** Design approved  
+**Scope:** All Configuration dialogs in the Construction view (wingconfig, ASB, fuselage)
+
+## Problem
+
+When editing segment/cross-section properties in the Configuration dialog, users must close the dialog, select a different segment in the component tree, and reopen the dialog. With many segments this is tedious and breaks the editing flow.
+
+## Solution
+
+Add a `SegmentPaginator` component to the Configuration dialog header that lets users navigate between segments/cross-sections inline, with auto-save on navigation.
+
+## Component: `SegmentPaginator`
+
+**File:** `frontend/components/workbench/SegmentPaginator.tsx`
+
+### Interface
+
+```tsx
+interface SegmentPaginatorProps {
+  current: number;
+  total: number;
+  onChange: (index: number) => Promise<void>;
+  disabled?: boolean;
+}
+```
+
+### Presentation
+
+- Pure, stateless presentation component (plus internal loading state for async onChange).
+- `current` highlighted with orange accent (`#FF8400`), inactive indices use `border-border` + `text-muted-foreground`.
+- Prev/next arrows: Lucide `ChevronLeft`/`ChevronRight`.
+- Prev disabled at index 0; next disabled at last index.
+- All buttons disabled while `onChange` promise is in flight (dimmed appearance).
+- Uses JetBrains Mono font, consistent with dialog header.
+
+### Ellipsis algorithm
+
+- `total <= 5`: show all indices `0..total-1`.
+- `total > 5`: always show first (0) and last (total-1), plus a ±1 window around `current`, with `…` filling gaps.
+
+Examples for `total=11`:
+- `current=0` → `0 1 … 10`
+- `current=1` → `0 1 2 … 10`
+- `current=5` → `0 … 4 5 6 … 10`
+- `current=9` → `0 … 8 9 10`
+- `current=10` → `0 … 9 10`
+
+## Integration in `page.tsx`
+
+### Placement
+
+Between the `<h2>Configuration</h2>` title and the close `<button>` in the dialog header flex row (line 214). The header is `flex items-center justify-between` in a 480px dialog.
+
+### Mode-aware props
+
+`page.tsx` currently destructures `selectedXsecIndex`, `selectedFuselageXsecIndex` from `useAeroplaneContext()` but does not import `treeMode` or the data hooks. The implementation must:
+
+1. Add `treeMode` to the `useAeroplaneContext()` destructure in `page.tsx`.
+2. Add `useWing`, `useWingConfig`, and `useFuselage` hook calls (same pattern as PropertyForm) to derive `total`. These hooks are already imported/used by PropertyForm, so the data is already fetched by SWR — no extra network calls.
+
+```tsx
+const { treeMode } = useAeroplaneContext();
+const { wing } = useWing(aeroplaneId, selectedWing);
+const { wingConfig } = useWingConfig(aeroplaneId, treeMode === "wingconfig" ? selectedWing : null);
+const { fuselage } = useFuselage(aeroplaneId, treeMode === "fuselage" ? selectedFuselage : null);
+
+const mode = treeMode === "fuselage" ? "fuselage" : treeMode;
+
+const paginatorCurrent = mode === "fuselage"
+  ? selectedFuselageXsecIndex
+  : selectedXsecIndex;
+
+const paginatorTotal = mode === "fuselage"
+  ? fuselage?.x_secs?.length
+  : mode === "wingconfig"
+    ? wingConfig?.segments?.length
+    : wing?.x_secs?.length;
+```
+
+Paginator renders only when `paginatorCurrent !== null && paginatorTotal != null && paginatorTotal > 1`.
+
+### Save-then-navigate handler
+
+```tsx
+const handleSegmentChange = useCallback(async (newIndex: number) => {
+  try {
+    await formRef.current.save();
+  } catch {
+    return; // save failed → stay on current segment
+  }
+  if (mode === "fuselage") {
+    selectFuselageXsec(newIndex);
+  } else {
+    selectXsec(newIndex);
+  }
+}, [mode, selectXsec, selectFuselageXsec]);
+```
+
+## PropertyForm: imperative save handle
+
+**Pattern:** `forwardRef` + `useImperativeHandle` to expose `save(): Promise<void>`.
+
+```tsx
+export interface PropertyFormHandle {
+  save(): Promise<void>;
+}
+```
+
+- `save()` reuses the existing save handlers (`handleSaveWingConfig`, `handleSaveAsb`, fuselage save).
+- If the form is not dirty, `save()` resolves immediately (no network call).
+- On failure, `save()` sets the existing `error` state AND re-throws so the caller knows navigation should be blocked.
+- The dialog creates a `formRef = useRef<PropertyFormHandle>(null)` and passes it to PropertyForm.
+
+## Auto-save flow
+
+1. User clicks paginator index `N` (or arrow).
+2. Paginator sets internal `loading = true`, disables all buttons.
+3. Paginator calls `await onChange(N)`.
+4. Parent calls `await formRef.current.save()`.
+   - **Not dirty:** resolves immediately.
+   - **Success:** proceeds to step 5.
+   - **Failure:** throws → parent returns without navigating → PropertyForm shows error → paginator re-enables.
+5. Parent calls `selectXsec(N)` or `selectFuselageXsec(N)`.
+6. PropertyForm re-renders with new segment data.
+7. Paginator `finally` sets `loading = false`.
+
+## Codebase references
+
+| File | Lines | Role |
+|------|-------|------|
+| `frontend/app/workbench/page.tsx` | 206–228 | Dialog container; header at 214–224 |
+| `frontend/app/workbench/page.tsx` | 139 | Dialog open trigger (`onNodeEdit`) |
+| `frontend/components/workbench/PropertyForm.tsx` | 519–711 | Form component; save handlers |
+| `frontend/components/workbench/PropertyForm.tsx` | 651 | Mode-based save dispatch |
+| `frontend/components/workbench/AeroplaneContext.tsx` | 16–29 | Context type: `selectXsec`, `selectFuselageXsec` |
+| `frontend/hooks/useWingConfig.ts` | 6–66 | `wingConfig.segments[]` |
+
+## Test plan
+
+### Unit: `SegmentPaginator.test.tsx`
+
+- Renders all indices for total ≤ 5
+- Renders ellipsis format for total > 5
+- Highlights current index (orange accent)
+- Prev disabled at 0, next disabled at last
+- Calls `onChange` with correct index on click
+- Window slides correctly at edges (0, 1, total-2, total-1)
+- All buttons disabled when `disabled={true}`
+- All buttons disabled while `onChange` promise in flight
+
+### Integration
+
+- Paginator appears in wingconfig mode with correct segment count
+- Paginator appears in ASB mode with correct x_sec count
+- Paginator appears in fuselage mode with correct x_sec count
+- Paginator hidden when only 1 segment/x_sec
+- Auto-save triggered before navigation
+- Navigation blocked on save failure, error displayed
+- Clean navigation (not dirty) skips save call
+
+## Scope — out of scope
+
+- Keyboard navigation (arrow keys) — future enhancement
+- Drag-to-reorder segments — unrelated feature
+- Segment add/delete from paginator — navigation-only
+- Unsaved changes warning dialog — replaced by auto-save
+
+## Changes vs GH#359
+
+- **Extended to all three modes** (wingconfig, ASB, fuselage) — original spec was wing-only.
+- **Added auto-save on navigation** — original spec deferred this.
+- **Added imperative save handle** on PropertyForm — required for auto-save integration.

--- a/frontend/__tests__/FuselageXSecFormSave.test.tsx
+++ b/frontend/__tests__/FuselageXSecFormSave.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * Integration tests for FuselageXSecForm's imperative save handle,
+ * tested via PropertyForm in fuselage mode (GH#359).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import React, { useRef } from "react";
+
+// ── Mocks ──────────────────────────────────────────────────────
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) =>
+    React.createElement("span", props);
+  return { ChevronDown: icon, ChevronRight: icon, Eye: icon, Box: icon };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), prefetch: vi.fn() }),
+}));
+
+vi.mock("@/lib/fetcher", () => ({
+  API_BASE: "http://localhost:8000",
+  fetcher: vi.fn(),
+}));
+
+vi.mock("@/components/workbench/AirfoilSelector", () => ({
+  AirfoilSelector: () => React.createElement("div", null, "airfoil-selector"),
+}));
+
+vi.mock("@/components/workbench/ImportFuselageDialog", () => ({
+  ImportFuselageDialog: () => null,
+}));
+
+// Track isDirty so PropertyForm's imperative handle doesn't skip
+let mockIsDirty = false;
+const mockSetDirty = vi.fn((v: boolean) => { mockIsDirty = v; });
+
+vi.mock("@/components/workbench/UnsavedChangesContext", () => ({
+  useUnsavedChanges: () => ({
+    isDirty: mockIsDirty,
+    setDirty: mockSetDirty,
+    registerSave: vi.fn(),
+    pendingHref: null,
+    isSaving: false,
+    confirmDiscard: vi.fn(),
+    confirmSave: vi.fn(),
+    cancelNavigation: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/workbench/AeroplaneContext", () => ({
+  useAeroplaneContext: () => ({
+    aeroplaneId: "aero-1",
+    selectedWing: null,
+    selectedXsecIndex: null,
+    selectedFuselage: "fuse-1",
+    selectedFuselageXsecIndex: 0,
+    treeMode: "fuselage",
+    setAeroplaneId: vi.fn(),
+    selectWing: vi.fn(),
+    selectXsec: vi.fn(),
+    selectFuselage: vi.fn(),
+    selectFuselageXsec: vi.fn(),
+    setTreeMode: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useWings", () => ({
+  useWing: () => ({ wing: null, updateXSec: vi.fn(), mutate: vi.fn(), isLoading: false }),
+}));
+
+vi.mock("@/hooks/useWingConfig", () => ({
+  useWingConfig: () => ({ wingConfig: null, saveWingConfig: vi.fn(), mutate: vi.fn(), isLoading: false }),
+}));
+
+const mockUpdateFuselageXSec = vi.fn().mockResolvedValue(undefined);
+const mockMutateFuselage = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@/hooks/useFuselage", () => ({
+  useFuselage: () => ({
+    fuselage: {
+      x_secs: [{ xyz: [1.0, 2.0, 3.0], a: 0.05, b: 0.04, n: 2.5 }],
+    },
+    updateXSec: mockUpdateFuselageXSec,
+    mutate: mockMutateFuselage,
+    isLoading: false,
+  }),
+}));
+
+import { PropertyForm, type PropertyFormHandle } from "@/components/workbench/PropertyForm";
+
+function Harness({ onSaveResult }: { onSaveResult?: (err: unknown) => void }) {
+  const ref = useRef<PropertyFormHandle>(null);
+  return (
+    <>
+      <PropertyForm ref={ref} onGeometryChanged={() => {}} />
+      <button
+        data-testid="trigger-save"
+        onClick={() => {
+          ref.current?.save()
+            .then(() => onSaveResult?.(null))
+            .catch((err) => onSaveResult?.(err));
+        }}
+      >
+        trigger
+      </button>
+    </>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsDirty = false;
+});
+
+describe("FuselageXSecForm imperative save (via PropertyForm fuselage mode)", () => {
+  it("renders fuselage xsec form fields", () => {
+    render(<Harness />);
+    expect(screen.getByDisplayValue("1")).toBeInTheDocument();
+  });
+
+  it("calls updateFuselageXSec with built payload on imperative save", async () => {
+    mockIsDirty = true;
+    render(<Harness />);
+
+    await act(async () => {
+      screen.getByTestId("trigger-save").click();
+    });
+
+    expect(mockUpdateFuselageXSec).toHaveBeenCalledOnce();
+    const [index, payload] = mockUpdateFuselageXSec.mock.calls[0];
+    expect(index).toBe(0);
+    expect(payload.xyz).toEqual([1.0, 2.0, 3.0]);
+    expect(payload.a).toBe(0.05);
+    expect(payload.b).toBe(0.04);
+    expect(payload.n).toBe(2.5);
+  });
+
+  it("skips save when not dirty", async () => {
+    mockIsDirty = false;
+    render(<Harness />);
+
+    await act(async () => {
+      screen.getByTestId("trigger-save").click();
+    });
+
+    expect(mockUpdateFuselageXSec).not.toHaveBeenCalled();
+  });
+
+  it("propagates save failure as thrown error", async () => {
+    mockIsDirty = true;
+    mockUpdateFuselageXSec.mockRejectedValueOnce(new Error("network error"));
+
+    let caughtError: unknown = null;
+    render(<Harness onSaveResult={(err) => { caughtError = err; }} />);
+
+    await act(async () => {
+      screen.getByTestId("trigger-save").click();
+    });
+
+    expect(caughtError).toBeInstanceOf(Error);
+  });
+});

--- a/frontend/__tests__/PropertyFormHandle.test.tsx
+++ b/frontend/__tests__/PropertyFormHandle.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, act } from "@testing-library/react";
+import React, { useRef, useImperativeHandle, forwardRef } from "react";
+
+interface SaveHandle {
+  save(): Promise<void>;
+}
+
+const MockForm = forwardRef<SaveHandle, { onSave: () => Promise<void>; dirty: boolean }>(
+  function MockForm({ onSave, dirty }, ref) {
+    useImperativeHandle(ref, () => ({
+      async save() {
+        if (!dirty) return;
+        await onSave();
+      },
+    }), [dirty, onSave]);
+    return <div>form</div>;
+  },
+);
+
+function Harness({ onSave, dirty }: { onSave: () => Promise<void>; dirty: boolean }) {
+  const ref = useRef<SaveHandle>(null);
+  return (
+    <>
+      <MockForm ref={ref} onSave={onSave} dirty={dirty} />
+      <button onClick={() => { ref.current?.save().catch(() => {}); }}>trigger-save</button>
+    </>
+  );
+}
+
+describe("imperative save handle", () => {
+  it("calls onSave when dirty", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const { getByText } = render(<Harness onSave={onSave} dirty={true} />);
+    await act(async () => { getByText("trigger-save").click(); });
+    expect(onSave).toHaveBeenCalledOnce();
+  });
+
+  it("skips save when not dirty", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const { getByText } = render(<Harness onSave={onSave} dirty={false} />);
+    await act(async () => { getByText("trigger-save").click(); });
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/__tests__/PropertyFormSave.test.tsx
+++ b/frontend/__tests__/PropertyFormSave.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * Integration tests for PropertyForm's imperative save handle
+ * and FuselageXSecForm's imperative save handle.
+ *
+ * These test the actual components (not mocks) to cover the
+ * useImperativeHandle save dispatch logic added in GH#359.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import React, { useRef } from "react";
+
+// ── Mocks ──────────────────────────────────────────────────────
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) =>
+    React.createElement("span", props);
+  return {
+    ChevronDown: icon, ChevronRight: icon, Eye: icon, Box: icon,
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), prefetch: vi.fn() }),
+}));
+
+vi.mock("@/lib/fetcher", () => ({
+  API_BASE: "http://localhost:8000",
+  fetcher: vi.fn(),
+}));
+
+// AirfoilSelector — stub to avoid complex dependency chain
+vi.mock("@/components/workbench/AirfoilSelector", () => ({
+  AirfoilSelector: () => React.createElement("div", null, "airfoil-selector"),
+}));
+
+// ImportFuselageDialog — stub
+vi.mock("@/components/workbench/ImportFuselageDialog", () => ({
+  ImportFuselageDialog: () => null,
+}));
+
+// ── Controllable mock values ───────────────────────────────────
+
+let mockIsDirty = false;
+const mockSetDirty = vi.fn((v: boolean) => { mockIsDirty = v; });
+
+vi.mock("@/components/workbench/UnsavedChangesContext", () => ({
+  useUnsavedChanges: () => ({
+    isDirty: mockIsDirty,
+    setDirty: mockSetDirty,
+    registerSave: vi.fn(),
+    pendingHref: null,
+    isSaving: false,
+    confirmDiscard: vi.fn(),
+    confirmSave: vi.fn(),
+    cancelNavigation: vi.fn(),
+  }),
+}));
+
+const mockUpdateXSec = vi.fn().mockResolvedValue(undefined);
+const mockMutateWing = vi.fn().mockResolvedValue(undefined);
+const mockSaveWingConfig = vi.fn().mockResolvedValue(undefined);
+const mockMutateWc = vi.fn().mockResolvedValue(undefined);
+const mockUpdateFuselageXSec = vi.fn().mockResolvedValue(undefined);
+const mockMutateFuselage = vi.fn().mockResolvedValue(undefined);
+
+const mockXsec = {
+  airfoil: "mh32",
+  chord: 0.3,
+  twist: 2,
+  xyz_le: [0, 0, 0] as [number, number, number],
+};
+
+const mockSegment = {
+  root_airfoil: { airfoil: "mh32", chord: 300, dihedral_as_rotation_in_degrees: 0, incidence: 0 },
+  tip_airfoil: { airfoil: "mh32", chord: 200, dihedral_as_rotation_in_degrees: 0, incidence: 0 },
+  length: 500,
+  sweep: 50,
+  number_interpolation_points: 201,
+  tip_type: "",
+};
+
+const mockWingConfig = {
+  segments: [mockSegment],
+  nose_pnt: [0, 0, 0],
+  symmetric: true,
+};
+
+let ctxOverrides: Record<string, unknown> = {};
+
+vi.mock("@/components/workbench/AeroplaneContext", () => ({
+  useAeroplaneContext: () => ({
+    aeroplaneId: "aero-1",
+    selectedWing: "wing-1",
+    selectedXsecIndex: 0,
+    selectedFuselage: null,
+    selectedFuselageXsecIndex: null,
+    treeMode: "wingconfig",
+    setAeroplaneId: vi.fn(),
+    selectWing: vi.fn(),
+    selectXsec: vi.fn(),
+    selectFuselage: vi.fn(),
+    selectFuselageXsec: vi.fn(),
+    setTreeMode: vi.fn(),
+    ...ctxOverrides,
+  }),
+}));
+
+vi.mock("@/hooks/useWings", () => ({
+  useWing: () => ({
+    wing: { x_secs: [mockXsec], design_model: null },
+    updateXSec: mockUpdateXSec,
+    mutate: mockMutateWing,
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@/hooks/useWingConfig", () => ({
+  useWingConfig: () => ({
+    wingConfig: mockWingConfig,
+    saveWingConfig: mockSaveWingConfig,
+    mutate: mockMutateWc,
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@/hooks/useFuselage", () => ({
+  useFuselage: () => ({
+    fuselage: { x_secs: [{ xyz: [0, 0, 0], a: 0.05, b: 0.04, n: 2 }] },
+    updateXSec: mockUpdateFuselageXSec,
+    mutate: mockMutateFuselage,
+    isLoading: false,
+  }),
+}));
+
+import { PropertyForm, type PropertyFormHandle } from "@/components/workbench/PropertyForm";
+
+// ── Test harness ───────────────────────────────────────────────
+
+function Harness({ onSaveResult }: { onSaveResult?: (err: unknown) => void }) {
+  const ref = useRef<PropertyFormHandle>(null);
+  return (
+    <>
+      <PropertyForm ref={ref} onGeometryChanged={() => {}} />
+      <button
+        data-testid="trigger-save"
+        onClick={() => {
+          ref.current?.save()
+            .then(() => onSaveResult?.(null))
+            .catch((err) => onSaveResult?.(err));
+        }}
+      >
+        trigger
+      </button>
+    </>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsDirty = false;
+  ctxOverrides = {};
+});
+
+// ── Tests ──────────────────────────────────────────────────────
+
+describe("PropertyForm imperative save handle", () => {
+  it("skips save when not dirty", async () => {
+    mockIsDirty = false;
+    render(<Harness />);
+    await act(async () => {
+      screen.getByTestId("trigger-save").click();
+    });
+    expect(mockSaveWingConfig).not.toHaveBeenCalled();
+    expect(mockUpdateXSec).not.toHaveBeenCalled();
+  });
+
+  it("calls saveWingConfig in wingconfig mode when dirty", async () => {
+    mockIsDirty = true;
+    ctxOverrides = { treeMode: "wingconfig" };
+    render(<Harness />);
+    await act(async () => {
+      screen.getByTestId("trigger-save").click();
+    });
+    expect(mockSaveWingConfig).toHaveBeenCalledOnce();
+  });
+
+  it("calls updateXSec in asb mode when dirty", async () => {
+    mockIsDirty = true;
+    ctxOverrides = { treeMode: "asb" };
+    render(<Harness />);
+    await act(async () => {
+      screen.getByTestId("trigger-save").click();
+    });
+    expect(mockUpdateXSec).toHaveBeenCalledOnce();
+  });
+
+  it("throws when wingconfig save fails", async () => {
+    mockIsDirty = true;
+    ctxOverrides = { treeMode: "wingconfig" };
+    mockSaveWingConfig.mockRejectedValueOnce(new Error("network error"));
+
+    let caughtError: unknown = null;
+    render(<Harness onSaveResult={(err) => { caughtError = err; }} />);
+    await act(async () => {
+      screen.getByTestId("trigger-save").click();
+    });
+    expect(caughtError).toBeInstanceOf(Error);
+    expect((caughtError as Error).message).toBe("Save failed");
+  });
+
+  it("throws when asb save fails", async () => {
+    mockIsDirty = true;
+    ctxOverrides = { treeMode: "asb" };
+    mockUpdateXSec.mockRejectedValueOnce(new Error("network error"));
+
+    let caughtError: unknown = null;
+    render(<Harness onSaveResult={(err) => { caughtError = err; }} />);
+    await act(async () => {
+      screen.getByTestId("trigger-save").click();
+    });
+    expect(caughtError).toBeInstanceOf(Error);
+    expect((caughtError as Error).message).toBe("Save failed");
+  });
+});

--- a/frontend/__tests__/SegmentPaginator.test.tsx
+++ b/frontend/__tests__/SegmentPaginator.test.tsx
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) =>
+    React.createElement("span", { ...props, "data-testid": props["data-testid"] || "icon" });
+  return { ChevronLeft: icon, ChevronRight: icon };
+});
+
+import { SegmentPaginator } from "@/components/workbench/SegmentPaginator";
+
+describe("SegmentPaginator", () => {
+  const onChange = vi.fn<(n: number) => Promise<void>>().mockResolvedValue(undefined);
+
+  beforeEach(() => vi.clearAllMocks());
+
+  describe("few segments (total <= 5)", () => {
+    it("renders all indices for total=4", () => {
+      render(<SegmentPaginator current={0} total={4} onChange={onChange} />);
+      expect(screen.getByRole("button", { name: "0" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "1" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "2" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "3" })).toBeInTheDocument();
+      expect(screen.queryByText("…")).not.toBeInTheDocument();
+    });
+
+    it("renders single index for total=1", () => {
+      render(<SegmentPaginator current={0} total={1} onChange={onChange} />);
+      expect(screen.getByRole("button", { name: "0" })).toBeInTheDocument();
+    });
+  });
+
+  describe("many segments (total > 5) — ellipsis", () => {
+    it("current=0: shows 0 1 … 10", () => {
+      render(<SegmentPaginator current={0} total={11} onChange={onChange} />);
+      expect(screen.getByRole("button", { name: "0" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "1" })).toBeInTheDocument();
+      expect(screen.getByText("…")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "10" })).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "2" })).not.toBeInTheDocument();
+    });
+
+    it("current=5: shows 0 … 4 5 6 … 10", () => {
+      render(<SegmentPaginator current={5} total={11} onChange={onChange} />);
+      expect(screen.getByRole("button", { name: "0" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "4" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "5" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "6" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "10" })).toBeInTheDocument();
+      expect(screen.getAllByText("…")).toHaveLength(2);
+    });
+
+    it("current=10: shows 0 … 9 10", () => {
+      render(<SegmentPaginator current={10} total={11} onChange={onChange} />);
+      expect(screen.getByRole("button", { name: "0" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "9" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "10" })).toBeInTheDocument();
+      expect(screen.getAllByText("…")).toHaveLength(1);
+    });
+
+    it("current=1: shows 0 1 2 … 10", () => {
+      render(<SegmentPaginator current={1} total={11} onChange={onChange} />);
+      expect(screen.getByRole("button", { name: "0" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "1" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "2" })).toBeInTheDocument();
+      expect(screen.getAllByText("…")).toHaveLength(1);
+      expect(screen.getByRole("button", { name: "10" })).toBeInTheDocument();
+    });
+
+    it("current=9: shows 0 … 8 9 10", () => {
+      render(<SegmentPaginator current={9} total={11} onChange={onChange} />);
+      expect(screen.getByRole("button", { name: "0" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "8" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "9" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "10" })).toBeInTheDocument();
+      expect(screen.getAllByText("…")).toHaveLength(1);
+    });
+  });
+
+  describe("current highlight", () => {
+    it("highlights current index with accent style", () => {
+      render(<SegmentPaginator current={2} total={4} onChange={onChange} />);
+      const btn = screen.getByRole("button", { name: "2" });
+      expect(btn.className).toMatch(/bg-primary/);
+    });
+  });
+
+  describe("arrow buttons", () => {
+    it("prev arrow disabled at index 0", () => {
+      render(<SegmentPaginator current={0} total={4} onChange={onChange} />);
+      const prev = screen.getByLabelText("Previous segment");
+      expect(prev).toBeDisabled();
+    });
+
+    it("next arrow disabled at last index", () => {
+      render(<SegmentPaginator current={3} total={4} onChange={onChange} />);
+      const next = screen.getByLabelText("Next segment");
+      expect(next).toBeDisabled();
+    });
+
+    it("prev arrow calls onChange(current - 1)", async () => {
+      render(<SegmentPaginator current={2} total={4} onChange={onChange} />);
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText("Previous segment"));
+      });
+      expect(onChange).toHaveBeenCalledWith(1);
+    });
+
+    it("next arrow calls onChange(current + 1)", async () => {
+      render(<SegmentPaginator current={1} total={4} onChange={onChange} />);
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText("Next segment"));
+      });
+      expect(onChange).toHaveBeenCalledWith(2);
+    });
+  });
+
+  describe("index click", () => {
+    it("calls onChange with clicked index", async () => {
+      render(<SegmentPaginator current={0} total={4} onChange={onChange} />);
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "3" }));
+      });
+      expect(onChange).toHaveBeenCalledWith(3);
+    });
+
+    it("does not call onChange when clicking current index", async () => {
+      render(<SegmentPaginator current={2} total={4} onChange={onChange} />);
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "2" }));
+      });
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("disabled states", () => {
+    it("all buttons disabled when disabled prop is true", () => {
+      render(<SegmentPaginator current={1} total={4} onChange={onChange} disabled />);
+      const buttons = screen.getAllByRole("button");
+      buttons.forEach((btn) => expect(btn).toBeDisabled());
+    });
+
+    it("all buttons disabled while onChange is in flight", async () => {
+      let resolveOnChange: () => void;
+      const slowChange = vi.fn<(n: number) => Promise<void>>(
+        () => new Promise((r) => { resolveOnChange = r; }),
+      );
+      render(<SegmentPaginator current={1} total={4} onChange={slowChange} />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText("Next segment"));
+      });
+
+      const buttons = screen.getAllByRole("button");
+      buttons.forEach((btn) => expect(btn).toBeDisabled());
+
+      await act(async () => { resolveOnChange!(); });
+
+      expect(screen.getByLabelText("Next segment")).not.toBeDisabled();
+    });
+  });
+});

--- a/frontend/__tests__/setup.ts
+++ b/frontend/__tests__/setup.ts
@@ -1,3 +1,5 @@
+import "@testing-library/jest-dom";
+
 /**
  * Vitest setup — polyfill HTMLDialogElement for jsdom.
  *

--- a/frontend/app/workbench/page.tsx
+++ b/frontend/app/workbench/page.tsx
@@ -46,11 +46,12 @@ export default function WorkbenchPage() {
   const formRef = useRef<PropertyFormHandle>(null);
 
   const handleSegmentChange = useCallback(async (newIndex: number) => {
-    try {
-      await formRef.current?.save();
-    } catch (err) {
-      console.error("[WorkbenchPage] Auto-save before segment change failed:", err);
-      return;
+    if (formRef.current) {
+      try {
+        await formRef.current.save();
+      } catch {
+        return;
+      }
     }
     if (mode === "fuselage") {
       selectFuselageXsec(newIndex);
@@ -261,6 +262,7 @@ export default function WorkbenchPage() {
                 />
               )}
               <button
+                aria-label="Close"
                 onClick={() => setConfigOpen(false)}
                 className="flex size-6 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent"
               >

--- a/frontend/app/workbench/page.tsx
+++ b/frontend/app/workbench/page.tsx
@@ -48,7 +48,8 @@ export default function WorkbenchPage() {
   const handleSegmentChange = useCallback(async (newIndex: number) => {
     try {
       await formRef.current?.save();
-    } catch {
+    } catch (err) {
+      console.error("[WorkbenchPage] Auto-save before segment change failed:", err);
       return;
     }
     if (mode === "fuselage") {

--- a/frontend/app/workbench/page.tsx
+++ b/frontend/app/workbench/page.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useCallback, useRef } from "react";
 import { PanelLeftOpen, Maximize2, Minimize2, X } from "lucide-react";
 import { useDialog } from "@/hooks/useDialog";
 import { PropertyForm } from "@/components/workbench/PropertyForm";
+import { SegmentPaginator } from "@/components/workbench/SegmentPaginator";
+import { type PropertyFormHandle } from "@/components/workbench/PropertyForm";
+import { useWingConfig } from "@/hooks/useWingConfig";
 import { AeroplaneTree } from "@/components/workbench/AeroplaneTree";
 import { SparEditDialog } from "@/components/workbench/SparEditDialog";
 import { TedEditDialog } from "@/components/workbench/TedEditDialog";
@@ -12,15 +15,45 @@ import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
 import { useAeroplanes } from "@/hooks/useAeroplanes";
 import { useWings, useWing, useAllWingData } from "@/hooks/useWings";
 import { useFuselages } from "@/hooks/useFuselages";
-import { useAllFuselageData } from "@/hooks/useFuselage";
+import { useAllFuselageData, useFuselage } from "@/hooks/useFuselage";
 import { API_BASE } from "@/lib/fetcher";
 
 export default function WorkbenchPage() {
-  const { aeroplaneId, setAeroplaneId, selectedWing, selectedXsecIndex, selectedFuselage, selectedFuselageXsecIndex } = useAeroplaneContext();
+  const { aeroplaneId, setAeroplaneId, selectedWing, selectedXsecIndex, selectXsec, selectedFuselage, selectedFuselageXsecIndex, selectFuselageXsec, treeMode } = useAeroplaneContext();
   const { aeroplanes, isLoading, createAeroplane } = useAeroplanes();
   const { wingNames, mutate: mutateWingNames } = useWings(aeroplaneId);
   const { fuselageNames, mutate: mutateFuselages } = useFuselages(aeroplaneId);
-  const { mutate: mutateSelectedWing } = useWing(aeroplaneId, selectedWing);
+  const { wing, mutate: mutateSelectedWing } = useWing(aeroplaneId, selectedWing);
+  const { wingConfig } = useWingConfig(aeroplaneId, treeMode === "wingconfig" ? selectedWing : null);
+  const { fuselage } = useFuselage(aeroplaneId, treeMode === "fuselage" ? selectedFuselage : null);
+
+  const mode = treeMode === "fuselage" ? "fuselage" : treeMode;
+
+  const paginatorCurrent = mode === "fuselage"
+    ? selectedFuselageXsecIndex
+    : selectedXsecIndex;
+
+  const paginatorTotal = mode === "fuselage"
+    ? fuselage?.x_secs?.length
+    : mode === "wingconfig"
+      ? wingConfig?.segments?.length
+      : wing?.x_secs?.length;
+
+  const formRef = useRef<PropertyFormHandle>(null);
+
+  const handleSegmentChange = useCallback(async (newIndex: number) => {
+    try {
+      await formRef.current?.save();
+    } catch {
+      return;
+    }
+    if (mode === "fuselage") {
+      selectFuselageXsec(newIndex);
+    } else {
+      selectXsec(newIndex);
+    }
+  }, [mode, selectXsec, selectFuselageXsec]);
+
   const aeroplaneName =
     aeroplanes.find((a) => a.id === aeroplaneId)?.name ?? "Aeroplane";
 
@@ -215,6 +248,13 @@ export default function WorkbenchPage() {
               <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
                 Configuration
               </h2>
+              {paginatorCurrent !== null && paginatorTotal != null && paginatorTotal > 1 && (
+                <SegmentPaginator
+                  current={paginatorCurrent}
+                  total={paginatorTotal}
+                  onChange={handleSegmentChange}
+                />
+              )}
               <button
                 onClick={() => setConfigOpen(false)}
                 className="flex size-6 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent"
@@ -222,7 +262,7 @@ export default function WorkbenchPage() {
                 <X size={14} />
               </button>
             </div>
-            <PropertyForm onGeometryChanged={() => { mutateAllWings(); mutateSelectedWing(); mutateAllFuselages(); }} />
+            <PropertyForm ref={formRef} onGeometryChanged={() => { mutateAllWings(); mutateSelectedWing(); mutateAllFuselages(); }} />
           </div>
         )}
       </dialog>

--- a/frontend/app/workbench/page.tsx
+++ b/frontend/app/workbench/page.tsx
@@ -3,9 +3,8 @@
 import { useState, useMemo, useCallback, useRef } from "react";
 import { PanelLeftOpen, Maximize2, Minimize2, X } from "lucide-react";
 import { useDialog } from "@/hooks/useDialog";
-import { PropertyForm } from "@/components/workbench/PropertyForm";
+import { PropertyForm, type PropertyFormHandle } from "@/components/workbench/PropertyForm";
 import { SegmentPaginator } from "@/components/workbench/SegmentPaginator";
-import { type PropertyFormHandle } from "@/components/workbench/PropertyForm";
 import { useWingConfig } from "@/hooks/useWingConfig";
 import { AeroplaneTree } from "@/components/workbench/AeroplaneTree";
 import { SparEditDialog } from "@/components/workbench/SparEditDialog";
@@ -19,7 +18,12 @@ import { useAllFuselageData, useFuselage } from "@/hooks/useFuselage";
 import { API_BASE } from "@/lib/fetcher";
 
 export default function WorkbenchPage() {
-  const { aeroplaneId, setAeroplaneId, selectedWing, selectedXsecIndex, selectXsec, selectedFuselage, selectedFuselageXsecIndex, selectFuselageXsec, treeMode } = useAeroplaneContext();
+  const {
+    aeroplaneId, setAeroplaneId,
+    selectedWing, selectedXsecIndex, selectXsec,
+    selectedFuselage, selectedFuselageXsecIndex, selectFuselageXsec,
+    treeMode,
+  } = useAeroplaneContext();
   const { aeroplanes, isLoading, createAeroplane } = useAeroplanes();
   const { wingNames, mutate: mutateWingNames } = useWings(aeroplaneId);
   const { fuselageNames, mutate: mutateFuselages } = useFuselages(aeroplaneId);
@@ -248,7 +252,7 @@ export default function WorkbenchPage() {
               <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
                 Configuration
               </h2>
-              {paginatorCurrent !== null && paginatorTotal != null && paginatorTotal > 1 && (
+              {paginatorCurrent != null && paginatorTotal != null && paginatorTotal > 1 && (
                 <SegmentPaginator
                   current={paginatorCurrent}
                   total={paginatorTotal}

--- a/frontend/components/workbench/PropertyForm.tsx
+++ b/frontend/components/workbench/PropertyForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useId, useRef, forwardRef, useImperativeHandle } from "react";
+import { useEffect, useState, useId, useRef, useImperativeHandle } from "react";
 import { useRouter } from "next/navigation";
 import { Box, ChevronDown, Eye } from "lucide-react";
 import { AirfoilSelector } from "./AirfoilSelector";
@@ -522,8 +522,10 @@ function renderFuselageXsecForm(opts: FuselageXsecFormOptions): React.ReactEleme
 
 // ── Main Component ──────────────────────────────────────────────
 
-export const PropertyForm = forwardRef<PropertyFormHandle, Readonly<{ onGeometryChanged?: (wingName: string) => void }>>(
-  function PropertyForm({ onGeometryChanged }, ref) {
+export function PropertyForm({ onGeometryChanged, ref }: Readonly<{
+  onGeometryChanged?: (wingName: string) => void;
+  ref?: React.Ref<PropertyFormHandle>;
+}>) {
   const { aeroplaneId, selectedWing, selectedXsecIndex, selectedFuselage, selectedFuselageXsecIndex, treeMode } =
     useAeroplaneContext();
   const { wing, updateXSec, mutate } = useWing(aeroplaneId, selectedWing);
@@ -599,14 +601,15 @@ export const PropertyForm = forwardRef<PropertyFormHandle, Readonly<{ onGeometry
     async save() {
       if (!isDirty) return;
       if (mode === "fuselage") {
-        await fuselageFormRef.current?.save();
+        if (!fuselageFormRef.current) throw new Error("Fuselage form not mounted");
+        await fuselageFormRef.current.save();
       } else if (mode === "wingconfig") {
-        await handleSaveWingConfig();
+        if (!await handleSaveWingConfig()) throw new Error("Save failed");
       } else {
-        await handleSaveAsb();
+        if (!await handleSaveAsb()) throw new Error("Save failed");
       }
     },
-  }), [isDirty, mode]);
+  }));
 
   // Fuselage xsec mode — delegate to dedicated form
   const fuselageXsecForm = renderFuselageXsecForm({
@@ -632,8 +635,8 @@ export const PropertyForm = forwardRef<PropertyFormHandle, Readonly<{ onGeometry
     setDirty(false);
   }
 
-  async function handleSaveAsb() {
-    if (!asb) return;
+  async function handleSaveAsb(): Promise<boolean> {
+    if (!asb) return false;
     setSaving(true);
     setError(null);
     try {
@@ -641,16 +644,17 @@ export const PropertyForm = forwardRef<PropertyFormHandle, Readonly<{ onGeometry
       await mutate();
       if (selectedWing) onGeometryChanged?.(selectedWing);
       setDirty(false);
+      return true;
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Save failed");
-      throw err;
+      return false;
     } finally {
       setSaving(false);
     }
   }
 
-  async function handleSaveWingConfig() {
-    if (!wc || !wingConfig || selectedXsecIndex === null) return;
+  async function handleSaveWingConfig(): Promise<boolean> {
+    if (!wc || !wingConfig || selectedXsecIndex === null) return false;
     setSaving(true);
     setError(null);
     try {
@@ -665,9 +669,10 @@ export const PropertyForm = forwardRef<PropertyFormHandle, Readonly<{ onGeometry
       await mutateWc();
       if (selectedWing) onGeometryChanged?.(selectedWing);
       setDirty(false);
+      return true;
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Save failed");
-      throw err;
+      return false;
     } finally {
       setSaving(false);
     }
@@ -721,7 +726,7 @@ export const PropertyForm = forwardRef<PropertyFormHandle, Readonly<{ onGeometry
               Cancel
             </button>
             <button
-              onClick={() => void handleSave().catch((err) => console.error("[PropertyForm] Save failed:", err))}
+              onClick={handleSave}
               disabled={saving}
               className="rounded-full bg-primary px-4 py-2 text-[13px] text-primary-foreground hover:opacity-90 disabled:opacity-50"
             >
@@ -733,20 +738,20 @@ export const PropertyForm = forwardRef<PropertyFormHandle, Readonly<{ onGeometry
       )}
     </div>
   );
-  },
-);
+}
 
 
 
 // ── Fuselage XSec Form ────────────────────────────────────────
 
-const FuselageXSecForm = forwardRef<PropertyFormHandle, Readonly<{
+function FuselageXSecForm({ aeroplaneId, fuselageName, xsecIndex, xsec, onSave, ref }: Readonly<{
   aeroplaneId: string | null;
   fuselageName: string;
   xsecIndex: number;
   xsec: FuselageXSec;
   onSave: (updated: FuselageXSec) => Promise<void>;
-}>>(function FuselageXSecForm({ aeroplaneId, fuselageName, xsecIndex, xsec, onSave }, ref) {
+  ref?: React.Ref<PropertyFormHandle>;
+}>) {
   const [xyz0, setXyz0] = useState(String(xsec.xyz[0]));
   const [xyz1, setXyz1] = useState(String(xsec.xyz[1]));
   const [xyz2, setXyz2] = useState(String(xsec.xyz[2]));
@@ -881,4 +886,4 @@ const FuselageXSecForm = forwardRef<PropertyFormHandle, Readonly<{
       </div>
     </div>
   );
-});
+}

--- a/frontend/components/workbench/PropertyForm.tsx
+++ b/frontend/components/workbench/PropertyForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useId, forwardRef, useImperativeHandle } from "react";
+import { useEffect, useState, useId, useRef, forwardRef, useImperativeHandle } from "react";
 import { useRouter } from "next/navigation";
 import { Box, ChevronDown, Eye } from "lucide-react";
 import { AirfoilSelector } from "./AirfoilSelector";
@@ -493,11 +493,12 @@ interface FuselageXsecFormOptions {
   updateFuselageXSec: (idx: number, xsec: FuselageXSec) => Promise<void>;
   mutateFuselage: () => Promise<unknown>;
   onGeometryChanged: ((wingName: string) => void) | undefined;
+  formRef: React.RefObject<PropertyFormHandle | null>;
 }
 
 function renderFuselageXsecForm(opts: FuselageXsecFormOptions): React.ReactElement | null {
   const { mode, selectedFuselage, selectedFuselageXsecIndex, fuselage,
-    aeroplaneId, updateFuselageXSec, mutateFuselage, onGeometryChanged } = opts;
+    aeroplaneId, updateFuselageXSec, mutateFuselage, onGeometryChanged, formRef } = opts;
   if (mode !== "fuselage" || !selectedFuselage || selectedFuselageXsecIndex === null || !fuselage) {
     return null;
   }
@@ -505,6 +506,7 @@ function renderFuselageXsecForm(opts: FuselageXsecFormOptions): React.ReactEleme
   if (!fxsec) return null;
   return (
     <FuselageXSecForm
+      ref={formRef}
       aeroplaneId={aeroplaneId}
       fuselageName={selectedFuselage}
       xsecIndex={selectedFuselageXsecIndex}
@@ -591,23 +593,26 @@ export const PropertyForm = forwardRef<PropertyFormHandle, Readonly<{ onGeometry
     }
   }, [wingConfig, selectedXsecIndex]);
 
+  const fuselageFormRef = useRef<PropertyFormHandle>(null);
+
   useImperativeHandle(ref, () => ({
     async save() {
       if (!isDirty) return;
-      if (mode === "wingconfig") {
+      if (mode === "fuselage") {
+        await fuselageFormRef.current?.save();
+      } else if (mode === "wingconfig") {
         await handleSaveWingConfig();
-      } else if (mode === "fuselage") {
-        await handleSaveFuselage();
       } else {
         await handleSaveAsb();
       }
     },
-  }));
+  }), [isDirty, mode]);
 
   // Fuselage xsec mode — delegate to dedicated form
   const fuselageXsecForm = renderFuselageXsecForm({
     mode, selectedFuselage, selectedFuselageXsecIndex, fuselage,
     aeroplaneId, updateFuselageXSec, mutateFuselage, onGeometryChanged,
+    formRef: fuselageFormRef,
   });
   if (fuselageXsecForm) return fuselageXsecForm;
 
@@ -668,25 +673,6 @@ export const PropertyForm = forwardRef<PropertyFormHandle, Readonly<{ onGeometry
     }
   }
 
-  async function handleSaveFuselage() {
-    if (mode !== "fuselage" || !selectedFuselage || selectedFuselageXsecIndex === null || !fuselage) return;
-    const fxsec = fuselage.x_secs[selectedFuselageXsecIndex];
-    if (!fxsec) return;
-    setSaving(true);
-    setError(null);
-    try {
-      await updateFuselageXSec(selectedFuselageXsecIndex, fxsec);
-      await mutateFuselage();
-      onGeometryChanged?.("");
-      setDirty(false);
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Save failed");
-      throw err;
-    } finally {
-      setSaving(false);
-    }
-  }
-
   const handleSave = mode === "wingconfig" ? handleSaveWingConfig : handleSaveAsb;
 
   return (
@@ -735,7 +721,7 @@ export const PropertyForm = forwardRef<PropertyFormHandle, Readonly<{ onGeometry
               Cancel
             </button>
             <button
-              onClick={() => void handleSave().catch(() => {})}
+              onClick={() => void handleSave().catch((err) => console.error("[PropertyForm] Save failed:", err))}
               disabled={saving}
               className="rounded-full bg-primary px-4 py-2 text-[13px] text-primary-foreground hover:opacity-90 disabled:opacity-50"
             >
@@ -754,19 +740,13 @@ export const PropertyForm = forwardRef<PropertyFormHandle, Readonly<{ onGeometry
 
 // ── Fuselage XSec Form ────────────────────────────────────────
 
-function FuselageXSecForm({
-  aeroplaneId,
-  fuselageName,
-  xsecIndex,
-  xsec,
-  onSave,
-}: Readonly<{
+const FuselageXSecForm = forwardRef<PropertyFormHandle, Readonly<{
   aeroplaneId: string | null;
   fuselageName: string;
   xsecIndex: number;
   xsec: FuselageXSec;
   onSave: (updated: FuselageXSec) => Promise<void>;
-}>) {
+}>>(function FuselageXSecForm({ aeroplaneId, fuselageName, xsecIndex, xsec, onSave }, ref) {
   const [xyz0, setXyz0] = useState(String(xsec.xyz[0]));
   const [xyz1, setXyz1] = useState(String(xsec.xyz[1]));
   const [xyz2, setXyz2] = useState(String(xsec.xyz[2]));
@@ -791,16 +771,34 @@ function FuselageXSecForm({
     setError(null);
   }, [xsec, xsecIndex]);
 
+  const buildPayload = (): FuselageXSec => ({
+    xyz: [Number.parseFloat(xyz0) || 0, Number.parseFloat(xyz1) || 0, Number.parseFloat(xyz2) || 0],
+    a: Number.parseFloat(a) || 0.001,
+    b: Number.parseFloat(b) || 0.001,
+    n: Math.max(0.5, Math.min(10, Number.parseFloat(n) || 2)),
+  });
+
+  useImperativeHandle(ref, () => ({
+    async save() {
+      setSaving(true);
+      setError(null);
+      try {
+        await onSave(buildPayload());
+        setDirty(false);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+        throw err;
+      } finally {
+        setSaving(false);
+      }
+    },
+  }));
+
   const handleSave = async () => {
     setSaving(true);
     setError(null);
     try {
-      await onSave({
-        xyz: [Number.parseFloat(xyz0) || 0, Number.parseFloat(xyz1) || 0, Number.parseFloat(xyz2) || 0],
-        a: Number.parseFloat(a) || 0.001,
-        b: Number.parseFloat(b) || 0.001,
-        n: Math.max(0.5, Math.min(10, Number.parseFloat(n) || 2)),
-      });
+      await onSave(buildPayload());
       setDirty(false);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -883,4 +881,4 @@ function FuselageXSecForm({
       </div>
     </div>
   );
-}
+});

--- a/frontend/components/workbench/PropertyForm.tsx
+++ b/frontend/components/workbench/PropertyForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useId } from "react";
+import { useEffect, useState, useId, forwardRef, useImperativeHandle } from "react";
 import { useRouter } from "next/navigation";
 import { Box, ChevronDown, Eye } from "lucide-react";
 import { AirfoilSelector } from "./AirfoilSelector";
@@ -22,6 +22,10 @@ function num(v: string, fallback = 0): number {
 // ── Types ───────────────────────────────────────────────────────
 
 type Mode = "wingconfig" | "asb" | "fuselage";
+
+export interface PropertyFormHandle {
+  save(): Promise<void>;
+}
 
 interface WingConfigState {
   root_airfoil: string;
@@ -516,7 +520,8 @@ function renderFuselageXsecForm(opts: FuselageXsecFormOptions): React.ReactEleme
 
 // ── Main Component ──────────────────────────────────────────────
 
-export function PropertyForm({ onGeometryChanged }: Readonly<{ onGeometryChanged?: (wingName: string) => void }>) {
+export const PropertyForm = forwardRef<PropertyFormHandle, Readonly<{ onGeometryChanged?: (wingName: string) => void }>>(
+  function PropertyForm({ onGeometryChanged }, ref) {
   const { aeroplaneId, selectedWing, selectedXsecIndex, selectedFuselage, selectedFuselageXsecIndex, treeMode } =
     useAeroplaneContext();
   const { wing, updateXSec, mutate } = useWing(aeroplaneId, selectedWing);
@@ -541,7 +546,7 @@ export function PropertyForm({ onGeometryChanged }: Readonly<{ onGeometryChanged
     treeMode === "fuselage" ? selectedFuselage : null,
   );
 
-  const { setDirty } = useUnsavedChanges();
+  const { isDirty, setDirty } = useUnsavedChanges();
   const router = useRouter();
 
   // (TED editing is now handled by TedEditDialog — no more tedSaveRef needed)
@@ -586,6 +591,19 @@ export function PropertyForm({ onGeometryChanged }: Readonly<{ onGeometryChanged
     }
   }, [wingConfig, selectedXsecIndex]);
 
+  useImperativeHandle(ref, () => ({
+    async save() {
+      if (!isDirty) return;
+      if (mode === "wingconfig") {
+        await handleSaveWingConfig();
+      } else if (mode === "fuselage") {
+        await handleSaveFuselage();
+      } else {
+        await handleSaveAsb();
+      }
+    },
+  }));
+
   // Fuselage xsec mode — delegate to dedicated form
   const fuselageXsecForm = renderFuselageXsecForm({
     mode, selectedFuselage, selectedFuselageXsecIndex, fuselage,
@@ -620,6 +638,7 @@ export function PropertyForm({ onGeometryChanged }: Readonly<{ onGeometryChanged
       setDirty(false);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Save failed");
+      throw err;
     } finally {
       setSaving(false);
     }
@@ -643,6 +662,26 @@ export function PropertyForm({ onGeometryChanged }: Readonly<{ onGeometryChanged
       setDirty(false);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Save failed");
+      throw err;
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleSaveFuselage() {
+    if (mode !== "fuselage" || !selectedFuselage || selectedFuselageXsecIndex === null || !fuselage) return;
+    const fxsec = fuselage.x_secs[selectedFuselageXsecIndex];
+    if (!fxsec) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await updateFuselageXSec(selectedFuselageXsecIndex, fxsec);
+      await mutateFuselage();
+      onGeometryChanged?.("");
+      setDirty(false);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Save failed");
+      throw err;
     } finally {
       setSaving(false);
     }
@@ -696,7 +735,7 @@ export function PropertyForm({ onGeometryChanged }: Readonly<{ onGeometryChanged
               Cancel
             </button>
             <button
-              onClick={handleSave}
+              onClick={() => void handleSave().catch(() => {})}
               disabled={saving}
               className="rounded-full bg-primary px-4 py-2 text-[13px] text-primary-foreground hover:opacity-90 disabled:opacity-50"
             >
@@ -708,7 +747,8 @@ export function PropertyForm({ onGeometryChanged }: Readonly<{ onGeometryChanged
       )}
     </div>
   );
-}
+  },
+);
 
 
 

--- a/frontend/components/workbench/SegmentPaginator.tsx
+++ b/frontend/components/workbench/SegmentPaginator.tsx
@@ -40,6 +40,8 @@ export function SegmentPaginator({ current, total, onChange, disabled }: Readonl
     setLoading(true);
     try {
       await onChange(index);
+    } catch (err) {
+      console.error("[SegmentPaginator] onChange failed:", err);
     } finally {
       setLoading(false);
     }

--- a/frontend/components/workbench/SegmentPaginator.tsx
+++ b/frontend/components/workbench/SegmentPaginator.tsx
@@ -66,6 +66,7 @@ export function SegmentPaginator({ current, total, onChange, disabled }: Readonl
         ) : (
           <button
             key={page}
+            title={`Segment ${page}`}
             disabled={isDisabled}
             onClick={() => handleClick(page)}
             className={`flex size-6 items-center justify-center rounded font-[family-name:var(--font-jetbrains-mono)] text-[11px] ${

--- a/frontend/components/workbench/SegmentPaginator.tsx
+++ b/frontend/components/workbench/SegmentPaginator.tsx
@@ -40,8 +40,6 @@ export function SegmentPaginator({ current, total, onChange, disabled }: Readonl
     setLoading(true);
     try {
       await onChange(index);
-    } catch (err) {
-      console.error("[SegmentPaginator] onChange failed:", err);
     } finally {
       setLoading(false);
     }

--- a/frontend/components/workbench/SegmentPaginator.tsx
+++ b/frontend/components/workbench/SegmentPaginator.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+interface SegmentPaginatorProps {
+  current: number;
+  total: number;
+  onChange: (index: number) => Promise<void>;
+  disabled?: boolean;
+}
+
+function buildPageIndices(current: number, total: number): (number | "ellipsis")[] {
+  if (total <= 5) {
+    return Array.from({ length: total }, (_, i) => i);
+  }
+  const pages = new Set<number>();
+  pages.add(0);
+  pages.add(total - 1);
+  for (let i = current - 1; i <= current + 1; i++) {
+    if (i >= 0 && i < total) pages.add(i);
+  }
+  const sorted = [...pages].sort((a, b) => a - b);
+  const result: (number | "ellipsis")[] = [];
+  for (let i = 0; i < sorted.length; i++) {
+    if (i > 0 && sorted[i] - sorted[i - 1] > 1) {
+      result.push("ellipsis");
+    }
+    result.push(sorted[i]);
+  }
+  return result;
+}
+
+export function SegmentPaginator({ current, total, onChange, disabled }: Readonly<SegmentPaginatorProps>) {
+  const [loading, setLoading] = useState(false);
+  const isDisabled = disabled || loading;
+
+  const handleClick = useCallback(async (index: number) => {
+    if (index === current) return;
+    setLoading(true);
+    try {
+      await onChange(index);
+    } finally {
+      setLoading(false);
+    }
+  }, [current, onChange]);
+
+  const pages = buildPageIndices(current, total);
+
+  return (
+    <div className="flex items-center gap-1">
+      <button
+        aria-label="Previous segment"
+        disabled={isDisabled || current === 0}
+        onClick={() => handleClick(current - 1)}
+        className="flex size-6 items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed"
+      >
+        <ChevronLeft size={14} />
+      </button>
+
+      {pages.map((page, i) =>
+        page === "ellipsis" ? (
+          <span key={`ellipsis-${i}`} className="px-0.5 text-[12px] text-muted-foreground">
+            …
+          </span>
+        ) : (
+          <button
+            key={page}
+            disabled={isDisabled}
+            onClick={() => handleClick(page)}
+            className={`flex size-6 items-center justify-center rounded font-[family-name:var(--font-jetbrains-mono)] text-[11px] ${
+              page === current
+                ? "bg-primary text-primary-foreground font-bold"
+                : "border border-border text-muted-foreground hover:bg-sidebar-accent"
+            } disabled:opacity-30 disabled:cursor-not-allowed`}
+          >
+            {page}
+          </button>
+        ),
+      )}
+
+      <button
+        aria-label="Next segment"
+        disabled={isDisabled || current === total - 1}
+        onClick={() => handleClick(current + 1)}
+        className="flex size-6 items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed"
+      >
+        <ChevronRight size={14} />
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds inline `SegmentPaginator` component with ellipsis truncation to the Configuration dialog header, enabling navigation between segments/cross-sections without closing the dialog
- Exposes an imperative `save()` handle on `PropertyForm` via `forwardRef`/`useImperativeHandle` for auto-save before switching segments
- Supports all three modes: wingconfig segments, ASB cross-sections, and fuselage cross-sections

Closes #359

## Test plan

- [x] 16 unit tests for `SegmentPaginator` (ellipsis logic, arrow buttons, click handling, disabled states, in-flight loading)
- [x] 2 pattern validation tests for `PropertyFormHandle` (dirty/clean save behavior)
- [x] All 299 frontend unit tests passing
- [x] Manual browser test: paginator visible in wingconfig mode, correct segment count, prev/next arrow boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)