### PR TITLE
fix(gh-299): correct endpoint route in WingConfig roundtrip tests

### DIFF
--- a/app/tests/test_wing_service_extended.py
+++ b/app/tests/test_wing_service_extended.py
@@ -1063,7 +1063,6 @@ class TestWingConfigRoundtrip:
         assert "segments" in data
         assert len(data["segments"]) == 1
 
-    @pytest.mark.xfail(reason="wrong endpoint route (gh-299)", strict=False)
     def test_put_wingconfig_replaces(self, client):
         """PUT wingconfig replaces an existing wing."""
         resp = client.post("/aeroplanes", params={"name": "wc-put"})
@@ -1096,10 +1095,9 @@ class TestWingConfigRoundtrip:
             ],
             "nose_pnt": [10, 0, 0],
         }
-        resp = client.put(f"/aeroplanes/{aid}/wings/wput/from-wingconfig", json=wc2)
+        resp = client.put(f"/aeroplanes/{aid}/wings/wput/wingconfig", json=wc2)
         assert resp.status_code == 200, resp.text
 
-    @pytest.mark.xfail(reason="wrong endpoint route (gh-299)", strict=False)
     def test_put_wingconfig_creates_if_new(self, client):
         """PUT wingconfig creates the wing if it does not exist."""
         resp = client.post("/aeroplanes", params={"name": "wc-putnew"})
@@ -1117,7 +1115,7 @@ class TestWingConfigRoundtrip:
             ],
             "nose_pnt": [0, 0, 0],
         }
-        resp = client.put(f"/aeroplanes/{aid}/wings/wnew/from-wingconfig", json=wc)
+        resp = client.put(f"/aeroplanes/{aid}/wings/wnew/wingconfig", json=wc)
         assert resp.status_code == 200
 
     def test_create_wingconfig_duplicate_raises_422(self, client):


### PR DESCRIPTION
## Summary
- Fixed 2 tests in `TestWingConfigRoundtrip` that used `PUT /from-wingconfig` (405 Method Not Allowed) instead of the correct `PUT /wingconfig` endpoint
- Removed `@pytest.mark.xfail` decorators since the tests now pass

## Details
The PUT endpoint for replacing a wing via WingConfiguration JSON is registered at `/aeroplanes/{id}/wings/{name}/wingconfig`, but the tests were incorrectly calling `/aeroplanes/{id}/wings/{name}/from-wingconfig` (which only accepts POST for creation).

Closes #299

## Test plan
- [x] `poetry run pytest app/tests/test_wing_service_extended.py -k "WingConfigRoundtrip" -x -v` — all 4 tests pass
- [x] `poetry run ruff check app/tests/test_wing_service_extended.py` — no lint issues
- [x] Broader test suite passes (329 tests pass; 1 pre-existing AVL failure unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)