### PR TITLE
feat(gh-370): delete aeroplanes and unified modal picker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ stls/
 *.stl
 *.zip
 *.stp
+.worktrees/
 
 # Created by .ignore support plugin (hsz.mobi)
 ### Python template

--- a/frontend/app/workbench/analysis/page.tsx
+++ b/frontend/app/workbench/analysis/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { X } from "lucide-react";
 import { useDialog } from "@/hooks/useDialog";
 import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
@@ -12,7 +12,7 @@ import { AnalysisViewerPanel, type Tab } from "@/components/workbench/AnalysisVi
 import { AnalysisConfigPanel } from "@/components/workbench/AnalysisConfigPanel";
 
 export default function AnalysisPage() {
-  const { aeroplaneId, selectedWing } = useAeroplaneContext();
+  const { aeroplaneId, selectedWing, openPicker } = useAeroplaneContext();
   const analysis = useAnalysis(aeroplaneId);
   const stripForces = useStripForces(aeroplaneId);
   const streamlines = useStreamlines(aeroplaneId);
@@ -28,6 +28,18 @@ export default function AnalysisPage() {
     "Streamlines": "Streamlines Configuration",
   };
   const modalTitle = modalTitleByTab[activeTab];
+
+  useEffect(() => {
+    if (!aeroplaneId) openPicker();
+  }, [aeroplaneId, openPicker]);
+
+  if (!aeroplaneId) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <span className="text-[13px] text-muted-foreground">No aeroplane selected</span>
+      </div>
+    );
+  }
 
   return (
     <>

--- a/frontend/app/workbench/analysis/page.tsx
+++ b/frontend/app/workbench/analysis/page.tsx
@@ -12,7 +12,7 @@ import { AnalysisViewerPanel, type Tab } from "@/components/workbench/AnalysisVi
 import { AnalysisConfigPanel } from "@/components/workbench/AnalysisConfigPanel";
 
 export default function AnalysisPage() {
-  const { aeroplaneId, selectedWing, openPicker } = useAeroplaneContext();
+  const { aeroplaneId, hydrated, selectedWing, openPicker } = useAeroplaneContext();
   const analysis = useAnalysis(aeroplaneId);
   const stripForces = useStripForces(aeroplaneId);
   const streamlines = useStreamlines(aeroplaneId);
@@ -30,8 +30,8 @@ export default function AnalysisPage() {
   const modalTitle = modalTitleByTab[activeTab];
 
   useEffect(() => {
-    if (!aeroplaneId) openPicker();
-  }, [aeroplaneId, openPicker]);
+    if (hydrated && !aeroplaneId) openPicker();
+  }, [hydrated, aeroplaneId, openPicker]);
 
   if (!aeroplaneId) {
     return (

--- a/frontend/app/workbench/construction-plans/page.tsx
+++ b/frontend/app/workbench/construction-plans/page.tsx
@@ -59,7 +59,7 @@ function toggleInSet<T>(prev: Set<T>, value: T): Set<T> {
 }
 
 export default function ConstructionPlansPage() {
-  const { aeroplaneId } = useAeroplaneContext();
+  const { aeroplaneId, openPicker } = useAeroplaneContext();
   const { creators, error: creatorsError } = useCreators();
 
   // ── Data fetching ─────────────────────────────────────────────
@@ -462,12 +462,14 @@ export default function ConstructionPlansPage() {
 
   // ── No-aeroplane guard ────────────────────────────────────────
 
+  useEffect(() => {
+    if (!aeroplaneId) openPicker();
+  }, [aeroplaneId, openPicker]);
+
   if (!aeroplaneId) {
     return (
       <div className="flex flex-1 items-center justify-center">
-        <p className="text-[13px] text-muted-foreground">
-          Select an aeroplane to view its construction plans.
-        </p>
+        <span className="text-[13px] text-muted-foreground">No aeroplane selected</span>
       </div>
     );
   }

--- a/frontend/app/workbench/construction-plans/page.tsx
+++ b/frontend/app/workbench/construction-plans/page.tsx
@@ -59,7 +59,7 @@ function toggleInSet<T>(prev: Set<T>, value: T): Set<T> {
 }
 
 export default function ConstructionPlansPage() {
-  const { aeroplaneId, openPicker } = useAeroplaneContext();
+  const { aeroplaneId, hydrated, openPicker } = useAeroplaneContext();
   const { creators, error: creatorsError } = useCreators();
 
   // ── Data fetching ─────────────────────────────────────────────
@@ -463,8 +463,8 @@ export default function ConstructionPlansPage() {
   // ── No-aeroplane guard ────────────────────────────────────────
 
   useEffect(() => {
-    if (!aeroplaneId) openPicker();
-  }, [aeroplaneId, openPicker]);
+    if (hydrated && !aeroplaneId) openPicker();
+  }, [hydrated, aeroplaneId, openPicker]);
 
   if (!aeroplaneId) {
     return (

--- a/frontend/app/workbench/layout.tsx
+++ b/frontend/app/workbench/layout.tsx
@@ -4,6 +4,7 @@ import { CopilotStrip } from "@/components/workbench/CopilotStrip";
 import { AeroplaneProvider } from "@/components/workbench/AeroplaneContext";
 import { UnsavedChangesProvider } from "@/components/workbench/UnsavedChangesContext";
 import { UnsavedChangesModal } from "@/components/workbench/UnsavedChangesModal";
+import { AeroplanePickerHost } from "@/components/workbench/AeroplanePickerHost";
 
 export default function WorkbenchLayout({
   children,
@@ -22,6 +23,7 @@ export default function WorkbenchLayout({
             <CopilotStrip />
           </div>
           <UnsavedChangesModal />
+          <AeroplanePickerHost />
         </UnsavedChangesProvider>
       </AeroplaneProvider>
     </Suspense>

--- a/frontend/app/workbench/page.tsx
+++ b/frontend/app/workbench/page.tsx
@@ -24,6 +24,7 @@ export default function WorkbenchPage() {
     selectedFuselage, selectedFuselageXsecIndex, selectFuselageXsec,
     treeMode,
     openPicker,
+    hydrated,
   } = useAeroplaneContext();
   const { aeroplanes } = useAeroplanes();
   const { wingNames, mutate: mutateWingNames } = useWings(aeroplaneId);
@@ -148,8 +149,8 @@ export default function WorkbenchPage() {
   const { fuselages: allFuselages, mutate: mutateAllFuselages } = useAllFuselageData(aeroplaneId, fuselageNames);
 
   useEffect(() => {
-    if (!aeroplaneId) openPicker();
-  }, [aeroplaneId, openPicker]);
+    if (hydrated && !aeroplaneId) openPicker();
+  }, [hydrated, aeroplaneId, openPicker]);
 
   if (!aeroplaneId) {
     return (

--- a/frontend/app/workbench/page.tsx
+++ b/frontend/app/workbench/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useCallback, useRef } from "react";
+import { useState, useMemo, useCallback, useRef, useEffect } from "react";
 import { PanelLeftOpen, Maximize2, Minimize2, X } from "lucide-react";
 import { useDialog } from "@/hooks/useDialog";
 import { PropertyForm, type PropertyFormHandle } from "@/components/workbench/PropertyForm";
@@ -23,8 +23,9 @@ export default function WorkbenchPage() {
     selectedWing, selectedXsecIndex, selectXsec,
     selectedFuselage, selectedFuselageXsecIndex, selectFuselageXsec,
     treeMode,
+    openPicker,
   } = useAeroplaneContext();
-  const { aeroplanes, isLoading, createAeroplane } = useAeroplanes();
+  const { aeroplanes } = useAeroplanes();
   const { wingNames, mutate: mutateWingNames } = useWings(aeroplaneId);
   const { fuselageNames, mutate: mutateFuselages } = useFuselages(aeroplaneId);
   const { wing, mutate: mutateSelectedWing } = useWing(aeroplaneId, selectedWing);
@@ -146,16 +147,16 @@ export default function WorkbenchPage() {
   const { wings: allWings, mutate: mutateAllWings } = useAllWingData(aeroplaneId, wingNames);
   const { fuselages: allFuselages, mutate: mutateAllFuselages } = useAllFuselageData(aeroplaneId, fuselageNames);
 
+  useEffect(() => {
+    if (!aeroplaneId) openPicker();
+  }, [aeroplaneId, openPicker]);
+
   if (!aeroplaneId) {
-    return <AeroplaneSelector
-      aeroplanes={aeroplanes}
-      isLoading={isLoading}
-      onSelect={setAeroplaneId}
-      onCreate={async (name: string) => {
-        const created = await createAeroplane(name);
-        setAeroplaneId(created.id);
-      }}
-    />;
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <span className="text-[13px] text-muted-foreground">No aeroplane selected</span>
+      </div>
+    );
   }
 
   return (
@@ -309,65 +310,5 @@ export default function WorkbenchPage() {
         />
       )}
     </>
-  );
-}
-
-function AeroplaneSelector({
-  aeroplanes,
-  isLoading,
-  onSelect,
-  onCreate,
-}: Readonly<{
-  aeroplanes: { id: string; name: string; created_at: string; updated_at: string }[];
-  isLoading: boolean;
-  onSelect: (id: string) => void;
-  onCreate: (name: string) => Promise<void>;
-}>) {
-  async function handleCreate() {
-    const name = prompt("Aeroplane name?");
-    if (!name) return;
-    await onCreate(name);
-  }
-
-  return (
-    <div className="flex flex-1 items-center justify-center">
-      <div className="flex w-[400px] flex-col gap-4 rounded-xl border border-border bg-card p-6">
-        <h2 className="font-[family-name:var(--font-jetbrains-mono)] text-[14px] text-foreground">
-          Select Aeroplane
-        </h2>
-
-        {isLoading && (
-          <span className="text-[13px] text-muted-foreground">Loading...</span>
-        )}
-        {!isLoading && aeroplanes.length === 0 && (
-          <span className="text-[13px] text-muted-foreground">
-            No aeroplanes yet. Create one to get started.
-          </span>
-        )}
-        {!isLoading && aeroplanes.length > 0 && (
-          <div className="flex flex-col gap-1">
-            {aeroplanes.map((a) => (
-              <button
-                key={a.id}
-                onClick={() => onSelect(a.id)}
-                className="flex items-center justify-between rounded-xl px-3 py-2.5 text-left hover:bg-sidebar-accent"
-              >
-                <span className="text-[13px] text-foreground">{a.name}</span>
-                <span className="font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-muted-foreground">
-                  {new Date(a.updated_at).toLocaleDateString()}
-                </span>
-              </button>
-            ))}
-          </div>
-        )}
-
-        <button
-          onClick={handleCreate}
-          className="rounded-full bg-primary px-4 py-2.5 text-[13px] text-primary-foreground hover:opacity-90"
-        >
-          + Create New
-        </button>
-      </div>
-    </div>
   );
 }

--- a/frontend/components/workbench/AeroplaneContext.tsx
+++ b/frontend/components/workbench/AeroplaneContext.tsx
@@ -15,6 +15,7 @@ export type TreeMode = "wingconfig" | "asb" | "fuselage";
 
 interface AeroplaneContextValue {
   aeroplaneId: string | null;
+  hydrated: boolean;
   selectedWing: string | null;
   selectedXsecIndex: number | null;
   selectedFuselage: string | null;
@@ -46,6 +47,7 @@ export function AeroplaneProvider({ children }: Readonly<{ children: ReactNode }
   const [selectedFuselage, setSelectedFuselage] = useState<string | null>(null);
   const [selectedFuselageXsecIndex, setSelectedFuselageXsecIndex] = useState<number | null>(null);
   const [treeMode, setTreeMode] = useState<TreeMode>("wingconfig");
+  const [hydrated, setHydrated] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
   const openPicker = useCallback(() => setPickerOpen(true), []);
   const closePicker = useCallback(() => setPickerOpen(false), []);
@@ -73,6 +75,7 @@ export function AeroplaneProvider({ children }: Readonly<{ children: ReactNode }
       setAeroplaneIdRaw(resolved);
       localStorage.setItem(STORAGE_KEY, resolved);
     }
+    setHydrated(true);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -108,6 +111,7 @@ export function AeroplaneProvider({ children }: Readonly<{ children: ReactNode }
 
   const ctxValue = useMemo(() => ({
     aeroplaneId,
+    hydrated,
     selectedWing,
     selectedXsecIndex,
     selectedFuselage,
@@ -124,6 +128,7 @@ export function AeroplaneProvider({ children }: Readonly<{ children: ReactNode }
     closePicker,
   }), [
     aeroplaneId,
+    hydrated,
     selectedWing,
     selectedXsecIndex,
     selectedFuselage,

--- a/frontend/components/workbench/AeroplaneContext.tsx
+++ b/frontend/components/workbench/AeroplaneContext.tsx
@@ -20,12 +20,15 @@ interface AeroplaneContextValue {
   selectedFuselage: string | null;
   selectedFuselageXsecIndex: number | null;
   treeMode: TreeMode;
+  pickerOpen: boolean;
   setAeroplaneId: (id: string | null) => void;
   selectWing: (name: string | null) => void;
   selectXsec: (index: number | null) => void;
   selectFuselage: (name: string | null) => void;
   selectFuselageXsec: (index: number | null) => void;
   setTreeMode: (mode: TreeMode) => void;
+  openPicker: () => void;
+  closePicker: () => void;
 }
 
 const Ctx = createContext<AeroplaneContextValue | null>(null);
@@ -43,6 +46,9 @@ export function AeroplaneProvider({ children }: Readonly<{ children: ReactNode }
   const [selectedFuselage, setSelectedFuselage] = useState<string | null>(null);
   const [selectedFuselageXsecIndex, setSelectedFuselageXsecIndex] = useState<number | null>(null);
   const [treeMode, setTreeMode] = useState<TreeMode>("wingconfig");
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const openPicker = useCallback(() => setPickerOpen(true), []);
+  const closePicker = useCallback(() => setPickerOpen(false), []);
 
   const setAeroplaneId = useCallback(
     (id: string | null) => {
@@ -107,12 +113,15 @@ export function AeroplaneProvider({ children }: Readonly<{ children: ReactNode }
     selectedFuselage,
     selectedFuselageXsecIndex,
     treeMode,
+    pickerOpen,
     setAeroplaneId,
     selectWing,
     selectXsec,
     selectFuselage,
     selectFuselageXsec,
     setTreeMode,
+    openPicker,
+    closePicker,
   }), [
     aeroplaneId,
     selectedWing,
@@ -120,12 +129,15 @@ export function AeroplaneProvider({ children }: Readonly<{ children: ReactNode }
     selectedFuselage,
     selectedFuselageXsecIndex,
     treeMode,
+    pickerOpen,
     setAeroplaneId,
     selectWing,
     selectXsec,
     selectFuselage,
     selectFuselageXsec,
     setTreeMode,
+    openPicker,
+    closePicker,
   ]);
 
   return (

--- a/frontend/components/workbench/AeroplanePickerHost.tsx
+++ b/frontend/components/workbench/AeroplanePickerHost.tsx
@@ -27,6 +27,7 @@ export function AeroplanePickerHost() {
       }}
       onCreate={async (name) => {
         const created = await createAeroplane(name);
+        if (!created?.id) throw new Error("Server returned aeroplane without an ID");
         setAeroplaneId(created.id);
         closePicker();
       }}

--- a/frontend/components/workbench/AeroplanePickerHost.tsx
+++ b/frontend/components/workbench/AeroplanePickerHost.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
+import { useAeroplanes } from "@/hooks/useAeroplanes";
+import { AeroplanePickerDialog } from "@/components/workbench/construction-plans/AeroplanePickerDialog";
+
+export function AeroplanePickerHost() {
+  const { aeroplaneId, setAeroplaneId, pickerOpen, closePicker } = useAeroplaneContext();
+  const { aeroplanes, createAeroplane, deleteAeroplane } = useAeroplanes();
+
+  return (
+    <AeroplanePickerDialog
+      open={pickerOpen}
+      aeroplanes={aeroplanes}
+      title="Select Aeroplane"
+      selectedAeroplaneId={aeroplaneId}
+      onClose={closePicker}
+      onSelect={async (id) => {
+        setAeroplaneId(id);
+        closePicker();
+      }}
+      onDelete={async (id) => {
+        await deleteAeroplane(id);
+        if (id === aeroplaneId) {
+          setAeroplaneId(null);
+        }
+      }}
+      onCreate={async (name) => {
+        const created = await createAeroplane(name);
+        setAeroplaneId(created.id);
+        closePicker();
+      }}
+    />
+  );
+}

--- a/frontend/components/workbench/Header.tsx
+++ b/frontend/components/workbench/Header.tsx
@@ -31,7 +31,7 @@ function isActive(href: string, pathname: string) {
 
 export function Header() {
   const pathname = usePathname();
-  const { aeroplaneId, selectedWing, selectedXsecIndex, setAeroplaneId } = useAeroplaneContext();
+  const { aeroplaneId, selectedWing, selectedXsecIndex, openPicker } = useAeroplaneContext();
   const { aeroplanes } = useAeroplanes();
   const aeroplaneName = aeroplanes.find((a) => a.id === aeroplaneId)?.name ?? "da3Dalus";
 
@@ -40,7 +40,7 @@ export function Header() {
       {/* Left cluster */}
       <div className="flex items-center gap-3">
         <button
-          onClick={() => setAeroplaneId(null)}
+          onClick={openPicker}
           className="flex items-center gap-2 rounded-full bg-sidebar-accent px-3 py-1.5 font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-foreground hover:bg-sidebar-accent/80"
           title="Switch aeroplane"
         >

--- a/frontend/components/workbench/construction-plans/AeroplanePickerDialog.tsx
+++ b/frontend/components/workbench/construction-plans/AeroplanePickerDialog.tsx
@@ -20,6 +20,7 @@ export function AeroplanePickerDialog({
   open,
   aeroplanes,
   title,
+  selectedAeroplaneId,
   onClose,
   onSelect,
   onDelete,
@@ -38,9 +39,9 @@ export function AeroplanePickerDialog({
     setSubmitting(true);
     try {
       await onSelect(id);
-      onClose();
     } catch (err) {
-      alert(`Failed: ${err instanceof Error ? err.message : String(err)}`);
+      console.error("handlePick failed:", err);
+      alert(err instanceof Error ? err.message : String(err));
     } finally {
       setSubmitting(false);
     }
@@ -53,7 +54,8 @@ export function AeroplanePickerDialog({
       await onDelete(confirmDelete.id);
       setConfirmDelete(null);
     } catch (err) {
-      alert(`Failed to delete: ${err instanceof Error ? err.message : String(err)}`);
+      console.error("handleDelete failed:", err);
+      alert(err instanceof Error ? err.message : String(err));
     } finally {
       setSubmitting(false);
     }
@@ -67,7 +69,8 @@ export function AeroplanePickerDialog({
     try {
       await onCreate(name);
     } catch (err) {
-      alert(`Failed to create: ${err instanceof Error ? err.message : String(err)}`);
+      console.error("handleCreate failed:", err);
+      alert(err instanceof Error ? err.message : String(err));
     } finally {
       setSubmitting(false);
     }
@@ -120,7 +123,7 @@ export function AeroplanePickerDialog({
                 filtered.map((a) => (
                   <div
                     key={a.id}
-                    className="group flex items-center gap-1 rounded-lg hover:bg-sidebar-accent"
+                    className={`group flex items-center gap-1 rounded-lg hover:bg-sidebar-accent ${a.id === selectedAeroplaneId ? "bg-sidebar-accent/60" : ""}`}
                   >
                     <button
                       type="button"
@@ -137,7 +140,7 @@ export function AeroplanePickerDialog({
                         type="button"
                         disabled={submitting}
                         onClick={(e) => { e.stopPropagation(); setConfirmDelete(a); }}
-                        className="mr-2 flex size-6 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-red-500/20 hover:text-red-400 group-hover:opacity-100 disabled:opacity-50"
+                        className="mr-2 flex size-6 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-red-500/20 hover:text-red-400 group-hover:opacity-100 focus-visible:opacity-100 disabled:opacity-50"
                         title={`Delete ${a.name}`}
                       >
                         <Trash2 size={14} />

--- a/frontend/components/workbench/construction-plans/AeroplanePickerDialog.tsx
+++ b/frontend/components/workbench/construction-plans/AeroplanePickerDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Search, ChevronDown, X } from "lucide-react";
+import { Search, ChevronDown, X, Trash2 } from "lucide-react";
 import { useDialog } from "@/hooks/useDialog";
 import type { Aeroplane } from "@/hooks/useAeroplanes";
 
@@ -9,8 +9,11 @@ interface AeroplanePickerDialogProps {
   open: boolean;
   aeroplanes: Aeroplane[];
   title: string;
+  selectedAeroplaneId?: string | null;
   onClose: () => void;
   onSelect: (aeroplaneId: string) => Promise<void> | void;
+  onDelete?: (aeroplaneId: string) => Promise<void>;
+  onCreate?: (name: string) => Promise<void>;
 }
 
 export function AeroplanePickerDialog({
@@ -19,10 +22,13 @@ export function AeroplanePickerDialog({
   title,
   onClose,
   onSelect,
+  onDelete,
+  onCreate,
 }: Readonly<AeroplanePickerDialogProps>) {
   const { dialogRef, handleClose } = useDialog(open, onClose);
   const [search, setSearch] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState<Aeroplane | null>(null);
 
   const filtered = aeroplanes.filter((a) =>
     a.name.toLowerCase().includes(search.toLowerCase()),
@@ -35,6 +41,33 @@ export function AeroplanePickerDialog({
       onClose();
     } catch (err) {
       alert(`Failed: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!confirmDelete || !onDelete) return;
+    setSubmitting(true);
+    try {
+      await onDelete(confirmDelete.id);
+      setConfirmDelete(null);
+    } catch (err) {
+      alert(`Failed to delete: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleCreate() {
+    if (!onCreate) return;
+    const name = window.prompt("Aeroplane name?");
+    if (!name) return;
+    setSubmitting(true);
+    try {
+      await onCreate(name);
+    } catch (err) {
+      alert(`Failed to create: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
       setSubmitting(false);
     }
@@ -85,21 +118,75 @@ export function AeroplanePickerDialog({
                 </p>
               ) : (
                 filtered.map((a) => (
-                  <button
+                  <div
                     key={a.id}
-                    type="button"
-                    disabled={submitting}
-                    onClick={() => handlePick(a.id)}
-                    className="block w-full rounded-lg px-3 py-2 text-left text-[13px] text-foreground hover:bg-sidebar-accent disabled:opacity-50"
+                    className="group flex items-center gap-1 rounded-lg hover:bg-sidebar-accent"
                   >
-                    <span className="font-[family-name:var(--font-jetbrains-mono)]">
-                      {a.name}
-                    </span>
-                  </button>
+                    <button
+                      type="button"
+                      disabled={submitting}
+                      onClick={() => handlePick(a.id)}
+                      className="flex flex-1 items-center px-3 py-2 text-left text-[13px] text-foreground disabled:opacity-50"
+                    >
+                      <span className="font-[family-name:var(--font-jetbrains-mono)]">
+                        {a.name}
+                      </span>
+                    </button>
+                    {onDelete && (
+                      <button
+                        type="button"
+                        disabled={submitting}
+                        onClick={(e) => { e.stopPropagation(); setConfirmDelete(a); }}
+                        className="mr-2 flex size-6 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-red-500/20 hover:text-red-400 group-hover:opacity-100 disabled:opacity-50"
+                        title={`Delete ${a.name}`}
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    )}
+                  </div>
                 ))
               )}
             </div>
+            {confirmDelete && (
+              <div className="flex flex-col gap-3 rounded-xl border border-red-500/30 bg-red-500/10 p-4">
+                <p className="text-[13px] text-foreground">
+                  Delete <strong>{confirmDelete.name}</strong>? This action cannot be undone.
+                </p>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    disabled={submitting}
+                    onClick={() => setConfirmDelete(null)}
+                    className="flex-1 rounded-lg border border-border px-3 py-2 text-[13px] text-foreground hover:bg-sidebar-accent disabled:opacity-50"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    disabled={submitting}
+                    onClick={handleDelete}
+                    className="flex-1 rounded-lg bg-red-600 px-3 py-2 text-[13px] text-white hover:bg-red-700 disabled:opacity-50"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
+
+          {/* Footer */}
+          {onCreate && (
+            <div className="border-t border-border px-6 py-4">
+              <button
+                type="button"
+                disabled={submitting}
+                onClick={handleCreate}
+                className="w-full rounded-full bg-primary px-4 py-2.5 text-[13px] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+              >
+                + Create New
+              </button>
+            </div>
+          )}
         </div>
       )}
     </dialog>


### PR DESCRIPTION
## Summary

Closes #370

- **Unified modal picker** — Replace inconsistent no-aeroplane guards across Construction (inline card), Analysis (no guard), Plans (text placeholder) with a single `AeroplanePickerDialog` rendered once in the workbench layout. Auto-opens when no aeroplane is selected; also opens via the Header switch button.
- **Delete capability** — Trash icon per aeroplane row with confirmation dialog, wired to the existing `deleteAeroplane()` hook. Deleting the active aeroplane clears the selection.
- **Create capability** — "+ Create New" button added to the picker dialog.
- **Hydration guard** — `hydrated` flag in `AeroplaneContext` prevents the picker from flashing open during initial context hydration from localStorage/URL.

## Files Changed

| File | Change |
|------|--------|
| `AeroplaneContext.tsx` | Add `pickerOpen`, `openPicker`, `closePicker`, `hydrated` |
| `AeroplanePickerDialog.tsx` | Add delete button, confirmation, create button |
| `AeroplanePickerHost.tsx` | New — wires dialog to context + hooks, rendered in layout |
| `layout.tsx` | Render `AeroplanePickerHost` |
| `Header.tsx` | Call `openPicker()` instead of `setAeroplaneId(null)` |
| `page.tsx` (workbench) | Remove `AeroplaneSelector`, use picker effect |
| `page.tsx` (analysis) | Add no-aeroplane guard with picker |
| `page.tsx` (plans) | Replace text placeholder with picker |

## Test plan

- [x] 308 frontend unit tests pass
- [x] Browser: Construction tab auto-opens picker when no aeroplane
- [x] Browser: Analysis tab auto-opens picker when no aeroplane
- [x] Browser: Plans tab auto-opens picker when no aeroplane
- [x] Browser: Header button opens picker (preserves current selection)
- [x] Browser: Delete shows confirmation, Cancel dismisses, Delete removes
- [x] Browser: No picker flash on page load with stored aeroplane ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)