### PR TITLE
feat(gh-449): remove substring matching from control surface detection

### DIFF
--- a/app/services/operating_point_generator_service.py
+++ b/app/services/operating_point_generator_service.py
@@ -38,11 +38,6 @@ ROLL_ROLES = {"aileron", "elevon"}
 YAW_ROLES = {"rudder"}
 FLAP_ROLES = {"flap"}
 
-PITCH_TOKENS = {"elevator", "stabilator", "elevon"}
-ROLL_TOKENS = {"aileron", "elevon"}
-YAW_TOKENS = {"rudder"}
-FLAP_TOKENS = {"flap"}
-
 ANALYSIS_GOALS: dict[str, str] = {
     "stall_near_clean": "Can the aircraft trim near stall? How much elevator authority remains?",
     "takeoff_climb": "What flap + elevator setting gives safe climb at takeoff speed?",
@@ -404,24 +399,13 @@ def _fallback_speeds(name: str, base_velocity: float) -> list[float]:
 
 def _pick_control_name(
     available_controls: list[str],
-    tokens: Optional[set[str]] = None,
-    roles: Optional[set[str]] = None,
+    roles: set[str],
 ) -> Optional[str]:
-    """Find a control surface name matching the given roles or tokens.
-
-    Prefers an exact ``[role]`` tag match via *roles*, then falls back to
-    substring matching via *tokens*.
-    """
-    target_roles = roles or tokens or set()
+    """Find a control surface name whose ``[role]`` tag matches *roles*."""
     for control_name in available_controls:
-        role, display = _parse_role_tag(control_name)
-        if role and role in target_roles:
+        role, _display = _parse_role_tag(control_name)
+        if role and role in roles:
             return control_name
-    if tokens:
-        for control_name in available_controls:
-            normalized = control_name.strip().lower()
-            if any(token in normalized for token in tokens):
-                return control_name
     return None
 
 
@@ -436,14 +420,9 @@ def _detect_control_capabilities(asb_airplane: asb.Airplane) -> dict[str, Any]:
                 if not raw_name:
                     continue
                 control_names.append(raw_name)
-                role, display = _parse_role_tag(raw_name)
+                role, _display = _parse_role_tag(raw_name)
                 if role:
                     roles_found.add(role)
-                else:
-                    normalized = raw_name.lower()
-                    for token in PITCH_TOKENS | ROLL_TOKENS | YAW_TOKENS | FLAP_TOKENS:
-                        if token in normalized:
-                            roles_found.add(token)
 
     return {
         "has_pitch_control": bool(roles_found & PITCH_ROLES),
@@ -510,9 +489,9 @@ def _solve_trim_candidate_with_opti(
         control_values: dict[str, Any] = {}
         control_variables: dict[str, Any] = {}
 
-        pitch_name = _pick_control_name(available_controls, tokens=PITCH_TOKENS, roles=PITCH_ROLES)
-        yaw_name = _pick_control_name(available_controls, tokens=YAW_TOKENS, roles=YAW_ROLES)
-        roll_name = _pick_control_name(available_controls, tokens=ROLL_TOKENS, roles=ROLL_ROLES)
+        pitch_name = _pick_control_name(available_controls, roles=PITCH_ROLES)
+        yaw_name = _pick_control_name(available_controls, roles=YAW_ROLES)
+        roll_name = _pick_control_name(available_controls, roles=ROLL_ROLES)
 
         if pitch_name:
             control_variables[pitch_name] = opti.variable(
@@ -532,7 +511,7 @@ def _solve_trim_candidate_with_opti(
             # Add fixed flap deflection (not an optimizer variable)
             flap_deflection = target.get("flap_deflection_deg")
             if flap_deflection is not None:
-                flap_name = _pick_control_name(available_controls, tokens=FLAP_TOKENS, roles=FLAP_ROLES)
+                flap_name = _pick_control_name(available_controls, roles=FLAP_ROLES)
                 if flap_name:
                     control_values[flap_name] = float(flap_deflection)
             airplane_for_eval = asb_airplane.with_control_deflections(control_values)
@@ -540,7 +519,7 @@ def _solve_trim_candidate_with_opti(
             # No control variables, but may still have fixed flap deflection
             flap_deflection = target.get("flap_deflection_deg")
             if flap_deflection is not None:
-                flap_name = _pick_control_name(available_controls, tokens=FLAP_TOKENS, roles=FLAP_ROLES)
+                flap_name = _pick_control_name(available_controls, roles=FLAP_ROLES)
                 if flap_name:
                     control_values[flap_name] = float(flap_deflection)
             if control_values:

--- a/app/services/retrim_service.py
+++ b/app/services/retrim_service.py
@@ -27,12 +27,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_PITCH_TOKENS = {"elevator", "stabilator", "elevon"}
+_PITCH_ROLES = {"elevator", "stabilator", "elevon"}
 
 
 def _find_pitch_control_name(db: Session, aeroplane_id: int) -> str | None:
     """Find the name of the first pitch control surface on the aeroplane."""
-    rows = (
+    row = (
         db.query(WingXSecTrailingEdgeDeviceModel.name)
         .join(
             WingXSecDetailModel,
@@ -40,13 +40,13 @@ def _find_pitch_control_name(db: Session, aeroplane_id: int) -> str | None:
         )
         .join(WingXSecModel, WingXSecDetailModel.wing_xsec_id == WingXSecModel.id)
         .join(WingModel, WingXSecModel.wing_id == WingModel.id)
-        .filter(WingModel.aeroplane_id == aeroplane_id)
-        .all()
+        .filter(
+            WingModel.aeroplane_id == aeroplane_id,
+            WingXSecTrailingEdgeDeviceModel.role.in_(_PITCH_ROLES),
+        )
+        .first()
     )
-    for (name,) in rows:
-        if name and any(token in name.lower() for token in _PITCH_TOKENS):
-            return name
-    return None
+    return row[0] if row else None
 
 
 def _op_model_to_schema(op: OperatingPointModel) -> OperatingPointSchema:

--- a/app/tests/test_control_surface_role.py
+++ b/app/tests/test_control_surface_role.py
@@ -145,10 +145,15 @@ class TestRoleBasedDetection:
         assert caps["has_yaw_control"] is False
         assert caps["has_flap"] is False
 
-    def test_fallback_to_substring_for_untagged_names(self):
+    def test_untagged_names_not_detected(self):
         airplane = _mock_airplane_with_controls(["elevator"])
         caps = _detect_control_capabilities(airplane)
-        assert caps["has_pitch_control"] is True
+        assert caps["has_pitch_control"] is False
+
+    def test_untagged_flap_not_detected(self):
+        airplane = _mock_airplane_with_controls(["flap_left"])
+        caps = _detect_control_capabilities(airplane)
+        assert caps["has_flap"] is False
 
 
 class TestRoleBasedPickControl:

--- a/app/tests/test_operating_point_generator_service.py
+++ b/app/tests/test_operating_point_generator_service.py
@@ -91,7 +91,7 @@ def test_generate_default_set_with_profile_assignment(db_session):
 
     with (
         patch("app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async", return_value=SimpleNamespace()),
-        patch("app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async", return_value=_mock_airplane_with_controls("rudder")),
+        patch("app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async", return_value=_mock_airplane_with_controls("[rudder]Rudder")),
         patch("app.services.operating_point_generator_service._trim_or_estimate_point", side_effect=_fake_trim),
     ):
         result = generate_default_set_for_aircraft(db_session, aircraft_uuid)
@@ -112,7 +112,7 @@ def test_generate_default_set_without_profile_uses_defaults(db_session):
 
     with (
         patch("app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async", return_value=SimpleNamespace()),
-        patch("app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async", return_value=_mock_airplane_with_controls("rudder")),
+        patch("app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async", return_value=_mock_airplane_with_controls("[rudder]Rudder")),
         patch("app.services.operating_point_generator_service._trim_or_estimate_point", side_effect=_fake_trim),
     ):
         result = generate_default_set_for_aircraft(db_session, aircraft_uuid)
@@ -129,7 +129,7 @@ def test_generate_replace_existing_replaces_old_rows(db_session):
 
     with (
         patch("app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async", return_value=SimpleNamespace()),
-        patch("app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async", return_value=_mock_airplane_with_controls("rudder")),
+        patch("app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async", return_value=_mock_airplane_with_controls("[rudder]Rudder")),
         patch("app.services.operating_point_generator_service._trim_or_estimate_point", side_effect=_fake_trim),
     ):
         generate_default_set_for_aircraft(db_session, aircraft_uuid)
@@ -170,7 +170,7 @@ def test_generate_with_rudder_keeps_dutch_role_point(db_session):
 
     with (
         patch("app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async", return_value=SimpleNamespace()),
-        patch("app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async", return_value=_mock_airplane_with_controls("rudder")),
+        patch("app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async", return_value=_mock_airplane_with_controls("[rudder]Rudder")),
         patch("app.services.operating_point_generator_service._trim_or_estimate_point", side_effect=_fake_trim),
     ):
         result = generate_default_set_for_aircraft(db_session, aircraft_uuid)
@@ -241,7 +241,7 @@ def test_trim_single_operating_point_for_aircraft(db_session):
         patch("app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async", return_value=SimpleNamespace()),
         patch(
             "app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async",
-            return_value=_mock_airplane_with_controls("elevator"),
+            return_value=_mock_airplane_with_controls("[elevator]Elevator"),
         ),
         patch("app.services.operating_point_generator_service._trim_or_estimate_point", side_effect=_fake_trim),
     ):

--- a/app/tests/test_operating_point_generator_service_extended.py
+++ b/app/tests/test_operating_point_generator_service_extended.py
@@ -283,21 +283,27 @@ class TestFallbackSpeeds:
 
 
 class TestPickControlName:
-    def test_finds_matching_control(self):
-        assert _pick_control_name(["Elevator_Main"], {"elevator"}) == "Elevator_Main"
+    def test_finds_matching_control_by_role_tag(self):
+        assert _pick_control_name(["[elevator]Main"], roles={"elevator"}) == "[elevator]Main"
 
-    def test_returns_none_when_no_match(self):
-        assert _pick_control_name(["Flap_Left"], {"elevator"}) is None
+    def test_returns_none_when_no_role_match(self):
+        assert _pick_control_name(["[flap]Left"], roles={"elevator"}) is None
 
-    def test_case_insensitive(self):
-        assert _pick_control_name(["RUDDER_1"], {"rudder"}) == "RUDDER_1"
+    def test_returns_none_for_untagged_names(self):
+        assert _pick_control_name(["RUDDER_1"], roles={"rudder"}) is None
 
     def test_empty_list(self):
-        assert _pick_control_name([], {"elevator"}) is None
+        assert _pick_control_name([], roles={"elevator"}) is None
 
     def test_first_match_wins(self):
-        result = _pick_control_name(["elevon_left", "elevator_right"], {"elevon", "elevator"})
-        assert result == "elevon_left"
+        result = _pick_control_name(
+            ["[elevon]Left", "[elevator]Right"], roles={"elevon", "elevator"}
+        )
+        assert result == "[elevon]Left"
+
+    def test_untagged_names_ignored_even_with_matching_substring(self):
+        result = _pick_control_name(["elevator_main", "[aileron]Left"], roles={"elevator"})
+        assert result is None
 
 
 # ================================================================== #
@@ -306,26 +312,33 @@ class TestPickControlName:
 
 
 class TestDetectControlCapabilities:
-    def test_with_elevator(self):
-        airplane = _mock_airplane_with_controls("elevator")
+    def test_with_tagged_elevator(self):
+        airplane = _mock_airplane_with_controls("[elevator]Main")
         caps = _detect_control_capabilities(airplane)
         assert caps["has_pitch_control"] is True
         assert caps["has_roll_control"] is False
         assert caps["has_yaw_control"] is False
-        assert "elevator" in caps["available_controls"]
+        assert "[elevator]Main" in caps["available_controls"]
 
-    def test_with_aileron_and_rudder(self):
-        airplane = _mock_airplane_with_controls("aileron", "rudder")
+    def test_with_tagged_aileron_and_rudder(self):
+        airplane = _mock_airplane_with_controls("[aileron]Left", "[rudder]Tail")
         caps = _detect_control_capabilities(airplane)
         assert caps["has_pitch_control"] is False
         assert caps["has_roll_control"] is True
         assert caps["has_yaw_control"] is True
 
-    def test_with_elevon(self):
-        airplane = _mock_airplane_with_controls("elevon_left")
+    def test_with_tagged_elevon(self):
+        airplane = _mock_airplane_with_controls("[elevon]Left")
         caps = _detect_control_capabilities(airplane)
         assert caps["has_pitch_control"] is True
         assert caps["has_roll_control"] is True
+
+    def test_untagged_names_not_detected(self):
+        airplane = _mock_airplane_with_controls("elevator", "aileron")
+        caps = _detect_control_capabilities(airplane)
+        assert caps["has_pitch_control"] is False
+        assert caps["has_roll_control"] is False
+        assert caps["available_controls"] == ["aileron", "elevator"]
 
     def test_no_controls(self):
         airplane = _mock_airplane_with_controls()

--- a/app/tests/test_retrim_service.py
+++ b/app/tests/test_retrim_service.py
@@ -44,7 +44,7 @@ class TestFindPitchControlName:
         db.add(detail)
         db.flush()
         ted = WingXSecTrailingEdgeDeviceModel(
-            wing_xsec_detail_id=detail.id, name="elevator",
+            wing_xsec_detail_id=detail.id, name="elevator", role="elevator",
         )
         db.add(ted)
         db.commit()
@@ -77,7 +77,7 @@ class TestFindPitchControlName:
         db.add(detail)
         db.flush()
         ted = WingXSecTrailingEdgeDeviceModel(
-            wing_xsec_detail_id=detail.id, name="elevon",
+            wing_xsec_detail_id=detail.id, name="elevon", role="elevon",
         )
         db.add(ted)
         db.commit()
@@ -119,7 +119,7 @@ class TestFindPitchControlName:
         db.add(detail)
         db.flush()
         ted = WingXSecTrailingEdgeDeviceModel(
-            wing_xsec_detail_id=detail.id, name="aileron",
+            wing_xsec_detail_id=detail.id, name="aileron", role="aileron",
         )
         db.add(ted)
         db.commit()
@@ -173,7 +173,7 @@ class TestRetrimDirtyOps:
         db.add(detail)
         db.flush()
         ted = WingXSecTrailingEdgeDeviceModel(
-            wing_xsec_detail_id=detail.id, name="elevator",
+            wing_xsec_detail_id=detail.id, name="elevator", role="elevator",
         )
         db.add(ted)
         db.commit()
@@ -234,7 +234,7 @@ class TestRetrimDirtyOps:
         db.add(detail)
         db.flush()
         ted = WingXSecTrailingEdgeDeviceModel(
-            wing_xsec_detail_id=detail.id, name="elevator",
+            wing_xsec_detail_id=detail.id, name="elevator", role="elevator",
         )
         db.add(ted)
         db.commit()
@@ -306,7 +306,7 @@ class TestRetrimDirtyOps:
         db.add(detail)
         db.flush()
         ted = WingXSecTrailingEdgeDeviceModel(
-            wing_xsec_detail_id=detail.id, name="elevator",
+            wing_xsec_detail_id=detail.id, name="elevator", role="elevator",
         )
         db.add(ted)
         db.commit()
@@ -379,7 +379,7 @@ class TestRetrimDirtyOps:
         db.add(detail)
         db.flush()
         ted = WingXSecTrailingEdgeDeviceModel(
-            wing_xsec_detail_id=detail.id, name="elevator",
+            wing_xsec_detail_id=detail.id, name="elevator", role="elevator",
         )
         db.add(ted)
         db.commit()
@@ -453,7 +453,7 @@ class TestRetrimDirtyOps:
         db.add(detail)
         db.flush()
         ted = WingXSecTrailingEdgeDeviceModel(
-            wing_xsec_detail_id=detail.id, name="elevator",
+            wing_xsec_detail_id=detail.id, name="elevator", role="elevator",
         )
         db.add(ted)
         db.commit()
@@ -516,7 +516,7 @@ class TestRetrimDirtyOps:
         db.add(detail)
         db.flush()
         ted = WingXSecTrailingEdgeDeviceModel(
-            wing_xsec_detail_id=detail.id, name="elevator",
+            wing_xsec_detail_id=detail.id, name="elevator", role="elevator",
         )
         db.add(ted)
         db.commit()
@@ -588,7 +588,7 @@ class TestRetrimIntegration:
         db.add(detail)
         db.flush()
         ted = WingXSecTrailingEdgeDeviceModel(
-            wing_xsec_detail_id=detail.id, name="elevator",
+            wing_xsec_detail_id=detail.id, name="elevator", role="elevator",
         )
         db.add(ted)
         db.commit()


### PR DESCRIPTION
## Summary

- Removes the substring matching fallback from `_detect_control_capabilities()` and `_pick_control_name()` — control surface detection now relies exclusively on the `[role]` tag encoded in ASB control surface names
- Eliminates `PITCH_TOKENS`, `ROLL_TOKENS`, `YAW_TOKENS`, `FLAP_TOKENS` constants that powered the old fallback
- Updates `retrim_service._find_pitch_control_name()` to query by the `role` DB column instead of substring-matching on `name`
- Updates all tests to use `[role]`-tagged control surface names, verifying that untagged names are no longer detected

## Context

The `ControlSurfaceRole` enum, `role` column, migration (6aa821735324), flap deployment in OPs, and `stall_with_flaps` were already implemented. This PR completes the final acceptance criterion of #449: "uses role field exclusively — no substring matching."

## Test plan

- [x] 2705 tests pass (0 failures, 120 deselected slow)
- [x] New tests verify untagged names are NOT detected as controls
- [x] Existing tests updated to use `[role]` tag format
- [x] Lint passes (ruff)

Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)