### PR TITLE
fix(gh-464): scope pitch-control warning to whole aeroplane

### DIFF
--- a/frontend/__tests__/AeroplaneTreeRoleIcons.test.tsx
+++ b/frontend/__tests__/AeroplaneTreeRoleIcons.test.tsx
@@ -1,7 +1,7 @@
 /**
  * Tests for AeroplaneTree role icons and pitch control surface warning (gh-450).
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import type { XSec } from "@/hooks/useWings";
@@ -57,12 +57,26 @@ vi.mock("@/components/workbench/AeroplaneContext", () => ({
   }),
 }));
 
-let mockWingData: { name: string; symmetric: boolean; x_secs: XSec[]; design_model?: string } | null = null;
+type MockWing = { name: string; symmetric: boolean; x_secs: XSec[]; design_model?: string };
+let mockWingData: MockWing | null = null;
+let mockAllWingsData: MockWing[] = [];
+
+function resolveMockAllWings(): MockWing[] {
+  if (mockAllWingsData.length > 0) return mockAllWingsData;
+  if (mockWingData) return [mockWingData];
+  return [];
+}
 
 vi.mock("@/hooks/useWings", () => ({
   useWing: () => ({
     wing: mockWingData,
     isLoading: false,
+    mutate: vi.fn(),
+  }),
+  useAllWingData: () => ({
+    wings: resolveMockAllWings(),
+    isLoading: false,
+    error: undefined,
     mutate: vi.fn(),
   }),
 }));
@@ -161,6 +175,10 @@ describe("AeroplaneTree role icons (gh-450)", () => {
 });
 
 describe("AeroplaneTree pitch warning (gh-450)", () => {
+  beforeEach(() => {
+    mockAllWingsData = [];
+  });
+
   it("shows warning when wing has no pitch control surface", () => {
     mockWingData = makeWing([
       makeXsec({ trailing_edge_device: { role: "aileron", label: "" } }),
@@ -219,5 +237,116 @@ describe("AeroplaneTree pitch warning (gh-450)", () => {
     expect(
       screen.queryByText(/No pitch control surface assigned/),
     ).toBeNull();
+  });
+});
+
+describe("AeroplaneTree pitch warning — aeroplane-wide scope (gh-464)", () => {
+  // Why: the warning must reflect aeroplane-wide capability, not just the
+  // currently-selected wing. A wing of ailerons should not show the warning
+  // when another wing on the same aeroplane has an elevator.
+  beforeEach(() => {
+    mockAllWingsData = [];
+  });
+
+  it("hides warning on aileron-only wing when another wing has elevator", () => {
+    const aileronWing: MockWing = {
+      name: "Main Wing",
+      symmetric: true,
+      x_secs: [
+        makeXsec({ trailing_edge_device: { role: "aileron", label: "" } }),
+        makeXsec(),
+      ],
+      design_model: "wc",
+    };
+    const tailWing: MockWing = {
+      name: "Horizontal Tail",
+      symmetric: true,
+      x_secs: [
+        makeXsec({ trailing_edge_device: { role: "elevator", label: "" } }),
+        makeXsec(),
+      ],
+      design_model: "wc",
+    };
+    mockWingData = aileronWing;
+    mockAllWingsData = [aileronWing, tailWing];
+
+    render(
+      <AeroplaneTree
+        aeroplaneId="1"
+        wingNames={["Main Wing", "Horizontal Tail"]}
+        aeroplaneName="Test Plane"
+      />,
+    );
+    expect(
+      screen.queryByText(/No pitch control surface assigned/),
+    ).toBeNull();
+  });
+
+  it("hides warning on rudder-only wing when another wing has elevon", () => {
+    const rudderWing: MockWing = {
+      name: "Vertical Tail",
+      symmetric: false,
+      x_secs: [
+        makeXsec({ trailing_edge_device: { role: "rudder", label: "" } }),
+        makeXsec(),
+      ],
+      design_model: "wc",
+    };
+    const flyingWing: MockWing = {
+      name: "Main Wing",
+      symmetric: true,
+      x_secs: [
+        makeXsec({ trailing_edge_device: { role: "elevon", label: "" } }),
+        makeXsec(),
+      ],
+      design_model: "wc",
+    };
+    mockWingData = rudderWing;
+    mockAllWingsData = [flyingWing, rudderWing];
+
+    render(
+      <AeroplaneTree
+        aeroplaneId="1"
+        wingNames={["Main Wing", "Vertical Tail"]}
+        aeroplaneName="Test Plane"
+      />,
+    );
+    expect(
+      screen.queryByText(/No pitch control surface assigned/),
+    ).toBeNull();
+  });
+
+  it("still shows warning when no wing on the aeroplane has a pitch surface", () => {
+    const aileronWing: MockWing = {
+      name: "Main Wing",
+      symmetric: true,
+      x_secs: [
+        makeXsec({ trailing_edge_device: { role: "aileron", label: "" } }),
+        makeXsec(),
+      ],
+      design_model: "wc",
+    };
+    const flapWing: MockWing = {
+      name: "Inner Wing",
+      symmetric: true,
+      x_secs: [
+        makeXsec({ trailing_edge_device: { role: "flap", label: "" } }),
+        makeXsec(),
+      ],
+      design_model: "wc",
+    };
+    mockWingData = aileronWing;
+    mockAllWingsData = [aileronWing, flapWing];
+
+    render(
+      <AeroplaneTree
+        aeroplaneId="1"
+        wingNames={["Main Wing", "Inner Wing"]}
+        aeroplaneName="Test Plane"
+      />,
+    );
+    expect(
+      screen.getByText(/No pitch control surface assigned/),
+    ).toBeTruthy();
   });
 });

--- a/frontend/__tests__/FuselageTree.test.tsx
+++ b/frontend/__tests__/FuselageTree.test.tsx
@@ -21,6 +21,7 @@ vi.mock("lucide-react", () => {
 
 vi.mock("@/hooks/useWings", () => ({
   useWing: () => ({ wing: null, isLoading: false, mutate: vi.fn() }),
+  useAllWingData: () => ({ wings: [], isLoading: false, error: undefined, mutate: vi.fn() }),
 }));
 
 const mockFuselageData = {

--- a/frontend/__tests__/XsecTreeCrud.test.tsx
+++ b/frontend/__tests__/XsecTreeCrud.test.tsx
@@ -32,6 +32,7 @@ const mockWing = {
 
 vi.mock("@/hooks/useWings", () => ({
   useWing: () => ({ wing: mockWing, isLoading: false, mutate: vi.fn() }),
+  useAllWingData: () => ({ wings: [mockWing], isLoading: false, error: undefined, mutate: vi.fn() }),
 }));
 
 vi.mock("@/hooks/useWingConfig", () => ({

--- a/frontend/components/workbench/AeroplaneTree.tsx
+++ b/frontend/components/workbench/AeroplaneTree.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useMemo } from "react";
 import { ChevronDown, ChevronRight, Plus, Trash2, Eye, EyeOff, Loader, PanelLeftClose, Pencil } from "lucide-react";
 import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
-import { useWing } from "@/hooks/useWings";
+import { useWing, useAllWingData } from "@/hooks/useWings";
 import type { XSec } from "@/hooks/useWings";
 import { useWingConfig } from "@/hooks/useWingConfig";
 import { API_BASE } from "@/lib/fetcher";
@@ -799,15 +799,21 @@ export function AeroplaneTree(props: Readonly<AeroplaneTreeProps>) {
     onNodeEdit, onEditSpar, onDeleteSpar, onEditTed, onDeleteTed, onAddSpar, onAddTed,
   });
 
+  // Pitch-control capability is an aeroplane-wide property: any wing with an
+  // elevator/elevon/stabilator satisfies the trim/stability requirement, so
+  // the warning must check across all wings rather than just the selected one.
+  const { wings: allWings } = useAllWingData(aeroplaneId, wingNames);
   const hasPitchSurface = useMemo(() => {
-    if (!wing) return true;
-    return wing.x_secs.some((xsec) => {
-      const ted = getTedData(xsec);
-      if (!ted) return false;
-      const role = (ted.role as string) ?? "";
-      return PITCH_ROLES.has(role);
-    });
-  }, [wing]);
+    if (allWings.length === 0) return true;
+    return allWings.some((w) =>
+      w.x_secs.some((xsec) => {
+        const ted = getTedData(xsec);
+        if (!ted) return false;
+        const role = (ted.role as string) ?? "";
+        return PITCH_ROLES.has(role);
+      }),
+    );
+  }, [allWings]);
 
   // Build tree data
   const treeData = buildTreeData({


### PR DESCRIPTION
## Summary

- Pitch-control warning in \`AeroplaneTree\` was evaluated only against the currently selected wing → false positive on every multi-wing aircraft (main wing + horizontal tail, V-tail, canard, etc.)
- Switches \`hasPitchSurface\` to use the existing \`useAllWingData\` hook so the banner reflects **aeroplane-wide** capability
- 3 new tests in \`AeroplaneTreeRoleIcons.test.tsx\` cover the multi-wing scope; existing single-wing tests retained via a mock fallback that wraps \`mockWingData\` into a 1-element list
- \`FuselageTree.test.tsx\` and \`XsecTreeCrud.test.tsx\` mocks updated to expose \`useAllWingData\` (otherwise they crash when rendering AeroplaneTree)

## Test plan

- [x] \`npx vitest run __tests__/AeroplaneTreeRoleIcons.test.tsx\` → 12/12 PASS
- [x] \`npx vitest run\` (full suite) → 584/584 PASS, 71 files
- [x] \`npm run lint\` → 0 errors (8 pre-existing warnings)
- [x] RED → GREEN verified: the two multi-wing tests fail against the per-wing implementation, pass against the aeroplane-wide implementation

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)