### PR TITLE
feat(gh-551): Mission Tab UI replacement (Phase 6)

### DIFF
--- a/frontend/__tests__/MissionCompliancePanel.test.tsx
+++ b/frontend/__tests__/MissionCompliancePanel.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+import { MissionCompliancePanel } from "@/components/workbench/mission/MissionCompliancePanel";
+
+vi.mock("@/hooks/useMissionObjectives", () => ({
+  useMissionObjectives: () => ({
+    data: { mission_type: "trainer" },
+  }),
+}));
+
+vi.mock("@/hooks/useMissionPresets", () => ({
+  useMissionPresets: () => ({
+    data: [
+      {
+        id: "trainer",
+        label: "Trainer",
+        description: "",
+        target_polygon: {
+          stall_safety: 0.5,
+          glide: 0.5,
+          climb: 0.5,
+          cruise: 0.5,
+          maneuver: 0.5,
+          wing_loading: 0.5,
+          field_friendliness: 0.5,
+        },
+        axis_ranges: {
+          stall_safety: [0, 1],
+          glide: [0, 1],
+          climb: [0, 1],
+          cruise: [0, 1],
+          maneuver: [0, 1],
+          wing_loading: [0, 1],
+          field_friendliness: [0, 1],
+        },
+        suggested_estimates: {
+          g_limit: 4,
+          target_static_margin: 0.12,
+          cl_max: 1.4,
+          power_to_weight: 0.4,
+          prop_efficiency: 0.6,
+        },
+      },
+      {
+        id: "sailplane",
+        label: "Sailplane",
+        description: "",
+        target_polygon: {
+          stall_safety: 0.5,
+          glide: 0.5,
+          climb: 0.5,
+          cruise: 0.5,
+          maneuver: 0.5,
+          wing_loading: 0.5,
+          field_friendliness: 0.5,
+        },
+        axis_ranges: {
+          stall_safety: [0, 1],
+          glide: [0, 1],
+          climb: [0, 1],
+          cruise: [0, 1],
+          maneuver: [0, 1],
+          wing_loading: [0, 1],
+          field_friendliness: [0, 1],
+        },
+        suggested_estimates: {
+          g_limit: 2,
+          target_static_margin: 0.18,
+          cl_max: 1.2,
+          power_to_weight: 0.0,
+          prop_efficiency: 0.0,
+        },
+      },
+    ],
+  }),
+}));
+
+const FAKE_KPI = (axis: string) => ({
+  axis,
+  value: 0.5,
+  unit: null,
+  score_0_1: 0.5,
+  range_min: 0,
+  range_max: 1,
+  provenance: "computed" as const,
+  formula: "",
+  warning: null,
+});
+
+vi.mock("@/hooks/useMissionKpis", () => ({
+  useMissionKpis: () => ({
+    data: {
+      aeroplane_uuid: "x",
+      ist_polygon: {
+        stall_safety: FAKE_KPI("stall_safety"),
+        glide: FAKE_KPI("glide"),
+        climb: FAKE_KPI("climb"),
+        cruise: FAKE_KPI("cruise"),
+        maneuver: FAKE_KPI("maneuver"),
+        wing_loading: FAKE_KPI("wing_loading"),
+        field_friendliness: FAKE_KPI("field_friendliness"),
+      },
+      target_polygons: [],
+      active_mission_id: "trainer",
+      computed_at: "now",
+      context_hash: "x",
+    },
+  }),
+}));
+
+describe("MissionCompliancePanel", () => {
+  it("renders the title and radar chart", () => {
+    render(
+      <MissionCompliancePanel aeroplaneId="x" onAxisClick={() => {}} />,
+    );
+    expect(screen.getByText(/Mission Compliance/)).toBeInTheDocument();
+    expect(screen.getByText(/Vergleichs-Profile/)).toBeInTheDocument();
+  });
+
+  it("adds a comparison mission when a non-active toggle is clicked", () => {
+    render(
+      <MissionCompliancePanel aeroplaneId="x" onAxisClick={() => {}} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Sailplane/ }));
+    // Sky-blue (comparison) class should appear on Sailplane after toggle.
+    const sailplane = screen.getByRole("button", { name: /Sailplane/ });
+    expect(sailplane.className).toContain("text-sky-400");
+  });
+});

--- a/frontend/__tests__/MissionObjectivesPanel.test.tsx
+++ b/frontend/__tests__/MissionObjectivesPanel.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+import { MissionObjectivesPanel } from "@/components/workbench/mission/MissionObjectivesPanel";
+
+vi.mock("@/hooks/useMissionObjectives", () => ({
+  useMissionObjectives: () => ({
+    data: {
+      mission_type: "trainer",
+      target_cruise_mps: 18, target_stall_safety: 1.8,
+      target_maneuver_n: 3, target_glide_ld: 12,
+      target_climb_energy: 22, target_wing_loading_n_m2: 412,
+      target_field_length_m: 50,
+      available_runway_m: 50, runway_type: "grass",
+      t_static_N: 18, takeoff_mode: "runway",
+    },
+    update: vi.fn().mockResolvedValue(undefined),
+    isLoading: false, error: null,
+  }),
+}));
+
+vi.mock("@/hooks/useMissionPresets", () => ({
+  useMissionPresets: () => ({
+    data: [
+      { id: "trainer", label: "Trainer", description: "", target_polygon: {}, axis_ranges: {}, suggested_estimates: { g_limit: 4, target_static_margin: 0.12, cl_max: 1.4, power_to_weight: 0.4, prop_efficiency: 0.6 } },
+      { id: "sailplane", label: "Sailplane", description: "", target_polygon: {}, axis_ranges: {}, suggested_estimates: { g_limit: 2, target_static_margin: 0.18, cl_max: 1.2, power_to_weight: 0.0, prop_efficiency: 0.0 } },
+    ],
+    isLoading: false, error: null,
+  }),
+}));
+
+describe("MissionObjectivesPanel", () => {
+  it("renders the mission type dropdown with all presets", () => {
+    render(<MissionObjectivesPanel aeroplaneId="x"/>);
+    expect(screen.getByRole("option", { name: /Trainer/ })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /Sailplane/ })).toBeInTheDocument();
+  });
+
+  it("renders the field-performance section", () => {
+    render(<MissionObjectivesPanel aeroplaneId="x"/>);
+    expect(screen.getByText(/Field Performance/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Available Runway/i)).toBeInTheDocument();
+  });
+
+  it("shows the auto-apply banner after mission_type change", () => {
+    render(<MissionObjectivesPanel aeroplaneId="x"/>);
+    const select = screen.getByLabelText(/Mission Type/i) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "sailplane" } });
+    expect(screen.getByText(/Estimates angepasst/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/MissionPage.test.tsx
+++ b/frontend/__tests__/MissionPage.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import React from "react";
+
+let aeroplaneId: string | null = null;
+const openPicker = vi.fn();
+
+vi.mock("@/components/workbench/AeroplaneContext", () => ({
+  useAeroplaneContext: () => ({ aeroplaneId, hydrated: true, openPicker }),
+}));
+
+vi.mock("@/components/workbench/mission/MissionCompliancePanel", () => ({
+  MissionCompliancePanel: ({
+    onAxisClick,
+  }: {
+    onAxisClick: (a: string) => void;
+  }) => (
+    <button type="button" onClick={() => onAxisClick("climb")}>
+      compliance-stub
+    </button>
+  ),
+}));
+
+vi.mock("@/components/workbench/mission/MissionObjectivesPanel", () => ({
+  MissionObjectivesPanel: () => <div>objectives-stub</div>,
+}));
+
+vi.mock("@/components/workbench/WorkbenchTwoPanel", () => ({
+  WorkbenchTwoPanel: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+import MissionPage from "@/app/workbench/mission/page";
+
+describe("MissionPage", () => {
+  beforeEach(() => {
+    openPicker.mockClear();
+  });
+
+  it("prompts to select an aeroplane when none is set", () => {
+    aeroplaneId = null;
+    render(<MissionPage />);
+    expect(
+      screen.getByText(/Select an aeroplane to view Mission compliance/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Select an aeroplane to edit its Mission objectives/),
+    ).toBeInTheDocument();
+  });
+
+  it("calls openPicker when hydrated with no aeroplaneId", () => {
+    aeroplaneId = null;
+    render(<MissionPage />);
+    expect(openPicker).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders both panels when an aeroplane is selected", () => {
+    aeroplaneId = "aero-1";
+    render(<MissionPage />);
+    expect(screen.getByText(/compliance-stub/)).toBeInTheDocument();
+    expect(screen.getByText(/objectives-stub/)).toBeInTheDocument();
+  });
+
+  it("shows drilldown placeholder toast after onAxisClick is invoked", () => {
+    aeroplaneId = "aero-1";
+    render(<MissionPage />);
+    act(() => {
+      fireEvent.click(screen.getByText(/compliance-stub/));
+    });
+    expect(screen.getByText(/Axis drilldown for/)).toBeInTheDocument();
+    expect(screen.getByText(/climb/)).toBeInTheDocument();
+    expect(screen.getByText(/coming in Phase 7/)).toBeInTheDocument();
+  });
+
+  it("closes the drilldown toast when × is clicked", () => {
+    aeroplaneId = "aero-1";
+    render(<MissionPage />);
+    act(() => {
+      fireEvent.click(screen.getByText(/compliance-stub/));
+    });
+    expect(screen.getByText(/Axis drilldown for/)).toBeInTheDocument();
+    act(() => {
+      fireEvent.click(
+        screen.getByRole("button", { name: /Close drilldown placeholder/ }),
+      );
+    });
+    expect(screen.queryByText(/Axis drilldown for/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/MissionToggleGrid.test.tsx
+++ b/frontend/__tests__/MissionToggleGrid.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+import { MissionToggleGrid } from "@/components/workbench/mission/MissionToggleGrid";
+import type { MissionPreset } from "@/hooks/useMissionPresets";
+
+const presets: MissionPreset[] = [
+  {
+    id: "trainer",
+    label: "Trainer",
+    description: "",
+    target_polygon: {} as Record<string, number>,
+    axis_ranges: {} as Record<string, [number, number]>,
+    suggested_estimates: {
+      g_limit: 4,
+      target_static_margin: 0.12,
+      cl_max: 1.4,
+      power_to_weight: 0.4,
+      prop_efficiency: 0.6,
+    },
+  },
+  {
+    id: "sport",
+    label: "Sport",
+    description: "",
+    target_polygon: {} as Record<string, number>,
+    axis_ranges: {} as Record<string, [number, number]>,
+    suggested_estimates: {
+      g_limit: 6,
+      target_static_margin: 0.1,
+      cl_max: 1.3,
+      power_to_weight: 0.7,
+      prop_efficiency: 0.6,
+    },
+  },
+];
+
+describe("MissionToggleGrid", () => {
+  it("disables the active preset button and marks it 'aktiv'", () => {
+    render(
+      <MissionToggleGrid
+        presets={presets}
+        activeId="trainer"
+        comparisonIds={[]}
+        onToggle={() => {}}
+      />,
+    );
+    const trainer = screen.getByRole("button", { name: /Trainer/ });
+    expect(trainer).toBeDisabled();
+    expect(screen.getByText(/aktiv/)).toBeInTheDocument();
+  });
+
+  it("calls onToggle when a non-active preset is clicked", () => {
+    const onToggle = vi.fn();
+    render(
+      <MissionToggleGrid
+        presets={presets}
+        activeId="trainer"
+        comparisonIds={[]}
+        onToggle={onToggle}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Sport/ }));
+    expect(onToggle).toHaveBeenCalledWith("sport");
+  });
+
+  it("highlights comparison presets distinctly from inactive ones", () => {
+    render(
+      <MissionToggleGrid
+        presets={presets}
+        activeId="trainer"
+        comparisonIds={["sport"]}
+        onToggle={() => {}}
+      />,
+    );
+    const sport = screen.getByRole("button", { name: /Sport/ });
+    expect(sport.className).toContain("text-sky-400");
+  });
+
+  it("does not call onToggle when active preset is clicked", () => {
+    const onToggle = vi.fn();
+    render(
+      <MissionToggleGrid
+        presets={presets}
+        activeId="trainer"
+        comparisonIds={[]}
+        onToggle={onToggle}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Trainer/ }));
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/workbench/mission/page.tsx
+++ b/frontend/app/workbench/mission/page.tsx
@@ -1,132 +1,64 @@
-import { Target, Radar, ChevronDown } from "lucide-react";
+"use client";
+
+import React, { useEffect, useState } from "react";
 import { WorkbenchTwoPanel } from "@/components/workbench/WorkbenchTwoPanel";
-import { AlertBanner } from "@/components/workbench/AlertBanner";
-import { RadarChart } from "@/components/workbench/RadarChart";
-
-const MISSION_AXES = [
-  { key: "payload_mass", label: "Payload", max: 10 },
-  { key: "flight_time", label: "Flight Time", max: 120 },
-  { key: "cruise_speed", label: "Cruise Speed", max: 30 },
-  { key: "range", label: "Range", max: 50 },
-  { key: "ceiling", label: "Ceiling", max: 2000 },
-];
-
-const FORM_VALUES: Record<string, number> = {
-  payload_mass: 2.5,
-  flight_time: 45,
-  cruise_speed: 14,
-  range: 12,
-  ceiling: 400,
-};
-
-function normalize(raw: Record<string, number>) {
-  const result: Record<string, number> = {};
-  for (const axis of MISSION_AXES) {
-    result[axis.key] = Math.min(1, Math.max(0, (raw[axis.key] ?? 0) / axis.max));
-  }
-  return result;
-}
-
-function Field({
-  label,
-  value,
-  suffix,
-  isSelect,
-}: Readonly<{
-  label: string;
-  value: string;
-  suffix?: string;
-  isSelect?: boolean;
-}>) {
-  return (
-    <div className="flex flex-1 flex-col gap-1">
-      <span className="text-[11px] text-muted-foreground">{label}</span>
-      <div className="flex items-center gap-2 rounded-xl border border-border bg-input px-3 py-2">
-        <span className="text-[13px] text-foreground">{value}</span>
-        <span className="flex-1" />
-        {isSelect && <ChevronDown className="size-3.5 text-muted-foreground" />}
-        {!isSelect && suffix && (
-          <span className="text-[11px] text-muted-foreground">{suffix}</span>
-        )}
-      </div>
-    </div>
-  );
-}
+import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
+import { MissionCompliancePanel } from "@/components/workbench/mission/MissionCompliancePanel";
+import { MissionObjectivesPanel } from "@/components/workbench/mission/MissionObjectivesPanel";
+import type { AxisName } from "@/hooks/useMissionPresets";
 
 export default function MissionPage() {
-  const targetValues = normalize(FORM_VALUES);
+  const { aeroplaneId, hydrated, openPicker } = useAeroplaneContext();
+  const [drawerAxis, setDrawerAxis] = useState<AxisName | null>(null);
+
+  useEffect(() => {
+    if (hydrated && !aeroplaneId) openPicker();
+  }, [hydrated, aeroplaneId, openPicker]);
+
+  if (!aeroplaneId) {
+    return (
+      <WorkbenchTwoPanel leftWidth={480}>
+        <div className="rounded-2xl border border-border bg-card p-6 text-sm text-muted-foreground">
+          Select an aeroplane to view Mission compliance.
+        </div>
+        <div className="rounded-2xl border border-border bg-card p-6 text-sm text-muted-foreground">
+          Select an aeroplane to edit its Mission objectives.
+        </div>
+      </WorkbenchTwoPanel>
+    );
+  }
 
   return (
-    <WorkbenchTwoPanel leftWidth={480}>
-      {/* Left: Radar Chart Card */}
-      <div className="flex h-full flex-col gap-4 rounded-2xl border border-border bg-card p-6">
-        <div className="flex items-center gap-3">
-          <Radar className="size-5 text-primary" />
-          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[18px] text-foreground">
-            Mission Compliance
-          </span>
-        </div>
-        <div className="flex-1">
-          <RadarChart
-            axes={MISSION_AXES.map((a) => ({ key: a.key, label: a.label }))}
-            target={targetValues}
-            analysis={null}
+    <>
+      <WorkbenchTwoPanel leftWidth={480}>
+        <div className="flex h-full flex-col rounded-2xl border border-border bg-card p-6">
+          <MissionCompliancePanel
+            aeroplaneId={aeroplaneId}
+            onAxisClick={(axis) => setDrawerAxis(axis)}
           />
         </div>
-        <div className="flex items-center justify-center gap-5">
-          <div className="flex items-center gap-1.5">
-            <div className="size-2.5 rounded-[2px] bg-primary" />
-            <span className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
-              Target
-            </span>
-          </div>
-          <div className="flex items-center gap-1.5">
-            <div className="size-2.5 rounded-[2px] bg-success" />
-            <span className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
-              Analysis
-            </span>
-          </div>
+        <div className="flex flex-col overflow-y-auto rounded-2xl border border-border bg-card p-6">
+          <MissionObjectivesPanel aeroplaneId={aeroplaneId} />
         </div>
-      </div>
+      </WorkbenchTwoPanel>
 
-      {/* Right: Mission Objectives Card */}
-      <div className="flex flex-col gap-6 rounded-2xl border border-border bg-card p-8">
-        <div className="flex items-center gap-3">
-          <Target className="size-5 text-primary" />
-          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[20px] text-foreground">
-            Mission Objectives
+      {drawerAxis && (
+        <div className="fixed bottom-4 right-4 z-50 flex items-center gap-3 rounded border border-orange-500/40 bg-card px-4 py-2 text-xs text-muted-foreground">
+          <span>
+            Axis drilldown for{" "}
+            <span className="font-mono text-orange-500">{drawerAxis}</span> —
+            coming in Phase 7
           </span>
-        </div>
-
-        <AlertBanner>
-          Mission Objectives is waiting on backend resource. The form below
-          renders but saving is disabled.
-        </AlertBanner>
-
-        <div className="flex flex-col gap-4 opacity-60">
-          <div className="flex gap-4">
-            <Field label="payload_mass" value="2.5" suffix="kg" />
-            <Field label="flight_time" value="45" suffix="min" />
-          </div>
-          <div className="flex gap-4">
-            <Field label="cruise_speed" value="14" suffix="m/s" />
-            <Field label="range" value="12" suffix="km" />
-          </div>
-          <div className="flex gap-4">
-            <Field label="ceiling" value="400" suffix="m" />
-            <Field label="mission_type" value="surveillance" isSelect />
-          </div>
-        </div>
-
-        <div className="flex justify-end gap-2">
-          <button className="rounded-full border border-border-strong bg-background px-3.5 py-2 text-[13px] text-muted-foreground">
-            Cancel
-          </button>
-          <button className="rounded-full border border-border bg-card-muted px-4 py-2 text-[13px] text-subtle-foreground">
-            Save
+          <button
+            type="button"
+            onClick={() => setDrawerAxis(null)}
+            aria-label="Close drilldown placeholder"
+            className="text-muted-foreground hover:text-foreground"
+          >
+            ×
           </button>
         </div>
-      </div>
-    </WorkbenchTwoPanel>
+      )}
+    </>
   );
 }

--- a/frontend/components/workbench/mission/MissionCompliancePanel.tsx
+++ b/frontend/components/workbench/mission/MissionCompliancePanel.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import React, { useState } from "react";
+import { MissionRadarChart } from "./MissionRadarChart";
+import { MissionToggleGrid } from "./MissionToggleGrid";
+import { useMissionKpis } from "@/hooks/useMissionKpis";
+import { useMissionPresets, type AxisName } from "@/hooks/useMissionPresets";
+import { useMissionObjectives } from "@/hooks/useMissionObjectives";
+
+interface Props {
+  readonly aeroplaneId: string;
+  readonly onAxisClick: (axis: AxisName) => void;
+}
+
+export function MissionCompliancePanel({ aeroplaneId, onAxisClick }: Props) {
+  const { data: objective } = useMissionObjectives(aeroplaneId);
+  const { data: presets } = useMissionPresets();
+  const [comparisons, setComparisons] = useState<string[]>([]);
+
+  const activeId = objective?.mission_type ?? "trainer";
+  const missionIds = [activeId, ...comparisons.filter((c) => c !== activeId)];
+  const { data: kpis } = useMissionKpis(aeroplaneId, missionIds);
+
+  if (!presets || !kpis) {
+    return <div className="text-sm text-muted-foreground">Loading…</div>;
+  }
+
+  const activePreset = presets.find((p) => p.id === activeId);
+  if (!activePreset) {
+    return (
+      <div className="text-sm text-muted-foreground">
+        Mission preset &ldquo;{activeId}&rdquo; not found.
+      </div>
+    );
+  }
+
+  const comparisonPresets = comparisons
+    .map((c) => presets.find((p) => p.id === c))
+    .filter((p): p is NonNullable<typeof p> => Boolean(p));
+
+  const toggle = (id: string) =>
+    setComparisons((cs) =>
+      cs.includes(id) ? cs.filter((x) => x !== id) : [...cs, id],
+    );
+
+  return (
+    <div className="flex h-full flex-col">
+      <h3 className="text-sm font-semibold text-orange-500 mb-2">
+        ⊙ Mission Compliance
+      </h3>
+      <MissionRadarChart
+        kpis={kpis}
+        activeMissions={[activePreset, ...comparisonPresets]}
+        onAxisClick={onAxisClick}
+      />
+      <div className="text-[10px] uppercase tracking-wider text-muted-foreground mt-3">
+        Vergleichs-Profile
+      </div>
+      <MissionToggleGrid
+        presets={presets}
+        activeId={activeId}
+        comparisonIds={comparisons}
+        onToggle={toggle}
+      />
+    </div>
+  );
+}

--- a/frontend/components/workbench/mission/MissionObjectivesPanel.tsx
+++ b/frontend/components/workbench/mission/MissionObjectivesPanel.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import React, { useRef, useState } from "react";
+import { useMissionObjectives, type MissionObjective } from "@/hooks/useMissionObjectives";
+import { useMissionPresets } from "@/hooks/useMissionPresets";
+
+interface Props {
+  readonly aeroplaneId: string;
+}
+
+export function MissionObjectivesPanel({ aeroplaneId }: Props) {
+  const { data: persisted, update } = useMissionObjectives(aeroplaneId);
+  const { data: presets } = useMissionPresets();
+  const [draft, setDraft] = useState<MissionObjective | null>(null);
+  const [bannerKey, setBannerKey] = useState<string | null>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // "Adjust state when a prop changes" pattern — avoids useEffect+setState
+  // (which react-hooks/set-state-in-effect forbids). Seed draft once on first
+  // server response; subsequent SWR revalidations are intentionally ignored so
+  // the user's in-flight edits are not clobbered.
+  if (persisted && !draft) setDraft({ ...persisted });
+
+  if (!draft || !presets) return <div className="text-muted-foreground text-sm">Loading…</div>;
+
+  const set = <K extends keyof MissionObjective>(key: K, value: MissionObjective[K]) => {
+    setDraft((d) => (d ? { ...d, [key]: value } : d));
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => {
+      void update({ ...(draft as MissionObjective), [key]: value });
+    }, 300);
+  };
+
+  const onMissionTypeChange = (id: string) => {
+    set("mission_type", id);
+    setBannerKey(id);
+  };
+
+  const activePreset = presets.find((p) => p.id === draft.mission_type);
+
+  return (
+    <div className="flex h-full flex-col gap-3">
+      <h3 className="text-sm font-semibold text-orange-500">⊙ Mission Objectives</h3>
+
+      {bannerKey && activePreset && (
+        <div className="rounded border-l-2 border-orange-500 bg-orange-500/10 p-3 text-xs">
+          <div className="font-semibold text-orange-500">
+            ⚡ Mission auf <span className="text-white">{activePreset.label}</span> gesetzt — Estimates angepasst
+          </div>
+          <div className="mt-1 font-mono text-[10px] text-foreground/80">
+            {Object.entries(activePreset.suggested_estimates).map(([k, v]) => `${k}=${v}`).join(" · ")}
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <label htmlFor="mission-type" className="block text-xs text-muted-foreground">
+          Mission Type
+        </label>
+        <select
+          id="mission-type" aria-label="Mission Type"
+          className="w-full rounded bg-background border border-border px-2 py-1.5 text-sm"
+          value={draft.mission_type}
+          onChange={(e) => onMissionTypeChange(e.target.value)}
+        >
+          {presets.map((p) => <option key={p.id} value={p.id}>{p.label}</option>)}
+        </select>
+      </div>
+
+      <div className="text-[10px] uppercase tracking-wider text-muted-foreground border-b border-border pb-1">
+        Performance Targets
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <NumField label="Target Cruise" suffix="m/s" value={draft.target_cruise_mps} onChange={(v) => set("target_cruise_mps", v)}/>
+        <NumField label="Stall Safety" suffix="–" value={draft.target_stall_safety} onChange={(v) => set("target_stall_safety", v)}/>
+        <NumField label="Max Maneuver" suffix="g" value={draft.target_maneuver_n} onChange={(v) => set("target_maneuver_n", v)}/>
+        <NumField label="Min Glide (L/D)" suffix="–" value={draft.target_glide_ld} onChange={(v) => set("target_glide_ld", v)}/>
+        <NumField label="Climb Energy" suffix="–" value={draft.target_climb_energy} onChange={(v) => set("target_climb_energy", v)}/>
+        <NumField label="Target Wing Load" suffix="N/m²" value={draft.target_wing_loading_n_m2} onChange={(v) => set("target_wing_loading_n_m2", v)}/>
+      </div>
+
+      <div className="text-[10px] uppercase tracking-wider text-muted-foreground border-b border-border pb-1 mt-2">
+        Field Performance
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <NumField label="Available Runway" suffix="m" value={draft.available_runway_m} onChange={(v) => set("available_runway_m", v)}/>
+        <SelectField label="Runway Type" value={draft.runway_type} options={["grass", "asphalt", "belly"]} onChange={(v) => set("runway_type", v as MissionObjective["runway_type"])}/>
+        <NumField label="Static Thrust" suffix="N" value={draft.t_static_N} onChange={(v) => set("t_static_N", v)}/>
+        <SelectField label="Takeoff Mode" value={draft.takeoff_mode} options={["runway", "hand_launch", "bungee", "catapult"]} onChange={(v) => set("takeoff_mode", v as MissionObjective["takeoff_mode"])}/>
+      </div>
+    </div>
+  );
+}
+
+function NumField(props: { label: string; suffix: string; value: number; onChange: (v: number) => void }) {
+  const id = `f-${props.label.replace(/\s+/g, "-").toLowerCase()}`;
+  return (
+    <div>
+      <label htmlFor={id} className="block text-xs text-muted-foreground mb-1">{props.label}</label>
+      <div className="flex">
+        <input
+          id={id} aria-label={props.label} type="number"
+          className="flex-1 rounded-l bg-background border border-border px-2 py-1.5 text-sm font-mono"
+          value={props.value}
+          onChange={(e) => props.onChange(parseFloat(e.target.value))}
+        />
+        <span className="rounded-r bg-card border border-l-0 border-border px-2 py-1.5 text-[10px] text-muted-foreground">
+          {props.suffix}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function SelectField(props: { label: string; value: string; options: string[]; onChange: (v: string) => void }) {
+  const id = `f-${props.label.replace(/\s+/g, "-").toLowerCase()}`;
+  return (
+    <div>
+      <label htmlFor={id} className="block text-xs text-muted-foreground mb-1">{props.label}</label>
+      <select id={id} aria-label={props.label}
+        className="w-full rounded bg-background border border-border px-2 py-1.5 text-sm"
+        value={props.value} onChange={(e) => props.onChange(e.target.value)}>
+        {props.options.map((o) => <option key={o} value={o}>{o}</option>)}
+      </select>
+    </div>
+  );
+}

--- a/frontend/components/workbench/mission/MissionToggleGrid.tsx
+++ b/frontend/components/workbench/mission/MissionToggleGrid.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import React from "react";
+import type { MissionPreset } from "@/hooks/useMissionPresets";
+
+interface Props {
+  readonly presets: MissionPreset[];
+  readonly activeId: string;
+  readonly comparisonIds: string[];
+  readonly onToggle: (id: string) => void;
+}
+
+export function MissionToggleGrid({
+  presets,
+  activeId,
+  comparisonIds,
+  onToggle,
+}: Props) {
+  return (
+    <div className="mt-3 rounded bg-card-muted p-2 grid grid-cols-2 gap-x-3 gap-y-1">
+      {presets.map((p) => {
+        const isActive = p.id === activeId;
+        const isComparison = comparisonIds.includes(p.id);
+
+        let textClass: string;
+        if (isActive) textClass = "text-orange-500 font-semibold cursor-default";
+        else if (isComparison) textClass = "text-sky-400";
+        else textClass = "text-muted-foreground hover:text-foreground";
+
+        let chipClass: string;
+        if (isActive) chipClass = "bg-orange-500 border-orange-500";
+        else if (isComparison) chipClass = "bg-sky-400 border-sky-400";
+        else chipClass = "border border-border";
+
+        return (
+          <button
+            key={p.id}
+            type="button"
+            disabled={isActive}
+            onClick={() => onToggle(p.id)}
+            className={`flex items-center gap-2 text-left text-xs py-1 ${textClass}`}
+          >
+            <span className={`inline-block w-3 h-3 rounded-sm ${chipClass}`} />
+            {p.label}
+            {isActive && (
+              <span className="ml-auto text-[10px] text-muted-foreground">
+                aktiv
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Phase 6 of epic #545. Replaces the placeholder Mission tab with the new two-panel layout:

- **Left:** `MissionCompliancePanel` — Mission Radar Chart + multi-mission toggle grid (Vergleichs-Profile). Active mission is orange, comparisons are sky-blue, disabled toggles for the active row.
- **Right:** `MissionObjectivesPanel` — full form with Performance Targets (6 numeric fields) + Field Performance (4 fields incl. runway type + takeoff mode). Debounced (300 ms) PUT to `/mission-objectives`. Auto-apply banner appears when mission_type changes, showing the preset's `suggested_estimates`.
- Until Phase 7 lands `AxisDrawer`, axis-click on the radar shows a small dismissible "drilldown coming in Phase 7" toast in the bottom-right.
- Aeroplane picker integration via `useAeroplaneContext()`, matching the analysis page.

## Test plan

- [x] `npx vitest run __tests__/Mission*.test.tsx __tests__/missionScale.test.ts __tests__/missionHooks.test.tsx` → 7 files, 28 tests pass
- [x] ESLint clean for new files
- [ ] Smoke: open Tab 1 with an aeroplane selected, switch mission type, see banner, toggle comparison, axis click → toast

Closes #551