### PR TITLE
chore(gh-537): schema↔ASB flap-name parity guard (epic #525 follow-up)

### DIFF
--- a/app/services/assumption_compute_service.py
+++ b/app/services/assumption_compute_service.py
@@ -160,6 +160,24 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
     )
 
     ted_max = _extract_flap_ted_max(aircraft)
+    # gh-537: parity guard between the schema walker
+    # (`_extract_flap_ted_max`, model.wings.x_secs.trailing_edge_device)
+    # and the ASB walker (`_detect_first_flap_name`, asb_airplane.wings.
+    # xsecs.control_surfaces). If the model claims a flap exists but the
+    # ASB conversion didn't propagate it (converter desync), route to the
+    # no-flap fallback with a clear warning — never let
+    # `_run_polar_for_deflection` raise AssertionError on the live path.
+    if ted_max is not None and _detect_first_flap_name(asb_airplane) is None:
+        logger.warning(
+            "Schema/ASB flap-name parity mismatch for aircraft %s: schema "
+            "reports a flap TED (positive_deflection_deg=%.1f°) but the ASB "
+            "airplane has no flap-role control surface. Falling back to "
+            "clean polar for takeoff/landing — investigate the converter.",
+            aeroplane_uuid,
+            ted_max,
+        )
+        ted_max = None  # route through the no-flap fallback below.
+
     if ted_max is None:
         # No flap geometry — fallback path: clone clean to takeoff & landing.
         polar_takeoff = polar_clean.model_copy(update={"provenance": "no_flap_geometry"})

--- a/app/tests/test_assumption_compute_service.py
+++ b/app/tests/test_assumption_compute_service.py
@@ -549,6 +549,81 @@ def test_flap_takeoff_deflection_clipped_to_ted_max(client_and_db):
     assert pbc["landing"]["flap_deflection_deg"] == 10.0
 
 
+def test_flap_geometry_mismatch_falls_back_with_warning(client_and_db, caplog):
+    """gh-537: when the schema reports a flap TED but the ASB airplane has
+    no flap-role control surface, the per-config polar must fall back to
+    `no_flap_geometry` provenance with a clear log warning — not raise.
+
+    Repro: `_extract_flap_ted_max` returns 25.0 (model says flap exists),
+    but `_make_fake_airplane(with_flap=False)` produces an airplane with
+    no flap-role control surface (ASB sees nothing).
+    """
+    import logging
+
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
+        aeroplane_id = aeroplane.id
+
+    asb_no_flap = _make_fake_airplane(with_flap=False)
+    caplog.set_level(logging.WARNING, logger="app.services.assumption_compute_service")
+    with (
+        patch(
+            "app.services.assumption_compute_service._build_asb_airplane",
+            return_value=asb_no_flap,
+        ),
+        patch(
+            "app.services.assumption_compute_service._stability_run_at_cruise",
+            return_value=(0.085, 0.20, 0.025, 0.30),
+        ),
+        patch(
+            "app.services.assumption_compute_service._coarse_alpha_sweep",
+            return_value=15.0,
+        ),
+        patch(
+            "app.services.assumption_compute_service._fine_sweep_cl_max",
+            return_value=(
+                1.35,
+                np.array([0.2, 0.4, 0.6, 0.8, 1.0, 1.2]),
+                np.array([0.026, 0.028, 0.032, 0.039, 0.049, 0.062]),
+                np.linspace(9.0, 28.0, 6),
+            ),
+        ),
+        patch(
+            "app.services.assumption_compute_service._extract_cl_alpha_from_linear_sweep",
+            return_value=5.7,
+        ),
+        patch(
+            "app.services.assumption_compute_service._load_flight_profile_speeds",
+            return_value=(18.0, 28.0, True),
+        ),
+        patch(
+            "app.services.assumption_compute_service._extract_flap_ted_max",
+            return_value=25.0,  # schema disagrees with ASB
+        ),
+    ):
+        with SessionLocal() as db:
+            # Must not raise — the parity guard catches the mismatch.
+            recompute_assumptions(db, aeroplane_uuid)
+            db.commit()
+
+    ctx = _load_ctx(SessionLocal, aeroplane_id)
+    pbc = ctx["polar_by_config"]
+    assert pbc["takeoff"]["provenance"] == "no_flap_geometry"
+    assert pbc["landing"]["provenance"] == "no_flap_geometry"
+    parity_warning = any(
+        "parity" in rec.message.lower() or "mismatch" in rec.message.lower()
+        for rec in caplog.records
+        if rec.levelno >= logging.WARNING
+    )
+    assert parity_warning, (
+        f"Expected a parity/mismatch warning; got: {[r.message for r in caplog.records]}"
+    )
+
+
 def test_landing_polar_uses_full_ted_limit_above_30deg(client_and_db):
     """gh-534: with a 40°-rated Fowler flap, the landing polar must run
     at the FULL TED max (40°), not the historical 30° cap.


### PR DESCRIPTION
## Summary

Two walkers identify the flap surface in `recompute_assumptions`:
- `_extract_flap_ted_max(aircraft)` — SQLAlchemy model walker.
- `_detect_first_flap_name(asb_airplane)` — ASB airplane walker.

If the converter desyncs, the schema walker can return non-None while the ASB walker returns None → `_run_polar_for_deflection` raises `AssertionError` on the live recompute. This PR detects the mismatch up-front and routes through the no-flap fallback with a clear log warning. Closes #537.

## What changed

`app/services/assumption_compute_service.py`: after `_extract_flap_ted_max`, check `_detect_first_flap_name` agrees. On mismatch:
- log WARNING with both signals + aircraft UUID,
- set `ted_max = None` so the no-flap fallback path runs,
- both takeoff and landing polars get `provenance="no_flap_geometry"`.

## Test plan

- [x] New `test_flap_geometry_mismatch_falls_back_with_warning`: simulates mismatch, asserts no exception + provenance flag + log warning.
- [x] 19 assumption_compute_service tests pass.
- [x] Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)