### PR TITLE
chore(gh-563): remove V_NE chip from envelope chip row

### DIFF
--- a/frontend/__tests__/InfoChipRow.test.tsx
+++ b/frontend/__tests__/InfoChipRow.test.tsx
@@ -124,7 +124,9 @@ describe("Info Chip Row", () => {
     render(<InfoChipRow aeroplaneId="42" cgAero={0.13} />);
 
     expect(screen.queryByRole("group", { name: /^V a:/ })).toBeNull();
-    expect(screen.getByRole("group", { name: /V NE/ })).toBeInTheDocument();
+    // gh-563: V_max chip (formerly relabeled V_NE for gliders) hidden for gliders.
+    expect(screen.queryByRole("group", { name: /V NE/ })).toBeNull();
+    expect(screen.queryByRole("group", { name: /^V max:/ })).toBeNull();
     expect(screen.getByRole("group", { name: /V min sink/ })).toBeInTheDocument();
   });
 

--- a/frontend/components/workbench/InfoChipRow.tsx
+++ b/frontend/components/workbench/InfoChipRow.tsx
@@ -166,17 +166,17 @@ export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: P
           stale={stale}
         />
       )}
-      <Chip
-        icon={Gauge}
-        symbol={ctx?.is_glider ? "V_NE" : "V_max"}
-        description={
-          ctx?.is_glider
-            ? "Never-exceed speed (CS-22 placard speed for gliders)"
-            : "Maximum operating speed"
-        }
-        value={fmt(ctx?.v_max_mps, 1, " m/s")}
-        stale={stale}
-      />
+      {/* V_max hidden for gliders — gh-563: no powertrain to define V_max, and
+          V_NE is a CS-22 placard speed with no user input. */}
+      {!ctx?.is_glider && (
+        <Chip
+          icon={Gauge}
+          symbol="V_max"
+          description="Maximum operating speed"
+          value={fmt(ctx?.v_max_mps, 1, " m/s")}
+          stale={stale}
+        />
+      )}
       <Chip
         icon={Zap}
         symbol="V_dive"


### PR DESCRIPTION
## Summary

- The V_max envelope chip was conditionally relabeled **V_NE** for gliders, backed by `v_max_mps` (level-flight max speed). That's not a CS-22 placard V_NE — and no user input exists to set the real V_NE either. Misleading.
- For gliders, V_max from level flight isn't physically meaningful (no powertrain). Solution: hide the chip for gliders, mirroring the existing V_a glider-hide pattern at `InfoChipRow.tsx:159`.
- Drops the conditional symbol/description ternaries — chip now only renders for powered aircraft with a single `V_max` label.

## Files changed

- `frontend/components/workbench/InfoChipRow.tsx` — wrap the chip in `{!ctx?.is_glider && (...)}`, remove ternaries.
- `frontend/__tests__/InfoChipRow.test.tsx` — glider-context test now asserts V_NE/V_max chip absent (was: V_NE present).

## Test plan

- [x] `npm run test:unit -- InfoChipRow` (7/7 pass)
- [x] `npm run test:unit` full suite (785/785 pass — no regressions)
- [x] `npm run lint` (0 errors, 8 pre-existing warnings in unrelated files)
- [x] `npm run deps:check` (0 errors, 6 pre-existing warnings in unrelated files)
- [ ] Manual smoke: load a glider aeroplane in the workbench Mission Tab → confirm no V_NE/V_max chip in the envelope row.

## Acceptance criteria (from #563)

- [x] No V_NE chip renders under any condition.
- [x] V_max chip renders for powered aircraft with original description and tooltip.
- [x] No V_NE / V_max chip for gliders.
- [x] Other envelope chips (V_min_sink, V_x, V_y, V_a, V_dive) unchanged.
- [x] `npm run test:unit` passes.
- [x] `npm run deps:check` passes.
- [ ] Manual smoke (pending — see test plan).

Closes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)