### PR TITLE
feat(gh-437): CG comparison warning in assumptions panel

### DIFF
--- a/frontend/__tests__/AssumptionsPanel.test.tsx
+++ b/frontend/__tests__/AssumptionsPanel.test.tsx
@@ -20,6 +20,11 @@ vi.mock("lucide-react", () => {
   };
 });
 
+vi.mock("@/components/workbench/CGComparisonBanner", () => ({
+  CGComparisonBanner: ({ aeroplaneId }: { aeroplaneId: string }) =>
+    React.createElement("div", { "data-testid": "cg-comparison-banner-mock", "data-aeroplane-id": aeroplaneId }),
+}));
+
 const mockSeedDefaults = vi.fn();
 const mockUpdateEstimate = vi.fn();
 const mockSwitchSource = vi.fn();
@@ -126,6 +131,19 @@ describe("AssumptionsPanel", () => {
 
     expect(screen.getByText("Total Mass")).toBeDefined();
     expect(screen.getByText("Zero-Lift Drag (CD₀)")).toBeDefined();
+  });
+
+  it("renders CGComparisonBanner when assumptions exist", () => {
+    hookReturn.data = {
+      assumptions: [makeAssumption()],
+      warnings_count: 0,
+    };
+
+    render(<AssumptionsPanel aeroplaneId="aero-1" />);
+
+    const banner = screen.getByTestId("cg-comparison-banner-mock");
+    expect(banner).toBeDefined();
+    expect(banner.getAttribute("data-aeroplane-id")).toBe("aero-1");
   });
 
   it("shows warnings badge when warnings_count > 0", () => {

--- a/frontend/__tests__/CGComparisonBanner.test.tsx
+++ b/frontend/__tests__/CGComparisonBanner.test.tsx
@@ -1,0 +1,214 @@
+/**
+ * Unit tests for CGComparisonBanner component (gh-437).
+ *
+ * Verifies rendering logic for various CG comparison states
+ * and sync button interaction.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import type { CGComparison } from "@/hooks/useCGComparison";
+
+// ── Mocks ─────────────────────────────────────────────────────────
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) =>
+    React.createElement("span", props);
+  return {
+    AlertTriangle: icon,
+    RefreshCw: icon,
+  };
+});
+
+const mockSyncDesignCG = vi.fn();
+const mockMutate = vi.fn();
+
+let hookReturn: {
+  data: CGComparison | null;
+  isLoading: boolean;
+  error: Error | null;
+  syncDesignCG: typeof mockSyncDesignCG;
+  mutate: typeof mockMutate;
+};
+
+vi.mock("@/hooks/useCGComparison", () => ({
+  useCGComparison: () => hookReturn,
+}));
+
+import { CGComparisonBanner } from "@/components/workbench/CGComparisonBanner";
+
+// ── Tests ─────────────────────────────────────────────────────────
+
+describe("CGComparisonBanner", () => {
+  const mockOnCGSynced = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hookReturn = {
+      data: null,
+      isLoading: false,
+      error: null,
+      syncDesignCG: mockSyncDesignCG,
+      mutate: mockMutate,
+    };
+  });
+
+  it("renders nothing when loading", () => {
+    hookReturn.isLoading = true;
+
+    const { container } = render(
+      <CGComparisonBanner aeroplaneId="aero-1" onCGSynced={mockOnCGSynced} />,
+    );
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when no data", () => {
+    hookReturn.data = null;
+
+    const { container } = render(
+      <CGComparisonBanner aeroplaneId="aero-1" onCGSynced={mockOnCGSynced} />,
+    );
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when within_tolerance is true", () => {
+    hookReturn.data = {
+      design_cg_x: 0.25,
+      component_cg_x: 0.255,
+      component_cg_y: null,
+      component_cg_z: null,
+      component_total_mass_kg: 2.5,
+      delta_x: -0.005,
+      within_tolerance: true,
+    };
+
+    const { container } = render(
+      <CGComparisonBanner aeroplaneId="aero-1" onCGSynced={mockOnCGSynced} />,
+    );
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when component_cg_x is null", () => {
+    hookReturn.data = {
+      design_cg_x: 0.25,
+      component_cg_x: null,
+      component_cg_y: null,
+      component_cg_z: null,
+      component_total_mass_kg: null,
+      delta_x: null,
+      within_tolerance: null,
+    };
+
+    const { container } = render(
+      <CGComparisonBanner aeroplaneId="aero-1" onCGSynced={mockOnCGSynced} />,
+    );
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders orange warning when delta_x <= 5cm and NOT within tolerance", () => {
+    hookReturn.data = {
+      design_cg_x: 0.25,
+      component_cg_x: 0.28,
+      component_cg_y: null,
+      component_cg_z: null,
+      component_total_mass_kg: 2.5,
+      delta_x: -0.03,
+      within_tolerance: false,
+    };
+
+    render(
+      <CGComparisonBanner aeroplaneId="aero-1" onCGSynced={mockOnCGSynced} />,
+    );
+
+    const banner = screen.getByTestId("cg-comparison-banner");
+    expect(banner).toBeDefined();
+    expect(banner.className).toContain("border-orange-500/30");
+    expect(banner.className).toContain("bg-orange-500/10");
+  });
+
+  it("renders red warning when delta_x > 5cm", () => {
+    hookReturn.data = {
+      design_cg_x: 0.25,
+      component_cg_x: 0.32,
+      component_cg_y: null,
+      component_cg_z: null,
+      component_total_mass_kg: 2.5,
+      delta_x: -0.07,
+      within_tolerance: false,
+    };
+
+    render(
+      <CGComparisonBanner aeroplaneId="aero-1" onCGSynced={mockOnCGSynced} />,
+    );
+
+    const banner = screen.getByTestId("cg-comparison-banner");
+    expect(banner).toBeDefined();
+    expect(banner.className).toContain("border-red-500/30");
+    expect(banner.className).toContain("bg-red-500/10");
+  });
+
+  it("displays correct delta in cm", () => {
+    hookReturn.data = {
+      design_cg_x: 0.25,
+      component_cg_x: 0.28,
+      component_cg_y: null,
+      component_cg_z: null,
+      component_total_mass_kg: 2.5,
+      delta_x: -0.03,
+      within_tolerance: false,
+    };
+
+    render(
+      <CGComparisonBanner aeroplaneId="aero-1" onCGSynced={mockOnCGSynced} />,
+    );
+
+    expect(screen.getByText(/3\.0cm/)).toBeDefined();
+  });
+
+  it("displays component and design CG values", () => {
+    hookReturn.data = {
+      design_cg_x: 0.25,
+      component_cg_x: 0.28,
+      component_cg_y: null,
+      component_cg_z: null,
+      component_total_mass_kg: 2.5,
+      delta_x: -0.03,
+      within_tolerance: false,
+    };
+
+    render(
+      <CGComparisonBanner aeroplaneId="aero-1" onCGSynced={mockOnCGSynced} />,
+    );
+
+    expect(screen.getByText(/0\.280m/)).toBeDefined();
+    expect(screen.getByText(/0\.250m/)).toBeDefined();
+  });
+
+  it("sync button calls syncDesignCG with component_cg_x and onCGSynced callback", async () => {
+    hookReturn.data = {
+      design_cg_x: 0.25,
+      component_cg_x: 0.28,
+      component_cg_y: null,
+      component_cg_z: null,
+      component_total_mass_kg: 2.5,
+      delta_x: -0.03,
+      within_tolerance: false,
+    };
+    mockSyncDesignCG.mockResolvedValue(undefined);
+    const user = userEvent.setup();
+
+    render(
+      <CGComparisonBanner aeroplaneId="aero-1" onCGSynced={mockOnCGSynced} />,
+    );
+
+    await user.click(screen.getByTestId("sync-cg-button"));
+
+    expect(mockSyncDesignCG).toHaveBeenCalledWith(0.28);
+    expect(mockOnCGSynced).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/__tests__/useCGComparison.test.ts
+++ b/frontend/__tests__/useCGComparison.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for the useCGComparison hook (gh-437).
+ *
+ * Verifies that the hook returns expected data shapes and that
+ * syncDesignCG sends the correct request.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useCGComparison } from "@/hooks/useCGComparison";
+
+// Mock SWR to avoid real network requests
+const mockMutate = vi.fn();
+vi.mock("swr", () => ({
+  default: vi.fn(() => ({
+    data: {
+      design_cg_x: 0.25,
+      component_cg_x: 0.28,
+      component_cg_y: null,
+      component_cg_z: null,
+      component_total_mass_kg: 2.5,
+      delta_x: -0.03,
+      within_tolerance: false,
+    },
+    error: undefined,
+    isLoading: false,
+    mutate: mockMutate,
+  })),
+}));
+
+describe("useCGComparison", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockMutate.mockClear();
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+  });
+
+  it("returns CG comparison data from SWR", () => {
+    const { result } = renderHook(() => useCGComparison("aero-1"));
+
+    expect(result.current.data).not.toBeNull();
+    expect(result.current.data?.design_cg_x).toBe(0.25);
+    expect(result.current.data?.component_cg_x).toBe(0.28);
+    expect(result.current.data?.delta_x).toBe(-0.03);
+    expect(result.current.data?.within_tolerance).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("syncDesignCG sends PUT with correct body and calls mutate", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    globalThis.fetch = mockFetch;
+
+    const { result } = renderHook(() => useCGComparison("aero-1"));
+
+    await act(async () => {
+      await result.current.syncDesignCG(0.28);
+    });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain("/aeroplanes/aero-1/assumptions/cg_x");
+    expect(options.method).toBe("PUT");
+    expect(JSON.parse(options.body)).toEqual({ estimate_value: 0.28 });
+    expect(mockMutate).toHaveBeenCalled();
+  });
+
+  it("syncDesignCG is a no-op when aeroplaneId is null", async () => {
+    const mockFetch = vi.fn();
+    globalThis.fetch = mockFetch;
+
+    const { result } = renderHook(() => useCGComparison(null));
+
+    await act(async () => {
+      await result.current.syncDesignCG(0.28);
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("syncDesignCG throws on non-ok response", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Internal error"),
+    });
+    globalThis.fetch = mockFetch;
+
+    const { result } = renderHook(() => useCGComparison("aero-1"));
+
+    await expect(
+      act(async () => {
+        await result.current.syncDesignCG(0.28);
+      }),
+    ).rejects.toThrow("Failed to sync CG: 500");
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/components/workbench/AssumptionsPanel.tsx
+++ b/frontend/components/workbench/AssumptionsPanel.tsx
@@ -3,13 +3,14 @@
 import { AlertTriangle, Loader2, Plus } from "lucide-react";
 import { useDesignAssumptions } from "@/hooks/useDesignAssumptions";
 import { AssumptionRow } from "@/components/workbench/AssumptionRow";
+import { CGComparisonBanner } from "@/components/workbench/CGComparisonBanner";
 
 interface Props {
   readonly aeroplaneId: string;
 }
 
 export function AssumptionsPanel({ aeroplaneId }: Props) {
-  const { data, isLoading, error, seedDefaults, updateEstimate, switchSource } =
+  const { data, isLoading, error, seedDefaults, updateEstimate, switchSource, mutate } =
     useDesignAssumptions(aeroplaneId);
 
   if (isLoading) {
@@ -71,6 +72,9 @@ export function AssumptionsPanel({ aeroplaneId }: Props) {
           </span>
         )}
       </div>
+
+      {/* CG comparison warning */}
+      <CGComparisonBanner aeroplaneId={aeroplaneId} onCGSynced={() => mutate()} />
 
       {/* Rows */}
       <div className="rounded-xl border border-border bg-card">

--- a/frontend/components/workbench/CGComparisonBanner.tsx
+++ b/frontend/components/workbench/CGComparisonBanner.tsx
@@ -14,11 +14,11 @@ export function CGComparisonBanner({ aeroplaneId, onCGSynced }: Props) {
   const [syncing, setSyncing] = useState(false);
 
   // Don't render if loading, no data, no component CG, or within tolerance
-  if (isLoading || !data || data.component_cg_x == null || data.within_tolerance !== false) {
+  if (isLoading || !data || data.component_cg_x == null || data.delta_x == null || data.within_tolerance !== false) {
     return null;
   }
 
-  const deltaM = data.delta_x!;
+  const deltaM = data.delta_x;
   const deltaCm = Math.abs(deltaM * 100);
   const isSevere = deltaCm > 5;
 
@@ -29,7 +29,7 @@ export function CGComparisonBanner({ aeroplaneId, onCGSynced }: Props) {
   async function handleSync() {
     setSyncing(true);
     try {
-      await syncDesignCG(data!.component_cg_x!);
+      await syncDesignCG(data.component_cg_x!);
       onCGSynced();
     } finally {
       setSyncing(false);
@@ -44,7 +44,7 @@ export function CGComparisonBanner({ aeroplaneId, onCGSynced }: Props) {
       <AlertTriangle size={14} className={textColor} />
       <div className="flex flex-1 flex-col gap-0.5">
         <span className={`font-[family-name:var(--font-jetbrains-mono)] text-[12px] ${textColor}`}>
-          Component CG ({data.component_cg_x!.toFixed(3)}m) differs from design CG ({data.design_cg_x.toFixed(3)}m) by {deltaCm.toFixed(1)}cm
+          Component CG ({data.component_cg_x.toFixed(3)}m) differs from design CG ({data.design_cg_x.toFixed(3)}m) by {deltaCm.toFixed(1)}cm
         </span>
       </div>
       <button

--- a/frontend/components/workbench/CGComparisonBanner.tsx
+++ b/frontend/components/workbench/CGComparisonBanner.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { useCGComparison } from "@/hooks/useCGComparison";
+
+interface Props {
+  readonly aeroplaneId: string;
+  readonly onCGSynced: () => void;
+}
+
+export function CGComparisonBanner({ aeroplaneId, onCGSynced }: Props) {
+  const { data, isLoading, syncDesignCG } = useCGComparison(aeroplaneId);
+  const [syncing, setSyncing] = useState(false);
+
+  // Don't render if loading, no data, no component CG, or within tolerance
+  if (isLoading || !data || data.component_cg_x == null || data.within_tolerance !== false) {
+    return null;
+  }
+
+  const deltaM = data.delta_x!;
+  const deltaCm = Math.abs(deltaM * 100);
+  const isSevere = deltaCm > 5;
+
+  const borderColor = isSevere ? "border-red-500/30" : "border-orange-500/30";
+  const bgColor = isSevere ? "bg-red-500/10" : "bg-orange-500/10";
+  const textColor = isSevere ? "text-red-400" : "text-orange-400";
+
+  async function handleSync() {
+    setSyncing(true);
+    try {
+      await syncDesignCG(data!.component_cg_x!);
+      onCGSynced();
+    } finally {
+      setSyncing(false);
+    }
+  }
+
+  return (
+    <div
+      className={`mx-4 mb-2 flex items-center gap-3 rounded-lg border ${borderColor} ${bgColor} px-4 py-2`}
+      data-testid="cg-comparison-banner"
+    >
+      <AlertTriangle size={14} className={textColor} />
+      <div className="flex flex-1 flex-col gap-0.5">
+        <span className={`font-[family-name:var(--font-jetbrains-mono)] text-[12px] ${textColor}`}>
+          Component CG ({data.component_cg_x!.toFixed(3)}m) differs from design CG ({data.design_cg_x.toFixed(3)}m) by {deltaCm.toFixed(1)}cm
+        </span>
+      </div>
+      <button
+        onClick={handleSync}
+        disabled={syncing}
+        className={`flex items-center gap-1.5 rounded-full border border-border px-3 py-1 text-[11px] ${textColor} hover:bg-sidebar-accent disabled:opacity-50`}
+        data-testid="sync-cg-button"
+      >
+        <RefreshCw size={10} className={syncing ? "animate-spin" : ""} />
+        {syncing ? "Syncing..." : "Update design CG"}
+      </button>
+    </div>
+  );
+}

--- a/frontend/hooks/useCGComparison.ts
+++ b/frontend/hooks/useCGComparison.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import useSWR from "swr";
+import { useCallback } from "react";
+import { API_BASE, fetcher } from "@/lib/fetcher";
+
+export interface CGComparison {
+  design_cg_x: number;
+  component_cg_x: number | null;
+  component_cg_y: number | null;
+  component_cg_z: number | null;
+  component_total_mass_kg: number | null;
+  delta_x: number | null;
+  within_tolerance: boolean | null;
+}
+
+export function useCGComparison(aeroplaneId: string | null) {
+  const path = aeroplaneId
+    ? `/aeroplanes/${aeroplaneId}/cg_comparison`
+    : null;
+  const { data, error, isLoading, mutate } = useSWR<CGComparison>(
+    path,
+    fetcher,
+  );
+
+  const syncDesignCG = useCallback(
+    async (componentCgX: number) => {
+      if (!aeroplaneId) return;
+      const res = await fetch(
+        `${API_BASE}/aeroplanes/${aeroplaneId}/assumptions/cg_x`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ estimate_value: componentCgX }),
+        },
+      );
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        throw new Error(`Failed to sync CG: ${res.status} ${body}`);
+      }
+      mutate();
+    },
+    [aeroplaneId, mutate],
+  );
+
+  return {
+    data: data ?? null,
+    isLoading,
+    error: error ?? null,
+    syncDesignCG,
+    mutate,
+  };
+}


### PR DESCRIPTION
## Summary
- Add warning banner to AssumptionsPanel that alerts when component-tree CG diverges from design assumption CG
- New `useCGComparison` SWR hook for `GET /cg_comparison` endpoint
- `CGComparisonBanner` component with orange/red severity levels (>1cm orange, >5cm red)
- One-click "Update design CG" button to sync design CG to component CG
- 14 new vitest unit tests across hook, banner, and integration

## Test plan
- [x] `useCGComparison` hook: data return, PUT body/mutate, null guard, error handling
- [x] `CGComparisonBanner`: 4 null-render conditions, 2 severity checks, delta display, CG values, sync button
- [x] `AssumptionsPanel` integration: banner renders with correct props
- [x] All 491 frontend tests pass

Closes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)