### PR TITLE
refactor(gh-379): remove redundant db.commit/rollback from services

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -99,6 +99,7 @@ def create_app() -> FastAPI:
             _seed_session = SessionLocal()
             try:
                 seed_default_types(_seed_session)
+                _seed_session.commit()
             finally:
                 _seed_session.close()
         except Exception as exc:  # noqa: BLE001 — never block startup on this

--- a/app/services/airfoil_service.py
+++ b/app/services/airfoil_service.py
@@ -147,6 +147,7 @@ def import_directory(db: Session, directory: str) -> AirfoilImportResult:
             result.imported += 1
         except SQLAlchemyError as exc:
             logger.warning("Failed to import airfoil '%s': %s", airfoil_name, exc)
+            db.rollback()  # Required: reset session state so next iteration can proceed
             result.errors += 1
             result.error_files.append(dat_file.name)
 

--- a/app/services/airfoil_service.py
+++ b/app/services/airfoil_service.py
@@ -147,16 +147,8 @@ def import_directory(db: Session, directory: str) -> AirfoilImportResult:
             result.imported += 1
         except SQLAlchemyError as exc:
             logger.warning("Failed to import airfoil '%s': %s", airfoil_name, exc)
-            db.rollback()
             result.errors += 1
             result.error_files.append(dat_file.name)
-
-    try:
-        db.commit()
-    except SQLAlchemyError as exc:
-        db.rollback()
-        logger.error("Failed to commit airfoil import: %s", exc)
-        raise InternalError(message=f"Import commit failed: {exc}") from exc
 
     logger.info(
         "Airfoil import: %d imported, %d skipped, %d errors",

--- a/app/services/component_service.py
+++ b/app/services/component_service.py
@@ -58,11 +58,10 @@ def create_component(db: Session, data: ComponentWrite) -> ComponentRead:
     try:
         comp = ComponentModel(**data.model_dump())
         db.add(comp)
-        db.commit()
+        db.flush()
         db.refresh(comp)
         return _to_schema(comp)
     except SQLAlchemyError as exc:
-        db.rollback()
         logger.error("DB error in create_component: %s", exc)
         raise InternalError(message=f"Database error: {exc}") from exc
 
@@ -85,13 +84,12 @@ def update_component(
             raise NotFoundError(entity="Component", resource_id=component_id)
         for key, value in data.model_dump().items():
             setattr(comp, key, value)
-        db.commit()
+        db.flush()
         db.refresh(comp)
         return _to_schema(comp)
     except NotFoundError:
         raise
     except SQLAlchemyError as exc:
-        db.rollback()
         logger.error("DB error in update_component: %s", exc)
         raise InternalError(message=f"Database error: {exc}") from exc
 
@@ -102,10 +100,9 @@ def delete_component(db: Session, component_id: int) -> None:
         if comp is None:
             raise NotFoundError(entity="Component", resource_id=component_id)
         db.delete(comp)
-        db.commit()
+        db.flush()
     except NotFoundError:
         raise
     except SQLAlchemyError as exc:
-        db.rollback()
         logger.error("DB error in delete_component: %s", exc)
         raise InternalError(message=f"Database error: {exc}") from exc

--- a/app/services/component_tree_service.py
+++ b/app/services/component_tree_service.py
@@ -204,13 +204,12 @@ def add_node(
 
         node = ComponentTreeNodeModel(aeroplane_id=aeroplane_id, **payload)
         db.add(node)
-        db.commit()
+        db.flush()
         db.refresh(node)
         return _to_schema(node)
     except (NotFoundError, ValidationError):
         raise
     except SQLAlchemyError as exc:
-        db.rollback()
         logger.error("DB error in add_node: %s", exc)
         raise InternalError(message=f"Database error: {exc}") from exc
 
@@ -229,13 +228,12 @@ def update_node(
 
         for key, value in data.model_dump().items():
             setattr(node, key, value)
-        db.commit()
+        db.flush()
         db.refresh(node)
         return _to_schema(node)
     except NotFoundError:
         raise
     except SQLAlchemyError as exc:
-        db.rollback()
         logger.error("DB error in update_node: %s", exc)
         raise InternalError(message=f"Database error: {exc}") from exc
 
@@ -259,11 +257,10 @@ def delete_node(db: Session, aeroplane_id: str, node_id: int) -> None:
         # Delete children recursively
         _delete_subtree(db, aeroplane_id, node_id)
         db.delete(node)
-        db.commit()
+        db.flush()
     except (NotFoundError, ValidationError):
         raise
     except SQLAlchemyError as exc:
-        db.rollback()
         logger.error("DB error in delete_node: %s", exc)
         raise InternalError(message=f"Database error: {exc}") from exc
 
@@ -304,13 +301,12 @@ def move_node(
 
         node.parent_id = new_parent_id
         node.sort_index = sort_index
-        db.commit()
+        db.flush()
         db.refresh(node)
         return _to_schema(node)
     except (NotFoundError, ValidationError):
         raise
     except SQLAlchemyError as exc:
-        db.rollback()
         logger.error("DB error in move_node: %s", exc)
         raise InternalError(message=f"Database error: {exc}") from exc
 

--- a/app/services/component_type_service.py
+++ b/app/services/component_type_service.py
@@ -131,14 +131,12 @@ def create_type(db: Session, data: ComponentTypeWrite) -> ComponentTypeRead:
             deletable=True,  # user-created types are always deletable
         )
         db.add(row)
-        db.commit()
+        db.flush()
         db.refresh(row)
         return _to_schema(db, row)
     except IntegrityError as exc:
-        db.rollback()
         raise ConflictError(message=f"Name conflict: {exc}") from exc
     except SQLAlchemyError as exc:
-        db.rollback()
         logger.error("DB error in create_type: %s", exc)
         raise InternalError(message=f"Database error: {exc}") from exc
 
@@ -153,13 +151,12 @@ def update_type(
         row.description = data.description
         row.schema_def = [p.model_dump() for p in data.schema]
         # name and deletable stay untouched
-        db.commit()
+        db.flush()
         db.refresh(row)
         return _to_schema(db, row)
     except NotFoundError:
         raise
     except SQLAlchemyError as exc:
-        db.rollback()
         logger.error("DB error in update_type: %s", exc)
         raise InternalError(message=f"Database error: {exc}") from exc
 
@@ -182,9 +179,8 @@ def delete_type(db: Session, type_id: int) -> None:
         )
     try:
         db.delete(row)
-        db.commit()
+        db.flush()
     except SQLAlchemyError as exc:
-        db.rollback()
         logger.error("DB error in delete_type: %s", exc)
         raise InternalError(message=f"Database error: {exc}") from exc
 
@@ -438,4 +434,3 @@ def seed_default_types(db: Session) -> None:
                 deletable=False,
             )
         )
-    db.commit()

--- a/app/services/construction_part_service.py
+++ b/app/services/construction_part_service.py
@@ -343,6 +343,10 @@ def delete_part(db: Session, aeroplane_id: str, part_id: int) -> None:
         db.delete(part)
         db.flush()
         if file_path:
+            # NOTE: File is unlinked before get_db() commits the DB deletion.
+            # If the commit fails, the DB row will reference a missing file.
+            # Acceptable trade-off: the alternative (delete after commit) risks
+            # orphaned files if the app crashes between commit and unlink.
             try:
                 os.unlink(file_path)
             except FileNotFoundError:

--- a/app/services/construction_part_service.py
+++ b/app/services/construction_part_service.py
@@ -86,13 +86,12 @@ def _set_locked(
     try:
         part = _get_part_or_404(db, aeroplane_id, part_id)
         part.locked = locked
-        db.commit()
+        db.flush()
         db.refresh(part)
         return ConstructionPartRead.model_validate(part)
     except NotFoundError:
         raise
     except SQLAlchemyError as exc:
-        db.rollback()
         logger.error("DB error while toggling lock on part %s: %s", part_id, exc)
         raise InternalError(message=f"Database error: {exc}") from exc
 
@@ -243,14 +242,12 @@ def create_part(
         geom = _extract_geometry(dest, fmt)
         for key, value in geom.items():
             setattr(part, key, value)
-        db.commit()
+        db.flush()
         db.refresh(part)
         return ConstructionPartRead.model_validate(part)
     except ValidationError:
-        db.rollback()
         raise
     except SQLAlchemyError as exc:
-        db.rollback()
         logger.error("DB error in create_part: %s", exc)
         raise InternalError(message=f"Database error: {exc}") from exc
 
@@ -320,13 +317,12 @@ def update_part(
             part.material_component_id = explicit["material_component_id"]
         if "thumbnail_url" in explicit:
             part.thumbnail_url = explicit["thumbnail_url"]
-        db.commit()
+        db.flush()
         db.refresh(part)
         return ConstructionPartRead.model_validate(part)
     except NotFoundError:
         raise
     except SQLAlchemyError as exc:
-        db.rollback()
         logger.error("DB error in update_part: %s", exc)
         raise InternalError(message=f"Database error: {exc}") from exc
 
@@ -345,7 +341,7 @@ def delete_part(db: Session, aeroplane_id: str, part_id: int) -> None:
             )
         file_path = part.file_path
         db.delete(part)
-        db.commit()
+        db.flush()
         if file_path:
             try:
                 os.unlink(file_path)
@@ -356,6 +352,5 @@ def delete_part(db: Session, aeroplane_id: str, part_id: int) -> None:
     except (NotFoundError, ConflictError):
         raise
     except SQLAlchemyError as exc:
-        db.rollback()
         logger.error("DB error in delete_part: %s", exc)
         raise InternalError(message=f"Database error: {exc}") from exc

--- a/app/services/construction_plan_service.py
+++ b/app/services/construction_plan_service.py
@@ -130,7 +130,7 @@ def _migrate_tree_json(db: Session, plan: ConstructionPlanModel) -> None:
         from sqlalchemy.orm.attributes import flag_modified
 
         flag_modified(plan, "tree_json")
-        db.commit()
+        db.flush()
 
 
 def get_plan(db: Session, plan_id: int) -> PlanRead:
@@ -158,11 +158,10 @@ def create_plan(db: Session, data: PlanCreate) -> PlanRead:
             aeroplane_id=data.aeroplane_id,
         )
         db.add(plan)
-        db.commit()
+        db.flush()
         db.refresh(plan)
         return _to_read(plan)
     except SQLAlchemyError as e:
-        db.rollback()
         logger.error("DB error creating plan: %s", e)
         raise InternalError(message=f"Database error: {e}")
 
@@ -178,13 +177,12 @@ def update_plan(db: Session, plan_id: int, data: PlanCreate) -> PlanRead:
         plan.tree_json = data.tree_json
         plan.plan_type = data.plan_type
         plan.aeroplane_id = data.aeroplane_id
-        db.commit()
+        db.flush()
         db.refresh(plan)
         return _to_read(plan)
     except NotFoundError:
         raise
     except SQLAlchemyError as e:
-        db.rollback()
         logger.error("DB error updating plan %s: %s", plan_id, e)
         raise InternalError(message=f"Database error: {e}")
 
@@ -195,11 +193,10 @@ def delete_plan(db: Session, plan_id: int) -> None:
         if plan is None:
             raise NotFoundError(entity=_ENTITY_CONSTRUCTION_PLAN, resource_id=plan_id)
         db.delete(plan)
-        db.commit()
+        db.flush()
     except NotFoundError:
         raise
     except SQLAlchemyError as e:
-        db.rollback()
         logger.error("DB error deleting plan %s: %s", plan_id, e)
         raise InternalError(message=f"Database error: {e}")
 

--- a/app/services/copilot_history_service.py
+++ b/app/services/copilot_history_service.py
@@ -33,14 +33,24 @@ def _msg_to_schema(msg: CopilotMessageModel) -> CopilotMessageRead:
 
 def get_history(db: Session, aeroplane_uuid) -> CopilotHistory:
     aeroplane = _get_aeroplane(db, aeroplane_uuid)
-    messages = [_msg_to_schema(m) for m in aeroplane.copilot_messages]
+    messages_query = (
+        db.query(CopilotMessageModel)
+        .filter(CopilotMessageModel.aeroplane_id == aeroplane.id)
+        .order_by(CopilotMessageModel.sort_index)
+        .all()
+    )
+    messages = [_msg_to_schema(m) for m in messages_query]
     return CopilotHistory(messages=messages)
 
 
 def append_message(db: Session, aeroplane_uuid, data: CopilotMessageWrite) -> CopilotMessageRead:
     try:
         aeroplane = _get_aeroplane(db, aeroplane_uuid)
-        next_index = len(aeroplane.copilot_messages)
+        next_index = (
+            db.query(CopilotMessageModel)
+            .filter(CopilotMessageModel.aeroplane_id == aeroplane.id)
+            .count()
+        )
         msg = CopilotMessageModel(
             aeroplane_id=aeroplane.id,
             sort_index=next_index,
@@ -51,13 +61,12 @@ def append_message(db: Session, aeroplane_uuid, data: CopilotMessageWrite) -> Co
             parent_id=data.parent_id,
         )
         db.add(msg)
-        db.commit()
+        db.flush()
         db.refresh(msg)
         return _msg_to_schema(msg)
     except NotFoundError:
         raise
     except SQLAlchemyError as exc:
-        db.rollback()
         logger.error("DB error in append_message: %s", exc)
         raise InternalError(message=f"Database error: {exc}") from exc
 
@@ -67,11 +76,10 @@ def clear_history(db: Session, aeroplane_uuid) -> None:
         aeroplane = _get_aeroplane(db, aeroplane_uuid)
         for msg in list(aeroplane.copilot_messages):  # list() required: deleting during iteration
             db.delete(msg)
-        db.commit()
+        db.flush()
     except NotFoundError:
         raise
     except SQLAlchemyError as exc:
-        db.rollback()
         logger.error("DB error in clear_history: %s", exc)
         raise InternalError(message=f"Database error: {exc}") from exc
 
@@ -83,10 +91,9 @@ def delete_message(db: Session, aeroplane_uuid, message_id: int) -> None:
         if msg is None:
             raise NotFoundError(entity="CopilotMessage", resource_id=message_id)
         db.delete(msg)
-        db.commit()
+        db.flush()
     except NotFoundError:
         raise
     except SQLAlchemyError as exc:
-        db.rollback()
         logger.error("DB error in delete_message: %s", exc)
         raise InternalError(message=f"Database error: {exc}") from exc

--- a/app/services/design_version_service.py
+++ b/app/services/design_version_service.py
@@ -32,8 +32,12 @@ def _get_aeroplane(db: Session, aeroplane_uuid) -> AeroplaneModel:
     return aeroplane
 
 
-def _get_version(aeroplane: AeroplaneModel, version_id: int) -> DesignVersionModel:
-    ver = next((v for v in aeroplane.design_versions if v.id == version_id), None)
+def _get_version(db: Session, aeroplane: AeroplaneModel, version_id: int) -> DesignVersionModel:
+    ver = (
+        db.query(DesignVersionModel)
+        .filter(DesignVersionModel.aeroplane_id == aeroplane.id, DesignVersionModel.id == version_id)
+        .first()
+    )
     if ver is None:
         raise NotFoundError(entity="DesignVersion", resource_id=version_id)
     return ver
@@ -108,6 +112,11 @@ def _build_snapshot(aeroplane: AeroplaneModel) -> dict[str, Any]:
 
 def list_versions(db: Session, aeroplane_uuid) -> list[DesignVersionSummary]:
     aeroplane = _get_aeroplane(db, aeroplane_uuid)
+    rows = (
+        db.query(DesignVersionModel)
+        .filter(DesignVersionModel.aeroplane_id == aeroplane.id)
+        .all()
+    )
     return [
         DesignVersionSummary(
             id=v.id,
@@ -116,7 +125,7 @@ def list_versions(db: Session, aeroplane_uuid) -> list[DesignVersionSummary]:
             parent_version_id=v.parent_version_id,
             created_at=v.created_at,
         )
-        for v in aeroplane.design_versions
+        for v in rows
     ]
 
 
@@ -133,7 +142,7 @@ def create_version(
             snapshot=snapshot,
         )
         db.add(ver)
-        db.commit()
+        db.flush()
         db.refresh(ver)
         return DesignVersionSummary(
             id=ver.id,
@@ -145,14 +154,13 @@ def create_version(
     except NotFoundError:
         raise
     except SQLAlchemyError as exc:
-        db.rollback()
         logger.error("DB error in create_version: %s", exc)
         raise InternalError(message=f"Database error: {exc}") from exc
 
 
 def get_version(db: Session, aeroplane_uuid, version_id: int) -> DesignVersionRead:
     aeroplane = _get_aeroplane(db, aeroplane_uuid)
-    ver = _get_version(aeroplane, version_id)
+    ver = _get_version(db, aeroplane, version_id)
     return DesignVersionRead(
         id=ver.id,
         label=ver.label,
@@ -166,13 +174,12 @@ def get_version(db: Session, aeroplane_uuid, version_id: int) -> DesignVersionRe
 def delete_version(db: Session, aeroplane_uuid, version_id: int) -> None:
     try:
         aeroplane = _get_aeroplane(db, aeroplane_uuid)
-        ver = _get_version(aeroplane, version_id)
+        ver = _get_version(db, aeroplane, version_id)
         db.delete(ver)
-        db.commit()
+        db.flush()
     except NotFoundError:
         raise
     except SQLAlchemyError as exc:
-        db.rollback()
         logger.error("DB error in delete_version: %s", exc)
         raise InternalError(message=f"Database error: {exc}") from exc
 
@@ -181,8 +188,8 @@ def diff_versions(
     db: Session, aeroplane_uuid, version_a_id: int, version_b_id: int
 ) -> DesignVersionDiff:
     aeroplane = _get_aeroplane(db, aeroplane_uuid)
-    ver_a = _get_version(aeroplane, version_a_id)
-    ver_b = _get_version(aeroplane, version_b_id)
+    ver_a = _get_version(db, aeroplane, version_a_id)
+    ver_b = _get_version(db, aeroplane, version_b_id)
     changes = _compute_diff(ver_a.snapshot, ver_b.snapshot)
     return DesignVersionDiff(
         version_a=version_a_id,

--- a/app/services/flight_profile_service.py
+++ b/app/services/flight_profile_service.py
@@ -53,16 +53,14 @@ def create_profile(db: Session, payload: RCFlightProfileCreate) -> RCFlightProfi
 
         profile = RCFlightProfileModel(**payload.model_dump())
         db.add(profile)
-        db.commit()
+        db.flush()
         db.refresh(profile)
         return RCFlightProfileRead.model_validate(profile, from_attributes=True)
     except ConflictError:
         raise
     except IntegrityError:
-        db.rollback()
         raise ConflictError(_ERR_NAME_EXISTS)
     except SQLAlchemyError as exc:
-        db.rollback()
         raise InternalError(f"Database error: {exc}")
 
 
@@ -122,17 +120,15 @@ def update_profile(db: Session, profile_id: int, payload: RCFlightProfileUpdate)
         profile.constraints = normalized.constraints.model_dump()
         profile.updated_at = datetime.now(timezone.utc)
         db.add(profile)
-        db.commit()
+        db.flush()
         db.refresh(profile)
 
         return RCFlightProfileRead.model_validate(profile, from_attributes=True)
     except (NotFoundError, ConflictError):
         raise
     except IntegrityError:
-        db.rollback()
         raise ConflictError(_ERR_NAME_EXISTS)
     except SQLAlchemyError as exc:
-        db.rollback()
         raise InternalError(f"Database error: {exc}")
 
 
@@ -148,11 +144,10 @@ def delete_profile(db: Session, profile_id: int) -> None:
             )
 
         db.delete(profile)
-        db.commit()
+        db.flush()
     except (NotFoundError, ConflictError):
         raise
     except SQLAlchemyError as exc:
-        db.rollback()
         raise InternalError(f"Database error: {exc}")
 
 
@@ -168,7 +163,7 @@ def assign_profile_to_aircraft(
         aircraft.flight_profile_id = profile.id
         aircraft.updated_at = datetime.now(timezone.utc)
         db.add(aircraft)
-        db.commit()
+        db.flush()
 
         return AircraftFlightProfileAssignmentRead(
             aircraft_id=str(aircraft.uuid),
@@ -177,7 +172,6 @@ def assign_profile_to_aircraft(
     except NotFoundError:
         raise
     except SQLAlchemyError as exc:
-        db.rollback()
         raise InternalError(f"Database error: {exc}")
 
 
@@ -188,7 +182,7 @@ def detach_profile_from_aircraft(db: Session, aircraft_id) -> AircraftFlightProf
         aircraft.flight_profile_id = None
         aircraft.updated_at = datetime.now(timezone.utc)
         db.add(aircraft)
-        db.commit()
+        db.flush()
 
         return AircraftFlightProfileAssignmentRead(
             aircraft_id=str(aircraft.uuid),
@@ -197,5 +191,4 @@ def detach_profile_from_aircraft(db: Session, aircraft_id) -> AircraftFlightProf
     except NotFoundError:
         raise
     except SQLAlchemyError as exc:
-        db.rollback()
         raise InternalError(f"Database error: {exc}")

--- a/app/services/mission_objectives_service.py
+++ b/app/services/mission_objectives_service.py
@@ -45,13 +45,12 @@ def upsert_mission_objectives(
             for key, value in flat.items():
                 setattr(obj, key, value)
 
-        db.commit()
+        db.flush()
         db.refresh(obj)
         return _model_to_schema(obj)
     except NotFoundError:
         raise
     except SQLAlchemyError as exc:
-        db.rollback()
         logger.error("DB error in upsert_mission_objectives: %s", exc)
         raise InternalError(message=f"Database error: {exc}") from exc
 
@@ -63,11 +62,10 @@ def delete_mission_objectives(db: Session, aeroplane_uuid) -> None:
         if obj is None:
             raise NotFoundError(entity="MissionObjectives", resource_id=aeroplane_uuid)
         db.delete(obj)
-        db.commit()
+        db.flush()
     except NotFoundError:
         raise
     except SQLAlchemyError as exc:
-        db.rollback()
         logger.error("DB error in delete_mission_objectives: %s", exc)
         raise InternalError(message=f"Database error: {exc}") from exc
 

--- a/app/services/operating_point_generator_service.py
+++ b/app/services/operating_point_generator_service.py
@@ -736,7 +736,7 @@ def generate_default_set_for_aircraft(
             replace_existing=replace_existing,
         )
 
-        db.commit()
+        db.flush()
         db.refresh(opset)
         for point in stored_points:
             db.refresh(point)
@@ -755,10 +755,8 @@ def generate_default_set_for_aircraft(
     except (NotFoundError, ValidationError):
         raise
     except SQLAlchemyError as exc:
-        db.rollback()
         raise InternalError(f"Database error: {exc}")
     except Exception as exc:
-        db.rollback()
         raise InternalError(f"Operating-point generation error: {exc}")
 
 

--- a/app/services/tessellation_cache_service.py
+++ b/app/services/tessellation_cache_service.py
@@ -74,7 +74,7 @@ def cache_tessellation(
         existing.geometry_hash = geometry_hash
         existing.tessellation_json = tessellation_json
         existing.is_stale = False
-        db.commit()
+        db.flush()
         db.refresh(existing)
         return existing
 
@@ -87,7 +87,7 @@ def cache_tessellation(
         is_stale=False,
     )
     db.add(entry)
-    db.commit()
+    db.flush()
     db.refresh(entry)
     return entry
 
@@ -113,7 +113,6 @@ def invalidate(
         query = query.filter(TessellationCacheModel.component_name == component_name)
 
     count = query.update({"is_stale": True})
-    db.commit()
     return count
 
 

--- a/app/services/tessellation_service.py
+++ b/app/services/tessellation_service.py
@@ -212,6 +212,7 @@ def start_tessellation_task(
                             geometry_hash or "manual",
                             worker_result["result"],
                         )
+                        db.commit()
                         logger.info("Cached tessellation for %s/%s", aeroplane_id, wing_name)
                 finally:
                     db.close()
@@ -376,6 +377,7 @@ def _start_tessellation_and_cache(
                 geometry_hash,
                 worker_result["result"],
             )
+            db.commit()
             logger.info("Cached background tessellation for %s", key)
         except Exception:
             logger.exception("Error caching tessellation for %s", key)

--- a/app/services/weight_items_service.py
+++ b/app/services/weight_items_service.py
@@ -37,7 +37,12 @@ def _item_to_schema(item: WeightItemModel) -> WeightItemRead:
 
 def list_weight_items(db: Session, aeroplane_uuid) -> WeightSummary:
     aeroplane = _get_aeroplane(db, aeroplane_uuid)
-    items = [_item_to_schema(i) for i in aeroplane.weight_items]
+    rows = (
+        db.query(WeightItemModel)
+        .filter(WeightItemModel.aeroplane_id == aeroplane.id)
+        .all()
+    )
+    items = [_item_to_schema(i) for i in rows]
     total = sum(i.mass_kg for i in items)
     return WeightSummary(items=items, total_mass_kg=round(total, 6))
 
@@ -49,20 +54,23 @@ def create_weight_item(
         aeroplane = _get_aeroplane(db, aeroplane_uuid)
         item = WeightItemModel(aeroplane_id=aeroplane.id, **data.model_dump())
         db.add(item)
-        db.commit()
+        db.flush()
         db.refresh(item)
         return _item_to_schema(item)
     except NotFoundError:
         raise
     except SQLAlchemyError as exc:
-        db.rollback()
         logger.error("DB error in create_weight_item: %s", exc)
         raise InternalError(message=f"Database error: {exc}") from exc
 
 
 def get_weight_item(db: Session, aeroplane_uuid, item_id: int) -> WeightItemRead:
     aeroplane = _get_aeroplane(db, aeroplane_uuid)
-    item = next((i for i in aeroplane.weight_items if i.id == item_id), None)
+    item = (
+        db.query(WeightItemModel)
+        .filter(WeightItemModel.aeroplane_id == aeroplane.id, WeightItemModel.id == item_id)
+        .first()
+    )
     if item is None:
         raise NotFoundError(entity="WeightItem", resource_id=item_id)
     return _item_to_schema(item)
@@ -73,18 +81,21 @@ def update_weight_item(
 ) -> WeightItemRead:
     try:
         aeroplane = _get_aeroplane(db, aeroplane_uuid)
-        item = next((i for i in aeroplane.weight_items if i.id == item_id), None)
+        item = (
+            db.query(WeightItemModel)
+            .filter(WeightItemModel.aeroplane_id == aeroplane.id, WeightItemModel.id == item_id)
+            .first()
+        )
         if item is None:
             raise NotFoundError(entity="WeightItem", resource_id=item_id)
         for key, value in data.model_dump().items():
             setattr(item, key, value)
-        db.commit()
+        db.flush()
         db.refresh(item)
         return _item_to_schema(item)
     except NotFoundError:
         raise
     except SQLAlchemyError as exc:
-        db.rollback()
         logger.error("DB error in update_weight_item: %s", exc)
         raise InternalError(message=f"Database error: {exc}") from exc
 
@@ -92,14 +103,17 @@ def update_weight_item(
 def delete_weight_item(db: Session, aeroplane_uuid, item_id: int) -> None:
     try:
         aeroplane = _get_aeroplane(db, aeroplane_uuid)
-        item = next((i for i in aeroplane.weight_items if i.id == item_id), None)
+        item = (
+            db.query(WeightItemModel)
+            .filter(WeightItemModel.aeroplane_id == aeroplane.id, WeightItemModel.id == item_id)
+            .first()
+        )
         if item is None:
             raise NotFoundError(entity="WeightItem", resource_id=item_id)
         db.delete(item)
-        db.commit()
+        db.flush()
     except NotFoundError:
         raise
     except SQLAlchemyError as exc:
-        db.rollback()
         logger.error("DB error in delete_weight_item: %s", exc)
         raise InternalError(message=f"Database error: {exc}") from exc

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -67,6 +67,7 @@ def client_and_db() -> Tuple[TestClient, sessionmaker]:
     _seed_session = TestingSessionLocal()
     try:
         seed_default_types(_seed_session)
+        _seed_session.commit()
     finally:
         _seed_session.close()
 

--- a/app/tests/test_aeroplane_wing_from_wingconfig_e2e.py
+++ b/app/tests/test_aeroplane_wing_from_wingconfig_e2e.py
@@ -28,6 +28,10 @@ def client_and_db():
         db = TestingSessionLocal()
         try:
             yield db
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
         finally:
             db.close()
 

--- a/app/tests/test_copilot_history_service.py
+++ b/app/tests/test_copilot_history_service.py
@@ -165,7 +165,7 @@ class TestAppendMessage:
         _, SessionLocal = client_and_db
         with SessionLocal() as db:
             aeroplane = make_aeroplane(db)
-            with patch.object(db, "commit", side_effect=SQLAlchemyError("boom")):
+            with patch.object(db, "flush", side_effect=SQLAlchemyError("boom")):
                 with pytest.raises(InternalError):
                     svc.append_message(db, aeroplane.uuid, _make_msg_write())
 
@@ -207,7 +207,7 @@ class TestClearHistory:
         with SessionLocal() as db:
             aeroplane = make_aeroplane(db)
             svc.append_message(db, aeroplane.uuid, _make_msg_write(content="x"))
-            with patch.object(db, "commit", side_effect=SQLAlchemyError("boom")):
+            with patch.object(db, "flush", side_effect=SQLAlchemyError("boom")):
                 with pytest.raises(InternalError):
                     svc.clear_history(db, aeroplane.uuid)
 
@@ -249,7 +249,7 @@ class TestDeleteMessage:
         with SessionLocal() as db:
             aeroplane = make_aeroplane(db)
             msg = svc.append_message(db, aeroplane.uuid, _make_msg_write(content="x"))
-            with patch.object(db, "commit", side_effect=SQLAlchemyError("boom")):
+            with patch.object(db, "flush", side_effect=SQLAlchemyError("boom")):
                 with pytest.raises(InternalError):
                     svc.delete_message(db, aeroplane.uuid, msg.id)
 

--- a/app/tests/test_design_version_service.py
+++ b/app/tests/test_design_version_service.py
@@ -170,15 +170,20 @@ class TestGetAeroplane:
 
 class TestGetVersion:
     def test_found(self):
-        v1 = _make_mock_version(version_id=1)
         v2 = _make_mock_version(version_id=2)
-        ap = _make_mock_aeroplane(design_versions=[v1, v2])
-        assert _get_version(ap, 2) is v2
+        ap = _make_mock_aeroplane(design_versions=[])
+        ap.id = 42
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = v2
+        assert _get_version(mock_db, ap, 2) is v2
 
     def test_not_found_raises(self):
         ap = _make_mock_aeroplane(design_versions=[])
+        ap.id = 42
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = None
         with pytest.raises(NotFoundError) as exc_info:
-            _get_version(ap, 999)
+            _get_version(mock_db, ap, 999)
         assert "DesignVersion" in str(exc_info.value)
 
 
@@ -324,7 +329,13 @@ class TestListVersions:
         v1 = _make_mock_version(version_id=1, label="v1", created_at=now)
         v2 = _make_mock_version(version_id=2, label="v2", created_at=now)
         ap = _make_mock_aeroplane(design_versions=[v1, v2])
-        mock_db.query.return_value.filter.return_value.first.return_value = ap
+
+        # First query returns aeroplane, second returns version rows
+        aeroplane_chain = MagicMock()
+        aeroplane_chain.filter.return_value.first.return_value = ap
+        version_chain = MagicMock()
+        version_chain.filter.return_value.all.return_value = [v1, v2]
+        mock_db.query.side_effect = [aeroplane_chain, version_chain]
 
         result = list_versions(mock_db, ap.uuid)
         assert len(result) == 2
@@ -335,7 +346,12 @@ class TestListVersions:
     def test_empty_list(self):
         mock_db = MagicMock()
         ap = _make_mock_aeroplane(design_versions=[])
-        mock_db.query.return_value.filter.return_value.first.return_value = ap
+
+        aeroplane_chain = MagicMock()
+        aeroplane_chain.filter.return_value.first.return_value = ap
+        version_chain = MagicMock()
+        version_chain.filter.return_value.all.return_value = []
+        mock_db.query.side_effect = [aeroplane_chain, version_chain]
 
         result = list_versions(mock_db, ap.uuid)
         assert result == []
@@ -359,7 +375,7 @@ class TestCreateVersion:
         )
         mock_db.query.return_value.filter.return_value.first.return_value = ap
 
-        # After commit + refresh, the version object should have an id and created_at
+        # After flush + refresh, the version object should have an id and created_at
         def fake_refresh(obj):
             obj.id = 42
             obj.created_at = now
@@ -375,7 +391,7 @@ class TestCreateVersion:
         assert result.label == "snapshot-1"
         assert result.description == "first version"
         mock_db.add.assert_called_once()
-        mock_db.commit.assert_called_once()
+        mock_db.flush.assert_called_once()
 
     def test_aeroplane_not_found(self):
         mock_db = MagicMock()
@@ -384,18 +400,17 @@ class TestCreateVersion:
         with pytest.raises(NotFoundError):
             create_version(mock_db, uuid.uuid4(), data)
 
-    def test_db_error_rolls_back(self):
+    def test_db_error_raises_internal_error(self):
         mock_db = MagicMock()
         ap = _make_mock_aeroplane(
             wings=[], fuselages=[], weight_items=[], mission_objectives=None
         )
         mock_db.query.return_value.filter.return_value.first.return_value = ap
-        mock_db.commit.side_effect = SQLAlchemyError("disk full")
+        mock_db.flush.side_effect = SQLAlchemyError("disk full")
 
         data = DesignVersionCreate(label="boom")
         with pytest.raises(InternalError, match="Database error"):
             create_version(mock_db, ap.uuid, data)
-        mock_db.rollback.assert_called_once()
 
 
 # ── get_version (CRUD) ──────────────────────────────────────────────────
@@ -408,7 +423,12 @@ class TestGetVersionCrud:
         snap = {"name": "plane", "wings": []}
         ver = _make_mock_version(version_id=5, label="v5", snapshot=snap, created_at=now)
         ap = _make_mock_aeroplane(design_versions=[ver])
-        mock_db.query.return_value.filter.return_value.first.return_value = ap
+
+        aeroplane_chain = MagicMock()
+        aeroplane_chain.filter.return_value.first.return_value = ap
+        version_chain = MagicMock()
+        version_chain.filter.return_value.first.return_value = ver
+        mock_db.query.side_effect = [aeroplane_chain, version_chain]
 
         result = get_version(mock_db, ap.uuid, 5)
         assert isinstance(result, DesignVersionRead)
@@ -424,7 +444,13 @@ class TestGetVersionCrud:
     def test_version_not_found(self):
         mock_db = MagicMock()
         ap = _make_mock_aeroplane(design_versions=[])
-        mock_db.query.return_value.filter.return_value.first.return_value = ap
+
+        aeroplane_chain = MagicMock()
+        aeroplane_chain.filter.return_value.first.return_value = ap
+        version_chain = MagicMock()
+        version_chain.filter.return_value.first.return_value = None
+        mock_db.query.side_effect = [aeroplane_chain, version_chain]
+
         with pytest.raises(NotFoundError):
             get_version(mock_db, ap.uuid, 999)
 
@@ -437,11 +463,16 @@ class TestDeleteVersion:
         mock_db = MagicMock()
         ver = _make_mock_version(version_id=7)
         ap = _make_mock_aeroplane(design_versions=[ver])
-        mock_db.query.return_value.filter.return_value.first.return_value = ap
+
+        aeroplane_chain = MagicMock()
+        aeroplane_chain.filter.return_value.first.return_value = ap
+        version_chain = MagicMock()
+        version_chain.filter.return_value.first.return_value = ver
+        mock_db.query.side_effect = [aeroplane_chain, version_chain]
 
         delete_version(mock_db, ap.uuid, 7)
         mock_db.delete.assert_called_once_with(ver)
-        mock_db.commit.assert_called_once()
+        mock_db.flush.assert_called_once()
 
     def test_aeroplane_not_found(self):
         mock_db = MagicMock()
@@ -452,20 +483,30 @@ class TestDeleteVersion:
     def test_version_not_found(self):
         mock_db = MagicMock()
         ap = _make_mock_aeroplane(design_versions=[])
-        mock_db.query.return_value.filter.return_value.first.return_value = ap
+
+        aeroplane_chain = MagicMock()
+        aeroplane_chain.filter.return_value.first.return_value = ap
+        version_chain = MagicMock()
+        version_chain.filter.return_value.first.return_value = None
+        mock_db.query.side_effect = [aeroplane_chain, version_chain]
+
         with pytest.raises(NotFoundError):
             delete_version(mock_db, ap.uuid, 1)
 
-    def test_db_error_rolls_back(self):
+    def test_db_error_raises_internal_error(self):
         mock_db = MagicMock()
         ver = _make_mock_version(version_id=7)
         ap = _make_mock_aeroplane(design_versions=[ver])
-        mock_db.query.return_value.filter.return_value.first.return_value = ap
-        mock_db.commit.side_effect = SQLAlchemyError("lock timeout")
+
+        aeroplane_chain = MagicMock()
+        aeroplane_chain.filter.return_value.first.return_value = ap
+        version_chain = MagicMock()
+        version_chain.filter.return_value.first.return_value = ver
+        mock_db.query.side_effect = [aeroplane_chain, version_chain]
+        mock_db.flush.side_effect = SQLAlchemyError("lock timeout")
 
         with pytest.raises(InternalError, match="Database error"):
             delete_version(mock_db, ap.uuid, 7)
-        mock_db.rollback.assert_called_once()
 
 
 # ── diff_versions ──────────────────────────────────────────────────────
@@ -478,7 +519,14 @@ class TestDiffVersions:
         v1 = _make_mock_version(version_id=1, snapshot=snap)
         v2 = _make_mock_version(version_id=2, snapshot=dict(snap))  # copy
         ap = _make_mock_aeroplane(design_versions=[v1, v2])
-        mock_db.query.return_value.filter.return_value.first.return_value = ap
+
+        aeroplane_chain = MagicMock()
+        aeroplane_chain.filter.return_value.first.return_value = ap
+        ver_chain_a = MagicMock()
+        ver_chain_a.filter.return_value.first.return_value = v1
+        ver_chain_b = MagicMock()
+        ver_chain_b.filter.return_value.first.return_value = v2
+        mock_db.query.side_effect = [aeroplane_chain, ver_chain_a, ver_chain_b]
 
         result = diff_versions(mock_db, ap.uuid, 1, 2)
         assert isinstance(result, DesignVersionDiff)
@@ -493,7 +541,14 @@ class TestDiffVersions:
         v1 = _make_mock_version(version_id=1, snapshot=snap_a)
         v2 = _make_mock_version(version_id=2, snapshot=snap_b)
         ap = _make_mock_aeroplane(design_versions=[v1, v2])
-        mock_db.query.return_value.filter.return_value.first.return_value = ap
+
+        aeroplane_chain = MagicMock()
+        aeroplane_chain.filter.return_value.first.return_value = ap
+        ver_chain_a = MagicMock()
+        ver_chain_a.filter.return_value.first.return_value = v1
+        ver_chain_b = MagicMock()
+        ver_chain_b.filter.return_value.first.return_value = v2
+        mock_db.query.side_effect = [aeroplane_chain, ver_chain_a, ver_chain_b]
 
         result = diff_versions(mock_db, ap.uuid, 1, 2)
         assert len(result.changes) == 1
@@ -504,7 +559,15 @@ class TestDiffVersions:
         mock_db = MagicMock()
         v1 = _make_mock_version(version_id=1)
         ap = _make_mock_aeroplane(design_versions=[v1])
-        mock_db.query.return_value.filter.return_value.first.return_value = ap
+
+        aeroplane_chain = MagicMock()
+        aeroplane_chain.filter.return_value.first.return_value = ap
+        ver_chain_a = MagicMock()
+        ver_chain_a.filter.return_value.first.return_value = v1
+        ver_chain_b = MagicMock()
+        ver_chain_b.filter.return_value.first.return_value = None
+        mock_db.query.side_effect = [aeroplane_chain, ver_chain_a, ver_chain_b]
+
         with pytest.raises(NotFoundError):
             diff_versions(mock_db, ap.uuid, 1, 999)
 

--- a/app/tests/test_flight_profile_service_extended.py
+++ b/app/tests/test_flight_profile_service_extended.py
@@ -128,7 +128,7 @@ class TestCreateProfile:
     def test_db_error_raises_internal_error(self, client_and_db):
         _, SessionLocal = client_and_db
         with SessionLocal() as db:
-            with patch.object(db, "commit", side_effect=SQLAlchemyError("boom")):
+            with patch.object(db, "flush", side_effect=SQLAlchemyError("boom")):
                 with pytest.raises(InternalError):
                     svc.create_profile(db, _make_profile_payload(name="db_fail"))
 
@@ -262,7 +262,7 @@ class TestUpdateProfile:
         _, SessionLocal = client_and_db
         with SessionLocal() as db:
             created = svc.create_profile(db, _make_profile_payload(name="db_fail_upd"))
-            with patch.object(db, "commit", side_effect=SQLAlchemyError("boom")):
+            with patch.object(db, "flush", side_effect=SQLAlchemyError("boom")):
                 with pytest.raises(InternalError):
                     svc.update_profile(db, created.id, _make_update_payload(name="new_name_fail"))
 
@@ -367,7 +367,7 @@ class TestAssignProfileToAircraft:
         with SessionLocal() as db:
             aeroplane = make_aeroplane(db)
             profile = svc.create_profile(db, _make_profile_payload(name="assign_db_fail"))
-            with patch.object(db, "commit", side_effect=SQLAlchemyError("boom")):
+            with patch.object(db, "flush", side_effect=SQLAlchemyError("boom")):
                 with pytest.raises(InternalError):
                     svc.assign_profile_to_aircraft(db, aeroplane.uuid, profile.id)
 
@@ -406,7 +406,7 @@ class TestDetachProfileFromAircraft:
         _, SessionLocal = client_and_db
         with SessionLocal() as db:
             aeroplane = make_aeroplane(db)
-            with patch.object(db, "commit", side_effect=SQLAlchemyError("boom")):
+            with patch.object(db, "flush", side_effect=SQLAlchemyError("boom")):
                 with pytest.raises(InternalError):
                     svc.detach_profile_from_aircraft(db, aeroplane.uuid)
 

--- a/app/tests/test_tessellation_cache.py
+++ b/app/tests/test_tessellation_cache.py
@@ -200,6 +200,7 @@ class TestAeroplaneTessellationEndpoint:
             session, aeroplane_internal_id,
             "wing", "tail", "hash_tail", tail_tess,
         )
+        session.commit()
         session.close()
 
         resp = client.get(f"/aeroplanes/{aeroplane_uuid}/tessellation")
@@ -249,6 +250,7 @@ class TestAeroplaneTessellationEndpoint:
             session, aeroplane_internal_id,
             component_type="wing", component_name="w1",
         )
+        session.commit()
         session.close()
 
         resp = client.get(f"/aeroplanes/{aeroplane_uuid}/tessellation")

--- a/app/tests/test_weight_items_service.py
+++ b/app/tests/test_weight_items_service.py
@@ -141,7 +141,7 @@ class TestCreateWeightItem:
         _, SessionLocal = client_and_db
         with SessionLocal() as db:
             aeroplane = make_aeroplane(db)
-            with patch.object(db, "commit", side_effect=SQLAlchemyError("boom")):
+            with patch.object(db, "flush", side_effect=SQLAlchemyError("boom")):
                 with pytest.raises(InternalError):
                     svc.create_weight_item(db, aeroplane.uuid, _make_item())
 
@@ -222,7 +222,7 @@ class TestUpdateWeightItem:
         with SessionLocal() as db:
             aeroplane = make_aeroplane(db)
             created = svc.create_weight_item(db, aeroplane.uuid, _make_item())
-            with patch.object(db, "commit", side_effect=SQLAlchemyError("boom")):
+            with patch.object(db, "flush", side_effect=SQLAlchemyError("boom")):
                 with pytest.raises(InternalError):
                     svc.update_weight_item(db, aeroplane.uuid, created.id, _make_item(name="new"))
 
@@ -260,7 +260,7 @@ class TestDeleteWeightItem:
         with SessionLocal() as db:
             aeroplane = make_aeroplane(db)
             created = svc.create_weight_item(db, aeroplane.uuid, _make_item())
-            with patch.object(db, "commit", side_effect=SQLAlchemyError("boom")):
+            with patch.object(db, "flush", side_effect=SQLAlchemyError("boom")):
                 with pytest.raises(InternalError):
                     svc.delete_weight_item(db, aeroplane.uuid, created.id)
 


### PR DESCRIPTION
## Summary

- Replace all `db.commit()` calls with `db.flush()` in service layer — transaction commit/rollback is handled by `get_db()` at request boundary
- Remove all `db.rollback()` from except blocks in services — exception propagation triggers rollback in `get_db()`
- Replace stale relationship access with direct DB queries in `weight_items_service`, `design_version_service`, and `copilot_history_service` to avoid stale collections after flush (since `autoflush=False`)
- Add explicit `session.commit()` in callers that use sessions outside `get_db()` (startup seed, test fixtures)

Closes #379

## Test plan

- [x] All 2215 non-slow tests pass (0 failures)
- [x] Lint passes (`ruff check`)
- [x] Tessellation cache endpoint tests fixed (commit before close for out-of-band sessions)
- [x] Design version service tests updated for new `_get_version(db, aeroplane, id)` signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)