### PR TITLE
fix(gh-529): AVL replay artefact — index snapshot + run state + hash (FE4, epic #525)

### DIFF
--- a/app/schemas/avl_artefact.py
+++ b/app/schemas/avl_artefact.py
@@ -1,0 +1,111 @@
+"""Pydantic schemas for AVL reproducibility artefacts (gh-529).
+
+An ``AvlArtefact`` packages the information required to **replay** an
+AVL trim solution exactly: which positional indices (``d1``, ``d2``, …)
+mapped to which control-surface names at solve time, what the operating
+point state was, and a canonical hash of the airplane geometry used to
+produce the result.
+
+Audit reference: gh-525 (epic) finding C4 — without this, AVL re-runs
+silently use mis-mapped surface indices whenever the user reorders xsec
+control surfaces.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class AvlIndexSnapshot(BaseModel):
+    """The control-surface ↔ AVL d-index map at AVL invocation time.
+
+    AVL assigns ``d1``, ``d2``, …  in input-parse order (avl_doc §SECTION
+    / §CONTROL).  The mapping shifts silently if the user reorders xsec
+    control surfaces in the source geometry — this snapshot pins the
+    binding for the OP's lifetime.
+    """
+
+    name_to_index: dict[str, int] = Field(
+        ...,
+        description=(
+            "Control-surface name → 1-based AVL d-index (``d1``, ``d2``, …) "
+            "at the time AVL was invoked."
+        ),
+    )
+    yduplicate_sign: dict[str, float] = Field(
+        default_factory=dict,
+        description=(
+            "Per-surface ``SgnDup`` factor for YDUPLICATE-deflected pairs: "
+            "+1 for symmetric (flaps), -1 for antisymmetric (aileron pair)."
+        ),
+    )
+    captured_at: datetime = Field(..., description="UTC timestamp when the snapshot was produced.")
+    geometry_hash: str = Field(
+        ...,
+        description=(
+            "SHA-256 of the canonicalised airplane geometry (independent of "
+            "float-formatting drift). Used by ``verify_avl_replay`` to reject "
+            "replays against a modified airplane."
+        ),
+        min_length=64,
+        max_length=64,
+    )
+
+
+class AvlRunState(BaseModel):
+    """The full AVL run-case state at solve time — enough to re-run AVL
+    later (e.g. for spar-load sizing at the same trim point) without
+    re-deriving anything from the OP.
+    """
+
+    alpha_deg: float = Field(..., description="Angle of attack [deg]")
+    beta_deg: float = Field(..., description="Sideslip angle [deg]")
+    velocity_mps: float = Field(..., description="True airspeed [m/s]")
+    mach: float = Field(0.0, description="Mach number (0 for incompressible)")
+    x_cg_m: float = Field(..., description="CG x-location [m] used as moment reference")
+    control_deflections_deg: dict[str, float] = Field(
+        default_factory=dict,
+        description=(
+            "Control-surface deflections at trim, keyed by **name** (not "
+            "AVL index — those drift on geometry edits)."
+        ),
+    )
+    run_case_constraints: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "AVL run-case constraints in source form, e.g. "
+            "``{'C1': 'bank=0', 'C2': 'velocity=22.0'}``."
+        ),
+    )
+
+
+class AvlArtefact(BaseModel):
+    """Bundle of ``AvlIndexSnapshot`` + ``AvlRunState`` — the canonical
+    payload stored on an ``OperatingPoint.trim_enrichment.avl`` when the
+    trim ran through AVL.
+    """
+
+    index_snapshot: AvlIndexSnapshot
+    run_state: AvlRunState
+    avl_version: str | None = Field(
+        None, description="AVL binary version string (parsed from runner stderr)."
+    )
+
+    def control_name_for_index(self, idx: int) -> str | None:
+        """Reverse lookup: which control surface name owns AVL index ``idx``?"""
+        for name, i in self.index_snapshot.name_to_index.items():
+            if i == idx:
+                return name
+        return None
+
+
+class AvlReplayMismatch(BaseModel):
+    """Structured result of a failed replay precondition check."""
+
+    reason: str = Field(..., description="Short label, e.g. 'geometry_hash_mismatch'")
+    expected: Any = Field(..., description="Value from the snapshot")
+    actual: Any = Field(..., description="Value derived from the current airplane")
+    details: str | None = Field(None, description="Free-form explanation for logs / UI")

--- a/app/services/avl_artefact_service.py
+++ b/app/services/avl_artefact_service.py
@@ -1,0 +1,152 @@
+"""AVL artefact service — build and verify replay-safe AVL snapshots (gh-529).
+
+An ``AvlArtefact`` captures the surface-index map, run-state, and a
+geometry hash at AVL invocation time so downstream tools (spar-load
+sizing, AVL re-runs at a converged trim point) can validate that the
+underlying airplane geometry hasn't drifted out from under them.
+
+Audit reference: gh-525 (epic) finding C4.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from app.schemas.avl_artefact import (
+    AvlArtefact,
+    AvlIndexSnapshot,
+    AvlReplayMismatch,
+    AvlRunState,
+)
+from app.services.avl_strip_forces import (
+    build_yduplicate_sign_map,
+    get_control_surface_index_map,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def compute_geometry_hash(airplane: Any) -> str:
+    """Return a deterministic SHA-256 of the airplane's control-surface geometry.
+
+    The hash covers ONLY the fields that govern AVL surface indexing:
+    wing-order, xsec-order within each wing, and (name, symmetric, hinge_point)
+    per control surface. Floating-point coordinates are excluded because
+    they're irrelevant to the index map and drift across model edits.
+
+    Two airplanes with the same canonical representation produce the same
+    hash; reordering any control surface produces a different hash.
+    """
+    canonical: list[dict[str, Any]] = []
+    for w_idx, wing in enumerate(getattr(airplane, "wings", []) or []):
+        wing_entry: dict[str, Any] = {
+            "wing_index": w_idx,
+            "xsecs": [],
+        }
+        for x_idx, xsec in enumerate(getattr(wing, "xsecs", []) or []):
+            xsec_entry: dict[str, Any] = {"xsec_index": x_idx, "control_surfaces": []}
+            for cs in getattr(xsec, "control_surfaces", []) or []:
+                xsec_entry["control_surfaces"].append(
+                    {
+                        "name": str(getattr(cs, "name", "")),
+                        "symmetric": bool(getattr(cs, "symmetric", True)),
+                        # hinge_point is dimensionless (chord fraction) — included
+                        # because moving the hinge produces a different AVL CONTROL
+                        # block even with the same name.
+                        "hinge_point": round(float(getattr(cs, "hinge_point", 0.75)), 6),
+                    }
+                )
+            wing_entry["xsecs"].append(xsec_entry)
+        canonical.append(wing_entry)
+
+    blob = json.dumps(canonical, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
+
+
+def build_avl_artefact(
+    airplane: Any,
+    *,
+    alpha_deg: float,
+    beta_deg: float,
+    velocity_mps: float,
+    x_cg_m: float,
+    control_deflections_deg: dict[str, float] | None = None,
+    mach: float = 0.0,
+    run_case_constraints: dict[str, str] | None = None,
+    avl_version: str | None = None,
+) -> AvlArtefact:
+    """Build a complete ``AvlArtefact`` from an airplane + trim state.
+
+    Call this at AVL invocation time so the resulting artefact can be
+    persisted alongside the trim result (or attached to an OP's
+    ``trim_enrichment``).
+    """
+    index_snapshot = AvlIndexSnapshot(
+        name_to_index=get_control_surface_index_map(airplane),
+        yduplicate_sign=build_yduplicate_sign_map(airplane),
+        captured_at=datetime.now(timezone.utc),
+        geometry_hash=compute_geometry_hash(airplane),
+    )
+    run_state = AvlRunState(
+        alpha_deg=float(alpha_deg),
+        beta_deg=float(beta_deg),
+        velocity_mps=float(velocity_mps),
+        mach=float(mach),
+        x_cg_m=float(x_cg_m),
+        control_deflections_deg=dict(control_deflections_deg or {}),
+        run_case_constraints=dict(run_case_constraints or {}),
+    )
+    return AvlArtefact(
+        index_snapshot=index_snapshot,
+        run_state=run_state,
+        avl_version=avl_version,
+    )
+
+
+def verify_avl_replay(
+    airplane: Any,
+    artefact: AvlArtefact,
+) -> AvlReplayMismatch | None:
+    """Validate that an airplane can replay an artefact's AVL run.
+
+    Returns ``None`` when the airplane geometry matches the snapshot.
+    Returns an ``AvlReplayMismatch`` (geometry_hash divergence, index
+    drift, or a surface added/removed) when replay must be rejected.
+
+    Callers should treat a non-None result as a hard failure — replaying
+    against drifted geometry produces silently mis-mapped AVL surfaces
+    (epic gh-525 finding C4).
+    """
+    current_hash = compute_geometry_hash(airplane)
+    if current_hash != artefact.index_snapshot.geometry_hash:
+        return AvlReplayMismatch(
+            reason="geometry_hash_mismatch",
+            expected=artefact.index_snapshot.geometry_hash,
+            actual=current_hash,
+            details=(
+                "Airplane geometry has changed since the AVL artefact was "
+                "captured — control-surface indices may no longer match. "
+                "Re-run AVL on the live geometry instead of replaying."
+            ),
+        )
+
+    current_index_map = get_control_surface_index_map(airplane)
+    if current_index_map != artefact.index_snapshot.name_to_index:
+        # Should be unreachable when the geometry hash matches, but defend
+        # against partial hash collisions or model edits that affect the
+        # index map without changing the hashed fields.
+        return AvlReplayMismatch(
+            reason="index_map_drift",
+            expected=artefact.index_snapshot.name_to_index,
+            actual=current_index_map,
+            details=(
+                "Surface index map drifted despite matching geometry hash — "
+                "investigate compute_geometry_hash coverage."
+            ),
+        )
+
+    return None

--- a/app/services/avl_strip_forces.py
+++ b/app/services/avl_strip_forces.py
@@ -153,6 +153,12 @@ def get_control_surface_index_map(airplane) -> dict[str, int]:
     Traverses airplane.wings -> xsecs -> control_surfaces in order,
     assigning indices based on first occurrence (same order as
     build_control_deflection_commands).
+
+    YDUPLICATE-dedup (gh-529): symmetric control surfaces (e.g. a flap or
+    aileron pair) share a single name in the ASB representation, so they
+    naturally collapse to ONE AVL d-index here. The corresponding
+    ``SgnDup`` factor is derived separately via
+    :func:`build_yduplicate_sign_map`.
     """
     seen: dict[str, int] = {}
     idx = 1
@@ -163,6 +169,28 @@ def get_control_surface_index_map(airplane) -> dict[str, int]:
                     seen[cs.name] = idx
                     idx += 1
     return seen
+
+
+def build_yduplicate_sign_map(airplane) -> dict[str, float]:
+    """Build the per-surface ``SgnDup`` factor for YDUPLICATE pairs (gh-529).
+
+    AVL convention (avl_doc §CONTROL): the ``SgnDup`` on a YDUPLICATEd
+    surface is +1 for symmetric deflection (flap, elevator) and -1 for
+    antisymmetric deflection (aileron pair). ASB encodes this via the
+    ``symmetric`` flag on each control surface, but we surface it
+    explicitly here so the snapshot can be replayed without re-walking
+    the geometry.
+    """
+    signs: dict[str, float] = {}
+    for wing in airplane.wings:
+        for xsec in wing.xsecs:
+            for cs in xsec.control_surfaces:
+                if cs.name in signs:
+                    continue
+                # symmetric=True → +1 (flap); symmetric=False → -1 (aileron)
+                symmetric = bool(getattr(cs, "symmetric", True))
+                signs[cs.name] = 1.0 if symmetric else -1.0
+    return signs
 
 
 _VARIABLE_TO_AVL: dict[str, str] = {

--- a/app/tests/test_avl_artefact_service.py
+++ b/app/tests/test_avl_artefact_service.py
@@ -1,0 +1,265 @@
+"""Tests for AVL reproducibility artefacts (gh-529 / epic gh-525 C4)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.schemas.avl_artefact import AvlArtefact, AvlIndexSnapshot, AvlRunState
+from app.services.avl_artefact_service import (
+    build_avl_artefact,
+    compute_geometry_hash,
+    verify_avl_replay,
+)
+from app.services.avl_strip_forces import (
+    build_yduplicate_sign_map,
+    get_control_surface_index_map,
+)
+
+
+def _cs(name: str, *, symmetric: bool = True, hinge_point: float = 0.75) -> SimpleNamespace:
+    """Build a minimal stub matching the asb.ControlSurface attributes
+    we read (name, symmetric, hinge_point, deflection)."""
+    return SimpleNamespace(
+        name=name,
+        symmetric=symmetric,
+        hinge_point=hinge_point,
+        deflection=0.0,
+    )
+
+
+def _wing(*xsec_control_groups: tuple[SimpleNamespace, ...]) -> SimpleNamespace:
+    """Build a stub wing with one xsec per group of control surfaces."""
+    xsecs = [SimpleNamespace(control_surfaces=list(group)) for group in xsec_control_groups]
+    return SimpleNamespace(xsecs=xsecs)
+
+
+def _airplane(*wings: SimpleNamespace) -> SimpleNamespace:
+    return SimpleNamespace(wings=list(wings))
+
+
+def _canonical_4surface_airplane() -> SimpleNamespace:
+    """Canonical fixture: aileron pair (symmetric=False), elevator,
+    rudder, flap. Replicates a typical RC trainer surface set."""
+    aileron = _cs("[aileron]Aileron", symmetric=False, hinge_point=0.75)
+    flap = _cs("[flap]Flap", symmetric=True, hinge_point=0.70)
+    elevator = _cs("[elevator]Elevator", symmetric=True, hinge_point=0.80)
+    rudder = _cs("[rudder]Rudder", symmetric=True, hinge_point=0.78)
+
+    main_wing = _wing((aileron,), (flap,))  # two xsecs on main wing
+    h_tail = _wing((elevator,))
+    v_tail = _wing((rudder,))
+    return _airplane(main_wing, h_tail, v_tail)
+
+
+# ============================================================================
+# YDUPLICATE-dedup
+# ============================================================================
+
+
+def test_index_map_dedupes_symmetric_pair_to_one_index():
+    """Canonical 4-surface fixture: aileron + elevator + rudder + flap →
+    4 indices, NOT 8 (ASB uses one control_surface per logical pair)."""
+    airplane = _canonical_4surface_airplane()
+    cs_map = get_control_surface_index_map(airplane)
+    assert len(cs_map) == 4, f"Expected 4 AVL d-indices, got {len(cs_map)}: {cs_map}"
+    # Order should match input traversal: aileron first (main wing first xsec)
+    assert cs_map["[aileron]Aileron"] == 1
+    assert cs_map["[flap]Flap"] == 2
+    assert cs_map["[elevator]Elevator"] == 3
+    assert cs_map["[rudder]Rudder"] == 4
+
+
+def test_yduplicate_sign_map_uses_symmetric_flag():
+    """gh-529: SgnDup factor is +1 for symmetric surfaces, -1 for
+    antisymmetric (aileron pair)."""
+    airplane = _canonical_4surface_airplane()
+    signs = build_yduplicate_sign_map(airplane)
+    assert signs["[aileron]Aileron"] == -1.0  # antisymmetric
+    assert signs["[flap]Flap"] == 1.0
+    assert signs["[elevator]Elevator"] == 1.0
+    assert signs["[rudder]Rudder"] == 1.0
+
+
+# ============================================================================
+# geometry_hash
+# ============================================================================
+
+
+def test_geometry_hash_is_deterministic():
+    """Same airplane built twice → identical hash."""
+    h1 = compute_geometry_hash(_canonical_4surface_airplane())
+    h2 = compute_geometry_hash(_canonical_4surface_airplane())
+    assert h1 == h2
+    assert len(h1) == 64  # SHA-256 hex digest
+
+
+def test_geometry_hash_changes_when_xsecs_are_reordered():
+    """gh-529: reordering xsec control surfaces produces a different hash
+    so replay can reject the drift."""
+    a = _canonical_4surface_airplane()
+    b = _canonical_4surface_airplane()
+    # Swap xsec order on the main wing.
+    b.wings[0].xsecs = list(reversed(b.wings[0].xsecs))
+    assert compute_geometry_hash(a) != compute_geometry_hash(b), (
+        "Hash must distinguish reordered xsec lists"
+    )
+
+
+def test_geometry_hash_changes_when_a_surface_is_removed():
+    a = _canonical_4surface_airplane()
+    b = _canonical_4surface_airplane()
+    # Drop the flap.
+    b.wings[0].xsecs[1].control_surfaces = []
+    assert compute_geometry_hash(a) != compute_geometry_hash(b)
+
+
+def test_geometry_hash_changes_when_symmetric_flag_flips():
+    """A flap toggled to antisymmetric is a different AVL geometry (the
+    SgnDup factor flips), so the hash must change."""
+    a = _canonical_4surface_airplane()
+    b = _canonical_4surface_airplane()
+    b.wings[0].xsecs[1].control_surfaces[0].symmetric = False
+    assert compute_geometry_hash(a) != compute_geometry_hash(b)
+
+
+# ============================================================================
+# build_avl_artefact
+# ============================================================================
+
+
+def test_build_avl_artefact_populates_all_required_fields():
+    airplane = _canonical_4surface_airplane()
+    artefact = build_avl_artefact(
+        airplane,
+        alpha_deg=3.5,
+        beta_deg=0.0,
+        velocity_mps=22.0,
+        x_cg_m=0.092,
+        control_deflections_deg={"[elevator]Elevator": -2.0, "[flap]Flap": 0.0},
+        mach=0.07,
+        run_case_constraints={"C1": "bank=0", "C2": "velocity=22.0"},
+        avl_version="3.40",
+    )
+
+    assert isinstance(artefact, AvlArtefact)
+    # Snapshot
+    assert artefact.index_snapshot.name_to_index["[aileron]Aileron"] == 1
+    assert artefact.index_snapshot.yduplicate_sign["[aileron]Aileron"] == -1.0
+    assert len(artefact.index_snapshot.geometry_hash) == 64
+    # Run state
+    assert artefact.run_state.alpha_deg == 3.5
+    assert artefact.run_state.velocity_mps == 22.0
+    assert artefact.run_state.x_cg_m == 0.092
+    assert artefact.run_state.control_deflections_deg["[elevator]Elevator"] == -2.0
+    assert artefact.run_state.run_case_constraints["C1"] == "bank=0"
+    assert artefact.avl_version == "3.40"
+
+
+def test_artefact_reverse_lookup_finds_control_name_for_index():
+    airplane = _canonical_4surface_airplane()
+    artefact = build_avl_artefact(
+        airplane,
+        alpha_deg=0.0,
+        beta_deg=0.0,
+        velocity_mps=20.0,
+        x_cg_m=0.1,
+    )
+    assert artefact.control_name_for_index(1) == "[aileron]Aileron"
+    assert artefact.control_name_for_index(99) is None
+
+
+# ============================================================================
+# verify_avl_replay
+# ============================================================================
+
+
+def test_verify_avl_replay_returns_none_when_geometry_unchanged():
+    airplane = _canonical_4surface_airplane()
+    artefact = build_avl_artefact(
+        airplane,
+        alpha_deg=1.0,
+        beta_deg=0.0,
+        velocity_mps=18.0,
+        x_cg_m=0.1,
+    )
+    assert verify_avl_replay(airplane, artefact) is None
+
+
+def test_verify_avl_replay_rejects_reordered_xsecs():
+    """gh-529 critical: a reordered geometry must fail replay validation
+    BEFORE AVL is invoked, so silent index mis-binding cannot happen."""
+    airplane_at_capture = _canonical_4surface_airplane()
+    artefact = build_avl_artefact(
+        airplane_at_capture,
+        alpha_deg=2.0,
+        beta_deg=0.0,
+        velocity_mps=20.0,
+        x_cg_m=0.1,
+    )
+
+    airplane_now = _canonical_4surface_airplane()
+    airplane_now.wings[0].xsecs = list(reversed(airplane_now.wings[0].xsecs))
+
+    mismatch = verify_avl_replay(airplane_now, artefact)
+    assert mismatch is not None
+    assert mismatch.reason == "geometry_hash_mismatch"
+    assert mismatch.expected == artefact.index_snapshot.geometry_hash
+    assert mismatch.actual != artefact.index_snapshot.geometry_hash
+
+
+def test_verify_avl_replay_rejects_added_surface():
+    airplane_at_capture = _canonical_4surface_airplane()
+    artefact = build_avl_artefact(
+        airplane_at_capture,
+        alpha_deg=0.0,
+        beta_deg=0.0,
+        velocity_mps=20.0,
+        x_cg_m=0.1,
+    )
+
+    airplane_now = _canonical_4surface_airplane()
+    # Add a new spoiler surface to a wing.
+    airplane_now.wings[0].xsecs[0].control_surfaces.append(
+        _cs("[spoiler]Spoiler", symmetric=True, hinge_point=0.5)
+    )
+    mismatch = verify_avl_replay(airplane_now, artefact)
+    assert mismatch is not None
+    assert mismatch.reason == "geometry_hash_mismatch"
+
+
+# ============================================================================
+# Schema sanity
+# ============================================================================
+
+
+def test_geometry_hash_field_enforces_sha256_length():
+    """Pydantic schema rejects a too-short hash."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        AvlIndexSnapshot(
+            name_to_index={},
+            yduplicate_sign={},
+            captured_at="2026-05-15T00:00:00+00:00",
+            geometry_hash="too-short",
+        )
+
+
+def test_run_state_round_trips_through_model_dump():
+    state = AvlRunState(
+        alpha_deg=2.5,
+        beta_deg=-1.0,
+        velocity_mps=21.0,
+        mach=0.06,
+        x_cg_m=0.085,
+        control_deflections_deg={"[elevator]Elevator": -1.5},
+        run_case_constraints={"C1": "bank=0"},
+    )
+    dumped = state.model_dump()
+    assert dumped["alpha_deg"] == 2.5
+    assert dumped["control_deflections_deg"]["[elevator]Elevator"] == -1.5
+    # Re-parse must succeed
+    re_parsed = AvlRunState.model_validate(dumped)
+    assert re_parsed == state


### PR DESCRIPTION
## Summary

Epic #525 finding C4: introduces the infrastructure to capture and validate AVL replay preconditions. AVL assigns ``d1``, ``d2``, … in input-parse order — if the user reorders xsec control surfaces between snapshot and replay, the indices drift silently. This PR makes that mismatch detectable. Closes #529.

## What changed

**New schemas** (`app/schemas/avl_artefact.py`):
- `AvlIndexSnapshot` — name→d-index map, YDUPLICATE SgnDup factors, captured_at, SHA-256 geometry_hash.
- `AvlRunState` — alpha/beta/V/mach/x_cg + control deflections by name + run-case constraints.
- `AvlArtefact` — bundle (snapshot + run-state + optional avl_version) with reverse `control_name_for_index` lookup.
- `AvlReplayMismatch` — structured failure reason / expected / actual.

**New service** (`app/services/avl_artefact_service.py`):
- `compute_geometry_hash(airplane)` — deterministic SHA-256 of canonical (wing-order, xsec-order, control surface names, symmetric, hinge_point). Excludes coordinate drift.
- `build_avl_artefact(...)` — factory.
- `verify_avl_replay(airplane, artefact)` — returns `AvlReplayMismatch | None`.

**Extended** (`app/services/avl_strip_forces.py`):
- `build_yduplicate_sign_map(airplane)` — extracts SgnDup factors (+1 for symmetric flap/elevator/rudder, -1 for aileron pair).

## Test plan

13 new tests in `test_avl_artefact_service.py`:
- **YDUPLICATE-dedup** canonical 4-surface fixture → 4 d-indices, not 8.
- SgnDup factor signs.
- Geometry-hash determinism + sensitivity to xsec reorder, surface removal, symmetric flag flip.
- `build_avl_artefact` populates all fields.
- `verify_avl_replay` returns None on unchanged geometry; rejects reordered xsecs (CRITICAL); rejects added surface.
- Schema validates SHA-256 length; `AvlRunState` round-trips through `model_dump`.

**CI:** ✅ 217 AVL-related fast tests pass, 3500 backend fast tests pass (+13 vs. FE3 baseline). Ruff clean.

## Out of scope (deferred)

- Persisting the artefact onto `OperatingPoint.trim_enrichment.avl`: `trim_with_avl` currently returns the result directly to the caller, not via OP storage. Wiring is a follow-up once the OP generator routes through AVL trim (audit's stability V-speeds follow-up).
- Reproducibility of OPs that did NOT touch AVL.

## Epic context

Part of epic #525.

| Code | Finding | Status |
|------|---------|--------|
| C1 | Single clean polar | ✅ merged (#530) |
| C2 | Flap bounds | FE2 #527 (next, depends on C1) |
| C3 | Grid-search velocity | ✅ merged (#531) |
| **C4** | **AVL reproducibility** | **this PR** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)