### PR TITLE
fix(gh-535): emit STALE_NO_POLAR warning when OPG cold-starts (epic #525 follow-up)

### DIFF
--- a/app/services/operating_point_generator_service.py
+++ b/app/services/operating_point_generator_service.py
@@ -257,7 +257,7 @@ def _load_effective_flight_profile(
 def _estimate_reference_speeds(
     profile: dict[str, Any],
     cached_context: dict[str, Any] | None = None,
-) -> dict[str, float]:
+) -> dict[str, Any]:
     """Estimate clean / take-off / landing stall speeds for OP seeding.
 
     Precedence (gh-526 — epic gh-525 finding C1; replaces the historical
@@ -292,17 +292,45 @@ def _estimate_reference_speeds(
         vs_clean = max(3.0, cruise / min_margin_clean)
         vs_to = vs_clean
         vs_ldg = vs_clean
+        provenance = "cold_start"  # gh-535: caller must stamp STALE_NO_POLAR
     else:
         vs_clean = vs_clean_ctx
         # Prefer per-config physics; fall back to clean value when missing.
         vs_to = _pick("v_s_to_mps") or vs_clean
         vs_ldg = _pick("v_s0_mps") or vs_clean
+        provenance = "polar"
 
     return {
         "vs_clean": max(3.0, vs_clean),
         "vs_to": max(2.5, vs_to),
         "vs_ldg": max(2.0, vs_ldg),
+        "provenance": provenance,
     }
+
+
+def _stamp_stale_no_polar(
+    targets: list[dict[str, Any]],
+    refs: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Append ``STALE_NO_POLAR`` to every target when refs came from the
+    cold-start path (no polar yet, V_s estimated from cruise/margin).
+
+    The warning rides through to the persisted ``OperatingPointModel.warnings``
+    so consumers (UI chip row, AVL replay, SonarQube enrichment) can flag
+    these OPs as estimated rather than physics-derived (gh-535 / epic
+    gh-525 M1 follow-up).
+    """
+    if refs.get("provenance") != "cold_start":
+        return targets
+    stamped: list[dict[str, Any]] = []
+    for target in targets:
+        copy = dict(target)
+        warnings = list(copy.get("warnings", []))
+        if "STALE_NO_POLAR" not in warnings:
+            warnings.append("STALE_NO_POLAR")
+        copy["warnings"] = warnings
+        stamped.append(copy)
+    return stamped
 
 
 def _build_target_definitions(
@@ -960,6 +988,10 @@ def generate_default_set_for_aircraft(
         # angles produce non-physical AVL / NeuralFoil results otherwise.
         _flap_limits_for_clip = build_deflection_limits_from_schema(plane_schema)
         targets = [_clip_flap_to_ted_limit(t, _flap_limits_for_clip) for t in targets]
+        # gh-535: when the OPG ran without a polar (cold-start fallback to
+        # cruise/margin), stamp every target's warnings list so persisted
+        # OPs surface the STALE_NO_POLAR signal to consumers.
+        targets = _stamp_stale_no_polar(targets, refs)
         # Use the design CG as the moment-reference point for trim, so
         # Cm=0 means "balanced about the user's design CG", not about
         # the origin. Mirrors what stability_summary already does.

--- a/app/tests/test_operating_point_generator_service.py
+++ b/app/tests/test_operating_point_generator_service.py
@@ -693,3 +693,55 @@ def test_trimmed_point_controls_include_flap_deflection():
         f"flap deflection must be in OP controls; got {list(point.controls.keys())}"
     )
     assert point.controls["[flap]Flap"] == pytest.approx(22.0)
+
+
+# ============================================================================
+# gh-535 — STALE_NO_POLAR warning on cold-start (epic gh-525 follow-up)
+# ============================================================================
+
+
+def test_estimate_reference_speeds_reports_polar_provenance_when_context_present():
+    """gh-535: when v_s1_mps is in context, provenance is 'polar'."""
+    cached_context = {
+        "v_stall_mps": 14.0,
+        "v_s1_mps": 14.0,
+        "v_s_to_mps": 12.5,
+        "v_s0_mps": 10.5,
+    }
+    refs = _estimate_reference_speeds(_profile_with_cruise(), cached_context)
+    assert refs.get("provenance") == "polar"
+
+
+def test_estimate_reference_speeds_reports_cold_start_when_context_missing():
+    """gh-535: with no context, provenance is 'cold_start' so callers
+    can stamp the STALE_NO_POLAR warning."""
+    refs = _estimate_reference_speeds(_profile_with_cruise(cruise_mps=24.0), None)
+    assert refs.get("provenance") == "cold_start"
+
+
+def test_stamp_stale_no_polar_appends_warning_on_cold_start_only():
+    """gh-535: targets coming through `_stamp_stale_no_polar` carry
+    'STALE_NO_POLAR' in `warnings` only when refs.provenance == 'cold_start'."""
+    from app.services.operating_point_generator_service import _stamp_stale_no_polar
+
+    targets = [
+        {"name": "cruise", "config": "clean", "velocity": 20.0},
+        {"name": "approach_landing", "config": "landing", "velocity": 14.0},
+    ]
+    stamped_cold = _stamp_stale_no_polar(targets, {"provenance": "cold_start"})
+    for t in stamped_cold:
+        assert "STALE_NO_POLAR" in t["warnings"]
+
+    stamped_polar = _stamp_stale_no_polar(targets, {"provenance": "polar"})
+    for t in stamped_polar:
+        assert "STALE_NO_POLAR" not in t.get("warnings", [])
+
+
+def test_stamp_stale_no_polar_does_not_duplicate_existing_warning():
+    """Idempotent: re-stamping a target that already has the warning
+    must not produce duplicates."""
+    from app.services.operating_point_generator_service import _stamp_stale_no_polar
+
+    targets = [{"name": "cruise", "warnings": ["STALE_NO_POLAR"]}]
+    stamped = _stamp_stale_no_polar(targets, {"provenance": "cold_start"})
+    assert stamped[0]["warnings"].count("STALE_NO_POLAR") == 1


### PR DESCRIPTION
## Summary

When `assumption_compute_service` hasn't run yet, `_estimate_reference_speeds` uses `cruise / min_speed_margin_vs_clean` to estimate V_s. For STOL designs this inflates V_s by ~2.5×. This PR stamps every OP with a `STALE_NO_POLAR` warning so downstream consumers can flag the result as estimated. Closes #535.

## What changed

- `_estimate_reference_speeds` adds a `provenance` field: `"polar"` (cached context) or `"cold_start"` (cruise/margin).
- New `_stamp_stale_no_polar(targets, refs)` helper: appends `STALE_NO_POLAR` to every target's warnings on cold-start (idempotent).
- `generate_default_set_for_aircraft` invokes the stamper so the warning rides through to `OperatingPointModel.warnings`.

## Test plan

- [x] 4 new tests: `provenance` field on both paths; stamper appends on cold-start only; stamper idempotent.
- [x] 121 OPG-related fast tests pass.
- [x] Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)