### PR TITLE
fix(gh-527): bound flap deflection by TED limits + control authority (FE2, epic #525)

### DIFF
--- a/app/services/operating_point_generator_service.py
+++ b/app/services/operating_point_generator_service.py
@@ -45,6 +45,62 @@ YAW_ROLES = {"rudder", "ruddervator"}
 FLAP_ROLES = {"flap"}
 
 
+def _clip_flap_to_ted_limit(
+    target: dict[str, Any],
+    deflection_limits: dict[str, tuple[float, float]],
+) -> dict[str, Any]:
+    """Clip a target's ``flap_deflection_deg`` to the TED limit (gh-527).
+
+    Epic gh-525 finding C2: the OPG historically hard-coded 15° (takeoff)
+    and 30° (landing) flap deflections without checking the aircraft's
+    ``TrailingEdgeDevice.positive_deflection_deg``. AVL has no internal
+    hinge clamp and NeuralFoil silently extrapolates τ(x_h/c) past the
+    training range, so an out-of-bound target produced physically wrong
+    (over-attached) flow with no warning.
+
+    This helper returns a copy of ``target`` with ``flap_deflection_deg``
+    clipped to the first flap-role surface in ``deflection_limits``.
+    A ``"FLAP_DEFLECTION_CLIPPED"`` warning is appended when clipping
+    occurs so the OP carries an audit trail.
+    """
+    raw_flap = target.get("flap_deflection_deg")
+    if raw_flap is None:
+        return target
+
+    flap_limits: tuple[float, float] | None = None
+    for name, limits in deflection_limits.items():
+        role, _ = parse_role_tag(name)
+        if role and role in FLAP_ROLES:
+            flap_limits = limits
+            break
+    if flap_limits is None:
+        # No flap-role TED in geometry → don't manufacture a limit from
+        # thin air. The trim solver itself will silently no-op the
+        # missing surface.
+        return target
+
+    max_pos, max_neg = flap_limits
+    requested = float(raw_flap)
+    limit = max_pos if requested >= 0 else max_neg
+    clipped_value = max(-max_neg, min(requested, max_pos))
+
+    result = dict(target)
+    result["flap_deflection_deg"] = clipped_value
+    if abs(requested) > limit + 1e-6:
+        warnings = list(result.get("warnings", []))
+        if "FLAP_DEFLECTION_CLIPPED" not in warnings:
+            warnings.append("FLAP_DEFLECTION_CLIPPED")
+        result["warnings"] = warnings
+        logger.warning(
+            "Clipped flap_deflection_deg for OP '%s' from %.1f° to %.1f° (TED limit %.1f°)",
+            target.get("name", "<unknown>"),
+            requested,
+            clipped_value,
+            limit,
+        )
+    return result
+
+
 @dataclass
 class TrimmedPoint:
     name: str
@@ -773,6 +829,19 @@ def _trim_or_estimate_point(
 
     trim_status = _apply_limit_warnings(best_alpha, best_beta, best_score, constraints, warnings)
 
+    # gh-527: surface the fixed flap deflection in the OP's controls dict
+    # so the enrichment pipeline reports its authority ratio alongside
+    # elevator / aileron / rudder.
+    flap_deflection_target = target.get("flap_deflection_deg")
+    if flap_deflection_target is not None:
+        available_controls = [
+            str(name).strip() for name in capabilities.get("available_controls", [])
+        ]
+        flap_name = _pick_control_name(available_controls, roles=FLAP_ROLES)
+        if flap_name is not None and flap_name not in best_controls:
+            best_controls = dict(best_controls)
+            best_controls[flap_name] = float(flap_deflection_target)
+
     return TrimmedPoint(
         name=target["name"],
         description=(
@@ -886,6 +955,11 @@ def generate_default_set_for_aircraft(
 
         plane_schema = aeroplane_model_to_aeroplane_schema_async(aircraft)
         asb_airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
+        # gh-527: clip per-target flap deflection to the TED mechanical
+        # limit BEFORE the trim solver sees the value. Out-of-bound flap
+        # angles produce non-physical AVL / NeuralFoil results otherwise.
+        _flap_limits_for_clip = build_deflection_limits_from_schema(plane_schema)
+        targets = [_clip_flap_to_ted_limit(t, _flap_limits_for_clip) for t in targets]
         # Use the design CG as the moment-reference point for trim, so
         # Cm=0 means "balanced about the user's design CG", not about
         # the origin. Mirrors what stability_summary already does.

--- a/app/tests/test_operating_point_generator_service.py
+++ b/app/tests/test_operating_point_generator_service.py
@@ -579,3 +579,117 @@ def test_opti_success_keeps_trim_method_opti_and_target_velocity():
     assert point.trim_method == "opti"
     assert point.velocity == pytest.approx(22.0)
     assert point.alpha_rad == pytest.approx(_m.radians(3.5))
+
+
+# ============================================================================
+# gh-527 / epic gh-525 finding C2 — flap deflection bounded by TED limits
+# ============================================================================
+
+
+def test_clip_flap_to_ted_limit_clips_excessive_deflection():
+    """gh-527: when a target's flap_deflection_deg exceeds the TED's
+    positive_deflection_deg, the OPG clips it to the limit before the
+    trim solver sees the value."""
+    from app.services.operating_point_generator_service import _clip_flap_to_ted_limit
+
+    target = {
+        "name": "approach_landing",
+        "config": "landing",
+        "flap_deflection_deg": 30.0,
+    }
+    # TED only goes to 20°
+    deflection_limits = {"[flap]Flap": (20.0, 20.0)}
+    clipped = _clip_flap_to_ted_limit(target, deflection_limits)
+    assert clipped["flap_deflection_deg"] == 20.0
+    assert "FLAP_DEFLECTION_CLIPPED" in clipped.get("warnings", [])
+
+
+def test_clip_flap_within_limit_is_unchanged():
+    """A 15° target on a 25°-rated flap is passed through unchanged with
+    no clip warning."""
+    from app.services.operating_point_generator_service import _clip_flap_to_ted_limit
+
+    target = {
+        "name": "takeoff_climb",
+        "config": "takeoff",
+        "flap_deflection_deg": 15.0,
+    }
+    deflection_limits = {"[flap]Flap": (25.0, 25.0)}
+    clipped = _clip_flap_to_ted_limit(target, deflection_limits)
+    assert clipped["flap_deflection_deg"] == 15.0
+    assert "FLAP_DEFLECTION_CLIPPED" not in clipped.get("warnings", [])
+
+
+def test_clip_flap_no_target_deflection_is_a_noop():
+    """Targets without flap_deflection_deg (clean configs) pass through."""
+    from app.services.operating_point_generator_service import _clip_flap_to_ted_limit
+
+    target = {"name": "cruise", "config": "clean"}
+    deflection_limits = {"[flap]Flap": (25.0, 25.0)}
+    clipped = _clip_flap_to_ted_limit(target, deflection_limits)
+    assert "flap_deflection_deg" not in clipped
+
+
+def test_clip_flap_no_flap_in_limits_is_a_noop():
+    """Aircraft without a flap-role TED → no clipping, no warning."""
+    from app.services.operating_point_generator_service import _clip_flap_to_ted_limit
+
+    target = {
+        "name": "approach_landing",
+        "config": "landing",
+        "flap_deflection_deg": 30.0,
+    }
+    deflection_limits = {"[elevator]Elevator": (25.0, 25.0)}
+    clipped = _clip_flap_to_ted_limit(target, deflection_limits)
+    # No flap geometry → leave the target alone (no spurious clip)
+    assert clipped["flap_deflection_deg"] == 30.0
+    assert "FLAP_DEFLECTION_CLIPPED" not in clipped.get("warnings", [])
+
+
+def test_trimmed_point_controls_include_flap_deflection():
+    """gh-527: when the target has a flap_deflection_deg, the resulting
+    TrimmedPoint must include the flap in its `controls` dict so the
+    enrichment pipeline can compute its authority ratio."""
+    from app.services.operating_point_generator_service import _trim_or_estimate_point
+
+    airplane = _mock_airplane_with_controls("[elevator]Elevator", "[flap]Flap")
+
+    target = {
+        "name": "approach_landing",
+        "config": "landing",
+        "velocity": 14.0,
+        "altitude": 0.0,
+        "beta_target_deg": 0.0,
+        "n_target": 1.0,
+        "flap_deflection_deg": 22.0,
+    }
+
+    with (
+        patch(
+            "app.services.operating_point_generator_service._solve_trim_candidate_with_opti",
+            return_value={
+                "score": 0.15,
+                "alpha_deg": 7.5,
+                "beta_deg": 0.0,
+                "controls": {"[elevator]Elevator": -3.0},
+                "metrics": {"cm": 0.001, "cl": 1.0, "cy": 0.0},
+            },
+        ),
+        patch(
+            "app.services.operating_point_generator_service._cl_target_for_velocity",
+            return_value=1.0,
+        ),
+    ):
+        point = _trim_or_estimate_point(
+            asb_airplane=airplane,
+            aircraft=SimpleNamespace(id=1, total_mass_kg=1.5),
+            target=target,
+            constraints={"max_alpha_deg": 18.0, "max_beta_deg": 12.0},
+            capabilities={"available_controls": ["[elevator]Elevator", "[flap]Flap"]},
+            effective_mass_kg=1.5,
+        )
+
+    assert "[flap]Flap" in point.controls, (
+        f"flap deflection must be in OP controls; got {list(point.controls.keys())}"
+    )
+    assert point.controls["[flap]Flap"] == pytest.approx(22.0)


### PR DESCRIPTION
## Summary

Epic #525 finding C2 (last sub-ticket of the epic). Clips per-OP `flap_deflection_deg` against the aircraft's `TrailingEdgeDevice.positive_deflection_deg` before the trim solver runs, and surfaces the flap deflection in the OP's `controls` dict so the existing enrichment pipeline reports its authority usage (warning >80 %, critical >95 %). Closes #527.

## What changed

- **New helper** `_clip_flap_to_ted_limit(target, deflection_limits)` in `operating_point_generator_service.py`:
  - Identifies the first flap-role TED via `parse_role_tag`.
  - Clips to the matching `positive_deflection_deg` / `negative_deflection_deg`.
  - Stamps `"FLAP_DEFLECTION_CLIPPED"` on the target's warnings when clipping changes the value.
  - No-ops when the target has no `flap_deflection_deg` (clean OPs) or the aircraft has no flap-role TED.
- **`generate_default_set_for_aircraft`** calls the clipper across the 12 targets immediately after `_build_target_definitions`.
- **`_trim_or_estimate_point`** now includes the (clipped) flap deflection in `TrimmedPoint.controls`. The existing `compute_enrichment` produces `DeflectionReserve.usage_fraction` and emits `DesignWarning` at the 80 % / 95 % thresholds — so flap authority is now reported alongside elevator / aileron / rudder.

## Test plan

5 new tests in `test_operating_point_generator_service.py`:
- 30° target on a 20° TED → clipped to 20°, audit warning emitted.
- 15° target on a 25° TED → unchanged, no warning.
- No `flap_deflection_deg` (clean OP) → no-op.
- No flap-role TED → no clipping (no spurious limits).
- Trimmed OP with `flap_deflection_deg` → flap appears in `controls`.

**CI:** ✅ 121 OPG-related tests pass, 3505 backend fast tests (+5 vs. FE4 baseline). Ruff clean.

## Epic context — closes the epic

Part of epic #525. **This is the final sub-ticket.**

| Code | Finding | Status |
|------|---------|--------|
| C1 | Single clean polar | ✅ merged (#530) |
| **C2** | **Flap bounds** | **this PR** |
| C3 | Grid-search velocity | ✅ merged (#531) |
| C4 | AVL reproducibility | ✅ merged (#532) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)