### PR TITLE
fix(gh-481): align TED role dropdown with backend enum (flaperon, ruddervator; drop spoiler)

### DIFF
--- a/app/schemas/aeroplaneschema.py
+++ b/app/schemas/aeroplaneschema.py
@@ -35,7 +35,6 @@ class ControlSurfaceRole(str, Enum):
     RUDDERVATOR = "ruddervator"
     STABILATOR = "stabilator"
     FLAP = "flap"
-    SPOILER = "spoiler"
     OTHER = "other"
 
 

--- a/app/tests/test_control_surface_role.py
+++ b/app/tests/test_control_surface_role.py
@@ -13,7 +13,7 @@ class TestControlSurfaceRole:
         assert ControlSurfaceRole.OTHER == "other"
 
     def test_all_roles_present(self):
-        expected = {"elevator", "aileron", "rudder", "elevon", "stabilator", "flap", "flaperon", "ruddervator", "spoiler", "other"}
+        expected = {"elevator", "aileron", "rudder", "elevon", "stabilator", "flap", "flaperon", "ruddervator", "other"}
         assert {r.value for r in ControlSurfaceRole} == expected
 
     def test_dual_roles_are_subset_of_enum(self):

--- a/frontend/__tests__/AeroplaneTreeRoleIcons.test.tsx
+++ b/frontend/__tests__/AeroplaneTreeRoleIcons.test.tsx
@@ -157,9 +157,10 @@ describe("AeroplaneTree role icons (gh-450)", () => {
       { role: "aileron", icon: "↔" },
       { role: "rudder", icon: "⟳" },
       { role: "elevon", icon: "⤡" },
+      { role: "flaperon", icon: "⇋" },
+      { role: "ruddervator", icon: "⋎" },
       { role: "stabilator", icon: "↕" },
       { role: "flap", icon: "▽" },
-      { role: "spoiler", icon: "▢" },
       { role: "other", icon: "○" },
     ];
     for (const { role, icon } of roles) {
@@ -229,6 +230,32 @@ describe("AeroplaneTree pitch warning (gh-450)", () => {
     expect(
       screen.queryByText(/No pitch control surface assigned/),
     ).toBeNull();
+  });
+
+  it("does not show warning when wing has ruddervator (V-tail)", () => {
+    // gh-481: ruddervator provides pitch authority (V-tail surface acting
+    // as elevator) and must satisfy the pitch-control check.
+    mockWingData = makeWing([
+      makeXsec({ trailing_edge_device: { role: "ruddervator", label: "" } }),
+      makeXsec(),
+    ]);
+    render(<AeroplaneTree {...baseProps} />);
+    expect(
+      screen.queryByText(/No pitch control surface assigned/),
+    ).toBeNull();
+  });
+
+  it("shows warning when wing has only flaperon (not a pitch surface)", () => {
+    // gh-481: flaperon is roll + lift augmentation only; does not satisfy
+    // the pitch-control requirement.
+    mockWingData = makeWing([
+      makeXsec({ trailing_edge_device: { role: "flaperon", label: "" } }),
+      makeXsec(),
+    ]);
+    render(<AeroplaneTree {...baseProps} />);
+    expect(
+      screen.getByText(/No pitch control surface assigned/),
+    ).toBeTruthy();
   });
 
   it("does not show warning when no wing is loaded", () => {

--- a/frontend/__tests__/TedEditDialog.test.tsx
+++ b/frontend/__tests__/TedEditDialog.test.tsx
@@ -52,11 +52,11 @@ describe("TedEditDialog role dropdown", () => {
     onSaved: vi.fn(),
   };
 
-  it("renders role dropdown with all 8 options", () => {
+  it("renders role dropdown with all 9 options", () => {
     render(<TedEditDialog {...defaultProps} />);
     const select = screen.getByLabelText("Role") as HTMLSelectElement;
     expect(select).toBeTruthy();
-    expect(select.options.length).toBe(8);
+    expect(select.options.length).toBe(9);
   });
 
   it("defaults role to 'other' for new TED", () => {
@@ -110,10 +110,12 @@ describe("TedEditDialog role dropdown", () => {
     expect(values).toContain("aileron");
     expect(values).toContain("rudder");
     expect(values).toContain("elevon");
+    expect(values).toContain("flaperon");
+    expect(values).toContain("ruddervator");
     expect(values).toContain("stabilator");
     expect(values).toContain("flap");
-    expect(values).toContain("spoiler");
     expect(values).toContain("other");
+    expect(values).not.toContain("spoiler");
   });
 });
 

--- a/frontend/components/workbench/AeroplaneTree.tsx
+++ b/frontend/components/workbench/AeroplaneTree.tsx
@@ -70,13 +70,17 @@ const ROLE_ICONS: Record<string, string> = {
   aileron: "↔",
   rudder: "⟳",
   elevon: "⤡",
+  flaperon: "⇋",
+  ruddervator: "⋎",
   stabilator: "↕",
   flap: "▽",
-  spoiler: "▢",
   other: "○",
 };
 
-const PITCH_ROLES = new Set(["elevator", "elevon", "stabilator"]);
+// Pitch-control roles. Ruddervator (V-tail) provides pitch authority
+// in addition to yaw, so it counts here. Flaperon does not (roll + lift
+// augmentation, not pitch).
+const PITCH_ROLES = new Set(["elevator", "elevon", "stabilator", "ruddervator"]);
 
 function getRoleIcon(role: string): string {
   return ROLE_ICONS[role] ?? "○";
@@ -900,7 +904,7 @@ export function AeroplaneTree(props: Readonly<AeroplaneTreeProps>) {
           role="alert"
           className="mt-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-[11px] text-amber-400"
         >
-          No pitch control surface assigned. Auto-trim and stability analysis require an elevator, elevon, or stabilator.
+          No pitch control surface assigned. Auto-trim and stability analysis require an elevator, elevon, stabilator, or ruddervator.
         </div>
       )}
 

--- a/frontend/components/workbench/TedEditDialog.tsx
+++ b/frontend/components/workbench/TedEditDialog.tsx
@@ -13,9 +13,10 @@ const CONTROL_SURFACE_ROLES = [
   { value: "aileron", label: "Aileron" },
   { value: "rudder", label: "Rudder" },
   { value: "elevon", label: "Elevon" },
+  { value: "flaperon", label: "Flaperon" },
+  { value: "ruddervator", label: "Ruddervator" },
   { value: "stabilator", label: "Stabilator" },
   { value: "flap", label: "Flap" },
-  { value: "spoiler", label: "Spoiler" },
   { value: "other", label: "Other" },
 ] as const;
 


### PR DESCRIPTION
## Summary

Follow-up to #463 — the frontend role dropdown is hardcoded and was never picking up the backend enum values added in 60bf59f. This PR aligns them.

- **Add** \`flaperon\` and \`ruddervator\` to the TED dropdown
- **Drop** \`spoiler\` from both the dropdown and the \`ControlSurfaceRole\` enum — no service/converter consumed it
- **Update** \`PITCH_ROLES\` to include \`ruddervator\` (V-tail surfaces provide pitch authority; flaperon does not)
- **Update** the "no pitch control surface" warning text accordingly
- **Add icons** for the two new roles in \`AeroplaneTree\`: flaperon=⇋, ruddervator=⋎

## Test plan

- [x] Backend \`test_control_surface_role.py\` updated; 31/31 pass
- [x] Frontend \`AeroplaneTreeRoleIcons.test.tsx\` + \`TedEditDialog.test.tsx\` updated; 24/24 pass (added 2 ruddervator/flaperon pitch tests)
- [x] Full frontend suite: 586/586 pass (71 files)
- [x] Backend ruff clean
- [x] Frontend ESLint clean (0 errors)

## Decision

Per user: remove only \`spoiler\`. Keep \`other\` ("man weiß ja nie, was einer mit other machen will").

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)