### PR TITLE
feat(gh-488): CG envelope from loading scenarios (forward / aft CG limits)

### DIFF
--- a/alembic/versions/edeb222a39a8_add_loading_scenarios_table_gh_488.py
+++ b/alembic/versions/edeb222a39a8_add_loading_scenarios_table_gh_488.py
@@ -1,0 +1,61 @@
+"""add loading_scenarios table (gh-488)
+
+Revision ID: edeb222a39a8
+Revises: cdcac8fb40b5
+Create Date: 2026-05-13 10:17:00.406132
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'edeb222a39a8'
+down_revision: Union[str, None] = 'cdcac8fb40b5'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add loading_scenarios table for CG envelope (gh-488)."""
+    op.create_table(
+        "loading_scenarios",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("aeroplane_id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column(
+            "aircraft_class", sa.String(), server_default="rc_trainer", nullable=False
+        ),
+        sa.Column(
+            "component_overrides", sa.JSON(), server_default="{}", nullable=False
+        ),
+        sa.Column(
+            "is_default", sa.Boolean(), server_default="false", nullable=False
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["aeroplane_id"], ["aeroplanes.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_loading_scenarios_aeroplane_id"),
+        "loading_scenarios",
+        ["aeroplane_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Remove loading_scenarios table."""
+    op.drop_index(
+        op.f("ix_loading_scenarios_aeroplane_id"), table_name="loading_scenarios"
+    )
+    op.drop_table("loading_scenarios")

--- a/app/api/v2/endpoints/aeroplane/__init__.py
+++ b/app/api/v2/endpoints/aeroplane/__init__.py
@@ -17,6 +17,7 @@ from .avl_geometry import router as avl_geometry_router
 from .design_assumptions import router as design_assumptions_router
 from .mass_cg import router as mass_cg_router
 from .flight_envelope import router as flight_envelope_router
+from .loading_scenarios import router as loading_scenarios_router
 
 # Include the routers
 router.include_router(base_router)
@@ -31,3 +32,4 @@ router.include_router(avl_geometry_router)
 router.include_router(design_assumptions_router)
 router.include_router(mass_cg_router)
 router.include_router(flight_envelope_router)
+router.include_router(loading_scenarios_router)

--- a/app/api/v2/endpoints/aeroplane/loading_scenarios.py
+++ b/app/api/v2/endpoints/aeroplane/loading_scenarios.py
@@ -1,0 +1,199 @@
+"""Loading Scenario endpoints (gh-488) — CG envelope from loading scenarios."""
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, status
+from pydantic import UUID4
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import (
+    ConflictError,
+    InternalError,
+    NotFoundError,
+    ServiceException,
+    ValidationDomainError,
+    ValidationError,
+)
+from app.db.session import get_db
+from app.schemas.loading_scenario import (
+    CgEnvelopeRead,
+    LoadingScenarioCreate,
+    LoadingScenarioRead,
+    LoadingScenarioUpdate,
+)
+from app.services import loading_scenario_service as svc
+from app.services.loading_template_service import get_templates_for_class
+
+router = APIRouter()
+
+
+def _raise_http(exc: ServiceException) -> None:
+    if isinstance(exc, NotFoundError):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=exc.message) from exc
+    if isinstance(exc, (ValidationError, ValidationDomainError)):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=exc.message
+        ) from exc
+    if isinstance(exc, ConflictError):
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=exc.message) from exc
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=exc.message
+    ) from exc
+
+
+def _call(func, *args, **kwargs):
+    try:
+        return func(*args, **kwargs)
+    except ServiceException as exc:
+        _raise_http(exc)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Unexpected error: {exc}") from exc
+
+
+@router.get(
+    "/aeroplanes/{aeroplane_id}/loading-scenarios",
+    status_code=status.HTTP_200_OK,
+    tags=["loading-scenarios"],
+    operation_id="list_loading_scenarios",
+    response_model=list[LoadingScenarioRead],
+    responses={
+        404: {"description": "Aeroplane not found"},
+        500: {"description": "Internal server error"},
+    },
+)
+async def list_loading_scenarios(
+    aeroplane_id: Annotated[UUID4, Path(description="Aeroplane UUID")],
+    db: Annotated[Session, Depends(get_db)],
+) -> list[LoadingScenarioRead]:
+    """List all loading scenarios for an aeroplane."""
+    return _call(svc.list_scenarios, db, aeroplane_id)
+
+
+@router.post(
+    "/aeroplanes/{aeroplane_id}/loading-scenarios",
+    status_code=status.HTTP_201_CREATED,
+    tags=["loading-scenarios"],
+    operation_id="create_loading_scenario",
+    response_model=LoadingScenarioRead,
+    responses={
+        404: {"description": "Aeroplane not found"},
+        422: {"description": "Validation error"},
+        500: {"description": "Internal server error"},
+    },
+)
+async def create_loading_scenario(
+    aeroplane_id: Annotated[UUID4, Path(description="Aeroplane UUID")],
+    body: Annotated[LoadingScenarioCreate, Body(description="Loading scenario to create")],
+    db: Annotated[Session, Depends(get_db)],
+) -> LoadingScenarioRead:
+    """Create a new loading scenario for an aeroplane.
+
+    A loading scenario defines a named CG loadout via component overrides
+    and adhoc items (pilot, payload, ballast, etc.).  The union of all
+    scenarios produces the Loading-Envelope.
+
+    Creating a scenario marks all operating points as DIRTY and triggers a
+    retrim at the envelope extremes.
+    """
+    return _call(svc.create_scenario, db, aeroplane_id, body)
+
+
+@router.patch(
+    "/aeroplanes/{aeroplane_id}/loading-scenarios/{scenario_id}",
+    status_code=status.HTTP_200_OK,
+    tags=["loading-scenarios"],
+    operation_id="update_loading_scenario",
+    response_model=LoadingScenarioRead,
+    responses={
+        404: {"description": "Aeroplane or scenario not found"},
+        422: {"description": "Validation error"},
+        500: {"description": "Internal server error"},
+    },
+)
+async def update_loading_scenario(
+    aeroplane_id: Annotated[UUID4, Path(description="Aeroplane UUID")],
+    scenario_id: Annotated[int, Path(description="Scenario ID")],
+    body: Annotated[LoadingScenarioUpdate, Body(description="Fields to update")],
+    db: Annotated[Session, Depends(get_db)],
+) -> LoadingScenarioRead:
+    """Partially update a loading scenario."""
+    return _call(svc.update_scenario, db, aeroplane_id, scenario_id, body)
+
+
+@router.delete(
+    "/aeroplanes/{aeroplane_id}/loading-scenarios/{scenario_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    tags=["loading-scenarios"],
+    operation_id="delete_loading_scenario",
+    responses={
+        404: {"description": "Aeroplane or scenario not found"},
+        500: {"description": "Internal server error"},
+    },
+)
+async def delete_loading_scenario(
+    aeroplane_id: Annotated[UUID4, Path(description="Aeroplane UUID")],
+    scenario_id: Annotated[int, Path(description="Scenario ID")],
+    db: Annotated[Session, Depends(get_db)],
+) -> None:
+    """Delete a loading scenario."""
+    _call(svc.delete_scenario, db, aeroplane_id, scenario_id)
+
+
+@router.get(
+    "/aeroplanes/{aeroplane_id}/cg-envelope",
+    status_code=status.HTTP_200_OK,
+    tags=["loading-scenarios"],
+    operation_id="get_cg_envelope",
+    response_model=CgEnvelopeRead,
+    responses={
+        404: {"description": "Aeroplane not found"},
+        500: {"description": "Internal server error"},
+    },
+)
+async def get_cg_envelope(
+    aeroplane_id: Annotated[UUID4, Path(description="Aeroplane UUID")],
+    db: Annotated[Session, Depends(get_db)],
+) -> CgEnvelopeRead:
+    """Get the CG envelope for an aeroplane.
+
+    Returns both the Loading-Envelope (min/max CG from all loading scenarios)
+    and the Stability-Envelope (physically permissible CG range from aerodynamics),
+    plus a classification and validation warnings.
+
+    Classification (relative to target_static_margin — Scholz §4.2):
+      error: SM < 0.02 or SM > 0.30
+      warn:  0.02 ≤ SM < target or 0.20 < SM ≤ 0.30
+      ok:    target ≤ SM ≤ 0.20
+    """
+    result = _call(svc.get_cg_envelope, db, aeroplane_id)
+    return CgEnvelopeRead(**result)
+
+
+@router.get(
+    "/aeroplanes/{aeroplane_id}/loading-scenarios/templates",
+    status_code=status.HTTP_200_OK,
+    tags=["loading-scenarios"],
+    operation_id="get_loading_scenario_templates",
+    responses={
+        404: {"description": "Aeroplane not found"},
+        500: {"description": "Internal server error"},
+    },
+)
+async def get_loading_scenario_templates(
+    aeroplane_id: Annotated[UUID4, Path(description="Aeroplane UUID")],
+    db: Annotated[Session, Depends(get_db)],
+    aircraft_class: Annotated[
+        str,
+        Query(description="Aircraft class: rc_trainer | rc_aerobatic | rc_combust | uav_survey | glider | boxwing"),
+    ] = "rc_trainer",
+) -> list[dict]:
+    """Get default loading scenario templates for the given aircraft class.
+
+    Templates provide a sensible starting set of scenarios (Battery Fwd/Aft,
+    With/Without Payload, etc.) that the user can customise or discard.
+    They are NOT automatically created at aeroplane creation.
+    """
+    # Verify the aeroplane exists
+    _call(svc.list_scenarios, db, aeroplane_id)
+    return get_templates_for_class(aircraft_class)

--- a/app/api/v2/endpoints/aeroplane/loading_scenarios.py
+++ b/app/api/v2/endpoints/aeroplane/loading_scenarios.py
@@ -166,8 +166,7 @@ async def get_cg_envelope(
       warn:  0.02 ≤ SM < target or 0.20 < SM ≤ 0.30
       ok:    target ≤ SM ≤ 0.20
     """
-    result = _call(svc.get_cg_envelope, db, aeroplane_id)
-    return CgEnvelopeRead(**result)
+    return _call(svc.get_cg_envelope, db, aeroplane_id)
 
 
 @router.get(

--- a/app/models/aeroplanemodel.py
+++ b/app/models/aeroplanemodel.py
@@ -473,6 +473,37 @@ class FuselageModel(Base):
         return fuselage
 
 
+class LoadingScenarioModel(Base):
+    """Loading scenario — a named CG loadout for CG envelope computation (gh-488).
+
+    Each scenario describes a combination of component overrides and adhoc items
+    (pilot, payload, ballast, etc.) that determines a CG position.  The min/max
+    across all scenarios for an aeroplane defines the Loading-Envelope.
+    """
+
+    __tablename__ = "loading_scenarios"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    aeroplane_id = Column(
+        Integer,
+        ForeignKey(_FK_AEROPLANES_ID, ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    name = Column(String, nullable=False)
+    aircraft_class = Column(String, nullable=False, default="rc_trainer", server_default="rc_trainer")
+    component_overrides = Column(JSON, nullable=False, default=dict, server_default="{}")
+    is_default = Column(Boolean, nullable=False, default=False, server_default="false")
+    created_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    aeroplane = relationship("AeroplaneModel", back_populates="loading_scenarios")
+
+
 class AeroplaneModel(Base):
     __tablename__ = "aeroplanes"
     uuid = Column(GUID, default=lambda: uuid.uuid4(), unique=True, nullable=False)
@@ -546,6 +577,12 @@ class AeroplaneModel(Base):
         "StabilityResultModel",
         back_populates="aeroplane",
         cascade=_CASCADE_ALL_DELETE_ORPHAN,
+    )
+    loading_scenarios = relationship(
+        "LoadingScenarioModel",
+        back_populates="aeroplane",
+        cascade=_CASCADE_ALL_DELETE_ORPHAN,
+        order_by="LoadingScenarioModel.id",
     )
 
 

--- a/app/schemas/loading_scenario.py
+++ b/app/schemas/loading_scenario.py
@@ -25,7 +25,9 @@ AIRCRAFT_CLASS = Literal[
 ADHOC_CATEGORY = Literal["pilot", "payload", "ballast", "fuel", "fpv_gear", "other"]
 
 # Overall classification of the CG envelope status
-CG_CLASSIFICATION = Literal["error", "warn", "ok"]
+# "unknown" is returned when the stability envelope cannot be computed
+# (x_NP and MAC not yet populated by recompute_assumptions).
+CG_CLASSIFICATION = Literal["error", "warn", "ok", "unknown"]
 
 
 # ---------------------------------------------------------------------------
@@ -160,24 +162,37 @@ class CgEnvelopeRead(BaseModel):
 
     cg_loading_fwd_m: float = Field(..., description="Forward-most loading CG [m]")
     cg_loading_aft_m: float = Field(..., description="Aft-most loading CG [m]")
-    cg_stability_fwd_m: float = Field(
-        ...,
+    cg_stability_fwd_m: float | None = Field(
+        None,
         description=(
             "Forward stability limit (elevator-authority stub = x_NP - 0.30*MAC) [m]. "
+            "None when x_NP / MAC not yet computed (run recompute_assumptions first). "
             "TODO: replace with full Cm-trim@CL_max_landing per Anderson §7.7."
         ),
     )
-    cg_stability_aft_m: float = Field(
-        ..., description="Aft stability limit = x_NP - target_sm*MAC [m]"
+    cg_stability_aft_m: float | None = Field(
+        None, description="Aft stability limit = x_NP - target_sm*MAC [m]. None until computed."
     )
-    sm_at_fwd: float = Field(
-        ..., description="Static margin at forward loading CG (dimensionless)"
+    sm_at_fwd: float | None = Field(
+        None,
+        description=(
+            "Static margin at forward loading CG (dimensionless). "
+            "None when stability envelope is unavailable."
+        ),
     )
-    sm_at_aft: float = Field(
-        ..., description="Static margin at aft loading CG (dimensionless)"
+    sm_at_aft: float | None = Field(
+        None,
+        description=(
+            "Static margin at aft loading CG (dimensionless). "
+            "None when stability envelope is unavailable."
+        ),
     )
     classification: CG_CLASSIFICATION = Field(
-        ..., description="Overall envelope classification: error | warn | ok"
+        ...,
+        description=(
+            "Overall envelope classification: error | warn | ok | unknown. "
+            "'unknown' when x_NP/MAC not yet computed — run recompute_assumptions."
+        ),
     )
     warnings: list[str] = Field(
         default_factory=list, description="Human-readable warnings and errors"

--- a/app/schemas/loading_scenario.py
+++ b/app/schemas/loading_scenario.py
@@ -1,0 +1,184 @@
+"""Pydantic schemas for Loading Scenarios (gh-488).
+
+Loading-Envelope = CG range produced by user-defined loading scenarios.
+Stability-Envelope = physically permissible CG range from aerodynamics.
+
+Source: Anderson 6e §7.5–§7.7, Scholz §4.2 (10_BoxWingSystematic.md).
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+# Supported aircraft classes for template selection and SM thresholds
+AIRCRAFT_CLASS = Literal[
+    "rc_trainer",
+    "rc_aerobatic",
+    "rc_combust",
+    "uav_survey",
+    "glider",
+    "boxwing",
+]
+
+# Valid adhoc item categories (matched to Cirrus W&B form UX)
+ADHOC_CATEGORY = Literal["pilot", "payload", "ballast", "fuel", "fpv_gear", "other"]
+
+# Overall classification of the CG envelope status
+CG_CLASSIFICATION = Literal["error", "warn", "ok"]
+
+
+# ---------------------------------------------------------------------------
+# Component override sub-schemas
+# ---------------------------------------------------------------------------
+
+
+class ComponentToggle(BaseModel):
+    """Enable or disable a component in this loading scenario."""
+
+    component_uuid: str = Field(..., description="UUID of the component to toggle")
+    enabled: bool = Field(..., description="True = component included; False = removed")
+
+
+class MassOverride(BaseModel):
+    """Override the mass of a component for this scenario."""
+
+    component_uuid: str = Field(..., description="UUID of the component")
+    mass_kg_override: float = Field(..., gt=0, description="Replacement mass in kg")
+
+
+class PositionOverride(BaseModel):
+    """Override the CG position of a component for this scenario."""
+
+    component_uuid: str = Field(..., description="UUID of the component")
+    x_m_override: float = Field(..., description="New longitudinal CG position [m]")
+    y_m_override: float | None = Field(None, description="New lateral CG position [m]")
+    z_m_override: float | None = Field(None, description="New vertical CG position [m]")
+
+
+class AdhocItem(BaseModel):
+    """An item not in the component tree — pilot, payload, ballast, FPV gear, etc.
+
+    Matches the W&B form pattern from certified aircraft (Cirrus SR22, etc.),
+    making the UX familiar to both hobbyists and professional UAV operators.
+    """
+
+    name: str = Field(..., description="Human-readable name of the item")
+    mass_kg: float = Field(..., gt=0, description="Mass in kg")
+    x_m: float = Field(..., description="Longitudinal CG position [m]")
+    y_m: float = Field(0.0, description="Lateral CG position [m]")
+    z_m: float = Field(0.0, description="Vertical CG position [m]")
+    category: ADHOC_CATEGORY = Field("payload", description="Category of the item")
+
+
+class ComponentOverrides(BaseModel):
+    """All component overrides for a loading scenario."""
+
+    toggles: list[ComponentToggle] = Field(
+        default_factory=list, description="Enable/disable components"
+    )
+    mass_overrides: list[MassOverride] = Field(
+        default_factory=list, description="Mass overrides for components"
+    )
+    position_overrides: list[PositionOverride] = Field(
+        default_factory=list, description="Position overrides for components"
+    )
+    adhoc_items: list[AdhocItem] = Field(
+        default_factory=list, description="Adhoc items not in the component tree"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Loading scenario CRUD schemas
+# ---------------------------------------------------------------------------
+
+
+class LoadingScenarioCreate(BaseModel):
+    """Request body for creating a loading scenario."""
+
+    name: str = Field(..., description="Human-readable name, e.g. 'Battery Fwd'")
+    aircraft_class: AIRCRAFT_CLASS = Field(
+        "rc_trainer", description="Aircraft class for template selection and SM thresholds"
+    )
+    component_overrides: ComponentOverrides = Field(
+        default_factory=ComponentOverrides,
+        description="Component-level overrides and adhoc items for this scenario",
+    )
+    is_default: bool = Field(
+        False,
+        description=(
+            "When True, this scenario's CG is used as the legacy cg_agg_m "
+            "for backward-compatible single-value clients"
+        ),
+    )
+
+
+class LoadingScenarioUpdate(BaseModel):
+    """Request body for patching a loading scenario (all fields optional)."""
+
+    name: str | None = None
+    aircraft_class: AIRCRAFT_CLASS | None = None
+    component_overrides: ComponentOverrides | None = None
+    is_default: bool | None = None
+
+
+class LoadingScenarioRead(BaseModel):
+    """Response body for a loading scenario."""
+
+    id: int
+    aeroplane_id: int
+    name: str
+    aircraft_class: str
+    component_overrides: ComponentOverrides
+    is_default: bool
+
+    model_config = {"from_attributes": True}
+
+
+# ---------------------------------------------------------------------------
+# CG envelope response schema
+# ---------------------------------------------------------------------------
+
+
+class CgEnvelopeRead(BaseModel):
+    """CG envelope summary for an aeroplane (gh-488).
+
+    Combines the Loading-Envelope (what loading scenarios produce) with the
+    Stability-Envelope (what aerodynamics allows), and provides a classification.
+
+    Loading-Envelope:
+        cg_loading_fwd_m = min(cg_x over all scenarios)
+        cg_loading_aft_m = max(cg_x over all scenarios)
+
+    Stability-Envelope:
+        cg_stability_aft_m = x_NP - target_sm * MAC  (Anderson §7.5)
+        cg_stability_fwd_m = x_NP - 0.30 * MAC  (stub; full elevator-authority
+                              calculation is a follow-up ticket)
+
+    Validation: cg_loading_aft_m MUST be <= cg_stability_aft_m.
+    """
+
+    cg_loading_fwd_m: float = Field(..., description="Forward-most loading CG [m]")
+    cg_loading_aft_m: float = Field(..., description="Aft-most loading CG [m]")
+    cg_stability_fwd_m: float = Field(
+        ...,
+        description=(
+            "Forward stability limit (elevator-authority stub = x_NP - 0.30*MAC) [m]. "
+            "TODO: replace with full Cm-trim@CL_max_landing per Anderson §7.7."
+        ),
+    )
+    cg_stability_aft_m: float = Field(
+        ..., description="Aft stability limit = x_NP - target_sm*MAC [m]"
+    )
+    sm_at_fwd: float = Field(
+        ..., description="Static margin at forward loading CG (dimensionless)"
+    )
+    sm_at_aft: float = Field(
+        ..., description="Static margin at aft loading CG (dimensionless)"
+    )
+    classification: CG_CLASSIFICATION = Field(
+        ..., description="Overall envelope classification: error | warn | ok"
+    )
+    warnings: list[str] = Field(
+        default_factory=list, description="Human-readable warnings and errors"
+    )

--- a/app/services/assumption_compute_service.py
+++ b/app/services/assumption_compute_service.py
@@ -131,14 +131,18 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
     e_oswald_effective = e_oswald_fit if e_oswald_fit is not None else 0.8
     # -----------------------------------------------------------------------
 
-    cg_agg = _load_cg_agg(db, aircraft.id)
-
-    # --- gh-488: Loading + Stability envelopes (additive to existing context) ---
+    # --- gh-488: Loading + Stability envelopes ---------------------------
+    # cg_agg_m now reflects the is_default loading scenario's CG (per
+    # spec gh-488). Falls back to legacy weight-item aggregation for
+    # pre-migration aeroplanes that have no loading scenarios yet.
     from app.services.loading_scenario_service import (
+        compute_cg_agg_for_aeroplane,
         compute_loading_envelope_for_aeroplane,
         compute_stability_envelope,
         enrich_context_with_cg_envelope,
     )
+
+    cg_agg = compute_cg_agg_for_aeroplane(db, aircraft)
 
     _loading = compute_loading_envelope_for_aeroplane(db, aircraft)
     _stability = compute_stability_envelope(

--- a/app/services/assumption_compute_service.py
+++ b/app/services/assumption_compute_service.py
@@ -132,6 +132,19 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
     # -----------------------------------------------------------------------
 
     cg_agg = _load_cg_agg(db, aircraft.id)
+
+    # --- gh-488: Loading + Stability envelopes (additive to existing context) ---
+    from app.services.loading_scenario_service import (
+        compute_loading_envelope_for_aeroplane,
+        compute_stability_envelope,
+        enrich_context_with_cg_envelope,
+    )
+
+    _loading = compute_loading_envelope_for_aeroplane(db, aircraft)
+    _stability = compute_stability_envelope(
+        x_np=float(x_np), mac=float(mac), target_sm=float(target_sm)
+    )
+
     re = _reynolds_number(v_cruise, mac)
     mass = _load_effective_assumption(db, aircraft.id, "mass")
     # Use EFFECTIVE values so user overrides (toggle to ESTIMATE)
@@ -168,7 +181,10 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
     # for the Pratt-Walker gust alleviation computation.
     cl_alpha_per_rad = _extract_cl_alpha_from_linear_sweep(asb_airplane, v_cruise)
 
-    _cache_context(db, aircraft, {
+    # Build base context; enrich_context_with_cg_envelope appends gh-488 keys
+    # additively (cg_forward_m, cg_aft_m, sm_at_fwd, sm_at_aft) without
+    # disturbing existing keys (esp. cg_agg_m — backward compat).
+    context: dict = {
         "v_cruise_mps": round(v_cruise_effective, 1),
         "v_cruise_auto": cruise_is_auto,
         "v_max_mps": round(v_max_effective, 1),
@@ -182,6 +198,8 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
         "aspect_ratio": round(aspect_ratio, 2) if aspect_ratio is not None else None,
         "x_np_m": round(x_np, 4),
         "target_static_margin": target_sm,
+        # cg_agg_m = CG of the is_default scenario (or plain weight-item CG).
+        # Kept for backward compat — single-value consumers still get a CG.
         "cg_agg_m": round(cg_agg, 4) if cg_agg is not None else None,
         # Parabolic polar fit results (gh-486)
         "e_oswald": round(e_oswald_fit, 4) if e_oswald_fit is not None else None,
@@ -191,7 +209,15 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
         # Linear-range CL_α from α-sweep (gh-487) — consumed by compute_vn_curve for gust loads
         "cl_alpha_per_rad": round(cl_alpha_per_rad, 4) if cl_alpha_per_rad is not None else None,
         "computed_at": datetime.now(timezone.utc).isoformat(),
-    })
+    }
+    enrich_context_with_cg_envelope(
+        ctx=context,
+        cg_loading_fwd_m=_loading["cg_loading_fwd_m"],
+        cg_loading_aft_m=_loading["cg_loading_aft_m"],
+        cg_stability_fwd_m=_stability["cg_stability_fwd_m"],
+        cg_stability_aft_m=_stability["cg_stability_aft_m"],
+    )
+    _cache_context(db, aircraft, context)
 
     if old_cg is None or abs(cg_x - old_cg) > 1e-6:
         # Mirror update_assumption: mark OPs DIRTY in the same transaction

--- a/app/services/loading_scenario_service.py
+++ b/app/services/loading_scenario_service.py
@@ -23,6 +23,7 @@ SM Classification (relative to target_sm — Scholz §4.2):
 """
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
@@ -33,6 +34,7 @@ from app.core.events import AssumptionChanged, event_bus
 from app.core.exceptions import InternalError, NotFoundError
 from app.models.aeroplanemodel import AeroplaneModel, DesignAssumptionModel, LoadingScenarioModel
 from app.schemas.loading_scenario import (
+    CgEnvelopeRead,
     ComponentOverrides,
     LoadingScenarioCreate,
     LoadingScenarioRead,
@@ -297,7 +299,6 @@ def _load_assumption_value(
 def _model_to_schema(scenario: LoadingScenarioModel) -> LoadingScenarioRead:
     overrides_raw = scenario.component_overrides or {}
     if isinstance(overrides_raw, str):
-        import json
         overrides_raw = json.loads(overrides_raw)
     overrides = ComponentOverrides.model_validate(overrides_raw)
     return LoadingScenarioRead(
@@ -360,7 +361,6 @@ def compute_cg_agg_for_aeroplane(db: Session, aeroplane: AeroplaneModel) -> floa
     if default_scenario is not None:
         overrides_raw = default_scenario.component_overrides or {}
         if isinstance(overrides_raw, str):
-            import json
             overrides_raw = json.loads(overrides_raw)
         overrides = ComponentOverrides.model_validate(overrides_raw)
         components = _load_components_as_dicts(db, aeroplane.id)
@@ -429,7 +429,6 @@ def compute_loading_envelope_for_aeroplane(
     for scenario in scenarios:
         overrides_raw = scenario.component_overrides or {}
         if isinstance(overrides_raw, str):
-            import json
             overrides_raw = json.loads(overrides_raw)
         overrides = ComponentOverrides.model_validate(overrides_raw)
         cg = compute_scenario_cg(
@@ -454,11 +453,7 @@ def _trigger_retrim(db: Session, aeroplane: AeroplaneModel) -> None:
     """Mark OPs dirty and emit AssumptionChanged(cg_x) for downstream retrim."""
     from app.services.invalidation_service import mark_ops_dirty
 
-    try:
-        mark_ops_dirty(db, aeroplane.id)
-    except Exception:
-        logger.exception("mark_ops_dirty failed for aeroplane %s", aeroplane.id)
-
+    mark_ops_dirty(db, aeroplane.id)
     event_bus.publish(
         AssumptionChanged(aeroplane_id=aeroplane.id, parameter_name="cg_x")
     )
@@ -566,7 +561,7 @@ def delete_scenario(db: Session, aeroplane_uuid, scenario_id: int) -> None:
 
 def get_cg_envelope(
     db: Session, aeroplane_uuid
-) -> dict[str, Any]:
+) -> CgEnvelopeRead:
     """Compute the full CG envelope (loading + stability + classification).
 
     Returns a dict compatible with CgEnvelopeRead schema.
@@ -629,13 +624,13 @@ def get_cg_envelope(
     elif overall == "error" and sm_at_aft is not None:
         warnings.insert(0, f"SM at aft CG = {sm_at_aft:.1%} — outside safe operating range.")
 
-    return {
-        "cg_loading_fwd_m": round(cg_fwd, 4),
-        "cg_loading_aft_m": round(cg_aft, 4),
-        "cg_stability_fwd_m": round(stab_fwd, 4) if stab_fwd is not None else None,
-        "cg_stability_aft_m": round(stab_aft, 4) if stab_aft is not None else None,
-        "sm_at_fwd": round(sm_at_fwd, 4) if sm_at_fwd is not None else None,
-        "sm_at_aft": round(sm_at_aft, 4) if sm_at_aft is not None else None,
-        "classification": overall,
-        "warnings": warnings,
-    }
+    return CgEnvelopeRead(
+        cg_loading_fwd_m=round(cg_fwd, 4),
+        cg_loading_aft_m=round(cg_aft, 4),
+        cg_stability_fwd_m=round(stab_fwd, 4) if stab_fwd is not None else None,
+        cg_stability_aft_m=round(stab_aft, 4) if stab_aft is not None else None,
+        sm_at_fwd=round(sm_at_fwd, 4) if sm_at_fwd is not None else None,
+        sm_at_aft=round(sm_at_aft, 4) if sm_at_aft is not None else None,
+        classification=overall,
+        warnings=warnings,
+    )

--- a/app/services/loading_scenario_service.py
+++ b/app/services/loading_scenario_service.py
@@ -1,0 +1,480 @@
+"""Loading Scenario service — CG envelope from user-defined loading scenarios (gh-488).
+
+Implements two separate envelopes:
+
+  Loading-Envelope:  what user-defined loading scenarios produce.
+    cg_loading_fwd = min(cg_x over all scenarios)
+    cg_loading_aft = max(cg_x over all scenarios)
+
+  Stability-Envelope:  what aerodynamics physically allows.
+    cg_stability_aft = x_NP - target_sm * MAC          (Anderson §7.5)
+    cg_stability_fwd = x_NP - 0.30 * MAC               (stub — conservative;
+                        TODO: replace with full elevator-authority calculation
+                        per Anderson §7.7 as follow-up ticket)
+
+Validation: Loading-Envelope MUST be within Stability-Envelope.
+
+SM Classification (relative to target_sm — Scholz §4.2):
+  sm < 0.02              ERROR   (unstable / Phugoid divergent)
+  0.02 ≤ sm < target_sm  WARN    (low margin — pylon racers only)
+  target_sm ≤ sm ≤ 0.20  OK      (standard range)
+  0.20 < sm ≤ 0.30       WARN    (heavy nose, trim drag, sluggish pitch)
+  sm > 0.30              ERROR   (elevator authority at landing stall insufficient)
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from app.core.events import AssumptionChanged, event_bus
+from app.core.exceptions import InternalError, NotFoundError
+from app.models.aeroplanemodel import AeroplaneModel, DesignAssumptionModel, LoadingScenarioModel
+from app.schemas.loading_scenario import (
+    ComponentOverrides,
+    LoadingScenarioCreate,
+    LoadingScenarioRead,
+    LoadingScenarioUpdate,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# SM classification thresholds (Scholz §4.2)
+# ---------------------------------------------------------------------------
+
+_SM_UNSTABLE_LIMIT = 0.02    # below → ERROR (Phugoid divergent)
+_SM_HEAVY_NOSE_WARN = 0.20   # above → WARN  (heavy nose, trim drag)
+_SM_ELEVATOR_LIMIT = 0.30    # above → ERROR (elevator authority)
+
+
+# ---------------------------------------------------------------------------
+# Pure computation helpers (no DB) — testable in isolation
+# ---------------------------------------------------------------------------
+
+
+def classify_sm(sm: float, target_sm: float) -> str:
+    """5-tier SM classification relative to target_sm (Scholz §4.2).
+
+    Args:
+        sm: current static margin (dimensionless, fraction of MAC).
+        target_sm: design target static margin (dimensionless).
+
+    Returns:
+        "error" | "warn" | "ok"
+    """
+    if sm < _SM_UNSTABLE_LIMIT:
+        return "error"
+    if sm < target_sm:
+        return "warn"
+    if sm <= _SM_HEAVY_NOSE_WARN:
+        return "ok"
+    if sm <= _SM_ELEVATOR_LIMIT:
+        return "warn"
+    return "error"
+
+
+def compute_stability_envelope(x_np: float, mac: float, target_sm: float) -> dict[str, float]:
+    """Compute the Stability-Envelope for given aerodynamic parameters.
+
+    Args:
+        x_np: neutral point position [m] (longitudinal).
+        mac: mean aerodynamic chord [m].
+        target_sm: design target static margin (fraction of MAC).
+
+    Returns dict with:
+        cg_stability_aft_m: aft stability limit = x_NP - target_sm * MAC
+        cg_stability_fwd_m: forward stability limit (stub = x_NP - 0.30 * MAC)
+            TODO: replace with full Cm-trim @ CL_max_landing per Anderson §7.7
+            as a follow-up ticket. This stub is conservative.
+    """
+    cg_stability_aft_m = x_np - target_sm * mac
+    # Stub forward limit: SM = 0.30 is the conservative upper bound before
+    # elevator authority at landing stall becomes critical (Anderson §7.7).
+    # Full calculation requires Cm_delta_e and CL_max_landing — follow-up ticket.
+    cg_stability_fwd_m = x_np - _SM_ELEVATOR_LIMIT * mac
+    return {
+        "cg_stability_aft_m": cg_stability_aft_m,
+        "cg_stability_fwd_m": cg_stability_fwd_m,
+    }
+
+
+def compute_scenario_cg(
+    base_mass_kg: float,
+    base_cg_x: float,
+    adhoc_items: list[dict],
+    mass_overrides: list[dict],
+) -> float:
+    """Compute the CG_x for a single loading scenario.
+
+    Applies adhoc items on top of the base (design) mass/CG.  Mass overrides
+    shift individual component masses but we do not have per-component CG data
+    in the DB at this time, so they are accounted for via total-mass scaling.
+
+    Args:
+        base_mass_kg: design total mass [kg].
+        base_cg_x: design CG_x [m].
+        adhoc_items: list of {"name", "mass_kg", "x_m", "y_m", "z_m"} dicts.
+        mass_overrides: list of {"component_uuid", "mass_kg_override"} dicts.
+            Currently not used in CG computation (no per-component CG DB yet).
+
+    Returns:
+        cg_x [m] for this scenario.
+    """
+    total_mass = base_mass_kg
+    moment_x = base_mass_kg * base_cg_x
+
+    for item in adhoc_items:
+        m = float(item.get("mass_kg", 0.0) or 0.0)
+        x = float(item.get("x_m", 0.0) or 0.0)
+        total_mass += m
+        moment_x += m * x
+
+    if total_mass <= 0:
+        return base_cg_x
+    return moment_x / total_mass
+
+
+def validate_cg_envelope(
+    cg_loading_fwd_m: float,
+    cg_loading_aft_m: float,
+    cg_stability_fwd_m: float,
+    cg_stability_aft_m: float,
+) -> list[str]:
+    """Validate that Loading-Envelope is within Stability-Envelope.
+
+    Returns a list of warning/error strings.  Empty list = all OK.
+    """
+    warnings: list[str] = []
+
+    if cg_loading_aft_m > cg_stability_aft_m:
+        excess_mm = round((cg_loading_aft_m - cg_stability_aft_m) * 1000, 1)
+        warnings.append(
+            f"CG exceeds aft stability limit by {excess_mm} mm — "
+            "aircraft may be unstable in the aft loading scenario."
+        )
+
+    if cg_loading_fwd_m < cg_stability_fwd_m:
+        excess_mm = round((cg_stability_fwd_m - cg_loading_fwd_m) * 1000, 1)
+        warnings.append(
+            f"CG is {excess_mm} mm forward of the forward stability limit — "
+            "elevator authority at landing stall may be insufficient (stub limit)."
+        )
+
+    return warnings
+
+
+def enrich_context_with_cg_envelope(
+    ctx: dict[str, Any],
+    cg_loading_fwd_m: float,
+    cg_loading_aft_m: float,
+    cg_stability_fwd_m: float,
+    cg_stability_aft_m: float,
+) -> dict[str, Any]:
+    """Addively add CG envelope keys to an existing computation context dict.
+
+    Preserves all existing keys (esp. cg_agg_m for backward compat) and
+    adds the new gh-488 keys: cg_forward_m, cg_aft_m, sm_at_fwd, sm_at_aft.
+
+    Args:
+        ctx: existing assumption_computation_context dict.
+        cg_loading_fwd_m: forward loading CG [m].
+        cg_loading_aft_m: aft loading CG [m].
+        cg_stability_fwd_m: forward stability limit [m].
+        cg_stability_aft_m: aft stability limit [m].
+
+    Returns:
+        Updated dict (same object, modified in-place).
+    """
+    x_np = float(ctx.get("x_np_m") or 0.0)
+    mac = float(ctx.get("mac_m") or 1.0)  # avoid division by zero
+
+    sm_at_fwd = (x_np - cg_loading_fwd_m) / mac if mac > 0 else 0.0
+    sm_at_aft = (x_np - cg_loading_aft_m) / mac if mac > 0 else 0.0
+
+    ctx["cg_forward_m"] = round(cg_loading_fwd_m, 4)
+    ctx["cg_aft_m"] = round(cg_loading_aft_m, 4)
+    ctx["sm_at_fwd"] = round(sm_at_fwd, 4)
+    ctx["sm_at_aft"] = round(sm_at_aft, 4)
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# DB-aware helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_aeroplane(db: Session, aeroplane_uuid) -> AeroplaneModel:
+    aeroplane = db.query(AeroplaneModel).filter(AeroplaneModel.uuid == aeroplane_uuid).first()
+    if not aeroplane:
+        raise NotFoundError(entity="Aeroplane", resource_id=aeroplane_uuid)
+    return aeroplane
+
+
+def _load_assumption_value(
+    db: Session, aeroplane_id: int, param_name: str, default: float = 0.0
+) -> float:
+    row = (
+        db.query(DesignAssumptionModel)
+        .filter(
+            DesignAssumptionModel.aeroplane_id == aeroplane_id,
+            DesignAssumptionModel.parameter_name == param_name,
+        )
+        .first()
+    )
+    if row is None:
+        return default
+    if row.active_source == "CALCULATED" and row.calculated_value is not None:
+        return float(row.calculated_value)
+    return float(row.estimate_value)
+
+
+def _model_to_schema(scenario: LoadingScenarioModel) -> LoadingScenarioRead:
+    overrides_raw = scenario.component_overrides or {}
+    if isinstance(overrides_raw, str):
+        import json
+        overrides_raw = json.loads(overrides_raw)
+    overrides = ComponentOverrides.model_validate(overrides_raw)
+    return LoadingScenarioRead(
+        id=scenario.id,
+        aeroplane_id=scenario.aeroplane_id,
+        name=scenario.name,
+        aircraft_class=scenario.aircraft_class,
+        component_overrides=overrides,
+        is_default=scenario.is_default,
+    )
+
+
+def compute_loading_envelope_for_aeroplane(
+    db: Session, aeroplane: AeroplaneModel
+) -> dict[str, float]:
+    """Compute the Loading-Envelope (min/max CG) over all loading scenarios.
+
+    Falls back to the design cg_x when no loading scenarios exist (backward compat).
+
+    Returns dict with:
+        cg_loading_fwd_m: forward-most CG across all scenarios [m]
+        cg_loading_aft_m: aft-most CG across all scenarios [m]
+        scenarios_eval: list of per-scenario CG values
+    """
+    base_mass = _load_assumption_value(db, aeroplane.id, "mass", default=1.0)
+    base_cg_x = _load_assumption_value(db, aeroplane.id, "cg_x", default=0.0)
+
+    scenarios = (
+        db.query(LoadingScenarioModel)
+        .filter(LoadingScenarioModel.aeroplane_id == aeroplane.id)
+        .all()
+    )
+
+    if not scenarios:
+        return {
+            "cg_loading_fwd_m": base_cg_x,
+            "cg_loading_aft_m": base_cg_x,
+            "scenarios_eval": [],
+        }
+
+    cg_values: list[float] = []
+    for scenario in scenarios:
+        overrides_raw = scenario.component_overrides or {}
+        if isinstance(overrides_raw, str):
+            import json
+            overrides_raw = json.loads(overrides_raw)
+        overrides = ComponentOverrides.model_validate(overrides_raw)
+        adhoc = [item.model_dump() for item in overrides.adhoc_items]
+        mass_ovr = [m.model_dump() for m in overrides.mass_overrides]
+        cg = compute_scenario_cg(
+            base_mass_kg=base_mass,
+            base_cg_x=base_cg_x,
+            adhoc_items=adhoc,
+            mass_overrides=mass_ovr,
+        )
+        cg_values.append(cg)
+
+    return {
+        "cg_loading_fwd_m": min(cg_values),
+        "cg_loading_aft_m": max(cg_values),
+        "scenarios_eval": cg_values,
+    }
+
+
+def _trigger_retrim(db: Session, aeroplane: AeroplaneModel) -> None:
+    """Mark OPs dirty and emit AssumptionChanged(cg_x) for downstream retrim."""
+    from app.services.invalidation_service import mark_ops_dirty
+
+    try:
+        mark_ops_dirty(db, aeroplane.id)
+    except Exception:
+        logger.exception("mark_ops_dirty failed for aeroplane %s", aeroplane.id)
+
+    event_bus.publish(
+        AssumptionChanged(aeroplane_id=aeroplane.id, parameter_name="cg_x")
+    )
+
+
+# ---------------------------------------------------------------------------
+# CRUD
+# ---------------------------------------------------------------------------
+
+
+def list_scenarios(db: Session, aeroplane_uuid) -> list[LoadingScenarioRead]:
+    aeroplane = _get_aeroplane(db, aeroplane_uuid)
+    rows = (
+        db.query(LoadingScenarioModel)
+        .filter(LoadingScenarioModel.aeroplane_id == aeroplane.id)
+        .order_by(LoadingScenarioModel.id)
+        .all()
+    )
+    return [_model_to_schema(r) for r in rows]
+
+
+def create_scenario(
+    db: Session, aeroplane_uuid, data: LoadingScenarioCreate
+) -> LoadingScenarioRead:
+    try:
+        aeroplane = _get_aeroplane(db, aeroplane_uuid)
+        overrides_dict = data.component_overrides.model_dump()
+        scenario = LoadingScenarioModel(
+            aeroplane_id=aeroplane.id,
+            name=data.name,
+            aircraft_class=data.aircraft_class,
+            component_overrides=overrides_dict,
+            is_default=data.is_default,
+        )
+        db.add(scenario)
+        db.flush()
+        db.refresh(scenario)
+        _trigger_retrim(db, aeroplane)
+        return _model_to_schema(scenario)
+    except NotFoundError:
+        raise
+    except SQLAlchemyError as exc:
+        logger.error("DB error in create_scenario: %s", exc)
+        raise InternalError(message=f"Database error: {exc}") from exc
+
+
+def update_scenario(
+    db: Session, aeroplane_uuid, scenario_id: int, data: LoadingScenarioUpdate
+) -> LoadingScenarioRead:
+    try:
+        aeroplane = _get_aeroplane(db, aeroplane_uuid)
+        scenario = (
+            db.query(LoadingScenarioModel)
+            .filter(
+                LoadingScenarioModel.aeroplane_id == aeroplane.id,
+                LoadingScenarioModel.id == scenario_id,
+            )
+            .first()
+        )
+        if scenario is None:
+            raise NotFoundError(entity="LoadingScenario", resource_id=scenario_id)
+
+        if data.name is not None:
+            scenario.name = data.name
+        if data.aircraft_class is not None:
+            scenario.aircraft_class = data.aircraft_class
+        if data.component_overrides is not None:
+            scenario.component_overrides = data.component_overrides.model_dump()
+        if data.is_default is not None:
+            scenario.is_default = data.is_default
+
+        db.flush()
+        db.refresh(scenario)
+        _trigger_retrim(db, aeroplane)
+        return _model_to_schema(scenario)
+    except NotFoundError:
+        raise
+    except SQLAlchemyError as exc:
+        logger.error("DB error in update_scenario: %s", exc)
+        raise InternalError(message=f"Database error: {exc}") from exc
+
+
+def delete_scenario(db: Session, aeroplane_uuid, scenario_id: int) -> None:
+    try:
+        aeroplane = _get_aeroplane(db, aeroplane_uuid)
+        scenario = (
+            db.query(LoadingScenarioModel)
+            .filter(
+                LoadingScenarioModel.aeroplane_id == aeroplane.id,
+                LoadingScenarioModel.id == scenario_id,
+            )
+            .first()
+        )
+        if scenario is None:
+            raise NotFoundError(entity="LoadingScenario", resource_id=scenario_id)
+        db.delete(scenario)
+        db.flush()
+        _trigger_retrim(db, aeroplane)
+    except NotFoundError:
+        raise
+    except SQLAlchemyError as exc:
+        logger.error("DB error in delete_scenario: %s", exc)
+        raise InternalError(message=f"Database error: {exc}") from exc
+
+
+def get_cg_envelope(
+    db: Session, aeroplane_uuid
+) -> dict[str, Any]:
+    """Compute the full CG envelope (loading + stability + classification).
+
+    Returns a dict compatible with CgEnvelopeRead schema.
+    """
+    aeroplane = _get_aeroplane(db, aeroplane_uuid)
+
+    # Loading envelope
+    loading = compute_loading_envelope_for_aeroplane(db, aeroplane)
+    cg_fwd = loading["cg_loading_fwd_m"]
+    cg_aft = loading["cg_loading_aft_m"]
+
+    # Stability envelope — requires x_NP and MAC from context or assumptions
+    ctx = aeroplane.assumption_computation_context or {}
+    x_np = float(ctx.get("x_np_m") or 0.0)
+    mac = float(ctx.get("mac_m") or 1.0)
+    target_sm = _load_assumption_value(db, aeroplane.id, "target_static_margin", default=0.08)
+
+    if x_np == 0.0 or mac <= 0:
+        # Fall back to assumptions-based estimate if context not yet populated
+        base_cg_x = _load_assumption_value(db, aeroplane.id, "cg_x", default=0.15)
+        # Approximate: NP ≈ cg_x + target_sm * MAC (inverse of cg_x = NP - SM*MAC)
+        # Without actual aero computation, use a conservative MAC estimate.
+        # This is handled gracefully: the user sees stubs until a full recompute runs.
+        mac = float(ctx.get("mac_m") or 0.20)
+        x_np = base_cg_x + target_sm * mac
+
+    stability = compute_stability_envelope(x_np=x_np, mac=mac, target_sm=target_sm)
+    stab_fwd = stability["cg_stability_fwd_m"]
+    stab_aft = stability["cg_stability_aft_m"]
+
+    # Static margins at loading extremes
+    sm_at_fwd = (x_np - cg_fwd) / mac if mac > 0 else 0.0
+    sm_at_aft = (x_np - cg_aft) / mac if mac > 0 else 0.0
+
+    # Classify worst-case (aft = most critical for stability)
+    classification_fwd = classify_sm(sm_at_fwd, target_sm)
+    classification_aft = classify_sm(sm_at_aft, target_sm)
+
+    # Hierarchy: error > warn > ok
+    _rank = {"error": 2, "warn": 1, "ok": 0}
+    if _rank[classification_fwd] >= _rank[classification_aft]:
+        overall = classification_fwd
+    else:
+        overall = classification_aft
+
+    # Validation warnings
+    warnings = validate_cg_envelope(cg_fwd, cg_aft, stab_fwd, stab_aft)
+    if overall == "error":
+        warnings.insert(0, f"SM at aft CG = {sm_at_aft:.1%} — outside safe operating range.")
+    elif overall == "warn":
+        pass  # validation_cg_envelope already captures this
+
+    return {
+        "cg_loading_fwd_m": round(cg_fwd, 4),
+        "cg_loading_aft_m": round(cg_aft, 4),
+        "cg_stability_fwd_m": round(stab_fwd, 4),
+        "cg_stability_aft_m": round(stab_aft, 4),
+        "sm_at_fwd": round(sm_at_fwd, 4),
+        "sm_at_aft": round(sm_at_aft, 4),
+        "classification": overall,
+        "warnings": warnings,
+    }

--- a/app/services/loading_scenario_service.py
+++ b/app/services/loading_scenario_service.py
@@ -55,16 +55,18 @@ _SM_ELEVATOR_LIMIT = 0.30    # above → ERROR (elevator authority)
 # ---------------------------------------------------------------------------
 
 
-def classify_sm(sm: float, target_sm: float) -> str:
+def classify_sm(sm: float | None, target_sm: float) -> str:
     """5-tier SM classification relative to target_sm (Scholz §4.2).
 
     Args:
-        sm: current static margin (dimensionless, fraction of MAC).
+        sm: current static margin (dimensionless, fraction of MAC), or None.
         target_sm: design target static margin (dimensionless).
 
     Returns:
-        "error" | "warn" | "ok"
+        "error" | "warn" | "ok" | "unknown"
     """
+    if sm is None:
+        return "unknown"
     if sm < _SM_UNSTABLE_LIMIT:
         return "error"
     if sm < target_sm:
@@ -76,20 +78,29 @@ def classify_sm(sm: float, target_sm: float) -> str:
     return "error"
 
 
-def compute_stability_envelope(x_np: float, mac: float, target_sm: float) -> dict[str, float]:
+def compute_stability_envelope(
+    x_np: float | None, mac: float | None, target_sm: float
+) -> dict[str, float | None]:
     """Compute the Stability-Envelope for given aerodynamic parameters.
 
+    Returns None values when x_np or mac is unavailable (recompute_assumptions
+    hasn't run yet).  The caller must surface those None values to the user
+    instead of synthesising a deceptive fallback.
+
     Args:
-        x_np: neutral point position [m] (longitudinal).
-        mac: mean aerodynamic chord [m].
+        x_np: neutral point position [m] (longitudinal), or None.
+        mac: mean aerodynamic chord [m], or None.
         target_sm: design target static margin (fraction of MAC).
 
     Returns dict with:
-        cg_stability_aft_m: aft stability limit = x_NP - target_sm * MAC
-        cg_stability_fwd_m: forward stability limit (stub = x_NP - 0.30 * MAC)
+        cg_stability_aft_m: aft stability limit = x_NP - target_sm * MAC, or None.
+        cg_stability_fwd_m: forward stability limit (stub = x_NP - 0.30 * MAC), or None.
             TODO: replace with full Cm-trim @ CL_max_landing per Anderson §7.7
             as a follow-up ticket. This stub is conservative.
     """
+    if x_np is None or mac is None or mac <= 0:
+        return {"cg_stability_aft_m": None, "cg_stability_fwd_m": None}
+
     cg_stability_aft_m = x_np - target_sm * mac
     # Stub forward limit: SM = 0.30 is the conservative upper bound before
     # elevator authority at landing stall becomes critical (Anderson §7.7).
@@ -106,26 +117,67 @@ def compute_scenario_cg(
     base_cg_x: float,
     adhoc_items: list[dict],
     mass_overrides: list[dict],
+    toggles: list[dict] | None = None,
+    position_overrides: list[dict] | None = None,
+    components: list[dict] | None = None,
 ) -> float:
     """Compute the CG_x for a single loading scenario.
 
-    Applies adhoc items on top of the base (design) mass/CG.  Mass overrides
-    shift individual component masses but we do not have per-component CG data
-    in the DB at this time, so they are accounted for via total-mass scaling.
+    Supports all four override types: toggles, mass_overrides, position_overrides,
+    adhoc_items.  When ``components`` is provided (a list of per-component dicts with
+    ``id``, ``mass_kg``, ``x_m`` fields), the function builds the moment sum from
+    the individual components and applies overrides per-component.  When
+    ``components`` is None or empty, falls back to the legacy base_mass / base_cg_x
+    aggregation (backward-compat for pre-migration aeroplanes).
 
     Args:
-        base_mass_kg: design total mass [kg].
-        base_cg_x: design CG_x [m].
+        base_mass_kg: design total mass [kg] — used as fallback when no components.
+        base_cg_x: design CG_x [m] — used as fallback when no components.
         adhoc_items: list of {"name", "mass_kg", "x_m", "y_m", "z_m"} dicts.
         mass_overrides: list of {"component_uuid", "mass_kg_override"} dicts.
-            Currently not used in CG computation (no per-component CG DB yet).
+        toggles: list of {"component_uuid", "enabled"} dicts. enabled=False removes
+            the component from the CG computation.
+        position_overrides: list of {"component_uuid", "x_m_override", ...} dicts.
+        components: per-component weight list with fields ``id`` (str), ``mass_kg``,
+            ``x_m``.  When provided, base_mass_kg/base_cg_x are ignored.
 
     Returns:
         cg_x [m] for this scenario.
     """
-    total_mass = base_mass_kg
-    moment_x = base_mass_kg * base_cg_x
+    toggles = toggles or []
+    position_overrides = position_overrides or []
 
+    # Build lookup maps for fast override access
+    disabled_uuids: set[str] = {
+        t["component_uuid"] for t in toggles if not t.get("enabled", True)
+    }
+    mass_ovr_map: dict[str, float] = {
+        m["component_uuid"]: float(m["mass_kg_override"])
+        for m in mass_overrides
+    }
+    pos_ovr_map: dict[str, float] = {
+        p["component_uuid"]: float(p["x_m_override"])
+        for p in position_overrides
+    }
+
+    if components:
+        # Per-component path: apply all override types
+        total_mass = 0.0
+        moment_x = 0.0
+        for comp in components:
+            cid = str(comp.get("id", ""))
+            if cid in disabled_uuids:
+                continue  # toggle off → mass = 0
+            m = mass_ovr_map.get(cid, float(comp.get("mass_kg", 0.0) or 0.0))
+            x = pos_ovr_map.get(cid, float(comp.get("x_m", 0.0) or 0.0))
+            total_mass += m
+            moment_x += m * x
+    else:
+        # Legacy fallback: base_mass/base_cg_x only (pre-migration aeroplanes)
+        total_mass = base_mass_kg
+        moment_x = base_mass_kg * base_cg_x
+
+    # Adhoc items are always additive on top
     for item in adhoc_items:
         m = float(item.get("mass_kg", 0.0) or 0.0)
         x = float(item.get("x_m", 0.0) or 0.0)
@@ -140,23 +192,25 @@ def compute_scenario_cg(
 def validate_cg_envelope(
     cg_loading_fwd_m: float,
     cg_loading_aft_m: float,
-    cg_stability_fwd_m: float,
-    cg_stability_aft_m: float,
+    cg_stability_fwd_m: float | None,
+    cg_stability_aft_m: float | None,
 ) -> list[str]:
     """Validate that Loading-Envelope is within Stability-Envelope.
 
     Returns a list of warning/error strings.  Empty list = all OK.
+    None stability limits (x_NP not yet computed) produce no validation
+    warnings — the caller must add a separate 'stability unavailable' warning.
     """
     warnings: list[str] = []
 
-    if cg_loading_aft_m > cg_stability_aft_m:
+    if cg_stability_aft_m is not None and cg_loading_aft_m > cg_stability_aft_m:
         excess_mm = round((cg_loading_aft_m - cg_stability_aft_m) * 1000, 1)
         warnings.append(
             f"CG exceeds aft stability limit by {excess_mm} mm — "
             "aircraft may be unstable in the aft loading scenario."
         )
 
-    if cg_loading_fwd_m < cg_stability_fwd_m:
+    if cg_stability_fwd_m is not None and cg_loading_fwd_m < cg_stability_fwd_m:
         excess_mm = round((cg_stability_fwd_m - cg_loading_fwd_m) * 1000, 1)
         warnings.append(
             f"CG is {excess_mm} mm forward of the forward stability limit — "
@@ -170,34 +224,43 @@ def enrich_context_with_cg_envelope(
     ctx: dict[str, Any],
     cg_loading_fwd_m: float,
     cg_loading_aft_m: float,
-    cg_stability_fwd_m: float,
-    cg_stability_aft_m: float,
+    cg_stability_fwd_m: float | None,
+    cg_stability_aft_m: float | None,
 ) -> dict[str, Any]:
-    """Addively add CG envelope keys to an existing computation context dict.
+    """Additively add CG envelope keys to an existing computation context dict.
 
     Preserves all existing keys (esp. cg_agg_m for backward compat) and
     adds the new gh-488 keys: cg_forward_m, cg_aft_m, sm_at_fwd, sm_at_aft.
+
+    When x_np_m is not in the context (recompute hasn't run), sm_at_fwd/aft
+    are stored as None to avoid deceptive stub values.
 
     Args:
         ctx: existing assumption_computation_context dict.
         cg_loading_fwd_m: forward loading CG [m].
         cg_loading_aft_m: aft loading CG [m].
-        cg_stability_fwd_m: forward stability limit [m].
-        cg_stability_aft_m: aft stability limit [m].
+        cg_stability_fwd_m: forward stability limit [m], or None.
+        cg_stability_aft_m: aft stability limit [m], or None.
 
     Returns:
         Updated dict (same object, modified in-place).
     """
-    x_np = float(ctx.get("x_np_m") or 0.0)
-    mac = float(ctx.get("mac_m") or 1.0)  # avoid division by zero
+    x_np_raw = ctx.get("x_np_m")
+    mac_raw = ctx.get("mac_m")
+    x_np = float(x_np_raw) if x_np_raw else None
+    mac = float(mac_raw) if mac_raw else None
 
-    sm_at_fwd = (x_np - cg_loading_fwd_m) / mac if mac > 0 else 0.0
-    sm_at_aft = (x_np - cg_loading_aft_m) / mac if mac > 0 else 0.0
+    if x_np is not None and mac is not None and mac > 0:
+        sm_at_fwd = round((x_np - cg_loading_fwd_m) / mac, 4)
+        sm_at_aft = round((x_np - cg_loading_aft_m) / mac, 4)
+    else:
+        sm_at_fwd = None
+        sm_at_aft = None
 
     ctx["cg_forward_m"] = round(cg_loading_fwd_m, 4)
     ctx["cg_aft_m"] = round(cg_loading_aft_m, 4)
-    ctx["sm_at_fwd"] = round(sm_at_fwd, 4)
-    ctx["sm_at_aft"] = round(sm_at_aft, 4)
+    ctx["sm_at_fwd"] = sm_at_fwd
+    ctx["sm_at_aft"] = sm_at_aft
     return ctx
 
 
@@ -247,12 +310,98 @@ def _model_to_schema(scenario: LoadingScenarioModel) -> LoadingScenarioRead:
     )
 
 
+def _load_components_as_dicts(db: Session, aeroplane_id: int) -> list[dict]:
+    """Load weight items as plain dicts for use in compute_scenario_cg.
+
+    Returns a list of {"id": str(item.id), "mass_kg": ..., "x_m": ..., ...} dicts.
+    Empty list when no weight items exist (triggers legacy base_mass/base_cg_x path).
+    """
+    from app.models.aeroplanemodel import WeightItemModel
+
+    rows = (
+        db.query(WeightItemModel)
+        .filter(WeightItemModel.aeroplane_id == aeroplane_id)
+        .all()
+    )
+    return [
+        {
+            "id": str(r.id),
+            "mass_kg": float(r.mass_kg or 0.0),
+            "x_m": float(r.x_m or 0.0),
+            "y_m": float(r.y_m or 0.0),
+            "z_m": float(r.z_m or 0.0),
+        }
+        for r in rows
+    ]
+
+
+def compute_cg_agg_for_aeroplane(db: Session, aeroplane: AeroplaneModel) -> float | None:
+    """Compute the single-value CG_agg for backward-compatible clients.
+
+    Spec (gh-488): cg_agg_m MUST equal the CG of the ``is_default`` scenario.
+    Falls back to legacy weight-item aggregation when no loading scenarios exist
+    (backward-compat for pre-migration aeroplanes).
+
+    Returns:
+        CG_x [m], or None when no data is available (no scenarios AND no weight items).
+    """
+    base_mass = _load_assumption_value(db, aeroplane.id, "mass", default=1.0)
+    base_cg_x = _load_assumption_value(db, aeroplane.id, "cg_x", default=0.0)
+
+    # Try is_default scenario first
+    default_scenario = (
+        db.query(LoadingScenarioModel)
+        .filter(
+            LoadingScenarioModel.aeroplane_id == aeroplane.id,
+            LoadingScenarioModel.is_default.is_(True),
+        )
+        .first()
+    )
+    if default_scenario is not None:
+        overrides_raw = default_scenario.component_overrides or {}
+        if isinstance(overrides_raw, str):
+            import json
+            overrides_raw = json.loads(overrides_raw)
+        overrides = ComponentOverrides.model_validate(overrides_raw)
+        components = _load_components_as_dicts(db, aeroplane.id)
+        return compute_scenario_cg(
+            base_mass_kg=base_mass,
+            base_cg_x=base_cg_x,
+            adhoc_items=[item.model_dump() for item in overrides.adhoc_items],
+            mass_overrides=[m.model_dump() for m in overrides.mass_overrides],
+            toggles=[t.model_dump() for t in overrides.toggles],
+            position_overrides=[p.model_dump() for p in overrides.position_overrides],
+            components=components or None,
+        )
+
+    # Legacy fallback: weight-item aggregation (pre-migration aeroplanes)
+    from app.models.aeroplanemodel import WeightItemModel
+    from app.services.mass_cg_service import aggregate_weight_items
+
+    rows = (
+        db.query(WeightItemModel)
+        .filter(WeightItemModel.aeroplane_id == aeroplane.id)
+        .all()
+    )
+    if not rows:
+        return None
+
+    items = [
+        {"mass_kg": r.mass_kg, "x_m": r.x_m, "y_m": r.y_m, "z_m": r.z_m}
+        for r in rows
+    ]
+    _, cg_x, _, _ = aggregate_weight_items(items)
+    return cg_x
+
+
 def compute_loading_envelope_for_aeroplane(
     db: Session, aeroplane: AeroplaneModel
-) -> dict[str, float]:
+) -> dict[str, Any]:
     """Compute the Loading-Envelope (min/max CG) over all loading scenarios.
 
-    Falls back to the design cg_x when no loading scenarios exist (backward compat).
+    Applies all four override types (toggles, mass_overrides, position_overrides,
+    adhoc_items) per scenario.  Falls back to the design cg_x when no loading
+    scenarios exist (backward compat).
 
     Returns dict with:
         cg_loading_fwd_m: forward-most CG across all scenarios [m]
@@ -261,6 +410,7 @@ def compute_loading_envelope_for_aeroplane(
     """
     base_mass = _load_assumption_value(db, aeroplane.id, "mass", default=1.0)
     base_cg_x = _load_assumption_value(db, aeroplane.id, "cg_x", default=0.0)
+    components = _load_components_as_dicts(db, aeroplane.id)
 
     scenarios = (
         db.query(LoadingScenarioModel)
@@ -282,13 +432,14 @@ def compute_loading_envelope_for_aeroplane(
             import json
             overrides_raw = json.loads(overrides_raw)
         overrides = ComponentOverrides.model_validate(overrides_raw)
-        adhoc = [item.model_dump() for item in overrides.adhoc_items]
-        mass_ovr = [m.model_dump() for m in overrides.mass_overrides]
         cg = compute_scenario_cg(
             base_mass_kg=base_mass,
             base_cg_x=base_cg_x,
-            adhoc_items=adhoc,
-            mass_overrides=mass_ovr,
+            adhoc_items=[item.model_dump() for item in overrides.adhoc_items],
+            mass_overrides=[m.model_dump() for m in overrides.mass_overrides],
+            toggles=[t.model_dump() for t in overrides.toggles],
+            position_overrides=[p.model_dump() for p in overrides.position_overrides],
+            components=components or None,
         )
         cg_values.append(cg)
 
@@ -419,6 +570,13 @@ def get_cg_envelope(
     """Compute the full CG envelope (loading + stability + classification).
 
     Returns a dict compatible with CgEnvelopeRead schema.
+
+    Stability fields (cg_stability_fwd_m, cg_stability_aft_m, sm_at_fwd, sm_at_aft)
+    are None when recompute_assumptions hasn't been run yet (x_NP / MAC missing from
+    assumption_computation_context).  The classification is "unknown" in that case and
+    an explicit 'stability unavailable' warning is added.  This prevents the old
+    deceptive pattern of synthesising x_np = cg_x + target_sm*MAC which made
+    sm_at_aft == target_sm always (a false-positive "perfect" envelope).
     """
     aeroplane = _get_aeroplane(db, aeroplane_uuid)
 
@@ -427,35 +585,33 @@ def get_cg_envelope(
     cg_fwd = loading["cg_loading_fwd_m"]
     cg_aft = loading["cg_loading_aft_m"]
 
-    # Stability envelope — requires x_NP and MAC from context or assumptions
+    # Stability envelope — requires x_NP and MAC from recompute_assumptions context.
+    # Do NOT synthesise fallback values: that produces a deceptively "perfect" envelope.
     ctx = aeroplane.assumption_computation_context or {}
-    x_np = float(ctx.get("x_np_m") or 0.0)
-    mac = float(ctx.get("mac_m") or 1.0)
+    x_np_raw = ctx.get("x_np_m")
+    mac_raw = ctx.get("mac_m")
+    x_np = float(x_np_raw) if x_np_raw else None
+    mac = float(mac_raw) if mac_raw else None
     target_sm = _load_assumption_value(db, aeroplane.id, "target_static_margin", default=0.08)
-
-    if x_np == 0.0 or mac <= 0:
-        # Fall back to assumptions-based estimate if context not yet populated
-        base_cg_x = _load_assumption_value(db, aeroplane.id, "cg_x", default=0.15)
-        # Approximate: NP ≈ cg_x + target_sm * MAC (inverse of cg_x = NP - SM*MAC)
-        # Without actual aero computation, use a conservative MAC estimate.
-        # This is handled gracefully: the user sees stubs until a full recompute runs.
-        mac = float(ctx.get("mac_m") or 0.20)
-        x_np = base_cg_x + target_sm * mac
 
     stability = compute_stability_envelope(x_np=x_np, mac=mac, target_sm=target_sm)
     stab_fwd = stability["cg_stability_fwd_m"]
     stab_aft = stability["cg_stability_aft_m"]
 
-    # Static margins at loading extremes
-    sm_at_fwd = (x_np - cg_fwd) / mac if mac > 0 else 0.0
-    sm_at_aft = (x_np - cg_aft) / mac if mac > 0 else 0.0
+    # Static margins — only computable when x_NP and MAC are available
+    if x_np is not None and mac is not None and mac > 0:
+        sm_at_fwd: float | None = (x_np - cg_fwd) / mac
+        sm_at_aft: float | None = (x_np - cg_aft) / mac
+    else:
+        sm_at_fwd = None
+        sm_at_aft = None
 
     # Classify worst-case (aft = most critical for stability)
     classification_fwd = classify_sm(sm_at_fwd, target_sm)
     classification_aft = classify_sm(sm_at_aft, target_sm)
 
-    # Hierarchy: error > warn > ok
-    _rank = {"error": 2, "warn": 1, "ok": 0}
+    # Hierarchy: error > warn > ok > unknown
+    _rank = {"error": 3, "warn": 2, "ok": 1, "unknown": 0}
     if _rank[classification_fwd] >= _rank[classification_aft]:
         overall = classification_fwd
     else:
@@ -463,18 +619,23 @@ def get_cg_envelope(
 
     # Validation warnings
     warnings = validate_cg_envelope(cg_fwd, cg_aft, stab_fwd, stab_aft)
-    if overall == "error":
+
+    if overall == "unknown":
+        warnings.insert(
+            0,
+            "Stability envelope unavailable — recompute_assumptions hasn't been run. "
+            "Run a full analysis to populate x_NP and MAC.",
+        )
+    elif overall == "error" and sm_at_aft is not None:
         warnings.insert(0, f"SM at aft CG = {sm_at_aft:.1%} — outside safe operating range.")
-    elif overall == "warn":
-        pass  # validation_cg_envelope already captures this
 
     return {
         "cg_loading_fwd_m": round(cg_fwd, 4),
         "cg_loading_aft_m": round(cg_aft, 4),
-        "cg_stability_fwd_m": round(stab_fwd, 4),
-        "cg_stability_aft_m": round(stab_aft, 4),
-        "sm_at_fwd": round(sm_at_fwd, 4),
-        "sm_at_aft": round(sm_at_aft, 4),
+        "cg_stability_fwd_m": round(stab_fwd, 4) if stab_fwd is not None else None,
+        "cg_stability_aft_m": round(stab_aft, 4) if stab_aft is not None else None,
+        "sm_at_fwd": round(sm_at_fwd, 4) if sm_at_fwd is not None else None,
+        "sm_at_aft": round(sm_at_aft, 4) if sm_at_aft is not None else None,
         "classification": overall,
         "warnings": warnings,
     }

--- a/app/services/loading_template_service.py
+++ b/app/services/loading_template_service.py
@@ -1,0 +1,283 @@
+"""Loading Scenario Templates — default scenarios per aircraft class (gh-488).
+
+Templates provide a sensible starting set of loading scenarios for each
+aircraft class.  They are applied client-side (the user can customise or
+discard them); they are not auto-created at aeroplane creation time.
+"""
+from __future__ import annotations
+
+_EMPTY: dict = {
+    "name": "Empty",
+    "component_overrides": {
+        "toggles": [],
+        "mass_overrides": [],
+        "position_overrides": [],
+        "adhoc_items": [],
+    },
+    "is_default": True,
+}
+
+_BATTERY_FWD: dict = {
+    "name": "Battery Forward",
+    "component_overrides": {
+        "toggles": [],
+        "mass_overrides": [],
+        "position_overrides": [],
+        "adhoc_items": [
+            {
+                "name": "Battery (forward position)",
+                "mass_kg": 0.2,
+                "x_m": 0.05,
+                "y_m": 0.0,
+                "z_m": 0.0,
+                "category": "payload",
+            }
+        ],
+    },
+    "is_default": False,
+}
+
+_BATTERY_AFT: dict = {
+    "name": "Battery Aft",
+    "component_overrides": {
+        "toggles": [],
+        "mass_overrides": [],
+        "position_overrides": [],
+        "adhoc_items": [
+            {
+                "name": "Battery (aft position)",
+                "mass_kg": 0.2,
+                "x_m": 0.25,
+                "y_m": 0.0,
+                "z_m": 0.0,
+                "category": "payload",
+            }
+        ],
+    },
+    "is_default": False,
+}
+
+_WITH_PAYLOAD: dict = {
+    "name": "With Payload",
+    "component_overrides": {
+        "toggles": [],
+        "mass_overrides": [],
+        "position_overrides": [],
+        "adhoc_items": [
+            {
+                "name": "Mission Payload",
+                "mass_kg": 0.3,
+                "x_m": 0.15,
+                "y_m": 0.0,
+                "z_m": 0.0,
+                "category": "payload",
+            }
+        ],
+    },
+    "is_default": False,
+}
+
+_WITHOUT_PAYLOAD: dict = {
+    "name": "Without Payload",
+    "component_overrides": {
+        "toggles": [],
+        "mass_overrides": [],
+        "position_overrides": [],
+        "adhoc_items": [],
+    },
+    "is_default": False,
+}
+
+_FUEL_FULL: dict = {
+    "name": "Fuel Full",
+    "component_overrides": {
+        "toggles": [],
+        "mass_overrides": [],
+        "position_overrides": [],
+        "adhoc_items": [
+            {
+                "name": "Fuel (full)",
+                "mass_kg": 0.5,
+                "x_m": 0.15,
+                "y_m": 0.0,
+                "z_m": 0.0,
+                "category": "fuel",
+            }
+        ],
+    },
+    "is_default": False,
+}
+
+_FUEL_HALF: dict = {
+    "name": "Fuel Half",
+    "component_overrides": {
+        "toggles": [],
+        "mass_overrides": [],
+        "position_overrides": [],
+        "adhoc_items": [
+            {
+                "name": "Fuel (half)",
+                "mass_kg": 0.25,
+                "x_m": 0.15,
+                "y_m": 0.0,
+                "z_m": 0.0,
+                "category": "fuel",
+            }
+        ],
+    },
+    "is_default": False,
+}
+
+_FUEL_EMPTY: dict = {
+    "name": "Fuel Empty",
+    "component_overrides": {
+        "toggles": [],
+        "mass_overrides": [],
+        "position_overrides": [],
+        "adhoc_items": [],
+    },
+    "is_default": False,
+}
+
+_MISSION_PAYLOAD_INSTALLED: dict = {
+    "name": "Mission Payload Installed",
+    "component_overrides": {
+        "toggles": [],
+        "mass_overrides": [],
+        "position_overrides": [],
+        "adhoc_items": [
+            {
+                "name": "Survey Camera",
+                "mass_kg": 0.4,
+                "x_m": 0.10,
+                "y_m": 0.0,
+                "z_m": -0.05,
+                "category": "payload",
+            }
+        ],
+    },
+    "is_default": False,
+}
+
+_MISSION_PAYLOAD_REMOVED: dict = {
+    "name": "Mission Payload Removed",
+    "component_overrides": {
+        "toggles": [],
+        "mass_overrides": [],
+        "position_overrides": [],
+        "adhoc_items": [],
+    },
+    "is_default": False,
+}
+
+_DROP_PRE: dict = {
+    "name": "Drop — Pre Release",
+    "component_overrides": {
+        "toggles": [],
+        "mass_overrides": [],
+        "position_overrides": [],
+        "adhoc_items": [
+            {
+                "name": "Drop Item",
+                "mass_kg": 0.3,
+                "x_m": 0.15,
+                "y_m": 0.0,
+                "z_m": 0.0,
+                "category": "payload",
+            }
+        ],
+    },
+    "is_default": False,
+}
+
+_DROP_POST: dict = {
+    "name": "Drop — Post Release",
+    "component_overrides": {
+        "toggles": [],
+        "mass_overrides": [],
+        "position_overrides": [],
+        "adhoc_items": [],
+    },
+    "is_default": False,
+}
+
+_BALLAST_FULL: dict = {
+    "name": "Ballast Full",
+    "component_overrides": {
+        "toggles": [],
+        "mass_overrides": [],
+        "position_overrides": [],
+        "adhoc_items": [
+            {
+                "name": "Ballast (full)",
+                "mass_kg": 0.5,
+                "x_m": 0.20,
+                "y_m": 0.0,
+                "z_m": 0.0,
+                "category": "ballast",
+            }
+        ],
+    },
+    "is_default": False,
+}
+
+_BALLAST_EMPTY: dict = {
+    "name": "Ballast Empty",
+    "component_overrides": {
+        "toggles": [],
+        "mass_overrides": [],
+        "position_overrides": [],
+        "adhoc_items": [],
+    },
+    "is_default": False,
+}
+
+# Templates per aircraft class
+TEMPLATES: dict[str, list[dict]] = {
+    "rc_trainer": [
+        _EMPTY,
+        _BATTERY_FWD,
+        _BATTERY_AFT,
+        _WITH_PAYLOAD,
+        _WITHOUT_PAYLOAD,
+    ],
+    "rc_aerobatic": [
+        _EMPTY,
+        _BATTERY_FWD,
+        _BATTERY_AFT,
+    ],
+    "rc_combust": [
+        _EMPTY,
+        _FUEL_EMPTY,
+        _FUEL_HALF,
+        _FUEL_FULL,
+    ],
+    "uav_survey": [
+        _EMPTY,
+        _MISSION_PAYLOAD_INSTALLED,
+        _MISSION_PAYLOAD_REMOVED,
+        _DROP_PRE,
+        _DROP_POST,
+    ],
+    "glider": [
+        _EMPTY,
+        _BALLAST_EMPTY,
+        _BALLAST_FULL,
+    ],
+    # Boxwing gets the rc_trainer set; SM tolerance band handled separately
+    "boxwing": [
+        _EMPTY,
+        _BATTERY_FWD,
+        _BATTERY_AFT,
+        _WITH_PAYLOAD,
+        _WITHOUT_PAYLOAD,
+    ],
+}
+
+
+def get_templates_for_class(aircraft_class: str) -> list[dict]:
+    """Return the default loading scenario templates for the given aircraft class.
+
+    Falls back to rc_trainer templates for unknown classes.
+    """
+    return TEMPLATES.get(aircraft_class, TEMPLATES["rc_trainer"])

--- a/app/tests/test_loading_scenarios.py
+++ b/app/tests/test_loading_scenarios.py
@@ -660,3 +660,367 @@ class TestRetrimIntegration:
         assert any(e.parameter_name == "cg_x" for e in received), (
             f"AssumptionChanged(cg_x) not emitted. Got: {received}"
         )
+
+
+# ---------------------------------------------------------------------------
+# TestComponentOverridesAffectCg  (Issue C — all 4 override types)
+# ---------------------------------------------------------------------------
+
+
+def _make_weight_items(session, aeroplane_id: int) -> tuple:
+    """Create two WeightItemModel rows: 'fuselage' and 'battery'.
+
+    Returns (fuselage_item, battery_item) — both committed and refreshed.
+    """
+    from app.models.aeroplanemodel import WeightItemModel
+
+    fuselage = WeightItemModel(
+        aeroplane_id=aeroplane_id,
+        name="Fuselage",
+        mass_kg=1.0,
+        x_m=0.20,
+        y_m=0.0,
+        z_m=0.0,
+        category="structural",
+    )
+    battery = WeightItemModel(
+        aeroplane_id=aeroplane_id,
+        name="Battery",
+        mass_kg=0.3,
+        x_m=0.10,
+        y_m=0.0,
+        z_m=0.0,
+        category="electronics",
+    )
+    session.add_all([fuselage, battery])
+    session.commit()
+    session.refresh(fuselage)
+    session.refresh(battery)
+    return fuselage, battery
+
+
+class TestComponentOverridesAffectCg:
+    """Issue C: compute_scenario_cg must honour all 4 override types."""
+
+    def test_mass_override_shifts_cg(self, client_and_db: Tuple[TestClient, any]) -> None:
+        """Doubling the battery mass (0.3→0.6 kg) shifts CG toward battery position."""
+        from app.services.loading_scenario_service import compute_scenario_cg
+
+        _client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            fuselage, battery = _make_weight_items(session, plane.id)
+            fus_uuid = str(fuselage.id)
+            bat_uuid = str(battery.id)
+
+        # Components as plain dicts (same shape as WeightItemModel fields)
+        components = [
+            {"id": fus_uuid, "mass_kg": 1.0, "x_m": 0.20, "y_m": 0.0, "z_m": 0.0},
+            {"id": bat_uuid, "mass_kg": 0.3, "x_m": 0.10, "y_m": 0.0, "z_m": 0.0},
+        ]
+
+        # Base CG: (1.0*0.20 + 0.3*0.10) / 1.3 = 0.23/1.3 ≈ 0.1769
+        base_cg = compute_scenario_cg(
+            base_mass_kg=1.3,
+            base_cg_x=0.0,  # ignored when components provided
+            adhoc_items=[],
+            mass_overrides=[],
+            toggles=[],
+            position_overrides=[],
+            components=components,
+        )
+        assert abs(base_cg - (1.0 * 0.20 + 0.3 * 0.10) / 1.3) < 1e-9
+
+        # Override battery mass 0.3→0.6 kg → CG shifts toward battery (x=0.10, forward)
+        overridden_cg = compute_scenario_cg(
+            base_mass_kg=1.6,
+            base_cg_x=0.0,
+            adhoc_items=[],
+            mass_overrides=[{"component_uuid": bat_uuid, "mass_kg_override": 0.6}],
+            toggles=[],
+            position_overrides=[],
+            components=components,
+        )
+        # Expected: (1.0*0.20 + 0.6*0.10) / 1.6 = 0.26/1.6 = 0.1625
+        assert abs(overridden_cg - (1.0 * 0.20 + 0.6 * 0.10) / 1.6) < 1e-9
+        # Battery is forward of base CG → heavier battery → more forward CG
+        assert overridden_cg < base_cg
+
+    def test_position_override_shifts_cg(self, client_and_db: Tuple[TestClient, any]) -> None:
+        """Moving battery 50mm forward (x=0.10→0.05) shifts CG forward."""
+        from app.services.loading_scenario_service import compute_scenario_cg
+
+        _client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            fuselage, battery = _make_weight_items(session, plane.id)
+            fus_uuid = str(fuselage.id)
+            bat_uuid = str(battery.id)
+
+        components = [
+            {"id": fus_uuid, "mass_kg": 1.0, "x_m": 0.20, "y_m": 0.0, "z_m": 0.0},
+            {"id": bat_uuid, "mass_kg": 0.3, "x_m": 0.10, "y_m": 0.0, "z_m": 0.0},
+        ]
+
+        base_cg = compute_scenario_cg(
+            base_mass_kg=1.3, base_cg_x=0.0,
+            adhoc_items=[], mass_overrides=[], toggles=[], position_overrides=[],
+            components=components,
+        )
+
+        # Move battery from x=0.10 to x=0.05 (50mm forward)
+        shifted_cg = compute_scenario_cg(
+            base_mass_kg=1.3, base_cg_x=0.0,
+            adhoc_items=[], mass_overrides=[], toggles=[],
+            position_overrides=[{"component_uuid": bat_uuid, "x_m_override": 0.05}],
+            components=components,
+        )
+        # Expected: (1.0*0.20 + 0.3*0.05) / 1.3 = 0.215/1.3 ≈ 0.1654
+        assert abs(shifted_cg - (1.0 * 0.20 + 0.3 * 0.05) / 1.3) < 1e-9
+        assert shifted_cg < base_cg
+
+    def test_toggle_disabled_excludes_component(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """Battery enabled=False → CG computed without battery contribution."""
+        from app.services.loading_scenario_service import compute_scenario_cg
+
+        _client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            fuselage, battery = _make_weight_items(session, plane.id)
+            fus_uuid = str(fuselage.id)
+            bat_uuid = str(battery.id)
+
+        components = [
+            {"id": fus_uuid, "mass_kg": 1.0, "x_m": 0.20, "y_m": 0.0, "z_m": 0.0},
+            {"id": bat_uuid, "mass_kg": 0.3, "x_m": 0.10, "y_m": 0.0, "z_m": 0.0},
+        ]
+
+        # Disable battery → only fuselage remains
+        no_battery_cg = compute_scenario_cg(
+            base_mass_kg=1.3, base_cg_x=0.0,
+            adhoc_items=[], mass_overrides=[],
+            toggles=[{"component_uuid": bat_uuid, "enabled": False}],
+            position_overrides=[],
+            components=components,
+        )
+        # Expected: fuselage only → CG = 0.20
+        assert abs(no_battery_cg - 0.20) < 1e-9
+
+    def test_combined_overrides(self, client_and_db: Tuple[TestClient, any]) -> None:
+        """All 4 override types applied simultaneously produce correct CG."""
+        from app.services.loading_scenario_service import compute_scenario_cg
+
+        _client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            fuselage, battery = _make_weight_items(session, plane.id)
+            fus_uuid = str(fuselage.id)
+            bat_uuid = str(battery.id)
+
+        # Add a third component (motor)
+        from app.models.aeroplanemodel import WeightItemModel
+        with SessionLocal() as session:
+            motor = WeightItemModel(
+                aeroplane_id=plane.id, name="Motor", mass_kg=0.2,
+                x_m=0.35, y_m=0.0, z_m=0.0, category="propulsion",
+            )
+            session.add(motor)
+            session.commit()
+            session.refresh(motor)
+            motor_uuid = str(motor.id)
+
+        components = [
+            {"id": fus_uuid, "mass_kg": 1.0, "x_m": 0.20, "y_m": 0.0, "z_m": 0.0},
+            {"id": bat_uuid, "mass_kg": 0.3, "x_m": 0.10, "y_m": 0.0, "z_m": 0.0},
+            {"id": motor_uuid, "mass_kg": 0.2, "x_m": 0.35, "y_m": 0.0, "z_m": 0.0},
+        ]
+
+        # mass_override: battery 0.3→0.5 kg
+        # position_override: motor x=0.35→0.30
+        # toggle: fuselage stays on, motor stays on
+        # adhoc: 0.1 kg camera at x=0.05
+        cg = compute_scenario_cg(
+            base_mass_kg=1.5, base_cg_x=0.0,
+            adhoc_items=[{"name": "Camera", "mass_kg": 0.1, "x_m": 0.05, "y_m": 0.0, "z_m": 0.0}],
+            mass_overrides=[{"component_uuid": bat_uuid, "mass_kg_override": 0.5}],
+            toggles=[],
+            position_overrides=[{"component_uuid": motor_uuid, "x_m_override": 0.30}],
+            components=components,
+        )
+        # Expected:
+        #   fuselage: 1.0 kg @ 0.20
+        #   battery:  0.5 kg @ 0.10 (mass override)
+        #   motor:    0.2 kg @ 0.30 (position override)
+        #   camera:   0.1 kg @ 0.05 (adhoc)
+        # total: 1.8, moment: 0.20 + 0.05 + 0.06 + 0.005 = 0.315
+        # CG = 0.315/1.8 = 0.175
+        expected = (1.0 * 0.20 + 0.5 * 0.10 + 0.2 * 0.30 + 0.1 * 0.05) / (1.0 + 0.5 + 0.2 + 0.1)
+        assert abs(cg - expected) < 1e-9
+
+    def test_overrides_fall_back_to_base_when_no_components(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """When components=None, function uses legacy base_mass/base_cg_x (backward compat)."""
+        from app.services.loading_scenario_service import compute_scenario_cg
+
+        _client, SessionLocal = client_and_db
+
+        # Old call signature — no components param
+        cg = compute_scenario_cg(
+            base_mass_kg=1.5,
+            base_cg_x=0.15,
+            adhoc_items=[{"name": "Item", "mass_kg": 0.5, "x_m": 0.05, "y_m": 0.0, "z_m": 0.0}],
+            mass_overrides=[],
+        )
+        # (1.5*0.15 + 0.5*0.05) / 2.0 = 0.25/2.0 = 0.125
+        assert abs(cg - 0.125) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# TestMissingContextFallback  (Issue A — no deceptive x_np synthesis)
+# ---------------------------------------------------------------------------
+
+
+class TestMissingContextFallback:
+    def test_stability_envelope_returns_none_when_no_context(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """compute_stability_envelope with x_np=None returns None values."""
+        from app.services.loading_scenario_service import compute_stability_envelope
+
+        result = compute_stability_envelope(x_np=None, mac=None, target_sm=0.08)
+        assert result["cg_stability_aft_m"] is None
+        assert result["cg_stability_fwd_m"] is None
+
+    def test_cg_envelope_warns_when_stability_unknown(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """GET /cg-envelope returns 'stability_unavailable' warning when x_np not computed yet."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            _seed_assumptions(session, plane.id)
+            # Deliberately NO assumption_computation_context → x_np missing
+            plane.assumption_computation_context = {}
+            session.commit()
+            aeroplane_uuid = str(plane.uuid)
+
+        resp = client.get(f"/aeroplanes/{aeroplane_uuid}/cg-envelope")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+
+        # Stability fields must be null, not fabricated
+        assert data["cg_stability_fwd_m"] is None
+        assert data["cg_stability_aft_m"] is None
+        assert data["sm_at_fwd"] is None
+        assert data["sm_at_aft"] is None
+
+        # Classification must be "unknown" (not "ok" from a fake-perfect envelope)
+        assert data["classification"] == "unknown"
+
+        # Must contain an explicit stability_unavailable warning
+        assert any("stability" in w.lower() and "unavailable" in w.lower() for w in data["warnings"]), (
+            f"Expected 'stability unavailable' warning. Got: {data['warnings']}"
+        )
+
+    def test_no_false_positive_perfect_envelope(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """Without real aero data, sm_at_aft must NOT equal target_sm (deceptive)."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            _seed_assumptions(session, plane.id)
+            plane.assumption_computation_context = {}
+            session.commit()
+            aeroplane_uuid = str(plane.uuid)
+
+        resp = client.get(f"/aeroplanes/{aeroplane_uuid}/cg-envelope")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+
+        # The old code synthesised x_np = cg_x + target_sm*MAC which made
+        # sm_at_aft == target_sm always (deceptive "perfect" envelope).
+        # After the fix, sm_at_aft must be None.
+        assert data["sm_at_aft"] is None, (
+            f"sm_at_aft should be None when x_np not computed. Got {data['sm_at_aft']!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestCgAggMatchesDefaultScenario  (Issue B — cg_agg_m wiring)
+# ---------------------------------------------------------------------------
+
+
+class TestCgAggMatchesDefaultScenario:
+    def test_cg_agg_m_equals_default_scenario_cg_after_recompute(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """cg_agg_m in context equals the CG of the is_default scenario."""
+        from app.services.loading_scenario_service import compute_scenario_cg
+
+        client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            _seed_assumptions(session, plane.id)
+            aeroplane_uuid = str(plane.uuid)
+
+        # Create a default scenario with an adhoc item that shifts CG
+        create_resp = client.post(
+            f"/aeroplanes/{aeroplane_uuid}/loading-scenarios",
+            json=_scenario_payload(
+                name="Default",
+                is_default=True,
+                component_overrides={
+                    "toggles": [],
+                    "mass_overrides": [],
+                    "position_overrides": [],
+                    "adhoc_items": [
+                        {"name": "Payload", "mass_kg": 0.5, "x_m": 0.25, "y_m": 0.0, "z_m": 0.0}
+                    ],
+                },
+            ),
+        )
+        assert create_resp.status_code == 201, create_resp.text
+
+        # Manually call compute_cg_agg_for_aeroplane to check it matches
+        from app.services.loading_scenario_service import compute_cg_agg_for_aeroplane
+
+        with SessionLocal() as session:
+            plane_row = session.query(AeroplaneModel).filter_by(uuid=plane.uuid).first()
+            cg_agg = compute_cg_agg_for_aeroplane(session, plane_row)
+
+        # base: mass=1.5, cg_x=0.15; adhoc: 0.5 kg at 0.25
+        # expected CG = (1.5*0.15 + 0.5*0.25) / 2.0 = (0.225 + 0.125) / 2.0 = 0.175
+        expected = (1.5 * 0.15 + 0.5 * 0.25) / 2.0
+        assert abs(cg_agg - expected) < 1e-9, f"Expected {expected}, got {cg_agg}"
+
+    def test_cg_agg_m_falls_back_to_legacy_when_no_scenarios(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """When no loading scenarios exist, compute_cg_agg falls back to legacy weight items."""
+        from app.services.loading_scenario_service import compute_cg_agg_for_aeroplane
+        from app.models.aeroplanemodel import WeightItemModel
+
+        _client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            _seed_assumptions(session, plane.id)
+            # Add weight items (no loading scenarios)
+            wi = WeightItemModel(
+                aeroplane_id=plane.id, name="Motor", mass_kg=0.5,
+                x_m=0.30, y_m=0.0, z_m=0.0, category="propulsion",
+            )
+            session.add(wi)
+            session.commit()
+            session.refresh(plane)
+
+        with SessionLocal() as session:
+            plane_row = session.query(AeroplaneModel).filter_by(uuid=plane.uuid).first()
+            cg_agg = compute_cg_agg_for_aeroplane(session, plane_row)
+
+        # No scenarios → falls back to weight-items aggregation → motor at x=0.30
+        # Only one item → cg = 0.30
+        assert abs(cg_agg - 0.30) < 1e-9, f"Expected 0.30 (legacy fallback), got {cg_agg}"

--- a/app/tests/test_loading_scenarios.py
+++ b/app/tests/test_loading_scenarios.py
@@ -1,0 +1,662 @@
+"""Tests for Loading Scenarios (gh-488) — CG envelope from loading scenarios.
+
+TDD RED phase: all tests fail until production code is implemented.
+
+Covers:
+- LoadingScenario CRUD
+- Loading envelope computation
+- Stability envelope computation
+- Validation (Loading ⊆ Stability)
+- 5-tier SM classification
+- Backward compatibility (cg_agg_m remains)
+- Templates per aircraft_class
+- Retrim integration
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Tuple
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.aeroplanemodel import AeroplaneModel, DesignAssumptionModel
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_aeroplane(session: Session, *, name: str = "test-plane") -> AeroplaneModel:
+    a = AeroplaneModel(name=name, uuid=uuid.uuid4(), total_mass_kg=1.5)
+    session.add(a)
+    session.commit()
+    session.refresh(a)
+    return a
+
+
+def _seed_assumptions(session: Session, aeroplane_id: int, extra: dict | None = None) -> None:
+    """Seed minimal design assumptions needed for CG envelope tests."""
+    params = {
+        "mass": 1.5,
+        "cg_x": 0.15,
+        "cl_max": 1.4,
+        "cd0": 0.03,
+        "target_static_margin": 0.08,
+        "g_limit": 3.0,
+        **(extra or {}),
+    }
+    for name, value in params.items():
+        session.add(
+            DesignAssumptionModel(
+                aeroplane_id=aeroplane_id,
+                parameter_name=name,
+                estimate_value=value,
+                active_source="ESTIMATE",
+                updated_at=datetime.now(timezone.utc),
+            )
+        )
+    session.commit()
+
+
+def _scenario_payload(**overrides) -> dict:
+    """Base loading scenario creation payload."""
+    base = {
+        "name": "Test Scenario",
+        "aircraft_class": "rc_trainer",
+        "component_overrides": {
+            "toggles": [],
+            "mass_overrides": [],
+            "position_overrides": [],
+            "adhoc_items": [],
+        },
+        "is_default": False,
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# TestLoadingScenarioCrud
+# ---------------------------------------------------------------------------
+
+
+class TestLoadingScenarioCrud:
+    def test_create_scenario_with_overrides(self, client_and_db: Tuple[TestClient, any]) -> None:
+        client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            aeroplane_uuid = str(plane.uuid)
+
+        payload = _scenario_payload(
+            name="Battery Fwd",
+            component_overrides={
+                "toggles": [],
+                "mass_overrides": [
+                    {"component_uuid": "abc123", "mass_kg_override": 0.3}
+                ],
+                "position_overrides": [
+                    {"component_uuid": "abc123", "x_m_override": 0.05}
+                ],
+                "adhoc_items": [],
+            },
+        )
+        resp = client.post(f"/aeroplanes/{aeroplane_uuid}/loading-scenarios", json=payload)
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["name"] == "Battery Fwd"
+        assert data["aircraft_class"] == "rc_trainer"
+        assert len(data["component_overrides"]["mass_overrides"]) == 1
+        assert data["id"] is not None
+
+    def test_create_scenario_with_adhoc_items(self, client_and_db: Tuple[TestClient, any]) -> None:
+        """Adhoc items (Pilot, Payload) can be added to a scenario."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            aeroplane_uuid = str(plane.uuid)
+
+        payload = _scenario_payload(
+            name="With FPV Gear",
+            component_overrides={
+                "toggles": [],
+                "mass_overrides": [],
+                "position_overrides": [],
+                "adhoc_items": [
+                    {
+                        "name": "FPV Camera",
+                        "mass_kg": 0.05,
+                        "x_m": 0.05,
+                        "y_m": 0.0,
+                        "z_m": 0.0,
+                        "category": "fpv_gear",
+                    }
+                ],
+            },
+        )
+        resp = client.post(f"/aeroplanes/{aeroplane_uuid}/loading-scenarios", json=payload)
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert len(data["component_overrides"]["adhoc_items"]) == 1
+        assert data["component_overrides"]["adhoc_items"][0]["category"] == "fpv_gear"
+
+    def test_list_scenarios(self, client_and_db: Tuple[TestClient, any]) -> None:
+        client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            aeroplane_uuid = str(plane.uuid)
+
+        client.post(
+            f"/aeroplanes/{aeroplane_uuid}/loading-scenarios",
+            json=_scenario_payload(name="Scenario A"),
+        )
+        client.post(
+            f"/aeroplanes/{aeroplane_uuid}/loading-scenarios",
+            json=_scenario_payload(name="Scenario B"),
+        )
+
+        resp = client.get(f"/aeroplanes/{aeroplane_uuid}/loading-scenarios")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert len(data) == 2
+        names = {s["name"] for s in data}
+        assert names == {"Scenario A", "Scenario B"}
+
+    def test_update_scenario(self, client_and_db: Tuple[TestClient, any]) -> None:
+        client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            aeroplane_uuid = str(plane.uuid)
+
+        create_resp = client.post(
+            f"/aeroplanes/{aeroplane_uuid}/loading-scenarios",
+            json=_scenario_payload(name="Old Name"),
+        )
+        scenario_id = create_resp.json()["id"]
+
+        patch_resp = client.patch(
+            f"/aeroplanes/{aeroplane_uuid}/loading-scenarios/{scenario_id}",
+            json={"name": "New Name"},
+        )
+        assert patch_resp.status_code == 200, patch_resp.text
+        assert patch_resp.json()["name"] == "New Name"
+
+    def test_delete_scenario(self, client_and_db: Tuple[TestClient, any]) -> None:
+        client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            aeroplane_uuid = str(plane.uuid)
+
+        create_resp = client.post(
+            f"/aeroplanes/{aeroplane_uuid}/loading-scenarios",
+            json=_scenario_payload(name="To Delete"),
+        )
+        scenario_id = create_resp.json()["id"]
+
+        del_resp = client.delete(
+            f"/aeroplanes/{aeroplane_uuid}/loading-scenarios/{scenario_id}"
+        )
+        assert del_resp.status_code == 204, del_resp.text
+
+        list_resp = client.get(f"/aeroplanes/{aeroplane_uuid}/loading-scenarios")
+        assert list_resp.status_code == 200
+        assert list_resp.json() == []
+
+    def test_is_default_flag(self, client_and_db: Tuple[TestClient, any]) -> None:
+        """is_default=True marks a scenario as the default for backward-compat cg_agg_m."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            aeroplane_uuid = str(plane.uuid)
+
+        resp = client.post(
+            f"/aeroplanes/{aeroplane_uuid}/loading-scenarios",
+            json=_scenario_payload(name="Default Scenario", is_default=True),
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["is_default"] is True
+
+    def test_list_scenarios_returns_empty_for_no_scenarios(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            aeroplane_uuid = str(plane.uuid)
+
+        resp = client.get(f"/aeroplanes/{aeroplane_uuid}/loading-scenarios")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+# ---------------------------------------------------------------------------
+# TestLoadingEnvelope
+# ---------------------------------------------------------------------------
+
+
+class TestLoadingEnvelope:
+    def test_loading_envelope_min_max_across_scenarios(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """Loading envelope is min/max CG across all scenarios with adhoc items."""
+        from app.services.loading_scenario_service import compute_loading_envelope_for_aeroplane
+
+        client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            _seed_assumptions(session, plane.id)
+            aeroplane_uuid = str(plane.uuid)
+
+        # Scenario A: forward CG (heavy item at front)
+        client.post(
+            f"/aeroplanes/{aeroplane_uuid}/loading-scenarios",
+            json=_scenario_payload(
+                name="Fwd",
+                component_overrides={
+                    "toggles": [],
+                    "mass_overrides": [],
+                    "position_overrides": [],
+                    "adhoc_items": [
+                        {"name": "Ballast", "mass_kg": 0.5, "x_m": 0.05, "y_m": 0.0, "z_m": 0.0}
+                    ],
+                },
+            ),
+        )
+        # Scenario B: aft CG (heavy item at rear)
+        client.post(
+            f"/aeroplanes/{aeroplane_uuid}/loading-scenarios",
+            json=_scenario_payload(
+                name="Aft",
+                component_overrides={
+                    "toggles": [],
+                    "mass_overrides": [],
+                    "position_overrides": [],
+                    "adhoc_items": [
+                        {"name": "Payload", "mass_kg": 0.5, "x_m": 0.40, "y_m": 0.0, "z_m": 0.0}
+                    ],
+                },
+            ),
+        )
+
+        with SessionLocal() as session:
+            plane = session.query(AeroplaneModel).filter_by(uuid=plane.uuid).first()
+            envelope = compute_loading_envelope_for_aeroplane(session, plane)
+
+        assert envelope["cg_loading_fwd_m"] < envelope["cg_loading_aft_m"]
+        # fwd scenario shifts CG forward from base (0.15), aft scenario shifts it aft
+        assert envelope["cg_loading_fwd_m"] < 0.15
+        assert envelope["cg_loading_aft_m"] > 0.15
+
+    def test_adhoc_items_shift_cg(self, client_and_db: Tuple[TestClient, any]) -> None:
+        """Adding adhoc items to a scenario changes the computed CG."""
+        from app.services.loading_scenario_service import compute_scenario_cg
+
+        _client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            _seed_assumptions(session, plane.id)
+
+        # Base mass 1.5 kg at x=0.15, adding 0.5 kg at x=0.05
+        # Expected CG = (1.5*0.15 + 0.5*0.05) / (1.5+0.5) = (0.225+0.025)/2.0 = 0.125
+        adhoc = [{"name": "Fwd Ballast", "mass_kg": 0.5, "x_m": 0.05, "y_m": 0.0, "z_m": 0.0}]
+        cg_x = compute_scenario_cg(
+            base_mass_kg=1.5,
+            base_cg_x=0.15,
+            adhoc_items=adhoc,
+            mass_overrides=[],
+        )
+        assert abs(cg_x - 0.125) < 1e-9, f"Expected 0.125, got {cg_x}"
+
+    def test_toggles_disable_components(self, client_and_db: Tuple[TestClient, any]) -> None:
+        """A disabled toggle reduces mass (and shifts CG)."""
+        from app.services.loading_scenario_service import compute_scenario_cg
+
+        _client, _SessionLocal = client_and_db
+
+        # Remove 0.3 kg item at x=0.30 from 1.5 kg plane
+        # Remaining: 1.2 kg at weighted CG
+        # This test just checks cg_x computes differently with a toggle
+        # We model toggles by subtracting the item from the base mass.
+        # If no component data is available (pure unit test), just verify the function signature.
+        cg_x_no_toggle = compute_scenario_cg(
+            base_mass_kg=1.5,
+            base_cg_x=0.15,
+            adhoc_items=[],
+            mass_overrides=[],
+        )
+        assert cg_x_no_toggle == pytest.approx(0.15)
+
+    def test_no_scenarios_returns_base_cg(self, client_and_db: Tuple[TestClient, any]) -> None:
+        """Without any loading scenarios, loading envelope uses the base design cg_x."""
+        from app.services.loading_scenario_service import compute_loading_envelope_for_aeroplane
+
+        _client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            _seed_assumptions(session, plane.id)
+            envelope = compute_loading_envelope_for_aeroplane(session, plane)
+
+        # No scenarios → forward = aft = design cg_x (0.15 from assumptions)
+        assert envelope["cg_loading_fwd_m"] == pytest.approx(0.15)
+        assert envelope["cg_loading_aft_m"] == pytest.approx(0.15)
+
+
+# ---------------------------------------------------------------------------
+# TestStabilityEnvelope
+# ---------------------------------------------------------------------------
+
+
+class TestStabilityEnvelope:
+    def test_stability_envelope_aft_uses_target_sm(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """cg_stability_aft = x_NP - target_sm * MAC (Anderson §7.5)."""
+        from app.services.loading_scenario_service import compute_stability_envelope
+
+        # x_NP = 0.30, MAC = 0.20, target_sm = 0.08
+        # cg_stability_aft = 0.30 - 0.08 * 0.20 = 0.284
+        envelope = compute_stability_envelope(
+            x_np=0.30,
+            mac=0.20,
+            target_sm=0.08,
+        )
+        assert envelope["cg_stability_aft_m"] == pytest.approx(0.30 - 0.08 * 0.20)
+
+    def test_stability_envelope_fwd_stub(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """cg_stability_fwd uses stub value: x_NP - 0.30 * MAC.
+
+        TODO: replace with full elevator-authority calculation as follow-up ticket.
+        Conservative stub per Anderson §7.7.
+        """
+        from app.services.loading_scenario_service import compute_stability_envelope
+
+        # x_NP = 0.30, MAC = 0.20
+        # cg_stability_fwd = 0.30 - 0.30 * 0.20 = 0.24
+        envelope = compute_stability_envelope(
+            x_np=0.30,
+            mac=0.20,
+            target_sm=0.08,
+        )
+        assert envelope["cg_stability_fwd_m"] == pytest.approx(0.30 - 0.30 * 0.20)
+
+    def test_stability_envelope_aft_gt_fwd(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """Aft stability limit must be forward of NP; fwd must be forward of aft."""
+        from app.services.loading_scenario_service import compute_stability_envelope
+
+        envelope = compute_stability_envelope(x_np=0.30, mac=0.20, target_sm=0.08)
+        # fwd < aft < NP
+        assert envelope["cg_stability_fwd_m"] < envelope["cg_stability_aft_m"]
+        assert envelope["cg_stability_aft_m"] < 0.30
+
+
+# ---------------------------------------------------------------------------
+# TestValidation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_loading_envelope_within_stability_envelope_passes(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """No warning when loading CG range is within stability envelope."""
+        from app.services.loading_scenario_service import validate_cg_envelope
+
+        warnings = validate_cg_envelope(
+            cg_loading_fwd_m=0.22,
+            cg_loading_aft_m=0.26,
+            cg_stability_fwd_m=0.18,
+            cg_stability_aft_m=0.28,
+        )
+        assert warnings == []
+
+    def test_loading_envelope_outside_stability_aft_raises(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """Error when loading CG aft exceeds stability aft limit."""
+        from app.services.loading_scenario_service import validate_cg_envelope
+
+        warnings = validate_cg_envelope(
+            cg_loading_fwd_m=0.22,
+            cg_loading_aft_m=0.30,  # Exceeds stability aft 0.28
+            cg_stability_fwd_m=0.18,
+            cg_stability_aft_m=0.28,
+        )
+        assert any("aft" in w.lower() for w in warnings)
+
+    def test_loading_envelope_outside_stability_fwd_warns(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """Warning when loading CG forward is ahead of stability forward limit."""
+        from app.services.loading_scenario_service import validate_cg_envelope
+
+        warnings = validate_cg_envelope(
+            cg_loading_fwd_m=0.16,  # Forward of stability fwd 0.18
+            cg_loading_aft_m=0.26,
+            cg_stability_fwd_m=0.18,
+            cg_stability_aft_m=0.28,
+        )
+        assert any("forward" in w.lower() or "fwd" in w.lower() for w in warnings)
+
+
+# ---------------------------------------------------------------------------
+# TestSmClassification5Tier
+# ---------------------------------------------------------------------------
+
+
+_SM_CASES = [
+    # (sm, target, expected_tier)
+    (0.01, 0.08, "error"),    # sm < 0.02 → ERROR (unstable)
+    (0.04, 0.08, "warn"),     # 0.02 ≤ sm < target → WARN (low margin)
+    (0.10, 0.08, "ok"),       # target ≤ sm ≤ 0.20 → OK
+    (0.22, 0.08, "warn"),     # 0.20 < sm ≤ 0.30 → WARN (heavy nose)
+    (0.32, 0.08, "error"),    # sm > 0.30 → ERROR (elevator authority)
+]
+
+
+class TestSmClassification5Tier:
+    @pytest.mark.parametrize("sm,target,expected", _SM_CASES)
+    def test_classification_relative_to_target_sm(
+        self, sm: float, target: float, expected: str, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        from app.services.loading_scenario_service import classify_sm
+
+        result = classify_sm(sm=sm, target_sm=target)
+        assert result == expected, f"classify_sm({sm}, {target}) = {result!r}, want {expected!r}"
+
+
+# ---------------------------------------------------------------------------
+# TestBackwardCompat
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompat:
+    def test_cg_agg_m_remains_in_context(self, client_and_db: Tuple[TestClient, any]) -> None:
+        """assumption_computation_context still contains cg_agg_m after gh-488."""
+        _client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            # Write a fake context that has cg_agg_m (simulating pre-existing data)
+            plane.assumption_computation_context = {
+                "cg_agg_m": 0.15,
+                "mac_m": 0.18,
+                "x_np_m": 0.25,
+                "target_static_margin": 0.08,
+            }
+            session.commit()
+            session.refresh(plane)
+            ctx = plane.assumption_computation_context
+            assert "cg_agg_m" in ctx
+
+    def test_new_keys_additively_added(self, client_and_db: Tuple[TestClient, any]) -> None:
+        """New context keys (cg_forward_m, cg_aft_m, sm_at_fwd, sm_at_aft) are additive."""
+        from app.services.loading_scenario_service import enrich_context_with_cg_envelope
+
+        ctx: dict = {
+            "cg_agg_m": 0.15,
+            "mac_m": 0.18,
+            "x_np_m": 0.25,
+            "target_static_margin": 0.08,
+        }
+        enriched = enrich_context_with_cg_envelope(
+            ctx=ctx,
+            cg_loading_fwd_m=0.14,
+            cg_loading_aft_m=0.17,
+            cg_stability_fwd_m=0.10,
+            cg_stability_aft_m=0.23,
+        )
+        # Original keys preserved
+        assert enriched["cg_agg_m"] == 0.15
+        # New keys added
+        assert "cg_forward_m" in enriched
+        assert "cg_aft_m" in enriched
+        assert "sm_at_fwd" in enriched
+        assert "sm_at_aft" in enriched
+
+    def test_no_scenarios_falls_back_to_legacy_cg(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """Without loading scenarios, cg_agg_m equals design cg_x (backward compat)."""
+        from app.services.loading_scenario_service import compute_loading_envelope_for_aeroplane
+
+        _client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            _seed_assumptions(session, plane.id)
+            envelope = compute_loading_envelope_for_aeroplane(session, plane)
+
+        # No scenarios → fwd = aft = design cg_x = 0.15
+        assert envelope["cg_loading_fwd_m"] == pytest.approx(0.15)
+        assert envelope["cg_loading_aft_m"] == pytest.approx(0.15)
+
+    def test_cg_endpoint_still_returns_cg_envelope_read(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """GET /cg-envelope returns the CgEnvelopeRead schema."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            _seed_assumptions(session, plane.id)
+            aeroplane_uuid = str(plane.uuid)
+
+        resp = client.get(f"/aeroplanes/{aeroplane_uuid}/cg-envelope")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        required_keys = {
+            "cg_loading_fwd_m",
+            "cg_loading_aft_m",
+            "cg_stability_fwd_m",
+            "cg_stability_aft_m",
+            "sm_at_fwd",
+            "sm_at_aft",
+            "classification",
+            "warnings",
+        }
+        assert required_keys.issubset(data.keys()), f"Missing keys: {required_keys - data.keys()}"
+
+
+# ---------------------------------------------------------------------------
+# TestTemplatesPerAircraftClass
+# ---------------------------------------------------------------------------
+
+
+_AIRCRAFT_CLASSES = [
+    "rc_trainer",
+    "rc_aerobatic",
+    "rc_combust",
+    "uav_survey",
+    "glider",
+    "boxwing",
+]
+
+
+class TestTemplatesPerAircraftClass:
+    @pytest.mark.parametrize("ac", _AIRCRAFT_CLASSES)
+    def test_template_for_class(
+        self, ac: str, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """Every aircraft_class has at least one loading scenario template."""
+        from app.services.loading_template_service import get_templates_for_class
+
+        templates = get_templates_for_class(ac)
+        assert len(templates) >= 1, f"No templates for {ac}"
+        for t in templates:
+            assert "name" in t, f"Template missing 'name': {t}"
+
+    def test_templates_endpoint(self, client_and_db: Tuple[TestClient, any]) -> None:
+        """GET /loading-scenarios/templates?aircraft_class=rc_trainer returns templates."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            aeroplane_uuid = str(plane.uuid)
+
+        resp = client.get(
+            f"/aeroplanes/{aeroplane_uuid}/loading-scenarios/templates",
+            params={"aircraft_class": "rc_trainer"},
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) >= 1
+
+
+# ---------------------------------------------------------------------------
+# TestRetrimIntegration
+# ---------------------------------------------------------------------------
+
+
+class TestRetrimIntegration:
+    def test_loading_scenario_change_marks_ops_dirty(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """Creating a loading scenario triggers mark_ops_dirty for the aeroplane."""
+        from app.models.analysismodels import OperatingPointModel
+        from app.tests.conftest import make_operating_point
+
+        client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            aeroplane_uuid = str(plane.uuid)
+            op = make_operating_point(session, aircraft_id=plane.id, status="TRIMMED")
+
+        # Create a loading scenario → should mark OPs DIRTY
+        client.post(
+            f"/aeroplanes/{aeroplane_uuid}/loading-scenarios",
+            json=_scenario_payload(name="Dirty Trigger"),
+        )
+
+        with SessionLocal() as session:
+            op_row = session.query(OperatingPointModel).filter_by(id=op.id).first()
+            assert op_row is not None
+            assert op_row.status == "DIRTY", f"Expected DIRTY, got {op_row.status}"
+
+    def test_assumption_changed_event_emitted(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """Creating a loading scenario emits AssumptionChanged(cg_x) event."""
+        from app.core.events import AssumptionChanged, event_bus
+
+        received: list[AssumptionChanged] = []
+        event_bus.subscribe(AssumptionChanged, received.append)
+
+        client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            aeroplane_uuid = str(plane.uuid)
+
+        try:
+            client.post(
+                f"/aeroplanes/{aeroplane_uuid}/loading-scenarios",
+                json=_scenario_payload(name="Event Trigger"),
+            )
+        finally:
+            event_bus._subscribers.pop(AssumptionChanged, None)
+
+        assert any(e.parameter_name == "cg_x" for e in received), (
+            f"AssumptionChanged(cg_x) not emitted. Got: {received}"
+        )

--- a/app/tests/test_loading_scenarios.py
+++ b/app/tests/test_loading_scenarios.py
@@ -1024,3 +1024,818 @@ class TestCgAggMatchesDefaultScenario:
         # No scenarios → falls back to weight-items aggregation → motor at x=0.30
         # Only one item → cg = 0.30
         assert abs(cg_agg - 0.30) < 1e-9, f"Expected 0.30 (legacy fallback), got {cg_agg}"
+
+
+# ---------------------------------------------------------------------------
+# TestEdgeCases — classify_sm thresholds, zero-mass, single-axis position override
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Covers boundary values in classify_sm and compute_scenario_cg edge paths."""
+
+    def test_classify_sm_none_returns_unknown(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """classify_sm(None, target) must return 'unknown'."""
+        from app.services.loading_scenario_service import classify_sm
+
+        assert classify_sm(None, 0.08) == "unknown"
+
+    def test_classify_sm_exactly_unstable_limit(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """classify_sm(0.02, target) is 'warn' (boundary is exclusive for error)."""
+        from app.services.loading_scenario_service import classify_sm
+
+        # sm == _SM_UNSTABLE_LIMIT (0.02): NOT < 0.02, so falls to next branch
+        # 0.02 < target_sm (0.08) → warn
+        assert classify_sm(0.02, 0.08) == "warn"
+
+    def test_classify_sm_just_below_unstable_limit(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """classify_sm(0.019, target) is 'error' (sm < 0.02)."""
+        from app.services.loading_scenario_service import classify_sm
+
+        assert classify_sm(0.019, 0.08) == "error"
+
+    def test_classify_sm_exactly_heavy_nose_warn_threshold(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """classify_sm(0.20, target) is 'ok' (sm <= 0.20 is still OK)."""
+        from app.services.loading_scenario_service import classify_sm
+
+        assert classify_sm(0.20, 0.08) == "ok"
+
+    def test_classify_sm_just_above_heavy_nose_warn(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """classify_sm(0.201, target) is 'warn' (heavy nose range 0.20 < sm <= 0.30)."""
+        from app.services.loading_scenario_service import classify_sm
+
+        assert classify_sm(0.201, 0.08) == "warn"
+
+    def test_classify_sm_exactly_elevator_limit(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """classify_sm(0.30, target) is 'warn' (sm == 0.30 is within warn band)."""
+        from app.services.loading_scenario_service import classify_sm
+
+        assert classify_sm(0.30, 0.08) == "warn"
+
+    def test_classify_sm_just_above_elevator_limit(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """classify_sm(0.301, target) is 'error' (sm > 0.30)."""
+        from app.services.loading_scenario_service import classify_sm
+
+        assert classify_sm(0.301, 0.08) == "error"
+
+    def test_classify_sm_exactly_at_target(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """classify_sm(target_sm, target_sm) is 'ok' (at the lower end of OK band)."""
+        from app.services.loading_scenario_service import classify_sm
+
+        assert classify_sm(0.08, 0.08) == "ok"
+
+    def test_compute_scenario_cg_zero_total_mass_falls_back_to_base_cg(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """When total_mass <= 0, compute_scenario_cg returns base_cg_x as fallback."""
+        from app.services.loading_scenario_service import compute_scenario_cg
+
+        # Disabled all components via toggle, no adhoc items → total_mass = 0
+        components = [
+            {"id": "comp1", "mass_kg": 1.0, "x_m": 0.20, "y_m": 0.0, "z_m": 0.0},
+        ]
+        result = compute_scenario_cg(
+            base_mass_kg=1.0,
+            base_cg_x=0.15,
+            adhoc_items=[],
+            mass_overrides=[],
+            toggles=[{"component_uuid": "comp1", "enabled": False}],
+            position_overrides=[],
+            components=components,
+        )
+        # total_mass == 0 → fallback to base_cg_x
+        assert result == pytest.approx(0.15)
+
+    def test_position_override_y_z_optional(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """PositionOverride with only x_m_override (y_m_override / z_m_override = None)
+        must not crash and must correctly apply x-only shift."""
+        from app.services.loading_scenario_service import compute_scenario_cg
+
+        components = [
+            {"id": "bat", "mass_kg": 0.3, "x_m": 0.10, "y_m": 0.0, "z_m": 0.0},
+            {"id": "fus", "mass_kg": 1.0, "x_m": 0.20, "y_m": 0.0, "z_m": 0.0},
+        ]
+        # PositionOverride only sets x_m_override — y/z stay at component values
+        result = compute_scenario_cg(
+            base_mass_kg=1.3,
+            base_cg_x=0.0,
+            adhoc_items=[],
+            mass_overrides=[],
+            toggles=[],
+            position_overrides=[{"component_uuid": "bat", "x_m_override": 0.05}],
+            components=components,
+        )
+        expected = (1.0 * 0.20 + 0.3 * 0.05) / 1.3
+        assert abs(result - expected) < 1e-9
+
+    def test_empty_component_overrides_no_crash(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """compute_scenario_cg with all-empty overrides returns correct base CG."""
+        from app.services.loading_scenario_service import compute_scenario_cg
+
+        result = compute_scenario_cg(
+            base_mass_kg=1.0,
+            base_cg_x=0.20,
+            adhoc_items=[],
+            mass_overrides=[],
+            toggles=None,
+            position_overrides=None,
+        )
+        assert result == pytest.approx(0.20)
+
+
+# ---------------------------------------------------------------------------
+# TestErrorPaths — 404 / missing scenario / invalid aircraft_class
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPaths:
+    """Covers 404 error paths for CRUD endpoints."""
+
+    def test_list_scenarios_404_unknown_aeroplane(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """GET /aeroplanes/{unknown_uuid}/loading-scenarios → 404."""
+        client, _SessionLocal = client_and_db
+        unknown = str(uuid.uuid4())
+        resp = client.get(f"/aeroplanes/{unknown}/loading-scenarios")
+        assert resp.status_code == 404
+
+    def test_create_scenario_404_unknown_aeroplane(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """POST /aeroplanes/{unknown_uuid}/loading-scenarios → 404."""
+        client, _SessionLocal = client_and_db
+        unknown = str(uuid.uuid4())
+        resp = client.post(
+            f"/aeroplanes/{unknown}/loading-scenarios",
+            json=_scenario_payload(name="Ghost Scenario"),
+        )
+        assert resp.status_code == 404
+
+    def test_update_scenario_404_missing_scenario_id(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """PATCH .../loading-scenarios/999 → 404 when scenario does not exist."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            aeroplane_uuid = str(plane.uuid)
+
+        resp = client.patch(
+            f"/aeroplanes/{aeroplane_uuid}/loading-scenarios/999999",
+            json={"name": "Nonexistent"},
+        )
+        assert resp.status_code == 404
+
+    def test_update_scenario_404_unknown_aeroplane(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """PATCH /aeroplanes/{unknown}/loading-scenarios/1 → 404."""
+        client, _SessionLocal = client_and_db
+        unknown = str(uuid.uuid4())
+        resp = client.patch(
+            f"/aeroplanes/{unknown}/loading-scenarios/1",
+            json={"name": "Ghost"},
+        )
+        assert resp.status_code == 404
+
+    def test_delete_scenario_404_missing_scenario_id(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """DELETE .../loading-scenarios/999 → 404 when scenario does not exist."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            aeroplane_uuid = str(plane.uuid)
+
+        resp = client.delete(
+            f"/aeroplanes/{aeroplane_uuid}/loading-scenarios/999999"
+        )
+        assert resp.status_code == 404
+
+    def test_delete_scenario_404_unknown_aeroplane(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """DELETE /aeroplanes/{unknown}/loading-scenarios/1 → 404."""
+        client, _SessionLocal = client_and_db
+        unknown = str(uuid.uuid4())
+        resp = client.delete(f"/aeroplanes/{unknown}/loading-scenarios/1")
+        assert resp.status_code == 404
+
+    def test_get_cg_envelope_404_unknown_aeroplane(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """GET /aeroplanes/{unknown}/cg-envelope → 404."""
+        client, _SessionLocal = client_and_db
+        unknown = str(uuid.uuid4())
+        resp = client.get(f"/aeroplanes/{unknown}/cg-envelope")
+        assert resp.status_code == 404
+
+    def test_update_scenario_partial_name_only(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """PATCH with only name updates name, leaves other fields intact."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            aeroplane_uuid = str(plane.uuid)
+
+        create_resp = client.post(
+            f"/aeroplanes/{aeroplane_uuid}/loading-scenarios",
+            json=_scenario_payload(name="Original", aircraft_class="rc_aerobatic"),
+        )
+        scenario_id = create_resp.json()["id"]
+
+        patch_resp = client.patch(
+            f"/aeroplanes/{aeroplane_uuid}/loading-scenarios/{scenario_id}",
+            json={"name": "Renamed"},
+        )
+        assert patch_resp.status_code == 200
+        result = patch_resp.json()
+        assert result["name"] == "Renamed"
+        assert result["aircraft_class"] == "rc_aerobatic"  # unchanged
+
+    def test_update_scenario_aircraft_class_only(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """PATCH with only aircraft_class updates it, leaves name intact."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            aeroplane_uuid = str(plane.uuid)
+
+        create_resp = client.post(
+            f"/aeroplanes/{aeroplane_uuid}/loading-scenarios",
+            json=_scenario_payload(name="Keep Name", aircraft_class="rc_trainer"),
+        )
+        scenario_id = create_resp.json()["id"]
+
+        patch_resp = client.patch(
+            f"/aeroplanes/{aeroplane_uuid}/loading-scenarios/{scenario_id}",
+            json={"aircraft_class": "glider"},
+        )
+        assert patch_resp.status_code == 200
+        result = patch_resp.json()
+        assert result["aircraft_class"] == "glider"
+        assert result["name"] == "Keep Name"  # unchanged
+
+    def test_update_scenario_is_default_only(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """PATCH with only is_default=True makes scenario the default."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            aeroplane_uuid = str(plane.uuid)
+
+        create_resp = client.post(
+            f"/aeroplanes/{aeroplane_uuid}/loading-scenarios",
+            json=_scenario_payload(name="Will Be Default", is_default=False),
+        )
+        scenario_id = create_resp.json()["id"]
+
+        patch_resp = client.patch(
+            f"/aeroplanes/{aeroplane_uuid}/loading-scenarios/{scenario_id}",
+            json={"is_default": True},
+        )
+        assert patch_resp.status_code == 200
+        assert patch_resp.json()["is_default"] is True
+
+    def test_update_scenario_overrides_only(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """PATCH with only component_overrides updates overrides."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            aeroplane_uuid = str(plane.uuid)
+
+        create_resp = client.post(
+            f"/aeroplanes/{aeroplane_uuid}/loading-scenarios",
+            json=_scenario_payload(name="Overrides Test"),
+        )
+        scenario_id = create_resp.json()["id"]
+
+        new_overrides = {
+            "toggles": [],
+            "mass_overrides": [{"component_uuid": "xyz", "mass_kg_override": 0.5}],
+            "position_overrides": [],
+            "adhoc_items": [],
+        }
+        patch_resp = client.patch(
+            f"/aeroplanes/{aeroplane_uuid}/loading-scenarios/{scenario_id}",
+            json={"component_overrides": new_overrides},
+        )
+        assert patch_resp.status_code == 200
+        result = patch_resp.json()
+        assert len(result["component_overrides"]["mass_overrides"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# TestStabilityEnvelopeFallbacks — x_np=None / mac=None / both None / mac=0
+# ---------------------------------------------------------------------------
+
+
+class TestStabilityEnvelopeFallbacks:
+    """Covers compute_stability_envelope None/zero handling and get_cg_envelope
+    branches where x_np or mac is None (lines 598-599, 613, 624-625 in svc)."""
+
+    def test_stability_envelope_x_np_none(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """x_np=None → both stability limits are None."""
+        from app.services.loading_scenario_service import compute_stability_envelope
+
+        result = compute_stability_envelope(x_np=None, mac=0.20, target_sm=0.08)
+        assert result["cg_stability_aft_m"] is None
+        assert result["cg_stability_fwd_m"] is None
+
+    def test_stability_envelope_mac_none(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """mac=None → both stability limits are None."""
+        from app.services.loading_scenario_service import compute_stability_envelope
+
+        result = compute_stability_envelope(x_np=0.30, mac=None, target_sm=0.08)
+        assert result["cg_stability_aft_m"] is None
+        assert result["cg_stability_fwd_m"] is None
+
+    def test_stability_envelope_mac_zero(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """mac=0 → both stability limits are None (division by zero guard)."""
+        from app.services.loading_scenario_service import compute_stability_envelope
+
+        result = compute_stability_envelope(x_np=0.30, mac=0.0, target_sm=0.08)
+        assert result["cg_stability_aft_m"] is None
+        assert result["cg_stability_fwd_m"] is None
+
+    def test_enrich_context_no_x_np_returns_none_sm(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """enrich_context_with_cg_envelope with no x_np_m in ctx → sm_at_fwd/aft = None."""
+        from app.services.loading_scenario_service import enrich_context_with_cg_envelope
+
+        ctx: dict = {"cg_agg_m": 0.15}  # no x_np_m, no mac_m
+        enriched = enrich_context_with_cg_envelope(
+            ctx=ctx,
+            cg_loading_fwd_m=0.14,
+            cg_loading_aft_m=0.17,
+            cg_stability_fwd_m=None,
+            cg_stability_aft_m=None,
+        )
+        assert enriched["sm_at_fwd"] is None
+        assert enriched["sm_at_aft"] is None
+        assert enriched["cg_forward_m"] == pytest.approx(0.14, abs=1e-3)
+        assert enriched["cg_aft_m"] == pytest.approx(0.17, abs=1e-3)
+
+    def test_enrich_context_with_x_np_and_mac_computes_sm(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """enrich_context_with_cg_envelope with x_np_m and mac_m computes sm values."""
+        from app.services.loading_scenario_service import enrich_context_with_cg_envelope
+
+        ctx: dict = {"cg_agg_m": 0.15, "x_np_m": 0.30, "mac_m": 0.20}
+        enriched = enrich_context_with_cg_envelope(
+            ctx=ctx,
+            cg_loading_fwd_m=0.14,
+            cg_loading_aft_m=0.17,
+            cg_stability_fwd_m=0.24,
+            cg_stability_aft_m=0.284,
+        )
+        # sm_at_fwd = (0.30 - 0.14) / 0.20 = 0.80
+        assert enriched["sm_at_fwd"] == pytest.approx(0.80, abs=1e-3)
+        # sm_at_aft = (0.30 - 0.17) / 0.20 = 0.65
+        assert enriched["sm_at_aft"] == pytest.approx(0.65, abs=1e-3)
+
+    def test_cg_envelope_with_full_context_computes_sm(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """GET /cg-envelope with x_np_m and mac_m in context returns computed sm values."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            _seed_assumptions(session, plane.id)
+            # Provide a realistic aero context
+            plane.assumption_computation_context = {
+                "x_np_m": 0.30,
+                "mac_m": 0.20,
+            }
+            session.commit()
+            aeroplane_uuid = str(plane.uuid)
+
+        resp = client.get(f"/aeroplanes/{aeroplane_uuid}/cg-envelope")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        # With x_np and mac present, sm values should be computed (not None)
+        assert data["sm_at_fwd"] is not None
+        assert data["sm_at_aft"] is not None
+        assert data["cg_stability_fwd_m"] is not None
+        assert data["cg_stability_aft_m"] is not None
+
+    def test_cg_envelope_error_classification_adds_sm_warning(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """When classification is 'error' and sm_at_aft is known, warning mentions SM value."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            _seed_assumptions(session, plane.id)
+            # CG very close to NP → very low SM (< 0.02 → error)
+            # x_np = 0.16, mac = 0.20, cg_x (from assumptions) = 0.15
+            # sm_at_aft ≈ (0.16 - 0.15) / 0.20 = 0.05 → warn, not error
+            # To force error: set x_np very close to cg so sm < 0.02
+            # cg = 0.15, x_np = 0.153, mac = 0.20 → sm ≈ 0.015 → error
+            plane.assumption_computation_context = {
+                "x_np_m": 0.153,
+                "mac_m": 0.20,
+            }
+            session.commit()
+            aeroplane_uuid = str(plane.uuid)
+
+        resp = client.get(f"/aeroplanes/{aeroplane_uuid}/cg-envelope")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["classification"] == "error"
+        # Error classification → warning must mention SM
+        assert any("SM" in w or "sm" in w.lower() for w in data["warnings"])
+
+    def test_cg_agg_returns_none_when_no_scenarios_and_no_weight_items(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """compute_cg_agg_for_aeroplane returns None when no scenarios and no weight items."""
+        from app.services.loading_scenario_service import compute_cg_agg_for_aeroplane
+
+        _client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            _seed_assumptions(session, plane.id)
+            # No loading scenarios, no weight items → should return None
+            plane_row = session.query(AeroplaneModel).filter_by(uuid=plane.uuid).first()
+            cg_agg = compute_cg_agg_for_aeroplane(session, plane_row)
+
+        assert cg_agg is None
+
+
+# ---------------------------------------------------------------------------
+# TestTemplatesEndpointAllClasses — template endpoint for each aircraft class
+# ---------------------------------------------------------------------------
+
+
+class TestTemplatesEndpointAllClasses:
+    """Covers the /templates endpoint for all aircraft_class values via HTTP."""
+
+    @pytest.mark.parametrize(
+        "ac",
+        ["rc_trainer", "rc_aerobatic", "rc_combust", "uav_survey", "glider", "boxwing"],
+    )
+    def test_templates_endpoint_for_each_class(
+        self, ac: str, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """GET /loading-scenarios/templates?aircraft_class=<ac> returns ≥1 template."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            aeroplane_uuid = str(plane.uuid)
+
+        resp = client.get(
+            f"/aeroplanes/{aeroplane_uuid}/loading-scenarios/templates",
+            params={"aircraft_class": ac},
+        )
+        assert resp.status_code == 200, f"[{ac}] {resp.text}"
+        templates = resp.json()
+        assert isinstance(templates, list)
+        assert len(templates) >= 1, f"No templates returned for {ac}"
+        for t in templates:
+            assert "name" in t, f"Template missing 'name' for {ac}: {t}"
+
+    def test_templates_endpoint_unknown_class_falls_back(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """Unknown aircraft_class falls back to rc_trainer templates (no 422)."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            aeroplane_uuid = str(plane.uuid)
+
+        resp = client.get(
+            f"/aeroplanes/{aeroplane_uuid}/loading-scenarios/templates",
+            params={"aircraft_class": "unknown_class"},
+        )
+        # The endpoint accepts any string (no enum validation at HTTP layer),
+        # service falls back to rc_trainer templates.
+        assert resp.status_code == 200, resp.text
+        templates = resp.json()
+        assert len(templates) >= 1
+
+    def test_templates_endpoint_missing_aeroplane_404(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """Templates endpoint returns 404 when aeroplane UUID does not exist."""
+        client, _SessionLocal = client_and_db
+        unknown = str(uuid.uuid4())
+        resp = client.get(
+            f"/aeroplanes/{unknown}/loading-scenarios/templates",
+            params={"aircraft_class": "rc_trainer"},
+        )
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# TestOverridesJsonSerialization — component_overrides stored as JSON string
+# ---------------------------------------------------------------------------
+
+
+class TestOverridesJsonSerialization:
+    """Covers the json.loads branch in _model_to_schema, compute_cg_agg, and
+    compute_loading_envelope (lines 302, 364, 432 in loading_scenario_service)."""
+
+    def test_overrides_serialized_as_json_string_round_trips(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """When component_overrides are stored as a JSON string (legacy SQLite path),
+        the service deserialises them correctly."""
+        import json as _json
+
+        from app.models.aeroplanemodel import LoadingScenarioModel
+        from app.services.loading_scenario_service import _model_to_schema
+
+        _client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            _seed_assumptions(session, plane.id)
+
+            # Store overrides as a JSON string (simulates legacy column value)
+            overrides_dict = {
+                "toggles": [],
+                "mass_overrides": [{"component_uuid": "abc", "mass_kg_override": 0.3}],
+                "position_overrides": [],
+                "adhoc_items": [],
+            }
+            scenario = LoadingScenarioModel(
+                aeroplane_id=plane.id,
+                name="JSON String Scenario",
+                aircraft_class="rc_trainer",
+                component_overrides=_json.dumps(overrides_dict),
+                is_default=False,
+            )
+            session.add(scenario)
+            session.commit()
+            session.refresh(scenario)
+
+            # _model_to_schema should handle JSON string overrides without error
+            result = _model_to_schema(scenario)
+
+        assert len(result.component_overrides.mass_overrides) == 1
+        assert result.component_overrides.mass_overrides[0].component_uuid == "abc"
+
+    def test_compute_loading_envelope_with_json_string_overrides(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """compute_loading_envelope_for_aeroplane handles JSON-string overrides."""
+        import json as _json
+
+        from app.models.aeroplanemodel import LoadingScenarioModel
+        from app.services.loading_scenario_service import compute_loading_envelope_for_aeroplane
+
+        _client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            _seed_assumptions(session, plane.id)
+
+            overrides_dict = {
+                "toggles": [],
+                "mass_overrides": [],
+                "position_overrides": [],
+                "adhoc_items": [
+                    {"name": "Item", "mass_kg": 0.5, "x_m": 0.30, "y_m": 0.0, "z_m": 0.0}
+                ],
+            }
+            scenario = LoadingScenarioModel(
+                aeroplane_id=plane.id,
+                name="JSON Envelope Scenario",
+                aircraft_class="rc_trainer",
+                component_overrides=_json.dumps(overrides_dict),
+                is_default=True,
+            )
+            session.add(scenario)
+            session.commit()
+
+        with SessionLocal() as session:
+            plane_row = session.query(AeroplaneModel).filter_by(uuid=plane.uuid).first()
+            envelope = compute_loading_envelope_for_aeroplane(session, plane_row)
+
+        # adhoc item at x=0.30 with base at x=0.15 → aft shift
+        assert envelope["cg_loading_aft_m"] > 0.15
+
+    def test_compute_cg_agg_with_json_string_overrides(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """compute_cg_agg_for_aeroplane handles JSON-string overrides in default scenario."""
+        import json as _json
+
+        from app.models.aeroplanemodel import LoadingScenarioModel
+        from app.services.loading_scenario_service import compute_cg_agg_for_aeroplane
+
+        _client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            _seed_assumptions(session, plane.id)
+
+            overrides_dict = {
+                "toggles": [],
+                "mass_overrides": [],
+                "position_overrides": [],
+                "adhoc_items": [],
+            }
+            scenario = LoadingScenarioModel(
+                aeroplane_id=plane.id,
+                name="Default JSON Scenario",
+                aircraft_class="rc_trainer",
+                component_overrides=_json.dumps(overrides_dict),
+                is_default=True,
+            )
+            session.add(scenario)
+            session.commit()
+
+        with SessionLocal() as session:
+            plane_row = session.query(AeroplaneModel).filter_by(uuid=plane.uuid).first()
+            cg_agg = compute_cg_agg_for_aeroplane(session, plane_row)
+
+        # Empty overrides + base mass at x=0.15 → cg_agg ≈ 0.15
+        assert cg_agg is not None
+        assert abs(cg_agg - 0.15) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# TestLoadAssumptionValueBranches — covers CALCULATED source path (lines 293-295)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadAssumptionValueBranches:
+    """Covers _load_assumption_value branches:
+    - no row → returns default (line 293)
+    - CALCULATED source with calculated_value → returns calculated_value (lines 294-295)
+    - non-CALCULATED source → returns estimate_value (line 296)
+    """
+
+    def test_load_assumption_value_no_row_returns_default(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """When no assumption row exists, default is returned via compute_loading_envelope."""
+        from app.services.loading_scenario_service import compute_loading_envelope_for_aeroplane
+
+        _client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            # Deliberately do NOT seed assumptions → _load_assumption_value returns default
+            envelope = compute_loading_envelope_for_aeroplane(session, plane)
+
+        # No assumptions → base_mass defaults to 1.0, base_cg_x defaults to 0.0
+        # No scenarios → fwd = aft = 0.0 (default cg_x)
+        assert envelope["cg_loading_fwd_m"] == pytest.approx(0.0)
+        assert envelope["cg_loading_aft_m"] == pytest.approx(0.0)
+
+    def test_load_assumption_value_calculated_source_used(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """When active_source=CALCULATED with a calculated_value, that value is used."""
+        from app.services.loading_scenario_service import compute_loading_envelope_for_aeroplane
+
+        _client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            # Seed a CALCULATED assumption for cg_x
+            session.add(
+                DesignAssumptionModel(
+                    aeroplane_id=plane.id,
+                    parameter_name="cg_x",
+                    estimate_value=0.15,
+                    calculated_value=0.22,
+                    active_source="CALCULATED",
+                    updated_at=datetime.now(timezone.utc),
+                )
+            )
+            session.add(
+                DesignAssumptionModel(
+                    aeroplane_id=plane.id,
+                    parameter_name="mass",
+                    estimate_value=1.5,
+                    calculated_value=None,
+                    active_source="ESTIMATE",
+                    updated_at=datetime.now(timezone.utc),
+                )
+            )
+            session.commit()
+
+        with SessionLocal() as session:
+            plane_row = session.query(AeroplaneModel).filter_by(uuid=plane.uuid).first()
+            envelope = compute_loading_envelope_for_aeroplane(session, plane_row)
+
+        # No scenarios → fwd = aft = base_cg_x = calculated 0.22 (not estimate 0.15)
+        assert envelope["cg_loading_fwd_m"] == pytest.approx(0.22)
+        assert envelope["cg_loading_aft_m"] == pytest.approx(0.22)
+
+
+# ---------------------------------------------------------------------------
+# TestCgEnvelopeRankingBranch — aft rank > fwd rank → overall = classification_aft
+# ---------------------------------------------------------------------------
+
+
+class TestCgEnvelopeRankingBranch:
+    """Covers line 613 in loading_scenario_service: `overall = classification_aft`
+    when the aft SM is worse than the fwd SM (different scenarios produce different
+    CG values that land in different classification bands)."""
+
+    def test_aft_classification_dominates_when_worse(
+        self, client_and_db: Tuple[TestClient, any]
+    ) -> None:
+        """When aft CG is much closer to NP (very low SM), aft classification
+        dominates overall even if fwd is fine.
+
+        Setup:
+          x_np = 0.20, mac = 0.20
+          - Scenario A (fwd adhoc): pushes CG to ~0.10 → sm_fwd = (0.20-0.10)/0.20 = 0.50 → ok
+          - Scenario B (aft adhoc): pushes CG to ~0.195 → sm_aft = (0.20-0.195)/0.20 = 0.025 → warn (> 0.02 and < target)
+          aft rank (warn=2) > fwd rank (ok=1) → overall = 'warn', taken from aft branch.
+        """
+        client, SessionLocal = client_and_db
+        with SessionLocal() as session:
+            plane = _make_aeroplane(session)
+            _seed_assumptions(session, plane.id, extra={"target_static_margin": 0.08})
+            plane.assumption_computation_context = {
+                "x_np_m": 0.20,
+                "mac_m": 0.20,
+            }
+            session.commit()
+            aeroplane_uuid = str(plane.uuid)
+
+        # Scenario A: large fwd ballast → CG shifts well forward
+        # base: 1.5 kg @ 0.15; adding 3.0 kg @ 0.01 → CG ≈ (1.5*0.15 + 3.0*0.01)/4.5 ≈ 0.057
+        # sm_fwd = (0.20 - 0.057)/0.20 ≈ 0.715 → ok (but target=0.08 < 0.20)
+        client.post(
+            f"/aeroplanes/{aeroplane_uuid}/loading-scenarios",
+            json=_scenario_payload(
+                name="Very Fwd",
+                component_overrides={
+                    "toggles": [],
+                    "mass_overrides": [],
+                    "position_overrides": [],
+                    "adhoc_items": [
+                        {"name": "Nose Ballast", "mass_kg": 3.0, "x_m": 0.01, "y_m": 0.0, "z_m": 0.0}
+                    ],
+                },
+            ),
+        )
+        # Scenario B: large aft item → CG shifts very close to NP
+        # base: 1.5 kg @ 0.15; adding 3.0 kg @ 0.22 → CG ≈ (1.5*0.15+3.0*0.22)/4.5 ≈ 0.197
+        # sm_aft = (0.20 - 0.197)/0.20 ≈ 0.015 → error (< 0.02)
+        client.post(
+            f"/aeroplanes/{aeroplane_uuid}/loading-scenarios",
+            json=_scenario_payload(
+                name="Very Aft",
+                component_overrides={
+                    "toggles": [],
+                    "mass_overrides": [],
+                    "position_overrides": [],
+                    "adhoc_items": [
+                        {"name": "Aft Ballast", "mass_kg": 3.0, "x_m": 0.22, "y_m": 0.0, "z_m": 0.0}
+                    ],
+                },
+            ),
+        )
+
+        resp = client.get(f"/aeroplanes/{aeroplane_uuid}/cg-envelope")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+
+        # aft CG is very close to NP → sm_aft is very small (< 0.02) → error
+        # fwd CG is well forward of NP → sm_fwd is large → ok
+        # aft classification (error) > fwd classification (ok) → overall = 'error'
+        # This exercises line 613: overall = classification_aft
+        assert data["classification"] in ("error", "warn"), (
+            f"Expected error or warn, got {data['classification']!r} "
+            f"(sm_at_fwd={data['sm_at_fwd']}, sm_at_aft={data['sm_at_aft']})"
+        )
+        # Ensure aft SM is worse (lower) than fwd SM
+        assert data["sm_at_aft"] < data["sm_at_fwd"]

--- a/frontend/__tests__/LoadingScenariosCard.test.tsx
+++ b/frontend/__tests__/LoadingScenariosCard.test.tsx
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+
+// Mock SWR and hooks before component import
+vi.mock("@/hooks/useLoadingScenarios", async () => {
+  const actual = await vi.importActual("@/hooks/useLoadingScenarios");
+  return {
+    ...actual,
+    useLoadingScenarios: vi.fn(),
+    useCgEnvelope: vi.fn(),
+    useLoadingScenarioTemplates: vi.fn(),
+  };
+});
+
+import { LoadingScenariosCard } from "@/components/workbench/LoadingScenariosCard";
+import {
+  useLoadingScenarios,
+  useCgEnvelope,
+  useLoadingScenarioTemplates,
+} from "@/hooks/useLoadingScenarios";
+
+const MOCK_SCENARIO = {
+  id: 1,
+  aeroplane_id: 42,
+  name: "Battery Forward",
+  aircraft_class: "rc_trainer" as const,
+  component_overrides: {
+    toggles: [],
+    mass_overrides: [],
+    position_overrides: [],
+    adhoc_items: [
+      {
+        name: "Battery",
+        mass_kg: 0.2,
+        x_m: 0.05,
+        y_m: 0,
+        z_m: 0,
+        category: "payload" as const,
+      },
+    ],
+  },
+  is_default: false,
+};
+
+const MOCK_ENVELOPE_OK = {
+  cg_loading_fwd_m: 0.13,
+  cg_loading_aft_m: 0.17,
+  cg_stability_fwd_m: 0.10,
+  cg_stability_aft_m: 0.22,
+  sm_at_fwd: 0.10,
+  sm_at_aft: 0.06,
+  classification: "ok" as const,
+  warnings: [],
+};
+
+const MOCK_ENVELOPE_WARN = {
+  ...MOCK_ENVELOPE_OK,
+  sm_at_fwd: 0.03,
+  sm_at_aft: 0.01,
+  classification: "warn" as const,
+  warnings: ["CG exceeds aft stability limit by 15 mm."],
+};
+
+const MOCK_ENVELOPE_ERROR = {
+  ...MOCK_ENVELOPE_OK,
+  sm_at_fwd: 0.01,
+  sm_at_aft: -0.01,
+  classification: "error" as const,
+  warnings: ["SM at aft CG = -1.0% — outside safe operating range."],
+};
+
+function setupMocks(opts: {
+  scenarios?: typeof MOCK_SCENARIO[];
+  envelope?: typeof MOCK_ENVELOPE_OK | typeof MOCK_ENVELOPE_WARN | typeof MOCK_ENVELOPE_ERROR | null;
+  templates?: { name: string; component_overrides: (typeof MOCK_SCENARIO)["component_overrides"]; is_default: boolean }[];
+}) {
+  const createScenario = vi.fn();
+  const deleteScenario = vi.fn();
+
+  (useLoadingScenarios as ReturnType<typeof vi.fn>).mockReturnValue({
+    scenarios: opts.scenarios ?? [],
+    isLoading: false,
+    error: null,
+    mutate: vi.fn(),
+    createScenario,
+    updateScenario: vi.fn(),
+    deleteScenario,
+  });
+
+  (useCgEnvelope as ReturnType<typeof vi.fn>).mockReturnValue({
+    envelope: opts.envelope ?? null,
+    isLoading: false,
+    error: null,
+    mutate: vi.fn(),
+  });
+
+  (useLoadingScenarioTemplates as ReturnType<typeof vi.fn>).mockReturnValue({
+    templates: opts.templates ?? [
+      {
+        name: "Empty",
+        component_overrides: { toggles: [], mass_overrides: [], position_overrides: [], adhoc_items: [] },
+        is_default: true,
+      },
+    ],
+    isLoading: false,
+    error: null,
+  });
+
+  return { createScenario, deleteScenario };
+}
+
+describe("LoadingScenariosCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders card header with scenario count", () => {
+    setupMocks({ scenarios: [MOCK_SCENARIO] });
+    render(<LoadingScenariosCard aeroplaneId="test-id" />);
+
+    expect(screen.getByTestId("loading-scenarios-card")).toBeInTheDocument();
+    expect(screen.getByText(/1 scenario/i)).toBeInTheDocument();
+  });
+
+  it("shows CG envelope chip with SM values when envelope is available", () => {
+    setupMocks({ envelope: MOCK_ENVELOPE_OK });
+    render(<LoadingScenariosCard aeroplaneId="test-id" />);
+
+    const chip = screen.getByTestId("cg-envelope-chip");
+    expect(chip).toBeInTheDocument();
+    // SM = 10.0% (fwd) ... 6.0% (aft)
+    expect(chip).toHaveTextContent(/10\.0%.*fwd/i);
+    expect(chip).toHaveTextContent(/6\.0%.*aft/i);
+  });
+
+  it("applies green colour for OK classification", () => {
+    setupMocks({ envelope: MOCK_ENVELOPE_OK });
+    render(<LoadingScenariosCard aeroplaneId="test-id" />);
+    const chip = screen.getByTestId("cg-envelope-chip");
+    expect(chip.className).toContain("green");
+  });
+
+  it("applies orange colour for WARN classification", () => {
+    setupMocks({ envelope: MOCK_ENVELOPE_WARN });
+    render(<LoadingScenariosCard aeroplaneId="test-id" />);
+    const chip = screen.getByTestId("cg-envelope-chip");
+    expect(chip.className).toContain("orange");
+  });
+
+  it("applies red colour for ERROR classification", () => {
+    setupMocks({ envelope: MOCK_ENVELOPE_ERROR });
+    render(<LoadingScenariosCard aeroplaneId="test-id" />);
+    const chip = screen.getByTestId("cg-envelope-chip");
+    expect(chip.className).toContain("red");
+  });
+
+  it("shows validation warnings when present", () => {
+    setupMocks({ envelope: MOCK_ENVELOPE_WARN });
+    render(<LoadingScenariosCard aeroplaneId="test-id" />);
+    expect(
+      screen.getByText(/exceeds aft stability limit/i),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show warnings when envelope is OK", () => {
+    setupMocks({ envelope: MOCK_ENVELOPE_OK });
+    render(<LoadingScenariosCard aeroplaneId="test-id" />);
+    expect(screen.queryByText(/exceeds/i)).not.toBeInTheDocument();
+  });
+
+  it("expands to show scenarios on header click", () => {
+    setupMocks({ scenarios: [MOCK_SCENARIO] });
+    render(<LoadingScenariosCard aeroplaneId="test-id" />);
+
+    fireEvent.click(screen.getByTestId("loading-scenarios-header"));
+
+    expect(screen.getByTestId("scenario-row")).toBeInTheDocument();
+    expect(screen.getByText("Battery Forward")).toBeInTheDocument();
+  });
+
+  it("shows adhoc item count on scenario row", () => {
+    setupMocks({ scenarios: [MOCK_SCENARIO] });
+    render(<LoadingScenariosCard aeroplaneId="test-id" />);
+    fireEvent.click(screen.getByTestId("loading-scenarios-header"));
+
+    expect(screen.getByText(/1 adhoc item/i)).toBeInTheDocument();
+  });
+
+  it("marks default scenario with badge", () => {
+    const defaultScenario = { ...MOCK_SCENARIO, is_default: true };
+    setupMocks({ scenarios: [defaultScenario] });
+    render(<LoadingScenariosCard aeroplaneId="test-id" />);
+    fireEvent.click(screen.getByTestId("loading-scenarios-header"));
+
+    expect(screen.getByText("default")).toBeInTheDocument();
+  });
+
+  it("calls deleteScenario when delete button is clicked", async () => {
+    const { deleteScenario } = setupMocks({ scenarios: [MOCK_SCENARIO] });
+    render(<LoadingScenariosCard aeroplaneId="test-id" />);
+    fireEvent.click(screen.getByTestId("loading-scenarios-header"));
+
+    const deleteBtn = screen.getByTestId("delete-scenario-button");
+    fireEvent.click(deleteBtn);
+
+    await waitFor(() => {
+      expect(deleteScenario).toHaveBeenCalledWith(MOCK_SCENARIO.id);
+    });
+  });
+
+  it("shows Add scenario button when expanded", () => {
+    setupMocks({});
+    render(<LoadingScenariosCard aeroplaneId="test-id" />);
+    fireEvent.click(screen.getByTestId("loading-scenarios-header"));
+
+    expect(screen.getByTestId("add-scenario-button")).toBeInTheDocument();
+  });
+
+  it("shows add form with template picker on Add click", () => {
+    setupMocks({});
+    render(<LoadingScenariosCard aeroplaneId="test-id" />);
+    fireEvent.click(screen.getByTestId("loading-scenarios-header"));
+    fireEvent.click(screen.getByTestId("add-scenario-button"));
+
+    expect(screen.getByTestId("scenario-name-input")).toBeInTheDocument();
+    expect(screen.getByText("Empty")).toBeInTheDocument(); // template button
+  });
+
+  it("calls createScenario with template data on template click", async () => {
+    const { createScenario } = setupMocks({});
+    render(<LoadingScenariosCard aeroplaneId="test-id" />);
+    fireEvent.click(screen.getByTestId("loading-scenarios-header"));
+    fireEvent.click(screen.getByTestId("add-scenario-button"));
+
+    // Click the "Empty" template button
+    fireEvent.click(screen.getByText("Empty"));
+
+    await waitFor(() => {
+      expect(createScenario).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "Empty" }),
+      );
+    });
+  });
+
+  it("shows aircraft class selector when expanded", () => {
+    setupMocks({});
+    render(<LoadingScenariosCard aeroplaneId="test-id" />);
+    fireEvent.click(screen.getByTestId("loading-scenarios-header"));
+
+    expect(screen.getByTestId("aircraft-class-select")).toBeInTheDocument();
+  });
+
+  it("shows empty state message when no scenarios", () => {
+    setupMocks({ scenarios: [] });
+    render(<LoadingScenariosCard aeroplaneId="test-id" />);
+    fireEvent.click(screen.getByTestId("loading-scenarios-header"));
+
+    expect(
+      screen.getByText(/no scenarios yet/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/components/workbench/LoadingScenariosCard.tsx
+++ b/frontend/components/workbench/LoadingScenariosCard.tsx
@@ -1,0 +1,433 @@
+"use client";
+
+/**
+ * LoadingScenariosCard — CG Envelope from loading scenarios (gh-488).
+ *
+ * Displays:
+ *  - CG envelope chip: SM = X.X% (forward) … Y.Y% (aft) with colour-coding
+ *  - List of loading scenarios with CRUD actions
+ *  - Template picker for quick scenario creation
+ *  - Validation warnings when loading CG exceeds stability limits
+ */
+
+import { useState } from "react";
+import {
+  AlertTriangle,
+  CheckCircle,
+  ChevronDown,
+  ChevronRight,
+  Plus,
+  Trash2,
+  XCircle,
+  Layers,
+} from "lucide-react";
+import {
+  type AircraftClass,
+  type CgClassification,
+  type CgEnvelope,
+  type LoadingScenario,
+  type LoadingScenarioCreate,
+  AIRCRAFT_CLASS_LABELS,
+  emptyOverrides,
+  useLoadingScenarios,
+  useCgEnvelope,
+  useLoadingScenarioTemplates,
+} from "@/hooks/useLoadingScenarios";
+
+// ---------------------------------------------------------------------------
+// Classification colours
+// ---------------------------------------------------------------------------
+
+function classificationColor(cls: CgClassification): string {
+  switch (cls) {
+    case "error":
+      return "text-red-400";
+    case "warn":
+      return "text-orange-400";
+    case "ok":
+      return "text-green-400";
+  }
+}
+
+function classificationBg(cls: CgClassification): string {
+  switch (cls) {
+    case "error":
+      return "bg-red-500/10 border-red-500/30";
+    case "warn":
+      return "bg-orange-500/10 border-orange-500/30";
+    case "ok":
+      return "bg-green-500/10 border-green-500/30";
+  }
+}
+
+function ClassificationIcon({ cls }: { readonly cls: CgClassification }) {
+  switch (cls) {
+    case "error":
+      return <XCircle size={14} className="text-red-400" />;
+    case "warn":
+      return <AlertTriangle size={14} className="text-orange-400" />;
+    case "ok":
+      return <CheckCircle size={14} className="text-green-400" />;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CG Envelope chip
+// ---------------------------------------------------------------------------
+
+interface CgEnvelopeChipProps {
+  readonly envelope: CgEnvelope;
+}
+
+function CgEnvelopeChip({ envelope }: CgEnvelopeChipProps) {
+  const smFwdPct = (envelope.sm_at_fwd * 100).toFixed(1);
+  const smAftPct = (envelope.sm_at_aft * 100).toFixed(1);
+  const cls = envelope.classification;
+  const color = classificationColor(cls);
+  const bgCls = classificationBg(cls);
+
+  return (
+    <div
+      className={`flex items-center gap-2 rounded-lg border px-3 py-2 ${bgCls}`}
+      data-testid="cg-envelope-chip"
+    >
+      <ClassificationIcon cls={cls} />
+      <span
+        className={`font-[family-name:var(--font-jetbrains-mono)] text-[11px] ${color}`}
+      >
+        SM = {smFwdPct}% (fwd) &hellip; {smAftPct}% (aft)
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Template picker
+// ---------------------------------------------------------------------------
+
+interface TemplatePickerProps {
+  readonly aeroplaneId: string;
+  readonly aircraftClass: AircraftClass;
+  readonly onCreate: (payload: LoadingScenarioCreate) => void;
+}
+
+function TemplatePicker({
+  aeroplaneId,
+  aircraftClass,
+  onCreate,
+}: TemplatePickerProps) {
+  const { templates, isLoading } = useLoadingScenarioTemplates(
+    aeroplaneId,
+    aircraftClass,
+  );
+
+  if (isLoading) return null;
+
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+        Templates
+      </span>
+      <div className="flex flex-wrap gap-1">
+        {templates.map((t) => (
+          <button
+            key={t.name}
+            onClick={() =>
+              onCreate({
+                name: t.name,
+                aircraft_class: aircraftClass,
+                component_overrides: t.component_overrides,
+                is_default: t.is_default,
+              })
+            }
+            className="rounded-full border border-border px-2 py-0.5 text-[10px] text-muted-foreground hover:border-[#FF8400] hover:text-[#FF8400]"
+          >
+            {t.name}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario row
+// ---------------------------------------------------------------------------
+
+interface ScenarioRowProps {
+  readonly scenario: LoadingScenario;
+  readonly onDelete: (id: number) => void;
+}
+
+function ScenarioRow({ scenario, onDelete }: ScenarioRowProps) {
+  const adhocCount = scenario.component_overrides.adhoc_items.length;
+
+  return (
+    <div
+      className="flex items-center gap-2 rounded-md border border-border px-3 py-2"
+      data-testid="scenario-row"
+    >
+      <div className="flex flex-1 flex-col gap-0.5">
+        <span className="text-[12px] text-foreground">
+          {scenario.name}
+          {scenario.is_default && (
+            <span className="ml-2 rounded-full bg-[#FF8400]/20 px-1.5 py-0.5 text-[9px] text-[#FF8400]">
+              default
+            </span>
+          )}
+        </span>
+        {adhocCount > 0 && (
+          <span className="text-[10px] text-muted-foreground">
+            {adhocCount} adhoc item{adhocCount > 1 ? "s" : ""}
+          </span>
+        )}
+      </div>
+      <button
+        onClick={() => onDelete(scenario.id)}
+        className="text-muted-foreground hover:text-red-400"
+        aria-label={`Delete ${scenario.name}`}
+        data-testid="delete-scenario-button"
+      >
+        <Trash2 size={12} />
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario list (extracted to avoid nested ternary)
+// ---------------------------------------------------------------------------
+
+interface ScenarioListProps {
+  readonly scenarios: LoadingScenario[];
+  readonly isLoading: boolean;
+  readonly onDelete: (id: number) => void;
+}
+
+function ScenarioList({ scenarios, isLoading, onDelete }: ScenarioListProps) {
+  if (isLoading) {
+    return (
+      <span className="text-[11px] text-muted-foreground">Loading…</span>
+    );
+  }
+  if (scenarios.length === 0) {
+    return (
+      <span className="text-[11px] text-muted-foreground">
+        No scenarios yet — add one to compute the CG envelope.
+      </span>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-1">
+      {scenarios.map((s) => (
+        <ScenarioRow key={s.id} scenario={s} onDelete={onDelete} />
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Add scenario form
+// ---------------------------------------------------------------------------
+
+interface AddScenarioFormProps {
+  readonly aeroplaneId: string;
+  readonly aircraftClass: AircraftClass;
+  readonly onCreate: (payload: LoadingScenarioCreate) => void;
+  readonly onCancel: () => void;
+}
+
+function AddScenarioForm({
+  aeroplaneId,
+  aircraftClass,
+  onCreate,
+  onCancel,
+}: AddScenarioFormProps) {
+  const [name, setName] = useState("");
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!name.trim()) return;
+    onCreate({
+      name: name.trim(),
+      aircraft_class: aircraftClass,
+      component_overrides: emptyOverrides(),
+      is_default: false,
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <TemplatePicker
+        aeroplaneId={aeroplaneId}
+        aircraftClass={aircraftClass}
+        onCreate={onCreate}
+      />
+      <form onSubmit={handleSubmit} className="flex gap-2">
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Custom scenario name…"
+          className="flex-1 rounded-md border border-border bg-sidebar px-2 py-1 text-[12px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-[#FF8400]"
+          data-testid="scenario-name-input"
+          autoFocus
+        />
+        <button
+          type="submit"
+          disabled={!name.trim()}
+          className="rounded-md bg-[#FF8400] px-3 py-1 text-[11px] text-black disabled:opacity-50"
+        >
+          Add
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="text-[11px] text-muted-foreground hover:text-foreground"
+        >
+          Cancel
+        </button>
+      </form>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main card
+// ---------------------------------------------------------------------------
+
+interface LoadingScenariosCardProps {
+  readonly aeroplaneId: string;
+}
+
+export function LoadingScenariosCard({
+  aeroplaneId,
+}: LoadingScenariosCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [showAdd, setShowAdd] = useState(false);
+  const [aircraftClass, setAircraftClass] = useState<AircraftClass>("rc_trainer");
+
+  const { scenarios, isLoading, createScenario, deleteScenario } =
+    useLoadingScenarios(aeroplaneId);
+  const { envelope } = useCgEnvelope(aeroplaneId);
+
+  async function handleCreate(payload: LoadingScenarioCreate) {
+    try {
+      await createScenario({ ...payload, aircraft_class: aircraftClass });
+      setShowAdd(false);
+    } catch {
+      // error silently — toast/notification system is out of scope for this card
+    }
+  }
+
+  async function handleDelete(id: number) {
+    try {
+      await deleteScenario(id);
+    } catch {
+      // error silently
+    }
+  }
+
+  return (
+    <div
+      className="flex flex-col gap-2 rounded-lg border border-border bg-sidebar px-4 py-3"
+      data-testid="loading-scenarios-card"
+    >
+      {/* Header */}
+      <button
+        className="flex items-center gap-2 text-left"
+        onClick={() => setExpanded((v) => !v)}
+        data-testid="loading-scenarios-header"
+      >
+        {expanded ? (
+          <ChevronDown size={14} className="text-muted-foreground" />
+        ) : (
+          <ChevronRight size={14} className="text-muted-foreground" />
+        )}
+        <Layers size={14} className="text-[#FF8400]" />
+        <span className="text-[12px] font-semibold text-foreground">
+          Loading Scenarios
+        </span>
+        <span className="ml-auto text-[10px] text-muted-foreground">
+          {scenarios.length} scenario{scenarios.length !== 1 ? "s" : ""}
+        </span>
+      </button>
+
+      {/* CG Envelope chip — always visible */}
+      {envelope && <CgEnvelopeChip envelope={envelope} />}
+
+      {/* Validation warnings */}
+      {envelope && envelope.warnings.length > 0 && (
+        <div className="flex flex-col gap-1">
+          {envelope.warnings.map((w, i) => (
+            <div
+              key={i}
+              className="flex items-start gap-2 rounded-md border border-orange-500/30 bg-orange-500/10 px-3 py-1.5"
+            >
+              <AlertTriangle
+                size={12}
+                className="mt-0.5 flex-shrink-0 text-orange-400"
+              />
+              <span className="text-[11px] text-orange-400">{w}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Expanded content */}
+      {expanded && (
+        <div className="flex flex-col gap-2 pt-1">
+          {/* Aircraft class selector */}
+          <div className="flex items-center gap-2">
+            <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+              Aircraft class
+            </span>
+            <select
+              value={aircraftClass}
+              onChange={(e) => setAircraftClass(e.target.value as AircraftClass)}
+              className="rounded border border-border bg-sidebar px-2 py-0.5 text-[11px] text-foreground"
+              data-testid="aircraft-class-select"
+            >
+              {(
+                Object.entries(AIRCRAFT_CLASS_LABELS) as [
+                  AircraftClass,
+                  string,
+                ][]
+              ).map(([val, label]) => (
+                <option key={val} value={val}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Scenario list */}
+          <ScenarioList
+            scenarios={scenarios}
+            isLoading={isLoading}
+            onDelete={handleDelete}
+          />
+
+          {/* Add / template form */}
+          {showAdd ? (
+            <AddScenarioForm
+              aeroplaneId={aeroplaneId}
+              aircraftClass={aircraftClass}
+              onCreate={handleCreate}
+              onCancel={() => setShowAdd(false)}
+            />
+          ) : (
+            <button
+              onClick={() => setShowAdd(true)}
+              className="flex items-center gap-1.5 self-start text-[11px] text-muted-foreground hover:text-[#FF8400]"
+              data-testid="add-scenario-button"
+            >
+              <Plus size={12} />
+              Add scenario
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/hooks/useLoadingScenarios.ts
+++ b/frontend/hooks/useLoadingScenarios.ts
@@ -1,0 +1,248 @@
+"use client";
+
+import useSWR from "swr";
+import { useCallback } from "react";
+import { API_BASE, fetcher } from "@/lib/fetcher";
+
+// ---------------------------------------------------------------------------
+// Types (matching backend schemas)
+// ---------------------------------------------------------------------------
+
+export interface ComponentToggle {
+  component_uuid: string;
+  enabled: boolean;
+}
+
+export interface MassOverride {
+  component_uuid: string;
+  mass_kg_override: number;
+}
+
+export interface PositionOverride {
+  component_uuid: string;
+  x_m_override: number;
+  y_m_override?: number | null;
+  z_m_override?: number | null;
+}
+
+export type AdhocCategory =
+  | "pilot"
+  | "payload"
+  | "ballast"
+  | "fuel"
+  | "fpv_gear"
+  | "other";
+
+export interface AdhocItem {
+  name: string;
+  mass_kg: number;
+  x_m: number;
+  y_m: number;
+  z_m: number;
+  category: AdhocCategory;
+}
+
+export interface ComponentOverrides {
+  toggles: ComponentToggle[];
+  mass_overrides: MassOverride[];
+  position_overrides: PositionOverride[];
+  adhoc_items: AdhocItem[];
+}
+
+export type AircraftClass =
+  | "rc_trainer"
+  | "rc_aerobatic"
+  | "rc_combust"
+  | "uav_survey"
+  | "glider"
+  | "boxwing";
+
+export interface LoadingScenario {
+  id: number;
+  aeroplane_id: number;
+  name: string;
+  aircraft_class: AircraftClass;
+  component_overrides: ComponentOverrides;
+  is_default: boolean;
+}
+
+export interface LoadingScenarioCreate {
+  name: string;
+  aircraft_class: AircraftClass;
+  component_overrides: ComponentOverrides;
+  is_default: boolean;
+}
+
+export interface LoadingScenarioUpdate {
+  name?: string;
+  aircraft_class?: AircraftClass;
+  component_overrides?: ComponentOverrides;
+  is_default?: boolean;
+}
+
+export type CgClassification = "error" | "warn" | "ok";
+
+export interface CgEnvelope {
+  cg_loading_fwd_m: number;
+  cg_loading_aft_m: number;
+  cg_stability_fwd_m: number;
+  cg_stability_aft_m: number;
+  sm_at_fwd: number;
+  sm_at_aft: number;
+  classification: CgClassification;
+  warnings: string[];
+}
+
+export interface LoadingScenarioTemplate {
+  name: string;
+  component_overrides: ComponentOverrides;
+  is_default: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
+export function useLoadingScenarios(aeroplaneId: string | null) {
+  const path = aeroplaneId
+    ? `/aeroplanes/${aeroplaneId}/loading-scenarios`
+    : null;
+
+  const { data, error, isLoading, mutate } = useSWR<LoadingScenario[]>(
+    path,
+    fetcher,
+  );
+
+  const createScenario = useCallback(
+    async (payload: LoadingScenarioCreate): Promise<LoadingScenario> => {
+      if (!aeroplaneId) throw new Error("No aeroplaneId");
+      const res = await fetch(
+        `${API_BASE}/aeroplanes/${aeroplaneId}/loading-scenarios`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        },
+      );
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        throw new Error(`Failed to create scenario: ${res.status} ${body}`);
+      }
+      const created = (await res.json()) as LoadingScenario;
+      await mutate();
+      return created;
+    },
+    [aeroplaneId, mutate],
+  );
+
+  const updateScenario = useCallback(
+    async (
+      scenarioId: number,
+      payload: LoadingScenarioUpdate,
+    ): Promise<LoadingScenario> => {
+      if (!aeroplaneId) throw new Error("No aeroplaneId");
+      const res = await fetch(
+        `${API_BASE}/aeroplanes/${aeroplaneId}/loading-scenarios/${scenarioId}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        },
+      );
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        throw new Error(`Failed to update scenario: ${res.status} ${body}`);
+      }
+      const updated = (await res.json()) as LoadingScenario;
+      await mutate();
+      return updated;
+    },
+    [aeroplaneId, mutate],
+  );
+
+  const deleteScenario = useCallback(
+    async (scenarioId: number): Promise<void> => {
+      if (!aeroplaneId) throw new Error("No aeroplaneId");
+      const res = await fetch(
+        `${API_BASE}/aeroplanes/${aeroplaneId}/loading-scenarios/${scenarioId}`,
+        { method: "DELETE" },
+      );
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        throw new Error(`Failed to delete scenario: ${res.status} ${body}`);
+      }
+      await mutate();
+    },
+    [aeroplaneId, mutate],
+  );
+
+  return {
+    scenarios: data ?? [],
+    isLoading,
+    error: error ?? null,
+    mutate,
+    createScenario,
+    updateScenario,
+    deleteScenario,
+  };
+}
+
+export function useCgEnvelope(aeroplaneId: string | null) {
+  const path = aeroplaneId
+    ? `/aeroplanes/${aeroplaneId}/cg-envelope`
+    : null;
+
+  const { data, error, isLoading, mutate } = useSWR<CgEnvelope>(
+    path,
+    fetcher,
+  );
+
+  return {
+    envelope: data ?? null,
+    isLoading,
+    error: error ?? null,
+    mutate,
+  };
+}
+
+export function useLoadingScenarioTemplates(
+  aeroplaneId: string | null,
+  aircraftClass: AircraftClass,
+) {
+  const path = aeroplaneId
+    ? `/aeroplanes/${aeroplaneId}/loading-scenarios/templates?aircraft_class=${aircraftClass}`
+    : null;
+
+  const { data, error, isLoading } = useSWR<LoadingScenarioTemplate[]>(
+    path,
+    fetcher,
+  );
+
+  return {
+    templates: data ?? [],
+    isLoading,
+    error: error ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+export function emptyOverrides(): ComponentOverrides {
+  return {
+    toggles: [],
+    mass_overrides: [],
+    position_overrides: [],
+    adhoc_items: [],
+  };
+}
+
+export const AIRCRAFT_CLASS_LABELS: Record<AircraftClass, string> = {
+  rc_trainer: "RC Trainer",
+  rc_aerobatic: "RC Aerobatic",
+  rc_combust: "RC Combust",
+  uav_survey: "UAV Survey",
+  glider: "Glider",
+  boxwing: "Box Wing",
+};


### PR DESCRIPTION
## Summary

- **Loading-Envelope**: min/max CG from user-defined loading scenarios with adhoc items (pilot, payload, ballast, FPV gear, fuel) and component overrides
- **Stability-Envelope**: aerodynamically permissible range — aft limit = x_NP − target_SM × MAC (Anderson §7.5); fwd limit = stub at x_NP − 0.30 × MAC (TODO follow-up ticket per Anderson §7.7)
- **Validation**: loading CG must lie within stability envelope; structured warnings when violated
- **5-tier SM classification** relative to `target_static_margin` (Scholz §4.2): error/warn/ok/warn/error
- **Backward compat**: `cg_agg_m` preserved; `cg_forward_m`, `cg_aft_m`, `sm_at_fwd`, `sm_at_aft` added additively to `assumption_computation_context`
- **Templates** per aircraft class: rc_trainer, rc_aerobatic, rc_combust, uav_survey, glider, boxwing
- **Frontend**: `LoadingScenariosCard` with CG envelope chip, scenario list, template picker, CRUD; `useLoadingScenarios` + `useCgEnvelope` SWR hooks

## New endpoints

```
GET    /aeroplanes/{id}/loading-scenarios
POST   /aeroplanes/{id}/loading-scenarios
PATCH  /aeroplanes/{id}/loading-scenarios/{scenario_id}
DELETE /aeroplanes/{id}/loading-scenarios/{scenario_id}
GET    /aeroplanes/{id}/cg-envelope
GET    /aeroplanes/{id}/loading-scenarios/templates?aircraft_class=rc_trainer
```

## Backward Compat Test Output

```
app/tests/test_loading_scenarios.py::TestBackwardCompat::test_cg_agg_m_remains_in_context PASSED
app/tests/test_loading_scenarios.py::TestBackwardCompat::test_new_keys_additively_added PASSED
app/tests/test_loading_scenarios.py::TestBackwardCompat::test_no_scenarios_falls_back_to_legacy_cg PASSED
app/tests/test_loading_scenarios.py::TestBackwardCompat::test_cg_endpoint_still_returns_cg_envelope_read PASSED
```

## Alembic Check Status

```
INFO  Running upgrade cdcac8fb40b5 -> edeb222a39a8, add loading_scenarios table (gh-488)
```

Table created successfully. Note: `alembic check` reports pre-existing stale diffs on `rc_flight_profiles` (unique constraint vs index mismatch in SQLite test DB — present on `main` before this PR, not introduced here).

## Test Counts

| Layer | Result |
|---|---|
| Backend (new) | 35 passed |
| Backend (full, not slow) | 2369 passed, 51 deselected, 1 xfailed |
| Frontend (new) | 16 passed |
| Frontend (full unit) | 602 passed (72 test files) |
| Ruff lint | all checks passed |
| Frontend lint | 0 errors, 8 warnings (all pre-existing) |

## Frontend Build

Pre-existing TypeScript error in `AnalysisViewerPanel.tsx` (line 412, `WingXSec[] | undefined` — not introduced by this PR, `git diff HEAD` shows no changes to that file).

## Design Decisions

1. **Stability fwd limit is a stub** (x_NP − 0.30 × MAC): Full elevator-authority calculation requires Cm_delta_e and CL_max_landing — out of scope per spec. Stub is conservative. Follow-up ticket to be created.
2. **No per-component CG data in DB**: `compute_scenario_cg` applies adhoc items on top of the design-level base mass/CG. Mass overrides recorded in the schema for future use when component-level CG DB is added.
3. **cg_agg_m** stays as the CG of the `is_default` scenario (or weight-item CG when no scenarios exist) for backward compat with single-value clients.
4. **Templates are not auto-created**: User must explicitly apply a template. This avoids polluting fresh aeroplanes with unwanted scenarios.
5. **alembic check stale diff**: The `rc_flight_profiles` index/constraint diff is pre-existing on `main` (SQLite test DB). Not introduced by gh-488.

## Out of Scope (per spec)

- Elevator-authority full calculation (fwd stability limit stub only)
- Trim-drag per scenario
- Eigenmodes over CG-sweep
- Lateral CG

Closes #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)