### PR TITLE
feat(gh-552): AxisDrawer drill-down (Phase 7)

### DIFF
--- a/frontend/__tests__/AxisDrawer.test.tsx
+++ b/frontend/__tests__/AxisDrawer.test.tsx
@@ -3,10 +3,39 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import React from "react";
 import { AxisDrawer } from "@/components/workbench/mission/AxisDrawer";
 
+type MockKpi = {
+  axis: string;
+  value: number | null;
+  unit: string | null;
+  score_0_1: number | null;
+  range_min: number;
+  range_max: number;
+  provenance: "computed" | "estimated" | "missing";
+  formula: string;
+  warning: string | null;
+};
+
+let mockKpis: { ist_polygon: Record<string, MockKpi> } | null = {
+  ist_polygon: {
+    stall_safety: {
+      axis: "stall_safety", value: 1.45, unit: "-",
+      score_0_1: 0.13, range_min: 1.3, range_max: 2.5,
+      provenance: "computed", formula: "V_cruise / V_s1", warning: null,
+    },
+  },
+};
+
 vi.mock("@/hooks/useMissionKpis", () => ({
   useMissionKpis: () => ({
-    data: {
-      aeroplane_uuid: "x",
+    data: mockKpis,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+describe("AxisDrawer", () => {
+  it("renders label, value, formula and provenance", () => {
+    mockKpis = {
       ist_polygon: {
         stall_safety: {
           axis: "stall_safety", value: 1.45, unit: "-",
@@ -14,22 +43,13 @@ vi.mock("@/hooks/useMissionKpis", () => ({
           provenance: "computed", formula: "V_cruise / V_s1", warning: null,
         },
       },
-      target_polygons: [],
-      active_mission_id: "trainer",
-      computed_at: "now",
-      context_hash: "h",
-    },
-    isLoading: false, error: null,
-  }),
-}));
-
-describe("AxisDrawer", () => {
-  it("renders label, value, formula and provenance", () => {
+    };
     render(<AxisDrawer aeroplaneId="x" axis="stall_safety" onClose={() => undefined} />);
     expect(screen.getByText(/Stall Safety/)).toBeInTheDocument();
     expect(screen.getByText(/1\.450/)).toBeInTheDocument();
     expect(screen.getByText(/V_cruise \/ V_s1/)).toBeInTheDocument();
     expect(screen.getByText(/computed/)).toBeInTheDocument();
+    expect(screen.getByText(/13 %/)).toBeInTheDocument();
   });
 
   it("close button triggers onClose", () => {
@@ -37,5 +57,54 @@ describe("AxisDrawer", () => {
     render(<AxisDrawer aeroplaneId="x" axis="stall_safety" onClose={onClose} />);
     fireEvent.click(screen.getByRole("button", { name: /close/i }));
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders an en-dash when value and score are null", () => {
+    mockKpis = {
+      ist_polygon: {
+        stall_safety: {
+          axis: "stall_safety", value: null, unit: null,
+          score_0_1: null, range_min: 0, range_max: 1,
+          provenance: "missing", formula: "n/a", warning: null,
+        },
+      },
+    };
+    render(<AxisDrawer aeroplaneId="x" axis="stall_safety" onClose={() => undefined} />);
+    // Both Ist and Score show the en-dash placeholder.
+    expect(screen.getAllByText("–").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText(/missing/)).toBeInTheDocument();
+  });
+
+  it("applies the estimated provenance color and renders the warning", () => {
+    mockKpis = {
+      ist_polygon: {
+        glide: {
+          axis: "glide", value: 8.2, unit: "-",
+          score_0_1: 0.5, range_min: 5, range_max: 15,
+          provenance: "estimated", formula: "L/D estimate",
+          warning: "polar stale",
+        },
+      },
+    };
+    render(<AxisDrawer aeroplaneId="x" axis="glide" onClose={() => undefined} />);
+    const prov = screen.getByText(/estimated/);
+    expect(prov.className).toContain("text-yellow-400");
+    expect(screen.getByText(/polar stale/)).toBeInTheDocument();
+  });
+
+  it("renders nothing when KPIs are not loaded", () => {
+    mockKpis = null;
+    const { container } = render(
+      <AxisDrawer aeroplaneId="x" axis="stall_safety" onClose={() => undefined} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when the requested axis is missing", () => {
+    mockKpis = { ist_polygon: {} };
+    const { container } = render(
+      <AxisDrawer aeroplaneId="x" axis="stall_safety" onClose={() => undefined} />,
+    );
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/frontend/__tests__/AxisDrawer.test.tsx
+++ b/frontend/__tests__/AxisDrawer.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+import { AxisDrawer } from "@/components/workbench/mission/AxisDrawer";
+
+vi.mock("@/hooks/useMissionKpis", () => ({
+  useMissionKpis: () => ({
+    data: {
+      aeroplane_uuid: "x",
+      ist_polygon: {
+        stall_safety: {
+          axis: "stall_safety", value: 1.45, unit: "-",
+          score_0_1: 0.13, range_min: 1.3, range_max: 2.5,
+          provenance: "computed", formula: "V_cruise / V_s1", warning: null,
+        },
+      },
+      target_polygons: [],
+      active_mission_id: "trainer",
+      computed_at: "now",
+      context_hash: "h",
+    },
+    isLoading: false, error: null,
+  }),
+}));
+
+describe("AxisDrawer", () => {
+  it("renders label, value, formula and provenance", () => {
+    render(<AxisDrawer aeroplaneId="x" axis="stall_safety" onClose={() => undefined} />);
+    expect(screen.getByText(/Stall Safety/)).toBeInTheDocument();
+    expect(screen.getByText(/1\.450/)).toBeInTheDocument();
+    expect(screen.getByText(/V_cruise \/ V_s1/)).toBeInTheDocument();
+    expect(screen.getByText(/computed/)).toBeInTheDocument();
+  });
+
+  it("close button triggers onClose", () => {
+    const onClose = vi.fn();
+    render(<AxisDrawer aeroplaneId="x" axis="stall_safety" onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: /close/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/__tests__/MissionPage.test.tsx
+++ b/frontend/__tests__/MissionPage.test.tsx
@@ -31,6 +31,15 @@ vi.mock("@/components/workbench/WorkbenchTwoPanel", () => ({
   ),
 }));
 
+vi.mock("@/components/workbench/mission/AxisDrawer", () => ({
+  AxisDrawer: ({ axis, onClose }: { axis: string; onClose: () => void }) => (
+    <div data-testid="axis-drawer">
+      drawer-axis-{axis}
+      <button type="button" onClick={onClose}>close-drawer</button>
+    </div>
+  ),
+}));
+
 import MissionPage from "@/app/workbench/mission/page";
 
 describe("MissionPage", () => {
@@ -62,29 +71,25 @@ describe("MissionPage", () => {
     expect(screen.getByText(/objectives-stub/)).toBeInTheDocument();
   });
 
-  it("shows drilldown placeholder toast after onAxisClick is invoked", () => {
+  it("shows AxisDrawer after onAxisClick is invoked", () => {
     aeroplaneId = "aero-1";
     render(<MissionPage />);
     act(() => {
       fireEvent.click(screen.getByText(/compliance-stub/));
     });
-    expect(screen.getByText(/Axis drilldown for/)).toBeInTheDocument();
-    expect(screen.getByText(/climb/)).toBeInTheDocument();
-    expect(screen.getByText(/coming in Phase 7/)).toBeInTheDocument();
+    expect(screen.getByTestId("axis-drawer")).toHaveTextContent("drawer-axis-climb");
   });
 
-  it("closes the drilldown toast when × is clicked", () => {
+  it("closes the AxisDrawer when its close button is clicked", () => {
     aeroplaneId = "aero-1";
     render(<MissionPage />);
     act(() => {
       fireEvent.click(screen.getByText(/compliance-stub/));
     });
-    expect(screen.getByText(/Axis drilldown for/)).toBeInTheDocument();
+    expect(screen.getByTestId("axis-drawer")).toBeInTheDocument();
     act(() => {
-      fireEvent.click(
-        screen.getByRole("button", { name: /Close drilldown placeholder/ }),
-      );
+      fireEvent.click(screen.getByText("close-drawer"));
     });
-    expect(screen.queryByText(/Axis drilldown for/)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("axis-drawer")).toBeNull();
   });
 });

--- a/frontend/app/workbench/mission/page.tsx
+++ b/frontend/app/workbench/mission/page.tsx
@@ -6,6 +6,7 @@ import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
 import { MissionCompliancePanel } from "@/components/workbench/mission/MissionCompliancePanel";
 import { MissionObjectivesPanel } from "@/components/workbench/mission/MissionObjectivesPanel";
 import type { AxisName } from "@/hooks/useMissionPresets";
+import { AxisDrawer } from "@/components/workbench/mission/AxisDrawer";
 
 export default function MissionPage() {
   const { aeroplaneId, hydrated, openPicker } = useAeroplaneContext();
@@ -43,21 +44,11 @@ export default function MissionPage() {
       </WorkbenchTwoPanel>
 
       {drawerAxis && (
-        <div className="fixed bottom-4 right-4 z-50 flex items-center gap-3 rounded border border-orange-500/40 bg-card px-4 py-2 text-xs text-muted-foreground">
-          <span>
-            Axis drilldown for{" "}
-            <span className="font-mono text-orange-500">{drawerAxis}</span> —
-            coming in Phase 7
-          </span>
-          <button
-            type="button"
-            onClick={() => setDrawerAxis(null)}
-            aria-label="Close drilldown placeholder"
-            className="text-muted-foreground hover:text-foreground"
-          >
-            ×
-          </button>
-        </div>
+        <AxisDrawer
+          aeroplaneId={aeroplaneId}
+          axis={drawerAxis}
+          onClose={() => setDrawerAxis(null)}
+        />
       )}
     </>
   );

--- a/frontend/components/workbench/mission/AxisDrawer.tsx
+++ b/frontend/components/workbench/mission/AxisDrawer.tsx
@@ -33,19 +33,10 @@ export function AxisDrawer({ aeroplaneId, axis, onClose }: Props) {
   const k = kpis.ist_polygon[axis];
   if (!k) return null;
 
-  let valueText: string;
-  if (k.value != null) {
-    valueText = `${k.value.toFixed(3)} ${k.unit ?? ""}`;
-  } else {
-    valueText = "–";
-  }
-
-  let scoreText: string;
-  if (k.score_0_1 != null) {
-    scoreText = `${(k.score_0_1 * 100).toFixed(0)} %`;
-  } else {
-    scoreText = "–";
-  }
+  const valueText =
+    k.value == null ? "–" : `${k.value.toFixed(3)} ${k.unit ?? ""}`;
+  const scoreText =
+    k.score_0_1 == null ? "–" : `${(k.score_0_1 * 100).toFixed(0)} %`;
 
   return (
     <div className="fixed right-4 top-20 w-80 rounded-lg border-l-2 border-orange-500 bg-card p-4 shadow-lg z-50">

--- a/frontend/components/workbench/mission/AxisDrawer.tsx
+++ b/frontend/components/workbench/mission/AxisDrawer.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import React from "react";
+import { useMissionKpis } from "@/hooks/useMissionKpis";
+import type { AxisName } from "@/hooks/useMissionPresets";
+import type { Provenance } from "@/hooks/useMissionKpis";
+
+interface Props {
+  readonly aeroplaneId: string;
+  readonly axis: AxisName;
+  readonly onClose: () => void;
+}
+
+const LABEL: Record<AxisName, string> = {
+  stall_safety: "Stall Safety",
+  glide: "Glide",
+  climb: "Climb",
+  cruise: "Cruise",
+  maneuver: "Maneuver",
+  wing_loading: "Wing Loading",
+  field_friendliness: "Field Friendliness",
+};
+
+function provenanceColor(p: Provenance): string {
+  if (p === "computed") return "text-green-400";
+  if (p === "estimated") return "text-yellow-400";
+  return "text-muted-foreground";
+}
+
+export function AxisDrawer({ aeroplaneId, axis, onClose }: Props) {
+  const { data: kpis } = useMissionKpis(aeroplaneId, []);
+  if (!kpis) return null;
+  const k = kpis.ist_polygon[axis];
+  if (!k) return null;
+
+  let valueText: string;
+  if (k.value != null) {
+    valueText = `${k.value.toFixed(3)} ${k.unit ?? ""}`;
+  } else {
+    valueText = "–";
+  }
+
+  let scoreText: string;
+  if (k.score_0_1 != null) {
+    scoreText = `${(k.score_0_1 * 100).toFixed(0)} %`;
+  } else {
+    scoreText = "–";
+  }
+
+  return (
+    <div className="fixed right-4 top-20 w-80 rounded-lg border-l-2 border-orange-500 bg-card p-4 shadow-lg z-50">
+      <div className="flex items-start justify-between">
+        <h4 className="text-orange-500 font-semibold text-sm">{LABEL[axis]}</h4>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="close"
+          className="text-muted-foreground hover:text-foreground"
+        >
+          ×
+        </button>
+      </div>
+
+      <div className="mt-3 space-y-2 text-xs">
+        <Row label="Ist" value={valueText} />
+        <Row label="Range" value={`${k.range_min.toFixed(2)} … ${k.range_max.toFixed(2)}`} />
+        <Row label="Score" value={scoreText} />
+        <Row
+          label="Provenance"
+          value={<span className={provenanceColor(k.provenance)}>{k.provenance}</span>}
+        />
+      </div>
+
+      <div className="mt-3 rounded bg-background p-2 font-mono text-[10px] text-muted-foreground">
+        {k.formula}
+      </div>
+
+      {k.warning && (
+        <div className="mt-3 text-[11px] text-yellow-400">
+          {`⚠ ${k.warning}`}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Row({
+  label,
+  value,
+}: {
+  readonly label: string;
+  readonly value: React.ReactNode;
+}) {
+  return (
+    <div className="flex justify-between border-b border-border/30 py-1">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-medium">{value}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Phase 7 of epic #545. Adds the drill-down side drawer to the Mission tab:

- Click an axis on the radar → fixed side panel slides in with raw Ist value (+ unit), range, score (0-100 %), provenance (color-coded), formula, and warning (if any).
- Replaces the temporary "coming in Phase 7" toast added by #559.
- Close via the `×` button.

## Test plan

- [x] `vitest run __tests__/AxisDrawer.test.tsx` → 2 tests pass
- [x] `vitest run __tests__/Mission*.test.tsx __tests__/AxisDrawer.test.tsx __tests__/missionScale.test.ts __tests__/missionHooks.test.tsx` → all pass
- [x] Full suite: 754/754
- [x] ESLint clean
- [ ] Manual smoke: click radar axis on Mission Tab → drawer appears → ×

Closes #552