### PR TITLE
feat(gh-450): TED role icons, pitch warning, and test coverage

### DIFF
--- a/frontend/__tests__/AeroplaneTreeRoleIcons.test.tsx
+++ b/frontend/__tests__/AeroplaneTreeRoleIcons.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * Tests for AeroplaneTree role icons and pitch control surface warning (gh-450).
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import type { XSec } from "@/hooks/useWings";
+
+// ── Mocks ─────────────────────────────────────────────────────────
+
+vi.mock("lucide-react", async (importOriginal) => {
+  const icon = (props: Record<string, unknown>) =>
+    React.createElement("span", props);
+  return {
+    ...(await importOriginal<Record<string, unknown>>()),
+    ChevronDown: icon,
+    ChevronRight: icon,
+    Plus: icon,
+    Trash2: icon,
+    Eye: icon,
+    EyeOff: icon,
+    Loader: icon,
+    PanelLeftClose: icon,
+    Pencil: icon,
+    X: icon,
+    Check: icon,
+    ChevronUp: icon,
+    Search: icon,
+    AlertTriangle: icon,
+    Scale: icon,
+    GripVertical: icon,
+  };
+});
+
+vi.mock("@/lib/fetcher", () => ({
+  API_BASE: "http://localhost:8001/v2",
+}));
+
+const mockSelectWing = vi.fn();
+const mockSelectXsec = vi.fn();
+const mockSelectFuselage = vi.fn();
+const mockSelectFuselageXsec = vi.fn();
+const mockSetTreeMode = vi.fn();
+
+vi.mock("@/components/workbench/AeroplaneContext", () => ({
+  useAeroplaneContext: () => ({
+    selectedWing: "Main Wing",
+    selectedXsecIndex: 0,
+    selectWing: mockSelectWing,
+    selectXsec: mockSelectXsec,
+    selectedFuselage: null,
+    selectedFuselageXsecIndex: null,
+    selectFuselage: mockSelectFuselage,
+    selectFuselageXsec: mockSelectFuselageXsec,
+    treeMode: "wingconfig",
+    setTreeMode: mockSetTreeMode,
+  }),
+}));
+
+let mockWingData: { name: string; symmetric: boolean; x_secs: XSec[]; design_model?: string } | null = null;
+
+vi.mock("@/hooks/useWings", () => ({
+  useWing: () => ({
+    wing: mockWingData,
+    isLoading: false,
+    mutate: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useWingConfig", () => ({
+  useWingConfig: () => ({ wingConfig: { nose_pnt: [0, 0, 0] } }),
+}));
+
+vi.mock("@/hooks/useFuselage", () => ({
+  useFuselage: () => ({ fuselage: null, mutate: vi.fn() }),
+}));
+
+vi.mock("@/hooks/useFuselages", () => ({
+  useFuselages: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("@/components/workbench/ImportFuselageDialog", () => ({
+  ImportFuselageDialog: () => null,
+}));
+
+vi.mock("@/components/workbench/CreateWingDialog", () => ({
+  CreateWingDialog: () => null,
+}));
+
+import { AeroplaneTree } from "@/components/workbench/AeroplaneTree";
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+function makeXsec(overrides: Partial<XSec> = {}): XSec {
+  return {
+    xyz_le: [0, 0, 0],
+    chord: 0.2,
+    twist: 0,
+    airfoil: "naca0012",
+    ...overrides,
+  };
+}
+
+function makeWing(xsecs: XSec[]) {
+  return {
+    name: "Main Wing",
+    symmetric: true,
+    x_secs: xsecs,
+    design_model: "wc",
+  };
+}
+
+const baseProps = {
+  aeroplaneId: "1",
+  wingNames: ["Main Wing"],
+  aeroplaneName: "Test Plane",
+};
+
+// ── Tests ─────────────────────────────────────────────────────────
+
+describe("AeroplaneTree role icons (gh-450)", () => {
+  it("shows role icon in segment chip for elevator TED", () => {
+    mockWingData = makeWing([
+      makeXsec({ trailing_edge_device: { role: "elevator", label: "" } }),
+      makeXsec(),
+    ]);
+    render(<AeroplaneTree {...baseProps} />);
+    expect(screen.getByText("↕ ELEVATOR")).toBeTruthy();
+  });
+
+  it("shows role icon in segment chip for aileron TED with custom label", () => {
+    mockWingData = makeWing([
+      makeXsec({ trailing_edge_device: { role: "aileron", label: "Left Aileron" } }),
+      makeXsec(),
+    ]);
+    render(<AeroplaneTree {...baseProps} />);
+    expect(screen.getByText("↔ AILERON")).toBeTruthy();
+  });
+
+  it("shows correct role icon for each role type in segment chip", () => {
+    const roles = [
+      { role: "elevator", icon: "↕" },
+      { role: "rudder", icon: "⟳" },
+      { role: "flap", icon: "▽" },
+      { role: "spoiler", icon: "▢" },
+      { role: "other", icon: "○" },
+    ];
+    for (const { role, icon } of roles) {
+      mockWingData = makeWing([
+        makeXsec({ trailing_edge_device: { role, label: "" } }),
+        makeXsec(),
+      ]);
+      const { unmount } = render(<AeroplaneTree {...baseProps} />);
+      expect(screen.getByText(`${icon} ${role.toUpperCase()}`)).toBeTruthy();
+      unmount();
+    }
+  });
+});
+
+describe("AeroplaneTree pitch warning (gh-450)", () => {
+  it("shows warning when wing has no pitch control surface", () => {
+    mockWingData = makeWing([
+      makeXsec({ trailing_edge_device: { role: "aileron", label: "" } }),
+      makeXsec(),
+    ]);
+    render(<AeroplaneTree {...baseProps} />);
+    expect(
+      screen.getByText(/No pitch control surface assigned/),
+    ).toBeTruthy();
+  });
+
+  it("shows warning when wing has no TEDs at all", () => {
+    mockWingData = makeWing([makeXsec(), makeXsec()]);
+    render(<AeroplaneTree {...baseProps} />);
+    expect(
+      screen.getByText(/No pitch control surface assigned/),
+    ).toBeTruthy();
+  });
+
+  it("does not show warning when wing has elevator", () => {
+    mockWingData = makeWing([
+      makeXsec({ trailing_edge_device: { role: "elevator", label: "" } }),
+      makeXsec(),
+    ]);
+    render(<AeroplaneTree {...baseProps} />);
+    expect(
+      screen.queryByText(/No pitch control surface assigned/),
+    ).toBeNull();
+  });
+
+  it("does not show warning when wing has elevon", () => {
+    mockWingData = makeWing([
+      makeXsec({ trailing_edge_device: { role: "elevon", label: "" } }),
+      makeXsec(),
+    ]);
+    render(<AeroplaneTree {...baseProps} />);
+    expect(
+      screen.queryByText(/No pitch control surface assigned/),
+    ).toBeNull();
+  });
+
+  it("does not show warning when wing has stabilator", () => {
+    mockWingData = makeWing([
+      makeXsec({ trailing_edge_device: { role: "stabilator", label: "" } }),
+      makeXsec(),
+    ]);
+    render(<AeroplaneTree {...baseProps} />);
+    expect(
+      screen.queryByText(/No pitch control surface assigned/),
+    ).toBeNull();
+  });
+
+  it("does not show warning when no wing is loaded", () => {
+    mockWingData = null;
+    render(<AeroplaneTree {...baseProps} />);
+    expect(
+      screen.queryByText(/No pitch control surface assigned/),
+    ).toBeNull();
+  });
+});

--- a/frontend/__tests__/AeroplaneTreeRoleIcons.test.tsx
+++ b/frontend/__tests__/AeroplaneTreeRoleIcons.test.tsx
@@ -140,7 +140,10 @@ describe("AeroplaneTree role icons (gh-450)", () => {
   it("shows correct role icon for each role type in segment chip", () => {
     const roles = [
       { role: "elevator", icon: "↕" },
+      { role: "aileron", icon: "↔" },
       { role: "rudder", icon: "⟳" },
+      { role: "elevon", icon: "⤡" },
+      { role: "stabilator", icon: "↕" },
       { role: "flap", icon: "▽" },
       { role: "spoiler", icon: "▢" },
       { role: "other", icon: "○" },

--- a/frontend/__tests__/TedEditDialog.test.tsx
+++ b/frontend/__tests__/TedEditDialog.test.tsx
@@ -1,7 +1,7 @@
 /**
- * Unit tests for the TedEditDialog role dropdown (gh-439).
+ * Unit tests for the TedEditDialog (gh-439, gh-450).
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
@@ -114,5 +114,85 @@ describe("TedEditDialog role dropdown", () => {
     expect(values).toContain("flap");
     expect(values).toContain("spoiler");
     expect(values).toContain("other");
+  });
+});
+
+describe("TedEditDialog save payload (gh-450)", () => {
+  const onSaved = vi.fn();
+  const onClose = vi.fn();
+  const defaultProps = {
+    open: true,
+    onClose,
+    aeroplaneId: "1",
+    wingName: "Main Wing",
+    xsecIndex: 0,
+    isNew: false,
+    initialData: { role: "elevator", label: "Main Elevator", rel_chord_root: 0.8 },
+    onSaved,
+  };
+
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({}), { status: 200 }),
+    );
+    onSaved.mockClear();
+    onClose.mockClear();
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("sends role and label in TED PATCH payload", async () => {
+    const user = userEvent.setup();
+    render(<TedEditDialog {...defaultProps} />);
+
+    const saveBtn = screen.getByText("Save");
+    await user.click(saveBtn);
+
+    expect(fetchSpy).toHaveBeenCalled();
+    const tedCall = fetchSpy.mock.calls.find(
+      (c) => typeof c[0] === "string" && c[0].includes("/trailing_edge_device"),
+    );
+    expect(tedCall).toBeTruthy();
+    const body = JSON.parse((tedCall![1] as RequestInit).body as string);
+    expect(body.role).toBe("elevator");
+    expect(body.label).toBe("Main Elevator");
+  });
+
+  it("sends null label when label is cleared", async () => {
+    const user = userEvent.setup();
+    render(<TedEditDialog {...defaultProps} />);
+
+    const labelInput = screen.getByPlaceholderText("e.g. Left Aileron") as HTMLInputElement;
+    await user.clear(labelInput);
+
+    const saveBtn = screen.getByText("Save");
+    await user.click(saveBtn);
+
+    const tedCall = fetchSpy.mock.calls.find(
+      (c) => typeof c[0] === "string" && c[0].includes("/trailing_edge_device"),
+    );
+    const body = JSON.parse((tedCall![1] as RequestInit).body as string);
+    expect(body.label).toBeNull();
+  });
+
+  it("sends changed role after dropdown selection", async () => {
+    const user = userEvent.setup();
+    render(<TedEditDialog {...defaultProps} />);
+
+    const select = screen.getByLabelText("Role") as HTMLSelectElement;
+    await user.selectOptions(select, "aileron");
+
+    const saveBtn = screen.getByText("Save");
+    await user.click(saveBtn);
+
+    const tedCall = fetchSpy.mock.calls.find(
+      (c) => typeof c[0] === "string" && c[0].includes("/trailing_edge_device"),
+    );
+    const body = JSON.parse((tedCall![1] as RequestInit).body as string);
+    expect(body.role).toBe("aileron");
   });
 });

--- a/frontend/components/workbench/AeroplaneTree.tsx
+++ b/frontend/components/workbench/AeroplaneTree.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { ChevronDown, ChevronRight, Plus, Trash2, Eye, EyeOff, Loader, PanelLeftClose, Pencil } from "lucide-react";
 import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
 import { useWing } from "@/hooks/useWings";
@@ -63,6 +63,25 @@ interface BuildNodeContext {
   callbacks: BuildNodeCallbacks;
 }
 
+// ── Role icon mapping ─────────────────────────────────────────
+
+const ROLE_ICONS: Record<string, string> = {
+  elevator: "↕",
+  aileron: "↔",
+  rudder: "⟳",
+  elevon: "⤡",
+  stabilator: "↕",
+  flap: "▽",
+  spoiler: "▢",
+  other: "○",
+};
+
+const PITCH_ROLES = new Set(["elevator", "elevon", "stabilator"]);
+
+function getRoleIcon(role: string): string {
+  return ROLE_ICONS[role] ?? "○";
+}
+
 // ── Shared helpers ─────────────────────────────────────────────
 
 function getTedData(xsec: XSec): Record<string, unknown> | null {
@@ -88,12 +107,13 @@ function buildTedNode(
   const tedRole = (tedObj.role as string) ?? "";
   const tedLabel = (tedObj.label as string) ?? "";
   const tedDisplay = tedLabel || tedRole || "TED";
+  const icon = getRoleIcon(tedRole);
   return {
     id: `${id}-ted`,
-    label: `TED: ${tedDisplay}`,
+    label: `${icon} ${tedDisplay}`,
     level: 3,
     leaf: true,
-    chip: "TED",
+    chip: tedRole ? tedRole.toUpperCase() : "TED",
     onEdit: callbacks.onEditTed ? () => callbacks.onEditTed!(wingName, xsecIndex, tedObj) : undefined,
     onDelete: callbacks.onDeleteTed ? () => {
       if (confirm(`Delete control surface "${tedDisplay}"?`)) callbacks.onDeleteTed!(wingName, xsecIndex);
@@ -402,10 +422,13 @@ function airfoilShort(raw: string): string {
 }
 
 function getChipLabel(xsec: XSec): string | undefined {
-  const ted = xsec.trailing_edge_device;
-  if (ted && typeof ted === "object" && "name" in ted) return String(ted.name).toUpperCase();
-  const cs = xsec.control_surface;
-  if (cs && typeof cs === "object" && "name" in cs) return String(cs.name).toUpperCase();
+  const ted = xsec.trailing_edge_device ?? xsec.control_surface;
+  if (ted && typeof ted === "object") {
+    const t = ted as Record<string, unknown>;
+    const role = t.role as string | undefined;
+    if (role) return `${getRoleIcon(role)} ${role.toUpperCase()}`;
+    if ("name" in t) return String(t.name).toUpperCase();
+  }
   return undefined;
 }
 
@@ -776,6 +799,16 @@ export function AeroplaneTree(props: Readonly<AeroplaneTreeProps>) {
     onNodeEdit, onEditSpar, onDeleteSpar, onEditTed, onDeleteTed, onAddSpar, onAddTed,
   });
 
+  const hasPitchSurface = useMemo(() => {
+    if (!wing) return true;
+    return wing.x_secs.some((xsec) => {
+      const ted = getTedData(xsec);
+      if (!ted) return false;
+      const role = (ted.role as string) ?? "";
+      return PITCH_ROLES.has(role);
+    });
+  }, [wing]);
+
   // Build tree data
   const treeData = buildTreeData({
     wingNames,
@@ -854,6 +887,16 @@ export function AeroplaneTree(props: Readonly<AeroplaneTreeProps>) {
           </>
         )}
       </div>
+
+      {/* Pitch control surface warning */}
+      {!hasPitchSurface && wing && (
+        <div
+          role="alert"
+          className="mt-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-[11px] text-amber-400"
+        >
+          No pitch control surface assigned. Auto-trim and stability analysis require an elevator, elevon, or stabilator.
+        </div>
+      )}
 
       {/* Segment add menu (Spar / Control Surface) — positioned at click location */}
       {segAddMenu && (

--- a/frontend/e2e/features/ted-role-ui.feature
+++ b/frontend/e2e/features/ted-role-ui.feature
@@ -1,0 +1,28 @@
+Feature: TED Role Dropdown and Pitch Warning (gh-450)
+  As an aircraft designer using the da3Dalus workbench
+  I want to assign roles to control surfaces via a dropdown
+  So that the system can identify elevator, aileron, and other surfaces
+
+  Background:
+    Given the backend is running
+    And the frontend is running
+
+  Scenario: Add TED with elevator role and verify chip in tree
+    Given the "eHawk E2E Test" has wing "main_wing" in the tree
+    When I click on "segment 0" in the tree
+    And I click the add button on the segment
+    And I select "Add Control Surface"
+    And I select role "elevator" in the TED dialog
+    And I fill label "Main Elevator" in the TED dialog
+    And I click "Add"
+    Then segment 0 shows an "↕ ELEVATOR" chip in the tree
+
+  Scenario: Pitch warning disappears when elevator is assigned
+    Given the "eHawk E2E Test" has wing "main_wing" in the tree
+    Then the pitch warning is not visible
+
+  Scenario: Pitch warning appears when no pitch surface exists
+    Given the "eHawk E2E Test" has wing "main_wing" in the tree
+    And no cross section has role "elevator" or "elevon" or "stabilator"
+    Then the pitch warning is visible
+    And the pitch warning text contains "No pitch control surface assigned"

--- a/frontend/e2e/features/ted-role-ui.feature
+++ b/frontend/e2e/features/ted-role-ui.feature
@@ -7,6 +7,12 @@ Feature: TED Role Dropdown and Pitch Warning (gh-450)
     Given the backend is running
     And the frontend is running
 
+  Scenario: Pitch warning appears when no pitch surface exists
+    Given the "eHawk E2E Test" has wing "main_wing" in the tree
+    And no cross section has role "elevator" or "elevon" or "stabilator"
+    Then the pitch warning is visible
+    And the pitch warning text contains "No pitch control surface assigned"
+
   Scenario: Add TED with elevator role and verify chip in tree
     Given the "eHawk E2E Test" has wing "main_wing" in the tree
     When I click on "segment 0" in the tree
@@ -17,12 +23,7 @@ Feature: TED Role Dropdown and Pitch Warning (gh-450)
     And I click "Add"
     Then segment 0 shows an "↕ ELEVATOR" chip in the tree
 
-  Scenario: Pitch warning disappears when elevator is assigned
+  Scenario: Pitch warning disappears after elevator is assigned
     Given the "eHawk E2E Test" has wing "main_wing" in the tree
+    And at least one cross section has a pitch role
     Then the pitch warning is not visible
-
-  Scenario: Pitch warning appears when no pitch surface exists
-    Given the "eHawk E2E Test" has wing "main_wing" in the tree
-    And no cross section has role "elevator" or "elevon" or "stabilator"
-    Then the pitch warning is visible
-    And the pitch warning text contains "No pitch control surface assigned"

--- a/frontend/e2e/steps/construction.steps.ts
+++ b/frontend/e2e/steps/construction.steps.ts
@@ -466,3 +466,80 @@ Then("the wing is symmetric", async ({}) => {
   const wing = loadWingData();
   expect(wing.symmetric).toBe(true);
 });
+
+// ── gh-450: TED role UI ────────────────────────────────────────
+
+When("I click the add button on the segment", async ({ page }) => {
+  const side = sidebar(page);
+  const segRow = side.getByRole("treeitem", { selected: true }).first();
+  const addBtn = segRow.getByTitle("Add");
+  await addBtn.click();
+});
+
+When("I select {string}", async ({ page }, optionText: string) => {
+  await page.getByText(optionText, { exact: true }).click();
+  await page.waitForTimeout(500);
+});
+
+When(
+  "I select role {string} in the TED dialog",
+  async ({ page }, role: string) => {
+    const dialog = page.locator("dialog").first();
+    const select = dialog.getByLabel("Role");
+    await select.selectOption(role);
+  },
+);
+
+When(
+  "I fill label {string} in the TED dialog",
+  async ({ page }, label: string) => {
+    const dialog = page.locator("dialog").first();
+    const input = dialog.getByPlaceholder("e.g. Left Aileron");
+    await input.fill(label);
+  },
+);
+
+Then("the pitch warning is visible", async ({ page }) => {
+  await expect(
+    page.getByRole("alert").getByText(/No pitch control surface/),
+  ).toBeVisible({ timeout: 5000 });
+});
+
+Then("the pitch warning is not visible", async ({ page }) => {
+  const warning = page.getByRole("alert").getByText(/No pitch control surface/);
+  await expect(warning).not.toBeVisible({ timeout: 3000 }).catch(() => {
+    // Element not found at all is fine
+  });
+});
+
+Then(
+  "the pitch warning text contains {string}",
+  async ({ page }, text: string) => {
+    await expect(
+      page.getByRole("alert").getByText(text),
+    ).toBeVisible({ timeout: 5000 });
+  },
+);
+
+Given(
+  "no cross section has role {string} or {string} or {string}",
+  async ({ request }, role1: string, role2: string, role3: string) => {
+    await ensureIdFromApi(request);
+    const res = await request.get(
+      `${API}/aeroplanes/${aeroplaneId}/wings/main_wing`,
+    );
+    const wing = await res.json();
+    const pitchRoles = [role1, role2, role3];
+    const hasPitch = wing.x_secs?.some(
+      (xs: Record<string, unknown>) => {
+        const ted = (xs.trailing_edge_device ?? xs.control_surface) as Record<string, unknown> | null;
+        return ted && pitchRoles.includes(ted.role as string);
+      },
+    );
+    if (hasPitch) {
+      throw new Error(
+        "Precondition failed: wing has a pitch control surface. Remove it first.",
+      );
+    }
+  },
+);

--- a/frontend/e2e/steps/construction.steps.ts
+++ b/frontend/e2e/steps/construction.steps.ts
@@ -507,9 +507,7 @@ Then("the pitch warning is visible", async ({ page }) => {
 
 Then("the pitch warning is not visible", async ({ page }) => {
   const warning = page.getByRole("alert").getByText(/No pitch control surface/);
-  await expect(warning).not.toBeVisible({ timeout: 3000 }).catch(() => {
-    // Element not found at all is fine
-  });
+  await expect(warning).not.toBeVisible({ timeout: 3000 });
 });
 
 Then(
@@ -518,6 +516,25 @@ Then(
     await expect(
       page.getByRole("alert").getByText(text),
     ).toBeVisible({ timeout: 5000 });
+  },
+);
+
+Given(
+  "at least one cross section has a pitch role",
+  async ({ request }) => {
+    await ensureIdFromApi(request);
+    const res = await request.get(
+      `${API}/aeroplanes/${aeroplaneId}/wings/main_wing`,
+    );
+    const wing = await res.json();
+    const pitchRoles = ["elevator", "elevon", "stabilator"];
+    const hasPitch = wing.x_secs?.some(
+      (xs: Record<string, unknown>) => {
+        const ted = (xs.trailing_edge_device ?? xs.control_surface) as Record<string, unknown> | null;
+        return ted && pitchRoles.includes(ted.role as string);
+      },
+    );
+    expect(hasPitch).toBeTruthy();
   },
 );
 


### PR DESCRIPTION
## Summary

- Add role-specific Unicode icons (↕ ↔ ⟳ ⤡ ▽ ▢ ○) to control surface tree node chips and segment chips via `ROLE_ICONS` mapping
- Show amber pitch control surface warning banner in AeroplaneTree when no elevator/elevon/stabilator role is assigned on the selected wing
- Extend TedEditDialog unit tests to verify save payload sends correct `role` and `label` fields
- Add AeroplaneTreeRoleIcons unit tests for chip rendering and pitch warning visibility
- Add Playwright-bdd E2E feature and step definitions for TED role dropdown workflow

## Test plan

- [x] All 542 Vitest unit tests pass (12 new: 3 dialog payload + 9 tree/warning)
- [x] ESLint passes with 0 new warnings
- [x] Pre-commit hooks pass
- [ ] Playwright E2E: `ted-role-ui.feature` (requires running backend)
- [ ] Manual: verify role icons display correctly in browser
- [ ] Manual: verify pitch warning appears/disappears when adding/removing pitch surfaces

Closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)