### PR TITLE
feat(gh-549): mission-preset auto-apply of design-assumption estimates (Phase 4)

### DIFF
--- a/app/services/mission_objective_service.py
+++ b/app/services/mission_objective_service.py
@@ -46,20 +46,63 @@ def get_mission_objective(db: Session, aeroplane_id: int) -> MissionObjective:
 def upsert_mission_objective(
     db: Session, aeroplane_id: int, payload: MissionObjective
 ) -> MissionObjective:
-    """Create or update the MissionObjective for an aeroplane."""
+    """Create or update the MissionObjective for an aeroplane.
+
+    When the mission_type changes (including the first create), the preset's
+    suggested_estimates are auto-applied to design_assumptions.estimate_value
+    via :func:`_apply_preset_estimates` (gh-549). Only estimate_value is
+    touched — calculated_value, calculated_source, and active_source remain
+    owned by assumption_compute_service / AeroBuildup.
+    """
     row = (
         db.query(MissionObjectiveModel)
         .filter(MissionObjectiveModel.aeroplane_id == aeroplane_id)
         .one_or_none()
     )
+    old_mission_type = row.mission_type if row else None
     if row is None:
         row = MissionObjectiveModel(aeroplane_id=aeroplane_id)
         db.add(row)
     for field, value in payload.model_dump().items():
         setattr(row, field, value)
     db.flush()
+
+    # Auto-apply preset estimates when mission_type changes (incl. first create)
+    if old_mission_type != payload.mission_type:
+        _apply_preset_estimates(db, aeroplane_id, payload.mission_type)
+
     db.refresh(row)
     return MissionObjective.model_validate(row, from_attributes=True)
+
+
+def _apply_preset_estimates(db: Session, aeroplane_id: int, mission_type: str) -> None:
+    """Write the preset's suggested_estimates to design_assumptions.estimate_value.
+
+    Never touches calculated_value or active_source — those remain owned by
+    assumption_compute_service / AeroBuildup. Silent no-op for unknown
+    mission_type; KPI service is responsible for raising on bad ids.
+    """
+    from app.models.aeroplanemodel import DesignAssumptionModel
+
+    preset = (
+        db.query(MissionPresetModel).filter_by(id=mission_type).one_or_none()
+    )
+    if preset is None:
+        return
+    estimates: dict = preset.suggested_estimates
+    for param_name, value in estimates.items():
+        a_row = (
+            db.query(DesignAssumptionModel)
+            .filter_by(aeroplane_id=aeroplane_id, parameter_name=param_name)
+            .one_or_none()
+        )
+        if a_row is None:
+            a_row = DesignAssumptionModel(
+                aeroplane_id=aeroplane_id, parameter_name=param_name
+            )
+            db.add(a_row)
+        a_row.estimate_value = value
+    db.flush()
 
 
 def list_mission_presets(db: Session) -> list[MissionPreset]:

--- a/app/tests/test_mission_objective_service.py
+++ b/app/tests/test_mission_objective_service.py
@@ -66,3 +66,120 @@ def test_list_mission_presets_returns_six_seeded(client_and_db):
         presets = list_mission_presets(db)
         ids = {p.id for p in presets}
     assert ids == {"trainer", "sport", "sailplane", "wing_racer", "acro_3d", "stol_bush"}
+
+
+def test_upsert_changes_mission_type_writes_suggested_estimates(client_and_db):
+    """gh-549: switching mission_type rewrites estimate_value per the preset."""
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        from app.tests.conftest import make_aeroplane
+        from app.services.design_assumptions_service import seed_defaults
+        from app.models.aeroplanemodel import DesignAssumptionModel
+
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aircraft_id = aeroplane.id
+
+    with SessionLocal() as db:
+        upsert_mission_objective(db, aircraft_id, _make_objective(mission_type="sailplane"))
+        db.commit()
+
+    with SessionLocal() as db:
+        rows = {
+            r.parameter_name: r
+            for r in db.query(DesignAssumptionModel)
+            .filter_by(aeroplane_id=aircraft_id).all()
+        }
+        # Sailplane preset values from app/services/mission_preset_seed.py
+        assert rows["g_limit"].estimate_value == 5.3
+        assert rows["target_static_margin"].estimate_value == 0.10
+        assert rows["cl_max"].estimate_value == 1.3
+        assert rows["power_to_weight"].estimate_value == 0.0
+        assert rows["prop_efficiency"].estimate_value == 0.0
+
+
+def test_upsert_does_not_touch_calculated_value_when_changing_mission(client_and_db):
+    """gh-549 safety: auto-apply must never touch calculated_value or active_source."""
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        from app.tests.conftest import make_aeroplane
+        from app.services.design_assumptions_service import (
+            seed_defaults,
+            update_calculated_value,
+        )
+        from app.models.aeroplanemodel import DesignAssumptionModel
+
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        # Set a calculated_value via the canonical path (simulate AeroBuildup output)
+        update_calculated_value(
+            db,
+            str(aeroplane.uuid),
+            "cl_max",
+            1.62,
+            "aerobuildup",
+            auto_switch_source=True,
+        )
+        db.commit()
+        aircraft_id = aeroplane.id
+
+    with SessionLocal() as db:
+        upsert_mission_objective(db, aircraft_id, _make_objective(mission_type="sailplane"))
+        db.commit()
+
+    with SessionLocal() as db:
+        cl_max_row = (
+            db.query(DesignAssumptionModel)
+            .filter_by(aeroplane_id=aircraft_id, parameter_name="cl_max")
+            .one()
+        )
+        # estimate_value was overwritten by the preset
+        assert cl_max_row.estimate_value == 1.3   # sailplane preset
+        # calculated_value preserved
+        assert cl_max_row.calculated_value == 1.62
+        # active_source preserved (CALCULATED takes precedence per existing convention)
+        assert cl_max_row.active_source == "CALCULATED"
+
+
+def test_upsert_no_change_in_mission_type_does_not_rewrite_estimates(client_and_db):
+    """Idempotent: re-saving the same mission_type must not rewrite estimates
+    (avoids unnecessary writes; matters if user manually tweaked an estimate)."""
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        from app.tests.conftest import make_aeroplane
+        from app.services.design_assumptions_service import seed_defaults
+        from app.models.aeroplanemodel import DesignAssumptionModel
+
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aircraft_id = aeroplane.id
+
+    # First upsert applies trainer defaults
+    with SessionLocal() as db:
+        upsert_mission_objective(db, aircraft_id, _make_objective(mission_type="trainer"))
+        db.commit()
+
+    # User manually overrides g_limit
+    with SessionLocal() as db:
+        row = (
+            db.query(DesignAssumptionModel)
+            .filter_by(aeroplane_id=aircraft_id, parameter_name="g_limit")
+            .one()
+        )
+        row.estimate_value = 4.5
+        db.commit()
+
+    # Re-upsert with SAME mission_type — should NOT rewrite g_limit
+    with SessionLocal() as db:
+        upsert_mission_objective(db, aircraft_id, _make_objective(mission_type="trainer"))
+        db.commit()
+
+    with SessionLocal() as db:
+        row = (
+            db.query(DesignAssumptionModel)
+            .filter_by(aeroplane_id=aircraft_id, parameter_name="g_limit")
+            .one()
+        )
+        assert row.estimate_value == 4.5   # user override preserved


### PR DESCRIPTION
## Summary

Phase 4 of the Mission Tab redesign (epic #545). When the user picks a mission type via `PUT /mission-objectives`, the matching preset's `suggested_estimates` are auto-written into `design_assumptions.estimate_value` for that aeroplane.

- Detection happens in `upsert_mission_objective` by comparing `old_mission_type` vs the incoming payload — covers both first-create (None → x) and switching (x → y).
- Helper `_apply_preset_estimates` writes only `estimate_value`. `calculated_value`, `calculated_source`, and `active_source` are never touched — those remain owned by `assumption_compute_service` / AeroBuildup.
- Re-saving the same mission_type is idempotent: no rewrites, so any manual estimate the user tweaked survives.
- Missing rows in `design_assumptions` are created on the fly (defensive — `seed_defaults` normally handles this earlier).

Closes #549.

## Test plan

- [x] `poetry run pytest app/tests/test_mission_objective_service.py -v` — 6/6 green (3 new + 3 existing).
- [x] `poetry run pytest app/tests/test_mission_kpi_service.py app/tests/test_mission_objectives_endpoint.py -v` — 31/31 green.
- [x] `poetry run pytest -q -m "not slow"` — 3567 passed, 163 deselected, 2 xfailed; no regressions.
- [x] `poetry run ruff check .` — clean.

New tests:
- `test_upsert_changes_mission_type_writes_suggested_estimates` — preset values land in `estimate_value`.
- `test_upsert_does_not_touch_calculated_value_when_changing_mission` — safety: `calculated_value` and `active_source` are preserved.
- `test_upsert_no_change_in_mission_type_does_not_rewrite_estimates` — idempotent: user override survives a re-save.

Generated with Claude Code.