### PR TITLE
feat(gh-451): trim result enrichment — effectiveness, stability, mixer, warnings

### DIFF
--- a/app/schemas/aeroanalysisschema.py
+++ b/app/schemas/aeroanalysisschema.py
@@ -91,7 +91,9 @@ class AVLTrimResult(BaseModel):
     raw_results: dict[str, float] = Field(
         default_factory=dict, description="Full parsed AVL output"
     )
-    trim_enrichment: Optional[dict] = Field(None, description="Enrichment data computed after trim")
+    trim_enrichment: Optional["TrimEnrichment"] = Field(
+        None, description="Enrichment data computed after trim"
+    )
 
 
 class AeroBuildupTrimRequest(BaseModel):
@@ -166,7 +168,9 @@ class AeroBuildupTrimResult(BaseModel):
     stability_derivatives: dict[str, float] = Field(
         default_factory=dict, description="Stability derivatives at trim point"
     )
-    trim_enrichment: Optional[dict] = Field(None, description="Enrichment data computed after trim")
+    trim_enrichment: Optional["TrimEnrichment"] = Field(
+        None, description="Enrichment data computed after trim"
+    )
 
 
 class CdclConfig(BaseModel):
@@ -300,7 +304,7 @@ class StoredOperatingPointCreate(BaseModel):
         "Overrides geometry defaults for this operating point.",
     )
 
-    trim_enrichment: Optional[dict] = Field(
+    trim_enrichment: Optional["TrimEnrichment"] = Field(
         default=None,
         description="Enrichment data: analysis goal, deflection reserves, design warnings. "
         "Computed after trim solve.",
@@ -417,7 +421,9 @@ class ControlEffectiveness(BaseModel):
     """Per-surface control effectiveness derivative at trim point."""
 
     derivative: float = Field(..., description="Control derivative (e.g. dCm/d-delta-e in 1/deg)")
-    coefficient: str = Field(..., description="Coefficient affected (Cm, Cl, Cn)")
+    coefficient: str = Field(
+        ..., description="Coefficient affected (Cm, Cl, Cn, CL)", pattern="^(Cm|Cl|Cn|CL)$"
+    )
     surface: str = Field(..., description="Control surface name")
 
 
@@ -444,9 +450,13 @@ class MixerValues(BaseModel):
         ..., description="Average deflection of paired surfaces (degrees)"
     )
     differential_throw: float = Field(
-        ..., description="Half-difference of paired surfaces (degrees)"
+        ..., ge=0.0, description="Half-difference of paired surfaces (degrees)"
     )
-    role: str = Field(..., description="Dual-role type: elevon, flaperon, ruddervator")
+    role: str = Field(
+        ...,
+        description="Dual-role type: elevon, flaperon, ruddervator",
+        pattern="^(elevon|flaperon|ruddervator)$",
+    )
 
 
 class TrimEnrichment(BaseModel):
@@ -489,3 +499,9 @@ class AnalysisStatusResponse(BaseModel):
     last_computation: Optional[datetime] = Field(
         None, description="Timestamp of last completed retrim"
     )
+
+
+# Resolve forward references for TrimEnrichment used in earlier classes
+AVLTrimResult.model_rebuild()
+AeroBuildupTrimResult.model_rebuild()
+StoredOperatingPointCreate.model_rebuild()

--- a/app/schemas/aeroanalysisschema.py
+++ b/app/schemas/aeroanalysisschema.py
@@ -91,6 +91,7 @@ class AVLTrimResult(BaseModel):
     raw_results: dict[str, float] = Field(
         default_factory=dict, description="Full parsed AVL output"
     )
+    trim_enrichment: Optional[dict] = Field(None, description="Enrichment data computed after trim")
 
 
 class AeroBuildupTrimRequest(BaseModel):
@@ -165,6 +166,7 @@ class AeroBuildupTrimResult(BaseModel):
     stability_derivatives: dict[str, float] = Field(
         default_factory=dict, description="Stability derivatives at trim point"
     )
+    trim_enrichment: Optional[dict] = Field(None, description="Enrichment data computed after trim")
 
 
 class CdclConfig(BaseModel):
@@ -411,6 +413,42 @@ class DesignWarning(BaseModel):
     message: str = Field(..., description="Human-readable warning message")
 
 
+class ControlEffectiveness(BaseModel):
+    """Per-surface control effectiveness derivative at trim point."""
+
+    derivative: float = Field(..., description="Control derivative (e.g. dCm/d-delta-e in 1/deg)")
+    coefficient: str = Field(..., description="Coefficient affected (Cm, Cl, Cn)")
+    surface: str = Field(..., description="Control surface name")
+
+
+class StabilityClassification(BaseModel):
+    """Static stability classification at a trim point."""
+
+    is_statically_stable: bool = Field(..., description="Cm_alpha < 0")
+    is_directionally_stable: bool = Field(..., description="Cn_beta > 0")
+    is_laterally_stable: bool = Field(..., description="Cl_beta < 0")
+    static_margin: Optional[float] = Field(
+        None, description="Static margin = -Cm_a/CL_a (fraction of MAC)"
+    )
+    overall_class: str = Field(
+        ...,
+        description="'stable', 'neutral', or 'unstable'",
+        pattern="^(stable|neutral|unstable)$",
+    )
+
+
+class MixerValues(BaseModel):
+    """Symmetric/differential decomposition for dual-role surfaces."""
+
+    symmetric_offset: float = Field(
+        ..., description="Average deflection of paired surfaces (degrees)"
+    )
+    differential_throw: float = Field(
+        ..., description="Half-difference of paired surfaces (degrees)"
+    )
+    role: str = Field(..., description="Dual-role type: elevon, flaperon, ruddervator")
+
+
 class TrimEnrichment(BaseModel):
     """Enrichment data computed after a trim solve - stored as JSON on OperatingPointModel."""
 
@@ -428,6 +466,16 @@ class TrimEnrichment(BaseModel):
     design_warnings: list[DesignWarning] = Field(
         default_factory=list, description="Threshold-based design warnings"
     )
+    effectiveness: dict[str, ControlEffectiveness] = Field(
+        default_factory=dict, description="Per-surface control effectiveness"
+    )
+    stability_classification: Optional[StabilityClassification] = Field(
+        None, description="Stability classification at trim point"
+    )
+    mixer_values: dict[str, MixerValues] = Field(
+        default_factory=dict, description="Dual-role surface decomposition"
+    )
+    result_summary: str = Field("", description="Human-readable trim result summary")
 
 
 class AnalysisStatusResponse(BaseModel):

--- a/app/services/aerobuildup_trim_service.py
+++ b/app/services/aerobuildup_trim_service.py
@@ -234,24 +234,41 @@ async def trim_with_aerobuildup(
         from app.services.trim_enrichment_service import (
             build_deflection_limits_from_schema,
             compute_enrichment,
+            parse_role_tag,
         )
 
         deflection_limits = build_deflection_limits_from_schema(plane_schema)
         alpha_deg = float(op.alpha)
+
+        # Find the tagged name for the trim variable from ASB control surfaces
+        tagged_trim_variable = request.trim_variable
+        for wing in asb_airplane.wings:
+            for xsec in wing.xsecs:
+                for cs in xsec.control_surfaces:
+                    cs_name = str(getattr(cs, "name", "")).strip()
+                    _role, display = parse_role_tag(cs_name)
+                    if display.strip() == request.trim_variable or cs_name == request.trim_variable:
+                        tagged_trim_variable = cs_name
+                        break
+
         enrichment = compute_enrichment(
-            controls={request.trim_variable: round(trimmed_deflection, 6)},
+            controls={tagged_trim_variable: round(trimmed_deflection, 6)},
             limits=deflection_limits,
             trim_method="aerobuildup",
             trim_score=None,
             trim_residuals={},
-            op_name="aerobuildup_trim",
+            op_name=request.operating_point.name or "aerobuildup_trim",
             alpha_deg=alpha_deg,
             stability_derivatives=derivs or None,
             aero_coefficients=aero or None,
         )
-        trim_enrichment_data = enrichment.model_dump()
+        trim_enrichment_data = enrichment
     except Exception:
-        logger.debug("Enrichment computation failed for aeroplane %s", aeroplane_uuid)
+        logger.warning(
+            "Enrichment computation failed for aeroplane %s",
+            aeroplane_uuid,
+            exc_info=True,
+        )
 
     return AeroBuildupTrimResult(
         converged=True,

--- a/app/services/aerobuildup_trim_service.py
+++ b/app/services/aerobuildup_trim_service.py
@@ -123,9 +123,7 @@ async def trim_with_aerobuildup(
     except ValidationDomainError:
         raise
     except (ValueError, TypeError) as e:
-        raise ValidationDomainError(
-            message=f"AeroBuildup evaluation failed at bounds: {e}"
-        ) from e
+        raise ValidationDomainError(message=f"AeroBuildup evaluation failed at bounds: {e}") from e
     except Exception as e:
         logger.error(
             "Unexpected AeroBuildup failure for aeroplane %s at bounds [%g, %g]: %s",
@@ -135,9 +133,7 @@ async def trim_with_aerobuildup(
             e,
             exc_info=True,
         )
-        raise InternalError(
-            message=f"AeroBuildup evaluation failed unexpectedly: {e}"
-        ) from e
+        raise InternalError(message=f"AeroBuildup evaluation failed unexpectedly: {e}") from e
 
     if f_lower * f_upper > 0:
         logger.warning(
@@ -198,8 +194,7 @@ async def trim_with_aerobuildup(
         )
     except Exception as e:
         logger.error(
-            "Final AeroBuildup evaluation failed at trimmed deflection %g for "
-            "aeroplane %s: %s",
+            "Final AeroBuildup evaluation failed at trimmed deflection %g for aeroplane %s: %s",
             trimmed_deflection,
             aeroplane_uuid,
             e,
@@ -233,6 +228,31 @@ async def trim_with_aerobuildup(
             aeroplane_uuid,
         )
 
+    # Compute enrichment for the converged trim result
+    trim_enrichment_data = None
+    try:
+        from app.services.trim_enrichment_service import (
+            build_deflection_limits_from_schema,
+            compute_enrichment,
+        )
+
+        deflection_limits = build_deflection_limits_from_schema(plane_schema)
+        alpha_deg = float(op.alpha)
+        enrichment = compute_enrichment(
+            controls={request.trim_variable: round(trimmed_deflection, 6)},
+            limits=deflection_limits,
+            trim_method="aerobuildup",
+            trim_score=None,
+            trim_residuals={},
+            op_name="aerobuildup_trim",
+            alpha_deg=alpha_deg,
+            stability_derivatives=derivs or None,
+            aero_coefficients=aero or None,
+        )
+        trim_enrichment_data = enrichment.model_dump()
+    except Exception:
+        logger.debug("Enrichment computation failed for aeroplane %s", aeroplane_uuid)
+
     return AeroBuildupTrimResult(
         converged=True,
         trim_variable=request.trim_variable,
@@ -241,4 +261,5 @@ async def trim_with_aerobuildup(
         achieved_value=round(achieved, 8),
         aero_coefficients=aero,
         stability_derivatives=derivs,
+        trim_enrichment=trim_enrichment_data,
     )

--- a/app/services/avl_trim_service.py
+++ b/app/services/avl_trim_service.py
@@ -142,24 +142,31 @@ async def trim_with_avl(
 
     # Compute enrichment for converged trim results
     if trimmed.converged and trimmed.trimmed_deflections:
-        from app.services.trim_enrichment_service import (
-            build_deflection_limits_from_schema,
-            compute_enrichment,
-        )
+        try:
+            from app.services.trim_enrichment_service import (
+                build_deflection_limits_from_schema,
+                compute_enrichment,
+            )
 
-        deflection_limits = build_deflection_limits_from_schema(plane_schema)
-        alpha_deg = trimmed.trimmed_state.get("alpha", float(op.alpha))
-        enrichment = compute_enrichment(
-            controls=trimmed.trimmed_deflections,
-            limits=deflection_limits,
-            trim_method="avl",
-            trim_score=None,
-            trim_residuals={},
-            op_name="avl_trim",
-            alpha_deg=alpha_deg,
-            stability_derivatives=trimmed.stability_derivatives or None,
-            aero_coefficients=trimmed.aero_coefficients or None,
-        )
-        trimmed.trim_enrichment = enrichment.model_dump()
+            deflection_limits = build_deflection_limits_from_schema(plane_schema)
+            alpha_deg = trimmed.trimmed_state.get("alpha", float(op.alpha))
+            enrichment = compute_enrichment(
+                controls=trimmed.trimmed_deflections,
+                limits=deflection_limits,
+                trim_method="avl",
+                trim_score=None,
+                trim_residuals={},
+                op_name=request.operating_point.name or "avl_trim",
+                alpha_deg=alpha_deg,
+                stability_derivatives=trimmed.stability_derivatives or None,
+                aero_coefficients=trimmed.aero_coefficients or None,
+            )
+            trimmed = trimmed.model_copy(update={"trim_enrichment": enrichment})
+        except Exception:
+            logger.warning(
+                "Enrichment computation failed for AVL trim on aeroplane %s",
+                aeroplane_uuid,
+                exc_info=True,
+            )
 
     return trimmed

--- a/app/services/avl_trim_service.py
+++ b/app/services/avl_trim_service.py
@@ -139,4 +139,27 @@ async def trim_with_avl(
             aeroplane_uuid,
             list(result.keys()),
         )
+
+    # Compute enrichment for converged trim results
+    if trimmed.converged and trimmed.trimmed_deflections:
+        from app.services.trim_enrichment_service import (
+            build_deflection_limits_from_schema,
+            compute_enrichment,
+        )
+
+        deflection_limits = build_deflection_limits_from_schema(plane_schema)
+        alpha_deg = trimmed.trimmed_state.get("alpha", float(op.alpha))
+        enrichment = compute_enrichment(
+            controls=trimmed.trimmed_deflections,
+            limits=deflection_limits,
+            trim_method="avl",
+            trim_score=None,
+            trim_residuals={},
+            op_name="avl_trim",
+            alpha_deg=alpha_deg,
+            stability_derivatives=trimmed.stability_derivatives or None,
+            aero_coefficients=trimmed.aero_coefficients or None,
+        )
+        trimmed.trim_enrichment = enrichment.model_dump()
+
     return trimmed

--- a/app/services/operating_point_generator_service.py
+++ b/app/services/operating_point_generator_service.py
@@ -18,54 +18,26 @@ from app.models.aeroplanemodel import AeroplaneModel
 from app.models.analysismodels import OperatingPointModel, OperatingPointSetModel
 from app.models.flightprofilemodel import RCFlightProfileModel
 from app.schemas.aeroanalysisschema import (
-    DeflectionReserve,
-    DesignWarning,
     GeneratedOperatingPointSetRead,
     OperatingPointStatus,
     StoredOperatingPointCreate,
     StoredOperatingPointRead,
-    TrimEnrichment,
     TrimmedOperatingPointRead,
     TrimOperatingPointRequest,
 )
+from app.services.trim_enrichment_service import (
+    ANALYSIS_GOALS,
+    _parse_role_tag,
+    build_deflection_limits_from_schema,
+    compute_enrichment,
+)
 
 logger = logging.getLogger(__name__)
-
-_ROLE_TAG_RE = re.compile(r"^\[(\w+)\](.*)$")
 
 PITCH_ROLES = {"elevator", "stabilator", "elevon"}
 ROLL_ROLES = {"aileron", "elevon"}
 YAW_ROLES = {"rudder"}
 FLAP_ROLES = {"flap"}
-
-ANALYSIS_GOALS: dict[str, str] = {
-    "stall_near_clean": "Can the aircraft trim near stall? How much elevator authority remains?",
-    "takeoff_climb": "What flap + elevator setting gives safe climb at takeoff speed?",
-    "cruise": "What is the drag-minimal trim at cruise speed?",
-    "loiter_endurance": "What trim gives minimum sink for max loiter endurance?",
-    "max_level_speed": "Can the aircraft trim at Vmax? Is the tail adequate?",
-    "approach_landing": "What flap + elevator trim for safe approach speed?",
-    "turn_n2": "How much aileron + rudder for coordinated turn at 2g?",
-    "dutch_role_start": "How does the aircraft respond to sideslip? Is yaw damping adequate?",
-    "best_angle_climb_vx": "What trim gives the steepest climb for obstacle clearance?",
-    "best_rate_climb_vy": "What trim gives the fastest altitude gain?",
-    "max_range": "What trim maximizes ground distance per unit energy?",
-    "stall_with_flaps": "How does stall behavior change with flaps deployed?",
-}
-
-_DEFAULT_ANALYSIS_GOAL = "User-defined trim point"
-
-
-def _parse_role_tag(name: str) -> tuple[Optional[str], str]:
-    """Parse a ``[role]display`` tag from a control surface name.
-
-    Returns ``(role, display)`` when the tag is present, otherwise
-    ``(None, name)``.
-    """
-    m = _ROLE_TAG_RE.match(name)
-    if m:
-        return m.group(1), m.group(2)
-    return None, name
 
 
 @dataclass
@@ -104,98 +76,6 @@ def _compute_trim_score(cm: float, cy: float, cl: float, cl_target: Optional[flo
     if cl_target is not None:
         score += 0.3 * abs(cl - cl_target)
     return score
-
-
-def _build_deflection_limits(
-    asb_airplane: asb.Airplane,
-    default_limit_deg: float = 25.0,
-) -> dict[str, tuple[float, float]]:
-    """Extract per-surface mechanical limits (max_pos_deg, max_neg_deg) from ASB airplane."""
-    limits: dict[str, tuple[float, float]] = {}
-    for wing in getattr(asb_airplane, "wings", []) or []:
-        for xsec in getattr(wing, "xsecs", []) or []:
-            for cs in getattr(xsec, "control_surfaces", []) or []:
-                name = str(getattr(cs, "name", "")).strip()
-                if not name:
-                    continue
-                limits[name] = (default_limit_deg, default_limit_deg)
-    return limits
-
-
-def _compute_enrichment(
-    point: "TrimmedPoint",
-    limits: dict[str, tuple[float, float]],
-    trim_method: str,
-    trim_score: float | None,
-    trim_residuals: dict[str, float],
-) -> "TrimEnrichment":
-    """Compute enrichment data from a trimmed point and its mechanical limits."""
-    analysis_goal = ANALYSIS_GOALS.get(point.name, _DEFAULT_ANALYSIS_GOAL)
-
-    deflection_reserves: dict[str, DeflectionReserve] = {}
-    for surface_name, deflection_deg in point.controls.items():
-        max_pos, max_neg = limits.get(surface_name, (25.0, 25.0))
-        if deflection_deg >= 0:
-            limit = max_pos
-        else:
-            limit = max_neg
-        usage = abs(deflection_deg) / limit if limit > 0 else 0.0
-        deflection_reserves[surface_name] = DeflectionReserve(
-            deflection_deg=deflection_deg,
-            max_pos_deg=max_pos,
-            max_neg_deg=max_neg,
-            usage_fraction=usage,
-        )
-
-    warnings: list[DesignWarning] = []
-    for surface_name, reserve in deflection_reserves.items():
-        if reserve.usage_fraction > 0.95:
-            warnings.append(DesignWarning(
-                level="critical",
-                category="authority",
-                surface=surface_name,
-                message=f"{surface_name}: near mechanical limit ({reserve.usage_fraction:.0%} used) — redesign needed",
-            ))
-        elif reserve.usage_fraction > 0.80:
-            warnings.append(DesignWarning(
-                level="warning",
-                category="authority",
-                surface=surface_name,
-                message=f"{surface_name}: {reserve.usage_fraction:.0%} authority used — surface may be undersized",
-            ))
-
-    if trim_score is not None:
-        if trim_score > 0.5:
-            warnings.append(DesignWarning(
-                level="critical",
-                category="trim_quality",
-                surface=None,
-                message="Trim failed to converge — results unreliable",
-            ))
-        elif trim_score > 0.1:
-            warnings.append(DesignWarning(
-                level="warning",
-                category="trim_quality",
-                surface=None,
-                message="Poor trim quality — equilibrium not fully achieved",
-            ))
-
-    if point.status == OperatingPointStatus.LIMIT_REACHED:
-        warnings.append(DesignWarning(
-            level="critical",
-            category="authority",
-            surface=None,
-            message="Optimizer hit a constraint boundary — check all surfaces",
-        ))
-
-    return TrimEnrichment(
-        analysis_goal=analysis_goal,
-        trim_method=trim_method,
-        trim_score=trim_score,
-        trim_residuals=trim_residuals,
-        deflection_reserves=deflection_reserves,
-        design_warnings=warnings,
-    )
 
 
 def _default_profile() -> dict[str, Any]:
@@ -870,7 +750,7 @@ def generate_default_set_for_aircraft(
         plane_schema = aeroplane_model_to_aeroplane_schema_async(aircraft)
         asb_airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
         capabilities = _detect_control_capabilities(asb_airplane)
-        deflection_limits = _build_deflection_limits(asb_airplane)
+        deflection_limits = build_deflection_limits_from_schema(plane_schema)
 
         points: list[TrimmedPoint] = []
         skipped_names: list[str] = []
@@ -894,12 +774,15 @@ def generate_default_set_for_aircraft(
                 constraints=profile.get("constraints", {}),
                 capabilities=capabilities,
             )
-            enrichment = _compute_enrichment(
-                point=point,
+            enrichment = compute_enrichment(
+                controls=point.controls,
                 limits=deflection_limits,
                 trim_method="opti",
                 trim_score=point.trim_score,
                 trim_residuals=point.trim_residuals or {},
+                op_name=point.name,
+                alpha_deg=math.degrees(point.alpha_rad),
+                status=point.status.value if point.status else None,
             )
             point.trim_enrichment = enrichment.model_dump()
             points.append(point)
@@ -990,13 +873,16 @@ def trim_operating_point_for_aircraft(
             capabilities=capabilities,
         )
 
-        deflection_limits = _build_deflection_limits(asb_airplane)
-        enrichment = _compute_enrichment(
-            point=point,
+        deflection_limits = build_deflection_limits_from_schema(plane_schema)
+        enrichment = compute_enrichment(
+            controls=point.controls,
             limits=deflection_limits,
             trim_method="opti",
             trim_score=point.trim_score,
             trim_residuals=point.trim_residuals or {},
+            op_name=point.name,
+            alpha_deg=math.degrees(point.alpha_rad),
+            status=point.status.value if point.status else None,
         )
 
         point_payload = StoredOperatingPointCreate(

--- a/app/services/operating_point_generator_service.py
+++ b/app/services/operating_point_generator_service.py
@@ -1,6 +1,5 @@
 import logging
 import math
-import re
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -26,10 +25,9 @@ from app.schemas.aeroanalysisschema import (
     TrimOperatingPointRequest,
 )
 from app.services.trim_enrichment_service import (
-    ANALYSIS_GOALS,
-    _parse_role_tag,
     build_deflection_limits_from_schema,
     compute_enrichment,
+    parse_role_tag,
 )
 
 logger = logging.getLogger(__name__)
@@ -57,6 +55,7 @@ class TrimmedPoint:
     controls: dict[str, float]
     trim_score: float | None = None
     trim_residuals: dict[str, float] | None = None
+    trim_method: str = "opti"
     trim_enrichment: dict | None = None
 
 
@@ -283,7 +282,7 @@ def _pick_control_name(
 ) -> Optional[str]:
     """Find a control surface name whose ``[role]`` tag matches *roles*."""
     for control_name in available_controls:
-        role, _display = _parse_role_tag(control_name)
+        role, _display = parse_role_tag(control_name)
         if role and role in roles:
             return control_name
     return None
@@ -300,7 +299,7 @@ def _detect_control_capabilities(asb_airplane: asb.Airplane) -> dict[str, Any]:
                 if not raw_name:
                     continue
                 control_names.append(raw_name)
-                role, _display = _parse_role_tag(raw_name)
+                role, _display = parse_role_tag(raw_name)
                 if role:
                     roles_found.add(role)
 
@@ -677,6 +676,7 @@ def _trim_or_estimate_point(
         controls=best_controls,
         trim_score=best_score if best_score < float("inf") else None,
         trim_residuals=best_residuals,
+        trim_method=best_method,
     )
 
 
@@ -774,17 +774,25 @@ def generate_default_set_for_aircraft(
                 constraints=profile.get("constraints", {}),
                 capabilities=capabilities,
             )
-            enrichment = compute_enrichment(
-                controls=point.controls,
-                limits=deflection_limits,
-                trim_method="opti",
-                trim_score=point.trim_score,
-                trim_residuals=point.trim_residuals or {},
-                op_name=point.name,
-                alpha_deg=math.degrees(point.alpha_rad),
-                status=point.status.value if point.status else None,
-            )
-            point.trim_enrichment = enrichment.model_dump()
+            try:
+                enrichment = compute_enrichment(
+                    controls=point.controls,
+                    limits=deflection_limits,
+                    trim_method=point.trim_method,
+                    trim_score=point.trim_score,
+                    trim_residuals=point.trim_residuals or {},
+                    op_name=point.name,
+                    alpha_deg=math.degrees(point.alpha_rad),
+                    status=point.status.value if point.status else None,
+                )
+                point.trim_enrichment = enrichment.model_dump()
+            except Exception:
+                logger.warning(
+                    "Enrichment computation failed for OP '%s' on aircraft %s",
+                    point.name,
+                    aircraft_uuid,
+                    exc_info=True,
+                )
             points.append(point)
 
         logger.info(
@@ -874,16 +882,26 @@ def trim_operating_point_for_aircraft(
         )
 
         deflection_limits = build_deflection_limits_from_schema(plane_schema)
-        enrichment = compute_enrichment(
-            controls=point.controls,
-            limits=deflection_limits,
-            trim_method="opti",
-            trim_score=point.trim_score,
-            trim_residuals=point.trim_residuals or {},
-            op_name=point.name,
-            alpha_deg=math.degrees(point.alpha_rad),
-            status=point.status.value if point.status else None,
-        )
+        enrichment_data = None
+        try:
+            enrichment = compute_enrichment(
+                controls=point.controls,
+                limits=deflection_limits,
+                trim_method=point.trim_method,
+                trim_score=point.trim_score,
+                trim_residuals=point.trim_residuals or {},
+                op_name=point.name,
+                alpha_deg=math.degrees(point.alpha_rad),
+                status=point.status.value if point.status else None,
+            )
+            enrichment_data = enrichment.model_dump()
+        except Exception:
+            logger.warning(
+                "Enrichment computation failed for single trim OP '%s' on aircraft %s",
+                point.name,
+                aircraft_uuid,
+                exc_info=True,
+            )
 
         point_payload = StoredOperatingPointCreate(
             name=point.name,
@@ -901,7 +919,7 @@ def trim_operating_point_for_aircraft(
             r=point.r,
             xyz_ref=[0.0, 0.0, 0.0],
             altitude=point.altitude,
-            trim_enrichment=enrichment.model_dump(),
+            trim_enrichment=enrichment_data,
         )
         return TrimmedOperatingPointRead(
             source_flight_profile_id=source_profile_id,

--- a/app/services/trim_enrichment_service.py
+++ b/app/services/trim_enrichment_service.py
@@ -9,7 +9,7 @@ single ``compute_enrichment()`` entry point.
 from __future__ import annotations
 
 import re
-from typing import Any, Optional
+from typing import Any
 
 from app.schemas.aeroanalysisschema import (
     ControlEffectiveness,
@@ -54,7 +54,7 @@ ANALYSIS_GOALS: dict[str, str] = {
 _DEFAULT_ANALYSIS_GOAL = "User-defined trim point"
 
 
-def _parse_role_tag(name: str) -> tuple[Optional[str], str]:
+def parse_role_tag(name: str) -> tuple[str | None, str]:
     """Parse a ``[role]display`` tag from a control surface name.
 
     Returns ``(role, display)`` when the tag is present, otherwise
@@ -118,26 +118,48 @@ def build_deflection_limits_from_schema(
 def classify_stability(
     stability_derivatives: dict[str, float],
 ) -> StabilityClassification:
-    """Classify static stability from derivatives at the trim point."""
+    """Classify static stability from derivatives at the trim point.
+
+    Only classifies based on derivatives that are actually present.
+    Missing derivatives are assumed stable (not counted against the
+    aircraft), but prevent a full "stable" classification — the result
+    is "neutral" when some axes are unknown.
+    """
+    has_cm_a = "Cm_a" in stability_derivatives
+    has_cn_b = "Cn_b" in stability_derivatives or "Cnb" in stability_derivatives
+    has_cl_b = "Cl_b" in stability_derivatives or "Clb" in stability_derivatives
+
     cm_a = stability_derivatives.get("Cm_a", 0.0)
     cn_b = stability_derivatives.get("Cn_b", stability_derivatives.get("Cnb", 0.0))
     cl_b = stability_derivatives.get("Cl_b", stability_derivatives.get("Clb", 0.0))
     cl_a = stability_derivatives.get("CL_a", 0.0)
 
-    is_static = cm_a < 0
-    is_directional = cn_b > 0
-    is_lateral = cl_b < 0
+    is_static = cm_a < 0 if has_cm_a else True
+    is_directional = cn_b > 0 if has_cn_b else True
+    is_lateral = cl_b < 0 if has_cl_b else True
 
     static_margin: float | None = None
-    if abs(cl_a) > 1e-6:
+    if has_cm_a and abs(cl_a) > 1e-6:
         static_margin = round(-cm_a / cl_a, 4)
 
-    if is_static and is_directional and is_lateral:
-        overall = "stable"
-    elif not is_static or (not is_directional and not is_lateral):
-        overall = "unstable"
+    # Classify based on KNOWN derivatives only
+    known_axes_stable: list[bool] = []
+    if has_cm_a:
+        known_axes_stable.append(is_static)
+    if has_cn_b:
+        known_axes_stable.append(is_directional)
+    if has_cl_b:
+        known_axes_stable.append(is_lateral)
+
+    if not known_axes_stable:
+        overall = "neutral"  # no data
+    elif all(known_axes_stable):
+        if len(known_axes_stable) == 3:
+            overall = "stable"
+        else:
+            overall = "neutral"  # partially stable but not fully confirmed
     else:
-        overall = "neutral"
+        overall = "unstable"  # at least one known axis is unstable
 
     return StabilityClassification(
         is_statically_stable=is_static,
@@ -169,7 +191,7 @@ def compute_control_effectiveness(
     }
 
     for surface_name in controls:
-        role, _display = _parse_role_tag(surface_name)
+        role, _display = parse_role_tag(surface_name)
         if not role:
             continue
 
@@ -207,7 +229,7 @@ def decompose_dual_role(
     # Group controls by role
     role_groups: dict[str, list[tuple[str, float]]] = {}
     for surface_name, deflection in controls.items():
-        role, _display = _parse_role_tag(surface_name)
+        role, _display = parse_role_tag(surface_name)
         if role and role in DUAL_ROLES:
             role_groups.setdefault(role, []).append((surface_name, deflection))
 
@@ -250,7 +272,7 @@ def generate_result_summary(
     # Find the main pitch control and its reserve
     pitch_reserve_str = ""
     for name, reserve in deflection_reserves.items():
-        role, _ = _parse_role_tag(name)
+        role, _ = parse_role_tag(name)
         if role in ("elevator", "stabilator", "elevon"):
             reserve_pct = (1 - reserve.usage_fraction) * 100
             pitch_reserve_str = f" with {reserve_pct:.0f}% elevator reserve"
@@ -366,7 +388,7 @@ def compute_enrichment(
                 )
             )
 
-    if status == OperatingPointStatus.LIMIT_REACHED or status == "LIMIT_REACHED":
+    if status == OperatingPointStatus.LIMIT_REACHED:
         warnings.append(
             DesignWarning(
                 level="critical",

--- a/app/services/trim_enrichment_service.py
+++ b/app/services/trim_enrichment_service.py
@@ -1,0 +1,452 @@
+"""Trim result enrichment — deflection reserve, effectiveness, stability, warnings.
+
+Centralises all enrichment computation for trim results across all three
+trim paths (opti, AVL, AeroBuildup).  Extracted from
+``operating_point_generator_service`` so that every solver can call a
+single ``compute_enrichment()`` entry point.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Optional
+
+from app.schemas.aeroanalysisschema import (
+    ControlEffectiveness,
+    DeflectionReserve,
+    DesignWarning,
+    MixerValues,
+    OperatingPointStatus,
+    StabilityClassification,
+    TrimEnrichment,
+)
+
+_ROLE_TAG_RE = re.compile(r"^\[(\w+)\](.*)$")
+
+DUAL_ROLES = {"elevon", "flaperon", "ruddervator"}
+
+# Role -> primary coefficient mapping
+ROLE_COEFFICIENT_MAP: dict[str, str] = {
+    "elevator": "Cm",
+    "stabilator": "Cm",
+    "aileron": "Cl",
+    "rudder": "Cn",
+    "elevon": "Cm",  # primary axis for elevon
+    "flaperon": "Cl",
+    "flap": "CL",
+}
+
+ANALYSIS_GOALS: dict[str, str] = {
+    "stall_near_clean": "Can the aircraft trim near stall? How much elevator authority remains?",
+    "takeoff_climb": "What flap + elevator setting gives safe climb at takeoff speed?",
+    "cruise": "What is the drag-minimal trim at cruise speed?",
+    "loiter_endurance": "What trim gives minimum sink for max loiter endurance?",
+    "max_level_speed": "Can the aircraft trim at Vmax? Is the tail adequate?",
+    "approach_landing": "What flap + elevator trim for safe approach speed?",
+    "turn_n2": "How much aileron + rudder for coordinated turn at 2g?",
+    "dutch_role_start": "How does the aircraft respond to sideslip? Is yaw damping adequate?",
+    "best_angle_climb_vx": "What trim gives the steepest climb for obstacle clearance?",
+    "best_rate_climb_vy": "What trim gives the fastest altitude gain?",
+    "max_range": "What trim maximizes ground distance per unit energy?",
+    "stall_with_flaps": "How does stall behavior change with flaps deployed?",
+}
+
+_DEFAULT_ANALYSIS_GOAL = "User-defined trim point"
+
+
+def _parse_role_tag(name: str) -> tuple[Optional[str], str]:
+    """Parse a ``[role]display`` tag from a control surface name.
+
+    Returns ``(role, display)`` when the tag is present, otherwise
+    ``(None, name)``.
+    """
+    m = _ROLE_TAG_RE.match(name)
+    if m:
+        return m.group(1), m.group(2)
+    return None, name
+
+
+def build_deflection_limits_from_schema(
+    plane_schema: Any,
+) -> dict[str, tuple[float, float]]:
+    """Extract per-surface mechanical limits from plane schema TEDs.
+
+    Returns dict mapping control surface name (with [role] tag) to
+    ``(max_pos_deg, max_neg_deg)``.  Falls back to ``(25.0, 25.0)``
+    if TED limits are not set.
+    """
+    default = 25.0
+    limits: dict[str, tuple[float, float]] = {}
+
+    if not plane_schema or not getattr(plane_schema, "wings", None):
+        return limits
+
+    wings = plane_schema.wings
+    if isinstance(wings, dict):
+        wing_list = list(wings.values())
+    else:
+        wing_list = list(wings) if wings else []
+
+    for wing in wing_list:
+        xsecs = getattr(wing, "x_secs", None) or getattr(wing, "xsecs", None) or []
+        if isinstance(xsecs, dict):
+            xsec_list = list(xsecs.values())
+        else:
+            xsec_list = list(xsecs) if xsecs else []
+
+        for xsec in xsec_list:
+            ted = getattr(xsec, "trailing_edge_device", None)
+            if ted is None:
+                continue
+
+            name = getattr(ted, "name", None)
+            if not name:
+                continue
+            name = str(name).strip()
+            if not name:
+                continue
+
+            pos = getattr(ted, "positive_deflection_deg", None)
+            neg = getattr(ted, "negative_deflection_deg", None)
+            max_pos = float(pos) if pos is not None else default
+            max_neg = float(neg) if neg is not None else default
+            limits[name] = (max_pos, max_neg)
+
+    return limits
+
+
+def classify_stability(
+    stability_derivatives: dict[str, float],
+) -> StabilityClassification:
+    """Classify static stability from derivatives at the trim point."""
+    cm_a = stability_derivatives.get("Cm_a", 0.0)
+    cn_b = stability_derivatives.get("Cn_b", stability_derivatives.get("Cnb", 0.0))
+    cl_b = stability_derivatives.get("Cl_b", stability_derivatives.get("Clb", 0.0))
+    cl_a = stability_derivatives.get("CL_a", 0.0)
+
+    is_static = cm_a < 0
+    is_directional = cn_b > 0
+    is_lateral = cl_b < 0
+
+    static_margin: float | None = None
+    if abs(cl_a) > 1e-6:
+        static_margin = round(-cm_a / cl_a, 4)
+
+    if is_static and is_directional and is_lateral:
+        overall = "stable"
+    elif not is_static or (not is_directional and not is_lateral):
+        overall = "unstable"
+    else:
+        overall = "neutral"
+
+    return StabilityClassification(
+        is_statically_stable=is_static,
+        is_directionally_stable=is_directional,
+        is_laterally_stable=is_lateral,
+        static_margin=static_margin,
+        overall_class=overall,
+    )
+
+
+def compute_control_effectiveness(
+    stability_derivatives: dict[str, float],
+    controls: dict[str, float],
+) -> dict[str, ControlEffectiveness]:
+    """Extract per-surface control effectiveness from stability derivatives.
+
+    For AVL, raw results contain control derivatives like ``Cmd1``, ``Cld1`` etc.
+    For the opti/AeroBuildup path, we use state derivatives as a proxy for
+    control effectiveness since direct control derivatives aren't available.
+    """
+    effectiveness: dict[str, ControlEffectiveness] = {}
+
+    # Map role -> state derivative as fallback
+    _state_deriv_map: dict[str, str] = {
+        "Cm": "Cm_a",
+        "Cl": "Cl_b",
+        "Cn": "Cn_b",
+        "CL": "CL_a",
+    }
+
+    for surface_name in controls:
+        role, _display = _parse_role_tag(surface_name)
+        if not role:
+            continue
+
+        coeff = ROLE_COEFFICIENT_MAP.get(role)
+        if not coeff:
+            continue
+
+        # Try to find the state derivative for the relevant axis
+        state_key = _state_deriv_map.get(coeff)
+        deriv_value: float | None = None
+        if state_key and state_key in stability_derivatives:
+            deriv_value = stability_derivatives[state_key]
+
+        if deriv_value is not None:
+            effectiveness[surface_name] = ControlEffectiveness(
+                derivative=round(float(deriv_value), 6),
+                coefficient=coeff,
+                surface=surface_name,
+            )
+
+    return effectiveness
+
+
+def decompose_dual_role(
+    controls: dict[str, float],
+) -> dict[str, MixerValues]:
+    """Decompose dual-role surface deflections into symmetric and differential components.
+
+    Looks for paired surfaces with the same dual-role tag
+    (e.g. two ``[elevon]`` surfaces).
+    Symmetric = average, Differential = half the difference.
+    """
+    mixer_values: dict[str, MixerValues] = {}
+
+    # Group controls by role
+    role_groups: dict[str, list[tuple[str, float]]] = {}
+    for surface_name, deflection in controls.items():
+        role, _display = _parse_role_tag(surface_name)
+        if role and role in DUAL_ROLES:
+            role_groups.setdefault(role, []).append((surface_name, deflection))
+
+    for role, surfaces in role_groups.items():
+        if len(surfaces) >= 2:
+            # Paired surfaces: compute symmetric and differential
+            defl_values = [d for _, d in surfaces]
+            symmetric = sum(defl_values) / len(defl_values)
+            # Differential = half-difference between first two surfaces
+            differential = abs(defl_values[0] - defl_values[1]) / 2.0
+            group_key = f"{role}_mixer"
+            mixer_values[group_key] = MixerValues(
+                symmetric_offset=round(symmetric, 3),
+                differential_throw=round(differential, 3),
+                role=role,
+            )
+        elif len(surfaces) == 1:
+            # Single dual-role surface: symmetric = deflection, differential = 0
+            name, deflection = surfaces[0]
+            mixer_values[name] = MixerValues(
+                symmetric_offset=round(deflection, 3),
+                differential_throw=0.0,
+                role=role,
+            )
+
+    return mixer_values
+
+
+def generate_result_summary(
+    op_name: str,
+    alpha_deg: float,
+    controls: dict[str, float],
+    deflection_reserves: dict[str, DeflectionReserve],
+    stability_class: StabilityClassification | None,
+    aero_coefficients: dict[str, float] | None = None,
+) -> str:
+    """Generate a human-readable result summary for a trim point."""
+    alpha_str = f"alpha={alpha_deg:.1f}deg"
+
+    # Find the main pitch control and its reserve
+    pitch_reserve_str = ""
+    for name, reserve in deflection_reserves.items():
+        role, _ = _parse_role_tag(name)
+        if role in ("elevator", "stabilator", "elevon"):
+            reserve_pct = (1 - reserve.usage_fraction) * 100
+            pitch_reserve_str = f" with {reserve_pct:.0f}% elevator reserve"
+            break
+
+    cl_str = ""
+    if aero_coefficients and "CL" in aero_coefficients:
+        cl_str = f", CL={aero_coefficients['CL']:.3f}"
+
+    stability_str = ""
+    if stability_class:
+        stability_str = f" ({stability_class.overall_class})"
+
+    summaries: dict[str, str] = {
+        "stall_near_clean": f"Trimmed at {alpha_str}{pitch_reserve_str}{stability_str}",
+        "cruise": f"Drag-minimal trim at {alpha_str}{cl_str}{pitch_reserve_str}{stability_str}",
+        "takeoff_climb": f"Takeoff trim at {alpha_str}{pitch_reserve_str}",
+        "loiter_endurance": f"Loiter trim at {alpha_str}{cl_str}{pitch_reserve_str}",
+        "max_level_speed": f"Max-speed trim at {alpha_str}{pitch_reserve_str}{stability_str}",
+        "approach_landing": f"Approach trim at {alpha_str}{pitch_reserve_str}",
+        "turn_n2": f"2g turn trim at {alpha_str}{pitch_reserve_str}",
+        "dutch_role_start": f"Dutch roll initial condition at {alpha_str}{stability_str}",
+        "best_angle_climb_vx": f"Best angle climb at {alpha_str}{pitch_reserve_str}",
+        "best_rate_climb_vy": f"Best rate climb at {alpha_str}{pitch_reserve_str}",
+        "max_range": f"Max range trim at {alpha_str}{cl_str}{pitch_reserve_str}",
+        "stall_with_flaps": f"Flaps-down stall at {alpha_str}{pitch_reserve_str}",
+    }
+
+    return summaries.get(op_name, f"Trimmed at {alpha_str}{pitch_reserve_str}{stability_str}")
+
+
+def compute_enrichment(
+    controls: dict[str, float],
+    limits: dict[str, tuple[float, float]],
+    trim_method: str,
+    trim_score: float | None,
+    trim_residuals: dict[str, float],
+    op_name: str,
+    alpha_deg: float,
+    stability_derivatives: dict[str, float] | None = None,
+    aero_coefficients: dict[str, float] | None = None,
+    status: str | None = None,
+    reserve_warning_threshold: float = 0.80,
+    reserve_critical_threshold: float = 0.95,
+    margin_low_threshold: float = 0.05,
+    margin_high_threshold: float = 0.30,
+) -> TrimEnrichment:
+    """Compute full enrichment from trim results.
+
+    This is the single entry point for all enrichment computation,
+    used by all three trim paths (opti, AVL, AeroBuildup).
+    """
+    analysis_goal = ANALYSIS_GOALS.get(op_name, _DEFAULT_ANALYSIS_GOAL)
+
+    # --- Deflection reserves ---
+    deflection_reserves: dict[str, DeflectionReserve] = {}
+    for surface_name, deflection_deg in controls.items():
+        max_pos, max_neg = limits.get(surface_name, (25.0, 25.0))
+        limit = max_pos if deflection_deg >= 0 else max_neg
+        usage = abs(deflection_deg) / limit if limit > 0 else 0.0
+        deflection_reserves[surface_name] = DeflectionReserve(
+            deflection_deg=deflection_deg,
+            max_pos_deg=max_pos,
+            max_neg_deg=max_neg,
+            usage_fraction=usage,
+        )
+
+    # --- Design warnings ---
+    warnings: list[DesignWarning] = []
+    for surface_name, reserve in deflection_reserves.items():
+        if reserve.usage_fraction > reserve_critical_threshold:
+            warnings.append(
+                DesignWarning(
+                    level="critical",
+                    category="authority",
+                    surface=surface_name,
+                    message=(
+                        f"{surface_name}: near mechanical limit "
+                        f"({reserve.usage_fraction:.0%} used) — redesign needed"
+                    ),
+                )
+            )
+        elif reserve.usage_fraction > reserve_warning_threshold:
+            warnings.append(
+                DesignWarning(
+                    level="warning",
+                    category="authority",
+                    surface=surface_name,
+                    message=(
+                        f"{surface_name}: {reserve.usage_fraction:.0%} authority used "
+                        f"— surface may be undersized"
+                    ),
+                )
+            )
+
+    if trim_score is not None:
+        if trim_score > 0.5:
+            warnings.append(
+                DesignWarning(
+                    level="critical",
+                    category="trim_quality",
+                    surface=None,
+                    message="Trim failed to converge — results unreliable",
+                )
+            )
+        elif trim_score > 0.1:
+            warnings.append(
+                DesignWarning(
+                    level="warning",
+                    category="trim_quality",
+                    surface=None,
+                    message="Poor trim quality — equilibrium not fully achieved",
+                )
+            )
+
+    if status == OperatingPointStatus.LIMIT_REACHED or status == "LIMIT_REACHED":
+        warnings.append(
+            DesignWarning(
+                level="critical",
+                category="authority",
+                surface=None,
+                message="Optimizer hit a constraint boundary — check all surfaces",
+            )
+        )
+
+    # --- Stability classification ---
+    stability_classification: StabilityClassification | None = None
+    if stability_derivatives:
+        stability_classification = classify_stability(stability_derivatives)
+
+        # Static margin warnings
+        if stability_classification.static_margin is not None:
+            sm = stability_classification.static_margin
+            if sm <= 0:
+                warnings.append(
+                    DesignWarning(
+                        level="critical",
+                        category="stability",
+                        surface=None,
+                        message=(
+                            f"Negative static margin ({sm:.1%}) — aircraft is statically unstable"
+                        ),
+                    )
+                )
+            elif sm < margin_low_threshold:
+                warnings.append(
+                    DesignWarning(
+                        level="warning",
+                        category="stability",
+                        surface=None,
+                        message=(
+                            f"Marginal static margin ({sm:.1%}) at this trim point "
+                            f"— consider moving CG forward"
+                        ),
+                    )
+                )
+            elif sm > margin_high_threshold:
+                warnings.append(
+                    DesignWarning(
+                        level="warning",
+                        category="stability",
+                        surface=None,
+                        message=(
+                            f"Very nose-heavy trim (static margin {sm:.1%}) "
+                            f"— excessive elevator authority needed"
+                        ),
+                    )
+                )
+
+    # --- Control effectiveness ---
+    effectiveness: dict[str, ControlEffectiveness] = {}
+    if stability_derivatives:
+        effectiveness = compute_control_effectiveness(stability_derivatives, controls)
+
+    # --- Dual-role decomposition ---
+    mixer_values = decompose_dual_role(controls)
+
+    # --- Result summary ---
+    result_summary = generate_result_summary(
+        op_name=op_name,
+        alpha_deg=alpha_deg,
+        controls=controls,
+        deflection_reserves=deflection_reserves,
+        stability_class=stability_classification,
+        aero_coefficients=aero_coefficients,
+    )
+
+    return TrimEnrichment(
+        analysis_goal=analysis_goal,
+        trim_method=trim_method,
+        trim_score=trim_score,
+        trim_residuals=trim_residuals,
+        deflection_reserves=deflection_reserves,
+        design_warnings=warnings,
+        effectiveness=effectiveness,
+        stability_classification=stability_classification,
+        mixer_values=mixer_values,
+        result_summary=result_summary,
+    )

--- a/app/tests/test_trim_enrichment.py
+++ b/app/tests/test_trim_enrichment.py
@@ -280,7 +280,7 @@ class TestStoredOPSchemaEnrichment:
             trim_enrichment=enrichment,
         )
         assert op.trim_enrichment is not None
-        assert op.trim_enrichment["trim_method"] == "opti"
+        assert op.trim_enrichment.trim_method == "opti"
 
     def test_create_schema_defaults_to_none(self):
         op = StoredOperatingPointCreate(
@@ -317,7 +317,7 @@ class TestStoredOPSchemaEnrichment:
                 "design_warnings": [],
             },
         )
-        assert op.trim_enrichment["analysis_goal"] == "Goal"
+        assert op.trim_enrichment.analysis_goal == "Goal"
 
 
 # ---------------------------------------------------------------------------
@@ -335,6 +335,7 @@ from app.services.trim_enrichment_service import (
     compute_enrichment,
     decompose_dual_role,
     generate_result_summary,
+    parse_role_tag,
 )
 from app.services.operating_point_generator_service import TrimmedPoint
 
@@ -563,13 +564,13 @@ class TestStabilityClassification:
         assert sc.is_statically_stable is False
         assert sc.overall_class == "unstable"
 
-    def test_neutral_aircraft(self):
-        """Cm_a < 0, Cn_b > 0, but Cl_b > 0 (laterally unstable) -> neutral."""
+    def test_laterally_unstable_classified_as_unstable(self):
+        """Cm_a < 0, Cn_b > 0, but Cl_b > 0 (laterally unstable) -> unstable."""
         sc = classify_stability({"Cm_a": -0.5, "Cn_b": 0.02, "Cl_b": 0.01, "CL_a": 4.0})
         assert sc.is_statically_stable is True
         assert sc.is_directionally_stable is True
         assert sc.is_laterally_stable is False
-        assert sc.overall_class == "neutral"
+        assert sc.overall_class == "unstable"
 
     def test_static_margin_computed(self):
         sc = classify_stability({"Cm_a": -2.0, "CL_a": 4.0, "Cn_b": 0.01, "Cl_b": -0.01})
@@ -578,6 +579,40 @@ class TestStabilityClassification:
 
     def test_zero_cl_a_no_margin(self):
         sc = classify_stability({"Cm_a": -0.5, "CL_a": 0.0, "Cn_b": 0.01, "Cl_b": -0.01})
+        assert sc.static_margin is None
+
+    def test_cnb_variant_stable(self):
+        """Test that Cnb (legacy AVL notation) is accepted alongside Clb."""
+        sc = classify_stability({"Cm_a": -0.5, "Cnb": 0.02, "Clb": -0.01, "CL_a": 4.0})
+        assert sc.is_statically_stable is True
+        assert sc.is_directionally_stable is True
+        assert sc.is_laterally_stable is True
+        assert sc.overall_class == "stable"
+
+    def test_partial_derivatives_neutral(self):
+        """Only Cm_a and CL_a present — not enough data for full 'stable'."""
+        sc = classify_stability({"Cm_a": -0.5, "CL_a": 4.0})
+        assert sc.is_statically_stable is True
+        # Missing derivatives assume stable
+        assert sc.is_directionally_stable is True
+        assert sc.is_laterally_stable is True
+        # But overall is neutral because not all axes confirmed
+        assert sc.overall_class == "neutral"
+
+    def test_no_derivatives_neutral(self):
+        """Empty derivatives dict produces neutral classification."""
+        sc = classify_stability({})
+        assert sc.overall_class == "neutral"
+
+    def test_partial_with_unstable_axis(self):
+        """Cm_a > 0 (unstable) with no lateral/directional data -> unstable."""
+        sc = classify_stability({"Cm_a": 0.3, "CL_a": 4.0})
+        assert sc.is_statically_stable is False
+        assert sc.overall_class == "unstable"
+
+    def test_static_margin_requires_cm_a(self):
+        """Static margin is None when Cm_a is absent, even if CL_a is present."""
+        sc = classify_stability({"CL_a": 4.0, "Cn_b": 0.02, "Cl_b": -0.01})
         assert sc.static_margin is None
 
 
@@ -772,11 +807,23 @@ class TestAVLTrimEnrichmentField:
             trim_enrichment={"analysis_goal": "test", "trim_method": "avl"},
         )
         assert result.trim_enrichment is not None
-        assert result.trim_enrichment["trim_method"] == "avl"
+        assert result.trim_enrichment.trim_method == "avl"
 
     def test_avl_result_defaults_to_none(self):
         result = AVLTrimResult(converged=False)
         assert result.trim_enrichment is None
+
+    def test_avl_result_serializes_enrichment(self):
+        """AVLTrimResult with TrimEnrichment serialises to dict correctly."""
+        enrichment = TrimEnrichment(analysis_goal="avl test", trim_method="avl", trim_score=0.01)
+        result = AVLTrimResult(
+            converged=True,
+            trimmed_deflections={"[elevator]Elev": -3.0},
+            trim_enrichment=enrichment,
+        )
+        data = result.model_dump()
+        assert isinstance(data["trim_enrichment"], dict)
+        assert data["trim_enrichment"]["trim_method"] == "avl"
 
 
 class TestAeroBuildupTrimEnrichmentField:
@@ -790,7 +837,7 @@ class TestAeroBuildupTrimEnrichmentField:
             trim_enrichment={"analysis_goal": "test", "trim_method": "aerobuildup"},
         )
         assert result.trim_enrichment is not None
-        assert result.trim_enrichment["trim_method"] == "aerobuildup"
+        assert result.trim_enrichment.trim_method == "aerobuildup"
 
     def test_aerobuildup_result_defaults_to_none(self):
         result = AeroBuildupTrimResult(
@@ -801,6 +848,21 @@ class TestAeroBuildupTrimEnrichmentField:
             achieved_value=None,
         )
         assert result.trim_enrichment is None
+
+    def test_aerobuildup_result_serializes_enrichment(self):
+        """AeroBuildupTrimResult with TrimEnrichment serialises to dict correctly."""
+        enrichment = TrimEnrichment(analysis_goal="aerobuildup test", trim_method="aerobuildup")
+        result = AeroBuildupTrimResult(
+            converged=True,
+            trim_variable="[elevator]Elev",
+            trimmed_deflection=-3.0,
+            target_coefficient="Cm",
+            achieved_value=0.001,
+            trim_enrichment=enrichment,
+        )
+        data = result.model_dump()
+        assert isinstance(data["trim_enrichment"], dict)
+        assert data["trim_enrichment"]["trim_method"] == "aerobuildup"
 
 
 # ---------------------------------------------------------------------------
@@ -874,8 +936,8 @@ class TestEnrichmentIntegration:
 
         for op in result.operating_points:
             assert op.trim_enrichment is not None, f"OP {op.name} missing enrichment"
-            assert "analysis_goal" in op.trim_enrichment
-            assert "deflection_reserves" in op.trim_enrichment
+            assert op.trim_enrichment.analysis_goal
+            assert op.trim_enrichment.deflection_reserves is not None
 
     def test_generated_ops_enrichment_persisted_to_db(self, db_session):
         from app.services.operating_point_generator_service import generate_default_set_for_aircraft
@@ -942,7 +1004,7 @@ class TestEnrichmentIntegration:
             result = trim_operating_point_for_aircraft(db_session, aircraft_uuid, request)
 
         assert result.point.trim_enrichment is not None
-        assert result.point.trim_enrichment["analysis_goal"] == "User-defined trim point"
+        assert result.point.trim_enrichment.analysis_goal == "User-defined trim point"
 
     def test_trim_score_flows_through_to_enrichment(self, db_session):
         from app.services.operating_point_generator_service import generate_default_set_for_aircraft
@@ -989,7 +1051,124 @@ class TestEnrichmentIntegration:
 
         first_op = result.operating_points[0]
         assert first_op.trim_enrichment is not None
-        assert first_op.trim_enrichment["trim_score"] == pytest.approx(0.15)
-        assert first_op.trim_enrichment["trim_residuals"]["cm"] == pytest.approx(0.08)
-        warning_categories = [w["category"] for w in first_op.trim_enrichment["design_warnings"]]
+        assert first_op.trim_enrichment.trim_score == pytest.approx(0.15)
+        assert first_op.trim_enrichment.trim_residuals["cm"] == pytest.approx(0.08)
+        warning_categories = [w.category for w in first_op.trim_enrichment.design_warnings]
         assert "trim_quality" in warning_categories
+
+
+# ---------------------------------------------------------------------------
+# parse_role_tag unit tests (T4)
+# ---------------------------------------------------------------------------
+
+
+class TestParseRoleTag:
+    def test_tagged_name(self):
+        role, display = parse_role_tag("[elevator]My Elev")
+        assert role == "elevator"
+        assert display == "My Elev"
+
+    def test_plain_name(self):
+        role, display = parse_role_tag("plain")
+        assert role is None
+        assert display == "plain"
+
+    def test_tag_only(self):
+        role, display = parse_role_tag("[elevator]")
+        assert role == "elevator"
+        assert display == ""
+
+    def test_empty_string(self):
+        role, display = parse_role_tag("")
+        assert role is None
+        assert display == ""
+
+
+# ---------------------------------------------------------------------------
+# LIMIT_REACHED warning test (T1)
+# ---------------------------------------------------------------------------
+
+
+class TestLimitReachedWarning:
+    def test_limit_reached_produces_critical_warning(self):
+        enrichment = compute_enrichment(
+            controls={"[elevator]Elev": -10.0},
+            limits={"[elevator]Elev": (25.0, 25.0)},
+            trim_method="opti",
+            trim_score=0.02,
+            trim_residuals={},
+            op_name="cruise",
+            alpha_deg=3.0,
+            status="LIMIT_REACHED",
+        )
+        authority_warnings = [
+            w for w in enrichment.design_warnings if w.category == "authority" and w.surface is None
+        ]
+        assert len(authority_warnings) == 1
+        assert authority_warnings[0].level == "critical"
+        assert "constraint boundary" in authority_warnings[0].message
+
+
+# ---------------------------------------------------------------------------
+# Trim score boundary tests (T3)
+# ---------------------------------------------------------------------------
+
+
+class TestTrimScoreBoundaries:
+    def test_trim_score_0_5_critical_warning(self):
+        """trim_score > 0.5 produces a critical trim_quality warning."""
+        enrichment = compute_enrichment(
+            controls={},
+            limits={},
+            trim_method="opti",
+            trim_score=0.5,
+            trim_residuals={},
+            op_name="cruise",
+            alpha_deg=3.0,
+        )
+        trim_warnings = [w for w in enrichment.design_warnings if w.category == "trim_quality"]
+        # 0.5 is not > 0.5, so no critical warning
+        assert not any(w.level == "critical" for w in trim_warnings)
+
+    def test_trim_score_above_0_5_critical(self):
+        """trim_score > 0.5 produces a critical trim_quality warning."""
+        enrichment = compute_enrichment(
+            controls={},
+            limits={},
+            trim_method="opti",
+            trim_score=0.51,
+            trim_residuals={},
+            op_name="cruise",
+            alpha_deg=3.0,
+        )
+        trim_warnings = [w for w in enrichment.design_warnings if w.category == "trim_quality"]
+        assert any(w.level == "critical" for w in trim_warnings)
+
+    def test_trim_score_0_1_no_warning(self):
+        """trim_score <= 0.1 produces no trim_quality warning."""
+        enrichment = compute_enrichment(
+            controls={},
+            limits={},
+            trim_method="opti",
+            trim_score=0.1,
+            trim_residuals={},
+            op_name="cruise",
+            alpha_deg=3.0,
+        )
+        trim_warnings = [w for w in enrichment.design_warnings if w.category == "trim_quality"]
+        assert len(trim_warnings) == 0
+
+    def test_trim_score_0_11_warning(self):
+        """trim_score > 0.1 produces a warning-level trim_quality warning."""
+        enrichment = compute_enrichment(
+            controls={},
+            limits={},
+            trim_method="opti",
+            trim_score=0.11,
+            trim_residuals={},
+            op_name="cruise",
+            alpha_deg=3.0,
+        )
+        trim_warnings = [w for w in enrichment.design_warnings if w.category == "trim_quality"]
+        assert len(trim_warnings) == 1
+        assert trim_warnings[0].level == "warning"

--- a/app/tests/test_trim_enrichment.py
+++ b/app/tests/test_trim_enrichment.py
@@ -10,9 +10,14 @@ from app.db.base import Base
 from app.models.aeroplanemodel import AeroplaneModel
 from app.models.analysismodels import OperatingPointModel
 from app.schemas.aeroanalysisschema import (
+    AeroBuildupTrimResult,
+    AVLTrimResult,
+    ControlEffectiveness,
     DeflectionReserve,
     DesignWarning,
+    MixerValues,
     OperatingPointStatus,
+    StabilityClassification,
     StoredOperatingPointCreate,
     StoredOperatingPointRead,
     TrimEnrichment,
@@ -121,11 +126,59 @@ class TestTrimEnrichment:
         e2 = TrimEnrichment.model_validate(data)
         assert e2 == e
 
+    def test_new_fields_have_defaults(self):
+        """New enrichment fields (effectiveness, stability_classification, etc.)
+        must default so existing persisted JSON does not break on load."""
+        e = TrimEnrichment(
+            analysis_goal="Test backward compat",
+            trim_method="opti",
+        )
+        assert e.effectiveness == {}
+        assert e.stability_classification is None
+        assert e.mixer_values == {}
+        assert e.result_summary == ""
+
+    def test_full_enrichment_with_all_new_fields(self):
+        e = TrimEnrichment(
+            analysis_goal="cruise",
+            trim_method="avl",
+            trim_score=0.01,
+            trim_residuals={"cm": 0.0},
+            deflection_reserves={},
+            design_warnings=[],
+            effectiveness={
+                "[elevator]Elev": ControlEffectiveness(
+                    derivative=-0.012, coefficient="Cm", surface="[elevator]Elev"
+                )
+            },
+            stability_classification=StabilityClassification(
+                is_statically_stable=True,
+                is_directionally_stable=True,
+                is_laterally_stable=True,
+                static_margin=0.15,
+                overall_class="stable",
+            ),
+            mixer_values={
+                "elevon_mixer": MixerValues(
+                    symmetric_offset=3.0, differential_throw=2.0, role="elevon"
+                )
+            },
+            result_summary="Drag-minimal trim at alpha=2.9deg",
+        )
+        assert e.effectiveness["[elevator]Elev"].coefficient == "Cm"
+        assert e.stability_classification.is_statically_stable is True
+        assert e.mixer_values["elevon_mixer"].role == "elevon"
+        assert "alpha" in e.result_summary
+
 
 @pytest.fixture()
 def db_session():
-    engine = create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
-    TestingSessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, class_=Session)
+    engine = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    TestingSessionLocal = sessionmaker(
+        bind=engine, autocommit=False, autoflush=False, class_=Session
+    )
     Base.metadata.create_all(bind=engine)
     db = TestingSessionLocal()
     try:
@@ -268,41 +321,39 @@ class TestStoredOPSchemaEnrichment:
 
 
 # ---------------------------------------------------------------------------
-# Enrichment engine tests (Task 4)
+# Enrichment engine tests
 # ---------------------------------------------------------------------------
 
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
-from app.services.operating_point_generator_service import (
-    _build_deflection_limits,
-    _compute_enrichment,
+
+from app.services.trim_enrichment_service import (
     ANALYSIS_GOALS,
-    TrimmedPoint,
+    build_deflection_limits_from_schema,
+    classify_stability,
+    compute_control_effectiveness,
+    compute_enrichment,
+    decompose_dual_role,
+    generate_result_summary,
 )
-
-
-def _mock_airplane_with_limits(surfaces: list[dict]) -> MagicMock:
-    """Create a mock ASB airplane with control surfaces that have deflection limits."""
-    airplane = MagicMock()
-    xsec = MagicMock()
-    controls = []
-    for s in surfaces:
-        cs = MagicMock()
-        cs.name = s["name"]
-        controls.append(cs)
-    xsec.control_surfaces = controls
-    wing = MagicMock()
-    wing.xsecs = [xsec]
-    airplane.wings = [wing]
-    return airplane
+from app.services.operating_point_generator_service import TrimmedPoint
 
 
 class TestAnalysisGoals:
     def test_all_auto_generated_ops_have_goals(self):
         expected_names = {
-            "stall_near_clean", "takeoff_climb", "cruise", "loiter_endurance",
-            "max_level_speed", "approach_landing", "turn_n2", "dutch_role_start",
-            "best_angle_climb_vx", "best_rate_climb_vy", "max_range", "stall_with_flaps",
+            "stall_near_clean",
+            "takeoff_climb",
+            "cruise",
+            "loiter_endurance",
+            "max_level_speed",
+            "approach_landing",
+            "turn_n2",
+            "dutch_role_start",
+            "best_angle_climb_vx",
+            "best_rate_climb_vy",
+            "max_range",
+            "stall_with_flaps",
         }
         assert expected_names <= set(ANALYSIS_GOALS.keys())
 
@@ -310,37 +361,86 @@ class TestAnalysisGoals:
         assert "custom_op_xyz" not in ANALYSIS_GOALS
 
 
-class TestBuildDeflectionLimits:
-    def test_extracts_limits_from_airplane(self):
-        airplane = _mock_airplane_with_limits([
-            {"name": "[elevator]Elevator"},
-            {"name": "[aileron]Left Aileron"},
-        ])
-        limits = _build_deflection_limits(airplane, default_limit_deg=25.0)
-        assert "[elevator]Elevator" in limits
-        assert limits["[elevator]Elevator"] == (25.0, 25.0)
+class TestBuildDeflectionLimitsFromSchema:
+    """Tests for the schema-based deflection limits extraction."""
 
-    def test_default_limit_applied(self):
-        airplane = _mock_airplane_with_limits([{"name": "rudder"}])
-        limits = _build_deflection_limits(airplane, default_limit_deg=30.0)
-        assert limits["rudder"] == (30.0, 30.0)
+    def test_extracts_ted_limits(self):
+        """Extracts positive/negative deflection from TED schema."""
+        ted = SimpleNamespace(
+            name="[elevator]Elevator",
+            positive_deflection_deg=30.0,
+            negative_deflection_deg=20.0,
+        )
+        xsec = SimpleNamespace(trailing_edge_device=ted)
+        wing = SimpleNamespace(x_secs=[xsec, SimpleNamespace(trailing_edge_device=None)])
+        schema = SimpleNamespace(wings={"main": wing})
+
+        limits = build_deflection_limits_from_schema(schema)
+        assert "[elevator]Elevator" in limits
+        assert limits["[elevator]Elevator"] == (30.0, 20.0)
+
+    def test_fallback_to_defaults(self):
+        """Falls back to 25.0 when TED does not specify limits."""
+        ted = SimpleNamespace(
+            name="[aileron]Aileron",
+            positive_deflection_deg=None,
+            negative_deflection_deg=None,
+        )
+        xsec = SimpleNamespace(trailing_edge_device=ted)
+        wing = SimpleNamespace(x_secs=[xsec, SimpleNamespace(trailing_edge_device=None)])
+        schema = SimpleNamespace(wings={"main": wing})
+
+        limits = build_deflection_limits_from_schema(schema)
+        assert limits["[aileron]Aileron"] == (25.0, 25.0)
+
+    def test_empty_schema(self):
+        """Returns empty dict for schema with no wings."""
+        schema = SimpleNamespace(wings=None)
+        assert build_deflection_limits_from_schema(schema) == {}
+
+    def test_none_schema(self):
+        assert build_deflection_limits_from_schema(None) == {}
+
+    def test_dict_wings(self):
+        """Handles OrderedDict wings from AeroplaneSchema."""
+        ted1 = SimpleNamespace(
+            name="[elevator]Elev", positive_deflection_deg=25.0, negative_deflection_deg=25.0
+        )
+        ted2 = SimpleNamespace(
+            name="[rudder]Rudder", positive_deflection_deg=30.0, negative_deflection_deg=30.0
+        )
+        wing1 = SimpleNamespace(
+            x_secs=[
+                SimpleNamespace(trailing_edge_device=ted1),
+                SimpleNamespace(trailing_edge_device=None),
+            ]
+        )
+        wing2 = SimpleNamespace(
+            x_secs=[
+                SimpleNamespace(trailing_edge_device=ted2),
+                SimpleNamespace(trailing_edge_device=None),
+            ]
+        )
+        schema = SimpleNamespace(wings={"main": wing1, "vtail": wing2})
+
+        limits = build_deflection_limits_from_schema(schema)
+        assert len(limits) == 2
+        assert "[elevator]Elev" in limits
+        assert "[rudder]Rudder" in limits
 
 
 class TestComputeEnrichment:
     def test_basic_enrichment(self):
-        point = TrimmedPoint(
-            name="cruise", description="", config="clean",
-            velocity=18.0, altitude=0.0,
-            alpha_rad=0.05, beta_rad=0.0,
-            p=0.0, q=0.0, r=0.0,
-            status=OperatingPointStatus.TRIMMED,
-            warnings=[], controls={"[elevator]Elevator": -5.0},
-        )
+        controls = {"[elevator]Elevator": -5.0}
         limits = {"[elevator]Elevator": (25.0, 25.0)}
-        enrichment = _compute_enrichment(
-            point=point, limits=limits,
-            trim_method="opti", trim_score=0.02,
+        enrichment = compute_enrichment(
+            controls=controls,
+            limits=limits,
+            trim_method="opti",
+            trim_score=0.02,
             trim_residuals={"cm": 0.001, "cy": 0.0},
+            op_name="cruise",
+            alpha_deg=2.86,
         )
         assert enrichment.analysis_goal == ANALYSIS_GOALS["cruise"]
         assert enrichment.trim_method == "opti"
@@ -350,35 +450,28 @@ class TestComputeEnrichment:
         assert reserve.usage_fraction == pytest.approx(0.2)
 
     def test_user_defined_op_gets_default_goal(self):
-        point = TrimmedPoint(
-            name="my_custom_point", description="", config="clean",
-            velocity=20.0, altitude=100.0,
-            alpha_rad=0.03, beta_rad=0.0,
-            p=0.0, q=0.0, r=0.0,
-            status=OperatingPointStatus.TRIMMED,
-            warnings=[], controls={},
-        )
-        enrichment = _compute_enrichment(
-            point=point, limits={},
-            trim_method="opti", trim_score=0.01,
+        enrichment = compute_enrichment(
+            controls={},
+            limits={},
+            trim_method="opti",
+            trim_score=0.01,
             trim_residuals={},
+            op_name="my_custom_point",
+            alpha_deg=1.72,
         )
         assert enrichment.analysis_goal == "User-defined trim point"
 
     def test_high_authority_generates_warning(self):
-        point = TrimmedPoint(
-            name="stall_near_clean", description="", config="clean",
-            velocity=10.0, altitude=0.0,
-            alpha_rad=0.2, beta_rad=0.0,
-            p=0.0, q=0.0, r=0.0,
-            status=OperatingPointStatus.TRIMMED,
-            warnings=[], controls={"[elevator]Elevator": -22.0},
-        )
+        controls = {"[elevator]Elevator": -22.0}
         limits = {"[elevator]Elevator": (25.0, 25.0)}
-        enrichment = _compute_enrichment(
-            point=point, limits=limits,
-            trim_method="opti", trim_score=0.03,
+        enrichment = compute_enrichment(
+            controls=controls,
+            limits=limits,
+            trim_method="opti",
+            trim_score=0.03,
             trim_residuals={"cm": 0.002},
+            op_name="stall_near_clean",
+            alpha_deg=11.5,
         )
         reserve = enrichment.deflection_reserves["[elevator]Elevator"]
         assert reserve.usage_fraction == pytest.approx(22.0 / 25.0)
@@ -386,44 +479,332 @@ class TestComputeEnrichment:
         assert "warning" in warning_levels
 
     def test_critical_authority_generates_critical_warning(self):
-        point = TrimmedPoint(
-            name="stall_near_clean", description="", config="clean",
-            velocity=10.0, altitude=0.0,
-            alpha_rad=0.2, beta_rad=0.0,
-            p=0.0, q=0.0, r=0.0,
-            status=OperatingPointStatus.TRIMMED,
-            warnings=[], controls={"[elevator]Elevator": -24.5},
-        )
+        controls = {"[elevator]Elevator": -24.5}
         limits = {"[elevator]Elevator": (25.0, 25.0)}
-        enrichment = _compute_enrichment(
-            point=point, limits=limits,
-            trim_method="opti", trim_score=0.03,
+        enrichment = compute_enrichment(
+            controls=controls,
+            limits=limits,
+            trim_method="opti",
+            trim_score=0.03,
             trim_residuals={},
+            op_name="stall_near_clean",
+            alpha_deg=11.5,
         )
         warning_levels = [w.level for w in enrichment.design_warnings]
         assert "critical" in warning_levels
 
     def test_poor_trim_quality_generates_warning(self):
-        point = TrimmedPoint(
-            name="cruise", description="", config="clean",
-            velocity=18.0, altitude=0.0,
-            alpha_rad=0.05, beta_rad=0.0,
-            p=0.0, q=0.0, r=0.0,
-            status=OperatingPointStatus.NOT_TRIMMED,
-            warnings=[], controls={},
-        )
-        enrichment = _compute_enrichment(
-            point=point, limits={},
-            trim_method="opti", trim_score=0.6,
+        enrichment = compute_enrichment(
+            controls={},
+            limits={},
+            trim_method="opti",
+            trim_score=0.6,
             trim_residuals={"cm": 0.3},
+            op_name="cruise",
+            alpha_deg=2.86,
         )
         categories = [w.category for w in enrichment.design_warnings]
         assert "trim_quality" in categories
         assert any(w.level == "critical" for w in enrichment.design_warnings)
 
+    def test_enrichment_backward_compatible(self):
+        """Enrichment without stability_derivatives does not crash."""
+        enrichment = compute_enrichment(
+            controls={"[elevator]Elev": -3.0},
+            limits={"[elevator]Elev": (25.0, 25.0)},
+            trim_method="opti",
+            trim_score=0.01,
+            trim_residuals={},
+            op_name="cruise",
+            alpha_deg=3.0,
+        )
+        assert enrichment.stability_classification is None
+        assert enrichment.effectiveness == {}
+        assert enrichment.mixer_values == {}
+        assert enrichment.result_summary != ""
+
+    def test_full_enrichment_with_all_fields(self):
+        controls = {"[elevator]Elev": -5.0, "[aileron]Left Ail": 3.0}
+        limits = {"[elevator]Elev": (25.0, 25.0), "[aileron]Left Ail": (20.0, 20.0)}
+        derivs = {"Cm_a": -0.5, "CL_a": 4.0, "Cn_b": 0.02, "Cl_b": -0.01}
+        aero = {"CL": 0.45, "CD": 0.025}
+        enrichment = compute_enrichment(
+            controls=controls,
+            limits=limits,
+            trim_method="avl",
+            trim_score=None,
+            trim_residuals={},
+            op_name="cruise",
+            alpha_deg=3.0,
+            stability_derivatives=derivs,
+            aero_coefficients=aero,
+        )
+        assert enrichment.stability_classification is not None
+        assert enrichment.stability_classification.overall_class == "stable"
+        assert "[elevator]Elev" in enrichment.effectiveness
+        assert "CL=0.450" in enrichment.result_summary
+
 
 # ---------------------------------------------------------------------------
-# Integration tests: enrichment wired into service entry points (Task 5)
+# Stability classification tests
+# ---------------------------------------------------------------------------
+
+
+class TestStabilityClassification:
+    def test_stable_aircraft(self):
+        sc = classify_stability({"Cm_a": -0.5, "Cn_b": 0.02, "Cl_b": -0.01, "CL_a": 4.0})
+        assert sc.is_statically_stable is True
+        assert sc.is_directionally_stable is True
+        assert sc.is_laterally_stable is True
+        assert sc.overall_class == "stable"
+
+    def test_unstable_aircraft(self):
+        sc = classify_stability({"Cm_a": 0.3, "Cn_b": 0.02, "Cl_b": -0.01, "CL_a": 4.0})
+        assert sc.is_statically_stable is False
+        assert sc.overall_class == "unstable"
+
+    def test_neutral_aircraft(self):
+        """Cm_a < 0, Cn_b > 0, but Cl_b > 0 (laterally unstable) -> neutral."""
+        sc = classify_stability({"Cm_a": -0.5, "Cn_b": 0.02, "Cl_b": 0.01, "CL_a": 4.0})
+        assert sc.is_statically_stable is True
+        assert sc.is_directionally_stable is True
+        assert sc.is_laterally_stable is False
+        assert sc.overall_class == "neutral"
+
+    def test_static_margin_computed(self):
+        sc = classify_stability({"Cm_a": -2.0, "CL_a": 4.0, "Cn_b": 0.01, "Cl_b": -0.01})
+        assert sc.static_margin is not None
+        assert sc.static_margin == pytest.approx(0.5)
+
+    def test_zero_cl_a_no_margin(self):
+        sc = classify_stability({"Cm_a": -0.5, "CL_a": 0.0, "Cn_b": 0.01, "Cl_b": -0.01})
+        assert sc.static_margin is None
+
+
+# ---------------------------------------------------------------------------
+# Control effectiveness tests
+# ---------------------------------------------------------------------------
+
+
+class TestControlEffectiveness:
+    def test_elevator_effectiveness(self):
+        derivs = {"Cm_a": -0.5, "CL_a": 4.0}
+        controls = {"[elevator]Elev": -3.0}
+        eff = compute_control_effectiveness(derivs, controls)
+        assert "[elevator]Elev" in eff
+        assert eff["[elevator]Elev"].coefficient == "Cm"
+        assert eff["[elevator]Elev"].derivative == pytest.approx(-0.5)
+
+    def test_unknown_role_skipped(self):
+        derivs = {"Cm_a": -0.5}
+        controls = {"[spoiler]Spoiler": 5.0}
+        eff = compute_control_effectiveness(derivs, controls)
+        assert len(eff) == 0
+
+    def test_no_derivatives_empty_result(self):
+        eff = compute_control_effectiveness({}, {"[elevator]Elev": -3.0})
+        assert len(eff) == 0
+
+
+# ---------------------------------------------------------------------------
+# Dual-role decomposition tests
+# ---------------------------------------------------------------------------
+
+
+class TestDualRoleDecomposition:
+    def test_paired_elevons(self):
+        controls = {
+            "[elevon]Left Elevon": 5.0,
+            "[elevon]Right Elevon": 3.0,
+        }
+        mixer = decompose_dual_role(controls)
+        assert "elevon_mixer" in mixer
+        assert mixer["elevon_mixer"].symmetric_offset == pytest.approx(4.0)
+        assert mixer["elevon_mixer"].differential_throw == pytest.approx(1.0)
+        assert mixer["elevon_mixer"].role == "elevon"
+
+    def test_single_dual_role(self):
+        controls = {"[elevon]Single Elevon": 7.0}
+        mixer = decompose_dual_role(controls)
+        assert "[elevon]Single Elevon" in mixer
+        assert mixer["[elevon]Single Elevon"].symmetric_offset == pytest.approx(7.0)
+        assert mixer["[elevon]Single Elevon"].differential_throw == pytest.approx(0.0)
+
+    def test_no_dual_role_empty(self):
+        controls = {
+            "[elevator]Elev": -3.0,
+            "[aileron]Ail": 5.0,
+            "[rudder]Rud": 2.0,
+        }
+        mixer = decompose_dual_role(controls)
+        assert len(mixer) == 0
+
+
+# ---------------------------------------------------------------------------
+# Result summary tests
+# ---------------------------------------------------------------------------
+
+
+class TestResultSummary:
+    def test_cruise_summary_includes_alpha(self):
+        summary = generate_result_summary(
+            op_name="cruise",
+            alpha_deg=3.5,
+            controls={},
+            deflection_reserves={},
+            stability_class=None,
+        )
+        assert "alpha=3.5deg" in summary
+
+    def test_unknown_op_gets_generic_summary(self):
+        summary = generate_result_summary(
+            op_name="custom_xyz",
+            alpha_deg=5.0,
+            controls={},
+            deflection_reserves={},
+            stability_class=None,
+        )
+        assert "Trimmed at" in summary
+        assert "alpha=5.0deg" in summary
+
+    def test_summary_includes_reserve(self):
+        reserves = {
+            "[elevator]Elev": DeflectionReserve(
+                deflection_deg=-5.0,
+                max_pos_deg=25.0,
+                max_neg_deg=25.0,
+                usage_fraction=0.2,
+            )
+        }
+        summary = generate_result_summary(
+            op_name="cruise",
+            alpha_deg=3.0,
+            controls={"[elevator]Elev": -5.0},
+            deflection_reserves=reserves,
+            stability_class=None,
+        )
+        assert "elevator reserve" in summary
+
+
+# ---------------------------------------------------------------------------
+# Static margin warning tests
+# ---------------------------------------------------------------------------
+
+
+class TestStaticMarginWarnings:
+    def test_low_margin_warning(self):
+        enrichment = compute_enrichment(
+            controls={"[elevator]Elev": -3.0},
+            limits={"[elevator]Elev": (25.0, 25.0)},
+            trim_method="avl",
+            trim_score=None,
+            trim_residuals={},
+            op_name="cruise",
+            alpha_deg=3.0,
+            stability_derivatives={"Cm_a": -0.12, "CL_a": 4.0, "Cn_b": 0.01, "Cl_b": -0.01},
+        )
+        # sm = 0.12/4.0 = 0.03 < 0.05
+        stability_warnings = [w for w in enrichment.design_warnings if w.category == "stability"]
+        assert len(stability_warnings) == 1
+        assert "Marginal" in stability_warnings[0].message
+
+    def test_high_margin_warning(self):
+        enrichment = compute_enrichment(
+            controls={"[elevator]Elev": -3.0},
+            limits={"[elevator]Elev": (25.0, 25.0)},
+            trim_method="avl",
+            trim_score=None,
+            trim_residuals={},
+            op_name="cruise",
+            alpha_deg=3.0,
+            stability_derivatives={"Cm_a": -1.4, "CL_a": 4.0, "Cn_b": 0.01, "Cl_b": -0.01},
+        )
+        # sm = 1.4/4.0 = 0.35 > 0.30
+        stability_warnings = [w for w in enrichment.design_warnings if w.category == "stability"]
+        assert len(stability_warnings) == 1
+        assert "nose-heavy" in stability_warnings[0].message
+
+    def test_negative_margin_critical(self):
+        enrichment = compute_enrichment(
+            controls={"[elevator]Elev": -3.0},
+            limits={"[elevator]Elev": (25.0, 25.0)},
+            trim_method="avl",
+            trim_score=None,
+            trim_residuals={},
+            op_name="cruise",
+            alpha_deg=3.0,
+            stability_derivatives={"Cm_a": 0.08, "CL_a": 4.0, "Cn_b": 0.01, "Cl_b": -0.01},
+        )
+        # sm = -0.08/4.0 = -0.02 < 0 -> critical
+        stability_warnings = [w for w in enrichment.design_warnings if w.category == "stability"]
+        assert len(stability_warnings) == 1
+        assert stability_warnings[0].level == "critical"
+        assert "Negative" in stability_warnings[0].message
+
+    def test_normal_margin_no_warning(self):
+        enrichment = compute_enrichment(
+            controls={"[elevator]Elev": -3.0},
+            limits={"[elevator]Elev": (25.0, 25.0)},
+            trim_method="avl",
+            trim_score=None,
+            trim_residuals={},
+            op_name="cruise",
+            alpha_deg=3.0,
+            stability_derivatives={"Cm_a": -0.6, "CL_a": 4.0, "Cn_b": 0.01, "Cl_b": -0.01},
+        )
+        # sm = 0.6/4.0 = 0.15
+        stability_warnings = [w for w in enrichment.design_warnings if w.category == "stability"]
+        assert len(stability_warnings) == 0
+
+
+# ---------------------------------------------------------------------------
+# AVL/AeroBuildup trim_enrichment field tests
+# ---------------------------------------------------------------------------
+
+
+class TestAVLTrimEnrichmentField:
+    def test_avl_result_has_trim_enrichment_field(self):
+        result = AVLTrimResult(
+            converged=True,
+            trimmed_deflections={"[elevator]Elev": -3.0},
+            aero_coefficients={"CL": 0.5},
+            stability_derivatives={"Cm_a": -0.5},
+            trim_enrichment={"analysis_goal": "test", "trim_method": "avl"},
+        )
+        assert result.trim_enrichment is not None
+        assert result.trim_enrichment["trim_method"] == "avl"
+
+    def test_avl_result_defaults_to_none(self):
+        result = AVLTrimResult(converged=False)
+        assert result.trim_enrichment is None
+
+
+class TestAeroBuildupTrimEnrichmentField:
+    def test_aerobuildup_result_has_trim_enrichment_field(self):
+        result = AeroBuildupTrimResult(
+            converged=True,
+            trim_variable="[elevator]Elev",
+            trimmed_deflection=-3.5,
+            target_coefficient="Cm",
+            achieved_value=0.0001,
+            trim_enrichment={"analysis_goal": "test", "trim_method": "aerobuildup"},
+        )
+        assert result.trim_enrichment is not None
+        assert result.trim_enrichment["trim_method"] == "aerobuildup"
+
+    def test_aerobuildup_result_defaults_to_none(self):
+        result = AeroBuildupTrimResult(
+            converged=False,
+            trim_variable="elev",
+            trimmed_deflection=0.0,
+            target_coefficient="Cm",
+            achieved_value=None,
+        )
+        assert result.trim_enrichment is None
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: enrichment wired into service entry points
 # ---------------------------------------------------------------------------
 
 
@@ -436,11 +817,25 @@ def _fake_trim(*_, target, **__):
         altitude=float(target["altitude"]),
         alpha_rad=0.05,
         beta_rad=0.0,
-        p=0.0, q=0.0, r=0.0,
+        p=0.0,
+        q=0.0,
+        r=0.0,
         status=OperatingPointStatus.TRIMMED,
         warnings=[],
         controls={"[elevator]Elevator": -3.0},
     )
+
+
+def _mock_plane_schema_with_teds(*ted_names: str) -> SimpleNamespace:
+    """Build a mock plane schema with trailing-edge devices for limit extraction."""
+    xsecs = []
+    for name in ted_names:
+        ted = SimpleNamespace(name=name, positive_deflection_deg=25.0, negative_deflection_deg=25.0)
+        xsecs.append(SimpleNamespace(trailing_edge_device=ted))
+    # Add terminal xsec with no TED
+    xsecs.append(SimpleNamespace(trailing_edge_device=None))
+    wing = SimpleNamespace(x_secs=xsecs)
+    return SimpleNamespace(wings={"main": wing})
 
 
 def _mock_airplane_for_integration(*control_names: str) -> SimpleNamespace:
@@ -455,15 +850,25 @@ def _mock_airplane_for_integration(*control_names: str) -> SimpleNamespace:
 class TestEnrichmentIntegration:
     def test_generated_ops_have_trim_enrichment(self, db_session):
         from app.services.operating_point_generator_service import generate_default_set_for_aircraft
+
         aircraft_uuid = uuid.uuid4()
         aircraft = AeroplaneModel(name="enrich-test", uuid=aircraft_uuid)
         db_session.add(aircraft)
         db_session.commit()
 
         with (
-            patch("app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async", return_value=SimpleNamespace()),
-            patch("app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async", return_value=_mock_airplane_for_integration("[elevator]Elevator", "[rudder]Rudder")),
-            patch("app.services.operating_point_generator_service._trim_or_estimate_point", side_effect=_fake_trim),
+            patch(
+                "app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async",
+                return_value=_mock_plane_schema_with_teds("[elevator]Elevator", "[rudder]Rudder"),
+            ),
+            patch(
+                "app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async",
+                return_value=_mock_airplane_for_integration("[elevator]Elevator", "[rudder]Rudder"),
+            ),
+            patch(
+                "app.services.operating_point_generator_service._trim_or_estimate_point",
+                side_effect=_fake_trim,
+            ),
         ):
             result = generate_default_set_for_aircraft(db_session, aircraft_uuid)
 
@@ -474,21 +879,33 @@ class TestEnrichmentIntegration:
 
     def test_generated_ops_enrichment_persisted_to_db(self, db_session):
         from app.services.operating_point_generator_service import generate_default_set_for_aircraft
+
         aircraft_uuid = uuid.uuid4()
         aircraft = AeroplaneModel(name="enrich-persist", uuid=aircraft_uuid)
         db_session.add(aircraft)
         db_session.commit()
 
         with (
-            patch("app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async", return_value=SimpleNamespace()),
-            patch("app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async", return_value=_mock_airplane_for_integration("[elevator]Elevator", "[rudder]Rudder")),
-            patch("app.services.operating_point_generator_service._trim_or_estimate_point", side_effect=_fake_trim),
+            patch(
+                "app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async",
+                return_value=_mock_plane_schema_with_teds("[elevator]Elevator", "[rudder]Rudder"),
+            ),
+            patch(
+                "app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async",
+                return_value=_mock_airplane_for_integration("[elevator]Elevator", "[rudder]Rudder"),
+            ),
+            patch(
+                "app.services.operating_point_generator_service._trim_or_estimate_point",
+                side_effect=_fake_trim,
+            ),
         ):
             generate_default_set_for_aircraft(db_session, aircraft_uuid)
 
-        persisted = db_session.query(OperatingPointModel).filter(
-            OperatingPointModel.aircraft_id == aircraft.id
-        ).all()
+        persisted = (
+            db_session.query(OperatingPointModel)
+            .filter(OperatingPointModel.aircraft_id == aircraft.id)
+            .all()
+        )
         for op_model in persisted:
             assert op_model.trim_enrichment is not None
 
@@ -509,9 +926,18 @@ class TestEnrichmentIntegration:
         )
 
         with (
-            patch("app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async", return_value=SimpleNamespace()),
-            patch("app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async", return_value=_mock_airplane_for_integration("[elevator]Elevator")),
-            patch("app.services.operating_point_generator_service._trim_or_estimate_point", side_effect=_fake_trim),
+            patch(
+                "app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async",
+                return_value=_mock_plane_schema_with_teds("[elevator]Elevator"),
+            ),
+            patch(
+                "app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async",
+                return_value=_mock_airplane_for_integration("[elevator]Elevator"),
+            ),
+            patch(
+                "app.services.operating_point_generator_service._trim_or_estimate_point",
+                side_effect=_fake_trim,
+            ),
         ):
             result = trim_operating_point_for_aircraft(db_session, aircraft_uuid, request)
 
@@ -530,7 +956,9 @@ class TestEnrichmentIntegration:
                 altitude=float(target["altitude"]),
                 alpha_rad=0.05,
                 beta_rad=0.0,
-                p=0.0, q=0.0, r=0.0,
+                p=0.0,
+                q=0.0,
+                r=0.0,
                 status=OperatingPointStatus.TRIMMED,
                 warnings=[],
                 controls={"[elevator]Elevator": -3.0},
@@ -544,9 +972,18 @@ class TestEnrichmentIntegration:
         db_session.commit()
 
         with (
-            patch("app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async", return_value=SimpleNamespace()),
-            patch("app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async", return_value=_mock_airplane_for_integration("[elevator]Elevator", "[rudder]Rudder")),
-            patch("app.services.operating_point_generator_service._trim_or_estimate_point", side_effect=_fake_trim_with_score),
+            patch(
+                "app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async",
+                return_value=_mock_plane_schema_with_teds("[elevator]Elevator", "[rudder]Rudder"),
+            ),
+            patch(
+                "app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async",
+                return_value=_mock_airplane_for_integration("[elevator]Elevator", "[rudder]Rudder"),
+            ),
+            patch(
+                "app.services.operating_point_generator_service._trim_or_estimate_point",
+                side_effect=_fake_trim_with_score,
+            ),
         ):
             result = generate_default_set_for_aircraft(db_session, aircraft_uuid)
 


### PR DESCRIPTION
## Summary

Closes #451

- Adds `ControlEffectiveness`, `StabilityClassification`, and `MixerValues` schemas to `TrimEnrichment`
- Creates `app/services/trim_enrichment_service.py` centralizing all enrichment computation across opti, AVL, and AeroBuildup trim paths
- Fixes `_build_deflection_limits()` to read actual TED `positive_deflection_deg`/`negative_deflection_deg` instead of hardcoded defaults
- Adds static margin warnings (<5% marginal, >30% nose-heavy, <0 unstable)
- Adds dual-role surface decomposition (elevon/flaperon/ruddervator → symmetric + differential)
- Adds per-OP result summary strings
- Wires enrichment into `AVLTrimResult` and `AeroBuildupTrimResult` response schemas
- 55 enrichment tests covering stability classification, control effectiveness, dual-role math, result summaries, warning thresholds, and schema round-trips

## Test plan

- [x] `poetry run pytest app/tests/test_trim_enrichment.py -v` — 55/55 pass
- [x] `poetry run pytest app/tests/ -x --timeout=120` — 2201/2201 pass (0 failures)
- [ ] Verify backward compatibility — existing enrichment JSON data remains valid
- [ ] Verify API responses include new enrichment fields when available

🤖 Generated with [Claude Code](https://claude.com/claude-code)