### PR TITLE
feat(gh-435): control surface deflection override UI on operating points

### DIFF
--- a/app/api/v2/endpoints/operating_points.py
+++ b/app/api/v2/endpoints/operating_points.py
@@ -22,6 +22,7 @@ from app.schemas.aeroanalysisschema import (
     AVLTrimResult,
     GeneratedOperatingPointSetRead,
     GenerateOperatingPointSetRequest,
+    OperatingPointDeflectionPatch,
     OperatingPointSetSchema,
     StoredOperatingPointCreate,
     StoredOperatingPointRead,
@@ -231,6 +232,30 @@ def update_operating_point(
         )
     for key, value in op_data.model_dump().items():
         setattr(op, key, value)
+    db.flush()
+    db.refresh(op)
+    return op
+
+
+@router.patch(
+    "/operating_points/{op_id}/deflections",
+    response_model=StoredOperatingPointRead,
+    operation_id="patch_operating_point_deflections",
+)
+def patch_operating_point_deflections(
+    op_id: int,
+    patch: OperatingPointDeflectionPatch,
+    db: Annotated[Session, Depends(get_db)],
+):
+    """Update only the control surface deflection overrides for an operating point."""
+    op = db.query(OperatingPointModel).filter(OperatingPointModel.id == op_id).first()
+    if not op:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"OperatingPoint {op_id} not found",
+        )
+    op.control_deflections = patch.control_deflections
+    op.status = "NOT_TRIMMED"
     db.flush()
     db.refresh(op)
     return op

--- a/app/api/v2/endpoints/operating_points.py
+++ b/app/api/v2/endpoints/operating_points.py
@@ -24,6 +24,7 @@ from app.schemas.aeroanalysisschema import (
     GenerateOperatingPointSetRequest,
     OperatingPointDeflectionPatch,
     OperatingPointSetSchema,
+    OperatingPointStatus,
     StoredOperatingPointCreate,
     StoredOperatingPointRead,
     TrimmedOperatingPointRead,
@@ -255,7 +256,7 @@ def patch_operating_point_deflections(
             detail=f"OperatingPoint {op_id} not found",
         )
     op.control_deflections = patch.control_deflections
-    op.status = "NOT_TRIMMED"
+    op.status = OperatingPointStatus.NOT_TRIMMED
     db.flush()
     db.refresh(op)
     return op

--- a/app/schemas/aeroanalysisschema.py
+++ b/app/schemas/aeroanalysisschema.py
@@ -314,6 +314,19 @@ class OperatingPointDeflectionPatch(BaseModel):
         "Set to null to clear all overrides.",
     )
 
+    @field_validator("control_deflections")
+    @classmethod
+    def validate_deflection_keys(cls, v: dict[str, float] | None) -> dict[str, float] | None:
+        if v is None:
+            return v
+        for key in v:
+            if not re.match(r"^[a-zA-Z][a-zA-Z0-9_ -]*$", key):
+                raise ValueError(
+                    f"Invalid control surface name '{key}'. "
+                    "Must start with a letter, followed by letters/digits/underscores/spaces/hyphens."
+                )
+        return v
+
 
 class GenerateOperatingPointSetRequest(BaseModel):
     replace_existing: bool = Field(

--- a/app/schemas/aeroanalysisschema.py
+++ b/app/schemas/aeroanalysisschema.py
@@ -304,6 +304,17 @@ class StoredOperatingPointRead(StoredOperatingPointCreate):
     id: int
 
 
+class OperatingPointDeflectionPatch(BaseModel):
+    """Partial update: only control surface deflection overrides."""
+
+    control_deflections: dict[str, float] | None = Field(
+        ...,
+        description="Runtime control surface deflections (name → degrees). "
+        "Overrides geometry defaults for this operating point. "
+        "Set to null to clear all overrides.",
+    )
+
+
 class GenerateOperatingPointSetRequest(BaseModel):
     replace_existing: bool = Field(
         False,

--- a/app/tests/test_operating_point_patch.py
+++ b/app/tests/test_operating_point_patch.py
@@ -1,0 +1,143 @@
+"""Tests for PATCH /operating_points/{op_id}/deflections endpoint.
+
+Covers partial update of control_deflections on an operating point,
+including field update, null clearing, 404 handling, and preservation
+of other fields.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.platform import aerosandbox_available
+
+pytestmark = pytest.mark.skipif(
+    not aerosandbox_available(),
+    reason="operating_points router requires aerosandbox",
+)
+
+
+def _op_payload(**overrides) -> dict:
+    """Return a valid StoredOperatingPointCreate payload dict."""
+    base = dict(
+        name="cruise",
+        description="Cruise flight",
+        velocity=25.0,
+        alpha=0.05,
+        beta=0.0,
+        p=0.0,
+        q=0.0,
+        r=0.0,
+        altitude=100.0,
+        config="clean",
+        status="TRIMMED",
+        warnings=[],
+        controls={"elevator": -0.02},
+        xyz_ref=[0.0, 0.0, 0.0],
+    )
+    base.update(overrides)
+    return base
+
+
+class TestPatchDeflections:
+    """Tests for PATCH /operating_points/{op_id}/deflections."""
+
+    def test_patch_deflections_updates_field_and_sets_not_trimmed(self, client_and_db):
+        """Patching deflections updates the field and resets status to NOT_TRIMMED."""
+        client, _ = client_and_db
+
+        # Create an OP with TRIMMED status
+        create_resp = client.post("/operating_points/", json=_op_payload(status="TRIMMED"))
+        assert create_resp.status_code == 200
+        op_id = create_resp.json()["id"]
+        assert create_resp.json()["status"] == "TRIMMED"
+
+        # Patch deflections
+        deflections = {"aileron": 5.0, "elevator": -2.0}
+        patch_resp = client.patch(
+            f"/operating_points/{op_id}/deflections",
+            json={"control_deflections": deflections},
+        )
+
+        assert patch_resp.status_code == 200
+        data = patch_resp.json()
+        assert data["control_deflections"] == deflections
+        assert data["status"] == "NOT_TRIMMED"
+        assert data["id"] == op_id
+
+    def test_patch_deflections_clears_with_null(self, client_and_db):
+        """Patching with null clears the control_deflections field."""
+        client, _ = client_and_db
+
+        # Create an OP with existing deflections
+        create_resp = client.post(
+            "/operating_points/",
+            json=_op_payload(control_deflections={"rudder": 3.0}),
+        )
+        assert create_resp.status_code == 200
+        op_id = create_resp.json()["id"]
+        assert create_resp.json()["control_deflections"] == {"rudder": 3.0}
+
+        # Patch with null to clear
+        patch_resp = client.patch(
+            f"/operating_points/{op_id}/deflections",
+            json={"control_deflections": None},
+        )
+
+        assert patch_resp.status_code == 200
+        data = patch_resp.json()
+        assert data["control_deflections"] is None
+
+    def test_patch_deflections_not_found(self, client_and_db):
+        """Patching a non-existent OP returns 404."""
+        client, _ = client_and_db
+
+        patch_resp = client.patch(
+            "/operating_points/99999/deflections",
+            json={"control_deflections": {"aileron": 1.0}},
+        )
+
+        assert patch_resp.status_code == 404
+        assert "not found" in patch_resp.json()["detail"].lower()
+
+    def test_patch_deflections_preserves_other_fields(self, client_and_db):
+        """Patching deflections does not modify other OP fields."""
+        client, _ = client_and_db
+
+        original = _op_payload(
+            name="preserve_test",
+            velocity=42.0,
+            alpha=0.1,
+            altitude=500.0,
+            controls={"throttle": 0.8},
+        )
+        create_resp = client.post("/operating_points/", json=original)
+        assert create_resp.status_code == 200
+        op_id = create_resp.json()["id"]
+
+        # Patch only deflections
+        patch_resp = client.patch(
+            f"/operating_points/{op_id}/deflections",
+            json={"control_deflections": {"flap": 10.0}},
+        )
+
+        assert patch_resp.status_code == 200
+        data = patch_resp.json()
+
+        # Verify all other fields are unchanged
+        assert data["name"] == "preserve_test"
+        assert data["velocity"] == 42.0
+        assert data["alpha"] == 0.1
+        assert data["altitude"] == 500.0
+        assert data["controls"] == {"throttle": 0.8}
+        assert data["description"] == "Cruise flight"
+        assert data["beta"] == 0.0
+        assert data["p"] == 0.0
+        assert data["q"] == 0.0
+        assert data["r"] == 0.0
+        assert data["config"] == "clean"
+        assert data["xyz_ref"] == [0.0, 0.0, 0.0]
+        assert data["warnings"] == []
+
+        # And the patched field is correct
+        assert data["control_deflections"] == {"flap": 10.0}

--- a/app/tests/test_operating_point_patch.py
+++ b/app/tests/test_operating_point_patch.py
@@ -141,3 +141,18 @@ class TestPatchDeflections:
 
         # And the patched field is correct
         assert data["control_deflections"] == {"flap": 10.0}
+
+    def test_patch_deflections_rejects_invalid_key(self, client_and_db):
+        """Patching with an invalid control surface name returns 422."""
+        client, _ = client_and_db
+
+        create_resp = client.post("/operating_points/", json=_op_payload())
+        assert create_resp.status_code == 200
+        op_id = create_resp.json()["id"]
+
+        patch_resp = client.patch(
+            f"/operating_points/{op_id}/deflections",
+            json={"control_deflections": {"<script>": 5.0}},
+        )
+
+        assert patch_resp.status_code == 422

--- a/frontend/__tests__/operating-points.test.tsx
+++ b/frontend/__tests__/operating-points.test.tsx
@@ -4,11 +4,14 @@ import userEvent from "@testing-library/user-event";
 import React from "react";
 import {
   useOperatingPoints,
+  extractControlSurfaces,
   type StoredOperatingPoint,
   type AVLTrimResult,
   type AeroBuildupTrimResult,
   type TrimConstraint,
+  type ControlSurface,
 } from "@/hooks/useOperatingPoints";
+import type { Wing } from "@/hooks/useWings";
 
 function makeOP(overrides: Partial<StoredOperatingPoint> = {}): StoredOperatingPoint {
   return {
@@ -301,6 +304,57 @@ describe("useOperatingPoints", () => {
     expect(result.current.error).toContain("500");
     expect(result.current.isTrimming).toBe(false);
   });
+
+  it("updateDeflections() calls PATCH endpoint and refreshes", async () => {
+    const point = makeOP();
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve([point]) })
+      .mockResolvedValueOnce({ ok: true, status: 200 })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve([point]) });
+    globalThis.fetch = mockFetch;
+
+    const { result } = renderHook(() => useOperatingPoints("42"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.updateDeflections(1, { elevator: -5 });
+    });
+
+    expect(mockFetch.mock.calls[1][0]).toContain("/operating_points/1/deflections");
+    expect(mockFetch.mock.calls[1][1]).toEqual(
+      expect.objectContaining({ method: "PATCH" }),
+    );
+    const body = JSON.parse(mockFetch.mock.calls[1][1].body);
+    expect(body).toEqual({ control_deflections: { elevator: -5 } });
+    // Refresh was called (3rd fetch call)
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("updateDeflections() sets error on failure", async () => {
+    const point = makeOP();
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve([point]) })
+      .mockResolvedValueOnce({ ok: false, status: 400, text: () => Promise.resolve("Bad request") });
+    globalThis.fetch = mockFetch;
+
+    const { result } = renderHook(() => useOperatingPoints("42"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.updateDeflections(1, { elevator: -5 });
+    });
+
+    expect(result.current.error).toContain("400");
+  });
 });
 
 vi.mock("lucide-react", () => {
@@ -346,6 +400,8 @@ describe("OperatingPointsPanel", () => {
       onGenerate: vi.fn(),
       onTrimWithAvl: vi.fn().mockResolvedValue(null),
       onTrimWithAerobuildup: vi.fn().mockResolvedValue(null),
+      controlSurfaces: [] as ControlSurface[],
+      onUpdateDeflections: vi.fn().mockResolvedValue(undefined),
       ...overrides,
     };
     return { ...render(<OperatingPointsPanel {...defaultProps} />), props: defaultProps };
@@ -738,5 +794,178 @@ describe("OperatingPointsPanel", () => {
     await user.click(screen.getByText("Beta (deg)"));
     const rowsBeta = screen.getAllByRole("row");
     expect(rowsBeta[1]).toHaveTextContent("Point2");
+  });
+
+  it("drawer shows Control Deflections section when control surfaces exist", async () => {
+    if (!OperatingPointsPanel) return;
+    const user = userEvent.setup();
+    const points = [makeOP({ id: 1, name: "DeflTest" })];
+    const controlSurfaces: ControlSurface[] = [
+      { name: "elevator", deflection_deg: 0 },
+      { name: "aileron", deflection_deg: 5 },
+    ];
+    renderPanel({ points, controlSurfaces });
+    await user.click(screen.getByText("DeflTest"));
+    await waitFor(() => {
+      expect(screen.getByText("Control Deflections")).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText("elevator deflection")).toBeInTheDocument();
+    expect(screen.getByLabelText("aileron deflection")).toBeInTheDocument();
+  });
+
+  it("shows 'No control surfaces found' when empty", async () => {
+    if (!OperatingPointsPanel) return;
+    const user = userEvent.setup();
+    const points = [makeOP({ id: 1, name: "EmptyCS" })];
+    renderPanel({ points, controlSurfaces: [] });
+    await user.click(screen.getByText("EmptyCS"));
+    await waitFor(() => {
+      expect(screen.getByText("Control Deflections")).toBeInTheDocument();
+    });
+    expect(screen.getByText("No control surfaces found")).toBeInTheDocument();
+  });
+
+  it("shows override values when control_deflections is set", async () => {
+    if (!OperatingPointsPanel) return;
+    const user = userEvent.setup();
+    const points = [
+      makeOP({
+        id: 1,
+        name: "OverrideTest",
+        control_deflections: { elevator: -3.5 },
+      }),
+    ];
+    const controlSurfaces: ControlSurface[] = [
+      { name: "elevator", deflection_deg: 0 },
+    ];
+    renderPanel({ points, controlSurfaces });
+    await user.click(screen.getByText("OverrideTest"));
+    await waitFor(() => {
+      expect(screen.getByText("Control Deflections")).toBeInTheDocument();
+    });
+    const input = screen.getByLabelText("elevator deflection");
+    expect(input).toHaveValue(-3.5);
+  });
+
+  it("Save Deflections button calls onUpdateDeflections", async () => {
+    if (!OperatingPointsPanel) return;
+    const user = userEvent.setup();
+    const points = [makeOP({ id: 1, name: "SaveTest" })];
+    const controlSurfaces: ControlSurface[] = [
+      { name: "elevator", deflection_deg: 0 },
+    ];
+    const onUpdateDeflections = vi.fn().mockResolvedValue(undefined);
+    renderPanel({ points, controlSurfaces, onUpdateDeflections });
+    await user.click(screen.getByText("SaveTest"));
+    await waitFor(() => {
+      expect(screen.getByText("Control Deflections")).toBeInTheDocument();
+    });
+    const saveBtn = screen.getByRole("button", { name: /save deflections/i });
+    await user.click(saveBtn);
+    expect(onUpdateDeflections).toHaveBeenCalledWith(1, { elevator: 0 });
+  });
+});
+
+describe("extractControlSurfaces", () => {
+  it("extracts control surfaces from wing trailing edge devices", () => {
+    const wings: Wing[] = [
+      {
+        name: "main_wing",
+        symmetric: true,
+        x_secs: [
+          {
+            xyz_le: [0, 0, 0],
+            chord: 1.0,
+            twist: 0,
+            airfoil: "NACA2412",
+            trailing_edge_device: { name: "elevator", deflection_deg: -2 },
+          },
+          {
+            xyz_le: [0, 1, 0],
+            chord: 0.8,
+            twist: 0,
+            airfoil: "NACA2412",
+            trailing_edge_device: null,
+          },
+        ],
+      },
+    ];
+    const result = extractControlSurfaces(wings);
+    expect(result).toEqual([{ name: "elevator", deflection_deg: -2 }]);
+  });
+
+  it("deduplicates by name, keeping first occurrence", () => {
+    const wings: Wing[] = [
+      {
+        name: "main_wing",
+        symmetric: true,
+        x_secs: [
+          {
+            xyz_le: [0, 0, 0],
+            chord: 1.0,
+            twist: 0,
+            airfoil: "NACA2412",
+            trailing_edge_device: { name: "aileron", deflection_deg: 5 },
+          },
+          {
+            xyz_le: [0, 1, 0],
+            chord: 0.8,
+            twist: 0,
+            airfoil: "NACA2412",
+            trailing_edge_device: { name: "aileron", deflection_deg: 10 },
+          },
+        ],
+      },
+    ];
+    const result = extractControlSurfaces(wings);
+    expect(result).toEqual([{ name: "aileron", deflection_deg: 5 }]);
+  });
+
+  it("returns empty array for wings without TEDs", () => {
+    const wings: Wing[] = [
+      {
+        name: "main_wing",
+        symmetric: true,
+        x_secs: [
+          {
+            xyz_le: [0, 0, 0],
+            chord: 1.0,
+            twist: 0,
+            airfoil: "NACA2412",
+          },
+        ],
+      },
+    ];
+    const result = extractControlSurfaces(wings);
+    expect(result).toEqual([]);
+  });
+
+  it("handles null/undefined trailing_edge_device", () => {
+    const wings: Wing[] = [
+      {
+        name: "main_wing",
+        symmetric: true,
+        x_secs: [
+          {
+            xyz_le: [0, 0, 0],
+            chord: 1.0,
+            twist: 0,
+            airfoil: "NACA2412",
+            trailing_edge_device: null,
+            control_surface: null,
+          },
+          {
+            xyz_le: [0, 1, 0],
+            chord: 0.8,
+            twist: 0,
+            airfoil: "NACA2412",
+            trailing_edge_device: undefined,
+            control_surface: undefined,
+          },
+        ],
+      },
+    ];
+    const result = extractControlSurfaces(wings);
+    expect(result).toEqual([]);
   });
 });

--- a/frontend/app/workbench/analysis/page.tsx
+++ b/frontend/app/workbench/analysis/page.tsx
@@ -1,16 +1,16 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { X } from "lucide-react";
 import { useDialog } from "@/hooks/useDialog";
 import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
 import { useAnalysis } from "@/hooks/useAnalysis";
 import { useStripForces } from "@/hooks/useStripForces";
 import { useStreamlines } from "@/hooks/useStreamlines";
-import { useWings, useWing } from "@/hooks/useWings";
+import { useWings, useAllWingData, useWing } from "@/hooks/useWings";
 import { useFlightEnvelope } from "@/hooks/useFlightEnvelope";
 import { useStability } from "@/hooks/useStability";
-import { useOperatingPoints } from "@/hooks/useOperatingPoints";
+import { useOperatingPoints, extractControlSurfaces } from "@/hooks/useOperatingPoints";
 import { AnalysisViewerPanel, type Tab } from "@/components/workbench/AnalysisViewerPanel";
 import { AnalysisConfigPanel } from "@/components/workbench/AnalysisConfigPanel";
 import { AvlGeometryEditor } from "@/components/workbench/AvlGeometryEditor";
@@ -25,7 +25,12 @@ export default function AnalysisPage() {
   const stability = useStability(aeroplaneId);
   const ops = useOperatingPoints(aeroplaneId);
   const { wingNames } = useWings(aeroplaneId);
+  const { wings: allWings } = useAllWingData(aeroplaneId, wingNames);
   const { wing } = useWing(aeroplaneId, selectedWing ?? wingNames[0] ?? null);
+  const controlSurfaces = useMemo(
+    () => extractControlSurfaces(allWings),
+    [allWings],
+  );
   const [configOpen, setConfigOpen] = useState(false);
   const [avlEditorOpen, setAvlEditorOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<Tab>("Polar");
@@ -94,6 +99,8 @@ export default function AnalysisPage() {
             onGenerateOps={ops.generate}
             onTrimWithAvl={ops.trimWithAvl}
             onTrimWithAerobuildup={ops.trimWithAerobuildup}
+            controlSurfaces={controlSurfaces}
+            onUpdateDeflections={ops.updateDeflections}
           />
         </div>
       </div>

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -8,7 +8,7 @@ import type { FlightEnvelopeData } from "@/hooks/useFlightEnvelope";
 import { EnvelopePanel } from "@/components/workbench/EnvelopePanel";
 import type { StabilityData } from "@/hooks/useStability";
 import { StabilityPanel } from "@/components/workbench/StabilityPanel";
-import type { StoredOperatingPoint, AVLTrimResult, AeroBuildupTrimResult, TrimConstraint } from "@/hooks/useOperatingPoints";
+import type { StoredOperatingPoint, AVLTrimResult, AeroBuildupTrimResult, TrimConstraint, ControlSurface } from "@/hooks/useOperatingPoints";
 import { OperatingPointsPanel } from "@/components/workbench/OperatingPointsPanel";
 
 const TABS = ["Assumptions", "Polar", "Trefftz Plane", "Streamlines", "Envelope", "Stability", "Operating Points"] as const;
@@ -53,6 +53,8 @@ interface Props {
   readonly onGenerateOps?: () => void;
   readonly onTrimWithAvl?: (point: StoredOperatingPoint, constraints: TrimConstraint[]) => Promise<AVLTrimResult | null>;
   readonly onTrimWithAerobuildup?: (point: StoredOperatingPoint, trimVariable: string, targetCoefficient: string, targetValue: number) => Promise<AeroBuildupTrimResult | null>;
+  readonly controlSurfaces?: ControlSurface[];
+  readonly onUpdateDeflections?: (opId: number, deflections: Record<string, number> | null) => Promise<void>;
 }
 
 // -- Plotly Chart (dynamic import) ----------------------------------------
@@ -561,6 +563,8 @@ export function AnalysisViewerPanel({
   onGenerateOps,
   onTrimWithAvl,
   onTrimWithAerobuildup,
+  controlSurfaces,
+  onUpdateDeflections,
 }: Readonly<Props>) {
   const [maximizedChart, setMaximizedChart] = useState<string | null>(null);
 
@@ -796,6 +800,8 @@ export function AnalysisViewerPanel({
           onGenerate={onGenerateOps ?? (() => {})}
           onTrimWithAvl={onTrimWithAvl ?? (() => Promise.resolve(null))}
           onTrimWithAerobuildup={onTrimWithAerobuildup ?? (() => Promise.resolve(null))}
+          controlSurfaces={controlSurfaces ?? []}
+          onUpdateDeflections={onUpdateDeflections ?? (async () => {})}
         />
       )}
 

--- a/frontend/components/workbench/OperatingPointsPanel.tsx
+++ b/frontend/components/workbench/OperatingPointsPanel.tsx
@@ -8,6 +8,7 @@ import type {
   AVLTrimResult,
   AeroBuildupTrimResult,
   TrimConstraint,
+  ControlSurface,
 } from "@/hooks/useOperatingPoints";
 
 const RAD_TO_DEG = 180 / Math.PI;
@@ -62,6 +63,11 @@ interface Props {
     targetCoefficient: string,
     targetValue: number,
   ) => Promise<AeroBuildupTrimResult | null>;
+  readonly controlSurfaces: ControlSurface[];
+  readonly onUpdateDeflections: (
+    opId: number,
+    deflections: Record<string, number> | null,
+  ) => Promise<void>;
 }
 
 function sortPoints(
@@ -105,6 +111,8 @@ export function OperatingPointsPanel({
   onGenerate,
   onTrimWithAvl,
   onTrimWithAerobuildup,
+  controlSurfaces,
+  onUpdateDeflections,
 }: Props) {
   const [sortKey, setSortKey] = useState<SortKey>("name");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
@@ -384,6 +392,15 @@ export function OperatingPointsPanel({
                 </div>
               )}
 
+              <ControlDeflectionsSection
+                controlSurfaces={controlSurfaces}
+                currentDeflections={selectedPoint.control_deflections}
+                onSave={(deflections) =>
+                  onUpdateDeflections(selectedPoint.id, deflections)
+                }
+                disabled={isTrimming}
+              />
+
               {Object.keys(selectedPoint.controls).length > 0 && (
                 <div className="flex flex-col gap-3 rounded-xl border border-border bg-card-muted p-4">
                   <span className="font-[family-name:var(--font-geist-sans)] text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
@@ -581,6 +598,127 @@ function TrimResultCard({
             </div>
           ))}
         </div>
+      )}
+    </div>
+  );
+}
+
+function ControlDeflectionsSection({
+  controlSurfaces,
+  currentDeflections,
+  onSave,
+  disabled,
+}: Readonly<{
+  controlSurfaces: ControlSurface[];
+  currentDeflections: Record<string, number> | null;
+  onSave: (deflections: Record<string, number> | null) => void;
+  disabled: boolean;
+}>) {
+  const initialDeflections = useMemo(() => {
+    const initial: Record<string, string> = {};
+    for (const cs of controlSurfaces) {
+      const overrideValue = currentDeflections?.[cs.name];
+      initial[cs.name] =
+        overrideValue != null
+          ? String(overrideValue)
+          : String(cs.deflection_deg);
+    }
+    return initial;
+  }, [controlSurfaces, currentDeflections]);
+
+  const [localDeflections, setLocalDeflections] = useState(initialDeflections);
+
+  // Reset local state when inputs change by comparing the serialized key
+  const deflectionKey = JSON.stringify(initialDeflections);
+  const [prevKey, setPrevKey] = useState(deflectionKey);
+  if (deflectionKey !== prevKey) {
+    setPrevKey(deflectionKey);
+    setLocalDeflections(initialDeflections);
+  }
+
+  const handleChange = useCallback((name: string, value: string) => {
+    setLocalDeflections((prev) => ({ ...prev, [name]: value }));
+  }, []);
+
+  const handleSave = useCallback(() => {
+    const deflections: Record<string, number> = {};
+    for (const [name, val] of Object.entries(localDeflections)) {
+      deflections[name] = parseFloat(val) || 0;
+    }
+    onSave(deflections);
+  }, [localDeflections, onSave]);
+
+  const handleReset = useCallback(() => {
+    onSave(null);
+  }, [onSave]);
+
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-border bg-card-muted p-4">
+      <span className="font-[family-name:var(--font-geist-sans)] text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+        Control Deflections
+      </span>
+      {controlSurfaces.length === 0 ? (
+        <span className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-muted-foreground">
+          No control surfaces found
+        </span>
+      ) : (
+        <>
+          <div className="flex flex-col gap-2">
+            {controlSurfaces.map((cs) => {
+              const isOverridden =
+                currentDeflections != null &&
+                cs.name in currentDeflections &&
+                currentDeflections[cs.name] !== cs.deflection_deg;
+              return (
+                <div key={cs.name} className="flex items-center gap-3">
+                  <span
+                    className={`flex-1 font-[family-name:var(--font-geist-sans)] text-[12px] ${
+                      isOverridden
+                        ? "text-[#FF8400]"
+                        : "text-muted-foreground"
+                    }`}
+                  >
+                    {isOverridden && (
+                      <span className="mr-1.5 inline-block size-1.5 rounded-full bg-[#FF8400]" />
+                    )}
+                    {cs.name}
+                  </span>
+                  <input
+                    type="number"
+                    step="any"
+                    value={localDeflections[cs.name] ?? "0"}
+                    onChange={(e) => handleChange(cs.name, e.target.value)}
+                    disabled={disabled}
+                    className={`w-24 rounded-lg border border-border bg-input px-2.5 py-1.5 font-[family-name:var(--font-jetbrains-mono)] text-[12px] outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none ${
+                      isOverridden ? "text-[#FF8400]" : "text-foreground"
+                    } disabled:opacity-50`}
+                    aria-label={`${cs.name} deflection`}
+                  />
+                  <span className="font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-muted-foreground">
+                    deg
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+          <div className="flex gap-2">
+            <button
+              onClick={handleReset}
+              disabled={disabled || currentDeflections == null}
+              className="rounded-full border border-border px-3 py-1 font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
+            >
+              Reset to Defaults
+            </button>
+            <div className="flex-1" />
+            <button
+              onClick={handleSave}
+              disabled={disabled}
+              className="rounded-full bg-[#FF8400] px-4 py-1 font-[family-name:var(--font-geist-sans)] text-[11px] font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+            >
+              Save Deflections
+            </button>
+          </div>
+        </>
       )}
     </div>
   );

--- a/frontend/hooks/useOperatingPoints.ts
+++ b/frontend/hooks/useOperatingPoints.ts
@@ -2,8 +2,37 @@
 
 import { useState, useCallback, useEffect } from "react";
 import { API_BASE } from "@/lib/fetcher";
+import type { Wing } from "@/hooks/useWings";
 
 export type OperatingPointStatus = "TRIMMED" | "NOT_TRIMMED" | "LIMIT_REACHED";
+
+export interface ControlSurface {
+  name: string;
+  deflection_deg: number;
+}
+
+function isValidControlDevice(
+  ted: Record<string, unknown> | null | undefined,
+): ted is Record<string, unknown> & { name: string } {
+  return ted != null && typeof ted === "object" && typeof ted.name === "string";
+}
+
+export function extractControlSurfaces(wings: Wing[]): ControlSurface[] {
+  const seen = new Map<string, number>();
+  const allXSecs = wings.flatMap((w) => w.x_secs);
+  for (const xsec of allXSecs) {
+    const ted = xsec.trailing_edge_device ?? xsec.control_surface;
+    if (!isValidControlDevice(ted)) continue;
+    if (seen.has(ted.name)) continue;
+    const deflection =
+      typeof ted.deflection_deg === "number" ? ted.deflection_deg : 0;
+    seen.set(ted.name, deflection);
+  }
+  return Array.from(seen.entries()).map(([name, deflection_deg]) => ({
+    name,
+    deflection_deg,
+  }));
+}
 
 export interface StoredOperatingPoint {
   id: number;
@@ -69,6 +98,10 @@ export interface UseOperatingPointsReturn {
     targetCoefficient: string,
     targetValue: number,
   ) => Promise<AeroBuildupTrimResult | null>;
+  updateDeflections: (
+    opId: number,
+    deflections: Record<string, number> | null,
+  ) => Promise<void>;
 }
 
 function toTrimPayload(point: StoredOperatingPoint) {
@@ -227,6 +260,35 @@ export function useOperatingPoints(
     [aeroplaneId, refresh],
   );
 
+  const updateDeflections = useCallback(
+    async (
+      opId: number,
+      deflections: Record<string, number> | null,
+    ): Promise<void> => {
+      setError(null);
+      try {
+        const res = await fetch(
+          `${API_BASE}/operating_points/${opId}/deflections`,
+          {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ control_deflections: deflections }),
+          },
+        );
+        if (!res.ok) {
+          const body = await res.text();
+          throw new Error(
+            `Failed to update deflections: ${res.status} ${body}`,
+          );
+        }
+        await refresh();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [refresh],
+  );
+
   useEffect(() => {
     if (aeroplaneId) {
       refresh();
@@ -245,5 +307,6 @@ export function useOperatingPoints(
     refresh,
     trimWithAvl,
     trimWithAerobuildup,
+    updateDeflections,
   };
 }


### PR DESCRIPTION
## Summary

- Adds a **Control Deflections** section to the operating point detail drawer, enabling per-surface deflection overrides directly from the UI
- Backend `PATCH /operating_points/{id}/deflections` endpoint for partial updates (auto-resets status to `NOT_TRIMMED`)
- Extracts available control surfaces from wing geometry (trailing edge devices) and displays editable inputs with orange override indicators
- "Reset to Defaults" clears all overrides; "Save Deflections" persists changes

## Test plan

- [x] 4 backend pytest tests (PATCH update, null clear, 404, field preservation)
- [x] 10 frontend vitest tests (hook method, extractControlSurfaces utility, panel rendering)
- [ ] Manual: open OP drawer, verify control surfaces appear, modify deflection, save, confirm status resets to NOT_TRIMMED
- [ ] Manual: verify Reset to Defaults clears overrides

Closes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)