### PR TITLE
fix(gh-373): add beta to Trefftz Plane strip forces response

### DIFF
--- a/app/schemas/strip_forces.py
+++ b/app/schemas/strip_forces.py
@@ -34,6 +34,7 @@ class SurfaceStripForces(BaseModel):
 
 class StripForcesResponse(BaseModel):
     alpha: float = Field(..., description="Angle of attack (deg)")
+    beta: float = Field(..., description="Sideslip angle (deg)")
     mach: float = Field(..., description="Mach number")
     sref: float = Field(..., description="Reference area (m²)")
     cref: float = Field(..., description="Reference chord (m)")

--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -1459,6 +1459,7 @@ async def analyze_airplane_strip_forces(
 
         return StripForcesResponse(
             alpha=result.get("alpha", operating_point.alpha),
+            beta=result.get("beta", operating_point.beta),
             mach=result.get("mach", 0),
             sref=result.get("Sref", 0),
             cref=result.get("Cref", 0),
@@ -1540,6 +1541,7 @@ async def analyze_wing_strip_forces(
 
         return StripForcesResponse(
             alpha=result.get("alpha", operating_point.alpha),
+            beta=result.get("beta", operating_point.beta),
             mach=result.get("mach", 0),
             sref=result.get("Sref", 0),
             cref=result.get("Cref", 0),

--- a/app/tests/test_avl_strip_forces.py
+++ b/app/tests/test_avl_strip_forces.py
@@ -50,6 +50,26 @@ SAMPLE_FS_OUTPUT = """
 """
 
 
+class TestStripForcesResponseSchema:
+    def test_beta_field_required(self):
+        from app.schemas.strip_forces import StripForcesResponse
+        import pydantic
+
+        with pytest.raises(pydantic.ValidationError):
+            StripForcesResponse(
+                alpha=5.0, mach=0.04, sref=0.25, cref=0.25, bref=1.0, surfaces=[]
+            )
+
+    def test_beta_field_included_in_response(self):
+        from app.schemas.strip_forces import StripForcesResponse
+
+        resp = StripForcesResponse(
+            alpha=5.0, beta=2.0, mach=0.04, sref=0.25, cref=0.25, bref=1.0, surfaces=[]
+        )
+        data = resp.model_dump()
+        assert data["beta"] == 2.0
+
+
 class TestParseStripForcesOutput:
     def test_parses_two_surfaces(self):
         result = parse_strip_forces_output(SAMPLE_FS_OUTPUT)

--- a/app/tests/test_avl_strip_forces_integration.py
+++ b/app/tests/test_avl_strip_forces_integration.py
@@ -91,3 +91,77 @@ class TestAVLWithStripForcesIntegration:
         for key in ["CL", "CD", "Cm", "CLa", "Cma"]:
             assert child_result[key] == pytest.approx(parent_result[key], rel=1e-4), \
                 f"{key}: {child_result[key]} != {parent_result[key]}"
+
+    def test_symmetric_airplane_produces_symmetric_strip_forces(self, op_point):
+        """For a symmetric multi-wing airplane at beta=0, YDUP strip forces must match exactly."""
+        import aerosandbox as asb
+        from app.services.avl_strip_forces import AVLWithStripForces
+
+        airplane = asb.Airplane(
+            name="symmetric_test",
+            wings=[
+                asb.Wing(
+                    name="main_wing",
+                    symmetric=True,
+                    xsecs=[
+                        asb.WingXSec(xyz_le=[0, 0, 0], chord=0.3, airfoil=asb.Airfoil("naca2412")),
+                        asb.WingXSec(xyz_le=[0.02, 0.5, 0], chord=0.2, airfoil=asb.Airfoil("naca2412")),
+                    ],
+                ),
+                asb.Wing(
+                    name="v-tail",
+                    symmetric=True,
+                    xsecs=[
+                        asb.WingXSec(xyz_le=[0.4, 0, 0], chord=0.15, airfoil=asb.Airfoil("naca0012")),
+                        asb.WingXSec(xyz_le=[0.42, 0.15, 0.1], chord=0.1, airfoil=asb.Airfoil("naca0012")),
+                    ],
+                ),
+            ],
+        )
+
+        avl = AVLWithStripForces(
+            airplane=airplane, op_point=op_point,
+            avl_command=str(AVL_BINARY), timeout=15,
+        )
+        surfaces = avl.run()["strip_forces"]
+
+        paired = {}
+        for s in surfaces:
+            base = s["surface_name"].replace(" (YDUP)", "")
+            paired.setdefault(base, {})[
+                "ydup" if "(YDUP)" in s["surface_name"] else "orig"
+            ] = s
+
+        for name, pair in paired.items():
+            assert "orig" in pair and "ydup" in pair, f"{name}: missing YDUP pair"
+            orig_strips = sorted(pair["orig"]["strips"], key=lambda s: s["Yle"])
+            ydup_strips = sorted(pair["ydup"]["strips"], key=lambda s: abs(s["Yle"]))
+
+            assert len(orig_strips) == len(ydup_strips), f"{name}: strip count mismatch"
+            for o, y in zip(orig_strips, ydup_strips):
+                assert o["cl"] == pytest.approx(y["cl"], rel=1e-6), \
+                    f"{name}: Cl asymmetry at y={o['Yle']}: {o['cl']} vs {y['cl']}"
+
+    def test_nonzero_beta_causes_asymmetry(self, simple_airplane):
+        """Non-zero beta legitimately produces asymmetric strip forces."""
+        import aerosandbox as asb
+        from app.services.avl_strip_forces import AVLWithStripForces
+
+        op_beta = asb.OperatingPoint(velocity=20, alpha=5, beta=2)
+
+        avl = AVLWithStripForces(
+            airplane=simple_airplane, op_point=op_beta,
+            avl_command=str(AVL_BINARY), timeout=15,
+        )
+        surfaces = avl.run()["strip_forces"]
+
+        orig = next(s for s in surfaces if "(YDUP)" not in s["surface_name"])
+        ydup = next(s for s in surfaces if "(YDUP)" in s["surface_name"])
+        orig_strips = sorted(orig["strips"], key=lambda s: s["Yle"])
+        ydup_strips = sorted(ydup["strips"], key=lambda s: abs(s["Yle"]))
+
+        max_cl_diff = max(
+            abs(o["cl"] - y["cl"]) for o, y in zip(orig_strips, ydup_strips)
+        )
+        assert max_cl_diff > 0.001, \
+            f"Expected asymmetry from beta=2, got max diff={max_cl_diff}"

--- a/app/tests/test_avl_strip_forces_integration.py
+++ b/app/tests/test_avl_strip_forces_integration.py
@@ -138,7 +138,7 @@ class TestAVLWithStripForcesIntegration:
             ydup_strips = sorted(pair["ydup"]["strips"], key=lambda s: abs(s["Yle"]))
 
             assert len(orig_strips) == len(ydup_strips), f"{name}: strip count mismatch"
-            for o, y in zip(orig_strips, ydup_strips):
+            for o, y in zip(orig_strips, ydup_strips, strict=True):
                 assert o["cl"] == pytest.approx(y["cl"], rel=1e-6), \
                     f"{name}: Cl asymmetry at y={o['Yle']}: {o['cl']} vs {y['cl']}"
 
@@ -161,7 +161,7 @@ class TestAVLWithStripForcesIntegration:
         ydup_strips = sorted(ydup["strips"], key=lambda s: abs(s["Yle"]))
 
         max_cl_diff = max(
-            abs(o["cl"] - y["cl"]) for o, y in zip(orig_strips, ydup_strips)
+            abs(o["cl"] - y["cl"]) for o, y in zip(orig_strips, ydup_strips, strict=True)
         )
         assert max_cl_diff > 0.001, \
             f"Expected asymmetry from beta=2, got max diff={max_cl_diff}"

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -373,6 +373,7 @@ function TrefftzPlaneChart({
         font: { color: "#71717A", family: "JetBrains Mono, monospace", size: 10 },
         text: [
           `\u03B1 = ${stripForces.alpha.toFixed(2)}\u00B0`,
+          `\u03B2 = ${stripForces.beta.toFixed(2)}\u00B0`,
           `Mach = ${stripForces.mach.toFixed(3)}`,
           `Sref = ${stripForces.sref.toFixed(4)} m\u00B2`,
           `Cref = ${stripForces.cref.toFixed(4)} m`,

--- a/frontend/hooks/useStripForces.ts
+++ b/frontend/hooks/useStripForces.ts
@@ -33,6 +33,7 @@ export interface SurfaceStripForces {
 
 export interface StripForcesResult {
   alpha: number;
+  beta: number;
   mach: number;
   sref: number;
   cref: number;


### PR DESCRIPTION
## Summary

- Add `beta` field to `StripForcesResponse` schema so the frontend knows what sideslip angle was used
- Display β in the Trefftz Plane chart annotation alongside α, Mach, Sref, Cref, Bref
- Add symmetry regression tests: symmetric geometry at β=0 must produce perfectly symmetric strip forces; non-zero β must produce asymmetric results

Closes #373

## Root Cause Analysis

Exhaustive investigation confirmed that AVL always produces perfectly symmetric strip forces for symmetric geometry at β=0 (YDUP enforces exact symmetry). The asymmetric plot the user observed was most likely caused by non-zero β, but the chart had no β annotation to make this diagnosable.

## Test plan

- [x] Unit test: `StripForcesResponse` requires `beta` field
- [x] Unit test: `beta` included in serialized response
- [x] Integration test: symmetric multi-wing airplane at β=0 produces identical YDUP strip forces
- [x] Integration test: β=2° produces measurable asymmetry
- [x] All 1549 existing tests pass
- [x] No new TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)