### PR TITLE
fix(gh-483): route ruddervator and flaperon through trim solver

### DIFF
--- a/app/services/operating_point_generator_service.py
+++ b/app/services/operating_point_generator_service.py
@@ -32,9 +32,16 @@ from app.services.trim_enrichment_service import (
 
 logger = logging.getLogger(__name__)
 
-PITCH_ROLES = {"elevator", "stabilator", "elevon"}
-ROLL_ROLES = {"aileron", "elevon"}
-YAW_ROLES = {"rudder"}
+# Dual-role surfaces are listed in every axis set whose primary or
+# secondary effect they provide:
+#   - elevon     = elevator (pitch) + aileron (roll)
+#   - flaperon   = aileron  (roll)  + flap     (lift augmentation)
+#   - ruddervator = elevator (pitch) + rudder  (yaw) — V-tail
+# Membership here drives _detect_control_capabilities and the
+# axis-specific _pick_control_name() lookups during trim solving.
+PITCH_ROLES = {"elevator", "stabilator", "elevon", "ruddervator"}
+ROLL_ROLES = {"aileron", "elevon", "flaperon"}
+YAW_ROLES = {"rudder", "ruddervator"}
 FLAP_ROLES = {"flap"}
 
 

--- a/app/services/retrim_service.py
+++ b/app/services/retrim_service.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_PITCH_ROLES = {"elevator", "stabilator", "elevon"}
+_PITCH_ROLES = {"elevator", "stabilator", "elevon", "ruddervator"}
 
 
 def _find_pitch_control_name(db: Session, aeroplane_id: int) -> str | None:

--- a/app/services/trim_enrichment_service.py
+++ b/app/services/trim_enrichment_service.py
@@ -31,8 +31,9 @@ ROLE_COEFFICIENT_MAP: dict[str, str] = {
     "stabilator": "Cm",
     "aileron": "Cl",
     "rudder": "Cn",
-    "elevon": "Cm",  # primary axis for elevon
-    "flaperon": "Cl",
+    "elevon": "Cm",       # dual-role: pitch is primary, roll via differential
+    "flaperon": "Cl",     # dual-role: roll is primary, flap (lift) via symmetric
+    "ruddervator": "Cm",  # V-tail: pitch is primary, yaw via differential
     "flap": "CL",
 }
 
@@ -273,7 +274,7 @@ def generate_result_summary(
     pitch_reserve_str = ""
     for name, reserve in deflection_reserves.items():
         role, _ = parse_role_tag(name)
-        if role in ("elevator", "stabilator", "elevon"):
+        if role in ("elevator", "stabilator", "elevon", "ruddervator"):
             reserve_pct = (1 - reserve.usage_fraction) * 100
             pitch_reserve_str = f" with {reserve_pct:.0f}% elevator reserve"
             break

--- a/app/tests/test_control_surface_role.py
+++ b/app/tests/test_control_surface_role.py
@@ -30,6 +30,32 @@ class TestControlSurfaceRole:
         from app.services.trim_enrichment_service import ROLE_COEFFICIENT_MAP
         assert set(ROLE_COEFFICIENT_MAP) <= {r.value for r in ControlSurfaceRole}
 
+    def test_every_actuating_role_is_covered_by_an_axis(self):
+        # Why (gh-483): every ControlSurfaceRole value that represents an
+        # actuating surface must appear in at least one of the four axis
+        # routing sets used by the trim solver. Otherwise a user-assignable
+        # role silently fails to influence trim. Only "other" is exempt
+        # (it's a catch-all label, not a routed axis).
+        from app.services.operating_point_generator_service import (
+            PITCH_ROLES, ROLL_ROLES, YAW_ROLES, FLAP_ROLES,
+        )
+        actuating = {r.value for r in ControlSurfaceRole} - {"other"}
+        covered = PITCH_ROLES | ROLL_ROLES | YAW_ROLES | FLAP_ROLES
+        assert actuating <= covered, (
+            f"Unrouted control surface roles (no axis assignment): "
+            f"{actuating - covered}"
+        )
+
+    def test_retrim_pitch_roles_match_op_generator(self):
+        # Why (gh-483): retrim_service decides which OPs to mark DIRTY
+        # when a hinge angle on a pitch surface changes. If retrim's
+        # pitch set is narrower than the OP generator's, changes to a
+        # ruddervator (or any other newly-added pitch role) silently
+        # leave stale trim values in place.
+        from app.services.operating_point_generator_service import PITCH_ROLES
+        from app.services.retrim_service import _PITCH_ROLES
+        assert _PITCH_ROLES == PITCH_ROLES
+
 
 class TestTedSchemaRoleField:
     def test_role_defaults_to_other(self):
@@ -151,6 +177,24 @@ class TestRoleBasedDetection:
         assert caps["has_pitch_control"] is True
         assert caps["has_roll_control"] is True
 
+    def test_ruddervator_detected_as_both_pitch_and_yaw(self):
+        # gh-483: V-tail surfaces provide pitch (via symmetric deflection)
+        # AND yaw (via differential deflection). Both capability flags
+        # must be set so the trim solver considers the aircraft trimmable
+        # in pitch and yaw.
+        airplane = _mock_airplane_with_controls(["[ruddervator]V-Tail"])
+        caps = _detect_control_capabilities(airplane)
+        assert caps["has_pitch_control"] is True
+        assert caps["has_yaw_control"] is True
+
+    def test_flaperon_detected_as_roll(self):
+        # gh-483: flaperon = flap + aileron. The roll-control flag must
+        # be set so trim points that require roll authority are not
+        # silently skipped on flaperon-only configurations.
+        airplane = _mock_airplane_with_controls(["[flaperon]Flap-Aileron"])
+        caps = _detect_control_capabilities(airplane)
+        assert caps["has_roll_control"] is True
+
     def test_other_role_not_detected_as_control(self):
         airplane = _mock_airplane_with_controls(["[other]Custom"])
         caps = _detect_control_capabilities(airplane)
@@ -177,6 +221,36 @@ class TestRoleBasedPickControl:
             roles={"elevator"},
         )
         assert result == "[elevator]Höhenruder"
+
+    def test_pick_ruddervator_for_pitch(self):
+        # gh-483: Pitch-axis trim must be able to select a ruddervator
+        # surface when no dedicated elevator exists.
+        from app.services.operating_point_generator_service import PITCH_ROLES
+        result = _pick_control_name(
+            ["[ruddervator]V-Tail-L", "[ruddervator]V-Tail-R"],
+            roles=PITCH_ROLES,
+        )
+        assert result == "[ruddervator]V-Tail-L"
+
+    def test_pick_ruddervator_for_yaw(self):
+        # gh-483: Yaw-axis trim must be able to select a ruddervator
+        # surface when no dedicated rudder exists.
+        from app.services.operating_point_generator_service import YAW_ROLES
+        result = _pick_control_name(
+            ["[ruddervator]V-Tail-L", "[ruddervator]V-Tail-R"],
+            roles=YAW_ROLES,
+        )
+        assert result == "[ruddervator]V-Tail-L"
+
+    def test_pick_flaperon_for_roll(self):
+        # gh-483: Roll-axis trim must be able to select a flaperon when
+        # the aircraft has no dedicated aileron.
+        from app.services.operating_point_generator_service import ROLL_ROLES
+        result = _pick_control_name(
+            ["[flaperon]Left", "[flaperon]Right"],
+            roles=ROLL_ROLES,
+        )
+        assert result == "[flaperon]Left"
 
     def test_pick_flap(self):
         result = _pick_control_name(


### PR DESCRIPTION
## Summary

After #481 wired flaperon and ruddervator into \`ControlSurfaceRole\` and the frontend dropdown, the backend trim-solver routing still didn't know about them. A V-tail aircraft with \`role="ruddervator"\` was silently reported as having no pitch / no yaw control, and every pitch-relevant operating point was skipped during OP generation. Same class of silent failure for flaperon-only aircraft on the roll axis.

## Changes

| File | What |
|---|---|
| \`operating_point_generator_service.py\` | \`ruddervator\` → \`PITCH_ROLES\` + \`YAW_ROLES\`; \`flaperon\` → \`ROLL_ROLES\` |
| \`retrim_service.py\` | \`_PITCH_ROLES\` updated so ruddervator hinge changes mark trim OPs DIRTY |
| \`trim_enrichment_service.py\` | \`ROLE_COEFFICIENT_MAP["ruddervator"] = "Cm"\`; pitch-reserve display recognises ruddervator |
| \`tests/test_control_surface_role.py\` | 5 detection/pick tests + 2 invariants (every actuating role is routed; retrim ≡ OP generator pitch sets) |

## Test plan

- [x] RED first: the 5 new ruddervator/flaperon tests fail on the previous code
- [x] After fix: \`pytest app/tests/test_control_surface_role.py\` → 38/38 pass
- [x] Wider regression: \`pytest test_control_surface_role test_operating_point_generator_service{,_extended} test_retrim_service test_trim_enrichment\` → 219/219 pass
- [x] ruff clean

## Why this is critical

This bug was hidden by the previous routing pre-481 (the enum values didn't exist, so no surface could carry these roles). After #481 made the roles assignable in the UI, the silent skip became reachable. Any user who tags their V-tail surfaces as \`ruddervator\` (which the new UI invites) would see all pitch trim points skipped without any error.

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)