### PR TITLE
feat(gh-540): chip hover descriptions + LaTeX-subscript V-speed labels

### DIFF
--- a/frontend/__tests__/InfoChipRow.test.tsx
+++ b/frontend/__tests__/InfoChipRow.test.tsx
@@ -88,16 +88,16 @@ describe("Info Chip Row", () => {
     const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
     render(<InfoChipRow aeroplaneId="42" cgAero={0.073} />);
 
-    // Chips are addressable by their accessible name (symbol: description).
-    expect(screen.getByRole("group", { name: /V_min_sink/ })).toBeInTheDocument();
+    // Chips are addressable by their humanized accessible name ("V min sink: …").
+    expect(screen.getByRole("group", { name: /V min sink/ })).toBeInTheDocument();
     expect(screen.getByText(/13\.2 m\/s/)).toBeInTheDocument();
-    expect(screen.getByRole("group", { name: /V_x/ })).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: /^V x:/ })).toBeInTheDocument();
     expect(screen.getByText(/12\.0 m\/s/)).toBeInTheDocument();
-    expect(screen.getByRole("group", { name: /V_y/ })).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: /^V y:/ })).toBeInTheDocument();
     expect(screen.getByText(/15\.5 m\/s/)).toBeInTheDocument();
-    expect(screen.getByRole("group", { name: /V_a/ })).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: /^V a:/ })).toBeInTheDocument();
     expect(screen.getByText(/17\.5 m\/s/)).toBeInTheDocument();
-    expect(screen.getByRole("group", { name: /V_dive/ })).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: /V dive/ })).toBeInTheDocument();
     expect(screen.getByText(/30\.0 m\/s/)).toBeInTheDocument();
   });
 
@@ -123,13 +123,13 @@ describe("Info Chip Row", () => {
     const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
     render(<InfoChipRow aeroplaneId="42" cgAero={0.13} />);
 
-    expect(screen.queryByRole("group", { name: /^V_a:/ })).toBeNull();
-    expect(screen.getByRole("group", { name: /V_NE/ })).toBeInTheDocument();
-    expect(screen.getByRole("group", { name: /V_min_sink/ })).toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: /^V a:/ })).toBeNull();
+    expect(screen.getByRole("group", { name: /V NE/ })).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: /V min sink/ })).toBeInTheDocument();
   });
 
-  // gh-540: each chip exposes a hover description via tooltip + aria-label.
-  it("renders hover-description tooltip and accessible aria-label per chip", async () => {
+  // gh-540: each chip exposes a hover description and is keyboard-focusable.
+  it("renders hover-description tooltip and is keyboard focusable", async () => {
     (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
       data: {
         v_min_sink_mps: 13.2,
@@ -144,10 +144,15 @@ describe("Info Chip Row", () => {
     const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
     render(<InfoChipRow aeroplaneId="42" cgAero={0.073} />);
 
-    const chip = screen.getByRole("group", { name: /V_min_sink:.*minimum sink/i });
+    const chip = screen.getByRole("group", { name: /V min sink.*minimum sink/i });
     expect(chip).toBeInTheDocument();
+    // WCAG 2.1 SC 1.4.13: hover-only tooltips must also reveal on focus.
+    expect(chip).toHaveAttribute("tabindex", "0");
 
-    const tooltip = chip.querySelector('[role="tooltip"]');
+    // Tooltip text is inside the chip subtree. It is aria-hidden because
+    // the parent chip already carries the description via aria-label.
+    expect(chip.textContent).toMatch(/minimum sink/i);
+    const tooltip = chip.querySelector('[aria-hidden="true"]');
     expect(tooltip).not.toBeNull();
     expect(tooltip!.textContent).toMatch(/minimum sink/i);
   });
@@ -168,5 +173,20 @@ describe("Info Chip Row", () => {
     expect(subTexts).toContain("min,sink");
     expect(subTexts).toContain("x");
     expect(subTexts).toContain("dive");
+  });
+
+  // gh-540: aria-label is humanized (no literal underscores spoken).
+  it("humanizes underscores in aria-label for screen readers", async () => {
+    (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: { v_min_sink_mps: 13.2 },
+      isLoading: false,
+      error: null,
+    });
+
+    const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
+    render(<InfoChipRow aeroplaneId="42" cgAero={null} />);
+
+    const chip = screen.getByRole("group", { name: /^V min sink:/ });
+    expect(chip.getAttribute("aria-label")).not.toMatch(/_/);
   });
 });

--- a/frontend/__tests__/InfoChipRow.test.tsx
+++ b/frontend/__tests__/InfoChipRow.test.tsx
@@ -88,15 +88,16 @@ describe("Info Chip Row", () => {
     const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
     render(<InfoChipRow aeroplaneId="42" cgAero={0.073} />);
 
-    expect(screen.getByText(/V_min_sink/)).toBeInTheDocument();
+    // Chips are addressable by their accessible name (symbol: description).
+    expect(screen.getByRole("group", { name: /V_min_sink/ })).toBeInTheDocument();
     expect(screen.getByText(/13\.2 m\/s/)).toBeInTheDocument();
-    expect(screen.getByText(/V_x/)).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: /V_x/ })).toBeInTheDocument();
     expect(screen.getByText(/12\.0 m\/s/)).toBeInTheDocument();
-    expect(screen.getByText(/V_y/)).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: /V_y/ })).toBeInTheDocument();
     expect(screen.getByText(/15\.5 m\/s/)).toBeInTheDocument();
-    expect(screen.getByText(/V_a/)).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: /V_a/ })).toBeInTheDocument();
     expect(screen.getByText(/17\.5 m\/s/)).toBeInTheDocument();
-    expect(screen.getByText(/V_dive/)).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: /V_dive/ })).toBeInTheDocument();
     expect(screen.getByText(/30\.0 m\/s/)).toBeInTheDocument();
   });
 
@@ -122,8 +123,50 @@ describe("Info Chip Row", () => {
     const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
     render(<InfoChipRow aeroplaneId="42" cgAero={0.13} />);
 
-    expect(screen.queryByText(/V_a = /)).toBeNull();
-    expect(screen.getByText(/V_NE/)).toBeInTheDocument();
-    expect(screen.getByText(/V_min_sink/)).toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: /^V_a:/ })).toBeNull();
+    expect(screen.getByRole("group", { name: /V_NE/ })).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: /V_min_sink/ })).toBeInTheDocument();
+  });
+
+  // gh-540: each chip exposes a hover description via tooltip + aria-label.
+  it("renders hover-description tooltip and accessible aria-label per chip", async () => {
+    (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        v_min_sink_mps: 13.2,
+        v_x_mps: 12.0,
+        v_a_mps: 17.5,
+        mac_m: 0.21,
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
+    render(<InfoChipRow aeroplaneId="42" cgAero={0.073} />);
+
+    const chip = screen.getByRole("group", { name: /V_min_sink:.*minimum sink/i });
+    expect(chip).toBeInTheDocument();
+
+    const tooltip = chip.querySelector('[role="tooltip"]');
+    expect(tooltip).not.toBeNull();
+    expect(tooltip!.textContent).toMatch(/minimum sink/i);
+  });
+
+  // gh-540: symbol underscores render as subscript groups.
+  it("renders V_min_sink with min,sink in a <sub> element", async () => {
+    (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: { v_min_sink_mps: 13.2, mac_m: 0.21 },
+      isLoading: false,
+      error: null,
+    });
+
+    const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
+    const { container } = render(<InfoChipRow aeroplaneId="42" cgAero={null} />);
+
+    const subs = container.querySelectorAll("sub");
+    const subTexts = Array.from(subs).map((s) => s.textContent);
+    expect(subTexts).toContain("min,sink");
+    expect(subTexts).toContain("x");
+    expect(subTexts).toContain("dive");
   });
 });

--- a/frontend/__tests__/renderSymbol.test.tsx
+++ b/frontend/__tests__/renderSymbol.test.tsx
@@ -17,27 +17,27 @@ describe("renderSymbol", () => {
   });
 
   it("renders single underscore as subscript", () => {
-    expect(html(renderSymbol("V_x"))).toBe('V<sub class="text-[9px]">x</sub>');
-    expect(html(renderSymbol("V_y"))).toBe('V<sub class="text-[9px]">y</sub>');
-    expect(html(renderSymbol("V_a"))).toBe('V<sub class="text-[9px]">a</sub>');
+    expect(html(renderSymbol("V_x"))).toBe('V<sub class="text-[10px]">x</sub>');
+    expect(html(renderSymbol("V_y"))).toBe('V<sub class="text-[10px]">y</sub>');
+    expect(html(renderSymbol("V_a"))).toBe('V<sub class="text-[10px]">a</sub>');
   });
 
   it("renders multi-underscore subscript with inner underscores → commas", () => {
     expect(html(renderSymbol("V_min_sink"))).toBe(
-      'V<sub class="text-[9px]">min,sink</sub>',
+      'V<sub class="text-[10px]">min,sink</sub>',
     );
   });
 
   it("keeps trailing non-word characters outside the subscript", () => {
     expect(html(renderSymbol("V_cruise*"))).toBe(
-      'V<sub class="text-[9px]">cruise</sub>*',
+      'V<sub class="text-[10px]">cruise</sub>*',
     );
   });
 
   it("renders multi-letter abbreviations after underscore (V_NE, V_md)", () => {
-    expect(html(renderSymbol("V_NE"))).toBe('V<sub class="text-[9px]">NE</sub>');
-    expect(html(renderSymbol("V_md"))).toBe('V<sub class="text-[9px]">md</sub>');
-    expect(html(renderSymbol("V_max"))).toBe('V<sub class="text-[9px]">max</sub>');
+    expect(html(renderSymbol("V_NE"))).toBe('V<sub class="text-[10px]">NE</sub>');
+    expect(html(renderSymbol("V_md"))).toBe('V<sub class="text-[10px]">md</sub>');
+    expect(html(renderSymbol("V_max"))).toBe('V<sub class="text-[10px]">max</sub>');
   });
 
   it("falls back to the original label for malformed input", () => {

--- a/frontend/__tests__/renderSymbol.test.tsx
+++ b/frontend/__tests__/renderSymbol.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import React from "react";
+
+import { renderSymbol } from "@/components/workbench/renderSymbol";
+
+function html(node: React.ReactNode): string {
+  const { container } = render(<>{node}</>);
+  return container.innerHTML;
+}
+
+describe("renderSymbol", () => {
+  it("passes through labels with no underscore", () => {
+    expect(html(renderSymbol("MAC"))).toBe("MAC");
+    expect(html(renderSymbol("Re"))).toBe("Re");
+    expect(html(renderSymbol("CG"))).toBe("CG");
+  });
+
+  it("renders single underscore as subscript", () => {
+    expect(html(renderSymbol("V_x"))).toBe('V<sub class="text-[9px]">x</sub>');
+    expect(html(renderSymbol("V_y"))).toBe('V<sub class="text-[9px]">y</sub>');
+    expect(html(renderSymbol("V_a"))).toBe('V<sub class="text-[9px]">a</sub>');
+  });
+
+  it("renders multi-underscore subscript with inner underscores → commas", () => {
+    expect(html(renderSymbol("V_min_sink"))).toBe(
+      'V<sub class="text-[9px]">min,sink</sub>',
+    );
+  });
+
+  it("keeps trailing non-word characters outside the subscript", () => {
+    expect(html(renderSymbol("V_cruise*"))).toBe(
+      'V<sub class="text-[9px]">cruise</sub>*',
+    );
+  });
+
+  it("renders multi-letter abbreviations after underscore (V_NE, V_md)", () => {
+    expect(html(renderSymbol("V_NE"))).toBe('V<sub class="text-[9px]">NE</sub>');
+    expect(html(renderSymbol("V_md"))).toBe('V<sub class="text-[9px]">md</sub>');
+    expect(html(renderSymbol("V_max"))).toBe('V<sub class="text-[9px]">max</sub>');
+  });
+
+  it("falls back to the original label for malformed input", () => {
+    expect(html(renderSymbol(""))).toBe("");
+    expect(html(renderSymbol("V_"))).toBe("V_");
+  });
+});

--- a/frontend/components/workbench/InfoChipRow.tsx
+++ b/frontend/components/workbench/InfoChipRow.tsx
@@ -13,6 +13,7 @@ import {
   Zap,
 } from "lucide-react";
 import { useComputationContext } from "@/hooks/useComputationContext";
+import { renderSymbol } from "@/components/workbench/renderSymbol";
 
 interface Props {
   readonly aeroplaneId: string | null;
@@ -23,22 +24,39 @@ interface Props {
 
 function Chip({
   icon: Icon,
-  prefix,
+  symbol,
   value,
+  description,
   stale = false,
 }: {
   readonly icon: React.ComponentType<{ size: number; className: string }>;
-  readonly prefix: string;
+  readonly symbol: string;
   readonly value: string;
+  readonly description?: string;
   readonly stale?: boolean;
 }) {
   const valueClass = stale ? "text-red-400" : "text-foreground";
+  const ariaLabel = description ? `${symbol}: ${description}` : symbol;
   return (
-    <div className="flex items-center gap-1.5 rounded-full bg-card-muted px-3 py-1.5">
+    <div
+      role="group"
+      aria-label={ariaLabel}
+      className="group/chip relative flex items-center gap-1.5 rounded-full bg-card-muted px-3 py-1.5"
+    >
       <Icon size={12} className="text-muted-foreground" />
       <span className="font-[family-name:var(--font-geist-sans)] text-[12px] text-foreground">
-        {prefix}<span className={valueClass}>{value}</span>
+        {renderSymbol(symbol)}
+        {" = "}
+        <span className={valueClass}>{value}</span>
       </span>
+      {description && (
+        <span
+          role="tooltip"
+          className="pointer-events-none absolute bottom-full left-1/2 z-50 mb-1.5 hidden w-max max-w-[240px] -translate-x-1/2 rounded-lg border border-border bg-card px-2.5 py-1.5 text-[10px] font-normal leading-snug text-foreground shadow-lg group-hover/chip:block"
+        >
+          {description}
+        </span>
+      )}
     </div>
   );
 }
@@ -59,6 +77,8 @@ export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: P
   const fmtRe = (v: number | null | undefined) => (v == null ? "–" : v.toExponential(1));
 
   const cgValue = cgAero != null ? `${cgAero.toFixed(3)} m` : "–";
+  const cgDescription =
+    "Centre of gravity — aerodynamic balance value; component-derived value in parentheses when available";
 
   // Values that depend on the geometry-driven recompute. While a job is
   // in flight these are stale → render in red so the user knows not to
@@ -70,32 +90,47 @@ export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: P
       {/* Envelope speeds (gh-476: extended chip set) */}
       <Chip
         icon={AlertTriangle}
-        prefix="V_stall = "
+        symbol="V_stall"
+        description="Stall speed in clean configuration at 1 g"
         value={fmt(ctx?.v_stall_mps, 1, " m/s")}
         stale={stale}
       />
       <Chip
         icon={Wind}
-        prefix="V_min_sink = "
+        symbol="V_min_sink"
+        description="Speed for minimum sink rate — best endurance / longest glide time"
         value={fmt(ctx?.v_min_sink_mps, 1, " m/s")}
         stale={stale}
       />
-      <Chip icon={Wind} prefix="V_md = " value={fmt(ctx?.v_md_mps, 1, " m/s")} stale={stale} />
       <Chip
         icon={Wind}
-        prefix={ctx?.v_cruise_auto ? "V_cruise* = " : "V_cruise = "}
+        symbol="V_md"
+        description="Minimum-drag speed — best L/D, longest glide distance"
+        value={fmt(ctx?.v_md_mps, 1, " m/s")}
+        stale={stale}
+      />
+      <Chip
+        icon={Wind}
+        symbol={ctx?.v_cruise_auto ? "V_cruise*" : "V_cruise"}
+        description={
+          ctx?.v_cruise_auto
+            ? "Design cruise speed (auto-derived from cruise sizing — asterisk)"
+            : "Design cruise speed"
+        }
         value={fmt(ctx?.v_cruise_mps, 1, " m/s")}
         stale={stale}
       />
       <Chip
         icon={TrendingUp}
-        prefix="V_x = "
+        symbol="V_x"
+        description="Best angle-of-climb speed — steepest altitude gain per unit ground distance"
         value={fmt(ctx?.v_x_mps, 1, " m/s")}
         stale={stale}
       />
       <Chip
         icon={Plane}
-        prefix="V_y = "
+        symbol="V_y"
+        description="Best rate-of-climb speed — fastest altitude gain per unit time"
         value={fmt(ctx?.v_y_mps, 1, " m/s")}
         stale={stale}
       />
@@ -103,31 +138,57 @@ export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: P
       {!ctx?.is_glider && (
         <Chip
           icon={Gauge}
-          prefix="V_a = "
+          symbol="V_a"
+          description="Design manoeuvring speed — structural limit at full control deflection"
           value={fmt(ctx?.v_a_mps, 1, " m/s")}
           stale={stale}
         />
       )}
       <Chip
         icon={Gauge}
-        prefix={ctx?.is_glider ? "V_NE = " : "V_max = "}
+        symbol={ctx?.is_glider ? "V_NE" : "V_max"}
+        description={
+          ctx?.is_glider
+            ? "Never-exceed speed (CS-22 placard speed for gliders)"
+            : "Maximum operating speed"
+        }
         value={fmt(ctx?.v_max_mps, 1, " m/s")}
         stale={stale}
       />
       <Chip
         icon={Zap}
-        prefix="V_dive = "
+        symbol="V_dive"
+        description="Design dive speed (heuristic: 1.4 × V_max)"
         value={fmt(ctx?.v_dive_mps, 1, " m/s")}
         stale={stale}
       />
       {/* Divider between envelope speeds and aero geometry */}
       <div className="h-5 w-px bg-border" />
-      <Chip icon={Wind} prefix="Re ≈ " value={fmtRe(ctx?.reynolds)} stale={stale} />
-      <Chip icon={Ruler} prefix="MAC = " value={fmt(ctx?.mac_m, 2, " m")} stale={stale} />
-      <Chip icon={Target} prefix="NP = " value={fmt(ctx?.x_np_m, 3, " m")} stale={stale} />
+      <Chip
+        icon={Wind}
+        symbol="Re"
+        description="Reynolds number at cruise, characteristic length = MAC"
+        value={fmtRe(ctx?.reynolds)}
+        stale={stale}
+      />
+      <Chip
+        icon={Ruler}
+        symbol="MAC"
+        description="Mean Aerodynamic Chord — reference length for force and moment coefficients"
+        value={fmt(ctx?.mac_m, 2, " m")}
+        stale={stale}
+      />
+      <Chip
+        icon={Target}
+        symbol="NP"
+        description="Neutral point — aerodynamic centre of the whole aircraft"
+        value={fmt(ctx?.x_np_m, 3, " m")}
+        stale={stale}
+      />
       <Chip
         icon={Navigation}
-        prefix="SM = "
+        symbol="SM"
+        description="Static margin = (NP − CG) / MAC — target value used for trim balancing"
         value={
           ctx?.target_static_margin != null
             ? (ctx.target_static_margin * 100).toFixed(0) + "%"
@@ -135,7 +196,11 @@ export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: P
         }
         stale={stale}
       />
-      <div className="flex items-center gap-1.5 rounded-full bg-card-muted px-3 py-1.5">
+      <div
+        role="group"
+        aria-label={`CG: ${cgDescription}`}
+        className="group/chip relative flex items-center gap-1.5 rounded-full bg-card-muted px-3 py-1.5"
+      >
         <Navigation size={12} className="text-muted-foreground" />
         <span className="font-[family-name:var(--font-geist-sans)] text-[12px] text-foreground">
           {"CG = "}
@@ -151,6 +216,12 @@ export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: P
               ({ctx.cg_agg_m.toFixed(3)})
             </span>
           )}
+        </span>
+        <span
+          role="tooltip"
+          className="pointer-events-none absolute bottom-full left-1/2 z-50 mb-1.5 hidden w-max max-w-[240px] -translate-x-1/2 rounded-lg border border-border bg-card px-2.5 py-1.5 text-[10px] font-normal leading-snug text-foreground shadow-lg group-hover/chip:block"
+        >
+          {cgDescription}
         </span>
       </div>
       <div className="flex-1" />

--- a/frontend/components/workbench/InfoChipRow.tsx
+++ b/frontend/components/workbench/InfoChipRow.tsx
@@ -22,37 +22,48 @@ interface Props {
   readonly rightSlot?: React.ReactNode;
 }
 
+// Replace underscores with spaces so screen readers say
+// "V min sink" instead of "V underscore min underscore sink".
+function humanize(symbol: string): string {
+  return symbol.replace(/_/g, " ");
+}
+
 function Chip({
   icon: Icon,
   symbol,
   value,
+  valueNode,
   description,
   stale = false,
 }: {
   readonly icon: React.ComponentType<{ size: number; className: string }>;
   readonly symbol: string;
-  readonly value: string;
+  readonly value?: string;
+  readonly valueNode?: React.ReactNode;
   readonly description?: string;
   readonly stale?: boolean;
 }) {
   const valueClass = stale ? "text-red-400" : "text-foreground";
-  const ariaLabel = description ? `${symbol}: ${description}` : symbol;
+  const ariaLabel = description
+    ? `${humanize(symbol)}: ${description}`
+    : humanize(symbol);
   return (
     <div
       role="group"
+      tabIndex={0}
       aria-label={ariaLabel}
-      className="group/chip relative flex items-center gap-1.5 rounded-full bg-card-muted px-3 py-1.5"
+      className="group/chip relative flex items-center gap-1.5 rounded-full bg-card-muted px-3 py-1.5 focus:outline-none focus-visible:ring-1 focus-visible:ring-primary"
     >
       <Icon size={12} className="text-muted-foreground" />
       <span className="font-[family-name:var(--font-geist-sans)] text-[12px] text-foreground">
         {renderSymbol(symbol)}
         {" = "}
-        <span className={valueClass}>{value}</span>
+        {valueNode ?? <span className={valueClass}>{value}</span>}
       </span>
       {description && (
         <span
-          role="tooltip"
-          className="pointer-events-none absolute bottom-full left-1/2 z-50 mb-1.5 hidden w-max max-w-[240px] -translate-x-1/2 rounded-lg border border-border bg-card px-2.5 py-1.5 text-[10px] font-normal leading-snug text-foreground shadow-lg group-hover/chip:block"
+          aria-hidden="true"
+          className="pointer-events-none absolute bottom-full left-1/2 z-50 mb-1.5 hidden w-max max-w-[240px] -translate-x-1/2 rounded-lg border border-border bg-card px-2.5 py-1.5 text-[10px] font-normal leading-snug text-foreground shadow-lg group-hover/chip:block group-focus-within/chip:block"
         >
           {description}
         </span>
@@ -84,6 +95,23 @@ export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: P
   // in flight these are stale → render in red so the user knows not to
   // trust them until the recompute settles.
   const stale = !!isRecomputing;
+
+  const cgValueNode = (
+    <>
+      <span className={stale ? "text-red-400" : ""}>{cgValue}</span>
+      {cgAero != null && ctx?.cg_agg_m != null && ctx?.mac_m != null && (
+        <span
+          className={`ml-1 ${
+            stale
+              ? "text-red-400"
+              : cgDivergenceColor(cgAero, ctx.cg_agg_m, ctx.mac_m)
+          }`}
+        >
+          ({ctx.cg_agg_m.toFixed(3)})
+        </span>
+      )}
+    </>
+  );
 
   return (
     <div className="flex flex-wrap items-center gap-2 border-t border-border bg-card px-4 py-3">
@@ -196,34 +224,13 @@ export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: P
         }
         stale={stale}
       />
-      <div
-        role="group"
-        aria-label={`CG: ${cgDescription}`}
-        className="group/chip relative flex items-center gap-1.5 rounded-full bg-card-muted px-3 py-1.5"
-      >
-        <Navigation size={12} className="text-muted-foreground" />
-        <span className="font-[family-name:var(--font-geist-sans)] text-[12px] text-foreground">
-          {"CG = "}
-          <span className={stale ? "text-red-400" : ""}>{cgValue}</span>
-          {cgAero != null && ctx?.cg_agg_m != null && ctx?.mac_m != null && (
-            <span
-              className={`ml-1 ${
-                stale
-                  ? "text-red-400"
-                  : cgDivergenceColor(cgAero, ctx.cg_agg_m, ctx.mac_m)
-              }`}
-            >
-              ({ctx.cg_agg_m.toFixed(3)})
-            </span>
-          )}
-        </span>
-        <span
-          role="tooltip"
-          className="pointer-events-none absolute bottom-full left-1/2 z-50 mb-1.5 hidden w-max max-w-[240px] -translate-x-1/2 rounded-lg border border-border bg-card px-2.5 py-1.5 text-[10px] font-normal leading-snug text-foreground shadow-lg group-hover/chip:block"
-        >
-          {cgDescription}
-        </span>
-      </div>
+      <Chip
+        icon={Navigation}
+        symbol="CG"
+        description={cgDescription}
+        valueNode={cgValueNode}
+        stale={stale}
+      />
       <div className="flex-1" />
       {isRecomputing && (
         <span

--- a/frontend/components/workbench/renderSymbol.tsx
+++ b/frontend/components/workbench/renderSymbol.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+/**
+ * Render an engineering symbol where `_` is treated as LaTeX-style subscript.
+ *
+ *   V_x         → V<sub>x</sub>
+ *   V_min_sink  → V<sub>min,sink</sub>   (inner _ → ',' per aerospace convention)
+ *   V_cruise*   → V<sub>cruise</sub>*    (trailing non-word chars stay outside)
+ *   MAC         → MAC                    (no underscore: passthrough)
+ *
+ * Differs from strict LaTeX (`V_min_sink` would otherwise be V_{m}in_sink):
+ * everything between the first `_` and the trailing non-word run is the
+ * subscript group. This matches how aerospace texts typeset V_{min,sink}.
+ */
+export function renderSymbol(label: string): React.ReactNode {
+  const idx = label.indexOf("_");
+  if (idx === -1) return label;
+
+  const base = label.slice(0, idx);
+  const tail = label.slice(idx + 1);
+
+  const match = /^\w+/.exec(tail);
+  if (!match) return label;
+
+  const subRaw = match[0];
+  const trailing = tail.slice(subRaw.length);
+  const sub = subRaw.replace(/_/g, ",");
+
+  return (
+    <>
+      {base}
+      <sub className="text-[9px]">{sub}</sub>
+      {trailing}
+    </>
+  );
+}

--- a/frontend/components/workbench/renderSymbol.tsx
+++ b/frontend/components/workbench/renderSymbol.tsx
@@ -29,7 +29,7 @@ export function renderSymbol(label: string): React.ReactNode {
   return (
     <>
       {base}
-      <sub className="text-[9px]">{sub}</sub>
+      <sub className="text-[10px]">{sub}</sub>
       {trailing}
     </>
   );


### PR DESCRIPTION
## Summary

- New `renderSymbol(label)` helper treats `_` in a label as LaTeX-style subscript: `V_min_sink` → *V*<sub>min,sink</sub>, `V_x` → *V*<sub>x</sub>, `V_cruise*` → *V*<sub>cruise</sub>*. Inner underscores in the subscript become commas (aerospace convention).
- `Chip` in `InfoChipRow` now takes `symbol` + `description`. Each chip is a `role="group"` with `aria-label="<symbol>: <description>"` (screen-reader friendly) and shows a `group-hover` tooltip mirroring the existing `InfoTooltip` CSS pattern. **No new dependency** — no KaTeX, no MathJax.
- All 14 chips wired with descriptions (V_stall, V_min_sink, V_md, V_cruise(*), V_x, V_y, V_a, V_max/V_NE, V_dive, Re, MAC, NP, SM, CG).

## Test plan

- [x] `npm run test:unit` — 723/723 pass
- [x] `npm run lint` — no errors in the changed files (pre-existing warnings elsewhere only)
- [x] New `renderSymbol.test.tsx`: passthrough, single underscore, multi-underscore → comma, trailing `*`, multi-letter abbrev (V_NE, V_md, V_max), malformed input
- [x] Updated `InfoChipRow.test.tsx`: chips locatable via `getByRole('group', { name: /V_min_sink/ })`; tooltip + aria-label assertions; `<sub>` text-content snapshot for V_min_sink / V_x / V_dive
- [ ] Visual smoke check in the workbench (hover any V-speed chip — tooltip appears)

Closes #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)