### PR TITLE
feat(gh-420): mass and CG as design parameters with what-if simulation

### DIFF
--- a/app/api/v2/endpoints/aeroplane/__init__.py
+++ b/app/api/v2/endpoints/aeroplane/__init__.py
@@ -15,6 +15,7 @@ from .design_versions import router as design_versions_router
 from .powertrain_sizing import router as powertrain_sizing_router
 from .avl_geometry import router as avl_geometry_router
 from .design_assumptions import router as design_assumptions_router
+from .mass_cg import router as mass_cg_router
 
 # Include the routers
 router.include_router(base_router)
@@ -27,3 +28,4 @@ router.include_router(design_versions_router)
 router.include_router(powertrain_sizing_router)
 router.include_router(avl_geometry_router)
 router.include_router(design_assumptions_router)
+router.include_router(mass_cg_router)

--- a/app/api/v2/endpoints/aeroplane/mass_cg.py
+++ b/app/api/v2/endpoints/aeroplane/mass_cg.py
@@ -1,0 +1,127 @@
+"""Mass / CG design parameter endpoints."""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, status
+from pydantic import UUID4
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import (
+    ConflictError,
+    InternalError,
+    NotFoundError,
+    ServiceException,
+    ValidationDomainError,
+    ValidationError,
+)
+from app.db.session import get_db
+from app.schemas.mass_cg import (
+    CGComparisonResponse,
+    DesignMetricsRequest,
+    DesignMetricsResponse,
+    MassSweepRequest,
+    MassSweepResponse,
+)
+from app.services import mass_cg_service as svc
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _raise_http(exc: ServiceException) -> None:
+    if isinstance(exc, NotFoundError):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=exc.message) from exc
+    if isinstance(exc, (ValidationError, ValidationDomainError)):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=exc.message
+        ) from exc
+    if isinstance(exc, ConflictError):
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=exc.message) from exc
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=exc.message
+    ) from exc
+
+
+def _call(func, *args, **kwargs):
+    try:
+        return func(*args, **kwargs)
+    except ServiceException as exc:
+        _raise_http(exc)
+    except Exception as exc:
+        logger.error("Unexpected error in mass_cg: %s", exc, exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Unexpected error: {exc}") from exc
+
+
+@router.post(
+    "/aeroplanes/{aeroplane_id}/design_metrics",
+    status_code=status.HTTP_200_OK,
+    tags=["mass-cg"],
+    operation_id="compute_design_metrics",
+    responses={
+        404: {"description": "Resource not found"},
+        422: {"description": "Validation error"},
+        500: {"description": "Internal server error"},
+    },
+)
+async def design_metrics_endpoint(
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    body: Annotated[DesignMetricsRequest, Body(..., description="Flight condition")],
+    db: Annotated[Session, Depends(get_db)],
+) -> DesignMetricsResponse:
+    """Compute mass-dependent design metrics (stall speed, wing loading, required CL)."""
+    return _call(
+        svc.get_design_metrics_for_aeroplane,
+        db,
+        aeroplane_id,
+        body.velocity,
+        body.altitude,
+    )
+
+
+@router.post(
+    "/aeroplanes/{aeroplane_id}/mass_sweep",
+    status_code=status.HTTP_200_OK,
+    tags=["mass-cg"],
+    operation_id="compute_mass_sweep",
+    responses={
+        404: {"description": "Resource not found"},
+        422: {"description": "Validation error"},
+        500: {"description": "Internal server error"},
+    },
+)
+async def mass_sweep_endpoint(
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    body: Annotated[MassSweepRequest, Body(..., description="Sweep parameters")],
+    db: Annotated[Session, Depends(get_db)],
+) -> MassSweepResponse:
+    """Sweep mass values and compute derived metrics at each point (no aero re-run)."""
+    return _call(
+        svc.get_mass_sweep_for_aeroplane,
+        db,
+        aeroplane_id,
+        body.masses_kg,
+        body.velocity,
+        body.altitude,
+    )
+
+
+@router.get(
+    "/aeroplanes/{aeroplane_id}/cg_comparison",
+    status_code=status.HTTP_200_OK,
+    tags=["mass-cg"],
+    operation_id="get_cg_comparison",
+    responses={
+        404: {"description": "Resource not found"},
+        500: {"description": "Internal server error"},
+    },
+)
+async def cg_comparison_endpoint(
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    db: Annotated[Session, Depends(get_db)],
+) -> CGComparisonResponse:
+    """Compare design CG (from assumptions) with component-tree CG (from weight items)."""
+    return _call(svc.get_cg_comparison, db, aeroplane_id)

--- a/app/schemas/mass_cg.py
+++ b/app/schemas/mass_cg.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 from pydantic import BaseModel, Field
 
 
@@ -44,8 +46,8 @@ class DesignMetricsResponse(BaseModel):
 class MassSweepRequest(BaseModel):
     """Input for a mass sweep (post-processing, no re-run of aero)."""
 
-    masses_kg: list[float] = Field(
-        ..., min_length=1, description="List of mass values to evaluate [kg]"
+    masses_kg: list[Annotated[float, Field(gt=0)]] = Field(
+        ..., min_length=1, max_length=100, description="List of mass values to evaluate [kg]"
     )
     velocity: float = Field(15.0, gt=0, description="Cruise velocity in m/s")
     altitude: float = Field(0.0, ge=0, description="Altitude in meters")
@@ -54,11 +56,11 @@ class MassSweepRequest(BaseModel):
 class MassSweepPoint(BaseModel):
     """One data point in a mass sweep."""
 
-    mass_kg: float
-    wing_loading_pa: float
-    stall_speed_ms: float
-    required_cl: float
-    cl_margin: float
+    mass_kg: float = Field(..., description="Mass at this sweep point [kg]")
+    wing_loading_pa: float = Field(..., description="Wing loading W/S [N/m^2]")
+    stall_speed_ms: float = Field(..., description="Stall speed at given altitude [m/s]")
+    required_cl: float = Field(..., description="CL required for level flight")
+    cl_margin: float = Field(..., description="CL_max - required_CL")
 
 
 class MassSweepResponse(BaseModel):

--- a/app/schemas/mass_cg.py
+++ b/app/schemas/mass_cg.py
@@ -1,0 +1,93 @@
+"""Schemas for mass/CG design parameter endpoints."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class RecommendedCGRequest(BaseModel):
+    """Input for computing the recommended CG position."""
+
+    velocity: float = Field(15.0, gt=0, description="Airspeed in m/s")
+    alpha: float = Field(0.0, description="Angle of attack in degrees")
+    altitude: float = Field(0.0, ge=0, description="Altitude in meters")
+
+
+class RecommendedCGResponse(BaseModel):
+    """Result of the recommended CG computation."""
+
+    neutral_point_x: float = Field(..., description="Neutral point x-position [m]")
+    mac: float = Field(..., description="Mean aerodynamic chord [m]")
+    target_static_margin: float = Field(..., description="Target static margin (fraction of MAC)")
+    recommended_cg_x: float = Field(..., description="Recommended CG x-position [m]: NP - SM * MAC")
+
+
+class DesignMetricsRequest(BaseModel):
+    """Input for computing mass-dependent design metrics."""
+
+    velocity: float = Field(15.0, gt=0, description="Cruise velocity in m/s")
+    altitude: float = Field(0.0, ge=0, description="Altitude in meters")
+
+
+class DesignMetricsResponse(BaseModel):
+    """Mass-dependent derived design quantities."""
+
+    mass_kg: float = Field(..., description="Effective mass used [kg]")
+    s_ref: float = Field(..., description="Wing reference area [m^2]")
+    cl_max: float = Field(..., description="Maximum lift coefficient")
+    wing_loading_pa: float = Field(..., description="Wing loading W/S [N/m^2]")
+    stall_speed_ms: float = Field(..., description="Stall speed at given altitude [m/s]")
+    required_cl: float = Field(..., description="CL required for level flight at given velocity")
+    cl_margin: float = Field(..., description="CL_max - required_CL (positive = above stall)")
+
+
+class MassSweepRequest(BaseModel):
+    """Input for a mass sweep (post-processing, no re-run of aero)."""
+
+    masses_kg: list[float] = Field(
+        ..., min_length=1, description="List of mass values to evaluate [kg]"
+    )
+    velocity: float = Field(15.0, gt=0, description="Cruise velocity in m/s")
+    altitude: float = Field(0.0, ge=0, description="Altitude in meters")
+
+
+class MassSweepPoint(BaseModel):
+    """One data point in a mass sweep."""
+
+    mass_kg: float
+    wing_loading_pa: float
+    stall_speed_ms: float
+    required_cl: float
+    cl_margin: float
+
+
+class MassSweepResponse(BaseModel):
+    """Result of a mass sweep."""
+
+    s_ref: float = Field(..., description="Wing reference area [m^2]")
+    cl_max: float = Field(..., description="Maximum lift coefficient")
+    velocity: float = Field(..., description="Cruise velocity used [m/s]")
+    altitude: float = Field(..., description="Altitude used [m]")
+    points: list[MassSweepPoint] = Field(..., description="Sweep data points")
+
+
+class CGComparisonResponse(BaseModel):
+    """Comparison between design CG and component-tree CG."""
+
+    design_cg_x: float = Field(..., description="CG from effective design assumption [m]")
+    component_cg_x: float | None = Field(
+        None, description="CG computed from weight items [m] (None if no items)"
+    )
+    component_cg_y: float | None = Field(None, description="CG Y from weight items [m]")
+    component_cg_z: float | None = Field(None, description="CG Z from weight items [m]")
+    component_total_mass_kg: float | None = Field(
+        None, description="Total mass from weight items [kg]"
+    )
+    delta_x: float | None = Field(
+        None,
+        description="design_cg_x - component_cg_x [m] (None if no component CG)",
+    )
+    within_tolerance: bool | None = Field(
+        None,
+        description="True if |delta_x| < 0.01 m (None if no component CG)",
+    )

--- a/app/schemas/weight_item.py
+++ b/app/schemas/weight_item.py
@@ -5,9 +5,7 @@ from typing import Literal, Optional
 from pydantic import BaseModel, Field
 
 
-WEIGHT_CATEGORIES = Literal[
-    "electronics", "battery", "structural", "payload", "other"
-]
+WEIGHT_CATEGORIES = Literal["electronics", "battery", "structural", "payload", "other"]
 
 
 class WeightItemWrite(BaseModel):
@@ -27,3 +25,6 @@ class WeightItemRead(WeightItemWrite):
 class WeightSummary(BaseModel):
     items: list[WeightItemRead] = Field(default_factory=list)
     total_mass_kg: float = Field(0.0, description="Sum of all item masses")
+    cg_x_m: float | None = Field(None, description="Mass-weighted CG X [m]")
+    cg_y_m: float | None = Field(None, description="Mass-weighted CG Y [m]")
+    cg_z_m: float | None = Field(None, description="Mass-weighted CG Z [m]")

--- a/app/services/design_assumptions_service.py
+++ b/app/services/design_assumptions_service.py
@@ -99,9 +99,7 @@ def list_assumptions(db: Session, aeroplane_uuid) -> AssumptionsSummary:
             .all()
         )
         assumptions = [_assumption_to_read(r) for r in rows]
-        warnings_count = sum(
-            1 for a in assumptions if a.divergence_level in ("warning", "alert")
-        )
+        warnings_count = sum(1 for a in assumptions if a.divergence_level in ("warning", "alert"))
         return AssumptionsSummary(assumptions=assumptions, warnings_count=warnings_count)
     except NotFoundError:
         raise
@@ -172,4 +170,42 @@ def switch_source(
         raise
     except SQLAlchemyError as exc:
         logger.error("DB error in switch_source: %s", exc)
+        raise InternalError(message=f"Database error: {exc}") from exc
+
+
+def update_calculated_value(
+    db: Session,
+    aeroplane_uuid,
+    param_name: str,
+    value: float | None,
+    source: str | None,
+) -> AssumptionRead:
+    """Update the calculated value and source for a design assumption.
+
+    Called by aggregation services (e.g. weight-item sync) to feed
+    computed values back into the assumption row. Recomputes divergence.
+    """
+    try:
+        aeroplane = _get_aeroplane(db, aeroplane_uuid)
+        row = (
+            db.query(DesignAssumptionModel)
+            .filter(
+                DesignAssumptionModel.aeroplane_id == aeroplane.id,
+                DesignAssumptionModel.parameter_name == param_name,
+            )
+            .first()
+        )
+        if row is None:
+            raise NotFoundError(entity="DesignAssumption", resource_id=param_name)
+
+        row.calculated_value = value
+        row.calculated_source = source
+        row.divergence_pct = compute_divergence_pct(row.estimate_value, value)
+        db.flush()
+        db.refresh(row)
+        return _assumption_to_read(row)
+    except NotFoundError:
+        raise
+    except SQLAlchemyError as exc:
+        logger.error("DB error in update_calculated_value: %s", exc)
         raise InternalError(message=f"Database error: {exc}") from exc

--- a/app/services/mass_cg_service.py
+++ b/app/services/mass_cg_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import math
-from typing import Sequence
+from typing import Sequence, TypedDict
 
 from sqlalchemy.orm import Session
 
@@ -21,6 +21,13 @@ logger = logging.getLogger(__name__)
 
 GRAVITY = 9.81
 CG_TOLERANCE_M = 0.01
+
+
+class WeightItemData(TypedDict):
+    mass_kg: float
+    x_m: float
+    y_m: float
+    z_m: float
 
 
 # ---------------------------------------------------------------------------
@@ -47,6 +54,10 @@ def compute_design_metrics(
         raise ValidationError(message="s_ref must be positive")
     if cl_max <= 0:
         raise ValidationError(message="cl_max must be positive")
+    if rho <= 0:
+        raise ValidationError(message="rho must be positive")
+    if velocity <= 0:
+        raise ValidationError(message="velocity must be positive")
 
     weight = mass_kg * GRAVITY
     wing_loading = weight / s_ref
@@ -90,7 +101,7 @@ def compute_mass_sweep(
 
 
 def aggregate_weight_items(
-    items: Sequence[dict],
+    items: Sequence[WeightItemData],
 ) -> tuple[float | None, float | None, float | None, float | None]:
     """Compute total mass and mass-weighted CG from a list of weight item dicts.
 
@@ -146,35 +157,36 @@ def sync_weight_items_to_assumptions(db: Session, aeroplane_uuid) -> None:
     """Aggregate weight items and update mass/cg_x calculated values."""
     aeroplane = _get_aeroplane(db, aeroplane_uuid)
 
-    has_assumptions = (
-        db.query(DesignAssumptionModel)
-        .filter(DesignAssumptionModel.aeroplane_id == aeroplane.id)
-        .first()
+    target_params = {"mass", "cg_x"}
+    existing = (
+        db.query(DesignAssumptionModel.parameter_name)
+        .filter(
+            DesignAssumptionModel.aeroplane_id == aeroplane.id,
+            DesignAssumptionModel.parameter_name.in_(target_params),
+        )
+        .all()
     )
-    if not has_assumptions:
+    existing_names = {row[0] for row in existing}
+    if not existing_names:
         return
 
     rows = db.query(WeightItemModel).filter(WeightItemModel.aeroplane_id == aeroplane.id).all()
-    items = [{"mass_kg": r.mass_kg, "x_m": r.x_m, "y_m": r.y_m, "z_m": r.z_m} for r in rows]
+    items: list[WeightItemData] = [
+        {"mass_kg": r.mass_kg, "x_m": r.x_m, "y_m": r.y_m, "z_m": r.z_m} for r in rows
+    ]
 
     total_mass, cg_x, _cg_y, _cg_z = aggregate_weight_items(items)
 
     from app.services.design_assumptions_service import update_calculated_value
 
-    update_calculated_value(
-        db,
-        aeroplane_uuid,
-        "mass",
-        total_mass,
-        "weight_items" if total_mass is not None else None,
-    )
-    update_calculated_value(
-        db,
-        aeroplane_uuid,
-        "cg_x",
-        cg_x,
-        "weight_items" if cg_x is not None else None,
-    )
+    source = "weight_items" if total_mass is not None else None
+    if "mass" in existing_names:
+        update_calculated_value(db, aeroplane_uuid, "mass", total_mass, source)
+    if "cg_x" in existing_names:
+        update_calculated_value(
+            db, aeroplane_uuid, "cg_x", cg_x,
+            "weight_items" if cg_x is not None else None,
+        )
 
 
 def get_cg_comparison(db: Session, aeroplane_uuid) -> CGComparisonResponse:
@@ -215,7 +227,7 @@ def get_s_ref_for_aeroplane(db: Session, aeroplane_uuid) -> float:
         asb_airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
     except Exception as e:
         logger.error("Error building ASB airplane for s_ref: %s", e)
-        raise InternalError(message=f"Could not compute wing reference area: {e}")
+        raise InternalError(message=f"Could not compute wing reference area: {e}") from e
     s_ref = float(getattr(asb_airplane, "s_ref", 0.0) or 0.0)
     if s_ref <= 0:
         raise ValidationError(

--- a/app/services/mass_cg_service.py
+++ b/app/services/mass_cg_service.py
@@ -1,0 +1,262 @@
+"""Mass / CG design parameter service — derived metrics, sweep, and CG comparison."""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Sequence
+
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import InternalError, NotFoundError, ValidationError
+from app.models.aeroplanemodel import AeroplaneModel, DesignAssumptionModel, WeightItemModel
+from app.schemas.mass_cg import (
+    CGComparisonResponse,
+    DesignMetricsResponse,
+    MassSweepPoint,
+    MassSweepResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+GRAVITY = 9.81
+CG_TOLERANCE_M = 0.01
+
+
+# ---------------------------------------------------------------------------
+# Pure computation helpers (no DB)
+# ---------------------------------------------------------------------------
+
+
+def compute_recommended_cg(np_x: float, mac: float, target_static_margin: float) -> float:
+    """CG_x = NP_x - target_static_margin * MAC."""
+    return np_x - target_static_margin * mac
+
+
+def compute_design_metrics(
+    mass_kg: float,
+    s_ref: float,
+    cl_max: float,
+    rho: float,
+    velocity: float,
+) -> DesignMetricsResponse:
+    """Compute mass-dependent design quantities at a given flight condition."""
+    if mass_kg <= 0:
+        raise ValidationError(message="mass_kg must be positive")
+    if s_ref <= 0:
+        raise ValidationError(message="s_ref must be positive")
+    if cl_max <= 0:
+        raise ValidationError(message="cl_max must be positive")
+
+    weight = mass_kg * GRAVITY
+    wing_loading = weight / s_ref
+    stall_speed = math.sqrt(2 * weight / (rho * s_ref * cl_max))
+    q = 0.5 * rho * velocity**2
+    required_cl = weight / (q * s_ref)
+    cl_margin = cl_max - required_cl
+
+    return DesignMetricsResponse(
+        mass_kg=mass_kg,
+        s_ref=s_ref,
+        cl_max=cl_max,
+        wing_loading_pa=wing_loading,
+        stall_speed_ms=stall_speed,
+        required_cl=required_cl,
+        cl_margin=cl_margin,
+    )
+
+
+def compute_mass_sweep(
+    masses_kg: list[float],
+    s_ref: float,
+    cl_max: float,
+    rho: float,
+    velocity: float,
+) -> list[MassSweepPoint]:
+    """Compute derived metrics at each mass point (no aero re-run needed)."""
+    points: list[MassSweepPoint] = []
+    for m in masses_kg:
+        dm = compute_design_metrics(m, s_ref, cl_max, rho, velocity)
+        points.append(
+            MassSweepPoint(
+                mass_kg=m,
+                wing_loading_pa=dm.wing_loading_pa,
+                stall_speed_ms=dm.stall_speed_ms,
+                required_cl=dm.required_cl,
+                cl_margin=dm.cl_margin,
+            )
+        )
+    return points
+
+
+def aggregate_weight_items(
+    items: Sequence[dict],
+) -> tuple[float | None, float | None, float | None, float | None]:
+    """Compute total mass and mass-weighted CG from a list of weight item dicts.
+
+    Returns (total_mass, cg_x, cg_y, cg_z). All None when items is empty
+    or total mass is zero.
+    """
+    if not items:
+        return None, None, None, None
+
+    total_mass = sum(it["mass_kg"] for it in items)
+    if total_mass <= 0:
+        return None, None, None, None
+
+    cg_x = sum(it["mass_kg"] * it["x_m"] for it in items) / total_mass
+    cg_y = sum(it["mass_kg"] * it["y_m"] for it in items) / total_mass
+    cg_z = sum(it["mass_kg"] * it["z_m"] for it in items) / total_mass
+
+    return total_mass, cg_x, cg_y, cg_z
+
+
+# ---------------------------------------------------------------------------
+# DB-aware helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_aeroplane(db: Session, aeroplane_uuid) -> AeroplaneModel:
+    aeroplane = db.query(AeroplaneModel).filter(AeroplaneModel.uuid == aeroplane_uuid).first()
+    if not aeroplane:
+        raise NotFoundError(entity="Aeroplane", resource_id=aeroplane_uuid)
+    return aeroplane
+
+
+def get_effective_assumption_value(db: Session, aeroplane_uuid, param_name: str) -> float:
+    """Return the effective value for a design assumption parameter."""
+    aeroplane = _get_aeroplane(db, aeroplane_uuid)
+    row = (
+        db.query(DesignAssumptionModel)
+        .filter(
+            DesignAssumptionModel.aeroplane_id == aeroplane.id,
+            DesignAssumptionModel.parameter_name == param_name,
+        )
+        .first()
+    )
+    if row is None:
+        raise NotFoundError(entity="DesignAssumption", resource_id=param_name)
+
+    if row.active_source == "CALCULATED" and row.calculated_value is not None:
+        return row.calculated_value
+    return row.estimate_value
+
+
+def sync_weight_items_to_assumptions(db: Session, aeroplane_uuid) -> None:
+    """Aggregate weight items and update mass/cg_x calculated values."""
+    aeroplane = _get_aeroplane(db, aeroplane_uuid)
+
+    has_assumptions = (
+        db.query(DesignAssumptionModel)
+        .filter(DesignAssumptionModel.aeroplane_id == aeroplane.id)
+        .first()
+    )
+    if not has_assumptions:
+        return
+
+    rows = db.query(WeightItemModel).filter(WeightItemModel.aeroplane_id == aeroplane.id).all()
+    items = [{"mass_kg": r.mass_kg, "x_m": r.x_m, "y_m": r.y_m, "z_m": r.z_m} for r in rows]
+
+    total_mass, cg_x, _cg_y, _cg_z = aggregate_weight_items(items)
+
+    from app.services.design_assumptions_service import update_calculated_value
+
+    update_calculated_value(
+        db,
+        aeroplane_uuid,
+        "mass",
+        total_mass,
+        "weight_items" if total_mass is not None else None,
+    )
+    update_calculated_value(
+        db,
+        aeroplane_uuid,
+        "cg_x",
+        cg_x,
+        "weight_items" if cg_x is not None else None,
+    )
+
+
+def get_cg_comparison(db: Session, aeroplane_uuid) -> CGComparisonResponse:
+    """Compare design CG assumption with component-tree CG from weight items."""
+    aeroplane = _get_aeroplane(db, aeroplane_uuid)
+
+    design_cg_x = get_effective_assumption_value(db, aeroplane_uuid, "cg_x")
+
+    rows = db.query(WeightItemModel).filter(WeightItemModel.aeroplane_id == aeroplane.id).all()
+    items = [{"mass_kg": r.mass_kg, "x_m": r.x_m, "y_m": r.y_m, "z_m": r.z_m} for r in rows]
+
+    total_mass, cg_x, cg_y, cg_z = aggregate_weight_items(items)
+
+    delta_x = None
+    within_tolerance = None
+    if cg_x is not None:
+        delta_x = design_cg_x - cg_x
+        within_tolerance = abs(delta_x) < CG_TOLERANCE_M
+
+    return CGComparisonResponse(
+        design_cg_x=design_cg_x,
+        component_cg_x=cg_x,
+        component_cg_y=cg_y,
+        component_cg_z=cg_z,
+        component_total_mass_kg=total_mass,
+        delta_x=delta_x,
+        within_tolerance=within_tolerance,
+    )
+
+
+def get_s_ref_for_aeroplane(db: Session, aeroplane_uuid) -> float:
+    """Build an ASB airplane and return its wing reference area [m^2]."""
+    from app.converters.model_schema_converters import aeroplane_schema_to_asb_airplane_async
+    from app.services.analysis_service import get_aeroplane_schema_or_raise
+
+    plane_schema = get_aeroplane_schema_or_raise(db, aeroplane_uuid)
+    try:
+        asb_airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
+    except Exception as e:
+        logger.error("Error building ASB airplane for s_ref: %s", e)
+        raise InternalError(message=f"Could not compute wing reference area: {e}")
+    s_ref = float(getattr(asb_airplane, "s_ref", 0.0) or 0.0)
+    if s_ref <= 0:
+        raise ValidationError(
+            message="Wing reference area (s_ref) is zero or negative — add wings first"
+        )
+    return s_ref
+
+
+def get_design_metrics_for_aeroplane(
+    db: Session, aeroplane_uuid, velocity: float, altitude: float
+) -> DesignMetricsResponse:
+    """Compute design metrics for an aeroplane using its effective assumptions."""
+    import aerosandbox as asb
+
+    mass_kg = get_effective_assumption_value(db, aeroplane_uuid, "mass")
+    cl_max = get_effective_assumption_value(db, aeroplane_uuid, "cl_max")
+    s_ref = get_s_ref_for_aeroplane(db, aeroplane_uuid)
+    rho = asb.Atmosphere(altitude=altitude).density()
+
+    return compute_design_metrics(mass_kg, s_ref, cl_max, rho, velocity)
+
+
+def get_mass_sweep_for_aeroplane(
+    db: Session,
+    aeroplane_uuid,
+    masses_kg: list[float],
+    velocity: float,
+    altitude: float,
+) -> MassSweepResponse:
+    """Compute a mass sweep for an aeroplane."""
+    import aerosandbox as asb
+
+    cl_max = get_effective_assumption_value(db, aeroplane_uuid, "cl_max")
+    s_ref = get_s_ref_for_aeroplane(db, aeroplane_uuid)
+    rho = asb.Atmosphere(altitude=altitude).density()
+
+    points = compute_mass_sweep(masses_kg, s_ref, cl_max, rho, velocity)
+    return MassSweepResponse(
+        s_ref=s_ref,
+        cl_max=cl_max,
+        velocity=velocity,
+        altitude=altitude,
+        points=points,
+    )

--- a/app/services/weight_items_service.py
+++ b/app/services/weight_items_service.py
@@ -14,9 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 def _get_aeroplane(db: Session, aeroplane_uuid) -> AeroplaneModel:
-    aeroplane = db.query(AeroplaneModel).filter(
-        AeroplaneModel.uuid == aeroplane_uuid
-    ).first()
+    aeroplane = db.query(AeroplaneModel).filter(AeroplaneModel.uuid == aeroplane_uuid).first()
     if not aeroplane:
         raise NotFoundError(entity="Aeroplane", resource_id=aeroplane_uuid)
     return aeroplane
@@ -37,25 +35,43 @@ def _item_to_schema(item: WeightItemModel) -> WeightItemRead:
 
 def list_weight_items(db: Session, aeroplane_uuid) -> WeightSummary:
     aeroplane = _get_aeroplane(db, aeroplane_uuid)
-    rows = (
-        db.query(WeightItemModel)
-        .filter(WeightItemModel.aeroplane_id == aeroplane.id)
-        .all()
-    )
+    rows = db.query(WeightItemModel).filter(WeightItemModel.aeroplane_id == aeroplane.id).all()
     items = [_item_to_schema(i) for i in rows]
     total = sum(i.mass_kg for i in items)
-    return WeightSummary(items=items, total_mass_kg=round(total, 6))
+
+    cg_x = cg_y = cg_z = None
+    if total > 0:
+        cg_x = round(sum(i.mass_kg * i.x_m for i in items) / total, 6)
+        cg_y = round(sum(i.mass_kg * i.y_m for i in items) / total, 6)
+        cg_z = round(sum(i.mass_kg * i.z_m for i in items) / total, 6)
+
+    return WeightSummary(
+        items=items,
+        total_mass_kg=round(total, 6),
+        cg_x_m=cg_x,
+        cg_y_m=cg_y,
+        cg_z_m=cg_z,
+    )
 
 
-def create_weight_item(
-    db: Session, aeroplane_uuid, data: WeightItemWrite
-) -> WeightItemRead:
+def _try_sync_assumptions(db: Session, aeroplane_uuid) -> None:
+    """Best-effort sync of weight items to design assumption calculated values."""
+    try:
+        from app.services.mass_cg_service import sync_weight_items_to_assumptions
+
+        sync_weight_items_to_assumptions(db, aeroplane_uuid)
+    except Exception:
+        logger.debug("Skipped assumption sync (assumptions may not be seeded yet)")
+
+
+def create_weight_item(db: Session, aeroplane_uuid, data: WeightItemWrite) -> WeightItemRead:
     try:
         aeroplane = _get_aeroplane(db, aeroplane_uuid)
         item = WeightItemModel(aeroplane_id=aeroplane.id, **data.model_dump())
         db.add(item)
         db.flush()
         db.refresh(item)
+        _try_sync_assumptions(db, aeroplane_uuid)
         return _item_to_schema(item)
     except NotFoundError:
         raise
@@ -92,6 +108,7 @@ def update_weight_item(
             setattr(item, key, value)
         db.flush()
         db.refresh(item)
+        _try_sync_assumptions(db, aeroplane_uuid)
         return _item_to_schema(item)
     except NotFoundError:
         raise
@@ -112,6 +129,7 @@ def delete_weight_item(db: Session, aeroplane_uuid, item_id: int) -> None:
             raise NotFoundError(entity="WeightItem", resource_id=item_id)
         db.delete(item)
         db.flush()
+        _try_sync_assumptions(db, aeroplane_uuid)
     except NotFoundError:
         raise
     except SQLAlchemyError as exc:

--- a/app/services/weight_items_service.py
+++ b/app/services/weight_items_service.py
@@ -60,8 +60,8 @@ def _try_sync_assumptions(db: Session, aeroplane_uuid) -> None:
         from app.services.mass_cg_service import sync_weight_items_to_assumptions
 
         sync_weight_items_to_assumptions(db, aeroplane_uuid)
-    except Exception:
-        logger.debug("Skipped assumption sync (assumptions may not be seeded yet)")
+    except (NotFoundError, SQLAlchemyError) as exc:
+        logger.warning("Skipped assumption sync: %s", exc)
 
 
 def create_weight_item(db: Session, aeroplane_uuid, data: WeightItemWrite) -> WeightItemRead:

--- a/app/tests/test_mass_cg_endpoints.py
+++ b/app/tests/test_mass_cg_endpoints.py
@@ -108,6 +108,17 @@ class TestMassSweepEndpoint:
         )
         assert resp.status_code == 422
 
+    def test_422_for_negative_mass(self, client_and_db):
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+
+        resp = client.post(
+            f"/aeroplanes/{aeroplane.uuid}/mass_sweep",
+            json={"masses_kg": [1.0, -0.5], "velocity": 15.0, "altitude": 0.0},
+        )
+        assert resp.status_code == 422
+
 
 # ---------------------------------------------------------------------------
 # GET /aeroplanes/{id}/cg_comparison

--- a/app/tests/test_mass_cg_endpoints.py
+++ b/app/tests/test_mass_cg_endpoints.py
@@ -1,0 +1,222 @@
+"""Tests for mass/CG API endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from app.schemas.design_assumption import PARAMETER_DEFAULTS
+from app.tests.conftest import make_aeroplane
+
+
+MOCK_S_REF = 0.30
+
+
+# ---------------------------------------------------------------------------
+# POST /aeroplanes/{id}/design_metrics
+# ---------------------------------------------------------------------------
+
+
+class TestDesignMetricsEndpoint:
+    def test_returns_200(self, client_and_db):
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+
+        client.post(f"/aeroplanes/{aeroplane.uuid}/assumptions")
+        with patch(
+            "app.services.mass_cg_service.get_s_ref_for_aeroplane",
+            return_value=MOCK_S_REF,
+        ):
+            resp = client.post(
+                f"/aeroplanes/{aeroplane.uuid}/design_metrics",
+                json={"velocity": 15.0, "altitude": 0.0},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "stall_speed_ms" in body
+        assert "wing_loading_pa" in body
+        assert "required_cl" in body
+        assert "cl_margin" in body
+        assert body["mass_kg"] == PARAMETER_DEFAULTS["mass"]
+        assert body["s_ref"] == MOCK_S_REF
+
+    def test_404_for_missing_aeroplane(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.post(
+            f"/aeroplanes/{uuid.uuid4()}/design_metrics",
+            json={"velocity": 15.0, "altitude": 0.0},
+        )
+        assert resp.status_code == 404
+
+    def test_422_for_zero_velocity(self, client_and_db):
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+
+        resp = client.post(
+            f"/aeroplanes/{aeroplane.uuid}/design_metrics",
+            json={"velocity": 0.0, "altitude": 0.0},
+        )
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# POST /aeroplanes/{id}/mass_sweep
+# ---------------------------------------------------------------------------
+
+
+class TestMassSweepEndpoint:
+    def test_returns_200(self, client_and_db):
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+
+        client.post(f"/aeroplanes/{aeroplane.uuid}/assumptions")
+        with patch(
+            "app.services.mass_cg_service.get_s_ref_for_aeroplane",
+            return_value=MOCK_S_REF,
+        ):
+            resp = client.post(
+                f"/aeroplanes/{aeroplane.uuid}/mass_sweep",
+                json={"masses_kg": [1.0, 1.5, 2.0], "velocity": 15.0, "altitude": 0.0},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["points"]) == 3
+        assert body["velocity"] == 15.0
+        assert body["s_ref"] == MOCK_S_REF
+
+    def test_404_for_missing_aeroplane(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.post(
+            f"/aeroplanes/{uuid.uuid4()}/mass_sweep",
+            json={"masses_kg": [1.0], "velocity": 15.0, "altitude": 0.0},
+        )
+        assert resp.status_code == 404
+
+    def test_422_for_empty_masses(self, client_and_db):
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+
+        resp = client.post(
+            f"/aeroplanes/{aeroplane.uuid}/mass_sweep",
+            json={"masses_kg": [], "velocity": 15.0, "altitude": 0.0},
+        )
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /aeroplanes/{id}/cg_comparison
+# ---------------------------------------------------------------------------
+
+
+class TestCGComparisonEndpoint:
+    def test_returns_200(self, client_and_db):
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+
+        client.post(f"/aeroplanes/{aeroplane.uuid}/assumptions")
+        resp = client.get(f"/aeroplanes/{aeroplane.uuid}/cg_comparison")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "design_cg_x" in body
+        assert body["design_cg_x"] == PARAMETER_DEFAULTS["cg_x"]
+        assert body["component_cg_x"] is None
+        assert body["within_tolerance"] is None
+
+    def test_with_weight_items(self, client_and_db):
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+
+        client.post(f"/aeroplanes/{aeroplane.uuid}/assumptions")
+        client.post(
+            f"/aeroplanes/{aeroplane.uuid}/weight-items",
+            json={
+                "name": "motor",
+                "mass_kg": 1.0,
+                "x_m": 0.15,
+                "y_m": 0.0,
+                "z_m": 0.0,
+            },
+        )
+
+        resp = client.get(f"/aeroplanes/{aeroplane.uuid}/cg_comparison")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["component_cg_x"] == pytest.approx(0.15)
+        assert body["component_total_mass_kg"] == pytest.approx(1.0)
+        assert body["delta_x"] is not None
+
+    def test_404_for_missing_aeroplane(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.get(f"/aeroplanes/{uuid.uuid4()}/cg_comparison")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Weight item CRUD triggers assumption sync
+# ---------------------------------------------------------------------------
+
+
+class TestWeightItemsSyncAssumptions:
+    def test_create_syncs_mass_assumption(self, client_and_db):
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+
+        client.post(f"/aeroplanes/{aeroplane.uuid}/assumptions")
+        client.post(
+            f"/aeroplanes/{aeroplane.uuid}/weight-items",
+            json={"name": "battery", "mass_kg": 0.5, "x_m": 0.1},
+        )
+
+        resp = client.get(f"/aeroplanes/{aeroplane.uuid}/assumptions")
+        by_name = {a["parameter_name"]: a for a in resp.json()["assumptions"]}
+        assert by_name["mass"]["calculated_value"] == pytest.approx(0.5)
+        assert by_name["mass"]["calculated_source"] == "weight_items"
+
+    def test_delete_clears_when_last_item(self, client_and_db):
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+
+        client.post(f"/aeroplanes/{aeroplane.uuid}/assumptions")
+        resp = client.post(
+            f"/aeroplanes/{aeroplane.uuid}/weight-items",
+            json={"name": "battery", "mass_kg": 0.5, "x_m": 0.1},
+        )
+        item_id = resp.json()["id"]
+
+        client.delete(f"/aeroplanes/{aeroplane.uuid}/weight-items/{item_id}")
+
+        resp = client.get(f"/aeroplanes/{aeroplane.uuid}/assumptions")
+        by_name = {a["parameter_name"]: a for a in resp.json()["assumptions"]}
+        assert by_name["mass"]["calculated_value"] is None
+
+    def test_update_resyncs_assumptions(self, client_and_db):
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+
+        client.post(f"/aeroplanes/{aeroplane.uuid}/assumptions")
+        resp = client.post(
+            f"/aeroplanes/{aeroplane.uuid}/weight-items",
+            json={"name": "battery", "mass_kg": 0.5, "x_m": 0.1},
+        )
+        item_id = resp.json()["id"]
+
+        client.put(
+            f"/aeroplanes/{aeroplane.uuid}/weight-items/{item_id}",
+            json={"name": "battery", "mass_kg": 1.0, "x_m": 0.2},
+        )
+
+        resp = client.get(f"/aeroplanes/{aeroplane.uuid}/assumptions")
+        by_name = {a["parameter_name"]: a for a in resp.json()["assumptions"]}
+        assert by_name["mass"]["calculated_value"] == pytest.approx(1.0)
+        assert by_name["cg_x"]["calculated_value"] == pytest.approx(0.2)

--- a/app/tests/test_mass_cg_service.py
+++ b/app/tests/test_mass_cg_service.py
@@ -1,0 +1,481 @@
+"""Tests for app.services.mass_cg_service — mass/CG design parameter computations."""
+
+from __future__ import annotations
+
+import math
+import uuid
+
+import pytest
+
+from app.core.exceptions import NotFoundError, ValidationError
+from app.schemas.design_assumption import PARAMETER_DEFAULTS
+from app.schemas.weight_item import WeightItemWrite
+from app.services import design_assumptions_service as da_svc
+from app.services import mass_cg_service as svc
+from app.services import weight_items_service as wi_svc
+from app.tests.conftest import make_aeroplane
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+GRAVITY = 9.81
+SEA_LEVEL_RHO = 1.225  # kg/m^3 (ISA sea level)
+
+
+def _seed_and_get(db, aeroplane_uuid):
+    """Seed design assumptions and return the summary."""
+    return da_svc.seed_defaults(db, aeroplane_uuid)
+
+
+def _make_weight_item(
+    name: str = "battery",
+    mass_kg: float = 0.5,
+    x_m: float = 0.1,
+    y_m: float = 0.0,
+    z_m: float = 0.0,
+) -> WeightItemWrite:
+    return WeightItemWrite(name=name, mass_kg=mass_kg, x_m=x_m, y_m=y_m, z_m=z_m)
+
+
+# ---------------------------------------------------------------------------
+# compute_recommended_cg
+# ---------------------------------------------------------------------------
+
+
+class TestComputeRecommendedCG:
+    def test_basic_formula(self):
+        """CG_x = NP_x - target_SM * MAC."""
+        np_x = 0.25
+        mac = 0.20
+        target_sm = 0.12
+        result = svc.compute_recommended_cg(np_x, mac, target_sm)
+        expected = np_x - target_sm * mac
+        assert result == pytest.approx(expected)
+
+    def test_zero_static_margin(self):
+        """With SM=0, recommended CG equals NP."""
+        np_x = 0.30
+        mac = 0.15
+        result = svc.compute_recommended_cg(np_x, mac, 0.0)
+        assert result == pytest.approx(np_x)
+
+    def test_large_static_margin(self):
+        """SM=1.0 pushes CG forward by one full MAC."""
+        np_x = 0.50
+        mac = 0.20
+        result = svc.compute_recommended_cg(np_x, mac, 1.0)
+        assert result == pytest.approx(0.50 - 0.20)
+
+
+# ---------------------------------------------------------------------------
+# compute_design_metrics
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDesignMetrics:
+    def test_stall_speed(self):
+        """V_stall = sqrt(2*m*g / (rho * S * CL_max))."""
+        mass_kg = 1.5
+        s_ref = 0.3
+        cl_max = 1.4
+        rho = SEA_LEVEL_RHO
+        velocity = 15.0
+
+        result = svc.compute_design_metrics(mass_kg, s_ref, cl_max, rho, velocity)
+        expected_vs = math.sqrt(2 * mass_kg * GRAVITY / (rho * s_ref * cl_max))
+        assert result.stall_speed_ms == pytest.approx(expected_vs)
+
+    def test_wing_loading(self):
+        """Wing loading = m*g / S."""
+        mass_kg = 2.0
+        s_ref = 0.4
+        cl_max = 1.4
+        rho = SEA_LEVEL_RHO
+        velocity = 15.0
+
+        result = svc.compute_design_metrics(mass_kg, s_ref, cl_max, rho, velocity)
+        assert result.wing_loading_pa == pytest.approx(mass_kg * GRAVITY / s_ref)
+
+    def test_required_cl(self):
+        """CL_req = 2*m*g / (rho * V^2 * S)."""
+        mass_kg = 1.5
+        s_ref = 0.3
+        cl_max = 1.4
+        rho = SEA_LEVEL_RHO
+        velocity = 20.0
+
+        result = svc.compute_design_metrics(mass_kg, s_ref, cl_max, rho, velocity)
+        q = 0.5 * rho * velocity**2
+        expected_cl = mass_kg * GRAVITY / (q * s_ref)
+        assert result.required_cl == pytest.approx(expected_cl)
+
+    def test_cl_margin(self):
+        """CL margin = CL_max - required_CL."""
+        mass_kg = 1.5
+        s_ref = 0.3
+        cl_max = 1.4
+        rho = SEA_LEVEL_RHO
+        velocity = 20.0
+
+        result = svc.compute_design_metrics(mass_kg, s_ref, cl_max, rho, velocity)
+        assert result.cl_margin == pytest.approx(cl_max - result.required_cl)
+
+    def test_zero_mass_raises(self):
+        """Mass must be positive."""
+        with pytest.raises(ValidationError):
+            svc.compute_design_metrics(0.0, 0.3, 1.4, SEA_LEVEL_RHO, 15.0)
+
+    def test_zero_s_ref_raises(self):
+        """S_ref must be positive."""
+        with pytest.raises(ValidationError):
+            svc.compute_design_metrics(1.5, 0.0, 1.4, SEA_LEVEL_RHO, 15.0)
+
+    def test_zero_cl_max_raises(self):
+        """CL_max must be positive for stall speed computation."""
+        with pytest.raises(ValidationError):
+            svc.compute_design_metrics(1.5, 0.3, 0.0, SEA_LEVEL_RHO, 15.0)
+
+    def test_response_fields(self):
+        """All response fields are populated."""
+        result = svc.compute_design_metrics(1.5, 0.3, 1.4, SEA_LEVEL_RHO, 15.0)
+        assert result.mass_kg == 1.5
+        assert result.s_ref == 0.3
+        assert result.cl_max == 1.4
+
+
+# ---------------------------------------------------------------------------
+# compute_mass_sweep
+# ---------------------------------------------------------------------------
+
+
+class TestComputeMassSweep:
+    def test_returns_correct_number_of_points(self):
+        masses = [1.0, 1.5, 2.0, 2.5]
+        result = svc.compute_mass_sweep(masses, 0.3, 1.4, SEA_LEVEL_RHO, 15.0)
+        assert len(result) == 4
+
+    def test_wing_loading_increases_with_mass(self):
+        masses = [1.0, 2.0, 3.0]
+        points = svc.compute_mass_sweep(masses, 0.3, 1.4, SEA_LEVEL_RHO, 15.0)
+        loadings = [p.wing_loading_pa for p in points]
+        assert loadings == sorted(loadings)
+
+    def test_stall_speed_increases_with_mass(self):
+        masses = [1.0, 2.0, 3.0]
+        points = svc.compute_mass_sweep(masses, 0.3, 1.4, SEA_LEVEL_RHO, 15.0)
+        speeds = [p.stall_speed_ms for p in points]
+        assert speeds == sorted(speeds)
+
+    def test_cl_margin_decreases_with_mass(self):
+        masses = [1.0, 2.0, 3.0]
+        points = svc.compute_mass_sweep(masses, 0.3, 1.4, SEA_LEVEL_RHO, 15.0)
+        margins = [p.cl_margin for p in points]
+        assert margins == sorted(margins, reverse=True)
+
+    def test_single_mass_point(self):
+        points = svc.compute_mass_sweep([1.5], 0.3, 1.4, SEA_LEVEL_RHO, 15.0)
+        assert len(points) == 1
+        assert points[0].mass_kg == 1.5
+
+    def test_each_point_matches_single_computation(self):
+        """Each sweep point must match a standalone compute_design_metrics call."""
+        masses = [1.0, 1.5, 2.0]
+        points = svc.compute_mass_sweep(masses, 0.3, 1.4, SEA_LEVEL_RHO, 15.0)
+        for pt in points:
+            single = svc.compute_design_metrics(pt.mass_kg, 0.3, 1.4, SEA_LEVEL_RHO, 15.0)
+            assert pt.wing_loading_pa == pytest.approx(single.wing_loading_pa)
+            assert pt.stall_speed_ms == pytest.approx(single.stall_speed_ms)
+            assert pt.required_cl == pytest.approx(single.required_cl)
+            assert pt.cl_margin == pytest.approx(single.cl_margin)
+
+
+# ---------------------------------------------------------------------------
+# aggregate_weight_items
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateWeightItems:
+    def test_empty_items(self):
+        """No items -> None for mass and CG."""
+        mass, cx, cy, cz = svc.aggregate_weight_items([])
+        assert mass is None
+        assert cx is None
+        assert cy is None
+        assert cz is None
+
+    def test_single_item(self):
+        """Single item -> mass and position equal to the item."""
+        items = [{"mass_kg": 0.5, "x_m": 0.1, "y_m": 0.2, "z_m": 0.3}]
+        mass, cx, cy, cz = svc.aggregate_weight_items(items)
+        assert mass == pytest.approx(0.5)
+        assert cx == pytest.approx(0.1)
+        assert cy == pytest.approx(0.2)
+        assert cz == pytest.approx(0.3)
+
+    def test_two_equal_items(self):
+        """Two equal items -> CG at midpoint."""
+        items = [
+            {"mass_kg": 1.0, "x_m": 0.0, "y_m": 0.0, "z_m": 0.0},
+            {"mass_kg": 1.0, "x_m": 0.2, "y_m": 0.4, "z_m": 0.6},
+        ]
+        mass, cx, cy, cz = svc.aggregate_weight_items(items)
+        assert mass == pytest.approx(2.0)
+        assert cx == pytest.approx(0.1)
+        assert cy == pytest.approx(0.2)
+        assert cz == pytest.approx(0.3)
+
+    def test_weighted_average(self):
+        """CG is mass-weighted average of positions."""
+        items = [
+            {"mass_kg": 3.0, "x_m": 0.1, "y_m": 0.0, "z_m": 0.0},
+            {"mass_kg": 1.0, "x_m": 0.5, "y_m": 0.0, "z_m": 0.0},
+        ]
+        mass, cx, cy, cz = svc.aggregate_weight_items(items)
+        assert mass == pytest.approx(4.0)
+        assert cx == pytest.approx((3.0 * 0.1 + 1.0 * 0.5) / 4.0)
+
+    def test_zero_total_mass(self):
+        """All items with zero mass -> None for CG."""
+        items = [
+            {"mass_kg": 0.0, "x_m": 0.1, "y_m": 0.0, "z_m": 0.0},
+        ]
+        mass, cx, cy, cz = svc.aggregate_weight_items(items)
+        assert mass is None
+        assert cx is None
+
+
+# ---------------------------------------------------------------------------
+# update_calculated_value (design_assumptions_service extension)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateCalculatedValue:
+    def test_updates_mass_calculated(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            _seed_and_get(db, aeroplane.uuid)
+
+            da_svc.update_calculated_value(db, aeroplane.uuid, "mass", 2.0, "weight_items")
+            summary = da_svc.list_assumptions(db, aeroplane.uuid)
+            by_name = {a.parameter_name: a for a in summary.assumptions}
+            assert by_name["mass"].calculated_value == 2.0
+            assert by_name["mass"].calculated_source == "weight_items"
+
+    def test_updates_cg_x_calculated(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            _seed_and_get(db, aeroplane.uuid)
+
+            da_svc.update_calculated_value(db, aeroplane.uuid, "cg_x", 0.12, "weight_items")
+            summary = da_svc.list_assumptions(db, aeroplane.uuid)
+            by_name = {a.parameter_name: a for a in summary.assumptions}
+            assert by_name["cg_x"].calculated_value == 0.12
+            assert by_name["cg_x"].calculated_source == "weight_items"
+
+    def test_recomputes_divergence_on_update(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            _seed_and_get(db, aeroplane.uuid)
+
+            da_svc.update_calculated_value(db, aeroplane.uuid, "mass", 2.0, "weight_items")
+            summary = da_svc.list_assumptions(db, aeroplane.uuid)
+            by_name = {a.parameter_name: a for a in summary.assumptions}
+            # estimate=1.5, calc=2.0 -> |1.5-2.0|/|2.0|*100 = 25.0
+            assert by_name["mass"].divergence_pct == 25.0
+
+    def test_clears_calculated_with_none(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            _seed_and_get(db, aeroplane.uuid)
+
+            da_svc.update_calculated_value(db, aeroplane.uuid, "mass", 2.0, "weight_items")
+            da_svc.update_calculated_value(db, aeroplane.uuid, "mass", None, None)
+            summary = da_svc.list_assumptions(db, aeroplane.uuid)
+            by_name = {a.parameter_name: a for a in summary.assumptions}
+            assert by_name["mass"].calculated_value is None
+            assert by_name["mass"].calculated_source is None
+
+    def test_raises_not_found_for_missing_param(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            _seed_and_get(db, aeroplane.uuid)
+
+            with pytest.raises(NotFoundError):
+                da_svc.update_calculated_value(db, aeroplane.uuid, "nonexistent", 1.0, "test")
+
+    def test_raises_not_found_for_missing_aeroplane(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            with pytest.raises(NotFoundError):
+                da_svc.update_calculated_value(db, uuid.uuid4(), "mass", 1.0, "test")
+
+
+# ---------------------------------------------------------------------------
+# sync_weight_items_to_assumptions (DB integration)
+# ---------------------------------------------------------------------------
+
+
+class TestSyncWeightItemsToAssumptions:
+    def test_creates_calculated_values_from_items(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            _seed_and_get(db, aeroplane.uuid)
+
+            wi_svc.create_weight_item(
+                db,
+                aeroplane.uuid,
+                _make_weight_item(name="motor", mass_kg=0.3, x_m=0.05),
+            )
+            wi_svc.create_weight_item(
+                db,
+                aeroplane.uuid,
+                _make_weight_item(name="battery", mass_kg=0.5, x_m=0.15),
+            )
+
+            svc.sync_weight_items_to_assumptions(db, aeroplane.uuid)
+
+            summary = da_svc.list_assumptions(db, aeroplane.uuid)
+            by_name = {a.parameter_name: a for a in summary.assumptions}
+            assert by_name["mass"].calculated_value == pytest.approx(0.8)
+            expected_cg = (0.3 * 0.05 + 0.5 * 0.15) / 0.8
+            assert by_name["cg_x"].calculated_value == pytest.approx(expected_cg)
+
+    def test_clears_calculated_when_no_items(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            _seed_and_get(db, aeroplane.uuid)
+
+            da_svc.update_calculated_value(db, aeroplane.uuid, "mass", 1.0, "weight_items")
+
+            svc.sync_weight_items_to_assumptions(db, aeroplane.uuid)
+
+            summary = da_svc.list_assumptions(db, aeroplane.uuid)
+            by_name = {a.parameter_name: a for a in summary.assumptions}
+            assert by_name["mass"].calculated_value is None
+            assert by_name["cg_x"].calculated_value is None
+
+    def test_tolerates_missing_assumptions(self, client_and_db):
+        """If assumptions are not seeded yet, sync is a no-op (no crash)."""
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            wi_svc.create_weight_item(
+                db,
+                aeroplane.uuid,
+                _make_weight_item(name="motor", mass_kg=0.3, x_m=0.05),
+            )
+            svc.sync_weight_items_to_assumptions(db, aeroplane.uuid)
+
+
+# ---------------------------------------------------------------------------
+# get_cg_comparison (DB integration)
+# ---------------------------------------------------------------------------
+
+
+class TestGetCGComparison:
+    def test_with_weight_items(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            _seed_and_get(db, aeroplane.uuid)
+
+            wi_svc.create_weight_item(
+                db,
+                aeroplane.uuid,
+                _make_weight_item(name="motor", mass_kg=0.5, x_m=0.10),
+            )
+            wi_svc.create_weight_item(
+                db,
+                aeroplane.uuid,
+                _make_weight_item(name="battery", mass_kg=0.5, x_m=0.20),
+            )
+
+            result = svc.get_cg_comparison(db, aeroplane.uuid)
+            assert result.design_cg_x == PARAMETER_DEFAULTS["cg_x"]
+            assert result.component_cg_x == pytest.approx(0.15)
+            assert result.component_total_mass_kg == pytest.approx(1.0)
+            assert result.delta_x == pytest.approx(PARAMETER_DEFAULTS["cg_x"] - 0.15)
+            assert result.within_tolerance is True or result.within_tolerance is False
+
+    def test_without_weight_items(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            _seed_and_get(db, aeroplane.uuid)
+
+            result = svc.get_cg_comparison(db, aeroplane.uuid)
+            assert result.design_cg_x == PARAMETER_DEFAULTS["cg_x"]
+            assert result.component_cg_x is None
+            assert result.delta_x is None
+            assert result.within_tolerance is None
+
+    def test_raises_not_found_for_missing_aeroplane(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            with pytest.raises(NotFoundError):
+                svc.get_cg_comparison(db, uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
+# get_effective_assumption_value helper
+# ---------------------------------------------------------------------------
+
+
+class TestGetEffectiveAssumptionValue:
+    def test_returns_estimate_by_default(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            _seed_and_get(db, aeroplane.uuid)
+
+            val = svc.get_effective_assumption_value(db, aeroplane.uuid, "mass")
+            assert val == PARAMETER_DEFAULTS["mass"]
+
+    def test_returns_calculated_when_active(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            _seed_and_get(db, aeroplane.uuid)
+
+            from app.models.aeroplanemodel import DesignAssumptionModel
+            from app.schemas.design_assumption import AssumptionSourceSwitch
+
+            row = (
+                db.query(DesignAssumptionModel)
+                .filter(
+                    DesignAssumptionModel.aeroplane_id == aeroplane.id,
+                    DesignAssumptionModel.parameter_name == "mass",
+                )
+                .first()
+            )
+            row.calculated_value = 2.5
+            row.calculated_source = "weight_items"
+            db.flush()
+
+            da_svc.switch_source(
+                db,
+                aeroplane.uuid,
+                "mass",
+                AssumptionSourceSwitch(active_source="CALCULATED"),
+            )
+
+            val = svc.get_effective_assumption_value(db, aeroplane.uuid, "mass")
+            assert val == 2.5
+
+    def test_raises_not_found(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            _seed_and_get(db, aeroplane.uuid)
+
+            with pytest.raises(NotFoundError):
+                svc.get_effective_assumption_value(db, aeroplane.uuid, "nonexistent")

--- a/app/tests/test_mass_cg_service.py
+++ b/app/tests/test_mass_cg_service.py
@@ -137,6 +137,14 @@ class TestComputeDesignMetrics:
         with pytest.raises(ValidationError):
             svc.compute_design_metrics(1.5, 0.3, 0.0, SEA_LEVEL_RHO, 15.0)
 
+    def test_zero_rho_raises(self):
+        with pytest.raises(ValidationError):
+            svc.compute_design_metrics(1.5, 0.3, 1.4, 0.0, 15.0)
+
+    def test_zero_velocity_raises(self):
+        with pytest.raises(ValidationError):
+            svc.compute_design_metrics(1.5, 0.3, 1.4, SEA_LEVEL_RHO, 0.0)
+
     def test_response_fields(self):
         """All response fields are populated."""
         result = svc.compute_design_metrics(1.5, 0.3, 1.4, SEA_LEVEL_RHO, 15.0)
@@ -404,7 +412,7 @@ class TestGetCGComparison:
             assert result.component_cg_x == pytest.approx(0.15)
             assert result.component_total_mass_kg == pytest.approx(1.0)
             assert result.delta_x == pytest.approx(PARAMETER_DEFAULTS["cg_x"] - 0.15)
-            assert result.within_tolerance is True or result.within_tolerance is False
+            assert result.within_tolerance is (abs(PARAMETER_DEFAULTS["cg_x"] - 0.15) < 0.01)
 
     def test_without_weight_items(self, client_and_db):
         _, SessionLocal = client_and_db
@@ -471,6 +479,30 @@ class TestGetEffectiveAssumptionValue:
             val = svc.get_effective_assumption_value(db, aeroplane.uuid, "mass")
             assert val == 2.5
 
+    def test_falls_back_to_estimate_when_calculated_is_none(self, client_and_db):
+        """When active_source is CALCULATED but calculated_value is None, return estimate."""
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            _seed_and_get(db, aeroplane.uuid)
+
+            from app.models.aeroplanemodel import DesignAssumptionModel
+
+            row = (
+                db.query(DesignAssumptionModel)
+                .filter(
+                    DesignAssumptionModel.aeroplane_id == aeroplane.id,
+                    DesignAssumptionModel.parameter_name == "mass",
+                )
+                .first()
+            )
+            row.active_source = "CALCULATED"
+            row.calculated_value = None
+            db.flush()
+
+            val = svc.get_effective_assumption_value(db, aeroplane.uuid, "mass")
+            assert val == PARAMETER_DEFAULTS["mass"]
+
     def test_raises_not_found(self, client_and_db):
         _, SessionLocal = client_and_db
         with SessionLocal() as db:
@@ -479,3 +511,40 @@ class TestGetEffectiveAssumptionValue:
 
             with pytest.raises(NotFoundError):
                 svc.get_effective_assumption_value(db, aeroplane.uuid, "nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# aggregate_weight_items edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateWeightItemsEdgeCases:
+    def test_negative_mass_item(self):
+        """Negative mass computes correctly (documents behavior)."""
+        items = [
+            {"mass_kg": 1.0, "x_m": 0.2, "y_m": 0.0, "z_m": 0.0},
+            {"mass_kg": -0.5, "x_m": 0.4, "y_m": 0.0, "z_m": 0.0},
+        ]
+        mass, cx, cy, cz = svc.aggregate_weight_items(items)
+        assert mass == pytest.approx(0.5)
+        assert cx == pytest.approx((1.0 * 0.2 + (-0.5) * 0.4) / 0.5)
+
+
+# ---------------------------------------------------------------------------
+# Weight item CRUD sync resilience
+# ---------------------------------------------------------------------------
+
+
+class TestWeightItemSyncResilience:
+    def test_crud_succeeds_without_seeded_assumptions(self, client_and_db):
+        """Weight item create works even if no assumptions are seeded."""
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            item = wi_svc.create_weight_item(
+                db,
+                aeroplane.uuid,
+                _make_weight_item(name="motor", mass_kg=0.3, x_m=0.05),
+            )
+            assert item.name == "motor"
+            assert item.mass_kg == pytest.approx(0.3)


### PR DESCRIPTION
## Summary

Closes #420

Implements mass and CG as first-class design parameters with what-if simulation support:

- **Design Metrics endpoint** — computes stall speed, wing loading, required CL, and CL margin from effective design assumption values (mass, CL_max) and wing reference area
- **Mass Sweep endpoint** — evaluates derived metrics across an array of mass values without re-running aerodynamic analysis (mass affects required CL, not aero coefficients)
- **CG Comparison endpoint** — compares design CG (from design assumption) with component-tree CG (aggregated from weight items), showing delta and tolerance status
- **Weight items → calculated assumptions auto-sync** — after any weight item CRUD operation, automatically aggregates total mass and mass-weighted CG into `mass.calculated_value` and `cg_x.calculated_value` design assumptions
- **`update_calculated_value()`** function added to `design_assumptions_service` — reusable mechanism for populating calculated values from any aggregation source
- **Recommended CG formula** — pure computation helper `compute_recommended_cg(np_x, mac, target_sm)` ready for use once NP calculation (#421) is wired up

### New API Endpoints (v2)

| Method | Path | Description |
|--------|------|-------------|
| POST | `/aeroplanes/{id}/design_metrics` | Mass-dependent derived quantities |
| POST | `/aeroplanes/{id}/mass_sweep` | Sweep over mass values |
| GET | `/aeroplanes/{id}/cg_comparison` | Design CG vs component-tree CG |

### Files Changed

- **New**: `app/schemas/mass_cg.py`, `app/services/mass_cg_service.py`, `app/api/v2/endpoints/aeroplane/mass_cg.py`
- **Modified**: `design_assumptions_service.py` (+`update_calculated_value`), `weight_items_service.py` (+auto-sync), `weight_item.py` (+CG fields on summary), `__init__.py` (+router)
- **Tests**: 49 new tests (37 service unit + 12 API integration)

## Test plan

- [x] 49 new tests pass (service unit + API integration)
- [x] Full test suite passes (pre-existing CAD/integration failures only)
- [x] Ruff lint clean
- [ ] Manual API testing via Swagger

🤖 Generated with [Claude Code](https://claude.com/claude-code)