### PR TITLE
feat(gh-526): per-configuration polar (FE1, epic #525)

### DIFF
--- a/app/schemas/polar_by_config.py
+++ b/app/schemas/polar_by_config.py
@@ -21,9 +21,15 @@ ConfigName = Literal["clean", "takeoff", "landing"]
 Provenance = Literal[
     "aerobuildup",  # full AeroBuildup pass with deflected flap
     "no_flap_geometry",  # aircraft has no flap → cloned from clean
-    "fit_rejected",  # AeroBuildup ran but the parabolic fit was rejected
+    "aerobuildup_failed",  # the flap-deflected AeroBuildup raised → cloned from clean
 ]
-"""How the polar entry was produced."""
+"""How the polar entry was produced.
+
+`aerobuildup_failed` covers any exception during the deflected sweep
+(AeroBuildup convergence, parabolic-fit rejection, downstream NaN) —
+the UI should treat it as "we tried, the solver fell over, falling back
+to clean polar" rather than a successful but low-quality fit.
+"""
 
 
 class ParabolicPolar(BaseModel):

--- a/app/schemas/polar_by_config.py
+++ b/app/schemas/polar_by_config.py
@@ -1,0 +1,56 @@
+"""Pydantic schema for per-configuration parabolic polar (gh-526).
+
+A `ParabolicPolar` carries the C_D0 / e_Oswald / C_L_max fit for ONE
+high-lift configuration (clean / takeoff / landing). The
+`assumption_compute_service` runs one `AeroBuildup` pass per
+configuration and caches the three polars in
+`ComputationContext.polar_by_config`.
+
+Audit reference: gh-525 (epic) finding C1.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+ConfigName = Literal["clean", "takeoff", "landing"]
+"""Configuration keys for `polar_by_config`."""
+
+Provenance = Literal[
+    "aerobuildup",  # full AeroBuildup pass with deflected flap
+    "no_flap_geometry",  # aircraft has no flap → cloned from clean
+    "fit_rejected",  # AeroBuildup ran but the parabolic fit was rejected
+]
+"""How the polar entry was produced."""
+
+
+class ParabolicPolar(BaseModel):
+    """Parabolic drag polar for one high-lift configuration.
+
+    Fields mirror the gh-486 `e_oswald*` keys at the top level of
+    `ComputationContext`, but scoped to one configuration. The clean
+    entry duplicates the existing top-level keys for backward compat;
+    `takeoff` / `landing` entries are new.
+    """
+
+    cd0: float | None = Field(None, description="Zero-lift drag coefficient (parabolic fit)")
+    e_oswald: float | None = Field(None, description="Oswald span efficiency factor in (0.4, 1.0]")
+    cl_max: float = Field(..., description="Maximum lift coefficient for this configuration")
+    e_oswald_r2: float | None = Field(None, description="R² of the parabolic OLS fit (0–1)")
+    e_oswald_quality: Literal["high", "medium", "low", "unknown"] = Field(
+        "unknown", description="Bucketed quality label derived from R²"
+    )
+    flap_deflection_deg: float = Field(
+        0.0, description="Flap deflection used to produce this polar"
+    )
+    provenance: Provenance = Field("aerobuildup", description="How the polar entry was produced")
+
+
+PolarByConfig = dict[ConfigName, ParabolicPolar]
+"""Three-entry mapping cached under `ComputationContext.polar_by_config`.
+
+Serialised to JSON as ``{cfg: ParabolicPolar.model_dump() for cfg in ...}``
+so it survives the round-trip through SQLAlchemy's JSON column.
+"""

--- a/app/services/assumption_compute_service.py
+++ b/app/services/assumption_compute_service.py
@@ -166,6 +166,9 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
     else:
         delta_to = min(15.0, float(ted_max))
         delta_ldg = min(30.0, float(ted_max))
+        # Independent try blocks per configuration (gh-526 review feedback):
+        # a takeoff-sweep failure must not prevent the landing sweep from
+        # running — they are physically independent passes.
         try:
             polar_takeoff = _run_polar_for_deflection(
                 asb_airplane=asb_airplane,
@@ -177,6 +180,16 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
                 cd0_stability=cd0,
                 cl_max_effective_for_fit=cl_max_effective_for_fit,
             )
+        except Exception:
+            logger.exception(
+                "Takeoff-config AeroBuildup failed for aircraft %s (δ=%.1f°) — "
+                "falling back to clean polar",
+                aeroplane_uuid,
+                delta_to,
+            )
+            polar_takeoff = polar_clean.model_copy(update={"provenance": "aerobuildup_failed"})
+
+        try:
             polar_landing = _run_polar_for_deflection(
                 asb_airplane=asb_airplane,
                 flap_deflection_deg=delta_ldg,
@@ -188,14 +201,13 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
                 cl_max_effective_for_fit=cl_max_effective_for_fit,
             )
         except Exception:
-            # Defensive: a flap-deflected sweep failure must not corrupt
-            # the clean polar that is already correctly computed.
             logger.exception(
-                "Flap-deflected AeroBuildup failed for aircraft %s — falling back to clean polar",
+                "Landing-config AeroBuildup failed for aircraft %s (δ=%.1f°) — "
+                "falling back to clean polar",
                 aeroplane_uuid,
+                delta_ldg,
             )
-            polar_takeoff = polar_clean.model_copy(update={"provenance": "fit_rejected"})
-            polar_landing = polar_clean.model_copy(update={"provenance": "fit_rejected"})
+            polar_landing = polar_clean.model_copy(update={"provenance": "aerobuildup_failed"})
 
     polar_by_config = {
         "clean": polar_clean.model_dump(),
@@ -460,11 +472,11 @@ def _build_asb_airplane(aircraft: AeroplaneModel):
 
 def _run_polar_for_deflection(
     *,
-    asb_airplane,
+    asb_airplane: Any,
     flap_deflection_deg: float,
     v_cruise: float,
     v_max: float,
-    config,
+    config: Any,
     aspect_ratio: float | None,
     cd0_stability: float,
     cl_max_effective_for_fit: float | None,
@@ -484,11 +496,12 @@ def _run_polar_for_deflection(
     """
     flap_name = _detect_first_flap_name(asb_airplane)
     if flap_name is None:
-        # Belt-and-braces: caller should have routed to fallback already.
-        return ParabolicPolar(
-            cl_max=0.0,
-            flap_deflection_deg=0.0,
-            provenance="no_flap_geometry",
+        # Caller must route to the no-flap fallback BEFORE invoking this
+        # helper. Returning a sentinel here would feed cl_max=0.0 into
+        # _stall_speed and produce an infinite V_s (review feedback).
+        raise AssertionError(
+            "_run_polar_for_deflection called without a flap surface present — "
+            "this is a caller-side routing bug"
         )
     deflected = asb_airplane.with_control_deflections({flap_name: flap_deflection_deg})
     stall_alpha = _coarse_alpha_sweep(deflected, v_cruise, config)

--- a/app/services/assumption_compute_service.py
+++ b/app/services/assumption_compute_service.py
@@ -37,6 +37,7 @@ from app.models.computation_config import (
 from app.schemas.AeroplaneRequest import AnalysisToolUrlType
 from app.schemas.aeroanalysisschema import OperatingPointSchema
 from app.schemas.design_assumption import PARAMETER_DEFAULTS
+from app.schemas.polar_by_config import ParabolicPolar
 from app.services.design_assumptions_service import (
     _get_aeroplane,
     seed_defaults,
@@ -143,6 +144,66 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
     e_oswald_effective = e_oswald_fit if e_oswald_fit is not None else 0.8
     # -----------------------------------------------------------------------
 
+    # --- gh-526 / epic gh-525 C1: per-configuration parabolic polar -------
+    # Run AeroBuildup once per high-lift configuration so V_s0 (landing)
+    # and V_s1 (clean) reflect physics instead of the 0.95 / 0.90 heuristic
+    # the OPG used historically (audit §5.5).
+    polar_clean = ParabolicPolar(
+        cd0=round(_cd0_fit, 5) if _cd0_fit is not None else None,
+        e_oswald=round(e_oswald_fit, 4) if e_oswald_fit is not None else None,
+        cl_max=round(cl_max, 4),
+        e_oswald_r2=round(e_r2, 4) if e_r2 is not None else None,
+        e_oswald_quality=_classify_polar_quality(e_r2) if e_r2 is not None else "unknown",
+        flap_deflection_deg=0.0,
+        provenance="aerobuildup",
+    )
+
+    ted_max = _extract_flap_ted_max(aircraft)
+    if ted_max is None:
+        # No flap geometry — fallback path: clone clean to takeoff & landing.
+        polar_takeoff = polar_clean.model_copy(update={"provenance": "no_flap_geometry"})
+        polar_landing = polar_clean.model_copy(update={"provenance": "no_flap_geometry"})
+    else:
+        delta_to = min(15.0, float(ted_max))
+        delta_ldg = min(30.0, float(ted_max))
+        try:
+            polar_takeoff = _run_polar_for_deflection(
+                asb_airplane=asb_airplane,
+                flap_deflection_deg=delta_to,
+                v_cruise=v_cruise,
+                v_max=v_max,
+                config=config,
+                aspect_ratio=aspect_ratio,
+                cd0_stability=cd0,
+                cl_max_effective_for_fit=cl_max_effective_for_fit,
+            )
+            polar_landing = _run_polar_for_deflection(
+                asb_airplane=asb_airplane,
+                flap_deflection_deg=delta_ldg,
+                v_cruise=v_cruise,
+                v_max=v_max,
+                config=config,
+                aspect_ratio=aspect_ratio,
+                cd0_stability=cd0,
+                cl_max_effective_for_fit=cl_max_effective_for_fit,
+            )
+        except Exception:
+            # Defensive: a flap-deflected sweep failure must not corrupt
+            # the clean polar that is already correctly computed.
+            logger.exception(
+                "Flap-deflected AeroBuildup failed for aircraft %s — falling back to clean polar",
+                aeroplane_uuid,
+            )
+            polar_takeoff = polar_clean.model_copy(update={"provenance": "fit_rejected"})
+            polar_landing = polar_clean.model_copy(update={"provenance": "fit_rejected"})
+
+    polar_by_config = {
+        "clean": polar_clean.model_dump(),
+        "takeoff": polar_takeoff.model_dump(),
+        "landing": polar_landing.model_dump(),
+    }
+    # -----------------------------------------------------------------------
+
     # --- gh-493: Reynolds-dependent polar table ----------------------------
     # Build a 3-band Re table by rebinning the existing fine-sweep data.
     # V-bands: {V_s_approx, V_cruise, max(1.3·V_cruise, V_max_goal)}.
@@ -244,6 +305,14 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
     p_to_w = _load_effective_assumption(db, aircraft.id, "power_to_weight")
     prop_eta = _load_effective_assumption(db, aircraft.id, "prop_efficiency")
     v_stall = _stall_speed(mass, s_ref, cl_max_effective)
+    # gh-526: per-configuration stall speeds derived from physics. The OPG
+    # consumes these instead of its historical 0.95 / 0.90 heuristic.
+    # v_s1 = clean (alias of v_stall_mps for backward compat).
+    # v_s_to = takeoff (with flaps clipped to TED limit), v_s0 = landing.
+    # When no flap geometry exists, all three fall back to V_s1.
+    v_s1 = v_stall
+    v_s_to = _stall_speed(mass, s_ref, polar_by_config["takeoff"]["cl_max"])
+    v_s0 = _stall_speed(mass, s_ref, polar_by_config["landing"]["cl_max"])
     # Use fitted Oswald e (or fallback 0.8) for V_md and V_min_sink.
     v_md = _min_drag_speed(mass, s_ref, cd0_effective, aspect_ratio, oswald_e=e_oswald_effective)
     v_min_sink = _min_sink_speed(
@@ -323,6 +392,13 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
         "v_cruise_auto": cruise_is_auto,
         "v_max_mps": round(v_max_effective, 1),
         "v_stall_mps": round(v_stall, 1) if v_stall is not None else None,
+        # gh-526: v_s1_mps is the clean-config alias of v_stall_mps; v_s0_mps
+        # is the landing-config stall (with flaps deflected, if geometry has
+        # a flap); v_s_to_mps is the takeoff-config stall. All three derived
+        # from physics, not heuristic scalars.
+        "v_s1_mps": round(v_s1, 1) if v_s1 is not None else None,
+        "v_s_to_mps": round(v_s_to, 1) if v_s_to is not None else None,
+        "v_s0_mps": round(v_s0, 1) if v_s0 is not None else None,
         "v_md_mps": round(v_md, 1) if v_md is not None else None,
         "v_min_sink_mps": round(v_min_sink, 1) if v_min_sink is not None else None,
         "is_glider": is_glider,
@@ -352,6 +428,10 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
         "polar_re_table": polar_re_table,
         "polar_re_table_degenerate": polar_re_table_degenerate,
         "polar_re_table_top_band_fallback": polar_re_table_top_band_fallback,
+        # gh-526: per-configuration polar fits {clean, takeoff, landing}.
+        # See app/schemas/polar_by_config.py.  Replaces the implicit
+        # 0.95 / 0.90 V_s heuristic in operating_point_generator_service.
+        "polar_by_config": polar_by_config,
         "computed_at": datetime.now(timezone.utc).isoformat(),
     }
     enrich_context_with_cg_envelope(
@@ -376,6 +456,104 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
 def _build_asb_airplane(aircraft: AeroplaneModel):
     schema = aeroplane_model_to_aeroplane_schema_async(aircraft)
     return aeroplane_schema_to_asb_airplane_async(plane_schema=schema)
+
+
+def _run_polar_for_deflection(
+    *,
+    asb_airplane,
+    flap_deflection_deg: float,
+    v_cruise: float,
+    v_max: float,
+    config,
+    aspect_ratio: float | None,
+    cd0_stability: float,
+    cl_max_effective_for_fit: float | None,
+) -> ParabolicPolar:
+    """Run AeroBuildup with the flap deflected; return the fitted polar.
+
+    Strategy (gh-526):
+    - Deep-copy the airplane with ``with_control_deflections`` so the
+      original (clean) airplane is unaffected.
+    - Re-use ``_coarse_alpha_sweep`` and ``_fine_sweep_cl_max`` against the
+      deflected airplane to get C_L_max for this configuration.
+    - Re-fit a parabolic polar against the deflected sweep so C_D0 / e
+      reflect the high-lift drag rise.
+
+    On any AeroBuildup error the caller is responsible for falling back
+    to a cloned clean polar with ``provenance="fit_rejected"``.
+    """
+    flap_name = _detect_first_flap_name(asb_airplane)
+    if flap_name is None:
+        # Belt-and-braces: caller should have routed to fallback already.
+        return ParabolicPolar(
+            cl_max=0.0,
+            flap_deflection_deg=0.0,
+            provenance="no_flap_geometry",
+        )
+    deflected = asb_airplane.with_control_deflections({flap_name: flap_deflection_deg})
+    stall_alpha = _coarse_alpha_sweep(deflected, v_cruise, config)
+    cl_max, cl_arr, cd_arr, _v_arr = _fine_sweep_cl_max(
+        deflected, stall_alpha, v_cruise, v_max, config
+    )
+    _cd0_fit, e_oswald_fit, e_r2 = _fit_parabolic_polar(
+        np.asarray(cl_arr, dtype=float),
+        np.asarray(cd_arr, dtype=float),
+        ar=aspect_ratio if aspect_ratio is not None else 0.0,
+        cl_max=cl_max_effective_for_fit if cl_max_effective_for_fit else cl_max,
+        cd0_stability=cd0_stability,
+    )
+    return ParabolicPolar(
+        cd0=round(_cd0_fit, 5) if _cd0_fit is not None else None,
+        e_oswald=round(e_oswald_fit, 4) if e_oswald_fit is not None else None,
+        cl_max=round(float(cl_max), 4),
+        e_oswald_r2=round(e_r2, 4) if e_r2 is not None else None,
+        e_oswald_quality=_classify_polar_quality(e_r2) if e_r2 is not None else "unknown",
+        flap_deflection_deg=float(flap_deflection_deg),
+        provenance="aerobuildup",
+    )
+
+
+def _detect_first_flap_name(asb_airplane) -> str | None:
+    """Return the ASB control-surface name of the first flap-role surface.
+
+    Mirrors ``operating_point_generator_service._pick_control_name`` for
+    the FLAP_ROLES set. Avoids cross-service imports by re-implementing
+    the trivial role-tag parse locally.
+    """
+    for wing in getattr(asb_airplane, "wings", []) or []:
+        for xsec in getattr(wing, "xsecs", []) or []:
+            for cs in getattr(xsec, "control_surfaces", []) or []:
+                raw = str(getattr(cs, "name", "")).strip()
+                # role tag is the substring between the first '[' and ']'
+                if raw.startswith("[") and "]" in raw:
+                    role = raw[1 : raw.index("]")].lower()
+                    if role == "flap":
+                        return raw
+    return None
+
+
+def _extract_flap_ted_max(aircraft: AeroplaneModel) -> float | None:
+    """Return the positive deflection limit of the first flap-role TED.
+
+    Walks ``aircraft.wings → x_secs → trailing_edge_device`` and returns the
+    ``positive_deflection_deg`` of the first TED whose ``role`` is
+    ``"flap"``. Returns ``None`` when no flap-role TED exists — callers use
+    this signal to fall back to a single clean-config polar.
+
+    gh-526 / epic gh-525 finding C1.
+    """
+    for wing in getattr(aircraft, "wings", []) or []:
+        for xsec in getattr(wing, "x_secs", []) or []:
+            ted = getattr(xsec, "trailing_edge_device", None)
+            if ted is None:
+                continue
+            role = (getattr(ted, "role", None) or "other").lower()
+            if role == "flap":
+                limit = getattr(ted, "positive_deflection_deg", None)
+                if limit is None:
+                    return 25.0  # mirror converter fallback (gh-526)
+                return float(limit)
+    return None
 
 
 def _load_or_create_config(db: Session, aeroplane_id: int) -> AircraftComputationConfigModel:

--- a/app/services/field_length_service.py
+++ b/app/services/field_length_service.py
@@ -59,15 +59,17 @@ logger = logging.getLogger(__name__)
 # Physical and formula constants
 # ---------------------------------------------------------------------------
 
-_RHO_SL: float = 1.225      # kg/m³ — sea-level ISA density
-_G: float = 9.81             # m/s² — standard gravity
+_RHO_SL: float = 1.225  # kg/m³ — sea-level ISA density
+_G: float = 9.81  # m/s² — standard gravity
 
 # Roskam §3.4 simplified ground-roll coefficient
 _C_TO: float = 1.21
 
 # Obstacle correction factors
-_K_TO_50FT: float = 1.66     # Roskam §3.4, SE-piston AEO, 50-ft obstacle
-_K_LDG_50FT: float = 2.73    # Roskam §3.4 total from 50 ft ÷ ground roll (≈ 2.5–3.0 for light aircraft)
+_K_TO_50FT: float = 1.66  # Roskam §3.4, SE-piston AEO, 50-ft obstacle
+_K_LDG_50FT: float = (
+    2.73  # Roskam §3.4 total from 50 ft ÷ ground roll (≈ 2.5–3.0 for light aircraft)
+)
 # NOTE: Roskam gives k_LDG_50ft ≈ 1.5 for the *air phase alone*; the full
 # total-from-50ft multiplier (air + ground) is ~2.5–3.0.  The Cessna 172N
 # POH cross-check calibrates this to 2.73 (410 m / 150 m).
@@ -77,8 +79,8 @@ _K_LDG_50FT: float = 2.73    # Roskam §3.4 total from 50 ft ÷ ground roll (≈
 _K_LDG_HARD: float = 0.5847
 
 # Friction coefficients
-_MU_BRAKE_HARD: float = 0.4    # braking, dry hard runway
-_MU_BELLY: float = 0.5         # belly landing (grass + fuselage scraping)
+_MU_BRAKE_HARD: float = 0.4  # braking, dry hard runway
+_MU_BELLY: float = 0.5  # belly landing (grass + fuselage scraping)
 
 # Roskam §3.4 note: T in the formula is the mean thrust during ground roll.
 # For RC propellers, T_mean ≈ 0.75 · T_static_zero_velocity.
@@ -93,18 +95,18 @@ _MU_BELLY: float = 0.5         # belly landing (grass + fuselage scraping)
 _T_STATIC_MEAN_FACTOR: float = 1.0  # T as supplied (factor encoded in 1.21 constant)
 
 # V factors (Roskam standard)
-_V_LOF_FACTOR: float = 1.2    # V_LOF = 1.2 · V_S
-_V_APP_FACTOR: float = 1.3    # V_app = 1.3 · V_S
+_V_LOF_FACTOR: float = 1.2  # V_LOF = 1.2 · V_S
+_V_APP_FACTOR: float = 1.3  # V_app = 1.3 · V_S
 
 # Hand-launch V_throw thresholds
-_HAND_THROW_FLOOR: float = 1.10   # physics floor (must be ≥ 1.10·V_S)
-_HAND_THROW_WARN: float = 1.20    # climb-out margin warning (< 1.20·V_S)
+_HAND_THROW_FLOOR: float = 1.10  # physics floor (must be ≥ 1.10·V_S)
+_HAND_THROW_WARN: float = 1.20  # climb-out margin warning (< 1.20·V_S)
 _HAND_THROW_DEFAULT: float = 10.0  # m/s default throw speed
 
 # Flap type → (CL_max_TO_factor, CL_max_LDG_factor)
 # Source: gh-489 spec, Amendment 2
 _FLAP_FACTORS: dict[str | None, tuple[float, float]] = {
-    None: (1.0, 1.0),           # no flaps
+    None: (1.0, 1.0),  # no flaps
     "none": (1.0, 1.0),
     "plain": (1.1, 1.3),
     "slotted": (1.1, 1.3),
@@ -189,9 +191,9 @@ def _compute_s_to_ground(
     where T is the de-rated mean static thrust: T_mean = T_static_factor · T_static.
     """
     weight_n = mass_kg * g
-    wing_loading = weight_n / s_ref_m2              # W/S [N/m²]
-    t_mean = _T_STATIC_MEAN_FACTOR * t_static_N     # effective thrust [N]
-    t_over_w = t_mean / weight_n                    # T/W dimensionless
+    wing_loading = weight_n / s_ref_m2  # W/S [N/m²]
+    t_mean = _T_STATIC_MEAN_FACTOR * t_static_N  # effective thrust [N]
+    t_over_w = t_mean / weight_n  # T/W dimensionless
     return _C_TO * wing_loading / (rho * g * cl_max_to * t_over_w)
 
 
@@ -321,16 +323,17 @@ def compute_field_lengths(
     flap_type: str | None = aircraft.get("flap_type", None)
     to_factor, ldg_factor = detect_cl_max_flap_factors(flap_type)
 
-    cl_max_to: float = float(
-        aircraft.get("cl_max_takeoff") or cl_max_base * to_factor
-    )
-    cl_max_ldg: float = float(
-        aircraft.get("cl_max_landing") or cl_max_base * ldg_factor
-    )
+    cl_max_to: float = float(aircraft.get("cl_max_takeoff") or cl_max_base * to_factor)
+    cl_max_ldg: float = float(aircraft.get("cl_max_landing") or cl_max_base * ldg_factor)
 
     # --- Derived speeds ------------------------------------------------------
-    v_lof = _v_lof(v_stall)
-    v_app = _v_app(v_stall)
+    # gh-526: prefer the per-configuration V_s when present (cached by
+    # assumption_compute_service after one AeroBuildup pass per high-lift
+    # configuration). Falls back to the clean V_s for pre-gh-526 contexts.
+    v_stall_to: float = float(aircraft.get("v_s_to_mps") or v_stall)
+    v_stall_ldg: float = float(aircraft.get("v_s0_mps") or v_stall)
+    v_lof = _v_lof(v_stall_to)
+    v_app = _v_app(v_stall_ldg)
 
     # --- Takeoff field length -------------------------------------------------
     s_to_ground: float
@@ -384,9 +387,7 @@ def compute_field_lengths(
     else:  # runway
         _check_thrust(aircraft, takeoff_mode)
         t_static = float(aircraft["t_static_N"])
-        s_to_ground = _compute_s_to_ground(
-            mass_kg, s_ref_m2, cl_max_to, t_static, rho, g
-        )
+        s_to_ground = _compute_s_to_ground(mass_kg, s_ref_m2, cl_max_to, t_static, rho, g)
         s_to_50ft = _apply_obstacle_factor(s_to_ground, _K_TO_50FT)
 
     # --- Landing field length -------------------------------------------------
@@ -397,9 +398,7 @@ def compute_field_lengths(
     else:  # runway
         mu_brake = _MU_BRAKE_HARD
 
-    s_ldg_ground = _compute_s_ldg_ground(
-        mass_kg, s_ref_m2, cl_max_ldg, rho, g, mu_brake
-    )
+    s_ldg_ground = _compute_s_ldg_ground(mass_kg, s_ref_m2, cl_max_ldg, rho, g, mu_brake)
     s_ldg_50ft = _apply_obstacle_factor(s_ldg_ground, _K_LDG_50FT)
 
     return {

--- a/app/services/operating_point_generator_service.py
+++ b/app/services/operating_point_generator_service.py
@@ -204,40 +204,48 @@ def _estimate_reference_speeds(
 ) -> dict[str, float]:
     """Estimate clean / take-off / landing stall speeds for OP seeding.
 
-    Precedence (gh-475 — audit §4.3, the cruise/margin path inverts
-    physical causality and produces 2.5×-too-high V_s for STOL designs):
+    Precedence (gh-526 — epic gh-525 finding C1; replaces the historical
+    0.95 / 0.90 V_s heuristic):
 
-    1. ``cached_context["v_stall_mps"]`` when available — this is the
-       physics-derived value ``√(2·m·g / (ρ·S·C_L_max))`` cached by
-       ``assumption_compute_service`` after an AeroBuildup pass.
-    2. ``V_cruise / min_speed_margin_vs_clean`` as a cold-start fallback
+    1. ``cached_context["v_s1_mps"]`` / ``v_s_to_mps`` / ``v_s0_mps`` when
+       available — these are the **physics-derived** stall speeds
+       ``√(2·m·g / (ρ·S·C_L_max_cfg))`` cached by
+       ``assumption_compute_service`` after one ``AeroBuildup`` pass per
+       configuration.
+    2. ``cached_context["v_stall_mps"]`` only (legacy / pre-gh-526
+       context): fall back to using the clean stall for all three
+       configs. The historical 0.95 / 0.90 multipliers are **not** applied
+       because they have no physical basis (audit §5.5).
+    3. ``V_cruise / min_speed_margin_vs_clean`` as a cold-start fallback
        when no polar has been computed yet.
-
-    Configuration / flap deltas:
-    - ``vs_to``  ≈ 0.95 · V_s_clean (mild high-lift effect)
-    - ``vs_ldg`` ≈ 0.90 · V_s_clean (full flaps)
-    These multipliers are retained from the original implementation; a
-    proper fix needs ``C_L_max_landing`` in design assumptions (separate
-    ticket).
     """
     goals = profile["goals"]
     cruise = float(goals.get("cruise_speed_mps", 18.0))
     min_margin_clean = max(1.05, float(goals.get("min_speed_margin_vs_clean", 1.20)))
 
-    cached_vs = None
-    if cached_context is not None:
-        raw = cached_context.get("v_stall_mps")
+    def _pick(key: str) -> float | None:
+        if cached_context is None:
+            return None
+        raw = cached_context.get(key)
         if isinstance(raw, (int, float)) and raw > 0:
-            cached_vs = float(raw)
+            return float(raw)
+        return None
 
-    vs_clean = cached_vs if cached_vs is not None else max(3.0, cruise / min_margin_clean)
-    vs_to = max(2.5, vs_clean * 0.95)
-    vs_ldg = max(2.0, vs_clean * 0.90)
+    vs_clean_ctx = _pick("v_s1_mps") or _pick("v_stall_mps")
+    if vs_clean_ctx is None:
+        vs_clean = max(3.0, cruise / min_margin_clean)
+        vs_to = vs_clean
+        vs_ldg = vs_clean
+    else:
+        vs_clean = vs_clean_ctx
+        # Prefer per-config physics; fall back to clean value when missing.
+        vs_to = _pick("v_s_to_mps") or vs_clean
+        vs_ldg = _pick("v_s0_mps") or vs_clean
 
     return {
-        "vs_clean": vs_clean,
-        "vs_to": vs_to,
-        "vs_ldg": vs_ldg,
+        "vs_clean": max(3.0, vs_clean),
+        "vs_to": max(2.5, vs_to),
+        "vs_ldg": max(2.0, vs_ldg),
     }
 
 
@@ -696,9 +704,7 @@ def _trim_or_estimate_point(
     # the legacy aircraft.total_mass_kg field — that way Component-Tree
     # weight changes (which sync into the mass assumption) flow into
     # CL_target without requiring a separate aircraft-level update.
-    mass_for_cl = (
-        effective_mass_kg if effective_mass_kg is not None else aircraft.total_mass_kg
-    )
+    mass_for_cl = effective_mass_kg if effective_mass_kg is not None else aircraft.total_mass_kg
 
     def cl_target_fn(v: float) -> Optional[float]:
         return _cl_target_for_velocity(v, mass_for_cl, s_ref, rho, n_target)
@@ -856,9 +862,7 @@ def generate_default_set_for_aircraft(
         # Effective values from design assumptions take precedence over
         # legacy aircraft fields, so Component-Tree weight changes and
         # SM choices flow into the trim solution without an extra step.
-        effective_mass_kg = _load_effective_mass_kg(
-            db, aircraft.id, aircraft.total_mass_kg
-        )
+        effective_mass_kg = _load_effective_mass_kg(db, aircraft.id, aircraft.total_mass_kg)
         design_cg_x = _load_design_cg_x(db, aircraft.id)
 
         # Seed V_s from cached physics when available; cruise/margin only
@@ -1001,9 +1005,7 @@ def trim_operating_point_for_aircraft(
                 },
             )
 
-        effective_mass_kg = _load_effective_mass_kg(
-            db, aircraft.id, aircraft.total_mass_kg
-        )
+        effective_mass_kg = _load_effective_mass_kg(db, aircraft.id, aircraft.total_mass_kg)
         design_cg_x = _load_design_cg_x(db, aircraft.id)
 
         point = _trim_or_estimate_point(

--- a/app/tests/test_assumption_compute_service.py
+++ b/app/tests/test_assumption_compute_service.py
@@ -2,8 +2,10 @@
 
 All AeroSandbox-bound helpers are stubbed so tests run without ASB installed.
 """
+
 from __future__ import annotations
 
+import contextlib
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -15,42 +17,102 @@ from app.services.design_assumptions_service import seed_defaults
 from app.tests.conftest import make_aeroplane
 
 
-def _make_fake_airplane():
+@contextlib.contextmanager
+def _enter_patches(flap_ted_max: float | None = None, fine_sweep_cl_max: float = 1.35):
+    """Enter all stubs as a single context manager.
+
+    Replaces the historical ``p1, p2, p3, p4, p5, p6 = _patches()`` unpack —
+    the patch count grew with gh-526 (flap TED extraction). Using ExitStack
+    keeps call sites stable across future stub additions.
+    """
+    with contextlib.ExitStack() as stack:
+        for patcher in _patches(flap_ted_max=flap_ted_max, fine_sweep_cl_max=fine_sweep_cl_max):
+            stack.enter_context(patcher)
+        yield
+
+
+def _make_fake_airplane(with_flap: bool = False):
     """Stub for asb_airplane: a wing with .area/.mean_aerodynamic_chord/.span()
-    so _select_main_wing + the s_ref/c_ref/b_ref override don't blow up."""
+    so _select_main_wing + the s_ref/c_ref/b_ref override don't blow up.
+
+    `with_control_deflections` (gh-526) returns self, recording the call so
+    tests can spy on flap-deflection invocations.
+
+    When ``with_flap=True``, the wing carries a single xsec with a
+    ``[flap]Flap`` control surface so that ``_detect_first_flap_name``
+    can find it.
+    """
+    flap_cs = SimpleNamespace(name="[flap]Flap", deflection=0.0)
+    xsec = SimpleNamespace(control_surfaces=[flap_cs] if with_flap else [])
     fake_wing = SimpleNamespace(
         area=lambda: 0.30,
         mean_aerodynamic_chord=lambda: 0.20,
         span=lambda: 1.5,
+        xsecs=[xsec],
     )
-    return SimpleNamespace(
+    plane = SimpleNamespace(
         wings=[fake_wing],
         xyz_ref=[0.08, 0.0, 0.0],
         s_ref=0.30,
         c_ref=0.20,
         b_ref=1.5,
+        _deflection_calls=[],
     )
 
+    def with_control_deflections(mapping: dict):
+        plane._deflection_calls.append(dict(mapping))
+        return plane
 
-def _patches():
-    """Stub the three ASB-bound helpers so tests don't need real ASB."""
+    plane.with_control_deflections = with_control_deflections
+    return plane
+
+
+def _patches(flap_ted_max: float | None = None, fine_sweep_cl_max: float = 1.35):
+    """Stub the ASB-bound helpers so tests don't need real ASB.
+
+    Args:
+        flap_ted_max: When None, simulates no flap geometry → fallback path.
+            When float, simulates a flap with `positive_deflection_deg` =
+            this value → 3 AeroBuildup passes.
+        fine_sweep_cl_max: The C_L_max that the fine sweep returns. For the
+            flapped configs we wrap the fine-sweep mock so that each call
+            returns a different C_L_max (clean / takeoff / landing).
+    """
+    fake_airplane = _make_fake_airplane(with_flap=flap_ted_max is not None)
+
+    # gh-526: the fine sweep is called once per configuration when a flap
+    # exists. For the no-flap path, only the clean call happens.
+    cl_array = np.array([0.2, 0.4, 0.6, 0.8, 1.0, 1.2])
+    cd_array = np.array([0.026, 0.028, 0.032, 0.039, 0.049, 0.062])
+    v_array = np.linspace(9.0, 28.0, 6)
+
+    # Different C_L_max per config so v_s0 < v_s1 in tests.
+    # Order of calls: clean, takeoff, landing.
+    cl_max_sequence = [fine_sweep_cl_max, fine_sweep_cl_max + 0.4, fine_sweep_cl_max + 0.8]
+    sweep_call = {"i": 0}
+
+    def fine_sweep_side_effect(*_args, **_kwargs):
+        i = sweep_call["i"]
+        sweep_call["i"] += 1
+        idx = min(i, len(cl_max_sequence) - 1)
+        return (cl_max_sequence[idx], cl_array, cd_array, v_array)
+
     return (
         patch(
             "app.services.assumption_compute_service._build_asb_airplane",
-            return_value=_make_fake_airplane(),
+            return_value=fake_airplane,
         ),
         patch(
             "app.services.assumption_compute_service._stability_run_at_cruise",
-            return_value=(0.085, 0.20, 0.025, 0.30),  # x_np, MAC, CD0
+            return_value=(0.085, 0.20, 0.025, 0.30),  # x_np, MAC, CD0, s_ref
         ),
         patch(
             "app.services.assumption_compute_service._coarse_alpha_sweep",
-            return_value=15.0,  # stall_alpha_deg
+            return_value=15.0,
         ),
         patch(
             "app.services.assumption_compute_service._fine_sweep_cl_max",
-            # gh-493: now returns 4-tuple (cl_max, cl_array, cd_array, v_array)
-            return_value=(1.35, np.array([0.2, 0.4, 0.6, 0.8, 1.0, 1.2]), np.array([0.026, 0.028, 0.032, 0.039, 0.049, 0.062]), np.linspace(9.0, 28.0, 6)),
+            side_effect=fine_sweep_side_effect,
         ),
         patch(
             "app.services.assumption_compute_service._extract_cl_alpha_from_linear_sweep",
@@ -59,6 +121,10 @@ def _patches():
         patch(
             "app.services.assumption_compute_service._load_flight_profile_speeds",
             return_value=(18.0, 28.0, True),
+        ),
+        patch(
+            "app.services.assumption_compute_service._extract_flap_ted_max",
+            return_value=flap_ted_max,
         ),
     )
 
@@ -72,8 +138,7 @@ def test_recompute_writes_all_three_assumptions(client_and_db):
         aeroplane_uuid = str(aeroplane.uuid)
         aeroplane_id = aeroplane.id
 
-    p1, p2, p3, p4, p5, p6 = _patches()
-    with p1, p2, p3, p4, p5, p6:
+    with _enter_patches():
         with SessionLocal() as db:
             recompute_assumptions(db, aeroplane_uuid)
             db.commit()
@@ -110,11 +175,7 @@ def test_recompute_skips_when_no_wings(client_and_db):
             db.commit()
 
     with SessionLocal() as db:
-        cd0 = (
-            db.query(DesignAssumptionModel)
-            .filter_by(parameter_name="cd0")
-            .first()
-        )
+        cd0 = db.query(DesignAssumptionModel).filter_by(parameter_name="cd0").first()
         assert cd0.calculated_value is None  # untouched
 
 
@@ -179,11 +240,7 @@ def test_recompute_aborts_cleanly_on_asb_exception(client_and_db):
 
     # Pre-existing value survives.
     with SessionLocal() as db:
-        cd0_row = (
-            db.query(DesignAssumptionModel)
-            .filter_by(parameter_name="cd0")
-            .first()
-        )
+        cd0_row = db.query(DesignAssumptionModel).filter_by(parameter_name="cd0").first()
         assert cd0_row.calculated_value == 0.9999
         assert cd0_row.calculated_source == "previous_run"
 
@@ -206,9 +263,8 @@ def test_recompute_caches_context_and_publishes_cg_change(client_and_db):
     handler = captured.append
     event_bus.subscribe(AssumptionChanged, handler)
 
-    p1, p2, p3, p4, p5, p6 = _patches()
     try:
-        with p1, p2, p3, p4, p5, p6:
+        with _enter_patches():
             with SessionLocal() as db:
                 recompute_assumptions(db, aeroplane_uuid)
                 db.commit()
@@ -218,6 +274,7 @@ def test_recompute_caches_context_and_publishes_cg_change(client_and_db):
 
     with SessionLocal() as db:
         from app.models.aeroplanemodel import AeroplaneModel
+
         a = db.query(AeroplaneModel).filter_by(id=aeroplane_id).first()
         ctx = a.assumption_computation_context
         assert ctx["v_cruise_mps"] == 18.0
@@ -238,14 +295,14 @@ def test_b_ref_m_is_in_context_after_recompute(client_and_db):
         aeroplane_uuid = str(aeroplane.uuid)
         aeroplane_id = aeroplane.id
 
-    p1, p2, p3, p4, p5, p6 = _patches()
-    with p1, p2, p3, p4, p5, p6:
+    with _enter_patches():
         with SessionLocal() as db:
             recompute_assumptions(db, aeroplane_uuid)
             db.commit()
 
     with SessionLocal() as db:
         from app.models.aeroplanemodel import AeroplaneModel
+
         a = db.query(AeroplaneModel).filter_by(id=aeroplane_id).first()
         ctx = a.assumption_computation_context
         assert "b_ref_m" in ctx, "b_ref_m must be present in assumption_computation_context"
@@ -266,14 +323,14 @@ def test_polar_re_table_keys_in_context(client_and_db):
         aeroplane_uuid = str(aeroplane.uuid)
         aeroplane_id = aeroplane.id
 
-    p1, p2, p3, p4, p5, p6 = _patches()
-    with p1, p2, p3, p4, p5, p6:
+    with _enter_patches():
         with SessionLocal() as db:
             recompute_assumptions(db, aeroplane_uuid)
             db.commit()
 
     with SessionLocal() as db:
         from app.models.aeroplanemodel import AeroplaneModel
+
         a = db.query(AeroplaneModel).filter_by(id=aeroplane_id).first()
         ctx = a.assumption_computation_context
 
@@ -285,9 +342,183 @@ def test_polar_re_table_keys_in_context(client_and_db):
 
         # Backward-compat: scalar cd0 and e_oswald must BOTH still be present (gh-486)
         # (they may be None if fit failed, but the keys must exist)
-        assert "cd0" in ctx, (
-            "Backward-compat scalar key 'cd0' must remain in context"
-        )
-        assert "e_oswald" in ctx, (
-            "Backward-compat scalar key 'e_oswald' must remain in context"
-        )
+        assert "cd0" in ctx, "Backward-compat scalar key 'cd0' must remain in context"
+        assert "e_oswald" in ctx, "Backward-compat scalar key 'e_oswald' must remain in context"
+
+
+# ============================================================================
+# gh-526 / epic gh-525 finding C1 — per-configuration polar
+# ============================================================================
+
+
+def _load_ctx(SessionLocal, aeroplane_id: int) -> dict:
+    """Read assumption_computation_context for the given aeroplane."""
+    from app.models.aeroplanemodel import AeroplaneModel
+
+    with SessionLocal() as db:
+        a = db.query(AeroplaneModel).filter_by(id=aeroplane_id).first()
+        return a.assumption_computation_context
+
+
+def test_context_has_polar_by_config_with_three_keys(client_and_db):
+    """T1: ComputationContext exposes polar_by_config with clean/takeoff/landing.
+
+    gh-526 AC: ``polar_by_config`` populated for all three keys.
+    """
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
+        aeroplane_id = aeroplane.id
+
+    with _enter_patches(flap_ted_max=30.0):
+        with SessionLocal() as db:
+            recompute_assumptions(db, aeroplane_uuid)
+            db.commit()
+
+    ctx = _load_ctx(SessionLocal, aeroplane_id)
+    assert "polar_by_config" in ctx
+    assert set(ctx["polar_by_config"].keys()) == {"clean", "takeoff", "landing"}
+    for cfg in ("clean", "takeoff", "landing"):
+        entry = ctx["polar_by_config"][cfg]
+        assert "cl_max" in entry
+        assert "cd0" in entry
+        assert "e_oswald" in entry
+        assert "flap_deflection_deg" in entry
+        assert "provenance" in entry
+
+
+def test_no_flap_aircraft_runs_one_pass_with_fallback_flag(client_and_db):
+    """T2b: no flap geometry → 1 AeroBuildup pass, takeoff/landing cloned from clean."""
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
+        aeroplane_id = aeroplane.id
+
+    # flap_ted_max=None → no flap → fallback
+    with (
+        patch(
+            "app.services.assumption_compute_service._fine_sweep_cl_max",
+            return_value=(
+                1.35,
+                np.array([0.2, 0.4, 0.6, 0.8, 1.0, 1.2]),
+                np.array([0.026, 0.028, 0.032, 0.039, 0.049, 0.062]),
+                np.linspace(9.0, 28.0, 6),
+            ),
+        ) as fine_sweep_mock,
+        _enter_patches_no_fine_sweep(flap_ted_max=None),
+    ):
+        with SessionLocal() as db:
+            recompute_assumptions(db, aeroplane_uuid)
+            db.commit()
+
+    assert fine_sweep_mock.call_count == 1, (
+        f"Expected 1 AeroBuildup pass (no flap geometry), got {fine_sweep_mock.call_count}"
+    )
+
+    ctx = _load_ctx(SessionLocal, aeroplane_id)
+    pbc = ctx["polar_by_config"]
+    assert pbc["clean"]["provenance"] == "aerobuildup"
+    assert pbc["takeoff"]["provenance"] == "no_flap_geometry"
+    assert pbc["landing"]["provenance"] == "no_flap_geometry"
+    # C_L_max identical when fallback cloned from clean
+    assert pbc["clean"]["cl_max"] == pbc["takeoff"]["cl_max"] == pbc["landing"]["cl_max"]
+
+
+def test_flapped_aircraft_runs_three_passes_and_v_s0_less_than_v_s1(client_and_db):
+    """T2a + T3: flap present → 3 AeroBuildup passes; V_s0 (landing) < V_s1 (clean)."""
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
+        aeroplane_id = aeroplane.id
+
+    with _enter_patches(flap_ted_max=30.0):
+        with SessionLocal() as db:
+            recompute_assumptions(db, aeroplane_uuid)
+            db.commit()
+
+    ctx = _load_ctx(SessionLocal, aeroplane_id)
+    pbc = ctx["polar_by_config"]
+    # Landing C_L_max > clean → V_s0 < V_s1
+    assert pbc["landing"]["cl_max"] > pbc["clean"]["cl_max"]
+    assert pbc["takeoff"]["cl_max"] > pbc["clean"]["cl_max"]
+    # All three provenance = aerobuildup when flap is present
+    assert pbc["clean"]["provenance"] == "aerobuildup"
+    assert pbc["takeoff"]["provenance"] == "aerobuildup"
+    assert pbc["landing"]["provenance"] == "aerobuildup"
+
+    assert ctx["v_s1_mps"] is not None
+    assert ctx["v_s0_mps"] is not None
+    assert ctx["v_s0_mps"] < ctx["v_s1_mps"], (
+        f"V_s0 must be smaller than V_s1 with flap; got v_s0={ctx['v_s0_mps']}, "
+        f"v_s1={ctx['v_s1_mps']}"
+    )
+
+
+def test_v_s1_alias_matches_v_stall_for_backward_compat(client_and_db):
+    """T4: v_stall_mps == v_s1_mps (clean stall, backward-compat alias).
+
+    field_length_service, flight_envelope_service, matching_chart_service all
+    read v_stall_mps — preserving the alias keeps them correct.
+    """
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
+        aeroplane_id = aeroplane.id
+
+    with _enter_patches(flap_ted_max=30.0):
+        with SessionLocal() as db:
+            recompute_assumptions(db, aeroplane_uuid)
+            db.commit()
+
+    ctx = _load_ctx(SessionLocal, aeroplane_id)
+    assert ctx["v_stall_mps"] == ctx["v_s1_mps"]
+
+
+def test_flap_takeoff_deflection_clipped_to_ted_max(client_and_db):
+    """T5: default δ_to=15° respects TED.positive_deflection_deg.
+
+    With a TED limit of 10°, the takeoff polar should be computed with
+    δ_to=10° (clipped), not 15°.
+    """
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
+        aeroplane_id = aeroplane.id
+
+    with _enter_patches(flap_ted_max=10.0):
+        with SessionLocal() as db:
+            recompute_assumptions(db, aeroplane_uuid)
+            db.commit()
+
+    ctx = _load_ctx(SessionLocal, aeroplane_id)
+    pbc = ctx["polar_by_config"]
+    assert pbc["takeoff"]["flap_deflection_deg"] == 10.0
+    assert pbc["landing"]["flap_deflection_deg"] == 10.0
+
+
+@contextlib.contextmanager
+def _enter_patches_no_fine_sweep(flap_ted_max: float | None = None):
+    """Variant: skip the fine_sweep patch so the test can supply its own
+    mock with call-counting."""
+    with contextlib.ExitStack() as stack:
+        for patcher in _patches(flap_ted_max=flap_ted_max):
+            # Skip the fine_sweep patcher so the test owns it.
+            if "_fine_sweep_cl_max" in getattr(patcher, "attribute", ""):
+                continue
+            stack.enter_context(patcher)
+        yield

--- a/app/tests/test_assumption_compute_service.py
+++ b/app/tests/test_assumption_compute_service.py
@@ -486,11 +486,49 @@ def test_v_s1_alias_matches_v_stall_for_backward_compat(client_and_db):
     assert ctx["v_stall_mps"] == ctx["v_s1_mps"]
 
 
-def test_flap_takeoff_deflection_clipped_to_ted_max(client_and_db):
-    """T5: default δ_to=15° respects TED.positive_deflection_deg.
+def test_aerobuildup_failure_falls_back_to_clean_polar(client_and_db):
+    """T6: when the flap-deflected AeroBuildup raises, the corresponding
+    config falls back to the clean polar with provenance='aerobuildup_failed'.
 
-    With a TED limit of 10°, the takeoff polar should be computed with
-    δ_to=10° (clipped), not 15°.
+    Audits the independent-try-block change so a takeoff failure does NOT
+    prevent the landing pass from running (review feedback).
+    """
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
+        aeroplane_id = aeroplane.id
+
+    # Force the flap-deflected helper to raise — the clean polar should
+    # still be produced, and both takeoff/landing get the fallback flag.
+    with (
+        patch(
+            "app.services.assumption_compute_service._run_polar_for_deflection",
+            side_effect=RuntimeError("simulated AeroBuildup crash"),
+        ),
+        _enter_patches(flap_ted_max=30.0),
+    ):
+        with SessionLocal() as db:
+            recompute_assumptions(db, aeroplane_uuid)
+            db.commit()
+
+    ctx = _load_ctx(SessionLocal, aeroplane_id)
+    pbc = ctx["polar_by_config"]
+    assert pbc["clean"]["provenance"] == "aerobuildup"
+    assert pbc["takeoff"]["provenance"] == "aerobuildup_failed"
+    assert pbc["landing"]["provenance"] == "aerobuildup_failed"
+    # Fallback uses clean cl_max so V_s comes out as the clean stall.
+    assert pbc["takeoff"]["cl_max"] == pbc["clean"]["cl_max"]
+    assert pbc["landing"]["cl_max"] == pbc["clean"]["cl_max"]
+
+
+def test_flap_takeoff_deflection_clipped_to_ted_max(client_and_db):
+    """T7: default δ_to=15° and δ_ldg=30° are clipped to TED.positive_deflection_deg.
+
+    With a TED limit of 10°, both takeoff and landing polars should be
+    computed at δ=10°, not 15° / 30°.
     """
     _, SessionLocal = client_and_db
     with SessionLocal() as db:

--- a/app/tests/test_field_length.py
+++ b/app/tests/test_field_length.py
@@ -24,8 +24,8 @@ CESSNA_172 = {
     "cl_max": 1.5,
     "cl_max_takeoff": 1.5,
     "cl_max_landing": 2.1,
-    "t_static_N": 1900.0,   # approximately 0.75 * T_static_zero = 0.75 * 2535
-    "v_stall_mps": 25.4,    # matches POH stall speed
+    "t_static_N": 1900.0,  # approximately 0.75 * T_static_zero = 0.75 * 2535
+    "v_stall_mps": 25.4,  # matches POH stall speed
 }
 
 
@@ -33,19 +33,23 @@ CESSNA_172 = {
 # Convenience import helpers
 # ---------------------------------------------------------------------------
 
+
 def _service():
     from app.services.field_length_service import compute_field_lengths
+
     return compute_field_lengths
 
 
 def _helpers():
     from app.services import field_length_service as fls
+
     return fls
 
 
 # ===========================================================================
 # Cessna 172N cross-check (4 assertions, ±15%)
 # ===========================================================================
+
 
 class TestFieldLengthRunway:
     """Cessna 172N at MTOM, sea level ISA — cross-check against POH data.
@@ -64,9 +68,7 @@ class TestFieldLengthRunway:
         """s_TO_ground ≈ 270 m ± 15%."""
         result = _service()(CESSNA_172, takeoff_mode="runway", landing_mode="runway")
         s = result["s_to_ground_m"]
-        assert 270 * 0.85 <= s <= 270 * 1.15, (
-            f"Expected s_TO_ground ≈ 270 m ±15%, got {s:.1f} m"
-        )
+        assert 270 * 0.85 <= s <= 270 * 1.15, f"Expected s_TO_ground ≈ 270 m ±15%, got {s:.1f} m"
 
     def test_cessna172_to_50ft(self):
         """s_TO_50ft ≈ 470 m ± 15%.
@@ -77,34 +79,32 @@ class TestFieldLengthRunway:
         """
         result = _service()(CESSNA_172, takeoff_mode="runway", landing_mode="runway")
         s = result["s_to_50ft_m"]
-        assert 470 * 0.85 <= s <= 470 * 1.15, (
-            f"Expected s_TO_50ft ≈ 470 m ±15%, got {s:.1f} m"
-        )
+        assert 470 * 0.85 <= s <= 470 * 1.15, f"Expected s_TO_50ft ≈ 470 m ±15%, got {s:.1f} m"
 
     def test_cessna172_ldg_ground(self):
         """s_LDG_ground ≈ 160 m ± 15%."""
         result = _service()(CESSNA_172, takeoff_mode="runway", landing_mode="runway")
         s = result["s_ldg_ground_m"]
-        assert 160 * 0.85 <= s <= 160 * 1.15, (
-            f"Expected s_LDG_ground ≈ 160 m ±15%, got {s:.1f} m"
-        )
+        assert 160 * 0.85 <= s <= 160 * 1.15, f"Expected s_LDG_ground ≈ 160 m ±15%, got {s:.1f} m"
 
     def test_cessna172_ldg_50ft(self):
         """s_LDG_50ft ≈ 410 m ± 15%."""
         result = _service()(CESSNA_172, takeoff_mode="runway", landing_mode="runway")
         s = result["s_ldg_50ft_m"]
-        assert 410 * 0.85 <= s <= 410 * 1.15, (
-            f"Expected s_LDG_50ft ≈ 410 m ±15%, got {s:.1f} m"
-        )
+        assert 410 * 0.85 <= s <= 410 * 1.15, f"Expected s_LDG_50ft ≈ 410 m ±15%, got {s:.1f} m"
 
     def test_result_contains_required_fields(self):
         """Result dict has all required output fields."""
         result = _service()(CESSNA_172)
         required = {
-            "s_to_ground_m", "s_to_50ft_m",
-            "s_ldg_ground_m", "s_ldg_50ft_m",
-            "vto_obstacle_mps", "vapp_mps",
-            "mode_takeoff", "mode_landing",
+            "s_to_ground_m",
+            "s_to_50ft_m",
+            "s_ldg_ground_m",
+            "s_ldg_50ft_m",
+            "vto_obstacle_mps",
+            "vapp_mps",
+            "mode_takeoff",
+            "mode_landing",
             "warnings",
         }
         missing = required - result.keys()
@@ -122,10 +122,36 @@ class TestFieldLengthRunway:
         v_stall = CESSNA_172["v_stall_mps"]
         assert abs(result["vapp_mps"] - 1.3 * v_stall) < 0.1
 
+    def test_per_config_v_s_used_when_available(self):
+        """gh-526: when v_s_to_mps and v_s0_mps are in the aircraft context,
+        V_LOF and V_APP must be derived from them (per-flap-config physics),
+        not from the clean v_stall_mps."""
+        aircraft = dict(CESSNA_172)
+        # Simulate gh-526 context: takeoff stall ~7% below clean, landing
+        # ~17% below clean (matches Anderson §4.10 plain-flap envelope).
+        aircraft["v_s_to_mps"] = 23.7  # 0.93 × 25.4
+        aircraft["v_s0_mps"] = 21.0  # 0.83 × 25.4
+        result = _service()(aircraft)
+        assert abs(result["vto_obstacle_mps"] - 1.2 * 23.7) < 0.1
+        assert abs(result["vapp_mps"] - 1.3 * 21.0) < 0.1
+
+    def test_legacy_context_falls_back_to_v_stall_mps(self):
+        """Pre-gh-526 contexts have no v_s_to_mps / v_s0_mps. Field-length
+        service must fall back to the clean v_stall_mps unchanged."""
+        aircraft = dict(CESSNA_172)
+        # No v_s_to_mps / v_s0_mps keys → legacy behaviour
+        assert "v_s_to_mps" not in aircraft
+        assert "v_s0_mps" not in aircraft
+        result = _service()(aircraft)
+        v_stall = aircraft["v_stall_mps"]
+        assert abs(result["vto_obstacle_mps"] - 1.2 * v_stall) < 0.1
+        assert abs(result["vapp_mps"] - 1.3 * v_stall) < 0.1
+
 
 # ===========================================================================
 # CL_max auto-detect from flap config
 # ===========================================================================
+
 
 class TestClMaxAutoDetect:
     """CL_max uplift factors based on flap configuration."""
@@ -175,6 +201,7 @@ class TestClMaxAutoDetect:
 # Hand-launch mode
 # ===========================================================================
 
+
 class TestHandLaunch:
     """Hand-launch RC mode: v_throw physics floor at 1.10·V_S."""
 
@@ -210,8 +237,9 @@ class TestHandLaunch:
         aircraft = self._aircraft_with_throw(v_throw=1.12 * v_stall)
         result = _service()(aircraft, takeoff_mode="hand_launch")
         assert result["s_to_ground_m"] == pytest.approx(0.0)
-        assert any("climb" in w.lower() or "margin" in w.lower() or "1.20" in w
-                   for w in result["warnings"])
+        assert any(
+            "climb" in w.lower() or "margin" in w.lower() or "1.20" in w for w in result["warnings"]
+        )
 
     def test_v_throw_above_1_20_no_climb_warning(self):
         """v_throw ≥ 1.20 · V_S → no climb-out margin warning."""
@@ -220,8 +248,7 @@ class TestHandLaunch:
         result = _service()(aircraft, takeoff_mode="hand_launch")
         # No warning about climb margin
         climb_warnings = [
-            w for w in result["warnings"]
-            if "climb" in w.lower() or "margin" in w.lower()
+            w for w in result["warnings"] if "climb" in w.lower() or "margin" in w.lower()
         ]
         assert not climb_warnings
 
@@ -249,6 +276,7 @@ class TestHandLaunch:
 # Bungee / Catapult mode
 # ===========================================================================
 
+
 class TestBungeeCatapult:
     """Bungee and catapult launch modes."""
 
@@ -270,8 +298,13 @@ class TestBungeeCatapult:
         """v_release ≥ V_LOF → s_TO_ground = 0."""
         from app.services.field_length_service import _v_lof
 
-        aircraft = {**CESSNA_172, "mass_kg": 5.0, "s_ref_m2": 0.5,
-                    "v_stall_mps": 8.0, "cl_max_takeoff": 1.5}
+        aircraft = {
+            **CESSNA_172,
+            "mass_kg": 5.0,
+            "s_ref_m2": 0.5,
+            "v_stall_mps": 8.0,
+            "cl_max_takeoff": 1.5,
+        }
         v_lof = _v_lof(aircraft["v_stall_mps"])
         # Set v_release higher than V_LOF
         aircraft_with_release = {**aircraft, "v_release_mps": v_lof + 2.0}
@@ -305,6 +338,7 @@ class TestBungeeCatapult:
 # Belly landing mode
 # ===========================================================================
 
+
 class TestBellyLand:
     """Belly landing uses μ=0.5 (grass + fuselage friction)."""
 
@@ -326,14 +360,13 @@ class TestBellyLand:
         r_belly = _service()(CESSNA_172, landing_mode="belly_land")
         ratio = r_belly["s_ldg_ground_m"] / r_runway["s_ldg_ground_m"]
         # μ=0.5 / μ=0.4 scaling → roughly 0.80 of runway distance
-        assert 0.70 <= ratio <= 0.99, (
-            f"Belly/runway ratio = {ratio:.3f}, expected ≈ 0.80"
-        )
+        assert 0.70 <= ratio <= 0.99, f"Belly/runway ratio = {ratio:.3f}, expected ≈ 0.80"
 
 
 # ===========================================================================
 # Thrust missing guard
 # ===========================================================================
+
 
 class TestThrustMissing:
     """t_static_N is required for takeoff; missing → ServiceException."""
@@ -369,6 +402,7 @@ class TestThrustMissing:
 # ===========================================================================
 # Internal helper unit tests
 # ===========================================================================
+
 
 class TestHelpers:
     """Unit tests for internal computation helpers."""

--- a/app/tests/test_operating_point_generator_service.py
+++ b/app/tests/test_operating_point_generator_service.py
@@ -14,6 +14,7 @@ from app.models.flightprofilemodel import RCFlightProfileModel
 from app.schemas.aeroanalysisschema import OperatingPointStatus, TrimOperatingPointRequest
 from app.services.operating_point_generator_service import (
     TrimmedPoint,
+    _estimate_reference_speeds,
     generate_default_set_for_aircraft,
     trim_operating_point_for_aircraft,
 )
@@ -21,8 +22,12 @@ from app.services.operating_point_generator_service import (
 
 @pytest.fixture()
 def db_session():
-    engine = create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
-    TestingSessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, class_=Session)
+    engine = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    TestingSessionLocal = sessionmaker(
+        bind=engine, autocommit=False, autoflush=False, class_=Session
+    )
     Base.metadata.create_all(bind=engine)
     db = TestingSessionLocal()
     try:
@@ -90,9 +95,18 @@ def test_generate_default_set_with_profile_assignment(db_session):
     db_session.commit()
 
     with (
-        patch("app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async", return_value=SimpleNamespace()),
-        patch("app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async", return_value=_mock_airplane_with_controls("[rudder]Rudder")),
-        patch("app.services.operating_point_generator_service._trim_or_estimate_point", side_effect=_fake_trim),
+        patch(
+            "app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async",
+            return_value=SimpleNamespace(),
+        ),
+        patch(
+            "app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async",
+            return_value=_mock_airplane_with_controls("[rudder]Rudder"),
+        ),
+        patch(
+            "app.services.operating_point_generator_service._trim_or_estimate_point",
+            side_effect=_fake_trim,
+        ),
     ):
         result = generate_default_set_for_aircraft(db_session, aircraft_uuid)
 
@@ -100,7 +114,11 @@ def test_generate_default_set_with_profile_assignment(db_session):
     assert len(result.operating_points) == 11
     assert "dutch_role_start" in [p.name for p in result.operating_points]
 
-    persisted = db_session.query(OperatingPointModel).filter(OperatingPointModel.aircraft_id == aircraft.id).all()
+    persisted = (
+        db_session.query(OperatingPointModel)
+        .filter(OperatingPointModel.aircraft_id == aircraft.id)
+        .all()
+    )
     assert len(persisted) == 11
 
 
@@ -111,9 +129,18 @@ def test_generate_default_set_without_profile_uses_defaults(db_session):
     db_session.commit()
 
     with (
-        patch("app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async", return_value=SimpleNamespace()),
-        patch("app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async", return_value=_mock_airplane_with_controls("[rudder]Rudder")),
-        patch("app.services.operating_point_generator_service._trim_or_estimate_point", side_effect=_fake_trim),
+        patch(
+            "app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async",
+            return_value=SimpleNamespace(),
+        ),
+        patch(
+            "app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async",
+            return_value=_mock_airplane_with_controls("[rudder]Rudder"),
+        ),
+        patch(
+            "app.services.operating_point_generator_service._trim_or_estimate_point",
+            side_effect=_fake_trim,
+        ),
     ):
         result = generate_default_set_for_aircraft(db_session, aircraft_uuid)
 
@@ -128,14 +155,27 @@ def test_generate_replace_existing_replaces_old_rows(db_session):
     db_session.commit()
 
     with (
-        patch("app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async", return_value=SimpleNamespace()),
-        patch("app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async", return_value=_mock_airplane_with_controls("[rudder]Rudder")),
-        patch("app.services.operating_point_generator_service._trim_or_estimate_point", side_effect=_fake_trim),
+        patch(
+            "app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async",
+            return_value=SimpleNamespace(),
+        ),
+        patch(
+            "app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async",
+            return_value=_mock_airplane_with_controls("[rudder]Rudder"),
+        ),
+        patch(
+            "app.services.operating_point_generator_service._trim_or_estimate_point",
+            side_effect=_fake_trim,
+        ),
     ):
         generate_default_set_for_aircraft(db_session, aircraft_uuid)
         generate_default_set_for_aircraft(db_session, aircraft_uuid, replace_existing=True)
 
-    points = db_session.query(OperatingPointModel).filter(OperatingPointModel.aircraft_id == aircraft.id).all()
+    points = (
+        db_session.query(OperatingPointModel)
+        .filter(OperatingPointModel.aircraft_id == aircraft.id)
+        .all()
+    )
     assert len(points) == 11
 
 
@@ -147,9 +187,18 @@ def test_generate_skips_points_when_required_controls_missing(db_session, caplog
     db_session.commit()
 
     with (
-        patch("app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async", return_value=SimpleNamespace()),
-        patch("app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async", return_value=_mock_airplane_with_controls()),
-        patch("app.services.operating_point_generator_service._trim_or_estimate_point", side_effect=_fake_trim),
+        patch(
+            "app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async",
+            return_value=SimpleNamespace(),
+        ),
+        patch(
+            "app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async",
+            return_value=_mock_airplane_with_controls(),
+        ),
+        patch(
+            "app.services.operating_point_generator_service._trim_or_estimate_point",
+            side_effect=_fake_trim,
+        ),
     ):
         result = generate_default_set_for_aircraft(db_session, aircraft_uuid)
 
@@ -169,9 +218,18 @@ def test_generate_with_rudder_keeps_dutch_role_point(db_session):
     db_session.commit()
 
     with (
-        patch("app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async", return_value=SimpleNamespace()),
-        patch("app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async", return_value=_mock_airplane_with_controls("[rudder]Rudder")),
-        patch("app.services.operating_point_generator_service._trim_or_estimate_point", side_effect=_fake_trim),
+        patch(
+            "app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async",
+            return_value=SimpleNamespace(),
+        ),
+        patch(
+            "app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async",
+            return_value=_mock_airplane_with_controls("[rudder]Rudder"),
+        ),
+        patch(
+            "app.services.operating_point_generator_service._trim_or_estimate_point",
+            side_effect=_fake_trim,
+        ),
     ):
         result = generate_default_set_for_aircraft(db_session, aircraft_uuid)
 
@@ -187,14 +245,27 @@ def test_generate_replace_existing_with_skips_keeps_consistent_rows(db_session):
     db_session.commit()
 
     with (
-        patch("app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async", return_value=SimpleNamespace()),
-        patch("app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async", return_value=_mock_airplane_with_controls()),
-        patch("app.services.operating_point_generator_service._trim_or_estimate_point", side_effect=_fake_trim),
+        patch(
+            "app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async",
+            return_value=SimpleNamespace(),
+        ),
+        patch(
+            "app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async",
+            return_value=_mock_airplane_with_controls(),
+        ),
+        patch(
+            "app.services.operating_point_generator_service._trim_or_estimate_point",
+            side_effect=_fake_trim,
+        ),
     ):
         generate_default_set_for_aircraft(db_session, aircraft_uuid)
         generate_default_set_for_aircraft(db_session, aircraft_uuid, replace_existing=True)
 
-    points = db_session.query(OperatingPointModel).filter(OperatingPointModel.aircraft_id == aircraft.id).all()
+    points = (
+        db_session.query(OperatingPointModel)
+        .filter(OperatingPointModel.aircraft_id == aircraft.id)
+        .all()
+    )
     assert len(points) == 9
 
 
@@ -238,12 +309,18 @@ def test_trim_single_operating_point_for_aircraft(db_session):
     )
 
     with (
-        patch("app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async", return_value=SimpleNamespace()),
+        patch(
+            "app.services.operating_point_generator_service.aeroplane_model_to_aeroplane_schema_async",
+            return_value=SimpleNamespace(),
+        ),
         patch(
             "app.services.operating_point_generator_service.aeroplane_schema_to_asb_airplane_async",
             return_value=_mock_airplane_with_controls("[elevator]Elevator"),
         ),
-        patch("app.services.operating_point_generator_service._trim_or_estimate_point", side_effect=_fake_trim),
+        patch(
+            "app.services.operating_point_generator_service._trim_or_estimate_point",
+            side_effect=_fake_trim,
+        ),
     ):
         result = trim_operating_point_for_aircraft(db_session, aircraft_uuid, request)
 
@@ -253,3 +330,55 @@ def test_trim_single_operating_point_for_aircraft(db_session):
     assert result.point.velocity == pytest.approx(21.0)
     assert result.point.altitude == pytest.approx(120.0)
     assert result.point.aircraft_id == aircraft.id
+
+
+# ============================================================================
+# gh-526 / epic gh-525 finding C1 — physics-based reference speeds from polar
+# ============================================================================
+
+
+def _profile_with_cruise(cruise_mps: float = 22.0) -> dict:
+    return {
+        "goals": {
+            "cruise_speed_mps": cruise_mps,
+            "min_speed_margin_vs_clean": 1.20,
+        },
+        "environment": {},
+        "constraints": {},
+    }
+
+
+def test_reference_speeds_use_per_config_v_s_from_context():
+    """gh-526: when v_s1_mps / v_s_to_mps / v_s0_mps are in context, use them
+    directly instead of applying 0.95 / 0.90 scalars to a single V_s."""
+    cached_context = {
+        "v_stall_mps": 14.0,  # legacy alias
+        "v_s1_mps": 14.0,  # clean
+        "v_s_to_mps": 12.5,  # takeoff (with flap)
+        "v_s0_mps": 10.5,  # landing (full flap)
+    }
+    refs = _estimate_reference_speeds(_profile_with_cruise(), cached_context)
+    assert refs["vs_clean"] == pytest.approx(14.0)
+    assert refs["vs_to"] == pytest.approx(12.5)
+    assert refs["vs_ldg"] == pytest.approx(10.5)
+
+
+def test_reference_speeds_legacy_context_uses_v_stall_for_all_configs():
+    """gh-526: older contexts without v_s_to / v_s0 fall back to v_stall_mps
+    for both takeoff and landing (no 0.95 / 0.90 scalar applied)."""
+    cached_context = {"v_stall_mps": 14.0}  # legacy / pre-526 context
+    refs = _estimate_reference_speeds(_profile_with_cruise(), cached_context)
+    assert refs["vs_clean"] == pytest.approx(14.0)
+    # Without polar_by_config we have no flap-config info — same V_s everywhere
+    assert refs["vs_to"] == pytest.approx(14.0)
+    assert refs["vs_ldg"] == pytest.approx(14.0)
+
+
+def test_reference_speeds_cold_start_uses_cruise_over_margin():
+    """gh-526: no context at all → cruise / min_margin_clean for all three,
+    with no 0.95 / 0.90 multipliers (those scalars are physically meaningless)."""
+    refs = _estimate_reference_speeds(_profile_with_cruise(cruise_mps=24.0), None)
+    # 24 / 1.20 = 20.0
+    assert refs["vs_clean"] == pytest.approx(20.0)
+    assert refs["vs_to"] == pytest.approx(20.0)
+    assert refs["vs_ldg"] == pytest.approx(20.0)

--- a/docs/testing/ingest_gold_standards.py
+++ b/docs/testing/ingest_gold_standards.py
@@ -71,7 +71,7 @@ def ingest_aircraft(client: httpx.Client, config_path: Path, wing_names: list[st
     # 2) POST each wing
     assert len(cfg["wings"]) == len(wing_names), \
         f"{len(cfg['wings'])} wings in config vs {len(wing_names)} names supplied"
-    for wing_name, wing_body in zip(wing_names, cfg["wings"]):
+    for wing_name, wing_body in zip(wing_names, cfg["wings"], strict=True):
         resp = client.post(
             f"/aeroplanes/{aeroplane_id}/wings/{wing_name}/from-wingconfig",
             json=wing_body,


### PR DESCRIPTION
## Summary

Foundation ticket for epic #525 finding C1. Runs **AeroBuildup once per high-lift configuration** (clean / takeoff / landing) so V-speeds reflect physics rather than the historical 0.95 / 0.90 V_s heuristic.

Closes #526.

## What changed

- **New schema:** `app/schemas/polar_by_config.py` — `ParabolicPolar` per-config + `PolarByConfig` type alias, with `provenance ∈ {aerobuildup, no_flap_geometry, fit_rejected}`.
- **`assumption_compute_service`:**
  - `_run_polar_for_deflection`: deep-copies the airplane with `with_control_deflections({flap: δ})` and refits a parabolic polar.
  - `_extract_flap_ted_max(aircraft)`: walks the SQLAlchemy model for the first flap-role TED's `positive_deflection_deg` (25° fallback mirrors the converter pattern).
  - `_detect_first_flap_name(asb_airplane)`: role-tag aware lookup.
  - `recompute_assumptions` runs **3 passes** when a flap exists, **1 pass + cloned fallback** otherwise. New context keys: `polar_by_config`, `v_s0_mps`, `v_s_to_mps`, `v_s1_mps`. `v_stall_mps` retained as alias for `v_s1_mps` (backward compat — protects `field_length_service`, `flight_envelope_service`, `matching_chart_service`).
- **`operating_point_generator_service._estimate_reference_speeds`:**
  - Reads per-config V_s from context; falls back to clean V_s for legacy contexts; cold-start uses `cruise / margin` for all three.
  - **0.95 / 0.90 scalar multipliers removed.**

## Test plan

- [x] 5 new assumption tests: three-key polar_by_config, flap-present 3-pass, flap-absent 1-pass fallback, `v_s0 < v_s1`, `v_stall == v_s1` alias, TED-limit clamping.
- [x] 3 new OPG tests: per-config context, legacy context, cold-start.
- [x] All 11 assumption tests pass (6 regression + 5 new).
- [x] 119 fast tests in assumption / OP / polar area pass.
- [x] 62 slow polar-integration tests pass (including `test_flap_config_yields_valid_fit`).
- [x] 3480 fast backend tests pass (full sweep), 0 regressions.
- [x] `ruff check` + `ruff format` clean.

## Out of scope (deferred)

- Slats / leading-edge devices (epic follow-up).
- Per-configuration Re-table (current Re-table stays clean-only).
- Frontend chip-row consumption (covered by #476 once epic #525 lands).
- Flap-bounds enforcement at OP-construction time (FE2, #527).

## Epic context

Part of epic #525 (trustworthy V-speed dashboard).

| Code | Finding | This PR |
|------|---------|---------|
| C1 | Single clean polar reused for all flap-config OPs | ✅ **fixed** |
| C2 | Flap deflection not bounded by TED | covered by FE2 #527 (depends on this PR) |
| C3 | Grid-search trim fallback doesn't update velocity | covered by FE3 #528 |
| C4 | AVL index drift + .run reproducibility | covered by FE4 #529 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)