### PR TITLE
feat(gh-569): NP / CG / Static Margin overlay in workbench construction preview

### DIFF
--- a/docs/superpowers/plans/2026-05-18-stability-overlay-plan.md
+++ b/docs/superpowers/plans/2026-05-18-stability-overlay-plan.md
@@ -1,0 +1,1142 @@
+# Stability Overlay (Plotly) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render NP, CG (SOLL design-target + IST component-aggregate), Static-Margin band, and SOLL↔IST delta-link as Plotly `scatter3d` traces composited into the workbench's existing Plotly-based `WingOutlineViewer` via a small composable overlay registry. Frontend-only — no backend changes.
+
+**Architecture:** `WingOutlineViewer` receives one new optional prop `extraTraces?: PlotlyData[]`. A `useOverlayRegistry` hook lets independent overlay components publish their own traces and own toggle. `StabilityOverlay` is the first such overlay; future overlays (mass distribution, axes, propeller disc, …) compose into the same registry without further changes to `WingOutlineViewer`.
+
+**Tech Stack:** Next.js 16 App Router, React 19, Plotly.js via `plotly.js-gl3d-dist-min` (already a project dep), SWR for data, Tailwind CSS (dark theme, accent `#FF8400`), Vitest for unit tests.
+
+**Issue:** #569
+**Spec (synced local copy):** `docs/superpowers/specs/2026-05-18-construction-view-stability-overlay-design.md`
+**Branch:** `feat/gh-569-stability-overlay`
+**Out of scope:** Backend changes, modifying `CadViewer.tsx` (different surface), removing the Stability tab (sub-issue #567), fixing `cg_agg_m` footer bug (#568), mounting in airfoil-preview page.
+
+---
+
+## File Structure
+
+**New files:**
+
+| File | Responsibility |
+|---|---|
+| `frontend/components/workbench/stability-overlay/divergence-color.ts` | Shared `cgDivergenceColor(soll, ist, mac)` helper extracted from `InfoChipRow.tsx`. |
+| `frontend/components/workbench/stability-overlay/buildStabilityTraces.ts` | Pure function: `(ctx) => PlotlyData[]`. No React, no Plotly imports — only the data shape. |
+| `frontend/components/workbench/stability-overlay/StabilityOverlay.tsx` | React component: `useComputationContext`, toggle state, registry call, toggle button UI. |
+| `frontend/hooks/useOverlayRegistry.ts` | Hook providing `{ traces, register(key) }`. Tiny — backed by `useReducer` over a `Record<string, PlotlyData[]>`. |
+| `frontend/__tests__/stability-overlay/divergence-color.test.ts` | Tests for color helper. |
+| `frontend/__tests__/stability-overlay/buildStabilityTraces.test.ts` | Tests for trace builder (all data states). |
+| `frontend/__tests__/stability-overlay/StabilityOverlay.test.tsx` | Tests for overlay component (toggle, persistence, registry call). |
+| `frontend/__tests__/useOverlayRegistry.test.ts` | Tests for registry hook. |
+
+**Modified files:**
+
+| File | Change |
+|---|---|
+| `frontend/components/workbench/WingOutlineViewer.tsx` | Add one optional prop `extraTraces?: PlotlyData[]`. Append it to `traces` before `Plotly.newPlot`. Extend the `useEffect` deps array to include `extraTraces`. Three-line additive change. Existing trace-building logic untouched. |
+| `frontend/app/workbench/page.tsx` (or whichever component mounts `WingOutlineViewer` in the workbench) | Use `useOverlayRegistry`; pass `traces` to `WingOutlineViewer.extraTraces`; mount `<StabilityOverlay register={...} />`. |
+| `frontend/components/workbench/InfoChipRow.tsx` | Replace local `cgDivergenceColor` (lines ~75-80) with import from the new shared module. |
+
+**Docs (committed in Task 0):**
+
+- `docs/superpowers/specs/2026-05-18-construction-view-stability-overlay-design.md` (already drafted)
+- `docs/superpowers/plans/2026-05-18-stability-overlay-plan.md` (this file)
+
+---
+
+## Dependency Graph
+
+```
+T0 (spec+plan commit)
+T1 (extract divergence-color) ─┐
+T2 (WingOutlineViewer extraTraces) ──┐
+T3 (useOverlayRegistry) ─────────────┤
+T4 (buildStabilityTraces pure fn) ───┤
+                                     │
+                                     └──> T5 (StabilityOverlay component + toggle + persistence)
+                                                            │
+                                                            └──> T6 (wire into workbench page)
+                                                                                │
+                                                                                └──> T7 (manual browser verification)
+```
+
+T1, T2, T3, T4 are pairwise independent and can be parallelised.
+
+---
+
+## Conventions Applied to Every Task
+
+- **TDD:** Each implementation task is RED → GREEN → REFACTOR.
+- **Test runner:** `cd frontend && npm run test:unit -- <pattern>` for Vitest.
+- **Commit cadence:** One commit per task, conventional message with `feat(gh-569):` / `refactor(gh-569):` / `test(gh-569):` / `docs(gh-569):` prefix.
+- **No backend touches.**
+- **Vercel best practices** (`/vercel-react-best-practices`, `/vercel-composition-patterns`): hooks at top level, exhaustive deps, memo where measurable, compose rather than extend.
+
+---
+
+## Task 0: Commit spec and plan to the feature branch
+
+**Files:**
+- `docs/superpowers/specs/2026-05-18-construction-view-stability-overlay-design.md` (already exists in this worktree)
+- `docs/superpowers/plans/2026-05-18-stability-overlay-plan.md` (this file)
+
+- [ ] **Step 1: Verify both files present**
+
+```bash
+cd /Users/szymanski/Projects/da3Dalus/cad-modelling-service/.claude/worktrees/feat+gh-569-stability-overlay
+ls -la docs/superpowers/specs/2026-05-18-construction-view-stability-overlay-design.md
+ls -la docs/superpowers/plans/2026-05-18-stability-overlay-plan.md
+```
+
+Expected: both files exist.
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/szymanski/Projects/da3Dalus/cad-modelling-service/.claude/worktrees/feat+gh-569-stability-overlay
+git add docs/superpowers/specs/2026-05-18-construction-view-stability-overlay-design.md \
+        docs/superpowers/plans/2026-05-18-stability-overlay-plan.md
+git commit -m "docs(gh-569): add spec and implementation plan for Plotly stability overlay"
+```
+
+- [ ] **Step 3: Push the branch**
+
+```bash
+git push -u github feat/gh-569-stability-overlay
+```
+
+---
+
+## Task 1: Extract `cgDivergenceColor` to a shared module
+
+Same as before — independent of the Plotly switch. The helper is reused by `StabilityOverlay` to colour the CG-IST marker.
+
+**Files:**
+- Create: `frontend/components/workbench/stability-overlay/divergence-color.ts`
+- Create: `frontend/__tests__/stability-overlay/divergence-color.test.ts`
+- Modify: `frontend/components/workbench/InfoChipRow.tsx` (replace local def with import)
+
+- [ ] **Step 1: Read the current implementation to capture exact thresholds**
+
+```bash
+grep -A 12 "function cgDivergenceColor" /Users/szymanski/Projects/da3Dalus/cad-modelling-service/.claude/worktrees/feat+gh-569-stability-overlay/frontend/components/workbench/InfoChipRow.tsx
+```
+
+Capture the **exact** threshold values and class names used. The example tests below assume:
+
+- `|Δ|/MAC ≤ 1 %` → green
+- `|Δ|/MAC ≤ 3 %` → yellow
+- `|Δ|/MAC > 3 %` → red
+
+If the real thresholds differ, adjust both the test expectations AND the implementation to the real values.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `frontend/__tests__/stability-overlay/divergence-color.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { cgDivergenceColor } from "../../components/workbench/stability-overlay/divergence-color";
+
+describe("cgDivergenceColor", () => {
+  it("returns the green class for |Δ| ≤ 1% MAC", () => {
+    expect(cgDivergenceColor(2.440, 2.445, 1.0)).toMatch(/green/);
+  });
+
+  it("returns the yellow class for 1% < |Δ| ≤ 3% MAC", () => {
+    expect(cgDivergenceColor(2.440, 2.460, 1.0)).toMatch(/yellow/);
+  });
+
+  it("returns the red class for |Δ| > 3% MAC", () => {
+    expect(cgDivergenceColor(2.440, 2.500, 1.0)).toMatch(/red/);
+  });
+
+  it("is symmetric in IST above vs below SOLL", () => {
+    expect(cgDivergenceColor(2.440, 2.420, 1.0)).toEqual(
+      cgDivergenceColor(2.440, 2.460, 1.0),
+    );
+  });
+
+  it("normalises by MAC", () => {
+    expect(cgDivergenceColor(2.440, 2.450, 2.0)).toMatch(/green/);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+cd /Users/szymanski/Projects/da3Dalus/cad-modelling-service/.claude/worktrees/feat+gh-569-stability-overlay/frontend
+npm run test:unit -- divergence-color
+```
+
+Expected: FAIL with module-not-found.
+
+- [ ] **Step 4: Implement**
+
+Create `frontend/components/workbench/stability-overlay/divergence-color.ts`:
+
+```typescript
+/**
+ * Color class for CG divergence indicator (SOLL vs IST).
+ *
+ * Returns a Tailwind text-color class based on the absolute delta
+ * between design CG and aggregated CG, normalised by MAC.
+ *
+ * Thresholds (match InfoChipRow legacy behaviour — verify in source):
+ *   |Δ|/MAC ≤ 1%  → green
+ *   |Δ|/MAC ≤ 3%  → yellow
+ *   |Δ|/MAC > 3%  → red
+ */
+export function cgDivergenceColor(
+  cgSoll: number,
+  cgIst: number,
+  mac: number,
+): string {
+  const deltaPct = (Math.abs(cgIst - cgSoll) / mac) * 100;
+  if (deltaPct <= 1) return "text-green-400";
+  if (deltaPct <= 3) return "text-yellow-400";
+  return "text-red-400";
+}
+```
+
+(Adjust the thresholds / class strings to match the source captured in Step 1.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+npm run test:unit -- divergence-color
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Refactor `InfoChipRow.tsx`**
+
+Add the import near the top:
+
+```typescript
+import { cgDivergenceColor } from "./stability-overlay/divergence-color";
+```
+
+Delete the local function definition (lines around 75-80).
+
+- [ ] **Step 7: Verify `InfoChipRow` tests still pass**
+
+```bash
+npm run test:unit -- InfoChipRow
+```
+
+Expected: PASS unchanged.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/szymanski/Projects/da3Dalus/cad-modelling-service/.claude/worktrees/feat+gh-569-stability-overlay
+git add frontend/components/workbench/stability-overlay/divergence-color.ts \
+        frontend/__tests__/stability-overlay/divergence-color.test.ts \
+        frontend/components/workbench/InfoChipRow.tsx
+git commit -m "refactor(gh-569): extract cgDivergenceColor to shared module"
+```
+
+---
+
+## Task 2: Add `extraTraces` prop to `WingOutlineViewer`
+
+**Files:**
+- Modify: `frontend/components/workbench/WingOutlineViewer.tsx`
+- (No new test file — exercised via component-integration; the trace concat is one line.)
+
+- [ ] **Step 1: Read the current props interface and the useEffect that calls `Plotly.newPlot`**
+
+```bash
+sed -n '8,30p' /Users/szymanski/Projects/da3Dalus/cad-modelling-service/.claude/worktrees/feat+gh-569-stability-overlay/frontend/components/workbench/WingOutlineViewer.tsx
+sed -n '855,912p' /Users/szymanski/Projects/da3Dalus/cad-modelling-service/.claude/worktrees/feat+gh-569-stability-overlay/frontend/components/workbench/WingOutlineViewer.tsx
+```
+
+Note the existing useEffect dep array (line 910) and the empty-scene placeholder (lines 870-877).
+
+- [ ] **Step 2: Extend the props interface**
+
+Add to `WingOutlineViewerProps`:
+
+```typescript
+interface WingOutlineViewerProps {
+  // ... existing props ...
+  /** Additional Plotly traces appended after wing/fuselage traces.
+   *  Used by overlay components (gh-569: stability) via useOverlayRegistry. */
+  extraTraces?: PlotlyData[];
+}
+```
+
+Where `PlotlyData` is the existing alias used in the file (search for `PlotlyData` to confirm the import or re-export).
+
+- [ ] **Step 3: Use the prop**
+
+In the component signature:
+
+```typescript
+export function WingOutlineViewer({
+  wings, fuselages, visibleWings, visibleFuselages,
+  selectedXsecIndex, selectedWing, selectedFuselage, selectedFuselageXsecIndex,
+  extraTraces,
+}: Readonly<WingOutlineViewerProps>) {
+```
+
+After the existing trace collection and before the empty-scene placeholder check (around line 868):
+
+```typescript
+const traces = await collectAllTraces({ ... });
+
+// gh-569: append overlay traces from useOverlayRegistry
+if (extraTraces && extraTraces.length > 0) {
+  traces.push(...extraTraces);
+}
+
+// Guard: empty scene placeholder (existing logic, line 869-877)
+if (traces.length === 0) {
+  traces.push({ ... });
+}
+```
+
+Add `extraTraces` to the `useEffect` deps array (line 910):
+
+```typescript
+}, [
+  wings, fuselages, visibleWings, visibleFuselages,
+  selectedXsecIndex, selectedWing, selectedFuselage, selectedFuselageXsecIndex,
+  showQuarterChord,
+  extraTraces,
+]);
+```
+
+- [ ] **Step 4: Run existing tests to verify no regression**
+
+```bash
+cd /Users/szymanski/Projects/da3Dalus/cad-modelling-service/.claude/worktrees/feat+gh-569-stability-overlay/frontend
+npm run test:unit -- WingOutlineViewer
+```
+
+Expected: existing tests pass unchanged (the prop is optional and defaults to undefined).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/components/workbench/WingOutlineViewer.tsx
+git commit -m "feat(gh-569): add additive extraTraces prop to WingOutlineViewer
+
+Enables overlay components (gh-569 stability, future expansions)
+to publish Plotly traces into the construction preview without
+modifying the viewer's trace-building logic."
+```
+
+---
+
+## Task 3: `useOverlayRegistry` hook
+
+**Files:**
+- Create: `frontend/hooks/useOverlayRegistry.ts`
+- Create: `frontend/__tests__/useOverlayRegistry.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/__tests__/useOverlayRegistry.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useOverlayRegistry } from "../hooks/useOverlayRegistry";
+
+describe("useOverlayRegistry", () => {
+  it("starts with an empty traces array", () => {
+    const { result } = renderHook(() => useOverlayRegistry());
+    expect(result.current.traces).toEqual([]);
+  });
+
+  it("returns a stable register(key) callback per key", () => {
+    const { result } = renderHook(() => useOverlayRegistry());
+    const cb1 = result.current.register("stability");
+    const cb2 = result.current.register("stability");
+    expect(cb1).toBe(cb2);
+  });
+
+  it("accumulates traces registered under different keys", () => {
+    const { result } = renderHook(() => useOverlayRegistry());
+
+    act(() => {
+      result.current.register("a")([{ type: "scatter3d", x: [1], y: [0], z: [0] }]);
+      result.current.register("b")([{ type: "scatter3d", x: [2], y: [0], z: [0] }]);
+    });
+
+    expect(result.current.traces).toHaveLength(2);
+    expect(result.current.traces[0].x).toEqual([1]);
+    expect(result.current.traces[1].x).toEqual([2]);
+  });
+
+  it("replaces traces for an existing key on re-register", () => {
+    const { result } = renderHook(() => useOverlayRegistry());
+    const register = result.current.register("stability");
+
+    act(() => { register([{ type: "scatter3d", x: [1], y: [0], z: [0] }]); });
+    act(() => { register([{ type: "scatter3d", x: [99], y: [0], z: [0] }]); });
+
+    expect(result.current.traces).toHaveLength(1);
+    expect(result.current.traces[0].x).toEqual([99]);
+  });
+
+  it("removes the key when registering an empty array", () => {
+    const { result } = renderHook(() => useOverlayRegistry());
+    const register = result.current.register("stability");
+    act(() => { register([{ type: "scatter3d", x: [1], y: [0], z: [0] }]); });
+    act(() => { register([]); });
+    expect(result.current.traces).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /Users/szymanski/Projects/da3Dalus/cad-modelling-service/.claude/worktrees/feat+gh-569-stability-overlay/frontend
+npm run test:unit -- useOverlayRegistry
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+Create `frontend/hooks/useOverlayRegistry.ts`:
+
+```typescript
+"use client";
+
+import { useCallback, useMemo, useRef, useState } from "react";
+
+// Use a loose type — the registry doesn't need to know the Plotly schema.
+// Components publish whatever Plotly accepts in its `data` array.
+export type PlotlyTrace = Record<string, unknown>;
+
+export interface UseOverlayRegistryReturn {
+  /** Flat list of all registered traces, in insertion order by key. */
+  traces: PlotlyTrace[];
+  /** Returns a stable setter that publishes (or clears) the traces for `key`. */
+  register: (key: string) => (next: PlotlyTrace[]) => void;
+}
+
+/**
+ * Composable overlay registry for the workbench Plotly preview.
+ *
+ * Each overlay component (e.g. StabilityOverlay) holds a stable
+ * `register(key)` setter; calling it with a non-empty array publishes
+ * those traces into the registry. Calling with an empty array removes
+ * the key entirely.
+ *
+ * The flat `traces` array is fed to <WingOutlineViewer extraTraces={...}/>.
+ *
+ * Order of traces follows the order in which keys were first registered.
+ */
+export function useOverlayRegistry(): UseOverlayRegistryReturn {
+  const [byKey, setByKey] = useState<Record<string, PlotlyTrace[]>>({});
+  // Insertion order tracker — stable across renders.
+  const orderRef = useRef<string[]>([]);
+  // Stable register callbacks, memoised per key.
+  const cbRef = useRef<Record<string, (next: PlotlyTrace[]) => void>>({});
+
+  const register = useCallback((key: string) => {
+    if (!cbRef.current[key]) {
+      cbRef.current[key] = (next) => {
+        setByKey((prev) => {
+          if (next.length === 0) {
+            // remove
+            const { [key]: _gone, ...rest } = prev;
+            orderRef.current = orderRef.current.filter((k) => k !== key);
+            return rest;
+          }
+          if (!orderRef.current.includes(key)) {
+            orderRef.current = [...orderRef.current, key];
+          }
+          return { ...prev, [key]: next };
+        });
+      };
+    }
+    return cbRef.current[key];
+  }, []);
+
+  const traces = useMemo<PlotlyTrace[]>(
+    () => orderRef.current.flatMap((k) => byKey[k] ?? []),
+    [byKey],
+  );
+
+  return { traces, register };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npm run test:unit -- useOverlayRegistry
+```
+
+Expected: all 5 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/hooks/useOverlayRegistry.ts \
+        frontend/__tests__/useOverlayRegistry.test.ts
+git commit -m "feat(gh-569): add useOverlayRegistry hook for composable Plotly overlays"
+```
+
+---
+
+## Task 4: `buildStabilityTraces` pure function
+
+**Files:**
+- Create: `frontend/components/workbench/stability-overlay/buildStabilityTraces.ts`
+- Create: `frontend/__tests__/stability-overlay/buildStabilityTraces.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/__tests__/stability-overlay/buildStabilityTraces.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { buildStabilityTraces } from "../../components/workbench/stability-overlay/buildStabilityTraces";
+
+const FULL = {
+  x_np_m: 2.607,
+  mac_m: 1.387,
+  cg_agg_m: 2.510,
+  target_static_margin: 0.12,
+};
+
+describe("buildStabilityTraces", () => {
+  describe("complete data", () => {
+    const traces = buildStabilityTraces(FULL);
+
+    it("returns 5 traces: NP, CG SOLL, CG IST, SM band, delta link", () => {
+      expect(traces).toHaveLength(5);
+    });
+
+    it("places NP at x_np_m * 1000 (mm) along the x axis", () => {
+      const np = traces.find((t) => t.name === "NP")!;
+      expect((np.x as number[])[0]).toBeCloseTo(2607, 0);
+    });
+
+    it("places CG SOLL at (x_np_m − target_sm · mac_m) * 1000", () => {
+      const cgSoll = traces.find((t) => t.name === "CG (design)")!;
+      const expected = (2.607 - 0.12 * 1.387) * 1000;
+      expect((cgSoll.x as number[])[0]).toBeCloseTo(expected, 0);
+    });
+
+    it("places CG IST at cg_agg_m * 1000", () => {
+      const cgIst = traces.find((t) => t.name === "CG (actual)")!;
+      expect((cgIst.x as number[])[0]).toBeCloseTo(2510, 0);
+    });
+
+    it("uses orange #FF8400 for CG SOLL marker", () => {
+      const cgSoll = traces.find((t) => t.name === "CG (design)")!;
+      const marker = cgSoll.marker as { color?: string };
+      expect(marker.color?.toUpperCase()).toBe("#FF8400");
+    });
+
+    it("renders SM band as a line between SOLL CG and NP", () => {
+      const band = traces.find((t) => t.name === "Static Margin")!;
+      expect((band.x as number[]).length).toBe(2);
+      expect(band.mode).toBe("lines");
+    });
+
+    it("renders delta link only when |Δ|/MAC > 1%", () => {
+      // FULL: |2.510 - (2.607-0.12*1.387)| / 1.387 ≈ ?
+      // soll = 2.607 - 0.16644 = 2.44056
+      // delta = |2.510 - 2.44056| / 1.387 = 0.0500 ≈ 5.0% → link present
+      const link = traces.find((t) => t.name === "Δ SOLL→IST");
+      expect(link).toBeDefined();
+    });
+  });
+
+  describe("graceful degradation", () => {
+    it("omits CG IST trace when cg_agg_m is null", () => {
+      const traces = buildStabilityTraces({ ...FULL, cg_agg_m: null });
+      expect(traces.find((t) => t.name === "CG (actual)")).toBeUndefined();
+      expect(traces.find((t) => t.name === "Δ SOLL→IST")).toBeUndefined();
+    });
+
+    it("returns empty array when x_np_m is null", () => {
+      const traces = buildStabilityTraces({ ...FULL, x_np_m: null });
+      expect(traces).toEqual([]);
+    });
+
+    it("omits SM band when target_static_margin is null", () => {
+      const traces = buildStabilityTraces({ ...FULL, target_static_margin: null });
+      expect(traces.find((t) => t.name === "Static Margin")).toBeUndefined();
+      expect(traces.find((t) => t.name === "CG (design)")).toBeUndefined();
+      // IST still rendered if cg_agg_m present
+      expect(traces.find((t) => t.name === "CG (actual)")).toBeDefined();
+      expect(traces.find((t) => t.name === "NP")).toBeDefined();
+    });
+
+    it("does not render delta link when |Δ|/MAC ≤ 1%", () => {
+      const cgIstAtSoll = 2.607 - 0.12 * 1.387; // exactly at SOLL
+      const traces = buildStabilityTraces({ ...FULL, cg_agg_m: cgIstAtSoll });
+      expect(traces.find((t) => t.name === "Δ SOLL→IST")).toBeUndefined();
+    });
+  });
+
+  describe("hovertext", () => {
+    const traces = buildStabilityTraces(FULL);
+
+    it("NP trace hovertext includes the NP value in metres", () => {
+      const np = traces.find((t) => t.name === "NP")!;
+      expect(String(np.hovertext)).toContain("2.607");
+    });
+
+    it("CG IST trace hovertext includes the Δ to target", () => {
+      const ist = traces.find((t) => t.name === "CG (actual)")!;
+      expect(String(ist.hovertext)).toMatch(/Δ|delta/i);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm run test:unit -- buildStabilityTraces
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+Create `frontend/components/workbench/stability-overlay/buildStabilityTraces.ts`:
+
+```typescript
+import { cgDivergenceColor } from "./divergence-color";
+
+/** Loose Plotly trace shape — keeps this file Plotly-import-free. */
+export type PlotlyTrace = Record<string, unknown>;
+
+export interface StabilityCtx {
+  x_np_m: number | null;
+  mac_m: number | null;
+  cg_agg_m: number | null;
+  target_static_margin: number | null;
+}
+
+const M_TO_MM = 1000;
+const DELTA_LINK_THRESHOLD_PCT = 1; // |Δ|/MAC > 1% renders the link
+
+const COLOR_NP = "#3b82f6";        // tailwind blue-500
+const COLOR_CG_SOLL = "#FF8400";   // project theme accent
+const COLOR_CG_IST_OUTLINE = "#9ca3af"; // tailwind gray-400 (overridden by divergence in 'line' colour)
+const COLOR_SM_BAND = "#a3e635";   // tailwind lime-400
+
+const SIZE_NP_PX = 8;
+const SIZE_CG_SOLL_PX = 12;
+const SIZE_CG_IST_PX = 6;
+
+/** Map a Tailwind text-color class to a hex string for Plotly. */
+function tailwindToHex(cls: string): string {
+  if (cls.includes("green")) return "#4ade80";
+  if (cls.includes("yellow")) return "#facc15";
+  if (cls.includes("red")) return "#f87171";
+  return "#9ca3af";
+}
+
+/**
+ * Build the Plotly scatter3d traces for the stability overlay.
+ *
+ * Returns an empty array when there is no NP — the overlay cannot
+ * usefully render anything without it.
+ *
+ * Coordinates: input is metres (backend); output is millimetres
+ * (matches WingOutlineViewer's coordinate frame).
+ */
+export function buildStabilityTraces(ctx: StabilityCtx): PlotlyTrace[] {
+  if (ctx.x_np_m == null) return [];
+
+  const traces: PlotlyTrace[] = [];
+  const xNpMm = ctx.x_np_m * M_TO_MM;
+  const hasMac = ctx.mac_m != null && ctx.mac_m > 0;
+  const hasSoll = hasMac && ctx.target_static_margin != null;
+  const xSollM = hasSoll ? ctx.x_np_m - (ctx.target_static_margin as number) * (ctx.mac_m as number) : null;
+  const xSollMm = xSollM != null ? xSollM * M_TO_MM : null;
+  const xIstMm = ctx.cg_agg_m != null ? ctx.cg_agg_m * M_TO_MM : null;
+
+  // NP marker
+  traces.push({
+    type: "scatter3d",
+    mode: "markers",
+    name: "NP",
+    x: [xNpMm], y: [0], z: [0],
+    marker: { size: SIZE_NP_PX, color: COLOR_NP, symbol: "circle" },
+    hovertext: `Neutral Point<br>x = ${ctx.x_np_m.toFixed(3)} m${hasMac ? `<br>MAC = ${(ctx.mac_m as number).toFixed(2)} m` : ""}`,
+    hoverinfo: "text",
+    showlegend: false,
+  });
+
+  // CG SOLL marker (design target)
+  if (hasSoll && xSollMm != null) {
+    traces.push({
+      type: "scatter3d",
+      mode: "markers",
+      name: "CG (design)",
+      x: [xSollMm], y: [0], z: [0],
+      marker: { size: SIZE_CG_SOLL_PX, color: COLOR_CG_SOLL, symbol: "circle" },
+      hovertext: `CG (design target)<br>x = ${(xSollM as number).toFixed(3)} m<br>target SM = ${((ctx.target_static_margin as number) * 100).toFixed(1)} % MAC`,
+      hoverinfo: "text",
+      showlegend: false,
+    });
+  }
+
+  // SM band (line between SOLL CG and NP)
+  if (hasSoll && xSollMm != null) {
+    traces.push({
+      type: "scatter3d",
+      mode: "lines",
+      name: "Static Margin",
+      x: [xSollMm, xNpMm], y: [0, 0], z: [0, 0],
+      line: { color: COLOR_SM_BAND, width: 4 },
+      hovertext: `Target Static Margin = ${((ctx.target_static_margin as number) * 100).toFixed(1)} % MAC`,
+      hoverinfo: "text",
+      showlegend: false,
+    });
+  }
+
+  // CG IST marker (component aggregate)
+  if (xIstMm != null) {
+    const istColor = hasSoll && hasMac
+      ? tailwindToHex(cgDivergenceColor(xSollM as number, ctx.cg_agg_m as number, ctx.mac_m as number))
+      : COLOR_CG_IST_OUTLINE;
+    const resultingSmPct = hasMac
+      ? ((ctx.x_np_m - (ctx.cg_agg_m as number)) / (ctx.mac_m as number)) * 100
+      : null;
+    const deltaPct = hasSoll && hasMac
+      ? (((ctx.cg_agg_m as number) - (xSollM as number)) / (ctx.mac_m as number)) * 100
+      : null;
+    const lines = [`CG (component aggregate)`, `x = ${(ctx.cg_agg_m as number).toFixed(3)} m`];
+    if (resultingSmPct != null) lines.push(`resulting SM = ${resultingSmPct.toFixed(1)} % MAC`);
+    if (deltaPct != null) lines.push(`Δ to target = ${deltaPct >= 0 ? "+" : ""}${deltaPct.toFixed(1)} % MAC`);
+    traces.push({
+      type: "scatter3d",
+      mode: "markers",
+      name: "CG (actual)",
+      x: [xIstMm], y: [0], z: [0],
+      marker: {
+        size: SIZE_CG_IST_PX,
+        color: istColor,
+        symbol: "circle-open",
+        line: { color: istColor, width: 2 },
+        opacity: 0.85,
+      },
+      hovertext: lines.join("<br>"),
+      hoverinfo: "text",
+      showlegend: false,
+    });
+
+    // Delta link — only when SOLL exists and |Δ|/MAC > threshold
+    if (hasSoll && xSollMm != null && deltaPct != null && Math.abs(deltaPct) > DELTA_LINK_THRESHOLD_PCT) {
+      traces.push({
+        type: "scatter3d",
+        mode: "lines",
+        name: "Δ SOLL→IST",
+        x: [xSollMm, xIstMm], y: [0, 0], z: [0, 0],
+        line: { color: istColor, width: 2, dash: "dash" },
+        hoverinfo: "skip",
+        showlegend: false,
+      });
+    }
+  }
+
+  return traces;
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+npm run test:unit -- buildStabilityTraces
+```
+
+Expected: all 11 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/components/workbench/stability-overlay/buildStabilityTraces.ts \
+        frontend/__tests__/stability-overlay/buildStabilityTraces.test.ts
+git commit -m "feat(gh-569): add buildStabilityTraces pure function (Plotly traces)"
+```
+
+---
+
+## Task 5: `StabilityOverlay` component + toggle + persistence
+
+**Files:**
+- Create: `frontend/components/workbench/stability-overlay/StabilityOverlay.tsx`
+- Create: `frontend/__tests__/stability-overlay/StabilityOverlay.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/__tests__/stability-overlay/StabilityOverlay.test.tsx`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+vi.mock("@/hooks/useComputationContext", () => ({
+  useComputationContext: vi.fn(),
+}));
+
+import { useComputationContext } from "@/hooks/useComputationContext";
+import { StabilityOverlay } from "../../components/workbench/stability-overlay/StabilityOverlay";
+
+const mockedHook = vi.mocked(useComputationContext);
+
+function withCtx(ctx: Record<string, unknown> | null) {
+  mockedHook.mockReturnValue({
+    data: ctx as never,
+    error: null,
+    isLoading: false,
+    mutate: vi.fn(),
+  } as never);
+}
+
+describe("StabilityOverlay", () => {
+  beforeEach(() => { localStorage.clear(); });
+
+  it("publishes 5 traces via register when fully enabled with complete data", () => {
+    withCtx({ x_np_m: 2.607, mac_m: 1.387, cg_agg_m: 2.510, target_static_margin: 0.12 });
+    const register = vi.fn();
+    render(<StabilityOverlay aeroplaneId="a" register={register} />);
+    expect(register).toHaveBeenCalled();
+    const lastCall = register.mock.calls[register.mock.calls.length - 1][0];
+    expect(lastCall).toHaveLength(5);
+  });
+
+  it("publishes empty array when ctx is null", () => {
+    withCtx(null);
+    const register = vi.fn();
+    render(<StabilityOverlay aeroplaneId="a" register={register} />);
+    const lastCall = register.mock.calls[register.mock.calls.length - 1][0];
+    expect(lastCall).toEqual([]);
+  });
+
+  it("publishes empty array when toggled off", () => {
+    withCtx({ x_np_m: 2.607, mac_m: 1.387, cg_agg_m: 2.510, target_static_margin: 0.12 });
+    const register = vi.fn();
+    render(<StabilityOverlay aeroplaneId="a" register={register} />);
+    fireEvent.click(screen.getByRole("button", { name: /stability/i }));
+    const lastCall = register.mock.calls[register.mock.calls.length - 1][0];
+    expect(lastCall).toEqual([]);
+  });
+
+  it("persists toggle state in localStorage", () => {
+    withCtx({ x_np_m: 2.607, mac_m: 1.387, cg_agg_m: 2.510, target_static_margin: 0.12 });
+    const register = vi.fn();
+    render(<StabilityOverlay aeroplaneId="a" register={register} />);
+    fireEvent.click(screen.getByRole("button", { name: /stability/i }));
+    expect(localStorage.getItem("stabilityOverlayEnabled")).toBe("false");
+  });
+
+  it("reads initial state from localStorage", () => {
+    localStorage.setItem("stabilityOverlayEnabled", "false");
+    withCtx({ x_np_m: 2.607, mac_m: 1.387, cg_agg_m: 2.510, target_static_margin: 0.12 });
+    const register = vi.fn();
+    render(<StabilityOverlay aeroplaneId="a" register={register} />);
+    const lastCall = register.mock.calls[register.mock.calls.length - 1][0];
+    expect(lastCall).toEqual([]);
+  });
+
+  it("omits IST trace when cg_agg_m is null", () => {
+    withCtx({ x_np_m: 2.607, mac_m: 1.387, cg_agg_m: null, target_static_margin: 0.12 });
+    const register = vi.fn();
+    render(<StabilityOverlay aeroplaneId="a" register={register} />);
+    const lastCall = register.mock.calls[register.mock.calls.length - 1][0];
+    const names = lastCall.map((t: { name: string }) => t.name);
+    expect(names).not.toContain("CG (actual)");
+    expect(names).toContain("NP");
+    expect(names).toContain("CG (design)");
+  });
+
+  it("clears its registered traces on unmount", () => {
+    withCtx({ x_np_m: 2.607, mac_m: 1.387, cg_agg_m: 2.510, target_static_margin: 0.12 });
+    const register = vi.fn();
+    const { unmount } = render(<StabilityOverlay aeroplaneId="a" register={register} />);
+    unmount();
+    // Last call should be the cleanup with empty array
+    const lastCall = register.mock.calls[register.mock.calls.length - 1][0];
+    expect(lastCall).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm run test:unit -- StabilityOverlay
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+Create `frontend/components/workbench/stability-overlay/StabilityOverlay.tsx`:
+
+```typescript
+"use client";
+
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useComputationContext } from "@/hooks/useComputationContext";
+import { buildStabilityTraces, type PlotlyTrace } from "./buildStabilityTraces";
+
+const STORAGE_KEY = "stabilityOverlayEnabled";
+
+interface Props {
+  aeroplaneId: string | null;
+  /** Stable setter from useOverlayRegistry — pass register('stability'). */
+  register: (next: PlotlyTrace[]) => void;
+}
+
+/**
+ * Self-contained overlay component that publishes Plotly traces for the
+ * stability visualisation (NP, CG SOLL, CG IST, SM band, delta link)
+ * into the parent overlay registry, and renders its own toggle button.
+ *
+ * Mount inside the workbench preview's overlay bar. Composes alongside
+ * <WingOutlineViewer extraTraces={registry.traces} />.
+ */
+export function StabilityOverlay({ aeroplaneId, register }: Readonly<Props>) {
+  const { data: ctx } = useComputationContext(aeroplaneId);
+
+  const [enabled, setEnabled] = useState<boolean>(() => {
+    if (typeof window === "undefined") return true;
+    return localStorage.getItem(STORAGE_KEY) !== "false";
+  });
+
+  const toggle = useCallback(() => {
+    setEnabled((prev) => {
+      const next = !prev;
+      if (typeof window !== "undefined") {
+        localStorage.setItem(STORAGE_KEY, String(next));
+      }
+      return next;
+    });
+  }, []);
+
+  const traces = useMemo<PlotlyTrace[]>(() => {
+    if (!enabled || !ctx) return [];
+    return buildStabilityTraces({
+      x_np_m: ctx.x_np_m,
+      mac_m: ctx.mac_m,
+      cg_agg_m: ctx.cg_agg_m,
+      target_static_margin: ctx.target_static_margin,
+    });
+  }, [enabled, ctx]);
+
+  useEffect(() => {
+    register(traces);
+    return () => { register([]); };
+  }, [register, traces]);
+
+  const hasData = ctx?.x_np_m != null;
+
+  return (
+    <button
+      onClick={toggle}
+      disabled={!hasData}
+      title={hasData ? "Toggle stability markers" : "No aero data — run analysis first"}
+      className={`rounded-lg border px-2 py-1 font-[family-name:var(--font-jetbrains-mono)] text-[10px] backdrop-blur-sm ${
+        enabled && hasData
+          ? "border-primary bg-primary/20 text-primary"
+          : "border-border bg-card/80 text-muted-foreground hover:text-foreground"
+      } disabled:opacity-50`}
+    >
+      Stability
+    </button>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+npm run test:unit -- StabilityOverlay
+```
+
+Expected: all 7 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/components/workbench/stability-overlay/StabilityOverlay.tsx \
+        frontend/__tests__/stability-overlay/StabilityOverlay.test.tsx
+git commit -m "feat(gh-569): add StabilityOverlay component with toggle and persistence"
+```
+
+---
+
+## Task 6: Wire into the workbench page
+
+**Files:**
+- Identify the workbench page that mounts `WingOutlineViewer` — likely `frontend/app/workbench/page.tsx`, but possibly via an intermediate panel.
+- Modify the identified file.
+
+- [ ] **Step 1: Locate the mount point**
+
+```bash
+grep -rln "WingOutlineViewer" /Users/szymanski/Projects/da3Dalus/cad-modelling-service/.claude/worktrees/feat+gh-569-stability-overlay/frontend/app /Users/szymanski/Projects/da3Dalus/cad-modelling-service/.claude/worktrees/feat+gh-569-stability-overlay/frontend/components --include="*.tsx"
+```
+
+Identify the workbench-only mount (NOT the airfoil-preview page). Verify it has access to `aeroplaneId`.
+
+- [ ] **Step 2: Modify the page/panel**
+
+Add the registry and overlay alongside the viewer:
+
+```typescript
+import { useOverlayRegistry } from "@/hooks/useOverlayRegistry";
+import { StabilityOverlay } from "@/components/workbench/stability-overlay/StabilityOverlay";
+
+// ...inside the component:
+const { traces: overlayTraces, register } = useOverlayRegistry();
+const stabilityRegister = register("stability");
+
+// In the render tree, where WingOutlineViewer is mounted:
+<div className="relative h-full w-full">
+  <WingOutlineViewer
+    wings={wings}
+    fuselages={fuselages}
+    visibleWings={visibleWings}
+    visibleFuselages={visibleFuselages}
+    selectedXsecIndex={selectedXsecIndex}
+    selectedWing={selectedWing}
+    selectedFuselage={selectedFuselage}
+    selectedFuselageXsecIndex={selectedFuselageXsecIndex}
+    extraTraces={overlayTraces}
+  />
+  {/* Overlay toolbar — augments the existing bottom-right bar in WingOutlineViewer */}
+  <div className="absolute bottom-3 right-3 z-30 flex gap-1" style={{ pointerEvents: "auto" }}>
+    <StabilityOverlay aeroplaneId={aeroplaneId} register={stabilityRegister} />
+    {/* Future overlays mount here */}
+  </div>
+</div>
+```
+
+**Important:** Place the overlay toolbar in a sibling absolute container so it appears alongside (or replaces) the `WingOutlineViewer`'s own toggle bar. Confirm there is no z-index or layout conflict with the existing `¼ Chord` button.
+
+If the existing `¼ Chord` button is also still desired, an alternative is to relocate the new toggle to a different corner (e.g. `bottom-3 left-3`). Pick whatever matches the visual hierarchy after a quick browser check.
+
+- [ ] **Step 3: Verify no regression in existing workbench tests**
+
+```bash
+cd /Users/szymanski/Projects/da3Dalus/cad-modelling-service/.claude/worktrees/feat+gh-569-stability-overlay/frontend
+npm run test:unit
+```
+
+Expected: full suite passes (new tests + existing tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/app/workbench/page.tsx   # or whichever file was modified
+git commit -m "feat(gh-569): mount StabilityOverlay in workbench construction preview"
+```
+
+---
+
+## Task 7: Manual browser verification against issue #569 acceptance criteria
+
+**Purpose:** Validate the feature in a real browser against every checkbox in issue #569.
+
+- [ ] **Step 1: Install frontend dependencies in the worktree (first time only)**
+
+```bash
+cd /Users/szymanski/Projects/da3Dalus/cad-modelling-service/.claude/worktrees/feat+gh-569-stability-overlay/frontend
+npm install
+```
+
+- [ ] **Step 2: Start the backend and frontend**
+
+```bash
+# Terminal 1 (backend):
+cd /Users/szymanski/Projects/da3Dalus/cad-modelling-service/.claude/worktrees/feat+gh-569-stability-overlay
+poetry install
+poetry run uvicorn app.main:app --host 0.0.0.0 --port 8001 --reload
+
+# Terminal 2 (frontend):
+cd /Users/szymanski/Projects/da3Dalus/cad-modelling-service/.claude/worktrees/feat+gh-569-stability-overlay/frontend
+npm run dev
+```
+
+- [ ] **Step 3: Walk through the issue #569 acceptance criteria**
+
+Open the workbench in a browser. Select an aeroplane with computed `x_np_m`. Verify each checkbox:
+
+- [ ] NP marker (blue) at correct longitudinal position.
+- [ ] CG SOLL marker (orange `#FF8400`) at `x_np_m − target_sm · mac_m`.
+- [ ] CG IST marker (outline-styled) at `cg_agg_m` (when present); colour green/yellow/red per divergence.
+- [ ] SM band between SOLL CG and NP.
+- [ ] SOLL↔IST link (dashed) when `|Δ|/MAC > 1 %`.
+- [ ] Hovertext shows the per-marker breakdown.
+- [ ] Update one of (NP, target SM, cg_agg) and confirm markers move; camera stays.
+- [ ] Graceful degradation: try an aircraft with `cg_agg_m == null` — only NP + SOLL + SM band shown.
+- [ ] Graceful degradation: try an aircraft with no aero analysis (no NP) — toggle disabled, no markers.
+- [ ] Toggle on/off works; preference persists across page reload.
+- [ ] **Not mounted in airfoil-preview page** — navigate to `/workbench/airfoil-preview` and verify no Stability toggle is present.
+- [ ] No console errors during mount, update, unmount.
+- [ ] Verify the existing `¼ Chord` toggle still works (no visual or functional regression).
+
+- [ ] **Step 4: Document the verification result**
+
+Append to this plan:
+
+```markdown
+## Appendix A: Manual Verification (T7)
+
+Date: YYYY-MM-DD
+Tester: <name>
+Result: [PASS | FAIL with notes]
+
+Notes / deviations from acceptance criteria:
+- ...
+```
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add docs/superpowers/plans/2026-05-18-stability-overlay-plan.md
+git commit -m "docs(gh-569): record manual browser verification result"
+```
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage** — every acceptance criterion in issue #569 mapped to a task:
+
+| Acceptance criterion (from #569) | Task |
+|---|---|
+| `useOverlayRegistry` with `{traces, register(key)}` + unit tests | T3 |
+| `WingOutlineViewer.extraTraces` additive prop; existing tests pass; deps array extended | T2 |
+| `StabilityOverlay` component built; renders its toggle only | T5 |
+| NP marker (blue) at `x_np_m * 1000` mm | T4, T5 |
+| CG SOLL marker (orange `#FF8400`, larger) at `(x_np_m − target_sm · mac_m) * 1000` | T4, T5 |
+| CG IST marker outline-styled; colour via `cgDivergenceColor()` | T1, T4, T5 |
+| SM band line trace between SOLL CG and NP | T4 |
+| Delta link (dashed) when `|Δ|/MAC > 1 %` | T4 |
+| Native Plotly hovertext per marker | T4 |
+| Traces update on ctx change; camera preserved | T4, T5, T6 (existing camera logic) |
+| Graceful degradation across 4 data states | T4, T5 |
+| Toggle in overlay bar; localStorage persistence | T5 |
+| Mounted only in workbench page (NOT airfoil-preview) | T6 |
+| Unit tests for registry, builder, color, overlay states | T1, T3, T4, T5 |
+| Manual browser verification | T7 |
+
+**Placeholder scan** — no "TBD" / "TODO" / "implement later". ✓
+
+**Type consistency** — `PlotlyTrace`/`PlotlyData` aliases consistent across T2/T3/T4/T5; `StabilityCtx` shape (`x_np_m`, `mac_m`, `cg_agg_m`, `target_static_margin`) consistent across T4/T5; `register(key) → (next: PlotlyTrace[]) => void` consistent across T3/T5/T6. ✓
+
+**Out-of-scope discipline** — no tasks touch backend, no tasks delete the Stability tab, no tasks fix #568, no mounting in airfoil-preview page. ✓

--- a/docs/superpowers/plans/2026-05-18-stability-overlay-plan.md
+++ b/docs/superpowers/plans/2026-05-18-stability-overlay-plan.md
@@ -1140,3 +1140,37 @@ git commit -m "docs(gh-569): record manual browser verification result"
 **Type consistency** — `PlotlyTrace`/`PlotlyData` aliases consistent across T2/T3/T4/T5; `StabilityCtx` shape (`x_np_m`, `mac_m`, `cg_agg_m`, `target_static_margin`) consistent across T4/T5; `register(key) → (next: PlotlyTrace[]) => void` consistent across T3/T5/T6. ✓
 
 **Out-of-scope discipline** — no tasks touch backend, no tasks delete the Stability tab, no tasks fix #568, no mounting in airfoil-preview page. ✓
+
+---
+
+## Appendix A — Divergences from plan (discovered during T7 verification)
+
+The plan made two wrong assumptions that the manual browser verification (T7) caught:
+
+1. **"Apply × 1000 (m → mm)" — wrong.** `WingOutlineViewer` actually consumes wing data in **metres** (not millimetres). The mm convention applies to the WingConfig schemas / CAD-designer topology, not the Plotly-rendered wing data the frontend receives. The first browser load showed the markers landing 1000× too far along x — fix in commit `d18b3e5` (drop the multiplier, rename `xNpMm → xNp`). See memory `feedback_plotly_units.md`.
+
+2. **Markers floating at `(x, 0, 0)` — bad UX for high-wing.** Placing every marker at the global origin's y/z made them float below the wing on a Hochdecker (high-wing). Fixed by extracting the **root LE y/z of the main wing** (largest by `halfSpan × rootChord` proxy) in `app/workbench/page.tsx` and forwarding through `<StabilityOverlay referenceY referenceZ />` to `buildStabilityTraces(ctx, opts)`. Markers now sit on the wing-root chord-line height. Commit `dfded7c`.
+
+Additional refinements (UX polish, not divergences):
+
+3. **`scatter3d` pixel markers → `mesh3d` icospheres** (commit `6ed5051`). Pixel-sized markers stayed the same size while zooming, leading to overlap at zoom-out. Switched the three sphere markers to `mesh3d` icospheres sized as a fraction of MAC — they now scale with zoom naturally. Lines stay as `scatter3d` (their `linewidth` in pixels is fine).
+
+4. **All sphere markers at `opacity: 0.4`** (commit `2cd9770`). With opaque spheres, the SM-band and delta-link endpoints (which sit at the sphere centres) were hidden. 40 % opacity makes the line endpoints visible through the sphere.
+
+## Appendix B — Manual Verification (T7)
+
+Date: 2026-05-18
+Tester: szymanski (user) via http://localhost:3001/workbench (dev server from the gh-569 worktree)
+
+Result: **PASS** after the four iterations documented in Appendix A above.
+
+Verified items:
+- Three sphere markers (NP, CG SOLL, CG IST) visible at correct longitudinal positions, sitting on the wing-root chord-line.
+- SM band and SOLL↔IST delta link visible (line endpoints visible through 40 %-opaque spheres).
+- Hovertext per marker readable; values match the footer chip values.
+- Toggle works, persists across reload.
+- Airfoil-preview page unaffected (no Stability toggle).
+- Existing `¼ Chord` toggle still works.
+- No console errors.
+
+The unit-and-placement divergences (Appendix A) are reflected in the final spec doc and issue #569 body via a follow-up doc-sync commit.

--- a/docs/superpowers/specs/2026-05-18-construction-view-stability-overlay-design.md
+++ b/docs/superpowers/specs/2026-05-18-construction-view-stability-overlay-design.md
@@ -34,15 +34,21 @@ app/workbench/page.tsx
 
 | Marker | Trace | Style | Hovertext |
 |---|---|---|---|
-| NP | `scatter3d` 1 pt | sphere, blue, 8 px | NP + MAC |
-| CG SOLL | `scatter3d` 1 pt | sphere, `#FF8400`, 12 px | CG soll + target SM |
-| CG IST | `scatter3d` 1 pt | sphere, ~6 px, semi-transparent, colour via `cgDivergenceColor(soll,ist,mac)` | CG ist + resulting SM + Δ |
+| NP | `mesh3d` icosphere | blue, radius = 2 % MAC (world units), `opacity: 0.4` | NP + MAC |
+| CG SOLL | `mesh3d` icosphere | `#FF8400` orange, radius = 3.5 % MAC, `opacity: 0.4` | CG soll + target SM |
+| CG IST | `mesh3d` icosphere | colour via `cgDivergenceColor(soll, ist, mac)` → hex, radius = 2.2 % MAC, `opacity: 0.4` | CG ist + resulting SM + Δ |
 | SM band | `scatter3d` 2 pts, `mode: "lines"` | solid yellow-green | target SM |
-| SOLL↔IST link | `scatter3d` 2 pts, `mode: "lines"`, dashed | colour from IST marker; only when both present and `|Δ|/MAC > 1 %` | (none) |
+| SOLL↔IST link | `scatter3d` 2 pts, `mode: "lines"`, dashed | colour from IST marker; only when both present and `\|Δ\|/MAC > 1 %` | (none) |
+
+**Sphere geometry note:** marker spheres are `mesh3d` icospheres (12 vertices, 20 triangles) sized in **world units** as a fraction of MAC. This means they **scale with zoom** (shrink when zooming out, grow when zooming in) — avoiding the overlap problem of pixel-based `scatter3d` markers. Lines stay as `scatter3d` because their `linewidth` (pixels) is acceptable for 1D elements. All three spheres render at `opacity: 0.4` so the SM-band and delta-link endpoints (which sit at the sphere centres) are visible inside the spheres.
 
 ### Coordinate handling
 
-Backend NP/CG in metres; `WingOutlineViewer` renders wings in mm with `aspectmode: "data"`. Apply `× 1000` to NP/CG values before placing in Plotly traces. Longitudinal axis is X.
+Backend NP/CG are in **metres**. `WingOutlineViewer` consumes wing data in **metres** directly (no scale conversion in `transformProfile`), with `aspectmode: "data"`. → marker coordinates are passed through **unchanged** (metres in, metres out). Longitudinal axis is X.
+
+### Marker origin (chord-line placement)
+
+Markers are placed at `(x_marker, refY, refZ)` where `refY` and `refZ` come from the **root leading edge of the main wing** (largest wing by `halfSpan × rootChord` proxy), forwarded from `app/workbench/page.tsx` → `<StabilityOverlay referenceY referenceZ />` → `buildStabilityTraces(ctx, opts)`. This puts all markers on the wing root's chord-line height — for a high-wing aircraft they sit at the wing root rather than floating at the global `z=0`. When no wing data is available, `refY` and `refZ` fall back to `0`.
 
 ### Tooltips
 

--- a/docs/superpowers/specs/2026-05-18-construction-view-stability-overlay-design.md
+++ b/docs/superpowers/specs/2026-05-18-construction-view-stability-overlay-design.md
@@ -1,0 +1,80 @@
+# Construction-View Stability Overlay — Design Spec
+
+**Date:** 2026-05-18 (corrected — initial draft targeted the OCP CadViewer; the real target is the Plotly-based `WingOutlineViewer`).
+**Epic:** #566 (move stability visualisation from Analysis tab to Construction view)
+**Sibling sub-issue:** #567 (remove Stability tab)
+**Related bug:** #568 (cg_agg_m not displayed in footer)
+**Authoritative source:** Issue #569 body. This document is a synchronised local copy.
+
+## Problem
+
+NP, CG and Static Margin are configuration properties of the geometry (Sadraey §11.4) — they belong on the geometry, not in a separate 2D-schematic Analysis tab. Two CGs exist and must be reconciled in the user's view: **SOLL CG** (design target) and **IST CG** (component-aggregated). The footer renders these as text + colour; the Construction view should render them spatially.
+
+## Architecture — Plotly trace overlay via composable registry
+
+The Construction view's 3D preview is the **Plotly-based** `WingOutlineViewer.tsx` (Three.js / OCP `CadViewer` is a different surface and not the target here).
+
+### Composition model
+
+```
+app/workbench/page.tsx
+  ├── const { traces, register } = useOverlayRegistry()
+  ├── <WingOutlineViewer ... extraTraces={traces} />
+  └── <OverlayBar>
+        ├── <StabilityOverlay aeroplaneId={...} register={register('stability')} />
+        └── (future overlays slot in here — same pattern)
+      </OverlayBar>
+```
+
+- `WingOutlineViewer` accepts one new optional prop `extraTraces?: PlotlyData[]`.
+- `useOverlayRegistry()` is a tiny hook that maps `overlay-key → trace[]` and exposes a flat array.
+- Each overlay component owns: its data hook, its enabled state, its traces, its toggle button.
+
+### Markers (Plotly traces)
+
+| Marker | Trace | Style | Hovertext |
+|---|---|---|---|
+| NP | `scatter3d` 1 pt | sphere, blue, 8 px | NP + MAC |
+| CG SOLL | `scatter3d` 1 pt | sphere, `#FF8400`, 12 px | CG soll + target SM |
+| CG IST | `scatter3d` 1 pt | sphere, ~6 px, semi-transparent, colour via `cgDivergenceColor(soll,ist,mac)` | CG ist + resulting SM + Δ |
+| SM band | `scatter3d` 2 pts, `mode: "lines"` | solid yellow-green | target SM |
+| SOLL↔IST link | `scatter3d` 2 pts, `mode: "lines"`, dashed | colour from IST marker; only when both present and `|Δ|/MAC > 1 %` | (none) |
+
+### Coordinate handling
+
+Backend NP/CG in metres; `WingOutlineViewer` renders wings in mm with `aspectmode: "data"`. Apply `× 1000` to NP/CG values before placing in Plotly traces. Longitudinal axis is X.
+
+### Tooltips
+
+Plotly native `hovertext` + `hovertemplate`. No HTML overlay, no projection math, no raycasting.
+
+### Update behaviour
+
+`useMemo` rebuilds traces on changes to ctx + enabled state. Register call triggers `WingOutlineViewer` replot. Camera preservation already implemented in `WingOutlineViewer.tsx:882-892`.
+
+### Toggle
+
+Button in `WingOutlineViewer`'s existing bottom-right overlay bar (sibling to `¼ Chord`). State persisted in `localStorage`. Default on. Disabled state → empty trace array → no perf cost.
+
+### Graceful degradation
+
+| Data state | Markers shown |
+|---|---|
+| All values present | NP + SOLL + IST + SM band + (delta link if `|Δ|/MAC > 1 %`) |
+| `cg_agg_m == null` | NP + SOLL + SM band |
+| `x_np_m == null` | nothing; toggle hidden |
+| `target_static_margin == null` | NP + IST; toggle hint *"No design target set"* |
+
+## Acceptance Criteria
+
+See issue #569 — keep in sync.
+
+## Out of scope
+
+Backend changes; CadViewer changes; airfoil-preview-page mounting; future overlays; #567; #568.
+
+## Open implementation risks
+
+1. `extraTraces` interaction with `WingOutlineViewer.tsx:870-877` empty-scene placeholder — plan handles it.
+2. Camera preservation across overlay-only updates — plan verifies via test.
+3. Trace-count scaling for future overlays — non-issue at 5 traces.

--- a/frontend/__tests__/stability-overlay/StabilityOverlay.test.tsx
+++ b/frontend/__tests__/stability-overlay/StabilityOverlay.test.tsx
@@ -79,6 +79,18 @@ describe("StabilityOverlay", () => {
     expect(names).toContain("CG (design)");
   });
 
+  it("forwards referenceY and referenceZ to the trace builder", () => {
+    withCtx({ x_np_m: 2.607, mac_m: 1.387, cg_agg_m: 2.510, target_static_margin: 0.12 });
+    const register = vi.fn();
+    render(
+      <StabilityOverlay aeroplaneId="a" register={register} referenceY={0} referenceZ={0.45} />,
+    );
+    const lastCall = register.mock.calls[register.mock.calls.length - 1][0];
+    const np = lastCall.find((t: { name: string }) => t.name === "NP")!;
+    expect((np.y as number[])[0]).toBeCloseTo(0, 6);
+    expect((np.z as number[])[0]).toBeCloseTo(0.45, 6);
+  });
+
   it("clears its registered traces on unmount", () => {
     withCtx({ x_np_m: 2.607, mac_m: 1.387, cg_agg_m: 2.510, target_static_margin: 0.12 });
     const register = vi.fn();

--- a/frontend/__tests__/stability-overlay/StabilityOverlay.test.tsx
+++ b/frontend/__tests__/stability-overlay/StabilityOverlay.test.tsx
@@ -68,6 +68,16 @@ describe("StabilityOverlay", () => {
     expect(lastCall).toEqual([]);
   });
 
+  it("reflects toggle state via aria-pressed", () => {
+    withCtx({ x_np_m: 2.607, mac_m: 1.387, cg_agg_m: 2.510, target_static_margin: 0.12 });
+    const register = vi.fn();
+    render(<StabilityOverlay aeroplaneId="a" register={register} />);
+    const btn = screen.getByRole("button", { name: /stability/i });
+    expect(btn).toHaveAttribute("aria-pressed", "true");
+    fireEvent.click(btn);
+    expect(btn).toHaveAttribute("aria-pressed", "false");
+  });
+
   it("omits IST trace when cg_agg_m is null", () => {
     withCtx({ x_np_m: 2.607, mac_m: 1.387, cg_agg_m: null, target_static_margin: 0.12 });
     const register = vi.fn();

--- a/frontend/__tests__/stability-overlay/StabilityOverlay.test.tsx
+++ b/frontend/__tests__/stability-overlay/StabilityOverlay.test.tsx
@@ -83,8 +83,9 @@ describe("StabilityOverlay", () => {
     withCtx({ x_np_m: 2.607, mac_m: 1.387, cg_agg_m: 2.510, target_static_margin: 0.12 });
     const register = vi.fn();
     const { unmount } = render(<StabilityOverlay aeroplaneId="a" register={register} />);
+    register.mockClear();
     unmount();
-    const lastCall = register.mock.calls[register.mock.calls.length - 1][0];
-    expect(lastCall).toEqual([]);
+    expect(register).toHaveBeenCalledTimes(1);
+    expect(register).toHaveBeenCalledWith([]);
   });
 });

--- a/frontend/__tests__/stability-overlay/StabilityOverlay.test.tsx
+++ b/frontend/__tests__/stability-overlay/StabilityOverlay.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+vi.mock("@/hooks/useComputationContext", () => ({
+  useComputationContext: vi.fn(),
+}));
+
+import { useComputationContext } from "@/hooks/useComputationContext";
+import { StabilityOverlay } from "@/components/workbench/stability-overlay/StabilityOverlay";
+
+const mockedHook = vi.mocked(useComputationContext);
+
+function withCtx(ctx: Record<string, unknown> | null) {
+  mockedHook.mockReturnValue({
+    data: ctx as never,
+    error: null,
+    isLoading: false,
+    mutate: vi.fn(),
+  } as never);
+}
+
+describe("StabilityOverlay", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("publishes 5 traces via register when fully enabled with complete data", () => {
+    withCtx({ x_np_m: 2.607, mac_m: 1.387, cg_agg_m: 2.510, target_static_margin: 0.12 });
+    const register = vi.fn();
+    render(<StabilityOverlay aeroplaneId="a" register={register} />);
+    expect(register).toHaveBeenCalled();
+    const lastCall = register.mock.calls[register.mock.calls.length - 1][0];
+    expect(lastCall).toHaveLength(5);
+  });
+
+  it("publishes empty array when ctx is null", () => {
+    withCtx(null);
+    const register = vi.fn();
+    render(<StabilityOverlay aeroplaneId="a" register={register} />);
+    const lastCall = register.mock.calls[register.mock.calls.length - 1][0];
+    expect(lastCall).toEqual([]);
+  });
+
+  it("publishes empty array when toggled off", () => {
+    withCtx({ x_np_m: 2.607, mac_m: 1.387, cg_agg_m: 2.510, target_static_margin: 0.12 });
+    const register = vi.fn();
+    render(<StabilityOverlay aeroplaneId="a" register={register} />);
+    fireEvent.click(screen.getByRole("button", { name: /stability/i }));
+    const lastCall = register.mock.calls[register.mock.calls.length - 1][0];
+    expect(lastCall).toEqual([]);
+  });
+
+  it("persists toggle state in localStorage", () => {
+    withCtx({ x_np_m: 2.607, mac_m: 1.387, cg_agg_m: 2.510, target_static_margin: 0.12 });
+    const register = vi.fn();
+    render(<StabilityOverlay aeroplaneId="a" register={register} />);
+    fireEvent.click(screen.getByRole("button", { name: /stability/i }));
+    expect(localStorage.getItem("stabilityOverlayEnabled")).toBe("false");
+  });
+
+  it("reads initial state from localStorage", () => {
+    localStorage.setItem("stabilityOverlayEnabled", "false");
+    withCtx({ x_np_m: 2.607, mac_m: 1.387, cg_agg_m: 2.510, target_static_margin: 0.12 });
+    const register = vi.fn();
+    render(<StabilityOverlay aeroplaneId="a" register={register} />);
+    const lastCall = register.mock.calls[register.mock.calls.length - 1][0];
+    expect(lastCall).toEqual([]);
+  });
+
+  it("omits IST trace when cg_agg_m is null", () => {
+    withCtx({ x_np_m: 2.607, mac_m: 1.387, cg_agg_m: null, target_static_margin: 0.12 });
+    const register = vi.fn();
+    render(<StabilityOverlay aeroplaneId="a" register={register} />);
+    const lastCall = register.mock.calls[register.mock.calls.length - 1][0];
+    const names = lastCall.map((t: { name: string }) => t.name);
+    expect(names).not.toContain("CG (actual)");
+    expect(names).toContain("NP");
+    expect(names).toContain("CG (design)");
+  });
+
+  it("clears its registered traces on unmount", () => {
+    withCtx({ x_np_m: 2.607, mac_m: 1.387, cg_agg_m: 2.510, target_static_margin: 0.12 });
+    const register = vi.fn();
+    const { unmount } = render(<StabilityOverlay aeroplaneId="a" register={register} />);
+    unmount();
+    const lastCall = register.mock.calls[register.mock.calls.length - 1][0];
+    expect(lastCall).toEqual([]);
+  });
+});

--- a/frontend/__tests__/stability-overlay/StabilityOverlay.test.tsx
+++ b/frontend/__tests__/stability-overlay/StabilityOverlay.test.tsx
@@ -87,8 +87,11 @@ describe("StabilityOverlay", () => {
     );
     const lastCall = register.mock.calls[register.mock.calls.length - 1][0];
     const np = lastCall.find((t: { name: string }) => t.name === "NP")!;
-    expect((np.y as number[])[0]).toBeCloseTo(0, 6);
-    expect((np.z as number[])[0]).toBeCloseTo(0.45, 6);
+    // NP is now a mesh3d icosphere — its centre (mean of vertex coords)
+    // must land at the supplied refY / refZ.
+    const avg = (a: number[]) => a.reduce((s, v) => s + v, 0) / a.length;
+    expect(avg(np.y as number[])).toBeCloseTo(0, 6);
+    expect(avg(np.z as number[])).toBeCloseTo(0.45, 6);
   });
 
   it("clears its registered traces on unmount", () => {

--- a/frontend/__tests__/stability-overlay/buildStabilityTraces.test.ts
+++ b/frontend/__tests__/stability-overlay/buildStabilityTraces.test.ts
@@ -8,6 +8,16 @@ const FULL = {
   target_static_margin: 0.12,
 };
 
+/** Mean of vertex coordinates — for a symmetric icosphere this equals the centre. */
+function meshCenter(trace: { x: unknown; y: unknown; z: unknown }) {
+  const avg = (a: number[]) => a.reduce((s, v) => s + v, 0) / a.length;
+  return {
+    x: avg(trace.x as number[]),
+    y: avg(trace.y as number[]),
+    z: avg(trace.z as number[]),
+  };
+}
+
 describe("buildStabilityTraces", () => {
   describe("complete data", () => {
     const traces = buildStabilityTraces(FULL);
@@ -16,26 +26,37 @@ describe("buildStabilityTraces", () => {
       expect(traces).toHaveLength(5);
     });
 
-    it("places NP at x_np_m (metres) along the x axis", () => {
+    it("places NP icosphere centred at x_np_m (metres)", () => {
       const np = traces.find((t) => t.name === "NP")!;
-      expect((np.x as number[])[0]).toBeCloseTo(2.607, 3);
+      const c = meshCenter(np);
+      expect(c.x).toBeCloseTo(2.607, 3);
+      expect(c.y).toBeCloseTo(0, 3);
+      expect(c.z).toBeCloseTo(0, 3);
     });
 
-    it("places CG SOLL at x_np_m − target_sm · mac_m (metres)", () => {
+    it("places CG SOLL icosphere centred at x_np_m − target_sm · mac_m (metres)", () => {
       const cgSoll = traces.find((t) => t.name === "CG (design)")!;
       const expected = 2.607 - 0.12 * 1.387;
-      expect((cgSoll.x as number[])[0]).toBeCloseTo(expected, 3);
+      const c = meshCenter(cgSoll);
+      expect(c.x).toBeCloseTo(expected, 3);
     });
 
-    it("places CG IST at cg_agg_m (metres)", () => {
+    it("places CG IST icosphere centred at cg_agg_m (metres)", () => {
       const cgIst = traces.find((t) => t.name === "CG (actual)")!;
-      expect((cgIst.x as number[])[0]).toBeCloseTo(2.510, 3);
+      const c = meshCenter(cgIst);
+      expect(c.x).toBeCloseTo(2.510, 3);
     });
 
-    it("uses orange #FF8400 for CG SOLL marker", () => {
+    it("uses orange #FF8400 for CG SOLL mesh colour", () => {
       const cgSoll = traces.find((t) => t.name === "CG (design)")!;
-      const marker = cgSoll.marker as { color?: string };
-      expect(marker.color?.toUpperCase()).toBe("#FF8400");
+      expect((cgSoll.color as string).toUpperCase()).toBe("#FF8400");
+    });
+
+    it("renders CG IST as a semi-transparent mesh3d (no scatter marker)", () => {
+      const cgIst = traces.find((t) => t.name === "CG (actual)")!;
+      expect(cgIst.type).toBe("mesh3d");
+      expect(cgIst.opacity).toBeLessThan(1);
+      expect(cgIst.marker).toBeUndefined();
     });
 
     it("renders SM band as a line between SOLL CG and NP", () => {
@@ -82,11 +103,12 @@ describe("buildStabilityTraces", () => {
   });
 
   describe("reference point (chord-line placement)", () => {
-    it("places NP at the provided y/z when opts.referenceY/referenceZ given", () => {
+    it("centres NP icosphere at the provided y/z when opts.referenceY/referenceZ given", () => {
       const traces = buildStabilityTraces(FULL, { referenceY: 0, referenceZ: 0.45 });
       const np = traces.find((t) => t.name === "NP")!;
-      expect((np.y as number[])[0]).toBeCloseTo(0, 6);
-      expect((np.z as number[])[0]).toBeCloseTo(0.45, 6);
+      const c = meshCenter(np);
+      expect(c.y).toBeCloseTo(0, 6);
+      expect(c.z).toBeCloseTo(0.45, 6);
     });
 
     it("places SM band endpoints at the provided z (line stays planar at refZ)", () => {
@@ -99,8 +121,9 @@ describe("buildStabilityTraces", () => {
     it("falls back to y=0, z=0 when opts is omitted", () => {
       const traces = buildStabilityTraces(FULL);
       const np = traces.find((t) => t.name === "NP")!;
-      expect((np.y as number[])[0]).toBe(0);
-      expect((np.z as number[])[0]).toBe(0);
+      const c = meshCenter(np);
+      expect(c.y).toBeCloseTo(0, 6);
+      expect(c.z).toBeCloseTo(0, 6);
     });
   });
 

--- a/frontend/__tests__/stability-overlay/buildStabilityTraces.test.ts
+++ b/frontend/__tests__/stability-overlay/buildStabilityTraces.test.ts
@@ -52,11 +52,19 @@ describe("buildStabilityTraces", () => {
       expect((cgSoll.color as string).toUpperCase()).toBe("#FF8400");
     });
 
-    it("renders CG IST as a semi-transparent mesh3d (no scatter marker)", () => {
+    it("renders CG IST as a mesh3d (no scatter marker)", () => {
       const cgIst = traces.find((t) => t.name === "CG (actual)")!;
       expect(cgIst.type).toBe("mesh3d");
-      expect(cgIst.opacity).toBeLessThan(1);
       expect(cgIst.marker).toBeUndefined();
+    });
+
+    it("renders all three sphere markers at 40% opacity (so lines show through)", () => {
+      const np = traces.find((t) => t.name === "NP")!;
+      const cgSoll = traces.find((t) => t.name === "CG (design)")!;
+      const cgIst = traces.find((t) => t.name === "CG (actual)")!;
+      expect(np.opacity).toBe(0.4);
+      expect(cgSoll.opacity).toBe(0.4);
+      expect(cgIst.opacity).toBe(0.4);
     });
 
     it("renders SM band as a line between SOLL CG and NP", () => {

--- a/frontend/__tests__/stability-overlay/buildStabilityTraces.test.ts
+++ b/frontend/__tests__/stability-overlay/buildStabilityTraces.test.ts
@@ -89,9 +89,11 @@ describe("buildStabilityTraces", () => {
       expect(String(np.hovertext)).toContain("2.607");
     });
 
-    it("CG IST trace hovertext includes the Δ to target", () => {
+    it("CG IST trace hovertext includes Δ value with % MAC suffix", () => {
       const ist = traces.find((t) => t.name === "CG (actual)")!;
-      expect(String(ist.hovertext)).toMatch(/Δ|delta/i);
+      const text = String(ist.hovertext);
+      expect(text).toContain("% MAC");
+      expect(text).toMatch(/Δ to target = [+-]\d+\.\d+ % MAC/);
     });
   });
 });

--- a/frontend/__tests__/stability-overlay/buildStabilityTraces.test.ts
+++ b/frontend/__tests__/stability-overlay/buildStabilityTraces.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { buildStabilityTraces } from "@/components/workbench/stability-overlay/buildStabilityTraces";
+
+const FULL = {
+  x_np_m: 2.607,
+  mac_m: 1.387,
+  cg_agg_m: 2.510,
+  target_static_margin: 0.12,
+};
+
+describe("buildStabilityTraces", () => {
+  describe("complete data", () => {
+    const traces = buildStabilityTraces(FULL);
+
+    it("returns 5 traces: NP, CG SOLL, CG IST, SM band, delta link", () => {
+      expect(traces).toHaveLength(5);
+    });
+
+    it("places NP at x_np_m * 1000 (mm) along the x axis", () => {
+      const np = traces.find((t) => t.name === "NP")!;
+      expect((np.x as number[])[0]).toBeCloseTo(2607, 0);
+    });
+
+    it("places CG SOLL at (x_np_m − target_sm · mac_m) * 1000", () => {
+      const cgSoll = traces.find((t) => t.name === "CG (design)")!;
+      const expected = (2.607 - 0.12 * 1.387) * 1000;
+      expect((cgSoll.x as number[])[0]).toBeCloseTo(expected, 0);
+    });
+
+    it("places CG IST at cg_agg_m * 1000", () => {
+      const cgIst = traces.find((t) => t.name === "CG (actual)")!;
+      expect((cgIst.x as number[])[0]).toBeCloseTo(2510, 0);
+    });
+
+    it("uses orange #FF8400 for CG SOLL marker", () => {
+      const cgSoll = traces.find((t) => t.name === "CG (design)")!;
+      const marker = cgSoll.marker as { color?: string };
+      expect(marker.color?.toUpperCase()).toBe("#FF8400");
+    });
+
+    it("renders SM band as a line between SOLL CG and NP", () => {
+      const band = traces.find((t) => t.name === "Static Margin")!;
+      expect((band.x as number[]).length).toBe(2);
+      expect(band.mode).toBe("lines");
+    });
+
+    it("renders delta link only when |Δ|/MAC > 1%", () => {
+      // FULL: SOLL = 2.607 - 0.12*1.387 ≈ 2.44056
+      // |2.510 - 2.44056| / 1.387 ≈ 5.0% MAC → above threshold → link rendered
+      const link = traces.find((t) => t.name === "Δ SOLL→IST");
+      expect(link).toBeDefined();
+    });
+  });
+
+  describe("graceful degradation", () => {
+    it("omits CG IST trace when cg_agg_m is null", () => {
+      const traces = buildStabilityTraces({ ...FULL, cg_agg_m: null });
+      expect(traces.find((t) => t.name === "CG (actual)")).toBeUndefined();
+      expect(traces.find((t) => t.name === "Δ SOLL→IST")).toBeUndefined();
+    });
+
+    it("returns empty array when x_np_m is null", () => {
+      const traces = buildStabilityTraces({ ...FULL, x_np_m: null });
+      expect(traces).toEqual([]);
+    });
+
+    it("omits SM band and CG SOLL when target_static_margin is null", () => {
+      const traces = buildStabilityTraces({ ...FULL, target_static_margin: null });
+      expect(traces.find((t) => t.name === "Static Margin")).toBeUndefined();
+      expect(traces.find((t) => t.name === "CG (design)")).toBeUndefined();
+      // IST still rendered (cg_agg_m present)
+      expect(traces.find((t) => t.name === "CG (actual)")).toBeDefined();
+      // NP always present
+      expect(traces.find((t) => t.name === "NP")).toBeDefined();
+    });
+
+    it("does not render delta link when |Δ|/MAC ≤ 1%", () => {
+      const cgIstAtSoll = 2.607 - 0.12 * 1.387; // exactly at SOLL → Δ = 0
+      const traces = buildStabilityTraces({ ...FULL, cg_agg_m: cgIstAtSoll });
+      expect(traces.find((t) => t.name === "Δ SOLL→IST")).toBeUndefined();
+    });
+  });
+
+  describe("hovertext", () => {
+    const traces = buildStabilityTraces(FULL);
+
+    it("NP trace hovertext includes the NP value in metres", () => {
+      const np = traces.find((t) => t.name === "NP")!;
+      expect(String(np.hovertext)).toContain("2.607");
+    });
+
+    it("CG IST trace hovertext includes the Δ to target", () => {
+      const ist = traces.find((t) => t.name === "CG (actual)")!;
+      expect(String(ist.hovertext)).toMatch(/Δ|delta/i);
+    });
+  });
+});

--- a/frontend/__tests__/stability-overlay/buildStabilityTraces.test.ts
+++ b/frontend/__tests__/stability-overlay/buildStabilityTraces.test.ts
@@ -149,5 +149,19 @@ describe("buildStabilityTraces", () => {
       expect(text).toContain("% MAC");
       expect(text).toMatch(/Δ to target = [+-]\d+\.\d+ % MAC/);
     });
+
+    it("CG SOLL trace hovertext includes target SM percent", () => {
+      const cgSoll = traces.find((t) => t.name === "CG (design)")!;
+      const text = String(cgSoll.hovertext);
+      expect(text).toContain("target SM");
+      expect(text).toMatch(/target SM = \d{1,3}\.\d{1,3} % MAC/);
+    });
+
+    it("SM band trace hovertext includes target Static Margin percent", () => {
+      const band = traces.find((t) => t.name === "Static Margin")!;
+      const text = String(band.hovertext);
+      expect(text).toContain("Static Margin");
+      expect(text).toMatch(/Target Static Margin = \d{1,3}\.\d{1,3} % MAC/);
+    });
   });
 });

--- a/frontend/__tests__/stability-overlay/buildStabilityTraces.test.ts
+++ b/frontend/__tests__/stability-overlay/buildStabilityTraces.test.ts
@@ -16,20 +16,20 @@ describe("buildStabilityTraces", () => {
       expect(traces).toHaveLength(5);
     });
 
-    it("places NP at x_np_m * 1000 (mm) along the x axis", () => {
+    it("places NP at x_np_m (metres) along the x axis", () => {
       const np = traces.find((t) => t.name === "NP")!;
-      expect((np.x as number[])[0]).toBeCloseTo(2607, 0);
+      expect((np.x as number[])[0]).toBeCloseTo(2.607, 3);
     });
 
-    it("places CG SOLL at (x_np_m − target_sm · mac_m) * 1000", () => {
+    it("places CG SOLL at x_np_m − target_sm · mac_m (metres)", () => {
       const cgSoll = traces.find((t) => t.name === "CG (design)")!;
-      const expected = (2.607 - 0.12 * 1.387) * 1000;
-      expect((cgSoll.x as number[])[0]).toBeCloseTo(expected, 0);
+      const expected = 2.607 - 0.12 * 1.387;
+      expect((cgSoll.x as number[])[0]).toBeCloseTo(expected, 3);
     });
 
-    it("places CG IST at cg_agg_m * 1000", () => {
+    it("places CG IST at cg_agg_m (metres)", () => {
       const cgIst = traces.find((t) => t.name === "CG (actual)")!;
-      expect((cgIst.x as number[])[0]).toBeCloseTo(2510, 0);
+      expect((cgIst.x as number[])[0]).toBeCloseTo(2.510, 3);
     });
 
     it("uses orange #FF8400 for CG SOLL marker", () => {

--- a/frontend/__tests__/stability-overlay/buildStabilityTraces.test.ts
+++ b/frontend/__tests__/stability-overlay/buildStabilityTraces.test.ts
@@ -81,6 +81,29 @@ describe("buildStabilityTraces", () => {
     });
   });
 
+  describe("reference point (chord-line placement)", () => {
+    it("places NP at the provided y/z when opts.referenceY/referenceZ given", () => {
+      const traces = buildStabilityTraces(FULL, { referenceY: 0, referenceZ: 0.45 });
+      const np = traces.find((t) => t.name === "NP")!;
+      expect((np.y as number[])[0]).toBeCloseTo(0, 6);
+      expect((np.z as number[])[0]).toBeCloseTo(0.45, 6);
+    });
+
+    it("places SM band endpoints at the provided z (line stays planar at refZ)", () => {
+      const traces = buildStabilityTraces(FULL, { referenceY: 0, referenceZ: 0.45 });
+      const band = traces.find((t) => t.name === "Static Margin")!;
+      const zs = band.z as number[];
+      expect(zs.every((z) => Math.abs(z - 0.45) < 1e-6)).toBe(true);
+    });
+
+    it("falls back to y=0, z=0 when opts is omitted", () => {
+      const traces = buildStabilityTraces(FULL);
+      const np = traces.find((t) => t.name === "NP")!;
+      expect((np.y as number[])[0]).toBe(0);
+      expect((np.z as number[])[0]).toBe(0);
+    });
+  });
+
   describe("hovertext", () => {
     const traces = buildStabilityTraces(FULL);
 

--- a/frontend/__tests__/stability-overlay/divergence-color.test.ts
+++ b/frontend/__tests__/stability-overlay/divergence-color.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { cgDivergenceColor } from "../../components/workbench/stability-overlay/divergence-color";
+
+// Thresholds (match the original InfoChipRow helper):
+//   |Δ|/MAC * 100 <  5%        → text-emerald-400 (green)
+//   5% <= |Δ|/MAC * 100 <= 15% → text-orange-400 (orange / yellow band)
+//   |Δ|/MAC * 100 >  15%       → text-red-400 (red)
+describe("cgDivergenceColor", () => {
+  it("returns the green class for |Δ| < 5% MAC", () => {
+    // 0.005 / 1.0 * 100 = 0.5%  → green
+    expect(cgDivergenceColor(2.440, 2.445, 1.0)).toMatch(/emerald/);
+  });
+
+  it("returns the orange class for 5% <= |Δ| <= 15% MAC", () => {
+    // 0.100 / 1.0 * 100 = 10.0% → orange
+    expect(cgDivergenceColor(2.440, 2.540, 1.0)).toMatch(/orange/);
+  });
+
+  it("returns the red class for |Δ| > 15% MAC", () => {
+    // 0.200 / 1.0 * 100 = 20.0% → red
+    expect(cgDivergenceColor(2.440, 2.640, 1.0)).toMatch(/red/);
+  });
+
+  it("is symmetric in IST above vs below SOLL", () => {
+    // Both are 10% absolute divergence → identical class
+    expect(cgDivergenceColor(2.440, 2.340, 1.0)).toEqual(
+      cgDivergenceColor(2.440, 2.540, 1.0),
+    );
+  });
+
+  it("normalises by MAC", () => {
+    // 0.050 / 2.0 * 100 = 2.5% → still under 5% → green
+    expect(cgDivergenceColor(2.440, 2.490, 2.0)).toMatch(/emerald/);
+  });
+});

--- a/frontend/__tests__/stability-overlay/divergence-color.test.ts
+++ b/frontend/__tests__/stability-overlay/divergence-color.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { cgDivergenceColor } from "../../components/workbench/stability-overlay/divergence-color";
+import { cgDivergenceColor } from "@/components/workbench/stability-overlay/divergence-color";
 
 // Thresholds (match the original InfoChipRow helper):
 //   |Δ|/MAC * 100 <  5%        → text-emerald-400 (green)

--- a/frontend/__tests__/stability-overlay/sphereGeometry.test.ts
+++ b/frontend/__tests__/stability-overlay/sphereGeometry.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { makeIcosphere } from "@/components/workbench/stability-overlay/sphereGeometry";
+
+describe("makeIcosphere", () => {
+  it("returns 12 vertices and 20 faces", () => {
+    const s = makeIcosphere(0, 0, 0, 1);
+    expect(s.x).toHaveLength(12);
+    expect(s.y).toHaveLength(12);
+    expect(s.z).toHaveLength(12);
+    expect(s.i).toHaveLength(20);
+    expect(s.j).toHaveLength(20);
+    expect(s.k).toHaveLength(20);
+  });
+
+  it("places all vertices at the requested radius from the centre", () => {
+    const s = makeIcosphere(2, 3, 4, 0.5);
+    for (let n = 0; n < s.x.length; n++) {
+      const dx = s.x[n] - 2;
+      const dy = s.y[n] - 3;
+      const dz = s.z[n] - 4;
+      const r = Math.sqrt(dx * dx + dy * dy + dz * dz);
+      expect(r).toBeCloseTo(0.5, 6);
+    }
+  });
+
+  it("face indices reference valid vertex slots", () => {
+    const s = makeIcosphere(0, 0, 0, 1);
+    for (let n = 0; n < s.i.length; n++) {
+      expect(s.i[n]).toBeGreaterThanOrEqual(0);
+      expect(s.i[n]).toBeLessThan(12);
+      expect(s.j[n]).toBeGreaterThanOrEqual(0);
+      expect(s.j[n]).toBeLessThan(12);
+      expect(s.k[n]).toBeGreaterThanOrEqual(0);
+      expect(s.k[n]).toBeLessThan(12);
+    }
+  });
+});

--- a/frontend/__tests__/useOverlayRegistry.test.ts
+++ b/frontend/__tests__/useOverlayRegistry.test.ts
@@ -16,6 +16,14 @@ describe("useOverlayRegistry", () => {
     expect(cb1).toBe(cb2);
   });
 
+  it("returns referentially identical traces array across renders without register calls", () => {
+    const { result, rerender } = renderHook(() => useOverlayRegistry());
+    act(() => { result.current.register("a")([{ type: "scatter3d", x: [1] }]); });
+    const t1 = result.current.traces;
+    rerender();
+    expect(result.current.traces).toBe(t1);
+  });
+
   it("accumulates traces registered under different keys (insertion order preserved)", () => {
     const { result } = renderHook(() => useOverlayRegistry());
 

--- a/frontend/__tests__/useOverlayRegistry.test.ts
+++ b/frontend/__tests__/useOverlayRegistry.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useOverlayRegistry } from "@/hooks/useOverlayRegistry";
+
+describe("useOverlayRegistry", () => {
+  it("starts with an empty traces array", () => {
+    const { result } = renderHook(() => useOverlayRegistry());
+    expect(result.current.traces).toEqual([]);
+  });
+
+  it("returns a stable register(key) callback per key across renders", () => {
+    const { result, rerender } = renderHook(() => useOverlayRegistry());
+    const cb1 = result.current.register("stability");
+    rerender();
+    const cb2 = result.current.register("stability");
+    expect(cb1).toBe(cb2);
+  });
+
+  it("accumulates traces registered under different keys (insertion order preserved)", () => {
+    const { result } = renderHook(() => useOverlayRegistry());
+
+    act(() => {
+      result.current.register("a")([{ type: "scatter3d", x: [1], y: [0], z: [0] }]);
+      result.current.register("b")([{ type: "scatter3d", x: [2], y: [0], z: [0] }]);
+    });
+
+    expect(result.current.traces).toHaveLength(2);
+    expect((result.current.traces[0] as { x: number[] }).x).toEqual([1]);
+    expect((result.current.traces[1] as { x: number[] }).x).toEqual([2]);
+  });
+
+  it("replaces traces for an existing key on re-register", () => {
+    const { result } = renderHook(() => useOverlayRegistry());
+
+    act(() => { result.current.register("stability")([{ type: "scatter3d", x: [1], y: [0], z: [0] }]); });
+    act(() => { result.current.register("stability")([{ type: "scatter3d", x: [99], y: [0], z: [0] }]); });
+
+    expect(result.current.traces).toHaveLength(1);
+    expect((result.current.traces[0] as { x: number[] }).x).toEqual([99]);
+  });
+
+  it("removes the key when registering an empty array", () => {
+    const { result } = renderHook(() => useOverlayRegistry());
+
+    act(() => { result.current.register("stability")([{ type: "scatter3d", x: [1], y: [0], z: [0] }]); });
+    act(() => { result.current.register("stability")([]); });
+
+    expect(result.current.traces).toEqual([]);
+  });
+});

--- a/frontend/app/workbench/page.tsx
+++ b/frontend/app/workbench/page.tsx
@@ -12,11 +12,13 @@ import { AeroplaneTree } from "@/components/workbench/AeroplaneTree";
 import { SparEditDialog } from "@/components/workbench/SparEditDialog";
 import { TedEditDialog } from "@/components/workbench/TedEditDialog";
 import { WingOutlineViewer } from "@/components/workbench/WingOutlineViewer";
+import { StabilityOverlay } from "@/components/workbench/stability-overlay/StabilityOverlay";
 import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
 import { useAeroplanes } from "@/hooks/useAeroplanes";
 import { useWings, useWing, useAllWingData } from "@/hooks/useWings";
 import { useFuselages } from "@/hooks/useFuselages";
 import { useAllFuselageData, useFuselage } from "@/hooks/useFuselage";
+import { useOverlayRegistry } from "@/hooks/useOverlayRegistry";
 import { API_BASE } from "@/lib/fetcher";
 
 export default function WorkbenchPage() {
@@ -150,6 +152,12 @@ export default function WorkbenchPage() {
   const { wings: allWings, mutate: mutateAllWings } = useAllWingData(aeroplaneId, wingNames);
   const { fuselages: allFuselages, mutate: mutateAllFuselages } = useAllFuselageData(aeroplaneId, fuselageNames);
 
+  // Composable Plotly overlay registry. Each overlay (e.g. StabilityOverlay)
+  // publishes traces into this registry via its own stable register(key) setter;
+  // WingOutlineViewer renders the flat `overlayTraces` array additively.
+  const { traces: overlayTraces, register } = useOverlayRegistry();
+  const stabilityRegister = useMemo(() => register("stability"), [register]);
+
   useEffect(() => {
     if (hydrated && !aeroplaneId) openPicker();
   }, [hydrated, aeroplaneId, openPicker]);
@@ -254,7 +262,7 @@ export default function WorkbenchPage() {
               {viewerMaximized ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
             </button>
           </div>
-          <div className="min-h-0 flex-1">
+          <div className="relative min-h-0 flex-1">
             <WingOutlineViewer
               wings={allWings}
               fuselages={allFuselages}
@@ -264,7 +272,19 @@ export default function WorkbenchPage() {
               selectedXsecIndex={selectedXsecIndex}
               selectedFuselage={selectedFuselage}
               selectedFuselageXsecIndex={selectedFuselageXsecIndex}
+              extraTraces={overlayTraces}
             />
+            {/* Overlay toolbar — sits to the left of WingOutlineViewer's own
+                ¼ Chord button (which lives at bottom-3 right-3, z-20). */}
+            <div
+              className="absolute bottom-3 right-20 z-30"
+              style={{ pointerEvents: "auto" }}
+            >
+              <StabilityOverlay
+                aeroplaneId={aeroplaneId}
+                register={stabilityRegister}
+              />
+            </div>
           </div>
         </div>
         </div>

--- a/frontend/app/workbench/page.tsx
+++ b/frontend/app/workbench/page.tsx
@@ -152,6 +152,25 @@ export default function WorkbenchPage() {
   const { wings: allWings, mutate: mutateAllWings } = useAllWingData(aeroplaneId, wingNames);
   const { fuselages: allFuselages, mutate: mutateAllFuselages } = useAllFuselageData(aeroplaneId, fuselageNames);
 
+  // Pick the main wing (largest planform-area proxy) and extract its root LE
+  // y/z so the stability overlay markers sit on the wing's chord line rather
+  // than at the global origin (which floats below the wing on high-wing aircraft).
+  const mainWingRoot = useMemo(() => {
+    if (!allWings || allWings.length === 0) return null;
+    const planArea = (w: (typeof allWings)[number]) => {
+      const xs = w.x_secs;
+      if (!xs || xs.length < 2) return 0;
+      const halfSpan = Math.abs(
+        (xs[xs.length - 1].xyz_le?.[1] ?? 0) - (xs[0].xyz_le?.[1] ?? 0),
+      );
+      return halfSpan * (xs[0].chord ?? 0);
+    };
+    const main = allWings.reduce((a, b) => (planArea(a) >= planArea(b) ? a : b));
+    const rootLe = main.x_secs?.[0]?.xyz_le;
+    if (!rootLe || rootLe.length < 3) return null;
+    return { y: rootLe[1] ?? 0, z: rootLe[2] ?? 0 };
+  }, [allWings]);
+
   // Composable Plotly overlay registry. Each overlay (e.g. StabilityOverlay)
   // publishes traces into this registry via its own stable register(key) setter;
   // WingOutlineViewer renders the flat `overlayTraces` array additively.
@@ -283,6 +302,8 @@ export default function WorkbenchPage() {
               <StabilityOverlay
                 aeroplaneId={aeroplaneId}
                 register={stabilityRegister}
+                referenceY={mainWingRoot?.y}
+                referenceZ={mainWingRoot?.z}
               />
             </div>
           </div>

--- a/frontend/app/workbench/page.tsx
+++ b/frontend/app/workbench/page.tsx
@@ -155,8 +155,11 @@ export default function WorkbenchPage() {
   // Composable Plotly overlay registry. Each overlay (e.g. StabilityOverlay)
   // publishes traces into this registry via its own stable register(key) setter;
   // WingOutlineViewer renders the flat `overlayTraces` array additively.
+  // register(key) returns the identical setter across renders for the same
+  // key (per the useOverlayRegistry contract — see T3 tests), so it is safe
+  // to use directly in StabilityOverlay's effect deps without memoisation.
   const { traces: overlayTraces, register } = useOverlayRegistry();
-  const stabilityRegister = useMemo(() => register("stability"), [register]);
+  const stabilityRegister = register("stability");
 
   useEffect(() => {
     if (hydrated && !aeroplaneId) openPicker();
@@ -276,10 +279,7 @@ export default function WorkbenchPage() {
             />
             {/* Overlay toolbar — sits to the left of WingOutlineViewer's own
                 ¼ Chord button (which lives at bottom-3 right-3, z-20). */}
-            <div
-              className="absolute bottom-3 right-20 z-30"
-              style={{ pointerEvents: "auto" }}
-            >
+            <div className="absolute bottom-3 right-20 z-30">
               <StabilityOverlay
                 aeroplaneId={aeroplaneId}
                 register={stabilityRegister}

--- a/frontend/app/workbench/page.tsx
+++ b/frontend/app/workbench/page.tsx
@@ -157,6 +157,8 @@ export default function WorkbenchPage() {
   // than at the global origin (which floats below the wing on high-wing aircraft).
   const mainWingRoot = useMemo(() => {
     if (!allWings || allWings.length === 0) return null;
+    // Planform-area proxy: halfSpan × root_chord (ignores taper).
+    // Sufficient to pick the main wing; not a true area measurement.
     const planArea = (w: (typeof allWings)[number]) => {
       const xs = w.x_secs;
       if (!xs || xs.length < 2) return 0;
@@ -167,16 +169,25 @@ export default function WorkbenchPage() {
     };
     const main = allWings.reduce((a, b) => (planArea(a) >= planArea(b) ? a : b));
     const rootLe = main.x_secs?.[0]?.xyz_le;
-    if (!rootLe || rootLe.length < 3) return null;
-    return { y: rootLe[1] ?? 0, z: rootLe[2] ?? 0 };
+    if (!rootLe || rootLe.length < 3 || rootLe[1] == null || rootLe[2] == null) {
+      if (rootLe) {
+        console.warn(
+          `[workbench] main wing "${main.name}" has malformed root xyz_le`,
+          rootLe,
+        );
+      }
+      return null;
+    }
+    return { y: rootLe[1], z: rootLe[2] };
   }, [allWings]);
 
   // Composable Plotly overlay registry. Each overlay (e.g. StabilityOverlay)
   // publishes traces into this registry via its own stable register(key) setter;
   // WingOutlineViewer renders the flat `overlayTraces` array additively.
   // register(key) returns the identical setter across renders for the same
-  // key (per the useOverlayRegistry contract — see T3 tests), so it is safe
-  // to use directly in StabilityOverlay's effect deps without memoisation.
+  // key (per the useOverlayRegistry contract — verified by
+  // `frontend/__tests__/useOverlayRegistry.test.ts`), so it is safe to use
+  // directly in StabilityOverlay's effect deps without memoisation.
   const { traces: overlayTraces, register } = useOverlayRegistry();
   const stabilityRegister = register("stability");
 

--- a/frontend/components/workbench/InfoChipRow.tsx
+++ b/frontend/components/workbench/InfoChipRow.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import { useComputationContext } from "@/hooks/useComputationContext";
 import { renderSymbol } from "@/components/workbench/renderSymbol";
+import { cgDivergenceColor } from "./stability-overlay/divergence-color";
 
 interface Props {
   readonly aeroplaneId: string | null;
@@ -70,13 +71,6 @@ function Chip({
       )}
     </div>
   );
-}
-
-function cgDivergenceColor(cgAero: number, cgAgg: number, mac: number): string {
-  const deltaPct = (Math.abs(cgAgg - cgAero) / mac) * 100;
-  if (deltaPct < 5) return "text-emerald-400";
-  if (deltaPct <= 15) return "text-orange-400";
-  return "text-red-400";
 }
 
 export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: Props) {

--- a/frontend/components/workbench/WingOutlineViewer.tsx
+++ b/frontend/components/workbench/WingOutlineViewer.tsx
@@ -14,6 +14,10 @@ interface WingOutlineViewerProps {
   selectedWing?: string | null;
   selectedFuselage?: string | null;
   selectedFuselageXsecIndex?: number | null;
+  /** Additional Plotly traces appended after wing/fuselage traces.
+   *  Used by overlay components (gh-569 stability overlay; future
+   *  expansions) via the useOverlayRegistry hook. */
+  extraTraces?: PlotlyData[];
 }
 
 // ── Airfoil coordinate cache ─────────────────────────────────────
@@ -836,6 +840,7 @@ export function WingOutlineViewer({
   wings, fuselages, visibleWings, visibleFuselages,
   selectedXsecIndex = null, selectedWing = null,
   selectedFuselage = null, selectedFuselageXsecIndex = null,
+  extraTraces,
 }: Readonly<WingOutlineViewerProps>) {
   const containerRef = useRef<HTMLDivElement>(null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -865,6 +870,11 @@ export function WingOutlineViewer({
         selectedFuselageXsecIndex: selectedFuselageXsecIndex ?? null,
         showQuarterChord,
       });
+
+      // gh-569: append overlay traces from useOverlayRegistry
+      if (extraTraces && extraTraces.length > 0) {
+        traces.push(...extraTraces);
+      }
 
       // Guard: empty scene placeholder to avoid Plotly GL crashes
       if (traces.length === 0) {
@@ -907,7 +917,7 @@ export function WingOutlineViewer({
         try { plotlyRef.current.purge(node); } catch { /* ok */ }
       }
     };
-  }, [wings, fuselages, visibleWings, visibleFuselages, selectedXsecIndex, selectedWing, selectedFuselage, selectedFuselageXsecIndex, showQuarterChord]);
+  }, [wings, fuselages, visibleWings, visibleFuselages, selectedXsecIndex, selectedWing, selectedFuselage, selectedFuselageXsecIndex, showQuarterChord, extraTraces]);
 
   return (
     <div className="relative h-full w-full">

--- a/frontend/components/workbench/WingOutlineViewer.tsx
+++ b/frontend/components/workbench/WingOutlineViewer.tsx
@@ -16,7 +16,9 @@ interface WingOutlineViewerProps {
   selectedFuselageXsecIndex?: number | null;
   /** Additional Plotly traces appended after wing/fuselage traces.
    *  Used by overlay components (gh-569 stability overlay; future
-   *  expansions) via the useOverlayRegistry hook. */
+   *  expansions) via the useOverlayRegistry hook.
+   *  Must be referentially stable (useMemo / useState) — a new array
+   *  reference on every render triggers a full replot. */
   extraTraces?: PlotlyData[];
 }
 

--- a/frontend/components/workbench/stability-overlay/StabilityOverlay.tsx
+++ b/frontend/components/workbench/stability-overlay/StabilityOverlay.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useComputationContext } from "@/hooks/useComputationContext";
+import type { PlotlyTrace } from "@/hooks/useOverlayRegistry";
+import { buildStabilityTraces } from "./buildStabilityTraces";
+
+const STORAGE_KEY = "stabilityOverlayEnabled";
+
+interface Props {
+  aeroplaneId: string | null;
+  /** Stable setter from useOverlayRegistry — pass register('stability'). */
+  register: (next: PlotlyTrace[]) => void;
+}
+
+/**
+ * Self-contained overlay component that publishes Plotly traces for the
+ * stability visualisation (NP, CG SOLL, CG IST, SM band, delta link)
+ * into the parent overlay registry, and renders its own toggle button.
+ *
+ * Mount inside the workbench preview's overlay bar. Composes alongside
+ * <WingOutlineViewer extraTraces={registry.traces} />.
+ */
+export function StabilityOverlay({ aeroplaneId, register }: Readonly<Props>) {
+  const { data: ctx } = useComputationContext(aeroplaneId);
+
+  const [enabled, setEnabled] = useState<boolean>(() => {
+    if (typeof window === "undefined") return true;
+    return localStorage.getItem(STORAGE_KEY) !== "false";
+  });
+
+  const toggle = useCallback(() => {
+    setEnabled((prev) => {
+      const next = !prev;
+      if (typeof window !== "undefined") {
+        localStorage.setItem(STORAGE_KEY, String(next));
+      }
+      return next;
+    });
+  }, []);
+
+  const traces = useMemo<PlotlyTrace[]>(() => {
+    if (!enabled || !ctx) return [];
+    return buildStabilityTraces({
+      x_np_m: ctx.x_np_m,
+      mac_m: ctx.mac_m,
+      cg_agg_m: ctx.cg_agg_m,
+      target_static_margin: ctx.target_static_margin,
+    });
+  }, [enabled, ctx]);
+
+  useEffect(() => {
+    register(traces);
+    return () => {
+      register([]);
+    };
+  }, [register, traces]);
+
+  const hasData = ctx?.x_np_m != null;
+  const buttonTitle = hasData
+    ? "Toggle stability markers"
+    : "No aero data — run analysis first";
+  const activeClasses =
+    enabled && hasData
+      ? "border-primary bg-primary/20 text-primary"
+      : "border-border bg-card/80 text-muted-foreground hover:text-foreground";
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      disabled={!hasData}
+      title={buttonTitle}
+      className={`rounded-lg border px-2 py-1 font-[family-name:var(--font-jetbrains-mono)] text-[10px] backdrop-blur-sm disabled:opacity-50 ${activeClasses}`}
+    >
+      Stability
+    </button>
+  );
+}

--- a/frontend/components/workbench/stability-overlay/StabilityOverlay.tsx
+++ b/frontend/components/workbench/stability-overlay/StabilityOverlay.tsx
@@ -11,6 +11,12 @@ interface Props {
   aeroplaneId: string | null;
   /** Stable setter from useOverlayRegistry — pass register('stability'). */
   register: (next: PlotlyTrace[]) => void;
+  /** Optional y-coordinate for marker placement (metres).
+   *  Use the main wing's root LE y so markers sit on the wing. */
+  referenceY?: number;
+  /** Optional z-coordinate for marker placement (metres).
+   *  Use the main wing's root LE z so markers sit on the wing's chord line. */
+  referenceZ?: number;
 }
 
 /**
@@ -21,7 +27,12 @@ interface Props {
  * Mount inside the workbench preview's overlay bar. Composes alongside
  * <WingOutlineViewer extraTraces={registry.traces} />.
  */
-export function StabilityOverlay({ aeroplaneId, register }: Readonly<Props>) {
+export function StabilityOverlay({
+  aeroplaneId,
+  register,
+  referenceY,
+  referenceZ,
+}: Readonly<Props>) {
   const { data: ctx } = useComputationContext(aeroplaneId);
 
   const [enabled, setEnabled] = useState<boolean>(() => {
@@ -41,13 +52,16 @@ export function StabilityOverlay({ aeroplaneId, register }: Readonly<Props>) {
 
   const traces = useMemo<PlotlyTrace[]>(() => {
     if (!enabled || !ctx) return [];
-    return buildStabilityTraces({
-      x_np_m: ctx.x_np_m,
-      mac_m: ctx.mac_m,
-      cg_agg_m: ctx.cg_agg_m,
-      target_static_margin: ctx.target_static_margin,
-    });
-  }, [enabled, ctx]);
+    return buildStabilityTraces(
+      {
+        x_np_m: ctx.x_np_m,
+        mac_m: ctx.mac_m,
+        cg_agg_m: ctx.cg_agg_m,
+        target_static_margin: ctx.target_static_margin,
+      },
+      { referenceY, referenceZ },
+    );
+  }, [enabled, ctx, referenceY, referenceZ]);
 
   useEffect(() => {
     register(traces);

--- a/frontend/components/workbench/stability-overlay/StabilityOverlay.tsx
+++ b/frontend/components/workbench/stability-overlay/StabilityOverlay.tsx
@@ -51,6 +51,10 @@ export function StabilityOverlay({ aeroplaneId, register }: Readonly<Props>) {
 
   useEffect(() => {
     register(traces);
+    // Cleanup fires on every traces change AND on unmount.
+    // Intentional: registry must always reflect the current overlay state.
+    // React 18+ batches the cleanup + new register call into a single commit,
+    // so consumers see one state update per change, not two.
     return () => {
       register([]);
     };
@@ -70,6 +74,7 @@ export function StabilityOverlay({ aeroplaneId, register }: Readonly<Props>) {
       type="button"
       onClick={toggle}
       disabled={!hasData}
+      aria-pressed={enabled}
       title={buttonTitle}
       className={`rounded-lg border px-2 py-1 font-[family-name:var(--font-jetbrains-mono)] text-[10px] backdrop-blur-sm disabled:opacity-50 ${activeClasses}`}
     >

--- a/frontend/components/workbench/stability-overlay/StabilityOverlay.tsx
+++ b/frontend/components/workbench/stability-overlay/StabilityOverlay.tsx
@@ -65,10 +65,15 @@ export function StabilityOverlay({
 
   useEffect(() => {
     register(traces);
-    // Cleanup fires on every traces change AND on unmount.
-    // Intentional: registry must always reflect the current overlay state.
-    // React 18+ batches the cleanup + new register call into a single commit,
-    // so consumers see one state update per change, not two.
+    // Cleanup fires on every traces change AND on unmount. Intentional:
+    // the registry must always reflect the current overlay state. Note
+    // that this re-runs the cleanup `register([])` and the setup
+    // `register(traces)` back-to-back — both setState calls are caught
+    // by React 18+ automatic batching, so consumers see one render per
+    // change. Side effect: this re-inserts the 'stability' key at the
+    // end of useOverlayRegistry's insertion order on every change —
+    // fine for a single overlay, watch out if cross-overlay z-ordering
+    // ever matters.
     return () => {
       register([]);
     };

--- a/frontend/components/workbench/stability-overlay/buildStabilityTraces.ts
+++ b/frontend/components/workbench/stability-overlay/buildStabilityTraces.ts
@@ -10,6 +10,15 @@ export interface StabilityCtx {
   target_static_margin: number | null;
 }
 
+export interface BuildStabilityTracesOpts {
+  /** y-coordinate for all markers, in metres. Default 0 (centreline). */
+  referenceY?: number;
+  /** z-coordinate for all markers, in metres. Default 0.
+   *  Pass the root LE z of the main wing so markers sit on the wing
+   *  rather than floating at z=0 (relevant for high-wing aircraft). */
+  referenceZ?: number;
+}
+
 // Link is rendered when |Δ| / MAC strictly exceeds this percentage threshold.
 const DELTA_LINK_THRESHOLD_PCT = 1;
 
@@ -64,15 +73,15 @@ function resolve(ctx: StabilityCtx): Resolved | null {
   };
 }
 
-function buildNpTrace(r: Resolved): PlotlyTrace {
+function buildNpTrace(r: Resolved, refY: number, refZ: number): PlotlyTrace {
   const macLine = r.hasMac ? `<br>MAC = ${(r.macM as number).toFixed(2)} m` : "";
   return {
     type: "scatter3d",
     mode: "markers",
     name: "NP",
     x: [r.xNp],
-    y: [0],
-    z: [0],
+    y: [refY],
+    z: [refZ],
     marker: { size: SIZE_NP_PX, color: COLOR_NP, symbol: "circle" },
     hovertext: `Neutral Point<br>x = ${r.xNp.toFixed(3)} m` + macLine,
     hoverinfo: "text",
@@ -80,15 +89,15 @@ function buildNpTrace(r: Resolved): PlotlyTrace {
   };
 }
 
-function buildCgSollTrace(r: Resolved): PlotlyTrace {
+function buildCgSollTrace(r: Resolved, refY: number, refZ: number): PlotlyTrace {
   const targetSmPct = ((r.targetSm as number) * 100).toFixed(1);
   return {
     type: "scatter3d",
     mode: "markers",
     name: "CG (design)",
     x: [r.xSoll as number],
-    y: [0],
-    z: [0],
+    y: [refY],
+    z: [refZ],
     marker: { size: SIZE_CG_SOLL_PX, color: COLOR_CG_SOLL, symbol: "circle" },
     hovertext:
       `CG (design target)<br>x = ${(r.xSoll as number).toFixed(3)} m` +
@@ -98,15 +107,15 @@ function buildCgSollTrace(r: Resolved): PlotlyTrace {
   };
 }
 
-function buildSmBandTrace(r: Resolved): PlotlyTrace {
+function buildSmBandTrace(r: Resolved, refY: number, refZ: number): PlotlyTrace {
   const targetSmPct = ((r.targetSm as number) * 100).toFixed(1);
   return {
     type: "scatter3d",
     mode: "lines",
     name: "Static Margin",
     x: [r.xSoll as number, r.xNp],
-    y: [0, 0],
-    z: [0, 0],
+    y: [refY, refY],
+    z: [refZ, refZ],
     line: { color: COLOR_SM_BAND, width: SM_BAND_WIDTH },
     hovertext: `Target Static Margin = ${targetSmPct} % MAC`,
     hoverinfo: "text",
@@ -135,14 +144,14 @@ function buildIstHovertext(r: Resolved): string {
   return lines.join("<br>");
 }
 
-function buildCgIstTrace(r: Resolved, color: string): PlotlyTrace {
+function buildCgIstTrace(r: Resolved, color: string, refY: number, refZ: number): PlotlyTrace {
   return {
     type: "scatter3d",
     mode: "markers",
     name: "CG (actual)",
     x: [r.xIst as number],
-    y: [0],
-    z: [0],
+    y: [refY],
+    z: [refZ],
     marker: {
       size: SIZE_CG_IST_PX,
       color,
@@ -156,7 +165,12 @@ function buildCgIstTrace(r: Resolved, color: string): PlotlyTrace {
   };
 }
 
-function buildDeltaLinkTrace(r: Resolved, color: string): PlotlyTrace | null {
+function buildDeltaLinkTrace(
+  r: Resolved,
+  color: string,
+  refY: number,
+  refZ: number,
+): PlotlyTrace | null {
   if (!(r.hasSoll && r.hasMac) || r.xIst == null || r.xSoll == null) return null;
   const deltaPct = (((r.xIst as number) - (r.xSoll as number)) / (r.macM as number)) * 100;
   if (Math.abs(deltaPct) <= DELTA_LINK_THRESHOLD_PCT) return null;
@@ -165,8 +179,8 @@ function buildDeltaLinkTrace(r: Resolved, color: string): PlotlyTrace | null {
     mode: "lines",
     name: "Δ SOLL→IST",
     x: [r.xSoll, r.xIst as number],
-    y: [0, 0],
-    z: [0, 0],
+    y: [refY, refY],
+    z: [refZ, refZ],
     line: { color, width: DELTA_LINK_WIDTH, dash: "dash" },
     hoverinfo: "skip",
     showlegend: false,
@@ -182,21 +196,27 @@ function buildDeltaLinkTrace(r: Resolved, color: string): PlotlyTrace | null {
  * Returns an empty array when there is no NP — the overlay cannot
  * meaningfully render anything without it.
  */
-export function buildStabilityTraces(ctx: StabilityCtx): PlotlyTrace[] {
+export function buildStabilityTraces(
+  ctx: StabilityCtx,
+  opts?: BuildStabilityTracesOpts,
+): PlotlyTrace[] {
   const r = resolve(ctx);
   if (r == null) return [];
 
-  const traces: PlotlyTrace[] = [buildNpTrace(r)];
+  const refY = opts?.referenceY ?? 0;
+  const refZ = opts?.referenceZ ?? 0;
+
+  const traces: PlotlyTrace[] = [buildNpTrace(r, refY, refZ)];
 
   if (r.hasSoll && r.xSoll != null) {
-    traces.push(buildCgSollTrace(r));
-    traces.push(buildSmBandTrace(r));
+    traces.push(buildCgSollTrace(r, refY, refZ));
+    traces.push(buildSmBandTrace(r, refY, refZ));
   }
 
   if (r.xIst != null) {
     const istColor = resolveIstColor(r);
-    traces.push(buildCgIstTrace(r, istColor));
-    const link = buildDeltaLinkTrace(r, istColor);
+    traces.push(buildCgIstTrace(r, istColor, refY, refZ));
+    const link = buildDeltaLinkTrace(r, istColor, refY, refZ);
     if (link != null) traces.push(link);
   }
 

--- a/frontend/components/workbench/stability-overlay/buildStabilityTraces.ts
+++ b/frontend/components/workbench/stability-overlay/buildStabilityTraces.ts
@@ -11,7 +11,8 @@ export interface StabilityCtx {
 }
 
 const M_TO_MM = 1000;
-const DELTA_LINK_THRESHOLD_PCT = 1; // |Δ|/MAC > 1% renders the dashed link
+// Link is rendered when |Δ| / MAC strictly exceeds this percentage threshold.
+const DELTA_LINK_THRESHOLD_PCT = 1;
 
 const COLOR_NP = "#3b82f6";        // tailwind blue-500
 const COLOR_CG_SOLL = "#FF8400";   // project theme accent

--- a/frontend/components/workbench/stability-overlay/buildStabilityTraces.ts
+++ b/frontend/components/workbench/stability-overlay/buildStabilityTraces.ts
@@ -38,7 +38,9 @@ const RADIUS_FALLBACK_M = 0.05;     // 5 cm when MAC unavailable
 
 const SM_BAND_WIDTH = 4;
 const DELTA_LINK_WIDTH = 2;
-const CG_IST_OPACITY = 0.55;
+// All three sphere markers share this opacity so the SM band / delta link
+// endpoints (which sit at the sphere centres) remain visible through them.
+const SPHERE_OPACITY = 0.4;
 
 function radiusFromMac(mac: number | null, frac: number): number {
   return mac != null && mac > 0 ? mac * frac : RADIUS_FALLBACK_M;
@@ -95,6 +97,7 @@ function buildNpTrace(r: Resolved, refY: number, refZ: number): PlotlyTrace {
     k: sphere.k,
     color: COLOR_NP,
     flatshading: true,
+    opacity: SPHERE_OPACITY,
     hovertext: `Neutral Point<br>x = ${r.xNp.toFixed(3)} m` + macLine,
     hoverinfo: "text",
     showlegend: false,
@@ -120,6 +123,7 @@ function buildCgSollTrace(r: Resolved, refY: number, refZ: number): PlotlyTrace 
     k: sphere.k,
     color: COLOR_CG_SOLL,
     flatshading: true,
+    opacity: SPHERE_OPACITY,
     hovertext:
       `CG (design target)<br>x = ${(r.xSoll as number).toFixed(3)} m` +
       `<br>target SM = ${targetSmPct} % MAC`,
@@ -183,7 +187,7 @@ function buildCgIstTrace(r: Resolved, color: string, refY: number, refZ: number)
     k: sphere.k,
     color,
     flatshading: true,
-    opacity: CG_IST_OPACITY,
+    opacity: SPHERE_OPACITY,
     hovertext: buildIstHovertext(r),
     hoverinfo: "text",
     showlegend: false,

--- a/frontend/components/workbench/stability-overlay/buildStabilityTraces.ts
+++ b/frontend/components/workbench/stability-overlay/buildStabilityTraces.ts
@@ -1,8 +1,6 @@
+import type { PlotlyTrace } from "@/hooks/useOverlayRegistry";
 import { cgDivergenceColor } from "./divergence-color";
 import { makeIcosphere } from "./sphereGeometry";
-
-/** Loose Plotly trace shape — keeps this module Plotly-import-free. */
-export type PlotlyTrace = Record<string, unknown>;
 
 export interface StabilityCtx {
   x_np_m: number | null;

--- a/frontend/components/workbench/stability-overlay/buildStabilityTraces.ts
+++ b/frontend/components/workbench/stability-overlay/buildStabilityTraces.ts
@@ -1,0 +1,210 @@
+import { cgDivergenceColor } from "./divergence-color";
+
+/** Loose Plotly trace shape — keeps this module Plotly-import-free. */
+export type PlotlyTrace = Record<string, unknown>;
+
+export interface StabilityCtx {
+  x_np_m: number | null;
+  mac_m: number | null;
+  cg_agg_m: number | null;
+  target_static_margin: number | null;
+}
+
+const M_TO_MM = 1000;
+const DELTA_LINK_THRESHOLD_PCT = 1; // |Δ|/MAC > 1% renders the dashed link
+
+const COLOR_NP = "#3b82f6";        // tailwind blue-500
+const COLOR_CG_SOLL = "#FF8400";   // project theme accent
+const COLOR_CG_IST_FALLBACK = "#9ca3af"; // tailwind gray-400
+const COLOR_SM_BAND = "#a3e635";   // tailwind lime-400
+
+const SIZE_NP_PX = 8;
+const SIZE_CG_SOLL_PX = 12;
+const SIZE_CG_IST_PX = 6;
+
+const SM_BAND_WIDTH = 4;
+const DELTA_LINK_WIDTH = 2;
+const CG_IST_OUTLINE_WIDTH = 2;
+const CG_IST_OPACITY = 0.85;
+
+/** Map cgDivergenceColor's Tailwind class string to a hex for Plotly. */
+function tailwindToHex(cls: string): string {
+  if (cls.includes("emerald")) return "#4ade80";
+  if (cls.includes("orange")) return "#fb923c";
+  if (cls.includes("red")) return "#f87171";
+  return COLOR_CG_IST_FALLBACK;
+}
+
+/** Resolved positional snapshot in millimetres + derived flags. */
+interface Resolved {
+  xNpM: number;
+  xNpMm: number;
+  macM: number | null;
+  hasMac: boolean;
+  hasSoll: boolean;
+  xSollM: number | null;
+  xSollMm: number | null;
+  xIstM: number | null;
+  xIstMm: number | null;
+  targetSm: number | null;
+}
+
+function resolve(ctx: StabilityCtx): Resolved | null {
+  if (ctx.x_np_m == null) return null;
+  const xNpM = ctx.x_np_m;
+  const macM = ctx.mac_m;
+  const hasMac = macM != null && macM > 0;
+  const hasSoll = hasMac && ctx.target_static_margin != null;
+  const xSollM = hasSoll ? xNpM - (ctx.target_static_margin as number) * (macM as number) : null;
+  return {
+    xNpM,
+    xNpMm: xNpM * M_TO_MM,
+    macM: hasMac ? (macM as number) : null,
+    hasMac,
+    hasSoll,
+    xSollM,
+    xSollMm: xSollM != null ? xSollM * M_TO_MM : null,
+    xIstM: ctx.cg_agg_m,
+    xIstMm: ctx.cg_agg_m != null ? ctx.cg_agg_m * M_TO_MM : null,
+    targetSm: ctx.target_static_margin,
+  };
+}
+
+function buildNpTrace(r: Resolved): PlotlyTrace {
+  const macLine = r.hasMac ? `<br>MAC = ${(r.macM as number).toFixed(2)} m` : "";
+  return {
+    type: "scatter3d",
+    mode: "markers",
+    name: "NP",
+    x: [r.xNpMm],
+    y: [0],
+    z: [0],
+    marker: { size: SIZE_NP_PX, color: COLOR_NP, symbol: "circle" },
+    hovertext: `Neutral Point<br>x = ${r.xNpM.toFixed(3)} m` + macLine,
+    hoverinfo: "text",
+    showlegend: false,
+  };
+}
+
+function buildCgSollTrace(r: Resolved): PlotlyTrace {
+  const targetSmPct = ((r.targetSm as number) * 100).toFixed(1);
+  return {
+    type: "scatter3d",
+    mode: "markers",
+    name: "CG (design)",
+    x: [r.xSollMm as number],
+    y: [0],
+    z: [0],
+    marker: { size: SIZE_CG_SOLL_PX, color: COLOR_CG_SOLL, symbol: "circle" },
+    hovertext:
+      `CG (design target)<br>x = ${(r.xSollM as number).toFixed(3)} m` +
+      `<br>target SM = ${targetSmPct} % MAC`,
+    hoverinfo: "text",
+    showlegend: false,
+  };
+}
+
+function buildSmBandTrace(r: Resolved): PlotlyTrace {
+  const targetSmPct = ((r.targetSm as number) * 100).toFixed(1);
+  return {
+    type: "scatter3d",
+    mode: "lines",
+    name: "Static Margin",
+    x: [r.xSollMm as number, r.xNpMm],
+    y: [0, 0],
+    z: [0, 0],
+    line: { color: COLOR_SM_BAND, width: SM_BAND_WIDTH },
+    hovertext: `Target Static Margin = ${targetSmPct} % MAC`,
+    hoverinfo: "text",
+    showlegend: false,
+  };
+}
+
+function resolveIstColor(r: Resolved): string {
+  if (!(r.hasSoll && r.hasMac)) return COLOR_CG_IST_FALLBACK;
+  return tailwindToHex(
+    cgDivergenceColor(r.xSollM as number, r.xIstM as number, r.macM as number),
+  );
+}
+
+function buildIstHovertext(r: Resolved): string {
+  const lines = [`CG (component aggregate)`, `x = ${(r.xIstM as number).toFixed(3)} m`];
+  if (r.hasMac) {
+    const resultingSmPct = ((r.xNpM - (r.xIstM as number)) / (r.macM as number)) * 100;
+    lines.push(`resulting SM = ${resultingSmPct.toFixed(1)} % MAC`);
+  }
+  if (r.hasSoll && r.hasMac) {
+    const deltaPct = (((r.xIstM as number) - (r.xSollM as number)) / (r.macM as number)) * 100;
+    const sign = deltaPct >= 0 ? "+" : "";
+    lines.push(`Δ to target = ${sign}${deltaPct.toFixed(1)} % MAC`);
+  }
+  return lines.join("<br>");
+}
+
+function buildCgIstTrace(r: Resolved, color: string): PlotlyTrace {
+  return {
+    type: "scatter3d",
+    mode: "markers",
+    name: "CG (actual)",
+    x: [r.xIstMm as number],
+    y: [0],
+    z: [0],
+    marker: {
+      size: SIZE_CG_IST_PX,
+      color,
+      symbol: "circle-open",
+      line: { color, width: CG_IST_OUTLINE_WIDTH },
+      opacity: CG_IST_OPACITY,
+    },
+    hovertext: buildIstHovertext(r),
+    hoverinfo: "text",
+    showlegend: false,
+  };
+}
+
+function buildDeltaLinkTrace(r: Resolved, color: string): PlotlyTrace | null {
+  if (!(r.hasSoll && r.hasMac) || r.xIstM == null || r.xSollMm == null) return null;
+  const deltaPct = (((r.xIstM as number) - (r.xSollM as number)) / (r.macM as number)) * 100;
+  if (Math.abs(deltaPct) <= DELTA_LINK_THRESHOLD_PCT) return null;
+  return {
+    type: "scatter3d",
+    mode: "lines",
+    name: "Δ SOLL→IST",
+    x: [r.xSollMm, r.xIstMm as number],
+    y: [0, 0],
+    z: [0, 0],
+    line: { color, width: DELTA_LINK_WIDTH, dash: "dash" },
+    hoverinfo: "skip",
+    showlegend: false,
+  };
+}
+
+/**
+ * Pure factory: build the Plotly scatter3d traces for the stability overlay.
+ *
+ * Coordinate convention: input is metres (backend convention), output is
+ * millimetres (matches WingOutlineViewer's wing coordinate frame).
+ *
+ * Returns an empty array when there is no NP — the overlay cannot
+ * meaningfully render anything without it.
+ */
+export function buildStabilityTraces(ctx: StabilityCtx): PlotlyTrace[] {
+  const r = resolve(ctx);
+  if (r == null) return [];
+
+  const traces: PlotlyTrace[] = [buildNpTrace(r)];
+
+  if (r.hasSoll && r.xSollMm != null) {
+    traces.push(buildCgSollTrace(r));
+    traces.push(buildSmBandTrace(r));
+  }
+
+  if (r.xIstMm != null) {
+    const istColor = resolveIstColor(r);
+    traces.push(buildCgIstTrace(r, istColor));
+    const link = buildDeltaLinkTrace(r, istColor);
+    if (link != null) traces.push(link);
+  }
+
+  return traces;
+}

--- a/frontend/components/workbench/stability-overlay/buildStabilityTraces.ts
+++ b/frontend/components/workbench/stability-overlay/buildStabilityTraces.ts
@@ -1,4 +1,5 @@
 import { cgDivergenceColor } from "./divergence-color";
+import { makeIcosphere } from "./sphereGeometry";
 
 /** Loose Plotly trace shape — keeps this module Plotly-import-free. */
 export type PlotlyTrace = Record<string, unknown>;
@@ -27,14 +28,21 @@ const COLOR_CG_SOLL = "#FF8400";   // project theme accent
 const COLOR_CG_IST_FALLBACK = "#9ca3af"; // tailwind gray-400
 const COLOR_SM_BAND = "#a3e635";   // tailwind lime-400
 
-const SIZE_NP_PX = 8;
-const SIZE_CG_SOLL_PX = 12;
-const SIZE_CG_IST_PX = 6;
+// Marker radii expressed as a fraction of MAC — markers scale with the
+// aircraft size so they stay visually proportional. When MAC is unknown
+// we fall back to a fixed metre radius tuned for small RC models.
+const NP_RADIUS_FRAC = 0.020;       // 2.0 % of MAC
+const CG_SOLL_RADIUS_FRAC = 0.035;  // 3.5 % of MAC (primary, larger)
+const CG_IST_RADIUS_FRAC = 0.022;   // 2.2 % of MAC
+const RADIUS_FALLBACK_M = 0.05;     // 5 cm when MAC unavailable
 
 const SM_BAND_WIDTH = 4;
 const DELTA_LINK_WIDTH = 2;
-const CG_IST_OUTLINE_WIDTH = 2;
-const CG_IST_OPACITY = 0.85;
+const CG_IST_OPACITY = 0.55;
+
+function radiusFromMac(mac: number | null, frac: number): number {
+  return mac != null && mac > 0 ? mac * frac : RADIUS_FALLBACK_M;
+}
 
 /** Map cgDivergenceColor's Tailwind class string to a hex for Plotly. */
 function tailwindToHex(cls: string): string {
@@ -75,14 +83,18 @@ function resolve(ctx: StabilityCtx): Resolved | null {
 
 function buildNpTrace(r: Resolved, refY: number, refZ: number): PlotlyTrace {
   const macLine = r.hasMac ? `<br>MAC = ${(r.macM as number).toFixed(2)} m` : "";
+  const sphere = makeIcosphere(r.xNp, refY, refZ, radiusFromMac(r.macM, NP_RADIUS_FRAC));
   return {
-    type: "scatter3d",
-    mode: "markers",
+    type: "mesh3d",
     name: "NP",
-    x: [r.xNp],
-    y: [refY],
-    z: [refZ],
-    marker: { size: SIZE_NP_PX, color: COLOR_NP, symbol: "circle" },
+    x: sphere.x,
+    y: sphere.y,
+    z: sphere.z,
+    i: sphere.i,
+    j: sphere.j,
+    k: sphere.k,
+    color: COLOR_NP,
+    flatshading: true,
     hovertext: `Neutral Point<br>x = ${r.xNp.toFixed(3)} m` + macLine,
     hoverinfo: "text",
     showlegend: false,
@@ -91,14 +103,23 @@ function buildNpTrace(r: Resolved, refY: number, refZ: number): PlotlyTrace {
 
 function buildCgSollTrace(r: Resolved, refY: number, refZ: number): PlotlyTrace {
   const targetSmPct = ((r.targetSm as number) * 100).toFixed(1);
+  const sphere = makeIcosphere(
+    r.xSoll as number,
+    refY,
+    refZ,
+    radiusFromMac(r.macM, CG_SOLL_RADIUS_FRAC),
+  );
   return {
-    type: "scatter3d",
-    mode: "markers",
+    type: "mesh3d",
     name: "CG (design)",
-    x: [r.xSoll as number],
-    y: [refY],
-    z: [refZ],
-    marker: { size: SIZE_CG_SOLL_PX, color: COLOR_CG_SOLL, symbol: "circle" },
+    x: sphere.x,
+    y: sphere.y,
+    z: sphere.z,
+    i: sphere.i,
+    j: sphere.j,
+    k: sphere.k,
+    color: COLOR_CG_SOLL,
+    flatshading: true,
     hovertext:
       `CG (design target)<br>x = ${(r.xSoll as number).toFixed(3)} m` +
       `<br>target SM = ${targetSmPct} % MAC`,
@@ -145,20 +166,24 @@ function buildIstHovertext(r: Resolved): string {
 }
 
 function buildCgIstTrace(r: Resolved, color: string, refY: number, refZ: number): PlotlyTrace {
+  const sphere = makeIcosphere(
+    r.xIst as number,
+    refY,
+    refZ,
+    radiusFromMac(r.macM, CG_IST_RADIUS_FRAC),
+  );
   return {
-    type: "scatter3d",
-    mode: "markers",
+    type: "mesh3d",
     name: "CG (actual)",
-    x: [r.xIst as number],
-    y: [refY],
-    z: [refZ],
-    marker: {
-      size: SIZE_CG_IST_PX,
-      color,
-      symbol: "circle-open",
-      line: { color, width: CG_IST_OUTLINE_WIDTH },
-      opacity: CG_IST_OPACITY,
-    },
+    x: sphere.x,
+    y: sphere.y,
+    z: sphere.z,
+    i: sphere.i,
+    j: sphere.j,
+    k: sphere.k,
+    color,
+    flatshading: true,
+    opacity: CG_IST_OPACITY,
     hovertext: buildIstHovertext(r),
     hoverinfo: "text",
     showlegend: false,
@@ -188,7 +213,12 @@ function buildDeltaLinkTrace(
 }
 
 /**
- * Pure factory: build the Plotly scatter3d traces for the stability overlay.
+ * Pure factory: build the Plotly traces for the stability overlay.
+ *
+ * Markers (NP / CG SOLL / CG IST) are `mesh3d` icospheres sized in world
+ * units (as a fraction of MAC) so they scale naturally with zoom. Lines
+ * (SM band, delta link) are `scatter3d` line traces — their pixel
+ * line-width is unaffected by overlap.
  *
  * Coordinate convention: metres in, metres out (matches WingOutlineViewer's
  * coordinate frame — wing outline positions are passed through unchanged).

--- a/frontend/components/workbench/stability-overlay/buildStabilityTraces.ts
+++ b/frontend/components/workbench/stability-overlay/buildStabilityTraces.ts
@@ -10,7 +10,6 @@ export interface StabilityCtx {
   target_static_margin: number | null;
 }
 
-const M_TO_MM = 1000;
 // Link is rendered when |Δ| / MAC strictly exceeds this percentage threshold.
 const DELTA_LINK_THRESHOLD_PCT = 1;
 
@@ -36,37 +35,31 @@ function tailwindToHex(cls: string): string {
   return COLOR_CG_IST_FALLBACK;
 }
 
-/** Resolved positional snapshot in millimetres + derived flags. */
+/** Resolved positional snapshot in metres + derived flags. */
 interface Resolved {
-  xNpM: number;
-  xNpMm: number;
+  xNp: number;
   macM: number | null;
   hasMac: boolean;
   hasSoll: boolean;
-  xSollM: number | null;
-  xSollMm: number | null;
-  xIstM: number | null;
-  xIstMm: number | null;
+  xSoll: number | null;
+  xIst: number | null;
   targetSm: number | null;
 }
 
 function resolve(ctx: StabilityCtx): Resolved | null {
   if (ctx.x_np_m == null) return null;
-  const xNpM = ctx.x_np_m;
+  const xNp = ctx.x_np_m;
   const macM = ctx.mac_m;
   const hasMac = macM != null && macM > 0;
   const hasSoll = hasMac && ctx.target_static_margin != null;
-  const xSollM = hasSoll ? xNpM - (ctx.target_static_margin as number) * (macM as number) : null;
+  const xSoll = hasSoll ? xNp - (ctx.target_static_margin as number) * (macM as number) : null;
   return {
-    xNpM,
-    xNpMm: xNpM * M_TO_MM,
+    xNp,
     macM: hasMac ? (macM as number) : null,
     hasMac,
     hasSoll,
-    xSollM,
-    xSollMm: xSollM != null ? xSollM * M_TO_MM : null,
-    xIstM: ctx.cg_agg_m,
-    xIstMm: ctx.cg_agg_m != null ? ctx.cg_agg_m * M_TO_MM : null,
+    xSoll,
+    xIst: ctx.cg_agg_m,
     targetSm: ctx.target_static_margin,
   };
 }
@@ -77,11 +70,11 @@ function buildNpTrace(r: Resolved): PlotlyTrace {
     type: "scatter3d",
     mode: "markers",
     name: "NP",
-    x: [r.xNpMm],
+    x: [r.xNp],
     y: [0],
     z: [0],
     marker: { size: SIZE_NP_PX, color: COLOR_NP, symbol: "circle" },
-    hovertext: `Neutral Point<br>x = ${r.xNpM.toFixed(3)} m` + macLine,
+    hovertext: `Neutral Point<br>x = ${r.xNp.toFixed(3)} m` + macLine,
     hoverinfo: "text",
     showlegend: false,
   };
@@ -93,12 +86,12 @@ function buildCgSollTrace(r: Resolved): PlotlyTrace {
     type: "scatter3d",
     mode: "markers",
     name: "CG (design)",
-    x: [r.xSollMm as number],
+    x: [r.xSoll as number],
     y: [0],
     z: [0],
     marker: { size: SIZE_CG_SOLL_PX, color: COLOR_CG_SOLL, symbol: "circle" },
     hovertext:
-      `CG (design target)<br>x = ${(r.xSollM as number).toFixed(3)} m` +
+      `CG (design target)<br>x = ${(r.xSoll as number).toFixed(3)} m` +
       `<br>target SM = ${targetSmPct} % MAC`,
     hoverinfo: "text",
     showlegend: false,
@@ -111,7 +104,7 @@ function buildSmBandTrace(r: Resolved): PlotlyTrace {
     type: "scatter3d",
     mode: "lines",
     name: "Static Margin",
-    x: [r.xSollMm as number, r.xNpMm],
+    x: [r.xSoll as number, r.xNp],
     y: [0, 0],
     z: [0, 0],
     line: { color: COLOR_SM_BAND, width: SM_BAND_WIDTH },
@@ -124,18 +117,18 @@ function buildSmBandTrace(r: Resolved): PlotlyTrace {
 function resolveIstColor(r: Resolved): string {
   if (!(r.hasSoll && r.hasMac)) return COLOR_CG_IST_FALLBACK;
   return tailwindToHex(
-    cgDivergenceColor(r.xSollM as number, r.xIstM as number, r.macM as number),
+    cgDivergenceColor(r.xSoll as number, r.xIst as number, r.macM as number),
   );
 }
 
 function buildIstHovertext(r: Resolved): string {
-  const lines = [`CG (component aggregate)`, `x = ${(r.xIstM as number).toFixed(3)} m`];
+  const lines = [`CG (component aggregate)`, `x = ${(r.xIst as number).toFixed(3)} m`];
   if (r.hasMac) {
-    const resultingSmPct = ((r.xNpM - (r.xIstM as number)) / (r.macM as number)) * 100;
+    const resultingSmPct = ((r.xNp - (r.xIst as number)) / (r.macM as number)) * 100;
     lines.push(`resulting SM = ${resultingSmPct.toFixed(1)} % MAC`);
   }
   if (r.hasSoll && r.hasMac) {
-    const deltaPct = (((r.xIstM as number) - (r.xSollM as number)) / (r.macM as number)) * 100;
+    const deltaPct = (((r.xIst as number) - (r.xSoll as number)) / (r.macM as number)) * 100;
     const sign = deltaPct >= 0 ? "+" : "";
     lines.push(`Δ to target = ${sign}${deltaPct.toFixed(1)} % MAC`);
   }
@@ -147,7 +140,7 @@ function buildCgIstTrace(r: Resolved, color: string): PlotlyTrace {
     type: "scatter3d",
     mode: "markers",
     name: "CG (actual)",
-    x: [r.xIstMm as number],
+    x: [r.xIst as number],
     y: [0],
     z: [0],
     marker: {
@@ -164,14 +157,14 @@ function buildCgIstTrace(r: Resolved, color: string): PlotlyTrace {
 }
 
 function buildDeltaLinkTrace(r: Resolved, color: string): PlotlyTrace | null {
-  if (!(r.hasSoll && r.hasMac) || r.xIstM == null || r.xSollMm == null) return null;
-  const deltaPct = (((r.xIstM as number) - (r.xSollM as number)) / (r.macM as number)) * 100;
+  if (!(r.hasSoll && r.hasMac) || r.xIst == null || r.xSoll == null) return null;
+  const deltaPct = (((r.xIst as number) - (r.xSoll as number)) / (r.macM as number)) * 100;
   if (Math.abs(deltaPct) <= DELTA_LINK_THRESHOLD_PCT) return null;
   return {
     type: "scatter3d",
     mode: "lines",
     name: "Δ SOLL→IST",
-    x: [r.xSollMm, r.xIstMm as number],
+    x: [r.xSoll, r.xIst as number],
     y: [0, 0],
     z: [0, 0],
     line: { color, width: DELTA_LINK_WIDTH, dash: "dash" },
@@ -183,8 +176,8 @@ function buildDeltaLinkTrace(r: Resolved, color: string): PlotlyTrace | null {
 /**
  * Pure factory: build the Plotly scatter3d traces for the stability overlay.
  *
- * Coordinate convention: input is metres (backend convention), output is
- * millimetres (matches WingOutlineViewer's wing coordinate frame).
+ * Coordinate convention: metres in, metres out (matches WingOutlineViewer's
+ * coordinate frame — wing outline positions are passed through unchanged).
  *
  * Returns an empty array when there is no NP — the overlay cannot
  * meaningfully render anything without it.
@@ -195,12 +188,12 @@ export function buildStabilityTraces(ctx: StabilityCtx): PlotlyTrace[] {
 
   const traces: PlotlyTrace[] = [buildNpTrace(r)];
 
-  if (r.hasSoll && r.xSollMm != null) {
+  if (r.hasSoll && r.xSoll != null) {
     traces.push(buildCgSollTrace(r));
     traces.push(buildSmBandTrace(r));
   }
 
-  if (r.xIstMm != null) {
+  if (r.xIst != null) {
     const istColor = resolveIstColor(r);
     traces.push(buildCgIstTrace(r, istColor));
     const link = buildDeltaLinkTrace(r, istColor);

--- a/frontend/components/workbench/stability-overlay/divergence-color.ts
+++ b/frontend/components/workbench/stability-overlay/divergence-color.ts
@@ -1,0 +1,22 @@
+/**
+ * Color class for CG divergence indicator (SOLL vs IST).
+ *
+ * Returns a Tailwind text-color class based on the absolute delta
+ * between design CG (`cgSoll`) and aggregated CG (`cgIst`), normalised
+ * by MAC.
+ *
+ * Thresholds and class names match the original InfoChipRow helper:
+ *   |Δ|/MAC * 100 <  5%        → text-emerald-400 (in tolerance)
+ *   5% <= |Δ|/MAC * 100 <= 15% → text-orange-400 (drift / caution)
+ *   |Δ|/MAC * 100 >  15%       → text-red-400 (out of envelope)
+ */
+export function cgDivergenceColor(
+  cgSoll: number,
+  cgIst: number,
+  mac: number,
+): string {
+  const deltaPct = (Math.abs(cgIst - cgSoll) / mac) * 100;
+  if (deltaPct < 5) return "text-emerald-400";
+  if (deltaPct <= 15) return "text-orange-400";
+  return "text-red-400";
+}

--- a/frontend/components/workbench/stability-overlay/divergence-color.ts
+++ b/frontend/components/workbench/stability-overlay/divergence-color.ts
@@ -4,11 +4,6 @@
  * Returns a Tailwind text-color class based on the absolute delta
  * between design CG (`cgSoll`) and aggregated CG (`cgIst`), normalised
  * by MAC.
- *
- * Thresholds and class names match the original InfoChipRow helper:
- *   |Δ|/MAC * 100 <  5%        → text-emerald-400 (in tolerance)
- *   5% <= |Δ|/MAC * 100 <= 15% → text-orange-400 (drift / caution)
- *   |Δ|/MAC * 100 >  15%       → text-red-400 (out of envelope)
  */
 export function cgDivergenceColor(
   cgSoll: number,
@@ -16,6 +11,10 @@ export function cgDivergenceColor(
   mac: number,
 ): string {
   const deltaPct = (Math.abs(cgIst - cgSoll) / mac) * 100;
+  // Thresholds (match the original InfoChipRow behaviour):
+  //   deltaPct < 5      → emerald-400 (in tolerance)
+  //   5 ≤ deltaPct ≤ 15 → orange-400  (drift / caution)
+  //   deltaPct > 15     → red-400     (out of envelope)
   if (deltaPct < 5) return "text-emerald-400";
   if (deltaPct <= 15) return "text-orange-400";
   return "text-red-400";

--- a/frontend/components/workbench/stability-overlay/sphereGeometry.ts
+++ b/frontend/components/workbench/stability-overlay/sphereGeometry.ts
@@ -68,6 +68,9 @@ export interface SphereMesh {
  * Build an icosphere centred at `(cx, cy, cz)` with the given `radius`.
  * Returns coordinate arrays and triangle index arrays in the shape
  * expected by Plotly `mesh3d` traces.
+ *
+ * Note: name uses "icosphere" for its sphere-marker role; the returned mesh
+ * is actually a bare icosahedron (12 verts, 20 faces) — no geodesic subdivision.
  */
 export function makeIcosphere(
   cx: number,

--- a/frontend/components/workbench/stability-overlay/sphereGeometry.ts
+++ b/frontend/components/workbench/stability-overlay/sphereGeometry.ts
@@ -1,0 +1,85 @@
+/**
+ * Hard-coded icosahedron geometry for the stability overlay markers.
+ *
+ * A bare icosahedron (12 verts, 20 faces) reads cleanly as a sphere at
+ * typical CAD-viewer distances. No subdivision needed.
+ *
+ * Used as `mesh3d` markers (world-units) instead of `scatter3d` with
+ * pixel-sized `marker.size` — so the markers scale naturally with zoom
+ * and never visually overlap.
+ */
+
+// Golden ratio — defines an icosahedron in (±1, ±PHI, 0) permutations.
+const PHI = (1 + Math.sqrt(5)) / 2;
+const NORM = Math.sqrt(1 + PHI * PHI);
+
+/** 12 unit-sphere vertices (icosahedron). */
+const ICO_VERTS: ReadonlyArray<readonly [number, number, number]> = (
+  [
+    [-1, PHI, 0],
+    [1, PHI, 0],
+    [-1, -PHI, 0],
+    [1, -PHI, 0],
+    [0, -1, PHI],
+    [0, 1, PHI],
+    [0, -1, -PHI],
+    [0, 1, -PHI],
+    [PHI, 0, -1],
+    [PHI, 0, 1],
+    [-PHI, 0, -1],
+    [-PHI, 0, 1],
+  ] as ReadonlyArray<readonly [number, number, number]>
+).map(([x, y, z]) => [x / NORM, y / NORM, z / NORM] as const);
+
+/** 20 triangle indices (CCW winding). */
+const ICO_FACES: ReadonlyArray<readonly [number, number, number]> = [
+  [0, 11, 5],
+  [0, 5, 1],
+  [0, 1, 7],
+  [0, 7, 10],
+  [0, 10, 11],
+  [1, 5, 9],
+  [5, 11, 4],
+  [11, 10, 2],
+  [10, 7, 6],
+  [7, 1, 8],
+  [3, 9, 4],
+  [3, 4, 2],
+  [3, 2, 6],
+  [3, 6, 8],
+  [3, 8, 9],
+  [4, 9, 5],
+  [2, 4, 11],
+  [6, 2, 10],
+  [8, 6, 7],
+  [9, 8, 1],
+];
+
+export interface SphereMesh {
+  x: number[];
+  y: number[];
+  z: number[];
+  i: number[];
+  j: number[];
+  k: number[];
+}
+
+/**
+ * Build an icosphere centred at `(cx, cy, cz)` with the given `radius`.
+ * Returns coordinate arrays and triangle index arrays in the shape
+ * expected by Plotly `mesh3d` traces.
+ */
+export function makeIcosphere(
+  cx: number,
+  cy: number,
+  cz: number,
+  radius: number,
+): SphereMesh {
+  const x = ICO_VERTS.map((v) => cx + v[0] * radius);
+  const y = ICO_VERTS.map((v) => cy + v[1] * radius);
+  const z = ICO_VERTS.map((v) => cz + v[2] * radius);
+  const i = ICO_FACES.map((f) => f[0]);
+  const j = ICO_FACES.map((f) => f[1]);
+  const k = ICO_FACES.map((f) => f[2]);
+  return { x, y, z, i, j, k };
+}

--- a/frontend/hooks/useOverlayRegistry.ts
+++ b/frontend/hooks/useOverlayRegistry.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import { useCallback, useMemo, useRef, useState } from "react";
+
+export type PlotlyTrace = Record<string, unknown>;
+
+export interface UseOverlayRegistryReturn {
+  /** Flat list of all registered traces, in key-insertion order. */
+  traces: PlotlyTrace[];
+  /** Returns a stable setter that publishes (or clears) the traces for `key`.
+   *  Calling with [] removes the key entirely. Calling with the same key
+   *  again replaces the previously-published traces. The returned setter
+   *  is referentially stable across renders. */
+  register: (key: string) => (next: PlotlyTrace[]) => void;
+}
+
+interface RegistryState {
+  /** Traces keyed by registration key. */
+  byKey: Record<string, PlotlyTrace[]>;
+  /** Insertion order of keys with non-empty traces. */
+  order: string[];
+}
+
+const EMPTY_STATE: RegistryState = { byKey: {}, order: [] };
+
+function applyUpdate(
+  prev: RegistryState,
+  key: string,
+  next: PlotlyTrace[],
+): RegistryState {
+  if (next.length === 0) {
+    if (!(key in prev.byKey)) return prev;
+    const byKey = { ...prev.byKey };
+    delete byKey[key];
+    return { byKey, order: prev.order.filter((k) => k !== key) };
+  }
+  const order = prev.order.includes(key) ? prev.order : [...prev.order, key];
+  return { byKey: { ...prev.byKey, [key]: next }, order };
+}
+
+/**
+ * Composable overlay registry for the workbench Plotly preview.
+ *
+ * Each overlay component (e.g. StabilityOverlay) holds a stable
+ * `register(key)` setter; calling it with a non-empty array publishes
+ * those traces into the registry. Calling with an empty array removes
+ * the key entirely. The flat `traces` array is fed to
+ * `<WingOutlineViewer extraTraces={...}/>` (gh-569).
+ *
+ * Order of traces follows the order in which keys were first registered.
+ * Removing then re-registering a key moves it to the end.
+ */
+export function useOverlayRegistry(): UseOverlayRegistryReturn {
+  const [state, setState] = useState<RegistryState>(EMPTY_STATE);
+  // Stable setter cache, memoised per key. Held in a ref so identical
+  // calls to register(key) return the exact same function reference,
+  // letting consumers use it safely in useEffect deps.
+  const setterRef = useRef<Record<string, (next: PlotlyTrace[]) => void>>({});
+
+  const register = useCallback((key: string) => {
+    let setter = setterRef.current[key];
+    if (!setter) {
+      setter = (next: PlotlyTrace[]) =>
+        setState((prev) => applyUpdate(prev, key, next));
+      setterRef.current[key] = setter;
+    }
+    return setter;
+  }, []);
+
+  const traces = useMemo<PlotlyTrace[]>(
+    () => state.order.flatMap((k) => state.byKey[k] ?? []),
+    [state],
+  );
+
+  return { traces, register };
+}


### PR DESCRIPTION
## Summary

Renders NP (Neutral Point), CG SOLL (design-target), CG IST (component-aggregate), Static Margin band, and SOLL↔IST delta link as Plotly traces in the workbench construction preview. Reuses `useComputationContext` for data; introduces `useOverlayRegistry` as a composition primitive so future overlay components (mass distribution, axes, propeller disc, ...) slot in without further changes to `WingOutlineViewer`.

Closes #569. Part of Epic #566. Blocks #567 (refactor — remove Stability tab).

## Architecture

- `useOverlayRegistry()` hook (`frontend/hooks/`) — `{ traces, register(key) }`. Stable per-key setters; insertion-ordered flat traces array.
- `WingOutlineViewer` gains a single optional prop `extraTraces?: PlotlyData[]` (additive, 3-line change; existing trace-building logic untouched).
- `StabilityOverlay` (`frontend/components/workbench/stability-overlay/`) — self-contained: reads `useComputationContext`, holds toggle state with `localStorage` persistence, publishes traces via `register("stability")`, renders its own toggle button alongside the existing `¼ Chord` toggle.
- `buildStabilityTraces` — pure function: `(ctx, opts) → PlotlyTrace[]`. Reuses extracted `cgDivergenceColor` from `InfoChipRow`.
- `sphereGeometry.ts` — small icosahedron helper for the `mesh3d` marker spheres.
- Wiring in `app/workbench/page.tsx` only (NOT in the airfoil-preview page).

## Marker design

| Marker | Trace type | Color | Size | Opacity |
|---|---|---|---|---|
| NP | `mesh3d` icosphere | blue | 2 % of MAC | 0.4 |
| CG SOLL | `mesh3d` icosphere | `#FF8400` orange | 3.5 % of MAC | 0.4 |
| CG IST | `mesh3d` icosphere | divergence colour | 2.2 % of MAC | 0.4 |
| SM band | `scatter3d` line | yellow-green | — | (line) |
| SOLL↔IST link | `scatter3d` dashed line | IST colour | — | (line) |

Spheres in **world units** (`mesh3d`) so they scale with zoom; lines in pixels (Plotly default for line width). All spheres at 40 % opacity so line endpoints inside the spheres remain visible.

Marker origin `(referenceY, referenceZ)` derived from the main wing's root LE so markers sit on the wing-root chord-line height (correct for high-wing aircraft).

## Test plan

- [x] Unit tests (Vitest): `cgDivergenceColor` (5), `useOverlayRegistry` (5), `buildStabilityTraces` (18), `makeIcosphere` (3), `StabilityOverlay` (8). All new tests TDD'd (RED → GREEN).
- [x] Full frontend suite: **92 files / 797 tests, 0 failures**.
- [x] No backend changes — no Python tests affected.
- [x] Manual browser verification (T7) — see plan Appendix B. Iterations during T7 caught two plan assumptions:
  1. Plotly viewer is metre-based, not mm.
  2. Markers must sit on main-wing root chord-line for high-wing aircraft to read correctly.
  Both fixed in-branch.

## What's intentionally out of scope

- Backend (no endpoints, no schema, no Python).
- Removing the old Stability tab in the Analysis view — separate sub-issue #567 (depends on this PR).
- Fixing `cg_agg_m` not appearing in the footer — separate bug #568.
- Full 3D-aware CG marker (y/z of the component-aggregated centroid) — current overlay is 1D longitudinal; can be a follow-up.

## Spec / Plan

- Spec doc: `docs/superpowers/specs/2026-05-18-construction-view-stability-overlay-design.md`
- Plan doc: `docs/superpowers/plans/2026-05-18-stability-overlay-plan.md` (with Appendix A documenting the T7 divergences and Appendix B the verification result)
- Issue body (#569) is the authoritative source and is in sync with the implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)