### PR TITLE
chore(gh-405): align Construction tab toggle with Components tab pattern

### DIFF
--- a/.specs/gh-405-ui-toggle-pattern.md
+++ b/.specs/gh-405-ui-toggle-pattern.md
@@ -1,0 +1,51 @@
+# Spec: GH-405 — Apply Global UI Patterns to Construction Tab Toggle
+
+## Problem
+
+The "Segments / X-Secs" toggle in the Construction tab (`AeroplaneTree.tsx`)
+uses a smaller, inconsistent style compared to the "Library / Construction
+Parts" toggle in the Components tab. The heading says "Aeroplane Tree"
+instead of "Configuration".
+
+## Solution
+
+Restyle the existing toggle and heading in `AeroplaneTree.tsx` to match
+the Components tab pattern exactly.
+
+## Changes
+
+### 1. Heading (line 819-821)
+
+**Before:** `Aeroplane Tree` (plain text, muted)
+**After:** `Plane` icon (size 14, text-primary) + `Configuration` (text-foreground, text-[13px])
+
+### 2. Toggle Container (line 823)
+
+**Before:** `rounded-full border border-primary/60 bg-card-muted p-0.5`
+**After:** `rounded-full border border-border bg-card p-1`
+
+### 3. Toggle Buttons (lines 824-843)
+
+**Before:** `px-3.5 py-0.5 text-[10px]` (text only, no icons)
+**After:** `flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[12px]` with icons:
+- Segments: `GalleryHorizontal` (size 12)
+- X-Secs: `GalleryHorizontalEnd` (size 12)
+
+### 4. Imports
+
+Add: `Plane`, `GalleryHorizontal`, `GalleryHorizontalEnd` from `lucide-react`
+
+## Acceptance Criteria
+
+- [ ] Toggle visually matches the Components tab pattern (same sizing, colors, rounded pill)
+- [ ] Segments button has gallery-horizontal icon
+- [ ] X-Secs button has gallery-horizontal-end icon
+- [ ] Heading reads "Configuration" with plane icon
+- [ ] No functional/logic changes — toggle still switches between wingconfig/asb modes
+- [ ] Dark theme renders correctly
+
+## Out of Scope
+
+- Moving the toggle to a different position in the DOM
+- Changing toggle behavior or state management
+- Other UI pattern alignment tasks

--- a/frontend/__tests__/FuselageTree.test.tsx
+++ b/frontend/__tests__/FuselageTree.test.tsx
@@ -15,7 +15,8 @@ vi.mock("lucide-react", () => {
     ChevronDown: icon, ChevronRight: icon, Plus: icon, Trash2: icon,
     Eye: icon, EyeOff: icon, Loader: icon, PanelLeftClose: icon, Pencil: icon,
     X: icon, Upload: icon, Check: icon, Loader2: icon, Maximize2: icon,
-    Minimize2: icon, Play: icon, Lock: icon,
+    Minimize2: icon, Play: icon, Lock: icon, Plane: icon,
+    GalleryHorizontal: icon, GalleryHorizontalEnd: icon,
   };
 });
 

--- a/frontend/__tests__/XsecTreeCrud.test.tsx
+++ b/frontend/__tests__/XsecTreeCrud.test.tsx
@@ -15,7 +15,8 @@ vi.mock("lucide-react", () => {
     ChevronDown: icon, ChevronRight: icon, Plus: icon, Trash2: icon,
     Eye: icon, EyeOff: icon, Loader: icon, PanelLeftClose: icon, Pencil: icon,
     X: icon, Upload: icon, Check: icon, Loader2: icon, Maximize2: icon,
-    Minimize2: icon, Play: icon, Lock: icon,
+    Minimize2: icon, Play: icon, Lock: icon, Plane: icon,
+    GalleryHorizontal: icon, GalleryHorizontalEnd: icon,
   };
 });
 

--- a/frontend/components/workbench/AeroplaneTree.tsx
+++ b/frontend/components/workbench/AeroplaneTree.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { ChevronDown, ChevronRight, Plus, Trash2, Eye, EyeOff, Loader, PanelLeftClose, Pencil } from "lucide-react";
+import { ChevronDown, ChevronRight, Plus, Trash2, Eye, EyeOff, Loader, PanelLeftClose, Pencil, Plane, GalleryHorizontal, GalleryHorizontalEnd } from "lucide-react";
 import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
 import { useWing } from "@/hooks/useWings";
 import type { XSec } from "@/hooks/useWings";
@@ -816,29 +816,32 @@ export function AeroplaneTree(props: Readonly<AeroplaneTreeProps>) {
             <PanelLeftClose size={14} />
           </button>
         )}
-        <span className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-muted-foreground">
-          Aeroplane Tree
+        <Plane size={14} className="text-primary" />
+        <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-foreground">
+          Configuration
         </span>
         <div className="flex-1" />
-        <div className="flex shrink-0 gap-0.5 rounded-full border border-primary/60 bg-card-muted p-0.5">
+        <div className="flex shrink-0 items-center gap-1 rounded-full border border-border bg-card p-1">
           <button
             onClick={() => setTreeMode("wingconfig")}
-            className={`whitespace-nowrap rounded-full px-3.5 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[10px] transition-colors ${
+            className={`flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[12px] transition-colors ${
               treeMode === "wingconfig"
                 ? "bg-primary text-primary-foreground"
                 : "text-muted-foreground hover:text-foreground"
             }`}
           >
+            <GalleryHorizontal size={12} />
             Segments
           </button>
           <button
             onClick={() => setTreeMode("asb")}
-            className={`whitespace-nowrap rounded-full px-3.5 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[10px] transition-colors ${
+            className={`flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[12px] transition-colors ${
               treeMode === "asb" || treeMode === "fuselage"
                 ? "bg-primary text-primary-foreground"
                 : "text-muted-foreground hover:text-foreground"
             }`}
           >
+            <GalleryHorizontalEnd size={12} />
             X-Secs
           </button>
         </div>


### PR DESCRIPTION
## Summary

Closes #405

- Restyle the Segments/X-Secs toggle in the Construction tab's `AeroplaneTree` header to match the Library/Construction Parts toggle in the Components tab
- Change heading from "Aeroplane Tree" to "Configuration" with a `Plane` icon
- Add `GalleryHorizontal` / `GalleryHorizontalEnd` icons to toggle buttons
- Match container and button sizing (`text-[12px]`, `px-3 py-1.5`, `border-border bg-card p-1`)

## Test plan

- [x] All 346 frontend unit tests pass
- [x] ESLint passes (pre-commit hook)
- [ ] Visual verification: toggle renders with icons, matches Components tab style
- [ ] Dark theme renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)