### PR TITLE
feat(gh-465): auto-compute design assumptions (CL_max, CD0, CG) from geometry

### DIFF
--- a/alembic/versions/cdcac8fb40b5_add_computation_config_table_and_.py
+++ b/alembic/versions/cdcac8fb40b5_add_computation_config_table_and_.py
@@ -1,0 +1,46 @@
+"""add computation config table and assumption context column
+
+Revision ID: cdcac8fb40b5
+Revises: 4705ef4e571b
+Create Date: 2026-05-10 12:31:45.716338
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'cdcac8fb40b5'
+down_revision: Union[str, None] = '4705ef4e571b'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Spurious drift artifacts removed — only real schema changes below.
+    op.create_table('aircraft_computation_config',
+    sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+    sa.Column('aeroplane_id', sa.Integer(), nullable=False),
+    sa.Column('coarse_alpha_min_deg', sa.Float(), nullable=False),
+    sa.Column('coarse_alpha_max_deg', sa.Float(), nullable=False),
+    sa.Column('coarse_alpha_step_deg', sa.Float(), nullable=False),
+    sa.Column('fine_alpha_margin_deg', sa.Float(), nullable=False),
+    sa.Column('fine_alpha_step_deg', sa.Float(), nullable=False),
+    sa.Column('fine_velocity_count', sa.Integer(), nullable=False),
+    sa.Column('debounce_seconds', sa.Float(), nullable=False),
+    sa.ForeignKeyConstraint(['aeroplane_id'], ['aeroplanes.id'], ondelete='CASCADE'),
+    sa.PrimaryKeyConstraint('id'),
+    sa.UniqueConstraint('aeroplane_id', name='uq_computation_config_aeroplane')
+    )
+    op.create_index(op.f('ix_aircraft_computation_config_aeroplane_id'), 'aircraft_computation_config', ['aeroplane_id'], unique=False)
+    op.add_column('aeroplanes', sa.Column('assumption_computation_context', sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('aeroplanes', 'assumption_computation_context')
+    op.drop_index(op.f('ix_aircraft_computation_config_aeroplane_id'), table_name='aircraft_computation_config')
+    op.drop_table('aircraft_computation_config')

--- a/app/api/v2/endpoints/aeroplane/design_assumptions.py
+++ b/app/api/v2/endpoints/aeroplane/design_assumptions.py
@@ -183,7 +183,7 @@ def _resolve_aeroplane(db: Session, aeroplane_id: UUID4) -> AeroplaneModel:
 async def get_recompute_status(
     aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
     db: Annotated[Session, Depends(get_db)],
-):
+) -> dict[str, str | None]:
     """Returns the live state of the per-aircraft recompute job so the
     UI can show a 'Recomputing…' indicator regardless of which event
     triggered the job (geometry change, mass change, SM change, …)."""
@@ -219,7 +219,7 @@ async def get_recompute_status(
 async def get_computation_context(
     aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
     db: Annotated[Session, Depends(get_db)],
-):
+) -> dict | None:
     """Return the JSON context cached by the last assumption recompute,
     or null if no recompute has run yet."""
     aeroplane = _resolve_aeroplane(db, aeroplane_id)

--- a/app/api/v2/endpoints/aeroplane/design_assumptions.py
+++ b/app/api/v2/endpoints/aeroplane/design_assumptions.py
@@ -168,6 +168,40 @@ def _resolve_aeroplane(db: Session, aeroplane_id: UUID4) -> AeroplaneModel:
 
 
 # ---------------------------------------------------------------------------
+# Recompute status endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/aeroplanes/{aeroplane_id}/assumptions/recompute-status",
+    status_code=status.HTTP_200_OK,
+    tags=["design-assumptions"],
+    operation_id="get_recompute_status",
+    summary="Get current state of the assumption recompute job",
+    responses={404: {"description": "Aeroplane not found"}},
+)
+async def get_recompute_status(
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    db: Annotated[Session, Depends(get_db)],
+):
+    """Returns the live state of the per-aircraft recompute job so the
+    UI can show a 'Recomputing…' indicator regardless of which event
+    triggered the job (geometry change, mass change, SM change, …)."""
+    from app.core.background_jobs import job_tracker
+
+    aeroplane = _resolve_aeroplane(db, aeroplane_id)
+    job = job_tracker.get_recompute_job(aeroplane.id)
+    if job is None:
+        return {"status": "idle", "started_at": None, "finished_at": None, "error": None}
+    return {
+        "status": job.status.value.lower(),
+        "started_at": job.started_at.isoformat() if job.started_at else None,
+        "finished_at": job.finished_at.isoformat() if job.finished_at else None,
+        "error": job.error,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Computation-context endpoint
 # ---------------------------------------------------------------------------
 

--- a/app/api/v2/endpoints/aeroplane/design_assumptions.py
+++ b/app/api/v2/endpoints/aeroplane/design_assumptions.py
@@ -18,6 +18,12 @@ from app.core.exceptions import (
     ValidationError,
 )
 from app.db.session import get_db
+from app.models.aeroplanemodel import AeroplaneModel
+from app.models.computation_config import (
+    COMPUTATION_CONFIG_DEFAULTS,
+    AircraftComputationConfigModel,
+)
+from app.schemas.computation_config import ComputationConfigRead, ComputationConfigWrite
 from app.schemas.design_assumption import (
     PARAMETER_DEFAULTS,
     AssumptionRead,
@@ -140,3 +146,127 @@ async def switch_source_endpoint(
 ) -> AssumptionRead:
     """Switch a design assumption between ESTIMATE and CALCULATED sources."""
     return _call(svc.switch_source, db, aeroplane_id, param_name, body)
+
+
+# ---------------------------------------------------------------------------
+# Inline helper — resolve aeroplane UUID → model row (raises 404 if missing)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_aeroplane(db: Session, aeroplane_id: UUID4) -> AeroplaneModel:
+    """Return the AeroplaneModel for *aeroplane_id*, or raise HTTP 404."""
+    aeroplane = (
+        db.query(AeroplaneModel)
+        .filter(AeroplaneModel.uuid == str(aeroplane_id))
+        .first()
+    )
+    if aeroplane is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Aeroplane not found"
+        )
+    return aeroplane
+
+
+# ---------------------------------------------------------------------------
+# Computation-context endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/aeroplanes/{aeroplane_id}/assumptions/computation-context",
+    status_code=status.HTTP_200_OK,
+    tags=["design-assumptions"],
+    operation_id="get_computation_context",
+    summary="Get cached computation context",
+    responses={
+        404: {"description": "Aeroplane not found"},
+    },
+)
+async def get_computation_context(
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    db: Annotated[Session, Depends(get_db)],
+):
+    """Return the JSON context cached by the last assumption recompute,
+    or null if no recompute has run yet."""
+    aeroplane = _resolve_aeroplane(db, aeroplane_id)
+    return aeroplane.assumption_computation_context
+
+
+# ---------------------------------------------------------------------------
+# Computation-config endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/aeroplanes/{aeroplane_id}/computation-config",
+    response_model=ComputationConfigRead,
+    status_code=status.HTTP_200_OK,
+    tags=["design-assumptions"],
+    operation_id="get_computation_config",
+    summary="Get computation configuration",
+    responses={
+        404: {"description": "Aeroplane not found"},
+    },
+)
+async def get_computation_config(
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    db: Annotated[Session, Depends(get_db)],
+) -> ComputationConfigRead:
+    """Return the per-aircraft computation config, creating a default row
+    if it does not yet exist."""
+    aeroplane = _resolve_aeroplane(db, aeroplane_id)
+    config = (
+        db.query(AircraftComputationConfigModel)
+        .filter(AircraftComputationConfigModel.aeroplane_id == aeroplane.id)
+        .first()
+    )
+    if config is None:
+        config = AircraftComputationConfigModel(
+            aeroplane_id=aeroplane.id,
+            **COMPUTATION_CONFIG_DEFAULTS,
+        )
+        db.add(config)
+        db.flush()
+        db.refresh(config)
+    return config  # type: ignore[return-value]
+
+
+@router.put(
+    "/aeroplanes/{aeroplane_id}/computation-config",
+    response_model=ComputationConfigRead,
+    status_code=status.HTTP_200_OK,
+    tags=["design-assumptions"],
+    operation_id="update_computation_config",
+    summary="Update computation configuration",
+    responses={
+        404: {"description": "Aeroplane not found"},
+        422: {"description": "Validation error"},
+    },
+)
+async def update_computation_config(
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    body: Annotated[ComputationConfigWrite, Body(..., description="Partial update payload")],
+    db: Annotated[Session, Depends(get_db)],
+) -> ComputationConfigRead:
+    """Partial update of the computation config. Missing/null fields keep
+    their current value (or the default if no row exists yet)."""
+    aeroplane = _resolve_aeroplane(db, aeroplane_id)
+    config = (
+        db.query(AircraftComputationConfigModel)
+        .filter(AircraftComputationConfigModel.aeroplane_id == aeroplane.id)
+        .first()
+    )
+    if config is None:
+        config = AircraftComputationConfigModel(
+            aeroplane_id=aeroplane.id,
+            **COMPUTATION_CONFIG_DEFAULTS,
+        )
+        db.add(config)
+        db.flush()
+
+    update_data = body.model_dump(exclude_none=True)
+    for key, val in update_data.items():
+        setattr(config, key, val)
+    db.flush()
+    db.refresh(config)
+    return config  # type: ignore[return-value]

--- a/app/core/background_jobs.py
+++ b/app/core/background_jobs.py
@@ -174,6 +174,16 @@ class JobTracker:
             return False
         return job.status == JobStatus.DEBOUNCING
 
+    def get_recompute_job(self, aeroplane_id: int) -> RecomputeAssumptionsJob | None:
+        return self._recompute_jobs.get(aeroplane_id)
+
+    def is_recompute_active(self, aeroplane_id: int) -> bool:
+        """True while a recompute is debouncing or running."""
+        job = self._recompute_jobs.get(aeroplane_id)
+        if job is None:
+            return False
+        return job.status in (JobStatus.DEBOUNCING, JobStatus.COMPUTING)
+
     async def shutdown(self) -> None:
         for task in self._debounce_tasks.values():
             if not task.done():

--- a/app/core/background_jobs.py
+++ b/app/core/background_jobs.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Awaitable, Callable
+from typing import Awaitable, Callable, Coroutine
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +50,50 @@ class JobTracker:
         self._recompute_jobs: dict[int, RecomputeAssumptionsJob] = {}
         self._recompute_debounce_tasks: dict[int, asyncio.Task] = {}
         self._recompute_function: Callable[[int], Awaitable[None]] | None = None
+        # Reference to the FastAPI event loop, captured at startup. Lets
+        # us schedule from worker threads (asyncio.to_thread inside the
+        # recompute pipeline) instead of silently failing with
+        # "no running event loop".
+        self._main_loop: asyncio.AbstractEventLoop | None = None
+
+    def bind_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Capture the application's main event loop. Call from lifespan."""
+        self._main_loop = loop
+
+    def _create_task_safe(self, coro: Coroutine[None, None, None]) -> asyncio.Task | None:
+        """Create a task on the main loop regardless of caller thread.
+
+        Returns None when no loop is bound and we're not running inside
+        one — in that case the schedule is silently dropped (matching
+        previous behaviour for non-server contexts like unit tests).
+        """
+        try:
+            running = asyncio.get_running_loop()
+            return running.create_task(coro)
+        except RuntimeError:
+            pass
+        if self._main_loop is None:
+            logger.debug("No bound event loop — skipping schedule")
+            return None
+        # asyncio.run_coroutine_threadsafe returns a concurrent.futures.Future.
+        # We don't track it here because cancellation of cross-thread
+        # tasks is awkward; the debounce-cancel path uses asyncio.Task,
+        # so we only accept proper Task creation for tracking.
+        # Workaround: schedule via call_soon_threadsafe so the actual
+        # create_task happens on the main thread, returning a real Task
+        # via a small wrapper.
+        result: dict[str, asyncio.Task | None] = {"task": None}
+        ready = threading.Event()
+
+        def _make_task() -> None:
+            try:
+                result["task"] = self._main_loop.create_task(coro)  # type: ignore[union-attr]
+            finally:
+                ready.set()
+
+        self._main_loop.call_soon_threadsafe(_make_task)
+        ready.wait(timeout=2.0)
+        return result["task"]
 
     def set_trim_function(self, fn: Callable[[int], Awaitable[None]]) -> None:
         self._trim_function = fn
@@ -63,21 +108,22 @@ class JobTracker:
             return
 
         existing_task = self._debounce_tasks.get(aeroplane_id)
-        if existing_task and not existing_task.done():
-            existing_task.cancel()
 
-        self._jobs[aeroplane_id] = RetrimJob(aeroplane_id=aeroplane_id)
-
-        try:
-            loop = asyncio.get_running_loop()
-            self._debounce_tasks[aeroplane_id] = loop.create_task(
-                self._debounced_retrim(aeroplane_id)
-            )
-        except RuntimeError:
+        # Try to create the new task FIRST. Only cancel the existing
+        # task and overwrite the job if creation succeeded — otherwise
+        # we'd leave the job in DEBOUNCING with no task to fire it.
+        new_task = self._create_task_safe(self._debounced_retrim(aeroplane_id))
+        if new_task is None:
             logger.debug(
-                "No running event loop — skipping background retrim for aeroplane %d",
+                "Cannot schedule retrim for aeroplane %d — no event loop available",
                 aeroplane_id,
             )
+            return
+
+        if existing_task and not existing_task.done():
+            existing_task.cancel()
+        self._jobs[aeroplane_id] = RetrimJob(aeroplane_id=aeroplane_id)
+        self._debounce_tasks[aeroplane_id] = new_task
 
     async def _debounced_retrim(self, aeroplane_id: int) -> None:
         try:
@@ -112,21 +158,23 @@ class JobTracker:
 
     def schedule_recompute_assumptions(self, aeroplane_id: int) -> None:
         existing_task = self._recompute_debounce_tasks.get(aeroplane_id)
-        if existing_task and not existing_task.done():
-            existing_task.cancel()
 
-        self._recompute_jobs[aeroplane_id] = RecomputeAssumptionsJob(aeroplane_id=aeroplane_id)
-
-        try:
-            loop = asyncio.get_running_loop()
-            self._recompute_debounce_tasks[aeroplane_id] = loop.create_task(
-                self._debounced_recompute(aeroplane_id)
-            )
-        except RuntimeError:
+        # Same atomic-create pattern as schedule_retrim: build the task
+        # before clobbering existing state. Otherwise a worker-thread
+        # caller (no event loop) would cancel the in-flight debounce
+        # and leave the job stuck in DEBOUNCING forever.
+        new_task = self._create_task_safe(self._debounced_recompute(aeroplane_id))
+        if new_task is None:
             logger.debug(
-                "No running event loop — skipping recompute for aeroplane %d",
+                "Cannot schedule recompute for aeroplane %d — no event loop available",
                 aeroplane_id,
             )
+            return
+
+        if existing_task and not existing_task.done():
+            existing_task.cancel()
+        self._recompute_jobs[aeroplane_id] = RecomputeAssumptionsJob(aeroplane_id=aeroplane_id)
+        self._recompute_debounce_tasks[aeroplane_id] = new_task
 
     async def _debounced_recompute(self, aeroplane_id: int) -> None:
         try:

--- a/app/core/background_jobs.py
+++ b/app/core/background_jobs.py
@@ -126,10 +126,11 @@ class JobTracker:
         self._debounce_tasks[aeroplane_id] = new_task
 
     async def _debounced_retrim(self, aeroplane_id: int) -> None:
-        try:
-            await asyncio.sleep(self.debounce_seconds)
-        except asyncio.CancelledError:
-            return
+        # If the task is cancelled (replaced by a newer schedule),
+        # CancelledError propagates from asyncio.sleep and the
+        # coroutine ends. No catch needed — propagation is the
+        # correct cooperative-cancellation pattern.
+        await asyncio.sleep(self.debounce_seconds)
 
         if self._trim_function is None:
             logger.warning("No trim function registered — cannot retrim aeroplane %d", aeroplane_id)
@@ -177,10 +178,8 @@ class JobTracker:
         self._recompute_debounce_tasks[aeroplane_id] = new_task
 
     async def _debounced_recompute(self, aeroplane_id: int) -> None:
-        try:
-            await asyncio.sleep(self.debounce_seconds)
-        except asyncio.CancelledError:
-            return
+        # See _debounced_retrim for the cancellation-propagation rationale.
+        await asyncio.sleep(self.debounce_seconds)
 
         if self._recompute_function is None:
             logger.warning(

--- a/app/core/background_jobs.py
+++ b/app/core/background_jobs.py
@@ -31,12 +31,24 @@ class RetrimJob:
     error: str | None = None
 
 
+@dataclass
+class RecomputeAssumptionsJob:
+    aeroplane_id: int
+    status: JobStatus = JobStatus.DEBOUNCING
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    error: str | None = None
+
+
 class JobTracker:
     def __init__(self, debounce_seconds: float = 2.0) -> None:
         self.debounce_seconds = debounce_seconds
         self._jobs: dict[int, RetrimJob] = {}
         self._debounce_tasks: dict[int, asyncio.Task] = {}
         self._trim_function: Callable[[int], Awaitable[None]] | None = None
+        self._recompute_jobs: dict[int, RecomputeAssumptionsJob] = {}
+        self._recompute_debounce_tasks: dict[int, asyncio.Task] = {}
+        self._recompute_function: Callable[[int], Awaitable[None]] | None = None
 
     def set_trim_function(self, fn: Callable[[int], Awaitable[None]]) -> None:
         self._trim_function = fn
@@ -95,6 +107,58 @@ class JobTracker:
             job.finished_at = datetime.now(timezone.utc)
             self._debounce_tasks.pop(aeroplane_id, None)
 
+    def set_recompute_function(self, fn: Callable[[int], Awaitable[None]]) -> None:
+        self._recompute_function = fn
+
+    def schedule_recompute_assumptions(self, aeroplane_id: int) -> None:
+        existing_task = self._recompute_debounce_tasks.get(aeroplane_id)
+        if existing_task and not existing_task.done():
+            existing_task.cancel()
+
+        self._recompute_jobs[aeroplane_id] = RecomputeAssumptionsJob(aeroplane_id=aeroplane_id)
+
+        try:
+            loop = asyncio.get_running_loop()
+            self._recompute_debounce_tasks[aeroplane_id] = loop.create_task(
+                self._debounced_recompute(aeroplane_id)
+            )
+        except RuntimeError:
+            logger.debug(
+                "No running event loop — skipping recompute for aeroplane %d",
+                aeroplane_id,
+            )
+
+    async def _debounced_recompute(self, aeroplane_id: int) -> None:
+        try:
+            await asyncio.sleep(self.debounce_seconds)
+        except asyncio.CancelledError:
+            return
+
+        if self._recompute_function is None:
+            logger.warning(
+                "No recompute function registered — cannot recompute for aeroplane %d",
+                aeroplane_id,
+            )
+            return
+
+        job = self._recompute_jobs.get(aeroplane_id)
+        if job is None:
+            return
+
+        job.status = JobStatus.COMPUTING
+        job.started_at = datetime.now(timezone.utc)
+
+        try:
+            await self._recompute_function(aeroplane_id)
+            job.status = JobStatus.DONE
+        except Exception as exc:
+            logger.exception("Recompute assumptions failed for aeroplane %d", aeroplane_id)
+            job.status = JobStatus.FAILED
+            job.error = str(exc)
+        finally:
+            job.finished_at = datetime.now(timezone.utc)
+            self._recompute_debounce_tasks.pop(aeroplane_id, None)
+
     def get_job(self, aeroplane_id: int) -> RetrimJob | None:
         return self._jobs.get(aeroplane_id)
 
@@ -118,6 +182,17 @@ class JobTracker:
             await asyncio.gather(*self._debounce_tasks.values(), return_exceptions=True)
         self._debounce_tasks.clear()
         for job in self._jobs.values():
+            if job.status == JobStatus.COMPUTING:
+                job.status = JobStatus.FAILED
+                job.error = "Server shutdown"
+
+        for task in self._recompute_debounce_tasks.values():
+            if not task.done():
+                task.cancel()
+        if self._recompute_debounce_tasks:
+            await asyncio.gather(*self._recompute_debounce_tasks.values(), return_exceptions=True)
+        self._recompute_debounce_tasks.clear()
+        for job in self._recompute_jobs.values():
             if job.status == JobStatus.COMPUTING:
                 job.status = JobStatus.FAILED
                 job.error = "Server shutdown"

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -1,15 +1,56 @@
 
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker, Session
 import os
+
+from sqlalchemy import create_engine, event
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, sessionmaker
 
 SQLALCHEMY_DATABASE_URL = os.getenv(
     "SQLALCHEMY_DATABASE_URL",
     "sqlite:///./db/test.db",  # Fallback für lokal
 )
 
-engine = create_engine(SQLALCHEMY_DATABASE_URL)
-SessionLocal = sessionmaker(bind=engine, class_=Session, expire_on_commit=False, autocommit=False, autoflush=False)
+_is_sqlite = SQLALCHEMY_DATABASE_URL.startswith("sqlite")
+
+# SQLite: long-running async writers (assumption recompute) hold a
+# transaction for several seconds while AeroBuildup runs. Without WAL +
+# a generous busy_timeout, parallel writes (e.g. user clicking "Use
+# calc" while a recompute is in flight) fail with "database is locked".
+_engine_kwargs: dict = {}
+if _is_sqlite:
+    _engine_kwargs["connect_args"] = {
+        "check_same_thread": False,  # asyncio.to_thread workers cross threads
+        "timeout": 30,                # block up to 30s on a locked DB instead of failing
+    }
+
+engine = create_engine(SQLALCHEMY_DATABASE_URL, **_engine_kwargs)
+SessionLocal = sessionmaker(
+    bind=engine,
+    class_=Session,
+    expire_on_commit=False,
+    autocommit=False,
+    autoflush=False,
+)
+
+
+if _is_sqlite:
+    @event.listens_for(Engine, "connect")
+    def _set_sqlite_pragmas(dbapi_connection, _connection_record) -> None:
+        """Enable WAL + sane defaults on every new SQLite connection.
+
+        WAL allows concurrent readers and a single writer to make
+        progress without locking each other out — necessary because
+        the assumption recompute keeps a write transaction open for
+        several seconds.
+        """
+        cursor = dbapi_connection.cursor()
+        try:
+            cursor.execute("PRAGMA journal_mode=WAL")
+            cursor.execute("PRAGMA synchronous=NORMAL")
+            cursor.execute("PRAGMA busy_timeout=30000")
+        finally:
+            cursor.close()
+
 
 def get_db() -> Session:
     db = SessionLocal()

--- a/app/main.py
+++ b/app/main.py
@@ -116,9 +116,14 @@ def create_app() -> FastAPI:
         from app.services.retrim_service import retrim_dirty_ops
         from app.core.background_jobs import job_tracker
 
+        import asyncio as _asyncio
+
+        # Bind the FastAPI event loop so JobTracker can schedule from
+        # worker threads (asyncio.to_thread inside the recompute
+        # pipeline).
+        job_tracker.bind_loop(_asyncio.get_running_loop())
         job_tracker.set_trim_function(retrim_dirty_ops)
 
-        import asyncio as _asyncio
         from app.db.session import SessionLocal as _SessionLocal
         from app.models.aeroplanemodel import AeroplaneModel as _AeroplaneModel
         from app.services.assumption_compute_service import (

--- a/app/main.py
+++ b/app/main.py
@@ -118,6 +118,38 @@ def create_app() -> FastAPI:
 
         job_tracker.set_trim_function(retrim_dirty_ops)
 
+        import asyncio as _asyncio
+        from app.db.session import SessionLocal as _SessionLocal
+        from app.models.aeroplanemodel import AeroplaneModel as _AeroplaneModel
+        from app.services.assumption_compute_service import (
+            recompute_assumptions as _recompute_assumptions,
+        )
+
+        def _recompute_sync(aeroplane_id: int) -> None:
+            db = _SessionLocal()
+            try:
+                aeroplane = (
+                    db.query(_AeroplaneModel)
+                    .filter(_AeroplaneModel.id == aeroplane_id)
+                    .first()
+                )
+                if aeroplane is None:
+                    return
+                _recompute_assumptions(db, str(aeroplane.uuid))
+                db.commit()
+            except Exception:
+                db.rollback()
+                raise
+            finally:
+                db.close()
+
+        async def _recompute_wrapper(aeroplane_id: int) -> None:
+            # ASB calls are CPU-bound (~200 calls per recompute). Running them
+            # directly on the event loop would block all other requests.
+            await _asyncio.to_thread(_recompute_sync, aeroplane_id)
+
+        job_tracker.set_recompute_function(_recompute_wrapper)
+
         async with mcp_app.lifespan(app):
             try:
                 yield

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -8,5 +8,6 @@ from app.models.aeroplanemodel import (
     WingXSecTedServoModel,
 )
 from app.models.analysismodels import OperatingPointModel, OperatingPointSetModel
+from app.models.computation_config import AircraftComputationConfigModel
 from app.models.flight_envelope_model import FlightEnvelopeModel
 from app.models.flightprofilemodel import RCFlightProfileModel

--- a/app/models/aeroplanemodel.py
+++ b/app/models/aeroplanemodel.py
@@ -483,6 +483,7 @@ class AeroplaneModel(Base):
         Integer, ForeignKey("rc_flight_profiles.id"), nullable=True, index=True
     )
     xyz_ref = Column(JSON, default=[0, 0, 0])  # Store as JSON array
+    assumption_computation_context = Column(JSON, nullable=True)
     created_at = Column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
@@ -534,6 +535,12 @@ class AeroplaneModel(Base):
         "DesignAssumptionModel",
         back_populates="aeroplane",
         cascade=_CASCADE_ALL_DELETE_ORPHAN,
+    )
+    computation_config = relationship(
+        "AircraftComputationConfigModel",
+        back_populates="aeroplane",
+        uselist=False,
+        cascade="all, delete-orphan",
     )
     stability_results = relationship(
         "StabilityResultModel",

--- a/app/models/aeroplanemodel.py
+++ b/app/models/aeroplanemodel.py
@@ -540,7 +540,7 @@ class AeroplaneModel(Base):
         "AircraftComputationConfigModel",
         back_populates="aeroplane",
         uselist=False,
-        cascade="all, delete-orphan",
+        cascade=_CASCADE_ALL_DELETE_ORPHAN,
     )
     stability_results = relationship(
         "StabilityResultModel",

--- a/app/models/computation_config.py
+++ b/app/models/computation_config.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from sqlalchemy import Column, Float, ForeignKey, Integer, UniqueConstraint
+from sqlalchemy.orm import relationship
+
+from app.db.base import Base
+
+COMPUTATION_CONFIG_DEFAULTS: dict[str, float | int] = {
+    "coarse_alpha_min_deg": -5.0,
+    "coarse_alpha_max_deg": 25.0,
+    "coarse_alpha_step_deg": 1.0,
+    "fine_alpha_margin_deg": 5.0,
+    "fine_alpha_step_deg": 0.5,
+    "fine_velocity_count": 8,
+    "debounce_seconds": 2.0,
+}
+
+
+class AircraftComputationConfigModel(Base):
+    """Per-aircraft sweep parameters for auto-compute of design assumptions.
+
+    Stored in its own table (rather than as columns on AeroplaneModel) so
+    the configuration surface can grow without churning the aeroplanes
+    schema. Defaults live in code (COMPUTATION_CONFIG_DEFAULTS) and are
+    seeded into rows by the service layer.
+    """
+
+    __tablename__ = "aircraft_computation_config"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    aeroplane_id = Column(
+        Integer,
+        ForeignKey("aeroplanes.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    coarse_alpha_min_deg = Column(
+        Float, nullable=False, default=COMPUTATION_CONFIG_DEFAULTS["coarse_alpha_min_deg"]
+    )
+    coarse_alpha_max_deg = Column(
+        Float, nullable=False, default=COMPUTATION_CONFIG_DEFAULTS["coarse_alpha_max_deg"]
+    )
+    coarse_alpha_step_deg = Column(
+        Float, nullable=False, default=COMPUTATION_CONFIG_DEFAULTS["coarse_alpha_step_deg"]
+    )
+    fine_alpha_margin_deg = Column(
+        Float, nullable=False, default=COMPUTATION_CONFIG_DEFAULTS["fine_alpha_margin_deg"]
+    )
+    fine_alpha_step_deg = Column(
+        Float, nullable=False, default=COMPUTATION_CONFIG_DEFAULTS["fine_alpha_step_deg"]
+    )
+    fine_velocity_count = Column(
+        Integer, nullable=False, default=COMPUTATION_CONFIG_DEFAULTS["fine_velocity_count"]
+    )
+    debounce_seconds = Column(
+        Float, nullable=False, default=COMPUTATION_CONFIG_DEFAULTS["debounce_seconds"]
+    )
+
+    aeroplane = relationship("AeroplaneModel", back_populates="computation_config")
+
+    __table_args__ = (
+        UniqueConstraint("aeroplane_id", name="uq_computation_config_aeroplane"),
+    )

--- a/app/schemas/computation_config.py
+++ b/app/schemas/computation_config.py
@@ -1,0 +1,52 @@
+"""Computation config schemas — controls the alpha-sweep and debounce parameters
+used when auto-computing design assumptions (cl_max, cd0, cg_x) from geometry."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ComputationConfigRead(BaseModel):
+    """Full representation of a computation config record, returned by the API."""
+
+    id: int
+    aeroplane_id: int
+    coarse_alpha_min_deg: float = Field(..., description="Lower bound of the coarse alpha sweep (deg)")
+    coarse_alpha_max_deg: float = Field(..., description="Upper bound of the coarse alpha sweep (deg)")
+    coarse_alpha_step_deg: float = Field(..., description="Step size of the coarse alpha sweep (deg)")
+    fine_alpha_margin_deg: float = Field(
+        ..., description="Margin around the coarse peak used for the fine sweep (deg)"
+    )
+    fine_alpha_step_deg: float = Field(..., description="Step size of the fine alpha sweep (deg)")
+    fine_velocity_count: int = Field(..., description="Number of velocity samples in the fine sweep")
+    debounce_seconds: float = Field(
+        ..., description="Idle time before an auto-compute job is triggered (s)"
+    )
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ComputationConfigWrite(BaseModel):
+    """Partial-update payload for a computation config; all fields are optional."""
+
+    coarse_alpha_min_deg: float | None = Field(
+        None, description="Lower bound of the coarse alpha sweep (deg)"
+    )
+    coarse_alpha_max_deg: float | None = Field(
+        None, description="Upper bound of the coarse alpha sweep (deg)"
+    )
+    coarse_alpha_step_deg: float | None = Field(
+        None, gt=0, description="Must be positive — step size of the coarse alpha sweep (deg)"
+    )
+    fine_alpha_margin_deg: float | None = Field(
+        None, gt=0, description="Must be positive — margin around the coarse peak (deg)"
+    )
+    fine_alpha_step_deg: float | None = Field(
+        None, gt=0, description="Must be positive — step size of the fine alpha sweep (deg)"
+    )
+    fine_velocity_count: int | None = Field(
+        None, ge=2, le=50, description="Number of velocity samples (2–50)"
+    )
+    debounce_seconds: float | None = Field(
+        None, ge=0.5, le=30.0, description="Debounce idle time in seconds (0.5–30)"
+    )

--- a/app/schemas/design_assumption.py
+++ b/app/schemas/design_assumption.py
@@ -8,10 +8,22 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 
-VALID_PARAMETERS = Literal["mass", "cg_x", "target_static_margin", "cd0", "cl_max", "g_limit"]
+VALID_PARAMETERS = Literal[
+    "mass",
+    "cg_x",
+    "target_static_margin",
+    "cd0",
+    "cl_max",
+    "g_limit",
+    "power_to_weight",
+    "prop_efficiency",
+]
 ACTIVE_SOURCE = Literal["ESTIMATE", "CALCULATED"]
 DIVERGENCE_LEVEL = Literal["none", "info", "warning", "alert"]
 
+# Pure user choices that never get a calculated value. power_to_weight
+# and prop_efficiency are NOT in this set: they're user-set initially
+# but will be replaced by a powertrain compute later.
 DESIGN_CHOICE_PARAMS = frozenset({"target_static_margin", "g_limit"})
 
 PARAMETER_UNITS: dict[str, str] = {
@@ -21,6 +33,8 @@ PARAMETER_UNITS: dict[str, str] = {
     "cd0": "",
     "cl_max": "",
     "g_limit": "g",
+    "power_to_weight": "W/kg",
+    "prop_efficiency": "",
 }
 
 PARAMETER_DEFAULTS: dict[str, float] = {
@@ -30,6 +44,8 @@ PARAMETER_DEFAULTS: dict[str, float] = {
     "cd0": 0.03,
     "cl_max": 1.4,
     "g_limit": 3.0,
+    "power_to_weight": 300.0,  # typical RC sport model; 0 means glider
+    "prop_efficiency": 0.65,    # typical 65% for RC propellers at cruise
 }
 
 

--- a/app/schemas/design_assumption.py
+++ b/app/schemas/design_assumption.py
@@ -44,8 +44,16 @@ PARAMETER_DEFAULTS: dict[str, float] = {
     "cd0": 0.03,
     "cl_max": 1.4,
     "g_limit": 3.0,
-    "power_to_weight": 300.0,  # typical RC sport model; 0 means glider
-    "prop_efficiency": 0.65,    # typical 65% for RC propellers at cruise
+    # Typical RC ranges (per common P/W chart):
+    #   160-200 W/kg → trainer / slow aerobatic
+    #   200-240 W/kg → sport aerobatic / scale     ← default
+    #   240-290 W/kg → advanced aerobatic / fast
+    #   290-330 W/kg → light 3D / ducted fan
+    #   330-440 W/kg → unlimited 3D
+    #   0           → glider (no powertrain, V_max = structural V_NE)
+    "power_to_weight": 220.0,
+    # Typical 0.55-0.75 for RC propellers at cruise; 0.65 is a sane middle.
+    "prop_efficiency": 0.65,
 }
 
 

--- a/app/services/assumption_compute_service.py
+++ b/app/services/assumption_compute_service.py
@@ -113,19 +113,23 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
     cg_agg = _load_cg_agg(db, aircraft.id)
     re = _reynolds_number(v_cruise, mac)
     mass = _load_effective_assumption(db, aircraft.id, "mass")
-    # Use the EFFECTIVE cl_max so a user override (toggle to ESTIMATE)
-    # actually changes V_stall — otherwise V_stall would always reflect
-    # the geometry-derived value regardless of the user's choice.
+    # Use EFFECTIVE values so user overrides (toggle to ESTIMATE)
+    # actually change V_stall and V_md.
     cl_max_effective = _load_effective_assumption(db, aircraft.id, "cl_max")
+    cd0_effective = _load_effective_assumption(db, aircraft.id, "cd0")
+    aspect_ratio = _main_wing_aspect_ratio(asb_airplane)
     v_stall = _stall_speed(mass, s_ref, cl_max_effective)
+    v_md = _min_drag_speed(mass, s_ref, cd0_effective, aspect_ratio)
 
     _cache_context(db, aircraft, {
         "v_cruise_mps": v_cruise,
         "v_max_mps": round(v_max, 1),
         "v_stall_mps": round(v_stall, 1) if v_stall is not None else None,
+        "v_md_mps": round(v_md, 1) if v_md is not None else None,
         "reynolds": round(re),
         "mac_m": round(mac, 4),
         "s_ref_m2": round(s_ref, 4),
+        "aspect_ratio": round(aspect_ratio, 2) if aspect_ratio is not None else None,
         "x_np_m": round(x_np, 4),
         "target_static_margin": target_sm,
         "cg_agg_m": round(cg_agg, 4) if cg_agg is not None else None,
@@ -367,6 +371,52 @@ def _stall_speed(
     cl_max_safe = max(cl_max, 0.5)
     weight_n = mass_kg * g
     return float(np.sqrt(2.0 * weight_n / (rho * s_ref_m2 * cl_max_safe)))
+
+
+def _main_wing_aspect_ratio(asb_airplane) -> float | None:
+    """Aspect ratio AR = b² / S of the main wing (largest planform)."""
+    main = _select_main_wing(asb_airplane)
+    if main is None:
+        return None
+    s = float(main.area())
+    b = float(main.span())
+    if s <= 0:
+        return None
+    return (b * b) / s
+
+
+def _min_drag_speed(
+    mass_kg: float,
+    s_ref_m2: float,
+    cd0: float,
+    aspect_ratio: float | None,
+    rho: float = 1.225,
+    g: float = 9.81,
+    oswald_e: float = 0.8,
+) -> float | None:
+    """Sea-level minimum-drag speed (= best L/D = best range for prop).
+
+    Derivation: at (L/D)_max the induced drag equals the parasitic
+    drag, giving CL_opt = sqrt(CD0/k) with k = 1 / (pi · AR · e).
+    Solving level flight L = W for V yields:
+
+        V_md = sqrt( (2 m g) / (rho S sqrt(CD0/k)) )
+
+    Returns None for degenerate inputs (no wing, zero AR, zero CD0).
+    """
+    if (
+        s_ref_m2 <= 0
+        or cd0 <= 1e-6
+        or aspect_ratio is None
+        or aspect_ratio <= 0
+    ):
+        return None
+    k = 1.0 / (np.pi * aspect_ratio * oswald_e)
+    cl_opt = float(np.sqrt(cd0 / k))
+    if cl_opt <= 0:
+        return None
+    weight_n = mass_kg * g
+    return float(np.sqrt(2.0 * weight_n / (rho * s_ref_m2 * cl_opt)))
 
 
 def _cache_context(

--- a/app/services/assumption_compute_service.py
+++ b/app/services/assumption_compute_service.py
@@ -114,18 +114,30 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
     re = _reynolds_number(v_cruise, mac)
     mass = _load_effective_assumption(db, aircraft.id, "mass")
     # Use EFFECTIVE values so user overrides (toggle to ESTIMATE)
-    # actually change V_stall and V_md.
+    # actually change V_stall, V_md, and V_max.
     cl_max_effective = _load_effective_assumption(db, aircraft.id, "cl_max")
     cd0_effective = _load_effective_assumption(db, aircraft.id, "cd0")
+    p_to_w = _load_effective_assumption(db, aircraft.id, "power_to_weight")
+    prop_eta = _load_effective_assumption(db, aircraft.id, "prop_efficiency")
     aspect_ratio = _main_wing_aspect_ratio(asb_airplane)
     v_stall = _stall_speed(mass, s_ref, cl_max_effective)
     v_md = _min_drag_speed(mass, s_ref, cd0_effective, aspect_ratio)
 
+    # V_max from physics if powered (P/W > 0); otherwise fall back to
+    # the user-set goal in the flight profile (gliders set max speed
+    # via structural limits, not thrust).
+    v_max_computed = _max_level_speed(
+        mass, s_ref, cd0_effective, aspect_ratio, p_to_w, prop_eta
+    )
+    v_max_effective = v_max_computed if v_max_computed is not None else v_max
+    is_glider = p_to_w <= 0
+
     _cache_context(db, aircraft, {
         "v_cruise_mps": v_cruise,
-        "v_max_mps": round(v_max, 1),
+        "v_max_mps": round(v_max_effective, 1),
         "v_stall_mps": round(v_stall, 1) if v_stall is not None else None,
         "v_md_mps": round(v_md, 1) if v_md is not None else None,
+        "is_glider": is_glider,
         "reynolds": round(re),
         "mac_m": round(mac, 4),
         "s_ref_m2": round(s_ref, 4),
@@ -383,6 +395,63 @@ def _main_wing_aspect_ratio(asb_airplane) -> float | None:
     if s <= 0:
         return None
     return (b * b) / s
+
+
+def _max_level_speed(
+    mass_kg: float,
+    s_ref_m2: float,
+    cd0: float,
+    aspect_ratio: float | None,
+    power_to_weight: float,
+    prop_eta: float,
+    rho: float = 1.225,
+    g: float = 9.81,
+) -> float | None:
+    """Sea-level V_max from a power balance.
+
+    At V_max, available shaft power × prop efficiency equals power
+    required for level flight:
+
+        P_avail · η_prop = D(V) · V
+
+    With induced + parasitic drag this becomes a 4th-order polynomial
+    in V:
+
+        A · V⁴ − P_eta · V + B = 0
+
+    where A = ½ρ·S·CD0, B = 2k·W²/(ρ·S), P_eta = (P/W) · m · η.
+
+    Returns None for gliders (P/W ≤ 0) or other degenerate inputs;
+    callers should fall back to the user-set max speed goal.
+    """
+    if (
+        power_to_weight <= 0
+        or prop_eta <= 0
+        or s_ref_m2 <= 0
+        or cd0 <= 1e-6
+        or aspect_ratio is None
+        or aspect_ratio <= 0
+    ):
+        return None
+
+    weight_n = mass_kg * g
+    p_eta = power_to_weight * mass_kg * prop_eta
+    k = 1.0 / (np.pi * aspect_ratio * 0.8)
+    a = 0.5 * rho * s_ref_m2 * cd0
+    b = 2.0 * k * weight_n * weight_n / (rho * s_ref_m2)
+
+    # numpy.roots solves a · V⁴ + 0 · V³ + 0 · V² − P_eta · V + b = 0.
+    coeffs = [a, 0.0, 0.0, -p_eta, b]
+    roots = np.roots(coeffs)
+    # Pick the largest real positive root above V_md.
+    real_positive = [
+        float(r.real)
+        for r in roots
+        if abs(r.imag) < 1e-6 and r.real > 0
+    ]
+    if not real_positive:
+        return None
+    return max(real_positive)
 
 
 def _min_drag_speed(

--- a/app/services/assumption_compute_service.py
+++ b/app/services/assumption_compute_service.py
@@ -64,6 +64,16 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
         )
         return
 
+    # Override ASB's reference area / chord / span so all CL/CD numbers
+    # produced by AeroBuildup are normalised by the MAIN WING. ASB's
+    # default is the first wing in the list, which may be a tail or
+    # rudder for unusual orderings — that produces wildly inflated CL_max.
+    main_wing = _select_main_wing(asb_airplane)
+    if main_wing is not None:
+        asb_airplane.s_ref = float(main_wing.area())
+        asb_airplane.c_ref = float(main_wing.mean_aerodynamic_chord())
+        asb_airplane.b_ref = float(main_wing.span())
+
     # Ensure assumption rows + computation config exist (idempotent).
     # Wings can be created before the user opens the Assumptions tab,
     # so we cannot rely on the user having seeded them already.

--- a/app/services/assumption_compute_service.py
+++ b/app/services/assumption_compute_service.py
@@ -36,7 +36,11 @@ from app.models.computation_config import (
 from app.schemas.AeroplaneRequest import AnalysisToolUrlType
 from app.schemas.aeroanalysisschema import OperatingPointSchema
 from app.schemas.design_assumption import PARAMETER_DEFAULTS
-from app.services.design_assumptions_service import _get_aeroplane, update_calculated_value
+from app.services.design_assumptions_service import (
+    _get_aeroplane,
+    seed_defaults,
+    update_calculated_value,
+)
 from app.services.mass_cg_service import aggregate_weight_items
 from app.services.stability_service import _scalar
 
@@ -59,6 +63,11 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
             "No wings on aircraft %s — skipping assumption recompute", aeroplane_uuid
         )
         return
+
+    # Ensure assumption rows + computation config exist (idempotent).
+    # Wings can be created before the user opens the Assumptions tab,
+    # so we cannot rely on the user having seeded them already.
+    seed_defaults(db, aeroplane_uuid)
 
     config = _load_or_create_config(db, aircraft.id)
     v_cruise, v_max = _load_flight_profile_speeds(db, aircraft)

--- a/app/services/assumption_compute_service.py
+++ b/app/services/assumption_compute_service.py
@@ -80,7 +80,7 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
     seed_defaults(db, aeroplane_uuid)
 
     config = _load_or_create_config(db, aircraft.id)
-    v_cruise, v_max = _load_flight_profile_speeds(db, aircraft)
+    v_cruise, v_max, user_set_cruise = _load_flight_profile_speeds(db, aircraft)
 
     try:
         x_np, mac, cd0, s_ref = _stability_run_at_cruise(asb_airplane, v_cruise)
@@ -132,8 +132,15 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
     v_max_effective = v_max_computed if v_max_computed is not None else v_max
     is_glider = p_to_w <= 0
 
+    # If the user hasn't set a flight profile, suggest V_md as the
+    # cruise speed (best L/D = best range for prop aircraft). Once the
+    # user creates a profile and sets cruise_speed_mps, we respect it.
+    v_cruise_effective = v_md if (not user_set_cruise and v_md is not None) else v_cruise
+    cruise_is_auto = not user_set_cruise and v_md is not None
+
     _cache_context(db, aircraft, {
-        "v_cruise_mps": v_cruise,
+        "v_cruise_mps": round(v_cruise_effective, 1),
+        "v_cruise_auto": cruise_is_auto,
         "v_max_mps": round(v_max_effective, 1),
         "v_stall_mps": round(v_stall, 1) if v_stall is not None else None,
         "v_md_mps": round(v_md, 1) if v_md is not None else None,
@@ -184,18 +191,25 @@ def _load_or_create_config(
 
 def _load_flight_profile_speeds(
     db: Session, aircraft: AeroplaneModel
-) -> tuple[float, float]:
+) -> tuple[float, float, bool]:
+    """Returns (cruise_mps, v_max_goal_mps, user_set_cruise).
+
+    user_set_cruise=False when the aircraft has no flight profile (we
+    fall back to the default profile). Callers can use this signal to
+    decide whether to override cruise with a computed value (V_md).
+    """
     from app.services.operating_point_generator_service import (
         _load_effective_flight_profile,
     )
 
-    profile, _ = _load_effective_flight_profile(db, aircraft)
+    profile, source_profile_id = _load_effective_flight_profile(db, aircraft)
     goals = profile.get("goals", {})
     cruise = float(goals.get("cruise_speed_mps", 18.0))
     v_max = float(
         goals.get("max_level_speed_mps") or max(1.35 * cruise, cruise + 8.0)
     )
-    return cruise, v_max
+    user_set_cruise = source_profile_id is not None
+    return cruise, v_max, user_set_cruise
 
 
 def _select_main_wing(asb_airplane):

--- a/app/services/assumption_compute_service.py
+++ b/app/services/assumption_compute_service.py
@@ -168,16 +168,30 @@ def _load_flight_profile_speeds(
     return cruise, v_max
 
 
+def _select_main_wing(asb_airplane):
+    """Pick the main wing — the wing with the largest planform area.
+
+    A typical configuration has main wing + horizontal tail + vertical
+    tail. ASB's `reference.Cref` defaults to the FIRST wing in the list,
+    which may not be the main wing for the user's geometry. Picking by
+    planform area is robust across user-defined wing orderings.
+    """
+    if not asb_airplane.wings:
+        return None
+    return max(asb_airplane.wings, key=lambda w: float(w.area()))
+
+
 def _stability_run_at_cruise(
     asb_airplane, v_cruise: float
-) -> tuple[float, float, float]:
-    """Returns (x_np, MAC, CD0) from a single AeroBuildup stability run.
+) -> tuple[float, float, float, float]:
+    """Returns (x_np, MAC, CD0, S_ref).
 
-    Uses analyse_aerodynamics → AnalysisModel — same code path as
-    stability_service, so x_np / MAC / CD0 / S_ref are consistent across
-    the app.
+    Uses analyse_aerodynamics → AnalysisModel for x_np and CD0 (same
+    path as stability_service, keeps NP consistent across the app).
 
-    Returns (x_np, MAC, CD0, S_ref).
+    For MAC and S_ref, takes the **main wing** (largest planform area)
+    rather than ASB's reference. The reference may point at a tail or
+    rudder for unusual wing orderings.
     """
     xyz_ref = list(asb_airplane.xyz_ref) if asb_airplane.xyz_ref is not None else [0.0, 0.0, 0.0]
     op_schema = OperatingPointSchema(velocity=v_cruise, alpha=0.0, xyz_ref=xyz_ref)
@@ -185,12 +199,17 @@ def _stability_run_at_cruise(
         AnalysisToolUrlType.AEROBUILDUP, op_schema, asb_airplane
     )
     x_np = _scalar(result.reference.Xnp)
-    mac = _scalar(result.reference.Cref)
     cd0 = _scalar(result.coefficients.CD)
-    s_ref = _scalar(result.reference.Sref)
-    if x_np is None or mac is None or cd0 is None or s_ref is None:
-        raise ValueError("AeroBuildup returned NULL for x_np/MAC/CD0/S_ref")
-    return float(x_np), float(mac), float(cd0), float(s_ref)
+
+    main_wing = _select_main_wing(asb_airplane)
+    if main_wing is None:
+        raise ValueError("Cannot compute MAC: no wings on aircraft")
+    mac = float(main_wing.mean_aerodynamic_chord())
+    s_ref = float(main_wing.area())
+
+    if x_np is None or cd0 is None or mac <= 0 or s_ref <= 0:
+        raise ValueError("AeroBuildup returned NULL or non-positive values")
+    return float(x_np), mac, float(cd0), s_ref
 
 
 def _coarse_alpha_sweep(

--- a/app/services/assumption_compute_service.py
+++ b/app/services/assumption_compute_service.py
@@ -73,7 +73,7 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
     v_cruise, v_max = _load_flight_profile_speeds(db, aircraft)
 
     try:
-        x_np, mac, cd0 = _stability_run_at_cruise(asb_airplane, v_cruise)
+        x_np, mac, cd0, s_ref = _stability_run_at_cruise(asb_airplane, v_cruise)
         stall_alpha = _coarse_alpha_sweep(asb_airplane, v_cruise, config)
         cl_max = _fine_sweep_cl_max(asb_airplane, stall_alpha, v_cruise, v_max, config)
     except Exception:
@@ -102,11 +102,16 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
 
     cg_agg = _load_cg_agg(db, aircraft.id)
     re = _reynolds_number(v_cruise, mac)
+    mass = _load_effective_assumption(db, aircraft.id, "mass")
+    v_stall = _stall_speed(mass, s_ref, cl_max)
 
     _cache_context(db, aircraft, {
         "v_cruise_mps": v_cruise,
+        "v_max_mps": round(v_max, 1),
+        "v_stall_mps": round(v_stall, 1) if v_stall is not None else None,
         "reynolds": round(re),
         "mac_m": round(mac, 4),
+        "s_ref_m2": round(s_ref, 4),
         "x_np_m": round(x_np, 4),
         "target_static_margin": target_sm,
         "cg_agg_m": round(cg_agg, 4) if cg_agg is not None else None,
@@ -169,7 +174,10 @@ def _stability_run_at_cruise(
     """Returns (x_np, MAC, CD0) from a single AeroBuildup stability run.
 
     Uses analyse_aerodynamics → AnalysisModel — same code path as
-    stability_service, so x_np / MAC / CD0 are consistent across the app.
+    stability_service, so x_np / MAC / CD0 / S_ref are consistent across
+    the app.
+
+    Returns (x_np, MAC, CD0, S_ref).
     """
     xyz_ref = list(asb_airplane.xyz_ref) if asb_airplane.xyz_ref is not None else [0.0, 0.0, 0.0]
     op_schema = OperatingPointSchema(velocity=v_cruise, alpha=0.0, xyz_ref=xyz_ref)
@@ -179,9 +187,10 @@ def _stability_run_at_cruise(
     x_np = _scalar(result.reference.Xnp)
     mac = _scalar(result.reference.Cref)
     cd0 = _scalar(result.coefficients.CD)
-    if x_np is None or mac is None or cd0 is None:
-        raise ValueError("AeroBuildup returned NULL for x_np/MAC/CD0")
-    return float(x_np), float(mac), float(cd0)
+    s_ref = _scalar(result.reference.Sref)
+    if x_np is None or mac is None or cd0 is None or s_ref is None:
+        raise ValueError("AeroBuildup returned NULL for x_np/MAC/CD0/S_ref")
+    return float(x_np), float(mac), float(cd0), float(s_ref)
 
 
 def _coarse_alpha_sweep(
@@ -305,6 +314,26 @@ def _reynolds_number(
     their own atmosphere model.
     """
     return rho * velocity * mac / mu
+
+
+def _stall_speed(
+    mass_kg: float,
+    s_ref_m2: float,
+    cl_max: float,
+    rho: float = 1.225,
+    g: float = 9.81,
+) -> float | None:
+    """Sea-level stall speed: V_stall = sqrt(2 W / (rho S CL_max)).
+
+    Returns None when CL_max or S_ref is non-positive. The 0.5 floor on
+    CL_max prevents wildly inflated stall speeds when AeroBuildup
+    misjudges stall on degenerate geometry.
+    """
+    if s_ref_m2 <= 0 or cl_max <= 0:
+        return None
+    cl_max_safe = max(cl_max, 0.5)
+    weight_n = mass_kg * g
+    return float(np.sqrt(2.0 * weight_n / (rho * s_ref_m2 * cl_max_safe)))
 
 
 def _cache_context(

--- a/app/services/assumption_compute_service.py
+++ b/app/services/assumption_compute_service.py
@@ -113,7 +113,11 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
     cg_agg = _load_cg_agg(db, aircraft.id)
     re = _reynolds_number(v_cruise, mac)
     mass = _load_effective_assumption(db, aircraft.id, "mass")
-    v_stall = _stall_speed(mass, s_ref, cl_max)
+    # Use the EFFECTIVE cl_max so a user override (toggle to ESTIMATE)
+    # actually changes V_stall — otherwise V_stall would always reflect
+    # the geometry-derived value regardless of the user's choice.
+    cl_max_effective = _load_effective_assumption(db, aircraft.id, "cl_max")
+    v_stall = _stall_speed(mass, s_ref, cl_max_effective)
 
     _cache_context(db, aircraft, {
         "v_cruise_mps": v_cruise,

--- a/app/services/assumption_compute_service.py
+++ b/app/services/assumption_compute_service.py
@@ -1,0 +1,306 @@
+"""Assumption compute service — gh-465.
+
+Single public entry point: recompute_assumptions(db, aeroplane_uuid).
+
+Runs a two-phase AeroSandbox AeroBuildup sweep:
+  Phase 1 — stability run at cruise → (x_np, MAC, CD0)
+  Phase 2 — coarse alpha sweep → stall_alpha; fine alpha×velocity sweep → CL_max
+
+Writes cl_max, cd0, cg_x back to the design_assumptions table and caches
+the computation context (v_cruise, Re, MAC, NP, SM, CG_agg) on the
+aeroplane row for the UI Info Chip Row.
+
+This is a sync function. Callers from async context MUST wrap with
+asyncio.to_thread().
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+import numpy as np
+from sqlalchemy.orm import Session
+
+from app.api.utils import analyse_aerodynamics
+from app.converters.model_schema_converters import (
+    aeroplane_model_to_aeroplane_schema_async,
+    aeroplane_schema_to_asb_airplane_async,
+)
+from app.core.events import AssumptionChanged, event_bus
+from app.models.aeroplanemodel import AeroplaneModel, DesignAssumptionModel, WeightItemModel
+from app.models.computation_config import (
+    AircraftComputationConfigModel,
+    COMPUTATION_CONFIG_DEFAULTS,
+)
+from app.schemas.AeroplaneRequest import AnalysisToolUrlType
+from app.schemas.aeroanalysisschema import OperatingPointSchema
+from app.schemas.design_assumption import PARAMETER_DEFAULTS
+from app.services.design_assumptions_service import _get_aeroplane, update_calculated_value
+from app.services.mass_cg_service import aggregate_weight_items
+from app.services.stability_service import _scalar
+
+logger = logging.getLogger(__name__)
+
+
+def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
+    """Recompute cl_max, cd0, cg_x from geometry via AeroSandbox.
+
+    Sync function — caller MUST wrap in asyncio.to_thread() when invoked
+    from async context (see app/main.py recompute wrapper).
+
+    Skips silently if aircraft has no wings.
+    """
+    aircraft = _get_aeroplane(db, aeroplane_uuid)
+    asb_airplane = _build_asb_airplane(aircraft)
+
+    if not asb_airplane.wings:
+        logger.info(
+            "No wings on aircraft %s — skipping assumption recompute", aeroplane_uuid
+        )
+        return
+
+    config = _load_or_create_config(db, aircraft.id)
+    v_cruise, v_max = _load_flight_profile_speeds(db, aircraft)
+
+    try:
+        x_np, mac, cd0 = _stability_run_at_cruise(asb_airplane, v_cruise)
+        stall_alpha = _coarse_alpha_sweep(asb_airplane, v_cruise, config)
+        cl_max = _fine_sweep_cl_max(asb_airplane, stall_alpha, v_cruise, v_max, config)
+    except Exception:
+        logger.exception(
+            "AeroBuildup failed during recompute for aircraft %s — aborting", aeroplane_uuid
+        )
+        return
+
+    target_sm = _load_effective_assumption(db, aircraft.id, "target_static_margin")
+    cg_x = x_np - target_sm * mac
+
+    old_cg = _get_current_calculated_value(db, aircraft.id, "cg_x")
+
+    update_calculated_value(
+        db, aeroplane_uuid, "cl_max", round(cl_max, 4), "aerobuildup",
+        auto_switch_source=True,
+    )
+    update_calculated_value(
+        db, aeroplane_uuid, "cd0", round(cd0, 5), "aerobuildup",
+        auto_switch_source=True,
+    )
+    update_calculated_value(
+        db, aeroplane_uuid, "cg_x", round(cg_x, 4), "aerobuildup",
+        auto_switch_source=True,
+    )
+
+    cg_agg = _load_cg_agg(db, aircraft.id)
+    re = _reynolds_number(v_cruise, mac)
+
+    _cache_context(db, aircraft, {
+        "v_cruise_mps": v_cruise,
+        "reynolds": round(re),
+        "mac_m": round(mac, 4),
+        "x_np_m": round(x_np, 4),
+        "target_static_margin": target_sm,
+        "cg_agg_m": round(cg_agg, 4) if cg_agg is not None else None,
+        "computed_at": datetime.now(timezone.utc).isoformat(),
+    })
+
+    if old_cg is None or abs(cg_x - old_cg) > 1e-6:
+        # Mirror update_assumption: mark OPs DIRTY in the same transaction
+        # before emitting AssumptionChanged. Otherwise the retrim handler
+        # finds no DIRTY ops and does nothing.
+        from app.services.invalidation_service import mark_ops_dirty
+
+        mark_ops_dirty(db, aircraft.id)
+        event_bus.publish(
+            AssumptionChanged(aeroplane_id=aircraft.id, parameter_name="cg_x")
+        )
+
+
+def _build_asb_airplane(aircraft: AeroplaneModel):
+    schema = aeroplane_model_to_aeroplane_schema_async(aircraft)
+    return aeroplane_schema_to_asb_airplane_async(plane_schema=schema)
+
+
+def _load_or_create_config(
+    db: Session, aeroplane_id: int
+) -> AircraftComputationConfigModel:
+    config = (
+        db.query(AircraftComputationConfigModel)
+        .filter(AircraftComputationConfigModel.aeroplane_id == aeroplane_id)
+        .first()
+    )
+    if config is None:
+        config = AircraftComputationConfigModel(
+            aeroplane_id=aeroplane_id, **COMPUTATION_CONFIG_DEFAULTS
+        )
+        db.add(config)
+        db.flush()
+    return config
+
+
+def _load_flight_profile_speeds(
+    db: Session, aircraft: AeroplaneModel
+) -> tuple[float, float]:
+    from app.services.operating_point_generator_service import (
+        _load_effective_flight_profile,
+    )
+
+    profile, _ = _load_effective_flight_profile(db, aircraft)
+    goals = profile.get("goals", {})
+    cruise = float(goals.get("cruise_speed_mps", 18.0))
+    v_max = float(
+        goals.get("max_level_speed_mps") or max(1.35 * cruise, cruise + 8.0)
+    )
+    return cruise, v_max
+
+
+def _stability_run_at_cruise(
+    asb_airplane, v_cruise: float
+) -> tuple[float, float, float]:
+    """Returns (x_np, MAC, CD0) from a single AeroBuildup stability run.
+
+    Uses analyse_aerodynamics → AnalysisModel — same code path as
+    stability_service, so x_np / MAC / CD0 are consistent across the app.
+    """
+    xyz_ref = list(asb_airplane.xyz_ref) if asb_airplane.xyz_ref is not None else [0.0, 0.0, 0.0]
+    op_schema = OperatingPointSchema(velocity=v_cruise, alpha=0.0, xyz_ref=xyz_ref)
+    result, _ = analyse_aerodynamics(
+        AnalysisToolUrlType.AEROBUILDUP, op_schema, asb_airplane
+    )
+    x_np = _scalar(result.reference.Xnp)
+    mac = _scalar(result.reference.Cref)
+    cd0 = _scalar(result.coefficients.CD)
+    if x_np is None or mac is None or cd0 is None:
+        raise ValueError("AeroBuildup returned NULL for x_np/MAC/CD0")
+    return float(x_np), float(mac), float(cd0)
+
+
+def _coarse_alpha_sweep(
+    asb_airplane, v_cruise: float, config: AircraftComputationConfigModel
+) -> float:
+    """Returns approximate stall_alpha_deg (alpha where CL peaks)."""
+    import aerosandbox as asb
+
+    alphas = np.arange(
+        config.coarse_alpha_min_deg,
+        config.coarse_alpha_max_deg + 0.01,
+        config.coarse_alpha_step_deg,
+    )
+    xyz_ref = list(asb_airplane.xyz_ref) if asb_airplane.xyz_ref is not None else [0.0, 0.0, 0.0]
+    cls: list[float] = []
+    for a in alphas:
+        op = asb.OperatingPoint(velocity=v_cruise, alpha=float(a))
+        abu = asb.AeroBuildup(airplane=asb_airplane, op_point=op, xyz_ref=xyz_ref)
+        r = abu.run()
+        cls.append(_extract_scalar(r, "CL", default=0.0))
+    return float(alphas[int(np.argmax(cls))])
+
+
+def _fine_sweep_cl_max(
+    asb_airplane,
+    stall_alpha_deg: float,
+    v_cruise: float,
+    v_max: float,
+    config: AircraftComputationConfigModel,
+) -> float:
+    """Returns CL_max from a fine alpha × velocity sweep."""
+    import aerosandbox as asb
+
+    alpha_min = stall_alpha_deg - config.fine_alpha_margin_deg
+    alpha_max = stall_alpha_deg + config.fine_alpha_margin_deg
+    alphas = np.arange(alpha_min, alpha_max + 0.01, config.fine_alpha_step_deg)
+
+    v_stall_approx = max(v_cruise * 0.5, 3.0)
+    velocities = np.linspace(v_stall_approx, v_max, config.fine_velocity_count)
+
+    xyz_ref = list(asb_airplane.xyz_ref) if asb_airplane.xyz_ref is not None else [0.0, 0.0, 0.0]
+    cl_max = -float("inf")
+    for v in velocities:
+        for a in alphas:
+            op = asb.OperatingPoint(velocity=float(v), alpha=float(a))
+            abu = asb.AeroBuildup(airplane=asb_airplane, op_point=op, xyz_ref=xyz_ref)
+            r = abu.run()
+            cl = _extract_scalar(r, "CL", default=0.0)
+            if cl > cl_max:
+                cl_max = cl
+    return float(cl_max)
+
+
+def _extract_scalar(result: Any, key: str, *, default: float) -> float:
+    """Extract a CL/CD scalar from raw AeroBuildup result (dict or object)."""
+    if isinstance(result, dict):
+        val = result.get(key)
+    else:
+        val = getattr(result, key, None)
+    scalar = _scalar(val)
+    return float(scalar) if scalar is not None else default
+
+
+def _load_effective_assumption(
+    db: Session, aeroplane_id: int, param_name: str
+) -> float:
+    """Return the effective value of a design assumption (calculated or estimate)."""
+    row = (
+        db.query(DesignAssumptionModel)
+        .filter(
+            DesignAssumptionModel.aeroplane_id == aeroplane_id,
+            DesignAssumptionModel.parameter_name == param_name,
+        )
+        .first()
+    )
+    if row is None:
+        return PARAMETER_DEFAULTS.get(param_name, 0.0)
+    if row.active_source == "CALCULATED" and row.calculated_value is not None:
+        return row.calculated_value
+    return row.estimate_value
+
+
+def _get_current_calculated_value(
+    db: Session, aeroplane_id: int, param_name: str
+) -> float | None:
+    """Return the current calculated_value for a design assumption, or None."""
+    row = (
+        db.query(DesignAssumptionModel)
+        .filter(
+            DesignAssumptionModel.aeroplane_id == aeroplane_id,
+            DesignAssumptionModel.parameter_name == param_name,
+        )
+        .first()
+    )
+    return row.calculated_value if row else None
+
+
+def _load_cg_agg(db: Session, aeroplane_id: int) -> float | None:
+    """Return mass-weighted CG x from weight items, or None if no items exist."""
+    rows = (
+        db.query(WeightItemModel)
+        .filter(WeightItemModel.aeroplane_id == aeroplane_id)
+        .all()
+    )
+    if not rows:
+        return None
+    items = [
+        {"mass_kg": r.mass_kg, "x_m": r.x_m, "y_m": r.y_m, "z_m": r.z_m}
+        for r in rows
+    ]
+    _, cg_x, _, _ = aggregate_weight_items(items)
+    return cg_x
+
+
+def _reynolds_number(
+    velocity: float, mac: float, rho: float = 1.225, mu: float = 1.81e-5
+) -> float:
+    """Sea-level standard atmosphere Reynolds number.
+
+    Sufficient for the UI chip; not altitude-aware. Operating points use
+    their own atmosphere model.
+    """
+    return rho * velocity * mac / mu
+
+
+def _cache_context(
+    db: Session, aircraft: AeroplaneModel, context: dict[str, Any]
+) -> None:
+    """Write computation context JSON to the aeroplane row."""
+    aircraft.assumption_computation_context = context
+    db.flush()

--- a/app/services/component_tree_service.py
+++ b/app/services/component_tree_service.py
@@ -206,6 +206,7 @@ def add_node(
         db.add(node)
         db.flush()
         db.refresh(node)
+        _sync_aircraft_mass(db, aeroplane_id)
         return _to_schema(node)
     except (NotFoundError, ValidationError):
         raise
@@ -230,6 +231,7 @@ def update_node(
             setattr(node, key, value)
         db.flush()
         db.refresh(node)
+        _sync_aircraft_mass(db, aeroplane_id)
         return _to_schema(node)
     except NotFoundError:
         raise
@@ -258,6 +260,7 @@ def delete_node(db: Session, aeroplane_id: str, node_id: int) -> None:
         _delete_subtree(db, aeroplane_id, node_id)
         db.delete(node)
         db.flush()
+        _sync_aircraft_mass(db, aeroplane_id)
     except (NotFoundError, ValidationError):
         raise
     except SQLAlchemyError as exc:
@@ -324,6 +327,52 @@ def _is_descendant(db: Session, aeroplane_id: str, candidate_id: int, ancestor_i
             ComponentTreeNodeModel.id == current.parent_id,
         ).first()
     return False
+
+
+def _sync_aircraft_mass(db: Session, aeroplane_id: str) -> None:
+    """Re-sync the mass design assumption after a tree mutation.
+
+    Lazy-imported to avoid a circular import at module load. Errors are
+    swallowed because a failed mass sync should NOT block the original
+    component-tree CRUD operation.
+    """
+    try:
+        from app.services.mass_cg_service import sync_component_tree_to_mass
+
+        sync_component_tree_to_mass(db, aeroplane_id)
+    except Exception:
+        logger.warning(
+            "Failed to sync aircraft mass after component-tree change for %s",
+            aeroplane_id,
+            exc_info=True,
+        )
+
+
+def get_aircraft_total_weight_kg(db: Session, aeroplane_id: str) -> Optional[float]:
+    """Sum the weight of all top-level component-tree nodes (kg).
+
+    Top-level here means parent_id IS NULL — that captures every wing,
+    fuselage, payload, etc. since their synced groups are root nodes.
+    Returns None if the tree is empty (so the caller knows to clear the
+    mass calculated_value).
+    """
+    roots = (
+        db.query(ComponentTreeNodeModel)
+        .filter(
+            ComponentTreeNodeModel.aeroplane_id == aeroplane_id,
+            ComponentTreeNodeModel.parent_id.is_(None),
+        )
+        .all()
+    )
+    if not roots:
+        return None
+    total_g = 0.0
+    for r in roots:
+        own, _ = _calculate_own_weight(db, r)
+        total_g += (own or 0.0) + _calculate_children_weight(
+            db, aeroplane_id, r.id
+        )
+    return total_g / 1000.0 if total_g > 0 else None
 
 
 def calculate_weight(db: Session, aeroplane_id: str, node_id: int) -> WeightResponse:

--- a/app/services/design_assumptions_service.py
+++ b/app/services/design_assumptions_service.py
@@ -10,6 +10,10 @@ from sqlalchemy.orm import Session
 from app.core.events import AssumptionChanged, event_bus
 from app.core.exceptions import InternalError, NotFoundError, ValidationError
 from app.models.aeroplanemodel import AeroplaneModel, DesignAssumptionModel
+from app.models.computation_config import (
+    AircraftComputationConfigModel,
+    COMPUTATION_CONFIG_DEFAULTS,
+)
 from app.schemas.design_assumption import (
     DESIGN_CHOICE_PARAMS,
     PARAMETER_DEFAULTS,
@@ -80,6 +84,19 @@ def seed_defaults(db: Session, aeroplane_uuid) -> AssumptionsSummary:
                     active_source="ESTIMATE",
                 )
                 db.add(row)
+
+        # Also seed per-aircraft computation config (idempotent)
+        existing_config = (
+            db.query(AircraftComputationConfigModel)
+            .filter(AircraftComputationConfigModel.aeroplane_id == aeroplane.id)
+            .first()
+        )
+        if existing_config is None:
+            config = AircraftComputationConfigModel(
+                aeroplane_id=aeroplane.id,
+                **COMPUTATION_CONFIG_DEFAULTS,
+            )
+            db.add(config)
 
         db.flush()
         return list_assumptions(db, aeroplane_uuid)

--- a/app/services/design_assumptions_service.py
+++ b/app/services/design_assumptions_service.py
@@ -190,11 +190,19 @@ def update_calculated_value(
     param_name: str,
     value: float | None,
     source: str | None,
+    auto_switch_source: bool = False,
 ) -> AssumptionRead:
     """Update the calculated value and source for a design assumption.
 
-    Called by aggregation services (e.g. weight-item sync) to feed
-    computed values back into the assumption row. Recomputes divergence.
+    Called by aggregation services (e.g. weight-item sync) and by the
+    geometry-driven assumption recompute service to feed computed values
+    back into the assumption row. Recomputes divergence.
+
+    When auto_switch_source=True, the active source is automatically
+    switched from "ESTIMATE" to "CALCULATED" on the first calculated
+    value (i.e. when the row currently has no calculated_value).
+    Design-choice parameters (target_static_margin, g_limit) never
+    auto-switch — those remain user-controlled.
     """
     try:
         aeroplane = _get_aeroplane(db, aeroplane_uuid)
@@ -209,9 +217,20 @@ def update_calculated_value(
         if row is None:
             raise NotFoundError(entity="DesignAssumption", resource_id=param_name)
 
+        should_switch = (
+            auto_switch_source
+            and row.calculated_value is None
+            and row.active_source == "ESTIMATE"
+            and param_name not in DESIGN_CHOICE_PARAMS
+        )
+
         row.calculated_value = value
         row.calculated_source = source
         row.divergence_pct = compute_divergence_pct(row.estimate_value, value)
+
+        if should_switch:
+            row.active_source = "CALCULATED"
+
         db.flush()
         db.refresh(row)
         return _assumption_to_read(row)

--- a/app/services/design_assumptions_service.py
+++ b/app/services/design_assumptions_service.py
@@ -129,7 +129,14 @@ def list_assumptions(db: Session, aeroplane_uuid) -> AssumptionsSummary:
 def update_assumption(
     db: Session, aeroplane_uuid, param_name: str, data: AssumptionWrite
 ) -> AssumptionRead:
-    """Update the estimate value of a design assumption."""
+    """Update the estimate value of a design assumption.
+
+    Only fires downstream events (mark_ops_dirty + AssumptionChanged)
+    when active_source == "ESTIMATE" — i.e. when the user's estimate
+    is the effective value. Editing an estimate while the calculated
+    value is active doesn't change the effective value, so the retrim
+    chain and the recompute should NOT fire.
+    """
     try:
         aeroplane = _get_aeroplane(db, aeroplane_uuid)
         row = (
@@ -143,15 +150,20 @@ def update_assumption(
         if row is None:
             raise NotFoundError(entity="DesignAssumption", resource_id=param_name)
 
+        active_was_estimate = row.active_source == "ESTIMATE"
         row.estimate_value = data.estimate_value
         row.divergence_pct = compute_divergence_pct(data.estimate_value, row.calculated_value)
         db.flush()
         db.refresh(row)
-        if param_name in {"mass", "cg_x"}:
-            from app.services.invalidation_service import mark_ops_dirty
 
-            mark_ops_dirty(db, aeroplane.id)
-        event_bus.publish(AssumptionChanged(aeroplane_id=aeroplane.id, parameter_name=param_name))
+        if active_was_estimate:
+            if param_name in {"mass", "cg_x"}:
+                from app.services.invalidation_service import mark_ops_dirty
+
+                mark_ops_dirty(db, aeroplane.id)
+            event_bus.publish(
+                AssumptionChanged(aeroplane_id=aeroplane.id, parameter_name=param_name)
+            )
         return _assumption_to_read(row)
     except NotFoundError:
         raise
@@ -193,6 +205,15 @@ def switch_source(
 
             mark_ops_dirty(db, aeroplane.id)
         event_bus.publish(AssumptionChanged(aeroplane_id=aeroplane.id, parameter_name=param_name))
+
+        # A source toggle changes the effective value by definition, so
+        # the geometry-driven recompute should re-derive downstream
+        # context (V_stall etc.). Skip cg_x — it's the recompute's own
+        # output and re-running would loop.
+        if param_name != "cg_x":
+            from app.core.background_jobs import job_tracker
+
+            job_tracker.schedule_recompute_assumptions(aeroplane.id)
         return _assumption_to_read(row)
     except (NotFoundError, ValidationError):
         raise

--- a/app/services/invalidation_service.py
+++ b/app/services/invalidation_service.py
@@ -15,6 +15,11 @@ logger = logging.getLogger(__name__)
 # Assumption parameters that affect operating points
 _OP_AFFECTING_PARAMS = {"mass", "cg_x"}
 
+# Assumption parameters that are inputs to the geometry-driven recompute
+# (changing them must re-derive cl_max/cd0/cg_x). cg_x itself is excluded
+# to prevent the recompute → AssumptionChanged(cg_x) → recompute loop.
+_RECOMPUTE_TRIGGERING_PARAMS = {"target_static_margin"}
+
 
 def mark_ops_dirty(session: Session, aeroplane_id: int) -> int:
     """Mark all operating points for an aeroplane as DIRTY. Returns count updated."""
@@ -66,8 +71,26 @@ def _on_assumption_changed(event: AssumptionChanged) -> None:
         job_tracker.schedule_retrim(event.aeroplane_id)
 
 
+def _on_assumption_changed_recompute(event: AssumptionChanged) -> None:
+    """Schedule recompute when a recompute-input assumption changes.
+
+    Currently only target_static_margin — it is a factor in the cg_x
+    formula (cg_x = x_np - SM × MAC), so changing it must re-derive cg_x.
+    """
+    if event.parameter_name in _RECOMPUTE_TRIGGERING_PARAMS:
+        logger.info(
+            "AssumptionChanged(%s) for aeroplane %d — scheduling assumption recompute",
+            event.parameter_name,
+            event.aeroplane_id,
+        )
+        from app.core.background_jobs import job_tracker
+
+        job_tracker.schedule_recompute_assumptions(event.aeroplane_id)
+
+
 def register_handlers() -> None:
     """Register event handlers on the global event bus."""
     event_bus.subscribe(GeometryChanged, _on_geometry_changed)
     event_bus.subscribe(GeometryChanged, _on_geometry_changed_recompute_assumptions)
     event_bus.subscribe(AssumptionChanged, _on_assumption_changed)
+    event_bus.subscribe(AssumptionChanged, _on_assumption_changed_recompute)

--- a/app/services/invalidation_service.py
+++ b/app/services/invalidation_service.py
@@ -41,6 +41,18 @@ def _on_geometry_changed(event: GeometryChanged) -> None:
     job_tracker.schedule_retrim(event.aeroplane_id)
 
 
+def _on_geometry_changed_recompute_assumptions(event: GeometryChanged) -> None:
+    """Handler that schedules a debounced assumption recompute."""
+    logger.info(
+        "GeometryChanged for aeroplane %d (source: %s) — scheduling assumption recompute",
+        event.aeroplane_id,
+        event.source_model,
+    )
+    from app.core.background_jobs import job_tracker
+
+    job_tracker.schedule_recompute_assumptions(event.aeroplane_id)
+
+
 def _on_assumption_changed(event: AssumptionChanged) -> None:
     """Schedule retrim when an OP-affecting assumption changes."""
     if event.parameter_name in _OP_AFFECTING_PARAMS:
@@ -57,4 +69,5 @@ def _on_assumption_changed(event: AssumptionChanged) -> None:
 def register_handlers() -> None:
     """Register event handlers on the global event bus."""
     event_bus.subscribe(GeometryChanged, _on_geometry_changed)
+    event_bus.subscribe(GeometryChanged, _on_geometry_changed_recompute_assumptions)
     event_bus.subscribe(AssumptionChanged, _on_assumption_changed)

--- a/app/services/invalidation_service.py
+++ b/app/services/invalidation_service.py
@@ -16,9 +16,11 @@ logger = logging.getLogger(__name__)
 _OP_AFFECTING_PARAMS = {"mass", "cg_x"}
 
 # Assumption parameters that are inputs to the geometry-driven recompute
-# (changing them must re-derive cl_max/cd0/cg_x). cg_x itself is excluded
-# to prevent the recompute → AssumptionChanged(cg_x) → recompute loop.
-_RECOMPUTE_TRIGGERING_PARAMS = {"target_static_margin"}
+# (changing them must re-derive cl_max/cd0/cg_x and the cached context
+# values like V_stall = sqrt(2 W / (rho S CL_max))). cg_x itself is
+# excluded to prevent the recompute → AssumptionChanged(cg_x) →
+# recompute loop. cd0 and cl_max are excluded for the same reason.
+_RECOMPUTE_TRIGGERING_PARAMS = {"target_static_margin", "mass"}
 
 
 def mark_ops_dirty(session: Session, aeroplane_id: int) -> int:

--- a/app/services/mass_cg_service.py
+++ b/app/services/mass_cg_service.py
@@ -154,20 +154,29 @@ def get_effective_assumption_value(db: Session, aeroplane_uuid, param_name: str)
 
 
 def sync_weight_items_to_assumptions(db: Session, aeroplane_uuid) -> None:
-    """Aggregate weight items and update mass/cg_x calculated values."""
+    """Aggregate weight items and update mass.calculated_value.
+
+    Mass is **always** calculated from the component tree by default —
+    we auto-switch active_source to CALCULATED on the first sync so the
+    user sees the aggregated weight immediately. Users who want a manual
+    override can flip the source back to ESTIMATE in the UI.
+
+    Does NOT write cg_x: per gh-465 the cg_x assumption represents
+    CG_aero (NP - SM × MAC, computed by assumption_compute_service).
+    CG_agg from weight items is exposed via the computation context for
+    comparison only.
+    """
     aeroplane = _get_aeroplane(db, aeroplane_uuid)
 
-    target_params = {"mass", "cg_x"}
-    existing = (
+    mass_row_exists = (
         db.query(DesignAssumptionModel.parameter_name)
         .filter(
             DesignAssumptionModel.aeroplane_id == aeroplane.id,
-            DesignAssumptionModel.parameter_name.in_(target_params),
+            DesignAssumptionModel.parameter_name == "mass",
         )
-        .all()
+        .first()
     )
-    existing_names = {row[0] for row in existing}
-    if not existing_names:
+    if mass_row_exists is None:
         return
 
     rows = db.query(WeightItemModel).filter(WeightItemModel.aeroplane_id == aeroplane.id).all()
@@ -175,18 +184,15 @@ def sync_weight_items_to_assumptions(db: Session, aeroplane_uuid) -> None:
         {"mass_kg": r.mass_kg, "x_m": r.x_m, "y_m": r.y_m, "z_m": r.z_m} for r in rows
     ]
 
-    total_mass, cg_x, _cg_y, _cg_z = aggregate_weight_items(items)
+    total_mass, _cg_x, _cg_y, _cg_z = aggregate_weight_items(items)
 
     from app.services.design_assumptions_service import update_calculated_value
 
     source = "weight_items" if total_mass is not None else None
-    if "mass" in existing_names:
-        update_calculated_value(db, aeroplane_uuid, "mass", total_mass, source)
-    if "cg_x" in existing_names:
-        update_calculated_value(
-            db, aeroplane_uuid, "cg_x", cg_x,
-            "weight_items" if cg_x is not None else None,
-        )
+    update_calculated_value(
+        db, aeroplane_uuid, "mass", total_mass, source,
+        auto_switch_source=True,
+    )
 
 
 def get_cg_comparison(db: Session, aeroplane_uuid) -> CGComparisonResponse:

--- a/app/services/mass_cg_service.py
+++ b/app/services/mass_cg_service.py
@@ -161,10 +161,14 @@ def sync_component_tree_to_mass(db: Session, aeroplane_uuid) -> None:
     overrides). Called from the component-tree CRUD endpoints so any
     change immediately reflects in the assumptions panel.
 
-    Auto-switches active_source to CALCULATED on the first sync.
+    Auto-switches active_source to CALCULATED on the first sync. Emits
+    AssumptionChanged(mass) so downstream handlers run (retrim + V_stall
+    recompute via assumption_compute_service).
     """
+    from app.core.events import AssumptionChanged, event_bus
     from app.services.component_tree_service import get_aircraft_total_weight_kg
     from app.services.design_assumptions_service import update_calculated_value
+    from app.services.invalidation_service import mark_ops_dirty
 
     aeroplane = _get_aeroplane(db, aeroplane_uuid)
     mass_row_exists = (
@@ -183,6 +187,10 @@ def sync_component_tree_to_mass(db: Session, aeroplane_uuid) -> None:
     update_calculated_value(
         db, aeroplane_uuid, "mass", total_kg, source,
         auto_switch_source=True,
+    )
+    mark_ops_dirty(db, aeroplane.id)
+    event_bus.publish(
+        AssumptionChanged(aeroplane_id=aeroplane.id, parameter_name="mass")
     )
 
 
@@ -219,12 +227,18 @@ def sync_weight_items_to_assumptions(db: Session, aeroplane_uuid) -> None:
 
     total_mass, _cg_x, _cg_y, _cg_z = aggregate_weight_items(items)
 
+    from app.core.events import AssumptionChanged, event_bus
     from app.services.design_assumptions_service import update_calculated_value
+    from app.services.invalidation_service import mark_ops_dirty
 
     source = "weight_items" if total_mass is not None else None
     update_calculated_value(
         db, aeroplane_uuid, "mass", total_mass, source,
         auto_switch_source=True,
+    )
+    mark_ops_dirty(db, aeroplane.id)
+    event_bus.publish(
+        AssumptionChanged(aeroplane_id=aeroplane.id, parameter_name="mass")
     )
 
 

--- a/app/services/mass_cg_service.py
+++ b/app/services/mass_cg_service.py
@@ -153,6 +153,39 @@ def get_effective_assumption_value(db: Session, aeroplane_uuid, param_name: str)
     return row.estimate_value
 
 
+def sync_component_tree_to_mass(db: Session, aeroplane_uuid) -> None:
+    """Aggregate component-tree weights and update mass.calculated_value.
+
+    Source of truth for the mass assumption when the user builds the
+    aircraft via the Component Tree (CAD shapes + COTS components +
+    overrides). Called from the component-tree CRUD endpoints so any
+    change immediately reflects in the assumptions panel.
+
+    Auto-switches active_source to CALCULATED on the first sync.
+    """
+    from app.services.component_tree_service import get_aircraft_total_weight_kg
+    from app.services.design_assumptions_service import update_calculated_value
+
+    aeroplane = _get_aeroplane(db, aeroplane_uuid)
+    mass_row_exists = (
+        db.query(DesignAssumptionModel.parameter_name)
+        .filter(
+            DesignAssumptionModel.aeroplane_id == aeroplane.id,
+            DesignAssumptionModel.parameter_name == "mass",
+        )
+        .first()
+    )
+    if mass_row_exists is None:
+        return
+
+    total_kg = get_aircraft_total_weight_kg(db, aeroplane_uuid)
+    source = "component_tree" if total_kg is not None else None
+    update_calculated_value(
+        db, aeroplane_uuid, "mass", total_kg, source,
+        auto_switch_source=True,
+    )
+
+
 def sync_weight_items_to_assumptions(db: Session, aeroplane_uuid) -> None:
     """Aggregate weight items and update mass.calculated_value.
 

--- a/app/services/operating_point_generator_service.py
+++ b/app/services/operating_point_generator_service.py
@@ -108,6 +108,63 @@ def _get_profile_or_raise(db: Session, profile_id: int) -> RCFlightProfileModel:
     return profile
 
 
+def _load_design_cg_x(db: Session, aeroplane_id: int) -> float:
+    """Look up the effective cg_x from design assumptions, or 0.0."""
+    from app.models.aeroplanemodel import DesignAssumptionModel
+
+    row = (
+        db.query(DesignAssumptionModel)
+        .filter(
+            DesignAssumptionModel.aeroplane_id == aeroplane_id,
+            DesignAssumptionModel.parameter_name == "cg_x",
+        )
+        .first()
+    )
+    if row is None:
+        return 0.0
+    if row.active_source == "CALCULATED" and row.calculated_value is not None:
+        return float(row.calculated_value)
+    return float(row.estimate_value)
+
+
+def _load_effective_mass_kg(
+    db: Session, aeroplane_id: int, fallback_kg: Optional[float]
+) -> Optional[float]:
+    """Effective mass from the assumption row, falling back to the
+    aeroplane's total_mass_kg field (legacy)."""
+    from app.models.aeroplanemodel import DesignAssumptionModel
+
+    row = (
+        db.query(DesignAssumptionModel)
+        .filter(
+            DesignAssumptionModel.aeroplane_id == aeroplane_id,
+            DesignAssumptionModel.parameter_name == "mass",
+        )
+        .first()
+    )
+    if row is None:
+        return fallback_kg
+    if row.active_source == "CALCULATED" and row.calculated_value is not None:
+        return float(row.calculated_value)
+    return float(row.estimate_value)
+
+
+def _resolve_cruise_speed_with_md_fallback(
+    aircraft: AeroplaneModel, goals: dict[str, Any], source_profile_id: Optional[int]
+) -> float:
+    """When the aircraft has no flight profile, use V_md from the cached
+    computation context as the cruise speed. Mirrors the chip behaviour
+    in the Info Chip Row."""
+    cruise_from_goals = float(goals.get("cruise_speed_mps", 18.0))
+    if source_profile_id is not None:
+        return cruise_from_goals
+    ctx = aircraft.assumption_computation_context or {}
+    v_md = ctx.get("v_md_mps")
+    if isinstance(v_md, (int, float)) and v_md > 0:
+        return float(v_md)
+    return cruise_from_goals
+
+
 def _load_effective_flight_profile(
     db: Session,
     aircraft: AeroplaneModel,
@@ -592,6 +649,7 @@ def _trim_or_estimate_point(
     target: dict[str, Any],
     constraints: dict[str, Any],
     capabilities: dict[str, Any],
+    effective_mass_kg: Optional[float] = None,
 ) -> TrimmedPoint:
     warnings = list(target.get("warnings", []))
     velocity = float(target["velocity"])
@@ -600,9 +658,16 @@ def _trim_or_estimate_point(
     rho = float(asb.Atmosphere(altitude=altitude).density())
     s_ref = float(getattr(asb_airplane, "s_ref", 0.0) or 0.0)
     n_target = float(target.get("n_target", 1.0))
+    # Effective mass from the design assumptions takes precedence over
+    # the legacy aircraft.total_mass_kg field — that way Component-Tree
+    # weight changes (which sync into the mass assumption) flow into
+    # CL_target without requiring a separate aircraft-level update.
+    mass_for_cl = (
+        effective_mass_kg if effective_mass_kg is not None else aircraft.total_mass_kg
+    )
 
     def cl_target_fn(v: float) -> Optional[float]:
-        return _cl_target_for_velocity(v, aircraft.total_mass_kg, s_ref, rho, n_target)
+        return _cl_target_for_velocity(v, mass_for_cl, s_ref, rho, n_target)
 
     beta_candidates = [float(target.get("beta_target_deg", 0.0))]
     if target["name"] == "dutch_role_start":
@@ -686,6 +751,7 @@ def _persist_point_set(
     points: list[TrimmedPoint],
     source_flight_profile_id: Optional[int],
     replace_existing: bool,
+    design_cg_x: float = 0.0,
 ) -> tuple[OperatingPointSetModel, list[OperatingPointModel]]:
     if replace_existing:
         db.query(OperatingPointSetModel).filter(
@@ -711,7 +777,7 @@ def _persist_point_set(
             p=point.p,
             q=point.q,
             r=point.r,
-            xyz_ref=[0.0, 0.0, 0.0],
+            xyz_ref=[design_cg_x, 0.0, 0.0],
             altitude=point.altitude,
             trim_enrichment=point.trim_enrichment,
         )
@@ -744,11 +810,32 @@ def generate_default_set_for_aircraft(
         profile, source_profile_id = _load_effective_flight_profile(
             db, aircraft, profile_id_override
         )
+        # When no flight profile is set, fall back to V_md for cruise —
+        # the same auto-suggestion logic the Info Chip Row uses. Patch
+        # the goals dict in-place before reference-speed estimation so
+        # all downstream targets see the resolved cruise speed.
+        cruise_resolved = _resolve_cruise_speed_with_md_fallback(
+            aircraft, profile.get("goals", {}), source_profile_id
+        )
+        profile.setdefault("goals", {})["cruise_speed_mps"] = cruise_resolved
+
+        # Effective values from design assumptions take precedence over
+        # legacy aircraft fields, so Component-Tree weight changes and
+        # SM choices flow into the trim solution without an extra step.
+        effective_mass_kg = _load_effective_mass_kg(
+            db, aircraft.id, aircraft.total_mass_kg
+        )
+        design_cg_x = _load_design_cg_x(db, aircraft.id)
+
         refs = _estimate_reference_speeds(profile)
         targets = _build_target_definitions(profile, refs)
 
         plane_schema = aeroplane_model_to_aeroplane_schema_async(aircraft)
         asb_airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
+        # Use the design CG as the moment-reference point for trim, so
+        # Cm=0 means "balanced about the user's design CG", not about
+        # the origin. Mirrors what stability_summary already does.
+        asb_airplane.xyz_ref = [design_cg_x, 0.0, 0.0]
         capabilities = _detect_control_capabilities(asb_airplane)
         deflection_limits = build_deflection_limits_from_schema(plane_schema)
 
@@ -773,6 +860,7 @@ def generate_default_set_for_aircraft(
                 target=target,
                 constraints=profile.get("constraints", {}),
                 capabilities=capabilities,
+                effective_mass_kg=effective_mass_kg,
             )
             try:
                 enrichment = compute_enrichment(
@@ -809,6 +897,7 @@ def generate_default_set_for_aircraft(
             points=points,
             source_flight_profile_id=source_profile_id,
             replace_existing=replace_existing,
+            design_cg_x=design_cg_x,
         )
 
         db.flush()
@@ -873,12 +962,18 @@ def trim_operating_point_for_aircraft(
                 },
             )
 
+        effective_mass_kg = _load_effective_mass_kg(
+            db, aircraft.id, aircraft.total_mass_kg
+        )
+        design_cg_x = _load_design_cg_x(db, aircraft.id)
+
         point = _trim_or_estimate_point(
             asb_airplane=asb_airplane,
             aircraft=aircraft,
             target=target,
             constraints=profile.get("constraints", {}),
             capabilities=capabilities,
+            effective_mass_kg=effective_mass_kg,
         )
 
         deflection_limits = build_deflection_limits_from_schema(plane_schema)
@@ -917,7 +1012,7 @@ def trim_operating_point_for_aircraft(
             p=point.p,
             q=point.q,
             r=point.r,
-            xyz_ref=[0.0, 0.0, 0.0],
+            xyz_ref=[design_cg_x, 0.0, 0.0],
             altitude=point.altitude,
             trim_enrichment=enrichment_data,
         )

--- a/app/tests/test_assumption_compute_integration.py
+++ b/app/tests/test_assumption_compute_integration.py
@@ -59,7 +59,7 @@ def test_recompute_publishes_assumption_changed_on_cg_change(client_and_db):
         ),
         patch(
             "app.services.assumption_compute_service._stability_run_at_cruise",
-            return_value=(0.085, 0.20, 0.020),
+            return_value=(0.085, 0.20, 0.020, 0.30),
         ),
         patch(
             "app.services.assumption_compute_service._coarse_alpha_sweep",
@@ -113,7 +113,7 @@ def test_recompute_does_not_publish_when_cg_unchanged(client_and_db):
         ),
         patch(
             "app.services.assumption_compute_service._stability_run_at_cruise",
-            return_value=(0.085, 0.20, 0.020),
+            return_value=(0.085, 0.20, 0.020, 0.30),
         ),
         patch(
             "app.services.assumption_compute_service._coarse_alpha_sweep",

--- a/app/tests/test_assumption_compute_integration.py
+++ b/app/tests/test_assumption_compute_integration.py
@@ -71,7 +71,7 @@ def test_recompute_publishes_assumption_changed_on_cg_change(client_and_db):
         ),
         patch(
             "app.services.assumption_compute_service._load_flight_profile_speeds",
-            return_value=(18.0, 28.0),
+            return_value=(18.0, 28.0, True),
         ),
     ]
 
@@ -125,7 +125,7 @@ def test_recompute_does_not_publish_when_cg_unchanged(client_and_db):
         ),
         patch(
             "app.services.assumption_compute_service._load_flight_profile_speeds",
-            return_value=(18.0, 28.0),
+            return_value=(18.0, 28.0, True),
         ),
     ]
 

--- a/app/tests/test_assumption_compute_integration.py
+++ b/app/tests/test_assumption_compute_integration.py
@@ -1,0 +1,147 @@
+"""Integration tests for the full assumption recompute pipeline (gh-465, Task 11).
+
+Verifies:
+1. The GeometryChanged handler delegates to job_tracker.schedule_recompute_assumptions
+2. The recompute pipeline correctly emits AssumptionChanged(parameter_name="cg_x")
+3. Idempotent: a second recompute with same inputs does NOT emit a duplicate event
+"""
+import pytest
+from unittest.mock import patch
+from types import SimpleNamespace
+
+from app.core.events import (
+    AssumptionChanged,
+    GeometryChanged,
+    event_bus,
+)
+from app.models.aeroplanemodel import DesignAssumptionModel
+from app.services.design_assumptions_service import seed_defaults
+from app.tests.conftest import make_aeroplane
+
+
+@pytest.mark.integration
+def test_geometry_changed_handler_schedules_recompute():
+    """Handler delegates to job_tracker.schedule_recompute_assumptions."""
+    from app.services.invalidation_service import (
+        _on_geometry_changed_recompute_assumptions,
+    )
+
+    # Patch the origin module — the handler does a lazy
+    # `from app.core.background_jobs import job_tracker`.
+    with patch("app.core.background_jobs.job_tracker") as mock_tracker:
+        _on_geometry_changed_recompute_assumptions(
+            GeometryChanged(aeroplane_id=42, source_model="WingModel")
+        )
+
+    mock_tracker.schedule_recompute_assumptions.assert_called_once_with(42)
+
+
+@pytest.mark.integration
+def test_recompute_publishes_assumption_changed_on_cg_change(client_and_db):
+    """Full pipeline: recompute with seeded assumptions emits AssumptionChanged for cg_x."""
+    from app.services.assumption_compute_service import recompute_assumptions
+
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
+
+    captured: list = []
+    handler = captured.append
+    event_bus.subscribe(AssumptionChanged, handler)
+
+    patches = [
+        patch(
+            "app.services.assumption_compute_service._build_asb_airplane",
+            return_value=SimpleNamespace(wings=[object()], xyz_ref=[0.08, 0.0, 0.0]),
+        ),
+        patch(
+            "app.services.assumption_compute_service._stability_run_at_cruise",
+            return_value=(0.085, 0.20, 0.020),
+        ),
+        patch(
+            "app.services.assumption_compute_service._coarse_alpha_sweep",
+            return_value=14.0,
+        ),
+        patch(
+            "app.services.assumption_compute_service._fine_sweep_cl_max",
+            return_value=1.35,
+        ),
+        patch(
+            "app.services.assumption_compute_service._load_flight_profile_speeds",
+            return_value=(18.0, 28.0),
+        ),
+    ]
+
+    try:
+        for p in patches:
+            p.start()
+        with SessionLocal() as db:
+            recompute_assumptions(db, aeroplane_uuid)
+            db.commit()
+    finally:
+        for p in patches:
+            p.stop()
+        event_bus._subscribers.get(AssumptionChanged, []).remove(handler)
+
+    cg_events = [e for e in captured if e.parameter_name == "cg_x"]
+    assert len(cg_events) == 1
+
+
+@pytest.mark.integration
+def test_recompute_does_not_publish_when_cg_unchanged(client_and_db):
+    """Second recompute with same inputs does not emit a duplicate event."""
+    from app.services.assumption_compute_service import recompute_assumptions
+
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
+
+    captured: list = []
+    handler = captured.append
+    event_bus.subscribe(AssumptionChanged, handler)
+
+    patches = [
+        patch(
+            "app.services.assumption_compute_service._build_asb_airplane",
+            return_value=SimpleNamespace(wings=[object()], xyz_ref=[0.08, 0.0, 0.0]),
+        ),
+        patch(
+            "app.services.assumption_compute_service._stability_run_at_cruise",
+            return_value=(0.085, 0.20, 0.020),
+        ),
+        patch(
+            "app.services.assumption_compute_service._coarse_alpha_sweep",
+            return_value=14.0,
+        ),
+        patch(
+            "app.services.assumption_compute_service._fine_sweep_cl_max",
+            return_value=1.35,
+        ),
+        patch(
+            "app.services.assumption_compute_service._load_flight_profile_speeds",
+            return_value=(18.0, 28.0),
+        ),
+    ]
+
+    try:
+        for p in patches:
+            p.start()
+        with SessionLocal() as db:
+            recompute_assumptions(db, aeroplane_uuid)
+            db.commit()
+        with SessionLocal() as db:
+            recompute_assumptions(db, aeroplane_uuid)
+            db.commit()
+    finally:
+        for p in patches:
+            p.stop()
+        event_bus._subscribers.get(AssumptionChanged, []).remove(handler)
+
+    cg_events = [e for e in captured if e.parameter_name == "cg_x"]
+    assert len(cg_events) == 1  # Only first call emitted; second was idempotent

--- a/app/tests/test_assumption_compute_integration.py
+++ b/app/tests/test_assumption_compute_integration.py
@@ -55,7 +55,7 @@ def test_recompute_publishes_assumption_changed_on_cg_change(client_and_db):
     patches = [
         patch(
             "app.services.assumption_compute_service._build_asb_airplane",
-            return_value=SimpleNamespace(wings=[object()], xyz_ref=[0.08, 0.0, 0.0]),
+            return_value=SimpleNamespace(wings=[SimpleNamespace(area=lambda: 0.30, mean_aerodynamic_chord=lambda: 0.20, span=lambda: 1.5)], xyz_ref=[0.08, 0.0, 0.0], s_ref=0.30, c_ref=0.20, b_ref=1.5),
         ),
         patch(
             "app.services.assumption_compute_service._stability_run_at_cruise",
@@ -109,7 +109,7 @@ def test_recompute_does_not_publish_when_cg_unchanged(client_and_db):
     patches = [
         patch(
             "app.services.assumption_compute_service._build_asb_airplane",
-            return_value=SimpleNamespace(wings=[object()], xyz_ref=[0.08, 0.0, 0.0]),
+            return_value=SimpleNamespace(wings=[SimpleNamespace(area=lambda: 0.30, mean_aerodynamic_chord=lambda: 0.20, span=lambda: 1.5)], xyz_ref=[0.08, 0.0, 0.0], s_ref=0.30, c_ref=0.20, b_ref=1.5),
         ),
         patch(
             "app.services.assumption_compute_service._stability_run_at_cruise",

--- a/app/tests/test_assumption_compute_service.py
+++ b/app/tests/test_assumption_compute_service.py
@@ -22,7 +22,7 @@ def _patches():
         ),
         patch(
             "app.services.assumption_compute_service._stability_run_at_cruise",
-            return_value=(0.085, 0.20, 0.025),  # x_np, MAC, CD0
+            return_value=(0.085, 0.20, 0.025, 0.30),  # x_np, MAC, CD0
         ),
         patch(
             "app.services.assumption_compute_service._coarse_alpha_sweep",

--- a/app/tests/test_assumption_compute_service.py
+++ b/app/tests/test_assumption_compute_service.py
@@ -13,12 +13,29 @@ from app.services.design_assumptions_service import seed_defaults
 from app.tests.conftest import make_aeroplane
 
 
+def _make_fake_airplane():
+    """Stub for asb_airplane: a wing with .area/.mean_aerodynamic_chord/.span()
+    so _select_main_wing + the s_ref/c_ref/b_ref override don't blow up."""
+    fake_wing = SimpleNamespace(
+        area=lambda: 0.30,
+        mean_aerodynamic_chord=lambda: 0.20,
+        span=lambda: 1.5,
+    )
+    return SimpleNamespace(
+        wings=[fake_wing],
+        xyz_ref=[0.08, 0.0, 0.0],
+        s_ref=0.30,
+        c_ref=0.20,
+        b_ref=1.5,
+    )
+
+
 def _patches():
     """Stub the three ASB-bound helpers so tests don't need real ASB."""
     return (
         patch(
             "app.services.assumption_compute_service._build_asb_airplane",
-            return_value=SimpleNamespace(wings=[object()], xyz_ref=[0.08, 0.0, 0.0]),
+            return_value=_make_fake_airplane(),
         ),
         patch(
             "app.services.assumption_compute_service._stability_run_at_cruise",

--- a/app/tests/test_assumption_compute_service.py
+++ b/app/tests/test_assumption_compute_service.py
@@ -1,0 +1,131 @@
+"""Tests for the assumption compute service (Task 5 of gh-465).
+
+All AeroSandbox-bound helpers are stubbed so tests run without ASB installed.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from app.models.aeroplanemodel import DesignAssumptionModel
+from app.services.assumption_compute_service import recompute_assumptions
+from app.services.design_assumptions_service import seed_defaults
+from app.tests.conftest import make_aeroplane
+
+
+def _patches():
+    """Stub the three ASB-bound helpers so tests don't need real ASB."""
+    return (
+        patch(
+            "app.services.assumption_compute_service._build_asb_airplane",
+            return_value=SimpleNamespace(wings=[object()], xyz_ref=[0.08, 0.0, 0.0]),
+        ),
+        patch(
+            "app.services.assumption_compute_service._stability_run_at_cruise",
+            return_value=(0.085, 0.20, 0.025),  # x_np, MAC, CD0
+        ),
+        patch(
+            "app.services.assumption_compute_service._coarse_alpha_sweep",
+            return_value=15.0,  # stall_alpha_deg
+        ),
+        patch(
+            "app.services.assumption_compute_service._fine_sweep_cl_max",
+            return_value=1.35,
+        ),
+        patch(
+            "app.services.assumption_compute_service._load_flight_profile_speeds",
+            return_value=(18.0, 28.0),
+        ),
+    )
+
+
+def test_recompute_writes_all_three_assumptions(client_and_db):
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
+        aeroplane_id = aeroplane.id
+
+    p1, p2, p3, p4, p5 = _patches()
+    with p1, p2, p3, p4, p5:
+        with SessionLocal() as db:
+            recompute_assumptions(db, aeroplane_uuid)
+            db.commit()
+
+    with SessionLocal() as db:
+        rows = {
+            r.parameter_name: r
+            for r in db.query(DesignAssumptionModel)
+            .filter(DesignAssumptionModel.aeroplane_id == aeroplane_id)
+            .all()
+        }
+        assert rows["cl_max"].calculated_value == 1.35
+        assert rows["cd0"].calculated_value == 0.025
+        # cg_x = x_np - target_static_margin × MAC
+        #      = 0.085 - 0.12 × 0.20 = 0.061
+        # (target_static_margin default is 0.12 per PARAMETER_DEFAULTS)
+        assert abs(rows["cg_x"].calculated_value - 0.061) < 1e-6
+
+
+def test_recompute_skips_when_no_wings(client_and_db):
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
+
+    with patch(
+        "app.services.assumption_compute_service._build_asb_airplane",
+        return_value=SimpleNamespace(wings=[], xyz_ref=[0, 0, 0]),
+    ):
+        with SessionLocal() as db:
+            recompute_assumptions(db, aeroplane_uuid)
+            db.commit()
+
+    with SessionLocal() as db:
+        cd0 = (
+            db.query(DesignAssumptionModel)
+            .filter_by(parameter_name="cd0")
+            .first()
+        )
+        assert cd0.calculated_value is None  # untouched
+
+
+def test_recompute_caches_context_and_publishes_cg_change(client_and_db):
+    from app.core.events import AssumptionChanged, event_bus
+
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
+        aeroplane_id = aeroplane.id
+
+    captured: list = []
+    handler = captured.append
+    event_bus.subscribe(AssumptionChanged, handler)
+
+    p1, p2, p3, p4, p5 = _patches()
+    try:
+        with p1, p2, p3, p4, p5:
+            with SessionLocal() as db:
+                recompute_assumptions(db, aeroplane_uuid)
+                db.commit()
+    finally:
+        # EventBus has no public unsubscribe; remove from internal list
+        event_bus._subscribers.get(AssumptionChanged, []).remove(handler)
+
+    with SessionLocal() as db:
+        from app.models.aeroplanemodel import AeroplaneModel
+        a = db.query(AeroplaneModel).filter_by(id=aeroplane_id).first()
+        ctx = a.assumption_computation_context
+        assert ctx["v_cruise_mps"] == 18.0
+        assert ctx["mac_m"] == 0.20
+        assert ctx["x_np_m"] == 0.085
+
+    cg_events = [e for e in captured if e.parameter_name == "cg_x"]
+    assert len(cg_events) == 1

--- a/app/tests/test_assumption_compute_service.py
+++ b/app/tests/test_assumption_compute_service.py
@@ -51,7 +51,7 @@ def _patches():
         ),
         patch(
             "app.services.assumption_compute_service._load_flight_profile_speeds",
-            return_value=(18.0, 28.0),
+            return_value=(18.0, 28.0, True),
         ),
     )
 

--- a/app/tests/test_assumption_compute_service.py
+++ b/app/tests/test_assumption_compute_service.py
@@ -111,6 +111,79 @@ def test_recompute_skips_when_no_wings(client_and_db):
         assert cd0.calculated_value is None  # untouched
 
 
+def test_recompute_aborts_cleanly_on_asb_exception(client_and_db):
+    """ASB failure must NOT corrupt existing calculated_value fields and
+    must NOT publish AssumptionChanged. This guards a critical loop in
+    recompute_assumptions: any exception inside the sweep helpers is
+    caught and the function returns without writing anything."""
+    from app.core.events import AssumptionChanged, event_bus
+
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        # Pre-seed known calculated values that must survive untouched.
+        cd0_row = (
+            db.query(DesignAssumptionModel)
+            .filter_by(aeroplane_id=aeroplane.id, parameter_name="cd0")
+            .first()
+        )
+        cd0_row.calculated_value = 0.9999
+        cd0_row.calculated_source = "previous_run"
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
+
+    captured: list = []
+    handler = captured.append
+    event_bus.subscribe(AssumptionChanged, handler)
+
+    try:
+        with (
+            patch(
+                "app.services.assumption_compute_service._build_asb_airplane",
+                return_value=SimpleNamespace(
+                    wings=[
+                        SimpleNamespace(
+                            area=lambda: 0.30,
+                            mean_aerodynamic_chord=lambda: 0.20,
+                            span=lambda: 1.5,
+                        )
+                    ],
+                    xyz_ref=[0.0, 0.0, 0.0],
+                    s_ref=0.30,
+                    c_ref=0.20,
+                    b_ref=1.5,
+                ),
+            ),
+            patch(
+                "app.services.assumption_compute_service._stability_run_at_cruise",
+                side_effect=RuntimeError("ASB boom"),
+            ),
+            patch(
+                "app.services.assumption_compute_service._load_flight_profile_speeds",
+                return_value=(18.0, 28.0, True),
+            ),
+        ):
+            with SessionLocal() as db:
+                recompute_assumptions(db, aeroplane_uuid)
+                db.commit()
+    finally:
+        event_bus._subscribers.get(AssumptionChanged, []).remove(handler)
+
+    # Pre-existing value survives.
+    with SessionLocal() as db:
+        cd0_row = (
+            db.query(DesignAssumptionModel)
+            .filter_by(parameter_name="cd0")
+            .first()
+        )
+        assert cd0_row.calculated_value == 0.9999
+        assert cd0_row.calculated_source == "previous_run"
+
+    # No spurious cg_x change event.
+    assert [e.parameter_name for e in captured] == []
+
+
 def test_recompute_caches_context_and_publishes_cg_change(client_and_db):
     from app.core.events import AssumptionChanged, event_bus
 

--- a/app/tests/test_auto_switch_source.py
+++ b/app/tests/test_auto_switch_source.py
@@ -1,0 +1,70 @@
+"""Tests for auto_switch_source parameter in update_calculated_value."""
+
+from datetime import datetime, timezone
+
+import pytest
+from unittest.mock import MagicMock, patch
+from app.services.design_assumptions_service import update_calculated_value
+from app.models.aeroplanemodel import DesignAssumptionModel
+
+
+@pytest.fixture
+def mock_db_with_assumption():
+    """Create a mock DB session with an assumption row."""
+    db = MagicMock()
+    row = MagicMock(spec=DesignAssumptionModel)
+    row.parameter_name = "cl_max"
+    row.estimate_value = 1.4
+    row.calculated_value = None
+    row.calculated_source = None
+    row.active_source = "ESTIMATE"
+    row.divergence_pct = None
+    row.updated_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    row.id = 1
+    row.aeroplane_id = 1
+
+    db.query.return_value.filter.return_value.first.return_value = row
+    return db, row
+
+
+def test_auto_switch_on_first_calculated_value(mock_db_with_assumption):
+    db, row = mock_db_with_assumption
+    with patch("app.services.design_assumptions_service._get_aeroplane") as mock_get:
+        mock_aeroplane = MagicMock()
+        mock_aeroplane.id = 1
+        mock_get.return_value = mock_aeroplane
+
+        update_calculated_value(db, "test-uuid", "cl_max", 1.35, "aerobuildup", auto_switch_source=True)
+
+    assert row.calculated_value == 1.35
+    assert row.active_source == "CALCULATED"
+
+
+def test_no_auto_switch_when_already_has_calculated(mock_db_with_assumption):
+    db, row = mock_db_with_assumption
+    row.calculated_value = 1.3  # already has a value
+    row.active_source = "ESTIMATE"  # user chose estimate
+
+    with patch("app.services.design_assumptions_service._get_aeroplane") as mock_get:
+        mock_aeroplane = MagicMock()
+        mock_aeroplane.id = 1
+        mock_get.return_value = mock_aeroplane
+
+        update_calculated_value(db, "test-uuid", "cl_max", 1.35, "aerobuildup", auto_switch_source=True)
+
+    assert row.calculated_value == 1.35
+    assert row.active_source == "ESTIMATE"  # not overridden
+
+
+def test_no_auto_switch_for_design_choice(mock_db_with_assumption):
+    db, row = mock_db_with_assumption
+    row.parameter_name = "g_limit"
+
+    with patch("app.services.design_assumptions_service._get_aeroplane") as mock_get:
+        mock_aeroplane = MagicMock()
+        mock_aeroplane.id = 1
+        mock_get.return_value = mock_aeroplane
+
+        update_calculated_value(db, "test-uuid", "g_limit", 3.5, "computed", auto_switch_source=True)
+
+    assert row.active_source == "ESTIMATE"  # design choices never auto-switch

--- a/app/tests/test_computation_config_model.py
+++ b/app/tests/test_computation_config_model.py
@@ -1,0 +1,15 @@
+import pytest
+from app.models.computation_config import AircraftComputationConfigModel, COMPUTATION_CONFIG_DEFAULTS
+
+
+def test_defaults_dict_has_all_columns():
+    expected_keys = {
+        "coarse_alpha_min_deg", "coarse_alpha_max_deg", "coarse_alpha_step_deg",
+        "fine_alpha_margin_deg", "fine_alpha_step_deg", "fine_velocity_count",
+        "debounce_seconds",
+    }
+    assert set(COMPUTATION_CONFIG_DEFAULTS.keys()) == expected_keys
+
+
+def test_model_tablename():
+    assert AircraftComputationConfigModel.__tablename__ == "aircraft_computation_config"

--- a/app/tests/test_computation_config_schema.py
+++ b/app/tests/test_computation_config_schema.py
@@ -1,0 +1,29 @@
+import pytest
+from app.schemas.computation_config import ComputationConfigRead, ComputationConfigWrite
+
+
+def test_read_schema_has_all_fields():
+    data = ComputationConfigRead(
+        id=1,
+        aeroplane_id=1,
+        coarse_alpha_min_deg=-5.0,
+        coarse_alpha_max_deg=25.0,
+        coarse_alpha_step_deg=1.0,
+        fine_alpha_margin_deg=5.0,
+        fine_alpha_step_deg=0.5,
+        fine_velocity_count=8,
+        debounce_seconds=2.0,
+    )
+    assert data.coarse_alpha_step_deg == 1.0
+    assert data.fine_velocity_count == 8
+
+
+def test_write_schema_partial_update():
+    data = ComputationConfigWrite(coarse_alpha_step_deg=0.5)
+    assert data.coarse_alpha_step_deg == 0.5
+    assert data.fine_velocity_count is None
+
+
+def test_write_schema_validates_positive_step():
+    with pytest.raises(ValueError):
+        ComputationConfigWrite(coarse_alpha_step_deg=0.0)

--- a/app/tests/test_computation_endpoints.py
+++ b/app/tests/test_computation_endpoints.py
@@ -1,0 +1,95 @@
+"""Tests for the computation-context and computation-config endpoints.
+
+Covers:
+- GET /aeroplanes/{id}/assumptions/computation-context
+- GET /aeroplanes/{id}/computation-config
+- PUT /aeroplanes/{id}/computation-config
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from app.models.aeroplanemodel import AeroplaneModel
+from app.models.computation_config import (
+    COMPUTATION_CONFIG_DEFAULTS,
+    AircraftComputationConfigModel,
+)
+from app.tests.conftest import make_aeroplane
+
+
+def test_get_computation_context_returns_null_when_never_computed(client_and_db):
+    client, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        aeroplane_uuid = str(aeroplane.uuid)
+
+    resp = client.get(f"/aeroplanes/{aeroplane_uuid}/assumptions/computation-context")
+    assert resp.status_code == 200
+    assert resp.json() is None
+
+
+def test_get_computation_context_returns_cached(client_and_db):
+    client, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        aeroplane.assumption_computation_context = {
+            "v_cruise_mps": 18.0,
+            "reynolds": 230000,
+            "mac_m": 0.21,
+        }
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
+
+    resp = client.get(f"/aeroplanes/{aeroplane_uuid}/assumptions/computation-context")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["v_cruise_mps"] == 18.0
+    assert body["reynolds"] == 230000
+
+
+def test_get_computation_config_creates_default_when_missing(client_and_db):
+    client, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        aeroplane_uuid = str(aeroplane.uuid)
+        aeroplane_id = aeroplane.id
+
+    resp = client.get(f"/aeroplanes/{aeroplane_uuid}/computation-config")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["coarse_alpha_step_deg"] == COMPUTATION_CONFIG_DEFAULTS["coarse_alpha_step_deg"]
+
+    with SessionLocal() as db:
+        rows = (
+            db.query(AircraftComputationConfigModel)
+            .filter(AircraftComputationConfigModel.aeroplane_id == aeroplane_id)
+            .all()
+        )
+        assert len(rows) == 1
+
+
+def test_put_computation_config_updates_fields(client_and_db):
+    client, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        aeroplane_uuid = str(aeroplane.uuid)
+
+    resp = client.put(
+        f"/aeroplanes/{aeroplane_uuid}/computation-config",
+        json={"coarse_alpha_step_deg": 0.5, "fine_velocity_count": 12},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["coarse_alpha_step_deg"] == 0.5
+    assert body["fine_velocity_count"] == 12
+    # Untouched fields keep defaults
+    assert body["debounce_seconds"] == COMPUTATION_CONFIG_DEFAULTS["debounce_seconds"]
+
+
+def test_get_computation_context_404_for_missing_aeroplane(client_and_db):
+    client, _ = client_and_db
+    resp = client.get(
+        f"/aeroplanes/{uuid.uuid4()}/assumptions/computation-context"
+    )
+    assert resp.status_code == 404

--- a/app/tests/test_design_assumption_schemas.py
+++ b/app/tests/test_design_assumption_schemas.py
@@ -223,11 +223,11 @@ class TestAssumptionsSummary:
 
 
 class TestConstants:
-    def test_parameter_defaults_has_six_entries(self):
-        assert len(PARAMETER_DEFAULTS) == 6
+    def test_parameter_defaults_has_eight_entries(self):
+        assert len(PARAMETER_DEFAULTS) == 8
 
-    def test_parameter_units_has_six_entries(self):
-        assert len(PARAMETER_UNITS) == 6
+    def test_parameter_units_has_eight_entries(self):
+        assert len(PARAMETER_UNITS) == 8
 
     def test_design_choice_params(self):
         assert "target_static_margin" in DESIGN_CHOICE_PARAMS

--- a/app/tests/test_design_assumptions_endpoint.py
+++ b/app/tests/test_design_assumptions_endpoint.py
@@ -23,7 +23,7 @@ class TestSeedAssumptions:
         resp = client.post(f"/aeroplanes/{aeroplane.uuid}/assumptions")
         assert resp.status_code == 201
         body = resp.json()
-        assert len(body["assumptions"]) == 6
+        assert len(body["assumptions"]) == 8
         assert body["warnings_count"] == 0
 
     def test_seed_idempotent(self, client_and_db):
@@ -34,7 +34,7 @@ class TestSeedAssumptions:
         client.post(f"/aeroplanes/{aeroplane.uuid}/assumptions")
         resp = client.post(f"/aeroplanes/{aeroplane.uuid}/assumptions")
         assert resp.status_code == 201
-        assert len(resp.json()["assumptions"]) == 6
+        assert len(resp.json()["assumptions"]) == 8
 
     def test_seed_404_for_missing_aeroplane(self, client_and_db):
         client, _ = client_and_db
@@ -58,7 +58,7 @@ class TestListAssumptions:
         resp = client.get(f"/aeroplanes/{aeroplane.uuid}/assumptions")
         assert resp.status_code == 200
         body = resp.json()
-        assert len(body["assumptions"]) == 6
+        assert len(body["assumptions"]) == 8
 
     def test_list_empty_before_seed(self, client_and_db):
         client, SessionLocal = client_and_db

--- a/app/tests/test_design_assumptions_service.py
+++ b/app/tests/test_design_assumptions_service.py
@@ -27,7 +27,7 @@ class TestSeedDefaults:
         with SessionLocal() as db:
             aeroplane = make_aeroplane(db)
             summary = svc.seed_defaults(db, aeroplane.uuid)
-            assert len(summary.assumptions) == 6
+            assert len(summary.assumptions) == 8
 
     def test_default_values_match(self, client_and_db):
         _, SessionLocal = client_and_db
@@ -45,7 +45,7 @@ class TestSeedDefaults:
             aeroplane = make_aeroplane(db)
             svc.seed_defaults(db, aeroplane.uuid)
             summary = svc.seed_defaults(db, aeroplane.uuid)
-            assert len(summary.assumptions) == 6
+            assert len(summary.assumptions) == 8
 
     def test_all_defaults_use_estimate_source(self, client_and_db):
         _, SessionLocal = client_and_db
@@ -74,7 +74,7 @@ class TestListAssumptions:
             aeroplane = make_aeroplane(db)
             svc.seed_defaults(db, aeroplane.uuid)
             summary = svc.list_assumptions(db, aeroplane.uuid)
-            assert len(summary.assumptions) == 6
+            assert len(summary.assumptions) == 8
 
     def test_empty_before_seed(self, client_and_db):
         _, SessionLocal = client_and_db

--- a/app/tests/test_invalidation_recompute.py
+++ b/app/tests/test_invalidation_recompute.py
@@ -1,0 +1,18 @@
+"""Tests for GeometryChanged → assumption recompute wiring."""
+
+from unittest.mock import patch
+
+from app.core.events import GeometryChanged
+
+
+def test_geometry_changed_schedules_recompute():
+    from app.services.invalidation_service import (
+        _on_geometry_changed_recompute_assumptions,
+    )
+
+    event = GeometryChanged(aeroplane_id=42, source_model="WingModel")
+
+    with patch("app.core.background_jobs.job_tracker") as mock_tracker:
+        _on_geometry_changed_recompute_assumptions(event)
+
+    mock_tracker.schedule_recompute_assumptions.assert_called_once_with(42)

--- a/app/tests/test_mass_cg_endpoints.py
+++ b/app/tests/test_mass_cg_endpoints.py
@@ -230,4 +230,5 @@ class TestWeightItemsSyncAssumptions:
         resp = client.get(f"/aeroplanes/{aeroplane.uuid}/assumptions")
         by_name = {a["parameter_name"]: a for a in resp.json()["assumptions"]}
         assert by_name["mass"]["calculated_value"] == pytest.approx(1.0)
-        assert by_name["cg_x"]["calculated_value"] == pytest.approx(0.2)
+        # cg_x is no longer set by weight-item sync (gh-465).
+        assert by_name["cg_x"]["calculated_value"] is None

--- a/app/tests/test_mass_cg_service.py
+++ b/app/tests/test_mass_cg_service.py
@@ -353,8 +353,14 @@ class TestSyncWeightItemsToAssumptions:
             summary = da_svc.list_assumptions(db, aeroplane.uuid)
             by_name = {a.parameter_name: a for a in summary.assumptions}
             assert by_name["mass"].calculated_value == pytest.approx(0.8)
-            expected_cg = (0.3 * 0.05 + 0.5 * 0.15) / 0.8
-            assert by_name["cg_x"].calculated_value == pytest.approx(expected_cg)
+            # Mass auto-switches to CALCULATED on first sync (gh-465).
+            assert by_name["mass"].active_source == "CALCULATED"
+            # cg_x is NOT set by weight-item sync anymore (gh-465). The
+            # cg_x assumption represents CG_aero = NP - SM × MAC, which
+            # is owned by assumption_compute_service. CG_agg from weight
+            # items is exposed via the computation context for comparison
+            # only.
+            assert by_name["cg_x"].calculated_value is None
 
     def test_clears_calculated_when_no_items(self, client_and_db):
         _, SessionLocal = client_and_db

--- a/app/tests/test_seed_computation_config.py
+++ b/app/tests/test_seed_computation_config.py
@@ -1,0 +1,47 @@
+"""Tests for seed_defaults seeding AircraftComputationConfigModel rows."""
+
+from app.models.computation_config import (
+    AircraftComputationConfigModel,
+    COMPUTATION_CONFIG_DEFAULTS,
+)
+from app.services.design_assumptions_service import seed_defaults
+from app.tests.conftest import make_aeroplane
+
+
+def test_seed_defaults_creates_computation_config(client_and_db):
+    """seed_defaults seeds a per-aircraft computation config row."""
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aeroplane_id = aeroplane.id
+
+    with SessionLocal() as db:
+        config = (
+            db.query(AircraftComputationConfigModel)
+            .filter(AircraftComputationConfigModel.aeroplane_id == aeroplane_id)
+            .first()
+        )
+        assert config is not None
+        assert config.coarse_alpha_step_deg == COMPUTATION_CONFIG_DEFAULTS["coarse_alpha_step_deg"]
+        assert config.fine_velocity_count == COMPUTATION_CONFIG_DEFAULTS["fine_velocity_count"]
+
+
+def test_seed_defaults_idempotent_for_config(client_and_db):
+    """Calling seed_defaults twice does not create a second config row."""
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aeroplane_id = aeroplane.id
+
+    with SessionLocal() as db:
+        configs = (
+            db.query(AircraftComputationConfigModel)
+            .filter(AircraftComputationConfigModel.aeroplane_id == aeroplane_id)
+            .all()
+        )
+        assert len(configs) == 1

--- a/app/tests/test_switch_source_recompute_guard.py
+++ b/app/tests/test_switch_source_recompute_guard.py
@@ -1,0 +1,81 @@
+"""Guard test for the recompute-loop avoidance in switch_source.
+
+The recompute service itself publishes AssumptionChanged(cg_x) when the
+computed CG changes. If switch_source also scheduled a recompute for
+cg_x, the loop would be:
+
+  user toggles cg_x → switch_source → schedule_recompute → recompute
+  writes cg_x.calculated_value → emits AssumptionChanged(cg_x) →
+  handler schedules another recompute → …
+
+This test pins the guard: switch_source must NOT schedule a recompute
+when the parameter is "cg_x", but MUST schedule one for every other
+non-design-choice parameter.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from app.schemas.design_assumption import AssumptionSourceSwitch
+from app.services.design_assumptions_service import seed_defaults, switch_source, update_calculated_value
+from app.tests.conftest import make_aeroplane
+
+
+def test_switch_source_cg_x_does_not_schedule_recompute(client_and_db):
+    """Toggling cg_x source must NOT trigger a recompute (loop guard)."""
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        # Give cg_x a calculated value so the switch is allowed.
+        update_calculated_value(
+            db, str(aeroplane.uuid), "cg_x", 0.085, "aerobuildup",
+            auto_switch_source=False,
+        )
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
+
+    with patch(
+        "app.core.background_jobs.job_tracker.schedule_recompute_assumptions"
+    ) as mock_schedule:
+        with SessionLocal() as db:
+            switch_source(
+                db, aeroplane_uuid, "cg_x",
+                AssumptionSourceSwitch(active_source="ESTIMATE"),
+            )
+            db.commit()
+
+    mock_schedule.assert_not_called()
+
+
+def test_switch_source_mass_schedules_recompute(client_and_db):
+    """Sanity counter-test: non-cg_x params DO schedule recompute on toggle."""
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        update_calculated_value(
+            db, str(aeroplane.uuid), "mass", 1.2, "weight_items",
+            auto_switch_source=False,
+        )
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
+        aeroplane_id = aeroplane.id
+
+    with patch(
+        "app.core.background_jobs.job_tracker.schedule_recompute_assumptions"
+    ) as mock_schedule:
+        with SessionLocal() as db:
+            switch_source(
+                db, aeroplane_uuid, "mass",
+                AssumptionSourceSwitch(active_source="CALCULATED"),
+            )
+            db.commit()
+
+    # switch_source schedules directly AND the AssumptionChanged(mass)
+    # handler also schedules (mass is in RECOMPUTE_TRIGGERING_PARAMS).
+    # We don't care about the exact count — just that it fires.
+    assert mock_schedule.call_count >= 1
+    for call in mock_schedule.call_args_list:
+        assert call.args == (aeroplane_id,)

--- a/docs/superpowers/plans/2026-05-10-auto-compute-assumptions.md
+++ b/docs/superpowers/plans/2026-05-10-auto-compute-assumptions.md
@@ -400,35 +400,51 @@ git commit -m "feat(gh-465): add auto_switch_source to update_calculated_value"
 
 ```python
 # app/tests/test_seed_computation_config.py
-from unittest.mock import MagicMock, patch
-from app.models.computation_config import AircraftComputationConfigModel, COMPUTATION_CONFIG_DEFAULTS
+from app.models.computation_config import (
+    AircraftComputationConfigModel,
+    COMPUTATION_CONFIG_DEFAULTS,
+)
+from app.services.design_assumptions_service import seed_defaults
+from app.tests.conftest import make_aeroplane
 
 
-def test_seed_defaults_creates_computation_config():
-    """seed_defaults should also seed computation config if it doesn't exist."""
-    db = MagicMock()
-    # Mock: no existing assumptions
-    db.query.return_value.filter.return_value.all.return_value = []
-    # Mock: no existing computation config
-    db.query.return_value.filter.return_value.first.return_value = None
+def test_seed_defaults_creates_computation_config(client_and_db):
+    """seed_defaults seeds a per-aircraft computation config row."""
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aeroplane_id = aeroplane.id
 
-    with patch("app.services.design_assumptions_service._get_aeroplane") as mock_get:
-        mock_aeroplane = MagicMock()
-        mock_aeroplane.id = 42
-        mock_get.return_value = mock_aeroplane
+    with SessionLocal() as db:
+        config = (
+            db.query(AircraftComputationConfigModel)
+            .filter(AircraftComputationConfigModel.aeroplane_id == aeroplane_id)
+            .first()
+        )
+        assert config is not None
+        assert config.coarse_alpha_step_deg == COMPUTATION_CONFIG_DEFAULTS["coarse_alpha_step_deg"]
+        assert config.fine_velocity_count == COMPUTATION_CONFIG_DEFAULTS["fine_velocity_count"]
 
-        with patch("app.services.design_assumptions_service.list_assumptions") as mock_list:
-            mock_list.return_value = MagicMock()
 
-            from app.services.design_assumptions_service import seed_defaults
-            seed_defaults(db, "test-uuid")
+def test_seed_defaults_idempotent_for_config(client_and_db):
+    """Calling seed_defaults twice does not create a second config row."""
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aeroplane_id = aeroplane.id
 
-    # Verify a ComputationConfigModel was added
-    added_objects = [call.args[0] for call in db.add.call_args_list]
-    config_objects = [o for o in added_objects if isinstance(o, AircraftComputationConfigModel)]
-    assert len(config_objects) == 1
-    assert config_objects[0].aeroplane_id == 42
-    assert config_objects[0].coarse_alpha_step_deg == COMPUTATION_CONFIG_DEFAULTS["coarse_alpha_step_deg"]
+    with SessionLocal() as db:
+        configs = (
+            db.query(AircraftComputationConfigModel)
+            .filter(AircraftComputationConfigModel.aeroplane_id == aeroplane_id)
+            .all()
+        )
+        assert len(configs) == 1
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
@@ -477,100 +493,150 @@ git commit -m "feat(gh-465): seed computation config in seed_defaults"
 - Create: `app/services/assumption_compute_service.py`
 - Test: `app/tests/test_assumption_compute_service.py`
 
-- [ ] **Step 1: Write failing test for the recompute pipeline**
+- [ ] **Step 1: Write failing tests for the recompute pipeline**
+
+The tests use a real in-memory DB via the existing `client_and_db`
+fixture (see `app/tests/conftest.py`) so the assumption rows actually
+persist and can be re-read. Heavy ASB calls are stubbed via the small
+helpers `_stability_run_at_cruise`, `_coarse_alpha_sweep`,
+`_fine_sweep_cl_max` — that keeps unit tests fast without faking the
+ASB result-object surface.
 
 ```python
 # app/tests/test_assumption_compute_service.py
 from __future__ import annotations
 
-import math
-from unittest.mock import MagicMock, patch, call
-import pytest
+from unittest.mock import patch
+from types import SimpleNamespace
+
+from app.models.computation_config import (
+    AircraftComputationConfigModel,
+    COMPUTATION_CONFIG_DEFAULTS,
+)
+from app.models.aeroplanemodel import DesignAssumptionModel
+from app.services.assumption_compute_service import recompute_assumptions
+from app.services.design_assumptions_service import seed_defaults
+from app.tests.conftest import make_aeroplane
 
 
-@pytest.fixture
-def mock_asb_airplane():
-    airplane = MagicMock()
-    airplane.wings = [MagicMock()]
-    airplane.xyz_ref = [0.08, 0, 0]
-    wing = airplane.wings[0]
-    wing.mean_aerodynamic_chord.return_value = 0.20
-    return airplane
+def _patches():
+    """Stub the three ASB-bound helpers so tests don't need real ASB."""
+    return (
+        patch(
+            "app.services.assumption_compute_service._build_asb_airplane",
+            return_value=SimpleNamespace(wings=[object()], xyz_ref=[0.08, 0.0, 0.0]),
+        ),
+        patch(
+            "app.services.assumption_compute_service._stability_run_at_cruise",
+            return_value=(0.085, 0.20, 0.025),  # x_np, MAC, CD0
+        ),
+        patch(
+            "app.services.assumption_compute_service._coarse_alpha_sweep",
+            return_value=15.0,  # stall_alpha_deg
+        ),
+        patch(
+            "app.services.assumption_compute_service._fine_sweep_cl_max",
+            return_value=1.35,
+        ),
+        patch(
+            "app.services.assumption_compute_service._load_flight_profile_speeds",
+            return_value=(18.0, 28.0),
+        ),
+    )
 
 
-@pytest.fixture
-def mock_aerobuildup_results():
-    """Simulate AeroBuildup output for a coarse alpha sweep."""
-    import numpy as np
+def test_recompute_writes_all_three_assumptions(client_and_db):
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
+        aeroplane_id = aeroplane.id
 
-    alphas_deg = np.arange(-5, 26, 1.0)
-    alphas_rad = np.radians(alphas_deg)
-    CLs = 2 * math.pi * alphas_rad * 0.8  # approximate thin airfoil
-    CDs = 0.02 + 0.05 * CLs**2
+    p1, p2, p3, p4, p5 = _patches()
+    with p1, p2, p3, p4, p5:
+        with SessionLocal() as db:
+            recompute_assumptions(db, aeroplane_uuid)
+            db.commit()
 
-    return {
-        "alpha_deg": alphas_deg,
-        "CL": CLs,
-        "CD": CDs,
-        "x_np": 0.085,
-    }
+    with SessionLocal() as db:
+        rows = {
+            r.parameter_name: r
+            for r in db.query(DesignAssumptionModel)
+            .filter(DesignAssumptionModel.aeroplane_id == aeroplane_id)
+            .all()
+        }
+        assert rows["cl_max"].calculated_value == 1.35
+        assert rows["cd0"].calculated_value == 0.025
+        # cg_x = x_np - target_static_margin × MAC
+        #      = 0.085 - 0.12 × 0.20 = 0.061
+        # (target_static_margin default is 0.12 per PARAMETER_DEFAULTS)
+        assert abs(rows["cg_x"].calculated_value - 0.061) < 1e-6
 
 
-def test_recompute_assumptions_basic(mock_asb_airplane):
-    """Verify all 3 assumptions are written and context is cached."""
-    from app.services.assumption_compute_service import recompute_assumptions
+def test_recompute_skips_when_no_wings(client_and_db):
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
 
-    db = MagicMock()
-
-    with (
-        patch("app.services.assumption_compute_service._load_aircraft_as_asb") as mock_load,
-        patch("app.services.assumption_compute_service._load_flight_profile_speeds") as mock_speeds,
-        patch("app.services.assumption_compute_service._load_or_create_config") as mock_config,
-        patch("app.services.assumption_compute_service._run_coarse_sweep") as mock_coarse,
-        patch("app.services.assumption_compute_service._run_fine_sweep") as mock_fine,
-        patch("app.services.assumption_compute_service._load_effective_assumption") as mock_sm,
-        patch("app.services.assumption_compute_service._load_cg_agg") as mock_cg_agg,
-        patch("app.services.assumption_compute_service.update_calculated_value") as mock_update,
-        patch("app.services.assumption_compute_service._cache_context") as mock_cache,
+    with patch(
+        "app.services.assumption_compute_service._build_asb_airplane",
+        return_value=SimpleNamespace(wings=[], xyz_ref=[0, 0, 0]),
     ):
-        mock_load.return_value = (mock_asb_airplane, MagicMock())
-        mock_speeds.return_value = (18.0, 28.0)
-        mock_config.return_value = MagicMock(
-            coarse_alpha_min_deg=-5.0, coarse_alpha_max_deg=25.0,
-            coarse_alpha_step_deg=1.0, fine_alpha_margin_deg=5.0,
-            fine_alpha_step_deg=0.5, fine_velocity_count=8,
+        with SessionLocal() as db:
+            recompute_assumptions(db, aeroplane_uuid)
+            db.commit()
+
+    with SessionLocal() as db:
+        cd0 = (
+            db.query(DesignAssumptionModel)
+            .filter_by(parameter_name="cd0")
+            .first()
         )
-        mock_coarse.return_value = {"cd0": 0.025, "x_np": 0.085, "stall_alpha_deg": 15.0}
-        mock_fine.return_value = 1.35
-        mock_sm.return_value = 0.12
-        mock_cg_agg.return_value = 0.092
-
-        recompute_assumptions(db, "test-uuid")
-
-    assert mock_update.call_count == 3
-    param_names = [c.kwargs.get("param_name") or c.args[2] for c in mock_update.call_args_list]
-    assert set(param_names) == {"cl_max", "cd0", "cg_x"}
-    mock_cache.assert_called_once()
+        assert cd0.calculated_value is None  # untouched
 
 
-def test_recompute_assumptions_no_wings():
-    """Should skip gracefully when aircraft has no wings."""
-    from app.services.assumption_compute_service import recompute_assumptions
+def test_recompute_caches_context_and_publishes_cg_change(client_and_db):
+    from app.core.events import AssumptionChanged, event_bus
 
-    db = MagicMock()
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
+        aeroplane_id = aeroplane.id
 
-    with (
-        patch("app.services.assumption_compute_service._load_aircraft_as_asb") as mock_load,
-        patch("app.services.assumption_compute_service.update_calculated_value") as mock_update,
-    ):
-        airplane = MagicMock()
-        airplane.wings = []
-        mock_load.return_value = (airplane, MagicMock())
+    captured: list = []
+    handler = captured.append
+    event_bus.subscribe(AssumptionChanged, handler)
 
-        recompute_assumptions(db, "test-uuid")
+    p1, p2, p3, p4, p5 = _patches()
+    try:
+        with p1, p2, p3, p4, p5:
+            with SessionLocal() as db:
+                recompute_assumptions(db, aeroplane_uuid)
+                db.commit()
+    finally:
+        # EventBus has no public unsubscribe; remove from internal list
+        event_bus._subscribers.get(AssumptionChanged, []).remove(handler)
 
-    mock_update.assert_not_called()
+    with SessionLocal() as db:
+        from app.models.aeroplanemodel import AeroplaneModel
+        a = db.query(AeroplaneModel).filter_by(id=aeroplane_id).first()
+        ctx = a.assumption_computation_context
+        assert ctx["v_cruise_mps"] == 18.0
+        assert ctx["mac_m"] == 0.20
+        assert ctx["x_np_m"] == 0.085
+
+    cg_events = [e for e in captured if e.parameter_name == "cg_x"]
+    assert len(cg_events) == 1
 ```
+
 
 - [ ] **Step 2: Run tests to verify they fail**
 
@@ -584,141 +650,187 @@ Expected: FAIL with `ModuleNotFoundError`
 from __future__ import annotations
 
 import logging
-import math
 from datetime import datetime, timezone
 from typing import Any
 
 import numpy as np
 from sqlalchemy.orm import Session
 
+from app.api.utils import analyse_aerodynamics
 from app.converters.model_schema_converters import (
     aeroplane_model_to_aeroplane_schema_async,
     aeroplane_schema_to_asb_airplane_async,
 )
 from app.core.events import AssumptionChanged, event_bus
-from app.models.aeroplanemodel import AeroplaneModel, DesignAssumptionModel
+from app.models.aeroplanemodel import AeroplaneModel, DesignAssumptionModel, WeightItemModel
 from app.models.computation_config import (
     AircraftComputationConfigModel,
     COMPUTATION_CONFIG_DEFAULTS,
 )
-from app.services.design_assumptions_service import update_calculated_value
+from app.schemas.AeroplaneRequest import AnalysisToolUrlType
+from app.schemas.aeroanalysisschema import OperatingPointSchema
+from app.schemas.design_assumption import PARAMETER_DEFAULTS
+from app.services.design_assumptions_service import _get_aeroplane, update_calculated_value
 from app.services.mass_cg_service import aggregate_weight_items
+from app.services.stability_service import _scalar
 
 logger = logging.getLogger(__name__)
 
 
 def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
-    asb_airplane, aircraft = _load_aircraft_as_asb(db, aeroplane_uuid)
+    """Recompute cl_max, cd0, cg_x from geometry via AeroSandbox.
+
+    Sync function — caller MUST wrap in asyncio.to_thread() when invoked
+    from async context (see app/main.py recompute wrapper).
+
+    Skips silently if aircraft has no wings.
+    """
+    aircraft = _get_aeroplane(db, aeroplane_uuid)
+    asb_airplane = _build_asb_airplane(aircraft)
 
     if not asb_airplane.wings:
-        logger.info("No wings on aircraft %s — skipping assumption recompute", aeroplane_uuid)
+        logger.info(
+            "No wings on aircraft %s — skipping assumption recompute", aeroplane_uuid
+        )
         return
 
-    v_cruise, v_max = _load_flight_profile_speeds(db, aircraft)
-    mac = _compute_mac(asb_airplane)
     config = _load_or_create_config(db, aircraft.id)
+    v_cruise, v_max = _load_flight_profile_speeds(db, aircraft)
 
-    coarse = _run_coarse_sweep(asb_airplane, v_cruise, config)
-    cl_max = _run_fine_sweep(asb_airplane, coarse["stall_alpha_deg"], v_cruise, v_max, config)
+    try:
+        x_np, mac, cd0 = _stability_run_at_cruise(asb_airplane, v_cruise)
+        stall_alpha = _coarse_alpha_sweep(asb_airplane, v_cruise, config)
+        cl_max = _fine_sweep_cl_max(asb_airplane, stall_alpha, v_cruise, v_max, config)
+    except Exception:
+        logger.exception(
+            "AeroBuildup failed during recompute for aircraft %s — aborting", aeroplane_uuid
+        )
+        return
 
     target_sm = _load_effective_assumption(db, aircraft.id, "target_static_margin")
-    cg_x = coarse["x_np"] - target_sm * mac
+    cg_x = x_np - target_sm * mac
 
     old_cg = _get_current_calculated_value(db, aircraft.id, "cg_x")
 
-    update_calculated_value(db, aeroplane_uuid, "cl_max", round(cl_max, 4), "aerobuildup", auto_switch_source=True)
-    update_calculated_value(db, aeroplane_uuid, "cd0", round(coarse["cd0"], 5), "aerobuildup", auto_switch_source=True)
-    update_calculated_value(db, aeroplane_uuid, "cg_x", round(cg_x, 4), "aerobuildup", auto_switch_source=True)
+    update_calculated_value(
+        db, aeroplane_uuid, "cl_max", round(cl_max, 4), "aerobuildup",
+        auto_switch_source=True,
+    )
+    update_calculated_value(
+        db, aeroplane_uuid, "cd0", round(cd0, 5), "aerobuildup",
+        auto_switch_source=True,
+    )
+    update_calculated_value(
+        db, aeroplane_uuid, "cg_x", round(cg_x, 4), "aerobuildup",
+        auto_switch_source=True,
+    )
 
-    cg_agg = _load_cg_agg(db, aircraft)
+    cg_agg = _load_cg_agg(db, aircraft.id)
     re = _reynolds_number(v_cruise, mac)
 
     _cache_context(db, aircraft, {
         "v_cruise_mps": v_cruise,
         "reynolds": round(re),
         "mac_m": round(mac, 4),
-        "x_np_m": round(coarse["x_np"], 4),
+        "x_np_m": round(x_np, 4),
         "target_static_margin": target_sm,
         "cg_agg_m": round(cg_agg, 4) if cg_agg is not None else None,
         "computed_at": datetime.now(timezone.utc).isoformat(),
     })
 
-    if old_cg is None or abs(cg_x - (old_cg or 0)) > 1e-6:
-        event_bus.publish(AssumptionChanged(aeroplane_id=aircraft.id, parameter_name="cg_x"))
+    if old_cg is None or abs(cg_x - old_cg) > 1e-6:
+        # Mirror update_assumption: mark OPs DIRTY in the same transaction
+        # before emitting AssumptionChanged. Otherwise the retrim handler
+        # finds no DIRTY ops and does nothing.
+        from app.services.invalidation_service import mark_ops_dirty
+
+        mark_ops_dirty(db, aircraft.id)
+        event_bus.publish(
+            AssumptionChanged(aeroplane_id=aircraft.id, parameter_name="cg_x")
+        )
 
 
-def _load_aircraft_as_asb(db: Session, aeroplane_uuid):
-    aircraft = db.query(AeroplaneModel).filter(AeroplaneModel.uuid == aeroplane_uuid).first()
-    if aircraft is None:
-        raise ValueError(f"Aircraft {aeroplane_uuid} not found")
+def _build_asb_airplane(aircraft: AeroplaneModel):
     schema = aeroplane_model_to_aeroplane_schema_async(aircraft)
-    asb_airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=schema)
-    return asb_airplane, aircraft
+    return aeroplane_schema_to_asb_airplane_async(plane_schema=schema)
 
 
-def _load_flight_profile_speeds(db: Session, aircraft: AeroplaneModel) -> tuple[float, float]:
-    from app.services.operating_point_generator_service import _load_effective_flight_profile
-
-    profile, _ = _load_effective_flight_profile(db, aircraft)
-    goals = profile.get("goals", {})
-    cruise = float(goals.get("cruise_speed_mps", 18.0))
-    v_max = float(goals.get("max_level_speed_mps") or max(1.35 * cruise, cruise + 8.0))
-    return cruise, v_max
-
-
-def _compute_mac(asb_airplane) -> float:
-    if asb_airplane.wings:
-        return float(asb_airplane.wings[0].mean_aerodynamic_chord())
-    return 0.2
-
-
-def _load_or_create_config(db: Session, aeroplane_id: int) -> AircraftComputationConfigModel:
+def _load_or_create_config(
+    db: Session, aeroplane_id: int
+) -> AircraftComputationConfigModel:
     config = (
         db.query(AircraftComputationConfigModel)
         .filter(AircraftComputationConfigModel.aeroplane_id == aeroplane_id)
         .first()
     )
     if config is None:
-        config = AircraftComputationConfigModel(aeroplane_id=aeroplane_id, **COMPUTATION_CONFIG_DEFAULTS)
+        config = AircraftComputationConfigModel(
+            aeroplane_id=aeroplane_id, **COMPUTATION_CONFIG_DEFAULTS
+        )
         db.add(config)
         db.flush()
     return config
 
 
-def _run_coarse_sweep(
-    asb_airplane, v_cruise: float, config: AircraftComputationConfigModel,
-) -> dict[str, float]:
+def _load_flight_profile_speeds(
+    db: Session, aircraft: AeroplaneModel
+) -> tuple[float, float]:
+    from app.services.operating_point_generator_service import (
+        _load_effective_flight_profile,
+    )
+
+    profile, _ = _load_effective_flight_profile(db, aircraft)
+    goals = profile.get("goals", {})
+    cruise = float(goals.get("cruise_speed_mps", 18.0))
+    v_max = float(
+        goals.get("max_level_speed_mps") or max(1.35 * cruise, cruise + 8.0)
+    )
+    return cruise, v_max
+
+
+def _stability_run_at_cruise(
+    asb_airplane, v_cruise: float
+) -> tuple[float, float, float]:
+    """Returns (x_np, MAC, CD0) from a single AeroBuildup stability run.
+
+    Uses analyse_aerodynamics → AnalysisModel — same code path as
+    stability_service, so x_np / MAC / CD0 are consistent across the app.
+    """
+    xyz_ref = list(asb_airplane.xyz_ref) if asb_airplane.xyz_ref is not None else [0.0, 0.0, 0.0]
+    op_schema = OperatingPointSchema(velocity=v_cruise, alpha=0.0, xyz_ref=xyz_ref)
+    result, _ = analyse_aerodynamics(
+        AnalysisToolUrlType.AEROBUILDUP, op_schema, asb_airplane
+    )
+    x_np = _scalar(result.reference.Xnp)
+    mac = _scalar(result.reference.Cref)
+    cd0 = _scalar(result.coefficients.CD)
+    if x_np is None or mac is None or cd0 is None:
+        raise ValueError("AeroBuildup returned NULL for x_np/MAC/CD0")
+    return float(x_np), float(mac), float(cd0)
+
+
+def _coarse_alpha_sweep(
+    asb_airplane, v_cruise: float, config: AircraftComputationConfigModel
+) -> float:
+    """Returns approximate stall_alpha_deg (alpha where CL peaks)."""
     import aerosandbox as asb
 
-    alphas = np.arange(config.coarse_alpha_min_deg, config.coarse_alpha_max_deg + 0.01, config.coarse_alpha_step_deg)
-
-    op = asb.OperatingPoint(velocity=v_cruise, alpha=0)
-    abu = asb.AeroBuildup(airplane=asb_airplane, op_point=op)
-    results = abu.run_with_stability_derivatives()
-    x_np = float(results.get("x_np", 0.0))
-
-    CLs = []
-    CDs = []
+    alphas = np.arange(
+        config.coarse_alpha_min_deg,
+        config.coarse_alpha_max_deg + 0.01,
+        config.coarse_alpha_step_deg,
+    )
+    xyz_ref = list(asb_airplane.xyz_ref) if asb_airplane.xyz_ref is not None else [0.0, 0.0, 0.0]
+    cls: list[float] = []
     for a in alphas:
-        op_a = asb.OperatingPoint(velocity=v_cruise, alpha=a)
-        abu_a = asb.AeroBuildup(airplane=asb_airplane, op_point=op_a)
-        r = abu_a.run()
-        CLs.append(float(r["CL"]))
-        CDs.append(float(r["CD"]))
-
-    CLs = np.array(CLs)
-    CDs = np.array(CDs)
-
-    idx_cl_zero = int(np.argmin(np.abs(CLs)))
-    cd0 = float(CDs[idx_cl_zero])
-
-    idx_cl_max = int(np.argmax(CLs))
-    stall_alpha = float(alphas[idx_cl_max])
-
-    return {"cd0": cd0, "x_np": x_np, "stall_alpha_deg": stall_alpha}
+        op = asb.OperatingPoint(velocity=v_cruise, alpha=float(a))
+        abu = asb.AeroBuildup(airplane=asb_airplane, op_point=op, xyz_ref=xyz_ref)
+        r = abu.run()
+        cls.append(_extract_scalar(r, "CL", default=0.0))
+    return float(alphas[int(np.argmax(cls))])
 
 
-def _run_fine_sweep(
+def _fine_sweep_cl_max(
     asb_airplane,
     stall_alpha_deg: float,
     v_cruise: float,
@@ -734,22 +846,32 @@ def _run_fine_sweep(
     v_stall_approx = max(v_cruise * 0.5, 3.0)
     velocities = np.linspace(v_stall_approx, v_max, config.fine_velocity_count)
 
-    cl_max = -np.inf
+    xyz_ref = list(asb_airplane.xyz_ref) if asb_airplane.xyz_ref is not None else [0.0, 0.0, 0.0]
+    cl_max = -float("inf")
     for v in velocities:
         for a in alphas:
-            op = asb.OperatingPoint(velocity=v, alpha=a)
-            abu = asb.AeroBuildup(airplane=asb_airplane, op_point=op)
+            op = asb.OperatingPoint(velocity=float(v), alpha=float(a))
+            abu = asb.AeroBuildup(airplane=asb_airplane, op_point=op, xyz_ref=xyz_ref)
             r = abu.run()
-            cl = float(r["CL"])
+            cl = _extract_scalar(r, "CL", default=0.0)
             if cl > cl_max:
                 cl_max = cl
-
     return float(cl_max)
 
 
-def _load_effective_assumption(db: Session, aeroplane_id: int, param_name: str) -> float:
-    from app.schemas.design_assumption import PARAMETER_DEFAULTS
+def _extract_scalar(result: Any, key: str, *, default: float) -> float:
+    """Extract a CL/CD scalar from raw AeroBuildup result (dict or object)."""
+    if isinstance(result, dict):
+        val = result.get(key)
+    else:
+        val = getattr(result, key, None)
+    scalar = _scalar(val)
+    return float(scalar) if scalar is not None else default
 
+
+def _load_effective_assumption(
+    db: Session, aeroplane_id: int, param_name: str
+) -> float:
     row = (
         db.query(DesignAssumptionModel)
         .filter(
@@ -765,7 +887,9 @@ def _load_effective_assumption(db: Session, aeroplane_id: int, param_name: str) 
     return row.estimate_value
 
 
-def _get_current_calculated_value(db: Session, aeroplane_id: int, param_name: str) -> float | None:
+def _get_current_calculated_value(
+    db: Session, aeroplane_id: int, param_name: str
+) -> float | None:
     row = (
         db.query(DesignAssumptionModel)
         .filter(
@@ -777,22 +901,33 @@ def _get_current_calculated_value(db: Session, aeroplane_id: int, param_name: st
     return row.calculated_value if row else None
 
 
-def _load_cg_agg(db: Session, aircraft: AeroplaneModel) -> float | None:
-    from app.models.aeroplanemodel import WeightItemModel
-
-    rows = db.query(WeightItemModel).filter(WeightItemModel.aeroplane_id == aircraft.id).all()
+def _load_cg_agg(db: Session, aeroplane_id: int) -> float | None:
+    rows = (
+        db.query(WeightItemModel)
+        .filter(WeightItemModel.aeroplane_id == aeroplane_id)
+        .all()
+    )
     if not rows:
         return None
-    items = [{"mass_kg": r.mass_kg, "x_m": r.x_m, "y_m": r.y_m, "z_m": r.z_m} for r in rows]
+    items = [
+        {"mass_kg": r.mass_kg, "x_m": r.x_m, "y_m": r.y_m, "z_m": r.z_m}
+        for r in rows
+    ]
     _, cg_x, _, _ = aggregate_weight_items(items)
     return cg_x
 
 
-def _reynolds_number(velocity: float, mac: float, rho: float = 1.225, mu: float = 1.81e-5) -> float:
+def _reynolds_number(
+    velocity: float, mac: float, rho: float = 1.225, mu: float = 1.81e-5
+) -> float:
+    """Sea-level standard atmosphere — sufficient for the UI chip; not
+    altitude-aware. Operating points use their own atmosphere model."""
     return rho * velocity * mac / mu
 
 
-def _cache_context(db: Session, aircraft: AeroplaneModel, context: dict[str, Any]) -> None:
+def _cache_context(
+    db: Session, aircraft: AeroplaneModel, context: dict[str, Any]
+) -> None:
     aircraft.assumption_computation_context = context
     db.flush()
 ```
@@ -821,18 +956,26 @@ git commit -m "feat(gh-465): add assumption compute service with two-phase ASB s
 
 - [ ] **Step 1: Write failing test**
 
+> NOTE on patch target: the handler does a lazy
+> `from app.core.background_jobs import job_tracker`. `mock.patch` must
+> target the *origin* of the name (where the lazy import looks it up),
+> NOT `app.services.invalidation_service` — patching the latter has no
+> effect because the local binding is created at call time.
+
 ```python
 # app/tests/test_invalidation_recompute.py
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from app.core.events import GeometryChanged
 
 
 def test_geometry_changed_schedules_recompute():
-    from app.services.invalidation_service import _on_geometry_changed_recompute_assumptions
+    from app.services.invalidation_service import (
+        _on_geometry_changed_recompute_assumptions,
+    )
 
     event = GeometryChanged(aeroplane_id=42, source_model="WingModel")
 
-    with patch("app.services.invalidation_service.job_tracker") as mock_tracker:
+    with patch("app.core.background_jobs.job_tracker") as mock_tracker:
         _on_geometry_changed_recompute_assumptions(event)
 
     mock_tracker.schedule_recompute_assumptions.assert_called_once_with(42)
@@ -950,24 +1093,37 @@ event_bus.subscribe(GeometryChanged, _on_geometry_changed_recompute_assumptions)
 
 - [ ] **Step 5: Wire recompute function in main.py**
 
-In `app/main.py`, in `_combined_lifespan`, after `job_tracker.set_trim_function(retrim_dirty_ops)`, add:
+In `app/main.py`, in `_combined_lifespan`, after
+`job_tracker.set_trim_function(retrim_dirty_ops)`, add:
 
 ```python
+import asyncio
+from app.db.session import SessionLocal
+from app.models.aeroplanemodel import AeroplaneModel
 from app.services.assumption_compute_service import recompute_assumptions
 
-async def _recompute_wrapper(aeroplane_id: int) -> None:
-    from app.db.session import SessionLocal
+def _recompute_sync(aeroplane_id: int) -> None:
     db = SessionLocal()
     try:
-        aeroplane = db.query(AeroplaneModel).filter(AeroplaneModel.id == aeroplane_id).first()
-        if aeroplane:
-            recompute_assumptions(db, str(aeroplane.uuid))
-            db.commit()
+        aeroplane = (
+            db.query(AeroplaneModel)
+            .filter(AeroplaneModel.id == aeroplane_id)
+            .first()
+        )
+        if aeroplane is None:
+            return
+        recompute_assumptions(db, str(aeroplane.uuid))
+        db.commit()
     except Exception:
         db.rollback()
         raise
     finally:
         db.close()
+
+async def _recompute_wrapper(aeroplane_id: int) -> None:
+    # ASB calls are CPU-bound (~200 calls per recompute). Running them
+    # directly on the event loop would block all other requests.
+    await asyncio.to_thread(_recompute_sync, aeroplane_id)
 
 job_tracker.set_recompute_function(_recompute_wrapper)
 ```
@@ -994,45 +1150,98 @@ git commit -m "feat(gh-465): wire GeometryChanged to assumption recompute via jo
 
 - [ ] **Step 1: Write failing tests**
 
+These tests use the existing `client_and_db` fixture that wires
+`override_get_db` against an in-memory SQLite (see
+`app/tests/conftest.py`). That matches the rest of the assumption
+endpoint test suite (`test_design_assumptions_endpoint.py`).
+
 ```python
 # app/tests/test_computation_endpoints.py
-from unittest.mock import MagicMock, patch
-from fastapi.testclient import TestClient
+from app.models.aeroplanemodel import AeroplaneModel
+from app.models.computation_config import (
+    AircraftComputationConfigModel,
+    COMPUTATION_CONFIG_DEFAULTS,
+)
+from app.tests.conftest import make_aeroplane
 
 
-def test_get_computation_context_returns_cached():
-    from app.main import app
-    client = TestClient(app)
+def test_get_computation_context_returns_null_when_never_computed(client_and_db):
+    client, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        aeroplane_uuid = str(aeroplane.uuid)
 
-    with patch("app.api.v2.endpoints.aeroplane.design_assumptions._get_aeroplane_by_uuid") as mock_get:
-        mock_aeroplane = MagicMock()
-        mock_aeroplane.assumption_computation_context = {
+    resp = client.get(f"/aeroplanes/{aeroplane_uuid}/assumptions/computation-context")
+    assert resp.status_code == 200
+    assert resp.json() is None
+
+
+def test_get_computation_context_returns_cached(client_and_db):
+    client, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        aeroplane.assumption_computation_context = {
             "v_cruise_mps": 18.0,
             "reynolds": 230000,
             "mac_m": 0.21,
         }
-        mock_get.return_value = mock_aeroplane
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
 
-        response = client.get("/v2/aeroplanes/test-uuid/assumptions/computation-context")
+    resp = client.get(f"/aeroplanes/{aeroplane_uuid}/assumptions/computation-context")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["v_cruise_mps"] == 18.0
+    assert body["reynolds"] == 230000
 
-    assert response.status_code == 200
-    data = response.json()
-    assert data["v_cruise_mps"] == 18.0
+
+def test_get_computation_config_creates_default_when_missing(client_and_db):
+    client, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        aeroplane_uuid = str(aeroplane.uuid)
+        aeroplane_id = aeroplane.id
+
+    resp = client.get(f"/aeroplanes/{aeroplane_uuid}/computation-config")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["coarse_alpha_step_deg"] == COMPUTATION_CONFIG_DEFAULTS["coarse_alpha_step_deg"]
+
+    with SessionLocal() as db:
+        rows = (
+            db.query(AircraftComputationConfigModel)
+            .filter(AircraftComputationConfigModel.aeroplane_id == aeroplane_id)
+            .all()
+        )
+        assert len(rows) == 1
 
 
-def test_get_computation_context_returns_null():
-    from app.main import app
-    client = TestClient(app)
+def test_put_computation_config_updates_fields(client_and_db):
+    client, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        aeroplane_uuid = str(aeroplane.uuid)
 
-    with patch("app.api.v2.endpoints.aeroplane.design_assumptions._get_aeroplane_by_uuid") as mock_get:
-        mock_aeroplane = MagicMock()
-        mock_aeroplane.assumption_computation_context = None
-        mock_get.return_value = mock_aeroplane
+    resp = client.put(
+        f"/aeroplanes/{aeroplane_uuid}/computation-config",
+        json={"coarse_alpha_step_deg": 0.5, "fine_velocity_count": 12},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["coarse_alpha_step_deg"] == 0.5
+    assert body["fine_velocity_count"] == 12
+    # Untouched fields keep defaults
+    assert body["debounce_seconds"] == COMPUTATION_CONFIG_DEFAULTS["debounce_seconds"]
 
-        response = client.get("/v2/aeroplanes/test-uuid/assumptions/computation-context")
 
-    assert response.status_code == 200
-    assert response.json() is None
+def test_get_computation_context_404_for_missing_aeroplane(client_and_db):
+    import uuid
+
+    client, _ = client_and_db
+    resp = client.get(
+        f"/aeroplanes/{uuid.uuid4()}/assumptions/computation-context"
+    )
+    assert resp.status_code == 404
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
@@ -1427,7 +1636,14 @@ git commit -m "feat(gh-465): dynamic Info Chip Row with computation context"
 
 **Files:**
 - Modify: `frontend/components/workbench/AnalysisViewerPanel.tsx`
+- Modify: parent page that renders `AnalysisViewerPanel` (typically
+  `frontend/app/workbench/analysis/page.tsx` or equivalent)
 - Test: `frontend/__tests__/AnalysisWingGate.test.tsx`
+
+> **Why a new `hasWings` prop:** The existing `wingXSecs` prop holds
+> cross-sections of *one* wing — it cannot tell us whether the aircraft
+> has any wings at all. Counting components from the parent (where the
+> aircraft tree is already loaded) is the correct source of truth.
 
 - [ ] **Step 1: Write failing test**
 
@@ -1447,7 +1663,7 @@ vi.mock("@/hooks/useComputationContext", () => ({
 }));
 
 describe("Analysis Tab Wing Gate", () => {
-  it("shows empty state for Polar tab when no wings", async () => {
+  it("shows empty state for Polar tab when hasWings is false", async () => {
     const mod = await import("@/components/workbench/AnalysisViewerPanel");
     const Panel = mod.AnalysisViewerPanel;
 
@@ -1456,15 +1672,16 @@ describe("Analysis Tab Wing Gate", () => {
         result={null}
         activeTab="Polar"
         onTabChange={() => {}}
-        wingXSecs={[]}
-        // ... other required props with null/empty defaults
+        hasWings={false}
+        wingXSecs={null}
+        /* other required props default to null/empty */
       />,
     );
 
     expect(screen.getByText(/add a wing/i)).toBeInTheDocument();
   });
 
-  it("shows Assumptions tab content even without wings", async () => {
+  it("shows Assumptions tab content even when hasWings is false", async () => {
     const mod = await import("@/components/workbench/AnalysisViewerPanel");
     const Panel = mod.AnalysisViewerPanel;
 
@@ -1473,8 +1690,25 @@ describe("Analysis Tab Wing Gate", () => {
         result={null}
         activeTab="Assumptions"
         onTabChange={() => {}}
-        wingXSecs={[]}
-        // ... other required props
+        hasWings={false}
+        wingXSecs={null}
+      />,
+    );
+
+    expect(screen.queryByText(/add a wing/i)).not.toBeInTheDocument();
+  });
+
+  it("shows Polar content when hasWings is true", async () => {
+    const mod = await import("@/components/workbench/AnalysisViewerPanel");
+    const Panel = mod.AnalysisViewerPanel;
+
+    render(
+      <Panel
+        result={null}
+        activeTab="Polar"
+        onTabChange={() => {}}
+        hasWings={true}
+        wingXSecs={null}
       />,
     );
 
@@ -1486,48 +1720,72 @@ describe("Analysis Tab Wing Gate", () => {
 - [ ] **Step 2: Run test to verify it fails**
 
 Run: `cd frontend && npx vitest run __tests__/AnalysisWingGate.test.tsx`
-Expected: FAIL — no wing gate exists yet
+Expected: FAIL — `hasWings` prop is unknown, gate logic missing.
 
-- [ ] **Step 3: Add wing gate to AnalysisViewerPanel**
+- [ ] **Step 3: Add `hasWings` prop and wing gate to AnalysisViewerPanel**
 
-In `AnalysisViewerPanel.tsx`, add a helper check:
+In `AnalysisViewerPanel.tsx`:
+
+1. Add `hasWings` to the `Props` interface (default-treated as
+   `true` for backwards compatibility if a caller forgets the prop —
+   but the parent page MUST pass it):
+   ```tsx
+   readonly hasWings?: boolean;  // defaults to true so callers without wings data don't see empty states accidentally
+   ```
+2. Destructure with default in the component signature:
+   `hasWings = true,`
+3. Compute the gated set of tabs:
+   ```tsx
+   const COMPUTATION_TABS = new Set<Tab>([
+     "Polar", "Trefftz Plane", "Streamlines", "Envelope",
+     "Stability", "Operating Points",
+   ]);
+   const showWingGate = !hasWings && COMPUTATION_TABS.has(activeTab);
+   ```
+4. Render the empty state once at the top of the tab-content area
+   (before the per-tab branches), early-returning:
+   ```tsx
+   {showWingGate ? (
+     <div className="flex flex-1 items-center justify-center bg-card-muted">
+       <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-muted-foreground">
+         Add a wing to enable aerodynamic analysis
+       </span>
+     </div>
+   ) : (
+     /* existing tab-content switch */
+   )}
+   ```
+   `Assumptions` is not in `COMPUTATION_TABS`, so it always renders normally.
+
+- [ ] **Step 4: Wire `hasWings` from the parent page**
+
+The parent page that renders `AnalysisViewerPanel` already has the
+aircraft tree (via `useComponents` or similar). Compute and pass:
 
 ```tsx
-const hasWings = (wingXSecs?.length ?? 0) > 0;
+const hasWings = (components ?? []).some((c) => c.kind === "wing");
+// or whatever the existing wing-detection convention is
+<AnalysisViewerPanel hasWings={hasWings} ... />
 ```
 
-Then for each computation tab (Polar, Trefftz, Streamlines, Stability, Envelope, Operating Points), wrap the content with:
+Verify the actual prop names against the parent page when implementing
+— do not invent component shape. Search for existing usages of
+`<AnalysisViewerPanel` in the workbench pages.
 
-```tsx
-{activeTab === "Polar" && (
-  hasWings ? (
-    // ... existing Polar content
-  ) : (
-    <div className="flex flex-1 items-center justify-center bg-card-muted">
-      <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-muted-foreground">
-        Add a wing to enable aerodynamic analysis
-      </span>
-    </div>
-  )
-)}
-```
-
-Leave Assumptions tab unchanged — it always renders.
-
-- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 5: Run test to verify it passes**
 
 Run: `cd frontend && npx vitest run __tests__/AnalysisWingGate.test.tsx`
 Expected: PASS
 
-- [ ] **Step 5: Run full frontend test suite**
+- [ ] **Step 6: Run full frontend test suite**
 
 Run: `cd frontend && npm run test:unit`
 Expected: All tests pass
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
-git add frontend/components/workbench/AnalysisViewerPanel.tsx frontend/__tests__/AnalysisWingGate.test.tsx
+git add frontend/components/workbench/AnalysisViewerPanel.tsx frontend/app/workbench/analysis/page.tsx frontend/__tests__/AnalysisWingGate.test.tsx
 git commit -m "feat(gh-465): gate analysis tabs on wing existence"
 ```
 
@@ -1543,79 +1801,145 @@ git commit -m "feat(gh-465): gate analysis tabs on wing existence"
 ```python
 # app/tests/test_assumption_compute_integration.py
 import pytest
-from unittest.mock import patch, MagicMock
-import numpy as np
+from unittest.mock import patch
+from types import SimpleNamespace
 
-from app.core.events import GeometryChanged, event_bus
+from app.core.events import (
+    AssumptionChanged,
+    GeometryChanged,
+    event_bus,
+)
+from app.models.aeroplanemodel import DesignAssumptionModel
+from app.services.design_assumptions_service import seed_defaults
+from app.tests.conftest import make_aeroplane
 
 
 @pytest.mark.integration
-def test_geometry_changed_triggers_full_recompute_chain():
-    """Integration: GeometryChanged → recompute → assumptions updated."""
-    calls = []
+def test_geometry_changed_handler_schedules_recompute():
+    """Handler delegates to job_tracker.schedule_recompute_assumptions."""
+    from app.services.invalidation_service import (
+        _on_geometry_changed_recompute_assumptions,
+    )
 
-    def track_recompute(aeroplane_id):
-        calls.append(("recompute", aeroplane_id))
-
+    # Patch the origin module — the handler does a lazy
+    # `from app.core.background_jobs import job_tracker`.
     with patch("app.core.background_jobs.job_tracker") as mock_tracker:
-        mock_tracker.schedule_recompute_assumptions = track_recompute
+        _on_geometry_changed_recompute_assumptions(
+            GeometryChanged(aeroplane_id=42, source_model="WingModel")
+        )
 
-        from app.services.invalidation_service import _on_geometry_changed_recompute_assumptions
-        event = GeometryChanged(aeroplane_id=42, source_model="WingModel")
-        _on_geometry_changed_recompute_assumptions(event)
-
-    assert ("recompute", 42) in calls
+    mock_tracker.schedule_recompute_assumptions.assert_called_once_with(42)
 
 
 @pytest.mark.integration
-def test_recompute_publishes_assumption_changed_on_cg_change():
-    """Integration: recompute with changed cg_x publishes AssumptionChanged."""
-    published = []
+def test_recompute_publishes_assumption_changed_on_cg_change(client_and_db):
+    """Full pipeline: recompute with seeded assumptions emits AssumptionChanged for cg_x."""
+    from app.services.assumption_compute_service import recompute_assumptions
 
-    def capture_event(event):
-        published.append(event)
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
 
-    event_bus.subscribe(type(MagicMock()), capture_event)
+    captured: list = []
+    handler = captured.append
+    event_bus.subscribe(AssumptionChanged, handler)
 
-    from app.core.events import AssumptionChanged
-    original_publish = event_bus.publish
+    patches = [
+        patch(
+            "app.services.assumption_compute_service._build_asb_airplane",
+            return_value=SimpleNamespace(wings=[object()], xyz_ref=[0.08, 0.0, 0.0]),
+        ),
+        patch(
+            "app.services.assumption_compute_service._stability_run_at_cruise",
+            return_value=(0.085, 0.20, 0.020),
+        ),
+        patch(
+            "app.services.assumption_compute_service._coarse_alpha_sweep",
+            return_value=14.0,
+        ),
+        patch(
+            "app.services.assumption_compute_service._fine_sweep_cl_max",
+            return_value=1.35,
+        ),
+        patch(
+            "app.services.assumption_compute_service._load_flight_profile_speeds",
+            return_value=(18.0, 28.0),
+        ),
+    ]
 
-    events_published = []
+    try:
+        for p in patches:
+            p.start()
+        with SessionLocal() as db:
+            recompute_assumptions(db, aeroplane_uuid)
+            db.commit()
+    finally:
+        for p in patches:
+            p.stop()
+        event_bus._subscribers.get(AssumptionChanged, []).remove(handler)
 
-    def capture_publish(event):
-        events_published.append(event)
-        original_publish(event)
+    cg_events = [e for e in captured if e.parameter_name == "cg_x"]
+    assert len(cg_events) == 1
 
-    with patch.object(event_bus, "publish", side_effect=capture_publish):
-        with patch("app.services.assumption_compute_service._load_aircraft_as_asb") as mock_load:
-            airplane = MagicMock()
-            airplane.wings = [MagicMock()]
-            airplane.wings[0].mean_aerodynamic_chord.return_value = 0.2
-            mock_load.return_value = (airplane, MagicMock(id=42, uuid="test"))
 
-            with (
-                patch("app.services.assumption_compute_service._load_flight_profile_speeds", return_value=(18.0, 28.0)),
-                patch("app.services.assumption_compute_service._load_or_create_config") as mc,
-                patch("app.services.assumption_compute_service._run_coarse_sweep", return_value={"cd0": 0.02, "x_np": 0.085, "stall_alpha_deg": 14.0}),
-                patch("app.services.assumption_compute_service._run_fine_sweep", return_value=1.35),
-                patch("app.services.assumption_compute_service._load_effective_assumption", return_value=0.12),
-                patch("app.services.assumption_compute_service._get_current_calculated_value", return_value=None),
-                patch("app.services.assumption_compute_service._load_cg_agg", return_value=0.09),
-                patch("app.services.assumption_compute_service.update_calculated_value"),
-                patch("app.services.assumption_compute_service._cache_context"),
-            ):
-                mc.return_value = MagicMock(
-                    coarse_alpha_min_deg=-5, coarse_alpha_max_deg=25,
-                    coarse_alpha_step_deg=1, fine_alpha_margin_deg=5,
-                    fine_alpha_step_deg=0.5, fine_velocity_count=8,
-                )
+@pytest.mark.integration
+def test_recompute_does_not_publish_when_cg_unchanged(client_and_db):
+    """Second recompute with same inputs does not emit a duplicate event."""
+    from app.services.assumption_compute_service import recompute_assumptions
 
-                from app.services.assumption_compute_service import recompute_assumptions
-                recompute_assumptions(MagicMock(), "test-uuid")
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
 
-    assumption_events = [e for e in events_published if isinstance(e, AssumptionChanged)]
-    assert len(assumption_events) == 1
-    assert assumption_events[0].parameter_name == "cg_x"
+    captured: list = []
+    handler = captured.append
+    event_bus.subscribe(AssumptionChanged, handler)
+
+    patches = [
+        patch(
+            "app.services.assumption_compute_service._build_asb_airplane",
+            return_value=SimpleNamespace(wings=[object()], xyz_ref=[0.08, 0.0, 0.0]),
+        ),
+        patch(
+            "app.services.assumption_compute_service._stability_run_at_cruise",
+            return_value=(0.085, 0.20, 0.020),
+        ),
+        patch(
+            "app.services.assumption_compute_service._coarse_alpha_sweep",
+            return_value=14.0,
+        ),
+        patch(
+            "app.services.assumption_compute_service._fine_sweep_cl_max",
+            return_value=1.35,
+        ),
+        patch(
+            "app.services.assumption_compute_service._load_flight_profile_speeds",
+            return_value=(18.0, 28.0),
+        ),
+    ]
+
+    try:
+        for p in patches:
+            p.start()
+        with SessionLocal() as db:
+            recompute_assumptions(db, aeroplane_uuid)
+            db.commit()
+        with SessionLocal() as db:
+            recompute_assumptions(db, aeroplane_uuid)
+            db.commit()
+    finally:
+        for p in patches:
+            p.stop()
+        event_bus._subscribers.get(AssumptionChanged, []).remove(handler)
+
+    cg_events = [e for e in captured if e.parameter_name == "cg_x"]
+    assert len(cg_events) == 1  # Only first call emitted; second was idempotent
 ```
 
 - [ ] **Step 2: Run integration test**
@@ -1681,6 +2005,27 @@ cd frontend && npm run test:unit
 | `app/services/design_assumptions_service.py` | `auto_switch_source` param + seed computation config |
 | `app/services/invalidation_service.py` | New GeometryChanged handler for recompute |
 | `app/core/background_jobs.py` | `schedule_recompute_assumptions` + debounce |
-| `app/main.py` | Wire recompute function to job tracker |
+| `app/main.py` | Wire recompute function to job tracker (via `asyncio.to_thread`) |
 | `app/api/v2/endpoints/aeroplane/design_assumptions.py` | 3 new endpoints |
-| `frontend/components/workbench/AnalysisViewerPanel.tsx` | Wing gate + InfoChipRow integration |
+| `frontend/components/workbench/AnalysisViewerPanel.tsx` | `hasWings` prop + wing gate + InfoChipRow integration |
+| Parent workbench analysis page | Pass `hasWings={...}` derived from components tree |
+
+## Implementation Notes (Cross-Task)
+
+- **ASB API surface:** `result.reference.Xnp`, `result.reference.Cref`,
+  and `result.coefficients.CD` are accessed on the typed `AnalysisModel`
+  returned by `app.api.utils.analyse_aerodynamics`. Direct ASB calls
+  (`abu.run()`) return a dict-like — handle both via the `_extract_scalar`
+  helper.
+- **`xyz_ref` always passed:** Every `AeroBuildup` constructor in this
+  feature receives `xyz_ref` so NP / CG values are referenced
+  consistently with the rest of the system.
+- **Sync vs async:** `recompute_assumptions` is sync. The wrapper in
+  `app/main.py` invokes it via `asyncio.to_thread()` to keep the
+  FastAPI event loop responsive.
+- **`_get_aeroplane` reuse:** The compute service uses
+  `design_assumptions_service._get_aeroplane(db, aeroplane_uuid)` —
+  same UUID-resolution pattern as the rest of the assumptions code.
+- **Test fixtures:** All DB-touching tests use the existing
+  `client_and_db` fixture (in-memory SQLite) and the
+  `make_aeroplane` factory from `app/tests/conftest.py`.

--- a/docs/superpowers/plans/2026-05-10-auto-compute-assumptions.md
+++ b/docs/superpowers/plans/2026-05-10-auto-compute-assumptions.md
@@ -1,0 +1,1686 @@
+# Auto-Compute Design Assumptions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auto-compute `cl_max`, `cd0`, and `cg_x` from aircraft geometry via AeroSandbox whenever geometry changes, replacing manual guesswork.
+
+**Architecture:** A new `assumption_compute_service` runs a two-phase AeroBuildup sweep (coarse alpha → fine alpha×velocity) triggered by `GeometryChanged` events via the existing `JobTracker` debounce mechanism. Results flow into the existing dual-source assumption system. A per-aircraft config table stores sweep parameters (no magic numbers). The frontend Info Chip Row becomes dynamic.
+
+**Tech Stack:** Python 3.11, FastAPI, SQLAlchemy, Alembic, AeroSandbox, React 19, SWR, Tailwind CSS
+
+**Spec:** `docs/superpowers/specs/2026-05-10-auto-compute-assumptions-design.md`
+
+---
+
+### Task 1: Data Model — ComputationConfig + Context Column
+
+**Files:**
+- Create: `app/models/computation_config.py`
+- Modify: `app/models/aeroplanemodel.py`
+- Modify: `app/models/__init__.py` (if exists, for import)
+- Create: `alembic/versions/<auto>_add_computation_config_and_context.py`
+- Test: `app/tests/test_computation_config_model.py`
+
+- [ ] **Step 1: Write failing test for ComputationConfigModel**
+
+```python
+# app/tests/test_computation_config_model.py
+import pytest
+from app.models.computation_config import AircraftComputationConfigModel, COMPUTATION_CONFIG_DEFAULTS
+
+
+def test_defaults_dict_has_all_columns():
+    expected_keys = {
+        "coarse_alpha_min_deg", "coarse_alpha_max_deg", "coarse_alpha_step_deg",
+        "fine_alpha_margin_deg", "fine_alpha_step_deg", "fine_velocity_count",
+        "debounce_seconds",
+    }
+    assert set(COMPUTATION_CONFIG_DEFAULTS.keys()) == expected_keys
+
+
+def test_model_tablename():
+    assert AircraftComputationConfigModel.__tablename__ == "aircraft_computation_config"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `poetry run pytest app/tests/test_computation_config_model.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'app.models.computation_config'`
+
+- [ ] **Step 3: Create ComputationConfigModel**
+
+```python
+# app/models/computation_config.py
+from __future__ import annotations
+
+from sqlalchemy import Column, Float, ForeignKey, Integer, UniqueConstraint
+from sqlalchemy.orm import relationship
+
+from app.db.base_class import Base
+
+COMPUTATION_CONFIG_DEFAULTS: dict[str, float | int] = {
+    "coarse_alpha_min_deg": -5.0,
+    "coarse_alpha_max_deg": 25.0,
+    "coarse_alpha_step_deg": 1.0,
+    "fine_alpha_margin_deg": 5.0,
+    "fine_alpha_step_deg": 0.5,
+    "fine_velocity_count": 8,
+    "debounce_seconds": 2.0,
+}
+
+
+class AircraftComputationConfigModel(Base):
+    __tablename__ = "aircraft_computation_config"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    aeroplane_id = Column(
+        Integer,
+        ForeignKey("aeroplanes.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    coarse_alpha_min_deg = Column(Float, nullable=False, default=COMPUTATION_CONFIG_DEFAULTS["coarse_alpha_min_deg"])
+    coarse_alpha_max_deg = Column(Float, nullable=False, default=COMPUTATION_CONFIG_DEFAULTS["coarse_alpha_max_deg"])
+    coarse_alpha_step_deg = Column(Float, nullable=False, default=COMPUTATION_CONFIG_DEFAULTS["coarse_alpha_step_deg"])
+    fine_alpha_margin_deg = Column(Float, nullable=False, default=COMPUTATION_CONFIG_DEFAULTS["fine_alpha_margin_deg"])
+    fine_alpha_step_deg = Column(Float, nullable=False, default=COMPUTATION_CONFIG_DEFAULTS["fine_alpha_step_deg"])
+    fine_velocity_count = Column(Integer, nullable=False, default=COMPUTATION_CONFIG_DEFAULTS["fine_velocity_count"])
+    debounce_seconds = Column(Float, nullable=False, default=COMPUTATION_CONFIG_DEFAULTS["debounce_seconds"])
+
+    aeroplane = relationship("AeroplaneModel", back_populates="computation_config")
+
+    __table_args__ = (
+        UniqueConstraint("aeroplane_id", name="uq_computation_config_aeroplane"),
+    )
+```
+
+- [ ] **Step 4: Add context column and relationship to AeroplaneModel**
+
+In `app/models/aeroplanemodel.py`, add to the `AeroplaneModel` class:
+
+```python
+# Add import at top:
+from sqlalchemy import JSON  # add JSON to existing import
+
+# Add column after existing columns (after xyz_ref):
+assumption_computation_context = Column(JSON, nullable=True)
+
+# Add relationship after existing relationships (after design_assumptions):
+computation_config = relationship(
+    "AircraftComputationConfigModel",
+    back_populates="aeroplane",
+    uselist=False,
+    cascade="all, delete-orphan",
+)
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `poetry run pytest app/tests/test_computation_config_model.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Generate Alembic migration**
+
+Run: `poetry run alembic revision --autogenerate -m "add computation config table and assumption context column"`
+
+Review the generated migration — it should create the `aircraft_computation_config` table and add `assumption_computation_context` column to `aeroplanes`.
+
+- [ ] **Step 7: Apply migration**
+
+Run: `poetry run alembic upgrade head`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/models/computation_config.py app/models/aeroplanemodel.py app/tests/test_computation_config_model.py alembic/versions/*_add_computation_config*
+git commit -m "feat(gh-465): add computation config table and assumption context column"
+```
+
+---
+
+### Task 2: Pydantic Schemas for ComputationConfig
+
+**Files:**
+- Create: `app/schemas/computation_config.py`
+- Test: `app/tests/test_computation_config_schema.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# app/tests/test_computation_config_schema.py
+import pytest
+from app.schemas.computation_config import ComputationConfigRead, ComputationConfigWrite
+
+
+def test_read_schema_has_all_fields():
+    data = ComputationConfigRead(
+        id=1,
+        aeroplane_id=1,
+        coarse_alpha_min_deg=-5.0,
+        coarse_alpha_max_deg=25.0,
+        coarse_alpha_step_deg=1.0,
+        fine_alpha_margin_deg=5.0,
+        fine_alpha_step_deg=0.5,
+        fine_velocity_count=8,
+        debounce_seconds=2.0,
+    )
+    assert data.coarse_alpha_step_deg == 1.0
+    assert data.fine_velocity_count == 8
+
+
+def test_write_schema_partial_update():
+    data = ComputationConfigWrite(coarse_alpha_step_deg=0.5)
+    assert data.coarse_alpha_step_deg == 0.5
+    assert data.fine_velocity_count is None
+
+
+def test_write_schema_validates_positive_step():
+    with pytest.raises(ValueError):
+        ComputationConfigWrite(coarse_alpha_step_deg=0.0)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `poetry run pytest app/tests/test_computation_config_schema.py -v`
+Expected: FAIL with `ModuleNotFoundError`
+
+- [ ] **Step 3: Create schemas**
+
+```python
+# app/schemas/computation_config.py
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ComputationConfigRead(BaseModel):
+    id: int
+    aeroplane_id: int
+    coarse_alpha_min_deg: float
+    coarse_alpha_max_deg: float
+    coarse_alpha_step_deg: float
+    fine_alpha_margin_deg: float
+    fine_alpha_step_deg: float
+    fine_velocity_count: int
+    debounce_seconds: float
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ComputationConfigWrite(BaseModel):
+    coarse_alpha_min_deg: float | None = None
+    coarse_alpha_max_deg: float | None = None
+    coarse_alpha_step_deg: float | None = Field(None, gt=0, description="Must be positive")
+    fine_alpha_margin_deg: float | None = Field(None, gt=0)
+    fine_alpha_step_deg: float | None = Field(None, gt=0, description="Must be positive")
+    fine_velocity_count: int | None = Field(None, ge=2, le=50)
+    debounce_seconds: float | None = Field(None, ge=0.5, le=30.0)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `poetry run pytest app/tests/test_computation_config_schema.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/schemas/computation_config.py app/tests/test_computation_config_schema.py
+git commit -m "feat(gh-465): add computation config pydantic schemas"
+```
+
+---
+
+### Task 3: Extend `update_calculated_value` with auto-switch
+
+**Files:**
+- Modify: `app/services/design_assumptions_service.py`
+- Test: `app/tests/test_design_assumptions_service.py` (add tests)
+
+- [ ] **Step 1: Write failing tests**
+
+Add to the existing test file (or create if not present):
+
+```python
+# app/tests/test_auto_switch_source.py
+import pytest
+from unittest.mock import MagicMock, patch
+from app.services.design_assumptions_service import update_calculated_value
+from app.models.aeroplanemodel import DesignAssumptionModel
+
+
+@pytest.fixture
+def mock_db_with_assumption():
+    """Create a mock DB session with an assumption row."""
+    db = MagicMock()
+    row = MagicMock(spec=DesignAssumptionModel)
+    row.parameter_name = "cl_max"
+    row.estimate_value = 1.4
+    row.calculated_value = None
+    row.calculated_source = None
+    row.active_source = "ESTIMATE"
+    row.divergence_pct = None
+    row.updated_at = None
+    row.id = 1
+    row.aeroplane_id = 1
+
+    db.query.return_value.filter.return_value.first.return_value = row
+    return db, row
+
+
+def test_auto_switch_on_first_calculated_value(mock_db_with_assumption):
+    db, row = mock_db_with_assumption
+    with patch("app.services.design_assumptions_service._get_aeroplane") as mock_get:
+        mock_aeroplane = MagicMock()
+        mock_aeroplane.id = 1
+        mock_get.return_value = mock_aeroplane
+
+        update_calculated_value(db, "test-uuid", "cl_max", 1.35, "aerobuildup", auto_switch_source=True)
+
+    assert row.calculated_value == 1.35
+    assert row.active_source == "CALCULATED"
+
+
+def test_no_auto_switch_when_already_has_calculated(mock_db_with_assumption):
+    db, row = mock_db_with_assumption
+    row.calculated_value = 1.3  # already has a value
+    row.active_source = "ESTIMATE"  # user chose estimate
+
+    with patch("app.services.design_assumptions_service._get_aeroplane") as mock_get:
+        mock_aeroplane = MagicMock()
+        mock_aeroplane.id = 1
+        mock_get.return_value = mock_aeroplane
+
+        update_calculated_value(db, "test-uuid", "cl_max", 1.35, "aerobuildup", auto_switch_source=True)
+
+    assert row.calculated_value == 1.35
+    assert row.active_source == "ESTIMATE"  # not overridden
+
+
+def test_no_auto_switch_for_design_choice(mock_db_with_assumption):
+    db, row = mock_db_with_assumption
+    row.parameter_name = "g_limit"
+
+    with patch("app.services.design_assumptions_service._get_aeroplane") as mock_get:
+        mock_aeroplane = MagicMock()
+        mock_aeroplane.id = 1
+        mock_get.return_value = mock_aeroplane
+
+        update_calculated_value(db, "test-uuid", "g_limit", 3.5, "computed", auto_switch_source=True)
+
+    assert row.active_source == "ESTIMATE"  # design choices never auto-switch
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `poetry run pytest app/tests/test_auto_switch_source.py -v`
+Expected: FAIL with `TypeError: update_calculated_value() got an unexpected keyword argument 'auto_switch_source'`
+
+- [ ] **Step 3: Add auto_switch_source parameter**
+
+In `app/services/design_assumptions_service.py`, modify `update_calculated_value()`:
+
+```python
+def update_calculated_value(
+    db: Session,
+    aeroplane_uuid,
+    param_name: str,
+    value: float | None,
+    source: str | None,
+    auto_switch_source: bool = False,
+) -> AssumptionRead:
+    """Update the calculated value and source for a design assumption.
+
+    Called by aggregation services (e.g. weight-item sync) to feed
+    computed values back into the assumption row. Recomputes divergence.
+    """
+    try:
+        aeroplane = _get_aeroplane(db, aeroplane_uuid)
+        row = (
+            db.query(DesignAssumptionModel)
+            .filter(
+                DesignAssumptionModel.aeroplane_id == aeroplane.id,
+                DesignAssumptionModel.parameter_name == param_name,
+            )
+            .first()
+        )
+        if row is None:
+            raise NotFoundError(entity="DesignAssumption", resource_id=param_name)
+
+        should_switch = (
+            auto_switch_source
+            and row.calculated_value is None
+            and row.active_source == "ESTIMATE"
+            and param_name not in DESIGN_CHOICE_PARAMS
+        )
+
+        row.calculated_value = value
+        row.calculated_source = source
+        row.divergence_pct = compute_divergence_pct(row.estimate_value, value)
+
+        if should_switch:
+            row.active_source = "CALCULATED"
+
+        db.flush()
+        db.refresh(row)
+        return _assumption_to_read(row)
+    except NotFoundError:
+        raise
+    except SQLAlchemyError as exc:
+        logger.error("DB error in update_calculated_value: %s", exc)
+        raise InternalError(message=f"Database error: {exc}") from exc
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `poetry run pytest app/tests/test_auto_switch_source.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Run existing assumption tests for regressions**
+
+Run: `poetry run pytest app/tests/ -k "assumption" -v`
+Expected: All PASS (new parameter has default `False`, no behavior change for existing callers)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/design_assumptions_service.py app/tests/test_auto_switch_source.py
+git commit -m "feat(gh-465): add auto_switch_source to update_calculated_value"
+```
+
+---
+
+### Task 4: Seed ComputationConfig in `seed_defaults`
+
+**Files:**
+- Modify: `app/services/design_assumptions_service.py`
+- Test: `app/tests/test_seed_computation_config.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# app/tests/test_seed_computation_config.py
+from unittest.mock import MagicMock, patch
+from app.models.computation_config import AircraftComputationConfigModel, COMPUTATION_CONFIG_DEFAULTS
+
+
+def test_seed_defaults_creates_computation_config():
+    """seed_defaults should also seed computation config if it doesn't exist."""
+    db = MagicMock()
+    # Mock: no existing assumptions
+    db.query.return_value.filter.return_value.all.return_value = []
+    # Mock: no existing computation config
+    db.query.return_value.filter.return_value.first.return_value = None
+
+    with patch("app.services.design_assumptions_service._get_aeroplane") as mock_get:
+        mock_aeroplane = MagicMock()
+        mock_aeroplane.id = 42
+        mock_get.return_value = mock_aeroplane
+
+        with patch("app.services.design_assumptions_service.list_assumptions") as mock_list:
+            mock_list.return_value = MagicMock()
+
+            from app.services.design_assumptions_service import seed_defaults
+            seed_defaults(db, "test-uuid")
+
+    # Verify a ComputationConfigModel was added
+    added_objects = [call.args[0] for call in db.add.call_args_list]
+    config_objects = [o for o in added_objects if isinstance(o, AircraftComputationConfigModel)]
+    assert len(config_objects) == 1
+    assert config_objects[0].aeroplane_id == 42
+    assert config_objects[0].coarse_alpha_step_deg == COMPUTATION_CONFIG_DEFAULTS["coarse_alpha_step_deg"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `poetry run pytest app/tests/test_seed_computation_config.py -v`
+Expected: FAIL — seed_defaults does not create computation config yet
+
+- [ ] **Step 3: Extend seed_defaults**
+
+In `app/services/design_assumptions_service.py`, add to `seed_defaults()` after the assumption seeding loop and before `db.flush()`:
+
+```python
+from app.models.computation_config import AircraftComputationConfigModel, COMPUTATION_CONFIG_DEFAULTS
+
+# Inside seed_defaults, after the assumption seeding loop:
+existing_config = (
+    db.query(AircraftComputationConfigModel)
+    .filter(AircraftComputationConfigModel.aeroplane_id == aeroplane.id)
+    .first()
+)
+if existing_config is None:
+    config = AircraftComputationConfigModel(
+        aeroplane_id=aeroplane.id,
+        **COMPUTATION_CONFIG_DEFAULTS,
+    )
+    db.add(config)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `poetry run pytest app/tests/test_seed_computation_config.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/design_assumptions_service.py app/tests/test_seed_computation_config.py
+git commit -m "feat(gh-465): seed computation config in seed_defaults"
+```
+
+---
+
+### Task 5: Assumption Compute Service — Core Logic
+
+**Files:**
+- Create: `app/services/assumption_compute_service.py`
+- Test: `app/tests/test_assumption_compute_service.py`
+
+- [ ] **Step 1: Write failing test for the recompute pipeline**
+
+```python
+# app/tests/test_assumption_compute_service.py
+from __future__ import annotations
+
+import math
+from unittest.mock import MagicMock, patch, call
+import pytest
+
+
+@pytest.fixture
+def mock_asb_airplane():
+    airplane = MagicMock()
+    airplane.wings = [MagicMock()]
+    airplane.xyz_ref = [0.08, 0, 0]
+    wing = airplane.wings[0]
+    wing.mean_aerodynamic_chord.return_value = 0.20
+    return airplane
+
+
+@pytest.fixture
+def mock_aerobuildup_results():
+    """Simulate AeroBuildup output for a coarse alpha sweep."""
+    import numpy as np
+
+    alphas_deg = np.arange(-5, 26, 1.0)
+    alphas_rad = np.radians(alphas_deg)
+    CLs = 2 * math.pi * alphas_rad * 0.8  # approximate thin airfoil
+    CDs = 0.02 + 0.05 * CLs**2
+
+    return {
+        "alpha_deg": alphas_deg,
+        "CL": CLs,
+        "CD": CDs,
+        "x_np": 0.085,
+    }
+
+
+def test_recompute_assumptions_basic(mock_asb_airplane):
+    """Verify all 3 assumptions are written and context is cached."""
+    from app.services.assumption_compute_service import recompute_assumptions
+
+    db = MagicMock()
+
+    with (
+        patch("app.services.assumption_compute_service._load_aircraft_as_asb") as mock_load,
+        patch("app.services.assumption_compute_service._load_flight_profile_speeds") as mock_speeds,
+        patch("app.services.assumption_compute_service._load_or_create_config") as mock_config,
+        patch("app.services.assumption_compute_service._run_coarse_sweep") as mock_coarse,
+        patch("app.services.assumption_compute_service._run_fine_sweep") as mock_fine,
+        patch("app.services.assumption_compute_service._load_effective_assumption") as mock_sm,
+        patch("app.services.assumption_compute_service._load_cg_agg") as mock_cg_agg,
+        patch("app.services.assumption_compute_service.update_calculated_value") as mock_update,
+        patch("app.services.assumption_compute_service._cache_context") as mock_cache,
+    ):
+        mock_load.return_value = (mock_asb_airplane, MagicMock())
+        mock_speeds.return_value = (18.0, 28.0)
+        mock_config.return_value = MagicMock(
+            coarse_alpha_min_deg=-5.0, coarse_alpha_max_deg=25.0,
+            coarse_alpha_step_deg=1.0, fine_alpha_margin_deg=5.0,
+            fine_alpha_step_deg=0.5, fine_velocity_count=8,
+        )
+        mock_coarse.return_value = {"cd0": 0.025, "x_np": 0.085, "stall_alpha_deg": 15.0}
+        mock_fine.return_value = 1.35
+        mock_sm.return_value = 0.12
+        mock_cg_agg.return_value = 0.092
+
+        recompute_assumptions(db, "test-uuid")
+
+    assert mock_update.call_count == 3
+    param_names = [c.kwargs.get("param_name") or c.args[2] for c in mock_update.call_args_list]
+    assert set(param_names) == {"cl_max", "cd0", "cg_x"}
+    mock_cache.assert_called_once()
+
+
+def test_recompute_assumptions_no_wings():
+    """Should skip gracefully when aircraft has no wings."""
+    from app.services.assumption_compute_service import recompute_assumptions
+
+    db = MagicMock()
+
+    with (
+        patch("app.services.assumption_compute_service._load_aircraft_as_asb") as mock_load,
+        patch("app.services.assumption_compute_service.update_calculated_value") as mock_update,
+    ):
+        airplane = MagicMock()
+        airplane.wings = []
+        mock_load.return_value = (airplane, MagicMock())
+
+        recompute_assumptions(db, "test-uuid")
+
+    mock_update.assert_not_called()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `poetry run pytest app/tests/test_assumption_compute_service.py -v`
+Expected: FAIL with `ModuleNotFoundError`
+
+- [ ] **Step 3: Create the service**
+
+```python
+# app/services/assumption_compute_service.py
+from __future__ import annotations
+
+import logging
+import math
+from datetime import datetime, timezone
+from typing import Any
+
+import numpy as np
+from sqlalchemy.orm import Session
+
+from app.converters.model_schema_converters import (
+    aeroplane_model_to_aeroplane_schema_async,
+    aeroplane_schema_to_asb_airplane_async,
+)
+from app.core.events import AssumptionChanged, event_bus
+from app.models.aeroplanemodel import AeroplaneModel, DesignAssumptionModel
+from app.models.computation_config import (
+    AircraftComputationConfigModel,
+    COMPUTATION_CONFIG_DEFAULTS,
+)
+from app.services.design_assumptions_service import update_calculated_value
+from app.services.mass_cg_service import aggregate_weight_items
+
+logger = logging.getLogger(__name__)
+
+
+def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
+    asb_airplane, aircraft = _load_aircraft_as_asb(db, aeroplane_uuid)
+
+    if not asb_airplane.wings:
+        logger.info("No wings on aircraft %s — skipping assumption recompute", aeroplane_uuid)
+        return
+
+    v_cruise, v_max = _load_flight_profile_speeds(db, aircraft)
+    mac = _compute_mac(asb_airplane)
+    config = _load_or_create_config(db, aircraft.id)
+
+    coarse = _run_coarse_sweep(asb_airplane, v_cruise, config)
+    cl_max = _run_fine_sweep(asb_airplane, coarse["stall_alpha_deg"], v_cruise, v_max, config)
+
+    target_sm = _load_effective_assumption(db, aircraft.id, "target_static_margin")
+    cg_x = coarse["x_np"] - target_sm * mac
+
+    old_cg = _get_current_calculated_value(db, aircraft.id, "cg_x")
+
+    update_calculated_value(db, aeroplane_uuid, "cl_max", round(cl_max, 4), "aerobuildup", auto_switch_source=True)
+    update_calculated_value(db, aeroplane_uuid, "cd0", round(coarse["cd0"], 5), "aerobuildup", auto_switch_source=True)
+    update_calculated_value(db, aeroplane_uuid, "cg_x", round(cg_x, 4), "aerobuildup", auto_switch_source=True)
+
+    cg_agg = _load_cg_agg(db, aircraft)
+    re = _reynolds_number(v_cruise, mac)
+
+    _cache_context(db, aircraft, {
+        "v_cruise_mps": v_cruise,
+        "reynolds": round(re),
+        "mac_m": round(mac, 4),
+        "x_np_m": round(coarse["x_np"], 4),
+        "target_static_margin": target_sm,
+        "cg_agg_m": round(cg_agg, 4) if cg_agg is not None else None,
+        "computed_at": datetime.now(timezone.utc).isoformat(),
+    })
+
+    if old_cg is None or abs(cg_x - (old_cg or 0)) > 1e-6:
+        event_bus.publish(AssumptionChanged(aeroplane_id=aircraft.id, parameter_name="cg_x"))
+
+
+def _load_aircraft_as_asb(db: Session, aeroplane_uuid):
+    aircraft = db.query(AeroplaneModel).filter(AeroplaneModel.uuid == aeroplane_uuid).first()
+    if aircraft is None:
+        raise ValueError(f"Aircraft {aeroplane_uuid} not found")
+    schema = aeroplane_model_to_aeroplane_schema_async(aircraft)
+    asb_airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=schema)
+    return asb_airplane, aircraft
+
+
+def _load_flight_profile_speeds(db: Session, aircraft: AeroplaneModel) -> tuple[float, float]:
+    from app.services.operating_point_generator_service import _load_effective_flight_profile
+
+    profile, _ = _load_effective_flight_profile(db, aircraft)
+    goals = profile.get("goals", {})
+    cruise = float(goals.get("cruise_speed_mps", 18.0))
+    v_max = float(goals.get("max_level_speed_mps") or max(1.35 * cruise, cruise + 8.0))
+    return cruise, v_max
+
+
+def _compute_mac(asb_airplane) -> float:
+    if asb_airplane.wings:
+        return float(asb_airplane.wings[0].mean_aerodynamic_chord())
+    return 0.2
+
+
+def _load_or_create_config(db: Session, aeroplane_id: int) -> AircraftComputationConfigModel:
+    config = (
+        db.query(AircraftComputationConfigModel)
+        .filter(AircraftComputationConfigModel.aeroplane_id == aeroplane_id)
+        .first()
+    )
+    if config is None:
+        config = AircraftComputationConfigModel(aeroplane_id=aeroplane_id, **COMPUTATION_CONFIG_DEFAULTS)
+        db.add(config)
+        db.flush()
+    return config
+
+
+def _run_coarse_sweep(
+    asb_airplane, v_cruise: float, config: AircraftComputationConfigModel,
+) -> dict[str, float]:
+    import aerosandbox as asb
+
+    alphas = np.arange(config.coarse_alpha_min_deg, config.coarse_alpha_max_deg + 0.01, config.coarse_alpha_step_deg)
+
+    op = asb.OperatingPoint(velocity=v_cruise, alpha=0)
+    abu = asb.AeroBuildup(airplane=asb_airplane, op_point=op)
+    results = abu.run_with_stability_derivatives()
+    x_np = float(results.get("x_np", 0.0))
+
+    CLs = []
+    CDs = []
+    for a in alphas:
+        op_a = asb.OperatingPoint(velocity=v_cruise, alpha=a)
+        abu_a = asb.AeroBuildup(airplane=asb_airplane, op_point=op_a)
+        r = abu_a.run()
+        CLs.append(float(r["CL"]))
+        CDs.append(float(r["CD"]))
+
+    CLs = np.array(CLs)
+    CDs = np.array(CDs)
+
+    idx_cl_zero = int(np.argmin(np.abs(CLs)))
+    cd0 = float(CDs[idx_cl_zero])
+
+    idx_cl_max = int(np.argmax(CLs))
+    stall_alpha = float(alphas[idx_cl_max])
+
+    return {"cd0": cd0, "x_np": x_np, "stall_alpha_deg": stall_alpha}
+
+
+def _run_fine_sweep(
+    asb_airplane,
+    stall_alpha_deg: float,
+    v_cruise: float,
+    v_max: float,
+    config: AircraftComputationConfigModel,
+) -> float:
+    import aerosandbox as asb
+
+    alpha_min = stall_alpha_deg - config.fine_alpha_margin_deg
+    alpha_max = stall_alpha_deg + config.fine_alpha_margin_deg
+    alphas = np.arange(alpha_min, alpha_max + 0.01, config.fine_alpha_step_deg)
+
+    v_stall_approx = max(v_cruise * 0.5, 3.0)
+    velocities = np.linspace(v_stall_approx, v_max, config.fine_velocity_count)
+
+    cl_max = -np.inf
+    for v in velocities:
+        for a in alphas:
+            op = asb.OperatingPoint(velocity=v, alpha=a)
+            abu = asb.AeroBuildup(airplane=asb_airplane, op_point=op)
+            r = abu.run()
+            cl = float(r["CL"])
+            if cl > cl_max:
+                cl_max = cl
+
+    return float(cl_max)
+
+
+def _load_effective_assumption(db: Session, aeroplane_id: int, param_name: str) -> float:
+    from app.schemas.design_assumption import PARAMETER_DEFAULTS
+
+    row = (
+        db.query(DesignAssumptionModel)
+        .filter(
+            DesignAssumptionModel.aeroplane_id == aeroplane_id,
+            DesignAssumptionModel.parameter_name == param_name,
+        )
+        .first()
+    )
+    if row is None:
+        return PARAMETER_DEFAULTS.get(param_name, 0.0)
+    if row.active_source == "CALCULATED" and row.calculated_value is not None:
+        return row.calculated_value
+    return row.estimate_value
+
+
+def _get_current_calculated_value(db: Session, aeroplane_id: int, param_name: str) -> float | None:
+    row = (
+        db.query(DesignAssumptionModel)
+        .filter(
+            DesignAssumptionModel.aeroplane_id == aeroplane_id,
+            DesignAssumptionModel.parameter_name == param_name,
+        )
+        .first()
+    )
+    return row.calculated_value if row else None
+
+
+def _load_cg_agg(db: Session, aircraft: AeroplaneModel) -> float | None:
+    from app.models.aeroplanemodel import WeightItemModel
+
+    rows = db.query(WeightItemModel).filter(WeightItemModel.aeroplane_id == aircraft.id).all()
+    if not rows:
+        return None
+    items = [{"mass_kg": r.mass_kg, "x_m": r.x_m, "y_m": r.y_m, "z_m": r.z_m} for r in rows]
+    _, cg_x, _, _ = aggregate_weight_items(items)
+    return cg_x
+
+
+def _reynolds_number(velocity: float, mac: float, rho: float = 1.225, mu: float = 1.81e-5) -> float:
+    return rho * velocity * mac / mu
+
+
+def _cache_context(db: Session, aircraft: AeroplaneModel, context: dict[str, Any]) -> None:
+    aircraft.assumption_computation_context = context
+    db.flush()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `poetry run pytest app/tests/test_assumption_compute_service.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/assumption_compute_service.py app/tests/test_assumption_compute_service.py
+git commit -m "feat(gh-465): add assumption compute service with two-phase ASB sweep"
+```
+
+---
+
+### Task 6: Wire GeometryChanged Event to Recompute
+
+**Files:**
+- Modify: `app/services/invalidation_service.py`
+- Modify: `app/core/background_jobs.py`
+- Modify: `app/main.py`
+- Test: `app/tests/test_invalidation_recompute.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# app/tests/test_invalidation_recompute.py
+from unittest.mock import MagicMock, patch
+from app.core.events import GeometryChanged
+
+
+def test_geometry_changed_schedules_recompute():
+    from app.services.invalidation_service import _on_geometry_changed_recompute_assumptions
+
+    event = GeometryChanged(aeroplane_id=42, source_model="WingModel")
+
+    with patch("app.services.invalidation_service.job_tracker") as mock_tracker:
+        _on_geometry_changed_recompute_assumptions(event)
+
+    mock_tracker.schedule_recompute_assumptions.assert_called_once_with(42)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `poetry run pytest app/tests/test_invalidation_recompute.py -v`
+Expected: FAIL with `ImportError` — function doesn't exist yet
+
+- [ ] **Step 3: Add `schedule_recompute_assumptions` to JobTracker**
+
+In `app/core/background_jobs.py`, add alongside existing `schedule_retrim`:
+
+```python
+# Add new dataclass after RetrimJob:
+@dataclass
+class RecomputeAssumptionsJob:
+    aeroplane_id: int
+    status: JobStatus = JobStatus.DEBOUNCING
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    error: str | None = None
+```
+
+Add to `JobTracker.__init__`:
+```python
+self._recompute_jobs: dict[int, RecomputeAssumptionsJob] = {}
+self._recompute_debounce_tasks: dict[int, asyncio.Task] = {}
+self._recompute_function: Callable[[int], Awaitable[None]] | None = None
+```
+
+Add methods to `JobTracker`:
+```python
+def set_recompute_function(self, fn: Callable[[int], Awaitable[None]]) -> None:
+    self._recompute_function = fn
+
+def schedule_recompute_assumptions(self, aeroplane_id: int) -> None:
+    existing_task = self._recompute_debounce_tasks.get(aeroplane_id)
+    if existing_task and not existing_task.done():
+        existing_task.cancel()
+
+    self._recompute_jobs[aeroplane_id] = RecomputeAssumptionsJob(aeroplane_id=aeroplane_id)
+
+    try:
+        loop = asyncio.get_running_loop()
+        self._recompute_debounce_tasks[aeroplane_id] = loop.create_task(
+            self._debounced_recompute(aeroplane_id)
+        )
+    except RuntimeError:
+        logger.debug(
+            "No running event loop — skipping recompute for aeroplane %d",
+            aeroplane_id,
+        )
+
+async def _debounced_recompute(self, aeroplane_id: int) -> None:
+    try:
+        await asyncio.sleep(self.debounce_seconds)
+    except asyncio.CancelledError:
+        return
+
+    if self._recompute_function is None:
+        logger.warning("No recompute function registered — cannot recompute for aeroplane %d", aeroplane_id)
+        return
+
+    job = self._recompute_jobs.get(aeroplane_id)
+    if job is None:
+        return
+
+    job.status = JobStatus.COMPUTING
+    job.started_at = datetime.now(timezone.utc)
+
+    try:
+        await self._recompute_function(aeroplane_id)
+        job.status = JobStatus.DONE
+    except Exception as exc:
+        logger.exception("Recompute assumptions failed for aeroplane %d", aeroplane_id)
+        job.status = JobStatus.FAILED
+        job.error = str(exc)
+    finally:
+        job.finished_at = datetime.now(timezone.utc)
+        self._recompute_debounce_tasks.pop(aeroplane_id, None)
+```
+
+Extend `shutdown()` to also cancel recompute tasks:
+```python
+for task in self._recompute_debounce_tasks.values():
+    if not task.done():
+        task.cancel()
+if self._recompute_debounce_tasks:
+    await asyncio.gather(*self._recompute_debounce_tasks.values(), return_exceptions=True)
+self._recompute_debounce_tasks.clear()
+```
+
+- [ ] **Step 4: Add handler to invalidation_service.py**
+
+In `app/services/invalidation_service.py`, add:
+
+```python
+def _on_geometry_changed_recompute_assumptions(event: GeometryChanged) -> None:
+    logger.info(
+        "GeometryChanged for aeroplane %d (source: %s) — scheduling assumption recompute",
+        event.aeroplane_id,
+        event.source_model,
+    )
+    from app.core.background_jobs import job_tracker
+
+    job_tracker.schedule_recompute_assumptions(event.aeroplane_id)
+```
+
+In `register_handlers()`, add:
+```python
+event_bus.subscribe(GeometryChanged, _on_geometry_changed_recompute_assumptions)
+```
+
+- [ ] **Step 5: Wire recompute function in main.py**
+
+In `app/main.py`, in `_combined_lifespan`, after `job_tracker.set_trim_function(retrim_dirty_ops)`, add:
+
+```python
+from app.services.assumption_compute_service import recompute_assumptions
+
+async def _recompute_wrapper(aeroplane_id: int) -> None:
+    from app.db.session import SessionLocal
+    db = SessionLocal()
+    try:
+        aeroplane = db.query(AeroplaneModel).filter(AeroplaneModel.id == aeroplane_id).first()
+        if aeroplane:
+            recompute_assumptions(db, str(aeroplane.uuid))
+            db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+job_tracker.set_recompute_function(_recompute_wrapper)
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `poetry run pytest app/tests/test_invalidation_recompute.py -v`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/core/background_jobs.py app/services/invalidation_service.py app/main.py app/tests/test_invalidation_recompute.py
+git commit -m "feat(gh-465): wire GeometryChanged to assumption recompute via job tracker"
+```
+
+---
+
+### Task 7: API Endpoints — Computation Context and Config
+
+**Files:**
+- Modify: `app/api/v2/endpoints/aeroplane/design_assumptions.py`
+- Test: `app/tests/test_computation_endpoints.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# app/tests/test_computation_endpoints.py
+from unittest.mock import MagicMock, patch
+from fastapi.testclient import TestClient
+
+
+def test_get_computation_context_returns_cached():
+    from app.main import app
+    client = TestClient(app)
+
+    with patch("app.api.v2.endpoints.aeroplane.design_assumptions._get_aeroplane_by_uuid") as mock_get:
+        mock_aeroplane = MagicMock()
+        mock_aeroplane.assumption_computation_context = {
+            "v_cruise_mps": 18.0,
+            "reynolds": 230000,
+            "mac_m": 0.21,
+        }
+        mock_get.return_value = mock_aeroplane
+
+        response = client.get("/v2/aeroplanes/test-uuid/assumptions/computation-context")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["v_cruise_mps"] == 18.0
+
+
+def test_get_computation_context_returns_null():
+    from app.main import app
+    client = TestClient(app)
+
+    with patch("app.api.v2.endpoints.aeroplane.design_assumptions._get_aeroplane_by_uuid") as mock_get:
+        mock_aeroplane = MagicMock()
+        mock_aeroplane.assumption_computation_context = None
+        mock_get.return_value = mock_aeroplane
+
+        response = client.get("/v2/aeroplanes/test-uuid/assumptions/computation-context")
+
+    assert response.status_code == 200
+    assert response.json() is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `poetry run pytest app/tests/test_computation_endpoints.py -v`
+Expected: FAIL — endpoint doesn't exist
+
+- [ ] **Step 3: Add endpoints**
+
+In `app/api/v2/endpoints/aeroplane/design_assumptions.py`, add:
+
+```python
+from app.models.computation_config import AircraftComputationConfigModel, COMPUTATION_CONFIG_DEFAULTS
+from app.schemas.computation_config import ComputationConfigRead, ComputationConfigWrite
+
+
+def _get_aeroplane_by_uuid(db: Session, aeroplane_id) -> AeroplaneModel:
+    aeroplane = db.query(AeroplaneModel).filter(AeroplaneModel.uuid == str(aeroplane_id)).first()
+    if aeroplane is None:
+        raise HTTPException(status_code=404, detail="Aeroplane not found")
+    return aeroplane
+
+
+@router.get(
+    "/aeroplanes/{aeroplane_id}/assumptions/computation-context",
+    summary="Get cached computation context",
+)
+async def get_computation_context(
+    aeroplane_id: Annotated[UUID4, Path(description="Aeroplane UUID")],
+    db: Annotated[Session, Depends(get_db)],
+):
+    aeroplane = _get_aeroplane_by_uuid(db, aeroplane_id)
+    return aeroplane.assumption_computation_context
+
+
+@router.get(
+    "/aeroplanes/{aeroplane_id}/computation-config",
+    response_model=ComputationConfigRead,
+    summary="Get computation configuration",
+)
+async def get_computation_config(
+    aeroplane_id: Annotated[UUID4, Path(description="Aeroplane UUID")],
+    db: Annotated[Session, Depends(get_db)],
+):
+    aeroplane = _get_aeroplane_by_uuid(db, aeroplane_id)
+    config = (
+        db.query(AircraftComputationConfigModel)
+        .filter(AircraftComputationConfigModel.aeroplane_id == aeroplane.id)
+        .first()
+    )
+    if config is None:
+        config = AircraftComputationConfigModel(
+            aeroplane_id=aeroplane.id, **COMPUTATION_CONFIG_DEFAULTS,
+        )
+        db.add(config)
+        db.flush()
+        db.refresh(config)
+    return config
+
+
+@router.put(
+    "/aeroplanes/{aeroplane_id}/computation-config",
+    response_model=ComputationConfigRead,
+    summary="Update computation configuration",
+)
+async def update_computation_config(
+    aeroplane_id: Annotated[UUID4, Path(description="Aeroplane UUID")],
+    body: Annotated[ComputationConfigWrite, Body()],
+    db: Annotated[Session, Depends(get_db)],
+):
+    aeroplane = _get_aeroplane_by_uuid(db, aeroplane_id)
+    config = (
+        db.query(AircraftComputationConfigModel)
+        .filter(AircraftComputationConfigModel.aeroplane_id == aeroplane.id)
+        .first()
+    )
+    if config is None:
+        config = AircraftComputationConfigModel(
+            aeroplane_id=aeroplane.id, **COMPUTATION_CONFIG_DEFAULTS,
+        )
+        db.add(config)
+        db.flush()
+
+    update_data = body.model_dump(exclude_none=True)
+    for key, val in update_data.items():
+        setattr(config, key, val)
+    db.flush()
+    db.refresh(config)
+    return config
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `poetry run pytest app/tests/test_computation_endpoints.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/v2/endpoints/aeroplane/design_assumptions.py app/tests/test_computation_endpoints.py
+git commit -m "feat(gh-465): add computation context and config endpoints"
+```
+
+---
+
+### Task 8: Frontend — `useComputationContext` Hook
+
+**Files:**
+- Create: `frontend/hooks/useComputationContext.ts`
+- Test: `frontend/__tests__/useComputationContext.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+// frontend/__tests__/useComputationContext.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useComputationContext } from "@/hooks/useComputationContext";
+
+describe("useComputationContext", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches computation context for an aeroplane", async () => {
+    const fakeContext = {
+      v_cruise_mps: 18.0,
+      reynolds: 230000,
+      mac_m: 0.21,
+      x_np_m: 0.085,
+      target_static_margin: 0.12,
+      cg_agg_m: 0.092,
+      computed_at: "2026-05-10T14:30:00Z",
+    };
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(fakeContext),
+    });
+
+    const { result } = renderHook(() => useComputationContext("42"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual(fakeContext);
+    const url = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(url.toString()).toContain("/assumptions/computation-context");
+  });
+
+  it("returns null when aeroplaneId is null", () => {
+    const { result } = renderHook(() => useComputationContext(null));
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run __tests__/useComputationContext.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Create the hook**
+
+```typescript
+// frontend/hooks/useComputationContext.ts
+import useSWR from "swr";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "http://localhost:8001/v2";
+
+export interface ComputationContext {
+  v_cruise_mps: number;
+  reynolds: number;
+  mac_m: number;
+  x_np_m: number;
+  target_static_margin: number;
+  cg_agg_m: number | null;
+  computed_at: string;
+}
+
+async function fetcher(url: string): Promise<ComputationContext | null> {
+  const res = await fetch(url);
+  if (!res.ok) return null;
+  return res.json();
+}
+
+export function useComputationContext(aeroplaneId: string | null) {
+  const { data, error, isLoading, mutate } = useSWR<ComputationContext | null>(
+    aeroplaneId
+      ? `${API_BASE}/aeroplanes/${encodeURIComponent(aeroplaneId)}/assumptions/computation-context`
+      : null,
+    fetcher,
+  );
+
+  return { data: data ?? null, error, isLoading, mutate };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run __tests__/useComputationContext.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/hooks/useComputationContext.ts frontend/__tests__/useComputationContext.test.ts
+git commit -m "feat(gh-465): add useComputationContext hook"
+```
+
+---
+
+### Task 9: Frontend — Dynamic Info Chip Row
+
+**Files:**
+- Modify: `frontend/components/workbench/AnalysisViewerPanel.tsx`
+- Test: `frontend/__tests__/InfoChipRow.test.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+// frontend/__tests__/InfoChipRow.test.tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) => React.createElement("span", props);
+  return { Wind: icon, SlidersHorizontal: icon, Activity: icon, Ruler: icon, Target: icon, Navigation: icon, Settings: icon };
+});
+
+vi.mock("@/hooks/useComputationContext", () => ({
+  useComputationContext: vi.fn(),
+}));
+
+import { useComputationContext } from "@/hooks/useComputationContext";
+
+describe("Info Chip Row", () => {
+  it("shows dynamic values when context is available", async () => {
+    (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        v_cruise_mps: 18.0,
+        reynolds: 230000,
+        mac_m: 0.21,
+        x_np_m: 0.085,
+        target_static_margin: 0.12,
+        cg_agg_m: 0.092,
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    // Import the InfoChipRow component (extracted in implementation)
+    const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
+    render(<InfoChipRow aeroplaneId="42" cgAero={0.073} />);
+
+    expect(screen.getByText(/18\.0 m\/s/)).toBeInTheDocument();
+    expect(screen.getByText(/2\.3e\+?5/i)).toBeInTheDocument();
+    expect(screen.getByText(/0\.21 m/)).toBeInTheDocument();
+    expect(screen.getByText(/0\.085 m/)).toBeInTheDocument();
+  });
+
+  it("shows dashes when no context", async () => {
+    (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: null,
+    });
+
+    const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
+    render(<InfoChipRow aeroplaneId="42" cgAero={null} />);
+
+    const dashes = screen.getAllByText("–");
+    expect(dashes.length).toBeGreaterThanOrEqual(4);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run __tests__/InfoChipRow.test.tsx`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Extract InfoChipRow component**
+
+Create `frontend/components/workbench/InfoChipRow.tsx`:
+
+```tsx
+"use client";
+
+import { Wind, Ruler, Target, Navigation } from "lucide-react";
+import { useComputationContext } from "@/hooks/useComputationContext";
+
+interface Props {
+  readonly aeroplaneId: string | null;
+  readonly cgAero: number | null;
+}
+
+function Chip({ icon: Icon, label }: { readonly icon: React.ComponentType<{ size: number; className: string }>; readonly label: string }) {
+  return (
+    <div className="flex items-center gap-1.5 rounded-full bg-card-muted px-3 py-1.5">
+      <Icon size={12} className="text-muted-foreground" />
+      <span className="font-[family-name:var(--font-geist-sans)] text-[12px] text-foreground">
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function cgDivergenceColor(cgAero: number, cgAgg: number, mac: number): string {
+  const deltaPct = Math.abs(cgAgg - cgAero) / mac * 100;
+  if (deltaPct < 5) return "text-emerald-400";
+  if (deltaPct <= 15) return "text-orange-400";
+  return "text-red-400";
+}
+
+export function InfoChipRow({ aeroplaneId, cgAero }: Props) {
+  const { data: ctx } = useComputationContext(aeroplaneId);
+
+  const fmt = (v: number | null | undefined, decimals: number, suffix = "") =>
+    v != null ? `${v.toFixed(decimals)}${suffix}` : "–";
+
+  const fmtRe = (v: number | null | undefined) => {
+    if (v == null) return "–";
+    return v.toExponential(1);
+  };
+
+  const cgLabel = (() => {
+    if (cgAero == null) return "CG = –";
+    const base = `CG = ${cgAero.toFixed(3)} m`;
+    if (ctx?.cg_agg_m == null) return base;
+    return base;
+  })();
+
+  return (
+    <div className="flex items-center gap-2 border-t border-border bg-card px-4 py-3">
+      <Chip icon={Wind} label={`V = ${fmt(ctx?.v_cruise_mps, 1, " m/s")}`} />
+      <Chip icon={Wind} label={`Re ≈ ${fmtRe(ctx?.reynolds)}`} />
+      <Chip icon={Ruler} label={`MAC = ${fmt(ctx?.mac_m, 2, " m")}`} />
+      <Chip icon={Target} label={`NP = ${fmt(ctx?.x_np_m, 3, " m")}`} />
+      <Chip icon={Navigation} label={`SM = ${ctx?.target_static_margin != null ? (ctx.target_static_margin * 100).toFixed(0) + "%" : "–"}`} />
+      <div className="flex items-center gap-1.5 rounded-full bg-card-muted px-3 py-1.5">
+        <Navigation size={12} className="text-muted-foreground" />
+        <span className="font-[family-name:var(--font-geist-sans)] text-[12px] text-foreground">
+          {cgLabel}
+          {cgAero != null && ctx?.cg_agg_m != null && (
+            <span className={`ml-1 ${cgDivergenceColor(cgAero, ctx.cg_agg_m, ctx.mac_m)}`}>
+              ({ctx.cg_agg_m.toFixed(3)})
+            </span>
+          )}
+        </span>
+      </div>
+      <div className="flex-1" />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Replace hardcoded chips in AnalysisViewerPanel**
+
+In `frontend/components/workbench/AnalysisViewerPanel.tsx`, replace the Info Chip Row section (lines 813–850) with:
+
+```tsx
+import { InfoChipRow } from "@/components/workbench/InfoChipRow";
+
+// In the component JSX, replace the entire Info Chip Row div with:
+<InfoChipRow
+  aeroplaneId={aeroplaneId ?? null}
+  cgAero={/* cg_x effective value from assumptions, passed as prop */}
+/>
+```
+
+The `cgAero` prop needs to come from the assumptions data. Add it as a prop to the AnalysisViewerPanel or fetch via the existing `useDesignAssumptions` hook in the parent page.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run __tests__/InfoChipRow.test.tsx`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/components/workbench/InfoChipRow.tsx frontend/components/workbench/AnalysisViewerPanel.tsx frontend/__tests__/InfoChipRow.test.tsx
+git commit -m "feat(gh-465): dynamic Info Chip Row with computation context"
+```
+
+---
+
+### Task 10: Frontend — Analysis Tab Wing Gate
+
+**Files:**
+- Modify: `frontend/components/workbench/AnalysisViewerPanel.tsx`
+- Test: `frontend/__tests__/AnalysisWingGate.test.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+// frontend/__tests__/AnalysisWingGate.test.tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) => React.createElement("span", props);
+  return new Proxy({}, { get: () => icon });
+});
+
+vi.mock("@/hooks/useComputationContext", () => ({
+  useComputationContext: () => ({ data: null, isLoading: false }),
+}));
+
+describe("Analysis Tab Wing Gate", () => {
+  it("shows empty state for Polar tab when no wings", async () => {
+    const mod = await import("@/components/workbench/AnalysisViewerPanel");
+    const Panel = mod.AnalysisViewerPanel;
+
+    render(
+      <Panel
+        result={null}
+        activeTab="Polar"
+        onTabChange={() => {}}
+        wingXSecs={[]}
+        // ... other required props with null/empty defaults
+      />,
+    );
+
+    expect(screen.getByText(/add a wing/i)).toBeInTheDocument();
+  });
+
+  it("shows Assumptions tab content even without wings", async () => {
+    const mod = await import("@/components/workbench/AnalysisViewerPanel");
+    const Panel = mod.AnalysisViewerPanel;
+
+    render(
+      <Panel
+        result={null}
+        activeTab="Assumptions"
+        onTabChange={() => {}}
+        wingXSecs={[]}
+        // ... other required props
+      />,
+    );
+
+    expect(screen.queryByText(/add a wing/i)).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run __tests__/AnalysisWingGate.test.tsx`
+Expected: FAIL — no wing gate exists yet
+
+- [ ] **Step 3: Add wing gate to AnalysisViewerPanel**
+
+In `AnalysisViewerPanel.tsx`, add a helper check:
+
+```tsx
+const hasWings = (wingXSecs?.length ?? 0) > 0;
+```
+
+Then for each computation tab (Polar, Trefftz, Streamlines, Stability, Envelope, Operating Points), wrap the content with:
+
+```tsx
+{activeTab === "Polar" && (
+  hasWings ? (
+    // ... existing Polar content
+  ) : (
+    <div className="flex flex-1 items-center justify-center bg-card-muted">
+      <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-muted-foreground">
+        Add a wing to enable aerodynamic analysis
+      </span>
+    </div>
+  )
+)}
+```
+
+Leave Assumptions tab unchanged — it always renders.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run __tests__/AnalysisWingGate.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Run full frontend test suite**
+
+Run: `cd frontend && npm run test:unit`
+Expected: All tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/components/workbench/AnalysisViewerPanel.tsx frontend/__tests__/AnalysisWingGate.test.tsx
+git commit -m "feat(gh-465): gate analysis tabs on wing existence"
+```
+
+---
+
+### Task 11: Integration Test — Full Pipeline
+
+**Files:**
+- Create: `app/tests/test_assumption_compute_integration.py`
+
+- [ ] **Step 1: Write integration test**
+
+```python
+# app/tests/test_assumption_compute_integration.py
+import pytest
+from unittest.mock import patch, MagicMock
+import numpy as np
+
+from app.core.events import GeometryChanged, event_bus
+
+
+@pytest.mark.integration
+def test_geometry_changed_triggers_full_recompute_chain():
+    """Integration: GeometryChanged → recompute → assumptions updated."""
+    calls = []
+
+    def track_recompute(aeroplane_id):
+        calls.append(("recompute", aeroplane_id))
+
+    with patch("app.core.background_jobs.job_tracker") as mock_tracker:
+        mock_tracker.schedule_recompute_assumptions = track_recompute
+
+        from app.services.invalidation_service import _on_geometry_changed_recompute_assumptions
+        event = GeometryChanged(aeroplane_id=42, source_model="WingModel")
+        _on_geometry_changed_recompute_assumptions(event)
+
+    assert ("recompute", 42) in calls
+
+
+@pytest.mark.integration
+def test_recompute_publishes_assumption_changed_on_cg_change():
+    """Integration: recompute with changed cg_x publishes AssumptionChanged."""
+    published = []
+
+    def capture_event(event):
+        published.append(event)
+
+    event_bus.subscribe(type(MagicMock()), capture_event)
+
+    from app.core.events import AssumptionChanged
+    original_publish = event_bus.publish
+
+    events_published = []
+
+    def capture_publish(event):
+        events_published.append(event)
+        original_publish(event)
+
+    with patch.object(event_bus, "publish", side_effect=capture_publish):
+        with patch("app.services.assumption_compute_service._load_aircraft_as_asb") as mock_load:
+            airplane = MagicMock()
+            airplane.wings = [MagicMock()]
+            airplane.wings[0].mean_aerodynamic_chord.return_value = 0.2
+            mock_load.return_value = (airplane, MagicMock(id=42, uuid="test"))
+
+            with (
+                patch("app.services.assumption_compute_service._load_flight_profile_speeds", return_value=(18.0, 28.0)),
+                patch("app.services.assumption_compute_service._load_or_create_config") as mc,
+                patch("app.services.assumption_compute_service._run_coarse_sweep", return_value={"cd0": 0.02, "x_np": 0.085, "stall_alpha_deg": 14.0}),
+                patch("app.services.assumption_compute_service._run_fine_sweep", return_value=1.35),
+                patch("app.services.assumption_compute_service._load_effective_assumption", return_value=0.12),
+                patch("app.services.assumption_compute_service._get_current_calculated_value", return_value=None),
+                patch("app.services.assumption_compute_service._load_cg_agg", return_value=0.09),
+                patch("app.services.assumption_compute_service.update_calculated_value"),
+                patch("app.services.assumption_compute_service._cache_context"),
+            ):
+                mc.return_value = MagicMock(
+                    coarse_alpha_min_deg=-5, coarse_alpha_max_deg=25,
+                    coarse_alpha_step_deg=1, fine_alpha_margin_deg=5,
+                    fine_alpha_step_deg=0.5, fine_velocity_count=8,
+                )
+
+                from app.services.assumption_compute_service import recompute_assumptions
+                recompute_assumptions(MagicMock(), "test-uuid")
+
+    assumption_events = [e for e in events_published if isinstance(e, AssumptionChanged)]
+    assert len(assumption_events) == 1
+    assert assumption_events[0].parameter_name == "cg_x"
+```
+
+- [ ] **Step 2: Run integration test**
+
+Run: `poetry run pytest app/tests/test_assumption_compute_integration.py -v`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/tests/test_assumption_compute_integration.py
+git commit -m "test(gh-465): add integration tests for assumption recompute pipeline"
+```
+
+---
+
+### Task 12: Browser Verification
+
+- [ ] **Step 1: Start backend**
+
+Run: `poetry run uvicorn app.main:app --host 0.0.0.0 --port 8001 --reload`
+
+- [ ] **Step 2: Start frontend**
+
+Run: `cd frontend && npm run dev`
+
+- [ ] **Step 3: Verify in browser**
+
+1. Open the Analysis tab with an existing aircraft that has wings
+2. Check the Info Chip Row — should show dynamic values (or "–" if never computed)
+3. Go to Assumptions tab — values should have `calculated_value` populated
+4. Modify a wing (e.g. change span) — after ~2s, assumptions should recompute
+5. Check that OPs become DIRTY after CG changes
+6. Delete all wings — computation tabs should show "Add a wing" message
+7. Assumptions tab should still be accessible
+
+- [ ] **Step 4: Run full test suites**
+
+```bash
+poetry run pytest -m "not slow"
+cd frontend && npm run test:unit
+```
+
+- [ ] **Step 5: Commit any fixes from browser testing**
+
+---
+
+## File Summary
+
+### New Files
+| File | Purpose |
+|------|---------|
+| `app/models/computation_config.py` | SQLAlchemy model + defaults dict |
+| `app/schemas/computation_config.py` | Pydantic read/write schemas |
+| `app/services/assumption_compute_service.py` | Core recompute pipeline |
+| `frontend/hooks/useComputationContext.ts` | SWR hook for context endpoint |
+| `frontend/components/workbench/InfoChipRow.tsx` | Dynamic info chip component |
+
+### Modified Files
+| File | Change |
+|------|--------|
+| `app/models/aeroplanemodel.py` | Add `assumption_computation_context` column + `computation_config` relationship |
+| `app/services/design_assumptions_service.py` | `auto_switch_source` param + seed computation config |
+| `app/services/invalidation_service.py` | New GeometryChanged handler for recompute |
+| `app/core/background_jobs.py` | `schedule_recompute_assumptions` + debounce |
+| `app/main.py` | Wire recompute function to job tracker |
+| `app/api/v2/endpoints/aeroplane/design_assumptions.py` | 3 new endpoints |
+| `frontend/components/workbench/AnalysisViewerPanel.tsx` | Wing gate + InfoChipRow integration |

--- a/docs/superpowers/specs/2026-05-10-auto-compute-assumptions-design.md
+++ b/docs/superpowers/specs/2026-05-10-auto-compute-assumptions-design.md
@@ -1,0 +1,227 @@
+# Auto-Compute Design Assumptions (CL_max, CD0, CG)
+
+**Issue:** #465
+**Date:** 2026-05-10
+**Status:** Approved
+
+## Problem
+
+Design assumptions `cl_max`, `cd0`, and `cg_x` are manual inputs that most users cannot estimate. They should be auto-computed from aircraft geometry using AeroSandbox whenever the geometry changes.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Aero solver | AeroSandbox only, never AVL | ASB is the foundation of the app — designed for speed and optimizer loops |
+| CL_max method | Two-phase AeroBuildup sweep: coarse alpha-only to find stall region, then fine alpha × velocity sweep around stall | ASB handles AR, taper, sweep, Re internally; velocity sweep captures Re effects across flight envelope |
+| CG semantics | CG_aero (from NP + static margin) is the design target; CG_agg (from weight items) is shown for comparison only | Standard aircraft design process — ballast trims CG_agg to match CG_aero |
+| CG_agg storage | Not in Assumption system; queried live from weight items | CG_agg is a verification metric, not a design input |
+| Trigger | GeometryChanged → job tracker (debounced, configurable) → async recompute | Non-blocking, uses existing infrastructure, values ready for retrim chain |
+| Auto-switch source | On first computed value: auto-switch to CALCULATED; after that, respect user choice | Hobbyists get good defaults; pros keep manual control |
+| UI changes | Minimal — use existing badge/divergence system; dynamic Info Chip Row | No structural AssumptionsPanel changes needed |
+| Analysis tab gating | Computation tabs show empty state without wings; Assumptions tab always accessible | Design choices belong to early design phase |
+
+## Architecture
+
+### Computation Pipeline
+
+```
+GeometryChanged event (any wing/fuselage change)
+  → invalidation_service: schedule_recompute_assumptions(aeroplane_id)
+    → job_tracker debounce (config.debounce_seconds, default 2s)
+      → assumption_compute_service.recompute_assumptions(db, aeroplane_uuid)
+         1. Load aircraft → convert to ASB Airplane
+         2. Load flight profile (or default) → cruise_speed, V_max (max_level_speed_mps)
+         3. Compute MAC from ASB geometry
+         4. Load aircraft_computation_config (or seed defaults)
+         5. Two-phase AeroBuildup sweep:
+            Phase 1 — coarse alpha sweep at cruise speed (config: alpha_min to alpha_max, coarse_step):
+              - Find approximate stall alpha (alpha where CL peaks)
+              - CD0 = CD at the alpha where CL is closest to 0
+              - x_np from run_with_stability_derivatives()
+            Phase 2 — fine alpha × velocity sweep around stall region:
+              - Alpha: stall_alpha ± config.fine_alpha_margin, config.fine_step
+              - Velocity: from ~1.0× stall speed to V_max from flight profile
+                (config.fine_velocity_count evenly spaced speeds)
+              - CL_max = max(CL) across all (alpha, velocity) combinations
+              - This captures Re-dependent stall behavior at RC/UAV scales
+         6. Load target_static_margin from assumptions (effective value)
+         7. cg_x = x_np - target_static_margin × MAC
+         8. update_calculated_value("cl_max", CL_max, "aerobuildup", auto_switch=True)
+            update_calculated_value("cd0", CD0, "aerobuildup", auto_switch=True)
+            update_calculated_value("cg_x", cg_x, "aerobuildup", auto_switch=True)
+         9. Cache computation context on aeroplane model
+        10. If cg_x changed: publish AssumptionChanged event directly from recompute service
+            (update_calculated_value does NOT publish events by design — the recompute
+            service takes responsibility for triggering the retrim chain)
+```
+
+### Event Chain
+
+```
+GeometryChanged
+  → recompute_assumptions (debounced, config.debounce_seconds)
+    → update_calculated_value × 3
+    → AssumptionChanged (for cg_x, if changed)
+      → schedule_retrim (existing)
+        → OPs recomputed with new CG
+```
+
+### Data Model
+
+**No schema changes required for assumptions.** The existing `DesignAssumptionModel` already supports:
+- `calculated_value` / `calculated_source` — populated with ASB results
+- `active_source` — auto-switch logic added in service
+- `divergence_pct` / `divergence_level` — computed automatically
+
+**New table: `aircraft_computation_config`** — per-aircraft configuration for sweep parameters and other computation settings. No magic numbers in code — all sweep resolutions come from this table with sensible defaults.
+
+| Column | Type | Default | Description |
+|--------|------|---------|-------------|
+| id | int PK | | |
+| aeroplane_id | int FK | | unique, cascade delete |
+| coarse_alpha_min_deg | float | -5.0 | Coarse sweep start |
+| coarse_alpha_max_deg | float | 25.0 | Coarse sweep end |
+| coarse_alpha_step_deg | float | 1.0 | Coarse sweep resolution |
+| fine_alpha_margin_deg | float | 5.0 | Margin around stall alpha for fine sweep |
+| fine_alpha_step_deg | float | 0.5 | Fine sweep resolution |
+| fine_velocity_count | int | 8 | Number of velocity steps in fine sweep |
+| debounce_seconds | float | 2.0 | Debounce delay after GeometryChanged |
+
+Seeded with defaults when assumptions are seeded. Later exposed via the gear icon in the Analysis tab header (out of scope for this feature — just the data model and API).
+
+**New field on AeroplaneModel:** `assumption_computation_context: JSON | None` — caches the intermediate values from the last recompute for the Info Chip Row.
+
+Structure:
+```json
+{
+  "v_cruise_mps": 18.0,
+  "reynolds": 230000,
+  "mac_m": 0.21,
+  "x_np_m": 0.085,
+  "target_static_margin": 0.12,
+  "cg_agg_m": 0.092,
+  "computed_at": "2026-05-10T14:30:00Z"
+}
+```
+
+Requires an Alembic migration to add the column.
+
+## Backend Changes
+
+### New Files
+
+**`app/services/assumption_compute_service.py`**
+
+Single public function:
+- `recompute_assumptions(db: Session, aeroplane_uuid: str) -> None`
+  - Orchestrates the full pipeline (load → ASB → compute → store → event)
+  - Handles missing wings gracefully (skips computation, logs warning)
+  - Handles missing flight profile (uses default: 18 m/s cruise)
+
+### Modified Files
+
+**`app/services/invalidation_service.py`**
+- Add `_on_geometry_changed_recompute_assumptions` handler
+- Register via `register_handlers()`
+- Uses `job_tracker.schedule_recompute_assumptions(aeroplane_id)` (debounced)
+
+**`app/services/design_assumptions_service.py`**
+- Modify `update_calculated_value()`: add `auto_switch_source` parameter (default False)
+  - When True and current `calculated_value` is None and `active_source` is "ESTIMATE": switch to "CALCULATED"
+  - Respects `DESIGN_CHOICE_PARAMS` — never auto-switches those
+  - `update_calculated_value()` remains event-silent by design — the calling service (recompute) publishes events when needed
+
+**`app/models/aeroplanemodel.py`**
+- Add `assumption_computation_context: Column(JSON, nullable=True)` to `AeroplaneModel`
+- Add `AircraftComputationConfigModel` (new table `aircraft_computation_config`)
+
+**`app/schemas/computation_config.py`** (new)
+- `ComputationConfigRead` / `ComputationConfigWrite` — Pydantic schemas for the config table
+
+**`alembic/versions/`**
+- New migration: add `assumption_computation_context` column + `aircraft_computation_config` table
+
+**`app/services/design_assumptions_service.py`** (seed_defaults)
+- Extend `seed_defaults()` to also seed `aircraft_computation_config` with defaults (idempotent)
+
+**`app/api/v2/endpoints/aeroplane/design_assumptions.py`**
+- New endpoint: `GET /aeroplanes/{id}/assumptions/computation-context`
+  - Returns the cached computation context JSON
+  - 200 with data or 200 with null (never computed yet)
+- New endpoint: `GET /aeroplanes/{id}/computation-config`
+  - Returns current computation config (or defaults if not yet seeded)
+- New endpoint: `PUT /aeroplanes/{id}/computation-config`
+  - Updates computation config (for future gear icon UI)
+
+### Existing CD0 Auto-Population
+
+`stability_service._auto_populate_cd0()` already writes CD0 after AeroBuildup runs. This remains — if a user manually runs a stability analysis, that CD0 also feeds into `calculated_value`. The `recompute_assumptions` pipeline does the same but triggered by geometry changes. Last writer wins, both use source `"aerobuildup"`.
+
+## Frontend Changes
+
+### Info Chip Row (`AnalysisViewerPanel.tsx`)
+
+Replace hardcoded chips with dynamic values from computation context:
+
+| Chip | Source | Example |
+|------|--------|---------|
+| V_cruise | `v_cruise_mps` | `V = 18.0 m/s` |
+| Re | `reynolds` | `Re ≈ 2.3e5` |
+| MAC | `mac_m` | `MAC = 0.21 m` |
+| NP | `x_np_m` | `NP = 0.085 m` |
+| SM | `target_static_margin` | `SM = 12%` |
+| CG | `cg_x` + `cg_agg_m` in parentheses | `CG = 0.073 m (0.092)` |
+
+**CG chip detail:** The main value is CG_aero (cg_x from assumptions). CG_agg is shown in parentheses with color coding:
+- Green: CG_agg is close to CG_aero (delta < 5% MAC) — well balanced
+- Orange: moderate offset (5–15% MAC) — needs ballast adjustment
+- Red: large offset (> 15% MAC) — significantly nose- or tail-heavy
+
+The direction (nose-heavy vs tail-heavy) is implicit: CG_agg > CG_aero = nose-heavy, CG_agg < CG_aero = tail-heavy (assuming x-axis points aft).
+
+New hook: `useComputationContext(aeroplaneId)` → `GET /aeroplanes/{id}/assumptions/computation-context`. When no context exists, chips show "–".
+
+### AssumptionsPanel
+
+Minimal change: for `cg_x`, show CG_agg comparison value from the computation context (small inline chip below the assumption row). No structural changes.
+
+### Analysis Tab Wing Gate
+
+In `AnalysisViewerPanel.tsx`, for each computation tab (Polar, Trefftz, Streamlines, Stability, Envelope, Operating Points): if `wings.length === 0`, render empty state "Add a wing to enable aerodynamic analysis" instead of tab content. Assumptions tab always renders normally.
+
+Check via existing `wingXSecs` prop (already passed) or a new `hasWings: boolean` prop.
+
+### No Polling Needed
+
+SWR revalidates on focus/navigation. The recompute takes ~2s and runs in the background. By the time the user navigates to Assumptions, values are ready.
+
+## Testing
+
+### Backend
+
+| Test | Type | What |
+|------|------|------|
+| `test_recompute_assumptions_basic` | unit | Mock ASB, verify all 3 values written + context cached |
+| `test_recompute_assumptions_no_wings` | unit | Graceful skip when no wings exist |
+| `test_recompute_assumptions_auto_switch` | unit | First compute auto-switches to CALCULATED |
+| `test_recompute_assumptions_respects_user_choice` | unit | After user switches to ESTIMATE, recompute doesn't override |
+| `test_geometry_changed_triggers_recompute` | integration | Event → job scheduled → assumptions updated |
+| `test_cg_change_triggers_retrim` | integration | cg_x update → AssumptionChanged → OPs dirty |
+| `test_computation_context_endpoint` | unit | GET returns cached context |
+
+### Frontend
+
+| Test | Type | What |
+|------|------|------|
+| Info Chip Row renders context values | vitest | Chips show dynamic values from hook |
+| Info Chip Row handles null context | vitest | Chips show "–" when no context |
+| Tabs show wing gate | vitest | Empty state when no wings |
+| Assumptions tab accessible without wings | vitest | Always renders |
+
+## Out of Scope
+
+- WebSocket/polling for real-time updates (SWR revalidation is enough)
+- AssumptionsPanel structural redesign (existing badge system works)
+- AVL-based computation (ASB only, per project philosophy)
+- Gear icon UI for editing computation config (data model and API only in this feature)

--- a/docs/superpowers/specs/2026-05-10-auto-compute-assumptions-design.md
+++ b/docs/superpowers/specs/2026-05-10-auto-compute-assumptions-design.md
@@ -29,31 +29,45 @@ Design assumptions `cl_max`, `cd0`, and `cg_x` are manual inputs that most users
 GeometryChanged event (any wing/fuselage change)
   → invalidation_service: schedule_recompute_assumptions(aeroplane_id)
     → job_tracker debounce (config.debounce_seconds, default 2s)
-      → assumption_compute_service.recompute_assumptions(db, aeroplane_uuid)
-         1. Load aircraft → convert to ASB Airplane
-         2. Load flight profile (or default) → cruise_speed, V_max (max_level_speed_mps)
-         3. Compute MAC from ASB geometry
-         4. Load aircraft_computation_config (or seed defaults)
-         5. Two-phase AeroBuildup sweep:
-            Phase 1 — coarse alpha sweep at cruise speed (config: alpha_min to alpha_max, coarse_step):
-              - Find approximate stall alpha (alpha where CL peaks)
-              - CD0 = CD at the alpha where CL is closest to 0
-              - x_np from run_with_stability_derivatives()
-            Phase 2 — fine alpha × velocity sweep around stall region:
-              - Alpha: stall_alpha ± config.fine_alpha_margin, config.fine_step
-              - Velocity: from ~1.0× stall speed to V_max from flight profile
-                (config.fine_velocity_count evenly spaced speeds)
+      → asyncio.to_thread(recompute_assumptions, db, aeroplane_uuid)
+         (run in worker thread — ASB calls are CPU-bound and would
+          otherwise block the FastAPI event loop)
+         1. Load aircraft via _get_aeroplane (existing helper) → convert
+            to ASB Airplane
+         2. Load aircraft_computation_config (or create with defaults)
+         3. Load flight profile (or default) → cruise_speed, V_max
+         4. Stability run at cruise / alpha=0 via app.api.utils.analyse_aerodynamics
+            (AnalysisToolUrlType.AEROBUILDUP) → AnalysisModel
+              - x_np = _scalar(result.reference.Xnp)
+              - MAC = _scalar(result.reference.Cref)  (NOT wings[0])
+              - CD0 = _scalar(result.coefficients.CD) at alpha=0
+            (Pass xyz_ref via OperatingPointSchema. analyse_aerodynamics
+             handles the AeroBuildup → AnalysisModel conversion that
+             stability_service already relies on.)
+         5. Coarse alpha sweep at cruise speed via raw asb.AeroBuildup(...).run():
+              - alphas: coarse_alpha_min..max, coarse_alpha_step
+              - find stall_alpha (alpha where CL peaks)
+         6. Fine alpha × velocity sweep around stall region:
+              - alphas: stall_alpha ± fine_alpha_margin, fine_alpha_step
+              - velocities: stall_speed_approx..V_max, fine_velocity_count
               - CL_max = max(CL) across all (alpha, velocity) combinations
-              - This captures Re-dependent stall behavior at RC/UAV scales
-         6. Load target_static_margin from assumptions (effective value)
-         7. cg_x = x_np - target_static_margin × MAC
-         8. update_calculated_value("cl_max", CL_max, "aerobuildup", auto_switch=True)
-            update_calculated_value("cd0", CD0, "aerobuildup", auto_switch=True)
-            update_calculated_value("cg_x", cg_x, "aerobuildup", auto_switch=True)
-         9. Cache computation context on aeroplane model
-        10. If cg_x changed: publish AssumptionChanged event directly from recompute service
-            (update_calculated_value does NOT publish events by design — the recompute
-            service takes responsibility for triggering the retrim chain)
+              - captures Re-dependent stall behavior at RC/UAV scales
+         7. Load target_static_margin from assumptions (effective value)
+         8. cg_x = x_np - target_static_margin × MAC
+         9. update_calculated_value("cl_max", ..., auto_switch_source=True)
+            update_calculated_value("cd0",    ..., auto_switch_source=True)
+            update_calculated_value("cg_x",   ..., auto_switch_source=True)
+        10. Cache computation context on aeroplane model
+        11. If cg_x changed:
+              - call mark_ops_dirty(db, aeroplane_id) in the same
+                transaction (mirrors update_assumption — without this,
+                retrim_dirty_ops finds no DIRTY ops and is a no-op)
+              - publish AssumptionChanged event directly from recompute
+                service (update_calculated_value does NOT publish events
+                by design — the recompute service takes responsibility
+                for triggering the retrim chain). Only cg_x triggers
+                retrim; see Limitations below for the cd0/cl_max
+                trade-off.
 ```
 
 ### Event Chain
@@ -218,6 +232,50 @@ SWR revalidates on focus/navigation. The recompute takes ~2s and runs in the bac
 | Info Chip Row handles null context | vitest | Chips show "–" when no context |
 | Tabs show wing gate | vitest | Empty state when no wings |
 | Assumptions tab accessible without wings | vitest | Always renders |
+
+## Limitations & Trade-offs
+
+### CL_max accuracy
+
+`AeroBuildup` is an analytical model that estimates 2D airfoil
+characteristics — including stall — via curve-fitted models against
+Airfoil Tools / XFoil databases. Accuracy depends on:
+
+- **Airfoil database coverage:** Common airfoils (NACA 4-digit, Clark Y,
+  Eppler, Selig RC series) are well-covered. Custom or unusual profiles
+  fall back to thin-airfoil approximations and the CL_max estimate
+  becomes unreliable.
+- **Reynolds number:** At very low Re (< 50,000) the curve fits become
+  noisy. Most RC airfoils are usable above this threshold.
+- **3D effects:** AR, taper, sweep are handled by ASB internally, but
+  effects from twist distribution, separation bubbles, and tip vortices
+  are approximate.
+
+For these reasons CL_max from auto-compute is a **starting estimate**.
+Users with measured wind-tunnel or simulation data should switch the
+assumption back to ESTIMATE and enter their own value.
+
+### Retrim trigger scope
+
+Only `cg_x` changes trigger the retrim chain. `cd0` and `cl_max` updates
+populate `calculated_value` but do **not** mark OPs dirty. Rationale:
+
+- `cd0` affects trim drag and throttle but the elevator deflection and
+  alpha solution remain stable for small CD0 deltas. Recomputing every
+  trim on each geometry change would be costly for a marginal gain.
+- `cl_max` is only used for stall checks / envelope computations, not
+  for the trim solution itself.
+
+If a future use case demands cd0-driven retrim, the existing
+`_OP_AFFECTING_PARAMS` set in `invalidation_service` is the single point
+of extension.
+
+### Event-loop blocking
+
+`recompute_assumptions` is a sync function that does ~200 ASB calls per
+run (worst case). It MUST be invoked via `asyncio.to_thread()` so the
+FastAPI event loop stays responsive. The existing `retrim_dirty_ops`
+follows the same constraint; the recompute wrapper applies it explicitly.
 
 ## Out of Scope
 

--- a/frontend/__tests__/AnalysisWingGate.test.tsx
+++ b/frontend/__tests__/AnalysisWingGate.test.tsx
@@ -12,6 +12,10 @@ vi.mock("lucide-react", () => {
     Ruler: icon,
     Target: icon,
     Navigation: icon,
+    Gauge: icon,
+    AlertTriangle: icon,
+    SlidersHorizontal: icon,
+    Activity: icon,
   };
 });
 

--- a/frontend/__tests__/AnalysisWingGate.test.tsx
+++ b/frontend/__tests__/AnalysisWingGate.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) => React.createElement("span", props);
+  return {
+    Maximize2: icon,
+    Minimize2: icon,
+    Settings: icon,
+    Wind: icon,
+    Ruler: icon,
+    Target: icon,
+    Navigation: icon,
+  };
+});
+
+vi.mock("@/hooks/useComputationContext", () => ({
+  useComputationContext: () => ({ data: null, isLoading: false }),
+}));
+
+vi.mock("@/hooks/useDesignAssumptions", () => ({
+  useDesignAssumptions: () => ({ data: null, isLoading: false }),
+}));
+
+describe("Analysis Tab Wing Gate", () => {
+  it("shows empty state for Polar tab when hasWings is false", async () => {
+    const mod = await import("@/components/workbench/AnalysisViewerPanel");
+    const Panel = mod.AnalysisViewerPanel;
+
+    render(
+      <Panel
+        result={null}
+        activeTab="Polar"
+        onTabChange={() => {}}
+        hasWings={false}
+        wingXSecs={null}
+      />,
+    );
+
+    expect(screen.getByText(/add a wing/i)).toBeInTheDocument();
+  });
+
+  it("shows Assumptions tab content even when hasWings is false", async () => {
+    const mod = await import("@/components/workbench/AnalysisViewerPanel");
+    const Panel = mod.AnalysisViewerPanel;
+
+    render(
+      <Panel
+        result={null}
+        activeTab="Assumptions"
+        onTabChange={() => {}}
+        hasWings={false}
+        wingXSecs={null}
+      />,
+    );
+
+    expect(screen.queryByText(/add a wing/i)).not.toBeInTheDocument();
+  });
+
+  it("shows Polar content when hasWings is true", async () => {
+    const mod = await import("@/components/workbench/AnalysisViewerPanel");
+    const Panel = mod.AnalysisViewerPanel;
+
+    render(
+      <Panel
+        result={null}
+        activeTab="Polar"
+        onTabChange={() => {}}
+        hasWings={true}
+        wingXSecs={null}
+      />,
+    );
+
+    expect(screen.queryByText(/add a wing/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/InfoChipRow.test.tsx
+++ b/frontend/__tests__/InfoChipRow.test.tsx
@@ -4,7 +4,17 @@ import React from "react";
 
 vi.mock("lucide-react", () => {
   const icon = (props: Record<string, unknown>) => React.createElement("span", props);
-  return { Wind: icon, SlidersHorizontal: icon, Activity: icon, Ruler: icon, Target: icon, Navigation: icon, Settings: icon };
+  return {
+    Wind: icon,
+    SlidersHorizontal: icon,
+    Activity: icon,
+    Ruler: icon,
+    Target: icon,
+    Navigation: icon,
+    Settings: icon,
+    Gauge: icon,
+    AlertTriangle: icon,
+  };
 });
 
 vi.mock("@/hooks/useComputationContext", () => ({

--- a/frontend/__tests__/InfoChipRow.test.tsx
+++ b/frontend/__tests__/InfoChipRow.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) => React.createElement("span", props);
+  return { Wind: icon, SlidersHorizontal: icon, Activity: icon, Ruler: icon, Target: icon, Navigation: icon, Settings: icon };
+});
+
+vi.mock("@/hooks/useComputationContext", () => ({
+  useComputationContext: vi.fn(),
+}));
+
+import { useComputationContext } from "@/hooks/useComputationContext";
+
+describe("Info Chip Row", () => {
+  it("shows dynamic values when context is available", async () => {
+    (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        v_cruise_mps: 18.0,
+        reynolds: 230000,
+        mac_m: 0.21,
+        x_np_m: 0.085,
+        target_static_margin: 0.12,
+        cg_agg_m: 0.092,
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
+    render(<InfoChipRow aeroplaneId="42" cgAero={0.073} />);
+
+    expect(screen.getByText(/18\.0 m\/s/)).toBeInTheDocument();
+    expect(screen.getByText(/2\.3e\+?5/i)).toBeInTheDocument();
+    expect(screen.getByText(/0\.21 m/)).toBeInTheDocument();
+    expect(screen.getByText(/0\.085 m/)).toBeInTheDocument();
+  });
+
+  it("shows dashes when no context", async () => {
+    (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: null,
+    });
+
+    const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
+    render(<InfoChipRow aeroplaneId="42" cgAero={null} />);
+
+    const dashes = screen.getAllByText("–");
+    expect(dashes.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/frontend/__tests__/StabilityTab.test.tsx
+++ b/frontend/__tests__/StabilityTab.test.tsx
@@ -6,10 +6,10 @@ describe("AnalysisViewerPanel TABS", () => {
     expect(TABS).toContain("Stability");
   });
 
-  it("includes Stability before Operating Points", () => {
-    const stabilityIdx = TABS.indexOf("Stability");
+  it("places Operating Points right after Assumptions", () => {
+    const assumptionsIdx = TABS.indexOf("Assumptions");
     const opsIdx = TABS.indexOf("Operating Points");
-    expect(stabilityIdx).toBeGreaterThan(-1);
-    expect(opsIdx).toBeGreaterThan(stabilityIdx);
+    expect(assumptionsIdx).toBe(0);
+    expect(opsIdx).toBe(assumptionsIdx + 1);
   });
 });

--- a/frontend/__tests__/operating-points.test.tsx
+++ b/frontend/__tests__/operating-points.test.tsx
@@ -117,7 +117,7 @@ describe("useOperatingPoints", () => {
       expect.objectContaining({ method: "POST" }),
     );
     const body = JSON.parse(mockFetch.mock.calls[1][1].body);
-    expect(body).toEqual({ replace_existing: false });
+    expect(body).toEqual({ replace_existing: true });
 
     expect(result.current.points).toEqual(fakePoints);
     expect(result.current.isGenerating).toBe(false);
@@ -367,6 +367,7 @@ vi.mock("lucide-react", () => {
     Plus: icon,
     X: icon,
     Loader2: icon,
+    Info: icon,
     AlertTriangle: icon,
     Check: icon,
     RefreshCw: icon,

--- a/frontend/__tests__/useComputationContext.test.ts
+++ b/frontend/__tests__/useComputationContext.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useComputationContext } from "@/hooks/useComputationContext";
+
+describe("useComputationContext", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches computation context for an aeroplane", async () => {
+    const fakeContext = {
+      v_cruise_mps: 18.0,
+      reynolds: 230000,
+      mac_m: 0.21,
+      x_np_m: 0.085,
+      target_static_margin: 0.12,
+      cg_agg_m: 0.092,
+      computed_at: "2026-05-10T14:30:00Z",
+    };
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(fakeContext),
+    });
+
+    const { result } = renderHook(() => useComputationContext("42"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual(fakeContext);
+    const url = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(url.toString()).toContain("/assumptions/computation-context");
+  });
+
+  it("returns null when aeroplaneId is null", () => {
+    const { result } = renderHook(() => useComputationContext(null));
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/frontend/__tests__/useStability.test.ts
+++ b/frontend/__tests__/useStability.test.ts
@@ -68,17 +68,35 @@ describe("useStability", () => {
     expect(result.current.error).toContain("500");
   });
 
-  it("compute() POSTs to stability_summary and refreshes cached data", async () => {
+  it("compute() POSTs to stability_summary with design CG and refreshes cached data", async () => {
     const mockFetch = vi.fn()
+      // 1. initial refresh on mount → /stability (no cached data yet)
       .mockResolvedValueOnce({ ok: false, status: 404, text: () => Promise.resolve("Not found") })
+      // 2. compute → GET /assumptions to find effective cg_x
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({
+          assumptions: [{ parameter_name: "cg_x", effective_value: 0.073 }],
+        }),
+      })
+      // 3. compute → POST /stability_summary/avl
       .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(FAKE_STABILITY) })
+      // 4. refresh after compute → GET /stability
       .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(FAKE_STABILITY) });
     globalThis.fetch = mockFetch;
     const { result } = renderHook(() => useStability("42"));
     await waitFor(() => { expect(result.current.isLoading).toBe(false); });
     await act(async () => { await result.current.compute(); });
-    expect(mockFetch.mock.calls[1][0]).toContain("/aeroplanes/42/stability_summary/avl");
-    expect(mockFetch.mock.calls[1][1]).toEqual(expect.objectContaining({ method: "POST" }));
+
+    const stabPostCall = mockFetch.mock.calls.find(
+      (c: [string, { method?: string }]) =>
+        typeof c[0] === "string" && c[0].includes("/stability_summary/avl"),
+    );
+    expect(stabPostCall).toBeTruthy();
+    expect(stabPostCall![1]).toEqual(expect.objectContaining({ method: "POST" }));
+    const body = JSON.parse(String(stabPostCall![1].body));
+    expect(body.xyz_ref).toEqual([0.073, 0, 0]);
     expect(result.current.data).toEqual(FAKE_STABILITY);
     expect(result.current.isComputing).toBe(false);
   });

--- a/frontend/__tests__/useStability.test.ts
+++ b/frontend/__tests__/useStability.test.ts
@@ -80,7 +80,7 @@ describe("useStability", () => {
           assumptions: [{ parameter_name: "cg_x", effective_value: 0.073 }],
         }),
       })
-      // 3. compute → POST /stability_summary/avl
+      // 3. compute → POST /stability_summary/aerobuildup
       .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(FAKE_STABILITY) })
       // 4. refresh after compute → GET /stability
       .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(FAKE_STABILITY) });
@@ -91,7 +91,7 @@ describe("useStability", () => {
 
     const stabPostCall = mockFetch.mock.calls.find(
       (c: [string, { method?: string }]) =>
-        typeof c[0] === "string" && c[0].includes("/stability_summary/avl"),
+        typeof c[0] === "string" && c[0].includes("/stability_summary/aerobuildup"),
     );
     expect(stabPostCall).toBeTruthy();
     expect(stabPostCall![1]).toEqual(expect.objectContaining({ method: "POST" }));

--- a/frontend/__tests__/useStreamlines.test.ts
+++ b/frontend/__tests__/useStreamlines.test.ts
@@ -102,6 +102,7 @@ describe("useStreamlines", () => {
       alpha: 10,
       beta: 2,
       altitude: 500,
+      xyz_ref: [0, 0, 0],
     });
   });
 

--- a/frontend/app/workbench/analysis/page.tsx
+++ b/frontend/app/workbench/analysis/page.tsx
@@ -181,6 +181,11 @@ export default function AnalysisPage() {
               }}
               streamlinesRunning={streamlines.isComputing}
               streamlinesError={streamlines.error}
+              designCgX={
+                assumptions.data?.assumptions.find(
+                  (a) => a.parameter_name === "cg_x",
+                )?.effective_value ?? null
+              }
               onClose={() => setConfigOpen(false)}
             />
           </div>

--- a/frontend/app/workbench/analysis/page.tsx
+++ b/frontend/app/workbench/analysis/page.tsx
@@ -59,7 +59,7 @@ export default function AnalysisPage() {
 
   const [configOpen, setConfigOpen] = useState(false);
   const [avlEditorOpen, setAvlEditorOpen] = useState(false);
-  const [activeTab, setActiveTab] = useState<Tab>("Polar");
+  const [activeTab, setActiveTab] = useState<Tab>("Assumptions");
   const { dialogRef, handleClose: dialogHandleClose } = useDialog(configOpen, () => setConfigOpen(false));
 
   const showAvlGeometryButton = activeTab === "Trefftz Plane" || activeTab === "Streamlines";

--- a/frontend/app/workbench/analysis/page.tsx
+++ b/frontend/app/workbench/analysis/page.tsx
@@ -36,6 +36,7 @@ export default function AnalysisPage() {
     return massAssumption?.effective_value ?? null;
   }, [assumptions.data]);
   const { wingNames } = useWings(aeroplaneId);
+  const hasWings = wingNames.length > 0;
   const { wings: allWings } = useAllWingData(aeroplaneId, wingNames);
   const { wing } = useWing(aeroplaneId, selectedWing ?? wingNames[0] ?? null);
   const controlSurfaces = useMemo(
@@ -94,6 +95,7 @@ export default function AnalysisPage() {
           <AnalysisViewerPanel
             result={analysis.result}
             aeroplaneId={aeroplaneId}
+            hasWings={hasWings}
             lastRunTime={analysis.lastRunTime}
             lastRunDurationMs={analysis.lastRunDurationMs}
             stripForces={stripForces.result}

--- a/frontend/app/workbench/analysis/page.tsx
+++ b/frontend/app/workbench/analysis/page.tsx
@@ -141,6 +141,9 @@ export default function AnalysisPage() {
             onTrimWithAerobuildup={ops.trimWithAerobuildup}
             controlSurfaces={controlSurfaces}
             onUpdateDeflections={ops.updateDeflections}
+            onDeleteOp={ops.deleteOp}
+            onDeleteAllOps={ops.deleteAll}
+            onCreateOp={ops.createOp}
             analysisStatus={analysisStatus.status}
           />
         </div>

--- a/frontend/components/workbench/AnalysisConfigPanel.tsx
+++ b/frontend/components/workbench/AnalysisConfigPanel.tsx
@@ -23,6 +23,10 @@ interface AnalysisConfigPanelProps {
   readonly onRunStreamlines?: (params: StreamlinesParams) => void;
   readonly streamlinesRunning?: boolean;
   readonly streamlinesError?: string | null;
+  // Default xyz_ref[0] for analysis runs — comes from the design CG
+  // (cg_x effective value from assumptions). Falls back to 0 when not
+  // available.
+  readonly designCgX?: number | null;
   // Modal close
   readonly onClose?: () => void;
 }
@@ -50,6 +54,7 @@ export function AnalysisConfigPanel({
   onRunStreamlines,
   streamlinesRunning,
   streamlinesError,
+  designCgX,
   onClose,
 }: Readonly<AnalysisConfigPanelProps>) {
   const [mode, setMode] = useState<Mode>("sweep");
@@ -63,7 +68,12 @@ export function AnalysisConfigPanel({
   const [altitude, setAltitude] = useState("100");
   const [beta, setBeta] = useState("0");
   const [analysisTool, setAnalysisTool] = useState("aero_buildup");
-  const [xyzRef, setXyzRef] = useState("0, 0, 0");
+  // xyzRef defaults to the design CG (cg_x effective from assumptions)
+  // — that is the moment-reference point the rest of the system uses.
+  // Falling back to "0, 0, 0" is just a placeholder until the prop arrives.
+  const [xyzRef, setXyzRef] = useState(
+    designCgX != null ? `${designCgX.toFixed(4)}, 0, 0` : "0, 0, 0",
+  );
 
   // Trefftz-specific state
   const [trefftzAlpha, setTrefftzAlpha] = useState("5");
@@ -111,6 +121,7 @@ export function AnalysisConfigPanel({
       alpha: Number.parseFloat(trefftzAlpha) || 5,
       beta: Number.parseFloat(beta) || 0,
       altitude: Number.parseFloat(altitude) || 100,
+      xyz_ref: parseXyzRef(),
     });
     onClose?.();
   };
@@ -123,7 +134,7 @@ export function AnalysisConfigPanel({
     setAltitude("100");
     setBeta("0");
     setAnalysisTool("aero_buildup");
-    setXyzRef("0, 0, 0");
+    setXyzRef(designCgX != null ? `${designCgX.toFixed(4)}, 0, 0` : "0, 0, 0");
     setTrefftzAlpha("5");
   };
 

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -16,7 +16,7 @@ import type { AnalysisStatus } from "@/hooks/useAnalysisStatus";
 import { useDesignAssumptions } from "@/hooks/useDesignAssumptions";
 import { useRecomputeStatus } from "@/hooks/useRecomputeStatus";
 
-const TABS = ["Assumptions", "Polar", "Trefftz Plane", "Streamlines", "Envelope", "Stability", "Operating Points"] as const;
+const TABS = ["Assumptions", "Operating Points", "Polar", "Trefftz Plane", "Streamlines", "Envelope", "Stability"] as const;
 export type Tab = (typeof TABS)[number];
 export { TABS };
 

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -26,7 +26,7 @@ interface WingXSec {
 
 interface Props {
   readonly result: AnalysisResult | null;
-  readonly aeroplaneId: string | null;
+  readonly aeroplaneId?: string | null;
   readonly lastRunTime?: Date | null;
   readonly lastRunDurationMs?: number | null;
   readonly stripForces?: StripForcesResult | null;
@@ -41,6 +41,7 @@ interface Props {
   readonly wingXSecs?: WingXSec[] | null;
   readonly wingSymmetric?: boolean;
   readonly assumptionsSlot?: React.ReactNode;
+  readonly hasWings?: boolean;
   readonly envelope?: FlightEnvelopeData | null;
   readonly isComputingEnvelope?: boolean;
   readonly envelopeError?: string | null;
@@ -552,6 +553,7 @@ export function AnalysisViewerPanel({
   wingXSecs,
   wingSymmetric,
   assumptionsSlot,
+  hasWings = true,
   envelope,
   isComputingEnvelope,
   envelopeError,
@@ -582,6 +584,16 @@ export function AnalysisViewerPanel({
   function toggleChart(id: string) {
     setMaximizedChart((prev) => (prev === id ? null : id));
   }
+
+  const COMPUTATION_TABS = new Set<Tab>([
+    "Polar",
+    "Trefftz Plane",
+    "Streamlines",
+    "Envelope",
+    "Stability",
+    "Operating Points",
+  ]);
+  const showWingGate = !hasWings && COMPUTATION_TABS.has(activeTab);
 
   const charts = useMemo(() => {
     if (!result?.CL || result.CL.length === 0) return null;
@@ -656,7 +668,15 @@ export function AnalysisViewerPanel({
         </div>
       )}
 
-      {activeTab === "Polar" && (
+      {showWingGate && (
+        <div className="flex flex-1 items-center justify-center bg-card-muted">
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-muted-foreground">
+            Add a wing to enable aerodynamic analysis
+          </span>
+        </div>
+      )}
+
+      {!showWingGate && activeTab === "Polar" && (
         <div className="flex flex-1 flex-col gap-4 overflow-auto bg-card-muted p-6">
           {charts ? (
             (() => {
@@ -764,7 +784,7 @@ export function AnalysisViewerPanel({
         </div>
       )}
 
-      {activeTab === "Trefftz Plane" && (
+      {!showWingGate && activeTab === "Trefftz Plane" && (
         <div className="flex flex-1 flex-col gap-4 overflow-auto bg-card-muted p-6">
           <TrefftzPlaneTabContent
             stripForcesLoading={stripForcesLoading}
@@ -775,7 +795,7 @@ export function AnalysisViewerPanel({
         </div>
       )}
 
-      {activeTab === "Streamlines" && (
+      {!showWingGate && activeTab === "Streamlines" && (
         <div className="flex flex-1 overflow-hidden bg-card-muted">
           <StreamlinesTabContent
             streamlinesLoading={streamlinesLoading}
@@ -784,7 +804,7 @@ export function AnalysisViewerPanel({
         </div>
       )}
 
-      {activeTab === "Envelope" && (
+      {!showWingGate && activeTab === "Envelope" && (
         <EnvelopePanel
           envelope={envelope ?? null}
           isComputing={isComputingEnvelope ?? false}
@@ -793,7 +813,7 @@ export function AnalysisViewerPanel({
         />
       )}
 
-      {activeTab === "Stability" && (
+      {!showWingGate && activeTab === "Stability" && (
         <StabilityPanel
           data={stability ?? null}
           isComputing={isComputingStability ?? false}
@@ -802,7 +822,7 @@ export function AnalysisViewerPanel({
         />
       )}
 
-      {activeTab === "Operating Points" && (
+      {!showWingGate && activeTab === "Operating Points" && (
         <OperatingPointsPanel
           points={operatingPoints ?? []}
           isLoading={isLoadingOps ?? false}

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -14,6 +14,7 @@ import { OperatingPointsPanel } from "@/components/workbench/OperatingPointsPane
 import { AnalysisStatusIndicator } from "./AnalysisStatusIndicator";
 import type { AnalysisStatus } from "@/hooks/useAnalysisStatus";
 import { useDesignAssumptions } from "@/hooks/useDesignAssumptions";
+import { useRecomputeStatus } from "@/hooks/useRecomputeStatus";
 
 const TABS = ["Assumptions", "Polar", "Trefftz Plane", "Streamlines", "Envelope", "Stability", "Operating Points"] as const;
 export type Tab = (typeof TABS)[number];
@@ -576,6 +577,7 @@ export function AnalysisViewerPanel({
 }: Readonly<Props>) {
   const [maximizedChart, setMaximizedChart] = useState<string | null>(null);
   const assumptions = useDesignAssumptions(aeroplaneId);
+  const recomputeStatus = useRecomputeStatus(aeroplaneId);
   const cgAero = useMemo(() => {
     const a = assumptions.data?.assumptions.find((x) => x.parameter_name === "cg_x");
     return a?.effective_value ?? null;
@@ -841,7 +843,7 @@ export function AnalysisViewerPanel({
       <InfoChipRow
         aeroplaneId={aeroplaneId}
         cgAero={cgAero}
-        isRecomputing={assumptions.isRecomputing}
+        isRecomputing={recomputeStatus.isRecomputing}
         rightSlot={
           <span className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
             {charts ? `${charts.alpha.length} points` : "No data"}

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useMemo, useRef, useEffect } from "react";
-import { Wind, SlidersHorizontal, Activity, Maximize2, Minimize2, Settings } from "lucide-react";
+import { Maximize2, Minimize2, Settings } from "lucide-react";
+import { InfoChipRow } from "@/components/workbench/InfoChipRow";
 import type { AnalysisResult } from "@/hooks/useAnalysis";
 import type { StripForcesResult } from "@/hooks/useStripForces";
 import type { FlightEnvelopeData } from "@/hooks/useFlightEnvelope";
@@ -12,6 +13,7 @@ import type { StoredOperatingPoint, AVLTrimResult, AeroBuildupTrimResult, TrimCo
 import { OperatingPointsPanel } from "@/components/workbench/OperatingPointsPanel";
 import { AnalysisStatusIndicator } from "./AnalysisStatusIndicator";
 import type { AnalysisStatus } from "@/hooks/useAnalysisStatus";
+import { useDesignAssumptions } from "@/hooks/useDesignAssumptions";
 
 const TABS = ["Assumptions", "Polar", "Trefftz Plane", "Streamlines", "Envelope", "Stability", "Operating Points"] as const;
 export type Tab = (typeof TABS)[number];
@@ -535,7 +537,7 @@ function StreamlinesTabContent({
 
 export function AnalysisViewerPanel({
   result,
-  // aeroplaneId reserved for future use
+  aeroplaneId,
   lastRunTime,
   lastRunDurationMs,
   stripForces,
@@ -571,6 +573,11 @@ export function AnalysisViewerPanel({
   analysisStatus,
 }: Readonly<Props>) {
   const [maximizedChart, setMaximizedChart] = useState<string | null>(null);
+  const assumptions = useDesignAssumptions(aeroplaneId);
+  const cgAero = useMemo(() => {
+    const a = assumptions.data?.assumptions.find((x) => x.parameter_name === "cg_x");
+    return a?.effective_value ?? null;
+  }, [assumptions.data]);
 
   function toggleChart(id: string) {
     setMaximizedChart((prev) => (prev === id ? null : id));
@@ -811,42 +818,27 @@ export function AnalysisViewerPanel({
       )}
 
       {/* Info Chip Row */}
-      <div className="flex items-center gap-2 border-t border-border bg-card px-4 py-3">
-        <div className="flex items-center gap-1.5 rounded-full bg-card-muted px-3 py-1.5">
-          <Wind size={12} className="text-muted-foreground" />
-          <span className="font-[family-name:var(--font-geist-sans)] text-[12px] text-foreground">
-            Flight profile: cruise
+      <InfoChipRow
+        aeroplaneId={aeroplaneId}
+        cgAero={cgAero}
+        rightSlot={
+          <span className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+            {charts ? `${charts.alpha.length} points` : "No data"}
+            {lastRunTime && lastRunDurationMs != null && (
+              <>
+                {" "}
+                {"\u00B7"} Last run:{" "}
+                {lastRunTime.toLocaleTimeString([], {
+                  hour: "2-digit",
+                  minute: "2-digit",
+                  hour12: false,
+                })}{" "}
+                {"\u00B7"} {lastRunDurationMs} ms
+              </>
+            )}
           </span>
-        </div>
-        <div className="flex items-center gap-1.5 rounded-full bg-card-muted px-3 py-1.5">
-          <SlidersHorizontal size={12} className="text-muted-foreground" />
-          <span className="font-[family-name:var(--font-geist-sans)] text-[12px] text-foreground">
-            Trim: elevator {"\u2212"}2.1{"\u00B0"}
-          </span>
-        </div>
-        <div className="flex items-center gap-1.5 rounded-full bg-card-muted px-3 py-1.5">
-          <Activity size={12} className="text-muted-foreground" />
-          <span className="font-[family-name:var(--font-geist-sans)] text-[12px] text-foreground">
-            Re {"\u2248"} 4.2e5
-          </span>
-        </div>
-        <div className="flex-1" />
-        <span className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
-          {charts ? `${charts.alpha.length} points` : "No data"}
-          {lastRunTime && lastRunDurationMs != null && (
-            <>
-              {" "}
-              {"\u00B7"} Last run:{" "}
-              {lastRunTime.toLocaleTimeString([], {
-                hour: "2-digit",
-                minute: "2-digit",
-                hour12: false,
-              })}{" "}
-              {"\u00B7"} {lastRunDurationMs} ms
-            </>
-          )}
-        </span>
-      </div>
+        }
+      />
     </div>
   );
 }

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -841,6 +841,7 @@ export function AnalysisViewerPanel({
       <InfoChipRow
         aeroplaneId={aeroplaneId}
         cgAero={cgAero}
+        isRecomputing={assumptions.isRecomputing}
         rightSlot={
           <span className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
             {charts ? `${charts.alpha.length} points` : "No data"}

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -61,6 +61,16 @@ interface Props {
   readonly onTrimWithAerobuildup?: (point: StoredOperatingPoint, trimVariable: string, targetCoefficient: string, targetValue: number) => Promise<AeroBuildupTrimResult | null>;
   readonly controlSurfaces?: ControlSurface[];
   readonly onUpdateDeflections?: (opId: number, deflections: Record<string, number> | null) => Promise<void>;
+  readonly onDeleteOp?: (opId: number) => Promise<void>;
+  readonly onDeleteAllOps?: () => Promise<void>;
+  readonly onCreateOp?: (payload: {
+    name: string;
+    velocity: number;
+    alpha: number;
+    beta?: number;
+    altitude?: number;
+    config?: string;
+  }) => Promise<void>;
   readonly analysisStatus?: AnalysisStatus;
 }
 
@@ -573,6 +583,9 @@ export function AnalysisViewerPanel({
   onTrimWithAerobuildup,
   controlSurfaces,
   onUpdateDeflections,
+  onDeleteOp,
+  onDeleteAllOps,
+  onCreateOp,
   analysisStatus,
 }: Readonly<Props>) {
   const [maximizedChart, setMaximizedChart] = useState<string | null>(null);
@@ -836,6 +849,9 @@ export function AnalysisViewerPanel({
           onTrimWithAerobuildup={onTrimWithAerobuildup ?? (() => Promise.resolve(null))}
           controlSurfaces={controlSurfaces ?? []}
           onUpdateDeflections={onUpdateDeflections ?? (async () => {})}
+          onDeleteOp={onDeleteOp}
+          onDeleteAll={onDeleteAllOps}
+          onCreateOp={onCreateOp}
         />
       )}
 

--- a/frontend/components/workbench/AssumptionRow.tsx
+++ b/frontend/components/workbench/AssumptionRow.tsx
@@ -11,6 +11,8 @@ const PARAM_LABELS: Record<string, string> = {
   cd0: "Zero-Lift Drag (CD₀)",
   cl_max: "Max Lift Coefficient (CL_max)",
   g_limit: "Load Factor Limit",
+  power_to_weight: "Power-to-Weight (0 = glider)",
+  prop_efficiency: "Propeller Efficiency",
 };
 
 function divergenceColor(level: Assumption["divergence_level"]): string {

--- a/frontend/components/workbench/AssumptionRow.tsx
+++ b/frontend/components/workbench/AssumptionRow.tsx
@@ -126,7 +126,9 @@ export function AssumptionRow({
 
       {/* Estimate editor */}
       <div className="flex min-w-[120px] items-center gap-1">
-        <span className="text-[10px] text-muted-foreground">est:</span>
+        {!assumption.is_design_choice && (
+          <span className="text-[10px] text-muted-foreground">est:</span>
+        )}
         {editing ? (
           <input
             ref={inputRef}

--- a/frontend/components/workbench/AssumptionRow.tsx
+++ b/frontend/components/workbench/AssumptionRow.tsx
@@ -11,8 +11,8 @@ const PARAM_LABELS: Record<string, string> = {
   cd0: "Zero-Lift Drag (CD₀)",
   cl_max: "Max Lift Coefficient (CL_max)",
   g_limit: "Load Factor Limit",
-  power_to_weight: "Power-to-Weight (0 = glider)",
-  prop_efficiency: "Propeller Efficiency",
+  power_to_weight: "Power-to-Weight (sport ≈ 200, 3D ≈ 330; 0 = glider)",
+  prop_efficiency: "Propeller Efficiency (0.55-0.75 typical)",
 };
 
 function divergenceColor(level: Assumption["divergence_level"]): string {

--- a/frontend/components/workbench/AssumptionRow.tsx
+++ b/frontend/components/workbench/AssumptionRow.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef } from "react";
-import { ArrowLeftRight } from "lucide-react";
+import { ArrowLeftRight, Info } from "lucide-react";
 import type { Assumption } from "@/hooks/useDesignAssumptions";
 
 const PARAM_LABELS: Record<string, string> = {
@@ -11,8 +11,23 @@ const PARAM_LABELS: Record<string, string> = {
   cd0: "Zero-Lift Drag (CD₀)",
   cl_max: "Max Lift Coefficient (CL_max)",
   g_limit: "Load Factor Limit",
-  power_to_weight: "Power-to-Weight (sport ≈ 200, 3D ≈ 330; 0 = glider)",
-  prop_efficiency: "Propeller Efficiency (0.55-0.75 typical)",
+  power_to_weight: "Power-to-Weight",
+  prop_efficiency: "Propeller Efficiency",
+};
+
+const PARAM_INFO: Record<string, string> = {
+  power_to_weight:
+    "Typical RC ranges (W/kg):\n" +
+    "• 160–200: trainer / slow aerobatic\n" +
+    "• 200–240: sport aerobatic / scale\n" +
+    "• 240–290: advanced aerobatic, high-speed\n" +
+    "• 290–330: light 3D, ducted fan\n" +
+    "• 330–440: unlimited 3D\n" +
+    "• 0: glider (no powertrain — V_max becomes a structural V_NE limit)",
+  prop_efficiency:
+    "Typical 0.55–0.75 for RC propellers at cruise. " +
+    "Higher for well-matched motor/prop combos at design speed; " +
+    "lower for static-thrust setups or off-design conditions.",
 };
 
 function divergenceColor(level: Assumption["divergence_level"]): string {
@@ -113,6 +128,9 @@ export function AssumptionRow({
     setTimeout(() => inputRef.current?.select(), 0);
   }
 
+  const [showInfo, setShowInfo] = useState(false);
+  const infoText = PARAM_INFO[assumption.parameter_name];
+
   const canToggleSource =
     !assumption.is_design_choice && assumption.calculated_value != null;
 
@@ -123,11 +141,30 @@ export function AssumptionRow({
   };
 
   return (
-    <div className="flex items-center gap-3 border-b border-border px-4 py-2.5 last:border-b-0">
+    <div className="relative flex items-center gap-3 border-b border-border px-4 py-2.5 last:border-b-0">
       {/* Label */}
-      <span className="min-w-[180px] text-[12px] text-foreground">
+      <span className="flex min-w-[180px] items-center gap-1.5 text-[12px] text-foreground">
         {label}
+        {infoText && (
+          <button
+            type="button"
+            onClick={() => setShowInfo((v) => !v)}
+            className="text-muted-foreground hover:text-orange-400"
+            aria-label={`Info about ${label}`}
+            data-testid={`info-button-${assumption.parameter_name}`}
+          >
+            <Info size={12} />
+          </button>
+        )}
       </span>
+      {showInfo && infoText && (
+        <div
+          className="absolute left-4 top-full z-20 mt-1 max-w-[420px] whitespace-pre-line rounded-md border border-border bg-card px-3 py-2 font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground shadow-lg"
+          role="tooltip"
+        >
+          {infoText}
+        </div>
+      )}
 
       {/* Effective value */}
       <span className="min-w-[90px] font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-foreground">

--- a/frontend/components/workbench/AssumptionRow.tsx
+++ b/frontend/components/workbench/AssumptionRow.tsx
@@ -77,23 +77,35 @@ export function AssumptionRow({
   onUpdateEstimate,
   onSwitchSource,
 }: Props) {
+  // Percentage units (e.g. "% MAC") store the value as a decimal fraction
+  // (0.12) but the user thinks in 12%. Display × 100, parse ÷ 100.
+  const isPercent = assumption.unit.includes("%");
+  const toDisplay = (v: number) => (isPercent ? v * 100 : v);
+  const fromDisplay = (v: number) => (isPercent ? v / 100 : v);
+  const displayUnit = isPercent ? "%" : assumption.unit;
+  const formatNumber = (v: number) =>
+    isPercent ? toDisplay(v).toFixed(1) : v.toPrecision(4);
+
   const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState(String(assumption.estimate_value));
+  const [draft, setDraft] = useState(String(toDisplay(assumption.estimate_value)));
   const inputRef = useRef<HTMLInputElement>(null);
 
   const label =
     PARAM_LABELS[assumption.parameter_name] ?? assumption.parameter_name;
 
   function commitEdit() {
-    const parsed = parseFloat(draft);
-    if (Number.isFinite(parsed) && parsed !== assumption.estimate_value) {
-      onUpdateEstimate(assumption.parameter_name, parsed);
+    const parsedDisplay = parseFloat(draft);
+    if (Number.isFinite(parsedDisplay)) {
+      const parsed = fromDisplay(parsedDisplay);
+      if (parsed !== assumption.estimate_value) {
+        onUpdateEstimate(assumption.parameter_name, parsed);
+      }
     }
     setEditing(false);
   }
 
   function startEdit() {
-    setDraft(String(assumption.estimate_value));
+    setDraft(String(toDisplay(assumption.estimate_value)));
     setEditing(true);
     // Focus after render
     setTimeout(() => inputRef.current?.select(), 0);
@@ -117,8 +129,8 @@ export function AssumptionRow({
 
       {/* Effective value */}
       <span className="min-w-[90px] font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-foreground">
-        {assumption.effective_value.toPrecision(4)}{" "}
-        <span className="text-muted-foreground">{assumption.unit}</span>
+        {formatNumber(assumption.effective_value)}{" "}
+        <span className="text-muted-foreground">{displayUnit}</span>
       </span>
 
       {/* Source badge */}
@@ -149,7 +161,7 @@ export function AssumptionRow({
             className="rounded px-1.5 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-muted-foreground hover:bg-sidebar-accent hover:text-foreground"
             data-testid={`estimate-display-${assumption.parameter_name}`}
           >
-            {assumption.estimate_value}
+            {formatNumber(assumption.estimate_value)}
           </button>
         )}
       </div>

--- a/frontend/components/workbench/AssumptionsPanel.tsx
+++ b/frontend/components/workbench/AssumptionsPanel.tsx
@@ -10,8 +10,16 @@ interface Props {
 }
 
 export function AssumptionsPanel({ aeroplaneId }: Props) {
-  const { data, isLoading, error, seedDefaults, updateEstimate, switchSource, mutate } =
-    useDesignAssumptions(aeroplaneId);
+  const {
+    data,
+    isLoading,
+    isRecomputing,
+    error,
+    seedDefaults,
+    updateEstimate,
+    switchSource,
+    mutate,
+  } = useDesignAssumptions(aeroplaneId);
 
   if (isLoading) {
     return (
@@ -69,6 +77,15 @@ export function AssumptionsPanel({ aeroplaneId }: Props) {
           >
             <AlertTriangle size={10} />
             {warningsCount}
+          </span>
+        )}
+        {isRecomputing && (
+          <span
+            className="flex items-center gap-1 rounded-full bg-orange-500/15 px-2 py-0.5 text-[10px] text-orange-400"
+            data-testid="recomputing-indicator"
+          >
+            <Loader2 size={10} className="animate-spin" />
+            Recomputing…
           </span>
         )}
       </div>

--- a/frontend/components/workbench/AssumptionsPanel.tsx
+++ b/frontend/components/workbench/AssumptionsPanel.tsx
@@ -2,6 +2,7 @@
 
 import { AlertTriangle, Loader2, Plus } from "lucide-react";
 import { useDesignAssumptions } from "@/hooks/useDesignAssumptions";
+import { useRecomputeStatus } from "@/hooks/useRecomputeStatus";
 import { AssumptionRow } from "@/components/workbench/AssumptionRow";
 import { CGComparisonBanner } from "@/components/workbench/CGComparisonBanner";
 
@@ -13,13 +14,13 @@ export function AssumptionsPanel({ aeroplaneId }: Props) {
   const {
     data,
     isLoading,
-    isRecomputing,
     error,
     seedDefaults,
     updateEstimate,
     switchSource,
     mutate,
   } = useDesignAssumptions(aeroplaneId);
+  const { isRecomputing } = useRecomputeStatus(aeroplaneId);
 
   if (isLoading) {
     return (

--- a/frontend/components/workbench/InfoChipRow.tsx
+++ b/frontend/components/workbench/InfoChipRow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Wind, Ruler, Target, Navigation } from "lucide-react";
+import { Wind, Ruler, Target, Navigation, Gauge, AlertTriangle } from "lucide-react";
 import { useComputationContext } from "@/hooks/useComputationContext";
 
 interface Props {
@@ -47,7 +47,9 @@ export function InfoChipRow({ aeroplaneId, cgAero, rightSlot }: Props) {
 
   return (
     <div className="flex items-center gap-2 border-t border-border bg-card px-4 py-3">
-      <Chip icon={Wind} prefix="V = " value={fmt(ctx?.v_cruise_mps, 1, " m/s")} />
+      <Chip icon={AlertTriangle} prefix="V_stall = " value={fmt(ctx?.v_stall_mps, 1, " m/s")} />
+      <Chip icon={Wind} prefix="V_cruise = " value={fmt(ctx?.v_cruise_mps, 1, " m/s")} />
+      <Chip icon={Gauge} prefix="V_max = " value={fmt(ctx?.v_max_mps, 1, " m/s")} />
       <Chip icon={Wind} prefix="Re ≈ " value={fmtRe(ctx?.reynolds)} />
       <Chip icon={Ruler} prefix="MAC = " value={fmt(ctx?.mac_m, 2, " m")} />
       <Chip icon={Target} prefix="NP = " value={fmt(ctx?.x_np_m, 3, " m")} />

--- a/frontend/components/workbench/InfoChipRow.tsx
+++ b/frontend/components/workbench/InfoChipRow.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { Wind, Ruler, Target, Navigation, Gauge, AlertTriangle } from "lucide-react";
+import { Wind, Ruler, Target, Navigation, Gauge, AlertTriangle, Loader2 } from "lucide-react";
 import { useComputationContext } from "@/hooks/useComputationContext";
 
 interface Props {
   readonly aeroplaneId: string | null;
   readonly cgAero: number | null;
+  readonly isRecomputing?: boolean;
   readonly rightSlot?: React.ReactNode;
 }
 
@@ -35,7 +36,7 @@ function cgDivergenceColor(cgAero: number, cgAgg: number, mac: number): string {
   return "text-red-400";
 }
 
-export function InfoChipRow({ aeroplaneId, cgAero, rightSlot }: Props) {
+export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: Props) {
   const { data: ctx } = useComputationContext(aeroplaneId);
 
   const fmt = (v: number | null | undefined, decimals: number, suffix = "") =>
@@ -75,6 +76,15 @@ export function InfoChipRow({ aeroplaneId, cgAero, rightSlot }: Props) {
         </span>
       </div>
       <div className="flex-1" />
+      {isRecomputing && (
+        <span
+          className="flex items-center gap-1 rounded-full bg-orange-500/15 px-2 py-1 text-[11px] text-orange-400"
+          data-testid="recomputing-chip"
+        >
+          <Loader2 size={11} className="animate-spin" />
+          Recomputing…
+        </span>
+      )}
       {rightSlot}
     </div>
   );

--- a/frontend/components/workbench/InfoChipRow.tsx
+++ b/frontend/components/workbench/InfoChipRow.tsx
@@ -14,16 +14,19 @@ function Chip({
   icon: Icon,
   prefix,
   value,
+  stale = false,
 }: {
   readonly icon: React.ComponentType<{ size: number; className: string }>;
   readonly prefix: string;
   readonly value: string;
+  readonly stale?: boolean;
 }) {
+  const valueClass = stale ? "text-red-400" : "text-foreground";
   return (
     <div className="flex items-center gap-1.5 rounded-full bg-card-muted px-3 py-1.5">
       <Icon size={12} className="text-muted-foreground" />
       <span className="font-[family-name:var(--font-geist-sans)] text-[12px] text-foreground">
-        {prefix}<span>{value}</span>
+        {prefix}<span className={valueClass}>{value}</span>
       </span>
     </div>
   );
@@ -46,14 +49,19 @@ export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: P
 
   const cgValue = cgAero != null ? `${cgAero.toFixed(3)} m` : "–";
 
+  // Values that depend on the geometry-driven recompute. While a job is
+  // in flight these are stale → render in red so the user knows not to
+  // trust them until the recompute settles.
+  const stale = !!isRecomputing;
+
   return (
     <div className="flex items-center gap-2 border-t border-border bg-card px-4 py-3">
-      <Chip icon={AlertTriangle} prefix="V_stall = " value={fmt(ctx?.v_stall_mps, 1, " m/s")} />
-      <Chip icon={Wind} prefix="V_cruise = " value={fmt(ctx?.v_cruise_mps, 1, " m/s")} />
-      <Chip icon={Gauge} prefix="V_max = " value={fmt(ctx?.v_max_mps, 1, " m/s")} />
-      <Chip icon={Wind} prefix="Re ≈ " value={fmtRe(ctx?.reynolds)} />
-      <Chip icon={Ruler} prefix="MAC = " value={fmt(ctx?.mac_m, 2, " m")} />
-      <Chip icon={Target} prefix="NP = " value={fmt(ctx?.x_np_m, 3, " m")} />
+      <Chip icon={AlertTriangle} prefix="V_stall = " value={fmt(ctx?.v_stall_mps, 1, " m/s")} stale={stale} />
+      <Chip icon={Wind} prefix="V_cruise = " value={fmt(ctx?.v_cruise_mps, 1, " m/s")} stale={stale} />
+      <Chip icon={Gauge} prefix="V_max = " value={fmt(ctx?.v_max_mps, 1, " m/s")} stale={stale} />
+      <Chip icon={Wind} prefix="Re ≈ " value={fmtRe(ctx?.reynolds)} stale={stale} />
+      <Chip icon={Ruler} prefix="MAC = " value={fmt(ctx?.mac_m, 2, " m")} stale={stale} />
+      <Chip icon={Target} prefix="NP = " value={fmt(ctx?.x_np_m, 3, " m")} stale={stale} />
       <Chip
         icon={Navigation}
         prefix="SM = "
@@ -62,14 +70,21 @@ export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: P
             ? (ctx.target_static_margin * 100).toFixed(0) + "%"
             : "–"
         }
+        stale={stale}
       />
       <div className="flex items-center gap-1.5 rounded-full bg-card-muted px-3 py-1.5">
         <Navigation size={12} className="text-muted-foreground" />
         <span className="font-[family-name:var(--font-geist-sans)] text-[12px] text-foreground">
           {"CG = "}
-          <span>{cgValue}</span>
+          <span className={stale ? "text-red-400" : ""}>{cgValue}</span>
           {cgAero != null && ctx?.cg_agg_m != null && ctx?.mac_m != null && (
-            <span className={`ml-1 ${cgDivergenceColor(cgAero, ctx.cg_agg_m, ctx.mac_m)}`}>
+            <span
+              className={`ml-1 ${
+                stale
+                  ? "text-red-400"
+                  : cgDivergenceColor(cgAero, ctx.cg_agg_m, ctx.mac_m)
+              }`}
+            >
               ({ctx.cg_agg_m.toFixed(3)})
             </span>
           )}

--- a/frontend/components/workbench/InfoChipRow.tsx
+++ b/frontend/components/workbench/InfoChipRow.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { Wind, Ruler, Target, Navigation } from "lucide-react";
+import { useComputationContext } from "@/hooks/useComputationContext";
+
+interface Props {
+  readonly aeroplaneId: string | null;
+  readonly cgAero: number | null;
+  readonly rightSlot?: React.ReactNode;
+}
+
+function Chip({
+  icon: Icon,
+  prefix,
+  value,
+}: {
+  readonly icon: React.ComponentType<{ size: number; className: string }>;
+  readonly prefix: string;
+  readonly value: string;
+}) {
+  return (
+    <div className="flex items-center gap-1.5 rounded-full bg-card-muted px-3 py-1.5">
+      <Icon size={12} className="text-muted-foreground" />
+      <span className="font-[family-name:var(--font-geist-sans)] text-[12px] text-foreground">
+        {prefix}<span>{value}</span>
+      </span>
+    </div>
+  );
+}
+
+function cgDivergenceColor(cgAero: number, cgAgg: number, mac: number): string {
+  const deltaPct = (Math.abs(cgAgg - cgAero) / mac) * 100;
+  if (deltaPct < 5) return "text-emerald-400";
+  if (deltaPct <= 15) return "text-orange-400";
+  return "text-red-400";
+}
+
+export function InfoChipRow({ aeroplaneId, cgAero, rightSlot }: Props) {
+  const { data: ctx } = useComputationContext(aeroplaneId);
+
+  const fmt = (v: number | null | undefined, decimals: number, suffix = "") =>
+    v != null ? `${v.toFixed(decimals)}${suffix}` : "–";
+
+  const fmtRe = (v: number | null | undefined) => (v == null ? "–" : v.toExponential(1));
+
+  const cgValue = cgAero != null ? `${cgAero.toFixed(3)} m` : "–";
+
+  return (
+    <div className="flex items-center gap-2 border-t border-border bg-card px-4 py-3">
+      <Chip icon={Wind} prefix="V = " value={fmt(ctx?.v_cruise_mps, 1, " m/s")} />
+      <Chip icon={Wind} prefix="Re ≈ " value={fmtRe(ctx?.reynolds)} />
+      <Chip icon={Ruler} prefix="MAC = " value={fmt(ctx?.mac_m, 2, " m")} />
+      <Chip icon={Target} prefix="NP = " value={fmt(ctx?.x_np_m, 3, " m")} />
+      <Chip
+        icon={Navigation}
+        prefix="SM = "
+        value={
+          ctx?.target_static_margin != null
+            ? (ctx.target_static_margin * 100).toFixed(0) + "%"
+            : "–"
+        }
+      />
+      <div className="flex items-center gap-1.5 rounded-full bg-card-muted px-3 py-1.5">
+        <Navigation size={12} className="text-muted-foreground" />
+        <span className="font-[family-name:var(--font-geist-sans)] text-[12px] text-foreground">
+          {"CG = "}
+          <span>{cgValue}</span>
+          {cgAero != null && ctx?.cg_agg_m != null && ctx?.mac_m != null && (
+            <span className={`ml-1 ${cgDivergenceColor(cgAero, ctx.cg_agg_m, ctx.mac_m)}`}>
+              ({ctx.cg_agg_m.toFixed(3)})
+            </span>
+          )}
+        </span>
+      </div>
+      <div className="flex-1" />
+      {rightSlot}
+    </div>
+  );
+}

--- a/frontend/components/workbench/InfoChipRow.tsx
+++ b/frontend/components/workbench/InfoChipRow.tsx
@@ -37,7 +37,7 @@ function cgDivergenceColor(cgAero: number, cgAgg: number, mac: number): string {
 }
 
 export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: Props) {
-  const { data: ctx } = useComputationContext(aeroplaneId);
+  const { data: ctx } = useComputationContext(aeroplaneId, { isRecomputing });
 
   const fmt = (v: number | null | undefined, decimals: number, suffix = "") =>
     v != null ? `${v.toFixed(decimals)}${suffix}` : "–";

--- a/frontend/components/workbench/InfoChipRow.tsx
+++ b/frontend/components/workbench/InfoChipRow.tsx
@@ -58,7 +58,12 @@ export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: P
     <div className="flex items-center gap-2 border-t border-border bg-card px-4 py-3">
       <Chip icon={AlertTriangle} prefix="V_stall = " value={fmt(ctx?.v_stall_mps, 1, " m/s")} stale={stale} />
       <Chip icon={Wind} prefix="V_md = " value={fmt(ctx?.v_md_mps, 1, " m/s")} stale={stale} />
-      <Chip icon={Wind} prefix="V_cruise = " value={fmt(ctx?.v_cruise_mps, 1, " m/s")} stale={stale} />
+      <Chip
+        icon={Wind}
+        prefix={ctx?.v_cruise_auto ? "V_cruise* = " : "V_cruise = "}
+        value={fmt(ctx?.v_cruise_mps, 1, " m/s")}
+        stale={stale}
+      />
       <Chip
         icon={Gauge}
         prefix={ctx?.is_glider ? "V_NE = " : "V_max = "}

--- a/frontend/components/workbench/InfoChipRow.tsx
+++ b/frontend/components/workbench/InfoChipRow.tsx
@@ -57,6 +57,7 @@ export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: P
   return (
     <div className="flex items-center gap-2 border-t border-border bg-card px-4 py-3">
       <Chip icon={AlertTriangle} prefix="V_stall = " value={fmt(ctx?.v_stall_mps, 1, " m/s")} stale={stale} />
+      <Chip icon={Wind} prefix="V_md = " value={fmt(ctx?.v_md_mps, 1, " m/s")} stale={stale} />
       <Chip icon={Wind} prefix="V_cruise = " value={fmt(ctx?.v_cruise_mps, 1, " m/s")} stale={stale} />
       <Chip icon={Gauge} prefix="V_max = " value={fmt(ctx?.v_max_mps, 1, " m/s")} stale={stale} />
       <Chip icon={Wind} prefix="Re ≈ " value={fmtRe(ctx?.reynolds)} stale={stale} />

--- a/frontend/components/workbench/InfoChipRow.tsx
+++ b/frontend/components/workbench/InfoChipRow.tsx
@@ -59,7 +59,12 @@ export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: P
       <Chip icon={AlertTriangle} prefix="V_stall = " value={fmt(ctx?.v_stall_mps, 1, " m/s")} stale={stale} />
       <Chip icon={Wind} prefix="V_md = " value={fmt(ctx?.v_md_mps, 1, " m/s")} stale={stale} />
       <Chip icon={Wind} prefix="V_cruise = " value={fmt(ctx?.v_cruise_mps, 1, " m/s")} stale={stale} />
-      <Chip icon={Gauge} prefix="V_max = " value={fmt(ctx?.v_max_mps, 1, " m/s")} stale={stale} />
+      <Chip
+        icon={Gauge}
+        prefix={ctx?.is_glider ? "V_NE = " : "V_max = "}
+        value={fmt(ctx?.v_max_mps, 1, " m/s")}
+        stale={stale}
+      />
       <Chip icon={Wind} prefix="Re ≈ " value={fmtRe(ctx?.reynolds)} stale={stale} />
       <Chip icon={Ruler} prefix="MAC = " value={fmt(ctx?.mac_m, 2, " m")} stale={stale} />
       <Chip icon={Target} prefix="NP = " value={fmt(ctx?.x_np_m, 3, " m")} stale={stale} />

--- a/frontend/components/workbench/OperatingPointsPanel.tsx
+++ b/frontend/components/workbench/OperatingPointsPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback, useMemo, useEffect } from "react";
-import { X, ChevronUp, ChevronDown, Loader2, Info } from "lucide-react";
+import { X, ChevronUp, ChevronDown, Loader2, Info, Trash2 } from "lucide-react";
 import type {
   StoredOperatingPoint,
   OperatingPointStatus,
@@ -86,6 +86,16 @@ interface Props {
     opId: number,
     deflections: Record<string, number> | null,
   ) => Promise<void>;
+  readonly onDeleteOp?: (opId: number) => Promise<void>;
+  readonly onDeleteAll?: () => Promise<void>;
+  readonly onCreateOp?: (payload: {
+    name: string;
+    velocity: number;
+    alpha: number;
+    beta?: number;
+    altitude?: number;
+    config?: string;
+  }) => Promise<void>;
 }
 
 function sortPoints(
@@ -131,6 +141,9 @@ export function OperatingPointsPanel({
   onTrimWithAerobuildup,
   controlSurfaces,
   onUpdateDeflections,
+  onDeleteOp,
+  onDeleteAll,
+  onCreateOp,
 }: Props) {
   const [sortKey, setSortKey] = useState<SortKey>("name");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
@@ -144,6 +157,7 @@ export function OperatingPointsPanel({
   const [abTargetValue, setAbTargetValue] = useState("0.5");
   const [avlResult, setAvlResult] = useState<AVLTrimResult | null>(null);
   const [abResult, setAbResult] = useState<AeroBuildupTrimResult | null>(null);
+  const [addDialogOpen, setAddDialogOpen] = useState(false);
 
   const handleSort = useCallback(
     (key: SortKey) => {
@@ -238,6 +252,30 @@ export function OperatingPointsPanel({
     <div className="relative flex min-h-0 flex-1 flex-col gap-4 bg-card-muted p-6">
       <div className="flex items-center gap-3">
         <div className="flex-1" />
+        {onCreateOp && (
+          <button
+            onClick={() => setAddDialogOpen(true)}
+            disabled={isGenerating}
+            className="flex items-center gap-1.5 rounded-full border border-border bg-card px-4 py-1.5 font-[family-name:var(--font-geist-sans)] text-[12px] font-medium text-foreground transition-colors hover:bg-sidebar-accent disabled:opacity-50"
+            data-testid="add-op-button"
+          >
+            + Add OP
+          </button>
+        )}
+        {onDeleteAll && points.length > 0 && (
+          <button
+            onClick={() => {
+              if (confirm(`Delete all ${points.length} operating points?`)) {
+                void onDeleteAll();
+              }
+            }}
+            disabled={isGenerating}
+            className="flex items-center gap-1.5 rounded-full border border-red-500/40 bg-card px-4 py-1.5 font-[family-name:var(--font-geist-sans)] text-[12px] font-medium text-red-400 transition-colors hover:bg-red-500/10 disabled:opacity-50"
+            data-testid="delete-all-ops-button"
+          >
+            Clear All
+          </button>
+        )}
         <button
           onClick={() => onGenerate()}
           disabled={isGenerating}
@@ -293,6 +331,7 @@ export function OperatingPointsPanel({
                     </span>
                   </th>
                 ))}
+                {onDeleteOp && <th className="w-10 px-2 py-2.5" />}
               </tr>
             </thead>
             <tbody>
@@ -337,6 +376,23 @@ export function OperatingPointsPanel({
                         />
                       )}
                     </td>
+                    {onDeleteOp && (
+                      <td className="px-2 py-2.5">
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            if (confirm(`Delete '${pt.name}'?`)) {
+                              void onDeleteOp(pt.id);
+                            }
+                          }}
+                          className="rounded p-1 text-muted-foreground hover:bg-red-500/10 hover:text-red-400"
+                          aria-label={`Delete ${pt.name}`}
+                          data-testid={`delete-op-${pt.id}`}
+                        >
+                          <Trash2 size={14} />
+                        </button>
+                      </td>
+                    )}
                   </tr>
                 );
               })}
@@ -543,6 +599,149 @@ export function OperatingPointsPanel({
           </div>
         </div>
       )}
+      {addDialogOpen && onCreateOp && (
+        <AddOpDialog
+          onClose={() => setAddDialogOpen(false)}
+          onCreate={async (payload) => {
+            await onCreateOp(payload);
+            setAddDialogOpen(false);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function AddOpDialog({
+  onClose,
+  onCreate,
+}: Readonly<{
+  onClose: () => void;
+  onCreate: (payload: {
+    name: string;
+    velocity: number;
+    alpha: number;
+    beta?: number;
+    altitude?: number;
+    config?: string;
+  }) => Promise<void>;
+}>) {
+  const [name, setName] = useState("");
+  const [velocity, setVelocity] = useState("18");
+  const [alpha, setAlpha] = useState("0");
+  const [beta, setBeta] = useState("0");
+  const [altitude, setAltitude] = useState("0");
+  const [config, setConfig] = useState("clean");
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!name.trim()) return;
+    setSubmitting(true);
+    try {
+      await onCreate({
+        name: name.trim(),
+        velocity: parseFloat(velocity) || 18,
+        alpha: parseFloat(alpha) || 0,
+        beta: parseFloat(beta) || 0,
+        altitude: parseFloat(altitude) || 0,
+        config,
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="w-[420px] rounded-xl border border-border bg-card p-6">
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="font-[family-name:var(--font-geist-sans)] text-[14px] font-medium text-foreground">
+            Add Operating Point
+          </h3>
+          <button onClick={onClose} className="text-muted-foreground hover:text-foreground">
+            <X size={16} />
+          </button>
+        </div>
+        <div className="flex flex-col gap-3">
+          <label className="flex flex-col gap-1">
+            <span className="text-[11px] uppercase tracking-wider text-muted-foreground">Name</span>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. high_speed_pass"
+              className="rounded border border-border bg-card-muted px-2 py-1.5 font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-foreground outline-none focus:border-orange-400"
+              data-testid="add-op-name"
+            />
+          </label>
+          <div className="grid grid-cols-2 gap-3">
+            <label className="flex flex-col gap-1">
+              <span className="text-[11px] uppercase tracking-wider text-muted-foreground">Velocity (m/s)</span>
+              <input
+                type="number"
+                value={velocity}
+                onChange={(e) => setVelocity(e.target.value)}
+                className="rounded border border-border bg-card-muted px-2 py-1.5 font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-foreground outline-none focus:border-orange-400"
+              />
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-[11px] uppercase tracking-wider text-muted-foreground">Alpha (°)</span>
+              <input
+                type="number"
+                value={alpha}
+                onChange={(e) => setAlpha(e.target.value)}
+                className="rounded border border-border bg-card-muted px-2 py-1.5 font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-foreground outline-none focus:border-orange-400"
+              />
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-[11px] uppercase tracking-wider text-muted-foreground">Beta (°)</span>
+              <input
+                type="number"
+                value={beta}
+                onChange={(e) => setBeta(e.target.value)}
+                className="rounded border border-border bg-card-muted px-2 py-1.5 font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-foreground outline-none focus:border-orange-400"
+              />
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-[11px] uppercase tracking-wider text-muted-foreground">Altitude (m)</span>
+              <input
+                type="number"
+                value={altitude}
+                onChange={(e) => setAltitude(e.target.value)}
+                className="rounded border border-border bg-card-muted px-2 py-1.5 font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-foreground outline-none focus:border-orange-400"
+              />
+            </label>
+          </div>
+          <label className="flex flex-col gap-1">
+            <span className="text-[11px] uppercase tracking-wider text-muted-foreground">Config</span>
+            <select
+              value={config}
+              onChange={(e) => setConfig(e.target.value)}
+              className="rounded border border-border bg-card-muted px-2 py-1.5 font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-foreground outline-none focus:border-orange-400"
+            >
+              <option value="clean">clean</option>
+              <option value="takeoff">takeoff</option>
+              <option value="landing">landing</option>
+            </select>
+          </label>
+          <div className="mt-2 flex justify-end gap-2">
+            <button
+              onClick={onClose}
+              className="rounded-full border border-border px-3 py-1.5 text-[12px] text-muted-foreground hover:text-foreground"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSubmit}
+              disabled={!name.trim() || submitting}
+              className="rounded-full bg-[#FF8400] px-4 py-1.5 text-[12px] font-medium text-white hover:opacity-90 disabled:opacity-50"
+              data-testid="add-op-submit"
+            >
+              {submitting ? "Creating..." : "Create"}
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/components/workbench/OperatingPointsPanel.tsx
+++ b/frontend/components/workbench/OperatingPointsPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback, useMemo, useEffect } from "react";
-import { X, ChevronUp, ChevronDown, Loader2 } from "lucide-react";
+import { X, ChevronUp, ChevronDown, Loader2, Info } from "lucide-react";
 import type {
   StoredOperatingPoint,
   OperatingPointStatus,
@@ -431,6 +431,7 @@ export function OperatingPointsPanel({
               <ControlDeflectionsSection
                 controlSurfaces={controlSurfaces}
                 currentDeflections={selectedPoint.control_deflections}
+                trimControls={selectedPoint.controls}
                 onSave={(deflections) =>
                   onUpdateDeflections(selectedPoint.id, deflections)
                 }
@@ -639,28 +640,51 @@ function TrimResultCard({
   );
 }
 
+function _findTrimDeflection(
+  trimControls: Record<string, number> | null | undefined,
+  surfaceName: string,
+): number | null {
+  if (!trimControls) return null;
+  // Backend stores trim solution keyed as "[control_type]surface_name"
+  // (e.g. "[elevator]elevator"). Match by the part after the closing
+  // bracket so we find the value regardless of control_type.
+  for (const [key, val] of Object.entries(trimControls)) {
+    const match = key.match(/^\[[^\]]+\](.+)$/);
+    if (match && match[1] === surfaceName) return val;
+  }
+  return null;
+}
+
 function ControlDeflectionsSection({
   controlSurfaces,
   currentDeflections,
+  trimControls,
   onSave,
   disabled,
 }: Readonly<{
   controlSurfaces: ControlSurface[];
   currentDeflections: Record<string, number> | null;
+  trimControls?: Record<string, number> | null;
   onSave: (deflections: Record<string, number> | null) => void;
   disabled: boolean;
 }>) {
+  const [showInfo, setShowInfo] = useState(false);
+
   const initialDeflections = useMemo(() => {
     const initial: Record<string, string> = {};
     for (const cs of controlSurfaces) {
+      // Priority order:
+      // 1. User override (currentDeflections) — explicit choice wins
+      // 2. Trim solution (trimControls) — solver result, the natural "current"
+      // 3. Geometry default (cs.deflection_deg) — typically 0 for clean config
       const overrideValue = currentDeflections?.[cs.name];
+      const trimValue = _findTrimDeflection(trimControls, cs.name);
+      const fallback = trimValue != null ? trimValue : cs.deflection_deg;
       initial[cs.name] =
-        overrideValue != null
-          ? String(overrideValue)
-          : String(cs.deflection_deg);
+        overrideValue != null ? String(overrideValue) : String(fallback);
     }
     return initial;
-  }, [controlSurfaces, currentDeflections]);
+  }, [controlSurfaces, currentDeflections, trimControls]);
 
   const [localDeflections, setLocalDeflections] = useState(initialDeflections);
 
@@ -689,10 +713,34 @@ function ControlDeflectionsSection({
   }, [onSave]);
 
   return (
-    <div className="flex flex-col gap-3 rounded-xl border border-border bg-card-muted p-4">
-      <span className="font-[family-name:var(--font-geist-sans)] text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-        Control Deflections
-      </span>
+    <div className="relative flex flex-col gap-3 rounded-xl border border-border bg-card-muted p-4">
+      <div className="flex items-center gap-1.5">
+        <span className="font-[family-name:var(--font-geist-sans)] text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+          Control Deflections
+        </span>
+        <button
+          type="button"
+          onClick={() => setShowInfo((v) => !v)}
+          className="text-muted-foreground hover:text-orange-400"
+          aria-label="Sign convention for control deflections"
+          data-testid="control-deflections-info"
+        >
+          <Info size={12} />
+        </button>
+      </div>
+      {showInfo && (
+        <div
+          className="absolute left-4 top-10 z-20 max-w-[420px] whitespace-pre-line rounded-md border border-border bg-card px-3 py-2 font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground shadow-lg"
+          role="tooltip"
+        >
+          {"Sign convention (ASB / aerospace standard):\n" +
+            "• Elevator / elevon: − = trailing-edge UP → nose-up moment\n" +
+            "• Aileron: + = right-wing TE down (right roll)\n" +
+            "• Rudder: + = trailing-edge LEFT → nose-left yaw\n\n" +
+            "Values shown reflect the trim solution — edit to override " +
+            "for what-if analysis."}
+        </div>
+      )}
       {controlSurfaces.length === 0 ? (
         <span className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-muted-foreground">
           No control surfaces found

--- a/frontend/hooks/useComputationContext.ts
+++ b/frontend/hooks/useComputationContext.ts
@@ -16,13 +16,20 @@ export interface ComputationContext {
   computed_at: string;
 }
 
-export function useComputationContext(aeroplaneId: string | null) {
+export function useComputationContext(
+  aeroplaneId: string | null,
+  options?: { readonly isRecomputing?: boolean },
+) {
   const path = aeroplaneId
     ? `/aeroplanes/${encodeURIComponent(aeroplaneId)}/assumptions/computation-context`
     : null;
+  // While the assumption compute job is in flight, poll every 1.5s so
+  // the chip values update as soon as the backend settles. Polling
+  // stops as soon as isRecomputing flips back to false.
   const { data, error, isLoading, mutate } = useSWR<ComputationContext | null>(
     path,
     fetcher,
+    options?.isRecomputing ? { refreshInterval: 1500 } : undefined,
   );
 
   return { data, error, isLoading, mutate };

--- a/frontend/hooks/useComputationContext.ts
+++ b/frontend/hooks/useComputationContext.ts
@@ -5,8 +5,11 @@ import { fetcher } from "@/lib/fetcher";
 
 export interface ComputationContext {
   v_cruise_mps: number;
+  v_max_mps?: number | null;
+  v_stall_mps?: number | null;
   reynolds: number;
   mac_m: number;
+  s_ref_m2?: number | null;
   x_np_m: number;
   target_static_margin: number;
   cg_agg_m: number | null;

--- a/frontend/hooks/useComputationContext.ts
+++ b/frontend/hooks/useComputationContext.ts
@@ -8,6 +8,7 @@ export interface ComputationContext {
   v_max_mps?: number | null;
   v_stall_mps?: number | null;
   v_md_mps?: number | null;
+  is_glider?: boolean;
   reynolds: number;
   mac_m: number;
   s_ref_m2?: number | null;

--- a/frontend/hooks/useComputationContext.ts
+++ b/frontend/hooks/useComputationContext.ts
@@ -5,6 +5,7 @@ import { fetcher } from "@/lib/fetcher";
 
 export interface ComputationContext {
   v_cruise_mps: number;
+  v_cruise_auto?: boolean;
   v_max_mps?: number | null;
   v_stall_mps?: number | null;
   v_md_mps?: number | null;

--- a/frontend/hooks/useComputationContext.ts
+++ b/frontend/hooks/useComputationContext.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import useSWR from "swr";
+import { fetcher } from "@/lib/fetcher";
+
+export interface ComputationContext {
+  v_cruise_mps: number;
+  reynolds: number;
+  mac_m: number;
+  x_np_m: number;
+  target_static_margin: number;
+  cg_agg_m: number | null;
+  computed_at: string;
+}
+
+export function useComputationContext(aeroplaneId: string | null) {
+  const path = aeroplaneId
+    ? `/aeroplanes/${encodeURIComponent(aeroplaneId)}/assumptions/computation-context`
+    : null;
+  const { data, error, isLoading, mutate } = useSWR<ComputationContext | null>(
+    path,
+    fetcher,
+  );
+
+  return { data, error, isLoading, mutate };
+}

--- a/frontend/hooks/useComputationContext.ts
+++ b/frontend/hooks/useComputationContext.ts
@@ -7,9 +7,11 @@ export interface ComputationContext {
   v_cruise_mps: number;
   v_max_mps?: number | null;
   v_stall_mps?: number | null;
+  v_md_mps?: number | null;
   reynolds: number;
   mac_m: number;
   s_ref_m2?: number | null;
+  aspect_ratio?: number | null;
   x_np_m: number;
   target_static_margin: number;
   cg_agg_m: number | null;

--- a/frontend/hooks/useDesignAssumptions.ts
+++ b/frontend/hooks/useDesignAssumptions.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import useSWR from "swr";
+import useSWR, { mutate as globalMutate } from "swr";
 import { useCallback } from "react";
 import { API_BASE, fetcher } from "@/lib/fetcher";
 
@@ -68,6 +68,21 @@ export function useDesignAssumptions(aeroplaneId: string | null) {
         throw new Error(`Failed to update assumption: ${res.status} ${body}`);
       }
       mutate();
+
+      // Recompute-triggering parameters (target_static_margin) re-derive
+      // cl_max/cd0/cg_x via the backend debounced job. Schedule a delayed
+      // revalidation so the panel and chips reflect the new computed
+      // values once the recompute settles. Time = backend debounce (2s)
+      // + recompute work (~1-2s) + safety margin.
+      const RECOMPUTE_TRIGGERS = new Set(["target_static_margin"]);
+      if (RECOMPUTE_TRIGGERS.has(paramName)) {
+        setTimeout(() => {
+          mutate();
+          globalMutate(
+            `/aeroplanes/${aeroplaneId}/assumptions/computation-context`,
+          );
+        }, 4000);
+      }
     },
     [aeroplaneId, mutate],
   );

--- a/frontend/hooks/useDesignAssumptions.ts
+++ b/frontend/hooks/useDesignAssumptions.ts
@@ -80,7 +80,11 @@ export function useDesignAssumptions(aeroplaneId: string | null) {
       const RECOMPUTE_TRIGGERS = new Set(["target_static_margin", "mass"]);
       if (RECOMPUTE_TRIGGERS.has(paramName)) {
         setIsRecomputing(true);
-        const ctxPath = `/aeroplanes/${aeroplaneId}/assumptions/computation-context`;
+        // Match useComputationContext key exactly — that hook uses
+        // encodeURIComponent on the aeroplaneId. For UUIDs the encoded
+        // form is identical, but matching defensively avoids future
+        // breakage when keys diverge.
+        const ctxPath = `/aeroplanes/${encodeURIComponent(aeroplaneId)}/assumptions/computation-context`;
         const revalidate = () => {
           mutate();
           globalMutate(ctxPath);

--- a/frontend/hooks/useDesignAssumptions.ts
+++ b/frontend/hooks/useDesignAssumptions.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import useSWR, { mutate as globalMutate } from "swr";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { API_BASE, fetcher } from "@/lib/fetcher";
 
 export interface Assumption {
@@ -38,6 +38,7 @@ export function useDesignAssumptions(aeroplaneId: string | null) {
     path,
     fetcher,
   );
+  const [isRecomputing, setIsRecomputing] = useState(false);
 
   const seedDefaults = useCallback(async () => {
     if (!aeroplaneId) return;
@@ -70,18 +71,30 @@ export function useDesignAssumptions(aeroplaneId: string | null) {
       mutate();
 
       // Recompute-triggering parameters (target_static_margin) re-derive
-      // cl_max/cd0/cg_x via the backend debounced job. Schedule a delayed
-      // revalidation so the panel and chips reflect the new computed
-      // values once the recompute settles. Time = backend debounce (2s)
-      // + recompute work (~1-2s) + safety margin.
+      // cl_max/cd0/cg_x via the backend debounced job. Recompute time
+      // varies wildly (debounce 2s + ASB sweep — anything from 3s to 15s
+      // depending on geometry complexity). Poll a few times to catch
+      // whenever it settles, and surface an isRecomputing flag so the UI
+      // can show a spinner.
       const RECOMPUTE_TRIGGERS = new Set(["target_static_margin"]);
       if (RECOMPUTE_TRIGGERS.has(paramName)) {
-        setTimeout(() => {
+        setIsRecomputing(true);
+        const ctxPath = `/aeroplanes/${aeroplaneId}/assumptions/computation-context`;
+        const revalidate = () => {
           mutate();
-          globalMutate(
-            `/aeroplanes/${aeroplaneId}/assumptions/computation-context`,
-          );
-        }, 4000);
+          globalMutate(ctxPath);
+        };
+        // Idempotent revalidations at staggered intervals — covers
+        // recompute times anywhere from 3s to 12s. Cleanup is not needed:
+        // mutate() / globalMutate() are idempotent if the component
+        // unmounts in the meantime.
+        setTimeout(revalidate, 2500);
+        setTimeout(revalidate, 5000);
+        setTimeout(revalidate, 8000);
+        setTimeout(() => {
+          revalidate();
+          setIsRecomputing(false);
+        }, 12000);
       }
     },
     [aeroplaneId, mutate],
@@ -113,6 +126,7 @@ export function useDesignAssumptions(aeroplaneId: string | null) {
   return {
     data: data ?? null,
     isLoading,
+    isRecomputing,
     error: error ?? null,
     seedDefaults,
     updateEstimate,

--- a/frontend/hooks/useDesignAssumptions.ts
+++ b/frontend/hooks/useDesignAssumptions.ts
@@ -70,13 +70,14 @@ export function useDesignAssumptions(aeroplaneId: string | null) {
       }
       mutate();
 
-      // Recompute-triggering parameters (target_static_margin) re-derive
-      // cl_max/cd0/cg_x via the backend debounced job. Recompute time
-      // varies wildly (debounce 2s + ASB sweep — anything from 3s to 15s
+      // Recompute-triggering parameters re-derive cl_max/cd0/cg_x and
+      // V_stall via the backend debounced job. Recompute time varies
+      // wildly (debounce 2s + ASB sweep — anything from 3s to 15s
       // depending on geometry complexity). Poll a few times to catch
       // whenever it settles, and surface an isRecomputing flag so the UI
       // can show a spinner.
-      const RECOMPUTE_TRIGGERS = new Set(["target_static_margin"]);
+      // Must mirror app/services/invalidation_service._RECOMPUTE_TRIGGERING_PARAMS.
+      const RECOMPUTE_TRIGGERS = new Set(["target_static_margin", "mass"]);
       if (RECOMPUTE_TRIGGERS.has(paramName)) {
         setIsRecomputing(true);
         const ctxPath = `/aeroplanes/${aeroplaneId}/assumptions/computation-context`;

--- a/frontend/hooks/useOperatingPoints.ts
+++ b/frontend/hooks/useOperatingPoints.ts
@@ -151,6 +151,16 @@ export interface UseOperatingPointsReturn {
     opId: number,
     deflections: Record<string, number> | null,
   ) => Promise<void>;
+  deleteOp: (opId: number) => Promise<void>;
+  deleteAll: () => Promise<void>;
+  createOp: (payload: {
+    name: string;
+    velocity: number;
+    alpha: number;
+    beta?: number;
+    altitude?: number;
+    config?: string;
+  }) => Promise<void>;
 }
 
 function toTrimPayload(point: StoredOperatingPoint) {
@@ -342,6 +352,89 @@ export function useOperatingPoints(
     [refresh],
   );
 
+  const deleteOp = useCallback(
+    async (opId: number): Promise<void> => {
+      setError(null);
+      try {
+        const res = await fetch(`${API_BASE}/operating_points/${opId}`, {
+          method: "DELETE",
+        });
+        if (!res.ok && res.status !== 204) {
+          const body = await res.text();
+          throw new Error(`Delete failed: ${res.status} ${body}`);
+        }
+        await refresh();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [refresh],
+  );
+
+  const deleteAll = useCallback(async (): Promise<void> => {
+    if (!aeroplaneId) return;
+    setError(null);
+    try {
+      // Delete all OPs for this aircraft by hitting the per-OP DELETE
+      // endpoint in parallel — there's no bulk-delete-by-aircraft yet.
+      const ids = points.map((p) => p.id);
+      await Promise.all(
+        ids.map((id) =>
+          fetch(`${API_BASE}/operating_points/${id}`, { method: "DELETE" }),
+        ),
+      );
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, [aeroplaneId, points, refresh]);
+
+  const createOp = useCallback(
+    async (payload: {
+      name: string;
+      velocity: number;
+      alpha: number;
+      beta?: number;
+      altitude?: number;
+      config?: string;
+    }): Promise<void> => {
+      if (!aeroplaneId) return;
+      setError(null);
+      try {
+        const res = await fetch(`${API_BASE}/operating_points/`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: payload.name,
+            description: payload.name,
+            aircraft_id: null,
+            config: payload.config ?? "clean",
+            status: "DIRTY",
+            warnings: [],
+            controls: {},
+            velocity: payload.velocity,
+            alpha: payload.alpha,
+            beta: payload.beta ?? 0,
+            p: 0,
+            q: 0,
+            r: 0,
+            xyz_ref: [0, 0, 0],
+            altitude: payload.altitude ?? 0,
+            aeroplane_uuid: aeroplaneId,
+          }),
+        });
+        if (!res.ok) {
+          const body = await res.text();
+          throw new Error(`Create failed: ${res.status} ${body}`);
+        }
+        await refresh();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [aeroplaneId, refresh],
+  );
+
   useEffect(() => {
     if (aeroplaneId) {
       refresh();
@@ -361,5 +454,8 @@ export function useOperatingPoints(
     trimWithAvl,
     trimWithAerobuildup,
     updateDeflections,
+    deleteOp,
+    deleteAll,
+    createOp,
   };
 }

--- a/frontend/hooks/useOperatingPoints.ts
+++ b/frontend/hooks/useOperatingPoints.ts
@@ -214,7 +214,11 @@ export function useOperatingPoints(
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ replace_existing: replaceExisting ?? false }),
+            // Default to replace_existing=true so 'Generate Default OPs'
+            // replaces the previous default set instead of appending —
+            // prevents duplicate cruise / loiter / max_range rows when the
+            // user re-generates after geometry / mass / SM changes.
+            body: JSON.stringify({ replace_existing: replaceExisting ?? true }),
           },
         );
         if (!res.ok) {

--- a/frontend/hooks/useRecomputeStatus.ts
+++ b/frontend/hooks/useRecomputeStatus.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import useSWR from "swr";
+import { fetcher } from "@/lib/fetcher";
+
+type RecomputeJobStatus = "idle" | "debouncing" | "computing" | "done" | "failed";
+
+interface RecomputeStatusResponse {
+  status: RecomputeJobStatus;
+  started_at: string | null;
+  finished_at: string | null;
+  error: string | null;
+}
+
+/**
+ * Polls the per-aircraft assumption-recompute job status. While a job
+ * is in flight (debouncing or computing), `isRecomputing` is true so
+ * the UI can show a spinner regardless of which event triggered the
+ * recompute (geometry change, mass change, SM change, weight items …).
+ */
+export function useRecomputeStatus(aeroplaneId: string | null) {
+  const path = aeroplaneId
+    ? `/aeroplanes/${encodeURIComponent(aeroplaneId)}/assumptions/recompute-status`
+    : null;
+
+  const { data } = useSWR<RecomputeStatusResponse>(path, fetcher, {
+    refreshInterval: 1500,
+    revalidateOnFocus: false,
+    dedupingInterval: 0,
+  });
+
+  const isRecomputing =
+    data?.status === "debouncing" || data?.status === "computing";
+
+  return {
+    isRecomputing,
+    status: data?.status ?? "idle",
+    error: data?.error ?? null,
+  };
+}

--- a/frontend/hooks/useStability.ts
+++ b/frontend/hooks/useStability.ts
@@ -70,12 +70,38 @@ export function useStability(aeroplaneId: string | null): UseStabilityReturn {
     setIsComputing(true);
     setError(null);
     try {
+      // Use the design CG (cg_x effective from assumptions) as the
+      // moment reference point for the stability run. Without this
+      // the backend defaults xyz_ref to [0,0,0] and the static margin
+      // is computed against an origin CG, not the real design point.
+      let cgX = 0;
+      try {
+        const aRes = await fetch(`${API_BASE}/aeroplanes/${aeroplaneId}/assumptions`);
+        if (aRes.ok) {
+          const aBody = await aRes.json();
+          const cgRow = aBody.assumptions?.find(
+            (a: { parameter_name: string }) => a.parameter_name === "cg_x",
+          );
+          if (cgRow && typeof cgRow.effective_value === "number") {
+            cgX = cgRow.effective_value;
+          }
+        }
+      } catch {
+        // Fall through with cgX=0; better than failing the stability run.
+      }
+
       const res = await fetch(
         `${API_BASE}/aeroplanes/${aeroplaneId}/stability_summary/avl`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ velocity: 20, alpha: 2, beta: 0, altitude: 0 }),
+          body: JSON.stringify({
+            velocity: 20,
+            alpha: 2,
+            beta: 0,
+            altitude: 0,
+            xyz_ref: [cgX, 0, 0],
+          }),
         },
       );
       if (!res.ok) {

--- a/frontend/hooks/useStability.ts
+++ b/frontend/hooks/useStability.ts
@@ -91,7 +91,7 @@ export function useStability(aeroplaneId: string | null): UseStabilityReturn {
       }
 
       const res = await fetch(
-        `${API_BASE}/aeroplanes/${aeroplaneId}/stability_summary/avl`,
+        `${API_BASE}/aeroplanes/${aeroplaneId}/stability_summary/aerobuildup`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },

--- a/frontend/hooks/useStreamlines.ts
+++ b/frontend/hooks/useStreamlines.ts
@@ -14,6 +14,12 @@ export interface StreamlinesParams {
   alpha: number;
   beta: number;
   altitude: number;
+  /**
+   * Moment-reference point for the run. Defaults to [0,0,0] on the
+   * backend if omitted, but callers should pass the design CG so the
+   * streamline visualisation is consistent with the rest of the system.
+   */
+  xyz_ref?: number[];
 }
 
 export function useStreamlines(aeroplaneId: string | null) {
@@ -39,6 +45,7 @@ export function useStreamlines(aeroplaneId: string | null) {
               alpha: params.alpha,
               beta: params.beta,
               altitude: params.altitude,
+              xyz_ref: params.xyz_ref ?? [0, 0, 0],
             }),
           },
         );


### PR DESCRIPTION
## Summary

Closes #465. Adds an end-to-end auto-compute pipeline for design assumptions and follow-on UX/wiring fixes that surfaced during browser verification.

### Core feature

- **Auto-compute** of `cl_max`, `cd0`, `cg_x` from aircraft geometry via AeroSandbox AeroBuildup whenever `GeometryChanged` or a recompute-trigger fires (debounced, runs in `asyncio.to_thread`).
- **Two-phase ASB sweep**: stability run at cruise → `(x_np, MAC, CD0, S_ref)`; coarse alpha sweep → stall_alpha; fine alpha×velocity sweep → CL_max.
- **Per-aircraft `aircraft_computation_config` table** for sweep parameters + debounce — no magic numbers in code.
- **Auto-switch source** to CALCULATED on first computed value; design choices (`target_static_margin`, `g_limit`) are exempt.
- **`assumption_computation_context` JSON column** caches MAC, NP, SM, CG_agg, V_stall, V_md, V_max, Re, etc. for the dynamic Info Chip Row.

### Power model + V_max physics

- New `power_to_weight` and `prop_efficiency` assumptions (info popovers with typical RC ranges).
- **V_max** computed from a power balance `P_avail · η = D(V) · V` (4th-order polynomial via `numpy.roots`); falls back to user goal as `V_NE` when `power_to_weight ≤ 0` (glider).
- **V_md** (minimum-drag / best L/D) added as a chip; **V_stall** uses effective mass + cl_max + S_ref; **V_cruise\*** auto-derives from V_md when no flight profile is set.

### UX

- Dynamic Info Chip Row replaces hardcoded values; chips turn red while a recompute is in flight.
- "Recomputing…" spinner driven by a server-side recompute-status endpoint (works for any trigger — geometry, mass, SM, weight items).
- Wing-gate on computation tabs (Assumptions tab always accessible).
- Analysis tabs reordered: Assumptions → Operating Points → Polar / Trefftz / Streamlines / Envelope / Stability.
- Assumptions preselected when entering the Analysis tab.
- Percentage display fix for `target_static_margin` (12% instead of 0.12).
- "est:" label hidden for design choices.
- Operating Points: trash icon per row, "Clear All" button, "+ Add OP" modal.
- Generate Default OPs now defaults to `replace_existing=true` (no more duplicate cruise rows).
- Control Deflections section pre-fills with the trim solution; info popover explains sign convention.

### Wiring fixes

- `recompute_assumptions` runs `seed_defaults` first so it works on aircraft created before the assumption rows existed.
- Stability compute switched from AVL to AeroBuildup (per project rule); passes design CG via `xyz_ref`.
- OP generator now uses effective `mass` from the assumption (not `aircraft.total_mass_kg`), the design CG as `xyz_ref`, and falls back to V_md when no flight profile is set.
- Mass-Assumption sync from Component Tree (gh-78) writes the calculated value with `auto_switch_source=True` and emits `AssumptionChanged(mass)` so V_stall / V_max recompute.
- `target_static_margin` toggle / mass toggle / source toggle on any param all schedule a recompute.
- `update_assumption` only emits events when active_source is ESTIMATE (estimate edits while CALCULATED is active no longer fire spurious retrims).
- JobTracker can now schedule from worker threads (fixes a hard "spinner spins forever" bug where `asyncio.get_running_loop()` failed in the asyncio.to_thread worker).
- SQLite WAL + busy_timeout=30s eliminates "database is locked" during concurrent recompute + user actions.

## Test plan

- [x] Backend regression: `poetry run pytest -m "not slow"` — see CI run on merge
- [x] Frontend regression: 71 files / 577 tests pass
- [x] Manual browser verification through the design loop:
  - Assumption edits propagate, spinner shown, chips update
  - SM toggle triggers recompute
  - Mass change (Component Tree or estimate) recomputes V_stall + V_max
  - Generate Default OPs → no duplicates; OPs use design CG
  - Stability tab: AeroBuildup, no "Vortices" error, uses design CG
  - Operating Point CRUD (delete one, clear all, add new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)