### PR TITLE
feat(gh-476): V-speed chip row — V_min_sink, V_dive, V_x, V_y, V_a

### DIFF
--- a/app/services/assumption_compute_service.py
+++ b/app/services/assumption_compute_service.py
@@ -17,6 +17,7 @@ asyncio.to_thread().
 from __future__ import annotations
 
 import logging
+import math
 from datetime import datetime, timezone
 from typing import Any
 
@@ -390,6 +391,14 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
     v_cruise_effective = v_md if (not user_set_cruise and v_md is not None) else v_cruise
     cruise_is_auto = not user_set_cruise and v_md is not None
 
+    # gh-476: extended V-speed set surfaced on the dashboard chip row.
+    # Must run AFTER v_max_effective is finalised (Picard iteration) and
+    # AFTER v_cruise_effective is resolved (drives the V_a cap).
+    g_limit_effective = _load_effective_assumption(db, aircraft.id, "g_limit")
+    v_a = _compute_v_a(v_s1_mps=v_s1, g_limit=g_limit_effective, v_cruise_mps=v_cruise_effective)
+    v_dive = _compute_v_dive(v_max_effective)
+    v_x, v_y = _read_vx_vy_from_ops(db, aircraft.id)
+
     # CL_α from linear-range alpha-sweep (gh-487 — gust envelope).
     # Regression over α ∈ [-2°, +6°] with R² > 0.995 quality gate.
     # Cached as cl_alpha_per_rad; downstream compute_vn_curve uses it
@@ -413,6 +422,14 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
         "v_s0_mps": round(v_s0, 1) if v_s0 is not None else None,
         "v_md_mps": round(v_md, 1) if v_md is not None else None,
         "v_min_sink_mps": round(v_min_sink, 1) if v_min_sink is not None else None,
+        # gh-476: extended V-speed set surfaced on the chip row.
+        # V_a, V_dive: physics / heuristic (provenance noted in field doc).
+        # V_x, V_y: pulled from operating-point rows when they exist;
+        # None until OPG has run.
+        "v_a_mps": round(v_a, 1) if v_a is not None else None,
+        "v_dive_mps": round(v_dive, 1) if v_dive is not None else None,
+        "v_x_mps": round(v_x, 1) if v_x is not None else None,
+        "v_y_mps": round(v_y, 1) if v_y is not None else None,
         "is_glider": is_glider,
         "reynolds": round(re),
         "mac_m": round(mac, 4),
@@ -543,6 +560,66 @@ def _detect_first_flap_name(asb_airplane) -> str | None:
                     if role == "flap":
                         return raw
     return None
+
+
+def _compute_v_a(
+    v_s1_mps: float | None,
+    g_limit: float | None,
+    v_cruise_mps: float | None,
+) -> float | None:
+    """Manoeuvring speed V_a = V_s1 · √n_max, capped at V_C (gh-476).
+
+    Anderson §6.7 / CS-25.335(c) / Scholz lecture §6: at V_a the wing
+    reaches C_L_max exactly at the structural load limit n_max, so a
+    full-deflection pitch input cannot exceed n_max. Scholz further
+    requires V_a ≤ V_C — without this cap, V_a can drift above cruise
+    on high-load-limit designs (e.g. acrobatic n+ = 6).
+
+    Returns ``None`` when any input is missing or non-positive.
+    """
+    if v_s1_mps is None or v_s1_mps <= 0 or g_limit is None or g_limit <= 0:
+        return None
+    raw = v_s1_mps * math.sqrt(g_limit)
+    if v_cruise_mps is not None and v_cruise_mps > 0:
+        return min(raw, v_cruise_mps)
+    return raw
+
+
+def _compute_v_dive(v_max_mps: float | None) -> float | None:
+    """V_dive heuristic = 1.4 · V_max (gh-476).
+
+    Provenance: ``heuristic`` — flutter analysis is out of project scope.
+    Anchored on V_max per the ticket spec; the audit (§5.5 / M3) prefers
+    anchoring on V_C, which is tracked as a separate follow-up.
+    """
+    if v_max_mps is None or v_max_mps <= 0:
+        return None
+    return 1.4 * v_max_mps
+
+
+def _read_vx_vy_from_ops(db: Session, aircraft_id: int) -> tuple[float | None, float | None]:
+    """Read V_x / V_y from existing operating-point rows (gh-476).
+
+    Both speeds come from the OPG's `best_angle_climb_vx` and
+    `best_rate_climb_vy` operating points. When the OPG has not yet
+    been run, returns ``(None, None)`` — the chip row renders '–'.
+    """
+    from app.models.analysismodels import OperatingPointModel
+
+    rows = (
+        db.query(OperatingPointModel)
+        .filter(
+            OperatingPointModel.aircraft_id == aircraft_id,
+            OperatingPointModel.name.in_(["best_angle_climb_vx", "best_rate_climb_vy"]),
+        )
+        .all()
+    )
+    by_name = {row.name: row for row in rows}
+    v_x_row = by_name.get("best_angle_climb_vx")
+    v_y_row = by_name.get("best_rate_climb_vy")
+    v_x = float(v_x_row.velocity) if v_x_row is not None else None
+    v_y = float(v_y_row.velocity) if v_y_row is not None else None
+    return v_x, v_y
 
 
 def _extract_flap_ted_max(aircraft: AeroplaneModel) -> float | None:

--- a/app/tests/test_assumption_compute_service.py
+++ b/app/tests/test_assumption_compute_service.py
@@ -549,6 +549,174 @@ def test_flap_takeoff_deflection_clipped_to_ted_max(client_and_db):
     assert pbc["landing"]["flap_deflection_deg"] == 10.0
 
 
+# ============================================================================
+# gh-476 — extended V-speed set (v_a, v_dive, v_x, v_y) in ComputationContext
+# ============================================================================
+
+
+def test_context_includes_v_a_mps_from_stall_and_g_limit(client_and_db):
+    """gh-476: V_a = V_s · √g_limit, capped at V_C (Scholz / CS-25.335(c))."""
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
+        aeroplane_id = aeroplane.id
+
+    with _enter_patches(flap_ted_max=30.0):
+        with SessionLocal() as db:
+            recompute_assumptions(db, aeroplane_uuid)
+            db.commit()
+
+    ctx = _load_ctx(SessionLocal, aeroplane_id)
+    assert "v_a_mps" in ctx
+    # The default g_limit is 3.0 (PARAMETER_DEFAULTS). v_a = v_s1 · √3
+    # capped at v_cruise.
+    expected_uncapped = ctx["v_s1_mps"] * (3.0**0.5)
+    expected = min(expected_uncapped, ctx["v_cruise_mps"])
+    assert abs(ctx["v_a_mps"] - expected) < 0.2
+
+
+def test_context_v_a_is_capped_at_v_cruise(client_and_db):
+    """gh-476 + Scholz M4: V_a must not exceed V_C even when V_s·√n+ does."""
+    from app.models.aeroplanemodel import DesignAssumptionModel
+
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        # Force a high g_limit so V_s · √n_max exceeds V_cruise.
+        g_row = (
+            db.query(DesignAssumptionModel)
+            .filter_by(aeroplane_id=aeroplane.id, parameter_name="g_limit")
+            .first()
+        )
+        g_row.calculated_value = 12.0
+        g_row.calculated_source = "test"
+        g_row.active_source = "CALCULATED"
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
+        aeroplane_id = aeroplane.id
+
+    with _enter_patches(flap_ted_max=30.0):
+        with SessionLocal() as db:
+            recompute_assumptions(db, aeroplane_uuid)
+            db.commit()
+
+    ctx = _load_ctx(SessionLocal, aeroplane_id)
+    assert ctx["v_a_mps"] == ctx["v_cruise_mps"], (
+        f"V_a must be capped at V_C; got V_a={ctx['v_a_mps']}, V_C={ctx['v_cruise_mps']}"
+    )
+
+
+def test_context_includes_v_dive_mps_as_heuristic(client_and_db):
+    """gh-476: V_dive = 1.4·V_max (heuristic placeholder until flutter analysis)."""
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
+        aeroplane_id = aeroplane.id
+
+    with _enter_patches(flap_ted_max=30.0):
+        with SessionLocal() as db:
+            recompute_assumptions(db, aeroplane_uuid)
+            db.commit()
+
+    ctx = _load_ctx(SessionLocal, aeroplane_id)
+    assert "v_dive_mps" in ctx
+    assert abs(ctx["v_dive_mps"] - 1.4 * ctx["v_max_mps"]) < 0.2
+
+
+def test_context_v_x_and_v_y_are_none_when_no_ops_exist(client_and_db):
+    """gh-476: V_x / V_y come from operating-point output. When no OPs
+    have been generated yet, both must be None (chip row shows '–')."""
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
+        aeroplane_id = aeroplane.id
+
+    with _enter_patches(flap_ted_max=30.0):
+        with SessionLocal() as db:
+            recompute_assumptions(db, aeroplane_uuid)
+            db.commit()
+
+    ctx = _load_ctx(SessionLocal, aeroplane_id)
+    assert "v_x_mps" in ctx
+    assert "v_y_mps" in ctx
+    assert ctx["v_x_mps"] is None
+    assert ctx["v_y_mps"] is None
+
+
+def test_context_v_x_and_v_y_read_from_existing_ops(client_and_db):
+    """gh-476: when operating points named `best_angle_climb_vx` /
+    `best_rate_climb_vy` exist, their `velocity` fields populate v_x_mps
+    and v_y_mps in the assumption context."""
+    from app.models.analysismodels import OperatingPointModel
+
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        # Seed two OPs that gh-476 should pick up.
+        db.add(
+            OperatingPointModel(
+                name="best_angle_climb_vx",
+                description="seed",
+                aircraft_id=aeroplane.id,
+                config="clean",
+                status="TRIMMED",
+                warnings=[],
+                controls={},
+                velocity=12.5,
+                alpha=0.08,
+                beta=0.0,
+                p=0.0,
+                q=0.0,
+                r=0.0,
+                xyz_ref=[0, 0, 0],
+                altitude=0.0,
+            )
+        )
+        db.add(
+            OperatingPointModel(
+                name="best_rate_climb_vy",
+                description="seed",
+                aircraft_id=aeroplane.id,
+                config="clean",
+                status="TRIMMED",
+                warnings=[],
+                controls={},
+                velocity=15.3,
+                alpha=0.04,
+                beta=0.0,
+                p=0.0,
+                q=0.0,
+                r=0.0,
+                xyz_ref=[0, 0, 0],
+                altitude=0.0,
+            )
+        )
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
+        aeroplane_id = aeroplane.id
+
+    with _enter_patches(flap_ted_max=30.0):
+        with SessionLocal() as db:
+            recompute_assumptions(db, aeroplane_uuid)
+            db.commit()
+
+    ctx = _load_ctx(SessionLocal, aeroplane_id)
+    assert ctx["v_x_mps"] == 12.5
+    assert ctx["v_y_mps"] == 15.3
+
+
 @contextlib.contextmanager
 def _enter_patches_no_fine_sweep(flap_ted_max: float | None = None):
     """Variant: skip the fine_sweep patch so the test can supply its own

--- a/frontend/__tests__/AnalysisWingGate.test.tsx
+++ b/frontend/__tests__/AnalysisWingGate.test.tsx
@@ -16,6 +16,10 @@ vi.mock("lucide-react", () => {
     AlertTriangle: icon,
     SlidersHorizontal: icon,
     Activity: icon,
+    Loader2: icon,
+    Plane: icon,
+    TrendingUp: icon,
+    Zap: icon,
   };
 });
 

--- a/frontend/__tests__/InfoChipRow.test.tsx
+++ b/frontend/__tests__/InfoChipRow.test.tsx
@@ -14,6 +14,10 @@ vi.mock("lucide-react", () => {
     Settings: icon,
     Gauge: icon,
     AlertTriangle: icon,
+    Loader2: icon,
+    Plane: icon,
+    TrendingUp: icon,
+    Zap: icon,
   };
 });
 
@@ -59,5 +63,67 @@ describe("Info Chip Row", () => {
 
     const dashes = screen.getAllByText("–");
     expect(dashes.length).toBeGreaterThanOrEqual(4);
+  });
+
+  // gh-476: extended V-speed chips
+  it("renders V_min_sink, V_x, V_y, V_a, V_dive when available", async () => {
+    (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        v_cruise_mps: 18.0,
+        v_min_sink_mps: 13.2,
+        v_x_mps: 12.0,
+        v_y_mps: 15.5,
+        v_a_mps: 17.5,
+        v_dive_mps: 30.0,
+        reynolds: 230000,
+        mac_m: 0.21,
+        x_np_m: 0.085,
+        target_static_margin: 0.12,
+        cg_agg_m: 0.092,
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
+    render(<InfoChipRow aeroplaneId="42" cgAero={0.073} />);
+
+    expect(screen.getByText(/V_min_sink/)).toBeInTheDocument();
+    expect(screen.getByText(/13\.2 m\/s/)).toBeInTheDocument();
+    expect(screen.getByText(/V_x/)).toBeInTheDocument();
+    expect(screen.getByText(/12\.0 m\/s/)).toBeInTheDocument();
+    expect(screen.getByText(/V_y/)).toBeInTheDocument();
+    expect(screen.getByText(/15\.5 m\/s/)).toBeInTheDocument();
+    expect(screen.getByText(/V_a/)).toBeInTheDocument();
+    expect(screen.getByText(/17\.5 m\/s/)).toBeInTheDocument();
+    expect(screen.getByText(/V_dive/)).toBeInTheDocument();
+    expect(screen.getByText(/30\.0 m\/s/)).toBeInTheDocument();
+  });
+
+  // gh-476: V_a hidden for gliders (no manoeuvring placard in CS-22).
+  it("hides V_a chip when is_glider is true", async () => {
+    (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        v_cruise_mps: 30.0,
+        v_min_sink_mps: 22.0,
+        v_a_mps: 25.0,
+        v_dive_mps: 60.0,
+        is_glider: true,
+        reynolds: 800000,
+        mac_m: 0.42,
+        x_np_m: 0.15,
+        target_static_margin: 0.12,
+        cg_agg_m: 0.13,
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
+    render(<InfoChipRow aeroplaneId="42" cgAero={0.13} />);
+
+    expect(screen.queryByText(/V_a = /)).toBeNull();
+    expect(screen.getByText(/V_NE/)).toBeInTheDocument();
+    expect(screen.getByText(/V_min_sink/)).toBeInTheDocument();
   });
 });

--- a/frontend/components/workbench/InfoChipRow.tsx
+++ b/frontend/components/workbench/InfoChipRow.tsx
@@ -1,6 +1,17 @@
 "use client";
 
-import { Wind, Ruler, Target, Navigation, Gauge, AlertTriangle, Loader2 } from "lucide-react";
+import {
+  Wind,
+  Ruler,
+  Target,
+  Navigation,
+  Gauge,
+  AlertTriangle,
+  Loader2,
+  Plane,
+  TrendingUp,
+  Zap,
+} from "lucide-react";
 import { useComputationContext } from "@/hooks/useComputationContext";
 
 interface Props {
@@ -55,8 +66,20 @@ export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: P
   const stale = !!isRecomputing;
 
   return (
-    <div className="flex items-center gap-2 border-t border-border bg-card px-4 py-3">
-      <Chip icon={AlertTriangle} prefix="V_stall = " value={fmt(ctx?.v_stall_mps, 1, " m/s")} stale={stale} />
+    <div className="flex flex-wrap items-center gap-2 border-t border-border bg-card px-4 py-3">
+      {/* Envelope speeds (gh-476: extended chip set) */}
+      <Chip
+        icon={AlertTriangle}
+        prefix="V_stall = "
+        value={fmt(ctx?.v_stall_mps, 1, " m/s")}
+        stale={stale}
+      />
+      <Chip
+        icon={Wind}
+        prefix="V_min_sink = "
+        value={fmt(ctx?.v_min_sink_mps, 1, " m/s")}
+        stale={stale}
+      />
       <Chip icon={Wind} prefix="V_md = " value={fmt(ctx?.v_md_mps, 1, " m/s")} stale={stale} />
       <Chip
         icon={Wind}
@@ -65,11 +88,40 @@ export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: P
         stale={stale}
       />
       <Chip
+        icon={TrendingUp}
+        prefix="V_x = "
+        value={fmt(ctx?.v_x_mps, 1, " m/s")}
+        stale={stale}
+      />
+      <Chip
+        icon={Plane}
+        prefix="V_y = "
+        value={fmt(ctx?.v_y_mps, 1, " m/s")}
+        stale={stale}
+      />
+      {/* V_a hidden for gliders — they use V_RA per CS-22 (separate ticket). */}
+      {!ctx?.is_glider && (
+        <Chip
+          icon={Gauge}
+          prefix="V_a = "
+          value={fmt(ctx?.v_a_mps, 1, " m/s")}
+          stale={stale}
+        />
+      )}
+      <Chip
         icon={Gauge}
         prefix={ctx?.is_glider ? "V_NE = " : "V_max = "}
         value={fmt(ctx?.v_max_mps, 1, " m/s")}
         stale={stale}
       />
+      <Chip
+        icon={Zap}
+        prefix="V_dive = "
+        value={fmt(ctx?.v_dive_mps, 1, " m/s")}
+        stale={stale}
+      />
+      {/* Divider between envelope speeds and aero geometry */}
+      <div className="h-5 w-px bg-border" />
       <Chip icon={Wind} prefix="Re ≈ " value={fmtRe(ctx?.reynolds)} stale={stale} />
       <Chip icon={Ruler} prefix="MAC = " value={fmt(ctx?.mac_m, 2, " m")} stale={stale} />
       <Chip icon={Target} prefix="NP = " value={fmt(ctx?.x_np_m, 3, " m")} stale={stale} />

--- a/frontend/hooks/useComputationContext.ts
+++ b/frontend/hooks/useComputationContext.ts
@@ -9,6 +9,12 @@ export interface ComputationContext {
   v_max_mps?: number | null;
   v_stall_mps?: number | null;
   v_md_mps?: number | null;
+  // gh-476: extended V-speed set surfaced on the chip row.
+  v_min_sink_mps?: number | null;
+  v_a_mps?: number | null;
+  v_dive_mps?: number | null;
+  v_x_mps?: number | null;
+  v_y_mps?: number | null;
   is_glider?: boolean;
   reynolds: number;
   mac_m: number;


### PR DESCRIPTION
## Summary

Adds the five new V-speed chips requested in #476 to the Analysis-page Info Chip Row, now that epic #525 has cleared the foundational issues. Closes #476.

## Backend (`app/services/assumption_compute_service.py`)

| Field | Formula | Provenance |
|------|--------|---|
| `v_a_mps` | `V_s1 · √g_limit`, capped at `V_cruise` | physics (Scholz / CS-25.335(c)) |
| `v_dive_mps` | `1.4 · V_max` | heuristic — anchor-on-V_C is a separate follow-up |
| `v_x_mps` | OP `best_angle_climb_vx.velocity` | trimmed OP output |
| `v_y_mps` | OP `best_rate_climb_vy.velocity` | trimmed OP output |
| `v_min_sink_mps` | (already in context since gh-486) | physics |

V_x / V_y return `None` when the OPG has not yet been run — chip row renders '–'.

## Frontend

- `hooks/useComputationContext.ts` — extended type.
- `components/workbench/InfoChipRow.tsx`:
  - Five new chips with icons per spec: `Wind` (V_min_sink), `TrendingUp` (V_x), `Plane` (V_y), `Gauge` (V_a), `Zap` (V_dive).
  - Row uses `flex-wrap` so it doesn't overflow on narrow viewports.
  - **V_a hidden** when `is_glider=true` (CS-22 has no manoeuvring placard; V_RA is the operational equivalent — tracked as a future ticket).
  - Visual divider between envelope speeds and aero-geometry chips.

## Test plan

- [x] 5 new backend tests: V_a (default), V_a-V_C-cap, V_dive, V_x/V_y-from-OPs, V_x/V_y-None-without-OPs.
- [x] 2 new frontend tests: all-5-chips-render, V_a-hidden-in-glider-mode.
- [x] **17 assumption_compute_service tests pass** (12 regression + 5 new).
- [x] **3510 backend fast tests pass** (+5 vs. epic-525 baseline).
- [x] **715 frontend unit tests pass** (78 test files).
- [x] Ruff check + format clean; ESLint clean.

## Out of scope (epic-525 follow-ups, tracked separately)

- **V_a / V_RA for gliders** (#535 covers the cold-start fallback warning; CS-22 manoeuvring/rough-air speeds will get their own ticket).
- **V_dive anchored on V_C** instead of V_max (audit M3; future ticket).
- **Per-OP V_x / V_y physics** (audit M2; depends on a powertrain model).

## Acceptance criteria from the ticket

- [x] `ComputationContext` schema exposes `v_min_sink_mps`, `v_dive_mps`, `v_x_mps`, `v_y_mps`, `v_a_mps` (all optional `float | None`).
- [x] `assumption_compute_service` populates all five fields when polar + design assumptions are available; returns `None` otherwise.
- [x] `InfoChipRow.tsx` renders five new chips with the correct icons and same stale-state behaviour as existing chips.
- [x] Chips show `–` placeholder when value is `None`.
- [x] `InfoChipRow.test.tsx` extended to assert each new chip renders.
- [x] Sailplane mode (`is_glider = true`): V_a hidden, V_min_sink rendered prominently.
- [x] No regression on existing chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)