### PR TITLE
fix(gh-281): handle numpy arrays in stability_service._scalar

### DIFF
--- a/app/services/stability_service.py
+++ b/app/services/stability_service.py
@@ -22,8 +22,12 @@ def _scalar(val) -> Optional[float]:
     if isinstance(val, np.ndarray):
         if val.ndim == 0:
             return float(val)
+        if val.size > 1:
+            logger.warning("_scalar received %s with %d elements; using first", type(val).__name__, val.size)
         return float(val[0]) if val.size > 0 else None
     if isinstance(val, list):
+        if len(val) > 1:
+            logger.warning("_scalar received %s with %d elements; using first", type(val).__name__, len(val))
         return float(val[0]) if len(val) > 0 else None
     return float(val)
 

--- a/app/services/stability_service.py
+++ b/app/services/stability_service.py
@@ -3,6 +3,7 @@
 import logging
 from typing import Optional
 
+import numpy as np
 from sqlalchemy.orm import Session
 
 from app.core.exceptions import InternalError
@@ -15,9 +16,13 @@ logger = logging.getLogger(__name__)
 
 
 def _scalar(val) -> Optional[float]:
-    """Extract a scalar float from a value that may be a list or None."""
+    """Extract a scalar float from a value that may be a list, numpy array, or None."""
     if val is None:
         return None
+    if isinstance(val, np.ndarray):
+        if val.ndim == 0:
+            return float(val)
+        return float(val[0]) if val.size > 0 else None
     if isinstance(val, list):
         return float(val[0]) if len(val) > 0 else None
     return float(val)

--- a/app/tests/test_stability_service.py
+++ b/app/tests/test_stability_service.py
@@ -52,23 +52,21 @@ class TestScalar:
         assert result == pytest.approx(4.2)
         assert isinstance(result, float)
 
-    def test_numpy_array_single_element_raises(self):
-        """NOTE: _scalar does not handle numpy arrays (not isinstance list).
+    def test_numpy_array_single_element(self):
+        """A single-element numpy array should return that element as float."""
+        result = _scalar(np.array([9.9]))
+        assert result == pytest.approx(9.9)
+        assert isinstance(result, float)
 
-        A single-element np.array falls through to float(), which raises
-        TypeError in numpy >= 1.24. This documents current production
-        behaviour. If numpy arrays need support, _scalar should be updated
-        to check for np.ndarray.
-        """
-        # numpy >= 1.24 raises TypeError for float(np.array([x]))
-        # numpy < 1.24 may succeed. We document both possibilities.
-        try:
-            result = _scalar(np.array([9.9]))
-            # If it succeeds (older numpy), the value should be correct.
-            assert result == pytest.approx(9.9)
-        except TypeError:
-            # Expected on numpy >= 1.24: cannot convert array to scalar.
-            pass
+    def test_numpy_array_multiple_elements(self):
+        """A multi-element numpy array should return the first element as float."""
+        result = _scalar(np.array([1.0, 2.0, 3.0]))
+        assert result == pytest.approx(1.0)
+        assert isinstance(result, float)
+
+    def test_numpy_array_empty_returns_none(self):
+        """An empty numpy array should return None."""
+        assert _scalar(np.array([])) is None
 
     def test_string_numeric(self):
         """A numeric string should convert to float."""


### PR DESCRIPTION
## Summary

- Added `np.ndarray` handling to `_scalar()` in `app/services/stability_service.py`
- The function now correctly extracts the first element from numpy arrays (matching existing list behavior), handles 0-d arrays, and returns `None` for empty arrays
- Replaced the documenting-the-bug test with proper assertion-based tests for numpy array inputs

Closes #281

## Test plan

- [x] `test_numpy_array_single_element` — single-element array returns float
- [x] `test_numpy_array_multiple_elements` — multi-element array returns first element
- [x] `test_numpy_array_empty_returns_none` — empty array returns None
- [x] `test_numpy_0d_array` — 0-d array converts correctly (pre-existing, still passes)
- [x] All 45 stability service tests pass
- [x] All 329 non-AVL backend tests pass (1 pre-existing AVL binary failure unrelated)
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)