### PR TITLE
fix(gh-528): grid-search trim fallback — distinct solver path + structured residuals (FE3, epic #525)

### DIFF
--- a/app/services/operating_point_generator_service.py
+++ b/app/services/operating_point_generator_service.py
@@ -736,10 +736,16 @@ def _trim_or_estimate_point(
         best_alpha = float(opti_solution["alpha_deg"])
         best_beta = float(opti_solution["beta_deg"])
         best_controls = dict(opti_solution["controls"])
+        # gh-528: surface solver_path on the success path so consumers
+        # can branch consistently with the fallback path.
         best_residuals = dict(opti_solution.get("metrics", {}))
+        best_residuals["solver_path"] = "opti"
         best_method = "opti"
 
-    # Fallback grid-search if opti didn't converge well enough
+    # gh-528 / epic gh-525 finding C3: grid-search fallback updates BOTH
+    # alpha AND velocity post-trim. Records solver_path in trim_residuals
+    # so downstream consumers (UI, AVL replay) can distinguish a confident
+    # Opti convergence from an estimated grid result.
     if best_score > 0.35:
         gs_score, gs_alpha, gs_beta, gs_velocity, gs_controls = _grid_search_trim(
             asb_airplane,
@@ -756,8 +762,13 @@ def _trim_or_estimate_point(
                 gs_beta,
                 gs_controls,
             )
-            best_residuals = {}
-            best_method = "grid_search"
+            best_residuals = {
+                "solver_path": "grid_fallback",
+                "final_residual": float(gs_score),
+                "grid_velocity_mps": float(gs_velocity),
+                "target_velocity_mps": float(velocity),
+            }
+            best_method = "grid_fallback"
             velocity = gs_velocity
 
     trim_status = _apply_limit_warnings(best_alpha, best_beta, best_score, constraints, warnings)

--- a/app/tests/test_operating_point_generator_service.py
+++ b/app/tests/test_operating_point_generator_service.py
@@ -382,3 +382,200 @@ def test_reference_speeds_cold_start_uses_cruise_over_margin():
     assert refs["vs_clean"] == pytest.approx(20.0)
     assert refs["vs_to"] == pytest.approx(20.0)
     assert refs["vs_ldg"] == pytest.approx(20.0)
+
+
+# ============================================================================
+# gh-528 / epic gh-525 finding C3 — grid-search fallback velocity update
+# ============================================================================
+
+
+def test_grid_search_returns_trim_method_grid_fallback():
+    """gh-528: when Opti fails to converge well, the trim fallback path
+    must set ``trim_method = 'grid_fallback'`` (not 'grid_search') so
+    downstream consumers can distinguish a confident Opti convergence
+    from an estimated grid result.
+    """
+    from app.services.operating_point_generator_service import _trim_or_estimate_point
+
+    airplane = _mock_airplane_with_controls("[elevator]Elevator")
+
+    target = {
+        "name": "best_angle_climb_vx",
+        "config": "clean",
+        "velocity": 18.0,
+        "altitude": 0.0,
+        "beta_target_deg": 0.0,
+        "n_target": 1.0,
+    }
+
+    # Force Opti to "fail" (return None) so we enter the grid fallback.
+    # Force the grid to return a sensible (alpha, beta, V, controls).
+    with (
+        patch(
+            "app.services.operating_point_generator_service._solve_trim_candidate_with_opti",
+            return_value=None,
+        ),
+        patch(
+            "app.services.operating_point_generator_service._grid_search_trim",
+            return_value=(0.20, 6.0, 0.0, 17.5, {"[elevator]Elevator": -2.5}),
+        ),
+        patch(
+            "app.services.operating_point_generator_service._cl_target_for_velocity",
+            return_value=0.65,
+        ),
+    ):
+        point = _trim_or_estimate_point(
+            asb_airplane=airplane,
+            aircraft=SimpleNamespace(id=1, total_mass_kg=1.5),
+            target=target,
+            constraints={"max_alpha_deg": 18.0, "max_beta_deg": 12.0},
+            capabilities={"available_controls": ["[elevator]Elevator"]},
+            effective_mass_kg=1.5,
+        )
+
+    assert point.trim_method == "grid_fallback", (
+        f"Expected trim_method='grid_fallback' on Opti failure, got '{point.trim_method}'"
+    )
+
+
+def test_grid_search_updates_velocity_from_grid_result():
+    """gh-528: after the grid fallback, the OP must record the grid's
+    chosen velocity, not the target heuristic.
+
+    Reproduces the regression: target velocity was 18.0 but the grid
+    converged at 17.5 — the OP must surface 17.5.
+    """
+    from app.services.operating_point_generator_service import _trim_or_estimate_point
+
+    airplane = _mock_airplane_with_controls("[elevator]Elevator")
+
+    target = {
+        "name": "best_angle_climb_vx",
+        "config": "clean",
+        "velocity": 18.0,  # target heuristic
+        "altitude": 0.0,
+        "beta_target_deg": 0.0,
+        "n_target": 1.0,
+    }
+
+    with (
+        patch(
+            "app.services.operating_point_generator_service._solve_trim_candidate_with_opti",
+            return_value=None,
+        ),
+        patch(
+            "app.services.operating_point_generator_service._grid_search_trim",
+            return_value=(0.20, 6.0, 0.0, 17.5, {"[elevator]Elevator": -2.5}),
+        ),
+        patch(
+            "app.services.operating_point_generator_service._cl_target_for_velocity",
+            return_value=0.65,
+        ),
+    ):
+        point = _trim_or_estimate_point(
+            asb_airplane=airplane,
+            aircraft=SimpleNamespace(id=1, total_mass_kg=1.5),
+            target=target,
+            constraints={"max_alpha_deg": 18.0, "max_beta_deg": 12.0},
+            capabilities={"available_controls": ["[elevator]Elevator"]},
+            effective_mass_kg=1.5,
+        )
+
+    assert point.velocity == pytest.approx(17.5), (
+        f"Expected velocity=17.5 from grid result, got {point.velocity}"
+    )
+
+
+def test_grid_fallback_records_solver_path_in_trim_enrichment():
+    """gh-528 AC: trim_residuals / trim_enrichment must surface
+    a ``solver_path`` field so downstream consumers can audit which
+    branch produced each OP."""
+    from app.services.operating_point_generator_service import _trim_or_estimate_point
+
+    airplane = _mock_airplane_with_controls("[elevator]Elevator")
+    target = {
+        "name": "approach_landing",
+        "config": "landing",
+        "velocity": 14.0,
+        "altitude": 0.0,
+        "beta_target_deg": 0.0,
+        "n_target": 1.0,
+        "flap_deflection_deg": 30.0,
+    }
+
+    with (
+        patch(
+            "app.services.operating_point_generator_service._solve_trim_candidate_with_opti",
+            return_value=None,
+        ),
+        patch(
+            "app.services.operating_point_generator_service._grid_search_trim",
+            return_value=(0.30, 8.0, 0.0, 13.8, {"[elevator]Elevator": -4.0}),
+        ),
+        patch(
+            "app.services.operating_point_generator_service._cl_target_for_velocity",
+            return_value=1.05,
+        ),
+    ):
+        point = _trim_or_estimate_point(
+            asb_airplane=airplane,
+            aircraft=SimpleNamespace(id=1, total_mass_kg=1.5),
+            target=target,
+            constraints={"max_alpha_deg": 18.0, "max_beta_deg": 12.0},
+            capabilities={"available_controls": ["[elevator]Elevator"]},
+            effective_mass_kg=1.5,
+        )
+
+    # trim_residuals receives the structured fallback metadata so
+    # downstream tools (UI, AVL replay) can branch on solver_path.
+    assert point.trim_residuals is not None
+    assert point.trim_residuals.get("solver_path") == "grid_fallback"
+
+
+def test_opti_success_keeps_trim_method_opti_and_target_velocity():
+    """Regression: when Opti converges, trim_method stays 'opti' and
+    the OP records the target velocity (Opti fixes V, solves for α)."""
+    from app.services.operating_point_generator_service import _trim_or_estimate_point
+
+    airplane = _mock_airplane_with_controls("[elevator]Elevator")
+
+    target = {
+        "name": "cruise",
+        "config": "clean",
+        "velocity": 22.0,
+        "altitude": 0.0,
+        "beta_target_deg": 0.0,
+        "n_target": 1.0,
+    }
+
+    # Opti succeeds with low residual → no fallback.
+    with (
+        patch(
+            "app.services.operating_point_generator_service._solve_trim_candidate_with_opti",
+            return_value={
+                "score": 0.10,
+                "alpha_deg": 3.5,
+                "beta_deg": 0.0,
+                "controls": {"[elevator]Elevator": -1.2},
+                "metrics": {"cm": 0.001, "cl": 0.42, "cy": 0.0},
+            },
+        ),
+        patch(
+            "app.services.operating_point_generator_service._cl_target_for_velocity",
+            return_value=0.42,
+        ),
+    ):
+        point = _trim_or_estimate_point(
+            asb_airplane=airplane,
+            aircraft=SimpleNamespace(id=1, total_mass_kg=1.5),
+            target=target,
+            constraints={"max_alpha_deg": 18.0, "max_beta_deg": 12.0},
+            capabilities={"available_controls": ["[elevator]Elevator"]},
+            effective_mass_kg=1.5,
+        )
+
+    import math as _m
+
+    assert point.trim_method == "opti"
+    assert point.velocity == pytest.approx(22.0)
+    assert point.alpha_rad == pytest.approx(_m.radians(3.5))


### PR DESCRIPTION
## Summary

Epic #525 finding C3: when the Opti solver fails to converge well, the trim fallback path now sets `trim_method = "grid_fallback"` (was `"grid_search"`) and surfaces a structured `solver_path` field in `trim_residuals`. Closes #528.

## What changed

- `app/services/operating_point_generator_service.py:`
  - `_trim_or_estimate_point`:
    - On Opti success: `trim_residuals["solver_path"] = "opti"` (new — consistent introspection).
    - On grid fallback: `trim_method = "grid_fallback"` and `trim_residuals = {solver_path: "grid_fallback", final_residual, grid_velocity_mps, target_velocity_mps}`.
  - Velocity propagation from grid → OP was already correct (line 761); preserved.

## Test plan

- [x] 4 new tests in `test_operating_point_generator_service.py`:
  - Opti forced to fail → `trim_method == "grid_fallback"`.
  - Velocity updated from grid result (17.5 m/s) instead of target heuristic (18.0 m/s).
  - `trim_residuals["solver_path"] == "grid_fallback"`.
  - Regression: Opti-success path still produces `trim_method="opti"` + target velocity.
- [x] 116 OPG-related fast tests pass.
- [x] 3487 backend fast tests pass (+4 vs. FE1 baseline).
- [x] `ruff check` + `ruff format --check` clean.

## Out of scope

- Recomputing V from L=W at converged α post-trim (option A in FE3 spec): the existing grid `_fallback_speeds` already picks the V that minimises trim residual, which is functionally equivalent here. A pure L=W solve would require a CL surrogate from the polar; deferred until FE6 (physics V_x/V_y) lands.
- Picard iteration with under-relaxation for V_md / V_min_sink: epic follow-up M9.

## Epic context

Part of epic #525.

| Code | Finding | Status |
|------|---------|--------|
| C1 | Single clean polar | ✅ merged (#530) |
| C2 | Flap bounds | FE2 #527 (next, depends on C1) |
| **C3** | **Grid-search velocity** | **this PR** |
| C4 | AVL reproducibility | FE4 #529 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)