### PR TITLE
fix(gh-280): guard against ZeroDivisionError in _required_power_w

### DIFF
--- a/app/services/powertrain_sizing_service.py
+++ b/app/services/powertrain_sizing_service.py
@@ -31,6 +31,8 @@ def _air_density(altitude_m: float) -> float:
 
 def _required_power_w(speed_ms: float, total_mass_kg: float, altitude_m: float) -> float:
     """Estimate power required for level flight at given speed."""
+    if speed_ms <= 0:
+        return 0.0
     rho = _air_density(altitude_m)
     # Parasitic drag: half rho v-squared Cd S
     drag_n = 0.5 * rho * speed_ms**2 * DRAG_COEFF_ESTIMATE * WING_AREA_ESTIMATE_M2

--- a/app/tests/test_powertrain_sizing_service.py
+++ b/app/tests/test_powertrain_sizing_service.py
@@ -129,16 +129,14 @@ class TestRequiredPowerW:
         assert p_sea != p_alt
 
     def test_zero_speed_returns_zero_power(self):
-        """At zero speed, drag is zero and power should be zero.
+        """At zero airspeed no aerodynamic power is needed; should return 0.0."""
+        result = _required_power_w(0.0, 2.0, 0.0)
+        assert result == 0.0
 
-        NOTE: _required_power_w divides by speed**2 when computing cl,
-        which causes a ZeroDivisionError at speed=0. This is a potential
-        production bug -- the function should guard against zero speed.
-        We mark this xfail to document the behavior without modifying
-        production code.
-        """
-        with pytest.raises(ZeroDivisionError):
-            _required_power_w(0.0, 2.0, 0.0)
+    def test_negative_speed_returns_zero_power(self):
+        """Negative speed is physically meaningless; should return 0.0."""
+        result = _required_power_w(-5.0, 2.0, 0.0)
+        assert result == 0.0
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

- Add early return of `0.0` in `_required_power_w` when `speed_ms <= 0` to prevent `ZeroDivisionError` in the induced-drag lift coefficient formula
- Update the existing test to assert the correct behavior (returns 0.0) instead of documenting the crash
- Add test for negative speed edge case

## Root Cause

The formula `cl = (2 * mass * g) / (rho * speed**2 * S)` divides by `speed_ms**2`, which is zero when `speed_ms=0`.

## Fix

Guard clause at the top of `_required_power_w`: at zero or negative airspeed, no aerodynamic power is needed, so return 0.0 immediately.

Closes #280

## Test plan

- [x] `test_zero_speed_returns_zero_power` — confirms no exception and returns 0.0
- [x] `test_negative_speed_returns_zero_power` — confirms negative speed also returns 0.0
- [x] All 42 powertrain tests pass
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)