### PR TITLE
chore(gh-348): migrate frontend tests from fireEvent to userEvent

### DIFF
--- a/docs/superpowers/plans/2026-05-03-userevent-migration.md
+++ b/docs/superpowers/plans/2026-05-03-userevent-migration.md
@@ -1,0 +1,323 @@
+# userEvent Migration Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace all `fireEvent` calls with `@testing-library/user-event` across 22 frontend test files to eliminate CI `act()` warnings.
+
+**Architecture:** Mechanical transform — no production code changes. Install userEvent, then convert each file following the pattern table. Tests must remain green after each batch.
+
+**Tech Stack:** `@testing-library/user-event@^14`, vitest, React Testing Library
+
+---
+
+### Task 1: Install @testing-library/user-event
+
+**Files:**
+- Modify: `frontend/package.json`
+
+- [ ] **Step 1: Install the package**
+
+```bash
+cd frontend && npm install --save-dev @testing-library/user-event@^14
+```
+
+- [ ] **Step 2: Verify installation**
+
+```bash
+grep "user-event" frontend/package.json
+```
+
+Expected: `"@testing-library/user-event": "^14.x.x"` in devDependencies
+
+- [ ] **Step 3: Run tests to confirm no regressions**
+
+```bash
+cd frontend && npm run test:unit -- --run
+```
+
+Expected: 346 tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/package.json frontend/package-lock.json
+git commit -m "chore(gh-348): install @testing-library/user-event@^14"
+```
+
+---
+
+### Task 2: Batch 1 — simple click-only files (8 files, ~29 calls)
+
+**Files:**
+- Modify: `frontend/__tests__/SplitHandle.test.tsx` (1 call)
+- Modify: `frontend/__tests__/ComponentTreeWeightDisplay.test.tsx` (1 call)
+- Modify: `frontend/__tests__/UnsavedChangesModal.test.tsx` (3 calls)
+- Modify: `frontend/__tests__/CotsPickerDialog.test.tsx` (2 calls)
+- Modify: `frontend/__tests__/ComponentsPage.test.tsx` (3 calls)
+- Modify: `frontend/__tests__/ComponentTypeManagementDialog.test.tsx` (3 calls)
+- Modify: `frontend/__tests__/FuselageTree.test.tsx` (6 calls)
+- Modify: `frontend/__tests__/ComponentTreeConstructionPartFlow.test.tsx` (6 calls)
+
+**Transform pattern for each file:**
+
+1. Replace `import { ..., fireEvent, ... } from "@testing-library/react"` — remove `fireEvent` from the import. Add `import userEvent from "@testing-library/user-event"`.
+2. Add `const user = userEvent.setup();` at the start of each test (or in a `beforeEach` if many tests share setup).
+3. Replace `fireEvent.click(el)` → `await user.click(el)`.
+4. Make test functions `async` if not already: `it("...", async () => { ... })`.
+
+- [ ] **Step 1: Transform all 8 files**
+
+Apply the pattern above to each file. Each file is click-only so only `fireEvent.click` → `await user.click` is needed.
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cd frontend && npm run test:unit -- --run
+```
+
+Expected: 346 tests pass, zero `fireEvent` in these 8 files.
+
+- [ ] **Step 3: Verify no fireEvent remains**
+
+```bash
+grep -l "fireEvent" frontend/__tests__/SplitHandle.test.tsx frontend/__tests__/ComponentTreeWeightDisplay.test.tsx frontend/__tests__/UnsavedChangesModal.test.tsx frontend/__tests__/CotsPickerDialog.test.tsx frontend/__tests__/ComponentsPage.test.tsx frontend/__tests__/ComponentTypeManagementDialog.test.tsx frontend/__tests__/FuselageTree.test.tsx frontend/__tests__/ComponentTreeConstructionPartFlow.test.tsx
+```
+
+Expected: no output (all clean).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/__tests__/SplitHandle.test.tsx frontend/__tests__/ComponentTreeWeightDisplay.test.tsx frontend/__tests__/UnsavedChangesModal.test.tsx frontend/__tests__/CotsPickerDialog.test.tsx frontend/__tests__/ComponentsPage.test.tsx frontend/__tests__/ComponentTypeManagementDialog.test.tsx frontend/__tests__/FuselageTree.test.tsx frontend/__tests__/ComponentTreeConstructionPartFlow.test.tsx
+git commit -m "chore(gh-348): migrate batch 1 (8 click-only files) to userEvent"
+```
+
+---
+
+### Task 3: Batch 2 — click + change files (8 files, ~44 calls)
+
+**Files:**
+- Modify: `frontend/__tests__/ConstructionPartPickerDialog.test.tsx` (3 calls)
+- Modify: `frontend/__tests__/CreatorGallery.test.tsx` (3 calls)
+- Modify: `frontend/__tests__/PropertyEditDialog.test.tsx` (6 calls)
+- Modify: `frontend/__tests__/GroupAddMenu.test.tsx` (5 calls)
+- Modify: `frontend/__tests__/NodePropertyPanel.test.tsx` (10 calls)
+- Modify: `frontend/__tests__/ConstructionPartsGrid.test.tsx` (4 calls)
+- Modify: `frontend/__tests__/ConstructionPlansPage.test.tsx` (10 calls)
+- Modify: `frontend/__tests__/XsecTreeCrud.test.tsx` (3 calls — added after issue creation)
+
+**Additional transform patterns (beyond click):**
+
+- `fireEvent.change(input, { target: { value: "x" } })` → `await user.clear(input); await user.type(input, "x")`.
+- `fireEvent.change(select, { target: { value: "v" } })` (for `<select>` elements) → `await user.selectOptions(select, "v")`.
+- `fireEvent.keyDown(el, { key: "Enter" })` → `await user.keyboard("{Enter}")`.
+  - Note: `user.keyboard` types on the currently focused element. Ensure the element is focused first (via `user.click` or `el.focus()`).
+
+- [ ] **Step 1: Transform all 8 files**
+
+Apply both click and change/keyDown patterns. Check each `fireEvent.change` to determine if it's an `<input>`, `<select>`, or `<textarea>` and use the appropriate userEvent method.
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cd frontend && npm run test:unit -- --run
+```
+
+Expected: 346 tests pass.
+
+- [ ] **Step 3: Verify no fireEvent remains**
+
+```bash
+grep -l "fireEvent" frontend/__tests__/ConstructionPartPickerDialog.test.tsx frontend/__tests__/CreatorGallery.test.tsx frontend/__tests__/PropertyEditDialog.test.tsx frontend/__tests__/GroupAddMenu.test.tsx frontend/__tests__/NodePropertyPanel.test.tsx frontend/__tests__/ConstructionPartsGrid.test.tsx frontend/__tests__/ConstructionPlansPage.test.tsx frontend/__tests__/XsecTreeCrud.test.tsx
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/__tests__/ConstructionPartPickerDialog.test.tsx frontend/__tests__/CreatorGallery.test.tsx frontend/__tests__/PropertyEditDialog.test.tsx frontend/__tests__/GroupAddMenu.test.tsx frontend/__tests__/NodePropertyPanel.test.tsx frontend/__tests__/ConstructionPartsGrid.test.tsx frontend/__tests__/ConstructionPlansPage.test.tsx frontend/__tests__/XsecTreeCrud.test.tsx
+git commit -m "chore(gh-348): migrate batch 2 (8 click+change files) to userEvent"
+```
+
+---
+
+### Task 4: Batch 3a — medium-complexity files (3 files, ~34 calls)
+
+**Files:**
+- Modify: `frontend/__tests__/ComponentEditDialogDynamic.test.tsx` (14 calls)
+- Modify: `frontend/__tests__/ComponentTreeAddFlow.test.tsx` (18 calls)
+- Modify: `frontend/__tests__/SegmentPaginator.test.tsx` (5 calls — added after issue creation)
+
+These files have mixed click/change patterns but no special handling (no file inputs, no flushMicrotasks).
+
+- [ ] **Step 1: Transform all 3 files**
+
+Same patterns as Task 3. Pay attention to `fireEvent.change` on `<select>` elements — use `user.selectOptions`.
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cd frontend && npm run test:unit -- --run
+```
+
+Expected: 346 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/__tests__/ComponentEditDialogDynamic.test.tsx frontend/__tests__/ComponentTreeAddFlow.test.tsx frontend/__tests__/SegmentPaginator.test.tsx
+git commit -m "chore(gh-348): migrate batch 3a (3 mixed files) to userEvent"
+```
+
+---
+
+### Task 5: Batch 3b — EditParamsModal (9 calls, added after issue creation)
+
+**Files:**
+- Modify: `frontend/__tests__/EditParamsModal.test.tsx` (9 calls)
+
+This file was added after the issue was created. Standard click + change transforms.
+
+- [ ] **Step 1: Transform the file**
+
+Same patterns as previous tasks.
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cd frontend && npm run test:unit -- --run
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/__tests__/EditParamsModal.test.tsx
+git commit -m "chore(gh-348): migrate EditParamsModal to userEvent"
+```
+
+---
+
+### Task 6: ConstructionPartUploadDialog — file input handling (11 calls)
+
+**Files:**
+- Modify: `frontend/__tests__/ConstructionPartUploadDialog.test.tsx`
+
+**Special handling:** 6 of the 11 `fireEvent.change` calls simulate file selection on `<input type="file">`. These must use `user.upload()`:
+
+```typescript
+// Before:
+fireEvent.change(fileInput, { target: { files: [file] } });
+
+// After:
+await user.upload(fileInput, file);
+```
+
+The `file` variable must be a proper `File` object (not just `{ name: "..." }`). Check if existing tests already construct `File` objects; if not, create them:
+
+```typescript
+const file = new File(["content"], "part.step", { type: "application/step" });
+```
+
+- [ ] **Step 1: Transform the file**
+
+Replace all `fireEvent.click` → `await user.click` and all file-input `fireEvent.change` → `await user.upload`. Convert non-file `fireEvent.change` with standard patterns.
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cd frontend && npm run test:unit -- --run
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/__tests__/ConstructionPartUploadDialog.test.tsx
+git commit -m "chore(gh-348): migrate ConstructionPartUploadDialog to userEvent.upload"
+```
+
+---
+
+### Task 7: ComponentTypeCreateFlow — flushMicrotasks removal (79 calls)
+
+**Files:**
+- Modify: `frontend/__tests__/ComponentTypeCreateFlow.test.tsx`
+
+**Special handling:**
+
+1. **Remove `flushMicrotasks()` helper** (lines 76-79) and all 11 call sites. With `userEvent`, state updates settle before `await` resolves.
+
+2. **Convert `clickSave()` helper** (line 69) to async:
+   ```typescript
+   // Before:
+   const clickSave = () => fireEvent.click(screen.getByRole("button", { name: /save/i }));
+   
+   // After:
+   const clickSave = async () => await user.click(screen.getByRole("button", { name: /save/i }));
+   ```
+   All call sites must add `await`: `clickSave()` → `await clickSave()`.
+
+3. **Convert `editableTextInputs()` helper** (line 61) if it uses fireEvent — make async if needed.
+
+4. **Standard transforms** for all remaining `fireEvent.click` and `fireEvent.change` calls.
+
+This is the largest and most complex file (79 calls). Take extra care with the `await` chain — missing a single `await` can cause flaky tests.
+
+- [ ] **Step 1: Transform the file**
+
+Remove flushMicrotasks, convert helpers, transform all fireEvent calls.
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cd frontend && npm run test:unit -- --run
+```
+
+- [ ] **Step 3: Verify zero fireEvent and zero flushMicrotasks**
+
+```bash
+grep -c "fireEvent\|flushMicrotasks" frontend/__tests__/ComponentTypeCreateFlow.test.tsx
+```
+
+Expected: 0
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/__tests__/ComponentTypeCreateFlow.test.tsx
+git commit -m "chore(gh-348): migrate ComponentTypeCreateFlow to userEvent, remove flushMicrotasks"
+```
+
+---
+
+### Task 8: Final verification and cleanup
+
+- [ ] **Step 1: Verify zero fireEvent across all test files**
+
+```bash
+grep -r "fireEvent" frontend/__tests__/ --include="*.tsx" --include="*.ts" -l
+```
+
+Expected: no output.
+
+- [ ] **Step 2: Run full test suite**
+
+```bash
+cd frontend && npm run test:unit -- --run
+```
+
+Expected: 346 tests pass, zero `act()` warnings in output.
+
+- [ ] **Step 3: Verify no production code changes**
+
+```bash
+git diff --name-only HEAD~7 | grep -v "__tests__/" | grep -v "package"
+```
+
+Expected: no output (only test files and package.json/lock changed).
+
+- [ ] **Step 4: Create PR**
+
+```bash
+gh pr create --title "chore(gh-348): migrate frontend tests from fireEvent to userEvent" --body "..."
+```

--- a/frontend/__tests__/ComponentEditDialogDynamic.test.tsx
+++ b/frontend/__tests__/ComponentEditDialogDynamic.test.tsx
@@ -6,7 +6,8 @@
  * type changes, and surfaces "Unknown properties" for legacy data.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 vi.mock("lucide-react", () => {
@@ -66,69 +67,75 @@ beforeEach(() => {
 });
 
 describe("ComponentEditDialog — dynamic specs rendering", () => {
-  it("renders number + enum fields for material type", () => {
+  it("renders number + enum fields for material type", async () => {
+    const user = userEvent.setup();
     render(
       <ComponentEditDialog open={true} onClose={vi.fn()} onSaved={vi.fn()}
         component={null} />,
     );
     // Select Material type
     const select = screen.getAllByRole("combobox")[0] as HTMLSelectElement;
-    fireEvent.change(select, { target: { value: "material" } });
+    await user.selectOptions(select, "material");
 
     expect(screen.getByText(/Dichte/i)).toBeDefined();
     expect(screen.getByText(/Drucktyp/i)).toBeDefined();
   });
 
-  it("required fields are marked with a star", () => {
+  it("required fields are marked with a star", async () => {
+    const user = userEvent.setup();
     render(
       <ComponentEditDialog open={true} onClose={vi.fn()} onSaved={vi.fn()}
         component={null} />,
     );
     const select = screen.getAllByRole("combobox")[0] as HTMLSelectElement;
-    fireEvent.change(select, { target: { value: "material" } });
+    await user.selectOptions(select, "material");
     // The Dichte label should have a * (since required=true)
     expect(screen.getByText(/Dichte/).textContent).toContain("*");
   });
 
-  it("type change preserves compatible specs (same name+type)", () => {
+  it("type change preserves compatible specs (same name+type)", async () => {
     // Create with a servo, fill torque, switch to a type that also has torque
     // — servo has torque_kg_cm, material doesn't. Switch servo→material
     // should drop torque, switching back should restore via user input only.
+    const user = userEvent.setup();
     const { container } = render(
       <ComponentEditDialog open={true} onClose={vi.fn()} onSaved={vi.fn()}
         component={null} />,
     );
 
     const select = screen.getAllByRole("combobox")[0] as HTMLSelectElement;
-    fireEvent.change(select, { target: { value: "servo" } });
+    await user.selectOptions(select, "servo");
     // fill torque
     const torque = container.querySelector('input[data-spec="torque_kg_cm"]') as HTMLInputElement;
     expect(torque).toBeDefined();
-    fireEvent.change(torque, { target: { value: "1.8" } });
+    await user.clear(torque);
+    await user.type(torque, "1.8");
     expect(torque.value).toBe("1.8");
 
     // switch to material — torque field disappears
-    fireEvent.change(select, { target: { value: "material" } });
+    await user.selectOptions(select, "material");
     expect(container.querySelector('input[data-spec="torque_kg_cm"]')).toBeNull();
 
     // switch back to servo — torque field reappears, value preserved
-    fireEvent.change(select, { target: { value: "servo" } });
+    await user.selectOptions(select, "servo");
     const torqueAgain = container.querySelector('input[data-spec="torque_kg_cm"]') as HTMLInputElement;
     expect(torqueAgain.value).toBe("1.8");
   });
 
-  it("blocks submit when a required field is missing", () => {
+  it("blocks submit when a required field is missing", async () => {
+    const user = userEvent.setup();
     render(
       <ComponentEditDialog open={true} onClose={vi.fn()} onSaved={vi.fn()}
         component={null} />,
     );
     const nameInput = screen.getAllByRole("textbox")[0] as HTMLInputElement;
-    fireEvent.change(nameInput, { target: { value: "My Material" } });
+    await user.clear(nameInput);
+    await user.type(nameInput, "My Material");
     const select = screen.getAllByRole("combobox")[0] as HTMLSelectElement;
-    fireEvent.change(select, { target: { value: "material" } });
+    await user.selectOptions(select, "material");
     // Don't fill density
 
-    fireEvent.click(screen.getByText(/^Create$/));
+    await user.click(screen.getByText(/^Create$/));
     expect(mockCreate).not.toHaveBeenCalled();
     // Error message (inside a destructive-styled box) mentions the missing field.
     // The label "Dichte" also appears as a regular label — so we filter to the
@@ -140,21 +147,24 @@ describe("ComponentEditDialog — dynamic specs rendering", () => {
     expect(inErrorBox).toBe(true);
   });
 
-  it("submits specs when all required fields are set", () => {
+  it("submits specs when all required fields are set", async () => {
+    const user = userEvent.setup();
     const { container } = render(
       <ComponentEditDialog open={true} onClose={vi.fn()} onSaved={vi.fn()}
         component={null} />,
     );
     const nameInput = screen.getAllByRole("textbox")[0] as HTMLInputElement;
-    fireEvent.change(nameInput, { target: { value: "PLA+" } });
+    await user.clear(nameInput);
+    await user.type(nameInput, "PLA+");
 
     const select = screen.getAllByRole("combobox")[0] as HTMLSelectElement;
-    fireEvent.change(select, { target: { value: "material" } });
+    await user.selectOptions(select, "material");
 
     const density = container.querySelector('input[data-spec="density_kg_m3"]') as HTMLInputElement;
-    fireEvent.change(density, { target: { value: "1240" } });
+    await user.clear(density);
+    await user.type(density, "1240");
 
-    fireEvent.click(screen.getByText(/^Create$/));
+    await user.click(screen.getByText(/^Create$/));
     expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({
       name: "PLA+",
       component_type: "material",
@@ -177,13 +187,14 @@ describe("ComponentEditDialog — dynamic specs rendering", () => {
     expect(screen.getByText(/Unknown properties/i)).toBeDefined();
   });
 
-  it("number field shows the unit as a hint", () => {
+  it("number field shows the unit as a hint", async () => {
+    const user = userEvent.setup();
     const { container } = render(
       <ComponentEditDialog open={true} onClose={vi.fn()} onSaved={vi.fn()}
         component={null} />,
     );
     const select = screen.getAllByRole("combobox")[0] as HTMLSelectElement;
-    fireEvent.change(select, { target: { value: "material" } });
+    await user.selectOptions(select, "material");
     // The unit "kg/m³" appears near the density input
     expect(container.textContent).toContain("kg/m³");
   });

--- a/frontend/__tests__/ComponentTreeAddFlow.test.tsx
+++ b/frontend/__tests__/ComponentTreeAddFlow.test.tsx
@@ -5,7 +5,8 @@
  *   - COTS picker wiring — clicking a component creates a cots tree node
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 vi.mock("lucide-react", () => {
@@ -122,10 +123,11 @@ beforeEach(() => {
 });
 
 describe("ComponentTree — per-group add flow", () => {
-  it("renders an add button for each group node (root + nested)", () => {
+  it("renders an add button for each group node (root + nested)", async () => {
+    const user = userEvent.setup();
     const { container } = render(<ComponentTree />);
     // Expand the root group so the nested group is visible.
-    fireEvent.click(screen.getByText("eHawk"));
+    await user.click(screen.getByText("eHawk"));
 
     // Expect one add button per group row; root (tree header) + 2 groups = 3 '+' affordances.
     // We query by title since buttons use an empty <span> icon.
@@ -133,28 +135,31 @@ describe("ComponentTree — per-group add flow", () => {
     expect(addButtons.length).toBeGreaterThanOrEqual(2);
   });
 
-  it("opens the popover when a group's (+) is clicked", () => {
+  it("opens the popover when a group's (+) is clicked", async () => {
+    const user = userEvent.setup();
     render(<ComponentTree />);
     // Click the (+) on the root group eHawk.
     const rootAddBtn = screen.getByTitle("Add to eHawk");
-    fireEvent.click(rootAddBtn);
+    await user.click(rootAddBtn);
 
     expect(screen.getByText("New Group")).toBeDefined();
     expect(screen.getByText("Assign COTS Component")).toBeDefined();
   });
 
   it("opens an inline input for 'New Group' and submits to create a sub-group", async () => {
+    const user = userEvent.setup();
     render(<ComponentTree />);
-    fireEvent.click(screen.getByTitle("Add to eHawk"));
-    fireEvent.click(screen.getByText("New Group"));
+    await user.click(screen.getByTitle("Add to eHawk"));
+    await user.click(screen.getByText("New Group"));
 
     // Inline input appears — we look for a text input placeholder
     const input = screen.getByPlaceholderText(/group name/i) as HTMLInputElement;
     expect(input).toBeDefined();
-    fireEvent.change(input, { target: { value: "electronics" } });
+    await user.clear(input);
+    await user.type(input, "electronics");
 
     // Submit by pressing Enter
-    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+    await user.keyboard("{Enter}");
 
     expect(mockAddTreeNode).toHaveBeenCalledWith(
       "aero-1",
@@ -166,37 +171,42 @@ describe("ComponentTree — per-group add flow", () => {
     );
   });
 
-  it("cancels the inline input on Escape without calling the API", () => {
+  it("cancels the inline input on Escape without calling the API", async () => {
+    const user = userEvent.setup();
     render(<ComponentTree />);
-    fireEvent.click(screen.getByTitle("Add to eHawk"));
-    fireEvent.click(screen.getByText("New Group"));
+    await user.click(screen.getByTitle("Add to eHawk"));
+    await user.click(screen.getByText("New Group"));
 
     const input = screen.getByPlaceholderText(/group name/i) as HTMLInputElement;
-    fireEvent.change(input, { target: { value: "not-saved" } });
-    fireEvent.keyDown(input, { key: "Escape", code: "Escape" });
+    await user.clear(input);
+    await user.type(input, "not-saved");
+    await user.keyboard("{Escape}");
 
     expect(mockAddTreeNode).not.toHaveBeenCalled();
     expect(screen.queryByPlaceholderText(/group name/i)).toBeNull();
   });
 
-  it("does not submit an empty group name", () => {
+  it("does not submit an empty group name", async () => {
+    const user = userEvent.setup();
     render(<ComponentTree />);
-    fireEvent.click(screen.getByTitle("Add to eHawk"));
-    fireEvent.click(screen.getByText("New Group"));
+    await user.click(screen.getByTitle("Add to eHawk"));
+    await user.click(screen.getByText("New Group"));
 
     const input = screen.getByPlaceholderText(/group name/i) as HTMLInputElement;
-    fireEvent.change(input, { target: { value: "   " } });
-    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+    await user.clear(input);
+    await user.type(input, "   ");
+    await user.keyboard("{Enter}");
 
     expect(mockAddTreeNode).not.toHaveBeenCalled();
   });
 
-  it("pencil icon per row fires onNodeEditRequested with the correct node", () => {
+  it("pencil icon per row fires onNodeEditRequested with the correct node", async () => {
+    const user = userEvent.setup();
     const onEdit = vi.fn();
     render(<ComponentTree onNodeEditRequested={onEdit} />);
 
     // Click the pencil icon on the root "eHawk" row.
-    fireEvent.click(screen.getByTitle("Edit eHawk"));
+    await user.click(screen.getByTitle("Edit eHawk"));
     expect(onEdit).toHaveBeenCalledTimes(1);
     expect(onEdit.mock.calls[0][0]).toEqual(
       expect.objectContaining({ id: 10, name: "eHawk" }),
@@ -204,13 +214,14 @@ describe("ComponentTree — per-group add flow", () => {
   });
 
   it("opens the COTS picker and creates a cots node on selection", async () => {
+    const user = userEvent.setup();
     render(<ComponentTree />);
-    fireEvent.click(screen.getByTitle("Add to eHawk"));
-    fireEvent.click(screen.getByText("Assign COTS Component"));
+    await user.click(screen.getByTitle("Add to eHawk"));
+    await user.click(screen.getByText("Assign COTS Component"));
 
     // The picker dialog is open, library component is listed
     const pickRow = screen.getByText("KST X08");
-    fireEvent.click(pickRow);
+    await user.click(pickRow);
 
     expect(mockAddTreeNode).toHaveBeenCalledWith(
       "aero-1",

--- a/frontend/__tests__/ComponentTreeConstructionPartFlow.test.tsx
+++ b/frontend/__tests__/ComponentTreeConstructionPartFlow.test.tsx
@@ -7,7 +7,8 @@
  * volume_mm3 / area_mm2 / material_id).
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 vi.mock("lucide-react", () => {
@@ -89,9 +90,10 @@ beforeEach(() => {
 });
 
 describe("ComponentTree — Construction-Part add flow (gh#57-wvg)", () => {
-  it("the 'Assign Construction Part' menu item is enabled", () => {
+  it("the 'Assign Construction Part' menu item is enabled", async () => {
+    const user = userEvent.setup();
     render(<ComponentTree />);
-    fireEvent.click(screen.getByTitle("Add to main_wing"));
+    await user.click(screen.getByTitle("Add to main_wing"));
 
     const buttons = screen.getAllByText("Assign Construction Part");
     const menuButton = buttons.find((el) => el.closest("button"))?.closest("button");
@@ -99,24 +101,26 @@ describe("ComponentTree — Construction-Part add flow (gh#57-wvg)", () => {
     expect(menuButton?.hasAttribute("disabled")).toBe(false);
   });
 
-  it("opens the Construction-Part picker on menu click", () => {
+  it("opens the Construction-Part picker on menu click", async () => {
+    const user = userEvent.setup();
     render(<ComponentTree />);
-    fireEvent.click(screen.getByTitle("Add to main_wing"));
+    await user.click(screen.getByTitle("Add to main_wing"));
     const buttons = screen.getAllByText("Assign Construction Part");
     const menuButton = buttons.find((el) => el.closest("button"))?.closest("button");
-    fireEvent.click(menuButton!);
+    await user.click(menuButton!);
 
     expect(screen.getByText(/Assign Construction Part to 'main_wing'/)).toBeDefined();
     expect(screen.getByText("Bulkhead-A")).toBeDefined();
   });
 
   it("creates a cad_shape tree node with construction_part_id on selection", async () => {
+    const user = userEvent.setup();
     render(<ComponentTree />);
-    fireEvent.click(screen.getByTitle("Add to main_wing"));
+    await user.click(screen.getByTitle("Add to main_wing"));
     const buttons = screen.getAllByText("Assign Construction Part");
     const menuButton = buttons.find((el) => el.closest("button"))?.closest("button");
-    fireEvent.click(menuButton!);
-    fireEvent.click(screen.getByText("Bulkhead-A"));
+    await user.click(menuButton!);
+    await user.click(screen.getByText("Bulkhead-A"));
 
     expect(mockAddTreeNode).toHaveBeenCalledWith(
       "a",

--- a/frontend/__tests__/ComponentTreeWeightDisplay.test.tsx
+++ b/frontend/__tests__/ComponentTreeWeightDisplay.test.tsx
@@ -6,7 +6,8 @@
  * total weight + status of the roots combined.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 vi.mock("lucide-react", () => {
@@ -257,7 +258,8 @@ describe("ComponentTree — virtual root (gh#89)", () => {
     expect(deleteButtons.length).toBe(1);
   });
 
-  it("collapsing the virtual root hides every child row", () => {
+  it("collapsing the virtual root hides every child row", async () => {
+    const user = userEvent.setup();
     treeReturnValue = {
       tree: [
         makeNode({ id: 1, name: "wing", weight_status: "valid", total_weight_g: 50 }),
@@ -270,7 +272,7 @@ describe("ComponentTree — virtual root (gh#89)", () => {
     expect(screen.getByText("wing")).toBeDefined();
     expect(screen.getByText("fuselage")).toBeDefined();
     // Click the virtual root label to toggle it collapsed.
-    fireEvent.click(screen.getByText("Aeroplane"));
+    await user.click(screen.getByText("Aeroplane"));
     expect(screen.queryByText("wing")).toBeNull();
     expect(screen.queryByText("fuselage")).toBeNull();
     // The virtual root itself stays visible.

--- a/frontend/__tests__/ComponentTypeCreateFlow.test.tsx
+++ b/frontend/__tests__/ComponentTypeCreateFlow.test.tsx
@@ -15,7 +15,8 @@
  * start firing bogus requests again.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, within, waitFor } from "@testing-library/react";
+import { render, screen, within, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 vi.mock("lucide-react", () => {
@@ -66,42 +67,37 @@ function editableTextInputs(container: HTMLElement): HTMLInputElement[] {
 }
 
 /** Click the Save button on the currently open dialog. */
-function clickSave() {
+async function clickSave(user: ReturnType<typeof userEvent.setup>) {
   const saveButtons = screen.getAllByText(/^Save$/);
   expect(saveButtons.length).toBeGreaterThan(0);
-  fireEvent.click(saveButtons[0]);
-}
-
-/** Flush two microtask ticks so awaited promises in handlers settle. */
-async function flushMicrotasks() {
-  await Promise.resolve();
-  await Promise.resolve();
-  await Promise.resolve();
+  await user.click(saveButtons[0]);
 }
 
 describe("Manage Types → New Type → Save flow (e2e)", () => {
   it("creates a new type end-to-end: open mgmt → click New Type → fill form → Save → createComponentType called", async () => {
+    const user = userEvent.setup();
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
 
     // 1. Click "+ New Type"
-    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
+    await user.click(screen.getByRole("button", { name: /New Type/i }));
 
     // 2. Verify Edit dialog opened
     expect(screen.getByText(/New Type:/i)).toBeDefined();
 
     // 3. Fill in Name + Label
     const editable = editableTextInputs(container);
-    fireEvent.change(editable[0], { target: { value: "carbon_tube" } });
+    await user.clear(editable[0]);
+    await user.type(editable[0], "carbon_tube");
     // [name, label, description] — index 1 is label
-    fireEvent.change(editable[1], { target: { value: "Carbon Tube" } });
+    await user.clear(editable[1]);
+    await user.type(editable[1], "Carbon Tube");
 
     // 4. Click Save
-    clickSave();
+    await clickSave(user);
 
     // 5. The backend client must have been called with the payload
-    await flushMicrotasks();
     expect(mockCreate).toHaveBeenCalledTimes(1);
     expect(mockCreate).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -112,27 +108,31 @@ describe("Manage Types → New Type → Save flow (e2e)", () => {
     );
   });
 
-  it("Save with empty Label is blocked — no API call", () => {
+  it("Save with empty Label is blocked — no API call", async () => {
+    const user = userEvent.setup();
     render(<ComponentTypeManagementDialog open={true} onClose={vi.fn()} />);
-    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
+    await user.click(screen.getByRole("button", { name: /New Type/i }));
     // No input → click Save
-    clickSave();
+    await clickSave(user);
     expect(mockCreate).not.toHaveBeenCalled();
     // Inline error appears
     expect(screen.getByText(/Label is required/i)).toBeDefined();
   });
 
-  it("Save with non-snake_case Name is blocked for new types", () => {
+  it("Save with non-snake_case Name is blocked for new types", async () => {
+    const user = userEvent.setup();
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
+    await user.click(screen.getByRole("button", { name: /New Type/i }));
 
     const editable = editableTextInputs(container);
-    fireEvent.change(editable[0], { target: { value: "CarbonTube" } });  // PascalCase
-    fireEvent.change(editable[1], { target: { value: "Carbon Tube" } });
+    await user.clear(editable[0]);
+    await user.type(editable[0], "CarbonTube");  // PascalCase
+    await user.clear(editable[1]);
+    await user.type(editable[1], "Carbon Tube");
 
-    clickSave();
+    await clickSave(user);
 
     expect(mockCreate).not.toHaveBeenCalled();
     // The inline error mentions snake_case. The label also mentions it, so we
@@ -147,36 +147,41 @@ describe("Manage Types → New Type → Save flow (e2e)", () => {
   // ------------------------------------------------------------------- //
 
   it("after successful save, onSaved is invoked so the list refetches", async () => {
+    const user = userEvent.setup();
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
+    await user.click(screen.getByRole("button", { name: /New Type/i }));
 
     const editable = editableTextInputs(container);
-    fireEvent.change(editable[0], { target: { value: "t1" } });
-    fireEvent.change(editable[1], { target: { value: "T1" } });
+    await user.clear(editable[0]);
+    await user.type(editable[0], "t1");
+    await user.clear(editable[1]);
+    await user.type(editable[1], "T1");
 
-    clickSave();
-    await flushMicrotasks();
+    await clickSave(user);
 
     expect(mockMutate).toHaveBeenCalled();
   });
 
-  it("clicking Save propagates: no event handler outside the dialog triggers before handleSave", () => {
+  it("clicking Save propagates: no event handler outside the dialog triggers before handleSave", async () => {
     // Guards against a regression where stopPropagation on the inner card
     // is dropped — which would let the parent backdrop's onClick close the
     // dialog before the async save settles.
+    const user = userEvent.setup();
     const onClose = vi.fn();
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={onClose} />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
+    await user.click(screen.getByRole("button", { name: /New Type/i }));
 
     const editable = editableTextInputs(container);
-    fireEvent.change(editable[0], { target: { value: "t2" } });
-    fireEvent.change(editable[1], { target: { value: "T2" } });
+    await user.clear(editable[0]);
+    await user.type(editable[0], "t2");
+    await user.clear(editable[1]);
+    await user.type(editable[1], "T2");
 
-    clickSave();
+    await clickSave(user);
     // The parent Management dialog must NOT have closed as a side-effect of
     // the Save click (Save closes the EDIT dialog via onSaved→onClose, but
     // the Management dialog's onClose must not fire).
@@ -192,18 +197,19 @@ describe("Manage Types → New Type → Save flow (e2e)", () => {
 
 describe("Create-Type payload contract", () => {
   it("Description field is included in the payload", async () => {
+    const user = userEvent.setup();
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
+    await user.click(screen.getByRole("button", { name: /New Type/i }));
     const editable = editableTextInputs(container);
-    fireEvent.change(editable[0], { target: { value: "motor_mount" } });
-    fireEvent.change(editable[1], { target: { value: "Motor Mount" } });
-    fireEvent.change(editable[2], {
-      target: { value: "Printed bracket for the motor" },
-    });
-    clickSave();
-    await flushMicrotasks();
+    await user.clear(editable[0]);
+    await user.type(editable[0], "motor_mount");
+    await user.clear(editable[1]);
+    await user.type(editable[1], "Motor Mount");
+    await user.clear(editable[2]);
+    await user.type(editable[2], "Printed bracket for the motor");
+    await clickSave(user);
 
     expect(mockCreate).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -215,17 +221,19 @@ describe("Create-Type payload contract", () => {
   });
 
   it("empty description is sent as null (not empty string)", async () => {
+    const user = userEvent.setup();
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
+    await user.click(screen.getByRole("button", { name: /New Type/i }));
     const editable = editableTextInputs(container);
-    fireEvent.change(editable[0], { target: { value: "empty_desc" } });
-    fireEvent.change(editable[1], { target: { value: "Empty Desc" } });
+    await user.clear(editable[0]);
+    await user.type(editable[0], "empty_desc");
+    await user.clear(editable[1]);
+    await user.type(editable[1], "Empty Desc");
     // description left blank
 
-    clickSave();
-    await flushMicrotasks();
+    await clickSave(user);
 
     const payload = mockCreate.mock.calls[0][0];
     expect(payload.description).toBeNull();
@@ -235,15 +243,17 @@ describe("Create-Type payload contract", () => {
     // Regression for the double-encoding bug:
     // backend rejected payloads where `schema` was a stringified JSON array.
     // The frontend must always send a real array — including when empty.
+    const user = userEvent.setup();
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
+    await user.click(screen.getByRole("button", { name: /New Type/i }));
     const editable = editableTextInputs(container);
-    fireEvent.change(editable[0], { target: { value: "arr_check" } });
-    fireEvent.change(editable[1], { target: { value: "Arr Check" } });
-    clickSave();
-    await flushMicrotasks();
+    await user.clear(editable[0]);
+    await user.type(editable[0], "arr_check");
+    await user.clear(editable[1]);
+    await user.type(editable[1], "Arr Check");
+    await clickSave(user);
 
     const payload = mockCreate.mock.calls[0][0];
     expect(Array.isArray(payload.schema)).toBe(true);
@@ -255,20 +265,37 @@ describe("Create-Type payload contract", () => {
     // would duplicate mutations and is one plausible explanation for the
     // "delete 1 wiped the table" symptom. Even if our investigation found the
     // backend to be safe, we pin this guarantee down in the UI as well.
+    //
+    // Use a deferred promise so the Save handler stays pending while we
+    // attempt a second click. The button should be disabled after the first
+    // click (React re-renders between awaited userEvent calls).
+    let resolveCreate!: (v: unknown) => void;
+    mockCreate.mockImplementationOnce(
+      () => new Promise((r) => { resolveCreate = r; }),
+    );
+
+    const user = userEvent.setup();
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
+    await user.click(screen.getByRole("button", { name: /New Type/i }));
     const editable = editableTextInputs(container);
-    fireEvent.change(editable[0], { target: { value: "nodup" } });
-    fireEvent.change(editable[1], { target: { value: "NoDup" } });
-    clickSave();
-    // The Save handler is async → the dialog disables the button after
-    // the first click so a second click should be a no-op.
-    clickSave();
-    await flushMicrotasks();
+    await user.clear(editable[0]);
+    await user.type(editable[0], "nodup");
+    await user.clear(editable[1]);
+    await user.type(editable[1], "NoDup");
 
-    expect(mockCreate).toHaveBeenCalledTimes(1);
+    // First click — starts the save, button becomes disabled while pending
+    await user.click(screen.getAllByText(/^Save$/)[0]);
+
+    // Second click — button is disabled, so this should be a no-op
+    await user.click(screen.getAllByText(/^Save$/)[0]);
+
+    // Resolve the pending save
+    resolveCreate({ id: 999, name: "nodup" });
+    await waitFor(() => {
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+    });
   });
 });
 
@@ -279,19 +306,22 @@ describe("Create-Type payload contract", () => {
 
 describe("Adding properties inside the type", () => {
   it("adds a 'number' property via PropertyEditDialog → appears in Save payload", async () => {
+    const user = userEvent.setup();
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
+    await user.click(screen.getByRole("button", { name: /New Type/i }));
 
     // Fill Name + Label
     let editable = editableTextInputs(container);
-    fireEvent.change(editable[0], { target: { value: "tube" } });
-    fireEvent.change(editable[1], { target: { value: "Tube" } });
+    await user.clear(editable[0]);
+    await user.type(editable[0], "tube");
+    await user.clear(editable[1]);
+    await user.type(editable[1], "Tube");
 
     // Open PropertyEditDialog: Button labelled "+ Property" (inside Edit dialog)
     // There are multiple Plus icons on screen — target by text of the label.
-    fireEvent.click(screen.getByText(/^Property$/));
+    await user.click(screen.getByText(/^Property$/));
 
     // PropertyEditDialog is now mounted. Fill Name + Label + Unit + Min/Max.
     // We re-query because new inputs appeared inside the nested dialog.
@@ -304,9 +334,12 @@ describe("Adding properties inside the type", () => {
     //   4: prop Label
     //   5: prop Unit
     //   6: prop Description
-    fireEvent.change(editable[3], { target: { value: "diameter_mm" } });
-    fireEvent.change(editable[4], { target: { value: "Diameter" } });
-    fireEvent.change(editable[5], { target: { value: "mm" } });
+    await user.clear(editable[3]);
+    await user.type(editable[3], "diameter_mm");
+    await user.clear(editable[4]);
+    await user.type(editable[4], "Diameter");
+    await user.clear(editable[5]);
+    await user.type(editable[5], "mm");
 
     // Number-type Min/Max/Default inputs are rendered as type="number"
     const numberInputs = container.querySelectorAll(
@@ -314,20 +347,22 @@ describe("Adding properties inside the type", () => {
     ) as NodeListOf<HTMLInputElement>;
     // Min, Max, Default
     expect(numberInputs.length).toBe(3);
-    fireEvent.change(numberInputs[0], { target: { value: "1" } });
-    fireEvent.change(numberInputs[1], { target: { value: "500" } });
-    fireEvent.change(numberInputs[2], { target: { value: "25" } });
+    await user.clear(numberInputs[0]);
+    await user.type(numberInputs[0], "1");
+    await user.clear(numberInputs[1]);
+    await user.type(numberInputs[1], "500");
+    await user.clear(numberInputs[2]);
+    await user.type(numberInputs[2], "25");
 
     // Apply
-    fireEvent.click(screen.getByText(/^Apply$/));
+    await user.click(screen.getByText(/^Apply$/));
 
     // Property row should now show in the outer dialog
     expect(screen.getByText(/diameter_mm/)).toBeDefined();
     expect(screen.getByText(/Properties \(1\)/)).toBeDefined();
 
     // Save the type
-    clickSave();
-    await flushMicrotasks();
+    await clickSave(user);
 
     expect(mockCreate).toHaveBeenCalledTimes(1);
     const payload = mockCreate.mock.calls[0][0];
@@ -346,28 +381,35 @@ describe("Adding properties inside the type", () => {
   });
 
   it("adds two properties; deletes the first; Save payload has only the survivor", async () => {
+    const user = userEvent.setup();
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
+    await user.click(screen.getByRole("button", { name: /New Type/i }));
 
     const firstEditable = editableTextInputs(container);
-    fireEvent.change(firstEditable[0], { target: { value: "multi" } });
-    fireEvent.change(firstEditable[1], { target: { value: "Multi" } });
+    await user.clear(firstEditable[0]);
+    await user.type(firstEditable[0], "multi");
+    await user.clear(firstEditable[1]);
+    await user.type(firstEditable[1], "Multi");
 
     // Add property #1 ("alpha")
-    fireEvent.click(screen.getByText(/^Property$/));
+    await user.click(screen.getByText(/^Property$/));
     let editable = editableTextInputs(container);
-    fireEvent.change(editable[3], { target: { value: "alpha" } });
-    fireEvent.change(editable[4], { target: { value: "Alpha" } });
-    fireEvent.click(screen.getByText(/^Apply$/));
+    await user.clear(editable[3]);
+    await user.type(editable[3], "alpha");
+    await user.clear(editable[4]);
+    await user.type(editable[4], "Alpha");
+    await user.click(screen.getByText(/^Apply$/));
 
     // Add property #2 ("beta")
-    fireEvent.click(screen.getByText(/^Property$/));
+    await user.click(screen.getByText(/^Property$/));
     editable = editableTextInputs(container);
-    fireEvent.change(editable[3], { target: { value: "beta" } });
-    fireEvent.change(editable[4], { target: { value: "Beta" } });
-    fireEvent.click(screen.getByText(/^Apply$/));
+    await user.clear(editable[3]);
+    await user.type(editable[3], "beta");
+    await user.clear(editable[4]);
+    await user.type(editable[4], "Beta");
+    await user.click(screen.getByText(/^Apply$/));
 
     expect(screen.getByText(/Properties \(2\)/)).toBeDefined();
 
@@ -377,40 +419,44 @@ describe("Adding properties inside the type", () => {
     const deleteBtn = within(alphaRow as HTMLElement).getByTitle(
       /Delete property/i,
     );
-    fireEvent.click(deleteBtn);
+    await user.click(deleteBtn);
 
     expect(screen.getByText(/Properties \(1\)/)).toBeDefined();
     expect(screen.queryByText("alpha")).toBeNull();
 
     // Save
-    clickSave();
-    await flushMicrotasks();
+    await clickSave(user);
 
     const payload = mockCreate.mock.calls[0][0];
     expect(payload.schema).toHaveLength(1);
     expect(payload.schema[0].name).toBe("beta");
   });
 
-  it("PropertyEditDialog validation blocks Apply: enum with no options", () => {
+  it("PropertyEditDialog validation blocks Apply: enum with no options", async () => {
+    const user = userEvent.setup();
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
+    await user.click(screen.getByRole("button", { name: /New Type/i }));
     const first = editableTextInputs(container);
-    fireEvent.change(first[0], { target: { value: "enum_t" } });
-    fireEvent.change(first[1], { target: { value: "Enum T" } });
+    await user.clear(first[0]);
+    await user.type(first[0], "enum_t");
+    await user.clear(first[1]);
+    await user.type(first[1], "Enum T");
 
-    fireEvent.click(screen.getByText(/^Property$/));
+    await user.click(screen.getByText(/^Property$/));
     const editable = editableTextInputs(container);
-    fireEvent.change(editable[3], { target: { value: "color" } });
-    fireEvent.change(editable[4], { target: { value: "Color" } });
+    await user.clear(editable[3]);
+    await user.type(editable[3], "color");
+    await user.clear(editable[4]);
+    await user.type(editable[4], "Color");
 
     // Switch type to enum
     const select = container.querySelector("select") as HTMLSelectElement;
-    fireEvent.change(select, { target: { value: "enum" } });
+    await user.selectOptions(select, "enum");
 
     // Click Apply with empty options CSV
-    fireEvent.click(screen.getByText(/^Apply$/));
+    await user.click(screen.getByText(/^Apply$/));
 
     // Property-row list must still show 0 properties, inline error shown
     expect(screen.getByText(/Enum needs at least one option/i)).toBeDefined();
@@ -425,19 +471,22 @@ describe("Adding properties inside the type", () => {
 
 describe("Backend error propagation on Save", () => {
   it("409 conflict: error is shown, dialog stays open, form preserved", async () => {
+    const user = userEvent.setup();
     mockCreate.mockRejectedValueOnce(
       new Error("Type with name 'dup' already exists."),
     );
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
+    await user.click(screen.getByRole("button", { name: /New Type/i }));
 
     const editable = editableTextInputs(container);
-    fireEvent.change(editable[0], { target: { value: "dup" } });
-    fireEvent.change(editable[1], { target: { value: "Dup" } });
+    await user.clear(editable[0]);
+    await user.type(editable[0], "dup");
+    await user.clear(editable[1]);
+    await user.type(editable[1], "Dup");
 
-    clickSave();
+    await clickSave(user);
 
     // Error is surfaced (waitFor — the rejected promise settles on a later tick)
     await waitFor(() => {
@@ -457,18 +506,21 @@ describe("Backend error propagation on Save", () => {
   });
 
   it("422 validation: message passes through unchanged", async () => {
+    const user = userEvent.setup();
     mockCreate.mockRejectedValueOnce(
       new Error("Ungültige Eingabedaten"),
     );
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
+    await user.click(screen.getByRole("button", { name: /New Type/i }));
     const editable = editableTextInputs(container);
-    fireEvent.change(editable[0], { target: { value: "t_x" } });
-    fireEvent.change(editable[1], { target: { value: "T X" } });
+    await user.clear(editable[0]);
+    await user.type(editable[0], "t_x");
+    await user.clear(editable[1]);
+    await user.type(editable[1], "T X");
 
-    clickSave();
+    await clickSave(user);
 
     await waitFor(() => {
       expect(screen.getByText(/Ungültige Eingabedaten/)).toBeDefined();
@@ -476,25 +528,28 @@ describe("Backend error propagation on Save", () => {
   });
 
   it("after a failed save, the user can retry: second call made on second Save", async () => {
+    const user = userEvent.setup();
     mockCreate
       .mockRejectedValueOnce(new Error("boom"))
       .mockResolvedValueOnce({ id: 5, name: "retry_me" });
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
+    await user.click(screen.getByRole("button", { name: /New Type/i }));
     const editable = editableTextInputs(container);
-    fireEvent.change(editable[0], { target: { value: "retry_me" } });
-    fireEvent.change(editable[1], { target: { value: "Retry" } });
+    await user.clear(editable[0]);
+    await user.type(editable[0], "retry_me");
+    await user.clear(editable[1]);
+    await user.type(editable[1], "Retry");
 
-    clickSave();
+    await clickSave(user);
     await waitFor(() => {
       expect(screen.getByText(/boom/)).toBeDefined();
     });
     expect(mockCreate).toHaveBeenCalledTimes(1);
 
     // Click Save again — this time it succeeds
-    clickSave();
+    await clickSave(user);
     await waitFor(() => {
       expect(mockCreate).toHaveBeenCalledTimes(2);
     });
@@ -531,11 +586,12 @@ describe("Edit existing type (not new)", () => {
     };
   });
 
-  it("opens with pre-filled values; Name is disabled (immutable)", () => {
+  it("opens with pre-filled values; Name is disabled (immutable)", async () => {
+    const user = userEvent.setup();
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByTitle(/Edit Carbon Tube/i));
+    await user.click(screen.getByTitle(/Edit Carbon Tube/i));
 
     // Name input should be disabled
     const nameInput = container.querySelector(
@@ -556,19 +612,20 @@ describe("Edit existing type (not new)", () => {
   });
 
   it("Save on an existing type calls updateComponentType(id, payload) — not create", async () => {
+    const user = userEvent.setup();
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByTitle(/Edit Carbon Tube/i));
+    await user.click(screen.getByTitle(/Edit Carbon Tube/i));
 
     // Update the label and description
     const labelInput = container.querySelector(
       'input[value="Carbon Tube"]',
     ) as HTMLInputElement;
-    fireEvent.change(labelInput, { target: { value: "Carbon Tube v2" } });
+    await user.clear(labelInput);
+    await user.type(labelInput, "Carbon Tube v2");
 
-    clickSave();
-    await flushMicrotasks();
+    await clickSave(user);
 
     expect(mockCreate).not.toHaveBeenCalled();
     expect(mockUpdate).toHaveBeenCalledTimes(1);
@@ -580,21 +637,22 @@ describe("Edit existing type (not new)", () => {
   });
 
   it("delete button inside edit dialog opens confirm → Confirm calls deleteComponentType(id)", async () => {
+    const user = userEvent.setup();
     render(<ComponentTypeManagementDialog open={true} onClose={vi.fn()} />);
-    fireEvent.click(screen.getByTitle(/Edit Carbon Tube/i));
+    await user.click(screen.getByTitle(/Edit Carbon Tube/i));
 
     // Delete-type button is visible because deletable=true AND ref_count=0
-    fireEvent.click(screen.getByTitle(/Delete type/i));
+    await user.click(screen.getByTitle(/Delete type/i));
 
     // Confirmation shows a Confirm button
-    fireEvent.click(screen.getByText(/^Confirm$/));
-    await flushMicrotasks();
+    await user.click(screen.getByText(/^Confirm$/));
 
     expect(mockDelete).toHaveBeenCalledTimes(1);
     expect(mockDelete).toHaveBeenCalledWith(42);
   });
 
-  it("seeded type: delete-type button is not rendered in the edit dialog", () => {
+  it("seeded type: delete-type button is not rendered in the edit dialog", async () => {
+    const user = userEvent.setup();
     hookReturn = {
       types: [{ ...existingType, id: 1, name: "material", label: "Material", deletable: false }],
       isLoading: false,
@@ -602,12 +660,13 @@ describe("Edit existing type (not new)", () => {
       error: null,
     };
     render(<ComponentTypeManagementDialog open={true} onClose={vi.fn()} />);
-    fireEvent.click(screen.getByTitle(/Edit Material/i));
+    await user.click(screen.getByTitle(/Edit Material/i));
 
     expect(screen.queryByTitle(/Delete type/i)).toBeNull();
   });
 
-  it("referenced type: delete-type button is not rendered in the edit dialog", () => {
+  it("referenced type: delete-type button is not rendered in the edit dialog", async () => {
+    const user = userEvent.setup();
     hookReturn = {
       types: [{ ...existingType, reference_count: 5 }],
       isLoading: false,
@@ -615,7 +674,7 @@ describe("Edit existing type (not new)", () => {
       error: null,
     };
     render(<ComponentTypeManagementDialog open={true} onClose={vi.fn()} />);
-    fireEvent.click(screen.getByTitle(/Edit Carbon Tube/i));
+    await user.click(screen.getByTitle(/Edit Carbon Tube/i));
 
     expect(screen.queryByTitle(/Delete type/i)).toBeNull();
   });
@@ -626,16 +685,19 @@ describe("Edit existing type (not new)", () => {
 // ----------------------------------------------------------------------- //
 
 describe("Cancel / dismiss paths", () => {
-  it("Cancel button in Edit dialog closes it without calling any CRUD", () => {
+  it("Cancel button in Edit dialog closes it without calling any CRUD", async () => {
+    const user = userEvent.setup();
     const { container } = render(
       <ComponentTypeManagementDialog open={true} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
+    await user.click(screen.getByRole("button", { name: /New Type/i }));
 
     // Type something so we can verify Cancel really drops it
     const editable = editableTextInputs(container);
-    fireEvent.change(editable[0], { target: { value: "throwaway" } });
-    fireEvent.change(editable[1], { target: { value: "Throwaway" } });
+    await user.clear(editable[0]);
+    await user.type(editable[0], "throwaway");
+    await user.clear(editable[1]);
+    await user.type(editable[1], "Throwaway");
 
     // Edit dialog has a "Cancel" button (so does the outer, for the mgmt
     // dialog itself). Target the Cancel that is a sibling of the Save inside
@@ -643,7 +705,7 @@ describe("Cancel / dismiss paths", () => {
     const saveBtn = screen.getByText(/^Save$/);
     const card = saveBtn.closest("div")?.parentElement as HTMLElement;
     const cancelInsideEdit = within(card).getByText(/^Cancel$/);
-    fireEvent.click(cancelInsideEdit);
+    await user.click(cancelInsideEdit);
 
     expect(mockCreate).not.toHaveBeenCalled();
     expect(mockUpdate).not.toHaveBeenCalled();

--- a/frontend/__tests__/ComponentTypeManagementDialog.test.tsx
+++ b/frontend/__tests__/ComponentTypeManagementDialog.test.tsx
@@ -7,7 +7,8 @@
  * user types with references.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 vi.mock("lucide-react", () => {
@@ -117,14 +118,16 @@ describe("ComponentTypeManagementDialog", () => {
     expect(btn.disabled).toBe(false);
   });
 
-  it("'+ New Type' button opens the Edit dialog with an empty type", () => {
+  it("'+ New Type' button opens the Edit dialog with an empty type", async () => {
+    const user = userEvent.setup();
     render(<ComponentTypeManagementDialog open={true} onClose={vi.fn()} />);
-    fireEvent.click(screen.getByRole("button", { name: /New Type/i }));
+    await user.click(screen.getByRole("button", { name: /New Type/i }));
     // The Edit dialog has its own title "Edit Type" or "New Type"
     expect(screen.getByText(/New Type:/i)).toBeDefined();
   });
 
-  it("pencil icon on a row opens the Edit dialog with that type", () => {
+  it("pencil icon on a row opens the Edit dialog with that type", async () => {
+    const user = userEvent.setup();
     typesReturn = {
       types: [
         makeType({ id: 1, name: "material", label: "Material", deletable: false }),
@@ -132,7 +135,7 @@ describe("ComponentTypeManagementDialog", () => {
       isLoading: false, mutate: vi.fn(),
     };
     render(<ComponentTypeManagementDialog open={true} onClose={vi.fn()} />);
-    fireEvent.click(screen.getByTitle(/Edit Material/i));
+    await user.click(screen.getByTitle(/Edit Material/i));
     expect(screen.getByText(/Edit Type: Material/i)).toBeDefined();
   });
 
@@ -152,10 +155,11 @@ describe("ComponentTypeManagementDialog", () => {
     expect(screen.getByText(/404/)).toBeDefined();
   });
 
-  it("Close button calls onClose", () => {
+  it("Close button calls onClose", async () => {
+    const user = userEvent.setup();
     const onClose = vi.fn();
     render(<ComponentTypeManagementDialog open={true} onClose={onClose} />);
-    fireEvent.click(screen.getByText(/^Close$/));
+    await user.click(screen.getByText(/^Close$/));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/__tests__/ComponentsPage.test.tsx
+++ b/frontend/__tests__/ComponentsPage.test.tsx
@@ -9,7 +9,8 @@
  * the WorkbenchTwoPanel (e.g. as a sibling via Fragment or via a portal).
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 // ── Mocks ─────────────────────────────────────────────────────────
@@ -110,10 +111,11 @@ describe("ComponentsPage — '+ New Component' dialog", () => {
   });
 
   it("opens the create dialog when '+ New Component' is clicked", async () => {
+    const user = userEvent.setup();
     const { container } = render(<ComponentsPage />);
 
     const button = screen.getByText("New Component");
-    fireEvent.click(button);
+    await user.click(button);
 
     // The ComponentEditDialog should now be mounted and open
     await waitFor(() => {
@@ -124,9 +126,10 @@ describe("ComponentsPage — '+ New Component' dialog", () => {
   });
 
   it("closes the dialog when Cancel is clicked", async () => {
+    const user = userEvent.setup();
     const { container } = render(<ComponentsPage />);
 
-    fireEvent.click(screen.getByText("New Component"));
+    await user.click(screen.getByText("New Component"));
 
     await waitFor(() => {
       const editDialog = container.querySelector('dialog[aria-label="New Component"]');
@@ -138,7 +141,7 @@ describe("ComponentsPage — '+ New Component' dialog", () => {
     // Find the Cancel button specifically
     const allBtns = editDialog?.querySelectorAll("button") ?? [];
     const cancelButton = Array.from(allBtns).find((b) => b.textContent === "Cancel");
-    fireEvent.click(cancelButton!);
+    await user.click(cancelButton!);
 
     // The dialog should unmount because the parent uses conditional rendering
     await waitFor(() => {

--- a/frontend/__tests__/ConstructionPartPickerDialog.test.tsx
+++ b/frontend/__tests__/ConstructionPartPickerDialog.test.tsx
@@ -7,7 +7,8 @@
  * `cad_shape` tree node with `construction_part_id` set (N1 wiring).
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 vi.mock("lucide-react", () => {
@@ -118,7 +119,8 @@ describe("ConstructionPartPickerDialog", () => {
     expect(screen.getByText("Frame-B")).toBeDefined();
   });
 
-  it("calls onSelect with the part on row click and closes", () => {
+  it("calls onSelect with the part on row click and closes", async () => {
+    const user = userEvent.setup();
     partsReturnValue = {
       parts: [
         { id: 42, name: "MyPart", volume_mm3: 500, area_mm2: 50, locked: false, material_component_id: null, file_format: "stl" },
@@ -136,14 +138,15 @@ describe("ConstructionPartPickerDialog", () => {
         onSelect={onSelect}
       />,
     );
-    fireEvent.click(screen.getByText("MyPart"));
+    await user.click(screen.getByText("MyPart"));
     expect(onSelect).toHaveBeenCalledWith(
       expect.objectContaining({ id: 42, name: "MyPart" }),
     );
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("closes on Cancel", () => {
+  it("closes on Cancel", async () => {
+    const user = userEvent.setup();
     const onClose = vi.fn();
     render(
       <ConstructionPartPickerDialog
@@ -153,11 +156,12 @@ describe("ConstructionPartPickerDialog", () => {
         onSelect={vi.fn()}
       />,
     );
-    fireEvent.click(screen.getByText("Cancel"));
+    await user.click(screen.getByText("Cancel"));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("filters by search", () => {
+  it("filters by search", async () => {
+    const user = userEvent.setup();
     partsReturnValue = {
       parts: [
         { id: 1, name: "Bulkhead", volume_mm3: 100, area_mm2: 10, locked: false, material_component_id: null, file_format: "step" },
@@ -175,7 +179,8 @@ describe("ConstructionPartPickerDialog", () => {
       />,
     );
     const input = screen.getByPlaceholderText(/search/i) as HTMLInputElement;
-    fireEvent.change(input, { target: { value: "bulk" } });
+    await user.clear(input);
+    await user.type(input, "bulk");
     expect(screen.getByText("Bulkhead")).toBeDefined();
     expect(screen.queryByText("Frame")).toBeNull();
   });

--- a/frontend/__tests__/ConstructionPartUploadDialog.test.tsx
+++ b/frontend/__tests__/ConstructionPartUploadDialog.test.tsx
@@ -5,7 +5,8 @@
  * Name is required; file is required; material is optional.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 vi.mock("lucide-react", () => {
@@ -88,6 +89,7 @@ describe("ConstructionPartUploadDialog", () => {
   });
 
   it("posts FormData with name + file on submit", async () => {
+    const user = userEvent.setup();
     const onSaved = vi.fn();
     const onClose = vi.fn();
     const { container } = render(
@@ -100,14 +102,14 @@ describe("ConstructionPartUploadDialog", () => {
     );
 
     const nameInput = container.querySelector('input[type="text"]') as HTMLInputElement;
-    fireEvent.change(nameInput, { target: { value: "My Part" } });
+    await user.clear(nameInput);
+    await user.type(nameInput, "My Part");
 
     const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
     const file = new File([new Uint8Array([1, 2, 3])], "part.stl", { type: "application/octet-stream" });
-    Object.defineProperty(fileInput, "files", { value: [file] });
-    fireEvent.change(fileInput);
+    await user.upload(fileInput, file);
 
-    fireEvent.click(screen.getByText(/Upload/i, { selector: "button" }));
+    await user.click(screen.getByText(/Upload/i, { selector: "button" }));
 
     // FormData equality is tricky — check positional args + instance type.
     expect(mockUpload).toHaveBeenCalled();
@@ -115,7 +117,8 @@ describe("ConstructionPartUploadDialog", () => {
     expect(mockUpload.mock.calls[0][1]).toBeInstanceOf(FormData);
   });
 
-  it("auto-fills the Name field from the filename (without suffix) when Name is empty", () => {
+  it("auto-fills the Name field from the filename (without suffix) when Name is empty", async () => {
+    const user = userEvent.setup();
     const { container } = render(
       <ConstructionPartUploadDialog
         open={true}
@@ -131,13 +134,13 @@ describe("ConstructionPartUploadDialog", () => {
     expect(nameInput.value).toBe("");
 
     const file = new File([new Uint8Array([1, 2, 3])], "Bulkhead-A.step", { type: "application/octet-stream" });
-    Object.defineProperty(fileInput, "files", { value: [file] });
-    fireEvent.change(fileInput);
+    await user.upload(fileInput, file);
 
     expect(nameInput.value).toBe("Bulkhead-A");
   });
 
-  it("auto-fill strips a double extension only to the last suffix", () => {
+  it("auto-fill strips a double extension only to the last suffix", async () => {
+    const user = userEvent.setup();
     const { container } = render(
       <ConstructionPartUploadDialog
         open={true}
@@ -150,13 +153,13 @@ describe("ConstructionPartUploadDialog", () => {
     const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
 
     const file = new File([new Uint8Array([1])], "part.v2.stl", { type: "application/octet-stream" });
-    Object.defineProperty(fileInput, "files", { value: [file] });
-    fireEvent.change(fileInput);
+    await user.upload(fileInput, file);
 
     expect(nameInput.value).toBe("part.v2");
   });
 
-  it("does NOT overwrite the Name field when the user has already typed something", () => {
+  it("does NOT overwrite the Name field when the user has already typed something", async () => {
+    const user = userEvent.setup();
     const { container } = render(
       <ConstructionPartUploadDialog
         open={true}
@@ -169,18 +172,19 @@ describe("ConstructionPartUploadDialog", () => {
     const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
 
     // User types a custom name first.
-    fireEvent.change(nameInput, { target: { value: "MyCustomName" } });
+    await user.clear(nameInput);
+    await user.type(nameInput, "MyCustomName");
     expect(nameInput.value).toBe("MyCustomName");
 
     // Then picks a file — the custom name must be preserved.
     const file = new File([new Uint8Array([1])], "some-file.step", { type: "application/octet-stream" });
-    Object.defineProperty(fileInput, "files", { value: [file] });
-    fireEvent.change(fileInput);
+    await user.upload(fileInput, file);
 
     expect(nameInput.value).toBe("MyCustomName");
   });
 
-  it("auto-fill re-engages if the user clears the Name and then picks another file", () => {
+  it("auto-fill re-engages if the user clears the Name and then picks another file", async () => {
+    const user = userEvent.setup();
     const { container } = render(
       <ConstructionPartUploadDialog
         open={true}
@@ -194,19 +198,18 @@ describe("ConstructionPartUploadDialog", () => {
 
     // First file -> auto-fill "First".
     const f1 = new File([new Uint8Array([1])], "First.step");
-    Object.defineProperty(fileInput, "files", { value: [f1], configurable: true });
-    fireEvent.change(fileInput);
+    await user.upload(fileInput, f1);
     expect(nameInput.value).toBe("First");
 
     // User wipes the name, then picks another file.
-    fireEvent.change(nameInput, { target: { value: "" } });
+    await user.clear(nameInput);
     const f2 = new File([new Uint8Array([1])], "Second.stl");
-    Object.defineProperty(fileInput, "files", { value: [f2], configurable: true });
-    fireEvent.change(fileInput);
+    await user.upload(fileInput, f2);
     expect(nameInput.value).toBe("Second");
   });
 
-  it("closes on Cancel", () => {
+  it("closes on Cancel", async () => {
+    const user = userEvent.setup();
     const onClose = vi.fn();
     render(
       <ConstructionPartUploadDialog
@@ -216,7 +219,7 @@ describe("ConstructionPartUploadDialog", () => {
         onSaved={vi.fn()}
       />,
     );
-    fireEvent.click(screen.getByText("Cancel"));
+    await user.click(screen.getByText("Cancel"));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/__tests__/ConstructionPartsGrid.test.tsx
+++ b/frontend/__tests__/ConstructionPartsGrid.test.tsx
@@ -7,7 +7,8 @@
  * part is locked — we surface that as a blocked button + tooltip.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 vi.mock("lucide-react", () => {
@@ -74,6 +75,7 @@ describe("ConstructionPartsGrid", () => {
   });
 
   it("lock-toggle calls the correct API (lock on unlocked, unlock on locked)", async () => {
+    const user = userEvent.setup();
     partsReturn = {
       parts: [
         { id: 1, name: "P1", volume_mm3: 100, area_mm2: 10, locked: false, material_component_id: null, file_format: "step", thumbnail_url: null },
@@ -83,11 +85,12 @@ describe("ConstructionPartsGrid", () => {
     render(<ConstructionPartsGrid aeroplaneId="a" onRequestUpload={vi.fn()} />);
 
     const lockBtn = screen.getByTitle("Lock part");
-    fireEvent.click(lockBtn);
+    await user.click(lockBtn);
     expect(mockLock).toHaveBeenCalledWith("a", 1);
   });
 
   it("delete asks for confirmation via modal and fires delete on confirm", async () => {
+    const user = userEvent.setup();
     partsReturn = {
       parts: [
         { id: 5, name: "Doomed", volume_mm3: 100, area_mm2: 10, locked: false, material_component_id: null, file_format: "step", thumbnail_url: null },
@@ -97,11 +100,11 @@ describe("ConstructionPartsGrid", () => {
     render(<ConstructionPartsGrid aeroplaneId="a" onRequestUpload={vi.fn()} />);
 
     // First click opens the modal
-    fireEvent.click(screen.getByTitle("Delete part"));
+    await user.click(screen.getByTitle("Delete part"));
     expect(screen.getByText(/Delete "Doomed"/i)).toBeDefined();
 
     // Confirm fires the API
-    fireEvent.click(screen.getByText(/Confirm/i));
+    await user.click(screen.getByText(/Confirm/i));
     expect(mockDelete).toHaveBeenCalledWith("a", 5);
   });
 
@@ -118,10 +121,11 @@ describe("ConstructionPartsGrid", () => {
     expect(btn.disabled).toBe(true);
   });
 
-  it("upload button calls onRequestUpload (parent opens the dialog)", () => {
+  it("upload button calls onRequestUpload (parent opens the dialog)", async () => {
+    const user = userEvent.setup();
     const onReq = vi.fn();
     render(<ConstructionPartsGrid aeroplaneId="a" onRequestUpload={onReq} />);
-    fireEvent.click(screen.getByText(/Upload Part/i));
+    await user.click(screen.getByText(/Upload Part/i));
     expect(onReq).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/__tests__/ConstructionPlansPage.test.tsx
+++ b/frontend/__tests__/ConstructionPlansPage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 // ── Mocks ─────────────────────────────────────────────────────────
@@ -243,11 +244,12 @@ describe("ConstructionPlansPage", () => {
   });
 
   it("shows template-specific actions after selecting a template in template mode", async () => {
+    const user = userEvent.setup();
     render(<ConstructionPlansPage />);
-    fireEvent.click(screen.getByText("Templates"));
+    await user.click(screen.getByText("Templates"));
     // Open the TemplateSelector dropdown and click "eHawk Wing"
-    fireEvent.click(screen.getByRole("combobox"));
-    fireEvent.click(screen.getByText("eHawk Wing"));
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByText("eHawk Wing"));
     // After selection, the TemplateModePanel renders the template-specific
     // toolbar: "Execute template against an aeroplane" (Play),
     // "Delete eHawk Wing" (Trash), and "Add step to eHawk Wing" (Plus).
@@ -272,15 +274,16 @@ describe("ConstructionPlansPage", () => {
   });
 
   it("creates a new plan via NewPlanDialog when '+' is clicked in plans mode", async () => {
+    const user = userEvent.setup();
     render(<ConstructionPlansPage />);
     // The TreeCard "+" header button (title="Create new plan") opens
     // NewPlanDialog. The dialog offers an "Empty plan" choice that
     // delegates to handleCreateEmptyPlan → createPlan({plan_type: "plan"}).
-    fireEvent.click(screen.getByTitle("Create new plan"));
+    await user.click(screen.getByTitle("Create new plan"));
     // Dialog renders with aria-label="Create new plan"
     const dialog = await screen.findByRole("dialog", { name: "Create new plan" });
     expect(dialog).toBeDefined();
-    fireEvent.click(screen.getByText("Empty plan"));
+    await user.click(screen.getByText("Empty plan"));
     await waitFor(() => {
       expect(mockCreatePlan).toHaveBeenCalledWith(
         expect.objectContaining({ plan_type: "plan", aeroplane_id: "aero-1" }),
@@ -289,13 +292,14 @@ describe("ConstructionPlansPage", () => {
   });
 
   it("opens AeroplanePickerDialog when executing a template", async () => {
+    const user = userEvent.setup();
     render(<ConstructionPlansPage />);
-    fireEvent.click(screen.getByText("Templates"));
-    fireEvent.click(screen.getByRole("combobox"));
-    fireEvent.click(screen.getByText("eHawk Wing"));
+    await user.click(screen.getByText("Templates"));
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByText("eHawk Wing"));
     // Click "Execute template against an aeroplane" — opens
     // AeroplanePickerDialog (gh-323).
-    fireEvent.click(
+    await user.click(
       await screen.findByTitle("Execute template against an aeroplane"),
     );
     const dialog = await screen.findByRole("dialog", {
@@ -322,13 +326,14 @@ describe("ConstructionPlansPage", () => {
   });
 
   it("starts streaming execution when Execute is clicked in plans mode", async () => {
+    const user = userEvent.setup();
     render(<ConstructionPlansPage />);
     // Plans mode is the default. Clicking the per-plan Play icon
     // (title="Execute <plan-name>") triggers handleExecutePlan which
     // builds a streaming URL via executeStreamUrl(aeroplaneId, planId)
     // and opens the ExecutionResultDialog with that streamUrl.
     const executeButton = await screen.findByTitle("Execute eHawk Build");
-    fireEvent.click(executeButton);
+    await user.click(executeButton);
 
     // The contract: the page asks for the streaming URL with the
     // active aeroplane id and the clicked plan id.

--- a/frontend/__tests__/CotsPickerDialog.test.tsx
+++ b/frontend/__tests__/CotsPickerDialog.test.tsx
@@ -3,7 +3,8 @@
  * the Component Library and reports the chosen ID back (gh#57-40g).
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 vi.mock("lucide-react", () => {
@@ -101,7 +102,8 @@ describe("CotsPickerDialog", () => {
     expect(screen.getByText("Sunnysky A2212")).toBeDefined();
   });
 
-  it("calls onSelect with the component ID and closes on pick", () => {
+  it("calls onSelect with the component ID and closes on pick", async () => {
+    const user = userEvent.setup();
     componentsReturnValue = {
       components: [
         { id: 42, name: "KST X08", component_type: "servo", manufacturer: "KST", mass_g: 7, specs: {} },
@@ -120,14 +122,15 @@ describe("CotsPickerDialog", () => {
       />,
     );
 
-    fireEvent.click(screen.getByText("KST X08"));
+    await user.click(screen.getByText("KST X08"));
     expect(onSelect).toHaveBeenCalledWith(
       expect.objectContaining({ id: 42, name: "KST X08" }),
     );
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("closes on Cancel click", () => {
+  it("closes on Cancel click", async () => {
+    const user = userEvent.setup();
     const onClose = vi.fn();
     render(
       <CotsPickerDialog
@@ -137,7 +140,7 @@ describe("CotsPickerDialog", () => {
       />,
     );
 
-    fireEvent.click(screen.getByText("Cancel"));
+    await user.click(screen.getByText("Cancel"));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 

--- a/frontend/__tests__/CreatorGallery.test.tsx
+++ b/frontend/__tests__/CreatorGallery.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 vi.mock("lucide-react", () => {
@@ -61,28 +62,32 @@ describe("CreatorGallery", () => {
     expect(screen.getByText("Fuse2ShapesCreator")).toBeDefined();
   });
 
-  it("filters creators by search text", () => {
+  it("filters creators by search text", async () => {
+    const user = userEvent.setup();
     render(<CreatorGallery creators={MOCK_CREATORS} onSelect={vi.fn()} />);
     const input = screen.getByPlaceholderText("Search creators...");
-    fireEvent.change(input, { target: { value: "vase" } });
+    await user.clear(input);
+    await user.type(input, "vase");
     expect(screen.getByText("VaseModeWingCreator")).toBeDefined();
     expect(screen.queryByText("ExportToStepCreator")).toBeNull();
   });
 
-  it("filters creators by category tab", () => {
+  it("filters creators by category tab", async () => {
+    const user = userEvent.setup();
     render(<CreatorGallery creators={MOCK_CREATORS} onSelect={vi.fn()} />);
     const exportTab = screen.getAllByText("Export").find(
       (el) => el.tagName === "BUTTON" && !el.closest(".grid"),
     )!;
-    fireEvent.click(exportTab);
+    await user.click(exportTab);
     expect(screen.getByText("ExportToStepCreator")).toBeDefined();
     expect(screen.queryByText("VaseModeWingCreator")).toBeNull();
   });
 
-  it("calls onSelect when a creator card is clicked", () => {
+  it("calls onSelect when a creator card is clicked", async () => {
+    const user = userEvent.setup();
     const onSelect = vi.fn();
     render(<CreatorGallery creators={MOCK_CREATORS} onSelect={onSelect} />);
-    fireEvent.click(screen.getByText("VaseModeWingCreator"));
+    await user.click(screen.getByText("VaseModeWingCreator"));
     expect(onSelect).toHaveBeenCalledWith(MOCK_CREATORS[0]);
   });
 });

--- a/frontend/__tests__/EditParamsModal.test.tsx
+++ b/frontend/__tests__/EditParamsModal.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 import type { PlanStepNode } from "@/components/workbench/PlanTree";
 import type { CreatorInfo } from "@/hooks/useCreators";
@@ -173,7 +174,8 @@ describe("EditParamsModal — reset button", () => {
 });
 
 describe("EditParamsModal — dirty state transitions", () => {
-  it("typing into ID field sets dirty and blocks auto-derivation on param change", () => {
+  it("typing into ID field sets dirty and blocks auto-derivation on param change", async () => {
+    const user = userEvent.setup();
     const node = makeNode();
     const creator = makeCreatorInfo({ suggested_id: "wing_{span}" });
 
@@ -192,7 +194,8 @@ describe("EditParamsModal — dirty state transitions", () => {
     const idInput = screen.getByLabelText("ID") as HTMLInputElement;
 
     // Type into the ID field — should become dirty
-    fireEvent.change(idInput, { target: { value: "my-custom-id" } });
+    await user.clear(idInput);
+    await user.type(idInput, "my-custom-id");
     expect(idInput.value).toBe("my-custom-id");
 
     // Now change a param — ID should NOT auto-derive because dirty
@@ -225,7 +228,8 @@ describe("EditParamsModal — dirty state transitions", () => {
 });
 
 describe("EditParamsModal — reset behavior", () => {
-  it("clicking reset clears dirty and re-derives ID from template", () => {
+  it("clicking reset clears dirty and re-derives ID from template", async () => {
+    const user = userEvent.setup();
     const node = makeNode({ _creatorIdDirty: true });
     const creator = makeCreatorInfo({ suggested_id: "wing_{span}" });
 
@@ -243,12 +247,13 @@ describe("EditParamsModal — reset behavior", () => {
 
     const idInput = screen.getByLabelText("ID") as HTMLInputElement;
     // Type custom value
-    fireEvent.change(idInput, { target: { value: "custom-id" } });
+    await user.clear(idInput);
+    await user.type(idInput, "custom-id");
     expect(idInput.value).toBe("custom-id");
 
     // Click reset
     const resetBtn = screen.getByTitle("Reset to auto-derived ID");
-    fireEvent.click(resetBtn);
+    await user.click(resetBtn);
 
     // ID should be resolved from template with current param values
     // Default span=1000, so template "wing_{span}" → "wing_1000"
@@ -261,6 +266,7 @@ describe("EditParamsModal — reset behavior", () => {
 
 describe("EditParamsModal — save payload", () => {
   it("sends _creatorIdDirty: true when ID was manually edited", async () => {
+    const user = userEvent.setup();
     const onSave = vi.fn().mockResolvedValue(undefined);
     const node = makeNode();
     const creator = makeCreatorInfo({ suggested_id: "wing_{span}" });
@@ -278,10 +284,12 @@ describe("EditParamsModal — save payload", () => {
     );
 
     // Type into ID field to set dirty
-    fireEvent.change(screen.getByLabelText("ID"), { target: { value: "my-id" } });
+    const idInput = screen.getByLabelText("ID") as HTMLInputElement;
+    await user.clear(idInput);
+    await user.type(idInput, "my-id");
 
     // Click save
-    fireEvent.click(screen.getByText("Save"));
+    await user.click(screen.getByText("Save"));
     await vi.waitFor(() => expect(onSave).toHaveBeenCalled());
 
     const [path, params] = onSave.mock.calls[0];
@@ -291,6 +299,7 @@ describe("EditParamsModal — save payload", () => {
   });
 
   it("forwards pre-existing dirty flag on save without editing", async () => {
+    const user = userEvent.setup();
     const onSave = vi.fn().mockResolvedValue(undefined);
     const node = makeNode({ _creatorIdDirty: true });
     const creator = makeCreatorInfo({ suggested_id: "wing_{span}" });
@@ -308,7 +317,7 @@ describe("EditParamsModal — save payload", () => {
     );
 
     // Save without editing anything
-    fireEvent.click(screen.getByText("Save"));
+    await user.click(screen.getByText("Save"));
     await vi.waitFor(() => expect(onSave).toHaveBeenCalled());
 
     const [, params] = onSave.mock.calls[0];
@@ -316,6 +325,7 @@ describe("EditParamsModal — save payload", () => {
   });
 
   it("omits _creatorIdDirty after reset and save", async () => {
+    const user = userEvent.setup();
     const onSave = vi.fn().mockResolvedValue(undefined);
     const node = makeNode({ _creatorIdDirty: true });
     const creator = makeCreatorInfo({ suggested_id: "wing_{span}" });
@@ -334,10 +344,10 @@ describe("EditParamsModal — save payload", () => {
 
     // Click reset to clear dirty
     const resetBtn = screen.getByTitle("Reset to auto-derived ID");
-    fireEvent.click(resetBtn);
+    await user.click(resetBtn);
 
     // Save
-    fireEvent.click(screen.getByText("Save"));
+    await user.click(screen.getByText("Save"));
     await vi.waitFor(() => expect(onSave).toHaveBeenCalled());
 
     const [, params] = onSave.mock.calls[0];
@@ -345,6 +355,7 @@ describe("EditParamsModal — save payload", () => {
   });
 
   it("omits _creatorIdDirty when ID was not manually edited", async () => {
+    const user = userEvent.setup();
     const onSave = vi.fn().mockResolvedValue(undefined);
     const node = makeNode();
     const creator = makeCreatorInfo({ suggested_id: "wing_{span}" });
@@ -362,7 +373,7 @@ describe("EditParamsModal — save payload", () => {
     );
 
     // Save without editing ID
-    fireEvent.click(screen.getByText("Save"));
+    await user.click(screen.getByText("Save"));
     await vi.waitFor(() => expect(onSave).toHaveBeenCalled());
 
     const [, params] = onSave.mock.calls[0];

--- a/frontend/__tests__/FuselageTree.test.tsx
+++ b/frontend/__tests__/FuselageTree.test.tsx
@@ -2,7 +2,8 @@
  * Tests for fuselage support in AeroplaneTree + PropertyForm (GH#32).
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 // ── Mocks ──────────────────────────────────────────────────────
@@ -90,7 +91,8 @@ describe("Fuselage in AeroplaneTree", () => {
     expect(screen.getByText("FUSELAGE")).toBeDefined();
   });
 
-  it("calls selectFuselage on fuselage node click", () => {
+  it("calls selectFuselage on fuselage node click", async () => {
+    const user = userEvent.setup();
     render(
       <AeroplaneTree
         aeroplaneId="aero-1"
@@ -99,11 +101,12 @@ describe("Fuselage in AeroplaneTree", () => {
         aeroplaneName="eHawk"
       />
     );
-    fireEvent.click(screen.getByText("MyFuselage"));
+    await user.click(screen.getByText("MyFuselage"));
     expect(mockSelectFuselage).toHaveBeenCalledWith("MyFuselage");
   });
 
-  it("shows loading when expanded but data not loaded", () => {
+  it("shows loading when expanded but data not loaded", async () => {
+    const user = userEvent.setup();
     // selectedFuselage is set (simulating after click)
     ctxOverrides = { selectedFuselage: "MyFuselage" };
     fuselageReturnValue = { fuselage: null };
@@ -118,11 +121,12 @@ describe("Fuselage in AeroplaneTree", () => {
     );
 
     // Click to expand — toggles expandedSet via TreeRow onToggle
-    fireEvent.click(screen.getByText("MyFuselage"));
+    await user.click(screen.getByText("MyFuselage"));
     expect(screen.getByText(/loading/i)).toBeDefined();
   });
 
-  it("shows xsec nodes with a/b/n details when data loaded", () => {
+  it("shows xsec nodes with a/b/n details when data loaded", async () => {
+    const user = userEvent.setup();
     ctxOverrides = { selectedFuselage: "TestFuselage" };
     fuselageReturnValue = { fuselage: mockFuselageData };
 
@@ -136,7 +140,7 @@ describe("Fuselage in AeroplaneTree", () => {
     );
 
     // Click to expand
-    fireEvent.click(screen.getByText("TestFuselage"));
+    await user.click(screen.getByText("TestFuselage"));
 
     // 3 xsec nodes visible
     expect(screen.getByText("xsec 0")).toBeDefined();
@@ -147,7 +151,8 @@ describe("Fuselage in AeroplaneTree", () => {
     expect(screen.getByText("a=50.0mm b=40.0mm n=2.3")).toBeDefined();
   });
 
-  it("calls selectFuselageXsec when clicking an xsec", () => {
+  it("calls selectFuselageXsec when clicking an xsec", async () => {
+    const user = userEvent.setup();
     ctxOverrides = { selectedFuselage: "TestFuselage" };
     fuselageReturnValue = { fuselage: mockFuselageData };
 
@@ -160,13 +165,14 @@ describe("Fuselage in AeroplaneTree", () => {
       />
     );
 
-    fireEvent.click(screen.getByText("TestFuselage"));
-    fireEvent.click(screen.getByText("xsec 1"));
+    await user.click(screen.getByText("TestFuselage"));
+    await user.click(screen.getByText("xsec 1"));
 
     expect(mockSelectFuselageXsec).toHaveBeenCalledWith(1);
   });
 
-  it("highlights selected xsec", () => {
+  it("highlights selected xsec", async () => {
+    const user = userEvent.setup();
     ctxOverrides = {
       selectedFuselage: "TestFuselage",
       selectedFuselageXsecIndex: 1,
@@ -182,7 +188,7 @@ describe("Fuselage in AeroplaneTree", () => {
       />
     );
 
-    fireEvent.click(screen.getByText("TestFuselage"));
+    await user.click(screen.getByText("TestFuselage"));
 
     // xsec 1 should have selected styling (bg-sidebar-accent + font-semibold)
     const xsec1 = screen.getByText("xsec 1").closest("div");

--- a/frontend/__tests__/GroupAddMenu.test.tsx
+++ b/frontend/__tests__/GroupAddMenu.test.tsx
@@ -8,7 +8,8 @@
  *   3. "Assign Construction Part" — disabled until gh#57-wvg (D4) ships
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 vi.mock("lucide-react", () => {
@@ -56,7 +57,8 @@ describe("GroupAddMenu", () => {
     expect(screen.getByText(/avionics/)).toBeDefined();
   });
 
-  it("calls onNewGroup (but not onClose) when 'New Group' is clicked", () => {
+  it("calls onNewGroup (but not onClose) when 'New Group' is clicked", async () => {
+    const user = userEvent.setup();
     const onNewGroup = vi.fn();
     const onClose = vi.fn();
     render(
@@ -69,7 +71,7 @@ describe("GroupAddMenu", () => {
       />,
     );
 
-    fireEvent.click(screen.getByText("New Group"));
+    await user.click(screen.getByText("New Group"));
 
     // The parent is responsible for dismissing the menu (typically by
     // transitioning into another state); GroupAddMenu must NOT auto-close.
@@ -77,7 +79,8 @@ describe("GroupAddMenu", () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
-  it("calls onAssignCots (but not onClose) when 'Assign COTS Component' is clicked", () => {
+  it("calls onAssignCots (but not onClose) when 'Assign COTS Component' is clicked", async () => {
+    const user = userEvent.setup();
     const onAssignCots = vi.fn();
     const onClose = vi.fn();
     render(
@@ -90,13 +93,14 @@ describe("GroupAddMenu", () => {
       />,
     );
 
-    fireEvent.click(screen.getByText("Assign COTS Component"));
+    await user.click(screen.getByText("Assign COTS Component"));
 
     expect(onAssignCots).toHaveBeenCalledTimes(1);
     expect(onClose).not.toHaveBeenCalled();
   });
 
-  it("disables 'Assign Construction Part' when constructionPartsEnabled=false", () => {
+  it("disables 'Assign Construction Part' when constructionPartsEnabled=false", async () => {
+    const user = userEvent.setup();
     const onAssign = vi.fn();
     render(
       <GroupAddMenu
@@ -110,11 +114,12 @@ describe("GroupAddMenu", () => {
     );
 
     // Clicking the disabled item must not fire the callback
-    fireEvent.click(screen.getByText("Assign Construction Part"));
+    await user.click(screen.getByText("Assign Construction Part"));
     expect(onAssign).not.toHaveBeenCalled();
   });
 
-  it("calls onClose when the Escape key is pressed", () => {
+  it("calls onClose when the Escape key is pressed", async () => {
+    const user = userEvent.setup();
     const onClose = vi.fn();
     render(
       <GroupAddMenu
@@ -125,11 +130,12 @@ describe("GroupAddMenu", () => {
         onClose={onClose}
       />,
     );
-    fireEvent.keyDown(window, { key: "Escape", code: "Escape" });
+    await user.keyboard("{Escape}");
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("enables 'Assign Construction Part' when constructionPartsEnabled=true", () => {
+  it("enables 'Assign Construction Part' when constructionPartsEnabled=true", async () => {
+    const user = userEvent.setup();
     const onAssign = vi.fn();
     const onClose = vi.fn();
     render(
@@ -143,7 +149,7 @@ describe("GroupAddMenu", () => {
       />,
     );
 
-    fireEvent.click(screen.getByText("Assign Construction Part"));
+    await user.click(screen.getByText("Assign Construction Part"));
     expect(onAssign).toHaveBeenCalledTimes(1);
     expect(onClose).not.toHaveBeenCalled();
   });

--- a/frontend/__tests__/NodePropertyPanel.test.tsx
+++ b/frontend/__tests__/NodePropertyPanel.test.tsx
@@ -9,7 +9,8 @@
  * endpoint and is disabled when construction_part_id is not set.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 import type { ComponentTreeNode } from "@/hooks/useComponentTree";
 
@@ -166,6 +167,7 @@ describe("NodePropertyPanel — material dropdown", () => {
 
 describe("NodePropertyPanel — save", () => {
   it("Save posts the edited fields via updateTreeNode", async () => {
+    const user = userEvent.setup();
     const node = makeNode({ id: 7, node_type: "group", name: "old" });
     const onMutate = vi.fn();
     const { container } = render(
@@ -173,9 +175,10 @@ describe("NodePropertyPanel — save", () => {
     );
 
     const nameInput = container.querySelector('input[type="text"]') as HTMLInputElement;
-    fireEvent.change(nameInput, { target: { value: "renamed" } });
+    await user.clear(nameInput);
+    await user.type(nameInput, "renamed");
 
-    fireEvent.click(screen.getByText("Save"));
+    await user.click(screen.getByText("Save"));
 
     expect(mockUpdate).toHaveBeenCalledWith(
       "a",
@@ -196,16 +199,18 @@ describe("NodePropertyPanel — save", () => {
     expect(saveBtn.disabled).toBe(true);
   });
 
-  it("Cancel resets the form without calling the API", () => {
+  it("Cancel resets the form without calling the API", async () => {
+    const user = userEvent.setup();
     const node = makeNode({ id: 1, node_type: "group", name: "orig" });
     const { container } = render(
       <NodePropertyPanel node={node} aeroplaneId="a" onMutate={vi.fn()} onClose={vi.fn()} />,
     );
     const nameInput = container.querySelector('input[type="text"]') as HTMLInputElement;
 
-    fireEvent.change(nameInput, { target: { value: "edited" } });
+    await user.clear(nameInput);
+    await user.type(nameInput, "edited");
     expect(nameInput.value).toBe("edited");
-    fireEvent.click(screen.getByText("Cancel"));
+    await user.click(screen.getByText("Cancel"));
     expect(nameInput.value).toBe("orig");
     expect(mockUpdate).not.toHaveBeenCalled();
   });
@@ -216,17 +221,19 @@ describe("NodePropertyPanel — save", () => {
 // --------------------------------------------------------------------------- //
 
 describe("NodePropertyPanel — delete", () => {
-  it("opens a confirmation modal on Delete click", () => {
+  it("opens a confirmation modal on Delete click", async () => {
+    const user = userEvent.setup();
     const node = makeNode({ id: 5, name: "doomed" });
     render(
       <NodePropertyPanel node={node} aeroplaneId="a" onMutate={vi.fn()} onClose={vi.fn()} />,
     );
 
-    fireEvent.click(screen.getByTitle("Delete node"));
+    await user.click(screen.getByTitle("Delete node"));
     expect(screen.getByText(/Delete "doomed"/)).toBeDefined();
   });
 
   it("Confirm in the modal fires deleteTreeNode; Cancel does not", async () => {
+    const user = userEvent.setup();
     const node = makeNode({ id: 5, name: "doomed" });
     const onClose = vi.fn();
     const onMutate = vi.fn();
@@ -234,8 +241,8 @@ describe("NodePropertyPanel — delete", () => {
       <NodePropertyPanel node={node} aeroplaneId="a" onMutate={onMutate} onClose={onClose} />,
     );
 
-    fireEvent.click(screen.getByTitle("Delete node"));
-    fireEvent.click(screen.getByText(/Confirm/));
+    await user.click(screen.getByTitle("Delete node"));
+    await user.click(screen.getByText(/Confirm/));
     expect(mockDelete).toHaveBeenCalledWith("a", 5);
 
     // Reset: re-render, click delete, then Cancel in the modal — no delete.
@@ -245,12 +252,12 @@ describe("NodePropertyPanel — delete", () => {
     rerender(
       <NodePropertyPanel node={node} aeroplaneId="a" onMutate={onMutate} onClose={onClose} />,
     );
-    fireEvent.click(screen.getByTitle("Delete node"));
+    await user.click(screen.getByTitle("Delete node"));
     const modalCancel = screen
       .getAllByText("Cancel")
       .find((el) => el.closest("dialog") !== null) as HTMLElement;
     expect(modalCancel).toBeDefined();
-    fireEvent.click(modalCancel);
+    await user.click(modalCancel);
     expect(mockDelete).not.toHaveBeenCalled();
   });
 });
@@ -294,14 +301,15 @@ describe("NodePropertyPanel — lock toggle", () => {
     expect(screen.queryByTitle(/Lock/i)).toBeNull();
   });
 
-  it("Lock click fires lockConstructionPart with the FK", () => {
+  it("Lock click fires lockConstructionPart with the FK", async () => {
+    const user = userEvent.setup();
     const node = makeNode({ node_type: "cad_shape", name: "p" });
     (node as unknown as { construction_part_id: number }).construction_part_id = 42;
 
     render(
       <NodePropertyPanel node={node} aeroplaneId="a" onMutate={vi.fn()} onClose={vi.fn()} />,
     );
-    fireEvent.click(screen.getByTitle("Lock part"));
+    await user.click(screen.getByTitle("Lock part"));
     expect(mockLock).toHaveBeenCalledWith("a", 42);
   });
 });

--- a/frontend/__tests__/PropertyEditDialog.test.tsx
+++ b/frontend/__tests__/PropertyEditDialog.test.tsx
@@ -6,7 +6,8 @@
  * return the edited property to the parent via onSave.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 vi.mock("lucide-react", () => {
@@ -105,7 +106,8 @@ describe("PropertyEditDialog", () => {
     expect(screen.queryByText(/^Min/i)).toBeNull();
   });
 
-  it("rejects non-snake_case names with an inline error", () => {
+  it("rejects non-snake_case names with an inline error", async () => {
+    const user = userEvent.setup();
     const onSave = vi.fn();
     const { container } = render(
       <PropertyEditDialog
@@ -116,8 +118,9 @@ describe("PropertyEditDialog", () => {
       />,
     );
     const nameInput = container.querySelector('input[type="text"]') as HTMLInputElement;
-    fireEvent.change(nameInput, { target: { value: "BadName" } });
-    fireEvent.click(screen.getByText(/^Apply$/i));
+    await user.clear(nameInput);
+    await user.type(nameInput, "BadName");
+    await user.click(screen.getByText(/^Apply$/i));
     expect(onSave).not.toHaveBeenCalled();
     // Error message appears (we know the text mentions snake_case — we
     // assert by getAllByText since the label "Name (snake_case) *" also
@@ -125,7 +128,8 @@ describe("PropertyEditDialog", () => {
     expect(screen.getAllByText(/snake_case/i).length).toBeGreaterThanOrEqual(2);
   });
 
-  it("Apply calls onSave with the edited property", () => {
+  it("Apply calls onSave with the edited property", async () => {
+    const user = userEvent.setup();
     const onSave = vi.fn();
     const { container } = render(
       <PropertyEditDialog
@@ -136,10 +140,12 @@ describe("PropertyEditDialog", () => {
       />,
     );
     const inputs = container.querySelectorAll('input[type="text"]') as NodeListOf<HTMLInputElement>;
-    fireEvent.change(inputs[0], { target: { value: "torque_kg_cm" } });
-    fireEvent.change(inputs[1], { target: { value: "Drehmoment" } });
+    await user.clear(inputs[0]);
+    await user.type(inputs[0], "torque_kg_cm");
+    await user.clear(inputs[1]);
+    await user.type(inputs[1], "Drehmoment");
 
-    fireEvent.click(screen.getByText(/^Apply$/));
+    await user.click(screen.getByText(/^Apply$/));
     expect(onSave).toHaveBeenCalledWith(
       expect.objectContaining({
         name: "torque_kg_cm",
@@ -176,7 +182,8 @@ describe("PropertyEditDialog", () => {
     }
   });
 
-  it("Cancel calls onCancel without onSave", () => {
+  it("Cancel calls onCancel without onSave", async () => {
+    const user = userEvent.setup();
     const onSave = vi.fn();
     const onCancel = vi.fn();
     render(
@@ -187,7 +194,7 @@ describe("PropertyEditDialog", () => {
         onCancel={onCancel}
       />,
     );
-    fireEvent.click(screen.getByText(/^Cancel$/));
+    await user.click(screen.getByText(/^Cancel$/));
     expect(onCancel).toHaveBeenCalledTimes(1);
     expect(onSave).not.toHaveBeenCalled();
   });

--- a/frontend/__tests__/SegmentPaginator.test.tsx
+++ b/frontend/__tests__/SegmentPaginator.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 vi.mock("lucide-react", () => {
@@ -100,36 +101,32 @@ describe("SegmentPaginator", () => {
     });
 
     it("prev arrow calls onChange(current - 1)", async () => {
+      const user = userEvent.setup();
       render(<SegmentPaginator current={2} total={4} onChange={onChange} />);
-      await act(async () => {
-        fireEvent.click(screen.getByLabelText("Previous segment"));
-      });
+      await user.click(screen.getByLabelText("Previous segment"));
       expect(onChange).toHaveBeenCalledWith(1);
     });
 
     it("next arrow calls onChange(current + 1)", async () => {
+      const user = userEvent.setup();
       render(<SegmentPaginator current={1} total={4} onChange={onChange} />);
-      await act(async () => {
-        fireEvent.click(screen.getByLabelText("Next segment"));
-      });
+      await user.click(screen.getByLabelText("Next segment"));
       expect(onChange).toHaveBeenCalledWith(2);
     });
   });
 
   describe("index click", () => {
     it("calls onChange with clicked index", async () => {
+      const user = userEvent.setup();
       render(<SegmentPaginator current={0} total={4} onChange={onChange} />);
-      await act(async () => {
-        fireEvent.click(screen.getByRole("button", { name: "3" }));
-      });
+      await user.click(screen.getByRole("button", { name: "3" }));
       expect(onChange).toHaveBeenCalledWith(3);
     });
 
     it("does not call onChange when clicking current index", async () => {
+      const user = userEvent.setup();
       render(<SegmentPaginator current={2} total={4} onChange={onChange} />);
-      await act(async () => {
-        fireEvent.click(screen.getByRole("button", { name: "2" }));
-      });
+      await user.click(screen.getByRole("button", { name: "2" }));
       expect(onChange).not.toHaveBeenCalled();
     });
   });
@@ -142,15 +139,14 @@ describe("SegmentPaginator", () => {
     });
 
     it("all buttons disabled while onChange is in flight", async () => {
+      const user = userEvent.setup();
       let resolveOnChange: () => void;
       const slowChange = vi.fn<(n: number) => Promise<void>>(
         () => new Promise((r) => { resolveOnChange = r; }),
       );
       render(<SegmentPaginator current={1} total={4} onChange={slowChange} />);
 
-      await act(async () => {
-        fireEvent.click(screen.getByLabelText("Next segment"));
-      });
+      await user.click(screen.getByLabelText("Next segment"));
 
       const buttons = screen.getAllByRole("button");
       buttons.forEach((btn) => expect(btn).toBeDisabled());

--- a/frontend/__tests__/SplitHandle.test.tsx
+++ b/frontend/__tests__/SplitHandle.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 vi.mock("react-resizable-panels", () => ({
@@ -43,10 +44,11 @@ describe("SplitHandle", () => {
     expect(chevron.getAttribute("class")).toContain("rotate-180");
   });
 
-  it("calls onCollapse when collapse button is clicked", () => {
+  it("calls onCollapse when collapse button is clicked", async () => {
+    const user = userEvent.setup();
     const onCollapse = vi.fn();
     render(<SplitHandle onCollapse={onCollapse} collapsed={false} />);
-    fireEvent.click(screen.getByRole("button"));
+    await user.click(screen.getByRole("button"));
     expect(onCollapse).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/__tests__/UnsavedChangesModal.test.tsx
+++ b/frontend/__tests__/UnsavedChangesModal.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 vi.mock("lucide-react", () => ({
@@ -51,30 +52,33 @@ describe("UnsavedChangesModal", () => {
     ).toBeDefined();
   });
 
-  it("Discard button calls confirmDiscard", () => {
+  it("Discard button calls confirmDiscard", async () => {
+    const user = userEvent.setup();
     const ctx = defaultCtx({ pendingHref: "/workbench/analysis" });
     mockUseUnsavedChanges.mockReturnValue(ctx);
     render(<UnsavedChangesModal />);
 
-    fireEvent.click(screen.getByText("Discard"));
+    await user.click(screen.getByText("Discard"));
     expect(ctx.confirmDiscard).toHaveBeenCalledOnce();
   });
 
-  it("Cancel button calls cancelNavigation", () => {
+  it("Cancel button calls cancelNavigation", async () => {
+    const user = userEvent.setup();
     const ctx = defaultCtx({ pendingHref: "/workbench/analysis" });
     mockUseUnsavedChanges.mockReturnValue(ctx);
     render(<UnsavedChangesModal />);
 
-    fireEvent.click(screen.getByText("Cancel"));
+    await user.click(screen.getByText("Cancel"));
     expect(ctx.cancelNavigation).toHaveBeenCalledOnce();
   });
 
-  it("Save & Continue button calls confirmSave", () => {
+  it("Save & Continue button calls confirmSave", async () => {
+    const user = userEvent.setup();
     const ctx = defaultCtx({ pendingHref: "/workbench/analysis" });
     mockUseUnsavedChanges.mockReturnValue(ctx);
     render(<UnsavedChangesModal />);
 
-    fireEvent.click(screen.getByText("Save & Continue"));
+    await user.click(screen.getByText("Save & Continue"));
     expect(ctx.confirmSave).toHaveBeenCalledOnce();
   });
 

--- a/frontend/__tests__/XsecTreeCrud.test.tsx
+++ b/frontend/__tests__/XsecTreeCrud.test.tsx
@@ -2,7 +2,8 @@
  * Tests for X-Secs tree CRUD controls in ASB mode (GH#358).
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 // ── Mocks ──────────────────────────────────────────────────────
@@ -95,12 +96,13 @@ describe("X-Secs tree CRUD controls (ASB mode)", () => {
   });
 
   it("clicking insert point calls handleInsertXsec", async () => {
+    const user = userEvent.setup();
     const mockFetch = vi.fn().mockResolvedValue({ ok: true });
     global.fetch = mockFetch;
 
     renderTree();
     const insertButtons = screen.getAllByText("insert");
-    fireEvent.click(insertButtons[0]);
+    await user.click(insertButtons[0]);
 
     // Insert at index 1 (between x_sec 0 and x_sec 1)
     expect(mockFetch).toHaveBeenCalledWith(
@@ -115,11 +117,12 @@ describe("X-Secs tree CRUD controls (ASB mode)", () => {
   });
 
   it("clicking + x_sec calls handleAddSegment", async () => {
+    const user = userEvent.setup();
     const mockFetch = vi.fn().mockResolvedValue({ ok: true });
     global.fetch = mockFetch;
 
     renderTree();
-    fireEvent.click(screen.getByText("+ x_sec"));
+    await user.click(screen.getByText("+ x_sec"));
 
     // Append at index equal to x_secs.length (3)
     expect(mockFetch).toHaveBeenCalledWith(
@@ -128,7 +131,8 @@ describe("X-Secs tree CRUD controls (ASB mode)", () => {
     );
   });
 
-  it("wing node has delete action", () => {
+  it("wing node has delete action", async () => {
+    const user = userEvent.setup();
     const mockConfirm = vi.fn().mockReturnValue(true);
     global.confirm = mockConfirm;
     const mockFetch = vi.fn().mockResolvedValue({ ok: true });
@@ -141,7 +145,7 @@ describe("X-Secs tree CRUD controls (ASB mode)", () => {
     const wingRow = wingNode.closest("[role='treeitem']")!;
     // The delete button is the last button with stopPropagation in the row
     const deleteBtn = wingRow.querySelector("button:last-of-type")!;
-    fireEvent.click(deleteBtn);
+    await user.click(deleteBtn);
 
     expect(mockConfirm).toHaveBeenCalledWith('Delete wing "TestWing"?');
     expect(mockFetch).toHaveBeenCalledWith(

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,6 +30,7 @@
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -2730,6 +2731,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@turf/area": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",


### PR DESCRIPTION
## Summary

Closes #348

- Install `@testing-library/user-event@^14` as devDependency
- Migrate all 22 test files (205 `fireEvent` calls) to `userEvent`
- Remove `flushMicrotasks()` helper and 11 call sites from `ComponentTypeCreateFlow`
- Convert file-input tests to `user.upload()` in `ConstructionPartUploadDialog`
- Zero `fireEvent` references remaining in `frontend/__tests__/`

### Transform patterns applied

| Before | After |
|--------|-------|
| `fireEvent.click(el)` | `await user.click(el)` |
| `fireEvent.change(input, { target: { value: "x" } })` | `await user.clear(input); await user.type(input, "x")` |
| `fireEvent.change(select, { target: { value: "v" } })` | `await user.selectOptions(select, "v")` |
| `fireEvent.change(fileInput, { target: { files: [...] } })` | `await user.upload(fileInput, file)` |
| `fireEvent.keyDown(el, { key: "Enter" })` | `await user.keyboard("{Enter}")` |
| `await flushMicrotasks()` | *(removed — userEvent settles state automatically)* |

### Scope

- **22 files migrated** (3 more than original issue — EditParamsModal, SegmentPaginator, XsecTreeCrud added since ticket creation)
- **Zero production code changes** — only `frontend/__tests__/*.tsx` and `package.json`/`package-lock.json`
- **346/346 tests passing**

## Test plan

- [x] `cd frontend && npm run test:unit -- --run` → 346 passed
- [x] `grep -rl "fireEvent" frontend/__tests__/` → empty (zero remaining)
- [x] `git diff --name-only HEAD~7 | grep -v "__tests__/" | grep -v "package" | grep -v "docs/"` → empty (no production changes)
- [ ] CI: verify `act()` warnings eliminated from stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)