### PR TITLE
fix(gh-290): preserve empty spare_list in WingSegment.__getstate__

### DIFF
--- a/cad_designer/airplane/aircraft_topology/wing/WingSegment.py
+++ b/cad_designer/airplane/aircraft_topology/wing/WingSegment.py
@@ -123,7 +123,7 @@ class WingSegment:
 
         # Create spare_list
         spare_list = None
-        if data.get('spare_list'):
+        if data.get('spare_list') is not None:
             spare_list = [Spare.from_json_dict(spare_data) for spare_data in data.get('spare_list')]
 
         # Create trailing_edge_device

--- a/cad_designer/airplane/aircraft_topology/wing/WingSegment.py
+++ b/cad_designer/airplane/aircraft_topology/wing/WingSegment.py
@@ -95,7 +95,7 @@ class WingSegment:
             if key == 'root_airfoil' or key == 'tip_airfoil':
                 data[key] = value.__getstate__() if value else None
             elif key == 'spare_list':
-                data[key] = [spare.__getstate__() for spare in value] if value else None
+                data[key] = [spare.__getstate__() for spare in value] if value is not None else None
             elif key == 'trailing_edge_device':
                 data[key] = value.__getstate__() if value else None
             else:

--- a/cad_designer/tests/test_wing_segment.py
+++ b/cad_designer/tests/test_wing_segment.py
@@ -236,6 +236,9 @@ class TestWingSegmentEdgeCases:
         state = ws.__getstate__()
         # Empty list should serialize as empty list, not None
         assert state["spare_list"] == []
+        # Roundtrip: from_json_dict must also preserve empty list (not coerce to None)
+        restored = WingSegment.from_json_dict(state)
+        assert restored.spare_list == []
 
     def test_from_json_dict_missing_optional_fields(self):
         data = {

--- a/cad_designer/tests/test_wing_segment.py
+++ b/cad_designer/tests/test_wing_segment.py
@@ -230,11 +230,8 @@ class TestWingSegmentSerialization:
 class TestWingSegmentEdgeCases:
     """Test edge cases and boundary conditions."""
 
-    @pytest.mark.xfail(
-        reason="Production bug: __getstate__ treats empty list as falsy, serializes as None instead of []",
-        strict=True,
-    )
     def test_empty_spare_list(self, root_airfoil):
+        """Regression test for gh-290: empty spare_list must serialize as [], not None."""
         ws = WingSegment(root_airfoil=root_airfoil, length=500.0, spare_list=[])
         state = ws.__getstate__()
         # Empty list should serialize as empty list, not None


### PR DESCRIPTION
## Summary
- Fixed `WingSegment.__getstate__` treating empty `spare_list=[]` as falsy and serializing it as `None`
- Changed `if value` to `if value is not None` on the spare_list branch (line 98)
- Removed `@pytest.mark.xfail` from the existing regression test, confirming the fix

Closes #290

## Test plan
- [x] `cad_designer/tests/test_wing_segment.py::TestWingSegmentEdgeCases::test_empty_spare_list` passes
- [x] All 608 `cad_designer/tests/` tests pass
- [x] All wing-related `app/tests/` tests pass (pre-existing unrelated STEP export failure excluded)
- [x] `ruff check` passes on the modified file

🤖 Generated with [Claude Code](https://claude.com/claude-code)