### PR TITLE
test(gh-463): lock DUAL_ROLES ⊆ ControlSurfaceRole invariant

### DIFF
--- a/app/tests/test_control_surface_role.py
+++ b/app/tests/test_control_surface_role.py
@@ -16,6 +16,20 @@ class TestControlSurfaceRole:
         expected = {"elevator", "aileron", "rudder", "elevon", "stabilator", "flap", "flaperon", "ruddervator", "spoiler", "other"}
         assert {r.value for r in ControlSurfaceRole} == expected
 
+    def test_dual_roles_are_subset_of_enum(self):
+        # Why: DUAL_ROLES and ControlSurfaceRole are two unlinked sources of
+        # truth (gh-463). If they diverge, V-tail/flaperon configs fail with
+        # 500 because trim enrichment expects roles the schema rejects.
+        from app.services.trim_enrichment_service import DUAL_ROLES
+        assert DUAL_ROLES <= {r.value for r in ControlSurfaceRole}
+
+    def test_role_coefficient_map_keys_are_valid_enum_values(self):
+        # Why: ROLE_COEFFICIENT_MAP keys must be assignable as ControlSurfaceRole
+        # values; otherwise trim enrichment looks up coefficients for roles that
+        # can never be set on a TED.
+        from app.services.trim_enrichment_service import ROLE_COEFFICIENT_MAP
+        assert set(ROLE_COEFFICIENT_MAP) <= {r.value for r in ControlSurfaceRole}
+
 
 class TestTedSchemaRoleField:
     def test_role_defaults_to_other(self):


### PR DESCRIPTION
## Summary

- The reported bug (flaperon and ruddervator missing from `ControlSurfaceRole`) was already fixed in 60bf59f, landed incidentally with the gh-468 smoke-test work the day after the issue was filed
- This PR adds **two invariant tests** so the same class of bug cannot recur silently:
  - `DUAL_ROLES` ⊆ `ControlSurfaceRole` values
  - `ROLE_COEFFICIENT_MAP` keys ⊆ `ControlSurfaceRole` values
- Both sets live in `trim_enrichment_service.py` and were never linked to the canonical enum in `aeroplaneschema.py` — the exact divergence that caused gh-463

## Test plan

- [x] `poetry run pytest app/tests/test_control_surface_role.py -v` → 31/31 PASS (29 prior + 2 new)
- [x] `poetry run ruff check app/tests/test_control_surface_role.py` → clean
- [x] Invariants verified to actually catch divergence: temporarily removed `FLAPERON` locally → `test_dual_roles_are_subset_of_enum` failed as expected (then reverted)

Closes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)