### PR TITLE
fix(gh-285): set Xnp_lat=None instead of [None] when CYb==0

### DIFF
--- a/cad_designer/airplane/aircraft_topology/models/analysis_model.py
+++ b/cad_designer/airplane/aircraft_topology/models/analysis_model.py
@@ -317,7 +317,7 @@ class AnalysisModel(BaseModel):
             Yref=data['Yref'],
             Zref=data['Zref'],
             Xnp=[data['Xnp']],
-            Xnp_lat=[data['Xref'] - (data["Cnb"] * (data['Bref'] / data["CYb"])) if data['CYb'] != 0 else None],  # Example calculation for Xnp_lat
+            Xnp_lat=[data['Xref'] - (data["Cnb"] * (data['Bref'] / data["CYb"]))] if data['CYb'] != 0 else None,
             Strips=data['Strips'],
             Surfaces=data['Surfaces'],
             Vortices=data['Vortices']

--- a/cad_designer/tests/test_analysis_model.py
+++ b/cad_designer/tests/test_analysis_model.py
@@ -612,14 +612,8 @@ class TestFromAvlDict:
         expected = data["Xref"] - (data["Cnb"] * (data["Bref"] / data["CYb"]))
         assert model.reference.Xnp_lat == [expected]
 
-    @pytest.mark.xfail(
-        reason="Production bug: Xnp_lat is list[float]|None but from_avl_dict "
-               "stores [None] when CYb==0, causing Pydantic validation error",
-        raises=ValidationError,
-        strict=True,
-    )
     def test_xnp_lat_cyb_zero(self):
-        """When CYb == 0, Xnp_lat should be [None] or None — currently crashes."""
+        """When CYb == 0, Xnp_lat must be None (not [None]) to satisfy type."""
         data = _make_avl_flat_dict()
         data["CYb"] = 0
         model = AnalysisModel.from_avl_dict(data)


### PR DESCRIPTION
## Summary

- Fixes `from_avl_dict` in `AnalysisModel` where `Xnp_lat=[None]` was produced when `CYb==0`, violating the `list[float] | None` type and causing a Pydantic `ValidationError`.
- Moves the conditional outside the list literal so the value becomes `None` (not `[None]`) when division by zero would occur.
- Removes the `@pytest.mark.xfail` marker from the regression test, making it a standard passing test.

Closes #285

## Test plan

- [x] `test_xnp_lat_cyb_zero` passes (was xfail, now green)
- [x] `test_xnp_lat_calculation` still passes (CYb != 0 path unchanged)
- [x] Full `cad_designer/tests/` suite passes (608 passed)
- [x] `ruff check` clean on the changed production file

🤖 Generated with [Claude Code](https://claude.com/claude-code)