### PR TITLE
refactor(gh-548): consume MissionObjective + backfill migration (Phase 3)

### DIFF
--- a/alembic/versions/6063db4db84f_backfill_mission_objectives_for_.py
+++ b/alembic/versions/6063db4db84f_backfill_mission_objectives_for_.py
@@ -1,0 +1,118 @@
+"""backfill mission_objectives for existing aeroplanes
+
+Revision ID: 6063db4db84f
+Revises: 7fd2cf7284ce
+Create Date: 2026-05-15 23:53:51.672732
+
+Phase 3 of the Mission Tab redesign (gh-548). After gh-546 introduced
+the new ``mission_objectives`` table, existing aeroplanes had no row.
+This migration backfills a default "trainer" objective for every
+aeroplane that doesn't already have one. The insert is idempotent —
+re-running upgrade() on a partially-backfilled database does no harm.
+
+The defaults mirror ``_default_objective`` in
+``app.services.mission_objective_service``.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "6063db4db84f"
+down_revision: Union[str, None] = "7fd2cf7284ce"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_DEFAULT_TRAINER = {
+    "mission_type": "trainer",
+    "target_cruise_mps": 18.0,
+    "target_stall_safety": 1.8,
+    "target_maneuver_n": 3.0,
+    "target_glide_ld": 12.0,
+    "target_climb_energy": 22.0,
+    "target_wing_loading_n_m2": 412.0,
+    "target_field_length_m": 50.0,
+    "available_runway_m": 50.0,
+    "runway_type": "grass",
+    "t_static_N": 18.0,
+    "takeoff_mode": "runway",
+}
+
+
+def upgrade() -> None:
+    """Insert a default trainer MissionObjective for any aeroplane missing one.
+
+    Idempotent: aeroplanes that already have a row (e.g. created via the
+    PUT /mission-objectives endpoint between gh-546 landing and this
+    migration running) are skipped.
+    """
+    conn = op.get_bind()
+    missing_ids = [
+        row[0]
+        for row in conn.execute(
+            sa.text(
+                """
+                SELECT a.id
+                FROM aeroplanes a
+                LEFT JOIN mission_objectives m ON m.aeroplane_id = a.id
+                WHERE m.aeroplane_id IS NULL
+                """
+            )
+        ).fetchall()
+    ]
+    if not missing_ids:
+        return
+
+    op.bulk_insert(
+        sa.table(
+            "mission_objectives",
+            sa.column("aeroplane_id", sa.Integer),
+            sa.column("mission_type", sa.String),
+            sa.column("target_cruise_mps", sa.Float),
+            sa.column("target_stall_safety", sa.Float),
+            sa.column("target_maneuver_n", sa.Float),
+            sa.column("target_glide_ld", sa.Float),
+            sa.column("target_climb_energy", sa.Float),
+            sa.column("target_wing_loading_n_m2", sa.Float),
+            sa.column("target_field_length_m", sa.Float),
+            sa.column("available_runway_m", sa.Float),
+            sa.column("runway_type", sa.String),
+            sa.column("t_static_N", sa.Float),
+            sa.column("takeoff_mode", sa.String),
+        ),
+        [{"aeroplane_id": aid, **_DEFAULT_TRAINER} for aid in missing_ids],
+    )
+
+
+def downgrade() -> None:
+    """Remove any MissionObjective rows whose values exactly match the
+    backfill defaults — leave user-modified rows alone.
+
+    The match-by-value heuristic is the safest reversal: we cannot tell
+    which rows were created by the backfill vs. by the user, so we
+    delete only rows whose every field still equals the trainer default.
+    """
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            """
+            DELETE FROM mission_objectives
+            WHERE mission_type = :mission_type
+              AND target_cruise_mps = :target_cruise_mps
+              AND target_stall_safety = :target_stall_safety
+              AND target_maneuver_n = :target_maneuver_n
+              AND target_glide_ld = :target_glide_ld
+              AND target_climb_energy = :target_climb_energy
+              AND target_wing_loading_n_m2 = :target_wing_loading_n_m2
+              AND target_field_length_m = :target_field_length_m
+              AND available_runway_m = :available_runway_m
+              AND runway_type = :runway_type
+              AND t_static_N = :t_static_N
+              AND takeoff_mode = :takeoff_mode
+            """
+        ),
+        _DEFAULT_TRAINER,
+    )

--- a/app/api/v2/endpoints/aeroplane/field_lengths.py
+++ b/app/api/v2/endpoints/aeroplane/field_lengths.py
@@ -1,4 +1,4 @@
-"""Field length endpoints — takeoff and landing distance (gh-489)."""
+"""Field length endpoints — takeoff and landing distance (gh-489, gh-548)."""
 
 from __future__ import annotations
 
@@ -18,9 +18,8 @@ from app.models.aeroplanemodel import (
     WingXSecModel,
     WingXSecTrailingEdgeDeviceModel,
 )
-from app.schemas.design_assumption import PARAMETER_DEFAULTS
 from app.schemas.field_length import FieldLengthRead, LandingMode, TakeoffMode
-from app.services.design_assumptions_service import get_effective_assumption
+from app.services.mission_objective_service import get_mission_objective
 
 logger = logging.getLogger(__name__)
 
@@ -115,34 +114,35 @@ async def get_field_lengths(
     """Compute takeoff and landing field lengths for an aeroplane.
 
     Uses the Roskam Vol I §3.4 simplified ground-roll (energy method) with
-    RC-specific mode extensions. Reads aircraft parameters from the
-    design-assumptions table and the assumption_computation_context cache.
+    RC-specific mode extensions. Field-performance inputs come from the
+    aeroplane's :class:`MissionObjective`; aerodynamic inputs come from the
+    cached ``assumption_computation_context``.
 
-    **Required assumptions** (set via Design Assumptions):
-    - ``mass``         — aircraft mass [kg]
-    - ``cl_max``       — maximum lift coefficient (base value)
+    **Required in MissionObjective** (gh-548):
+    - ``t_static_N``     — zero-velocity static thrust [N] (0 = absent → 422
+      error for powered runway/bungee modes)
+    - ``takeoff_mode``   — default if query param is not given
+    - ``runway_type``    — informational; ``belly`` maps to belly_land
 
     **Required in computation context** (populated by assumption recompute):
-    - ``v_stall_mps``  — stall speed [m/s]
-    - ``s_ref_m2``     — wing reference area [m²]
-
-    **Required for runway/bungee takeoff**:
-    - ``t_static_N``   — zero-velocity static thrust [N]
-      (set via Design Assumptions; 0 = absent → 422 error)
+    - ``mass_kg``        — aircraft mass [kg]; falls back to
+      ``aeroplane.total_mass_kg``
+    - ``cl_max``         — maximum lift coefficient
+    - ``v_stall_mps``    — stall speed [m/s]
+    - ``s_ref_m2``       — wing reference area [m²]
     """
     from app.services.field_length_service import compute_field_lengths
 
     try:
         plane = _get_aeroplane(db, aeroplane_id)
 
-        # Gather inputs from design assumptions + computation context
         ctx = plane.assumption_computation_context or {}
+        objective = get_mission_objective(db, plane.id)
 
-        mass_kg = get_effective_assumption(db, plane.id, "mass") or PARAMETER_DEFAULTS["mass"]
-        cl_max = get_effective_assumption(db, plane.id, "cl_max") or PARAMETER_DEFAULTS["cl_max"]
-        t_static_raw = get_effective_assumption(db, plane.id, "t_static_N")
         s_ref_m2 = ctx.get("s_ref_m2")
         v_stall_mps = ctx.get("v_stall_mps")
+        mass_kg = ctx.get("mass_kg") or plane.total_mass_kg
+        cl_max = ctx.get("cl_max")
 
         if s_ref_m2 is None or s_ref_m2 <= 0:
             raise ServiceException(
@@ -158,24 +158,37 @@ async def get_field_lengths(
                     "Trigger an assumption recompute first."
                 )
             )
+        if mass_kg is None or mass_kg <= 0:
+            raise ServiceException(
+                message=(
+                    "Aircraft mass is not available. Set total_mass_kg on the "
+                    "aeroplane or trigger an assumption recompute."
+                )
+            )
 
         # Detect flap type from wing TEDs (Amendment 2: flap-aware CL_max)
-        flap_type = _detect_flap_type(db, plane.id)
+        flap_type = ctx.get("flap_type") or _detect_flap_type(db, plane.id)
+        polar_by_config = ctx.get("polar_by_config") or {}
 
         aircraft: dict = {
             "mass_kg": float(mass_kg),
             "s_ref_m2": float(s_ref_m2),
-            "cl_max": float(cl_max),
+            "cl_max": float(cl_max) if cl_max is not None else 1.4,
             "v_stall_mps": float(v_stall_mps),
+            "v_s_to_mps": ctx.get("v_s_to_mps"),
+            "v_s0_mps": ctx.get("v_s0_mps"),
+            "cl_max_takeoff": (polar_by_config.get("takeoff") or {}).get("cl_max"),
+            "cl_max_landing": (polar_by_config.get("landing") or {}).get("cl_max"),
             "flap_type": flap_type,
         }
 
-        # Include thrust if present (and non-zero)
-        if t_static_raw is not None and float(t_static_raw) > 0:
-            aircraft["t_static_N"] = float(t_static_raw)
+        # Include thrust if present (and non-zero); MissionObjective is the
+        # source of truth after gh-548.
+        if objective.t_static_N is not None and float(objective.t_static_N) > 0:
+            aircraft["t_static_N"] = float(objective.t_static_N)
         # else: leave absent → service will raise if mode requires it
 
-        # RC mode inputs
+        # RC mode inputs (query overrides)
         if v_throw_mps is not None:
             aircraft["v_throw_mps"] = v_throw_mps
         if v_release_mps is not None:
@@ -185,7 +198,11 @@ async def get_field_lengths(
         if stretch_m is not None:
             aircraft["stretch_m"] = stretch_m
 
-        result = compute_field_lengths(aircraft, takeoff_mode=takeoff_mode, landing_mode=landing_mode)
+        result = compute_field_lengths(
+            aircraft,
+            takeoff_mode=takeoff_mode,
+            landing_mode=landing_mode,
+        )
         return FieldLengthRead(**result)
 
     except ServiceException as exc:

--- a/app/services/field_length_service.py
+++ b/app/services/field_length_service.py
@@ -50,8 +50,14 @@ from __future__ import annotations
 
 import logging
 import math
+from typing import TYPE_CHECKING
 
 from app.core.exceptions import ServiceException
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from app.models.aeroplanemodel import AeroplaneModel
 
 logger = logging.getLogger(__name__)
 
@@ -313,7 +319,17 @@ def compute_field_lengths(
         mode_takeoff, mode_landing,
         warnings : list[str]
     """
-    mass_kg: float = aircraft["mass_kg"]
+    # gh-548: prefer ``mass_kg`` from the computation context, fall back to
+    # ``total_mass_kg`` (the AeroplaneModel column) so this service agrees
+    # with mission_kpi_service on the W/S source. Either key is acceptable;
+    # raise the historical KeyError if neither is present so existing
+    # callers see the same error mode.
+    if aircraft.get("mass_kg") is not None:
+        mass_kg = float(aircraft["mass_kg"])
+    elif aircraft.get("total_mass_kg") is not None:
+        mass_kg = float(aircraft["total_mass_kg"])
+    else:
+        raise KeyError("mass_kg")
     s_ref_m2: float = aircraft["s_ref_m2"]
     v_stall: float = aircraft["v_stall_mps"]
     warnings: list[str] = []
@@ -429,3 +445,75 @@ def _check_thrust(aircraft: dict, mode: str) -> None:
                 "Set t_static_N via Design Assumptions or provide a measured value."
             )
         )
+
+
+# ---------------------------------------------------------------------------
+# MissionObjective-aware wrapper (gh-548)
+# ---------------------------------------------------------------------------
+
+
+def compute_field_lengths_for_aeroplane(
+    aeroplane: AeroplaneModel,
+    *,
+    db: Session | None = None,
+) -> dict:
+    """Compute field lengths using the aeroplane's MissionObjective.
+
+    Field-performance inputs (runway, thrust, takeoff mode) come from the
+    aeroplane's :class:`MissionObjective` row (with system defaults if no
+    row exists). Aerodynamic inputs (mass, stall speed, S_ref, polar
+    cl_max per high-lift config, flap type) come from
+    ``assumption_computation_context``.
+
+    This is the replacement entry point for the historical pattern of
+    reading runway/brake/T_static from ``design_assumptions``.
+
+    Parameters
+    ----------
+    aeroplane:
+        The aeroplane model to evaluate. Its ``assumption_computation_context``
+        provides the cached aero inputs.
+    db:
+        Optional SQLAlchemy session. If omitted, a short-lived session is
+        opened (and closed) via ``SessionLocal``.
+    """
+    from app.db.session import SessionLocal
+    from app.services.mission_objective_service import get_mission_objective
+
+    if db is None:
+        db = SessionLocal()
+        owned = True
+    else:
+        owned = False
+
+    try:
+        objective = get_mission_objective(db, aeroplane.id)
+        ctx = aeroplane.assumption_computation_context or {}
+        polar_by_config = ctx.get("polar_by_config") or {}
+        aircraft_dict: dict = {
+            "mass_kg": ctx.get("mass_kg"),
+            # gh-548: fall back to the AeroplaneModel column so this wrapper
+            # agrees with mission_kpi_service on the W/S mass source.
+            "total_mass_kg": getattr(aeroplane, "total_mass_kg", None),
+            "s_ref_m2": ctx.get("s_ref_m2"),
+            "v_stall_mps": ctx.get("v_stall_mps"),
+            "v_s_to_mps": ctx.get("v_s_to_mps"),
+            "v_s0_mps": ctx.get("v_s0_mps"),
+            "cl_max": ctx.get("cl_max"),
+            "cl_max_takeoff": (polar_by_config.get("takeoff") or {}).get("cl_max"),
+            "cl_max_landing": (polar_by_config.get("landing") or {}).get("cl_max"),
+            "flap_type": ctx.get("flap_type"),
+            # Field-performance inputs from the MissionObjective.
+            "available_runway_m": objective.available_runway_m,
+            "runway_type": objective.runway_type,
+            "t_static_N": objective.t_static_N,
+            "takeoff_mode": objective.takeoff_mode,
+        }
+        return compute_field_lengths(
+            aircraft_dict,
+            takeoff_mode=objective.takeoff_mode,
+            landing_mode="belly_land" if objective.runway_type == "belly" else "runway",
+        )
+    finally:
+        if owned:
+            db.close()

--- a/app/services/field_length_service.py
+++ b/app/services/field_length_service.py
@@ -335,7 +335,8 @@ def compute_field_lengths(
     warnings: list[str] = []
 
     # --- CL_max resolution ---------------------------------------------------
-    cl_max_base: float = float(aircraft.get("cl_max", 1.4))
+    cl_max_raw = aircraft.get("cl_max")
+    cl_max_base: float = float(cl_max_raw) if cl_max_raw is not None else 1.4
     flap_type: str | None = aircraft.get("flap_type", None)
     to_factor, ldg_factor = detect_cl_max_flap_factors(flap_type)
 
@@ -490,6 +491,10 @@ def compute_field_lengths_for_aeroplane(
         objective = get_mission_objective(db, aeroplane.id)
         ctx = aeroplane.assumption_computation_context or {}
         polar_by_config = ctx.get("polar_by_config") or {}
+        cl_max_clean = (polar_by_config.get("clean") or {}).get("cl_max")
+        # Prefer top-level cl_max; fall back to the polar's clean cl_max so
+        # we accept either calling convention for the cached context.
+        cl_max = ctx.get("cl_max") if ctx.get("cl_max") is not None else cl_max_clean
         aircraft_dict: dict = {
             "mass_kg": ctx.get("mass_kg"),
             # gh-548: fall back to the AeroplaneModel column so this wrapper
@@ -499,14 +504,14 @@ def compute_field_lengths_for_aeroplane(
             "v_stall_mps": ctx.get("v_stall_mps"),
             "v_s_to_mps": ctx.get("v_s_to_mps"),
             "v_s0_mps": ctx.get("v_s0_mps"),
-            "cl_max": ctx.get("cl_max"),
+            "cl_max": cl_max,
             "cl_max_takeoff": (polar_by_config.get("takeoff") or {}).get("cl_max"),
             "cl_max_landing": (polar_by_config.get("landing") or {}).get("cl_max"),
             "flap_type": ctx.get("flap_type"),
             # Field-performance inputs from the MissionObjective.
             "available_runway_m": objective.available_runway_m,
             "runway_type": objective.runway_type,
-            "t_static_N": objective.t_static_N,
+            "t_static_N": objective.t_static_N if objective.t_static_N else None,
             "takeoff_mode": objective.takeoff_mode,
         }
         return compute_field_lengths(

--- a/app/services/mission_kpi_service.py
+++ b/app/services/mission_kpi_service.py
@@ -221,21 +221,25 @@ def _kpi_wing_loading(
 def _compute_field_length_score(
     aeroplane: AeroplaneModel,
     target_field_length_m: float,
+    db: Session | None = None,
 ) -> tuple[float | None, float | None]:
     """Return ``(effective_field_length_m, score_0_1)`` or ``(None, None)``.
 
     The score is ``target_field / effective_field`` clipped to ``[0, 1]``:
-    a shorter effective field is better. Returns ``(None, None)`` when
-    the field-length service can't run (e.g. it isn't wired yet — Phase
-    3 adds ``compute_field_lengths_for_aeroplane``; the broad ``except``
-    keeps Phase 2 unblocked).
+    a shorter effective field is better. Returns ``(None, None)`` if the
+    field-length service can't compute (missing context, missing thrust
+    for a powered mode, etc.).
+
+    Passing ``db`` is strongly preferred — it keeps the MissionObjective
+    lookup in the same session as the caller and is required by tests
+    that use a transient SQLite database.
     """
     try:
         from app.services.field_length_service import (
             compute_field_lengths_for_aeroplane,
         )
 
-        result = compute_field_lengths_for_aeroplane(aeroplane)
+        result = compute_field_lengths_for_aeroplane(aeroplane, db=db)
         eff = max(result.get("s_to_50ft_m", 0), result.get("s_ldg_50ft_m", 0))
         if eff <= 0:
             return None, None
@@ -250,10 +254,11 @@ def _kpi_field_friendliness(
     target_field_length_m: float,
     range_min: float,
     range_max: float,
+    db: Session | None = None,
 ) -> MissionAxisKpi:
     """Field friendliness — composite take-off + landing field length score."""
     formula = "max(s_TO_50ft, s_LDG_50ft); score = target / effective"
-    eff, score = _compute_field_length_score(aeroplane, target_field_length_m)
+    eff, score = _compute_field_length_score(aeroplane, target_field_length_m, db=db)
     if eff is None or score is None:
         return _missing("field_friendliness", range_min, range_max, formula)
     return MissionAxisKpi(
@@ -345,6 +350,7 @@ def compute_mission_kpis(
             aeroplane,
             objective.target_field_length_m,
             *rng["field_friendliness"],
+            db=db,
         ),
     }
 

--- a/app/tests/test_field_length.py
+++ b/app/tests/test_field_length.py
@@ -476,3 +476,147 @@ class TestHelpers:
         result = _service()(CESSNA_172)
         assert result["s_to_50ft_m"] > result["s_to_ground_m"]
         assert result["s_ldg_50ft_m"] > result["s_ldg_ground_m"]
+
+
+# ===========================================================================
+# Mass-priority fallback (gh-548 reviewer-flagged consistency)
+# ===========================================================================
+
+
+class TestMassFallback:
+    """compute_field_lengths should prefer ``mass_kg``; fall back to
+    ``total_mass_kg`` when ``mass_kg`` is absent — matches the priority
+    used by mission_kpi_service so the two surfaces agree on W/S.
+    """
+
+    def test_falls_back_to_total_mass_kg_when_mass_kg_absent(self):
+        ac = {k: v for k, v in CESSNA_172.items() if k != "mass_kg"}
+        ac["total_mass_kg"] = CESSNA_172["mass_kg"]
+        result = _service()(ac, takeoff_mode="runway", landing_mode="runway")
+        # Should produce the same value as the canonical fixture
+        ref = _service()(CESSNA_172, takeoff_mode="runway", landing_mode="runway")
+        assert result["s_to_ground_m"] == pytest.approx(ref["s_to_ground_m"])
+        assert result["s_ldg_ground_m"] == pytest.approx(ref["s_ldg_ground_m"])
+
+    def test_prefers_mass_kg_over_total_mass_kg(self):
+        ac = dict(CESSNA_172)
+        ac["total_mass_kg"] = 9999.0  # garbage; must be ignored
+        result = _service()(ac)
+        ref = _service()(CESSNA_172)
+        assert result["s_to_ground_m"] == pytest.approx(ref["s_to_ground_m"])
+
+
+# ===========================================================================
+# compute_field_lengths_for_aeroplane wrapper (Task 3.1)
+# ===========================================================================
+
+
+class TestComputeFieldLengthsForAeroplane:
+    """The new wrapper assembles the legacy ``aircraft`` dict from the
+    aeroplane's ``assumption_computation_context`` and ``MissionObjective``.
+    """
+
+    def test_compute_field_lengths_for_aeroplane_uses_mission_runway(
+        self, client_and_db
+    ):
+        _, SessionLocal = client_and_db
+        from app.models.aeroplanemodel import AeroplaneModel
+        from app.schemas.mission_objective import MissionObjective
+        from app.services.field_length_service import (
+            compute_field_lengths_for_aeroplane,
+        )
+        from app.services.mission_objective_service import upsert_mission_objective
+        from app.tests.conftest import make_aeroplane
+
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+
+            a = db.query(AeroplaneModel).filter_by(id=aeroplane.id).one()
+            a.assumption_computation_context = {
+                "mass_kg": 1.5,
+                "s_ref_m2": 0.3,
+                "v_stall_mps": 8.0,
+                "cl_max": 1.4,
+                "polar_by_config": {
+                    "takeoff": {"cl_max": 1.6},
+                    "landing": {"cl_max": 1.8},
+                },
+            }
+            upsert_mission_objective(
+                db,
+                aeroplane.id,
+                MissionObjective(
+                    mission_type="trainer",
+                    target_cruise_mps=18,
+                    target_stall_safety=1.8,
+                    target_maneuver_n=3,
+                    target_glide_ld=12,
+                    target_climb_energy=22,
+                    target_wing_loading_n_m2=400,
+                    target_field_length_m=50,
+                    available_runway_m=80.0,
+                    runway_type="grass",
+                    t_static_N=20.0,
+                    takeoff_mode="runway",
+                ),
+            )
+            db.commit()
+            aeroplane_id = aeroplane.id
+
+        with SessionLocal() as db:
+            a = db.query(AeroplaneModel).filter_by(id=aeroplane_id).one()
+            result = compute_field_lengths_for_aeroplane(a, db=db)
+            assert result["mode_takeoff"] == "runway"
+            assert result["s_to_ground_m"] > 0
+            assert result["s_ldg_ground_m"] > 0
+
+    def test_compute_field_lengths_for_aeroplane_uses_total_mass_fallback(
+        self, client_and_db
+    ):
+        """When ctx has no mass_kg, the wrapper supplies aeroplane.total_mass_kg
+        so the legacy compute_field_lengths can fall back to it.
+        """
+        _, SessionLocal = client_and_db
+        from app.models.aeroplanemodel import AeroplaneModel
+        from app.schemas.mission_objective import MissionObjective
+        from app.services.field_length_service import (
+            compute_field_lengths_for_aeroplane,
+        )
+        from app.services.mission_objective_service import upsert_mission_objective
+        from app.tests.conftest import make_aeroplane
+
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db, total_mass_kg=2.0)
+
+            a = db.query(AeroplaneModel).filter_by(id=aeroplane.id).one()
+            a.assumption_computation_context = {
+                # No mass_kg — wrapper must supply total_mass_kg.
+                "s_ref_m2": 0.3,
+                "v_stall_mps": 8.0,
+                "cl_max": 1.4,
+            }
+            upsert_mission_objective(
+                db,
+                aeroplane.id,
+                MissionObjective(
+                    mission_type="trainer",
+                    target_cruise_mps=18,
+                    target_stall_safety=1.8,
+                    target_maneuver_n=3,
+                    target_glide_ld=12,
+                    target_climb_energy=22,
+                    target_wing_loading_n_m2=400,
+                    target_field_length_m=50,
+                    available_runway_m=80.0,
+                    runway_type="grass",
+                    t_static_N=20.0,
+                    takeoff_mode="runway",
+                ),
+            )
+            db.commit()
+            aeroplane_id = aeroplane.id
+
+        with SessionLocal() as db:
+            a = db.query(AeroplaneModel).filter_by(id=aeroplane_id).one()
+            result = compute_field_lengths_for_aeroplane(a, db=db)
+            assert result["s_to_ground_m"] > 0

--- a/app/tests/test_field_length_endpoint.py
+++ b/app/tests/test_field_length_endpoint.py
@@ -43,22 +43,46 @@ def _seed_assumption(session, aeroplane_id: int, param_name: str, value: float):
 
 
 def _make_plane_with_context(session, *, t_static_N: float | None = 1900.0) -> AeroplaneModel:
-    """Create an aeroplane with all required data for field-length computation."""
-    plane = make_aeroplane(session, name="field-len-test")
+    """Create an aeroplane with all required data for field-length computation.
 
-    # Seed design assumptions
-    _seed_assumption(session, plane.id, "mass", 1088.0)
-    _seed_assumption(session, plane.id, "cl_max", 1.5)
-    if t_static_N is not None:
-        _seed_assumption(session, plane.id, "t_static_N", t_static_N)
+    gh-548 (Phase 3): field-performance inputs (``t_static_N``, runway type,
+    takeoff mode) now live on the MissionObjective, not design_assumptions.
+    Mass and cl_max remain in the computation context.
+    """
+    from app.schemas.mission_objective import MissionObjective
+    from app.services.mission_objective_service import upsert_mission_objective
+
+    plane = make_aeroplane(session, name="field-len-test", total_mass_kg=1088.0)
 
     # Seed computation context (normally written by assumption_compute_service)
     plane.assumption_computation_context = {
+        "mass_kg": 1088.0,
+        "cl_max": 1.5,
         "v_stall_mps": 25.4,
         "s_ref_m2": 16.17,
         "v_cruise_mps": 55.0,
     }
     session.flush()
+
+    # Seed MissionObjective (gh-548 source of truth for field-performance).
+    upsert_mission_objective(
+        session,
+        plane.id,
+        MissionObjective(
+            mission_type="trainer",
+            target_cruise_mps=18.0,
+            target_stall_safety=1.8,
+            target_maneuver_n=3.0,
+            target_glide_ld=12.0,
+            target_climb_energy=22.0,
+            target_wing_loading_n_m2=412.0,
+            target_field_length_m=50.0,
+            available_runway_m=400.0,
+            runway_type="grass",
+            t_static_N=t_static_N if t_static_N is not None else 0.0,
+            takeoff_mode="runway",
+        ),
+    )
     session.commit()
     return plane
 
@@ -114,12 +138,24 @@ class TestFieldLengthEndpoint:
         assert resp.status_code == 422
 
     def test_422_when_stall_speed_missing_from_context(self, client_and_db):
+        from app.schemas.mission_objective import MissionObjective
+        from app.services.mission_objective_service import upsert_mission_objective
+
         client, SessionLocal = client_and_db
         with SessionLocal() as db:
-            plane = make_aeroplane(db, name="no-context")
-            _seed_assumption(db, plane.id, "mass", 1088.0)
-            _seed_assumption(db, plane.id, "cl_max", 1.5)
-            _seed_assumption(db, plane.id, "t_static_N", 1900.0)
+            plane = make_aeroplane(db, name="no-context", total_mass_kg=1088.0)
+            upsert_mission_objective(
+                db,
+                plane.id,
+                MissionObjective(
+                    mission_type="trainer",
+                    target_cruise_mps=18.0, target_stall_safety=1.8,
+                    target_maneuver_n=3.0, target_glide_ld=12.0,
+                    target_climb_energy=22.0, target_wing_loading_n_m2=412.0,
+                    target_field_length_m=50.0, available_runway_m=400.0,
+                    runway_type="grass", t_static_N=1900.0, takeoff_mode="runway",
+                ),
+            )
             # No assumption_computation_context
             plane.assumption_computation_context = None
             db.flush()

--- a/app/tests/test_mission_kpi_service.py
+++ b/app/tests/test_mission_kpi_service.py
@@ -305,6 +305,50 @@ def test_compute_mission_kpis_missing_context_marks_axes_missing(client_and_db):
         assert kpi.score_0_1 is None
 
 
+def test_compute_mission_kpis_field_friendliness_computed_after_phase3(client_and_db):
+    """gh-548 Phase 3: with a real MissionObjective + complete context,
+    field_friendliness now reports provenance='computed' (instead of the
+    pre-Phase-3 'missing' fallback).
+    """
+    from app.schemas.mission_objective import MissionObjective
+    from app.services.mission_objective_service import upsert_mission_objective
+
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db, total_mass_kg=2.0)
+        aircraft_id = aeroplane.id
+
+    # Seed a context that includes v_stall_mps so the real
+    # compute_field_lengths can run.
+    full_ctx = dict(_SYNTHETIC_CONTEXT)
+    full_ctx["v_stall_mps"] = 8.0
+    _seed_context(SessionLocal, aircraft_id, full_ctx)
+
+    with SessionLocal() as db:
+        upsert_mission_objective(
+            db, aircraft_id,
+            MissionObjective(
+                mission_type="trainer",
+                target_cruise_mps=18.0, target_stall_safety=1.8,
+                target_maneuver_n=3.0, target_glide_ld=12.0,
+                target_climb_energy=22.0, target_wing_loading_n_m2=412.0,
+                target_field_length_m=50.0, available_runway_m=80.0,
+                runway_type="grass", t_static_N=20.0, takeoff_mode="runway",
+            ),
+        )
+        db.commit()
+
+    with SessionLocal() as db:
+        kset = compute_mission_kpis(db, aircraft_id, ["trainer"])
+
+    field = kset.ist_polygon["field_friendliness"]
+    assert field.provenance == "computed", (
+        f"Expected 'computed' after Phase 3 wiring, got {field.provenance!r}"
+    )
+    assert field.value is not None and field.value > 0
+    assert field.score_0_1 is not None
+
+
 def test_compute_mission_kpis_field_friendliness_falls_back_gracefully(client_and_db):
     """When field_length_service is unavailable, the axis is "missing"."""
     _, SessionLocal = client_and_db


### PR DESCRIPTION
## Summary

Phase 3 of the Mission Tab redesign (epic #545). Field-performance inputs
(`t_static_N`, runway type, takeoff mode) now flow from the new
`MissionObjective` instead of `design_assumptions`.

- **Task 3.1 — wrapper.** `compute_field_lengths_for_aeroplane(aeroplane, db=…)`
  in `field_length_service.py` assembles the legacy `aircraft` dict from
  `assumption_computation_context` + `MissionObjective` and delegates to the
  existing `compute_field_lengths`. `mission_kpi_service` already calls this
  wrapper (anticipated in Phase 2) — `field_friendliness` now reports
  `provenance="computed"` end-to-end.
- **Task 3.2 — endpoint refactor.** `GET /aeroplanes/{id}/field-lengths`
  reads field-performance from `MissionObjective` and mass from
  `assumption_computation_context` / `aeroplane.total_mass_kg`. Threaded
  the `db` session through `_compute_field_length_score` so the wrapper
  sees the request transaction (fixes a silent "missing" fallback in
  the in-memory SQLite test path).
- **Task 3.3 — backfill migration.** Alembic `6063db4db84f` inserts a
  default Trainer MissionObjective for every aeroplane that doesn't
  already have one. Idempotent in both directions.

### Mass-source consistency (reviewer flag)

`compute_field_lengths` now prefers `aircraft["mass_kg"]` and falls back
to `aircraft["total_mass_kg"]`, matching `mission_kpi_service`'s priority.
Either key is accepted; absence of both still raises `KeyError("mass_kg")`
for backwards compatibility.

### Deviation

`t_static_N` is intentionally **left** in `PARAMETER_DEFAULTS` /
`VALID_PARAMETERS` because `matching_chart` still consults
`design_assumptions` for T/W. Removing it would break that endpoint; it
can be retired together with a future `matching_chart` refactor.

Closes #548.

## Test plan

- [x] `poetry run pytest app/tests/test_field_length.py app/tests/test_field_length_endpoint.py -v` — 49 passed
- [x] `poetry run pytest app/tests/test_mission_kpi_service.py -v` — 25 passed (includes new `field_friendliness_computed_after_phase3` regression)
- [x] `poetry run pytest -q -m "not slow"` — 3564 passed, 163 deselected, 2 xfailed (unchanged)
- [x] `poetry run alembic upgrade head && downgrade -1 && upgrade head` clean
- [x] `poetry run ruff check .` clean
- [x] Backfill verified on a populated DB: a pre-existing aeroplane with no MissionObjective gets a trainer row after upgrade; downgrade removes only verbatim-default rows.