### PR TITLE
feat(gh-494): SM sizing constraint with auto-suggest (Scholz Step 9↔11 iteration)

### DIFF
--- a/app/api/v2/endpoints/aeroplane/__init__.py
+++ b/app/api/v2/endpoints/aeroplane/__init__.py
@@ -21,6 +21,7 @@ from .loading_scenarios import router as loading_scenarios_router
 from .field_lengths import router as field_lengths_router
 from .tail_sizing import router as tail_sizing_router
 from .matching_chart import router as matching_chart_router
+from .sm_suggestions import router as sm_suggestions_router
 
 # Include the routers
 router.include_router(base_router)
@@ -39,3 +40,4 @@ router.include_router(loading_scenarios_router)
 router.include_router(field_lengths_router)
 router.include_router(tail_sizing_router)
 router.include_router(matching_chart_router)
+router.include_router(sm_suggestions_router)

--- a/app/api/v2/endpoints/aeroplane/sm_suggestions.py
+++ b/app/api/v2/endpoints/aeroplane/sm_suggestions.py
@@ -1,0 +1,181 @@
+"""SM sizing suggestion endpoint — gh-494.
+
+GET  /aeroplanes/{uuid}/sm-suggestion         — suggest wing_shift / htail_scale
+POST /aeroplanes/{uuid}/sm-suggestions/apply  — apply (or dry-run) a suggestion
+"""
+from __future__ import annotations
+
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, status
+from pydantic import UUID4
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.models.aeroplanemodel import AeroplaneModel
+from app.schemas.sm_sizing import (
+    SmApplyRequest,
+    SmApplyResponse,
+    SmOption,
+    SmSuggestionResponse,
+)
+from app.services import sm_sizing_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _get_aeroplane(db: Session, aeroplane_id: UUID4) -> AeroplaneModel:
+    """Resolve aeroplane by UUID or raise HTTP 404."""
+    plane = (
+        db.query(AeroplaneModel)
+        .filter(AeroplaneModel.uuid == str(aeroplane_id))
+        .first()
+    )
+    if plane is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Aeroplane {aeroplane_id} not found",
+        )
+    return plane
+
+
+@router.get(
+    "/aeroplanes/{aeroplane_id}/sm-suggestion",
+    status_code=status.HTTP_200_OK,
+    tags=["sm-sizing"],
+    operation_id="get_sm_suggestion",
+    response_model=SmSuggestionResponse,
+    summary="Static margin sizing suggestion (Step 9 ↔ Step 11)",
+    description=(
+        "Analyse the current static margin at aft CG versus the target_static_margin "
+        "assumption.  Returns up to two banner options: move the main wing fore/aft "
+        "(wing_shift) OR chord-scale the horizontal tail (htail_scale). "
+        "Silent when SM is already in target range [target_sm, 0.20]. "
+        "Returns not_applicable for canard, tailless, or no-analysis-yet configurations."
+    ),
+    responses={
+        404: {"description": "Aeroplane not found"},
+        200: {"description": "SM suggestion computed (status=ok|suggestion|error|not_applicable)"},
+    },
+)
+async def get_sm_suggestion(
+    aeroplane_id: Annotated[UUID4, Path(..., description="Aeroplane UUID")],
+    db: Session = Depends(get_db),
+) -> SmSuggestionResponse:
+    """Compute SM sizing suggestions for an aeroplane."""
+    plane = _get_aeroplane(db, aeroplane_id)
+    ctx = plane.assumption_computation_context or {}
+    target_sm = ctx.get("target_static_margin", 0.10)
+
+    try:
+        raw = sm_sizing_service.suggest_corrections(ctx, target_sm=target_sm, at_cg="aft")
+    except Exception as exc:
+        logger.error(
+            "SM suggestion failed for %s: %s", aeroplane_id, exc, exc_info=True
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"SM suggestion computation failed: {exc}",
+        ) from exc
+
+    options = [SmOption(**o) for o in raw.get("options", [])]
+    return SmSuggestionResponse(
+        status=raw["status"],
+        options=options,
+        block_save=raw.get("block_save", False),
+        mass_coupling_warning=raw.get("mass_coupling_warning"),
+        message=raw.get("message"),
+        hint=raw.get("hint"),
+        warnings=raw.get("warnings", []),
+    )
+
+
+@router.post(
+    "/aeroplanes/{aeroplane_id}/sm-suggestions/apply",
+    status_code=status.HTTP_200_OK,
+    tags=["sm-sizing"],
+    operation_id="apply_sm_suggestion",
+    response_model=SmApplyResponse,
+    summary="Apply (or dry-run preview) an SM sizing suggestion",
+    description=(
+        "Apply a wing_shift or htail_scale suggestion to the aeroplane geometry. "
+        "When dry_run=True, returns predicted_sm without touching the database. "
+        "When dry_run=False, updates geometry and schedules a background recompute. "
+        "Not applicable for canard / tailless configurations."
+    ),
+    responses={
+        404: {"description": "Aeroplane not found"},
+        400: {"description": "Configuration not applicable (canard, tailless, no NP)"},
+        422: {"description": "Invalid lever or delta_value"},
+    },
+)
+async def apply_sm_suggestion(
+    aeroplane_id: Annotated[UUID4, Path(..., description="Aeroplane UUID")],
+    body: Annotated[SmApplyRequest, Body(...)],
+    db: Session = Depends(get_db),
+) -> SmApplyResponse:
+    """Apply an SM sizing suggestion to an aeroplane."""
+    # Verify aeroplane exists (raises 404 if not)
+    _get_aeroplane(db, aeroplane_id)
+
+    aeroplane_uuid_str = str(aeroplane_id)
+
+    try:
+        if body.lever == "wing_shift":
+            result = sm_sizing_service.apply_wing_shift(
+                db,
+                aeroplane_uuid_str,
+                delta_m=body.delta_value,
+                dry_run=body.dry_run,
+            )
+        elif body.lever == "htail_scale":
+            result = sm_sizing_service.apply_htail_scale(
+                db,
+                aeroplane_uuid_str,
+                delta_pct=body.delta_value,
+                dry_run=body.dry_run,
+            )
+        else:
+            # Should not reach here due to Pydantic Literal validation, but be defensive
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Unknown lever '{body.lever}'. Must be 'wing_shift' or 'htail_scale'.",
+            )
+    except ValueError as exc:
+        msg = str(exc)
+        if "not_applicable" in msg or "not found" not in msg:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=msg,
+            ) from exc
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=msg,
+        ) from exc
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(
+            "SM suggestion apply failed for %s: %s", aeroplane_id, exc, exc_info=True
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"SM suggestion apply failed: {exc}",
+        ) from exc
+
+    warnings: list[str] = []
+    if not body.dry_run and body.lever == "wing_shift":
+        warnings.append(sm_sizing_service._MASS_COUPLING_WARNING)
+    if not body.dry_run and body.lever == "htail_scale" and body.delta_value < 0:
+        warnings.append(sm_sizing_service._NEGATIVE_SH_WARNING)
+
+    return SmApplyResponse(
+        lever=result["lever"],
+        delta_value=result["delta_value"],
+        predicted_sm=result["predicted_sm"],
+        dry_run=result["dry_run"],
+        warnings=warnings,
+    )

--- a/app/schemas/sm_sizing.py
+++ b/app/schemas/sm_sizing.py
@@ -1,0 +1,113 @@
+"""Pydantic schemas for SM sizing constraint — gh-494."""
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class SmOption(BaseModel):
+    """A single sizing suggestion option."""
+
+    lever: Literal["wing_shift", "htail_scale"] = Field(
+        ...,
+        description="Which lever to apply: 'wing_shift' (move wing fore/aft) or 'htail_scale' (chord-scale HS).",
+    )
+    delta_value: float = Field(
+        ...,
+        description=(
+            "Magnitude of the change. For wing_shift: metres (negative = forward). "
+            "For htail_scale: fraction (0.20 = +20% chord)."
+        ),
+    )
+    delta_unit: str = Field(
+        ...,
+        description="Unit of delta_value. 'm' for wing_shift, 'fraction' for htail_scale.",
+    )
+    predicted_sm: float = Field(
+        ...,
+        description="Predicted SM after applying this option (dimensionless, fraction of MAC).",
+    )
+    narrative: str = Field(
+        ...,
+        description="Human-readable description of the change and its expected effect.",
+    )
+
+
+class SmSuggestionResponse(BaseModel):
+    """Response from GET /aeroplanes/{uuid}/sm-suggestion."""
+
+    status: Literal["ok", "suggestion", "error", "not_applicable"] = Field(
+        ...,
+        description=(
+            "ok: SM already in target range [target_sm, 0.20]. "
+            "suggestion: SM deviates, options provided. "
+            "error: SM < 0.02 (unstable), block_save=True. "
+            "not_applicable: canard/tailless/no-analysis."
+        ),
+    )
+    options: list[SmOption] = Field(
+        default_factory=list,
+        description="One option per lever (wing_shift, htail_scale). Empty when status=ok or not_applicable.",
+    )
+    block_save: bool = Field(
+        False,
+        description="True when SM < 0.02 — aircraft is aerodynamically unstable.",
+    )
+    mass_coupling_warning: str | None = Field(
+        None,
+        description=(
+            "Present when wing_shift option exists: warns that wing-mass CG shift "
+            "is not included in the analytic formula (~15% systematic error)."
+        ),
+    )
+    message: str | None = Field(
+        None,
+        description="Human-readable status message (for ok/error/not_applicable).",
+    )
+    hint: str | None = Field(
+        None,
+        description="Hint for not_applicable (e.g. 'Run analysis first').",
+    )
+    warnings: list[str] = Field(
+        default_factory=list,
+        description="Additional advisory warnings (e.g. negative S_H, forward-CG clip).",
+    )
+
+
+class SmApplyRequest(BaseModel):
+    """Request body for POST /aeroplanes/{uuid}/sm-suggestions/apply."""
+
+    lever: Literal["wing_shift", "htail_scale"] = Field(
+        ...,
+        description="Which lever to apply.",
+    )
+    delta_value: float = Field(
+        ...,
+        description=(
+            "Change magnitude. wing_shift: metres. htail_scale: fraction (0.20 = +20%)."
+        ),
+    )
+    dry_run: bool = Field(
+        False,
+        description="When True: compute predicted SM only; do NOT modify the database.",
+    )
+
+
+class SmApplyResponse(BaseModel):
+    """Response from POST /aeroplanes/{uuid}/sm-suggestions/apply."""
+
+    lever: str = Field(..., description="Which lever was applied.")
+    delta_value: float = Field(..., description="The delta_value that was applied.")
+    predicted_sm: float = Field(
+        ...,
+        description="Predicted (analytic) SM after applying this change.",
+    )
+    dry_run: bool = Field(
+        ...,
+        description="True when no DB changes were made (preview mode).",
+    )
+    warnings: list[str] = Field(
+        default_factory=list,
+        description="Advisory warnings about the apply operation.",
+    )

--- a/app/schemas/sm_sizing.py
+++ b/app/schemas/sm_sizing.py
@@ -84,8 +84,11 @@ class SmApplyRequest(BaseModel):
     )
     delta_value: float = Field(
         ...,
+        gt=-0.9,
+        lt=2.0,
         description=(
-            "Change magnitude. wing_shift: metres. htail_scale: fraction (0.20 = +20%)."
+            "Change magnitude. wing_shift: metres. htail_scale: fraction (0.20 = +20%). "
+            "For htail_scale: must be > -0.9 (prevents non-positive chord) and < 2.0."
         ),
     )
     dry_run: bool = Field(

--- a/app/services/sm_sizing_service.py
+++ b/app/services/sm_sizing_service.py
@@ -1,0 +1,552 @@
+"""SM sizing constraint service — gh-494 (Wave 4, Scholz Step 9 ↔ Step 11 iteration).
+
+Two analytical sensitivity levers:
+  1. wing_shift: move the main wing fore/aft → changes x_NP via Λ_VH downwash factor
+  2. htail_scale: chord-scale the horizontal tail → changes S_H contribution to x_NP
+
+Formulas (Anderson §7.6 Eq. 7.41, spec-gate A1):
+  SM = (x_NP - x_CG) / MAC
+
+  ∂SM/∂x_wing ≈ (1 - α_VH) / MAC
+    where α_VH = (a_t/a)·(1 - dε/dα)·(S_H/S_w)·(1/c_ref)  [dimensionless, ~0.05–0.15]
+    (a_t/a) ≈ 1.0  (assumption; split into separate wings TODO)
+    (1 - dε/dα) = 0.6  (Roskam Vol I, §8.1; typical for conventional tail config)
+    c_ref = MAC
+
+  ∂SM/∂S_H = (a_t/a)·(1 - dε/dα)·l_H / (S_w·MAC)
+
+Scope (spec-gate A4): aft-CG only.
+  TODO(gh-500): after gh-500 merge → add fwd-CG trim-drag suggestion using
+  Cm_δe, δe_max, ΔCm_flap.  Binding limit becomes min(aft_violation, fwd_violation).
+
+Mass-coupling warning (spec-gate A5):
+  Wing-mass ≈ 30% MTOW → Δx_wing = 0.05·MAC shifts CG by ~0.015·MAC ≈ 1 SM unit.
+  MVP: warn in narrative; mass-coupling factor NOT included in formula.
+
+Apply operations (spec-gate A3):
+  wing_shift: batch update WingXSecModel.xyz_le[0] for all xsecs of the main wing.
+  htail_scale: chord-scale each htail xsec chord by (1 + delta_pct).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal
+
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_SM_UNSTABLE_LIMIT = 0.02     # below → ERROR, block_save
+_SM_HEAVY_NOSE_WARN = 0.20    # above → overshoot suggestion
+
+# Roskam Vol I §8.1: downwash factor (1 - dε/dα) for conventional tail
+_DE_DA_FACTOR = 0.6   # (1 - dε/dα), typical for conventional aft tail
+
+# Forward stability stub limit: SM = 0.30 (see loading_scenario_service.py)
+_SM_FORWARD_CLIP_LIMIT = 0.30
+
+# Maximum reasonable wing shift (5× MAC per iteration, safety clip)
+_MAX_X_WING_SHIFT_MAC = 5.0
+
+# Mass-coupling warning (spec-gate A5)
+_MASS_COUPLING_WARNING = (
+    "Suggestion ignoriert Wingbox-Mass-Shift; ggf. nach Apply iterieren. "
+    "(Wing mass ~30% MTOW — a Δx_wing of 0.05·MAC shifts CG by ~0.015·MAC ≈ 1 SM unit.)"
+)
+
+# Negative S_H warning (overshoot path, spec-gate A6)
+_NEGATIVE_SH_WARNING = (
+    "Shrinking HS reduces yaw damping — verify Dutch-roll mode after Apply."
+)
+
+
+# ---------------------------------------------------------------------------
+# Sensitivity helpers (public for unit-test access)
+# ---------------------------------------------------------------------------
+
+def _alpha_vh(ctx: dict) -> float:
+    """Compute the tail efficiency factor α_VH (dimensionless, ~0.05–0.15).
+
+    α_VH = (a_t/a)·(1 - dε/dα)·(S_H/S_w)·(1/c_ref)
+
+    (a_t/a) is approximated as 1.0 (both wings in same freestream; a proper
+    split requires separate 2π-per-rad estimates for wing vs tail — follow-up).
+    """
+    s_h_m2: float | None = ctx.get("s_h_m2")
+    s_ref_m2: float | None = ctx.get("s_ref_m2")
+    mac_m: float | None = ctx.get("mac_m")
+    if not s_h_m2 or not s_ref_m2 or not mac_m or mac_m <= 0 or s_ref_m2 <= 0:
+        return 0.10  # fallback typical value
+    at_over_a = 1.0  # TODO: split tail/wing CL_α when separable
+    a_vh = at_over_a * _DE_DA_FACTOR * (s_h_m2 / s_ref_m2) / mac_m
+    # Clamp to physically meaningful range
+    return max(0.02, min(0.30, a_vh))
+
+
+def _dsm_dx_wing(ctx: dict) -> float:
+    """Analytic ∂SM/∂x_wing [1/m].
+
+    ∂SM/∂x_wing ≈ (1 - α_VH) / MAC
+
+    Positive: moving the wing aft (larger x) increases x_NP → increases SM.
+    """
+    mac_m: float = ctx.get("mac_m") or 0.30
+    a_vh = _alpha_vh(ctx)
+    return (1.0 - a_vh) / mac_m
+
+
+def _dsm_dsh(ctx: dict) -> float:
+    """Analytic ∂SM/∂S_H [1/m²].
+
+    ∂SM/∂S_H = (a_t/a)·(1 - dε/dα)·l_H / (S_w·MAC)
+
+    Positive: increasing S_H increases S_H contribution to x_NP → increases SM.
+    """
+    mac_m: float = ctx.get("mac_m") or 0.30
+    s_ref_m2: float = ctx.get("s_ref_m2") or 0.60
+    l_h_m: float | None = ctx.get("l_h_m")
+    if not l_h_m or l_h_m <= 0:
+        # Fall back: estimate l_H as 2.0 × MAC
+        l_h_m = 2.0 * mac_m
+    at_over_a = 1.0
+    return at_over_a * _DE_DA_FACTOR * l_h_m / (s_ref_m2 * mac_m)
+
+
+# ---------------------------------------------------------------------------
+# Configuration-guard helpers
+# ---------------------------------------------------------------------------
+
+def _is_not_applicable(ctx: dict) -> tuple[bool, str]:
+    """Return (True, reason) when SM suggestion is not applicable for this config."""
+    if ctx.get("is_canard"):
+        return True, "Canard configuration — SM sizing not applicable (no aft-tail lever)."
+    if ctx.get("is_tailless"):
+        return True, "Tailless/flying-wing configuration — SM sizing not applicable."
+    if ctx.get("is_boxwing"):
+        return True, "Boxwing configuration — SM sizing not applicable (complex NP coupling)."
+    if ctx.get("is_tandem"):
+        return True, "Tandem-wing configuration — SM sizing not applicable."
+    x_np_m = ctx.get("x_np_m")
+    if x_np_m is None:
+        return True, "Run analysis first to compute x_NP (assumption recompute not yet run)."
+    return False, ""
+
+
+# ---------------------------------------------------------------------------
+# Main public service function
+# ---------------------------------------------------------------------------
+
+def suggest_corrections(
+    ctx: dict,
+    target_sm: float = 0.10,
+    at_cg: Literal["aft"] = "aft",  # noqa: ARG001  (gh-500 will add fwd)
+) -> dict[str, Any]:
+    """Suggest geometry changes to hit target_sm for the aft-CG loading.
+
+    Reads from the assumption_computation_context dict (produced by
+    recompute_assumptions and enriched by loading-scenario/CG-envelope services).
+
+    Returns a dict with:
+      status: "ok" | "suggestion" | "error" | "not_applicable"
+      options: list of {lever, delta_value, delta_unit, predicted_sm, narrative}
+      block_save: True when SM < _SM_UNSTABLE_LIMIT (error state)
+      mass_coupling_warning: str  (always present when wing_shift option is returned)
+      message: str  (present for not_applicable / error)
+    """
+    # --- Guard: configuration not supported --------------------------------
+    na, reason = _is_not_applicable(ctx)
+    if na:
+        return {
+            "status": "not_applicable",
+            "options": [],
+            "message": reason,
+            "hint": reason,
+        }
+
+    sm_at_aft: float | None = ctx.get("sm_at_aft")
+    mac_m: float = ctx.get("mac_m") or 0.30
+
+    # If sm_at_aft not pre-computed in context, derive it
+    if sm_at_aft is None:
+        x_np_m: float | None = ctx.get("x_np_m")
+        cg_aft_m: float | None = ctx.get("cg_aft_m")
+        if x_np_m is None or cg_aft_m is None:
+            return {
+                "status": "not_applicable",
+                "options": [],
+                "message": "Run analysis first to compute x_NP (assumption recompute not yet run).",
+                "hint": "Run analysis first to compute x_NP (assumption recompute not yet run).",
+            }
+        sm_at_aft = (x_np_m - cg_aft_m) / mac_m
+
+    # --- Edge: ERROR — SM below instability threshold ----------------------
+    if sm_at_aft < _SM_UNSTABLE_LIMIT:
+        delta_needed = target_sm - sm_at_aft
+        dsm_dx = _dsm_dx_wing(ctx)
+        dsm_dsh = _dsm_dsh(ctx)
+        s_h_m2: float = ctx.get("s_h_m2") or 0.08
+        delta_x = delta_needed / dsm_dx
+        delta_sh_m2 = delta_needed / dsm_dsh
+        delta_pct = delta_sh_m2 / s_h_m2
+
+        return {
+            "status": "error",
+            "block_save": True,
+            "message": (
+                f"SM = {sm_at_aft:.3f} at aft CG is BELOW the minimum stability threshold "
+                f"({_SM_UNSTABLE_LIMIT:.2f}) — aircraft may be aerodynamically unstable. "
+                "Apply one of the suggested corrections before saving."
+            ),
+            "options": [
+                _wing_shift_option(ctx, delta_x, sm_at_aft, target_sm),
+                _htail_scale_option(ctx, delta_pct, sm_at_aft, target_sm),
+            ],
+            "mass_coupling_warning": _MASS_COUPLING_WARNING,
+        }
+
+    # --- Edge: OK — SM in [target_sm, 0.20] --------------------------------
+    if target_sm <= sm_at_aft <= _SM_HEAVY_NOSE_WARN:
+        return {
+            "status": "ok",
+            "options": [],
+            "message": f"SM = {sm_at_aft:.3f} is within target range [{target_sm:.2f}, {_SM_HEAVY_NOSE_WARN:.2f}].",
+        }
+
+    # --- Suggestion: SM ≠ target (either too low or heavy-nose overshoot) --
+    dsm_dx = _dsm_dx_wing(ctx)
+    dsm_dsh = _dsm_dsh(ctx)
+    s_h_m2 = ctx.get("s_h_m2") or 0.08
+
+    # Invert: ΔSM = target_sm - sm_at_aft → Δlevers
+    delta_needed = target_sm - sm_at_aft
+    delta_x = delta_needed / dsm_dx        # metres (negative = move wing fwd)
+    delta_sh_m2 = delta_needed / dsm_dsh   # m² (negative = shrink HS)
+    delta_pct = delta_sh_m2 / s_h_m2      # fraction (negative = shrink)
+
+    # Clip: wing shift must not violate forward SM stability limit
+    # (forward stability fwd limit: SM <= 0.30 → cg_fwd >= x_NP - 0.30*MAC)
+    # The clip prevents the suggestion from pushing the wing so far forward
+    # that even the FORWARD CG loading exceeds the elevator-authority limit.
+    x_np_m = ctx.get("x_np_m") or 0.0
+    cg_aft_m = ctx.get("cg_aft_m")
+    clip_warning = None
+    if cg_aft_m is not None:
+        sm_after_shift = sm_at_aft + dsm_dx * delta_x
+        if sm_after_shift > _SM_FORWARD_CLIP_LIMIT:
+            # Would overshoot forward limit: clip
+            delta_x = (_SM_FORWARD_CLIP_LIMIT - sm_at_aft) / dsm_dx
+            clip_warning = (
+                "Suggestion limited by forward CG stability envelope "
+                f"(SM would exceed {_SM_FORWARD_CLIP_LIMIT:.2f})."
+            )
+
+    warnings: list[str] = []
+    if clip_warning:
+        warnings.append(clip_warning)
+    if delta_sh_m2 < 0:
+        warnings.append(_NEGATIVE_SH_WARNING)
+
+    wing_opt = _wing_shift_option(ctx, delta_x, sm_at_aft, target_sm)
+    htail_opt = _htail_scale_option(ctx, delta_pct, sm_at_aft, target_sm)
+
+    return {
+        "status": "suggestion",
+        "options": [wing_opt, htail_opt],
+        "mass_coupling_warning": _MASS_COUPLING_WARNING,
+        "warnings": warnings,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Option builder helpers
+# ---------------------------------------------------------------------------
+
+def _wing_shift_option(
+    ctx: dict,
+    delta_x_m: float,
+    sm_at_aft: float,
+    target_sm: float,
+) -> dict:
+    """Build the wing_shift option dict."""
+    mac_m: float = ctx.get("mac_m") or 0.30
+    dsm_dx = _dsm_dx_wing(ctx)
+    predicted_sm = sm_at_aft + dsm_dx * delta_x_m
+    delta_mm = round(delta_x_m * 1000.0, 1)
+    direction = "forward" if delta_x_m < 0 else "aft"
+    narrative = (
+        f"Move main wing {abs(delta_mm):.1f} mm {direction} (Δx = {delta_mm:+.1f} mm) "
+        f"to reach SM ≈ {target_sm*100:.0f}% at aft CG. "
+        f"MAC = {mac_m*1000:.0f} mm. "
+        f"{_MASS_COUPLING_WARNING}"
+    )
+    return {
+        "lever": "wing_shift",
+        "delta_value": round(delta_x_m, 5),
+        "delta_unit": "m",
+        "predicted_sm": round(predicted_sm, 4),
+        "narrative": narrative,
+    }
+
+
+def _htail_scale_option(
+    ctx: dict,
+    delta_pct: float,
+    sm_at_aft: float,
+    target_sm: float,
+) -> dict:
+    """Build the htail_scale option dict."""
+    mac_m: float = ctx.get("mac_m") or 0.30
+    s_h_m2: float = ctx.get("s_h_m2") or 0.08
+    dsm_dsh = _dsm_dsh(ctx)
+    predicted_sm = sm_at_aft + dsm_dsh * delta_pct * s_h_m2
+    action = "Enlarge" if delta_pct > 0 else "Shrink"
+    narrative = (
+        f"{action} horizontal tail chord by {abs(delta_pct)*100:.1f}% "
+        f"(Δ = {delta_pct*100:+.1f}%) to reach SM ≈ {target_sm*100:.0f}% at aft CG. "
+        f"Chord-scale preserves AR. "
+    )
+    if delta_pct < 0:
+        narrative += _NEGATIVE_SH_WARNING
+    return {
+        "lever": "htail_scale",
+        "delta_value": round(delta_pct, 5),
+        "delta_unit": "fraction",  # 0.20 = +20%
+        "predicted_sm": round(predicted_sm, 4),
+        "narrative": narrative,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Apply helpers
+# ---------------------------------------------------------------------------
+
+def _find_aeroplane(db: Session, aeroplane_uuid: str):
+    """Find AeroplaneModel by UUID string, return None if not found."""
+    from app.models.aeroplanemodel import AeroplaneModel
+    return (
+        db.query(AeroplaneModel)
+        .filter(AeroplaneModel.uuid == aeroplane_uuid)
+        .first()
+    )
+
+
+def _find_main_wing(aircraft):
+    """Find the main wing (largest area, not horizontal/vertical/canard)."""
+    wings = aircraft.wings if hasattr(aircraft, "wings") else []
+    candidates = []
+    for w in wings:
+        wname = (w.name or "").lower()
+        if (
+            "horizontal" not in wname
+            and "vertical" not in wname
+            and "canard" not in wname
+        ):
+            candidates.append(w)
+    if not candidates:
+        return None
+    # Pick by approximate area (sum of chord segments × span)
+    def _approx_area(wing) -> float:
+        xsecs = wing.x_secs if hasattr(wing, "x_secs") else []
+        total = 0.0
+        for i in range(len(xsecs) - 1):
+            c0 = float(xsecs[i].chord or 0.0)
+            c1 = float(xsecs[i + 1].chord or 0.0)
+            le0 = xsecs[i].xyz_le or [0.0, 0.0, 0.0]
+            le1 = xsecs[i + 1].xyz_le or [0.0, 0.0, 0.0]
+            dy = abs(float(le1[1]) - float(le0[1]))
+            dz = abs(float(le1[2]) - float(le0[2]))
+            span_seg = (dy**2 + dz**2) ** 0.5
+            total += 0.5 * (c0 + c1) * span_seg
+        return total
+    return max(candidates, key=_approx_area)
+
+
+def _find_htail(aircraft):
+    """Find the horizontal tail wing model."""
+    wings = aircraft.wings if hasattr(aircraft, "wings") else []
+    for w in wings:
+        wname = (w.name or "").lower()
+        if "horizontal" in wname or "htail" in wname:
+            return w
+    return None
+
+
+def apply_wing_shift(
+    db: Session,
+    aeroplane_uuid: str,
+    delta_m: float,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Apply (or preview) a main-wing longitudinal shift.
+
+    Updates xyz_le[0] of ALL WingXSecModel rows belonging to the main wing
+    by delta_m (positive = aft). Triggers assumption recompute when dry_run=False.
+
+    Args:
+        db: open SQLAlchemy session
+        aeroplane_uuid: aeroplane UUID string
+        delta_m: shift [m] (positive = aft, negative = forward)
+        dry_run: when True, return predicted_sm only; do NOT flush/commit
+
+    Returns:
+        dict with dry_run, predicted_sm, (on real apply) new_sm.
+    """
+    aircraft = _find_aeroplane(db, aeroplane_uuid)
+    if aircraft is None:
+        raise ValueError(f"Aeroplane {aeroplane_uuid} not found")
+
+    ctx = aircraft.assumption_computation_context or {}
+
+    # Validate configuration
+    na, reason = _is_not_applicable(ctx)
+    if na:
+        raise ValueError(f"not_applicable: {reason}")
+
+    sm_at_aft: float | None = ctx.get("sm_at_aft")
+    x_np_m: float | None = ctx.get("x_np_m")
+    cg_aft_m: float | None = ctx.get("cg_aft_m")
+    mac_m: float = ctx.get("mac_m") or 0.30
+
+    if sm_at_aft is None and x_np_m is not None and cg_aft_m is not None:
+        sm_at_aft = (x_np_m - cg_aft_m) / mac_m
+
+    dsm_dx = _dsm_dx_wing(ctx)
+    predicted_sm = (sm_at_aft or 0.0) + dsm_dx * delta_m
+
+    if dry_run:
+        return {
+            "dry_run": True,
+            "lever": "wing_shift",
+            "delta_value": delta_m,
+            "predicted_sm": round(predicted_sm, 4),
+        }
+
+    # --- Real apply: update all main-wing xsec xyz_le[0] ---
+    main_wing = _find_main_wing(aircraft)
+    if main_wing is None:
+        raise ValueError("No main wing found on aeroplane")
+
+    for xsec in (main_wing.x_secs or []):
+        current_le = list(xsec.xyz_le or [0.0, 0.0, 0.0])
+        current_le[0] = float(current_le[0]) + delta_m
+        xsec.xyz_le = current_le
+
+    db.flush()
+
+    # Trigger assumption recompute via geometry event
+    _trigger_geometry_recompute(aircraft)
+
+    logger.info(
+        "apply_wing_shift: aircraft=%s delta_m=%.4f predicted_sm=%.4f xsecs_updated=%d",
+        aeroplane_uuid, delta_m, predicted_sm, len(main_wing.x_secs or []),
+    )
+
+    return {
+        "dry_run": False,
+        "lever": "wing_shift",
+        "delta_value": delta_m,
+        "predicted_sm": round(predicted_sm, 4),
+    }
+
+
+def apply_htail_scale(
+    db: Session,
+    aeroplane_uuid: str,
+    delta_pct: float,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Apply (or preview) a horizontal tail chord-scale.
+
+    Scales chord of ALL horizontal-tail WingXSecModel rows by (1 + delta_pct).
+    Chord-scale preserves AR (no span change). Triggers recompute when dry_run=False.
+
+    Args:
+        db: open SQLAlchemy session
+        aeroplane_uuid: aeroplane UUID string
+        delta_pct: fractional chord change (0.20 = +20%, -0.15 = -15%)
+        dry_run: when True, return predicted_sm only; do NOT flush/commit
+
+    Returns:
+        dict with dry_run, predicted_sm, (on real apply) new_sm.
+    """
+    aircraft = _find_aeroplane(db, aeroplane_uuid)
+    if aircraft is None:
+        raise ValueError(f"Aeroplane {aeroplane_uuid} not found")
+
+    ctx = aircraft.assumption_computation_context or {}
+
+    na, reason = _is_not_applicable(ctx)
+    if na:
+        raise ValueError(f"not_applicable: {reason}")
+
+    sm_at_aft: float | None = ctx.get("sm_at_aft")
+    x_np_m: float | None = ctx.get("x_np_m")
+    cg_aft_m: float | None = ctx.get("cg_aft_m")
+    mac_m: float = ctx.get("mac_m") or 0.30
+    s_h_m2: float = ctx.get("s_h_m2") or 0.08
+
+    if sm_at_aft is None and x_np_m is not None and cg_aft_m is not None:
+        sm_at_aft = (x_np_m - cg_aft_m) / mac_m
+
+    dsm_dsh = _dsm_dsh(ctx)
+    delta_sh_m2 = delta_pct * s_h_m2
+    predicted_sm = (sm_at_aft or 0.0) + dsm_dsh * delta_sh_m2
+
+    if dry_run:
+        return {
+            "dry_run": True,
+            "lever": "htail_scale",
+            "delta_value": delta_pct,
+            "predicted_sm": round(predicted_sm, 4),
+        }
+
+    # --- Real apply: chord-scale all htail xsecs ---
+    htail = _find_htail(aircraft)
+    if htail is None:
+        raise ValueError("No horizontal tail found on aeroplane")
+
+    scale = 1.0 + delta_pct
+    for xsec in (htail.x_secs or []):
+        xsec.chord = float(xsec.chord or 0.0) * scale
+
+    db.flush()
+
+    _trigger_geometry_recompute(aircraft)
+
+    logger.info(
+        "apply_htail_scale: aircraft=%s delta_pct=%.4f predicted_sm=%.4f xsecs_updated=%d",
+        aeroplane_uuid, delta_pct, predicted_sm, len(htail.x_secs or []),
+    )
+
+    return {
+        "dry_run": False,
+        "lever": "htail_scale",
+        "delta_value": delta_pct,
+        "predicted_sm": round(predicted_sm, 4),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Recompute trigger
+# ---------------------------------------------------------------------------
+
+def _trigger_geometry_recompute(aircraft) -> None:
+    """Schedule a background assumption recompute by publishing GeometryChanged.
+
+    The event bus handler (see invalidation_service.py) will pick this up and
+    call job_tracker.schedule_recompute_assumptions(aeroplane_id).
+    """
+    try:
+        from app.core.events import GeometryChanged, event_bus
+        event_bus.publish(GeometryChanged(
+            aeroplane_id=aircraft.id,
+            source_model="WingXSecModel",  # geometry of wing changed
+        ))
+    except Exception:
+        logger.warning(
+            "Could not publish GeometryChanged event for aircraft %d", aircraft.id, exc_info=True
+        )

--- a/app/services/sm_sizing_service.py
+++ b/app/services/sm_sizing_service.py
@@ -8,10 +8,9 @@ Formulas (Anderson §7.6 Eq. 7.41, spec-gate A1):
   SM = (x_NP - x_CG) / MAC
 
   ∂SM/∂x_wing ≈ (1 - α_VH) / MAC
-    where α_VH = (a_t/a)·(1 - dε/dα)·(S_H/S_w)·(1/c_ref)  [dimensionless, ~0.05–0.15]
+    where α_VH = (a_t/a)·(1 - dε/dα)·(S_H/S_w)  [dimensionless, ~0.05–0.15]
     (a_t/a) ≈ 1.0  (assumption; split into separate wings TODO)
     (1 - dε/dα) = 0.6  (Roskam Vol I, §8.1; typical for conventional tail config)
-    c_ref = MAC
 
   ∂SM/∂S_H = (a_t/a)·(1 - dε/dα)·l_H / (S_w·MAC)
 
@@ -71,20 +70,23 @@ _NEGATIVE_SH_WARNING = (
 def _alpha_vh(ctx: dict) -> float:
     """Compute the tail efficiency factor α_VH (dimensionless, ~0.05–0.15).
 
-    α_VH = (a_t/a)·(1 - dε/dα)·(S_H/S_w)·(1/c_ref)
+    α_VH = (a_t/a)·(1 − dε/dα)·(S_H/S_w)
+
+    Anderson §7.6: α_VH is a dimensionless ratio.  Earlier versions of this
+    function incorrectly divided by mac_m (metres), which produced 1/m units and
+    a ~20% systematic error at model scale (MAC≈0.30 m).  Removed (gh-494 fix).
 
     (a_t/a) is approximated as 1.0 (both wings in same freestream; a proper
     split requires separate 2π-per-rad estimates for wing vs tail — follow-up).
     """
     s_h_m2: float | None = ctx.get("s_h_m2")
     s_ref_m2: float | None = ctx.get("s_ref_m2")
-    mac_m: float | None = ctx.get("mac_m")
-    if not s_h_m2 or not s_ref_m2 or not mac_m or mac_m <= 0 or s_ref_m2 <= 0:
+    if not s_h_m2 or not s_ref_m2 or s_ref_m2 <= 0:
         return 0.10  # fallback typical value
     at_over_a = 1.0  # TODO: split tail/wing CL_α when separable
-    a_vh = at_over_a * _DE_DA_FACTOR * (s_h_m2 / s_ref_m2) / mac_m
-    # Clamp to physically meaningful range
-    return max(0.02, min(0.30, a_vh))
+    a_vh = at_over_a * _DE_DA_FACTOR * (s_h_m2 / s_ref_m2)
+    # Clamp to physically meaningful range (spec §A1: 0.05–0.15 typical)
+    return max(0.01, min(0.20, a_vh))
 
 
 def _dsm_dx_wing(ctx: dict) -> float:
@@ -93,8 +95,12 @@ def _dsm_dx_wing(ctx: dict) -> float:
     ∂SM/∂x_wing ≈ (1 - α_VH) / MAC
 
     Positive: moving the wing aft (larger x) increases x_NP → increases SM.
+
+    Callers in suggest_corrections / apply_* are guarded by _is_not_applicable,
+    so mac_m is always valid there.  The fallback covers unit-test call paths.
     """
-    mac_m: float = ctx.get("mac_m") or 0.30
+    mac_m_raw = ctx.get("mac_m")
+    mac_m: float = float(mac_m_raw) if mac_m_raw and float(mac_m_raw) > 0 else 0.30
     a_vh = _alpha_vh(ctx)
     return (1.0 - a_vh) / mac_m
 
@@ -105,9 +111,14 @@ def _dsm_dsh(ctx: dict) -> float:
     ∂SM/∂S_H = (a_t/a)·(1 - dε/dα)·l_H / (S_w·MAC)
 
     Positive: increasing S_H increases S_H contribution to x_NP → increases SM.
+
+    Callers in suggest_corrections / apply_* are guarded by _is_not_applicable,
+    so mac_m / s_ref_m2 are always valid there.  The fallbacks cover unit tests.
     """
-    mac_m: float = ctx.get("mac_m") or 0.30
-    s_ref_m2: float = ctx.get("s_ref_m2") or 0.60
+    mac_m_raw = ctx.get("mac_m")
+    mac_m: float = float(mac_m_raw) if mac_m_raw and float(mac_m_raw) > 0 else 0.30
+    s_ref_raw = ctx.get("s_ref_m2")
+    s_ref_m2: float = float(s_ref_raw) if s_ref_raw and float(s_ref_raw) > 0 else 0.60
     l_h_m: float | None = ctx.get("l_h_m")
     if not l_h_m or l_h_m <= 0:
         # Fall back: estimate l_H as 2.0 × MAC
@@ -133,6 +144,16 @@ def _is_not_applicable(ctx: dict) -> tuple[bool, str]:
     x_np_m = ctx.get("x_np_m")
     if x_np_m is None:
         return True, "Run analysis first to compute x_NP (assumption recompute not yet run)."
+    mac_m = ctx.get("mac_m")
+    if mac_m is None or float(mac_m) <= 0:
+        return True, (
+            "MAC is missing or zero — run analysis to compute MAC/S_ref first."
+        )
+    s_ref_m2 = ctx.get("s_ref_m2")
+    if s_ref_m2 is None or float(s_ref_m2) <= 0:
+        return True, (
+            "S_ref is missing or zero — run analysis to compute MAC/S_ref first."
+        )
     return False, ""
 
 
@@ -167,8 +188,9 @@ def suggest_corrections(
             "hint": reason,
         }
 
+    # mac_m and s_ref_m2 are guaranteed non-None/non-zero by _is_not_applicable guard above
+    mac_m: float = float(ctx["mac_m"])
     sm_at_aft: float | None = ctx.get("sm_at_aft")
-    mac_m: float = ctx.get("mac_m") or 0.30
 
     # If sm_at_aft not pre-computed in context, derive it
     if sm_at_aft is None:
@@ -182,6 +204,15 @@ def suggest_corrections(
                 "hint": "Run analysis first to compute x_NP (assumption recompute not yet run).",
             }
         sm_at_aft = (x_np_m - cg_aft_m) / mac_m
+
+    # --- Guard: cannot compute without sm_at_aft ---------------------------
+    if sm_at_aft is None:
+        return {
+            "status": "not_applicable",
+            "options": [],
+            "message": "sm_at_aft could not be derived — provide x_np_m and cg_aft_m.",
+            "hint": "sm_at_aft could not be derived — provide x_np_m and cg_aft_m.",
+        }
 
     # --- Edge: ERROR — SM below instability threshold ----------------------
     if sm_at_aft < _SM_UNSTABLE_LIMIT:
@@ -227,22 +258,29 @@ def suggest_corrections(
     delta_sh_m2 = delta_needed / dsm_dsh   # m² (negative = shrink HS)
     delta_pct = delta_sh_m2 / s_h_m2      # fraction (negative = shrink)
 
-    # Clip: wing shift must not violate forward SM stability limit
-    # (forward stability fwd limit: SM <= 0.30 → cg_fwd >= x_NP - 0.30*MAC)
-    # The clip prevents the suggestion from pushing the wing so far forward
-    # that even the FORWARD CG loading exceeds the elevator-authority limit.
-    x_np_m = ctx.get("x_np_m") or 0.0
-    cg_aft_m = ctx.get("cg_aft_m")
+    # Clip: wing shift must not push forward CG past elevator-authority limit.
+    # When cg_stability_fwd_m is available (from gh-488 CG envelope), compute the
+    # SM at the forward CG after the wing shift and clip if it would exceed 0.30.
+    # x_NP shifts with the wing: x_NP_new ≈ x_NP_old + delta_x * (1 − α_VH)
+    x_np_m: float | None = ctx.get("x_np_m")
+    cg_fwd_m: float | None = ctx.get("cg_stability_fwd_m")
     clip_warning = None
-    if cg_aft_m is not None:
-        sm_after_shift = sm_at_aft + dsm_dx * delta_x
-        if sm_after_shift > _SM_FORWARD_CLIP_LIMIT:
-            # Would overshoot forward limit: clip
-            delta_x = (_SM_FORWARD_CLIP_LIMIT - sm_at_aft) / dsm_dx
+    if x_np_m is not None and cg_fwd_m is not None:
+        a_vh = _alpha_vh(ctx)
+        x_np_new = x_np_m + delta_x * (1.0 - a_vh)
+        sm_at_fwd_after_shift = (x_np_new - cg_fwd_m) / mac_m
+        if sm_at_fwd_after_shift > _SM_FORWARD_CLIP_LIMIT:
+            # Clip: solve for delta_x such that sm_at_fwd == _SM_FORWARD_CLIP_LIMIT
+            # (x_NP + Δx·(1-α_VH) - cg_fwd) / MAC = clip_limit
+            # Δx·(1-α_VH) = clip_limit·MAC + cg_fwd - x_NP
+            delta_x = (_SM_FORWARD_CLIP_LIMIT * mac_m + cg_fwd_m - x_np_m) / (1.0 - a_vh)
             clip_warning = (
-                "Suggestion limited by forward CG stability envelope "
-                f"(SM would exceed {_SM_FORWARD_CLIP_LIMIT:.2f})."
+                "Wing-shift clipped: forward CG stability envelope would be violated "
+                f"(SM_fwd would exceed {_SM_FORWARD_CLIP_LIMIT:.2f})."
             )
+    elif x_np_m is None:
+        # No x_NP available — cannot perform forward-clip check
+        pass  # TODO(gh-500): forward-CG clip fully enabled when fwd CG data is available
 
     warnings: list[str] = []
     if clip_warning:
@@ -272,7 +310,8 @@ def _wing_shift_option(
     target_sm: float,
 ) -> dict:
     """Build the wing_shift option dict."""
-    mac_m: float = ctx.get("mac_m") or 0.30
+    mac_m_raw = ctx.get("mac_m")
+    mac_m: float = float(mac_m_raw) if mac_m_raw and float(mac_m_raw) > 0 else 0.30
     dsm_dx = _dsm_dx_wing(ctx)
     predicted_sm = sm_at_aft + dsm_dx * delta_x_m
     delta_mm = round(delta_x_m * 1000.0, 1)
@@ -299,7 +338,8 @@ def _htail_scale_option(
     target_sm: float,
 ) -> dict:
     """Build the htail_scale option dict."""
-    mac_m: float = ctx.get("mac_m") or 0.30
+    mac_m_raw = ctx.get("mac_m")
+    mac_m: float = float(mac_m_raw) if mac_m_raw and float(mac_m_raw) > 0 else 0.30  # noqa: F841
     s_h_m2: float = ctx.get("s_h_m2") or 0.08
     dsm_dsh = _dsm_dsh(ctx)
     predicted_sm = sm_at_aft + dsm_dsh * delta_pct * s_h_m2
@@ -307,7 +347,7 @@ def _htail_scale_option(
     narrative = (
         f"{action} horizontal tail chord by {abs(delta_pct)*100:.1f}% "
         f"(Δ = {delta_pct*100:+.1f}%) to reach SM ≈ {target_sm*100:.0f}% at aft CG. "
-        f"Chord-scale preserves AR. "
+        f"Chord-scale preserves span (AR changes proportionally). "
     )
     if delta_pct < 0:
         narrative += _NEGATIVE_SH_WARNING
@@ -394,6 +434,9 @@ def apply_wing_shift(
 
     Returns:
         dict with dry_run, predicted_sm, (on real apply) new_sm.
+
+    TODO(gh-509): 3-iter convergence guard per Scholz A6 spec.
+    After 3 apply operations without a fresh recompute, return 409 Conflict.
     """
     aircraft = _find_aeroplane(db, aeroplane_uuid)
     if aircraft is None:
@@ -406,16 +449,20 @@ def apply_wing_shift(
     if na:
         raise ValueError(f"not_applicable: {reason}")
 
+    # mac_m and s_ref_m2 are guaranteed valid by _is_not_applicable guard above
+    mac_m: float = float(ctx["mac_m"])
     sm_at_aft: float | None = ctx.get("sm_at_aft")
     x_np_m: float | None = ctx.get("x_np_m")
     cg_aft_m: float | None = ctx.get("cg_aft_m")
-    mac_m: float = ctx.get("mac_m") or 0.30
 
     if sm_at_aft is None and x_np_m is not None and cg_aft_m is not None:
         sm_at_aft = (x_np_m - cg_aft_m) / mac_m
 
+    if sm_at_aft is None:
+        raise ValueError("cannot compute predicted_sm without sm_at_aft — run analysis first")
+
     dsm_dx = _dsm_dx_wing(ctx)
-    predicted_sm = (sm_at_aft or 0.0) + dsm_dx * delta_m
+    predicted_sm = sm_at_aft + dsm_dx * delta_m
 
     if dry_run:
         return {
@@ -462,7 +509,7 @@ def apply_htail_scale(
     """Apply (or preview) a horizontal tail chord-scale.
 
     Scales chord of ALL horizontal-tail WingXSecModel rows by (1 + delta_pct).
-    Chord-scale preserves AR (no span change). Triggers recompute when dry_run=False.
+    Chord-scale preserves span (AR changes proportionally). Triggers recompute when dry_run=False.
 
     Args:
         db: open SQLAlchemy session
@@ -483,18 +530,22 @@ def apply_htail_scale(
     if na:
         raise ValueError(f"not_applicable: {reason}")
 
+    # mac_m and s_ref_m2 are guaranteed valid by _is_not_applicable guard above
+    mac_m: float = float(ctx["mac_m"])
     sm_at_aft: float | None = ctx.get("sm_at_aft")
     x_np_m: float | None = ctx.get("x_np_m")
     cg_aft_m: float | None = ctx.get("cg_aft_m")
-    mac_m: float = ctx.get("mac_m") or 0.30
     s_h_m2: float = ctx.get("s_h_m2") or 0.08
 
     if sm_at_aft is None and x_np_m is not None and cg_aft_m is not None:
         sm_at_aft = (x_np_m - cg_aft_m) / mac_m
 
+    if sm_at_aft is None:
+        raise ValueError("cannot compute predicted_sm without sm_at_aft — run analysis first")
+
     dsm_dsh = _dsm_dsh(ctx)
     delta_sh_m2 = delta_pct * s_h_m2
-    predicted_sm = (sm_at_aft or 0.0) + dsm_dsh * delta_sh_m2
+    predicted_sm = sm_at_aft + dsm_dsh * delta_sh_m2
 
     if dry_run:
         return {
@@ -510,6 +561,11 @@ def apply_htail_scale(
         raise ValueError("No horizontal tail found on aeroplane")
 
     scale = 1.0 + delta_pct
+    if scale <= 0.1:
+        raise ValueError(
+            f"htail_scale would produce non-positive chord (scale={scale:.3f}). "
+            "delta_pct must be greater than -0.9."
+        )
     for xsec in (htail.x_secs or []):
         xsec.chord = float(xsec.chord or 0.0) * scale
 

--- a/app/tests/test_sm_sizing.py
+++ b/app/tests/test_sm_sizing.py
@@ -687,3 +687,198 @@ class TestApplyHtailScaleService:
         assert hxsec0.chord == pytest.approx(0.12 * (1 + delta_pct), rel=1e-4)
         assert hxsec1.chord == pytest.approx(0.10 * (1 + delta_pct), rel=1e-4)
         db.flush.assert_called_once()
+
+
+# ===========================================================================
+# Class 6: gh-494 fix — B2/B3/B4 and physics-reviewer findings
+# ===========================================================================
+
+class TestAlphaVhDimensionlessFix:
+    """P1 (Scholz): α_VH must be dimensionless — no /mac_m in formula."""
+
+    def test_alpha_vh_dimensionless_for_model_scale(self):
+        """With S_H/S_w=0.08/0.60 and dε/dα=0.6: α_VH ≈ 0.08, not 0.27."""
+        svc = _import_module()
+        ctx = {
+            "mac_m": 0.30,
+            "s_ref_m2": 0.60,
+            "s_h_m2": 0.08,
+        }
+        a_vh = svc._alpha_vh(ctx)
+        # (0.6 * 0.08 / 0.60) = 0.08 — within 0.01–0.20 clamp
+        assert 0.07 < a_vh < 0.09, (
+            f"α_VH = {a_vh:.4f} — expected ~0.08, old bug gave ~0.27 (1/m)"
+        )
+
+    def test_alpha_vh_independent_of_mac(self):
+        """α_VH must not change when MAC changes (it is dimensionless)."""
+        svc = _import_module()
+        ctx_small_mac = {"mac_m": 0.20, "s_ref_m2": 0.60, "s_h_m2": 0.08}
+        ctx_large_mac = {"mac_m": 1.00, "s_ref_m2": 0.60, "s_h_m2": 0.08}
+        a_small = svc._alpha_vh(ctx_small_mac)
+        a_large = svc._alpha_vh(ctx_large_mac)
+        assert abs(a_small - a_large) < 1e-6, (
+            f"α_VH must be MAC-independent: small={a_small:.4f}, large={a_large:.4f}"
+        )
+
+    def test_alpha_vh_clamp_lower_bound(self):
+        """Very small tail (S_H/S_w→0): α_VH clamps to 0.01."""
+        svc = _import_module()
+        ctx = {"mac_m": 0.30, "s_ref_m2": 10.0, "s_h_m2": 0.001}
+        a_vh = svc._alpha_vh(ctx)
+        assert a_vh >= 0.01, f"α_VH clamp lower bound violated: {a_vh}"
+
+    def test_alpha_vh_clamp_upper_bound(self):
+        """Very large tail (S_H/S_w→big): α_VH clamps to 0.20."""
+        svc = _import_module()
+        ctx = {"mac_m": 0.30, "s_ref_m2": 0.10, "s_h_m2": 1.0}
+        a_vh = svc._alpha_vh(ctx)
+        assert a_vh <= 0.20, f"α_VH clamp upper bound violated: {a_vh}"
+
+    def test_dsm_dx_correct_range_after_fix(self):
+        """With fixed α_VH, ∂SM/∂x_wing should be ~3.07 for the standard fixture."""
+        svc = _import_module()
+        ctx = {
+            "mac_m": 0.30,
+            "s_ref_m2": 0.60,
+            "s_h_m2": 0.08,
+            "l_h_m": 0.55,
+        }
+        dsm_dx = svc._dsm_dx_wing(ctx)
+        # With fix: α_VH=0.08 → (1-0.08)/0.30 = 3.067
+        # Old bug: α_VH=0.267 → (1-0.267)/0.30 = 2.444
+        assert 2.9 < dsm_dx < 3.2, (
+            f"∂SM/∂x_wing = {dsm_dx:.4f} — expected ~3.07 after fix (was ~2.44 before fix)"
+        )
+
+
+class TestMissingMacNotApplicable:
+    """B2: missing mac_m or s_ref_m2 → not_applicable, not silent fallback."""
+
+    def test_missing_mac_suggest_returns_not_applicable(self):
+        """suggest_corrections with mac_m=None → not_applicable with helpful message."""
+        suggest = _import_service()
+        ctx = _ctx(mac_m=0.30, x_np_m=0.12, cg_aft_m=0.105, sm_at_aft=0.05)
+        ctx["mac_m"] = None  # remove mac_m
+        result = suggest(ctx, target_sm=0.10, at_cg="aft")
+        assert result["status"] == "not_applicable"
+        msg = (result.get("message") or result.get("hint") or "").lower()
+        assert "mac" in msg or "run analysis" in msg
+
+    def test_zero_mac_suggest_returns_not_applicable(self):
+        """suggest_corrections with mac_m=0 → not_applicable."""
+        suggest = _import_service()
+        ctx = _ctx(x_np_m=0.12, cg_aft_m=0.105, sm_at_aft=0.05)
+        ctx["mac_m"] = 0.0
+        result = suggest(ctx, target_sm=0.10, at_cg="aft")
+        assert result["status"] == "not_applicable"
+
+    def test_missing_s_ref_suggest_returns_not_applicable(self):
+        """suggest_corrections with s_ref_m2=None → not_applicable."""
+        suggest = _import_service()
+        ctx = _ctx(x_np_m=0.12, cg_aft_m=0.105, sm_at_aft=0.05)
+        ctx["s_ref_m2"] = None
+        result = suggest(ctx, target_sm=0.10, at_cg="aft")
+        assert result["status"] == "not_applicable"
+
+
+class TestHtailScaleNegativeDelta:
+    """B4: delta_value ≤ -0.9 must be rejected by schema and service."""
+
+    def test_htail_scale_delta_minus_1_raises_422(self, client_and_db):
+        """POST apply htail_scale with delta_value=-1.0 → 422 (Pydantic gt=-0.9 guard)."""
+        client, SessionLocal = client_and_db
+        # Create a plane with wings
+        from app.models.aeroplanemodel import AeroplaneModel, WingModel, WingXSecModel
+        with SessionLocal() as db:
+            uid_str = str(uuid.uuid4())
+            ctx = {
+                "mac_m": 0.30, "s_ref_m2": 0.60, "x_np_m": 0.12,
+                "cg_aft_m": 0.105, "sm_at_aft": 0.05, "target_static_margin": 0.10,
+                "cl_alpha_per_rad": 5.5, "s_h_m2": 0.08, "l_h_m": 0.55,
+                "is_canard": False, "is_tailless": False,
+                "is_boxwing": False, "is_tandem": False,
+            }
+            ap = AeroplaneModel(
+                name="b4-test-plane", uuid=uid_str,
+                assumption_computation_context=ctx,
+            )
+            db.add(ap)
+            db.flush()
+            htail = WingModel(name="horizontal_tail", symmetric=True, aeroplane_id=ap.id)
+            db.add(htail)
+            db.flush()
+            hxs = WingXSecModel(
+                wing_id=htail.id, xyz_le=[0.6, 0.0, 0.0], chord=0.12,
+                twist=0.0, airfoil="naca0012", sort_index=0,
+            )
+            db.add(hxs)
+            db.commit()
+            uid = str(ap.uuid)
+
+        resp = client.post(
+            f"/aeroplanes/{uid}/sm-suggestions/apply",
+            json={"lever": "htail_scale", "delta_value": -1.0, "dry_run": False},
+        )
+        assert resp.status_code == 422, (
+            f"Expected 422 for delta_value=-1.0, got {resp.status_code}: {resp.text}"
+        )
+
+    def test_htail_scale_service_raises_for_scale_near_zero(self):
+        """apply_htail_scale service-level check: scale ≤ 0.1 raises ValueError."""
+        from app.services.sm_sizing_service import apply_htail_scale
+        db = MagicMock()
+
+        hxsec = MagicMock()
+        hxsec.chord = 0.12
+        htail_mock = MagicMock()
+        htail_mock.name = "horizontal_tail"
+        htail_mock.x_secs = [hxsec]
+
+        plane_mock = MagicMock()
+        plane_mock.assumption_computation_context = {
+            "mac_m": 0.30, "s_ref_m2": 0.60, "x_np_m": 0.12,
+            "cg_aft_m": 0.105, "sm_at_aft": 0.05, "target_static_margin": 0.10,
+            "cl_alpha_per_rad": 5.5, "s_h_m2": 0.08, "l_h_m": 0.55,
+            "is_canard": False, "is_tailless": False,
+            "is_boxwing": False, "is_tandem": False,
+        }
+        plane_mock.id = 1
+        plane_mock.wings = [htail_mock]
+
+        db.query.return_value.filter.return_value.first.return_value = plane_mock
+
+        with pytest.raises(ValueError, match="non-positive chord"):
+            apply_htail_scale(db, "test-uuid", delta_pct=-0.92, dry_run=False)
+
+
+class TestTandemNotApplicable:
+    """is_tandem=True → not_applicable (coverage for tandem-wing configs)."""
+
+    def test_tandem_suggest_not_applicable(self):
+        """suggest_corrections with is_tandem=True → not_applicable."""
+        suggest = _import_service()
+        ctx = _ctx(is_tandem=True)
+        result = suggest(ctx, target_sm=0.10, at_cg="aft")
+        assert result["status"] == "not_applicable"
+        msg = (result.get("message") or result.get("hint") or "").lower()
+        assert "tandem" in msg
+
+
+class TestHtailScaleNarrativePreservesSpan:
+    """FIX-2 (Scholz P6): narrative must say 'preserves span' not 'preserves AR'."""
+
+    def test_htail_scale_narrative_preserves_span(self):
+        """htail_scale option narrative must say 'preserves span' (AR changes)."""
+        suggest = _import_service()
+        ctx = _ctx(x_np_m=0.12, mac_m=0.30, target_static_margin=0.10, sm_at_aft=0.05)
+        result = suggest(ctx, target_sm=0.10, at_cg="aft")
+        htail_opts = [o for o in result["options"] if o["lever"] == "htail_scale"]
+        assert htail_opts, "Expected htail_scale option in result"
+        narrative = htail_opts[0]["narrative"]
+        assert "preserves span" in narrative.lower(), (
+            f"Narrative should say 'preserves span (AR changes)' but got: {narrative}"
+        )
+        assert "preserves ar" not in narrative.lower(), (
+            f"Narrative must NOT say 'preserves AR' — it is physically wrong: {narrative}"
+        )

--- a/app/tests/test_sm_sizing.py
+++ b/app/tests/test_sm_sizing.py
@@ -507,7 +507,7 @@ class TestApplyEndpoint:
             from app.models.aeroplanemodel import WingXSecModel
             xsecs = db.query(WingXSecModel).filter(WingXSecModel.wing_id == htail_id).all()
             original_chords = [0.12, 0.10]
-            for xs, orig in zip(sorted(xsecs, key=lambda x: x.sort_index), original_chords):
+            for xs, orig in zip(sorted(xsecs, key=lambda x: x.sort_index), original_chords, strict=True):
                 assert xs.chord == pytest.approx(orig * (1 + delta_pct), rel=1e-4), (
                     f"htail xsec sort_index={xs.sort_index}: chord={xs.chord}, "
                     f"expected {orig * (1 + delta_pct):.4f}"

--- a/app/tests/test_sm_sizing.py
+++ b/app/tests/test_sm_sizing.py
@@ -1,0 +1,689 @@
+"""Tests for SM sizing constraint service — gh-494.
+
+TDD: these tests were written BEFORE the implementation.
+
+Analytical sensitivities (spec-gate A1):
+  ∂SM/∂x_wing ≈ (1 − α_VH) / MAC
+  ∂SM/∂S_H   = (a_t/a)·(1 − dε/dα)·l_H / (S_w·MAC)
+
+Apply strategy (spec-gate A3):
+  wing_shift: batch update xyz_le[0] of all main-wing xsecs
+  htail_scale: chord-scale each htail xsec chord by (1 + delta_pct)
+
+Scope: aft-CG only (spec-gate A4); fwd-CG is gh-500 follow-up.
+
+Edge cases (spec-gate A6):
+  SM in [target, 0.20] → silent (no options)
+  SM > 0.20            → negative deltas (shrink / move aft)
+  SM < 0.02            → ERROR, block_save=True
+  x_np_m is None       → not_applicable
+  canard/tailless      → not_applicable
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Minimal context factories (pure-unit helpers)
+# ---------------------------------------------------------------------------
+
+def _ctx(
+    *,
+    mac_m: float = 0.30,
+    s_ref_m2: float = 0.60,
+    x_np_m: float | None = 0.12,
+    cg_aft_m: float | None = 0.11,
+    sm_at_aft: float | None = None,
+    target_static_margin: float = 0.10,
+    cl_alpha_per_rad: float | None = 5.5,
+    # tail info (from #491)
+    s_h_m2: float | None = 0.08,
+    l_h_m: float | None = 0.55,
+    # configuration flags
+    is_canard: bool = False,
+    is_tailless: bool = False,
+    is_boxwing: bool = False,
+    is_tandem: bool = False,
+) -> dict:
+    """Minimal assumption_computation_context mimicking what #488/#491 produce."""
+    if sm_at_aft is None and x_np_m is not None and cg_aft_m is not None:
+        sm_at_aft = (x_np_m - cg_aft_m) / mac_m
+    return {
+        "mac_m": mac_m,
+        "s_ref_m2": s_ref_m2,
+        "x_np_m": x_np_m,
+        "cg_aft_m": cg_aft_m,
+        "sm_at_aft": sm_at_aft,
+        "target_static_margin": target_static_margin,
+        "cl_alpha_per_rad": cl_alpha_per_rad,
+        "s_h_m2": s_h_m2,
+        "l_h_m": l_h_m,
+        "is_canard": is_canard,
+        "is_tailless": is_tailless,
+        "is_boxwing": is_boxwing,
+        "is_tandem": is_tandem,
+    }
+
+
+def _import_service():
+    from app.services.sm_sizing_service import suggest_corrections
+    return suggest_corrections
+
+
+def _import_module():
+    import app.services.sm_sizing_service as svc
+    return svc
+
+
+# ===========================================================================
+# Class 1: suggest_corrections — pure service, no DB
+# ===========================================================================
+
+class TestSuggestCorrections:
+    """Unit tests for suggest_corrections() pure function."""
+
+    def test_sm_below_target_returns_two_options(self):
+        """SM = 0.05 (above error threshold of 0.02, below target 0.10) → suggestion with 2 options."""
+        suggest = _import_service()
+        # SM = 0.05 — clearly above error threshold (0.02) but below target (0.10)
+        ctx = _ctx(x_np_m=0.12, mac_m=0.30, target_static_margin=0.10, sm_at_aft=0.05)
+        result = suggest(ctx, target_sm=0.10, at_cg="aft")
+        assert result["status"] == "suggestion"
+        assert len(result["options"]) == 2
+        levers = {opt["lever"] for opt in result["options"]}
+        assert "wing_shift" in levers
+        assert "htail_scale" in levers
+
+    def test_each_option_has_required_fields(self):
+        """Each option must have lever, delta_value, delta_unit, predicted_sm, narrative."""
+        suggest = _import_service()
+        ctx = _ctx(x_np_m=0.12, mac_m=0.30, target_static_margin=0.10, sm_at_aft=0.05)
+        result = suggest(ctx, target_sm=0.10, at_cg="aft")
+        for opt in result["options"]:
+            assert "lever" in opt
+            assert "delta_value" in opt
+            assert "delta_unit" in opt
+            assert "predicted_sm" in opt
+            assert "narrative" in opt
+
+    def test_sm_in_range_returns_empty_options(self):
+        """SM ∈ [target_sm, 0.20]: silent, no options."""
+        suggest = _import_service()
+        # SM = 0.12: target=0.10 → in range
+        ctx = _ctx(x_np_m=0.12, cg_aft_m=0.084, mac_m=0.30, target_static_margin=0.10)
+        # sm_at_aft = (0.12 - 0.084) / 0.30 = 0.12 → in [0.10, 0.20]
+        result = suggest(ctx, target_sm=0.10, at_cg="aft")
+        assert result["status"] == "ok"
+        assert result["options"] == []
+
+    def test_sm_above_heavy_nose_returns_negative_deltas(self):
+        """SM > 0.20 (heavy nose): suggestion has negative delta (shrink HS / move wing aft)."""
+        suggest = _import_service()
+        # SM = 0.25: above 0.20 overshoot
+        ctx = _ctx(x_np_m=0.12, cg_aft_m=0.045, mac_m=0.30, target_static_margin=0.10)
+        # sm_at_aft = (0.12 - 0.045) / 0.30 = 0.25
+        result = suggest(ctx, target_sm=0.10, at_cg="aft")
+        # Need to reduce SM toward target: wing moves aft (positive dx), or HS shrinks (negative %)
+        assert result["status"] == "suggestion"
+        for opt in result["options"]:
+            # delta should bring SM from 0.25 DOWN to 0.10
+            assert opt["predicted_sm"] == pytest.approx(0.10, abs=0.02)
+
+    def test_sm_below_error_threshold_returns_block_save(self):
+        """SM < 0.02 → ERROR-level, block_save=True in result."""
+        suggest = _import_service()
+        # SM = -0.01: negative = aerodynamically unstable
+        ctx = _ctx(x_np_m=0.12, cg_aft_m=0.123, mac_m=0.30, target_static_margin=0.10)
+        # sm_at_aft = (0.12 - 0.123) / 0.30 = -0.01
+        result = suggest(ctx, target_sm=0.10, at_cg="aft")
+        assert result["status"] == "error"
+        assert result.get("block_save") is True
+
+    def test_x_np_none_returns_not_applicable(self):
+        """x_np_m is None → not_applicable with hint."""
+        suggest = _import_service()
+        ctx = _ctx(x_np_m=None, cg_aft_m=None, sm_at_aft=None)
+        result = suggest(ctx, target_sm=0.10, at_cg="aft")
+        assert result["status"] == "not_applicable"
+        assert "hint" in result or "message" in result
+
+    def test_canard_returns_not_applicable(self):
+        """Canard configuration → not_applicable."""
+        suggest = _import_service()
+        ctx = _ctx(is_canard=True)
+        result = suggest(ctx, target_sm=0.10, at_cg="aft")
+        assert result["status"] == "not_applicable"
+
+    def test_tailless_returns_not_applicable(self):
+        """Tailless configuration → not_applicable."""
+        suggest = _import_service()
+        ctx = _ctx(is_tailless=True)
+        result = suggest(ctx, target_sm=0.10, at_cg="aft")
+        assert result["status"] == "not_applicable"
+
+    def test_boxwing_returns_not_applicable(self):
+        """Boxwing configuration → not_applicable."""
+        suggest = _import_service()
+        ctx = _ctx(is_boxwing=True)
+        result = suggest(ctx, target_sm=0.10, at_cg="aft")
+        assert result["status"] == "not_applicable"
+
+    def test_predicted_sm_matches_target(self):
+        """predicted_sm of each option must equal target_sm (within 2%)."""
+        suggest = _import_service()
+        ctx = _ctx(x_np_m=0.12, mac_m=0.30, target_static_margin=0.10, sm_at_aft=0.05)
+        result = suggest(ctx, target_sm=0.10, at_cg="aft")
+        for opt in result["options"]:
+            assert opt["predicted_sm"] == pytest.approx(0.10, abs=0.02), (
+                f"lever={opt['lever']}: predicted_sm={opt['predicted_sm']:.4f} not ≈ 0.10"
+            )
+
+    def test_narrative_is_nonempty_string(self):
+        """Narrative must be a non-empty string."""
+        suggest = _import_service()
+        ctx = _ctx(x_np_m=0.12, mac_m=0.30, target_static_margin=0.10, sm_at_aft=0.05)
+        result = suggest(ctx, target_sm=0.10, at_cg="aft")
+        for opt in result["options"]:
+            assert isinstance(opt["narrative"], str) and len(opt["narrative"]) > 0
+
+    def test_mass_coupling_warning_present(self):
+        """Result must include mass_coupling_warning when wing_shift option is present."""
+        suggest = _import_service()
+        ctx = _ctx(x_np_m=0.12, mac_m=0.30, target_static_margin=0.10, sm_at_aft=0.05)
+        result = suggest(ctx, target_sm=0.10, at_cg="aft")
+        wing_shift_opts = [o for o in result["options"] if o["lever"] == "wing_shift"]
+        if wing_shift_opts:
+            assert "mass_coupling_warning" in result or any(
+                "mass" in o.get("narrative", "").lower() or "wingbox" in o.get("narrative", "").lower()
+                for o in wing_shift_opts
+            ), "Mass-coupling warning must be present for wing_shift option"
+
+
+# ===========================================================================
+# Class 2: Analytic sensitivity validation
+# ===========================================================================
+
+class TestAnalyticSensitivities:
+    """Validate analytic ∂SM/∂lever formulas."""
+
+    def test_dsm_dx_wing_formula(self):
+        """∂SM/∂x_wing = (1 - alpha_vh) / MAC — verify formula returns correct ballpark."""
+        svc = _import_module()
+        mac_m = 0.30
+        s_ref_m2 = 0.60
+        s_h_m2 = 0.08
+        l_h_m = 0.55
+        cl_alpha_per_rad = 5.5
+        ctx = {
+            "mac_m": mac_m,
+            "s_ref_m2": s_ref_m2,
+            "s_h_m2": s_h_m2,
+            "l_h_m": l_h_m,
+            "cl_alpha_per_rad": cl_alpha_per_rad,
+        }
+        dsm_dx = svc._dsm_dx_wing(ctx)
+        # alpha_VH ~ 0.05–0.20 → dsm_dx ~ (0.80–0.95) / 0.30 ~ 2.67–3.17 /m
+        assert 1.5 < dsm_dx < 5.0, f"∂SM/∂x_wing = {dsm_dx:.3f} outside expected range [1.5, 5.0]"
+
+    def test_dsm_dsh_formula(self):
+        """∂SM/∂S_H = (a_t/a)·(1 − dε/dα)·l_H/(S_w·MAC)."""
+        svc = _import_module()
+        mac_m = 0.30
+        s_ref_m2 = 0.60
+        s_h_m2 = 0.08
+        l_h_m = 0.55
+        cl_alpha_per_rad = 5.5
+        ctx = {
+            "mac_m": mac_m,
+            "s_ref_m2": s_ref_m2,
+            "s_h_m2": s_h_m2,
+            "l_h_m": l_h_m,
+            "cl_alpha_per_rad": cl_alpha_per_rad,
+        }
+        dsm_dsh = svc._dsm_dsh(ctx)
+        # Typical: (0.6 * 0.55) / (0.60 * 0.30) ~ 1.83 /m²  (factor 0.6 for (1-de/da))
+        assert 0.5 < dsm_dsh < 5.0, f"∂SM/∂S_H = {dsm_dsh:.3f} outside expected range [0.5, 5.0]"
+
+    def test_inversion_round_trip_wing_shift(self):
+        """Δx_wing = ΔSM / (∂SM/∂x_wing) → applying Δx shifts SM by ΔSM."""
+        svc = _import_module()
+        mac_m = 0.30
+        s_ref_m2 = 0.60
+        s_h_m2 = 0.08
+        l_h_m = 0.55
+        cl_alpha_per_rad = 5.5
+        ctx = {
+            "mac_m": mac_m,
+            "s_ref_m2": s_ref_m2,
+            "s_h_m2": s_h_m2,
+            "l_h_m": l_h_m,
+            "cl_alpha_per_rad": cl_alpha_per_rad,
+        }
+        target_sm = 0.10
+        sm_at_aft = 0.02  # needs to increase by 0.08
+        dsm_dx = svc._dsm_dx_wing(ctx)
+        delta_needed = (target_sm - sm_at_aft) / dsm_dx
+        predicted = sm_at_aft + dsm_dx * delta_needed
+        assert predicted == pytest.approx(target_sm, abs=1e-6)
+
+    def test_inversion_round_trip_htail_scale(self):
+        """ΔS_H% = ΔSM / (∂SM/∂S_H · S_H_current) → applying scale shifts SM by ΔSM."""
+        svc = _import_module()
+        mac_m = 0.30
+        s_ref_m2 = 0.60
+        s_h_m2 = 0.08
+        l_h_m = 0.55
+        cl_alpha_per_rad = 5.5
+        ctx = {
+            "mac_m": mac_m,
+            "s_ref_m2": s_ref_m2,
+            "s_h_m2": s_h_m2,
+            "l_h_m": l_h_m,
+            "cl_alpha_per_rad": cl_alpha_per_rad,
+        }
+        target_sm = 0.10
+        sm_at_aft = 0.02
+        dsm_dsh = svc._dsm_dsh(ctx)
+        delta_sh = (target_sm - sm_at_aft) / dsm_dsh      # m²
+        delta_pct = delta_sh / s_h_m2                      # fraction of current S_H
+        predicted = sm_at_aft + dsm_dsh * delta_pct * s_h_m2
+        assert predicted == pytest.approx(target_sm, abs=1e-6)
+
+
+# ===========================================================================
+# Class 3: Endpoint unit tests (FastAPI TestClient, no real ASB/DB ops)
+# ===========================================================================
+
+class TestSmSuggestEndpoint:
+    """Integration-level endpoint tests using in-memory DB."""
+
+    def _setup_aeroplane(self, db_session, ctx_override: dict | None = None) -> str:
+        """Create a minimal aeroplane with computation context, return UUID."""
+        from app.models.aeroplanemodel import AeroplaneModel
+        aeroplane_uuid = str(uuid.uuid4())
+        ctx = {
+            "mac_m": 0.30,
+            "s_ref_m2": 0.60,
+            "x_np_m": 0.12,
+            "cg_aft_m": 0.105,
+            "sm_at_aft": 0.05,  # clearly above 0.02 threshold, below target 0.10
+            "target_static_margin": 0.10,
+            "cl_alpha_per_rad": 5.5,
+            "s_h_m2": 0.08,
+            "l_h_m": 0.55,
+            "is_canard": False,
+            "is_tailless": False,
+            "is_boxwing": False,
+            "is_tandem": False,
+        }
+        if ctx_override:
+            ctx.update(ctx_override)
+        aeroplane = AeroplaneModel(
+            name="test-sm-plane",
+            uuid=aeroplane_uuid,
+            assumption_computation_context=ctx,
+        )
+        db_session.add(aeroplane)
+        db_session.commit()
+        return aeroplane_uuid
+
+    def test_get_sm_suggestion_returns_two_options(self, client_and_db):
+        """GET sm-suggestion endpoint returns options for a plane with SM < target."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            uid = self._setup_aeroplane(db)
+        resp = client.get(f"/aeroplanes/{uid}/sm-suggestion")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["status"] == "suggestion"
+        assert len(data["options"]) == 2
+
+    def test_get_sm_suggestion_404_unknown_aeroplane(self, client_and_db):
+        """GET sm-suggestion for unknown UUID → 404."""
+        client, _ = client_and_db
+        resp = client.get(f"/aeroplanes/{uuid.uuid4()}/sm-suggestion")
+        assert resp.status_code == 404
+
+    def test_get_sm_suggestion_canard_not_applicable(self, client_and_db):
+        """GET sm-suggestion for canard → 200 with not_applicable."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            uid = self._setup_aeroplane(db, ctx_override={"is_canard": True})
+        resp = client.get(f"/aeroplanes/{uid}/sm-suggestion")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "not_applicable"
+
+    def test_get_sm_suggestion_x_np_none_not_applicable(self, client_and_db):
+        """GET sm-suggestion when x_np_m is None → not_applicable with hint."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            uid = self._setup_aeroplane(db, ctx_override={"x_np_m": None, "sm_at_aft": None})
+        resp = client.get(f"/aeroplanes/{uid}/sm-suggestion")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "not_applicable"
+
+
+# ===========================================================================
+# Class 4: Apply endpoint — dry_run and real apply
+# ===========================================================================
+
+class TestApplyEndpoint:
+    """Tests for POST /aeroplanes/{uuid}/sm-suggestions/apply."""
+
+    def _setup_plane_with_wings(self, db_session) -> tuple[str, int, int]:
+        """Create aeroplane with main_wing + htail, return (uuid, main_wing_id, htail_id)."""
+        from app.models.aeroplanemodel import AeroplaneModel, WingModel, WingXSecModel
+        aeroplane_uuid = str(uuid.uuid4())
+        ctx = {
+            "mac_m": 0.30,
+            "s_ref_m2": 0.60,
+            "x_np_m": 0.12,
+            "cg_aft_m": 0.105,
+            "sm_at_aft": 0.05,  # above 0.02, below 0.10
+            "target_static_margin": 0.10,
+            "cl_alpha_per_rad": 5.5,
+            "s_h_m2": 0.08,
+            "l_h_m": 0.55,
+            "is_canard": False,
+            "is_tailless": False,
+            "is_boxwing": False,
+            "is_tandem": False,
+        }
+        aeroplane = AeroplaneModel(
+            name="apply-test-plane",
+            uuid=aeroplane_uuid,
+            assumption_computation_context=ctx,
+        )
+        db_session.add(aeroplane)
+        db_session.flush()
+
+        # Main wing with two xsecs
+        main_wing = WingModel(name="main_wing", symmetric=True, aeroplane_id=aeroplane.id)
+        db_session.add(main_wing)
+        db_session.flush()
+        xs0 = WingXSecModel(wing_id=main_wing.id, xyz_le=[0.0, 0.0, 0.0], chord=0.30, twist=0.0,
+                            airfoil="naca2412", sort_index=0)
+        xs1 = WingXSecModel(wing_id=main_wing.id, xyz_le=[0.0, 0.5, 0.0], chord=0.20, twist=0.0,
+                            airfoil="naca2412", sort_index=1)
+        db_session.add_all([xs0, xs1])
+
+        # Horizontal tail
+        htail = WingModel(name="horizontal_tail", symmetric=True, aeroplane_id=aeroplane.id)
+        db_session.add(htail)
+        db_session.flush()
+        hxs0 = WingXSecModel(wing_id=htail.id, xyz_le=[0.60, 0.0, 0.0], chord=0.12, twist=0.0,
+                              airfoil="naca0012", sort_index=0)
+        hxs1 = WingXSecModel(wing_id=htail.id, xyz_le=[0.60, 0.25, 0.0], chord=0.10, twist=0.0,
+                              airfoil="naca0012", sort_index=1)
+        db_session.add_all([hxs0, hxs1])
+        db_session.commit()
+        return aeroplane_uuid, main_wing.id, htail.id
+
+    def test_apply_wing_shift_dry_run_no_db_change(self, client_and_db):
+        """POST apply with dry_run=True returns predicted_sm without changing DB."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            uid, wing_id, _ = self._setup_plane_with_wings(db)
+
+        resp = client.post(
+            f"/aeroplanes/{uid}/sm-suggestions/apply",
+            json={"lever": "wing_shift", "delta_value": -0.02, "dry_run": True},
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "predicted_sm" in data
+        assert data["dry_run"] is True
+
+        # Verify no DB change
+        with SessionLocal() as db:
+            from app.models.aeroplanemodel import WingXSecModel
+            xs = db.query(WingXSecModel).filter(WingXSecModel.wing_id == wing_id).first()
+            # xyz_le[0] should still be 0.0 (no commit)
+            assert xs.xyz_le[0] == pytest.approx(0.0, abs=1e-9)
+
+    def test_apply_wing_shift_updates_all_xsecs(self, client_and_db):
+        """POST apply with dry_run=False shifts xyz_le[0] of ALL main_wing xsecs."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            uid, wing_id, _ = self._setup_plane_with_wings(db)
+
+        delta_m = -0.024  # shift wing forward by 24 mm (negative x)
+        resp = client.post(
+            f"/aeroplanes/{uid}/sm-suggestions/apply",
+            json={"lever": "wing_shift", "delta_value": delta_m, "dry_run": False},
+        )
+        assert resp.status_code == 200, resp.text
+
+        # Verify ALL xsecs shifted
+        with SessionLocal() as db:
+            from app.models.aeroplanemodel import WingXSecModel
+            xsecs = db.query(WingXSecModel).filter(WingXSecModel.wing_id == wing_id).all()
+            for xs in xsecs:
+                assert xs.xyz_le[0] == pytest.approx(delta_m, abs=1e-6), (
+                    f"xsec sort_index={xs.sort_index}: xyz_le[0]={xs.xyz_le[0]}, expected {delta_m}"
+                )
+
+    def test_apply_htail_scale_dry_run_no_db_change(self, client_and_db):
+        """POST apply htail_scale dry_run=True returns predicted_sm without changing DB."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            uid, _, htail_id = self._setup_plane_with_wings(db)
+
+        resp = client.post(
+            f"/aeroplanes/{uid}/sm-suggestions/apply",
+            json={"lever": "htail_scale", "delta_value": 0.15, "dry_run": True},
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "predicted_sm" in data
+        assert data["dry_run"] is True
+
+        # Verify no DB change
+        with SessionLocal() as db:
+            from app.models.aeroplanemodel import WingXSecModel
+            xs = db.query(WingXSecModel).filter(WingXSecModel.wing_id == htail_id).first()
+            assert xs.chord == pytest.approx(0.12, abs=1e-9)  # unchanged
+
+    def test_apply_htail_scale_chord_scales_all_xsecs(self, client_and_db):
+        """POST apply htail_scale dry_run=False chord-scales ALL htail xsecs."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            uid, _, htail_id = self._setup_plane_with_wings(db)
+
+        delta_pct = 0.20  # scale HS chord by 1.20
+        resp = client.post(
+            f"/aeroplanes/{uid}/sm-suggestions/apply",
+            json={"lever": "htail_scale", "delta_value": delta_pct, "dry_run": False},
+        )
+        assert resp.status_code == 200, resp.text
+
+        with SessionLocal() as db:
+            from app.models.aeroplanemodel import WingXSecModel
+            xsecs = db.query(WingXSecModel).filter(WingXSecModel.wing_id == htail_id).all()
+            original_chords = [0.12, 0.10]
+            for xs, orig in zip(sorted(xsecs, key=lambda x: x.sort_index), original_chords):
+                assert xs.chord == pytest.approx(orig * (1 + delta_pct), rel=1e-4), (
+                    f"htail xsec sort_index={xs.sort_index}: chord={xs.chord}, "
+                    f"expected {orig * (1 + delta_pct):.4f}"
+                )
+
+    def test_apply_unknown_lever_returns_422(self, client_and_db):
+        """POST apply with unknown lever → 422 Unprocessable Entity."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            uid, _, _ = self._setup_plane_with_wings(db)
+
+        resp = client.post(
+            f"/aeroplanes/{uid}/sm-suggestions/apply",
+            json={"lever": "invalid_lever", "delta_value": 0.05, "dry_run": True},
+        )
+        assert resp.status_code == 422
+
+    def test_apply_canard_not_applicable(self, client_and_db):
+        """POST apply on canard plane → 422 or 400 (not_applicable)."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            from app.models.aeroplanemodel import AeroplaneModel
+            uid_str = str(uuid.uuid4())
+            ctx = {
+                "mac_m": 0.30, "s_ref_m2": 0.60, "x_np_m": 0.12,
+                "cg_aft_m": 0.105, "sm_at_aft": 0.05, "target_static_margin": 0.10,
+                "cl_alpha_per_rad": 5.5, "s_h_m2": 0.08, "l_h_m": 0.55,
+                "is_canard": True, "is_tailless": False, "is_boxwing": False, "is_tandem": False,
+            }
+            ap = AeroplaneModel(name="canard-plane", uuid=uid_str, assumption_computation_context=ctx)
+            db.add(ap)
+            db.commit()
+        resp = client.post(
+            f"/aeroplanes/{uid_str}/sm-suggestions/apply",
+            json={"lever": "wing_shift", "delta_value": -0.02, "dry_run": False},
+        )
+        assert resp.status_code in (400, 422)
+
+    def test_apply_404_unknown_aeroplane(self, client_and_db):
+        """POST apply for unknown UUID → 404."""
+        client, _ = client_and_db
+        resp = client.post(
+            f"/aeroplanes/{uuid.uuid4()}/sm-suggestions/apply",
+            json={"lever": "wing_shift", "delta_value": -0.02, "dry_run": True},
+        )
+        assert resp.status_code == 404
+
+
+# ===========================================================================
+# Class 5: Service-layer apply helpers (unit tests with mock DB)
+# ===========================================================================
+
+class TestApplyWingShiftService:
+    """Unit tests for apply_wing_shift service function."""
+
+    def _make_wing_xsec(self, x0: float, sort_index: int) -> Any:
+        """Create a mock WingXSecModel."""
+        xsec = MagicMock()
+        xsec.xyz_le = [x0, 0.0, 0.0]
+        xsec.sort_index = sort_index
+        return xsec
+
+    def test_dry_run_returns_predicted_sm_no_flush(self):
+        """apply_wing_shift dry_run=True returns predicted_sm, does NOT call db.flush()."""
+        from app.services.sm_sizing_service import apply_wing_shift
+        db = MagicMock()
+        db.flush = MagicMock()
+
+        # Mock query chain: db.query(...).filter(...).first() → plane with context
+        plane_mock = MagicMock()
+        plane_mock.assumption_computation_context = {
+            "mac_m": 0.30, "s_ref_m2": 0.60, "x_np_m": 0.12,
+            "cg_aft_m": 0.105, "sm_at_aft": 0.05, "target_static_margin": 0.10,
+            "cl_alpha_per_rad": 5.5, "s_h_m2": 0.08, "l_h_m": 0.55,
+            "is_canard": False, "is_tailless": False, "is_boxwing": False, "is_tandem": False,
+        }
+        plane_mock.id = 1
+        plane_mock.wings = []
+
+        db.query.return_value.filter.return_value.first.return_value = plane_mock
+
+        result = apply_wing_shift(db, "test-uuid", delta_m=-0.02, dry_run=True)
+        assert "predicted_sm" in result
+        assert result["dry_run"] is True
+        db.flush.assert_not_called()
+
+    def test_real_apply_shifts_xsecs_and_flushes(self):
+        """apply_wing_shift dry_run=False updates xyz_le[0] for all main_wing xsecs."""
+        from app.services.sm_sizing_service import apply_wing_shift
+        db = MagicMock()
+
+        xsec0 = self._make_wing_xsec(0.0, 0)
+        xsec1 = self._make_wing_xsec(0.0, 1)
+
+        wing_mock = MagicMock()
+        wing_mock.name = "main_wing"
+        wing_mock.x_secs = [xsec0, xsec1]
+
+        plane_mock = MagicMock()
+        plane_mock.assumption_computation_context = {
+            "mac_m": 0.30, "s_ref_m2": 0.60, "x_np_m": 0.12,
+            "cg_aft_m": 0.105, "sm_at_aft": 0.05, "target_static_margin": 0.10,
+            "cl_alpha_per_rad": 5.5, "s_h_m2": 0.08, "l_h_m": 0.55,
+            "is_canard": False, "is_tailless": False, "is_boxwing": False, "is_tandem": False,
+        }
+        plane_mock.id = 1
+        plane_mock.wings = [wing_mock]
+
+        db.query.return_value.filter.return_value.first.return_value = plane_mock
+
+        delta_m = -0.024
+        result = apply_wing_shift(db, "test-uuid", delta_m=delta_m, dry_run=False)
+
+        # Both xsecs should have been shifted
+        assert xsec0.xyz_le[0] == pytest.approx(delta_m, abs=1e-9)
+        assert xsec1.xyz_le[0] == pytest.approx(delta_m, abs=1e-9)
+        db.flush.assert_called_once()
+
+
+class TestApplyHtailScaleService:
+    """Unit tests for apply_htail_scale service function."""
+
+    def test_dry_run_returns_predicted_sm_no_flush(self):
+        """apply_htail_scale dry_run=True returns predicted_sm, does NOT call db.flush()."""
+        from app.services.sm_sizing_service import apply_htail_scale
+        db = MagicMock()
+        db.flush = MagicMock()
+
+        plane_mock = MagicMock()
+        plane_mock.assumption_computation_context = {
+            "mac_m": 0.30, "s_ref_m2": 0.60, "x_np_m": 0.12,
+            "cg_aft_m": 0.105, "sm_at_aft": 0.05, "target_static_margin": 0.10,
+            "cl_alpha_per_rad": 5.5, "s_h_m2": 0.08, "l_h_m": 0.55,
+            "is_canard": False, "is_tailless": False, "is_boxwing": False, "is_tandem": False,
+        }
+        plane_mock.id = 1
+        plane_mock.wings = []
+
+        db.query.return_value.filter.return_value.first.return_value = plane_mock
+
+        result = apply_htail_scale(db, "test-uuid", delta_pct=0.15, dry_run=True)
+        assert "predicted_sm" in result
+        assert result["dry_run"] is True
+        db.flush.assert_not_called()
+
+    def test_real_apply_chord_scales_htail_xsecs(self):
+        """apply_htail_scale dry_run=False chord-scales all htail xsecs."""
+        from app.services.sm_sizing_service import apply_htail_scale
+        db = MagicMock()
+
+        hxsec0 = MagicMock()
+        hxsec0.chord = 0.12
+        hxsec0.sort_index = 0
+        hxsec1 = MagicMock()
+        hxsec1.chord = 0.10
+        hxsec1.sort_index = 1
+
+        htail_mock = MagicMock()
+        htail_mock.name = "horizontal_tail"
+        htail_mock.x_secs = [hxsec0, hxsec1]
+
+        plane_mock = MagicMock()
+        plane_mock.assumption_computation_context = {
+            "mac_m": 0.30, "s_ref_m2": 0.60, "x_np_m": 0.12,
+            "cg_aft_m": 0.105, "sm_at_aft": 0.05, "target_static_margin": 0.10,
+            "cl_alpha_per_rad": 5.5, "s_h_m2": 0.08, "l_h_m": 0.55,
+            "is_canard": False, "is_tailless": False, "is_boxwing": False, "is_tandem": False,
+        }
+        plane_mock.id = 1
+        plane_mock.wings = [htail_mock]
+
+        db.query.return_value.filter.return_value.first.return_value = plane_mock
+
+        delta_pct = 0.20
+        result = apply_htail_scale(db, "test-uuid", delta_pct=delta_pct, dry_run=False)
+
+        assert hxsec0.chord == pytest.approx(0.12 * (1 + delta_pct), rel=1e-4)
+        assert hxsec1.chord == pytest.approx(0.10 * (1 + delta_pct), rel=1e-4)
+        db.flush.assert_called_once()


### PR DESCRIPTION
## Summary

- Adds analytic SM sensitivity formulas (`∂SM/∂x_wing` and `∂SM/∂S_H`) per spec-gate A1 — no expensive finite-difference sweeps
- Returns two separate banner options (`wing_shift`, `htail_scale`) per Strategy A (spec-gate A2) — no hidden Pareto tradeoff
- `apply_wing_shift`: batch-updates `xyz_le[0]` of all main-wing xsecs (spec-gate A3)
- `apply_htail_scale`: chord-scales all htail xsecs, preserving AR (spec-gate A3)
- Aft-CG focus only with `TODO(gh-500)` marker for forward-CG coupling (spec-gate A4)
- Mass-coupling warning embedded in narrative (spec-gate A5, ~15% systematic error)
- Full edge-case coverage: SM in range → silent; SM > 0.20 → negative deltas (shrink HS / move wing aft); SM < 0.02 → ERROR + `block_save=True`; canard/tailless/boxwing/tandem → `not_applicable` (spec-gate A6)

## New endpoints

- `GET /aeroplanes/{uuid}/sm-suggestion` — compute suggestions
- `POST /aeroplanes/{uuid}/sm-suggestions/apply` — apply (or `dry_run=true` preview)

## Files

- `app/services/sm_sizing_service.py` — service with analytic sensitivities + apply helpers
- `app/schemas/sm_sizing.py` — Pydantic schemas
- `app/api/v2/endpoints/aeroplane/sm_suggestions.py` — FastAPI endpoint
- `app/tests/test_sm_sizing.py` — 31 tests

## Test plan

- [x] 31 unit + integration tests, all green
- [x] Coverage: `sm_sizing_service.py` 89%, `sm_suggestions.py` 80%, `sm_sizing.py` 100%
- [x] Full fast suite: 3290 passed (6 pre-existing `test_analysis_smoke.py` failures unrelated to this PR)
- [x] Pure service tests (no DB, no ASB) for all edge cases
- [x] Endpoint tests with in-memory SQLite for GET + POST (dry_run and real apply)
- [x] Service unit tests with mock DB for `apply_wing_shift` and `apply_htail_scale`

Closes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)