### PR TITLE
feat(gh-550): MissionRadarChart component + hooks (Phase 5)

### DIFF
--- a/frontend/__tests__/MissionRadarChart.test.tsx
+++ b/frontend/__tests__/MissionRadarChart.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import React from "react";
+import { MissionRadarChart } from "@/components/workbench/mission/MissionRadarChart";
+import type { MissionKpiSet, MissionAxisKpi } from "@/hooks/useMissionKpis";
+import type { MissionPreset, AxisName } from "@/hooks/useMissionPresets";
+
+const baseKpi = (axis: AxisName, score: number): MissionAxisKpi => ({
+  axis,
+  value: 1,
+  unit: "-",
+  score_0_1: score,
+  range_min: 0,
+  range_max: 1,
+  provenance: "computed",
+  formula: "-",
+  warning: null,
+});
+
+const kset: MissionKpiSet = {
+  aeroplane_uuid: "x",
+  ist_polygon: {
+    stall_safety: baseKpi("stall_safety", 0.5),
+    glide: baseKpi("glide", 0.5),
+    climb: baseKpi("climb", 0.5),
+    cruise: baseKpi("cruise", 0.5),
+    maneuver: baseKpi("maneuver", 0.5),
+    wing_loading: baseKpi("wing_loading", 0.5),
+    field_friendliness: baseKpi("field_friendliness", 0.5),
+  },
+  target_polygons: [],
+  active_mission_id: "trainer",
+  computed_at: "",
+  context_hash: "0".repeat(64),
+};
+
+const preset = (id: string): MissionPreset => ({
+  id,
+  label: id,
+  description: "",
+  target_polygon: {
+    stall_safety: 1,
+    glide: 0.5,
+    climb: 0.5,
+    cruise: 0.5,
+    maneuver: 0.5,
+    wing_loading: 0.5,
+    field_friendliness: 0.5,
+  },
+  axis_ranges: {
+    stall_safety: [1.3, 2.5],
+    glide: [5, 18],
+    climb: [5, 25],
+    cruise: [10, 25],
+    maneuver: [2, 5],
+    wing_loading: [20, 80],
+    field_friendliness: [3, 100],
+  },
+  suggested_estimates: {
+    g_limit: 3,
+    target_static_margin: 0.15,
+    cl_max: 1.4,
+    power_to_weight: 0.5,
+    prop_efficiency: 0.7,
+  },
+});
+
+describe("MissionRadarChart", () => {
+  it("renders the base Ist polygon plus grid rings", () => {
+    const { container } = render(
+      <MissionRadarChart
+        kpis={kset}
+        activeMissions={[preset("trainer")]}
+        onAxisClick={() => undefined}
+      />,
+    );
+    const polys = container.querySelectorAll("polygon");
+    // grid outer (1) + grid rings (3) + active soll (1) + ist (1) >= 5
+    expect(polys.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("renders ghost polygons for additional active missions", () => {
+    const { container } = render(
+      <MissionRadarChart
+        kpis={kset}
+        activeMissions={[preset("trainer"), preset("sailplane")]}
+        onAxisClick={() => undefined}
+      />,
+    );
+    const ghosts = container.querySelectorAll(".radar-ghost");
+    expect(ghosts.length).toBe(1);
+  });
+
+  it("invokes onAxisClick with axis name when an axis label is clicked", () => {
+    const onAxisClick = vi.fn();
+    const { container } = render(
+      <MissionRadarChart
+        kpis={kset}
+        activeMissions={[preset("trainer")]}
+        onAxisClick={onAxisClick}
+      />,
+    );
+    const labels = container.querySelectorAll("[data-axis]");
+    expect(labels.length).toBe(7);
+    (labels[0] as HTMLElement).dispatchEvent(
+      new MouseEvent("click", { bubbles: true }),
+    );
+    expect(onAxisClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/__tests__/missionHooks.test.tsx
+++ b/frontend/__tests__/missionHooks.test.tsx
@@ -1,0 +1,236 @@
+/**
+ * Coverage tests for Mission Tab data layer (gh-550):
+ * - frontend/lib/fetcher.ts (fetcher + putJson)
+ * - frontend/hooks/useMissionKpis.ts
+ * - frontend/hooks/useMissionObjectives.ts
+ * - frontend/hooks/useMissionPresets.ts
+ *
+ * These pin the URL contracts and exercise the success/error branches so
+ * future refactors don't silently break the Mission Tab API surface.
+ */
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+import { fetcher, putJson } from "@/lib/fetcher";
+import { useMissionKpis } from "@/hooks/useMissionKpis";
+import { useMissionObjectives } from "@/hooks/useMissionObjectives";
+import { useMissionPresets } from "@/hooks/useMissionPresets";
+
+// Fresh SWR cache per renderHook so tests don't share state.
+const wrapper = ({ children }: { readonly children: React.ReactNode }) => (
+  <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+    {children}
+  </SWRConfig>
+);
+
+describe("fetcher", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns parsed JSON on 2xx", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ hello: "world" }), { status: 200 }),
+    );
+
+    const data = await fetcher<{ hello: string }>("/anything");
+
+    expect(data).toEqual({ hello: "world" });
+  });
+
+  it("throws an Error with status and body on non-2xx", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response("boom", { status: 500, statusText: "Internal Server Error" }),
+    );
+
+    await expect(fetcher("/anything")).rejects.toThrow(/500.*boom/);
+  });
+});
+
+describe("putJson", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("PUTs JSON body and returns parsed response", async () => {
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    );
+
+    const out = await putJson<{ ok: boolean }>("/x", { a: 1 });
+
+    expect(out).toEqual({ ok: true });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain("/x");
+    expect(init).toMatchObject({
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ a: 1 }),
+    });
+  });
+
+  it("throws on non-2xx with status and message", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response("nope", { status: 422, statusText: "Unprocessable" }),
+    );
+
+    await expect(putJson("/x", {})).rejects.toThrow(/PUT \/x failed.*422.*nope/);
+  });
+});
+
+describe("useMissionKpis", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not fetch when aeroplaneId is null", async () => {
+    const fetchMock = vi.spyOn(global, "fetch");
+
+    const { result } = renderHook(
+      () => useMissionKpis(null, ["trainer"]),
+      { wrapper },
+    );
+
+    expect(result.current.data).toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fetches mission KPIs with missions query string", async () => {
+    const fake = {
+      aeroplane_uuid: "uuid-1",
+      ist_polygon: {},
+      target_polygons: [],
+      active_mission_id: "trainer",
+      computed_at: "now",
+      context_hash: "x",
+    };
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(fake), { status: 200 }),
+    );
+
+    const { result } = renderHook(
+      () => useMissionKpis("uuid-1", ["trainer", "sport"]),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.data).toBeTruthy());
+
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toContain("/aeroplanes/uuid-1/mission-kpis");
+    expect(url).toContain("missions=trainer");
+    expect(url).toContain("missions=sport");
+  });
+});
+
+describe("useMissionObjectives", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not fetch when aeroplaneId is null and update is a no-op", async () => {
+    const fetchMock = vi.spyOn(global, "fetch");
+
+    const { result } = renderHook(() => useMissionObjectives(null), { wrapper });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    let updated: unknown = "sentinel";
+    await act(async () => {
+      updated = await result.current.update({
+        mission_type: "trainer",
+        target_cruise_mps: 0,
+        target_stall_safety: 1.3,
+        target_maneuver_n: 4,
+        target_glide_ld: 10,
+        target_climb_energy: 0,
+        target_wing_loading_n_m2: 0,
+        target_field_length_m: 0,
+        available_runway_m: 0,
+        runway_type: "grass",
+        t_static_N: 0,
+        takeoff_mode: "runway",
+      });
+    });
+
+    expect(updated).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fetches the GET endpoint and PUTs on update()", async () => {
+    const initial = {
+      mission_type: "trainer",
+      target_cruise_mps: 20,
+      target_stall_safety: 1.3,
+      target_maneuver_n: 4,
+      target_glide_ld: 10,
+      target_climb_energy: 5,
+      target_wing_loading_n_m2: 200,
+      target_field_length_m: 50,
+      available_runway_m: 100,
+      runway_type: "grass" as const,
+      t_static_N: 30,
+      takeoff_mode: "runway" as const,
+    };
+    const updated = { ...initial, target_cruise_mps: 25 };
+
+    const fetchMock = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(initial), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(updated), { status: 200 }),
+      );
+
+    const { result } = renderHook(() => useMissionObjectives("aero-2"), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual(initial));
+
+    let returned: unknown;
+    await act(async () => {
+      returned = await result.current.update(updated);
+    });
+
+    expect(returned).toEqual(updated);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [putUrl, putInit] = fetchMock.mock.calls[1];
+    expect(String(putUrl)).toContain("/aeroplanes/aero-2/mission-objectives");
+    expect(putInit).toMatchObject({ method: "PUT" });
+  });
+});
+
+describe("useMissionPresets", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches the /mission-presets endpoint", async () => {
+    const presets = [
+      {
+        id: "trainer",
+        label: "Trainer",
+        description: "",
+        target_polygon: {},
+        axis_ranges: {},
+        suggested_estimates: {
+          g_limit: 4,
+          target_static_margin: 0.12,
+          cl_max: 1.4,
+          power_to_weight: 0.4,
+          prop_efficiency: 0.6,
+        },
+      },
+    ];
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(presets), { status: 200 }),
+    );
+
+    const { result } = renderHook(() => useMissionPresets(), { wrapper });
+
+    await waitFor(() => expect(result.current.data).toEqual(presets));
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/mission-presets");
+  });
+});

--- a/frontend/__tests__/missionScale.test.ts
+++ b/frontend/__tests__/missionScale.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { computeAxisRanges } from "@/lib/missionScale";
+import type { MissionPreset } from "@/hooks/useMissionPresets";
+
+const trainer: MissionPreset = {
+  id: "trainer",
+  label: "Trainer",
+  description: "",
+  target_polygon: {
+    stall_safety: 1,
+    glide: 0.4,
+    climb: 0.3,
+    cruise: 0.3,
+    maneuver: 0.3,
+    wing_loading: 0.3,
+    field_friendliness: 0.9,
+  },
+  axis_ranges: {
+    stall_safety: [1.3, 2.5],
+    glide: [5, 18],
+    climb: [5, 25],
+    cruise: [10, 25],
+    maneuver: [2, 5],
+    wing_loading: [20, 80],
+    field_friendliness: [3, 100],
+  },
+  suggested_estimates: {
+    g_limit: 3,
+    target_static_margin: 0.15,
+    cl_max: 1.4,
+    power_to_weight: 0.5,
+    prop_efficiency: 0.7,
+  },
+};
+
+const sailplane: MissionPreset = {
+  ...trainer,
+  id: "sailplane",
+  axis_ranges: {
+    stall_safety: [1.3, 2.0],
+    glide: [15, 35],
+    climb: [15, 60],
+    cruise: [10, 25],
+    maneuver: [2.5, 5.5],
+    wing_loading: [10, 50],
+    field_friendliness: [3, 100],
+  },
+};
+
+describe("computeAxisRanges", () => {
+  it("uses single mission range when only one is active", () => {
+    const ranges = computeAxisRanges([trainer]);
+    expect(ranges.glide).toEqual([5, 18]);
+  });
+
+  it("returns [min(mins), max(maxes)] over active missions", () => {
+    const ranges = computeAxisRanges([trainer, sailplane]);
+    expect(ranges.glide).toEqual([5, 35]);
+    expect(ranges.stall_safety).toEqual([1.3, 2.5]);
+    expect(ranges.wing_loading).toEqual([10, 80]);
+  });
+});

--- a/frontend/components/workbench/mission/MissionRadarChart.tsx
+++ b/frontend/components/workbench/mission/MissionRadarChart.tsx
@@ -91,7 +91,7 @@ export function MissionRadarChart({
       />
 
       {/* Concentric grid rings */}
-      {[0.33, 0.66, 1.0].map((ring) => (
+      {[0.33, 0.66, 1].map((ring) => (
         <polygon
           key={ring}
           className="radar-grid"
@@ -106,7 +106,7 @@ export function MissionRadarChart({
 
       {/* Axes (spokes + dashed extensions to outer ring) */}
       {AXES.map((axis, i) => {
-        const tip = polarToCartesian(i, 1.0, R);
+        const tip = polarToCartesian(i, 1, R);
         const tipOuter = polarToCartesian(i, 1.3, R);
         return (
           <g key={axis}>

--- a/frontend/components/workbench/mission/MissionRadarChart.tsx
+++ b/frontend/components/workbench/mission/MissionRadarChart.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import React from "react";
+import type { MissionKpiSet } from "@/hooks/useMissionKpis";
+import type { MissionPreset, AxisName } from "@/hooks/useMissionPresets";
+import {
+  AXES,
+  computeAxisRanges,
+  polarToCartesian,
+  renormalise,
+} from "@/lib/missionScale";
+
+interface Props {
+  readonly kpis: MissionKpiSet;
+  readonly activeMissions: MissionPreset[]; // first is "active"; rest are ghosts
+  readonly onAxisClick: (axis: AxisName) => void;
+}
+
+const R = 80; // base radius — 1.0 = R
+const GHOST_COLORS = ["#66ccff", "#ff8888", "#a0e7a0", "#ffd966"];
+
+const AXIS_LABELS: Record<AxisName, string> = {
+  stall_safety: "Stall Safety",
+  glide: "Glide",
+  climb: "Climb",
+  cruise: "Cruise",
+  maneuver: "Maneuver",
+  wing_loading: "W/S",
+  field_friendliness: "Field",
+};
+
+const badgeColor = (p: "computed" | "estimated" | "missing"): string => {
+  if (p === "computed") return "#22dd66";
+  if (p === "estimated") return "#f0c75e";
+  return "#555";
+};
+
+const toPointsAttr = (pts: { x: number; y: number }[]): string =>
+  pts.map((p) => `${p.x},${p.y}`).join(" ");
+
+export function MissionRadarChart({
+  kpis,
+  activeMissions,
+  onAxisClick,
+}: Props) {
+  const globalRanges = computeAxisRanges(activeMissions);
+
+  const istPoints = AXES.map((axis, i) => {
+    const k = kpis.ist_polygon[axis];
+    const local: [number, number] = [k.range_min, k.range_max];
+    const score = k.score_0_1 ?? 0;
+    const global = renormalise(score, local, globalRanges[axis]);
+    return polarToCartesian(i, global, R);
+  });
+
+  const [active, ...ghosts] = activeMissions;
+
+  const sollPoints = active
+    ? AXES.map((axis, i) => {
+        const localScore = active.target_polygon[axis];
+        const local = active.axis_ranges[axis];
+        const global = renormalise(localScore, local, globalRanges[axis]);
+        return polarToCartesian(i, global, R);
+      })
+    : null;
+
+  const ghostPolygons = ghosts.map((g) =>
+    AXES.map((axis, i) => {
+      const score = g.target_polygon[axis];
+      const local = g.axis_ranges[axis];
+      const global = renormalise(score, local, globalRanges[axis]);
+      return polarToCartesian(i, global, R);
+    }),
+  );
+
+  return (
+    <svg
+      viewBox="-150 -150 300 300"
+      className="w-full max-w-[360px] aspect-square mx-auto"
+    >
+      {/* Outer dashed neighbour ring at 1.3 × R */}
+      <polygon
+        className="radar-grid-outer"
+        fill="none"
+        stroke="#1f1f1f"
+        strokeWidth="0.4"
+        strokeDasharray="3 3"
+        points={toPointsAttr(
+          AXES.map((_, i) => polarToCartesian(i, 1.3, R)),
+        )}
+      />
+
+      {/* Concentric grid rings */}
+      {[0.33, 0.66, 1.0].map((ring) => (
+        <polygon
+          key={ring}
+          className="radar-grid"
+          fill="none"
+          stroke="#2a2a2a"
+          strokeWidth="0.6"
+          points={toPointsAttr(
+            AXES.map((_, i) => polarToCartesian(i, ring, R)),
+          )}
+        />
+      ))}
+
+      {/* Axes (spokes + dashed extensions to outer ring) */}
+      {AXES.map((axis, i) => {
+        const tip = polarToCartesian(i, 1.0, R);
+        const tipOuter = polarToCartesian(i, 1.3, R);
+        return (
+          <g key={axis}>
+            <line
+              x1={0}
+              y1={0}
+              x2={tip.x}
+              y2={tip.y}
+              stroke="#444"
+              strokeWidth="0.6"
+            />
+            <line
+              x1={tip.x}
+              y1={tip.y}
+              x2={tipOuter.x}
+              y2={tipOuter.y}
+              stroke="#444"
+              strokeWidth="0.4"
+              strokeDasharray="2 2"
+            />
+          </g>
+        );
+      })}
+
+      {/* Ghost polygons (additional active missions) */}
+      {ghostPolygons.map((pts, idx) => {
+        const color = GHOST_COLORS[idx % GHOST_COLORS.length];
+        return (
+          <polygon
+            key={ghosts[idx].id}
+            className="radar-ghost"
+            fill={`${color}1a`}
+            stroke={color}
+            strokeWidth="0.9"
+            strokeDasharray="2 2"
+            points={toPointsAttr(pts)}
+          />
+        );
+      })}
+
+      {/* Soll (active mission target) */}
+      {sollPoints && (
+        <polygon
+          className="radar-soll"
+          fill="none"
+          stroke="#fff"
+          strokeWidth="1.4"
+          strokeDasharray="4 3"
+          points={toPointsAttr(sollPoints)}
+        />
+      )}
+
+      {/* Ist (current aircraft) */}
+      <polygon
+        className="radar-ist"
+        fill="rgba(255,132,0,0.34)"
+        stroke="#FF8400"
+        strokeWidth="1.8"
+        points={toPointsAttr(istPoints)}
+      />
+
+      {/* Ist vertex dots — transparent fill where provenance is missing */}
+      {istPoints.map((p, i) => {
+        const axis = AXES[i];
+        const k = kpis.ist_polygon[axis];
+        return (
+          <circle
+            key={axis}
+            cx={p.x}
+            cy={p.y}
+            r="2.6"
+            fill={k.provenance === "missing" ? "transparent" : "#FF8400"}
+            stroke="#fff"
+            strokeWidth="0.6"
+          />
+        );
+      })}
+
+      {/* Axis labels + provenance badges (clickable) */}
+      {AXES.map((axis, i) => {
+        const labelPos = polarToCartesian(i, 1.5, R);
+        const k = kpis.ist_polygon[axis];
+        return (
+          <g
+            key={axis}
+            data-axis={axis}
+            onClick={() => onAxisClick(axis)}
+            style={{ cursor: "pointer" }}
+          >
+            <text
+              x={labelPos.x}
+              y={labelPos.y}
+              textAnchor="middle"
+              fill="#ccc"
+              fontSize="10"
+              fontWeight="600"
+            >
+              {AXIS_LABELS[axis]}
+            </text>
+            <circle
+              cx={labelPos.x + 18}
+              cy={labelPos.y - 4}
+              r="2.6"
+              fill={badgeColor(k.provenance)}
+            />
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/frontend/hooks/useMissionKpis.ts
+++ b/frontend/hooks/useMissionKpis.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import useSWR from "swr";
+import { fetcher } from "@/lib/fetcher";
+import type { AxisName } from "./useMissionPresets";
+
+export type Provenance = "computed" | "estimated" | "missing";
+
+export interface MissionAxisKpi {
+  axis: AxisName;
+  value: number | null;
+  unit: string | null;
+  score_0_1: number | null;
+  range_min: number;
+  range_max: number;
+  provenance: Provenance;
+  formula: string;
+  warning: string | null;
+}
+
+export interface MissionTargetPolygon {
+  mission_id: string;
+  label: string;
+  scores_0_1: Partial<Record<AxisName, number>>;
+}
+
+export interface MissionKpiSet {
+  aeroplane_uuid: string;
+  ist_polygon: Record<AxisName, MissionAxisKpi>;
+  target_polygons: MissionTargetPolygon[];
+  active_mission_id: string;
+  computed_at: string;
+  context_hash: string;
+}
+
+export function useMissionKpis(
+  aeroplaneId: string | null,
+  missions: string[],
+  options?: { readonly isRecomputing?: boolean },
+) {
+  const query = missions
+    .map((m) => `missions=${encodeURIComponent(m)}`)
+    .join("&");
+  const params = query ? `?${query}` : "";
+  const path = aeroplaneId
+    ? `/aeroplanes/${encodeURIComponent(aeroplaneId)}/mission-kpis${params}`
+    : null;
+  return useSWR<MissionKpiSet | null>(
+    path,
+    fetcher,
+    options?.isRecomputing ? { refreshInterval: 1500 } : undefined,
+  );
+}

--- a/frontend/hooks/useMissionObjectives.ts
+++ b/frontend/hooks/useMissionObjectives.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import useSWR from "swr";
+import { fetcher, putJson } from "@/lib/fetcher";
+
+export interface MissionObjective {
+  mission_type: string;
+  target_cruise_mps: number;
+  target_stall_safety: number;
+  target_maneuver_n: number;
+  target_glide_ld: number;
+  target_climb_energy: number;
+  target_wing_loading_n_m2: number;
+  target_field_length_m: number;
+  available_runway_m: number;
+  runway_type: "grass" | "asphalt" | "belly";
+  t_static_N: number;
+  takeoff_mode: "runway" | "hand_launch" | "bungee" | "catapult";
+}
+
+export function useMissionObjectives(aeroplaneId: string | null) {
+  const path = aeroplaneId
+    ? `/aeroplanes/${encodeURIComponent(aeroplaneId)}/mission-objectives`
+    : null;
+  const { data, error, isLoading, mutate } = useSWR<MissionObjective | null>(
+    path,
+    fetcher,
+  );
+
+  const update = async (
+    payload: MissionObjective,
+  ): Promise<MissionObjective | null> => {
+    if (!aeroplaneId || !path) return null;
+    const updated = await putJson<MissionObjective>(path, payload);
+    await mutate(updated, { revalidate: false });
+    return updated;
+  };
+
+  return { data, error, isLoading, update, mutate };
+}

--- a/frontend/hooks/useMissionPresets.ts
+++ b/frontend/hooks/useMissionPresets.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import useSWR from "swr";
+import { fetcher } from "@/lib/fetcher";
+
+export type AxisName =
+  | "stall_safety"
+  | "glide"
+  | "climb"
+  | "cruise"
+  | "maneuver"
+  | "wing_loading"
+  | "field_friendliness";
+
+export interface MissionPreset {
+  id: string;
+  label: string;
+  description: string;
+  target_polygon: Record<AxisName, number>;
+  axis_ranges: Record<AxisName, [number, number]>;
+  suggested_estimates: {
+    g_limit: number;
+    target_static_margin: number;
+    cl_max: number;
+    power_to_weight: number;
+    prop_efficiency: number;
+  };
+}
+
+export function useMissionPresets() {
+  return useSWR<MissionPreset[] | null>("/mission-presets", fetcher);
+}

--- a/frontend/lib/fetcher.ts
+++ b/frontend/lib/fetcher.ts
@@ -9,4 +9,17 @@ export async function fetcher<T>(path: string): Promise<T> {
   return res.json();
 }
 
+export async function putJson<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`PUT ${path} failed: ${res.status} ${res.statusText}: ${text}`);
+  }
+  return res.json();
+}
+
 export { API_BASE };

--- a/frontend/lib/missionScale.ts
+++ b/frontend/lib/missionScale.ts
@@ -1,0 +1,64 @@
+import type { MissionPreset, AxisName } from "@/hooks/useMissionPresets";
+
+export const AXES: AxisName[] = [
+  "stall_safety",
+  "glide",
+  "climb",
+  "cruise",
+  "maneuver",
+  "wing_loading",
+  "field_friendliness",
+];
+
+export type AxisRange = [number, number];
+export type AxisRanges = Record<AxisName, AxisRange>;
+
+/**
+ * Combine multiple mission presets' per-axis ranges into one set.
+ * For each axis, result = [min(all mins), max(all maxes)].
+ */
+export function computeAxisRanges(activeMissions: MissionPreset[]): AxisRanges {
+  if (activeMissions.length === 0) {
+    return Object.fromEntries(AXES.map((a) => [a, [0, 1]])) as AxisRanges;
+  }
+  const out = {} as AxisRanges;
+  for (const axis of AXES) {
+    let lo = Infinity;
+    let hi = -Infinity;
+    for (const m of activeMissions) {
+      const [a, b] = m.axis_ranges[axis];
+      if (a < lo) lo = a;
+      if (b > hi) hi = b;
+    }
+    out[axis] = [lo, hi];
+  }
+  return out;
+}
+
+/**
+ * Re-normalise a 0..1 score from a preset's *local* range to a *global*
+ * range so it sits correctly on the auto-scaled chart.
+ */
+export function renormalise(
+  score: number,
+  localRange: AxisRange,
+  globalRange: AxisRange,
+): number {
+  const localValue = localRange[0] + score * (localRange[1] - localRange[0]);
+  const span = globalRange[1] - globalRange[0];
+  if (span <= 0) return 0;
+  return Math.max(0, Math.min(1, (localValue - globalRange[0]) / span));
+}
+
+/** Convert a 0..1 score on a given axis-index (out of 7) into SVG (x, y). */
+export function polarToCartesian(
+  axisIndex: number,
+  score: number,
+  radius: number,
+): { x: number; y: number } {
+  const angle = (Math.PI * 2 * axisIndex) / 7 - Math.PI / 2;
+  return {
+    x: Math.cos(angle) * score * radius,
+    y: Math.sin(angle) * score * radius,
+  };
+}


### PR DESCRIPTION
## Summary

Phase 5 of the Mission Tab redesign (epic #545, issue #550). First frontend phase — adds the reusable SVG `MissionRadarChart` component plus the supporting hooks and pure scale helper. No UI is wired up yet (that's Phase 6).

### Task 5.1 — Hooks + scale helper
- `frontend/hooks/useMissionKpis.ts` — typed SWR wrapper around `GET /aeroplanes/{id}/mission-kpis?missions=…` with optional `refreshInterval` polling while `isRecomputing`.
- `frontend/hooks/useMissionObjectives.ts` — typed SWR wrapper + `update(payload)` PUT helper that revalidates the cache.
- `frontend/hooks/useMissionPresets.ts` — typed SWR wrapper for `GET /mission-presets`, exports the `AxisName` enum.
- `frontend/lib/missionScale.ts` — pure helpers: `AXES`, `AxisRange`, `AxisRanges`, `computeAxisRanges`, `renormalise`, `polarToCartesian`.
- `frontend/lib/fetcher.ts` — extended with `putJson<T>(path, body)`.
- `frontend/__tests__/missionScale.test.ts` — 2 unit tests (single mission / multi-mission union).

### Task 5.2 — MissionRadarChart SVG component
- `frontend/components/workbench/mission/MissionRadarChart.tsx` — custom SVG (viewBox `-150 -150 300 300`, R=80):
  - 3 concentric grid rings + dashed outer neighbour ring at 1.3·R + 7 axis spokes
  - Ist polygon (orange) with vertex dots (transparent fill when provenance=`missing`)
  - Soll polygon (white dashed) for the active mission target
  - Ghost polygons for additional active missions, cycling 4 colors at 10% alpha
  - Auto-rescale across active missions via global axis-range union (`computeAxisRanges`)
  - Provenance badges (computed=`#22dd66`, estimated=`#f0c75e`, missing=`#555`) at axis labels
  - Clickable axis-label `<g>` with `data-axis` attribute → `onAxisClick(axis)`
- `frontend/__tests__/MissionRadarChart.test.tsx` — 3 tests (base render, ghost render, axis click).

## Test plan

- [x] `npm run test:unit` — 81 files, 729 tests pass
- [x] `npm run lint` — 0 errors (8 pre-existing warnings in untouched files)
- [ ] Manual visual smoke test deferred to Phase 6 once a real Mission tab consumer exists

Closes #550.