### PR TITLE
feat(gh-419): AeroBuildup trim analysis via optimization loop

### DIFF
--- a/app/api/v2/endpoints/operating_points.py
+++ b/app/api/v2/endpoints/operating_points.py
@@ -16,6 +16,8 @@ from app.db.session import get_db
 from app.models.aeroplanemodel import AeroplaneModel
 from app.models.analysismodels import OperatingPointModel, OperatingPointSetModel
 from app.schemas.aeroanalysisschema import (
+    AeroBuildupTrimRequest,
+    AeroBuildupTrimResult,
     AVLTrimRequest,
     AVLTrimResult,
     GeneratedOperatingPointSetRead,
@@ -117,6 +119,33 @@ async def avl_trim_operating_point(
         from app.services import avl_trim_service
 
         return await avl_trim_service.trim_with_avl(
+            db=db,
+            aeroplane_uuid=aeroplane_id,
+            request=request,
+        )
+    except ServiceException as exc:
+        _raise_http_from_domain(exc)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Unexpected error: {exc}",
+        ) from exc
+
+
+@router.post(
+    "/aeroplanes/{aeroplane_id}/operating-points/aerobuildup-trim",
+    operation_id="aerobuildup_trim_operating_point",
+)
+async def aerobuildup_trim_operating_point(
+    aeroplane_id: Annotated[UUID4, Path(..., description="Aeroplane UUID")],
+    request: Annotated[AeroBuildupTrimRequest, Body(...)],
+    db: Annotated[Session, Depends(get_db)],
+) -> AeroBuildupTrimResult:
+    """Run AeroBuildup trim analysis using scipy root-finding."""
+    try:
+        from app.services import aerobuildup_trim_service
+
+        return await aerobuildup_trim_service.trim_with_aerobuildup(
             db=db,
             aeroplane_uuid=aeroplane_id,
             request=request,

--- a/app/schemas/aeroanalysisschema.py
+++ b/app/schemas/aeroanalysisschema.py
@@ -104,11 +104,11 @@ class AeroBuildupTrimRequest(BaseModel):
     )
     target_coefficient: str = Field(
         "Cm",
-        description="Aerodynamic coefficient to target. Typically 'Cm' for pitch trim.",
+        description="Aerodynamic coefficient to target (one of: CL, CD, CY, Cm, Cl, Cn).",
     )
     target_value: float = Field(
         0.0,
-        description="Target value for the coefficient (default: 0 = zero pitching moment)",
+        description="Target value for the coefficient (default: 0)",
     )
     deflection_bounds: list[float] = Field(
         default=[-25.0, 25.0],
@@ -124,6 +124,16 @@ class AeroBuildupTrimRequest(BaseModel):
             raise ValueError(
                 f"Invalid trim variable name '{v}'. Must be a letter followed by "
                 f"letters/digits/underscores."
+            )
+        return v
+
+    @field_validator("target_coefficient")
+    @classmethod
+    def validate_target_coefficient(cls, v: str) -> str:
+        allowed = {"CL", "CD", "CY", "Cm", "Cl", "Cn"}
+        if v not in allowed:
+            raise ValueError(
+                f"Invalid target coefficient '{v}'. Must be one of: {sorted(allowed)}"
             )
         return v
 
@@ -146,7 +156,9 @@ class AeroBuildupTrimResult(BaseModel):
         ..., description="Deflection angle that achieves trim (degrees)"
     )
     target_coefficient: str = Field(..., description="Coefficient that was targeted")
-    achieved_value: float = Field(..., description="Achieved value of target coefficient at trim")
+    achieved_value: Optional[float] = Field(
+        ..., description="Achieved value of target coefficient at trim, or null if not converged"
+    )
     aero_coefficients: dict[str, float] = Field(
         default_factory=dict,
         description="All aero coefficients at trim (CL, CD, Cm, etc.)",

--- a/app/schemas/aeroanalysisschema.py
+++ b/app/schemas/aeroanalysisschema.py
@@ -92,6 +92,70 @@ class AVLTrimResult(BaseModel):
     )
 
 
+class AeroBuildupTrimRequest(BaseModel):
+    """Request to run AeroBuildup trim analysis."""
+
+    operating_point: "OperatingPointSchema" = Field(
+        ..., description="Operating point for the trim analysis"
+    )
+    trim_variable: str = Field(
+        "elevator",
+        description="Control surface name to vary for trim (e.g. 'elevator')",
+    )
+    target_coefficient: str = Field(
+        "Cm",
+        description="Aerodynamic coefficient to target. Typically 'Cm' for pitch trim.",
+    )
+    target_value: float = Field(
+        0.0,
+        description="Target value for the coefficient (default: 0 = zero pitching moment)",
+    )
+    deflection_bounds: list[float] = Field(
+        default=[-25.0, 25.0],
+        min_length=2,
+        max_length=2,
+        description="Search bounds for deflection in degrees [lower, upper]",
+    )
+
+    @field_validator("trim_variable")
+    @classmethod
+    def validate_trim_variable_format(cls, v: str) -> str:
+        if not re.match(r"^[a-zA-Z][a-zA-Z0-9_]*$", v):
+            raise ValueError(
+                f"Invalid trim variable name '{v}'. Must be a letter followed by "
+                f"letters/digits/underscores."
+            )
+        return v
+
+    @model_validator(mode="after")
+    def validate_bounds_order(self) -> "AeroBuildupTrimRequest":
+        if self.deflection_bounds[0] >= self.deflection_bounds[1]:
+            raise ValueError("deflection_bounds[0] must be less than deflection_bounds[1]")
+        op = self.operating_point
+        if isinstance(getattr(op, "alpha", None), list):
+            raise ValueError("Alpha must be a scalar float for trim analysis, not a list")
+        return self
+
+
+class AeroBuildupTrimResult(BaseModel):
+    """Result of AeroBuildup trim analysis."""
+
+    converged: bool = Field(..., description="Whether the root-finding converged")
+    trim_variable: str = Field(..., description="Control surface that was varied")
+    trimmed_deflection: float = Field(
+        ..., description="Deflection angle that achieves trim (degrees)"
+    )
+    target_coefficient: str = Field(..., description="Coefficient that was targeted")
+    achieved_value: float = Field(..., description="Achieved value of target coefficient at trim")
+    aero_coefficients: dict[str, float] = Field(
+        default_factory=dict,
+        description="All aero coefficients at trim (CL, CD, Cm, etc.)",
+    )
+    stability_derivatives: dict[str, float] = Field(
+        default_factory=dict, description="Stability derivatives at trim point"
+    )
+
+
 class CdclConfig(BaseModel):
     """Configuration for NeuralFoil CDCL profile-drag computation."""
 

--- a/app/services/aerobuildup_trim_service.py
+++ b/app/services/aerobuildup_trim_service.py
@@ -1,13 +1,11 @@
-"""AeroBuildup trim analysis — find control deflections via scipy root-finding."""
+"""AeroBuildup trim — find a single control deflection via scipy Brent root-finding."""
 
 from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING
 
-import aerosandbox as asb
 from pydantic import UUID4
-from scipy.optimize import brentq
 
 from app.schemas.aeroanalysisschema import (
     AeroBuildupTrimRequest,
@@ -19,6 +17,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Aerosandbox uses underscore notation (CL_a = dCL/dalpha);
+# legacy AVL-style keys (Clb, Cnr) may also appear in output.
 _AERO_COEFF_KEYS = {"CL", "CD", "CY", "Cm", "Cl", "Cn"}
 _STABILITY_DERIV_KEYS = {
     "CL_a",
@@ -36,13 +36,15 @@ _STABILITY_DERIV_KEYS = {
 
 
 def _run_single_aerobuildup(
-    asb_airplane: asb.Airplane,
-    op_point: asb.OperatingPoint,
+    asb_airplane,
+    op_point,
     xyz_ref: list[float],
     trim_variable: str,
     deflection_deg: float,
 ) -> dict:
     """Run a single AeroBuildup analysis at a specific control deflection."""
+    import aerosandbox as asb
+
     deflected = asb_airplane.with_control_deflections({trim_variable: deflection_deg})
     abu = asb.AeroBuildup(
         airplane=deflected,
@@ -57,9 +59,12 @@ async def trim_with_aerobuildup(
     aeroplane_uuid: UUID4,
     request: AeroBuildupTrimRequest,
 ) -> AeroBuildupTrimResult:
-    """Run AeroBuildup trim: vary a control surface deflection to achieve target coefficient."""
+    """Find the control deflection that achieves a target aero coefficient via Brent's method."""
+    import aerosandbox as asb
+    from scipy.optimize import brentq
+
     from app.converters.model_schema_converters import aeroplane_schema_to_asb_airplane_async
-    from app.core.exceptions import ValidationDomainError
+    from app.core.exceptions import InternalError, ValidationDomainError
     from app.services.analysis_service import get_aeroplane_schema_or_raise
 
     plane_schema = get_aeroplane_schema_or_raise(db, aeroplane_uuid)
@@ -79,7 +84,7 @@ async def trim_with_aerobuildup(
         atmosphere=atmosphere,
     )
 
-    # Verify the trim variable (control surface) exists on the airplane
+    # Fail fast before expensive solver iterations if the surface doesn't exist
     control_names: set[str] = set()
     for wing in asb_airplane.wings:
         for xsec in wing.xsecs:
@@ -112,47 +117,103 @@ async def trim_with_aerobuildup(
 
     lower, upper = request.deflection_bounds
 
-    # Check that the root is bracketed
     try:
         f_lower = residual(lower)
         f_upper = residual(upper)
     except ValidationDomainError:
         raise
+    except (ValueError, TypeError) as e:
+        raise ValidationDomainError(
+            message=f"AeroBuildup evaluation failed at bounds: {e}"
+        ) from e
     except Exception as e:
-        raise ValidationDomainError(message=f"AeroBuildup evaluation failed at bounds: {e}") from e
+        logger.error(
+            "Unexpected AeroBuildup failure for aeroplane %s at bounds [%g, %g]: %s",
+            aeroplane_uuid,
+            lower,
+            upper,
+            e,
+            exc_info=True,
+        )
+        raise InternalError(
+            message=f"AeroBuildup evaluation failed unexpectedly: {e}"
+        ) from e
 
     if f_lower * f_upper > 0:
+        logger.warning(
+            "AeroBuildup trim root not bracketed for aeroplane %s: "
+            "residual(%s=%g)=%g, residual(%s=%g)=%g — target %s=%g not achievable "
+            "within [%g, %g]",
+            aeroplane_uuid,
+            request.trim_variable,
+            lower,
+            f_lower,
+            request.trim_variable,
+            upper,
+            f_upper,
+            target_coeff,
+            target_val,
+            lower,
+            upper,
+        )
         return AeroBuildupTrimResult(
             converged=False,
             trim_variable=request.trim_variable,
             trimmed_deflection=0.0,
             target_coefficient=target_coeff,
-            achieved_value=float("nan"),
+            achieved_value=None,
             aero_coefficients={},
             stability_derivatives={},
         )
 
     try:
         trimmed_deflection = brentq(residual, lower, upper, xtol=1e-6, maxiter=50)
-    except ValueError:
+    except ValueError as e:
+        logger.warning(
+            "AeroBuildup brentq failed for aeroplane %s, %s targeting %s=%g: %s",
+            aeroplane_uuid,
+            request.trim_variable,
+            target_coeff,
+            target_val,
+            e,
+        )
         return AeroBuildupTrimResult(
             converged=False,
             trim_variable=request.trim_variable,
             trimmed_deflection=0.0,
             target_coefficient=target_coeff,
-            achieved_value=float("nan"),
+            achieved_value=None,
             aero_coefficients={},
             stability_derivatives={},
         )
 
-    # Final run at trim to get full coefficients
-    final_result = _run_single_aerobuildup(
-        asb_airplane,
-        op_point,
-        op.xyz_ref,
-        request.trim_variable,
-        trimmed_deflection,
-    )
+    # Re-run at converged deflection for full coefficient and derivative set
+    try:
+        final_result = _run_single_aerobuildup(
+            asb_airplane,
+            op_point,
+            op.xyz_ref,
+            request.trim_variable,
+            trimmed_deflection,
+        )
+    except Exception as e:
+        logger.error(
+            "Final AeroBuildup evaluation failed at trimmed deflection %g for "
+            "aeroplane %s: %s",
+            trimmed_deflection,
+            aeroplane_uuid,
+            e,
+            exc_info=True,
+        )
+        return AeroBuildupTrimResult(
+            converged=True,
+            trim_variable=request.trim_variable,
+            trimmed_deflection=round(trimmed_deflection, 6),
+            target_coefficient=target_coeff,
+            achieved_value=None,
+            aero_coefficients={},
+            stability_derivatives={},
+        )
 
     aero = {
         k: float(v)
@@ -165,6 +226,12 @@ async def trim_with_aerobuildup(
         if k in _STABILITY_DERIV_KEYS and isinstance(v, (int, float))
     }
     achieved = float(final_result.get(target_coeff, float("nan")))
+    if target_coeff not in final_result:
+        logger.warning(
+            "Target coefficient '%s' missing from final AeroBuildup result for aeroplane %s",
+            target_coeff,
+            aeroplane_uuid,
+        )
 
     return AeroBuildupTrimResult(
         converged=True,

--- a/app/services/aerobuildup_trim_service.py
+++ b/app/services/aerobuildup_trim_service.py
@@ -1,0 +1,177 @@
+"""AeroBuildup trim analysis — find control deflections via scipy root-finding."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import aerosandbox as asb
+from pydantic import UUID4
+from scipy.optimize import brentq
+
+from app.schemas.aeroanalysisschema import (
+    AeroBuildupTrimRequest,
+    AeroBuildupTrimResult,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+_AERO_COEFF_KEYS = {"CL", "CD", "CY", "Cm", "Cl", "Cn"}
+_STABILITY_DERIV_KEYS = {
+    "CL_a",
+    "CL_b",
+    "CY_a",
+    "CY_b",
+    "Cm_a",
+    "Cn_b",
+    "Cl_b",
+    "Clb",
+    "Cnr",
+    "Clr",
+    "Cnb",
+}
+
+
+def _run_single_aerobuildup(
+    asb_airplane: asb.Airplane,
+    op_point: asb.OperatingPoint,
+    xyz_ref: list[float],
+    trim_variable: str,
+    deflection_deg: float,
+) -> dict:
+    """Run a single AeroBuildup analysis at a specific control deflection."""
+    deflected = asb_airplane.with_control_deflections({trim_variable: deflection_deg})
+    abu = asb.AeroBuildup(
+        airplane=deflected,
+        op_point=op_point,
+        xyz_ref=xyz_ref,
+    )
+    return abu.run_with_stability_derivatives()
+
+
+async def trim_with_aerobuildup(
+    db: Session,
+    aeroplane_uuid: UUID4,
+    request: AeroBuildupTrimRequest,
+) -> AeroBuildupTrimResult:
+    """Run AeroBuildup trim: vary a control surface deflection to achieve target coefficient."""
+    from app.converters.model_schema_converters import aeroplane_schema_to_asb_airplane_async
+    from app.core.exceptions import ValidationDomainError
+    from app.services.analysis_service import get_aeroplane_schema_or_raise
+
+    plane_schema = get_aeroplane_schema_or_raise(db, aeroplane_uuid)
+    op = request.operating_point
+
+    asb_airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
+    asb_airplane.xyz_ref = op.xyz_ref
+
+    atmosphere = asb.Atmosphere(altitude=op.altitude)
+    op_point = asb.OperatingPoint(
+        velocity=op.velocity,
+        alpha=op.alpha,
+        beta=op.beta,
+        p=op.p,
+        q=op.q,
+        r=op.r,
+        atmosphere=atmosphere,
+    )
+
+    # Verify the trim variable (control surface) exists on the airplane
+    control_names: set[str] = set()
+    for wing in asb_airplane.wings:
+        for xsec in wing.xsecs:
+            for cs in xsec.control_surfaces:
+                control_names.add(cs.name)
+    if request.trim_variable not in control_names:
+        raise ValidationDomainError(
+            message=f"Control surface '{request.trim_variable}' not found on airplane. "
+            f"Available: {sorted(control_names)}"
+        )
+
+    target_coeff = request.target_coefficient
+    target_val = request.target_value
+
+    def residual(deflection_deg: float) -> float:
+        result = _run_single_aerobuildup(
+            asb_airplane,
+            op_point,
+            op.xyz_ref,
+            request.trim_variable,
+            deflection_deg,
+        )
+        coeff_val = result.get(target_coeff)
+        if coeff_val is None:
+            raise ValidationDomainError(
+                message=f"Coefficient '{target_coeff}' not found in AeroBuildup output. "
+                f"Available: {sorted(k for k in result if isinstance(result[k], (int, float)))}"
+            )
+        return float(coeff_val) - target_val
+
+    lower, upper = request.deflection_bounds
+
+    # Check that the root is bracketed
+    try:
+        f_lower = residual(lower)
+        f_upper = residual(upper)
+    except ValidationDomainError:
+        raise
+    except Exception as e:
+        raise ValidationDomainError(message=f"AeroBuildup evaluation failed at bounds: {e}") from e
+
+    if f_lower * f_upper > 0:
+        return AeroBuildupTrimResult(
+            converged=False,
+            trim_variable=request.trim_variable,
+            trimmed_deflection=0.0,
+            target_coefficient=target_coeff,
+            achieved_value=float("nan"),
+            aero_coefficients={},
+            stability_derivatives={},
+        )
+
+    try:
+        trimmed_deflection = brentq(residual, lower, upper, xtol=1e-6, maxiter=50)
+    except ValueError:
+        return AeroBuildupTrimResult(
+            converged=False,
+            trim_variable=request.trim_variable,
+            trimmed_deflection=0.0,
+            target_coefficient=target_coeff,
+            achieved_value=float("nan"),
+            aero_coefficients={},
+            stability_derivatives={},
+        )
+
+    # Final run at trim to get full coefficients
+    final_result = _run_single_aerobuildup(
+        asb_airplane,
+        op_point,
+        op.xyz_ref,
+        request.trim_variable,
+        trimmed_deflection,
+    )
+
+    aero = {
+        k: float(v)
+        for k, v in final_result.items()
+        if k in _AERO_COEFF_KEYS and isinstance(v, (int, float))
+    }
+    derivs = {
+        k: float(v)
+        for k, v in final_result.items()
+        if k in _STABILITY_DERIV_KEYS and isinstance(v, (int, float))
+    }
+    achieved = float(final_result.get(target_coeff, float("nan")))
+
+    return AeroBuildupTrimResult(
+        converged=True,
+        trim_variable=request.trim_variable,
+        trimmed_deflection=round(trimmed_deflection, 6),
+        target_coefficient=target_coeff,
+        achieved_value=round(achieved, 8),
+        aero_coefficients=aero,
+        stability_derivatives=derivs,
+    )

--- a/app/tests/test_aerobuildup_trim.py
+++ b/app/tests/test_aerobuildup_trim.py
@@ -7,7 +7,6 @@ trim_with_aerobuildup service, and the aerobuildup-trim endpoint.
 from __future__ import annotations
 
 import asyncio
-import math
 import uuid
 from unittest.mock import MagicMock, patch
 
@@ -151,6 +150,34 @@ class TestAeroBuildupTrimRequest:
         assert req.target_coefficient == "CL"
         assert req.target_value == 0.5
 
+    def test_invalid_target_coefficient_rejected(self):
+        from pydantic import ValidationError as PydanticValidationError
+
+        from app.schemas.aeroanalysisschema import (
+            AeroBuildupTrimRequest,
+            OperatingPointSchema,
+        )
+
+        with pytest.raises(PydanticValidationError, match="Invalid target coefficient"):
+            AeroBuildupTrimRequest(
+                operating_point=OperatingPointSchema(velocity=15.0),
+                target_coefficient="CZ",
+            )
+
+    def test_case_sensitive_target_coefficient(self):
+        from pydantic import ValidationError as PydanticValidationError
+
+        from app.schemas.aeroanalysisschema import (
+            AeroBuildupTrimRequest,
+            OperatingPointSchema,
+        )
+
+        with pytest.raises(PydanticValidationError, match="Invalid target coefficient"):
+            AeroBuildupTrimRequest(
+                operating_point=OperatingPointSchema(velocity=15.0),
+                target_coefficient="cm",
+            )
+
 
 # =========================================================================== #
 # Schema validation — AeroBuildupTrimResult
@@ -188,11 +215,12 @@ class TestAeroBuildupTrimResult:
             trim_variable="elevator",
             trimmed_deflection=0.0,
             target_coefficient="Cm",
-            achieved_value=float("nan"),
+            achieved_value=None,
         )
         assert result.converged is False
         assert result.trim_variable == "elevator"
         assert result.trimmed_deflection == 0.0
+        assert result.achieved_value is None
         assert result.aero_coefficients == {}
         assert result.stability_derivatives == {}
 
@@ -203,7 +231,7 @@ class TestAeroBuildupTrimResult:
 
 
 def _make_mock_airplane_with_controls(control_names: list[str]) -> MagicMock:
-    """Build a mock ASB airplane with the given control surfaces."""
+    """Build a mock ASB airplane with all given control surfaces on one wing/xsec."""
     airplane = MagicMock()
     cs_list = []
     for name in control_names:
@@ -236,38 +264,8 @@ class TestTrimWithAerobuildup:
         mock_airplane = _make_mock_airplane_with_controls(["elevator"])
         mock_to_asb.return_value = mock_airplane
 
-        # Mock AeroBuildup: Cm = 0.1 * deflection (trim at deflection=0)
-        # But we want Cm=0 for trim — the residual is Cm - 0 = 0.1*d
-        # So trim should find deflection=0.0
-        def mock_aerobuildup_init(airplane, op_point, xyz_ref):
-            abu = MagicMock()
-
-            def run_with_stability_derivatives():
-                # We need to get the deflection from the airplane's control surface
-                # But since we're mocking with_control_deflections, we track the deflection
-                return {
-                    "CL": 0.5,
-                    "CD": 0.03,
-                    "CY": 0.0,
-                    "Cm": 0.0,  # Will be overridden below
-                    "Cl": 0.0,
-                    "Cn": 0.0,
-                    "CL_a": 6.1,
-                    "Cm_a": -1.2,
-                }
-
-            abu.run_with_stability_derivatives = run_with_stability_derivatives
-            return abu
-
-        # Instead of mocking AeroBuildup class, mock _run_single_aerobuildup
-        call_count = [0]
-        deflections_seen = []
-
         def mock_run_single(asb_airplane, op_point, xyz_ref, trim_variable, deflection_deg):
-            call_count[0] += 1
-            deflections_seen.append(deflection_deg)
-            # Cm varies linearly: Cm = 0.1 + 0.02 * deflection
-            # Root at deflection = -5.0
+            # Cm = 0.1 + 0.02 * deflection → root at deflection = -5.0
             cm_val = 0.1 + 0.02 * deflection_deg
             return {
                 "CL": 0.5,
@@ -296,9 +294,55 @@ class TestTrimWithAerobuildup:
         assert result.trim_variable == "elevator"
         assert result.target_coefficient == "Cm"
         assert abs(result.trimmed_deflection - (-5.0)) < 1e-4
+        assert result.achieved_value is not None
         assert abs(result.achieved_value) < 1e-4
         assert "CL" in result.aero_coefficients
         assert "CL_a" in result.stability_derivatives
+        # Verify coefficient categorization: non-aero/non-deriv keys are excluded
+        assert "some_junk" not in result.aero_coefficients
+
+    @patch("app.converters.model_schema_converters.aeroplane_schema_to_asb_airplane_async")
+    @patch("app.services.analysis_service.get_aeroplane_schema_or_raise")
+    def test_success_trim_non_default_target(self, mock_get_schema, mock_to_asb):
+        """Trim CL to 0.5 instead of default Cm=0."""
+        from app.schemas.aeroanalysisschema import (
+            AeroBuildupTrimRequest,
+            OperatingPointSchema,
+        )
+        from app.services.aerobuildup_trim_service import trim_with_aerobuildup
+
+        mock_get_schema.return_value = MagicMock()
+        mock_airplane = _make_mock_airplane_with_controls(["elevator"])
+        mock_to_asb.return_value = mock_airplane
+
+        def mock_run_single(asb_airplane, op_point, xyz_ref, trim_variable, deflection_deg):
+            # CL = 0.1 * deflection + 0.3 → CL=0.5 at deflection=2.0
+            cl_val = 0.1 * deflection_deg + 0.3
+            return {
+                "CL": cl_val,
+                "CD": 0.03,
+                "Cm": -0.01,
+            }
+
+        with patch(
+            "app.services.aerobuildup_trim_service._run_single_aerobuildup",
+            side_effect=mock_run_single,
+        ):
+            request = AeroBuildupTrimRequest(
+                operating_point=OperatingPointSchema(velocity=15.0, alpha=5.0),
+                trim_variable="elevator",
+                target_coefficient="CL",
+                target_value=0.5,
+            )
+            result = asyncio.run(
+                trim_with_aerobuildup(db=MagicMock(), aeroplane_uuid="test-uuid", request=request)
+            )
+
+        assert result.converged is True
+        assert result.target_coefficient == "CL"
+        assert abs(result.trimmed_deflection - 2.0) < 1e-4
+        assert result.achieved_value is not None
+        assert abs(result.achieved_value - 0.5) < 1e-4
 
     @patch("app.services.analysis_service.get_aeroplane_schema_or_raise")
     def test_aeroplane_not_found(self, mock_get_schema):
@@ -331,7 +375,6 @@ class TestTrimWithAerobuildup:
         from app.services.aerobuildup_trim_service import trim_with_aerobuildup
 
         mock_get_schema.return_value = MagicMock()
-        # Airplane has no control surfaces
         mock_airplane = _make_mock_airplane_with_controls([])
         mock_to_asb.return_value = mock_airplane
 
@@ -359,12 +402,11 @@ class TestTrimWithAerobuildup:
         mock_airplane = _make_mock_airplane_with_controls(["elevator"])
         mock_to_asb.return_value = mock_airplane
 
-        # Cm is always positive — no root in bounds
         def mock_run_single(asb_airplane, op_point, xyz_ref, trim_variable, deflection_deg):
             return {
                 "CL": 0.5,
                 "CD": 0.03,
-                "Cm": 1.0,  # Always positive, never crosses zero
+                "Cm": 1.0,  # Always positive — no root in bounds
             }
 
         with patch(
@@ -380,7 +422,7 @@ class TestTrimWithAerobuildup:
             )
 
         assert result.converged is False
-        assert math.isnan(result.achieved_value)
+        assert result.achieved_value is None
 
     @patch("app.converters.model_schema_converters.aeroplane_schema_to_asb_airplane_async")
     @patch("app.services.analysis_service.get_aeroplane_schema_or_raise")
@@ -396,31 +438,6 @@ class TestTrimWithAerobuildup:
         mock_airplane = _make_mock_airplane_with_controls(["elevator"])
         mock_to_asb.return_value = mock_airplane
 
-        # Residual changes sign (so bracket check passes) but brentq fails
-        call_count = [0]
-
-        def mock_run_single(asb_airplane, op_point, xyz_ref, trim_variable, deflection_deg):
-            call_count[0] += 1
-            # First two calls: bounds evaluation (opposite signs)
-            if call_count[0] <= 2:
-                return {
-                    "CL": 0.5,
-                    "CD": 0.03,
-                    "Cm": -1.0 if deflection_deg < 0 else 1.0,
-                }
-            # Subsequent calls during brentq: raise to simulate failure
-            raise RuntimeError("simulation diverged")
-
-        with patch(
-            "app.services.aerobuildup_trim_service._run_single_aerobuildup",
-            side_effect=mock_run_single,
-        ):
-            # brentq will catch the RuntimeError and re-raise as ValueError
-            # Actually, brentq doesn't catch runtime errors — it will propagate.
-            # Let's mock brentq itself to raise ValueError
-            pass
-
-        # Better approach: mock brentq directly
         with (
             patch(
                 "app.services.aerobuildup_trim_service._run_single_aerobuildup",
@@ -431,7 +448,7 @@ class TestTrimWithAerobuildup:
                 },
             ),
             patch(
-                "app.services.aerobuildup_trim_service.brentq",
+                "scipy.optimize.brentq",
                 side_effect=ValueError("convergence failed"),
             ),
         ):
@@ -444,7 +461,72 @@ class TestTrimWithAerobuildup:
             )
 
         assert result.converged is False
-        assert math.isnan(result.achieved_value)
+        assert result.achieved_value is None
+
+    @patch("app.converters.model_schema_converters.aeroplane_schema_to_asb_airplane_async")
+    @patch("app.services.analysis_service.get_aeroplane_schema_or_raise")
+    def test_bounds_evaluation_runtime_error_raises_internal_error(
+        self, mock_get_schema, mock_to_asb
+    ):
+        """When AeroBuildup crashes at bounds, raise InternalError (not ValidationDomainError)."""
+        from app.core.exceptions import InternalError
+        from app.schemas.aeroanalysisschema import (
+            AeroBuildupTrimRequest,
+            OperatingPointSchema,
+        )
+        from app.services.aerobuildup_trim_service import trim_with_aerobuildup
+
+        mock_get_schema.return_value = MagicMock()
+        mock_airplane = _make_mock_airplane_with_controls(["elevator"])
+        mock_to_asb.return_value = mock_airplane
+
+        with patch(
+            "app.services.aerobuildup_trim_service._run_single_aerobuildup",
+            side_effect=RuntimeError("simulation diverged"),
+        ):
+            request = AeroBuildupTrimRequest(
+                operating_point=OperatingPointSchema(velocity=15.0, alpha=5.0),
+                trim_variable="elevator",
+            )
+            with pytest.raises(InternalError, match="AeroBuildup evaluation failed unexpectedly"):
+                asyncio.run(
+                    trim_with_aerobuildup(
+                        db=MagicMock(), aeroplane_uuid="test-uuid", request=request
+                    )
+                )
+
+    @patch("app.converters.model_schema_converters.aeroplane_schema_to_asb_airplane_async")
+    @patch("app.services.analysis_service.get_aeroplane_schema_or_raise")
+    def test_invalid_target_coefficient_in_output_raises(self, mock_get_schema, mock_to_asb):
+        """When the target coefficient is missing from AeroBuildup output, raise ValidationDomainError."""
+        from app.core.exceptions import ValidationDomainError
+        from app.schemas.aeroanalysisschema import (
+            AeroBuildupTrimRequest,
+            OperatingPointSchema,
+        )
+        from app.services.aerobuildup_trim_service import trim_with_aerobuildup
+
+        mock_get_schema.return_value = MagicMock()
+        mock_airplane = _make_mock_airplane_with_controls(["elevator"])
+        mock_to_asb.return_value = mock_airplane
+
+        def mock_run_single(asb_airplane, op_point, xyz_ref, trim_variable, deflection_deg):
+            return {"CL": 0.5, "CD": 0.03}  # No "Cm" key
+
+        with patch(
+            "app.services.aerobuildup_trim_service._run_single_aerobuildup",
+            side_effect=mock_run_single,
+        ):
+            request = AeroBuildupTrimRequest(
+                operating_point=OperatingPointSchema(velocity=15.0, alpha=5.0),
+                trim_variable="elevator",
+            )
+            with pytest.raises(ValidationDomainError, match="Coefficient 'Cm' not found"):
+                asyncio.run(
+                    trim_with_aerobuildup(
+                        db=MagicMock(), aeroplane_uuid="test-uuid", request=request
+                    )
+                )
 
 
 # =========================================================================== #
@@ -578,3 +660,30 @@ class TestAeroBuildupTrimEndpoint:
             json=payload,
         )
         assert resp.status_code == 422
+
+    @patch("app.services.aerobuildup_trim_service.trim_with_aerobuildup")
+    def test_endpoint_not_converged_returns_null_achieved(self, mock_trim, client_and_db):
+        from app.schemas.aeroanalysisschema import AeroBuildupTrimResult
+
+        client, _ = client_and_db
+        aeroplane_uuid = str(uuid.uuid4())
+
+        mock_trim.return_value = AeroBuildupTrimResult(
+            converged=False,
+            trim_variable="elevator",
+            trimmed_deflection=0.0,
+            target_coefficient="Cm",
+            achieved_value=None,
+        )
+
+        payload = {
+            "operating_point": {"velocity": 15.0, "alpha": 5.0},
+        }
+        resp = client.post(
+            f"/aeroplanes/{aeroplane_uuid}/operating-points/aerobuildup-trim",
+            json=payload,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["converged"] is False
+        assert data["achieved_value"] is None

--- a/app/tests/test_aerobuildup_trim.py
+++ b/app/tests/test_aerobuildup_trim.py
@@ -1,0 +1,580 @@
+"""Tests for AeroBuildup trim analysis — scipy root-finding.
+
+Covers: AeroBuildupTrimRequest, AeroBuildupTrimResult schemas,
+trim_with_aerobuildup service, and the aerobuildup-trim endpoint.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# =========================================================================== #
+# Schema validation — AeroBuildupTrimRequest
+# =========================================================================== #
+
+
+class TestAeroBuildupTrimRequest:
+    """Verify AeroBuildupTrimRequest schema validation."""
+
+    def test_valid_request_with_defaults(self):
+        from app.schemas.aeroanalysisschema import (
+            AeroBuildupTrimRequest,
+            OperatingPointSchema,
+        )
+
+        req = AeroBuildupTrimRequest(
+            operating_point=OperatingPointSchema(velocity=15.0, alpha=5.0),
+        )
+        assert req.trim_variable == "elevator"
+        assert req.target_coefficient == "Cm"
+        assert req.target_value == 0.0
+        assert req.deflection_bounds == [-25.0, 25.0]
+
+    def test_valid_request_custom_values(self):
+        from app.schemas.aeroanalysisschema import (
+            AeroBuildupTrimRequest,
+            OperatingPointSchema,
+        )
+
+        req = AeroBuildupTrimRequest(
+            operating_point=OperatingPointSchema(velocity=20.0, alpha=3.0),
+            trim_variable="aileron",
+            target_coefficient="Cl",
+            target_value=0.01,
+            deflection_bounds=[-15.0, 15.0],
+        )
+        assert req.trim_variable == "aileron"
+        assert req.target_coefficient == "Cl"
+        assert req.target_value == 0.01
+        assert req.deflection_bounds == [-15.0, 15.0]
+
+    def test_invalid_trim_variable_special_chars(self):
+        from pydantic import ValidationError as PydanticValidationError
+
+        from app.schemas.aeroanalysisschema import (
+            AeroBuildupTrimRequest,
+            OperatingPointSchema,
+        )
+
+        with pytest.raises(PydanticValidationError, match="Invalid trim variable name"):
+            AeroBuildupTrimRequest(
+                operating_point=OperatingPointSchema(velocity=15.0),
+                trim_variable="bad-name!",
+            )
+
+    def test_invalid_trim_variable_starts_with_digit(self):
+        from pydantic import ValidationError as PydanticValidationError
+
+        from app.schemas.aeroanalysisschema import (
+            AeroBuildupTrimRequest,
+            OperatingPointSchema,
+        )
+
+        with pytest.raises(PydanticValidationError, match="Invalid trim variable name"):
+            AeroBuildupTrimRequest(
+                operating_point=OperatingPointSchema(velocity=15.0),
+                trim_variable="1elevator",
+            )
+
+    def test_invalid_trim_variable_empty(self):
+        from pydantic import ValidationError as PydanticValidationError
+
+        from app.schemas.aeroanalysisschema import (
+            AeroBuildupTrimRequest,
+            OperatingPointSchema,
+        )
+
+        with pytest.raises(PydanticValidationError, match="Invalid trim variable name"):
+            AeroBuildupTrimRequest(
+                operating_point=OperatingPointSchema(velocity=15.0),
+                trim_variable="",
+            )
+
+    def test_bounds_wrong_order_rejected(self):
+        from pydantic import ValidationError as PydanticValidationError
+
+        from app.schemas.aeroanalysisschema import (
+            AeroBuildupTrimRequest,
+            OperatingPointSchema,
+        )
+
+        with pytest.raises(PydanticValidationError, match="must be less than"):
+            AeroBuildupTrimRequest(
+                operating_point=OperatingPointSchema(velocity=15.0),
+                deflection_bounds=[25.0, -25.0],
+            )
+
+    def test_bounds_equal_rejected(self):
+        from pydantic import ValidationError as PydanticValidationError
+
+        from app.schemas.aeroanalysisschema import (
+            AeroBuildupTrimRequest,
+            OperatingPointSchema,
+        )
+
+        with pytest.raises(PydanticValidationError, match="must be less than"):
+            AeroBuildupTrimRequest(
+                operating_point=OperatingPointSchema(velocity=15.0),
+                deflection_bounds=[0.0, 0.0],
+            )
+
+    def test_alpha_as_list_rejected(self):
+        from pydantic import ValidationError as PydanticValidationError
+
+        from app.schemas.aeroanalysisschema import (
+            AeroBuildupTrimRequest,
+            OperatingPointSchema,
+        )
+
+        with pytest.raises(PydanticValidationError, match="Alpha must be a scalar"):
+            AeroBuildupTrimRequest(
+                operating_point=OperatingPointSchema(velocity=15.0, alpha=[1.0, 2.0]),
+            )
+
+    def test_custom_target_coefficient(self):
+        from app.schemas.aeroanalysisschema import (
+            AeroBuildupTrimRequest,
+            OperatingPointSchema,
+        )
+
+        req = AeroBuildupTrimRequest(
+            operating_point=OperatingPointSchema(velocity=15.0, alpha=5.0),
+            target_coefficient="CL",
+            target_value=0.5,
+        )
+        assert req.target_coefficient == "CL"
+        assert req.target_value == 0.5
+
+
+# =========================================================================== #
+# Schema validation — AeroBuildupTrimResult
+# =========================================================================== #
+
+
+class TestAeroBuildupTrimResult:
+    """Verify AeroBuildupTrimResult schema construction."""
+
+    def test_result_with_all_fields(self):
+        from app.schemas.aeroanalysisschema import AeroBuildupTrimResult
+
+        result = AeroBuildupTrimResult(
+            converged=True,
+            trim_variable="elevator",
+            trimmed_deflection=-3.5,
+            target_coefficient="Cm",
+            achieved_value=0.0001,
+            aero_coefficients={"CL": 0.5, "CD": 0.03, "Cm": 0.0001},
+            stability_derivatives={"CL_a": 6.1, "Cm_a": -1.2},
+        )
+        assert result.converged is True
+        assert result.trim_variable == "elevator"
+        assert result.trimmed_deflection == -3.5
+        assert result.target_coefficient == "Cm"
+        assert result.achieved_value == 0.0001
+        assert result.aero_coefficients["CL"] == 0.5
+        assert result.stability_derivatives["CL_a"] == 6.1
+
+    def test_result_not_converged(self):
+        from app.schemas.aeroanalysisschema import AeroBuildupTrimResult
+
+        result = AeroBuildupTrimResult(
+            converged=False,
+            trim_variable="elevator",
+            trimmed_deflection=0.0,
+            target_coefficient="Cm",
+            achieved_value=float("nan"),
+        )
+        assert result.converged is False
+        assert result.trim_variable == "elevator"
+        assert result.trimmed_deflection == 0.0
+        assert result.aero_coefficients == {}
+        assert result.stability_derivatives == {}
+
+
+# =========================================================================== #
+# Service unit tests — trim_with_aerobuildup (mocked)
+# =========================================================================== #
+
+
+def _make_mock_airplane_with_controls(control_names: list[str]) -> MagicMock:
+    """Build a mock ASB airplane with the given control surfaces."""
+    airplane = MagicMock()
+    cs_list = []
+    for name in control_names:
+        cs = MagicMock()
+        cs.name = name
+        cs.deflection = 0.0
+        cs_list.append(cs)
+    xsec = MagicMock()
+    xsec.control_surfaces = cs_list
+    wing = MagicMock()
+    wing.xsecs = [xsec]
+    airplane.wings = [wing]
+    return airplane
+
+
+class TestTrimWithAerobuildup:
+    """Verify the trim_with_aerobuildup service orchestrates correctly."""
+
+    @patch("app.converters.model_schema_converters.aeroplane_schema_to_asb_airplane_async")
+    @patch("app.services.analysis_service.get_aeroplane_schema_or_raise")
+    def test_success_trim_converges(self, mock_get_schema, mock_to_asb):
+        """Mock AeroBuildup so Cm varies linearly with deflection; verify convergence."""
+        from app.schemas.aeroanalysisschema import (
+            AeroBuildupTrimRequest,
+            OperatingPointSchema,
+        )
+        from app.services.aerobuildup_trim_service import trim_with_aerobuildup
+
+        mock_get_schema.return_value = MagicMock()
+        mock_airplane = _make_mock_airplane_with_controls(["elevator"])
+        mock_to_asb.return_value = mock_airplane
+
+        # Mock AeroBuildup: Cm = 0.1 * deflection (trim at deflection=0)
+        # But we want Cm=0 for trim — the residual is Cm - 0 = 0.1*d
+        # So trim should find deflection=0.0
+        def mock_aerobuildup_init(airplane, op_point, xyz_ref):
+            abu = MagicMock()
+
+            def run_with_stability_derivatives():
+                # We need to get the deflection from the airplane's control surface
+                # But since we're mocking with_control_deflections, we track the deflection
+                return {
+                    "CL": 0.5,
+                    "CD": 0.03,
+                    "CY": 0.0,
+                    "Cm": 0.0,  # Will be overridden below
+                    "Cl": 0.0,
+                    "Cn": 0.0,
+                    "CL_a": 6.1,
+                    "Cm_a": -1.2,
+                }
+
+            abu.run_with_stability_derivatives = run_with_stability_derivatives
+            return abu
+
+        # Instead of mocking AeroBuildup class, mock _run_single_aerobuildup
+        call_count = [0]
+        deflections_seen = []
+
+        def mock_run_single(asb_airplane, op_point, xyz_ref, trim_variable, deflection_deg):
+            call_count[0] += 1
+            deflections_seen.append(deflection_deg)
+            # Cm varies linearly: Cm = 0.1 + 0.02 * deflection
+            # Root at deflection = -5.0
+            cm_val = 0.1 + 0.02 * deflection_deg
+            return {
+                "CL": 0.5,
+                "CD": 0.03,
+                "CY": 0.0,
+                "Cm": cm_val,
+                "Cl": 0.0,
+                "Cn": 0.0,
+                "CL_a": 6.1,
+                "Cm_a": -1.2,
+            }
+
+        with patch(
+            "app.services.aerobuildup_trim_service._run_single_aerobuildup",
+            side_effect=mock_run_single,
+        ):
+            request = AeroBuildupTrimRequest(
+                operating_point=OperatingPointSchema(velocity=15.0, alpha=5.0),
+                trim_variable="elevator",
+            )
+            result = asyncio.run(
+                trim_with_aerobuildup(db=MagicMock(), aeroplane_uuid="test-uuid", request=request)
+            )
+
+        assert result.converged is True
+        assert result.trim_variable == "elevator"
+        assert result.target_coefficient == "Cm"
+        assert abs(result.trimmed_deflection - (-5.0)) < 1e-4
+        assert abs(result.achieved_value) < 1e-4
+        assert "CL" in result.aero_coefficients
+        assert "CL_a" in result.stability_derivatives
+
+    @patch("app.services.analysis_service.get_aeroplane_schema_or_raise")
+    def test_aeroplane_not_found(self, mock_get_schema):
+        from app.core.exceptions import NotFoundError
+        from app.schemas.aeroanalysisschema import (
+            AeroBuildupTrimRequest,
+            OperatingPointSchema,
+        )
+        from app.services.aerobuildup_trim_service import trim_with_aerobuildup
+
+        mock_get_schema.side_effect = NotFoundError(message="not found")
+
+        request = AeroBuildupTrimRequest(
+            operating_point=OperatingPointSchema(velocity=15.0),
+        )
+
+        with pytest.raises(NotFoundError):
+            asyncio.run(
+                trim_with_aerobuildup(db=MagicMock(), aeroplane_uuid="bad-uuid", request=request)
+            )
+
+    @patch("app.converters.model_schema_converters.aeroplane_schema_to_asb_airplane_async")
+    @patch("app.services.analysis_service.get_aeroplane_schema_or_raise")
+    def test_control_surface_not_found(self, mock_get_schema, mock_to_asb):
+        from app.core.exceptions import ValidationDomainError
+        from app.schemas.aeroanalysisschema import (
+            AeroBuildupTrimRequest,
+            OperatingPointSchema,
+        )
+        from app.services.aerobuildup_trim_service import trim_with_aerobuildup
+
+        mock_get_schema.return_value = MagicMock()
+        # Airplane has no control surfaces
+        mock_airplane = _make_mock_airplane_with_controls([])
+        mock_to_asb.return_value = mock_airplane
+
+        request = AeroBuildupTrimRequest(
+            operating_point=OperatingPointSchema(velocity=15.0, alpha=5.0),
+            trim_variable="elevator",
+        )
+
+        with pytest.raises(ValidationDomainError, match="Control surface 'elevator' not found"):
+            asyncio.run(
+                trim_with_aerobuildup(db=MagicMock(), aeroplane_uuid="test-uuid", request=request)
+            )
+
+    @patch("app.converters.model_schema_converters.aeroplane_schema_to_asb_airplane_async")
+    @patch("app.services.analysis_service.get_aeroplane_schema_or_raise")
+    def test_root_not_bracketed_returns_not_converged(self, mock_get_schema, mock_to_asb):
+        """When residual has the same sign at both bounds, return converged=False."""
+        from app.schemas.aeroanalysisschema import (
+            AeroBuildupTrimRequest,
+            OperatingPointSchema,
+        )
+        from app.services.aerobuildup_trim_service import trim_with_aerobuildup
+
+        mock_get_schema.return_value = MagicMock()
+        mock_airplane = _make_mock_airplane_with_controls(["elevator"])
+        mock_to_asb.return_value = mock_airplane
+
+        # Cm is always positive — no root in bounds
+        def mock_run_single(asb_airplane, op_point, xyz_ref, trim_variable, deflection_deg):
+            return {
+                "CL": 0.5,
+                "CD": 0.03,
+                "Cm": 1.0,  # Always positive, never crosses zero
+            }
+
+        with patch(
+            "app.services.aerobuildup_trim_service._run_single_aerobuildup",
+            side_effect=mock_run_single,
+        ):
+            request = AeroBuildupTrimRequest(
+                operating_point=OperatingPointSchema(velocity=15.0, alpha=5.0),
+                trim_variable="elevator",
+            )
+            result = asyncio.run(
+                trim_with_aerobuildup(db=MagicMock(), aeroplane_uuid="test-uuid", request=request)
+            )
+
+        assert result.converged is False
+        assert math.isnan(result.achieved_value)
+
+    @patch("app.converters.model_schema_converters.aeroplane_schema_to_asb_airplane_async")
+    @patch("app.services.analysis_service.get_aeroplane_schema_or_raise")
+    def test_brentq_convergence_failure_returns_not_converged(self, mock_get_schema, mock_to_asb):
+        """If brentq raises ValueError internally, return converged=False."""
+        from app.schemas.aeroanalysisschema import (
+            AeroBuildupTrimRequest,
+            OperatingPointSchema,
+        )
+        from app.services.aerobuildup_trim_service import trim_with_aerobuildup
+
+        mock_get_schema.return_value = MagicMock()
+        mock_airplane = _make_mock_airplane_with_controls(["elevator"])
+        mock_to_asb.return_value = mock_airplane
+
+        # Residual changes sign (so bracket check passes) but brentq fails
+        call_count = [0]
+
+        def mock_run_single(asb_airplane, op_point, xyz_ref, trim_variable, deflection_deg):
+            call_count[0] += 1
+            # First two calls: bounds evaluation (opposite signs)
+            if call_count[0] <= 2:
+                return {
+                    "CL": 0.5,
+                    "CD": 0.03,
+                    "Cm": -1.0 if deflection_deg < 0 else 1.0,
+                }
+            # Subsequent calls during brentq: raise to simulate failure
+            raise RuntimeError("simulation diverged")
+
+        with patch(
+            "app.services.aerobuildup_trim_service._run_single_aerobuildup",
+            side_effect=mock_run_single,
+        ):
+            # brentq will catch the RuntimeError and re-raise as ValueError
+            # Actually, brentq doesn't catch runtime errors — it will propagate.
+            # Let's mock brentq itself to raise ValueError
+            pass
+
+        # Better approach: mock brentq directly
+        with (
+            patch(
+                "app.services.aerobuildup_trim_service._run_single_aerobuildup",
+                side_effect=lambda *a, **kw: {
+                    "CL": 0.5,
+                    "CD": 0.03,
+                    "Cm": -0.5 if a[4] < 0 else 0.5,
+                },
+            ),
+            patch(
+                "app.services.aerobuildup_trim_service.brentq",
+                side_effect=ValueError("convergence failed"),
+            ),
+        ):
+            request = AeroBuildupTrimRequest(
+                operating_point=OperatingPointSchema(velocity=15.0, alpha=5.0),
+                trim_variable="elevator",
+            )
+            result = asyncio.run(
+                trim_with_aerobuildup(db=MagicMock(), aeroplane_uuid="test-uuid", request=request)
+            )
+
+        assert result.converged is False
+        assert math.isnan(result.achieved_value)
+
+
+# =========================================================================== #
+# Endpoint integration tests
+# =========================================================================== #
+
+
+class TestAeroBuildupTrimEndpoint:
+    """Verify the /aeroplanes/{uuid}/operating-points/aerobuildup-trim endpoint."""
+
+    @pytest.fixture()
+    def client_and_db(self):
+        from fastapi.testclient import TestClient
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import sessionmaker
+        from sqlalchemy.pool import StaticPool
+
+        from app.db.base import Base
+        from app.db.session import get_db
+        from app.main import create_app
+
+        engine = create_engine(
+            "sqlite://",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(bind=engine)
+        TestingSessionLocal = sessionmaker(bind=engine)
+
+        app = create_app()
+
+        def override_get_db():
+            db = TestingSessionLocal()
+            try:
+                yield db
+                db.commit()
+            except Exception:
+                db.rollback()
+                raise
+            finally:
+                db.close()
+
+        app.dependency_overrides[get_db] = override_get_db
+        with TestClient(app) as client:
+            yield client, TestingSessionLocal
+
+        app.dependency_overrides.clear()
+        Base.metadata.drop_all(bind=engine)
+
+    @patch("app.services.aerobuildup_trim_service.trim_with_aerobuildup")
+    def test_endpoint_success(self, mock_trim, client_and_db):
+        from app.schemas.aeroanalysisschema import AeroBuildupTrimResult
+
+        client, _ = client_and_db
+        aeroplane_uuid = str(uuid.uuid4())
+
+        mock_trim.return_value = AeroBuildupTrimResult(
+            converged=True,
+            trim_variable="elevator",
+            trimmed_deflection=-3.5,
+            target_coefficient="Cm",
+            achieved_value=0.0001,
+            aero_coefficients={"CL": 0.5, "CD": 0.03, "Cm": 0.0001},
+            stability_derivatives={"CL_a": 6.1},
+        )
+
+        payload = {
+            "operating_point": {"velocity": 15.0, "alpha": 5.0},
+            "trim_variable": "elevator",
+        }
+        resp = client.post(
+            f"/aeroplanes/{aeroplane_uuid}/operating-points/aerobuildup-trim",
+            json=payload,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["converged"] is True
+        assert data["trim_variable"] == "elevator"
+        assert data["trimmed_deflection"] == -3.5
+        assert data["aero_coefficients"]["CL"] == 0.5
+
+    @patch("app.services.aerobuildup_trim_service.trim_with_aerobuildup")
+    def test_endpoint_not_found(self, mock_trim, client_and_db):
+        from app.core.exceptions import NotFoundError
+
+        client, _ = client_and_db
+        aeroplane_uuid = str(uuid.uuid4())
+
+        mock_trim.side_effect = NotFoundError(message="Aeroplane not found")
+
+        payload = {
+            "operating_point": {"velocity": 15.0, "alpha": 5.0},
+        }
+        resp = client.post(
+            f"/aeroplanes/{aeroplane_uuid}/operating-points/aerobuildup-trim",
+            json=payload,
+        )
+        assert resp.status_code == 404
+
+    def test_endpoint_validation_error_from_schema(self, client_and_db):
+        """Invalid trim_variable should be rejected at the schema level (422)."""
+        client, _ = client_and_db
+        aeroplane_uuid = str(uuid.uuid4())
+
+        payload = {
+            "operating_point": {"velocity": 15.0, "alpha": 5.0},
+            "trim_variable": "bad-name!",
+        }
+        resp = client.post(
+            f"/aeroplanes/{aeroplane_uuid}/operating-points/aerobuildup-trim",
+            json=payload,
+        )
+        assert resp.status_code == 422
+
+    @patch("app.services.aerobuildup_trim_service.trim_with_aerobuildup")
+    def test_endpoint_domain_validation_error(self, mock_trim, client_and_db):
+        from app.core.exceptions import ValidationDomainError
+
+        client, _ = client_and_db
+        aeroplane_uuid = str(uuid.uuid4())
+
+        mock_trim.side_effect = ValidationDomainError(
+            message="Control surface 'elevator' not found on airplane."
+        )
+
+        payload = {
+            "operating_point": {"velocity": 15.0, "alpha": 5.0},
+        }
+        resp = client.post(
+            f"/aeroplanes/{aeroplane_uuid}/operating-points/aerobuildup-trim",
+            json=payload,
+        )
+        assert resp.status_code == 422


### PR DESCRIPTION
## Summary

- Adds AeroBuildup trim analysis using `scipy.optimize.brentq` root-finding to find control surface deflections that achieve a target aerodynamic coefficient (default: Cm=0 for pitch trim)
- New endpoint `POST /v2/aeroplanes/{id}/operating-points/aerobuildup-trim` following the same pattern as the AVL trim endpoint (#418)
- 20 new tests covering schema validation, service unit tests, and endpoint integration

## Changes

### New files
- `app/services/aerobuildup_trim_service.py` — Service using brentq to find the deflection angle that zeros a target coefficient
- `app/tests/test_aerobuildup_trim.py` — 20 comprehensive tests

### Modified files
- `app/schemas/aeroanalysisschema.py` — `AeroBuildupTrimRequest` and `AeroBuildupTrimResult` schemas
- `app/api/v2/endpoints/operating_points.py` — New endpoint wired to the service

## Design decisions
- Single-variable optimization (brentq) rather than multi-variable (Opti) — simpler, faster, matches the issue spec
- Graceful `converged=False` return when root is not bracketed or brentq fails, rather than raising exceptions
- Validates control surface existence on the airplane before attempting trim
- Final run at trim deflection to capture full aero coefficients + stability derivatives

## Test plan
- [x] Schema validation: defaults, custom values, invalid trim variable, bounds ordering, alpha-as-list rejection
- [x] Service: convergence (linear Cm model), not found, missing control surface, no bracket, brentq failure
- [x] Endpoint: 200 success, 404, 422 schema, 422 domain
- [x] AVL trim regression: all 41 existing tests pass
- [x] Full suite: 2419 tests pass

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)