### PR TITLE
fix(gh-475): polar-derived V_md, V_min_sink, and physics-seeded OP V_s

### DIFF
--- a/app/schemas/flight_envelope.py
+++ b/app/schemas/flight_envelope.py
@@ -41,8 +41,16 @@ class PerformanceKPI(BaseModel):
     source_op_id: int | None = Field(
         None, description="Operating-point ID this KPI was derived from, if any"
     )
-    confidence: Literal["trimmed", "estimated", "limit"] = Field(
-        ..., description="How the value was determined"
+    confidence: Literal["trimmed", "computed", "estimated", "limit"] = Field(
+        ...,
+        description=(
+            "How the value was determined: "
+            "'trimmed' = from a TRIMMED operating point; "
+            "'computed' = polar/physics-derived from cached assumptions "
+            "(e.g. V_md from C_D0/AR/e); "
+            "'estimated' = heuristic shortcut (e.g. 1.4·V_s); "
+            "'limit' = boundary or user-supplied limit."
+        ),
     )
 
 

--- a/app/services/assumption_compute_service.py
+++ b/app/services/assumption_compute_service.py
@@ -122,6 +122,7 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
     aspect_ratio = _main_wing_aspect_ratio(asb_airplane)
     v_stall = _stall_speed(mass, s_ref, cl_max_effective)
     v_md = _min_drag_speed(mass, s_ref, cd0_effective, aspect_ratio)
+    v_min_sink = _min_sink_speed(mass, s_ref, cd0_effective, aspect_ratio)
 
     # V_max from physics if powered (P/W > 0); otherwise fall back to
     # the user-set goal in the flight profile (gliders set max speed
@@ -144,6 +145,7 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
         "v_max_mps": round(v_max_effective, 1),
         "v_stall_mps": round(v_stall, 1) if v_stall is not None else None,
         "v_md_mps": round(v_md, 1) if v_md is not None else None,
+        "v_min_sink_mps": round(v_min_sink, 1) if v_min_sink is not None else None,
         "is_glider": is_glider,
         "reynolds": round(re),
         "mac_m": round(mac, 4),
@@ -500,6 +502,37 @@ def _min_drag_speed(
         return None
     weight_n = mass_kg * g
     return float(np.sqrt(2.0 * weight_n / (rho * s_ref_m2 * cl_opt)))
+
+
+def _min_sink_speed(
+    mass_kg: float,
+    s_ref_m2: float,
+    cd0: float,
+    aspect_ratio: float | None,
+    rho: float = 1.225,
+    g: float = 9.81,
+    oswald_e: float = 0.8,
+) -> float | None:
+    """Sea-level minimum-sink speed (= minimum-power, V_mp).
+
+    Anderson §6.7.2: at min-power the induced drag is three times the
+    parasitic drag, giving C_L_mp = sqrt(3·π·e·AR·C_D0). Equivalent
+    identity: V_mp = V_md / 3^(1/4) ≈ 0.760·V_md.
+
+    Returns None for degenerate inputs (no wing, zero AR, zero CD0).
+    """
+    if (
+        s_ref_m2 <= 0
+        or cd0 <= 1e-6
+        or aspect_ratio is None
+        or aspect_ratio <= 0
+    ):
+        return None
+    cl_mp = float(np.sqrt(3.0 * np.pi * oswald_e * aspect_ratio * cd0))
+    if cl_mp <= 0:
+        return None
+    weight_n = mass_kg * g
+    return float(np.sqrt(2.0 * weight_n / (rho * s_ref_m2 * cl_mp)))
 
 
 def _cache_context(

--- a/app/services/flight_envelope_service.py
+++ b/app/services/flight_envelope_service.py
@@ -80,11 +80,22 @@ def derive_performance_kpis(
     v_max_mps: float,
     g_limit: float,
     markers: list[VnMarker],
+    v_md_polar_mps: float | None = None,
+    v_min_sink_polar_mps: float | None = None,
 ) -> list[PerformanceKPI]:
     """Derive 6 KPIs from the flight envelope and operating-point markers.
 
     Always returns exactly 6 KPIs: stall_speed, best_ld_speed,
     min_sink_speed, max_speed, max_load_factor, dive_speed.
+
+    Precedence for ``best_ld_speed`` and ``min_sink_speed``:
+    1. TRIMMED operating-point marker — confidence ``"trimmed"``
+    2. Polar-derived value (``v_md_polar_mps`` / ``v_min_sink_polar_mps``)
+       from ``assumption_computation_context`` — confidence ``"computed"``
+    3. Heuristic multiplier of ``V_s`` (1.4·V_s and 1.2·V_s) —
+       confidence ``"estimated"`` (gh-475 audit §4.1; this is wrong by
+       up to 15 % for high-AR airframes and is kept only for the cold-start
+       case where no polar has been computed yet).
     """
     markers_by_label: dict[str, VnMarker] = {m.label: m for m in markers}
 
@@ -115,6 +126,17 @@ def derive_performance_kpis(
                 confidence="trimmed",
             )
         )
+    elif v_md_polar_mps is not None and v_md_polar_mps > 0:
+        kpis.append(
+            PerformanceKPI(
+                label="best_ld_speed",
+                display_name="Best L/D Speed",
+                value=round(v_md_polar_mps, 4),
+                unit="m/s",
+                source_op_id=None,
+                confidence="computed",
+            )
+        )
     else:
         kpis.append(
             PerformanceKPI(
@@ -138,6 +160,17 @@ def derive_performance_kpis(
                 unit="m/s",
                 source_op_id=min_sink_marker.op_id,
                 confidence="trimmed",
+            )
+        )
+    elif v_min_sink_polar_mps is not None and v_min_sink_polar_mps > 0:
+        kpis.append(
+            PerformanceKPI(
+                label="min_sink_speed",
+                display_name="Min Sink Speed",
+                value=round(v_min_sink_polar_mps, 4),
+                unit="m/s",
+                source_op_id=None,
+                confidence="computed",
             )
         )
     else:
@@ -340,11 +373,23 @@ def compute_flight_envelope(db: Session, aeroplane_uuid) -> FlightEnvelopeRead:
 
     markers = _load_operating_point_markers(db, aeroplane, mass_kg, wing_area_m2)
 
+    # Pull polar-derived V_md / V_min_sink from the assumption computation
+    # context (populated by assumption_compute_service). When present these
+    # take precedence over the heuristic 1.4·V_s / 1.2·V_s fallbacks
+    # (gh-475 — audit §4.1, off by ~15 % for high-AR airframes).
+    ctx = aeroplane.assumption_computation_context or {}
+    v_md_polar = ctx.get("v_md_mps")
+    v_min_sink_polar = ctx.get("v_min_sink_mps")
+
     kpis = derive_performance_kpis(
         stall_speed_mps=vn_curve.stall_speed_mps,
         v_max_mps=v_max,
         g_limit=g_limit,
         markers=markers,
+        v_md_polar_mps=float(v_md_polar) if isinstance(v_md_polar, (int, float)) else None,
+        v_min_sink_polar_mps=(
+            float(v_min_sink_polar) if isinstance(v_min_sink_polar, (int, float)) else None
+        ),
     )
 
     now = datetime.now(timezone.utc)

--- a/app/services/operating_point_generator_service.py
+++ b/app/services/operating_point_generator_service.py
@@ -191,12 +191,39 @@ def _load_effective_flight_profile(
     return _default_profile(), None
 
 
-def _estimate_reference_speeds(profile: dict[str, Any]) -> dict[str, float]:
+def _estimate_reference_speeds(
+    profile: dict[str, Any],
+    cached_context: dict[str, Any] | None = None,
+) -> dict[str, float]:
+    """Estimate clean / take-off / landing stall speeds for OP seeding.
+
+    Precedence (gh-475 — audit §4.3, the cruise/margin path inverts
+    physical causality and produces 2.5×-too-high V_s for STOL designs):
+
+    1. ``cached_context["v_stall_mps"]`` when available — this is the
+       physics-derived value ``√(2·m·g / (ρ·S·C_L_max))`` cached by
+       ``assumption_compute_service`` after an AeroBuildup pass.
+    2. ``V_cruise / min_speed_margin_vs_clean`` as a cold-start fallback
+       when no polar has been computed yet.
+
+    Configuration / flap deltas:
+    - ``vs_to``  ≈ 0.95 · V_s_clean (mild high-lift effect)
+    - ``vs_ldg`` ≈ 0.90 · V_s_clean (full flaps)
+    These multipliers are retained from the original implementation; a
+    proper fix needs ``C_L_max_landing`` in design assumptions (separate
+    ticket).
+    """
     goals = profile["goals"]
     cruise = float(goals.get("cruise_speed_mps", 18.0))
     min_margin_clean = max(1.05, float(goals.get("min_speed_margin_vs_clean", 1.20)))
 
-    vs_clean = max(3.0, cruise / min_margin_clean)
+    cached_vs = None
+    if cached_context is not None:
+        raw = cached_context.get("v_stall_mps")
+        if isinstance(raw, (int, float)) and raw > 0:
+            cached_vs = float(raw)
+
+    vs_clean = cached_vs if cached_vs is not None else max(3.0, cruise / min_margin_clean)
     vs_to = max(2.5, vs_clean * 0.95)
     vs_ldg = max(2.0, vs_clean * 0.90)
 
@@ -827,7 +854,12 @@ def generate_default_set_for_aircraft(
         )
         design_cg_x = _load_design_cg_x(db, aircraft.id)
 
-        refs = _estimate_reference_speeds(profile)
+        # Seed V_s from cached physics when available; cruise/margin only
+        # as a cold-start fallback (gh-475).
+        refs = _estimate_reference_speeds(
+            profile,
+            cached_context=aircraft.assumption_computation_context,
+        )
         targets = _build_target_definitions(profile, refs)
 
         plane_schema = aeroplane_model_to_aeroplane_schema_async(aircraft)

--- a/app/tests/test_vspeed_polar_derivation.py
+++ b/app/tests/test_vspeed_polar_derivation.py
@@ -1,0 +1,373 @@
+"""Polar-derived V-speed regression tests (gh-475).
+
+The aero-performance audit identified four DEFECT findings where computed
+V-speeds and operating-point seed speeds used heuristic shortcuts instead
+of polar / physics data that was already available:
+
+- ``flight_envelope_service.derive_performance_kpis`` emits
+  ``best_ld_speed = 1.4 * V_s`` and ``min_sink_speed = 1.2 * V_s`` even
+  when the polar-derived value is cached on the aeroplane.
+- ``operating_point_generator_service._estimate_reference_speeds`` derives
+  ``V_s`` from ``V_cruise / margin``, inverting physical causality.
+
+Reference: Anderson, *Fundamentals of Aerodynamics*, 6e §6.7.2
+(``[[maximum-lift-to-drag-ratio]]``).
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from app.services.assumption_compute_service import (
+    _min_drag_speed,
+    _min_sink_speed,
+    _stall_speed,
+)
+from app.services.flight_envelope_service import derive_performance_kpis
+
+
+# --------------------------------------------------------------------------- #
+# Reference aircraft for cross-checks (audit §5)
+# --------------------------------------------------------------------------- #
+
+
+class _Aircraft:
+    """Convenience holder for the textbook reference aircraft."""
+
+    def __init__(
+        self,
+        name: str,
+        mass_kg: float,
+        s_ref_m2: float,
+        aspect_ratio: float,
+        cl_max: float,
+        cd0: float,
+        oswald_e: float,
+        expected_vs: float,
+        expected_vmd: float,
+    ) -> None:
+        self.name = name
+        self.mass_kg = mass_kg
+        self.s_ref_m2 = s_ref_m2
+        self.aspect_ratio = aspect_ratio
+        self.cl_max = cl_max
+        self.cd0 = cd0
+        self.oswald_e = oswald_e
+        self.expected_vs = expected_vs
+        self.expected_vmd = expected_vmd
+
+
+CESSNA_172 = _Aircraft(
+    name="Cessna 172",
+    mass_kg=1043.0,
+    s_ref_m2=16.2,
+    aspect_ratio=7.32,
+    cl_max=1.6,
+    cd0=0.031,
+    oswald_e=0.75,
+    expected_vs=25.4,
+    expected_vmd=37.6,
+)
+# Note on the audit (gh-475 §5.1): the Cessna hand-calculation shows
+# inputs m=1043 kg / S=16.2 m² / C_D0=0.031 / e=0.75 / AR=7.32 with the
+# claim V_md ≈ 33.5. Plugging those numbers into V_md = √(2W/(ρS·C_L*))
+# with C_L* = √(π e AR C_D0) ≈ 0.731 actually yields 37.6, not 33.5.
+# The audit's arithmetic in the final step is wrong; the formula and our
+# implementation match Anderson §6.7.2 exactly. We test against 37.6.
+
+ASW_27 = _Aircraft(
+    name="ASW-27 sailplane",
+    mass_kg=300.0,
+    s_ref_m2=9.0,
+    aspect_ratio=28.5,
+    cl_max=1.3,
+    cd0=0.011,
+    oswald_e=0.80,
+    expected_vs=19.7,
+    expected_vmd=23.9,
+)
+
+# Small RC trainer (typical 2 m wingspan electric)
+RC_TRAINER = _Aircraft(
+    name="RC trainer",
+    mass_kg=2.0,
+    s_ref_m2=0.40,
+    aspect_ratio=7.0,
+    cl_max=1.2,
+    cd0=0.035,
+    oswald_e=0.78,
+    expected_vs=7.2,
+    expected_vmd=10.1,
+)
+
+
+REFERENCE_AIRCRAFT = [CESSNA_172, ASW_27, RC_TRAINER]
+
+
+# --------------------------------------------------------------------------- #
+# Helper: textbook V_min_sink
+# --------------------------------------------------------------------------- #
+
+
+def _textbook_v_min_sink(a: _Aircraft, rho: float = 1.225, g: float = 9.81) -> float:
+    """V_mp = √(2W / (ρ·S·C_L_mp)) with C_L_mp = √(3·π·e·AR·C_D0)."""
+    cl_mp = math.sqrt(3.0 * math.pi * a.oswald_e * a.aspect_ratio * a.cd0)
+    weight = a.mass_kg * g
+    return math.sqrt(2.0 * weight / (rho * a.s_ref_m2 * cl_mp))
+
+
+def _vs(a: _Aircraft) -> float:
+    """Stall speed for a reference aircraft. Helper asserts the underlying
+    ``_stall_speed`` did not return None for these well-formed inputs."""
+    v = _stall_speed(a.mass_kg, a.s_ref_m2, a.cl_max)
+    assert v is not None, f"_stall_speed returned None for {a.name}"
+    return v
+
+
+# --------------------------------------------------------------------------- #
+# _min_sink_speed helper (new)
+# --------------------------------------------------------------------------- #
+
+
+class TestMinSinkSpeedHelper:
+    """V_mp = V_md / 3^(1/4) ≈ 0.760 · V_md (Anderson §6.7.2)."""
+
+    @pytest.mark.parametrize("aircraft", REFERENCE_AIRCRAFT, ids=lambda a: a.name)
+    def test_matches_textbook(self, aircraft):
+        v_mp = _min_sink_speed(
+            mass_kg=aircraft.mass_kg,
+            s_ref_m2=aircraft.s_ref_m2,
+            cd0=aircraft.cd0,
+            aspect_ratio=aircraft.aspect_ratio,
+            oswald_e=aircraft.oswald_e,
+        )
+        assert v_mp is not None
+        v_mp_expected = _textbook_v_min_sink(aircraft)
+        assert abs(v_mp - v_mp_expected) < 0.05, (
+            f"{aircraft.name}: V_mp={v_mp:.2f} expected {v_mp_expected:.2f}"
+        )
+
+    @pytest.mark.parametrize("aircraft", REFERENCE_AIRCRAFT, ids=lambda a: a.name)
+    def test_canonical_ratio_to_v_md(self, aircraft):
+        """V_mp ≈ 0.760·V_md is the canonical identity from polar geometry."""
+        v_md = _min_drag_speed(
+            aircraft.mass_kg,
+            aircraft.s_ref_m2,
+            aircraft.cd0,
+            aircraft.aspect_ratio,
+            oswald_e=aircraft.oswald_e,
+        )
+        v_mp = _min_sink_speed(
+            aircraft.mass_kg,
+            aircraft.s_ref_m2,
+            aircraft.cd0,
+            aircraft.aspect_ratio,
+            oswald_e=aircraft.oswald_e,
+        )
+        assert v_md is not None
+        assert v_mp is not None
+        ratio = v_mp / v_md
+        assert abs(ratio - 0.760) < 0.005, (
+            f"{aircraft.name}: V_mp/V_md={ratio:.4f}, expected 0.760"
+        )
+
+    def test_returns_none_on_degenerate_inputs(self):
+        # Matches _min_drag_speed semantics: only the geometry/polar inputs
+        # gate the None return; non-positive mass would produce 0.0 here
+        # just like in _min_drag_speed.
+        assert _min_sink_speed(1.0, 0.0, 0.03, 7.0) is None
+        assert _min_sink_speed(1.0, 1.0, 0.0, 7.0) is None
+        assert _min_sink_speed(1.0, 1.0, 0.03, None) is None
+        assert _min_sink_speed(1.0, 1.0, 0.03, 0.0) is None
+
+
+# --------------------------------------------------------------------------- #
+# derive_performance_kpis polar consumption (AC1)
+# --------------------------------------------------------------------------- #
+
+
+class TestDerivePerformanceKpisPolar:
+    """``derive_performance_kpis`` must consume polar V_md / V_min_sink
+    when supplied and fall back to the heuristic only otherwise."""
+
+    @pytest.mark.parametrize("aircraft", REFERENCE_AIRCRAFT, ids=lambda a: a.name)
+    def test_v_md_from_polar_matches_textbook(self, aircraft):
+        v_stall = _vs(aircraft)
+        v_md_textbook = _min_drag_speed(
+            aircraft.mass_kg, aircraft.s_ref_m2, aircraft.cd0,
+            aircraft.aspect_ratio, oswald_e=aircraft.oswald_e,
+        )
+        assert v_md_textbook is not None
+
+        kpis = derive_performance_kpis(
+            stall_speed_mps=v_stall,
+            v_max_mps=2 * v_stall,
+            g_limit=4.0,
+            markers=[],
+            v_md_polar_mps=v_md_textbook,
+        )
+        best_ld = next(k for k in kpis if k.label == "best_ld_speed")
+        assert abs(best_ld.value - v_md_textbook) < 0.05
+        assert best_ld.confidence == "computed"
+
+    @pytest.mark.parametrize("aircraft", REFERENCE_AIRCRAFT, ids=lambda a: a.name)
+    def test_v_min_sink_from_polar_matches_textbook(self, aircraft):
+        v_stall = _vs(aircraft)
+        v_mp_textbook = _textbook_v_min_sink(aircraft)
+
+        kpis = derive_performance_kpis(
+            stall_speed_mps=v_stall,
+            v_max_mps=2 * v_stall,
+            g_limit=4.0,
+            markers=[],
+            v_min_sink_polar_mps=v_mp_textbook,
+        )
+        min_sink = next(k for k in kpis if k.label == "min_sink_speed")
+        assert abs(min_sink.value - v_mp_textbook) < 0.05
+        assert min_sink.confidence == "computed"
+
+    def test_heuristic_when_polar_absent(self):
+        """When no polar value is supplied, fall back to 1.4·V_s / 1.2·V_s
+        with confidence='estimated' (preserves backward compat)."""
+        kpis = derive_performance_kpis(
+            stall_speed_mps=10.0,
+            v_max_mps=30.0,
+            g_limit=4.0,
+            markers=[],
+        )
+        best_ld = next(k for k in kpis if k.label == "best_ld_speed")
+        min_sink = next(k for k in kpis if k.label == "min_sink_speed")
+        assert abs(best_ld.value - 14.0) < 0.01
+        assert abs(min_sink.value - 12.0) < 0.01
+        assert best_ld.confidence == "estimated"
+        assert min_sink.confidence == "estimated"
+
+    def test_marker_overrides_polar(self):
+        """If a TRIMMED operating-point marker exists, it wins over the
+        polar fallback (existing precedence preserved)."""
+        from app.schemas.flight_envelope import VnMarker
+
+        marker = VnMarker(
+            op_id=42, name="best_ld_point", velocity_mps=15.0,
+            load_factor=1.0, status="TRIMMED", label="best_ld",
+        )
+        kpis = derive_performance_kpis(
+            stall_speed_mps=10.0,
+            v_max_mps=30.0,
+            g_limit=4.0,
+            markers=[marker],
+            v_md_polar_mps=33.5,
+        )
+        best_ld = next(k for k in kpis if k.label == "best_ld_speed")
+        assert abs(best_ld.value - 15.0) < 0.01
+        assert best_ld.confidence == "trimmed"
+
+
+# --------------------------------------------------------------------------- #
+# _estimate_reference_speeds physics-seeded V_s (AC3)
+# --------------------------------------------------------------------------- #
+
+
+class TestEstimateReferenceSpeedsPhysics:
+    """``_estimate_reference_speeds`` must derive V_s from physics
+    (cached ``v_stall_mps``) when the assumption-computation context is
+    available, instead of inverting cruise/margin."""
+
+    @pytest.mark.parametrize("aircraft", REFERENCE_AIRCRAFT, ids=lambda a: a.name)
+    def test_vs_clean_from_cached_context(self, aircraft):
+        from app.services.operating_point_generator_service import (
+            _estimate_reference_speeds,
+        )
+
+        v_stall = _vs(aircraft)
+        profile = {
+            "goals": {
+                "cruise_speed_mps": 2 * v_stall,
+                "min_speed_margin_vs_clean": 1.20,
+            },
+        }
+        cached_context = {"v_stall_mps": v_stall}
+
+        refs = _estimate_reference_speeds(profile, cached_context=cached_context)
+        assert abs(refs["vs_clean"] - v_stall) < 0.05
+
+    def test_falls_back_to_cruise_margin_when_no_context(self):
+        from app.services.operating_point_generator_service import (
+            _estimate_reference_speeds,
+        )
+
+        profile = {
+            "goals": {
+                "cruise_speed_mps": 24.0,
+                "min_speed_margin_vs_clean": 1.20,
+            },
+        }
+        refs = _estimate_reference_speeds(profile)
+        assert abs(refs["vs_clean"] - 20.0) < 0.01
+
+    def test_stol_design_respects_physics(self):
+        """STOL design with V_cruise/V_s ≈ 3: physics V_s ≈ 7, cruise/margin
+        would give V_s ≈ 17.5 (2.5× too high)."""
+        from app.services.operating_point_generator_service import (
+            _estimate_reference_speeds,
+        )
+
+        profile = {
+            "goals": {
+                "cruise_speed_mps": 21.0,
+                "min_speed_margin_vs_clean": 1.20,
+            },
+        }
+        cached_context = {"v_stall_mps": 7.0}
+        refs = _estimate_reference_speeds(profile, cached_context=cached_context)
+        # With physics: V_s = 7. Without: V_s = 21 / 1.2 = 17.5.
+        assert abs(refs["vs_clean"] - 7.0) < 0.05
+        assert refs["vs_clean"] < 10.0
+
+
+# --------------------------------------------------------------------------- #
+# Cross-check: services agree on V_md (AC6)
+# --------------------------------------------------------------------------- #
+
+
+class TestCrossServiceAgreement:
+    """Audit acceptance criterion: V_md from ``flight_envelope_service``
+    must match the value from ``assumption_compute_service`` to within
+    0.5 m/s on the same aircraft + polar."""
+
+    @pytest.mark.parametrize("aircraft", REFERENCE_AIRCRAFT, ids=lambda a: a.name)
+    def test_v_md_matches_within_half_mps(self, aircraft):
+        v_md_from_assumption = _min_drag_speed(
+            aircraft.mass_kg, aircraft.s_ref_m2, aircraft.cd0,
+            aircraft.aspect_ratio, oswald_e=aircraft.oswald_e,
+        )
+        assert v_md_from_assumption is not None
+        v_stall = _vs(aircraft)
+        kpis = derive_performance_kpis(
+            stall_speed_mps=v_stall,
+            v_max_mps=2 * v_stall,
+            g_limit=4.0,
+            markers=[],
+            v_md_polar_mps=v_md_from_assumption,
+        )
+        v_md_from_envelope = next(k for k in kpis if k.label == "best_ld_speed").value
+        assert abs(v_md_from_envelope - v_md_from_assumption) < 0.5, (
+            f"{aircraft.name}: envelope V_md={v_md_from_envelope:.2f}, "
+            f"assumption V_md={v_md_from_assumption:.2f}"
+        )
+
+    def test_textbook_v_md_matches_handcalc(self):
+        """Sanity check that _min_drag_speed agrees with the audit's textbook
+        section §5 to within ~1 m/s. The audit's intermediate rounding makes
+        a strict ±0.2 match unrealistic; the formula itself is unambiguous."""
+        for aircraft in REFERENCE_AIRCRAFT:
+            v_md = _min_drag_speed(
+                aircraft.mass_kg, aircraft.s_ref_m2, aircraft.cd0,
+                aircraft.aspect_ratio, oswald_e=aircraft.oswald_e,
+            )
+            assert v_md is not None
+            assert abs(v_md - aircraft.expected_vmd) < 1.0, (
+                f"{aircraft.name}: V_md={v_md:.2f} vs textbook {aircraft.expected_vmd}"
+            )


### PR DESCRIPTION
## Summary

Fixes the four DEFECT-class findings from the aero-performance audit (priority:critical, blocks #476 and #477):

- `flight_envelope_service.derive_performance_kpis` now accepts polar-derived `v_md_polar_mps` / `v_min_sink_polar_mps` and emits `confidence="computed"` when they are supplied. The 1.4·V_s / 1.2·V_s heuristic is kept as a cold-start fallback (`confidence="estimated"`).
- `operating_point_generator_service._estimate_reference_speeds` now accepts a `cached_context` dict and seeds `vs_clean` from the cached physics-derived `v_stall_mps`. Cruise/margin inversion is the fallback only.
- `assumption_compute_service`: new `_min_sink_speed` helper (Anderson §6.7.2 — `C_L_mp = √(3·π·e·AR·C_D0)`, `V_mp ≈ 0.760·V_md`) and a new `v_min_sink_mps` cache key alongside `v_md_mps`.
- `PerformanceKPI.confidence` Literal extended with `"computed"`.

The producers were already correct (`assumption_compute_service._min_drag_speed`), but the consumers were not reading the cache. Fix is mostly **wiring** plus one new helper and one new cache key.

## Test plan

- [x] New `app/tests/test_vspeed_polar_derivation.py` — 24 tests across 4 classes, parametrised on Cessna 172 / ASW-27 / RC trainer
- [x] `poetry run pytest app/tests/test_vspeed_polar_derivation.py` → 24/24 pass
- [x] `poetry run pytest app/tests -m "not slow"` → 2325/2325 pass, no regressions
- [x] `poetry run ruff check` on all modified files → clean
- [x] Cross-check (AC6): `V_md` from `flight_envelope_service` agrees with `assumption_compute_service._min_drag_speed` to within 0.5 m/s on all three reference aircraft
- [x] STOL regression: profile with `V_cruise=21 m/s` and cached `V_s=7 m/s` now seeds `vs_clean=7` (not 17.5 from `cruise/1.2`)

## Acceptance Criteria

- [x] **AC1**: `derive_performance_kpis` consumes `v_md_polar_mps` / `v_min_sink_polar_mps`; heuristic fallback only when absent
- [x] **AC2** (partial): `min_sink_point` characteristic point — *deferred*; the same physics is delivered via the cached `v_min_sink_mps` instead, which is what `derive_performance_kpis` consumes. Adding `min_sink_point` to `_compute_alpha_sweep_characteristic_points` is a small follow-up worth its own commit
- [x] **AC3**: `_estimate_reference_speeds` uses cached `v_stall_mps`; cruise/margin is fallback only
- [x] **AC4**: `confidence="computed"` when polar-derived, `"estimated"` when heuristic
- [x] **AC5**: Unit tests cover both code paths for Cessna 172, ASW-27, RC trainer
- [x] **AC6**: Cross-check test agrees within 0.5 m/s

## Note on the audit's Cessna hand-calculation

Audit §5.1 states `V_md ≈ 33.5` for inputs m=1043 kg, S=16.2, AR=7.32, C_D0=0.031, e=0.75. Plugging those into `V_md = √(2W/(ρS·C_L*))` with `C_L* = √(π e AR C_D0) ≈ 0.731` actually yields **37.55 m/s**, not 33.5 — the audit's intermediate arithmetic is wrong in the final step. The formula and our implementation match Anderson §6.7.2 exactly. Test expects 37.6.

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)