### PR TITLE
feat(gh-436): mass sweep visualization chart in analysis workbench

### DIFF
--- a/frontend/__tests__/MassSweepPanel.test.tsx
+++ b/frontend/__tests__/MassSweepPanel.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import type { MassSweepData } from "@/hooks/useMassSweep";
+
+vi.mock("plotly.js-gl3d-dist-min", () => ({
+  default: { react: vi.fn(), purge: vi.fn() },
+  react: vi.fn(),
+  purge: vi.fn(),
+}));
+
+import { MassSweepPanel } from "@/components/workbench/MassSweepPanel";
+
+const FAKE_SWEEP: MassSweepData = {
+  s_ref: 0.42,
+  cl_max: 1.5,
+  velocity: 15.0,
+  altitude: 0.0,
+  points: [
+    { mass_kg: 1.0, wing_loading_pa: 23.4, stall_speed_ms: 8.1, required_cl: 0.3, cl_margin: 1.2 },
+    { mass_kg: 2.0, wing_loading_pa: 46.8, stall_speed_ms: 11.5, required_cl: 0.6, cl_margin: 0.9 },
+    { mass_kg: 3.0, wing_loading_pa: 70.1, stall_speed_ms: 14.1, required_cl: 0.9, cl_margin: 0.6 },
+    { mass_kg: 5.0, wing_loading_pa: 116.9, stall_speed_ms: 18.2, required_cl: 1.5, cl_margin: 0.0 },
+    { mass_kg: 6.0, wing_loading_pa: 140.3, stall_speed_ms: 19.9, required_cl: 1.8, cl_margin: -0.3 },
+  ],
+};
+
+describe("MassSweepPanel", () => {
+  it("shows empty state when data is null and not computing", () => {
+    render(
+      <MassSweepPanel
+        data={null}
+        isComputing={false}
+        error={null}
+        onCompute={vi.fn()}
+        currentMassKg={null}
+      />,
+    );
+    expect(
+      screen.getByText(/click.*compute.*to visualize/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows computing state", () => {
+    render(
+      <MassSweepPanel
+        data={null}
+        isComputing={true}
+        error={null}
+        onCompute={vi.fn()}
+        currentMassKg={null}
+      />,
+    );
+    expect(screen.getByText("Computing mass sweep...")).toBeInTheDocument();
+  });
+
+  it("shows error banner", () => {
+    render(
+      <MassSweepPanel
+        data={null}
+        isComputing={false}
+        error="Something went wrong"
+        onCompute={vi.fn()}
+        currentMassKg={null}
+      />,
+    );
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+  });
+
+  it("calls onCompute when Compute button is clicked", async () => {
+    const onCompute = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <MassSweepPanel
+        data={null}
+        isComputing={false}
+        error={null}
+        onCompute={onCompute}
+        currentMassKg={null}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /compute mass sweep/i }));
+    expect(onCompute).toHaveBeenCalledOnce();
+    const args = onCompute.mock.calls[0][0];
+    expect(args).toHaveProperty("velocity");
+    expect(args).toHaveProperty("altitude");
+  });
+
+  it("disables compute button when isComputing", () => {
+    render(
+      <MassSweepPanel
+        data={FAKE_SWEEP}
+        isComputing={true}
+        error={null}
+        onCompute={vi.fn()}
+        currentMassKg={2.5}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /computing/i })).toBeDisabled();
+  });
+
+  it("renders chart container when data is present", () => {
+    render(
+      <MassSweepPanel
+        data={FAKE_SWEEP}
+        isComputing={false}
+        error={null}
+        onCompute={vi.fn()}
+        currentMassKg={2.5}
+      />,
+    );
+    expect(screen.getByTestId("mass-sweep-chart")).toBeInTheDocument();
+  });
+
+  it("renders velocity and altitude inputs", () => {
+    render(
+      <MassSweepPanel
+        data={null}
+        isComputing={false}
+        error={null}
+        onCompute={vi.fn()}
+        currentMassKg={null}
+      />,
+    );
+    expect(screen.getByLabelText(/velocity/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/altitude/i)).toBeInTheDocument();
+  });
+
+  it("passes velocity and altitude values to onCompute", async () => {
+    const onCompute = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <MassSweepPanel
+        data={null}
+        isComputing={false}
+        error={null}
+        onCompute={onCompute}
+        currentMassKg={null}
+      />,
+    );
+
+    const velocityInput = screen.getByLabelText(/velocity/i);
+    await user.clear(velocityInput);
+    await user.type(velocityInput, "20");
+
+    const altitudeInput = screen.getByLabelText(/altitude/i);
+    await user.clear(altitudeInput);
+    await user.type(altitudeInput, "500");
+
+    await user.click(screen.getByRole("button", { name: /compute mass sweep/i }));
+    expect(onCompute).toHaveBeenCalledWith(
+      expect.objectContaining({ velocity: 20, altitude: 500 }),
+    );
+  });
+});

--- a/frontend/__tests__/useMassSweep.test.ts
+++ b/frontend/__tests__/useMassSweep.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useMassSweep, type MassSweepData } from "@/hooks/useMassSweep";
+
+const FAKE_SWEEP: MassSweepData = {
+  s_ref: 0.42,
+  cl_max: 1.5,
+  velocity: 15.0,
+  altitude: 0.0,
+  points: [
+    { mass_kg: 1.0, wing_loading_pa: 23.4, stall_speed_ms: 8.1, required_cl: 0.3, cl_margin: 1.2 },
+    { mass_kg: 2.0, wing_loading_pa: 46.8, stall_speed_ms: 11.5, required_cl: 0.6, cl_margin: 0.9 },
+    { mass_kg: 3.0, wing_loading_pa: 70.1, stall_speed_ms: 14.1, required_cl: 0.9, cl_margin: 0.6 },
+    { mass_kg: 4.0, wing_loading_pa: 93.5, stall_speed_ms: 16.3, required_cl: 1.2, cl_margin: 0.3 },
+    { mass_kg: 5.0, wing_loading_pa: 116.9, stall_speed_ms: 18.2, required_cl: 1.5, cl_margin: 0.0 },
+    { mass_kg: 6.0, wing_loading_pa: 140.3, stall_speed_ms: 19.9, required_cl: 1.8, cl_margin: -0.3 },
+  ],
+};
+
+describe("useMassSweep", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns null data when aeroplaneId is null", () => {
+    const { result } = renderHook(() => useMassSweep(null));
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.isComputing).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("compute() POSTs mass sweep request and sets data", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(FAKE_SWEEP),
+    });
+
+    const { result } = renderHook(() => useMassSweep("42"));
+
+    await act(async () => {
+      await result.current.compute({ velocity: 15, altitude: 0 });
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
+    const [url, opts] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toContain("/aeroplanes/42/mass_sweep");
+    expect(opts.method).toBe("POST");
+    const body = JSON.parse(opts.body);
+    expect(body.velocity).toBe(15);
+    expect(body.altitude).toBe(0);
+    expect(body.masses_kg).toBeDefined();
+    expect(body.masses_kg.length).toBeGreaterThan(0);
+
+    expect(result.current.data).toEqual(FAKE_SWEEP);
+    expect(result.current.isComputing).toBe(false);
+  });
+
+  it("sets error on failed compute", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Internal server error"),
+    });
+
+    const { result } = renderHook(() => useMassSweep("42"));
+
+    await act(async () => {
+      await result.current.compute({ velocity: 15, altitude: 0 });
+    });
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toContain("500");
+    expect(result.current.isComputing).toBe(false);
+  });
+
+  it("sets isComputing during compute", async () => {
+    let resolvePromise: (value: unknown) => void;
+    const pending = new Promise((resolve) => {
+      resolvePromise = resolve;
+    });
+    globalThis.fetch = vi.fn().mockReturnValue(pending);
+
+    const { result } = renderHook(() => useMassSweep("42"));
+
+    act(() => {
+      result.current.compute({ velocity: 15, altitude: 0 });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isComputing).toBe(true);
+    });
+
+    await act(async () => {
+      resolvePromise!({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(FAKE_SWEEP),
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isComputing).toBe(false);
+    });
+  });
+
+  it("clears previous error on new compute", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve("Server error"),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(FAKE_SWEEP),
+      });
+    globalThis.fetch = mockFetch;
+
+    const { result } = renderHook(() => useMassSweep("42"));
+
+    await act(async () => {
+      await result.current.compute({ velocity: 15, altitude: 0 });
+    });
+    expect(result.current.error).toContain("500");
+
+    await act(async () => {
+      await result.current.compute({ velocity: 15, altitude: 0 });
+    });
+    expect(result.current.error).toBeNull();
+    expect(result.current.data).toEqual(FAKE_SWEEP);
+  });
+
+  it("uses custom masses when provided", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(FAKE_SWEEP),
+    });
+
+    const { result } = renderHook(() => useMassSweep("42"));
+
+    const customMasses = [1, 2, 3, 4, 5];
+    await act(async () => {
+      await result.current.compute({ velocity: 20, altitude: 100, masses: customMasses });
+    });
+
+    const body = JSON.parse(
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body,
+    );
+    expect(body.masses_kg).toEqual(customMasses);
+    expect(body.velocity).toBe(20);
+    expect(body.altitude).toBe(100);
+  });
+});

--- a/frontend/__tests__/useMassSweep.test.ts
+++ b/frontend/__tests__/useMassSweep.test.ts
@@ -134,6 +134,51 @@ describe("useMassSweep", () => {
     expect(result.current.data).toEqual(FAKE_SWEEP);
   });
 
+  it("clears data when aeroplaneId changes", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(FAKE_SWEEP),
+    });
+
+    const { result, rerender } = renderHook(
+      ({ id }) => useMassSweep(id),
+      { initialProps: { id: "42" as string | null } },
+    );
+
+    await act(async () => {
+      await result.current.compute({ velocity: 15, altitude: 0 });
+    });
+    expect(result.current.data).toEqual(FAKE_SWEEP);
+
+    rerender({ id: "99" });
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("clears data when aeroplaneId becomes null", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(FAKE_SWEEP),
+    });
+
+    const { result, rerender } = renderHook(
+      ({ id }) => useMassSweep(id),
+      { initialProps: { id: "42" as string | null } },
+    );
+
+    await act(async () => {
+      await result.current.compute({ velocity: 15, altitude: 0 });
+    });
+    expect(result.current.data).toEqual(FAKE_SWEEP);
+
+    rerender({ id: null });
+
+    expect(result.current.data).toBeNull();
+  });
+
   it("uses custom masses when provided", async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,

--- a/frontend/app/workbench/analysis/page.tsx
+++ b/frontend/app/workbench/analysis/page.tsx
@@ -11,10 +11,13 @@ import { useWings, useAllWingData, useWing } from "@/hooks/useWings";
 import { useFlightEnvelope } from "@/hooks/useFlightEnvelope";
 import { useStability } from "@/hooks/useStability";
 import { useOperatingPoints, extractControlSurfaces } from "@/hooks/useOperatingPoints";
+import { useMassSweep } from "@/hooks/useMassSweep";
+import { useDesignAssumptions } from "@/hooks/useDesignAssumptions";
 import { AnalysisViewerPanel, type Tab } from "@/components/workbench/AnalysisViewerPanel";
 import { AnalysisConfigPanel } from "@/components/workbench/AnalysisConfigPanel";
 import { AvlGeometryEditor } from "@/components/workbench/AvlGeometryEditor";
 import { AssumptionsPanel } from "@/components/workbench/AssumptionsPanel";
+import { MassSweepPanel } from "@/components/workbench/MassSweepPanel";
 
 export default function AnalysisPage() {
   const { aeroplaneId, hydrated, selectedWing, openPicker } = useAeroplaneContext();
@@ -24,6 +27,12 @@ export default function AnalysisPage() {
   const envelope = useFlightEnvelope(aeroplaneId);
   const stability = useStability(aeroplaneId);
   const ops = useOperatingPoints(aeroplaneId);
+  const massSweep = useMassSweep(aeroplaneId);
+  const assumptions = useDesignAssumptions(aeroplaneId);
+  const currentMassKg = useMemo(() => {
+    const massAssumption = assumptions.data?.assumptions.find((a) => a.parameter_name === "mass");
+    return massAssumption?.effective_value ?? null;
+  }, [assumptions.data]);
   const { wingNames } = useWings(aeroplaneId);
   const { wings: allWings } = useAllWingData(aeroplaneId, wingNames);
   const { wing } = useWing(aeroplaneId, selectedWing ?? wingNames[0] ?? null);
@@ -82,7 +91,20 @@ export default function AnalysisPage() {
             onEditAvlGeometry={() => setAvlEditorOpen(true)}
             wingXSecs={wing?.x_secs}
             wingSymmetric={wing?.symmetric}
-            assumptionsSlot={<AssumptionsPanel aeroplaneId={aeroplaneId} />}
+            assumptionsSlot={
+              <>
+                <AssumptionsPanel aeroplaneId={aeroplaneId} />
+                <div className="mt-6">
+                  <MassSweepPanel
+                    data={massSweep.data}
+                    isComputing={massSweep.isComputing}
+                    error={massSweep.error}
+                    onCompute={massSweep.compute}
+                    currentMassKg={currentMassKg}
+                  />
+                </div>
+              </>
+            }
             envelope={envelope.data}
             isComputingEnvelope={envelope.isComputing}
             envelopeError={envelope.error}

--- a/frontend/components/workbench/MassSweepChart.tsx
+++ b/frontend/components/workbench/MassSweepChart.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useRef, useEffect } from "react";
+import type { MassSweepPoint } from "@/hooks/useMassSweep";
+
+interface Props {
+  readonly points: MassSweepPoint[];
+  readonly currentMassKg: number | null;
+}
+
+export function MassSweepChart({ points, currentMassKg }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node || points.length === 0) return;
+    let disposed = false;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let PlotlyRef: any = null;
+
+    (async () => {
+      PlotlyRef = await import("plotly.js-gl3d-dist-min");
+      if (disposed || !node) return;
+
+      const masses = points.map((p) => p.mass_kg);
+      const firstNegIdx = points.findIndex((p) => p.cl_margin < 0);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const traces: Record<string, any>[] = [
+        {
+          x: masses,
+          y: points.map((p) => p.stall_speed_ms),
+          type: "scatter",
+          mode: "lines",
+          name: "Stall Speed",
+          line: { color: "#E5484D", width: 2 },
+          hovertemplate: "Mass: %{x:.1f} kg<br>V_stall: %{y:.1f} m/s<extra></extra>",
+        },
+        {
+          x: masses,
+          y: points.map((p) => p.wing_loading_pa),
+          type: "scatter",
+          mode: "lines",
+          name: "Wing Loading",
+          line: { color: "#FF8400", width: 2 },
+          hovertemplate: "Mass: %{x:.1f} kg<br>W/S: %{y:.1f} Pa<extra></extra>",
+        },
+        {
+          x: masses,
+          y: points.map((p) => p.cl_margin),
+          type: "scatter",
+          mode: "lines",
+          name: "CL Margin",
+          yaxis: "y2",
+          line: { color: "#30A46C", width: 2 },
+          hovertemplate: "Mass: %{x:.1f} kg<br>CL margin: %{y:.2f}<extra></extra>",
+        },
+      ];
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const shapes: Record<string, any>[] = [];
+
+      // Infeasible region (CL margin < 0)
+      if (firstNegIdx !== -1) {
+        const xStart = firstNegIdx > 0
+          ? masses[firstNegIdx - 1] + (masses[firstNegIdx] - masses[firstNegIdx - 1]) *
+            (points[firstNegIdx - 1].cl_margin / (points[firstNegIdx - 1].cl_margin - points[firstNegIdx].cl_margin))
+          : masses[firstNegIdx];
+        shapes.push({
+          type: "rect",
+          x0: xStart,
+          x1: masses[masses.length - 1],
+          y0: 0,
+          y1: 1,
+          yref: "paper",
+          fillcolor: "rgba(229, 72, 77, 0.08)",
+          line: { width: 0 },
+        });
+      }
+
+      // Current mass marker
+      if (currentMassKg !== null && currentMassKg > 0) {
+        shapes.push({
+          type: "line",
+          x0: currentMassKg,
+          x1: currentMassKg,
+          y0: 0,
+          y1: 1,
+          yref: "paper",
+          line: { color: "#A78BFA", width: 2, dash: "dash" },
+        });
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const annotations: Record<string, any>[] = [];
+      if (currentMassKg !== null && currentMassKg > 0) {
+        annotations.push({
+          x: currentMassKg,
+          y: 1.02,
+          yref: "paper" as const,
+          text: `m = ${currentMassKg.toFixed(1)} kg`,
+          showarrow: false,
+          font: { size: 10, color: "#A78BFA", family: "JetBrains Mono, monospace" },
+        });
+      }
+      if (firstNegIdx !== -1) {
+        annotations.push({
+          x: masses[masses.length - 1],
+          y: 0.95,
+          yref: "paper" as const,
+          xanchor: "right" as const,
+          text: "Infeasible",
+          showarrow: false,
+          font: { size: 10, color: "#E5484D", family: "JetBrains Mono, monospace" },
+        });
+      }
+
+      const layout = {
+        paper_bgcolor: "transparent",
+        plot_bgcolor: "transparent",
+        font: { color: "#A1A1AA", family: "JetBrains Mono, monospace", size: 10 },
+        margin: { l: 55, r: 55, t: 30, b: 45 },
+        xaxis: {
+          title: { text: "Mass [kg]", font: { size: 11 } },
+          gridcolor: "#27272A",
+          zerolinecolor: "#3F3F46",
+        },
+        yaxis: {
+          title: { text: "Stall Speed [m/s] / Wing Loading [Pa]", font: { size: 11 } },
+          gridcolor: "#27272A",
+          zerolinecolor: "#3F3F46",
+        },
+        yaxis2: {
+          title: { text: "CL Margin", font: { size: 11, color: "#30A46C" } },
+          overlaying: "y",
+          side: "right",
+          gridcolor: "transparent",
+          zerolinecolor: "#3F3F46",
+          tickfont: { color: "#30A46C" },
+        },
+        showlegend: true,
+        legend: {
+          x: 0.02,
+          y: 0.98,
+          xanchor: "left",
+          yanchor: "top",
+          bgcolor: "rgba(0,0,0,0.4)",
+          bordercolor: "#3F3F46",
+          borderwidth: 1,
+          font: { size: 10, color: "#A1A1AA" },
+        },
+        autosize: true,
+        shapes,
+        annotations,
+      };
+
+      await PlotlyRef.react(node, traces, layout, {
+        responsive: true,
+        displayModeBar: false,
+      });
+    })();
+
+    return () => {
+      disposed = true;
+      if (node && PlotlyRef) PlotlyRef.purge(node);
+    };
+  }, [points, currentMassKg]);
+
+  if (points.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center rounded-xl border border-border bg-card p-4">
+        <span className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-muted-foreground">
+          No mass sweep data
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-1 flex-col overflow-hidden" data-testid="mass-sweep-chart">
+      <div ref={containerRef} className="min-h-0 flex-1" style={{ minHeight: 280 }} />
+    </div>
+  );
+}

--- a/frontend/components/workbench/MassSweepPanel.tsx
+++ b/frontend/components/workbench/MassSweepPanel.tsx
@@ -32,13 +32,15 @@ export function MassSweepPanel({
         <div className="flex-1" />
 
         <label className="flex items-center gap-1.5 font-[family-name:var(--font-geist-sans)] text-[12px] text-muted-foreground">
-          <span id="velocity-label">Velocity</span>
+          Velocity
           <input
             type="number"
-            aria-labelledby="velocity-label"
             aria-label="Velocity"
             value={velocity}
-            onChange={(e) => setVelocity(Number(e.target.value))}
+            onChange={(e) => {
+              const v = Number(e.target.value);
+              if (!Number.isNaN(v)) setVelocity(v);
+            }}
             step={1}
             min={1}
             className="w-16 rounded-md border border-border bg-card px-2 py-1 text-[12px] text-foreground"
@@ -47,13 +49,15 @@ export function MassSweepPanel({
         </label>
 
         <label className="flex items-center gap-1.5 font-[family-name:var(--font-geist-sans)] text-[12px] text-muted-foreground">
-          <span id="altitude-label">Altitude</span>
+          Altitude
           <input
             type="number"
-            aria-labelledby="altitude-label"
             aria-label="Altitude"
             value={altitude}
-            onChange={(e) => setAltitude(Number(e.target.value))}
+            onChange={(e) => {
+              const v = Number(e.target.value);
+              if (!Number.isNaN(v)) setAltitude(v);
+            }}
             step={100}
             min={0}
             className="w-20 rounded-md border border-border bg-card px-2 py-1 text-[12px] text-foreground"

--- a/frontend/components/workbench/MassSweepPanel.tsx
+++ b/frontend/components/workbench/MassSweepPanel.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState } from "react";
+import type { MassSweepData, ComputeOptions } from "@/hooks/useMassSweep";
+import { MassSweepChart } from "@/components/workbench/MassSweepChart";
+
+interface Props {
+  readonly data: MassSweepData | null;
+  readonly isComputing: boolean;
+  readonly error: string | null;
+  readonly onCompute: (opts: ComputeOptions) => void;
+  readonly currentMassKg: number | null;
+}
+
+export function MassSweepPanel({
+  data,
+  isComputing,
+  error,
+  onCompute,
+  currentMassKg,
+}: Props) {
+  const [velocity, setVelocity] = useState(15);
+  const [altitude, setAltitude] = useState(0);
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Header + Controls */}
+      <div className="flex items-center gap-3">
+        <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-foreground">
+          Mass Sweep
+        </span>
+        <div className="flex-1" />
+
+        <label className="flex items-center gap-1.5 font-[family-name:var(--font-geist-sans)] text-[12px] text-muted-foreground">
+          <span id="velocity-label">Velocity</span>
+          <input
+            type="number"
+            aria-labelledby="velocity-label"
+            aria-label="Velocity"
+            value={velocity}
+            onChange={(e) => setVelocity(Number(e.target.value))}
+            step={1}
+            min={1}
+            className="w-16 rounded-md border border-border bg-card px-2 py-1 text-[12px] text-foreground"
+          />
+          <span className="text-[10px]">m/s</span>
+        </label>
+
+        <label className="flex items-center gap-1.5 font-[family-name:var(--font-geist-sans)] text-[12px] text-muted-foreground">
+          <span id="altitude-label">Altitude</span>
+          <input
+            type="number"
+            aria-labelledby="altitude-label"
+            aria-label="Altitude"
+            value={altitude}
+            onChange={(e) => setAltitude(Number(e.target.value))}
+            step={100}
+            min={0}
+            className="w-20 rounded-md border border-border bg-card px-2 py-1 text-[12px] text-foreground"
+          />
+          <span className="text-[10px]">m</span>
+        </label>
+
+        <button
+          onClick={() => onCompute({ velocity, altitude })}
+          disabled={isComputing}
+          className="flex items-center gap-1.5 rounded-full bg-[#FF8400] px-4 py-1.5 font-[family-name:var(--font-geist-sans)] text-[12px] font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+        >
+          {isComputing ? "Computing..." : "Compute Mass Sweep"}
+        </button>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-2">
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-red-400">
+            {error}
+          </span>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!data && !isComputing && !error && (
+        <div className="flex items-center justify-center rounded-xl border border-border bg-card py-10">
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-muted-foreground">
+            Click Compute Mass Sweep to visualize metrics across mass range
+          </span>
+        </div>
+      )}
+
+      {/* Loading state */}
+      {isComputing && !data && (
+        <div className="flex items-center justify-center rounded-xl border border-border bg-card py-10">
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-muted-foreground">
+            Computing mass sweep...
+          </span>
+        </div>
+      )}
+
+      {/* Chart */}
+      {data && (
+        <div className="rounded-xl border border-border bg-card">
+          <MassSweepChart points={data.points} currentMassKg={currentMassKg} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/hooks/useMassSweep.ts
+++ b/frontend/hooks/useMassSweep.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { API_BASE } from "@/lib/fetcher";
 
 export interface MassSweepPoint {
@@ -37,6 +37,11 @@ export function useMassSweep(aeroplaneId: string | null) {
   const [data, setData] = useState<MassSweepData | null>(null);
   const [isComputing, setIsComputing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setData(null);
+    setError(null);
+  }, [aeroplaneId]);
 
   const compute = useCallback(
     async (opts: ComputeOptions = {}) => {

--- a/frontend/hooks/useMassSweep.ts
+++ b/frontend/hooks/useMassSweep.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { API_BASE } from "@/lib/fetcher";
+
+export interface MassSweepPoint {
+  mass_kg: number;
+  wing_loading_pa: number;
+  stall_speed_ms: number;
+  required_cl: number;
+  cl_margin: number;
+}
+
+export interface MassSweepData {
+  s_ref: number;
+  cl_max: number;
+  velocity: number;
+  altitude: number;
+  points: MassSweepPoint[];
+}
+
+export interface ComputeOptions {
+  velocity?: number;
+  altitude?: number;
+  masses?: number[];
+}
+
+function defaultMasses(): number[] {
+  const masses: number[] = [];
+  for (let m = 0.5; m <= 10; m += 0.5) {
+    masses.push(m);
+  }
+  return masses;
+}
+
+export function useMassSweep(aeroplaneId: string | null) {
+  const [data, setData] = useState<MassSweepData | null>(null);
+  const [isComputing, setIsComputing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const compute = useCallback(
+    async (opts: ComputeOptions = {}) => {
+      if (!aeroplaneId) return;
+      setIsComputing(true);
+      setError(null);
+
+      try {
+        const res = await fetch(
+          `${API_BASE}/aeroplanes/${aeroplaneId}/mass_sweep`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              masses_kg: opts.masses ?? defaultMasses(),
+              velocity: opts.velocity ?? 15.0,
+              altitude: opts.altitude ?? 0.0,
+            }),
+          },
+        );
+        if (!res.ok) {
+          const body = await res.text();
+          throw new Error(`Compute failed: ${res.status} ${body}`);
+        }
+        const json: MassSweepData = await res.json();
+        setData(json);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setIsComputing(false);
+      }
+    },
+    [aeroplaneId],
+  );
+
+  return { data, isComputing, error, compute };
+}


### PR DESCRIPTION
## Summary

- Add `useMassSweep` hook — POST-based fetch to `/aeroplanes/{id}/mass_sweep` with configurable velocity, altitude, and mass range
- Add `MassSweepChart` — multi-axis Plotly chart (stall speed + wing loading on left Y-axis, CL margin on right Y-axis) with infeasible region shading and current-mass marker
- Add `MassSweepPanel` — toolbar with velocity/altitude inputs and Compute button, wrapping the chart with standard empty/loading/error states
- Integrate into the Assumptions tab of the Analysis workbench, below the existing design assumptions list

## Test plan

- [x] 14 new vitest tests (hook + component): null ID, compute POST, error handling, loading state, input wiring
- [x] All 475 frontend tests pass
- [x] Lint clean (no new warnings)
- [x] No new type errors
- [ ] Manual: open Analysis workbench → Assumptions tab → see Mass Sweep section → set velocity/altitude → click Compute → verify chart renders with markers and infeasible region

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)