### PR TITLE
fix(gh-536): use most-restrictive flap limit across multi-flap aircraft (epic #525 follow-up)

### DIFF
--- a/app/services/operating_point_generator_service.py
+++ b/app/services/operating_point_generator_service.py
@@ -59,25 +59,32 @@ def _clip_flap_to_ted_limit(
     (over-attached) flow with no warning.
 
     This helper returns a copy of ``target`` with ``flap_deflection_deg``
-    clipped to the first flap-role surface in ``deflection_limits``.
-    A ``"FLAP_DEFLECTION_CLIPPED"`` warning is appended when clipping
-    occurs so the OP carries an audit trail.
+    clipped to the most restrictive flap-role surface in
+    ``deflection_limits`` (gh-536: multi-flap aircraft such as an
+    inboard + outboard pair with different `positive_deflection_deg`
+    must be governed by the smaller authority so the smaller surface
+    never over-deflects). A ``"FLAP_DEFLECTION_CLIPPED"`` warning is
+    appended when clipping occurs so the OP carries an audit trail.
     """
     raw_flap = target.get("flap_deflection_deg")
     if raw_flap is None:
         return target
 
-    flap_limits: tuple[float, float] | None = None
+    flap_pos_limits: list[float] = []
+    flap_neg_limits: list[float] = []
     for name, limits in deflection_limits.items():
         role, _ = parse_role_tag(name)
         if role and role in FLAP_ROLES:
-            flap_limits = limits
-            break
-    if flap_limits is None:
+            flap_pos_limits.append(limits[0])
+            flap_neg_limits.append(limits[1])
+    if not flap_pos_limits:
         # No flap-role TED in geometry → don't manufacture a limit from
         # thin air. The trim solver itself will silently no-op the
         # missing surface.
         return target
+
+    # gh-536: most restrictive limit governs across all flap-role TEDs.
+    flap_limits = (min(flap_pos_limits), min(flap_neg_limits))
 
     max_pos, max_neg = flap_limits
     requested = float(raw_flap)

--- a/app/tests/test_operating_point_generator_service.py
+++ b/app/tests/test_operating_point_generator_service.py
@@ -630,6 +630,43 @@ def test_clip_flap_no_target_deflection_is_a_noop():
     assert "flap_deflection_deg" not in clipped
 
 
+def test_clip_flap_uses_minimum_limit_across_multi_flap_aircraft():
+    """gh-536: when multiple flap-role TEDs are present with different
+    `positive_deflection_deg`, the clipper must use the MOST RESTRICTIVE
+    (minimum) limit so the outboard flap is never over-deflected.
+    """
+    from app.services.operating_point_generator_service import _clip_flap_to_ted_limit
+
+    target = {
+        "name": "approach_landing",
+        "config": "landing",
+        "flap_deflection_deg": 30.0,
+    }
+    # Inboard flap rated 40°, outboard flap rated 20°. Min(40, 20) = 20.
+    deflection_limits = {
+        "[flap]Inboard": (40.0, 40.0),
+        "[flap]Outboard": (20.0, 20.0),
+    }
+    clipped = _clip_flap_to_ted_limit(target, deflection_limits)
+    assert clipped["flap_deflection_deg"] == 20.0
+    assert "FLAP_DEFLECTION_CLIPPED" in clipped.get("warnings", [])
+
+
+def test_clip_flap_single_flap_unchanged_by_multi_flap_logic():
+    """Regression: single flap-role TED → behaviour identical to pre-gh-536."""
+    from app.services.operating_point_generator_service import _clip_flap_to_ted_limit
+
+    target = {
+        "name": "approach_landing",
+        "config": "landing",
+        "flap_deflection_deg": 30.0,
+    }
+    deflection_limits = {"[flap]Flap": (40.0, 40.0)}  # only flap, well above target
+    clipped = _clip_flap_to_ted_limit(target, deflection_limits)
+    assert clipped["flap_deflection_deg"] == 30.0
+    assert "FLAP_DEFLECTION_CLIPPED" not in clipped.get("warnings", [])
+
+
 def test_clip_flap_no_flap_in_limits_is_a_noop():
     """Aircraft without a flap-role TED → no clipping, no warning."""
     from app.services.operating_point_generator_service import _clip_flap_to_ted_limit


### PR DESCRIPTION
## Summary

`_clip_flap_to_ted_limit` previously matched only the **first** flap-role TED in the deflection-limits dict. A real multi-flap aircraft (inboard 40°, outboard 20°) could over-deflect the smaller surface depending on iteration order. This PR takes the minimum across all flap-role TEDs so the most restrictive limit governs. Closes #536.

## What changed

`_clip_flap_to_ted_limit`: collect every flap-role TED's `(positive, negative)` limits, then govern with `min(positive)` / `min(negative)`. Single-flap aircraft behaviour unchanged.

## Test plan

- [x] New `test_clip_flap_uses_minimum_limit_across_multi_flap_aircraft`: 40° inboard + 20° outboard → 30° target clipped to 20°.
- [x] New regression `test_clip_flap_single_flap_unchanged_by_multi_flap_logic`.
- [x] 123 OPG-related fast tests pass.
- [x] Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)