### PR TITLE
chore(gh-377): add eslint-plugin-sonarjs with pre-commit hook

### DIFF
--- a/docs/superpowers/plans/2026-05-02-eslint-plugin-sonarjs.md
+++ b/docs/superpowers/plans/2026-05-02-eslint-plugin-sonarjs.md
@@ -1,0 +1,819 @@
+# eslint-plugin-sonarjs Integration Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Install eslint-plugin-sonarjs, fix all existing violations, and add Husky pre-commit hook to enforce linting on every commit.
+
+**Architecture:** Add sonarjs recommended ruleset to existing ESLint flat config. Fix ~31 violations across 15 files. Install Husky + lint-staged in `frontend/` with subdirectory-aware setup.
+
+**Tech Stack:** eslint-plugin-sonarjs, husky, lint-staged, ESLint 9 flat config
+
+**Worktree:** `/Users/szymanski/Projects/da3Dalus/cad-modelling-service.worktrees/gh-377`
+**Branch:** `chore/gh-377-eslint-plugin-sonarjs`
+
+---
+
+### Task 1: Install eslint-plugin-sonarjs and update ESLint config
+
+**Files:**
+- Modify: `frontend/package.json` (add devDependency)
+- Modify: `frontend/eslint.config.mjs` (add sonarjs preset + rule overrides)
+
+- [ ] **Step 1: Install eslint-plugin-sonarjs**
+
+```bash
+cd frontend && npm install --save-dev eslint-plugin-sonarjs
+```
+
+- [ ] **Step 2: Update eslint.config.mjs**
+
+Replace the entire file with:
+
+```javascript
+import { defineConfig, globalIgnores } from "eslint/config";
+import nextVitals from "eslint-config-next/core-web-vitals";
+import nextTs from "eslint-config-next/typescript";
+import sonarjs from "eslint-plugin-sonarjs";
+
+const eslintConfig = defineConfig([
+  ...nextVitals,
+  ...nextTs,
+  sonarjs.configs.recommended,
+  {
+    rules: {
+      "sonarjs/no-clear-text-protocols": "off",
+      "sonarjs/publicly-writable-directories": "off",
+    },
+  },
+  globalIgnores([
+    ".next/**",
+    "out/**",
+    "build/**",
+    "next-env.d.ts",
+    "coverage/**",
+  ]),
+]);
+
+export default eslintConfig;
+```
+
+- [ ] **Step 3: Run eslint to verify config loads and see violations**
+
+```bash
+cd frontend && npx eslint . 2>&1 | grep "sonarjs/" | wc -l
+```
+
+Expected: ~31 sonarjs errors. This is the RED state.
+
+- [ ] **Step 4: Commit config changes**
+
+```bash
+git add frontend/package.json frontend/package-lock.json frontend/eslint.config.mjs
+git commit -m "chore(gh-377): add eslint-plugin-sonarjs to ESLint config"
+```
+
+---
+
+### Task 2: Fix test file violations — unused vars, imports, void-use, readonly
+
+**Files:**
+- Modify: `frontend/__tests__/ComponentTreeWeightDisplay.test.tsx:303` (void-use)
+- Modify: `frontend/__tests__/ComponentsPage.test.tsx:138` (unused cancelBtn)
+- Modify: `frontend/__tests__/FuselageXSecFormSave.test.tsx:6` (unused fireEvent import)
+- Modify: `frontend/__tests__/ConstructionPlansPage.test.tsx:183-185` (public-static-readonly)
+
+- [ ] **Step 1: Fix void-use in ComponentTreeWeightDisplay.test.tsx**
+
+At line 303, remove the `void container;` line. Check if `container` is actually used elsewhere in the test — if it's only used in the `render()` destructuring and not referenced after, also remove it from the destructuring.
+
+- [ ] **Step 2: Fix unused cancelBtn in ComponentsPage.test.tsx**
+
+At line 138, delete the line:
+```typescript
+const cancelBtn = editDialog?.querySelector("button");
+```
+
+The variable is never used — `cancelButton` (line 141) is the one that gets clicked.
+
+- [ ] **Step 3: Fix unused fireEvent import in FuselageXSecFormSave.test.tsx**
+
+At line 6, change:
+```typescript
+import { render, screen, act, fireEvent } from "@testing-library/react";
+```
+to:
+```typescript
+import { render, screen, act } from "@testing-library/react";
+```
+
+- [ ] **Step 4: Fix public-static-readonly in ConstructionPlansPage.test.tsx**
+
+At lines 183-185, add `readonly` to the static properties:
+
+```typescript
+class FakeEventSource {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
+```
+
+- [ ] **Step 5: Run tests to ensure no regressions**
+
+```bash
+cd frontend && npm run test:unit -- --run 2>&1 | tail -20
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/__tests__/ComponentTreeWeightDisplay.test.tsx \
+       frontend/__tests__/ComponentsPage.test.tsx \
+       frontend/__tests__/FuselageXSecFormSave.test.tsx \
+       frontend/__tests__/ConstructionPlansPage.test.tsx
+git commit -m "fix(gh-377): fix sonarjs violations in test files"
+```
+
+---
+
+### Task 3: Fix e2e step file and production code unused vars
+
+**Files:**
+- Modify: `frontend/e2e/steps/common.steps.ts:43` (unused firstAeroplane)
+- Modify: `frontend/e2e/steps/construction.steps.ts:270` (unused placeholder)
+- Modify: `frontend/app/workbench/page.tsx:22` (unused setAeroplaneId)
+- Modify: `frontend/lib/planTreeUtils.ts:186,208,271` (unused destructured vars)
+
+- [ ] **Step 1: Fix unused firstAeroplane in common.steps.ts**
+
+At line 43, delete the declaration and its closing line. The variable `firstAeroplane` is declared but `aeroplaneButtons` is used instead. Remove lines 43-45:
+
+```typescript
+    const firstAeroplane = page.locator(
+      'button:has-text("") >> nth=0',
+    );
+```
+
+- [ ] **Step 2: Fix unused placeholder in construction.steps.ts**
+
+At line 270, inside the `waitForFunction` callback, remove the unused variable:
+
+```typescript
+// Before:
+const placeholder = document.querySelector('[class*="items-center"]');
+const hasPlaceholder = !!document.body.innerText.includes("Run an analysis to see results");
+
+// After:
+const hasPlaceholder = !!document.body.innerText.includes("Run an analysis to see results");
+```
+
+- [ ] **Step 3: Fix unused setAeroplaneId in page.tsx**
+
+At line 22, remove `setAeroplaneId` from the destructuring:
+
+```typescript
+// Before:
+const {
+  aeroplaneId, setAeroplaneId,
+
+// After:
+const {
+  aeroplaneId,
+```
+
+- [ ] **Step 4: Fix unused destructured vars in planTreeUtils.ts**
+
+Three locations need fixing:
+
+**Line 186** — `childSuccessors` and `_creatorIdDirty` are unused in the destructuring:
+```typescript
+// Before:
+const { $TYPE, creator_id, successors: childSuccessors, _creatorIdDirty, ...creatorParams } = child;
+
+// After:
+const { $TYPE, creator_id, successors: _childSuccessors, _creatorIdDirty: _dirty, ...creatorParams } = child;
+```
+
+Wait — if they're unused, we should use rest-property to exclude them. Since `$TYPE` and `creator_id` are used, and `creatorParams` captures the rest, we only need to exclude `successors` and `_creatorIdDirty`. They're already being excluded by destructuring into named vars. The sonarjs rule wants them prefixed with `_` or removed.
+
+Correct fix:
+```typescript
+const { $TYPE, creator_id, successors: _successors, _creatorIdDirty: _dirty, ...creatorParams } = child;
+```
+
+**Line 208** — `_s` and `_d` are already underscore-prefixed but sonarjs still flags them:
+```typescript
+// Before:
+const { successors: _s, _creatorIdDirty: _d, ...rootFields } = node as Record<string, unknown>;
+
+// After — use Omit-style exclude via rest:
+const { successors: _excluded1, _creatorIdDirty: _excluded2, ...rootFields } = node as Record<string, unknown>;
+```
+
+Actually, sonarjs/no-unused-vars respects `_` prefix in some versions. Read the actual error — if it still flags `_s`, the simplest fix is an inline disable comment since the destructuring is intentional (stripping fields from the spread):
+```typescript
+// eslint-disable-next-line sonarjs/no-unused-vars -- destructure-to-exclude
+const { successors: _s, _creatorIdDirty: _d, ...rootFields } = node as Record<string, unknown>;
+```
+
+**Line 271** — same pattern:
+```typescript
+// eslint-disable-next-line sonarjs/no-unused-vars -- destructure-to-exclude
+const { successors: _s, ...nodeFields } = node as Record<string, unknown>;
+```
+
+Read each line to verify the exact code before applying. Use `eslint-disable-next-line` only where the unused var is intentional (destructure-to-exclude pattern).
+
+- [ ] **Step 5: Run eslint on changed files**
+
+```bash
+cd frontend && npx eslint app/workbench/page.tsx lib/planTreeUtils.ts e2e/steps/common.steps.ts e2e/steps/construction.steps.ts 2>&1 | grep "sonarjs/"
+```
+
+Expected: No sonarjs/no-unused-vars or sonarjs/no-dead-store errors in these files.
+
+- [ ] **Step 6: Run unit tests**
+
+```bash
+cd frontend && npm run test:unit -- --run 2>&1 | tail -10
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/e2e/steps/common.steps.ts \
+       frontend/e2e/steps/construction.steps.ts \
+       frontend/app/workbench/page.tsx \
+       frontend/lib/planTreeUtils.ts
+git commit -m "fix(gh-377): remove unused variables and dead stores"
+```
+
+---
+
+### Task 4: Extract resolveParamValue helper and fix nested ternaries in plan files
+
+The nested ternary `typeof val === "string" ? val : typeof val === "number" ? String(val) : \`{${param}}\`` appears in 4 places across 3 files. Extract a shared helper.
+
+**Files:**
+- Modify: `frontend/lib/planTreeUtils.ts:310,367` (two occurrences)
+- Modify: `frontend/lib/planValidation.ts:73` (one occurrence)
+- Modify: `frontend/components/workbench/construction-plans/PlanTreeSection.tsx:35` (one occurrence)
+
+- [ ] **Step 1: Add resolveParamValue to planTreeUtils.ts**
+
+Add this exported function near the top of `planTreeUtils.ts`, after the imports and type definitions:
+
+```typescript
+export function resolveParamValue(val: unknown, fallback: string): string {
+  if (typeof val === "string") return val;
+  if (typeof val === "number") return String(val);
+  return fallback;
+}
+```
+
+- [ ] **Step 2: Replace nested ternary in buildStepNode (planTreeUtils.ts:308-310)**
+
+```typescript
+// Before (line 308-310):
+node.creator_id = base.replace(/\{(\w+)\}/g, (_match, param) => {
+  const val = nodeRecord[param];
+  return typeof val === "string" ? val : typeof val === "number" ? String(val) : `{${param}}`;
+});
+
+// After:
+node.creator_id = base.replace(/\{(\w+)\}/g, (_match, param) =>
+  resolveParamValue(nodeRecord[param], `{${param}}`),
+);
+```
+
+- [ ] **Step 3: Replace nested ternary in resolveNodeShapes (planTreeUtils.ts:365-367)**
+
+```typescript
+// Before (line 365-367):
+resolved = resolved.replace(/\{(\w+)\}/g, (_match, param) => {
+  const val = nodeRecord[param];
+  return typeof val === "string" ? val : typeof val === "number" ? String(val) : `{${param}}`;
+});
+
+// After:
+resolved = resolved.replace(/\{(\w+)\}/g, (_match, param) =>
+  resolveParamValue(nodeRecord[param], `{${param}}`),
+);
+```
+
+- [ ] **Step 4: Replace nested ternary in planValidation.ts:71-73**
+
+Add import at top of file:
+```typescript
+import { isShapeRefType, resolveParamValue } from "./planTreeUtils";
+```
+
+Then fix the ternary:
+```typescript
+// Before (line 71-73):
+resolved = resolved.replace(/\{(\w+)\}/g, (_match, param) => {
+  const val = nodeRecord[param];
+  return typeof val === "string" ? val : typeof val === "number" ? String(val) : `{${param}}`;
+});
+
+// After:
+resolved = resolved.replace(/\{(\w+)\}/g, (_match, param) =>
+  resolveParamValue(nodeRecord[param], `{${param}}`),
+);
+```
+
+Note: `isShapeRefType` is already imported from `planTreeUtils` in this file. Verify the existing import and add `resolveParamValue` to it.
+
+- [ ] **Step 5: Replace nested ternary in PlanTreeSection.tsx:33-35**
+
+Add import:
+```typescript
+import { resolveParamValue } from "@/lib/planTreeUtils";
+```
+
+Then fix:
+```typescript
+// Before (lines 33-35):
+const val = nodeRecord[param];
+return typeof val === "string" ? val : typeof val === "number" ? String(val) : `{${param}}`;
+
+// After:
+return resolveParamValue(nodeRecord[param], `{${param}}`);
+```
+
+Remove the now-unnecessary `val` variable declaration inside the callback.
+
+- [ ] **Step 6: Run eslint on changed files**
+
+```bash
+cd frontend && npx eslint lib/planTreeUtils.ts lib/planValidation.ts components/workbench/construction-plans/PlanTreeSection.tsx 2>&1 | grep "sonarjs/"
+```
+
+Expected: No sonarjs/no-nested-conditional errors in these files.
+
+- [ ] **Step 7: Run unit tests**
+
+```bash
+cd frontend && npm run test:unit -- --run 2>&1 | tail -10
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/lib/planTreeUtils.ts \
+       frontend/lib/planValidation.ts \
+       frontend/components/workbench/construction-plans/PlanTreeSection.tsx
+git commit -m "refactor(gh-377): extract resolveParamValue helper to fix nested ternaries"
+```
+
+---
+
+### Task 5: Fix remaining nested ternaries in UI components and tests
+
+**Files:**
+- Modify: `frontend/app/workbench/page.tsx:42-46`
+- Modify: `frontend/app/workbench/construction-plans/page.tsx:205`
+- Modify: `frontend/components/workbench/AvlGeometryEditor.tsx:189-193`
+- Modify: `frontend/components/workbench/SimpleTreeRow.tsx:94`
+- Modify: `frontend/__tests__/ConstructionPlansPage.test.tsx:78`
+
+- [ ] **Step 1: Fix nested ternary in page.tsx:42-46**
+
+```typescript
+// Before:
+const paginatorTotal = mode === "fuselage"
+  ? fuselage?.x_secs?.length
+  : mode === "wingconfig"
+    ? wingConfig?.segments?.length
+    : wing?.x_secs?.length;
+
+// After — use a lookup or function:
+function getPaginatorTotal() {
+  if (mode === "fuselage") return fuselage?.x_secs?.length;
+  if (mode === "wingconfig") return wingConfig?.segments?.length;
+  return wing?.x_secs?.length;
+}
+const paginatorTotal = getPaginatorTotal();
+```
+
+Since this is inside a React component, use a plain function declared before the assignment (or `useMemo` if the computation is expensive — it's not here, so a function is fine).
+
+- [ ] **Step 2: Fix nested ternary in construction-plans/page.tsx:205**
+
+```typescript
+// Before:
+const detail = isTemplate ? templateDetail : (activePlanDetail?.id === planId ? activePlanDetail : null);
+
+// After:
+let detail = null;
+if (isTemplate) {
+  detail = templateDetail;
+} else if (activePlanDetail?.id === planId) {
+  detail = activePlanDetail;
+}
+```
+
+- [ ] **Step 3: Fix nested ternary in AvlGeometryEditor.tsx:189-193**
+
+This is JSX conditional rendering (`isLoading ? ... : mode === "diff" ? ... : ...`). Refactor into an early-determined variable:
+
+```typescript
+// Before the return statement, compute the editor content:
+const editorContent = geometry.isLoading ? (
+  <div className="flex h-full items-center justify-center text-[13px] text-muted-foreground">
+    Loading AVL geometry…
+  </div>
+) : mode === "diff" && regeneratedContent !== null ? (
+  <MonacoDiffEditor ... />
+) : (
+  <MonacoEditor ... />
+);
+
+// Then in JSX:
+{/* Editor Body */}
+<div className="flex-1 overflow-hidden">
+  {editorContent}
+</div>
+```
+
+Actually, the simplest compliant fix is to extract the nested part into a helper:
+
+```typescript
+function renderEditor() {
+  if (geometry.isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center text-[13px] text-muted-foreground">
+        Loading AVL geometry…
+      </div>
+    );
+  }
+  if (mode === "diff" && regeneratedContent !== null) {
+    return <MonacoDiffEditor ... />;
+  }
+  return <MonacoEditor ... />;
+}
+```
+
+Read the full JSX to get the exact props for MonacoDiffEditor and MonacoEditor. Place the function inside the component before the return.
+
+- [ ] **Step 4: Fix nested ternary in SimpleTreeRow.tsx:94**
+
+```typescript
+// Before (line 94):
+className={`whitespace-nowrap ${node.error ? "text-[12px] text-red-400/70" : node.muted ? "text-[12px] text-muted-foreground" : "font-[family-name:var(--font-geist-sans)] text-[13px] text-foreground"}`}
+
+// After — extract a function:
+const labelClass = (() => {
+  if (node.error) return "text-[12px] text-red-400/70";
+  if (node.muted) return "text-[12px] text-muted-foreground";
+  return "font-[family-name:var(--font-geist-sans)] text-[13px] text-foreground";
+})();
+
+// Then:
+<span className={`whitespace-nowrap ${labelClass}`}>
+```
+
+- [ ] **Step 5: Fix nested ternary in ConstructionPlansPage.test.tsx:78**
+
+This is in mock data — a large ternary choosing mock responses by `id`. Refactor into a `Map` or `switch`:
+
+```typescript
+// Before: id === 1 ? {...} : id === 2 ? {...} : {...}
+// After: use a lookup object
+
+const mockPlans: Record<number, Plan> = {
+  1: { id: 1, name: "Wing Template", ... },
+  2: { id: 2, name: "eHawk Build", ... },
+};
+// In the mock handler:
+return mockPlans[id] ?? null;
+```
+
+Read the full mock to get exact shapes. The key is eliminating the nested `id === 1 ? ... : id === 2 ? ...` chain.
+
+- [ ] **Step 6: Run eslint on changed files**
+
+```bash
+cd frontend && npx eslint app/workbench/page.tsx app/workbench/construction-plans/page.tsx components/workbench/AvlGeometryEditor.tsx components/workbench/SimpleTreeRow.tsx __tests__/ConstructionPlansPage.test.tsx 2>&1 | grep "sonarjs/no-nested-conditional"
+```
+
+Expected: Zero results.
+
+- [ ] **Step 7: Run unit tests**
+
+```bash
+cd frontend && npm run test:unit -- --run 2>&1 | tail -10
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/app/workbench/page.tsx \
+       frontend/app/workbench/construction-plans/page.tsx \
+       frontend/components/workbench/AvlGeometryEditor.tsx \
+       frontend/components/workbench/SimpleTreeRow.tsx \
+       frontend/__tests__/ConstructionPlansPage.test.tsx
+git commit -m "refactor(gh-377): eliminate nested ternaries in UI components and tests"
+```
+
+---
+
+### Task 6: Fix cognitive complexity violations
+
+**Files:**
+- Modify: `frontend/app/workbench/construction-plans/page.tsx:428` (handleDragEnd — complexity 17)
+- Modify: `frontend/lib/planValidation.ts:22` (validateNode — complexity 20)
+- Modify: `frontend/lib/planTreeUtils.ts:332` (resolveNodeShapes — complexity 23)
+
+- [ ] **Step 1: Reduce complexity of handleDragEnd (construction-plans/page.tsx:428)**
+
+Extract the drop-target parsing into a helper function:
+
+```typescript
+function parseDropTarget(overId: string): { planId: number; path: string } | null {
+  if (overId.startsWith("plan-root-")) {
+    return { planId: Number(overId.slice("plan-root-".length)), path: "root" };
+  }
+  if (overId.startsWith("node-plan-")) {
+    const rest = overId.slice("node-plan-".length);
+    const dotIdx = rest.indexOf("-");
+    if (dotIdx > 0) {
+      return { planId: Number(rest.slice(0, dotIdx)), path: rest.slice(dotIdx + 1) };
+    }
+  }
+  return null;
+}
+```
+
+Place this function **outside** the component (it's pure, no dependencies on component state). Then simplify handleDragEnd:
+
+```typescript
+const handleDragEnd = useCallback(
+  async (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over) return;
+    const activeId = String(active.id);
+    if (!activeId.startsWith("creator-")) return;
+
+    const creator = active.data.current?.creator as CreatorInfo | undefined;
+    if (!creator) return;
+
+    const target = parseDropTarget(String(over.id));
+    if (!target) return;
+
+    try {
+      await addCreatorToPlan(target.planId, target.path, creator);
+    } catch (err) {
+      alert(`Drop failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  },
+  [addCreatorToPlan],
+);
+```
+
+- [ ] **Step 2: Reduce complexity of validateNode (planValidation.ts:22)**
+
+Extract the shape-reference check into a helper:
+
+```typescript
+function checkShapeRefs(
+  val: unknown,
+  paramName: string,
+  availableShapes: Set<string>,
+  path: string,
+  creatorId: string,
+  issues: ValidationIssue[],
+): void {
+  const refs = Array.isArray(val) ? val.map(String) : [String(val)];
+  for (const ref of refs) {
+    if (ref.trim() && !availableShapes.has(ref)) {
+      issues.push({
+        path,
+        creatorId,
+        message: `Shape reference "${ref}" (${paramName}) is not available at this point`,
+      });
+    }
+  }
+}
+```
+
+Then in validateNode, replace lines 51-62:
+```typescript
+if (isShapeRefType(param.type) && !isEmpty(val)) {
+  checkShapeRefs(val, param.name, availableShapes, path, node.creator_id, issues);
+}
+```
+
+- [ ] **Step 3: Reduce complexity of resolveNodeShapes (planTreeUtils.ts:332)**
+
+Extract the input-building logic for a single parameter into a helper:
+
+```typescript
+function collectParamInputs(
+  param: CreatorParam,
+  val: unknown,
+): ResolvedShapeInput[] {
+  if (param.type === "list[ShapeId]" && Array.isArray(val)) {
+    if (val.length === 0) return [{ paramName: param.name, boundValue: null }];
+    return val.map((v) => ({
+      paramName: param.name,
+      boundValue: typeof v === "string" && v.trim() !== "" ? v : null,
+    }));
+  }
+  const bound = typeof val === "string" && val.trim() !== "" ? val : null;
+  return [{ paramName: param.name, boundValue: bound }];
+}
+```
+
+Then in resolveNodeShapes, replace the loop body:
+```typescript
+const inputs: ResolvedShapeInput[] = [];
+for (const p of info.parameters) {
+  if (!isShapeRefType(p.type)) continue;
+  const val = (node as Record<string, unknown>)[p.name];
+  inputs.push(...collectParamInputs(p, val));
+}
+```
+
+- [ ] **Step 4: Run eslint on changed files**
+
+```bash
+cd frontend && npx eslint app/workbench/construction-plans/page.tsx lib/planValidation.ts lib/planTreeUtils.ts 2>&1 | grep "sonarjs/cognitive-complexity"
+```
+
+Expected: Zero results.
+
+- [ ] **Step 5: Run unit tests**
+
+```bash
+cd frontend && npm run test:unit -- --run 2>&1 | tail -10
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/app/workbench/construction-plans/page.tsx \
+       frontend/lib/planValidation.ts \
+       frontend/lib/planTreeUtils.ts
+git commit -m "refactor(gh-377): extract helpers to reduce cognitive complexity"
+```
+
+---
+
+### Task 7: Fix slow-regex violations
+
+**Files:**
+- Modify: `frontend/components/workbench/avlLanguage.ts:29,34` (two regexes in Monaco tokenizer)
+- Modify: `frontend/components/workbench/AnalysisViewerPanel.tsx:252` (YDUP regex)
+
+- [ ] **Step 1: Fix slow-regex in avlLanguage.ts**
+
+**Line 29** — `/[!#].*$/` — `.*$` can backtrack. Fix by being explicit:
+```typescript
+// Before:
+[/[!#].*$/, "comment"],
+// After:
+[/[!#][^\n]*/, "comment"],
+```
+
+**Line 34** — `/-?\d+\.?\d*([eE][+-]?\d+)?/` — `\d+` and `\d*` overlap causing backtracking. Fix by grouping the decimal part:
+```typescript
+// Before:
+[/-?\d+\.?\d*([eE][+-]?\d+)?/, "number"],
+// After:
+[/-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?/, "number"],
+```
+
+- [ ] **Step 2: Fix slow-regex in AnalysisViewerPanel.tsx:252**
+
+```typescript
+// Before:
+const baseName = surface.surface_name.replace(/\s*\(YDUP\)$/, "");
+// After — use string methods instead of regex:
+const baseName = surface.surface_name.endsWith("(YDUP)")
+  ? surface.surface_name.slice(0, -6).trimEnd()
+  : surface.surface_name;
+```
+
+`"(YDUP)".length === 6`. `trimEnd()` removes any trailing whitespace that was before `(YDUP)`.
+
+- [ ] **Step 3: Run eslint on changed files**
+
+```bash
+cd frontend && npx eslint components/workbench/avlLanguage.ts components/workbench/AnalysisViewerPanel.tsx 2>&1 | grep "sonarjs/slow-regex"
+```
+
+Expected: Zero results.
+
+- [ ] **Step 4: Run unit tests**
+
+```bash
+cd frontend && npm run test:unit -- --run 2>&1 | tail -10
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/components/workbench/avlLanguage.ts \
+       frontend/components/workbench/AnalysisViewerPanel.tsx
+git commit -m "fix(gh-377): rewrite slow regexes to avoid backtracking"
+```
+
+---
+
+### Task 8: Install Husky + lint-staged and create pre-commit hook
+
+**Files:**
+- Modify: `frontend/package.json` (add devDeps, prepare script, lint-staged config)
+- Create: `frontend/.husky/pre-commit`
+
+- [ ] **Step 1: Install husky and lint-staged**
+
+```bash
+cd frontend && npm install --save-dev husky lint-staged
+```
+
+- [ ] **Step 2: Add prepare script and lint-staged config to package.json**
+
+In `frontend/package.json`, add to `"scripts"`:
+```json
+"prepare": "cd .. && husky frontend/.husky"
+```
+
+Add top-level:
+```json
+"lint-staged": {
+  "*.{ts,tsx,js,jsx}": "eslint --max-warnings=0"
+}
+```
+
+- [ ] **Step 3: Create pre-commit hook**
+
+```bash
+mkdir -p frontend/.husky
+cat > frontend/.husky/pre-commit << 'EOF'
+cd frontend && npx lint-staged
+EOF
+```
+
+- [ ] **Step 4: Run prepare to install the hook**
+
+```bash
+cd frontend && npm run prepare
+```
+
+Expected: Husky installs the git hook successfully.
+
+- [ ] **Step 5: Verify hook is installed**
+
+```bash
+cat .git/hooks/pre-commit 2>/dev/null || cat ../.git/hooks/pre-commit 2>/dev/null
+```
+
+The file should exist and reference the husky hook runner.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/package.json frontend/package-lock.json frontend/.husky/pre-commit
+git commit -m "chore(gh-377): add Husky pre-commit hook with lint-staged"
+```
+
+This commit itself will trigger the new pre-commit hook — if it passes, the hook is working.
+
+---
+
+### Task 9: Final verification — clean lint + passing tests
+
+- [ ] **Step 1: Run full eslint**
+
+```bash
+cd frontend && npx eslint . 2>&1 | grep "sonarjs/"
+```
+
+Expected: **Zero sonarjs errors.** There may be pre-existing warnings from other rules (react-hooks, typescript-eslint) — those are out of scope.
+
+- [ ] **Step 2: Run full unit test suite**
+
+```bash
+cd frontend && npm run test:unit -- --run
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 3: Run npm run lint (the standard command)**
+
+```bash
+cd frontend && npm run lint
+```
+
+Expected: Exits cleanly (exit code 0) or shows only pre-existing warnings.
+
+- [ ] **Step 4: Verify lint count**
+
+```bash
+cd frontend && npx eslint . 2>&1 | grep -c "error"
+```
+
+Expected: 0 errors. Any errors mean a violation was missed — go back and fix.

--- a/docs/superpowers/specs/2026-05-02-eslint-plugin-sonarjs-design.md
+++ b/docs/superpowers/specs/2026-05-02-eslint-plugin-sonarjs-design.md
@@ -1,0 +1,119 @@
+# eslint-plugin-sonarjs + Pre-commit Hook
+
+**Issue:** #377
+**Date:** 2026-05-02
+
+## Goal
+
+Catch SonarQube-style issues locally before they reach the server by
+integrating `eslint-plugin-sonarjs` into the frontend ESLint config
+and enforcing it via a Husky pre-commit hook.
+
+## Acceptance Criteria
+
+- [ ] `eslint-plugin-sonarjs` is a devDependency in `frontend/package.json`
+- [ ] `eslint.config.mjs` includes the sonarjs `recommended` preset
+- [ ] All sonarjs rules run as errors (recommended default)
+- [ ] `sonarjs/no-clear-text-protocols` is disabled (localhost URLs are intentional)
+- [ ] `sonarjs/publicly-writable-directories` is disabled (/tmp refs are harmless)
+- [ ] `coverage/` directory is added to globalIgnores
+- [ ] All existing violations (~31) are fixed
+- [ ] `husky` and `lint-staged` are devDependencies
+- [ ] `.husky/pre-commit` hook runs lint-staged
+- [ ] `prepare` script in package.json installs Husky on `npm install`
+- [ ] lint-staged runs `eslint --max-warnings=0` on staged `*.{ts,tsx,js,jsx}` files
+- [ ] `npm run lint` passes with zero errors
+
+## Design
+
+### 1. ESLint Configuration
+
+**File:** `frontend/eslint.config.mjs`
+
+Add `eslint-plugin-sonarjs` using its flat-config recommended preset:
+
+```javascript
+import sonarjs from "eslint-plugin-sonarjs";
+
+const eslintConfig = defineConfig([
+  ...nextVitals,
+  ...nextTs,
+  sonarjs.configs.recommended,
+  {
+    rules: {
+      "sonarjs/no-clear-text-protocols": "off",
+      "sonarjs/publicly-writable-directories": "off",
+    },
+  },
+  globalIgnores([
+    ".next/**",
+    "out/**",
+    "build/**",
+    "next-env.d.ts",
+    "coverage/**",
+  ]),
+]);
+```
+
+### 2. Fix Existing Violations
+
+48 total violations detected during audit. After disabling the two
+false-positive rules (~17 hits) and ignoring `coverage/` (~1 hit),
+~31 genuine violations remain:
+
+| Rule | Count | Fix |
+|------|-------|-----|
+| `no-nested-conditional` | 8 | Extract nested ternaries into variables or early returns |
+| `no-unused-vars` / `no-dead-store` | 12 | Remove unused variables and dead assignments |
+| `cognitive-complexity` | 3 | Extract helpers to reduce function complexity |
+| `public-static-readonly` | 3 | Add `readonly` modifier to public static properties |
+| `slow-regex` | 2 | Rewrite regexes to avoid catastrophic backtracking |
+| `unused-import` / `void-use` | 2 | Remove unused import, replace void operator |
+
+### 3. Husky + lint-staged
+
+**New devDependencies:**
+- `husky` (latest)
+- `lint-staged` (latest)
+
+**package.json changes:**
+
+```json
+{
+  "scripts": {
+    "prepare": "cd .. && husky frontend/.husky"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,jsx}": "eslint --max-warnings=0"
+  }
+}
+```
+
+The `cd ..` is required because `frontend/` is a subdirectory of the
+git root. Husky must install the git hook from the repo root, pointing
+to `frontend/.husky/` for the hook scripts.
+
+**New file:** `frontend/.husky/pre-commit`
+
+```sh
+cd frontend && npx lint-staged
+```
+
+The `cd frontend` ensures lint-staged runs in the correct directory
+where `node_modules` and the ESLint config live.
+
+`--max-warnings=0` ensures even warnings block commits.
+`prepare` script auto-installs hooks on `npm install`.
+
+### 4. Ignored / Suppressed Rules
+
+| Rule | Disposition | Rationale |
+|------|------------|-----------|
+| `sonarjs/no-clear-text-protocols` | Disabled globally | Frontend uses `http://localhost` for local dev API calls; HTTPS is enforced in deployment |
+| `sonarjs/publicly-writable-directories` | Disabled globally | References are in coverage tooling, not application code |
+
+### 5. Out of Scope
+
+- Python/backend pre-commit hooks (separate concern)
+- Root-level hook orchestration
+- Custom sonarjs rule tuning beyond the two suppressions

--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -1,0 +1,1 @@
+cd frontend && npx lint-staged

--- a/frontend/__tests__/ComponentTreeWeightDisplay.test.tsx
+++ b/frontend/__tests__/ComponentTreeWeightDisplay.test.tsx
@@ -289,7 +289,7 @@ describe("ComponentTree — virtual root (gh#89)", () => {
       tree: [makeNode({ id: 1, name: "wing", weight_status: "valid", total_weight_g: 50 })],
       totalNodes: 1, isLoading: false, error: null,
     };
-    const { container } = render(<ComponentTree />);
+    render(<ComponentTree />);
     // Find the row for "wing" and verify its padding-left corresponds to level=1
     // (= 20px) rather than the pre-gh#89 level=0 (= 0px).
     const wingText = screen.getByText("wing");
@@ -299,7 +299,5 @@ describe("ComponentTree — virtual root (gh#89)", () => {
     const aeroText = screen.getByText("Aeroplane");
     const rootRow = aeroText.closest('[aria-roledescription="sortable"]') as HTMLElement;
     expect(rootRow.style.paddingLeft).toBe("0px");
-    // Silence unused
-    void container;
   });
 });

--- a/frontend/__tests__/ComponentsPage.test.tsx
+++ b/frontend/__tests__/ComponentsPage.test.tsx
@@ -135,7 +135,6 @@ describe("ComponentsPage — '+ New Component' dialog", () => {
 
     // Cancel buttons exist in the page and dialog; click the one inside the edit dialog
     const editDialog = container.querySelector('dialog[aria-label="New Component"]');
-    const cancelBtn = editDialog?.querySelector("button");
     // Find the Cancel button specifically
     const allBtns = editDialog?.querySelectorAll("button") ?? [];
     const cancelButton = Array.from(allBtns).find((b) => b.textContent === "Cancel");

--- a/frontend/__tests__/ConstructionPlansPage.test.tsx
+++ b/frontend/__tests__/ConstructionPlansPage.test.tsx
@@ -180,9 +180,9 @@ import ConstructionPlansPage from "@/app/workbench/construction-plans/page";
 // jsdom does not implement EventSource. Stub it so that ExecutionResultDialog
 // can mount with a streamUrl prop without throwing.
 class FakeEventSource {
-  static CONNECTING = 0;
-  static OPEN = 1;
-  static CLOSED = 2;
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
   readyState = FakeEventSource.CONNECTING;
   url: string;
   constructor(url: string) {

--- a/frontend/__tests__/ConstructionPlansPage.test.tsx
+++ b/frontend/__tests__/ConstructionPlansPage.test.tsx
@@ -50,60 +50,62 @@ vi.mock("@/hooks/useConstructionPlans", () => ({
     isLoading: false,
     mutate: mockMutateAeroplanePlans,
   }),
-  useConstructionPlan: (id: number | null) => ({
-    plan: id === 1
-      ? {
-          id: 1,
-          name: "eHawk Wing",
-          description: null,
-          tree_json: {
-            $TYPE: "ConstructionRootNode",
-            creator_id: "root",
-            loglevel: 50,
-            successors: {
-              VaseModeWingCreator: {
-                $TYPE: "ConstructionStepNode",
-                creator_id: "VaseModeWingCreator",
-                loglevel: 50,
-                creator: { $TYPE: "VaseModeWingCreator", creator_id: "VaseModeWingCreator", wing_index: "main_wing", loglevel: 50 },
-                successors: {},
-              },
+  useConstructionPlan: (id: number | null) => {
+    const mockPlanDetails: Record<number, object> = {
+      1: {
+        id: 1,
+        name: "eHawk Wing",
+        description: null,
+        tree_json: {
+          $TYPE: "ConstructionRootNode",
+          creator_id: "root",
+          loglevel: 50,
+          successors: {
+            VaseModeWingCreator: {
+              $TYPE: "ConstructionStepNode",
+              creator_id: "VaseModeWingCreator",
+              loglevel: 50,
+              creator: { $TYPE: "VaseModeWingCreator", creator_id: "VaseModeWingCreator", wing_index: "main_wing", loglevel: 50 },
+              successors: {},
             },
           },
-          plan_type: "template",
-          aeroplane_id: null,
-          created_at: "2026-01-01",
-          updated_at: "2026-01-01",
-        }
-      : id === 2
-      ? {
-          id: 2,
-          name: "eHawk Build",
-          description: null,
-          tree_json: {
-            $TYPE: "ConstructionRootNode",
-            creator_id: "root",
-            loglevel: 50,
-            successors: {
-              VaseModeWingCreator: {
-                $TYPE: "ConstructionStepNode",
-                creator_id: "VaseModeWingCreator",
-                loglevel: 50,
-                creator: { $TYPE: "VaseModeWingCreator", creator_id: "VaseModeWingCreator", wing_index: "main_wing", loglevel: 50 },
-                successors: {},
-              },
+        },
+        plan_type: "template",
+        aeroplane_id: null,
+        created_at: "2026-01-01",
+        updated_at: "2026-01-01",
+      },
+      2: {
+        id: 2,
+        name: "eHawk Build",
+        description: null,
+        tree_json: {
+          $TYPE: "ConstructionRootNode",
+          creator_id: "root",
+          loglevel: 50,
+          successors: {
+            VaseModeWingCreator: {
+              $TYPE: "ConstructionStepNode",
+              creator_id: "VaseModeWingCreator",
+              loglevel: 50,
+              creator: { $TYPE: "VaseModeWingCreator", creator_id: "VaseModeWingCreator", wing_index: "main_wing", loglevel: 50 },
+              successors: {},
             },
           },
-          plan_type: "plan",
-          aeroplane_id: "aero-1",
-          created_at: "2026-01-01",
-          updated_at: "2026-01-01",
-        }
-      : null,
-    error: null,
-    isLoading: false,
-    mutate: mockMutatePlan,
-  }),
+        },
+        plan_type: "plan",
+        aeroplane_id: "aero-1",
+        created_at: "2026-01-01",
+        updated_at: "2026-01-01",
+      },
+    };
+    return {
+      plan: id !== null ? (mockPlanDetails[id] ?? null) : null,
+      error: null,
+      isLoading: false,
+      mutate: mockMutatePlan,
+    };
+  },
   createPlan: (...args: unknown[]) => mockCreatePlan(...args),
   updatePlan: vi.fn().mockResolvedValue({}),
   deletePlan: (...args: unknown[]) => mockDeletePlan(...args),

--- a/frontend/__tests__/FuselageXSecFormSave.test.tsx
+++ b/frontend/__tests__/FuselageXSecFormSave.test.tsx
@@ -3,7 +3,7 @@
  * tested via PropertyForm in fuselage mode (GH#359).
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, act, fireEvent } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import React, { useRef } from "react";
 
 // ── Mocks ──────────────────────────────────────────────────────

--- a/frontend/__tests__/planTreeUtils.test.ts
+++ b/frontend/__tests__/planTreeUtils.test.ts
@@ -12,6 +12,7 @@ import {
   toBackendTree,
   fromBackendTree,
   appendChildAtPath,
+  resolveParamValue,
 } from "@/lib/planTreeUtils";
 
 function makeNode(type: string, id: string, successors: PlanStepNode[] = []): PlanStepNode {
@@ -500,6 +501,27 @@ describe("round-trip conversion", () => {
     expect(creator.$TYPE).toBe("WingLoftCreator");
     expect(creator.loglevel).toBe(10);
     expect(creator.offset).toBe(5);
+  });
+});
+
+describe("resolveParamValue", () => {
+  it("returns string values as-is", () => {
+    expect(resolveParamValue("hello", "{x}")).toBe("hello");
+    expect(resolveParamValue("", "{x}")).toBe("");
+  });
+
+  it("converts numbers to strings", () => {
+    expect(resolveParamValue(42, "{x}")).toBe("42");
+    expect(resolveParamValue(0, "{x}")).toBe("0");
+    expect(resolveParamValue(-1.5, "{x}")).toBe("-1.5");
+  });
+
+  it("returns fallback for non-string/non-number types", () => {
+    expect(resolveParamValue(null, "{x}")).toBe("{x}");
+    expect(resolveParamValue(undefined, "{x}")).toBe("{x}");
+    expect(resolveParamValue(true, "{x}")).toBe("{x}");
+    expect(resolveParamValue({}, "{x}")).toBe("{x}");
+    expect(resolveParamValue([], "{x}")).toBe("{x}");
   });
 });
 

--- a/frontend/app/workbench/construction-plans/page.tsx
+++ b/frontend/app/workbench/construction-plans/page.tsx
@@ -202,7 +202,12 @@ export default function ConstructionPlansPage() {
     async (planId: number, newName: string) => {
       // Need the plan's tree_json to call updatePlan — fetch detail if not loaded
       const isTemplate = templates.some((t) => t.id === planId);
-      const detail = isTemplate ? templateDetail : (activePlanDetail?.id === planId ? activePlanDetail : null);
+      let detail = null;
+      if (isTemplate) {
+        detail = templateDetail;
+      } else if (activePlanDetail?.id === planId) {
+        detail = activePlanDetail;
+      }
       if (!detail || detail.id !== planId) {
         alert("Cannot rename: plan data not loaded. Expand the plan first.");
         return;

--- a/frontend/app/workbench/construction-plans/page.tsx
+++ b/frontend/app/workbench/construction-plans/page.tsx
@@ -50,6 +50,21 @@ import type { ExecutionResult } from "@/hooks/useConstructionPlans";
 
 // ── Helpers ───────────────────────────────────────────────────────
 
+/** Parse a DnD drop target ID into plan ID and path. */
+function parseDropTarget(overId: string): { planId: number; path: string } | null {
+  if (overId.startsWith("plan-root-")) {
+    return { planId: Number(overId.slice("plan-root-".length)), path: "root" };
+  }
+  if (overId.startsWith("node-plan-")) {
+    const rest = overId.slice("node-plan-".length);
+    const dotIdx = rest.indexOf("-");
+    if (dotIdx > 0) {
+      return { planId: Number(rest.slice(0, dotIdx)), path: rest.slice(dotIdx + 1) };
+    }
+  }
+  return null;
+}
+
 /** Toggle a value in a Set, returning a new Set (immutable update). */
 function toggleInSet<T>(prev: Set<T>, value: T): Set<T> {
   const next = new Set(prev);
@@ -434,33 +449,19 @@ export default function ConstructionPlansPage() {
       const { active, over } = event;
       if (!over) return;
       const activeId = String(active.id);
-      const overId = String(over.id);
+      if (!activeId.startsWith("creator-")) return;
 
-      // Source: gallery creator → tree
-      if (activeId.startsWith("creator-")) {
-        const creator = active.data.current?.creator as CreatorInfo | undefined;
-        if (!creator) return;
-        // Resolve drop target: either "plan-root-{planId}" or "node-plan-{planId}-{path}"
-        let targetPlanId: number | null = null;
-        let targetPath = "root";
-        if (overId.startsWith("plan-root-")) {
-          targetPlanId = Number(overId.slice("plan-root-".length));
-        } else if (overId.startsWith("node-plan-")) {
-          const rest = overId.slice("node-plan-".length);
-          const dotIdx = rest.indexOf("-");
-          if (dotIdx > 0) {
-            targetPlanId = Number(rest.slice(0, dotIdx));
-            targetPath = rest.slice(dotIdx + 1);
-          }
-        }
-        if (!targetPlanId) return;
-        try {
-          await addCreatorToPlan(targetPlanId, targetPath, creator);
-        } catch (err) {
-          alert(`Drop failed: ${err instanceof Error ? err.message : String(err)}`);
-        }
+      const creator = active.data.current?.creator as CreatorInfo | undefined;
+      if (!creator) return;
+
+      const target = parseDropTarget(String(over.id));
+      if (!target) return;
+
+      try {
+        await addCreatorToPlan(target.planId, target.path, creator);
+      } catch (err) {
+        alert(`Drop failed: ${err instanceof Error ? err.message : String(err)}`);
       }
-      // Tree-to-tree reorder/reparent could go here in a future iteration
     },
     [addCreatorToPlan],
   );

--- a/frontend/app/workbench/page.tsx
+++ b/frontend/app/workbench/page.tsx
@@ -39,11 +39,11 @@ export default function WorkbenchPage() {
     ? selectedFuselageXsecIndex
     : selectedXsecIndex;
 
-  const paginatorTotal = mode === "fuselage"
-    ? fuselage?.x_secs?.length
-    : mode === "wingconfig"
-      ? wingConfig?.segments?.length
-      : wing?.x_secs?.length;
+  const paginatorTotal = (() => {
+    if (mode === "fuselage") return fuselage?.x_secs?.length;
+    if (mode === "wingconfig") return wingConfig?.segments?.length;
+    return wing?.x_secs?.length;
+  })();
 
   const formRef = useRef<PropertyFormHandle>(null);
 

--- a/frontend/app/workbench/page.tsx
+++ b/frontend/app/workbench/page.tsx
@@ -19,7 +19,7 @@ import { API_BASE } from "@/lib/fetcher";
 
 export default function WorkbenchPage() {
   const {
-    aeroplaneId, setAeroplaneId,
+    aeroplaneId,
     selectedWing, selectedXsecIndex, selectXsec,
     selectedFuselage, selectedFuselageXsecIndex, selectFuselageXsec,
     treeMode,

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -249,7 +249,9 @@ const SURFACE_COLORS = [
 function groupSurfaceStrips(surfaces: StripForcesResult["surfaces"]) {
   const groups = new Map<string, { strips: typeof surfaces[0]["strips"] }>();
   for (const surface of surfaces) {
-    const baseName = surface.surface_name.replace(/\s*\(YDUP\)$/, "");
+    const baseName = surface.surface_name.endsWith("(YDUP)")
+      ? surface.surface_name.slice(0, -6).trimEnd()
+      : surface.surface_name;
     const existing = groups.get(baseName);
     if (existing) {
       existing.strips = [...existing.strips, ...surface.strips];

--- a/frontend/components/workbench/AvlGeometryEditor.tsx
+++ b/frontend/components/workbench/AvlGeometryEditor.tsx
@@ -132,6 +132,54 @@ export function AvlGeometryEditor({ aeroplaneId, open, onClose }: Props) {
     ? "fixed inset-4 z-50"
     : "w-[900px] h-[650px]";
 
+  function renderEditorBody() {
+    if (geometry.isLoading) {
+      return (
+        <div className="flex h-full items-center justify-center text-[13px] text-muted-foreground">
+          Loading AVL geometry…
+        </div>
+      );
+    }
+    if (mode === "diff" && regeneratedContent !== null) {
+      return (
+        <MonacoDiffEditor
+          original={localContent}
+          modified={regeneratedContent}
+          language="avl"
+          theme="avl-dark"
+          onMount={handleEditorDidMount}
+          options={{
+            readOnly: false,
+            renderSideBySide: true,
+            fontFamily: "var(--font-jetbrains-mono), monospace",
+            fontSize: 13,
+            minimap: { enabled: false },
+            lineNumbers: "on",
+            scrollBeyondLastLine: false,
+          }}
+        />
+      );
+    }
+    return (
+      <MonacoEditor
+        value={localContent}
+        onChange={(v) => setLocalContent(v ?? "")}
+        language="avl"
+        theme="avl-dark"
+        onMount={handleEditorDidMount}
+        options={{
+          fontFamily: "var(--font-jetbrains-mono), monospace",
+          fontSize: 13,
+          minimap: { enabled: false },
+          lineNumbers: "on",
+          scrollBeyondLastLine: false,
+          wordWrap: "off",
+          automaticLayout: true,
+        }}
+      />
+    );
+  }
+
   return (
     <>
       <AvlDirtyWarning
@@ -186,45 +234,7 @@ export function AvlGeometryEditor({ aeroplaneId, open, onClose }: Props) {
 
           {/* Editor Body */}
           <div className="flex-1 overflow-hidden">
-            {geometry.isLoading ? (
-              <div className="flex h-full items-center justify-center text-[13px] text-muted-foreground">
-                Loading AVL geometry…
-              </div>
-            ) : mode === "diff" && regeneratedContent !== null ? (
-              <MonacoDiffEditor
-                original={localContent}
-                modified={regeneratedContent}
-                language="avl"
-                theme="avl-dark"
-                onMount={handleEditorDidMount}
-                options={{
-                  readOnly: false,
-                  renderSideBySide: true,
-                  fontFamily: "var(--font-jetbrains-mono), monospace",
-                  fontSize: 13,
-                  minimap: { enabled: false },
-                  lineNumbers: "on",
-                  scrollBeyondLastLine: false,
-                }}
-              />
-            ) : (
-              <MonacoEditor
-                value={localContent}
-                onChange={(v) => setLocalContent(v ?? "")}
-                language="avl"
-                theme="avl-dark"
-                onMount={handleEditorDidMount}
-                options={{
-                  fontFamily: "var(--font-jetbrains-mono), monospace",
-                  fontSize: 13,
-                  minimap: { enabled: false },
-                  lineNumbers: "on",
-                  scrollBeyondLastLine: false,
-                  wordWrap: "off",
-                  automaticLayout: true,
-                }}
-              />
-            )}
+            {renderEditorBody()}
           </div>
 
           {/* Footer */}

--- a/frontend/components/workbench/SimpleTreeRow.tsx
+++ b/frontend/components/workbench/SimpleTreeRow.tsx
@@ -67,6 +67,15 @@ export function SimpleTreeRow({ node, onToggle }: Readonly<SimpleTreeRowProps>) 
     node.onClick?.();
   }
 
+  let labelClass: string;
+  if (node.error) {
+    labelClass = "text-[12px] text-red-400/70";
+  } else if (node.muted) {
+    labelClass = "text-[12px] text-muted-foreground";
+  } else {
+    labelClass = "font-[family-name:var(--font-geist-sans)] text-[13px] text-foreground";
+  }
+
   return (
     <div
       ref={setRefs}
@@ -91,7 +100,7 @@ export function SimpleTreeRow({ node, onToggle }: Readonly<SimpleTreeRowProps>) 
         <ChevronRight size={12} className="shrink-0 text-muted-foreground" />
       )}
       <span
-        className={`whitespace-nowrap ${node.error ? "text-[12px] text-red-400/70" : node.muted ? "text-[12px] text-muted-foreground" : "font-[family-name:var(--font-geist-sans)] text-[13px] text-foreground"}`}
+        className={`whitespace-nowrap ${labelClass}`}
       >
         {node.label}
       </span>

--- a/frontend/components/workbench/avlLanguage.ts
+++ b/frontend/components/workbench/avlLanguage.ts
@@ -26,12 +26,12 @@ export const avlLanguage: languages.IMonarchLanguage & { keywords: string[] } = 
   ],
   tokenizer: {
     root: [
-      [/[!#].*$/, "comment"],
+      [/[!#][^\n]*/, "comment"],
       [
         /[A-Z][A-Z_]+/,
         { cases: { "@keywords": "keyword", "@default": "identifier" } },
       ],
-      [/-?\d+\.?\d*([eE][+-]?\d+)?/, "number"],
+      [/-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?/, "number"],
       [/[a-zA-Z_]\w*/, "identifier"],
     ],
   },

--- a/frontend/components/workbench/construction-plans/PlanTreeSection.tsx
+++ b/frontend/components/workbench/construction-plans/PlanTreeSection.tsx
@@ -5,7 +5,7 @@ import { useDroppable } from "@dnd-kit/core";
 import { Play, Plus, BookTemplate, Pencil, Trash2, FolderOpen, ChevronDown, ChevronRight } from "lucide-react";
 import { SimpleTreeRow } from "@/components/workbench/SimpleTreeRow";
 import type { PlanStepNode } from "@/components/workbench/PlanTree";
-import { resolveNodeShapes } from "@/lib/planTreeUtils";
+import { resolveNodeShapes, resolveParamValue } from "@/lib/planTreeUtils";
 import type { PlanSummary } from "@/hooks/useConstructionPlans";
 import type { CreatorInfo } from "@/hooks/useCreators";
 import { InlineEditableName } from "./InlineEditableName";
@@ -30,10 +30,9 @@ export function renderCreatorTree(
   const nodeRecord = node as Record<string, unknown>;
   const displayLabel = nodeRecord._creatorIdDirty
     ? node.creator_id
-    : node.creator_id.replace(/\{(\w+)\}/g, (_match, param) => {
-        const val = nodeRecord[param];
-        return typeof val === "string" ? val : typeof val === "number" ? String(val) : `{${param}}`;
-      });
+    : node.creator_id.replace(/\{(\w+)\}/g, (_match, param) =>
+        resolveParamValue(nodeRecord[param], `{${param}}`),
+      );
 
   return (
     <div key={creatorKey} className="flex flex-col">

--- a/frontend/e2e/steps/common.steps.ts
+++ b/frontend/e2e/steps/common.steps.ts
@@ -39,10 +39,6 @@ Given("I am on the workbench with an aeroplane", async ({ page, request }) => {
     .catch(() => false);
 
   if (selectorVisible) {
-    // Click the first aeroplane button in the list
-    const firstAeroplane = page.locator(
-      'button:has-text("") >> nth=0',
-    );
     // Find a button that is NOT "Create New"
     const aeroplaneButtons = page.locator(
       'div.flex.flex-col.gap-1 button',

--- a/frontend/e2e/steps/construction.steps.ts
+++ b/frontend/e2e/steps/construction.steps.ts
@@ -267,7 +267,6 @@ Then("the analysis completes without error", async ({ page }) => {
   // The "Run an analysis" placeholder disappears when results arrive
   await page.waitForFunction(
     () => {
-      const placeholder = document.querySelector('[class*="items-center"]');
       const hasPlaceholder = !!document.body.innerText.includes("Run an analysis to see results");
       const hasError = !!document.body.innerText.match(/Analysis failed|Error/i);
       return !hasPlaceholder || hasError;

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -11,6 +11,11 @@ const eslintConfig = defineConfig([
     rules: {
       "sonarjs/no-clear-text-protocols": "off",
       "sonarjs/publicly-writable-directories": "off",
+      "@typescript-eslint/no-unused-vars": ["warn", {
+        varsIgnorePattern: "^_",
+        argsIgnorePattern: "^_",
+        caughtErrorsIgnorePattern: "^_",
+      }],
     },
   },
   globalIgnores([

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -1,18 +1,25 @@
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
+import sonarjs from "eslint-plugin-sonarjs";
 
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
-  // Override default ignores of eslint-config-next.
+  sonarjs.configs.recommended,
+  {
+    rules: {
+      "sonarjs/no-clear-text-protocols": "off",
+      "sonarjs/publicly-writable-directories": "off",
+    },
+  },
   globalIgnores([
-    // Default ignores of eslint-config-next:
     ".next/**",
     "out/**",
     "build/**",
     "next-env.d.ts",
+    ".features-gen/**",
+    "coverage/**",
   ]),
 ]);
-
 export default eslintConfig;

--- a/frontend/lib/planTreeUtils.ts
+++ b/frontend/lib/planTreeUtils.ts
@@ -1,6 +1,16 @@
 import type { PlanStepNode } from "@/components/workbench/PlanTree";
 import type { CreatorInfo } from "@/hooks/useCreators";
 
+/**
+ * Resolve a parameter value to a string.
+ * Returns the value as-is if it is a string, converts numbers, or returns the fallback.
+ */
+export function resolveParamValue(val: unknown, fallback: string): string {
+  if (typeof val === "string") return val;
+  if (typeof val === "number") return String(val);
+  return fallback;
+}
+
 /** Navigate the plan tree to find the node at the given dot-separated path. */
 export function getStepAtPath(tree: PlanStepNode, path: string): PlanStepNode | null {
   if (path === "root") return tree;
@@ -308,10 +318,9 @@ export function buildStepNode(creator: CreatorInfo, tree: PlanStepNode): PlanSte
   }
   // Resolve {placeholder} in creator_id using the seeded default values
   const nodeRecord = node as Record<string, unknown>;
-  node.creator_id = base.replace(/\{(\w+)\}/g, (_match, param) => {
-    const val = nodeRecord[param];
-    return typeof val === "string" ? val : typeof val === "number" ? String(val) : `{${param}}`;
-  });
+  node.creator_id = base.replace(/\{(\w+)\}/g, (_match, param) =>
+    resolveParamValue(nodeRecord[param], `{${param}}`),
+  );
   // Ensure uniqueness after resolution
   node.creator_id = uniqueCreatorId(tree, node.creator_id);
   return node;
@@ -365,10 +374,9 @@ export function resolveNodeShapes(
   const resolveKey = (key: string): string => {
     let resolved = key.replaceAll("{id}", stepId);
     // Replace remaining {param_name} placeholders with actual values
-    resolved = resolved.replace(/\{(\w+)\}/g, (_match, param) => {
-      const val = nodeRecord[param];
-      return typeof val === "string" ? val : typeof val === "number" ? String(val) : `{${param}}`;
-    });
+    resolved = resolved.replace(/\{(\w+)\}/g, (_match, param) =>
+      resolveParamValue(nodeRecord[param], `{${param}}`),
+    );
     return resolved;
   };
 

--- a/frontend/lib/planTreeUtils.ts
+++ b/frontend/lib/planTreeUtils.ts
@@ -341,6 +341,22 @@ export function isShapeRefType(type: string): boolean {
   return type === "ShapeId" || type === "list[ShapeId]";
 }
 
+function collectParamInputs(
+  paramName: string,
+  paramType: string,
+  val: unknown,
+): ResolvedShapeInput[] {
+  if (paramType === "list[ShapeId]" && Array.isArray(val)) {
+    if (val.length === 0) return [{ paramName, boundValue: null }];
+    return val.map((v) => ({
+      paramName,
+      boundValue: typeof v === "string" && v.trim() !== "" ? v : null,
+    }));
+  }
+  const bound = typeof val === "string" && val.trim() !== "" ? val : null;
+  return [{ paramName, boundValue: bound }];
+}
+
 export function resolveNodeShapes(
   node: PlanStepNode,
   creators: CreatorInfo[],
@@ -353,20 +369,7 @@ export function resolveNodeShapes(
   for (const p of info.parameters) {
     if (!isShapeRefType(p.type)) continue;
     const val = (node as Record<string, unknown>)[p.name];
-    if (p.type === "list[ShapeId]" && Array.isArray(val)) {
-      // Multi-shape ref: each element is a separate input
-      for (const v of val) {
-        const bound = typeof v === "string" && v.trim() !== "" ? v : null;
-        inputs.push({ paramName: p.name, boundValue: bound });
-      }
-      // If list is empty, show one unbound entry
-      if (val.length === 0) {
-        inputs.push({ paramName: p.name, boundValue: null });
-      }
-    } else {
-      const bound = typeof val === "string" && val.trim() !== "" ? val : null;
-      inputs.push({ paramName: p.name, boundValue: bound });
-    }
+    inputs.push(...collectParamInputs(p.name, p.type, val));
   }
 
   // Resolve output key placeholders: {id} → creator_id, {param} → node[param]

--- a/frontend/lib/planTreeUtils.ts
+++ b/frontend/lib/planTreeUtils.ts
@@ -183,7 +183,8 @@ export function toBackendTree(
   const backendSuccessors: Record<string, Record<string, unknown>> = {};
 
   for (const child of successors) {
-    const { $TYPE, creator_id, successors: childSuccessors, _creatorIdDirty, ...creatorParams } = child;
+    // eslint-disable-next-line sonarjs/no-unused-vars -- destructure-to-exclude
+    const { $TYPE, creator_id, successors: _childSuccessors, _creatorIdDirty: _dirty, ...creatorParams } = child;
     const loglevel = (creatorParams.loglevel as number) ?? DEFAULT_LOGLEVEL;
     // Remove loglevel from creatorParams to avoid duplication — it's set explicitly
     delete creatorParams.loglevel;
@@ -205,6 +206,7 @@ export function toBackendTree(
     };
   }
 
+  // eslint-disable-next-line sonarjs/no-unused-vars -- destructure-to-exclude
   const { successors: _s, _creatorIdDirty: _d, ...rootFields } = node as Record<string, unknown>;
   return {
     ...rootFields,
@@ -268,6 +270,7 @@ export function fromBackendTree(
     } as PlanStepNode;
   });
 
+  // eslint-disable-next-line sonarjs/no-unused-vars -- destructure-to-exclude
   const { successors: _s, ...rootFields } = tree;
   return {
     ...(rootFields as unknown as PlanStepNode),

--- a/frontend/lib/planValidation.ts
+++ b/frontend/lib/planValidation.ts
@@ -19,6 +19,26 @@ function isEmpty(v: unknown): boolean {
   return false;
 }
 
+function checkShapeRefs(
+  val: unknown,
+  paramName: string,
+  availableShapes: Set<string>,
+  path: string,
+  creatorId: string,
+  issues: ValidationIssue[],
+): void {
+  const refs = Array.isArray(val) ? val.map(String) : [String(val)];
+  for (const ref of refs) {
+    if (ref.trim() && !availableShapes.has(ref)) {
+      issues.push({
+        path,
+        creatorId,
+        message: `Shape reference "${ref}" (${paramName}) is not available at this point`,
+      });
+    }
+  }
+}
+
 function validateNode(
   node: PlanStepNode,
   path: string,
@@ -49,16 +69,7 @@ function validateNode(
     }
     // Check shape references (ShapeId or list[ShapeId])
     if (isShapeRefType(param.type) && !isEmpty(val)) {
-      const refs = Array.isArray(val) ? val.map(String) : [String(val)];
-      for (const ref of refs) {
-        if (ref.trim() && !availableShapes.has(ref)) {
-          issues.push({
-            path,
-            creatorId: node.creator_id,
-            message: `Shape reference "${ref}" (${param.name}) is not available at this point`,
-          });
-        }
-      }
+      checkShapeRefs(val, param.name, availableShapes, path, node.creator_id, issues);
     }
   }
 

--- a/frontend/lib/planValidation.ts
+++ b/frontend/lib/planValidation.ts
@@ -1,6 +1,6 @@
 import type { PlanStepNode } from "@/components/workbench/PlanTree";
 import type { CreatorInfo } from "@/hooks/useCreators";
-import { isShapeRefType } from "@/lib/planTreeUtils";
+import { isShapeRefType, resolveParamValue } from "@/lib/planTreeUtils";
 
 export interface ValidationIssue {
   path: string;
@@ -68,10 +68,9 @@ function validateNode(
   const nodeRecord = node as Record<string, unknown>;
   const resolveKey = (key: string): string => {
     let resolved = key.replaceAll("{id}", stepId);
-    resolved = resolved.replace(/\{(\w+)\}/g, (_match, param) => {
-      const val = nodeRecord[param];
-      return typeof val === "string" ? val : typeof val === "number" ? String(val) : `{${param}}`;
-    });
+    resolved = resolved.replace(/\{(\w+)\}/g, (_match, param) =>
+      resolveParamValue(nodeRecord[param], `{${param}}`),
+    );
     return resolved;
   };
   const ownOutputs = info.outputs.length

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38,7 +38,9 @@
         "eslint": "^9",
         "eslint-config-next": "16.2.1-canary.33",
         "eslint-plugin-sonarjs": "^4.0.3",
+        "husky": "^9.1.7",
         "jsdom": "^29.0.2",
+        "lint-staged": "^16.4.0",
         "playwright-bdd": "^8.5.0",
         "tailwindcss": "^4",
         "typescript": "^5",
@@ -3825,6 +3827,22 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -4433,6 +4451,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-table3": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
@@ -4447,6 +4481,69 @@
       },
       "optionalDependencies": {
         "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/client-only": {
@@ -4564,6 +4661,13 @@
       "integrity": "sha512-BcKnbOEsOarCwyoLstcoEztwT0IJxqqQkNwDuA3a65sICvvHL2yoeV13psoDFh5IuiOMnIOKdQDwB4Mk3BypiA==",
       "license": "Unlicense",
       "peer": true
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "13.1.0",
@@ -5344,6 +5448,19 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-abstract": {
@@ -6174,6 +6291,13 @@
         "es5-ext": "~0.10.14"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -6523,6 +6647,19 @@
       "integrity": "sha512-LnpfLf/TNzr9zVOGiIY6aKCz8EKuXmlYNV7CM2pUjBa/B+c2I15tS7KLySep75+FuerJdmArvJLcsAXWEy2H0A==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
@@ -7214,6 +7351,22 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -8444,6 +8597,71 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lint-staged": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
+      "integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^14.0.3",
+        "listr2": "^9.0.5",
+        "picomatch": "^4.0.3",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.0.4",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/lint-staged/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -8472,6 +8690,101 @@
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -8826,6 +9139,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/min-indent": {
@@ -9281,6 +9607,22 @@
       "peer": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -10237,6 +10579,23 @@
         "protocol-buffers-schema": "^3.3.1"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -10247,6 +10606,13 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/right-now": {
       "version": "1.0.0",
@@ -10687,6 +11053,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/signum": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/signum/-/signum-1.0.0.tgz",
@@ -10700,6 +11079,52 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -10841,6 +11266,16 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
     },
     "node_modules/string-split-by": {
       "version": "1.0.0",
@@ -12248,6 +12683,91 @@
         "object-assign": "^4.1.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -12298,6 +12818,22 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -37,6 +37,7 @@
         "dependency-cruiser": "^17.3.10",
         "eslint": "^9",
         "eslint-config-next": "16.2.1-canary.33",
+        "eslint-plugin-sonarjs": "^4.0.3",
         "jsdom": "^29.0.2",
         "playwright-bdd": "^8.5.0",
         "tailwindcss": "^4",
@@ -4278,6 +4279,29 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
     },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
@@ -5918,6 +5942,95 @@
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
       }
     },
+    "node_modules/eslint-plugin-sonarjs": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.0.3.tgz",
+      "integrity": "sha512-5drkJKLC9qQddIiaATV0e8+ygbUc7b0Ti6VB7M2d3jmKNh3X0RaiIJYTs3dr9xnlhlrxo+/s1FoO3Jgv6O/c7g==",
+      "dev": true,
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "builtin-modules": "^3.3.0",
+        "bytes": "^3.1.2",
+        "functional-red-black-tree": "^1.0.1",
+        "globals": "^17.4.0",
+        "jsx-ast-utils-x": "^0.1.0",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^10.2.5",
+        "scslre": "^0.3.0",
+        "semver": "^7.7.4",
+        "ts-api-utils": "^2.5.0",
+        "typescript": ">=5"
+      },
+      "peerDependencies": {
+        "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/globals": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
@@ -6359,6 +6472,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
@@ -7968,6 +8088,16 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jsx-ast-utils-x": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils-x/-/jsx-ast-utils-x-0.1.0.tgz",
+      "integrity": "sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/kdbush": {
@@ -9866,6 +9996,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/refa": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/refa/-/refa-0.12.1.tgz",
+      "integrity": "sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
@@ -9894,6 +10037,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp-ast-analysis": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.7.1.tgz",
+      "integrity": "sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.1"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/regexp-match-indices": {
@@ -10284,6 +10441,21 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/scslre": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.3.0.tgz",
+      "integrity": "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.0",
+        "regexp-ast-analysis": "^0.7.0"
+      },
+      "engines": {
+        "node": "^14.0.0 || >=16.0.0"
+      }
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,11 @@
     "test:e2e:ui": "npx -p playwright-bdd bddgen && npx playwright test --ui",
     "test:e2e:headed": "npx -p playwright-bdd bddgen && npx playwright test --headed --grep-invert @slow",
     "deps:check": "depcruise --config .dependency-cruiser.cjs components/ hooks/ lib/ app/",
-    "deps:graph": "depcruise --config .dependency-cruiser.cjs --output-type dot components/ hooks/ lib/ app/ | dot -T svg > dependency-graph.svg"
+    "deps:graph": "depcruise --config .dependency-cruiser.cjs --output-type dot components/ hooks/ lib/ app/ | dot -T svg > dependency-graph.svg",
+    "prepare": "cd .. && husky frontend/.husky"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,jsx}": "eslint --max-warnings=0"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -46,7 +50,9 @@
     "eslint": "^9",
     "eslint-config-next": "16.2.1-canary.33",
     "eslint-plugin-sonarjs": "^4.0.3",
+    "husky": "^9.1.7",
     "jsdom": "^29.0.2",
+    "lint-staged": "^16.4.0",
     "playwright-bdd": "^8.5.0",
     "tailwindcss": "^4",
     "typescript": "^5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,6 +45,7 @@
     "dependency-cruiser": "^17.3.10",
     "eslint": "^9",
     "eslint-config-next": "16.2.1-canary.33",
+    "eslint-plugin-sonarjs": "^4.0.3",
     "jsdom": "^29.0.2",
     "playwright-bdd": "^8.5.0",
     "tailwindcss": "^4",


### PR DESCRIPTION
## Summary

Closes #377

- Install `eslint-plugin-sonarjs` with recommended rules (all errors) in `eslint.config.mjs`
- Fix all 31 existing sonarjs violations across 15 files (unused vars, nested ternaries, cognitive complexity, slow regexes, readonly statics)
- Add Husky + lint-staged pre-commit hook that runs ESLint on staged `*.{ts,tsx,js,jsx}` files

### Rule suppressions
- `sonarjs/no-clear-text-protocols`: off — `http://localhost` for local dev
- `sonarjs/publicly-writable-directories`: off — `/tmp` refs in tooling

### Key refactors
- Extracted `resolveParamValue()` helper shared across 3 files
- Extracted `parseDropTarget()`, `checkShapeRefs()`, `collectParamInputs()` helpers to reduce cognitive complexity
- Rewrote 3 slow regexes (avlLanguage tokenizer, YDUP surface name matching)

## Test plan

- [x] `npm run lint` — 0 errors (18 pre-existing warnings from other rules)
- [x] `npm run test:unit` — 336/336 tests pass
- [x] Pre-commit hook fires and blocks on lint errors
- [ ] Manual: `cd frontend && git commit` should trigger lint-staged

🤖 Generated with [Claude Code](https://claude.com/claude-code)