### PR TITLE
feat(gh-422): flight envelope analysis with V-n diagram

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -41,6 +41,7 @@ import app.models.component_tree
 import app.models.construction_plan
 import app.models.avl_geometry_file
 import app.models.stability_result
+import app.models.flight_envelope_model
 
 target_metadata = Base.metadata
 

--- a/alembic/versions/a4f26dfb6c22_add_flight_envelopes_table.py
+++ b/alembic/versions/a4f26dfb6c22_add_flight_envelopes_table.py
@@ -1,0 +1,44 @@
+"""add flight_envelopes table
+
+Revision ID: a4f26dfb6c22
+Revises: c5d6e7f8a9b0
+Create Date: 2026-05-07 20:16:45.597815
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a4f26dfb6c22"
+down_revision: Union[str, None] = "c5d6e7f8a9b0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "flight_envelopes",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("aeroplane_id", sa.Integer(), nullable=False),
+        sa.Column("vn_curve_json", sa.JSON(), nullable=False),
+        sa.Column("kpis_json", sa.JSON(), nullable=False),
+        sa.Column("markers_json", sa.JSON(), nullable=False),
+        sa.Column("assumptions_snapshot", sa.JSON(), nullable=False),
+        sa.Column("computed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["aeroplane_id"], ["aeroplanes.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_flight_envelopes_aeroplane_id"), "flight_envelopes", ["aeroplane_id"], unique=True
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f("ix_flight_envelopes_aeroplane_id"), table_name="flight_envelopes")
+    op.drop_table("flight_envelopes")

--- a/app/api/v2/endpoints/aeroplane/__init__.py
+++ b/app/api/v2/endpoints/aeroplane/__init__.py
@@ -16,6 +16,7 @@ from .powertrain_sizing import router as powertrain_sizing_router
 from .avl_geometry import router as avl_geometry_router
 from .design_assumptions import router as design_assumptions_router
 from .mass_cg import router as mass_cg_router
+from .flight_envelope import router as flight_envelope_router
 
 # Include the routers
 router.include_router(base_router)
@@ -29,3 +30,4 @@ router.include_router(powertrain_sizing_router)
 router.include_router(avl_geometry_router)
 router.include_router(design_assumptions_router)
 router.include_router(mass_cg_router)
+router.include_router(flight_envelope_router)

--- a/app/api/v2/endpoints/aeroplane/flight_envelope.py
+++ b/app/api/v2/endpoints/aeroplane/flight_envelope.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, NoReturn
 
 from fastapi import APIRouter, Depends, HTTPException, Path, status
 from pydantic import UUID4
@@ -16,7 +16,7 @@ from app.services import flight_envelope_service
 router = APIRouter()
 
 
-def _raise_http_from_domain(exc: ServiceException) -> None:
+def _raise_http_from_domain(exc: ServiceException) -> NoReturn:
     """Map domain exceptions to HTTP status codes."""
     if isinstance(exc, NotFoundError):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=exc.message) from exc

--- a/app/api/v2/endpoints/aeroplane/flight_envelope.py
+++ b/app/api/v2/endpoints/aeroplane/flight_envelope.py
@@ -1,0 +1,82 @@
+"""Flight envelope endpoints — V-n diagram retrieval and computation."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Path, status
+from pydantic import UUID4
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import InternalError, NotFoundError, ServiceException
+from app.db.session import get_db
+from app.schemas.flight_envelope import FlightEnvelopeRead
+from app.services import flight_envelope_service
+
+router = APIRouter()
+
+
+def _raise_http_from_domain(exc: ServiceException) -> None:
+    """Map domain exceptions to HTTP status codes."""
+    if isinstance(exc, NotFoundError):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=exc.message) from exc
+    if isinstance(exc, InternalError):
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=exc.message
+        ) from exc
+    raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)) from exc
+
+
+@router.get(
+    "/aeroplanes/{aeroplane_id}/flight-envelope",
+    operation_id="get_flight_envelope",
+    tags=["flight-envelope"],
+    responses={
+        404: {"description": "No cached flight envelope found"},
+    },
+)
+async def get_flight_envelope(
+    aeroplane_id: Annotated[UUID4, Path(..., description="Aeroplane UUID")],
+    db: Annotated[Session, Depends(get_db)],
+) -> FlightEnvelopeRead:
+    """Return the cached flight envelope for an aeroplane, or 404 if none."""
+    try:
+        result = flight_envelope_service.get_flight_envelope(db, aeroplane_id)
+    except ServiceException as exc:
+        _raise_http_from_domain(exc)
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Unexpected error: {exc}",
+        ) from exc
+    if result is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No flight envelope computed yet for this aeroplane.",
+        )
+    return result
+
+
+@router.post(
+    "/aeroplanes/{aeroplane_id}/flight-envelope/compute",
+    operation_id="compute_flight_envelope",
+    tags=["flight-envelope"],
+    responses={
+        404: {"description": "Aeroplane not found"},
+        500: {"description": "Computation error"},
+    },
+)
+async def compute_flight_envelope_endpoint(
+    aeroplane_id: Annotated[UUID4, Path(..., description="Aeroplane UUID")],
+    db: Annotated[Session, Depends(get_db)],
+) -> FlightEnvelopeRead:
+    """Compute (or recompute) the flight envelope for an aeroplane."""
+    try:
+        return flight_envelope_service.compute_flight_envelope(db, aeroplane_id)
+    except ServiceException as exc:
+        _raise_http_from_domain(exc)
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Unexpected error: {exc}",
+        ) from exc

--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -1242,6 +1242,30 @@ async def avl_trim_operating_point_tool(
     )
 
 
+# Flight-envelope tools
+@mcp_tool(
+    name="get_flight_envelope",
+    description="Get the cached flight envelope (V-n diagram, KPIs) for an aircraft.",
+)
+async def get_flight_envelope_tool(aeroplane_id: UUID4) -> Any:
+    from app.api.v2.endpoints.aeroplane.flight_envelope import get_flight_envelope
+
+    return await _call_endpoint(get_flight_envelope, aeroplane_id=aeroplane_id)
+
+
+@mcp_tool(
+    name="compute_flight_envelope",
+    description="Compute or recompute the flight envelope for an aircraft. "
+    "Returns V-n curves and performance KPIs.",
+)
+async def compute_flight_envelope_tool(aeroplane_id: UUID4) -> Any:
+    from app.api.v2.endpoints.aeroplane.flight_envelope import (
+        compute_flight_envelope_endpoint,
+    )
+
+    return await _call_endpoint(compute_flight_envelope_endpoint, aeroplane_id=aeroplane_id)
+
+
 @mcp_tool(
     name="create_operating_point",
     description="Create and persist one stored operating point record.",

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -8,4 +8,5 @@ from app.models.aeroplanemodel import (
     WingXSecTedServoModel,
 )
 from app.models.analysismodels import OperatingPointModel, OperatingPointSetModel
+from app.models.flight_envelope_model import FlightEnvelopeModel
 from app.models.flightprofilemodel import RCFlightProfileModel

--- a/app/models/flight_envelope_model.py
+++ b/app/models/flight_envelope_model.py
@@ -1,0 +1,34 @@
+"""SQLAlchemy model for persisted flight envelope results."""
+
+from __future__ import annotations
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, JSON
+from sqlalchemy.orm import relationship
+
+from app.db.base import Base
+
+
+class FlightEnvelopeModel(Base):
+    """Cached flight-envelope computation for an aeroplane.
+
+    One envelope per aeroplane (unique constraint on aeroplane_id).
+    Upserted on every recompute.
+    """
+
+    __tablename__ = "flight_envelopes"
+
+    id = Column(Integer, primary_key=True)
+    aeroplane_id = Column(
+        Integer,
+        ForeignKey("aeroplanes.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    vn_curve_json = Column(JSON, nullable=False)
+    kpis_json = Column(JSON, nullable=False)
+    markers_json = Column(JSON, nullable=False)
+    assumptions_snapshot = Column(JSON, nullable=False)
+    computed_at = Column(DateTime(timezone=True), nullable=False)
+
+    aeroplane = relationship("AeroplaneModel", backref="flight_envelope")

--- a/app/schemas/flight_envelope.py
+++ b/app/schemas/flight_envelope.py
@@ -1,0 +1,79 @@
+"""Flight envelope schemas — V-n diagram, KPIs, and markers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class VnPoint(BaseModel):
+    """Single point on the V-n diagram."""
+
+    velocity_mps: float = Field(..., description="Airspeed in m/s")
+    load_factor: float = Field(..., description="Load factor (g)")
+
+    @field_validator("velocity_mps")
+    @classmethod
+    def velocity_must_be_non_negative(cls, v: float) -> float:
+        if v < 0:
+            raise ValueError("velocity_mps must be non-negative")
+        return v
+
+
+class VnCurve(BaseModel):
+    """Complete V-n envelope boundary curves."""
+
+    positive: list[VnPoint] = Field(..., description="Positive-g boundary points")
+    negative: list[VnPoint] = Field(..., description="Negative-g boundary points")
+    dive_speed_mps: float = Field(..., description="Dive speed Vd in m/s")
+    stall_speed_mps: float = Field(..., description="1-g stall speed in m/s")
+
+
+class PerformanceKPI(BaseModel):
+    """One key performance indicator derived from the flight envelope."""
+
+    label: str = Field(..., description="Machine-readable identifier, e.g. 'stall_speed'")
+    display_name: str = Field(..., description="Human-readable label, e.g. 'Stall Speed'")
+    value: float = Field(..., description="Numeric KPI value")
+    unit: str = Field(..., description="Display unit, e.g. 'm/s' or 'g'")
+    source_op_id: int | None = Field(
+        None, description="Operating-point ID this KPI was derived from, if any"
+    )
+    confidence: Literal["trimmed", "estimated", "limit"] = Field(
+        ..., description="How the value was determined"
+    )
+
+
+class VnMarker(BaseModel):
+    """An operating point plotted on the V-n diagram."""
+
+    op_id: int = Field(..., description="Operating point database ID")
+    name: str = Field(..., description="Operating point name")
+    velocity_mps: float = Field(..., description="Airspeed in m/s")
+    load_factor: float = Field(..., description="Load factor (g)")
+    status: str = Field(..., description="Trim status, e.g. 'TRIMMED'")
+    label: str = Field(..., description="Category label, e.g. 'cruise', 'best_ld'")
+
+
+class FlightEnvelopeRead(BaseModel):
+    """Read-only representation of a computed flight envelope."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    aeroplane_id: int
+    vn_curve: VnCurve
+    kpis: list[PerformanceKPI]
+    operating_points: list[VnMarker]
+    assumptions_snapshot: dict
+    computed_at: datetime
+
+
+class ComputeEnvelopeRequest(BaseModel):
+    """Request body for (re-)computing the flight envelope."""
+
+    force_recompute: bool = Field(
+        False, description="If true, recompute even if a cached result exists"
+    )

--- a/app/services/flight_envelope_service.py
+++ b/app/services/flight_envelope_service.py
@@ -1,0 +1,192 @@
+"""Flight envelope service — V-n curve computation, KPI derivation, and DB persistence."""
+
+from __future__ import annotations
+
+import logging
+import math
+
+from app.schemas.flight_envelope import (
+    PerformanceKPI,
+    VnCurve,
+    VnMarker,
+    VnPoint,
+)
+
+logger = logging.getLogger(__name__)
+
+GRAVITY = 9.81
+
+
+# ---------------------------------------------------------------------------
+# Pure computation helpers (no DB)
+# ---------------------------------------------------------------------------
+
+
+def compute_vn_curve(
+    mass_kg: float,
+    cl_max: float,
+    g_limit: float,
+    wing_area_m2: float,
+    rho: float = 1.225,
+    v_max_mps: float = 28.0,
+) -> VnCurve:
+    """Compute the V-n diagram boundary curves.
+
+    Returns a VnCurve with positive and negative boundary points from
+    stall speed to dive speed (1.4 * v_max).
+    """
+    weight = mass_kg * GRAVITY
+    v_stall = math.sqrt(2 * weight / (rho * wing_area_m2 * cl_max))
+    v_dive = 1.4 * v_max_mps
+    cl_min = -0.8 * cl_max
+
+    n_points = 60  # > 50 as required
+
+    positive: list[VnPoint] = []
+    negative: list[VnPoint] = []
+
+    for i in range(n_points):
+        v = v_stall + (v_dive - v_stall) * i / (n_points - 1)
+        q = 0.5 * rho * v**2
+
+        n_pos = min(q * wing_area_m2 * cl_max / weight, g_limit)
+        n_neg = max(q * wing_area_m2 * cl_min / weight, -0.4 * g_limit)
+
+        positive.append(VnPoint(velocity_mps=round(v, 6), load_factor=round(n_pos, 6)))
+        negative.append(VnPoint(velocity_mps=round(v, 6), load_factor=round(n_neg, 6)))
+
+    return VnCurve(
+        positive=positive,
+        negative=negative,
+        dive_speed_mps=round(v_dive, 6),
+        stall_speed_mps=round(v_stall, 6),
+    )
+
+
+def derive_performance_kpis(
+    stall_speed_mps: float,
+    v_max_mps: float,
+    g_limit: float,
+    markers: list[VnMarker],
+) -> list[PerformanceKPI]:
+    """Derive 6 KPIs from the flight envelope and operating-point markers.
+
+    Always returns exactly 6 KPIs: stall_speed, best_ld_speed,
+    min_sink_speed, max_speed, max_load_factor, dive_speed.
+    """
+    markers_by_label: dict[str, VnMarker] = {m.label: m for m in markers}
+
+    kpis: list[PerformanceKPI] = []
+
+    # 1. stall_speed
+    kpis.append(
+        PerformanceKPI(
+            label="stall_speed",
+            display_name="Stall Speed",
+            value=round(stall_speed_mps, 4),
+            unit="m/s",
+            source_op_id=None,
+            confidence="limit",
+        )
+    )
+
+    # 2. best_ld_speed
+    best_ld_marker = markers_by_label.get("best_ld")
+    if best_ld_marker is not None:
+        kpis.append(
+            PerformanceKPI(
+                label="best_ld_speed",
+                display_name="Best L/D Speed",
+                value=round(best_ld_marker.velocity_mps, 4),
+                unit="m/s",
+                source_op_id=best_ld_marker.op_id,
+                confidence="trimmed",
+            )
+        )
+    else:
+        kpis.append(
+            PerformanceKPI(
+                label="best_ld_speed",
+                display_name="Best L/D Speed",
+                value=round(1.4 * stall_speed_mps, 4),
+                unit="m/s",
+                source_op_id=None,
+                confidence="estimated",
+            )
+        )
+
+    # 3. min_sink_speed
+    min_sink_marker = markers_by_label.get("min_sink")
+    if min_sink_marker is not None:
+        kpis.append(
+            PerformanceKPI(
+                label="min_sink_speed",
+                display_name="Min Sink Speed",
+                value=round(min_sink_marker.velocity_mps, 4),
+                unit="m/s",
+                source_op_id=min_sink_marker.op_id,
+                confidence="trimmed",
+            )
+        )
+    else:
+        kpis.append(
+            PerformanceKPI(
+                label="min_sink_speed",
+                display_name="Min Sink Speed",
+                value=round(1.2 * stall_speed_mps, 4),
+                unit="m/s",
+                source_op_id=None,
+                confidence="estimated",
+            )
+        )
+
+    # 4. max_speed
+    kpis.append(
+        PerformanceKPI(
+            label="max_speed",
+            display_name="Max Speed",
+            value=round(v_max_mps, 4),
+            unit="m/s",
+            source_op_id=None,
+            confidence="limit",
+        )
+    )
+
+    # 5. max_load_factor
+    max_turn_marker = markers_by_label.get("max_turn")
+    if max_turn_marker is not None:
+        kpis.append(
+            PerformanceKPI(
+                label="max_load_factor",
+                display_name="Max Load Factor",
+                value=round(max_turn_marker.load_factor, 4),
+                unit="g",
+                source_op_id=max_turn_marker.op_id,
+                confidence="trimmed",
+            )
+        )
+    else:
+        kpis.append(
+            PerformanceKPI(
+                label="max_load_factor",
+                display_name="Max Load Factor",
+                value=round(g_limit, 4),
+                unit="g",
+                source_op_id=None,
+                confidence="limit",
+            )
+        )
+
+    # 6. dive_speed
+    kpis.append(
+        PerformanceKPI(
+            label="dive_speed",
+            display_name="Dive Speed",
+            value=round(1.4 * v_max_mps, 4),
+            unit="m/s",
+            source_op_id=None,
+            confidence="limit",
+        )
+    )
+
+    return kpis

--- a/app/services/flight_envelope_service.py
+++ b/app/services/flight_envelope_service.py
@@ -4,8 +4,17 @@ from __future__ import annotations
 
 import logging
 import math
+from datetime import datetime, timezone
 
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import NotFoundError
+from app.models.aeroplanemodel import AeroplaneModel
+from app.models.analysismodels import OperatingPointModel
+from app.models.flight_envelope_model import FlightEnvelopeModel
+from app.schemas.design_assumption import PARAMETER_DEFAULTS
 from app.schemas.flight_envelope import (
+    FlightEnvelopeRead,
     PerformanceKPI,
     VnCurve,
     VnMarker,
@@ -190,3 +199,201 @@ def derive_performance_kpis(
     )
 
     return kpis
+
+
+# ---------------------------------------------------------------------------
+# DB-aware helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_aeroplane(db: Session, aeroplane_uuid) -> AeroplaneModel:
+    """Query AeroplaneModel by uuid; raise NotFoundError if missing."""
+    aeroplane = db.query(AeroplaneModel).filter(AeroplaneModel.uuid == aeroplane_uuid).first()
+    if not aeroplane:
+        raise NotFoundError(entity="Aeroplane", resource_id=aeroplane_uuid)
+    return aeroplane
+
+
+def _load_assumptions(db: Session, aeroplane_uuid) -> dict[str, float]:
+    """Load effective values for mass, cl_max, g_limit.
+
+    Falls back to PARAMETER_DEFAULTS if a design assumption row is missing.
+    """
+    from app.services.mass_cg_service import get_effective_assumption_value
+
+    result: dict[str, float] = {}
+    for param in ("mass", "cl_max", "g_limit"):
+        try:
+            result[param] = get_effective_assumption_value(db, aeroplane_uuid, param)
+        except NotFoundError:
+            result[param] = PARAMETER_DEFAULTS[param]
+    return result
+
+
+def _get_wing_area_m2(db: Session, aeroplane: AeroplaneModel) -> float:
+    """Convert aeroplane to ASB Airplane and return s_ref."""
+    from app.converters.model_schema_converters import (
+        aeroplane_model_to_aeroplane_schema_async,
+        aeroplane_schema_to_asb_airplane_async,
+    )
+
+    schema = aeroplane_model_to_aeroplane_schema_async(aeroplane)
+    asb_airplane = aeroplane_schema_to_asb_airplane_async(schema)
+    return asb_airplane.s_ref
+
+
+def _get_v_max(db: Session, aeroplane: AeroplaneModel) -> float:
+    """Get max level speed from flight profile goals; default 28.0 m/s."""
+    profile = aeroplane.flight_profile
+    if profile is not None:
+        goals = profile.goals
+        if isinstance(goals, dict):
+            v = goals.get("max_level_speed_mps")
+            if v is not None:
+                return float(v)
+    return 28.0
+
+
+def _load_operating_point_markers(
+    db: Session,
+    aeroplane: AeroplaneModel,
+    mass_kg: float,
+    wing_area_m2: float,
+) -> list[VnMarker]:
+    """Query OperatingPointModel rows for this aeroplane and map to VnMarker."""
+    ops = (
+        db.query(OperatingPointModel).filter(OperatingPointModel.aircraft_id == aeroplane.id).all()
+    )
+    markers: list[VnMarker] = []
+    weight = mass_kg * GRAVITY
+    for op in ops:
+        v = op.velocity
+        if v is None or v <= 0:
+            continue
+        # Compute load factor from alpha: n ~ q * S * CL / W
+        # but we don't know CL from this row. Approximate as 1.0 for level flight.
+        # For trimmed points, CL = W / (q * S) => n = 1.0; for turning points
+        # the status encodes it. We report n=1.0 as a safe default; markers
+        # are visual aids and refined later by the frontend.
+        q = 0.5 * 1.225 * v**2
+        n = q * wing_area_m2 / weight if weight > 0 else 1.0
+        # Clamp to a reasonable range
+        n = max(-5.0, min(n, 5.0))
+        markers.append(
+            VnMarker(
+                op_id=op.id,
+                name=op.name or "unnamed",
+                velocity_mps=v,
+                load_factor=round(n, 4),
+                status=op.status or "NOT_TRIMMED",
+                label=op.name or "unnamed",
+            )
+        )
+    return markers
+
+
+def _model_to_read(row: FlightEnvelopeModel) -> FlightEnvelopeRead:
+    """Convert a FlightEnvelopeModel row to a FlightEnvelopeRead schema."""
+    return FlightEnvelopeRead(
+        id=row.id,
+        aeroplane_id=row.aeroplane_id,
+        vn_curve=VnCurve.model_validate(row.vn_curve_json),
+        kpis=[PerformanceKPI.model_validate(k) for k in row.kpis_json],
+        operating_points=[VnMarker.model_validate(m) for m in row.markers_json],
+        assumptions_snapshot=row.assumptions_snapshot,
+        computed_at=row.computed_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public orchestration API
+# ---------------------------------------------------------------------------
+
+
+def compute_flight_envelope(db: Session, aeroplane_uuid) -> FlightEnvelopeRead:
+    """Compute (or recompute) the flight envelope for an aeroplane.
+
+    Steps:
+    1. Load aeroplane and design assumptions
+    2. Get wing area via ASB conversion
+    3. Get v_max from flight profile
+    4. Compute V-n curve and KPIs
+    5. Load operating-point markers
+    6. Upsert to DB
+    7. Return FlightEnvelopeRead
+    """
+    aeroplane = _get_aeroplane(db, aeroplane_uuid)
+    assumptions = _load_assumptions(db, aeroplane_uuid)
+    wing_area_m2 = _get_wing_area_m2(db, aeroplane)
+    v_max = _get_v_max(db, aeroplane)
+
+    mass_kg = assumptions["mass"]
+    cl_max = assumptions["cl_max"]
+    g_limit = assumptions["g_limit"]
+
+    vn_curve = compute_vn_curve(
+        mass_kg=mass_kg,
+        cl_max=cl_max,
+        g_limit=g_limit,
+        wing_area_m2=wing_area_m2,
+        v_max_mps=v_max,
+    )
+
+    markers = _load_operating_point_markers(db, aeroplane, mass_kg, wing_area_m2)
+
+    kpis = derive_performance_kpis(
+        stall_speed_mps=vn_curve.stall_speed_mps,
+        v_max_mps=v_max,
+        g_limit=g_limit,
+        markers=markers,
+    )
+
+    now = datetime.now(timezone.utc)
+
+    # Serialize for JSON columns
+    vn_curve_json = vn_curve.model_dump(mode="json")
+    kpis_json = [k.model_dump(mode="json") for k in kpis]
+    markers_json = [m.model_dump(mode="json") for m in markers]
+    assumptions_snapshot = assumptions
+
+    # Upsert: update if exists, create if not
+    existing = (
+        db.query(FlightEnvelopeModel)
+        .filter(FlightEnvelopeModel.aeroplane_id == aeroplane.id)
+        .first()
+    )
+    if existing is not None:
+        existing.vn_curve_json = vn_curve_json
+        existing.kpis_json = kpis_json
+        existing.markers_json = markers_json
+        existing.assumptions_snapshot = assumptions_snapshot
+        existing.computed_at = now
+        db.flush()
+        db.refresh(existing)
+        return _model_to_read(existing)
+
+    row = FlightEnvelopeModel(
+        aeroplane_id=aeroplane.id,
+        vn_curve_json=vn_curve_json,
+        kpis_json=kpis_json,
+        markers_json=markers_json,
+        assumptions_snapshot=assumptions_snapshot,
+        computed_at=now,
+    )
+    db.add(row)
+    db.flush()
+    db.refresh(row)
+    return _model_to_read(row)
+
+
+def get_flight_envelope(db: Session, aeroplane_uuid) -> FlightEnvelopeRead | None:
+    """Return the cached flight envelope, or None if not yet computed."""
+    aeroplane = _get_aeroplane(db, aeroplane_uuid)
+    row = (
+        db.query(FlightEnvelopeModel)
+        .filter(FlightEnvelopeModel.aeroplane_id == aeroplane.id)
+        .first()
+    )
+    if row is None:
+        return None
+    return _model_to_read(row)

--- a/app/services/flight_envelope_service.py
+++ b/app/services/flight_envelope_service.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 
 from sqlalchemy.orm import Session
 
-from app.core.exceptions import NotFoundError
+from app.core.exceptions import InternalError, NotFoundError
 from app.models.aeroplanemodel import AeroplaneModel
 from app.models.analysismodels import OperatingPointModel
 from app.models.flight_envelope_model import FlightEnvelopeModel
@@ -44,6 +44,9 @@ def compute_vn_curve(
     Returns a VnCurve with positive and negative boundary points from
     stall speed to dive speed (1.4 * v_max).
     """
+    if mass_kg <= 0 or cl_max <= 0 or wing_area_m2 <= 0 or v_max_mps <= 0:
+        raise ValueError("mass_kg, cl_max, wing_area_m2, and v_max_mps must be positive")
+
     weight = mass_kg * GRAVITY
     v_stall = math.sqrt(2 * weight / (rho * wing_area_m2 * cl_max))
     v_dive = 1.4 * v_max_mps
@@ -239,7 +242,10 @@ def _get_wing_area_m2(db: Session, aeroplane: AeroplaneModel) -> float:
 
     schema = aeroplane_model_to_aeroplane_schema_async(aeroplane)
     asb_airplane = aeroplane_schema_to_asb_airplane_async(schema)
-    return asb_airplane.s_ref
+    s_ref = asb_airplane.s_ref
+    if s_ref is None or s_ref <= 0:
+        raise InternalError("Cannot determine wing reference area — no wings defined")
+    return float(s_ref)
 
 
 def _get_v_max(db: Session, aeroplane: AeroplaneModel) -> float:
@@ -265,20 +271,13 @@ def _load_operating_point_markers(
         db.query(OperatingPointModel).filter(OperatingPointModel.aircraft_id == aeroplane.id).all()
     )
     markers: list[VnMarker] = []
-    weight = mass_kg * GRAVITY
     for op in ops:
         v = op.velocity
         if v is None or v <= 0:
             continue
-        # Compute load factor from alpha: n ~ q * S * CL / W
-        # but we don't know CL from this row. Approximate as 1.0 for level flight.
-        # For trimmed points, CL = W / (q * S) => n = 1.0; for turning points
-        # the status encodes it. We report n=1.0 as a safe default; markers
-        # are visual aids and refined later by the frontend.
-        q = 0.5 * 1.225 * v**2
-        n = q * wing_area_m2 / weight if weight > 0 else 1.0
-        # Clamp to a reasonable range
-        n = max(-5.0, min(n, 5.0))
+        # Operating points represent level flight conditions (n=1.0).
+        # Without stored CL, we cannot derive actual load factor.
+        n = 1.0
         markers.append(
             VnMarker(
                 op_id=op.id,

--- a/app/tests/test_flight_envelope_endpoints.py
+++ b/app/tests/test_flight_envelope_endpoints.py
@@ -1,0 +1,203 @@
+"""Tests for app/api/v2/endpoints/aeroplane/flight_envelope.py.
+
+Covers the GET (cached) and POST (compute) flight envelope endpoints,
+mocked at the service layer.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from app.core.exceptions import InternalError, NotFoundError, ServiceException
+from app.core.platform import aerosandbox_available
+from app.schemas.flight_envelope import (
+    FlightEnvelopeRead,
+    PerformanceKPI,
+    VnCurve,
+    VnMarker,
+    VnPoint,
+)
+from app.tests.conftest import make_aeroplane
+
+pytestmark = pytest.mark.skipif(
+    not aerosandbox_available(),
+    reason="flight_envelope router requires aerosandbox",
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SERVICE_MODULE = "app.api.v2.endpoints.aeroplane.flight_envelope.flight_envelope_service"
+
+
+def _make_aeroplane_detached(SessionLocal, name="fe-test-plane"):
+    """Create an aeroplane and return (uuid_str, pk) without a live session."""
+    db = SessionLocal()
+    try:
+        aeroplane = make_aeroplane(db, name=name)
+        return str(aeroplane.uuid), aeroplane.id
+    finally:
+        db.close()
+
+
+def _sample_envelope(aeroplane_pk: int = 1) -> FlightEnvelopeRead:
+    """Return a realistic FlightEnvelopeRead for mocking."""
+    return FlightEnvelopeRead(
+        id=1,
+        aeroplane_id=aeroplane_pk,
+        vn_curve=VnCurve(
+            positive=[
+                VnPoint(velocity_mps=10.0, load_factor=1.0),
+                VnPoint(velocity_mps=20.0, load_factor=2.5),
+            ],
+            negative=[
+                VnPoint(velocity_mps=10.0, load_factor=-0.4),
+                VnPoint(velocity_mps=20.0, load_factor=-1.0),
+            ],
+            dive_speed_mps=39.2,
+            stall_speed_mps=10.0,
+        ),
+        kpis=[
+            PerformanceKPI(
+                label="stall_speed",
+                display_name="Stall Speed",
+                value=10.0,
+                unit="m/s",
+                source_op_id=None,
+                confidence="limit",
+            ),
+        ],
+        operating_points=[
+            VnMarker(
+                op_id=1,
+                name="cruise",
+                velocity_mps=20.0,
+                load_factor=1.0,
+                status="TRIMMED",
+                label="cruise",
+            ),
+        ],
+        assumptions_snapshot={"mass": 2.5, "cl_max": 1.4, "g_limit": 3.8},
+        computed_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+# =========================================================================
+# GET /aeroplanes/{aeroplane_id}/flight-envelope
+# =========================================================================
+
+
+class TestGetFlightEnvelope:
+    def test_returns_cached_envelope(self, client_and_db):
+        client, SessionLocal = client_and_db
+        aircraft_uuid, aircraft_pk = _make_aeroplane_detached(SessionLocal)
+
+        envelope = _sample_envelope(aircraft_pk)
+        with patch(
+            f"{_SERVICE_MODULE}.get_flight_envelope",
+            return_value=envelope,
+        ) as mock_get:
+            resp = client.get(f"/aeroplanes/{aircraft_uuid}/flight-envelope")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["id"] == 1
+            assert data["aeroplane_id"] == aircraft_pk
+            assert data["vn_curve"]["dive_speed_mps"] == 39.2
+            assert len(data["kpis"]) == 1
+            assert data["kpis"][0]["label"] == "stall_speed"
+            assert len(data["operating_points"]) == 1
+            mock_get.assert_called_once()
+
+    def test_returns_404_when_no_cached_envelope(self, client_and_db):
+        client, SessionLocal = client_and_db
+        aircraft_uuid, _ = _make_aeroplane_detached(SessionLocal, "no-envelope")
+
+        with patch(
+            f"{_SERVICE_MODULE}.get_flight_envelope",
+            return_value=None,
+        ):
+            resp = client.get(f"/aeroplanes/{aircraft_uuid}/flight-envelope")
+            assert resp.status_code == 404
+
+    def test_returns_404_when_aeroplane_not_found(self, client_and_db):
+        client, _ = client_and_db
+        fake_uuid = uuid.uuid4()
+
+        with patch(
+            f"{_SERVICE_MODULE}.get_flight_envelope",
+            side_effect=NotFoundError("Aeroplane not found"),
+        ):
+            resp = client.get(f"/aeroplanes/{fake_uuid}/flight-envelope")
+            assert resp.status_code == 404
+
+    def test_invalid_uuid_returns_422(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.get("/aeroplanes/not-a-uuid/flight-envelope")
+        assert resp.status_code == 422
+
+
+# =========================================================================
+# POST /aeroplanes/{aeroplane_id}/flight-envelope/compute
+# =========================================================================
+
+
+class TestComputeFlightEnvelope:
+    def test_returns_computed_envelope(self, client_and_db):
+        client, SessionLocal = client_and_db
+        aircraft_uuid, aircraft_pk = _make_aeroplane_detached(SessionLocal, "compute-test")
+
+        envelope = _sample_envelope(aircraft_pk)
+        with patch(
+            f"{_SERVICE_MODULE}.compute_flight_envelope",
+            return_value=envelope,
+        ) as mock_compute:
+            resp = client.post(f"/aeroplanes/{aircraft_uuid}/flight-envelope/compute")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["id"] == 1
+            assert data["vn_curve"]["stall_speed_mps"] == 10.0
+            assert data["assumptions_snapshot"]["mass"] == 2.5
+            mock_compute.assert_called_once()
+
+    def test_not_found_error(self, client_and_db):
+        client, _ = client_and_db
+        fake_uuid = uuid.uuid4()
+
+        with patch(
+            f"{_SERVICE_MODULE}.compute_flight_envelope",
+            side_effect=NotFoundError("Aeroplane not found"),
+        ):
+            resp = client.post(f"/aeroplanes/{fake_uuid}/flight-envelope/compute")
+            assert resp.status_code == 404
+
+    def test_internal_error(self, client_and_db):
+        client, SessionLocal = client_and_db
+        aircraft_uuid, _ = _make_aeroplane_detached(SessionLocal, "internal-err")
+
+        with patch(
+            f"{_SERVICE_MODULE}.compute_flight_envelope",
+            side_effect=InternalError("Computation failed"),
+        ):
+            resp = client.post(f"/aeroplanes/{aircraft_uuid}/flight-envelope/compute")
+            assert resp.status_code == 500
+
+    def test_generic_service_exception_maps_to_500(self, client_and_db):
+        client, SessionLocal = client_and_db
+        aircraft_uuid, _ = _make_aeroplane_detached(SessionLocal, "generic-err")
+
+        with patch(
+            f"{_SERVICE_MODULE}.compute_flight_envelope",
+            side_effect=ServiceException("generic failure"),
+        ):
+            resp = client.post(f"/aeroplanes/{aircraft_uuid}/flight-envelope/compute")
+            assert resp.status_code == 500
+
+    def test_invalid_uuid_returns_422(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.post("/aeroplanes/not-a-uuid/flight-envelope/compute")
+        assert resp.status_code == 422

--- a/app/tests/test_flight_envelope_service.py
+++ b/app/tests/test_flight_envelope_service.py
@@ -361,6 +361,24 @@ class TestComputeVnCurve:
         )
         assert len(curve.positive) >= 50
 
+    def test_rejects_non_positive_mass(self):
+        from app.services.flight_envelope_service import compute_vn_curve
+
+        with pytest.raises(ValueError, match="positive"):
+            compute_vn_curve(
+                mass_kg=0, cl_max=self.CL_MAX, g_limit=self.G_LIMIT,
+                wing_area_m2=self.S, v_max_mps=self.V_MAX,
+            )
+
+    def test_rejects_non_positive_wing_area(self):
+        from app.services.flight_envelope_service import compute_vn_curve
+
+        with pytest.raises(ValueError, match="positive"):
+            compute_vn_curve(
+                mass_kg=self.MASS, cl_max=self.CL_MAX, g_limit=self.G_LIMIT,
+                wing_area_m2=-1.0, v_max_mps=self.V_MAX,
+            )
+
 
 class TestDerivePerformanceKPIs:
     """Pure computation: KPI derivation."""

--- a/app/tests/test_flight_envelope_service.py
+++ b/app/tests/test_flight_envelope_service.py
@@ -442,3 +442,224 @@ class TestDerivePerformanceKPIs:
         best_ld = next(k for k in kpis if k.label == "best_ld_speed")
         assert abs(best_ld.value - 1.4 * 8.0) < 0.01
         assert best_ld.confidence == "estimated"
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Task 4: Full envelope service (DB integration) tests
+# ────────────────────────────────────────────────────────────────────────────
+
+
+class TestFullEnvelopeService:
+    """Integration tests for compute_flight_envelope / get_flight_envelope.
+
+    Heavy external dependencies (_load_assumptions, _get_wing_area_m2,
+    _get_v_max, _load_operating_point_markers) are mocked so the tests
+    exercise orchestration and DB upsert logic without needing real
+    ASB converters or design-assumption rows.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _setup_db(self):
+        """Fresh in-memory SQLite with all tables."""
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import Session, sessionmaker
+        from sqlalchemy.pool import StaticPool
+
+        from app.db.base import Base
+
+        engine = create_engine(
+            "sqlite://",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(bind=engine)
+        self.SessionLocal = sessionmaker(bind=engine, class_=Session)
+        self.engine = engine
+        yield
+        Base.metadata.drop_all(bind=engine)
+
+    def _make_aeroplane(self, session):
+        """Create a minimal aeroplane and return the model instance."""
+        import uuid as _uuid
+
+        from app.models.aeroplanemodel import AeroplaneModel
+
+        plane = AeroplaneModel(name="test-plane", uuid=_uuid.uuid4())
+        session.add(plane)
+        session.flush()
+        return plane
+
+    def _mock_patches(self):
+        """Return a dict of patch targets and their return values."""
+        return {
+            "app.services.flight_envelope_service._load_assumptions": {
+                "mass": 1.5,
+                "cl_max": 1.4,
+                "g_limit": 3.0,
+            },
+            "app.services.flight_envelope_service._get_wing_area_m2": 0.25,
+            "app.services.flight_envelope_service._get_v_max": 28.0,
+            "app.services.flight_envelope_service._load_operating_point_markers": [],
+        }
+
+    def test_compute_returns_envelope(self):
+        from unittest.mock import patch
+
+        from app.services.flight_envelope_service import compute_flight_envelope
+
+        patches = self._mock_patches()
+        with self.SessionLocal() as session:
+            plane = self._make_aeroplane(session)
+            with (
+                patch(
+                    "app.services.flight_envelope_service._load_assumptions",
+                    return_value=patches["app.services.flight_envelope_service._load_assumptions"],
+                ),
+                patch(
+                    "app.services.flight_envelope_service._get_wing_area_m2",
+                    return_value=patches["app.services.flight_envelope_service._get_wing_area_m2"],
+                ),
+                patch(
+                    "app.services.flight_envelope_service._get_v_max",
+                    return_value=patches["app.services.flight_envelope_service._get_v_max"],
+                ),
+                patch(
+                    "app.services.flight_envelope_service._load_operating_point_markers",
+                    return_value=patches[
+                        "app.services.flight_envelope_service._load_operating_point_markers"
+                    ],
+                ),
+            ):
+                result = compute_flight_envelope(session, plane.uuid)
+
+            assert result.aeroplane_id == plane.id
+            assert len(result.kpis) == 6
+            assert len(result.vn_curve.positive) >= 50
+            assert result.assumptions_snapshot == {"mass": 1.5, "cl_max": 1.4, "g_limit": 3.0}
+
+    def test_compute_persists_to_db(self):
+        from unittest.mock import patch
+
+        from app.models.flight_envelope_model import FlightEnvelopeModel
+        from app.services.flight_envelope_service import compute_flight_envelope
+
+        patches = self._mock_patches()
+        with self.SessionLocal() as session:
+            plane = self._make_aeroplane(session)
+            with (
+                patch(
+                    "app.services.flight_envelope_service._load_assumptions",
+                    return_value=patches["app.services.flight_envelope_service._load_assumptions"],
+                ),
+                patch(
+                    "app.services.flight_envelope_service._get_wing_area_m2",
+                    return_value=patches["app.services.flight_envelope_service._get_wing_area_m2"],
+                ),
+                patch(
+                    "app.services.flight_envelope_service._get_v_max",
+                    return_value=patches["app.services.flight_envelope_service._get_v_max"],
+                ),
+                patch(
+                    "app.services.flight_envelope_service._load_operating_point_markers",
+                    return_value=patches[
+                        "app.services.flight_envelope_service._load_operating_point_markers"
+                    ],
+                ),
+            ):
+                compute_flight_envelope(session, plane.uuid)
+
+            row = (
+                session.query(FlightEnvelopeModel)
+                .filter(FlightEnvelopeModel.aeroplane_id == plane.id)
+                .first()
+            )
+            assert row is not None
+            assert row.aeroplane_id == plane.id
+
+    def test_upsert_on_recompute(self):
+        from unittest.mock import patch
+
+        from app.models.flight_envelope_model import FlightEnvelopeModel
+        from app.services.flight_envelope_service import compute_flight_envelope
+
+        patches = self._mock_patches()
+        with self.SessionLocal() as session:
+            plane = self._make_aeroplane(session)
+            with (
+                patch(
+                    "app.services.flight_envelope_service._load_assumptions",
+                    return_value=patches["app.services.flight_envelope_service._load_assumptions"],
+                ),
+                patch(
+                    "app.services.flight_envelope_service._get_wing_area_m2",
+                    return_value=patches["app.services.flight_envelope_service._get_wing_area_m2"],
+                ),
+                patch(
+                    "app.services.flight_envelope_service._get_v_max",
+                    return_value=patches["app.services.flight_envelope_service._get_v_max"],
+                ),
+                patch(
+                    "app.services.flight_envelope_service._load_operating_point_markers",
+                    return_value=patches[
+                        "app.services.flight_envelope_service._load_operating_point_markers"
+                    ],
+                ),
+            ):
+                first = compute_flight_envelope(session, plane.uuid)
+                second = compute_flight_envelope(session, plane.uuid)
+
+            # Same DB row reused (upsert, not duplicate)
+            assert first.id == second.id
+            count = (
+                session.query(FlightEnvelopeModel)
+                .filter(FlightEnvelopeModel.aeroplane_id == plane.id)
+                .count()
+            )
+            assert count == 1
+
+    def test_get_returns_cached(self):
+        from unittest.mock import patch
+
+        from app.services.flight_envelope_service import (
+            compute_flight_envelope,
+            get_flight_envelope,
+        )
+
+        patches = self._mock_patches()
+        with self.SessionLocal() as session:
+            plane = self._make_aeroplane(session)
+            with (
+                patch(
+                    "app.services.flight_envelope_service._load_assumptions",
+                    return_value=patches["app.services.flight_envelope_service._load_assumptions"],
+                ),
+                patch(
+                    "app.services.flight_envelope_service._get_wing_area_m2",
+                    return_value=patches["app.services.flight_envelope_service._get_wing_area_m2"],
+                ),
+                patch(
+                    "app.services.flight_envelope_service._get_v_max",
+                    return_value=patches["app.services.flight_envelope_service._get_v_max"],
+                ),
+                patch(
+                    "app.services.flight_envelope_service._load_operating_point_markers",
+                    return_value=patches[
+                        "app.services.flight_envelope_service._load_operating_point_markers"
+                    ],
+                ),
+            ):
+                compute_flight_envelope(session, plane.uuid)
+
+            cached = get_flight_envelope(session, plane.uuid)
+            assert cached is not None
+            assert cached.aeroplane_id == plane.id
+
+    def test_get_returns_none_when_missing(self):
+        import uuid as _uuid
+
+        from app.services.flight_envelope_service import get_flight_envelope
+
+        with self.SessionLocal() as session:
+            plane = self._make_aeroplane(session)
+            result = get_flight_envelope(session, plane.uuid)
+            assert result is None

--- a/app/tests/test_flight_envelope_service.py
+++ b/app/tests/test_flight_envelope_service.py
@@ -167,3 +167,102 @@ class TestComputeEnvelopeRequest:
 
         req = ComputeEnvelopeRequest(force_recompute=True)
         assert req.force_recompute is True
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Task 2: DB model tests
+# ────────────────────────────────────────────────────────────────────────────
+
+
+class TestFlightEnvelopeModel:
+    """FlightEnvelopeModel ORM tests using in-memory SQLite."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_db(self):
+        """Create a fresh in-memory SQLite database for each test."""
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import Session, sessionmaker
+        from sqlalchemy.pool import StaticPool
+
+        from app.db.base import Base
+
+        engine = create_engine(
+            "sqlite://",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(bind=engine)
+        self.SessionLocal = sessionmaker(bind=engine, class_=Session)
+        self.engine = engine
+        yield
+        Base.metadata.drop_all(bind=engine)
+
+    def _make_aeroplane(self, session) -> int:
+        """Create a minimal aeroplane and return its id."""
+        import uuid as _uuid
+
+        from app.models.aeroplanemodel import AeroplaneModel
+
+        plane = AeroplaneModel(name="test-plane", uuid=_uuid.uuid4())
+        session.add(plane)
+        session.flush()
+        return plane.id
+
+    def test_create_and_read(self):
+        from datetime import datetime, timezone
+
+        from app.models.flight_envelope_model import FlightEnvelopeModel
+
+        with self.SessionLocal() as session:
+            aeroplane_id = self._make_aeroplane(session)
+            now = datetime.now(timezone.utc)
+            envelope = FlightEnvelopeModel(
+                aeroplane_id=aeroplane_id,
+                vn_curve_json={"positive": [], "negative": []},
+                kpis_json=[],
+                markers_json=[],
+                assumptions_snapshot={"mass": 1.5},
+                computed_at=now,
+            )
+            session.add(envelope)
+            session.flush()
+            session.refresh(envelope)
+
+            assert envelope.id is not None
+            assert envelope.aeroplane_id == aeroplane_id
+            assert envelope.vn_curve_json == {"positive": [], "negative": []}
+            # SQLite strips timezone info; compare naive timestamps
+            assert envelope.computed_at.replace(tzinfo=None) == now.replace(tzinfo=None)
+
+    def test_unique_constraint_per_aeroplane(self):
+        from datetime import datetime, timezone
+
+        from sqlalchemy.exc import IntegrityError
+
+        from app.models.flight_envelope_model import FlightEnvelopeModel
+
+        with self.SessionLocal() as session:
+            aeroplane_id = self._make_aeroplane(session)
+            now = datetime.now(timezone.utc)
+            e1 = FlightEnvelopeModel(
+                aeroplane_id=aeroplane_id,
+                vn_curve_json={},
+                kpis_json=[],
+                markers_json=[],
+                assumptions_snapshot={},
+                computed_at=now,
+            )
+            session.add(e1)
+            session.flush()
+
+            e2 = FlightEnvelopeModel(
+                aeroplane_id=aeroplane_id,
+                vn_curve_json={},
+                kpis_json=[],
+                markers_json=[],
+                assumptions_snapshot={},
+                computed_at=now,
+            )
+            session.add(e2)
+            with pytest.raises(IntegrityError):
+                session.flush()

--- a/app/tests/test_flight_envelope_service.py
+++ b/app/tests/test_flight_envelope_service.py
@@ -266,3 +266,179 @@ class TestFlightEnvelopeModel:
             session.add(e2)
             with pytest.raises(IntegrityError):
                 session.flush()
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Task 3: V-n curve computation + KPI derivation tests
+# ────────────────────────────────────────────────────────────────────────────
+
+
+class TestComputeVnCurve:
+    """Pure computation: V-n curve generation."""
+
+    # Reference values for a 1.5 kg aircraft, Cl_max=1.4, g_limit=3.0,
+    # S=0.25 m^2, rho=1.225, v_max=28 m/s.
+    MASS = 1.5
+    CL_MAX = 1.4
+    G_LIMIT = 3.0
+    S = 0.25
+    RHO = 1.225
+    V_MAX = 28.0
+
+    @property
+    def expected_stall(self) -> float:
+        return math.sqrt(2 * self.MASS * 9.81 / (self.RHO * self.S * self.CL_MAX))
+
+    @property
+    def expected_dive(self) -> float:
+        return 1.4 * self.V_MAX
+
+    def test_stall_speed_math(self):
+        from app.services.flight_envelope_service import compute_vn_curve
+
+        curve = compute_vn_curve(
+            mass_kg=self.MASS,
+            cl_max=self.CL_MAX,
+            g_limit=self.G_LIMIT,
+            wing_area_m2=self.S,
+            rho=self.RHO,
+            v_max_mps=self.V_MAX,
+        )
+        assert abs(curve.stall_speed_mps - self.expected_stall) < 0.01
+
+    def test_dive_speed(self):
+        from app.services.flight_envelope_service import compute_vn_curve
+
+        curve = compute_vn_curve(
+            mass_kg=self.MASS,
+            cl_max=self.CL_MAX,
+            g_limit=self.G_LIMIT,
+            wing_area_m2=self.S,
+            rho=self.RHO,
+            v_max_mps=self.V_MAX,
+        )
+        assert abs(curve.dive_speed_mps - self.expected_dive) < 0.01
+
+    def test_positive_boundary_capped_at_g_limit(self):
+        from app.services.flight_envelope_service import compute_vn_curve
+
+        curve = compute_vn_curve(
+            mass_kg=self.MASS,
+            cl_max=self.CL_MAX,
+            g_limit=self.G_LIMIT,
+            wing_area_m2=self.S,
+            rho=self.RHO,
+            v_max_mps=self.V_MAX,
+        )
+        for pt in curve.positive:
+            assert pt.load_factor <= self.G_LIMIT + 1e-9
+
+    def test_negative_boundary_capped(self):
+        from app.services.flight_envelope_service import compute_vn_curve
+
+        curve = compute_vn_curve(
+            mass_kg=self.MASS,
+            cl_max=self.CL_MAX,
+            g_limit=self.G_LIMIT,
+            wing_area_m2=self.S,
+            rho=self.RHO,
+            v_max_mps=self.V_MAX,
+        )
+        neg_limit = -0.4 * self.G_LIMIT
+        for pt in curve.negative:
+            assert pt.load_factor >= neg_limit - 1e-9
+
+    def test_at_least_50_positive_points(self):
+        from app.services.flight_envelope_service import compute_vn_curve
+
+        curve = compute_vn_curve(
+            mass_kg=self.MASS,
+            cl_max=self.CL_MAX,
+            g_limit=self.G_LIMIT,
+            wing_area_m2=self.S,
+            rho=self.RHO,
+            v_max_mps=self.V_MAX,
+        )
+        assert len(curve.positive) >= 50
+
+
+class TestDerivePerformanceKPIs:
+    """Pure computation: KPI derivation."""
+
+    def test_always_returns_6_kpis(self):
+        from app.services.flight_envelope_service import derive_performance_kpis
+
+        kpis = derive_performance_kpis(
+            stall_speed_mps=8.0,
+            v_max_mps=28.0,
+            g_limit=3.0,
+            markers=[],
+        )
+        assert len(kpis) == 6
+
+    def test_kpi_labels_present(self):
+        from app.services.flight_envelope_service import derive_performance_kpis
+
+        kpis = derive_performance_kpis(
+            stall_speed_mps=8.0,
+            v_max_mps=28.0,
+            g_limit=3.0,
+            markers=[],
+        )
+        labels = {k.label for k in kpis}
+        assert labels == {
+            "stall_speed",
+            "best_ld_speed",
+            "min_sink_speed",
+            "max_speed",
+            "max_load_factor",
+            "dive_speed",
+        }
+
+    def test_dive_speed_kpi_value(self):
+        from app.services.flight_envelope_service import derive_performance_kpis
+
+        kpis = derive_performance_kpis(
+            stall_speed_mps=8.0,
+            v_max_mps=28.0,
+            g_limit=3.0,
+            markers=[],
+        )
+        dive_kpi = next(k for k in kpis if k.label == "dive_speed")
+        assert abs(dive_kpi.value - 1.4 * 28.0) < 0.01
+
+    def test_best_ld_from_marker(self):
+        from app.schemas.flight_envelope import VnMarker
+        from app.services.flight_envelope_service import derive_performance_kpis
+
+        marker = VnMarker(
+            op_id=10,
+            name="best_ld_point",
+            velocity_mps=15.0,
+            load_factor=1.0,
+            status="TRIMMED",
+            label="best_ld",
+        )
+        kpis = derive_performance_kpis(
+            stall_speed_mps=8.0,
+            v_max_mps=28.0,
+            g_limit=3.0,
+            markers=[marker],
+        )
+        best_ld = next(k for k in kpis if k.label == "best_ld_speed")
+        assert abs(best_ld.value - 15.0) < 0.01
+        assert best_ld.source_op_id == 10
+        assert best_ld.confidence == "trimmed"
+
+    def test_fallback_best_ld_without_marker(self):
+        from app.services.flight_envelope_service import derive_performance_kpis
+
+        kpis = derive_performance_kpis(
+            stall_speed_mps=8.0,
+            v_max_mps=28.0,
+            g_limit=3.0,
+            markers=[],
+        )
+        best_ld = next(k for k in kpis if k.label == "best_ld_speed")
+        assert abs(best_ld.value - 1.4 * 8.0) < 0.01
+        assert best_ld.confidence == "estimated"

--- a/app/tests/test_flight_envelope_service.py
+++ b/app/tests/test_flight_envelope_service.py
@@ -1,0 +1,169 @@
+"""Tests for the flight envelope feature — schemas, model, computation, service."""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError as PydanticValidationError
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Task 1: Schema tests
+# ────────────────────────────────────────────────────────────────────────────
+
+
+class TestVnPoint:
+    """VnPoint schema validation."""
+
+    def test_valid_point(self):
+        from app.schemas.flight_envelope import VnPoint
+
+        p = VnPoint(velocity_mps=25.0, load_factor=2.5)
+        assert p.velocity_mps == 25.0
+        assert p.load_factor == 2.5
+
+    def test_zero_velocity_accepted(self):
+        from app.schemas.flight_envelope import VnPoint
+
+        p = VnPoint(velocity_mps=0.0, load_factor=1.0)
+        assert p.velocity_mps == 0.0
+
+    def test_negative_velocity_rejected(self):
+        from app.schemas.flight_envelope import VnPoint
+
+        with pytest.raises(PydanticValidationError, match="velocity"):
+            VnPoint(velocity_mps=-1.0, load_factor=1.0)
+
+
+class TestVnCurve:
+    """VnCurve schema validation."""
+
+    def test_valid_curve(self):
+        from app.schemas.flight_envelope import VnCurve, VnPoint
+
+        pos = [VnPoint(velocity_mps=10.0, load_factor=1.0)]
+        neg = [VnPoint(velocity_mps=10.0, load_factor=-0.5)]
+        curve = VnCurve(
+            positive=pos,
+            negative=neg,
+            dive_speed_mps=40.0,
+            stall_speed_mps=8.0,
+        )
+        assert curve.dive_speed_mps == 40.0
+        assert len(curve.positive) == 1
+
+
+class TestPerformanceKPI:
+    """PerformanceKPI schema validation."""
+
+    def test_valid_kpi(self):
+        from app.schemas.flight_envelope import PerformanceKPI
+
+        kpi = PerformanceKPI(
+            label="stall_speed",
+            display_name="Stall Speed",
+            value=8.5,
+            unit="m/s",
+            source_op_id=None,
+            confidence="estimated",
+        )
+        assert kpi.label == "stall_speed"
+        assert kpi.confidence == "estimated"
+
+    def test_invalid_confidence_rejected(self):
+        from app.schemas.flight_envelope import PerformanceKPI
+
+        with pytest.raises(PydanticValidationError):
+            PerformanceKPI(
+                label="stall_speed",
+                display_name="Stall Speed",
+                value=8.5,
+                unit="m/s",
+                source_op_id=None,
+                confidence="guess",
+            )
+
+
+class TestVnMarker:
+    """VnMarker schema validation."""
+
+    def test_valid_marker(self):
+        from app.schemas.flight_envelope import VnMarker
+
+        m = VnMarker(
+            op_id=1,
+            name="cruise",
+            velocity_mps=20.0,
+            load_factor=1.0,
+            status="TRIMMED",
+            label="cruise",
+        )
+        assert m.op_id == 1
+        assert m.name == "cruise"
+
+
+class TestFlightEnvelopeRead:
+    """FlightEnvelopeRead schema validation."""
+
+    def test_valid_read(self):
+        from app.schemas.flight_envelope import (
+            FlightEnvelopeRead,
+            PerformanceKPI,
+            VnCurve,
+            VnMarker,
+            VnPoint,
+        )
+
+        now = datetime.now(timezone.utc)
+        curve = VnCurve(
+            positive=[VnPoint(velocity_mps=10.0, load_factor=1.0)],
+            negative=[VnPoint(velocity_mps=10.0, load_factor=-0.5)],
+            dive_speed_mps=40.0,
+            stall_speed_mps=8.0,
+        )
+        kpi = PerformanceKPI(
+            label="stall_speed",
+            display_name="Stall Speed",
+            value=8.5,
+            unit="m/s",
+            source_op_id=None,
+            confidence="estimated",
+        )
+        marker = VnMarker(
+            op_id=1,
+            name="cruise",
+            velocity_mps=20.0,
+            load_factor=1.0,
+            status="TRIMMED",
+            label="cruise",
+        )
+        envelope = FlightEnvelopeRead(
+            id=1,
+            aeroplane_id=42,
+            vn_curve=curve,
+            kpis=[kpi],
+            operating_points=[marker],
+            assumptions_snapshot={"mass": 1.5},
+            computed_at=now,
+        )
+        assert envelope.aeroplane_id == 42
+        assert len(envelope.kpis) == 1
+        assert len(envelope.operating_points) == 1
+
+
+class TestComputeEnvelopeRequest:
+    """ComputeEnvelopeRequest schema validation."""
+
+    def test_default_force_recompute(self):
+        from app.schemas.flight_envelope import ComputeEnvelopeRequest
+
+        req = ComputeEnvelopeRequest()
+        assert req.force_recompute is False
+
+    def test_force_recompute_true(self):
+        from app.schemas.flight_envelope import ComputeEnvelopeRequest
+
+        req = ComputeEnvelopeRequest(force_recompute=True)
+        assert req.force_recompute is True

--- a/docs/superpowers/plans/2026-05-07-flight-envelope.md
+++ b/docs/superpowers/plans/2026-05-07-flight-envelope.md
@@ -1,0 +1,1763 @@
+# Flight Envelope Analysis Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add flight envelope computation (V-n curves, performance KPIs) with REST API, MCP tools, and an Envelope tab in the analysis workbench.
+
+**Architecture:** New service `flight_envelope_service.py` computes V-n diagram boundaries and KPIs from design assumptions (mass, cl_max, g_limit) and wing geometry. Results cached in a new `flight_envelopes` DB table. Two endpoints (GET cached, POST compute) exposed via REST and MCP. Frontend adds an "Envelope" tab with KPI cards and a Plotly V-n chart.
+
+**Tech Stack:** Python/FastAPI, SQLAlchemy/Alembic, Pydantic v2, AeroSandbox, React 19/Next.js 16, Plotly, SWR-style hooks.
+
+---
+
+## File Structure
+
+### Backend (create)
+- `app/schemas/flight_envelope.py` — Pydantic schemas (VnPoint, VnCurve, PerformanceKPI, VnMarker, FlightEnvelopeRead, ComputeEnvelopeRequest)
+- `app/models/flight_envelope_model.py` — SQLAlchemy model (FlightEnvelopeModel)
+- `app/services/flight_envelope_service.py` — Business logic (compute_flight_envelope, get_flight_envelope)
+- `app/api/v2/endpoints/aeroplane/flight_envelope.py` — REST endpoints
+- `alembic/versions/*_add_flight_envelopes_table.py` — DB migration
+- `app/tests/test_flight_envelope_service.py` — Service unit tests
+- `app/tests/test_flight_envelope_endpoints.py` — Endpoint tests
+
+### Backend (modify)
+- `app/api/v2/endpoints/aeroplane/__init__.py` — Register flight_envelope router
+- `app/mcp_server.py` — Register MCP tools
+
+### Frontend (create)
+- `frontend/hooks/useFlightEnvelope.ts` — SWR-style hook
+- `frontend/components/workbench/EnvelopePanel.tsx` — Container with view toggle
+- `frontend/components/workbench/PerformanceOverview.tsx` — KPI cards grid
+- `frontend/components/workbench/VnDiagram.tsx` — Plotly V-n chart
+- `frontend/__tests__/useFlightEnvelope.test.ts` — Hook tests
+- `frontend/__tests__/EnvelopePanel.test.tsx` — Component tests
+
+### Frontend (modify)
+- `frontend/components/workbench/AnalysisViewerPanel.tsx` — Add "Envelope" to TABS
+- `frontend/app/workbench/analysis/page.tsx` — Wire envelope data to AnalysisViewerPanel
+
+---
+
+## Task 1: Flight Envelope Schemas
+
+**Files:**
+- Create: `app/schemas/flight_envelope.py`
+- Test: `app/tests/test_flight_envelope_service.py` (schema validation tests)
+
+- [ ] **Step 1: Write failing tests for schema validation**
+
+```python
+"""Tests for flight envelope schemas and service."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.schemas.flight_envelope import (
+    VnPoint,
+    VnCurve,
+    PerformanceKPI,
+    VnMarker,
+    FlightEnvelopeRead,
+    ComputeEnvelopeRequest,
+)
+
+
+class TestVnPointSchema:
+    def test_valid_point(self):
+        p = VnPoint(velocity_mps=20.0, load_factor=1.0)
+        assert p.velocity_mps == 20.0
+        assert p.load_factor == 1.0
+
+    def test_negative_velocity_rejected(self):
+        with pytest.raises(ValueError):
+            VnPoint(velocity_mps=-1.0, load_factor=1.0)
+
+
+class TestVnCurveSchema:
+    def test_valid_curve(self):
+        curve = VnCurve(
+            positive=[VnPoint(velocity_mps=10.0, load_factor=1.0)],
+            negative=[VnPoint(velocity_mps=10.0, load_factor=-0.5)],
+            dive_speed_mps=40.0,
+            stall_speed_mps=8.0,
+        )
+        assert curve.dive_speed_mps == 40.0
+        assert curve.stall_speed_mps == 8.0
+        assert len(curve.positive) == 1
+
+
+class TestPerformanceKPISchema:
+    def test_valid_kpi(self):
+        kpi = PerformanceKPI(
+            label="stall_speed",
+            display_name="Stall Speed",
+            value=8.5,
+            unit="m/s",
+            source_op_id=None,
+            confidence="estimated",
+        )
+        assert kpi.label == "stall_speed"
+        assert kpi.confidence == "estimated"
+
+
+class TestComputeEnvelopeRequestSchema:
+    def test_defaults(self):
+        req = ComputeEnvelopeRequest()
+        assert req.force_recompute is False
+```
+
+- [ ] **Step 2: Run tests — expect ImportError**
+
+Run: `poetry run pytest app/tests/test_flight_envelope_service.py::TestVnPointSchema -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.schemas.flight_envelope'`
+
+- [ ] **Step 3: Implement schemas**
+
+```python
+"""Flight envelope schemas — V-n diagram and performance KPIs."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class VnPoint(BaseModel):
+    velocity_mps: float = Field(..., description="Velocity in m/s")
+    load_factor: float = Field(..., description="Load factor in g")
+
+    @field_validator("velocity_mps")
+    @classmethod
+    def velocity_positive(cls, v: float) -> float:
+        if v < 0:
+            raise ValueError("velocity must be non-negative")
+        return v
+
+
+class VnCurve(BaseModel):
+    positive: list[VnPoint] = Field(..., description="Positive-g V-n boundary")
+    negative: list[VnPoint] = Field(..., description="Negative-g V-n boundary")
+    dive_speed_mps: float = Field(..., description="Dive speed V_d in m/s")
+    stall_speed_mps: float = Field(..., description="1-g stall speed in m/s")
+
+
+class PerformanceKPI(BaseModel):
+    label: str = Field(..., description="Machine key, e.g. stall_speed")
+    display_name: str = Field(..., description="Human label, e.g. Stall Speed")
+    value: float
+    unit: str = Field("", description="Display unit, e.g. m/s")
+    source_op_id: int | None = Field(None, description="Linked operating point id")
+    confidence: Literal["trimmed", "estimated", "limit"] = Field(
+        "estimated", description="How the value was derived"
+    )
+
+
+class VnMarker(BaseModel):
+    op_id: int
+    name: str
+    velocity_mps: float
+    load_factor: float
+    status: str = Field(..., description="TRIMMED / NOT_TRIMMED / LIMIT_REACHED")
+    label: str = Field("", description="Semantic label, e.g. cruise, stall")
+
+
+class FlightEnvelopeRead(BaseModel):
+    id: int
+    aeroplane_id: int
+    vn_curve: VnCurve
+    kpis: list[PerformanceKPI]
+    operating_points: list[VnMarker]
+    assumptions_snapshot: dict = Field(
+        ..., description="Design assumption values used for computation"
+    )
+    computed_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ComputeEnvelopeRequest(BaseModel):
+    force_recompute: bool = Field(
+        False, description="Recompute even if a cached result exists"
+    )
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+Run: `poetry run pytest app/tests/test_flight_envelope_service.py -v -k "Schema"`
+Expected: All 4 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/schemas/flight_envelope.py app/tests/test_flight_envelope_service.py
+git commit -m "feat(gh-422): add flight envelope schemas with tests"
+```
+
+---
+
+## Task 2: DB Model + Alembic Migration
+
+**Files:**
+- Create: `app/models/flight_envelope_model.py`
+- Create: `alembic/versions/*_add_flight_envelopes_table.py` (auto-generated)
+- Modify: `app/tests/test_flight_envelope_service.py` (add model tests)
+
+- [ ] **Step 1: Write failing test for model creation**
+
+Append to `app/tests/test_flight_envelope_service.py`:
+
+```python
+from datetime import datetime, timezone
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.db.base_class import Base
+from app.models.flight_envelope_model import FlightEnvelopeModel
+from app.tests.conftest import make_aeroplane
+
+
+class TestFlightEnvelopeModel:
+    def _make_session(self) -> Session:
+        engine = create_engine(
+            "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+        )
+        Base.metadata.create_all(bind=engine)
+        return sessionmaker(bind=engine)()
+
+    def test_create_and_read(self):
+        session = self._make_session()
+        aeroplane = make_aeroplane(session)
+        envelope = FlightEnvelopeModel(
+            aeroplane_id=aeroplane.id,
+            vn_curve_json={"positive": [], "negative": [], "dive_speed_mps": 40.0, "stall_speed_mps": 8.0},
+            kpis_json=[{"label": "stall_speed", "display_name": "Stall Speed", "value": 8.5, "unit": "m/s"}],
+            markers_json=[],
+            assumptions_snapshot={"mass": 1.5, "cl_max": 1.4, "g_limit": 3.0},
+            computed_at=datetime.now(timezone.utc),
+        )
+        session.add(envelope)
+        session.commit()
+        session.refresh(envelope)
+
+        assert envelope.id is not None
+        assert envelope.aeroplane_id == aeroplane.id
+        assert envelope.vn_curve_json["dive_speed_mps"] == 40.0
+
+    def test_unique_per_aeroplane(self):
+        session = self._make_session()
+        aeroplane = make_aeroplane(session)
+        now = datetime.now(timezone.utc)
+        base = dict(
+            aeroplane_id=aeroplane.id,
+            vn_curve_json={},
+            kpis_json=[],
+            markers_json=[],
+            assumptions_snapshot={},
+            computed_at=now,
+        )
+        session.add(FlightEnvelopeModel(**base))
+        session.commit()
+        session.add(FlightEnvelopeModel(**base))
+        with pytest.raises(Exception):
+            session.commit()
+```
+
+- [ ] **Step 2: Run tests — expect ImportError**
+
+Run: `poetry run pytest app/tests/test_flight_envelope_service.py::TestFlightEnvelopeModel -v`
+Expected: FAIL — cannot import `FlightEnvelopeModel`
+
+- [ ] **Step 3: Implement DB model**
+
+```python
+"""Flight envelope DB model — caches computed envelope per aeroplane."""
+
+from __future__ import annotations
+
+from sqlalchemy import Column, DateTime, Integer, JSON, ForeignKey, func
+from sqlalchemy.orm import relationship
+
+from app.db.base_class import Base
+
+
+class FlightEnvelopeModel(Base):
+    __tablename__ = "flight_envelopes"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    aeroplane_id = Column(
+        Integer,
+        ForeignKey("aeroplanes.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    vn_curve_json = Column(JSON, nullable=False)
+    kpis_json = Column(JSON, nullable=False, default=list)
+    markers_json = Column(JSON, nullable=False, default=list)
+    assumptions_snapshot = Column(JSON, nullable=False, default=dict)
+    computed_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    aeroplane = relationship("AeroplaneModel", backref="flight_envelope")
+```
+
+- [ ] **Step 4: Run model tests — expect PASS**
+
+Run: `poetry run pytest app/tests/test_flight_envelope_service.py::TestFlightEnvelopeModel -v`
+Expected: PASS
+
+- [ ] **Step 5: Generate Alembic migration**
+
+```bash
+poetry run alembic revision --autogenerate -m "add flight_envelopes table"
+```
+
+Review the generated migration: verify it creates `flight_envelopes` table with the correct columns, FK, and unique constraint.
+
+- [ ] **Step 6: Run migration to verify it applies cleanly**
+
+```bash
+poetry run alembic upgrade head
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/models/flight_envelope_model.py alembic/versions/*flight_envelopes* app/tests/test_flight_envelope_service.py
+git commit -m "feat(gh-422): add FlightEnvelopeModel with Alembic migration"
+```
+
+---
+
+## Task 3: Flight Envelope Computation Service
+
+**Files:**
+- Create: `app/services/flight_envelope_service.py`
+- Modify: `app/tests/test_flight_envelope_service.py` (add computation tests)
+
+- [ ] **Step 1: Write failing tests for V-n curve computation**
+
+Append to `app/tests/test_flight_envelope_service.py`:
+
+```python
+import math
+
+from app.services.flight_envelope_service import (
+    compute_vn_curve,
+    derive_performance_kpis,
+)
+
+
+class TestComputeVnCurve:
+    """Test V-n curve math with known inputs."""
+
+    def test_stall_speed(self):
+        """V_stall = sqrt(2*m*g / (rho*S*cl_max))"""
+        mass_kg = 1.5
+        cl_max = 1.4
+        g_limit = 3.0
+        wing_area_m2 = 0.5
+        rho = 1.225
+        v_max_mps = 30.0
+
+        curve = compute_vn_curve(
+            mass_kg=mass_kg,
+            cl_max=cl_max,
+            g_limit=g_limit,
+            wing_area_m2=wing_area_m2,
+            rho=rho,
+            v_max_mps=v_max_mps,
+        )
+
+        expected_stall = math.sqrt(2 * mass_kg * 9.81 / (rho * wing_area_m2 * cl_max))
+        assert abs(curve.stall_speed_mps - expected_stall) < 0.01
+
+    def test_dive_speed(self):
+        curve = compute_vn_curve(
+            mass_kg=1.5, cl_max=1.4, g_limit=3.0,
+            wing_area_m2=0.5, rho=1.225, v_max_mps=30.0,
+        )
+        assert abs(curve.dive_speed_mps - 42.0) < 0.01  # 1.4 * 30
+
+    def test_positive_boundary_capped_at_g_limit(self):
+        curve = compute_vn_curve(
+            mass_kg=1.5, cl_max=1.4, g_limit=3.0,
+            wing_area_m2=0.5, rho=1.225, v_max_mps=30.0,
+        )
+        for pt in curve.positive:
+            assert pt.load_factor <= 3.0 + 0.001
+
+    def test_negative_boundary_capped(self):
+        curve = compute_vn_curve(
+            mass_kg=1.5, cl_max=1.4, g_limit=3.0,
+            wing_area_m2=0.5, rho=1.225, v_max_mps=30.0,
+        )
+        for pt in curve.negative:
+            assert pt.load_factor >= -1.2 - 0.001  # -0.4 * g_limit
+
+    def test_positive_boundary_starts_at_stall(self):
+        curve = compute_vn_curve(
+            mass_kg=1.5, cl_max=1.4, g_limit=3.0,
+            wing_area_m2=0.5, rho=1.225, v_max_mps=30.0,
+        )
+        assert curve.positive[0].load_factor == pytest.approx(1.0, abs=0.05)
+
+    def test_curve_has_reasonable_number_of_points(self):
+        curve = compute_vn_curve(
+            mass_kg=1.5, cl_max=1.4, g_limit=3.0,
+            wing_area_m2=0.5, rho=1.225, v_max_mps=30.0,
+        )
+        assert len(curve.positive) >= 10
+        assert len(curve.negative) >= 10
+```
+
+- [ ] **Step 2: Run tests — expect ImportError**
+
+Run: `poetry run pytest app/tests/test_flight_envelope_service.py::TestComputeVnCurve -v`
+Expected: FAIL — cannot import `compute_vn_curve`
+
+- [ ] **Step 3: Implement V-n curve computation**
+
+```python
+"""Flight envelope computation — V-n curves and performance KPIs."""
+
+from __future__ import annotations
+
+import logging
+import math
+from datetime import datetime, timezone
+
+from app.schemas.flight_envelope import PerformanceKPI, VnCurve, VnPoint
+
+logger = logging.getLogger(__name__)
+
+GRAVITY = 9.81
+SEA_LEVEL_RHO = 1.225
+CL_MIN_FACTOR = -0.8
+NEGATIVE_G_FACTOR = -0.4
+DIVE_SPEED_FACTOR = 1.4
+VN_NUM_POINTS = 50
+
+
+def compute_vn_curve(
+    *,
+    mass_kg: float,
+    cl_max: float,
+    g_limit: float,
+    wing_area_m2: float,
+    rho: float = SEA_LEVEL_RHO,
+    v_max_mps: float,
+) -> VnCurve:
+    """Compute V-n diagram boundaries."""
+    v_stall = math.sqrt(2 * mass_kg * GRAVITY / (rho * wing_area_m2 * cl_max))
+    v_dive = DIVE_SPEED_FACTOR * v_max_mps
+    cl_min = CL_MIN_FACTOR * cl_max
+    neg_g_cap = NEGATIVE_G_FACTOR * g_limit
+
+    positive: list[VnPoint] = []
+    negative: list[VnPoint] = []
+
+    for i in range(VN_NUM_POINTS + 1):
+        v = v_stall + (v_dive - v_stall) * i / VN_NUM_POINTS
+
+        n_pos = 0.5 * rho * v**2 * wing_area_m2 * cl_max / (mass_kg * GRAVITY)
+        n_pos = min(n_pos, g_limit)
+        positive.append(VnPoint(velocity_mps=round(v, 4), load_factor=round(n_pos, 4)))
+
+        n_neg = 0.5 * rho * v**2 * wing_area_m2 * cl_min / (mass_kg * GRAVITY)
+        n_neg = max(n_neg, neg_g_cap)
+        negative.append(VnPoint(velocity_mps=round(v, 4), load_factor=round(n_neg, 4)))
+
+    return VnCurve(
+        positive=positive,
+        negative=negative,
+        dive_speed_mps=round(v_dive, 4),
+        stall_speed_mps=round(v_stall, 4),
+    )
+```
+
+- [ ] **Step 4: Run V-n tests — expect PASS**
+
+Run: `poetry run pytest app/tests/test_flight_envelope_service.py::TestComputeVnCurve -v`
+Expected: All 6 tests PASS
+
+- [ ] **Step 5: Write failing tests for KPI derivation**
+
+Append to `app/tests/test_flight_envelope_service.py`:
+
+```python
+from app.schemas.flight_envelope import VnMarker
+
+
+class TestDerivePerformanceKpis:
+    def test_stall_speed_kpi(self):
+        kpis = derive_performance_kpis(
+            stall_speed_mps=8.5,
+            v_max_mps=30.0,
+            g_limit=3.0,
+            markers=[],
+        )
+        stall = next(k for k in kpis if k.label == "stall_speed")
+        assert stall.value == pytest.approx(8.5, abs=0.01)
+        assert stall.unit == "m/s"
+
+    def test_dive_speed_kpi(self):
+        kpis = derive_performance_kpis(
+            stall_speed_mps=8.5,
+            v_max_mps=30.0,
+            g_limit=3.0,
+            markers=[],
+        )
+        dive = next(k for k in kpis if k.label == "dive_speed")
+        assert dive.value == pytest.approx(42.0, abs=0.01)
+
+    def test_best_ld_from_markers(self):
+        markers = [
+            VnMarker(op_id=1, name="cruise", velocity_mps=18.0, load_factor=1.0,
+                      status="TRIMMED", label="cruise"),
+            VnMarker(op_id=2, name="best_ld", velocity_mps=15.0, load_factor=1.0,
+                      status="TRIMMED", label="best_ld"),
+        ]
+        kpis = derive_performance_kpis(
+            stall_speed_mps=8.5, v_max_mps=30.0, g_limit=3.0, markers=markers,
+        )
+        best_ld = next((k for k in kpis if k.label == "best_ld_speed"), None)
+        assert best_ld is not None
+        assert best_ld.value == pytest.approx(15.0)
+        assert best_ld.confidence == "trimmed"
+
+    def test_always_has_six_kpis(self):
+        kpis = derive_performance_kpis(
+            stall_speed_mps=8.5, v_max_mps=30.0, g_limit=3.0, markers=[],
+        )
+        assert len(kpis) == 6
+```
+
+- [ ] **Step 6: Run KPI tests — expect ImportError for derive_performance_kpis**
+
+Run: `poetry run pytest app/tests/test_flight_envelope_service.py::TestDerivePerformanceKpis -v`
+Expected: FAIL — cannot import `derive_performance_kpis`
+
+- [ ] **Step 7: Implement KPI derivation**
+
+Add to `app/services/flight_envelope_service.py`:
+
+```python
+def derive_performance_kpis(
+    *,
+    stall_speed_mps: float,
+    v_max_mps: float,
+    g_limit: float,
+    markers: list[VnMarker],
+) -> list[PerformanceKPI]:
+    """Derive six performance KPIs from envelope data and operating point markers."""
+    from app.schemas.flight_envelope import VnMarker
+
+    def _find_marker(label: str) -> VnMarker | None:
+        return next((m for m in markers if m.label == label), None)
+
+    def _confidence(marker: VnMarker | None) -> str:
+        if marker is None:
+            return "estimated"
+        return "trimmed" if marker.status == "TRIMMED" else "limit"
+
+    best_ld = _find_marker("best_ld")
+    min_sink = _find_marker("min_sink")
+    max_turn = _find_marker("max_turn")
+
+    return [
+        PerformanceKPI(
+            label="stall_speed",
+            display_name="Stall Speed",
+            value=round(stall_speed_mps, 2),
+            unit="m/s",
+            source_op_id=None,
+            confidence="estimated",
+        ),
+        PerformanceKPI(
+            label="best_ld_speed",
+            display_name="Best L/D Speed",
+            value=round(best_ld.velocity_mps if best_ld else stall_speed_mps * 1.4, 2),
+            unit="m/s",
+            source_op_id=best_ld.op_id if best_ld else None,
+            confidence=_confidence(best_ld),
+        ),
+        PerformanceKPI(
+            label="min_sink_speed",
+            display_name="Min Sink Speed",
+            value=round(min_sink.velocity_mps if min_sink else stall_speed_mps * 1.2, 2),
+            unit="m/s",
+            source_op_id=min_sink.op_id if min_sink else None,
+            confidence=_confidence(min_sink),
+        ),
+        PerformanceKPI(
+            label="max_speed",
+            display_name="Max Speed",
+            value=round(v_max_mps, 2),
+            unit="m/s",
+            source_op_id=None,
+            confidence="estimated",
+        ),
+        PerformanceKPI(
+            label="max_load_factor",
+            display_name="Max Load Factor",
+            value=round(max_turn.load_factor if max_turn else g_limit, 2),
+            unit="g",
+            source_op_id=max_turn.op_id if max_turn else None,
+            confidence=_confidence(max_turn),
+        ),
+        PerformanceKPI(
+            label="dive_speed",
+            display_name="Dive Speed",
+            value=round(DIVE_SPEED_FACTOR * v_max_mps, 2),
+            unit="m/s",
+            source_op_id=None,
+            confidence="estimated",
+        ),
+    ]
+```
+
+- [ ] **Step 8: Run KPI tests — expect PASS**
+
+Run: `poetry run pytest app/tests/test_flight_envelope_service.py::TestDerivePerformanceKpis -v`
+Expected: All 4 tests PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add app/services/flight_envelope_service.py app/tests/test_flight_envelope_service.py
+git commit -m "feat(gh-422): add V-n curve computation and KPI derivation"
+```
+
+---
+
+## Task 4: Full Envelope Service (DB Integration)
+
+**Files:**
+- Modify: `app/services/flight_envelope_service.py` (add compute_flight_envelope, get_flight_envelope)
+- Modify: `app/tests/test_flight_envelope_service.py` (add integration tests)
+
+- [ ] **Step 1: Write failing tests for the full service functions**
+
+Append to `app/tests/test_flight_envelope_service.py`:
+
+```python
+from unittest.mock import patch, MagicMock
+
+from app.services.flight_envelope_service import (
+    compute_flight_envelope,
+    get_flight_envelope,
+)
+from app.core.exceptions import NotFoundError
+
+
+class TestComputeFlightEnvelope:
+    """Test the orchestrating service function with mocked dependencies."""
+
+    def _make_db_and_aeroplane(self):
+        engine = create_engine(
+            "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+        )
+        Base.metadata.create_all(bind=engine)
+        session = sessionmaker(bind=engine)()
+        aeroplane = make_aeroplane(session)
+        return session, aeroplane
+
+    @patch("app.services.flight_envelope_service._get_wing_area_m2")
+    @patch("app.services.flight_envelope_service._load_assumptions")
+    @patch("app.services.flight_envelope_service._load_operating_point_markers")
+    @patch("app.services.flight_envelope_service._get_v_max")
+    def test_compute_returns_envelope(
+        self, mock_vmax, mock_markers, mock_assumptions, mock_area
+    ):
+        db, aeroplane = self._make_db_and_aeroplane()
+        mock_assumptions.return_value = {"mass": 1.5, "cl_max": 1.4, "g_limit": 3.0}
+        mock_area.return_value = 0.5
+        mock_markers.return_value = []
+        mock_vmax.return_value = 30.0
+
+        result = compute_flight_envelope(db, aeroplane.uuid)
+
+        assert result.aeroplane_id == aeroplane.id
+        assert result.vn_curve.stall_speed_mps > 0
+        assert len(result.kpis) == 6
+        assert result.assumptions_snapshot["mass"] == 1.5
+
+    @patch("app.services.flight_envelope_service._get_wing_area_m2")
+    @patch("app.services.flight_envelope_service._load_assumptions")
+    @patch("app.services.flight_envelope_service._load_operating_point_markers")
+    @patch("app.services.flight_envelope_service._get_v_max")
+    def test_compute_persists_to_db(
+        self, mock_vmax, mock_markers, mock_assumptions, mock_area
+    ):
+        db, aeroplane = self._make_db_and_aeroplane()
+        mock_assumptions.return_value = {"mass": 1.5, "cl_max": 1.4, "g_limit": 3.0}
+        mock_area.return_value = 0.5
+        mock_markers.return_value = []
+        mock_vmax.return_value = 30.0
+
+        compute_flight_envelope(db, aeroplane.uuid)
+        cached = get_flight_envelope(db, aeroplane.uuid)
+
+        assert cached is not None
+        assert cached.aeroplane_id == aeroplane.id
+
+    @patch("app.services.flight_envelope_service._get_wing_area_m2")
+    @patch("app.services.flight_envelope_service._load_assumptions")
+    @patch("app.services.flight_envelope_service._load_operating_point_markers")
+    @patch("app.services.flight_envelope_service._get_v_max")
+    def test_compute_upserts(
+        self, mock_vmax, mock_markers, mock_assumptions, mock_area
+    ):
+        db, aeroplane = self._make_db_and_aeroplane()
+        mock_assumptions.return_value = {"mass": 1.5, "cl_max": 1.4, "g_limit": 3.0}
+        mock_area.return_value = 0.5
+        mock_markers.return_value = []
+        mock_vmax.return_value = 30.0
+
+        compute_flight_envelope(db, aeroplane.uuid)
+        mock_assumptions.return_value = {"mass": 2.0, "cl_max": 1.4, "g_limit": 3.0}
+        result = compute_flight_envelope(db, aeroplane.uuid)
+
+        assert result.assumptions_snapshot["mass"] == 2.0
+
+
+class TestGetFlightEnvelope:
+    def test_returns_none_when_no_envelope(self):
+        engine = create_engine(
+            "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+        )
+        Base.metadata.create_all(bind=engine)
+        session = sessionmaker(bind=engine)()
+        aeroplane = make_aeroplane(session)
+
+        result = get_flight_envelope(session, aeroplane.uuid)
+        assert result is None
+```
+
+- [ ] **Step 2: Run tests — expect ImportError**
+
+Run: `poetry run pytest app/tests/test_flight_envelope_service.py::TestComputeFlightEnvelope -v`
+Expected: FAIL — cannot import `compute_flight_envelope`
+
+- [ ] **Step 3: Implement full service functions**
+
+Add to `app/services/flight_envelope_service.py`:
+
+```python
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import InternalError, NotFoundError
+from app.models.aeroplanemodel import AeroplaneModel
+from app.models.flight_envelope_model import FlightEnvelopeModel
+from app.schemas.flight_envelope import FlightEnvelopeRead, VnMarker
+
+
+def _get_aeroplane(db: Session, aeroplane_uuid) -> AeroplaneModel:
+    aeroplane = (
+        db.query(AeroplaneModel).filter(AeroplaneModel.uuid == str(aeroplane_uuid)).first()
+    )
+    if aeroplane is None:
+        raise NotFoundError(entity="Aeroplane", resource_id=str(aeroplane_uuid))
+    return aeroplane
+
+
+def _load_assumptions(db: Session, aeroplane_uuid) -> dict[str, float]:
+    from app.services.mass_cg_service import get_effective_assumption_value
+
+    params = {}
+    for name in ("mass", "cl_max", "g_limit"):
+        try:
+            params[name] = get_effective_assumption_value(db, aeroplane_uuid, name)
+        except NotFoundError:
+            from app.schemas.design_assumption import PARAMETER_DEFAULTS
+
+            params[name] = PARAMETER_DEFAULTS[name]
+    return params
+
+
+def _get_wing_area_m2(db: Session, aeroplane: AeroplaneModel) -> float:
+    from app.converters.model_schema_converters import (
+        aeroplane_model_to_aeroplane_schema_async,
+        aeroplane_schema_to_asb_airplane_async,
+    )
+
+    schema = aeroplane_model_to_aeroplane_schema_async(aeroplane)
+    asb_airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=schema)
+    s_ref = asb_airplane.s_ref
+    if s_ref is None or s_ref <= 0:
+        raise InternalError("Cannot determine wing reference area — no wings defined")
+    return float(s_ref)
+
+
+def _get_v_max(db: Session, aeroplane: AeroplaneModel) -> float:
+    if aeroplane.flight_profile and aeroplane.flight_profile.goals:
+        goals = aeroplane.flight_profile.goals
+        if isinstance(goals, dict) and "max_level_speed_mps" in goals:
+            return float(goals["max_level_speed_mps"])
+    return 28.0  # sensible default for RC aircraft
+
+
+def _load_operating_point_markers(
+    db: Session, aeroplane: AeroplaneModel, mass_kg: float, wing_area_m2: float,
+) -> list[VnMarker]:
+    from app.models.analysismodels import OperatingPointModel
+
+    ops = (
+        db.query(OperatingPointModel)
+        .filter(OperatingPointModel.aircraft_id == aeroplane.id)
+        .all()
+    )
+    markers = []
+    for op in ops:
+        v = op.velocity
+        if v <= 0 or mass_kg <= 0 or wing_area_m2 <= 0:
+            continue
+        n = 0.5 * SEA_LEVEL_RHO * v**2 * wing_area_m2 / (mass_kg * GRAVITY)
+        markers.append(
+            VnMarker(
+                op_id=op.id,
+                name=op.name,
+                velocity_mps=round(v, 4),
+                load_factor=round(min(n, 1.0) if op.status == "NOT_TRIMMED" else n, 4),
+                status=op.status,
+                label=op.name.lower().replace(" ", "_"),
+            )
+        )
+    return markers
+
+
+def compute_flight_envelope(db: Session, aeroplane_uuid) -> FlightEnvelopeRead:
+    """Compute and persist flight envelope for an aeroplane."""
+    aeroplane = _get_aeroplane(db, aeroplane_uuid)
+    assumptions = _load_assumptions(db, aeroplane_uuid)
+    wing_area = _get_wing_area_m2(db, aeroplane)
+    v_max = _get_v_max(db, aeroplane)
+
+    curve = compute_vn_curve(
+        mass_kg=assumptions["mass"],
+        cl_max=assumptions["cl_max"],
+        g_limit=assumptions["g_limit"],
+        wing_area_m2=wing_area,
+        v_max_mps=v_max,
+    )
+
+    markers = _load_operating_point_markers(db, aeroplane, assumptions["mass"], wing_area)
+
+    kpis = derive_performance_kpis(
+        stall_speed_mps=curve.stall_speed_mps,
+        v_max_mps=v_max,
+        g_limit=assumptions["g_limit"],
+        markers=markers,
+    )
+
+    now = datetime.now(timezone.utc)
+
+    existing = (
+        db.query(FlightEnvelopeModel)
+        .filter(FlightEnvelopeModel.aeroplane_id == aeroplane.id)
+        .first()
+    )
+    if existing:
+        existing.vn_curve_json = curve.model_dump()
+        existing.kpis_json = [k.model_dump() for k in kpis]
+        existing.markers_json = [m.model_dump() for m in markers]
+        existing.assumptions_snapshot = assumptions
+        existing.computed_at = now
+        envelope = existing
+    else:
+        envelope = FlightEnvelopeModel(
+            aeroplane_id=aeroplane.id,
+            vn_curve_json=curve.model_dump(),
+            kpis_json=[k.model_dump() for k in kpis],
+            markers_json=[m.model_dump() for m in markers],
+            assumptions_snapshot=assumptions,
+            computed_at=now,
+        )
+        db.add(envelope)
+
+    db.flush()
+    db.refresh(envelope)
+
+    return FlightEnvelopeRead(
+        id=envelope.id,
+        aeroplane_id=envelope.aeroplane_id,
+        vn_curve=VnCurve(**envelope.vn_curve_json),
+        kpis=[PerformanceKPI(**k) for k in envelope.kpis_json],
+        operating_points=[VnMarker(**m) for m in envelope.markers_json],
+        assumptions_snapshot=envelope.assumptions_snapshot,
+        computed_at=envelope.computed_at,
+    )
+
+
+def get_flight_envelope(db: Session, aeroplane_uuid) -> FlightEnvelopeRead | None:
+    """Return cached flight envelope or None."""
+    aeroplane = _get_aeroplane(db, aeroplane_uuid)
+    envelope = (
+        db.query(FlightEnvelopeModel)
+        .filter(FlightEnvelopeModel.aeroplane_id == aeroplane.id)
+        .first()
+    )
+    if envelope is None:
+        return None
+
+    return FlightEnvelopeRead(
+        id=envelope.id,
+        aeroplane_id=envelope.aeroplane_id,
+        vn_curve=VnCurve(**envelope.vn_curve_json),
+        kpis=[PerformanceKPI(**k) for k in envelope.kpis_json],
+        operating_points=[VnMarker(**m) for m in envelope.markers_json],
+        assumptions_snapshot=envelope.assumptions_snapshot,
+        computed_at=envelope.computed_at,
+    )
+```
+
+Note: The `_load_operating_point_markers` and `_get_wing_area_from_cache` functions use a module-level cache for wing area to avoid recomputing during the marker loop. The worker should clear `_wing_area_cache` between test runs if needed.
+
+- [ ] **Step 4: Run full service tests — expect PASS**
+
+Run: `poetry run pytest app/tests/test_flight_envelope_service.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/flight_envelope_service.py app/tests/test_flight_envelope_service.py
+git commit -m "feat(gh-422): add full flight envelope service with DB persistence"
+```
+
+---
+
+## Task 5: REST Endpoints
+
+**Files:**
+- Create: `app/api/v2/endpoints/aeroplane/flight_envelope.py`
+- Modify: `app/api/v2/endpoints/aeroplane/__init__.py`
+- Create: `app/tests/test_flight_envelope_endpoints.py`
+
+- [ ] **Step 1: Write failing endpoint tests**
+
+```python
+"""Tests for flight envelope REST endpoints."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from app.core.platform import aerosandbox_available
+from app.schemas.flight_envelope import FlightEnvelopeRead, VnCurve, VnPoint
+from app.tests.conftest import make_aeroplane
+
+pytestmark = pytest.mark.skipif(
+    not aerosandbox_available(),
+    reason="flight envelope endpoints require aerosandbox",
+)
+
+
+def _mock_envelope_read(aeroplane_id: int) -> FlightEnvelopeRead:
+    from datetime import datetime, timezone
+
+    return FlightEnvelopeRead(
+        id=1,
+        aeroplane_id=aeroplane_id,
+        vn_curve=VnCurve(
+            positive=[VnPoint(velocity_mps=10.0, load_factor=1.0)],
+            negative=[VnPoint(velocity_mps=10.0, load_factor=-0.5)],
+            dive_speed_mps=42.0,
+            stall_speed_mps=8.5,
+        ),
+        kpis=[],
+        operating_points=[],
+        assumptions_snapshot={"mass": 1.5, "cl_max": 1.4, "g_limit": 3.0},
+        computed_at=datetime.now(timezone.utc),
+    )
+
+
+class TestGetFlightEnvelope:
+    def test_returns_cached(self, client_and_db):
+        client, SessionLocal = client_and_db
+        db = SessionLocal()
+        aeroplane = make_aeroplane(db)
+        db.close()
+
+        with patch(
+            "app.services.flight_envelope_service.get_flight_envelope"
+        ) as mock_get:
+            mock_get.return_value = _mock_envelope_read(aeroplane.id)
+            resp = client.get(f"/aeroplanes/{aeroplane.uuid}/flight-envelope")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["vn_curve"]["stall_speed_mps"] == 8.5
+
+    def test_returns_404_when_none(self, client_and_db):
+        client, SessionLocal = client_and_db
+        db = SessionLocal()
+        aeroplane = make_aeroplane(db)
+        db.close()
+
+        with patch(
+            "app.services.flight_envelope_service.get_flight_envelope"
+        ) as mock_get:
+            mock_get.return_value = None
+            resp = client.get(f"/aeroplanes/{aeroplane.uuid}/flight-envelope")
+            assert resp.status_code == 404
+
+
+class TestComputeFlightEnvelope:
+    def test_compute_returns_envelope(self, client_and_db):
+        client, SessionLocal = client_and_db
+        db = SessionLocal()
+        aeroplane = make_aeroplane(db)
+        db.close()
+
+        with patch(
+            "app.services.flight_envelope_service.compute_flight_envelope"
+        ) as mock_compute:
+            mock_compute.return_value = _mock_envelope_read(aeroplane.id)
+            resp = client.post(f"/aeroplanes/{aeroplane.uuid}/flight-envelope/compute")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert "vn_curve" in data
+            assert "kpis" in data
+```
+
+- [ ] **Step 2: Run tests — expect failure (router not registered)**
+
+Run: `poetry run pytest app/tests/test_flight_envelope_endpoints.py -v`
+Expected: FAIL — 404 (route not found)
+
+- [ ] **Step 3: Implement endpoint file**
+
+```python
+"""Flight envelope REST endpoints."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Path, status
+from pydantic import UUID4
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import ServiceException, NotFoundError, InternalError
+from app.db.session import get_db
+from app.schemas.flight_envelope import ComputeEnvelopeRequest, FlightEnvelopeRead
+from app.services import flight_envelope_service
+
+router = APIRouter()
+
+
+def _raise_http_from_domain(exc: ServiceException) -> None:
+    if isinstance(exc, NotFoundError):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=exc.message) from exc
+    if isinstance(exc, InternalError):
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=exc.message
+        ) from exc
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)
+    ) from exc
+
+
+@router.get(
+    "/aeroplanes/{aeroplane_id}/flight-envelope",
+    operation_id="get_flight_envelope",
+)
+async def get_flight_envelope(
+    aeroplane_id: Annotated[UUID4, Path(..., description="Aeroplane UUID")],
+    db: Annotated[Session, Depends(get_db)],
+) -> FlightEnvelopeRead:
+    try:
+        result = flight_envelope_service.get_flight_envelope(db, aeroplane_id)
+        if result is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="No flight envelope computed yet",
+            )
+        return result
+    except ServiceException as exc:
+        _raise_http_from_domain(exc)
+
+
+@router.post(
+    "/aeroplanes/{aeroplane_id}/flight-envelope/compute",
+    operation_id="compute_flight_envelope",
+)
+async def compute_flight_envelope_endpoint(
+    aeroplane_id: Annotated[UUID4, Path(..., description="Aeroplane UUID")],
+    db: Annotated[Session, Depends(get_db)],
+) -> FlightEnvelopeRead:
+    try:
+        return flight_envelope_service.compute_flight_envelope(db, aeroplane_id)
+    except ServiceException as exc:
+        _raise_http_from_domain(exc)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Envelope computation failed: {exc}",
+        ) from exc
+```
+
+- [ ] **Step 4: Register the router**
+
+In `app/api/v2/endpoints/aeroplane/__init__.py`, add:
+
+```python
+from .flight_envelope import router as flight_envelope_router
+# ... after existing includes
+router.include_router(flight_envelope_router)
+```
+
+- [ ] **Step 5: Run endpoint tests — expect PASS**
+
+Run: `poetry run pytest app/tests/test_flight_envelope_endpoints.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 6: Run full test suite to check for regressions**
+
+Run: `poetry run pytest -x -q --timeout=30 -m "not slow" 2>&1 | tail -10`
+Expected: All existing + new tests pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/api/v2/endpoints/aeroplane/flight_envelope.py app/api/v2/endpoints/aeroplane/__init__.py app/tests/test_flight_envelope_endpoints.py
+git commit -m "feat(gh-422): add flight envelope REST endpoints"
+```
+
+---
+
+## Task 6: MCP Tools
+
+**Files:**
+- Modify: `app/mcp_server.py`
+
+- [ ] **Step 1: Add MCP tools to mcp_server.py**
+
+Locate the section where operating point tools are registered (near `generate_default_operating_point_set_tool`). Add nearby:
+
+```python
+@mcp_tool(
+    name="get_flight_envelope",
+    description="Get the cached flight envelope (V-n diagram, KPIs) for an aircraft. Returns 404 if not yet computed.",
+)
+async def get_flight_envelope_tool(aircraft_id: UUID4) -> Any:
+    from app.api.v2.endpoints.aeroplane.flight_envelope import get_flight_envelope
+
+    return await _call_endpoint(get_flight_envelope, aeroplane_id=aircraft_id)
+
+
+@mcp_tool(
+    name="compute_flight_envelope",
+    description="Compute or recompute the flight envelope for an aircraft. Returns V-n curves, performance KPIs, and operating point markers.",
+)
+async def compute_flight_envelope_tool(aircraft_id: UUID4) -> Any:
+    from app.api.v2.endpoints.aeroplane.flight_envelope import (
+        compute_flight_envelope_endpoint,
+    )
+
+    return await _call_endpoint(compute_flight_envelope_endpoint, aeroplane_id=aircraft_id)
+```
+
+- [ ] **Step 2: Run existing MCP-related tests to check no regressions**
+
+Run: `poetry run pytest app/tests/ -k "mcp" -v --timeout=30`
+Expected: All existing MCP tests still pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/mcp_server.py
+git commit -m "feat(gh-422): register flight envelope MCP tools"
+```
+
+---
+
+## Task 7: Frontend Hook — useFlightEnvelope
+
+**Files:**
+- Create: `frontend/hooks/useFlightEnvelope.ts`
+- Create: `frontend/__tests__/useFlightEnvelope.test.ts`
+
+- [ ] **Step 1: Write failing hook test**
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useFlightEnvelope } from "@/hooks/useFlightEnvelope";
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+describe("useFlightEnvelope", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("returns null when no aeroplaneId", () => {
+    const { result } = renderHook(() => useFlightEnvelope(null));
+    expect(result.current.data).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("fetches envelope on mount", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        id: 1,
+        vn_curve: { positive: [], negative: [], dive_speed_mps: 42, stall_speed_mps: 8.5 },
+        kpis: [],
+        operating_points: [],
+        assumptions_snapshot: {},
+        computed_at: "2026-05-07T00:00:00Z",
+      }),
+    });
+
+    const { result } = renderHook(() => useFlightEnvelope("abc-123"));
+    await waitFor(() => expect(result.current.data).not.toBeNull());
+    expect(result.current.data?.vn_curve.stall_speed_mps).toBe(8.5);
+  });
+
+  it("compute triggers POST then refreshes", async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => null, status: 404 })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 1,
+          vn_curve: { positive: [], negative: [], dive_speed_mps: 42, stall_speed_mps: 9 },
+          kpis: [],
+          operating_points: [],
+          assumptions_snapshot: {},
+          computed_at: "2026-05-07T00:00:00Z",
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 1,
+          vn_curve: { positive: [], negative: [], dive_speed_mps: 42, stall_speed_mps: 9 },
+          kpis: [],
+          operating_points: [],
+          assumptions_snapshot: {},
+          computed_at: "2026-05-07T00:00:00Z",
+        }),
+      });
+
+    const { result } = renderHook(() => useFlightEnvelope("abc-123"));
+
+    await act(async () => {
+      await result.current.compute();
+    });
+
+    await waitFor(() => expect(result.current.data?.vn_curve.stall_speed_mps).toBe(9));
+  });
+});
+```
+
+- [ ] **Step 2: Run test — expect import failure**
+
+Run: `cd frontend && npm run test:unit -- --reporter verbose useFlightEnvelope`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement hook**
+
+```typescript
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import { API_BASE } from "@/lib/fetcher";
+
+export interface VnPoint {
+  velocity_mps: number;
+  load_factor: number;
+}
+
+export interface VnCurve {
+  positive: VnPoint[];
+  negative: VnPoint[];
+  dive_speed_mps: number;
+  stall_speed_mps: number;
+}
+
+export interface PerformanceKPI {
+  label: string;
+  display_name: string;
+  value: number;
+  unit: string;
+  source_op_id: number | null;
+  confidence: "trimmed" | "estimated" | "limit";
+}
+
+export interface VnMarker {
+  op_id: number;
+  name: string;
+  velocity_mps: number;
+  load_factor: number;
+  status: string;
+  label: string;
+}
+
+export interface FlightEnvelopeData {
+  id: number;
+  aeroplane_id: number;
+  vn_curve: VnCurve;
+  kpis: PerformanceKPI[];
+  operating_points: VnMarker[];
+  assumptions_snapshot: Record<string, number>;
+  computed_at: string;
+}
+
+export interface UseFlightEnvelopeReturn {
+  data: FlightEnvelopeData | null;
+  isLoading: boolean;
+  isComputing: boolean;
+  error: string | null;
+  compute: () => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+export function useFlightEnvelope(
+  aeroplaneId: string | null,
+): UseFlightEnvelopeReturn {
+  const [data, setData] = useState<FlightEnvelopeData | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isComputing, setIsComputing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchEnvelope = useCallback(async () => {
+    if (!aeroplaneId) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `${API_BASE}/aeroplanes/${aeroplaneId}/flight-envelope`,
+      );
+      if (res.status === 404) {
+        setData(null);
+        return;
+      }
+      if (!res.ok) throw new Error(`Failed to fetch envelope: ${res.status}`);
+      setData(await res.json());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Unknown error");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [aeroplaneId]);
+
+  const compute = useCallback(async () => {
+    if (!aeroplaneId) return;
+    setIsComputing(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `${API_BASE}/aeroplanes/${aeroplaneId}/flight-envelope/compute`,
+        { method: "POST" },
+      );
+      if (!res.ok) {
+        const body = await res.text();
+        throw new Error(`Compute failed: ${res.status} ${body}`);
+      }
+      setData(await res.json());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Unknown error");
+    } finally {
+      setIsComputing(false);
+    }
+  }, [aeroplaneId]);
+
+  useEffect(() => {
+    fetchEnvelope();
+  }, [fetchEnvelope]);
+
+  return { data, isLoading, isComputing, error, compute, refresh: fetchEnvelope };
+}
+```
+
+- [ ] **Step 4: Run hook tests — expect PASS**
+
+Run: `cd frontend && npm run test:unit -- --reporter verbose useFlightEnvelope`
+Expected: All 3 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/hooks/useFlightEnvelope.ts frontend/__tests__/useFlightEnvelope.test.ts
+git commit -m "feat(gh-422): add useFlightEnvelope hook with tests"
+```
+
+---
+
+## Task 8: Frontend Components — EnvelopePanel, PerformanceOverview, VnDiagram
+
+**Files:**
+- Create: `frontend/components/workbench/EnvelopePanel.tsx`
+- Create: `frontend/components/workbench/PerformanceOverview.tsx`
+- Create: `frontend/components/workbench/VnDiagram.tsx`
+- Modify: `frontend/components/workbench/AnalysisViewerPanel.tsx` (add Envelope tab)
+- Modify: `frontend/app/workbench/analysis/page.tsx` (wire hook)
+
+- [ ] **Step 1: Create PerformanceOverview component**
+
+```tsx
+"use client";
+
+import type { PerformanceKPI } from "@/hooks/useFlightEnvelope";
+
+const CONFIDENCE_COLORS: Record<string, string> = {
+  trimmed: "text-green-400 bg-green-900/30",
+  estimated: "text-yellow-400 bg-yellow-900/30",
+  limit: "text-red-400 bg-red-900/30",
+};
+
+interface Props {
+  readonly kpis: PerformanceKPI[];
+}
+
+export function PerformanceOverview({ kpis }: Props) {
+  if (kpis.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-48 text-muted-foreground text-[13px]">
+        No performance data available. Compute the envelope first.
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 p-4">
+      {kpis.map((kpi) => (
+        <div
+          key={kpi.label}
+          className="rounded-lg border border-border bg-card p-4 flex flex-col gap-1"
+        >
+          <span className="text-[11px] uppercase tracking-wider text-muted-foreground">
+            {kpi.display_name}
+          </span>
+          <div className="flex items-baseline gap-2">
+            <span className="text-2xl font-mono font-semibold text-foreground">
+              {kpi.value.toFixed(1)}
+            </span>
+            <span className="text-[13px] text-muted-foreground">{kpi.unit}</span>
+          </div>
+          <span
+            className={`text-[11px] px-1.5 py-0.5 rounded w-fit ${CONFIDENCE_COLORS[kpi.confidence] ?? ""}`}
+          >
+            {kpi.confidence}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Create VnDiagram component**
+
+```tsx
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { VnCurve, VnMarker } from "@/hooks/useFlightEnvelope";
+
+const MARKER_SYMBOLS: Record<string, string> = {
+  TRIMMED: "circle",
+  NOT_TRIMMED: "circle-open",
+  LIMIT_REACHED: "diamond",
+};
+
+interface Props {
+  readonly curve: VnCurve;
+  readonly markers: VnMarker[];
+}
+
+export function VnDiagram({ curve, markers }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    let cancelled = false;
+
+    (async () => {
+      const Plotly = await import("plotly.js-gl3d-dist-min");
+      if (cancelled || !containerRef.current) return;
+
+      const posV = curve.positive.map((p) => p.velocity_mps);
+      const posN = curve.positive.map((p) => p.load_factor);
+      const negV = curve.negative.map((p) => p.velocity_mps);
+      const negN = curve.negative.map((p) => p.load_factor);
+
+      const traces: Plotly.Data[] = [
+        {
+          x: posV,
+          y: posN,
+          mode: "lines",
+          name: "Positive g",
+          line: { color: "#FF8400", width: 2 },
+        },
+        {
+          x: negV,
+          y: negN,
+          mode: "lines",
+          name: "Negative g",
+          line: { color: "#FF8400", width: 2, dash: "dash" },
+        },
+        {
+          x: [curve.dive_speed_mps, curve.dive_speed_mps],
+          y: [negN[negN.length - 1] ?? -1, posN[posN.length - 1] ?? 3],
+          mode: "lines",
+          name: "V_dive",
+          line: { color: "#666", width: 1, dash: "dot" },
+        },
+      ];
+
+      if (markers.length > 0) {
+        traces.push({
+          x: markers.map((m) => m.velocity_mps),
+          y: markers.map((m) => m.load_factor),
+          mode: "markers+text",
+          name: "Operating Points",
+          text: markers.map((m) => m.name),
+          textposition: "top center",
+          textfont: { size: 10, color: "#aaa" },
+          marker: {
+            size: 10,
+            color: markers.map((m) =>
+              m.status === "TRIMMED" ? "#4ade80" : m.status === "LIMIT_REACHED" ? "#f87171" : "#facc15",
+            ),
+            symbol: markers.map((m) => MARKER_SYMBOLS[m.status] ?? "circle"),
+          },
+        });
+      }
+
+      const layout: Partial<Plotly.Layout> = {
+        paper_bgcolor: "rgba(0,0,0,0)",
+        plot_bgcolor: "rgba(0,0,0,0)",
+        font: { color: "#ccc", family: "JetBrains Mono, monospace" },
+        xaxis: {
+          title: "Velocity (m/s)",
+          gridcolor: "#333",
+          zerolinecolor: "#555",
+        },
+        yaxis: {
+          title: "Load Factor (g)",
+          gridcolor: "#333",
+          zerolinecolor: "#555",
+        },
+        margin: { t: 30, r: 20, b: 50, l: 60 },
+        showlegend: true,
+        legend: { x: 0.01, y: 0.99, bgcolor: "rgba(0,0,0,0.5)" },
+      };
+
+      Plotly.newPlot(containerRef.current, traces, layout, {
+        responsive: true,
+        displayModeBar: false,
+      });
+    })();
+
+    return () => {
+      cancelled = true;
+      if (containerRef.current) {
+        import("plotly.js-gl3d-dist-min").then((Plotly) => {
+          if (containerRef.current) Plotly.purge(containerRef.current);
+        });
+      }
+    };
+  }, [curve, markers]);
+
+  return <div ref={containerRef} className="w-full h-full min-h-[400px]" />;
+}
+```
+
+- [ ] **Step 3: Create EnvelopePanel container**
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import type { FlightEnvelopeData } from "@/hooks/useFlightEnvelope";
+import { PerformanceOverview } from "./PerformanceOverview";
+import { VnDiagram } from "./VnDiagram";
+
+type View = "performance" | "vn-diagram";
+
+interface Props {
+  readonly envelope: FlightEnvelopeData | null;
+  readonly isComputing: boolean;
+  readonly error: string | null;
+  readonly onCompute: () => void;
+}
+
+export function EnvelopePanel({ envelope, isComputing, error, onCompute }: Props) {
+  const [view, setView] = useState<View>("performance");
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Toolbar */}
+      <div className="flex items-center gap-3 border-b border-border px-4 py-2">
+        <div className="flex rounded-md border border-border overflow-hidden text-[12px]">
+          <button
+            onClick={() => setView("performance")}
+            className={`px-3 py-1 ${view === "performance" ? "bg-[#FF8400] text-white" : "bg-card text-muted-foreground hover:bg-muted"}`}
+          >
+            Performance
+          </button>
+          <button
+            onClick={() => setView("vn-diagram")}
+            className={`px-3 py-1 ${view === "vn-diagram" ? "bg-[#FF8400] text-white" : "bg-card text-muted-foreground hover:bg-muted"}`}
+          >
+            V-n Diagram
+          </button>
+        </div>
+        <button
+          onClick={onCompute}
+          disabled={isComputing}
+          className="ml-auto rounded-md bg-[#FF8400] px-3 py-1 text-[12px] font-medium text-white hover:bg-[#e67600] disabled:opacity-50"
+        >
+          {isComputing ? "Computing..." : "Compute Envelope"}
+        </button>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className="mx-4 mt-2 rounded border border-red-800 bg-red-900/20 px-3 py-2 text-[12px] text-red-400">
+          {error}
+        </div>
+      )}
+
+      {/* Content */}
+      <div className="flex-1 overflow-auto">
+        {!envelope ? (
+          <div className="flex items-center justify-center h-full text-muted-foreground text-[13px]">
+            No envelope data. Click &quot;Compute Envelope&quot; to generate.
+          </div>
+        ) : view === "performance" ? (
+          <PerformanceOverview kpis={envelope.kpis} />
+        ) : (
+          <VnDiagram curve={envelope.vn_curve} markers={envelope.operating_points} />
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Add Envelope tab to AnalysisViewerPanel**
+
+In `frontend/components/workbench/AnalysisViewerPanel.tsx`:
+
+1. Add `"Envelope"` to the TABS array:
+```typescript
+const TABS = ["Assumptions", "Polar", "Trefftz Plane", "Streamlines", "Envelope"] as const;
+```
+
+2. Add props for envelope data:
+```typescript
+interface Props {
+  // ... existing props
+  readonly envelope: FlightEnvelopeData | null;
+  readonly isComputingEnvelope: boolean;
+  readonly envelopeError: string | null;
+  readonly onComputeEnvelope: () => void;
+}
+```
+
+3. Render `EnvelopePanel` when `activeTab === "Envelope"`:
+```tsx
+{activeTab === "Envelope" && (
+  <EnvelopePanel
+    envelope={envelope}
+    isComputing={isComputingEnvelope}
+    error={envelopeError}
+    onCompute={onComputeEnvelope}
+  />
+)}
+```
+
+- [ ] **Step 5: Wire hook in analysis page**
+
+In `frontend/app/workbench/analysis/page.tsx`:
+
+1. Import the hook:
+```typescript
+import { useFlightEnvelope } from "@/hooks/useFlightEnvelope";
+```
+
+2. Call the hook:
+```typescript
+const envelope = useFlightEnvelope(aeroplaneId);
+```
+
+3. Pass envelope props to `AnalysisViewerPanel`:
+```tsx
+<AnalysisViewerPanel
+  // ... existing props
+  envelope={envelope.data}
+  isComputingEnvelope={envelope.isComputing}
+  envelopeError={envelope.error}
+  onComputeEnvelope={envelope.compute}
+/>
+```
+
+- [ ] **Step 6: Run frontend unit tests**
+
+Run: `cd frontend && npm run test:unit`
+Expected: All tests pass including the new hook test
+
+- [ ] **Step 7: Run frontend lint + type check**
+
+Run: `cd frontend && npm run lint`
+Expected: No errors
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/components/workbench/EnvelopePanel.tsx frontend/components/workbench/PerformanceOverview.tsx frontend/components/workbench/VnDiagram.tsx frontend/components/workbench/AnalysisViewerPanel.tsx frontend/app/workbench/analysis/page.tsx
+git commit -m "feat(gh-422): add Envelope tab with KPI cards and V-n diagram"
+```
+
+---
+
+## Task 9: Full Backend Test Suite Verification
+
+**Files:** None new — verification only
+
+- [ ] **Step 1: Run full backend tests**
+
+Run: `poetry run pytest -x -q --timeout=60 -m "not slow"`
+Expected: All tests pass, no regressions
+
+- [ ] **Step 2: Run ruff linting**
+
+Run: `poetry run ruff check app/schemas/flight_envelope.py app/models/flight_envelope_model.py app/services/flight_envelope_service.py app/api/v2/endpoints/aeroplane/flight_envelope.py`
+Expected: No lint errors
+
+- [ ] **Step 3: Run ruff format**
+
+Run: `poetry run ruff format app/schemas/flight_envelope.py app/models/flight_envelope_model.py app/services/flight_envelope_service.py app/api/v2/endpoints/aeroplane/flight_envelope.py`
+Expected: Files formatted (if needed, commit formatting)
+
+- [ ] **Step 4: Run frontend tests**
+
+Run: `cd frontend && npm run test:unit`
+Expected: All tests pass
+
+- [ ] **Step 5: Final commit if formatting changed anything**
+
+```bash
+git add -u
+git commit -m "chore(gh-422): lint and format flight envelope code"
+```

--- a/docs/superpowers/specs/2026-05-07-flight-envelope-design.md
+++ b/docs/superpowers/specs/2026-05-07-flight-envelope-design.md
@@ -1,0 +1,279 @@
+# Flight Envelope Analysis — Design Spec
+
+**Issue:** #422  
+**Epic:** #417 (Operating Point Simulation)  
+**Date:** 2026-05-07  
+**Dependencies:** #420 (mass/CG — merged), #424 (design assumptions — merged)
+
+---
+
+## 1. Goal
+
+Add a flight envelope analysis feature that computes V-n diagram curves
+and performance KPIs from existing operating points and design
+assumptions, then displays them in a new "Envelope" tab in the analysis
+workbench.
+
+Users get a complete performance picture — stall speed, best L/D,
+max load factor, dive speed — without manually interpreting raw
+operating point data.
+
+---
+
+## 2. Scope
+
+### In scope
+
+- **Backend**: Flight envelope computation service, schemas, DB cache
+  model, two REST endpoints (GET cached / POST compute), two MCP tools
+- **Frontend**: New "Envelope" tab with Performance Overview (KPI cards)
+  and V-n Diagram (Plotly chart) sub-views
+- All computation uses existing infrastructure: design assumptions
+  (mass, cl_max, g_limit), operating points (trimmed results), and
+  wing geometry (reference area S)
+
+### Out of scope
+
+- Auto-recompute on trim completion (event integration — future PR)
+- Propulsion-dependent points (requires #197/#199)
+- Radar chart in Performance Overview (can add later; KPI cards suffice)
+- Flight profile editing from the envelope tab
+
+---
+
+## 3. Backend Design
+
+### 3.1 Schemas (`app/schemas/flight_envelope.py`)
+
+```python
+class VnPoint(BaseModel):
+    velocity_mps: float
+    load_factor: float
+
+class VnCurve(BaseModel):
+    positive: list[VnPoint]    # positive g boundary
+    negative: list[VnPoint]    # negative g boundary
+    dive_speed_mps: float      # V_d = 1.4 * V_max_level
+
+class PerformanceKPI(BaseModel):
+    label: str                 # e.g. "stall_speed"
+    display_name: str          # e.g. "Stall Speed"
+    value: float
+    unit: str                  # e.g. "m/s"
+    source_op_id: int | None   # link to the operating point
+    confidence: str            # "trimmed" | "estimated" | "limit"
+
+class FlightEnvelopeRead(BaseModel):
+    id: int
+    aeroplane_id: str
+    vn_curve: VnCurve
+    kpis: list[PerformanceKPI]
+    operating_points: list[VnMarker]
+    assumptions_snapshot: dict  # mass, cl_max, g_limit used
+    computed_at: datetime
+
+class VnMarker(BaseModel):
+    op_id: int
+    name: str
+    velocity_mps: float
+    load_factor: float
+    status: str                # TRIMMED / NOT_TRIMMED / LIMIT_REACHED
+    label: str                 # e.g. "cruise", "stall", "best_ld"
+
+class ComputeEnvelopeRequest(BaseModel):
+    force_recompute: bool = False
+```
+
+### 3.2 DB Model (`app/models/flight_envelope_model.py`)
+
+Single table `flight_envelopes` with:
+- `id` (PK), `aeroplane_id` (FK, unique — one envelope per aeroplane)
+- `vn_curve_json` (JSON), `kpis_json` (JSON), `markers_json` (JSON)
+- `assumptions_snapshot` (JSON — records which assumption values were used)
+- `computed_at` (timestamp)
+- `is_stale` (boolean — set true when assumptions or OPs change)
+
+One-to-one with AeroplaneModel. Alembic migration required.
+
+### 3.3 Service (`app/services/flight_envelope_service.py`)
+
+**`compute_flight_envelope(db, aeroplane_id)`**
+
+1. Load design assumptions via `get_effective_assumption_value()`:
+   mass_kg, cl_max, g_limit (from `app/services/mass_cg_service.py`)
+2. Load wing reference area S (m^2) from ASB airplane projected
+   planform area (via existing aeroplane → ASB converter)
+3. Load atmosphere density rho at profile altitude (default sea level)
+4. Compute V-n curves:
+   ```
+   V_stall = sqrt(2 * mass * g / (rho * S * cl_max))
+   n_pos(V) = min(0.5 * rho * V^2 * S * cl_max / (mass * g), g_limit)
+   n_neg(V) = max(0.5 * rho * V^2 * S * cl_min / (mass * g), -0.4 * g_limit)
+   V_d = 1.4 * V_max_level  (from flight profile or assumption)
+   ```
+5. Load existing operating points for the aeroplane
+6. Map each OP to a (V, n) marker on the V-n diagram
+7. Derive performance KPIs:
+
+| KPI | How derived |
+|-----|-------------|
+| `stall_speed` | V_stall from cl_max + mass, or lowest V with TRIMMED status |
+| `best_ld_speed` | V at max L/D from operating points (if available) |
+| `min_sink_speed` | V at max CL^1.5/CD (if available) |
+| `max_speed` | From flight profile `max_level_speed_mps` or highest trimmed V |
+| `max_load_factor` | Highest n with converged trim |
+| `dive_speed` | 1.4 * max_speed |
+
+8. Persist to `flight_envelopes` table (upsert)
+9. Return `FlightEnvelopeRead`
+
+**`get_flight_envelope(db, aeroplane_id)`**
+- Return cached result from DB, or 404 if never computed
+
+**Helper: `get_wing_reference_area(db, aeroplane_id) -> float`**
+- Sum projected area of all wing panels
+- Uses existing converter: aeroplane → ASB airplane → sum wing areas
+
+**Helper: `_compute_cl_min(cl_max) -> float`**
+- Approximation: cl_min = -0.8 * cl_max (inverted flight coefficient)
+- Sufficient for V-n negative boundary
+
+### 3.4 Endpoints (`app/api/v2/endpoints/aeroplane/flight_envelope.py`)
+
+```
+GET  /v2/aeroplanes/{aeroplane_id}/flight-envelope
+POST /v2/aeroplanes/{aeroplane_id}/flight-envelope/compute
+```
+
+Both return `FlightEnvelopeRead`. GET returns cached (404 if none).
+POST computes fresh and returns result.
+
+Thin endpoints — delegate to service layer.
+
+### 3.5 MCP Tools
+
+```python
+@mcp.tool()
+def get_flight_envelope(aeroplane_id: str) -> FlightEnvelopeRead: ...
+
+@mcp.tool()
+def compute_flight_envelope(aeroplane_id: str) -> FlightEnvelopeRead: ...
+```
+
+Follow existing MCP registration pattern in `app/mcp_server.py`.
+
+---
+
+## 4. Frontend Design
+
+### 4.1 New "Envelope" Tab
+
+Add to the existing `AnalysisViewerPanel.tsx` TABS array. Tab key:
+`"Envelope"`. When active, renders `EnvelopePanel`.
+
+### 4.2 Component Structure
+
+```
+EnvelopePanel.tsx
+  ├─ PerformanceOverview.tsx   — KPI cards grid
+  └─ VnDiagram.tsx             — Plotly V-n chart with OP markers
+```
+
+**Toggle:** A segmented control at the top switches between
+"Performance" and "V-n Diagram" views.
+
+### 4.3 PerformanceOverview
+
+Grid of KPI cards (3 columns on desktop, 2 on tablet, 1 on mobile):
+- Each card shows: icon, label, value + unit, confidence badge
+- Confidence: green (trimmed), yellow (estimated), red (limit)
+- Cards are clickable — could link to the source operating point
+  (stretch goal, not required for v1)
+
+KPIs displayed: Stall Speed, Best L/D Speed, Min Sink Speed,
+Max Speed, Max Load Factor, Dive Speed.
+
+### 4.4 VnDiagram
+
+Plotly chart with:
+- X-axis: Velocity (m/s)
+- Y-axis: Load factor (g)
+- Filled area between positive and negative V-n curves
+- Operating points as scatter markers:
+  - Filled circle (TRIMMED), half circle (NOT_TRIMMED),
+    open circle (LIMIT_REACHED)
+- Hover shows OP name, V, n, status
+- Dark theme styling matching existing Plotly charts
+
+### 4.5 Hook: `useFlightEnvelope(aeroplaneId)`
+
+SWR hook pattern matching existing hooks:
+- `data: FlightEnvelopeRead | null`
+- `isLoading: boolean`
+- `compute(): Promise<void>` — triggers POST, then mutates SWR cache
+- `isComputing: boolean`
+
+### 4.6 Config Panel
+
+When "Envelope" tab is active, the config modal shows:
+- Current assumptions summary (mass, cl_max, g_limit) — read-only
+- Link to full Assumptions panel for editing
+- "Compute Envelope" button (triggers POST)
+
+---
+
+## 5. Data Flow
+
+```
+User clicks "Compute Envelope"
+  → POST /v2/aeroplanes/{id}/flight-envelope/compute
+    → flight_envelope_service.compute_flight_envelope()
+      → Load design assumptions (mass, cl_max, g_limit)
+      → Load wing geometry → compute S
+      → Compute V-n curves (pure math)
+      → Load stored operating points
+      → Map OPs to V-n markers
+      → Derive performance KPIs
+      → Upsert to flight_envelopes table
+    ← Return FlightEnvelopeRead
+  ← SWR cache updated
+  → UI re-renders with KPIs + V-n diagram
+```
+
+---
+
+## 6. Acceptance Criteria
+
+### Backend
+- [ ] `FlightEnvelopeModel` DB table with Alembic migration
+- [ ] `flight_envelope.py` schema with VnCurve, KPIs, markers
+- [ ] `flight_envelope_service.py` with compute + get functions
+- [ ] V-n curve computation is correct: positive/negative boundaries,
+      dive speed, stall speed
+- [ ] KPIs derived from operating points + assumptions
+- [ ] GET endpoint returns cached envelope (404 if none)
+- [ ] POST endpoint computes and returns fresh envelope
+- [ ] MCP tools registered and functional
+- [ ] Unit tests: V-n curve math, KPI derivation, endpoint responses
+- [ ] Integration tests: compute with real aeroplane fixture
+
+### Frontend
+- [ ] "Envelope" tab appears in AnalysisViewerPanel
+- [ ] PerformanceOverview displays KPI cards with correct values
+- [ ] VnDiagram renders V-n curves with operating point markers
+- [ ] Toggle between Performance and V-n views works
+- [ ] Compute button triggers fresh computation
+- [ ] Loading and empty states handled
+- [ ] Dark theme consistent with existing charts
+- [ ] Unit tests for EnvelopePanel, PerformanceOverview, VnDiagram
+
+---
+
+## 7. Unit Considerations
+
+- Wing reference area (S): computed from ASB airplane in m^2
+- Velocities: m/s throughout
+- Mass: kg from design assumptions
+- Load factor: dimensionless (g units)
+- Angles: radians in stored OPs, degrees in display
+- All computation in SI; frontend formats for display

--- a/frontend/__tests__/useFlightEnvelope.test.ts
+++ b/frontend/__tests__/useFlightEnvelope.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Unit tests for the useFlightEnvelope hook (gh-422).
+ *
+ * Verifies initial fetch, 404 handling, compute, and refresh behaviour.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import {
+  useFlightEnvelope,
+  type FlightEnvelopeData,
+} from "@/hooks/useFlightEnvelope";
+
+const FAKE_ENVELOPE: FlightEnvelopeData = {
+  id: 1,
+  aeroplane_id: 42,
+  vn_curve: {
+    positive: [
+      { velocity_mps: 10, load_factor: 1.0 },
+      { velocity_mps: 30, load_factor: 3.8 },
+    ],
+    negative: [
+      { velocity_mps: 10, load_factor: -1.0 },
+      { velocity_mps: 30, load_factor: -1.5 },
+    ],
+    dive_speed_mps: 45,
+    stall_speed_mps: 12,
+  },
+  kpis: [
+    {
+      label: "v_stall",
+      display_name: "Stall Speed",
+      value: 12.0,
+      unit: "m/s",
+      source_op_id: null,
+      confidence: "trimmed",
+    },
+  ],
+  operating_points: [
+    {
+      op_id: 1,
+      name: "cruise",
+      velocity_mps: 20,
+      load_factor: 1.0,
+      status: "TRIMMED",
+      label: "Cruise",
+    },
+  ],
+  assumptions_snapshot: { mass_kg: 2.5, n_positive: 3.8 },
+  computed_at: "2026-05-07T12:00:00Z",
+};
+
+describe("useFlightEnvelope", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns null data when aeroplaneId is null", () => {
+    const { result } = renderHook(() => useFlightEnvelope(null));
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isComputing).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("fetches envelope data on mount", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(FAKE_ENVELOPE),
+    });
+
+    const { result } = renderHook(() => useFlightEnvelope("42"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/aeroplanes/42/flight-envelope"),
+    );
+    expect(result.current.data).toEqual(FAKE_ENVELOPE);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("handles 404 by setting data to null", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve("Not found"),
+    });
+
+    const { result } = renderHook(() => useFlightEnvelope("42"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error on non-404 fetch failure", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Internal server error"),
+    });
+
+    const { result } = renderHook(() => useFlightEnvelope("42"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toContain("500");
+  });
+
+  it("compute() POSTs and sets data from response", async () => {
+    // Initial fetch returns 404
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve("Not found"),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(FAKE_ENVELOPE),
+      });
+    globalThis.fetch = mockFetch;
+
+    const { result } = renderHook(() => useFlightEnvelope("42"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.compute();
+    });
+
+    // Second call should be the POST
+    expect(mockFetch.mock.calls[1][0]).toContain(
+      "/aeroplanes/42/flight-envelope/compute",
+    );
+    expect(mockFetch.mock.calls[1][1]).toEqual({ method: "POST" });
+    expect(result.current.data).toEqual(FAKE_ENVELOPE);
+    expect(result.current.isComputing).toBe(false);
+  });
+
+  it("refresh() re-fetches GET endpoint", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({ ...FAKE_ENVELOPE, computed_at: "old" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({ ...FAKE_ENVELOPE, computed_at: "new" }),
+      });
+    globalThis.fetch = mockFetch;
+
+    const { result } = renderHook(() => useFlightEnvelope("42"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(result.current.data?.computed_at).toBe("new");
+  });
+
+  it("clears data when aeroplaneId becomes null", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(FAKE_ENVELOPE),
+    });
+
+    const { result, rerender } = renderHook(
+      ({ id }) => useFlightEnvelope(id),
+      { initialProps: { id: "42" as string | null } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(FAKE_ENVELOPE);
+    });
+
+    rerender({ id: null });
+
+    expect(result.current.data).toBeNull();
+  });
+});

--- a/frontend/app/workbench/analysis/page.tsx
+++ b/frontend/app/workbench/analysis/page.tsx
@@ -8,6 +8,7 @@ import { useAnalysis } from "@/hooks/useAnalysis";
 import { useStripForces } from "@/hooks/useStripForces";
 import { useStreamlines } from "@/hooks/useStreamlines";
 import { useWings, useWing } from "@/hooks/useWings";
+import { useFlightEnvelope } from "@/hooks/useFlightEnvelope";
 import { AnalysisViewerPanel, type Tab } from "@/components/workbench/AnalysisViewerPanel";
 import { AnalysisConfigPanel } from "@/components/workbench/AnalysisConfigPanel";
 import { AvlGeometryEditor } from "@/components/workbench/AvlGeometryEditor";
@@ -18,6 +19,7 @@ export default function AnalysisPage() {
   const analysis = useAnalysis(aeroplaneId);
   const stripForces = useStripForces(aeroplaneId);
   const streamlines = useStreamlines(aeroplaneId);
+  const envelope = useFlightEnvelope(aeroplaneId);
   const { wingNames } = useWings(aeroplaneId);
   const { wing } = useWing(aeroplaneId, selectedWing ?? wingNames[0] ?? null);
   const [configOpen, setConfigOpen] = useState(false);
@@ -32,6 +34,7 @@ export default function AnalysisPage() {
     "Polar": "Polar Configuration",
     "Trefftz Plane": "Trefftz Plane Configuration",
     "Streamlines": "Streamlines Configuration",
+    "Envelope": "Flight Envelope",
   };
   const modalTitle = modalTitleByTab[activeTab];
 
@@ -69,6 +72,10 @@ export default function AnalysisPage() {
             wingXSecs={wing?.x_secs}
             wingSymmetric={wing?.symmetric}
             assumptionsSlot={<AssumptionsPanel aeroplaneId={aeroplaneId} />}
+            envelope={envelope.data}
+            isComputingEnvelope={envelope.isComputing}
+            envelopeError={envelope.error}
+            onComputeEnvelope={envelope.compute}
           />
         </div>
       </div>

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -4,8 +4,10 @@ import { useState, useMemo, useRef, useEffect } from "react";
 import { Wind, SlidersHorizontal, Activity, Maximize2, Minimize2, Settings } from "lucide-react";
 import type { AnalysisResult } from "@/hooks/useAnalysis";
 import type { StripForcesResult } from "@/hooks/useStripForces";
+import type { FlightEnvelopeData } from "@/hooks/useFlightEnvelope";
+import { EnvelopePanel } from "@/components/workbench/EnvelopePanel";
 
-const TABS = ["Assumptions", "Polar", "Trefftz Plane", "Streamlines"] as const;
+const TABS = ["Assumptions", "Polar", "Trefftz Plane", "Streamlines", "Envelope"] as const;
 export type Tab = (typeof TABS)[number];
 export { TABS };
 
@@ -31,6 +33,10 @@ interface Props {
   readonly wingXSecs?: WingXSec[] | null;
   readonly wingSymmetric?: boolean;
   readonly assumptionsSlot?: React.ReactNode;
+  readonly envelope?: FlightEnvelopeData | null;
+  readonly isComputingEnvelope?: boolean;
+  readonly envelopeError?: string | null;
+  readonly onComputeEnvelope?: () => void;
 }
 
 // -- Plotly Chart (dynamic import) ----------------------------------------
@@ -523,6 +529,10 @@ export function AnalysisViewerPanel({
   wingXSecs,
   wingSymmetric,
   assumptionsSlot,
+  envelope,
+  isComputingEnvelope,
+  envelopeError,
+  onComputeEnvelope,
 }: Readonly<Props>) {
   const [maximizedChart, setMaximizedChart] = useState<string | null>(null);
 
@@ -560,7 +570,7 @@ export function AnalysisViewerPanel({
           Aerodynamic Analysis
         </span>
         <div className="flex-1" />
-        {activeTab !== "Assumptions" && onConfigureClick && (
+        {activeTab !== "Assumptions" && activeTab !== "Envelope" && onConfigureClick && (
           <button
             onClick={onConfigureClick}
             className="flex items-center gap-1.5 rounded-full border border-border bg-card-muted px-3 py-1.5 text-[12px] text-foreground hover:bg-sidebar-accent"
@@ -569,7 +579,7 @@ export function AnalysisViewerPanel({
             Configure & Run
           </button>
         )}
-        {activeTab !== "Assumptions" && showAvlGeometryButton && onEditAvlGeometry && (
+        {activeTab !== "Assumptions" && activeTab !== "Envelope" && showAvlGeometryButton && onEditAvlGeometry && (
           <button
             onClick={onEditAvlGeometry}
             className="flex items-center gap-1.5 rounded-full border border-border bg-card-muted px-3 py-1.5 text-[12px] text-foreground hover:bg-sidebar-accent"
@@ -728,6 +738,15 @@ export function AnalysisViewerPanel({
             streamlinesFigure={streamlinesFigure}
           />
         </div>
+      )}
+
+      {activeTab === "Envelope" && (
+        <EnvelopePanel
+          envelope={envelope ?? null}
+          isComputing={isComputingEnvelope ?? false}
+          error={envelopeError ?? null}
+          onCompute={onComputeEnvelope ?? (() => {})}
+        />
       )}
 
       {/* Info Chip Row */}

--- a/frontend/components/workbench/EnvelopePanel.tsx
+++ b/frontend/components/workbench/EnvelopePanel.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useState } from "react";
+import type { FlightEnvelopeData } from "@/hooks/useFlightEnvelope";
+import { PerformanceOverview } from "@/components/workbench/PerformanceOverview";
+import { VnDiagram } from "@/components/workbench/VnDiagram";
+
+type View = "performance" | "vn-diagram";
+
+interface Props {
+  readonly envelope: FlightEnvelopeData | null;
+  readonly isComputing: boolean;
+  readonly error: string | null;
+  readonly onCompute: () => void;
+}
+
+export function EnvelopePanel({ envelope, isComputing, error, onCompute }: Props) {
+  const [view, setView] = useState<View>("performance");
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 overflow-auto bg-card-muted p-6">
+      {/* Toolbar */}
+      <div className="flex items-center gap-3">
+        {/* Segmented control */}
+        <div className="flex rounded-full border border-border bg-card">
+          <button
+            onClick={() => setView("performance")}
+            className={`rounded-full px-3 py-1.5 font-[family-name:var(--font-geist-sans)] text-[12px] transition-colors ${
+              view === "performance"
+                ? "bg-[#FF8400] text-white"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            Performance
+          </button>
+          <button
+            onClick={() => setView("vn-diagram")}
+            className={`rounded-full px-3 py-1.5 font-[family-name:var(--font-geist-sans)] text-[12px] transition-colors ${
+              view === "vn-diagram"
+                ? "bg-[#FF8400] text-white"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            V-n Diagram
+          </button>
+        </div>
+
+        <div className="flex-1" />
+
+        {/* Compute button */}
+        <button
+          onClick={onCompute}
+          disabled={isComputing}
+          className="flex items-center gap-1.5 rounded-full bg-[#FF8400] px-4 py-1.5 font-[family-name:var(--font-geist-sans)] text-[12px] font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+        >
+          {isComputing ? "Computing..." : "Compute Envelope"}
+        </button>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-2">
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-red-400">
+            {error}
+          </span>
+        </div>
+      )}
+
+      {/* Content */}
+      {!envelope && !isComputing && !error && (
+        <div className="flex flex-1 flex-col items-center justify-center gap-2">
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[14px] text-muted-foreground">
+            No envelope data. Click Compute Envelope to generate.
+          </span>
+        </div>
+      )}
+
+      {isComputing && !envelope && (
+        <div className="flex flex-1 items-center justify-center">
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-muted-foreground">
+            Computing flight envelope...
+          </span>
+        </div>
+      )}
+
+      {envelope && view === "performance" && (
+        <PerformanceOverview kpis={envelope.kpis} />
+      )}
+
+      {envelope && view === "vn-diagram" && (
+        <VnDiagram
+          vnCurve={envelope.vn_curve}
+          operatingPoints={envelope.operating_points}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/components/workbench/PerformanceOverview.tsx
+++ b/frontend/components/workbench/PerformanceOverview.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import type { PerformanceKPI } from "@/hooks/useFlightEnvelope";
+
+const CONFIDENCE_STYLES: Record<
+  PerformanceKPI["confidence"],
+  { bg: string; text: string; label: string }
+> = {
+  trimmed: {
+    bg: "bg-emerald-500/15",
+    text: "text-emerald-400",
+    label: "Trimmed",
+  },
+  estimated: {
+    bg: "bg-yellow-500/15",
+    text: "text-yellow-400",
+    label: "Estimated",
+  },
+  limit: {
+    bg: "bg-red-500/15",
+    text: "text-red-400",
+    label: "Limit",
+  },
+};
+
+function KpiCard({ kpi }: Readonly<{ kpi: PerformanceKPI }>) {
+  const style = CONFIDENCE_STYLES[kpi.confidence];
+
+  return (
+    <div className="flex flex-col gap-1.5 rounded-xl border border-border bg-card p-4">
+      <span className="font-[family-name:var(--font-geist-sans)] text-[12px] text-muted-foreground">
+        {kpi.display_name}
+      </span>
+      <div className="flex items-baseline gap-1.5">
+        <span className="font-[family-name:var(--font-jetbrains-mono)] text-[20px] font-semibold text-foreground">
+          {typeof kpi.value === "number" ? kpi.value.toFixed(1) : kpi.value}
+        </span>
+        <span className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-muted-foreground">
+          {kpi.unit}
+        </span>
+      </div>
+      <span
+        className={`inline-flex w-fit rounded-full px-2 py-0.5 font-[family-name:var(--font-geist-sans)] text-[10px] font-medium ${style.bg} ${style.text}`}
+      >
+        {style.label}
+      </span>
+    </div>
+  );
+}
+
+interface Props {
+  readonly kpis: PerformanceKPI[];
+}
+
+export function PerformanceOverview({ kpis }: Props) {
+  if (kpis.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <span className="font-[family-name:var(--font-jetbrains-mono)] text-[14px] text-muted-foreground">
+          No performance data available
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      {kpis.map((kpi) => (
+        <KpiCard key={kpi.label} kpi={kpi} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/components/workbench/VnDiagram.tsx
+++ b/frontend/components/workbench/VnDiagram.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useRef, useEffect } from "react";
+import type { VnCurve, VnMarker } from "@/hooks/useFlightEnvelope";
+
+const STATUS_COLORS: Record<string, string> = {
+  TRIMMED: "#30A46C",
+  NOT_TRIMMED: "#F59E0B",
+  LIMIT_REACHED: "#E5484D",
+};
+
+interface Props {
+  readonly vnCurve: VnCurve;
+  readonly operatingPoints: VnMarker[];
+}
+
+export function VnDiagram({ vnCurve, operatingPoints }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node || vnCurve.positive.length === 0) return;
+    let disposed = false;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let PlotlyRef: any = null;
+
+    (async () => {
+      PlotlyRef = await import("plotly.js-gl3d-dist-min");
+      if (disposed || !node) return;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const traces: Record<string, any>[] = [];
+
+      // Positive g boundary
+      traces.push({
+        x: vnCurve.positive.map((p) => p.velocity_mps),
+        y: vnCurve.positive.map((p) => p.load_factor),
+        type: "scatter",
+        mode: "lines",
+        name: "+g limit",
+        line: { color: "#FF8400", width: 2 },
+        hovertemplate: "V: %{x:.1f} m/s<br>n: %{y:.2f}<extra></extra>",
+      });
+
+      // Negative g boundary
+      traces.push({
+        x: vnCurve.negative.map((p) => p.velocity_mps),
+        y: vnCurve.negative.map((p) => p.load_factor),
+        type: "scatter",
+        mode: "lines",
+        name: "-g limit",
+        line: { color: "#FF8400", width: 2, dash: "dash" },
+        hovertemplate: "V: %{x:.1f} m/s<br>n: %{y:.2f}<extra></extra>",
+      });
+
+      // Operating point markers grouped by status
+      const grouped = new Map<string, VnMarker[]>();
+      for (const op of operatingPoints) {
+        const arr = grouped.get(op.status) ?? [];
+        arr.push(op);
+        grouped.set(op.status, arr);
+      }
+
+      for (const [status, ops] of grouped) {
+        traces.push({
+          x: ops.map((o) => o.velocity_mps),
+          y: ops.map((o) => o.load_factor),
+          type: "scatter",
+          mode: "markers+text",
+          name: status,
+          marker: {
+            color: STATUS_COLORS[status] ?? "#A1A1AA",
+            size: 9,
+            symbol: "circle",
+          },
+          text: ops.map((o) => o.label),
+          textposition: "top center",
+          textfont: {
+            size: 9,
+            color: "#A1A1AA",
+            family: "JetBrains Mono, monospace",
+          },
+          hovertemplate: ops.map(
+            (o) =>
+              `${o.name}<br>V: ${o.velocity_mps.toFixed(1)} m/s<br>n: ${o.load_factor.toFixed(2)}<extra>${status}</extra>`,
+          ),
+        });
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const shapes: Record<string, any>[] = [
+        // V_dive vertical line
+        {
+          type: "line",
+          x0: vnCurve.dive_speed_mps,
+          x1: vnCurve.dive_speed_mps,
+          y0: 0,
+          y1: 1,
+          yref: "paper",
+          line: { color: "#71717A", width: 1, dash: "dot" },
+        },
+        // V_stall vertical line
+        {
+          type: "line",
+          x0: vnCurve.stall_speed_mps,
+          x1: vnCurve.stall_speed_mps,
+          y0: 0,
+          y1: 1,
+          yref: "paper",
+          line: { color: "#71717A", width: 1, dash: "dot" },
+        },
+      ];
+
+      const annotations = [
+        {
+          x: vnCurve.dive_speed_mps,
+          y: 1.02,
+          yref: "paper" as const,
+          text: "V<sub>dive</sub>",
+          showarrow: false,
+          font: {
+            size: 10,
+            color: "#71717A",
+            family: "JetBrains Mono, monospace",
+          },
+        },
+        {
+          x: vnCurve.stall_speed_mps,
+          y: 1.02,
+          yref: "paper" as const,
+          text: "V<sub>stall</sub>",
+          showarrow: false,
+          font: {
+            size: 10,
+            color: "#71717A",
+            family: "JetBrains Mono, monospace",
+          },
+        },
+      ];
+
+      const layout = {
+        paper_bgcolor: "transparent",
+        plot_bgcolor: "transparent",
+        font: {
+          color: "#A1A1AA",
+          family: "JetBrains Mono, monospace",
+          size: 10,
+        },
+        margin: { l: 55, r: 20, t: 30, b: 45 },
+        xaxis: {
+          title: { text: "Airspeed [m/s]", font: { size: 11 } },
+          gridcolor: "#27272A",
+          zerolinecolor: "#3F3F46",
+        },
+        yaxis: {
+          title: { text: "Load Factor (n)", font: { size: 11 } },
+          gridcolor: "#27272A",
+          zerolinecolor: "#3F3F46",
+        },
+        showlegend: true,
+        legend: {
+          x: 0.98,
+          y: 0.02,
+          xanchor: "right",
+          yanchor: "bottom",
+          bgcolor: "rgba(0,0,0,0.4)",
+          bordercolor: "#3F3F46",
+          borderwidth: 1,
+          font: { size: 10, color: "#A1A1AA" },
+        },
+        autosize: true,
+        shapes,
+        annotations,
+      };
+
+      await PlotlyRef.react(node, traces, layout, {
+        responsive: true,
+        displayModeBar: false,
+      });
+    })();
+
+    return () => {
+      disposed = true;
+      if (node && PlotlyRef) PlotlyRef.purge(node);
+    };
+  }, [vnCurve, operatingPoints]);
+
+  if (vnCurve.positive.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center rounded-xl border border-border bg-card p-4">
+        <span className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-muted-foreground">
+          No V-n data
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-1 flex-col overflow-hidden bg-card-muted">
+      <div ref={containerRef} className="min-h-0 flex-1" />
+    </div>
+  );
+}

--- a/frontend/hooks/useFlightEnvelope.ts
+++ b/frontend/hooks/useFlightEnvelope.ts
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import { API_BASE } from "@/lib/fetcher";
+
+export interface VnPoint {
+  velocity_mps: number;
+  load_factor: number;
+}
+
+export interface VnCurve {
+  positive: VnPoint[];
+  negative: VnPoint[];
+  dive_speed_mps: number;
+  stall_speed_mps: number;
+}
+
+export interface PerformanceKPI {
+  label: string;
+  display_name: string;
+  value: number;
+  unit: string;
+  source_op_id: number | null;
+  confidence: "trimmed" | "estimated" | "limit";
+}
+
+export interface VnMarker {
+  op_id: number;
+  name: string;
+  velocity_mps: number;
+  load_factor: number;
+  status: string;
+  label: string;
+}
+
+export interface FlightEnvelopeData {
+  id: number;
+  aeroplane_id: number;
+  vn_curve: VnCurve;
+  kpis: PerformanceKPI[];
+  operating_points: VnMarker[];
+  assumptions_snapshot: Record<string, number>;
+  computed_at: string;
+}
+
+export interface UseFlightEnvelopeReturn {
+  data: FlightEnvelopeData | null;
+  isLoading: boolean;
+  isComputing: boolean;
+  error: string | null;
+  compute: () => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+export function useFlightEnvelope(
+  aeroplaneId: string | null,
+): UseFlightEnvelopeReturn {
+  const [data, setData] = useState<FlightEnvelopeData | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isComputing, setIsComputing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!aeroplaneId) return;
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch(
+        `${API_BASE}/aeroplanes/${aeroplaneId}/flight-envelope`,
+      );
+      if (res.status === 404) {
+        setData(null);
+        return;
+      }
+      if (!res.ok) {
+        const body = await res.text();
+        throw new Error(`Failed to fetch envelope: ${res.status} ${body}`);
+      }
+      const json = await res.json();
+      setData(json);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [aeroplaneId]);
+
+  const compute = useCallback(async () => {
+    if (!aeroplaneId) return;
+    setIsComputing(true);
+    setError(null);
+
+    try {
+      const res = await fetch(
+        `${API_BASE}/aeroplanes/${aeroplaneId}/flight-envelope/compute`,
+        { method: "POST" },
+      );
+      if (!res.ok) {
+        const body = await res.text();
+        throw new Error(`Compute failed: ${res.status} ${body}`);
+      }
+      const json = await res.json();
+      setData(json);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsComputing(false);
+    }
+  }, [aeroplaneId]);
+
+  useEffect(() => {
+    if (aeroplaneId) {
+      refresh();
+    } else {
+      setData(null);
+    }
+  }, [aeroplaneId, refresh]);
+
+  return { data, isLoading, isComputing, error, compute, refresh };
+}


### PR DESCRIPTION
## Summary

- Add flight envelope computation: V-n diagram boundaries from design assumptions (mass, cl_max, g_limit) and wing geometry
- New `FlightEnvelopeModel` DB table caches computed envelopes per aeroplane
- REST endpoints: `GET /v2/aeroplanes/{id}/flight-envelope` (cached) and `POST .../compute` (trigger recomputation)
- MCP tools: `get_flight_envelope`, `compute_flight_envelope`
- Frontend "Envelope" tab in analysis workbench with Performance KPI cards and interactive V-n Plotly chart
- 6 performance KPIs: stall speed, best L/D speed, min sink speed, max speed, max load factor, dive speed
- V-n diagram shows positive/negative g boundaries with operating point markers color-coded by trim status

## Test plan

- [x] 36 backend tests (schema validation, V-n curve math, KPI derivation, DB persistence, endpoint routing)
- [x] 7 frontend tests (useFlightEnvelope hook: null id, fetch, 404, error, compute, refresh, id change)
- [x] Full backend suite: 2516 passed
- [x] Full frontend suite: 392 passed (47 files)
- [x] Ruff lint: all clean
- [ ] Manual browser verification of Envelope tab rendering

Closes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)