### PR TITLE
chore(gh-405): apply global UI patterns - toggle button in Header row

### DIFF
--- a/docs/superpowers/plans/2026-05-05-pill-toggle-header-pattern.md
+++ b/docs/superpowers/plans/2026-05-05-pill-toggle-header-pattern.md
@@ -1,0 +1,562 @@
+# GH-405: PillToggle Header Pattern — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract inline toggle patterns into a shared `PillToggle` component, add a header row to the Construction tab (toggle left, "Configuration" heading right), and retrofit the Components and Construction Plans tabs.
+
+**Architecture:** New shared component in `frontend/components/ui/PillToggle.tsx` with generic typed API. TDD — tests first, then component, then integration into three page files. Each page retrofit is a pure refactor (identical visual output).
+
+**Tech Stack:** React 19, TypeScript, lucide-react, Tailwind CSS, vitest, @testing-library/react, userEvent
+
+---
+
+### Task 1: PillToggle Unit Tests (RED)
+
+**Files:**
+- Create: `frontend/__tests__/PillToggle.test.tsx`
+
+- [ ] **Step 1: Create test file**
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = ({ size, ...rest }: Record<string, unknown>) =>
+    React.createElement("span", { "data-testid": `icon-${size}`, ...rest });
+  return { Package: icon, Box: icon };
+});
+
+import { PillToggle } from "@/components/ui/PillToggle";
+import { Package, Box } from "lucide-react";
+
+type View = "library" | "construction";
+
+const OPTIONS = [
+  { value: "library" as View, label: "Library", icon: Package },
+  { value: "construction" as View, label: "Construction Parts", icon: Box },
+];
+
+describe("PillToggle", () => {
+  it("renders all option labels", () => {
+    render(<PillToggle options={OPTIONS} value="library" onChange={() => {}} />);
+    expect(screen.getByText("Library")).toBeDefined();
+    expect(screen.getByText("Construction Parts")).toBeDefined();
+  });
+
+  it("applies active styling to the selected option", () => {
+    render(<PillToggle options={OPTIONS} value="library" onChange={() => {}} />);
+    const activeBtn = screen.getByText("Library").closest("button")!;
+    expect(activeBtn.className).toContain("bg-primary");
+    const inactiveBtn = screen.getByText("Construction Parts").closest("button")!;
+    expect(inactiveBtn.className).not.toContain("bg-primary");
+  });
+
+  it("calls onChange with the clicked option value", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<PillToggle options={OPTIONS} value="library" onChange={onChange} />);
+    await user.click(screen.getByText("Construction Parts"));
+    expect(onChange).toHaveBeenCalledWith("construction");
+  });
+
+  it("calls onChange even when clicking the already-active option", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<PillToggle options={OPTIONS} value="library" onChange={onChange} />);
+    await user.click(screen.getByText("Library"));
+    expect(onChange).toHaveBeenCalledWith("library");
+  });
+
+  it("uses custom isActive when provided", () => {
+    const isActive = (opt: View, cur: View) =>
+      opt === cur || (opt === "construction" && cur === "library");
+    render(
+      <PillToggle options={OPTIONS} value="library" onChange={() => {}} isActive={isActive} />,
+    );
+    // Both should be active with this custom comparator
+    const libraryBtn = screen.getByText("Library").closest("button")!;
+    const constructionBtn = screen.getByText("Construction Parts").closest("button")!;
+    expect(libraryBtn.className).toContain("bg-primary");
+    expect(constructionBtn.className).toContain("bg-primary");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx vitest run __tests__/PillToggle.test.tsx`
+Expected: FAIL — module `@/components/ui/PillToggle` not found.
+
+- [ ] **Step 3: Commit failing tests**
+
+```bash
+git add frontend/__tests__/PillToggle.test.tsx
+git commit -m "test(gh-405): add failing PillToggle unit tests (RED)"
+```
+
+---
+
+### Task 2: PillToggle Component (GREEN)
+
+**Files:**
+- Create: `frontend/components/ui/PillToggle.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+import type { LucideIcon } from "lucide-react";
+
+export interface PillToggleOption<T extends string> {
+  value: T;
+  label: string;
+  icon: LucideIcon;
+}
+
+interface PillToggleProps<T extends string> {
+  options: PillToggleOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  isActive?: (optionValue: T, currentValue: T) => boolean;
+}
+
+export function PillToggle<T extends string>({
+  options,
+  value,
+  onChange,
+  isActive,
+}: Readonly<PillToggleProps<T>>) {
+  const check = isActive ?? ((opt: T, cur: T) => opt === cur);
+
+  return (
+    <div className="flex items-center gap-1 rounded-full border border-border bg-card p-1">
+      {options.map((opt) => {
+        const active = check(opt.value, value);
+        const Icon = opt.icon;
+        return (
+          <button
+            key={opt.value}
+            onClick={() => onChange(opt.value)}
+            className={`flex items-center gap-1.5 rounded-full px-3 py-1.5 font-[family-name:var(--font-jetbrains-mono)] text-[12px] transition-colors ${
+              active
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            <Icon size={12} />
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `cd frontend && npx vitest run __tests__/PillToggle.test.tsx`
+Expected: PASS — all 5 tests green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/components/ui/PillToggle.tsx
+git commit -m "feat(gh-405): add shared PillToggle component (GREEN)"
+```
+
+---
+
+### Task 3: Construction Tab — Add Header Row
+
+**Files:**
+- Modify: `frontend/app/workbench/page.tsx`
+- Modify: `frontend/components/workbench/AeroplaneTree.tsx`
+
+- [ ] **Step 1: Add header row to the Construction page**
+
+In `frontend/app/workbench/page.tsx`:
+
+1. Add imports at the top of the file:
+
+```tsx
+import { GalleryHorizontal, GalleryHorizontalEnd, Plane } from "lucide-react";
+import { PillToggle } from "@/components/ui/PillToggle";
+import type { TreeMode } from "@/components/workbench/AeroplaneContext";
+```
+
+2. Add `setTreeMode` to the destructured `useAeroplaneContext()` call on line 22. The current destructuring is:
+
+```tsx
+  const {
+    aeroplaneId,
+    selectedWing, selectedXsecIndex, selectXsec,
+    selectedFuselage, selectedFuselageXsecIndex, selectFuselageXsec,
+    treeMode,
+    openPicker,
+    hydrated,
+  } = useAeroplaneContext();
+```
+
+Add `setTreeMode` after `treeMode`:
+
+```tsx
+  const {
+    aeroplaneId,
+    selectedWing, selectedXsecIndex, selectXsec,
+    selectedFuselage, selectedFuselageXsecIndex, selectFuselageXsec,
+    treeMode, setTreeMode,
+    openPicker,
+    hydrated,
+  } = useAeroplaneContext();
+```
+
+3. Define the toggle options constant inside the component, before the early return (before line 155):
+
+```tsx
+  const treeModeOptions: PillToggleOption<TreeMode>[] = [
+    { value: "wingconfig", label: "Segments", icon: GalleryHorizontal },
+    { value: "asb", label: "X-Secs", icon: GalleryHorizontalEnd },
+  ];
+```
+
+You need to import `PillToggleOption` from `@/components/ui/PillToggle` as well — add it to the existing import:
+
+```tsx
+import { PillToggle, type PillToggleOption } from "@/components/ui/PillToggle";
+```
+
+4. Wrap the existing layout in a flex column and add the header row. The current return (starting at line 163) is:
+
+```tsx
+    return (
+      <>
+        <div className="flex h-full min-h-0 flex-1 gap-4 overflow-hidden">
+          {/* Tree Panel — collapsible, fixed width, scrollable */}
+```
+
+Replace the opening with:
+
+```tsx
+    return (
+      <>
+        <div className="flex h-full min-h-0 flex-1 flex-col gap-3 overflow-hidden">
+          {/* Header row: toggle left, heading right */}
+          <div className="flex items-center gap-2">
+            <PillToggle
+              options={treeModeOptions}
+              value={treeMode}
+              onChange={setTreeMode}
+              isActive={(opt, cur) => opt === cur || (opt === "asb" && cur === "fuselage")}
+            />
+            <div className="flex-1" />
+            <div className="flex items-center gap-2.5">
+              <Plane className="size-5 text-primary" />
+              <h1 className="font-[family-name:var(--font-jetbrains-mono)] text-[20px] text-foreground">
+                Configuration
+              </h1>
+            </div>
+          </div>
+
+          <div className="flex min-h-0 flex-1 gap-4 overflow-hidden">
+            {/* Tree Panel — collapsible, fixed width, scrollable */}
+```
+
+And at the end of the two-panel layout (after the closing `</div>` for the Preview panel, before the `<dialog>` for configuration modal), add the matching closing `</div>`:
+
+The current structure around line 243-246 is:
+
+```tsx
+          </div>
+        </div>
+```
+
+It becomes:
+
+```tsx
+          </div>
+          </div>
+        </div>
+```
+
+- [ ] **Step 2: Remove toggle from AeroplaneTree**
+
+In `frontend/components/workbench/AeroplaneTree.tsx`, replace the header section (lines 808-845):
+
+Current:
+
+```tsx
+      {/* Header with collapse + mode toggle */}
+      <div className="mb-2 flex items-center gap-2">
+        {onCollapseTree && (
+          <button
+            onClick={onCollapseTree}
+            className="flex size-6 items-center justify-center rounded-xl text-muted-foreground hover:bg-sidebar-accent"
+            title="Collapse tree panel"
+          >
+            <PanelLeftClose size={14} />
+          </button>
+        )}
+        <span className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-muted-foreground">
+          Aeroplane Tree
+        </span>
+        <div className="flex-1" />
+        <div className="flex shrink-0 gap-0.5 rounded-full border border-primary/60 bg-card-muted p-0.5">
+          <button
+            onClick={() => setTreeMode("wingconfig")}
+            className={`whitespace-nowrap rounded-full px-3.5 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[10px] transition-colors ${
+              treeMode === "wingconfig"
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            Segments
+          </button>
+          <button
+            onClick={() => setTreeMode("asb")}
+            className={`whitespace-nowrap rounded-full px-3.5 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[10px] transition-colors ${
+              treeMode === "asb" || treeMode === "fuselage"
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            X-Secs
+          </button>
+        </div>
+      </div>
+```
+
+Replace with:
+
+```tsx
+      {/* Header with collapse button */}
+      <div className="mb-2 flex items-center gap-2">
+        {onCollapseTree && (
+          <button
+            onClick={onCollapseTree}
+            className="flex size-6 items-center justify-center rounded-xl text-muted-foreground hover:bg-sidebar-accent"
+            title="Collapse tree panel"
+          >
+            <PanelLeftClose size={14} />
+          </button>
+        )}
+        <span className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-muted-foreground">
+          Aeroplane Tree
+        </span>
+      </div>
+```
+
+- [ ] **Step 3: Run all frontend unit tests**
+
+Run: `cd frontend && npx vitest run`
+Expected: ALL PASS — no regressions.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/app/workbench/page.tsx frontend/components/workbench/AeroplaneTree.tsx
+git commit -m "feat(gh-405): add header row with PillToggle to Construction tab"
+```
+
+---
+
+### Task 4: Retrofit Components Tab
+
+**Files:**
+- Modify: `frontend/app/workbench/components/page.tsx`
+
+- [ ] **Step 1: Replace inline toggle with PillToggle**
+
+In `frontend/app/workbench/components/page.tsx`:
+
+1. Update the lucide-react import on line 4 — remove `Box` since PillToggle renders the icons internally. Keep the other icons:
+
+```tsx
+import { Package, Search, Plus, Settings, Trash2 } from "lucide-react";
+```
+
+2. Add imports after the lucide-react import:
+
+```tsx
+import { Package as PackageIcon, Box } from "lucide-react";
+import { PillToggle, type PillToggleOption } from "@/components/ui/PillToggle";
+```
+
+Wait — `Package` is already imported and used for both the toggle icon and the heading icon (line 114) and the empty-state icon (line 175). Keep `Package` in the main import and use it for the heading/empty-state. For the `PillToggle` options, just reference it directly.
+
+Simpler approach — add only the new imports:
+
+```tsx
+import { PillToggle, type PillToggleOption } from "@/components/ui/PillToggle";
+```
+
+`Package` and `Box` stay in the existing lucide-react import since `Package` is also used elsewhere in the file (heading, empty state).
+
+3. Add the options constant inside the component function, just after the state declarations (after line 51):
+
+```tsx
+  const viewOptions: PillToggleOption<View>[] = [
+    { value: "library", label: "Library", icon: Package },
+    { value: "construction", label: "Construction Parts", icon: Box },
+  ];
+```
+
+4. Replace lines 67-92 (the toggle JSX inside the `<WorkbenchTwoPanel>`):
+
+Current:
+
+```tsx
+        <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1 rounded-full border border-border bg-card p-1">
+            <button
+              onClick={() => setView("library")}
+              className={`flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[12px] ${
+                view === "library"
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              <Package size={12} />
+              Library
+            </button>
+            <button
+              onClick={() => setView("construction")}
+              className={`flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[12px] ${
+                view === "construction"
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              <Box size={12} />
+              Construction Parts
+            </button>
+          </div>
+        </div>
+```
+
+Replace with:
+
+```tsx
+        <PillToggle options={viewOptions} value={view} onChange={setView} />
+```
+
+- [ ] **Step 2: Run all frontend unit tests**
+
+Run: `cd frontend && npx vitest run`
+Expected: ALL PASS — identical behavior, ComponentsPage tests still green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/app/workbench/components/page.tsx
+git commit -m "refactor(gh-405): retrofit Components tab to use PillToggle"
+```
+
+---
+
+### Task 5: Retrofit Construction Plans Tab
+
+**Files:**
+- Modify: `frontend/app/workbench/construction-plans/page.tsx`
+
+- [ ] **Step 1: Replace ModeButton with PillToggle**
+
+In `frontend/app/workbench/construction-plans/page.tsx`:
+
+1. Add import (near the top, with other component imports):
+
+```tsx
+import { PillToggle, type PillToggleOption } from "@/components/ui/PillToggle";
+```
+
+2. Add the options constant inside the component function, near the other derived values (after line 512):
+
+```tsx
+  const viewModeOptions: PillToggleOption<"plans" | "templates">[] = [
+    { value: "plans", label: "Plans", icon: Hammer },
+    { value: "templates", label: "Templates", icon: BookTemplate },
+  ];
+```
+
+3. Delete the entire `ModeButton` function (lines 514-531):
+
+```tsx
+  function ModeButton({
+    mode,
+    Icon,
+    label,
+  }: Readonly<{ mode: "plans" | "templates"; Icon: typeof Hammer; label: string }>) {
+    return (
+      <button
+        onClick={() => setViewMode(mode)}
+        className={`flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[12px] ${
+          viewMode === mode
+            ? "bg-primary text-primary-foreground"
+            : "text-muted-foreground hover:text-foreground"
+        }`}
+      >
+        <Icon size={12} /> {label}
+      </button>
+    );
+  }
+```
+
+4. Replace lines 555-560 (the toggle container):
+
+Current:
+
+```tsx
+            <div className="flex items-center gap-2">
+              <div className="flex items-center gap-1 rounded-full border border-border bg-card p-1">
+                <ModeButton mode="plans" Icon={Hammer} label="Plans" />
+                <ModeButton mode="templates" Icon={BookTemplate} label="Templates" />
+              </div>
+            </div>
+```
+
+Replace with:
+
+```tsx
+            <PillToggle options={viewModeOptions} value={viewMode} onChange={setViewMode} />
+```
+
+- [ ] **Step 2: Run all frontend unit tests**
+
+Run: `cd frontend && npx vitest run`
+Expected: ALL PASS — ConstructionPlansPage tests still find "Templates" and "Plans" text.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/app/workbench/construction-plans/page.tsx
+git commit -m "refactor(gh-405): retrofit Construction Plans tab to use PillToggle"
+```
+
+---
+
+### Task 6: Final Verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full frontend unit test suite**
+
+Run: `cd frontend && npx vitest run`
+Expected: ALL PASS — all 42+ test files, 346+ tests green.
+
+- [ ] **Step 2: Run dependency check**
+
+Run: `cd frontend && npm run deps:check`
+Expected: PASS — no circular dependencies introduced.
+
+- [ ] **Step 3: Run TypeScript type check**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: PASS — no type errors.
+
+- [ ] **Step 4: Final commit if any cleanup needed, then push**
+
+```bash
+git push origin chore/gh-405-ui-pattern-toggle-header
+```

--- a/docs/superpowers/specs/2026-05-05-pill-toggle-header-pattern-design.md
+++ b/docs/superpowers/specs/2026-05-05-pill-toggle-header-pattern-design.md
@@ -1,0 +1,147 @@
+# GH-405: Apply Global UI Pattern — Toggle Button in Header Row
+
+## Problem
+
+The "2 - Construction" tab uses a different layout for its
+Segments/X-Secs toggle than the established pattern in the
+"4 - Components" tab. The toggle is buried inside the AeroplaneTree
+component header, styled differently, and positioned on the right
+side of the tree header. There is no "Configuration" heading above
+the preview area.
+
+The goal is to enforce a consistent UI pattern across all workbench
+tabs: **toggle on the left in the header row, heading on the right
+above the content area.**
+
+## Approach
+
+Extract the inline toggle pattern into a shared `PillToggle`
+component, apply it to the Construction tab with the correct layout,
+and retrofit the Components and Construction Plans tabs to use the
+same shared component.
+
+## Design
+
+### 1. PillToggle Component
+
+**File:** `frontend/components/ui/PillToggle.tsx`
+
+A generic, reusable pill-shaped toggle group.
+
+**API:**
+
+```tsx
+interface PillToggleOption<T extends string> {
+  value: T;
+  label: string;
+  icon: LucideIcon;
+}
+
+interface PillToggleProps<T extends string> {
+  options: PillToggleOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  isActive?: (optionValue: T, currentValue: T) => boolean;
+}
+```
+
+**Styling (matches existing Components tab inline pattern):**
+
+- Container: `rounded-full border border-border bg-card p-1`,
+  with `gap-1` between buttons
+- Button: `rounded-full px-3 py-1.5 text-[12px]`, with `gap-1.5`
+  between icon and label, JetBrains Mono font
+- Active: `bg-primary text-primary-foreground`
+- Inactive: `text-muted-foreground hover:text-foreground`
+- Icon size: 12px
+- Transition: `transition-colors`
+
+### 2. Construction Tab Layout Changes
+
+**File:** `frontend/app/workbench/page.tsx`
+
+Add a header row above the existing two-panel layout:
+
+- **Left side:** `<PillToggle>` with two options:
+  - Segments — `GalleryHorizontal` icon, value `"wingconfig"`
+  - X-Secs — `GalleryHorizontalEnd` icon, value `"asb"`
+  - Wired to `treeMode`/`setTreeMode` from `AeroplaneContext`
+- **Right side:** Heading "Configuration" with `Plane` icon
+  - Icon: `size-5 text-primary`
+  - Text: `text-[20px]` JetBrains Mono, `text-foreground`
+  - Same styling as "Component Library" heading in Components tab
+
+The X-Secs option maps to the `"asb"` tree mode. When `treeMode`
+is `"fuselage"` (set by clicking a fuselage in the tree), the
+X-Secs button should appear active (matching current behavior where
+`treeMode === "asb" || treeMode === "fuselage"` triggers the active
+state). This is handled via the optional `isActive` prop on
+`PillToggle` — default behavior is `optionValue === currentValue`,
+but the Construction tab passes a custom comparator:
+`(opt, cur) => opt === cur || (opt === "asb" && cur === "fuselage")`.
+
+**File:** `frontend/components/workbench/AeroplaneTree.tsx`
+
+Remove the Segments/X-Secs toggle from the tree component header
+(the `<div>` containing the two toggle buttons). The tree header
+retains its collapse button and "Aeroplane Tree" label.
+
+### 3. Retrofit Existing Tabs
+
+**Components tab** (`frontend/app/workbench/components/page.tsx`):
+
+Replace the inline toggle JSX with `<PillToggle>`:
+- Library — `Package` icon, value `"library"`
+- Construction Parts — `Box` icon, value `"construction"`
+
+No other changes to this file.
+
+**Construction Plans tab**
+(`frontend/app/workbench/construction-plans/page.tsx`):
+
+Replace the local `ModeButton` component and its usage with
+`<PillToggle>`:
+- Plans — `Hammer` icon, value `"plans"`
+- Templates — `BookTemplate` icon, value `"templates"`
+
+Delete the `ModeButton` function.
+
+### 4. Testing
+
+**New test:** `frontend/__tests__/PillToggle.test.tsx`
+
+- Renders all options with correct labels
+- Active option has `bg-primary` class
+- Clicking inactive option calls `onChange` with correct value
+- Clicking active option still calls `onChange`
+
+**Existing tests:** No changes expected — the refactor preserves
+identical visual output and behavior. If any tests reference
+inline toggle markup, they will be updated to match the new
+component structure.
+
+**E2E:** No changes — toggle buttons keep the same visible text
+labels for Playwright selectors.
+
+## Acceptance Criteria
+
+1. The Segments/X-Secs toggle in the Construction tab is positioned
+   in the header row (left side), matching the Components tab layout
+2. Toggle buttons have icons: `GalleryHorizontal` for Segments,
+   `GalleryHorizontalEnd` for X-Secs
+3. "Configuration" heading with `Plane` icon appears above the
+   preview area (right side of header row)
+4. A shared `PillToggle` component is used by all three tabs
+5. All existing unit and E2E tests pass
+6. New unit tests cover the `PillToggle` component
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `frontend/components/ui/PillToggle.tsx` | New shared component |
+| `frontend/__tests__/PillToggle.test.tsx` | New unit tests |
+| `frontend/app/workbench/page.tsx` | Add header row with toggle + heading |
+| `frontend/components/workbench/AeroplaneTree.tsx` | Remove toggle from tree header |
+| `frontend/app/workbench/components/page.tsx` | Replace inline toggle with PillToggle |
+| `frontend/app/workbench/construction-plans/page.tsx` | Replace ModeButton with PillToggle |

--- a/frontend/__tests__/PillToggle.test.tsx
+++ b/frontend/__tests__/PillToggle.test.tsx
@@ -50,6 +50,16 @@ describe("PillToggle", () => {
     expect(onChange).toHaveBeenCalledWith("library");
   });
 
+  it("has radiogroup ARIA semantics", () => {
+    render(<PillToggle options={OPTIONS} value="library" onChange={() => {}} />);
+    const group = screen.getByRole("radiogroup");
+    expect(group).toBeDefined();
+    const radios = screen.getAllByRole("radio");
+    expect(radios).toHaveLength(2);
+    expect(radios[0].getAttribute("aria-checked")).toBe("true");
+    expect(radios[1].getAttribute("aria-checked")).toBe("false");
+  });
+
   it("uses custom isActive when provided", () => {
     const isActive = (opt: View, cur: View) =>
       opt === cur || (opt === "construction" && cur === "library");

--- a/frontend/__tests__/PillToggle.test.tsx
+++ b/frontend/__tests__/PillToggle.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = ({ size, ...rest }: Record<string, unknown>) =>
+    React.createElement("span", { "data-testid": `icon-${size}`, ...rest });
+  return { Package: icon, Box: icon };
+});
+
+import { PillToggle } from "@/components/ui/PillToggle";
+import { Package, Box } from "lucide-react";
+
+type View = "library" | "construction";
+
+const OPTIONS = [
+  { value: "library" as View, label: "Library", icon: Package },
+  { value: "construction" as View, label: "Construction Parts", icon: Box },
+];
+
+describe("PillToggle", () => {
+  it("renders all option labels", () => {
+    render(<PillToggle options={OPTIONS} value="library" onChange={() => {}} />);
+    expect(screen.getByText("Library")).toBeDefined();
+    expect(screen.getByText("Construction Parts")).toBeDefined();
+  });
+
+  it("applies active styling to the selected option", () => {
+    render(<PillToggle options={OPTIONS} value="library" onChange={() => {}} />);
+    const activeBtn = screen.getByText("Library").closest("button")!;
+    expect(activeBtn.className).toContain("bg-primary");
+    const inactiveBtn = screen.getByText("Construction Parts").closest("button")!;
+    expect(inactiveBtn.className).not.toContain("bg-primary");
+  });
+
+  it("calls onChange with the clicked option value", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<PillToggle options={OPTIONS} value="library" onChange={onChange} />);
+    await user.click(screen.getByText("Construction Parts"));
+    expect(onChange).toHaveBeenCalledWith("construction");
+  });
+
+  it("calls onChange even when clicking the already-active option", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<PillToggle options={OPTIONS} value="library" onChange={onChange} />);
+    await user.click(screen.getByText("Library"));
+    expect(onChange).toHaveBeenCalledWith("library");
+  });
+
+  it("uses custom isActive when provided", () => {
+    const isActive = (opt: View, cur: View) =>
+      opt === cur || (opt === "construction" && cur === "library");
+    render(
+      <PillToggle options={OPTIONS} value="library" onChange={() => {}} isActive={isActive} />,
+    );
+    const libraryBtn = screen.getByText("Library").closest("button")!;
+    const constructionBtn = screen.getByText("Construction Parts").closest("button")!;
+    expect(libraryBtn.className).toContain("bg-primary");
+    expect(constructionBtn.className).toContain("bg-primary");
+  });
+});

--- a/frontend/app/workbench/components/page.tsx
+++ b/frontend/app/workbench/components/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Package, Search, Plus, Settings, Trash2, Box } from "lucide-react";
+import { PillToggle, type PillToggleOption } from "@/components/ui/PillToggle";
 import { WorkbenchTwoPanel } from "@/components/workbench/WorkbenchTwoPanel";
 import { ComponentTree } from "@/components/workbench/ComponentTree";
 import { ComponentEditDialog } from "@/components/workbench/ComponentEditDialog";
@@ -50,6 +51,11 @@ export default function ComponentsPage() {
   const { tree, mutate: mutateTree } = useComponentTree(aeroplaneId);
   const editingNode = editingNodeId == null ? null : findNode(tree, editingNodeId);
 
+  const viewOptions: PillToggleOption<View>[] = [
+    { value: "library", label: "Library", icon: Package },
+    { value: "construction", label: "Construction Parts", icon: Box },
+  ];
+
   const handleDelete = async (comp: Component) => {
     if (!confirm(`Delete "${comp.name}"?`)) return;
     try {
@@ -64,32 +70,7 @@ export default function ComponentsPage() {
     <>
     <WorkbenchTwoPanel>
       <div className="flex h-full flex-col gap-3 overflow-hidden">
-        <div className="flex items-center gap-2">
-          <div className="flex items-center gap-1 rounded-full border border-border bg-card p-1">
-            <button
-              onClick={() => setView("library")}
-              className={`flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[12px] ${
-                view === "library"
-                  ? "bg-primary text-primary-foreground"
-                  : "text-muted-foreground hover:text-foreground"
-              }`}
-            >
-              <Package size={12} />
-              Library
-            </button>
-            <button
-              onClick={() => setView("construction")}
-              className={`flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[12px] ${
-                view === "construction"
-                  ? "bg-primary text-primary-foreground"
-                  : "text-muted-foreground hover:text-foreground"
-              }`}
-            >
-              <Box size={12} />
-              Construction Parts
-            </button>
-          </div>
-        </div>
+        <PillToggle options={viewOptions} value={view} onChange={setView} />
         <ComponentTree
           onNodeEditRequested={(n: ComponentTreeNode) => setEditingNodeId(n.id)}
         />

--- a/frontend/app/workbench/construction-plans/page.tsx
+++ b/frontend/app/workbench/construction-plans/page.tsx
@@ -47,6 +47,7 @@ import { ExecutionResultDialog } from "@/components/workbench/construction-plans
 import { ArtifactBrowserDialog } from "@/components/workbench/construction-plans/ArtifactBrowserDialog";
 import { NewPlanDialog } from "@/components/workbench/construction-plans/NewPlanDialog";
 import type { ExecutionResult } from "@/hooks/useConstructionPlans";
+import { PillToggle, type PillToggleOption } from "@/components/ui/PillToggle";
 
 // ── Helpers ───────────────────────────────────────────────────────
 
@@ -511,24 +512,10 @@ export default function ConstructionPlansPage() {
   const totalSteps = plans.reduce((s, p) => s + p.step_count, 0);
   const panelStyle = { width: treeWide ? "66%" : 360, minWidth: treeWide ? "66%" : 360 };
 
-  function ModeButton({
-    mode,
-    Icon,
-    label,
-  }: Readonly<{ mode: "plans" | "templates"; Icon: typeof Hammer; label: string }>) {
-    return (
-      <button
-        onClick={() => setViewMode(mode)}
-        className={`flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[12px] ${
-          viewMode === mode
-            ? "bg-primary text-primary-foreground"
-            : "text-muted-foreground hover:text-foreground"
-        }`}
-      >
-        <Icon size={12} /> {label}
-      </button>
-    );
-  }
+  const viewModeOptions: PillToggleOption<"plans" | "templates">[] = [
+    { value: "plans", label: "Plans", icon: Hammer },
+    { value: "templates", label: "Templates", icon: BookTemplate },
+  ];
 
   function WidthToggle() {
     return (
@@ -552,12 +539,7 @@ export default function ConstructionPlansPage() {
           style={panelStyle}
         >
           <div className="flex h-full flex-col gap-3 overflow-hidden">
-            <div className="flex items-center gap-2">
-              <div className="flex items-center gap-1 rounded-full border border-border bg-card p-1">
-                <ModeButton mode="plans" Icon={Hammer} label="Plans" />
-                <ModeButton mode="templates" Icon={BookTemplate} label="Templates" />
-              </div>
-            </div>
+            <PillToggle options={viewModeOptions} value={viewMode} onChange={setViewMode} />
 
             {viewMode === "plans" && (
               <TreeCard

--- a/frontend/app/workbench/page.tsx
+++ b/frontend/app/workbench/page.tsx
@@ -170,15 +170,16 @@ export default function WorkbenchPage() {
   return (
     <>
       <div className="flex h-full min-h-0 flex-1 flex-col gap-3 overflow-hidden">
-        {/* Header row: toggle left, heading right */}
-        <div className="flex items-center gap-2">
-          <PillToggle
-            options={treeModeOptions}
-            value={treeMode}
-            onChange={setTreeMode}
-            isActive={(opt, cur) => opt === cur || (opt === "asb" && cur === "fuselage")}
-          />
-          <div className="flex-1" />
+        {/* Header row: toggle left (aligned with tree), heading left-aligned with preview */}
+        <div className="flex items-center gap-4">
+          <div className="w-[320px] shrink-0">
+            <PillToggle
+              options={treeModeOptions}
+              value={treeMode}
+              onChange={setTreeMode}
+              isActive={(opt, cur) => opt === cur || (opt === "asb" && cur === "fuselage")}
+            />
+          </div>
           <div className="flex items-center gap-2.5">
             <Plane className="size-5 text-primary" />
             <h1 className="font-[family-name:var(--font-jetbrains-mono)] text-[20px] text-foreground">

--- a/frontend/app/workbench/page.tsx
+++ b/frontend/app/workbench/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useState, useMemo, useCallback, useRef, useEffect } from "react";
-import { PanelLeftOpen, Maximize2, Minimize2, X } from "lucide-react";
+import { PanelLeftOpen, Maximize2, Minimize2, X, GalleryHorizontal, GalleryHorizontalEnd, Plane } from "lucide-react";
+import { PillToggle, type PillToggleOption } from "@/components/ui/PillToggle";
+import type { TreeMode } from "@/components/workbench/AeroplaneContext";
 import { useDialog } from "@/hooks/useDialog";
 import { PropertyForm, type PropertyFormHandle } from "@/components/workbench/PropertyForm";
 import { SegmentPaginator } from "@/components/workbench/SegmentPaginator";
@@ -22,7 +24,7 @@ export default function WorkbenchPage() {
     aeroplaneId,
     selectedWing, selectedXsecIndex, selectXsec,
     selectedFuselage, selectedFuselageXsecIndex, selectFuselageXsec,
-    treeMode,
+    treeMode, setTreeMode,
     openPicker,
     hydrated,
   } = useAeroplaneContext();
@@ -152,6 +154,11 @@ export default function WorkbenchPage() {
     if (hydrated && !aeroplaneId) openPicker();
   }, [hydrated, aeroplaneId, openPicker]);
 
+  const treeModeOptions: PillToggleOption<TreeMode>[] = [
+    { value: "wingconfig", label: "Segments", icon: GalleryHorizontal },
+    { value: "asb", label: "X-Secs", icon: GalleryHorizontalEnd },
+  ];
+
   if (!aeroplaneId) {
     return (
       <div className="flex flex-1 items-center justify-center">
@@ -162,9 +169,27 @@ export default function WorkbenchPage() {
 
   return (
     <>
-      <div className="flex h-full min-h-0 flex-1 gap-4 overflow-hidden">
-        {/* Tree Panel — collapsible, fixed width, scrollable */}
-        {treeOpen && !viewerMaximized && (
+      <div className="flex h-full min-h-0 flex-1 flex-col gap-3 overflow-hidden">
+        {/* Header row: toggle left, heading right */}
+        <div className="flex items-center gap-2">
+          <PillToggle
+            options={treeModeOptions}
+            value={treeMode}
+            onChange={setTreeMode}
+            isActive={(opt, cur) => opt === cur || (opt === "asb" && cur === "fuselage")}
+          />
+          <div className="flex-1" />
+          <div className="flex items-center gap-2.5">
+            <Plane className="size-5 text-primary" />
+            <h1 className="font-[family-name:var(--font-jetbrains-mono)] text-[20px] text-foreground">
+              Configuration
+            </h1>
+          </div>
+        </div>
+
+        <div className="flex min-h-0 flex-1 gap-4 overflow-hidden">
+          {/* Tree Panel — collapsible, fixed width, scrollable */}
+          {treeOpen && !viewerMaximized && (
           <div className="flex h-full min-h-0 w-[320px] shrink-0 flex-col overflow-hidden">
             <AeroplaneTree
               aeroplaneId={aeroplaneId}
@@ -240,6 +265,7 @@ export default function WorkbenchPage() {
               selectedFuselageXsecIndex={selectedFuselageXsecIndex}
             />
           </div>
+        </div>
         </div>
       </div>
 

--- a/frontend/app/workbench/page.tsx
+++ b/frontend/app/workbench/page.tsx
@@ -172,7 +172,7 @@ export default function WorkbenchPage() {
       <div className="flex h-full min-h-0 flex-1 flex-col gap-3 overflow-hidden">
         {/* Header row: toggle left (aligned with tree), heading left-aligned with preview */}
         <div className="flex items-center gap-4">
-          <div className="w-[320px] shrink-0">
+          <div className={treeOpen && !viewerMaximized ? "w-[320px] shrink-0" : ""}>
             <PillToggle
               options={treeModeOptions}
               value={treeMode}

--- a/frontend/components/ui/PillToggle.tsx
+++ b/frontend/components/ui/PillToggle.tsx
@@ -22,13 +22,15 @@ export function PillToggle<T extends string>({
   const check = isActive ?? ((opt: T, cur: T) => opt === cur);
 
   return (
-    <div className="flex items-center gap-1 rounded-full border border-border bg-card p-1">
+    <div role="radiogroup" className="flex items-center gap-1 rounded-full border border-border bg-card p-1">
       {options.map((opt) => {
         const active = check(opt.value, value);
         const Icon = opt.icon;
         return (
           <button
             key={opt.value}
+            role="radio"
+            aria-checked={active}
             onClick={() => onChange(opt.value)}
             className={`flex items-center gap-1.5 rounded-full px-3 py-1.5 font-[family-name:var(--font-jetbrains-mono)] text-[12px] transition-colors ${
               active

--- a/frontend/components/ui/PillToggle.tsx
+++ b/frontend/components/ui/PillToggle.tsx
@@ -1,0 +1,46 @@
+import type { LucideIcon } from "lucide-react";
+
+export interface PillToggleOption<T extends string> {
+  value: T;
+  label: string;
+  icon: LucideIcon;
+}
+
+interface PillToggleProps<T extends string> {
+  options: PillToggleOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  isActive?: (optionValue: T, currentValue: T) => boolean;
+}
+
+export function PillToggle<T extends string>({
+  options,
+  value,
+  onChange,
+  isActive,
+}: Readonly<PillToggleProps<T>>) {
+  const check = isActive ?? ((opt: T, cur: T) => opt === cur);
+
+  return (
+    <div className="flex items-center gap-1 rounded-full border border-border bg-card p-1">
+      {options.map((opt) => {
+        const active = check(opt.value, value);
+        const Icon = opt.icon;
+        return (
+          <button
+            key={opt.value}
+            onClick={() => onChange(opt.value)}
+            className={`flex items-center gap-1.5 rounded-full px-3 py-1.5 font-[family-name:var(--font-jetbrains-mono)] text-[12px] transition-colors ${
+              active
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            <Icon size={12} />
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/components/workbench/AeroplaneTree.tsx
+++ b/frontend/components/workbench/AeroplaneTree.tsx
@@ -805,7 +805,7 @@ export function AeroplaneTree(props: Readonly<AeroplaneTreeProps>) {
 
   return (
     <div className="flex h-full min-h-0 flex-col rounded-xl border border-border bg-card p-3 px-4 overflow-hidden">
-      {/* Header with collapse + mode toggle */}
+      {/* Header with collapse button */}
       <div className="mb-2 flex items-center gap-2">
         {onCollapseTree && (
           <button
@@ -819,29 +819,6 @@ export function AeroplaneTree(props: Readonly<AeroplaneTreeProps>) {
         <span className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-muted-foreground">
           Aeroplane Tree
         </span>
-        <div className="flex-1" />
-        <div className="flex shrink-0 gap-0.5 rounded-full border border-primary/60 bg-card-muted p-0.5">
-          <button
-            onClick={() => setTreeMode("wingconfig")}
-            className={`whitespace-nowrap rounded-full px-3.5 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[10px] transition-colors ${
-              treeMode === "wingconfig"
-                ? "bg-primary text-primary-foreground"
-                : "text-muted-foreground hover:text-foreground"
-            }`}
-          >
-            Segments
-          </button>
-          <button
-            onClick={() => setTreeMode("asb")}
-            className={`whitespace-nowrap rounded-full px-3.5 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[10px] transition-colors ${
-              treeMode === "asb" || treeMode === "fuselage"
-                ? "bg-primary text-primary-foreground"
-                : "text-muted-foreground hover:text-foreground"
-            }`}
-          >
-            X-Secs
-          </button>
-        </div>
       </div>
 
       {/* Tree rows */}


### PR DESCRIPTION
## Summary

- Extract inline toggle pattern into reusable `PillToggle` component (`frontend/components/ui/PillToggle.tsx`)
- Add header row to Construction tab: Segments/X-Secs toggle (left) + "Configuration" heading with Plane icon (right)
- Retrofit Components and Construction Plans tabs to use shared `PillToggle`
- Remove toggle from `AeroplaneTree` component header

Closes #405

## Test plan

- [x] New unit tests for PillToggle (5 tests: renders labels, active styling, onChange, custom isActive)
- [x] All 43 test files / 351 tests passing
- [x] Dependency check: 0 errors
- [x] TypeScript: no errors in changed files
- [x] Visual verification: toggle position matches Components tab pattern
- [x] Verify fuselage selection still highlights X-Secs toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)