### PR TITLE
feat(gh-534): lift landing-flap clamp to TED.positive_deflection_deg (epic #525 follow-up)

### DIFF
--- a/app/services/assumption_compute_service.py
+++ b/app/services/assumption_compute_service.py
@@ -165,8 +165,13 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
         polar_takeoff = polar_clean.model_copy(update={"provenance": "no_flap_geometry"})
         polar_landing = polar_clean.model_copy(update={"provenance": "no_flap_geometry"})
     else:
+        # gh-534: takeoff keeps a moderate 15° seed (high deflection at TO
+        # hurts climb performance — Scholz §8 / Loftin). Landing uses the
+        # FULL TED limit so a real Fowler flap doesn't get capped at 30°
+        # and over-state V_s0 / V_APP (Cessna-172 POH cross-check was off
+        # by 23 % with the old 30° cap).
         delta_to = min(15.0, float(ted_max))
-        delta_ldg = min(30.0, float(ted_max))
+        delta_ldg = float(ted_max)
         # Independent try blocks per configuration (gh-526 review feedback):
         # a takeoff-sweep failure must not prevent the landing sweep from
         # running — they are physically independent passes.

--- a/app/tests/test_assumption_compute_service.py
+++ b/app/tests/test_assumption_compute_service.py
@@ -549,6 +549,36 @@ def test_flap_takeoff_deflection_clipped_to_ted_max(client_and_db):
     assert pbc["landing"]["flap_deflection_deg"] == 10.0
 
 
+def test_landing_polar_uses_full_ted_limit_above_30deg(client_and_db):
+    """gh-534: with a 40°-rated Fowler flap, the landing polar must run
+    at the FULL TED max (40°), not the historical 30° cap.
+
+    The old 30° cap (assumption_compute_service:168) under-deflected
+    real Fowler flaps → CL_max_LDG too low → V_s0 too high → V_APP
+    overshot the POH by ~23 % on a Cessna-172 cross-check.
+    """
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
+        aeroplane_id = aeroplane.id
+
+    with _enter_patches(flap_ted_max=40.0):
+        with SessionLocal() as db:
+            recompute_assumptions(db, aeroplane_uuid)
+            db.commit()
+
+    ctx = _load_ctx(SessionLocal, aeroplane_id)
+    pbc = ctx["polar_by_config"]
+    # Takeoff stays at the 15° seed (high-deflection at takeoff would
+    # hurt climb performance — keep the moderate seed).
+    assert pbc["takeoff"]["flap_deflection_deg"] == 15.0
+    # Landing uses the FULL TED limit (no 30° cap).
+    assert pbc["landing"]["flap_deflection_deg"] == 40.0
+
+
 # ============================================================================
 # gh-476 — extended V-speed set (v_a, v_dive, v_x, v_y) in ComputationContext
 # ============================================================================


### PR DESCRIPTION
## Summary

Removes the hard `min(30.0, ted_max)` cap on the landing-config flap deflection (`assumption_compute_service.py:169`). The landing polar now uses the **full** `TrailingEdgeDevice.positive_deflection_deg`, so Cessna-172-class Fowler designs reach POH-accurate V_s0 / V_APP. Closes #534.

## What changed

`assumption_compute_service.recompute_assumptions`:
- Takeoff keeps the 15° moderate seed (high δ at TO hurts climb performance per Scholz §8). Still clamped to TED limit when TED < 15°.
- **Landing** now uses `δ_ldg = float(ted_max)` — the full TED authority.

## Test plan

- [x] New test `test_landing_polar_uses_full_ted_limit_above_30deg`: TED at 40° → `polar_by_config["landing"]["flap_deflection_deg"] == 40.0`; takeoff still 15°.
- [x] 18 assumption_compute_service tests pass (17 + 1 new).
- [x] Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)