### PR TITLE
fix(gh-521): KpiCard crash on confidence='computed' — sync FE/BE type

### DIFF
--- a/frontend/__tests__/PerformanceOverview.test.tsx
+++ b/frontend/__tests__/PerformanceOverview.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * Unit tests for PerformanceOverview KPI cards (gh-521 regression).
+ *
+ * Ensures that KpiCard renders for every backend confidence literal
+ * including the 'computed' tier introduced in gh-475/#480. Prevents
+ * frontend/backend type drift that caused TypeError on style.bg.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PerformanceOverview } from "@/components/workbench/PerformanceOverview";
+import type { PerformanceKPI } from "@/hooks/useFlightEnvelope";
+
+const ALL_CONFIDENCE_VALUES: PerformanceKPI["confidence"][] = [
+  "trimmed",
+  "computed",
+  "estimated",
+  "limit",
+];
+
+function makeKpi(
+  confidence: PerformanceKPI["confidence"],
+  label: string,
+): PerformanceKPI {
+  return {
+    label,
+    display_name: label.toUpperCase(),
+    value: 12.5,
+    unit: "m/s",
+    source_op_id: null,
+    confidence,
+  };
+}
+
+describe("PerformanceOverview (gh-521)", () => {
+  it("renders each backend confidence tier without crashing", () => {
+    const kpis = ALL_CONFIDENCE_VALUES.map((c) => makeKpi(c, `v_${c}`));
+    render(<PerformanceOverview kpis={kpis} />);
+    for (const c of ALL_CONFIDENCE_VALUES) {
+      expect(screen.getByText(`V_${c.toUpperCase()}`)).toBeDefined();
+    }
+  });
+
+  it("renders 'Computed' badge for polar-derived KPIs (gh-475)", () => {
+    const kpi = makeKpi("computed", "v_md");
+    render(<PerformanceOverview kpis={[kpi]} />);
+    expect(screen.getByText(/Computed/)).toBeDefined();
+  });
+
+  it("shows empty-state when no KPIs", () => {
+    render(<PerformanceOverview kpis={[]} />);
+    expect(screen.getByText(/No performance data available/)).toBeDefined();
+  });
+});

--- a/frontend/__tests__/PerformanceOverview.test.tsx
+++ b/frontend/__tests__/PerformanceOverview.test.tsx
@@ -50,4 +50,19 @@ describe("PerformanceOverview (gh-521)", () => {
     render(<PerformanceOverview kpis={[]} />);
     expect(screen.getByText(/No performance data available/)).toBeDefined();
   });
+
+  it("falls back to 'Estimated' badge when backend emits an unknown confidence literal", () => {
+    // Simulates future backend type drift — bypasses TS type union to test
+    // the runtime defensive fallback (?? CONFIDENCE_STYLES.estimated).
+    const future = {
+      label: "v_md",
+      display_name: "V_MD",
+      value: 12.5,
+      unit: "m/s",
+      source_op_id: null,
+      confidence: "preliminary",
+    } as unknown as PerformanceKPI;
+    render(<PerformanceOverview kpis={[future]} />);
+    expect(screen.getByText(/Estimated/)).toBeDefined();
+  });
 });

--- a/frontend/components/workbench/PerformanceOverview.tsx
+++ b/frontend/components/workbench/PerformanceOverview.tsx
@@ -11,6 +11,11 @@ const CONFIDENCE_STYLES: Record<
     text: "text-emerald-400",
     label: "Trimmed",
   },
+  computed: {
+    bg: "bg-sky-500/15",
+    text: "text-sky-400",
+    label: "Computed",
+  },
   estimated: {
     bg: "bg-yellow-500/15",
     text: "text-yellow-400",
@@ -24,7 +29,10 @@ const CONFIDENCE_STYLES: Record<
 };
 
 function KpiCard({ kpi }: Readonly<{ kpi: PerformanceKPI }>) {
-  const style = CONFIDENCE_STYLES[kpi.confidence];
+  // Defensive fallback: if backend adds a new confidence literal before
+  // this map is updated, surface as 'Estimated' rather than crashing
+  // the entire analysis page (gh-521).
+  const style = CONFIDENCE_STYLES[kpi.confidence] ?? CONFIDENCE_STYLES.estimated;
 
   return (
     <div className="flex flex-col gap-1.5 rounded-xl border border-border bg-card p-4">

--- a/frontend/hooks/useFlightEnvelope.ts
+++ b/frontend/hooks/useFlightEnvelope.ts
@@ -61,7 +61,13 @@ export interface PerformanceKPI {
   value: number;
   unit: string;
   source_op_id: number | null;
-  confidence: "trimmed" | "estimated" | "limit";
+  /**
+   * - `trimmed`: from a TRIMMED operating point
+   * - `computed`: polar/physics-derived from cached assumptions (gh-475)
+   * - `estimated`: heuristic shortcut (e.g. 1.4·V_s)
+   * - `limit`: boundary or user-supplied limit
+   */
+  confidence: "trimmed" | "computed" | "estimated" | "limit";
 }
 
 export interface VnMarker {


### PR DESCRIPTION
## Summary

- **Root cause**: PR #480 (gh-475) added `confidence: 'computed'` to the backend KPI schema. Frontend TS type and `CONFIDENCE_STYLES` map weren't updated → `style.bg` crashed on undefined.
- Frontend type now matches backend `Literal['trimmed', 'computed', 'estimated', 'limit']` exactly.
- Added sky-blue style for `computed` (physics-derived, distinct from green `trimmed` which is measurement-derived).
- Defensive fallback to `estimated` prevents future type drift from crashing the analysis page.

## Test plan

- [x] 3 new TDD regression tests in `frontend/__tests__/PerformanceOverview.test.tsx`:
  - All 4 backend confidence literals render without crashing
  - `computed` shows 'Computed' badge label
  - Empty-state still renders
- [x] Full frontend unit suite: **712/712 passing** (no regressions)
- [x] Reproduces the exact production stack trace in RED before fix (verified)

Closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)