### PR TITLE
fix(gh-411): align polar analysis params with backend schema

### DIFF
--- a/frontend/__tests__/useAnalysis.test.ts
+++ b/frontend/__tests__/useAnalysis.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for the useAnalysis hook.
+ *
+ * Verifies that AlphaSweepParams matches the backend's AlphaSweepRequest
+ * schema and that runAlphaSweep sends the correct request body (gh-411).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useAnalysis, type AlphaSweepParams } from "@/hooks/useAnalysis";
+
+const FAKE_RESPONSE = {
+  analysis: {
+    coefficients: { CL: [0.1, 0.5], CD: [0.01, 0.03], Cm: [-0.02, -0.05] },
+    flight_condition: { alpha: [-5, 15] },
+  },
+};
+
+describe("useAnalysis", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("AlphaSweepParams has fields matching backend AlphaSweepRequest", () => {
+    const params: AlphaSweepParams = {
+      alpha_start: -5,
+      alpha_end: 15,
+      alpha_num: 21,
+      velocity: 14,
+      beta: 0,
+      altitude: 100,
+      xyz_ref: [0, 0, 0],
+    };
+
+    // Verify the required field names exist at runtime
+    expect(params).toHaveProperty("alpha_start");
+    expect(params).toHaveProperty("alpha_end");
+    expect(params).toHaveProperty("alpha_num");
+    expect(params).toHaveProperty("velocity");
+    expect(params).toHaveProperty("altitude");
+    expect(params).toHaveProperty("xyz_ref");
+
+    // These old field names must NOT exist in the interface
+    expect(params).not.toHaveProperty("alpha_start_deg");
+    expect(params).not.toHaveProperty("alpha_end_deg");
+    expect(params).not.toHaveProperty("alpha_step_deg");
+    expect(params).not.toHaveProperty("velocity_m_s");
+    expect(params).not.toHaveProperty("xyz_ref_m");
+  });
+
+  it("sends all fields to the backend API", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(FAKE_RESPONSE),
+    });
+    globalThis.fetch = mockFetch;
+
+    const { result } = renderHook(() => useAnalysis("aero-1"));
+
+    const params: AlphaSweepParams = {
+      alpha_start: -5,
+      alpha_end: 15,
+      alpha_num: 21,
+      velocity: 14,
+      beta: 0,
+      altitude: 100,
+      xyz_ref: [0.1, 0, 0],
+    };
+
+    await act(async () => {
+      await result.current.runAlphaSweep(params);
+    });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+
+    expect(body).toStrictEqual({
+      alpha_start: -5,
+      alpha_end: 15,
+      alpha_num: 21,
+      velocity: 14,
+      beta: 0,
+      altitude: 100,
+      xyz_ref: [0.1, 0, 0],
+    });
+  });
+
+  it("extracts CL/CD/Cm/alpha from nested API response", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(FAKE_RESPONSE),
+    });
+
+    const { result } = renderHook(() => useAnalysis("aero-1"));
+
+    await act(async () => {
+      await result.current.runAlphaSweep({
+        alpha_start: -5,
+        alpha_end: 15,
+        alpha_num: 21,
+        velocity: 14,
+        beta: 0,
+        altitude: 0,
+        xyz_ref: [0, 0, 0],
+      });
+    });
+
+    expect(result.current.result).toEqual({
+      CL: [0.1, 0.5],
+      CD: [0.01, 0.03],
+      Cm: [-0.02, -0.05],
+      alpha: [-5, 15],
+    });
+  });
+});

--- a/frontend/components/workbench/AnalysisConfigPanel.tsx
+++ b/frontend/components/workbench/AnalysisConfigPanel.tsx
@@ -77,14 +77,17 @@ export function AnalysisConfigPanel({
 
   // ── Polar handlers ──
   const handleRunPolar = () => {
+    const start = Number.parseFloat(alphaStart) || -5;
+    const end = Number.parseFloat(alphaEnd) || 15;
+    const step = Number.parseFloat(alphaStep) || 1;
     analysis.runAlphaSweep({
-      analysis_tool: analysisTool,
-      velocity_m_s: Number.parseFloat(velocity) || 14,
-      alpha_start_deg: Number.parseFloat(alphaStart) || -5,
-      alpha_end_deg: Number.parseFloat(alphaEnd) || 15,
-      alpha_step_deg: Number.parseFloat(alphaStep) || 1,
-      beta_deg: Number.parseFloat(beta) || 0,
-      xyz_ref_m: parseXyzRef(),
+      alpha_start: start,
+      alpha_end: end,
+      alpha_num: Math.max(2, Math.round((end - start) / step) + 1),
+      velocity: Number.parseFloat(velocity) || 14,
+      beta: Number.parseFloat(beta) || 0,
+      altitude: Number.parseFloat(altitude) || 0,
+      xyz_ref: parseXyzRef(),
     });
     onClose?.();
   };

--- a/frontend/hooks/useAnalysis.ts
+++ b/frontend/hooks/useAnalysis.ts
@@ -4,13 +4,13 @@ import { useState, useCallback } from "react";
 import { API_BASE } from "@/lib/fetcher";
 
 export interface AlphaSweepParams {
-  analysis_tool: string;
-  velocity_m_s: number;
-  alpha_start_deg: number;
-  alpha_end_deg: number;
-  alpha_step_deg: number;
-  beta_deg: number;
-  xyz_ref_m: number[];
+  alpha_start: number;
+  alpha_end: number;
+  alpha_num: number;
+  velocity: number;
+  beta: number;
+  altitude: number;
+  xyz_ref: number[];
 }
 
 export interface AnalysisResult {


### PR DESCRIPTION
## Summary

- Frontend sent parameters with wrong field names (`alpha_start_deg`, `velocity_m_s`, `beta_deg`, `xyz_ref_m`) that didn't match the backend's `AlphaSweepRequest` schema (`alpha_start`, `velocity`, `beta`, `xyz_ref`). Pydantic v2 silently ignored all unrecognized fields and used defaults (-15° to 20°), making the polar config dialog completely non-functional.
- Also converts `alpha_step` (step size from UI) to `alpha_num` (point count expected by backend): `Math.round((end - start) / step) + 1`
- Adds missing `altitude` parameter to the request

## Test plan

- [x] RED: TypeScript compiler (tsc) reports 3 type errors for test using correct field names vs old `AlphaSweepParams`
- [x] GREEN: 0 TypeScript errors, 3 vitest tests pass
- [x] Full frontend suite: 355 tests pass, 0 regressions
- [ ] Manual: open polar config dialog, set alpha range (e.g. -5° to 10°), run analysis — chart should show the user-set range, not -15° to 20°

Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)