### PR TITLE
chore(gh-573): hide V_dive chip for gliders

### DIFF
--- a/frontend/__tests__/InfoChipRow.test.tsx
+++ b/frontend/__tests__/InfoChipRow.test.tsx
@@ -127,6 +127,8 @@ describe("Info Chip Row", () => {
     // gh-563: V_max chip (formerly relabeled V_NE for gliders) hidden for gliders.
     expect(screen.queryByRole("group", { name: /V NE/ })).toBeNull();
     expect(screen.queryByRole("group", { name: /^V max:/ })).toBeNull();
+    // gh-573: V_dive (heuristic 1.4 × V_max) hidden for gliders since V_max is hidden too.
+    expect(screen.queryByRole("group", { name: /V dive/ })).toBeNull();
     expect(screen.getByRole("group", { name: /V min sink/ })).toBeInTheDocument();
   });
 

--- a/frontend/components/workbench/InfoChipRow.tsx
+++ b/frontend/components/workbench/InfoChipRow.tsx
@@ -177,13 +177,17 @@ export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: P
           stale={stale}
         />
       )}
-      <Chip
-        icon={Zap}
-        symbol="V_dive"
-        description="Design dive speed (heuristic: 1.4 × V_max)"
-        value={fmt(ctx?.v_dive_mps, 1, " m/s")}
-        stale={stale}
-      />
+      {/* V_dive hidden for gliders — gh-573: the 1.4 × V_max heuristic is invalid
+          without V_max (hidden by gh-563); CS-22 V_D is a placard value. */}
+      {!ctx?.is_glider && (
+        <Chip
+          icon={Zap}
+          symbol="V_dive"
+          description="Design dive speed (heuristic: 1.4 × V_max)"
+          value={fmt(ctx?.v_dive_mps, 1, " m/s")}
+          stale={stale}
+        />
+      )}
       {/* Divider between envelope speeds and aero geometry */}
       <div className="h-5 w-px bg-border" />
       <Chip


### PR DESCRIPTION
## Summary

Follow-up to #563/#572. V_dive is computed as `1.4 × v_max_mps` (heuristic). Now that V_max is hidden for gliders (gh-563, since `v_max_mps` is not meaningful without a powertrain), V_dive built on top of that heuristic is also misleading for gliders. For sailplanes, V_D is a CS-22 placard value, not a heuristic.

Wrap V_dive chip in `{!ctx?.is_glider && (...)}`, mirroring the V_a (line 159) and V_max (line 169, gh-563) glider-hide pattern.

## Files changed

- `frontend/components/workbench/InfoChipRow.tsx` — wrap V_dive chip in `!is_glider` guard.
- `frontend/__tests__/InfoChipRow.test.tsx` — glider-context test asserts V_dive chip absent.

## Test plan

- [x] `npm run test:unit -- InfoChipRow` (7/7 pass)
- [x] `npm run test:unit` full suite (785/785 pass — no regressions)
- [x] `npm run lint` (0 errors, 8 pre-existing warnings in unrelated files)
- [x] `npm run deps:check` (0 errors, 6 pre-existing warnings in unrelated files)
- [ ] Manual smoke: glider aeroplane in workbench Mission Tab → no V_dive chip in envelope row.

## Acceptance criteria (from #573)

- [x] V_dive chip no longer renders when `is_glider === true`.
- [x] V_dive chip still renders for powered aircraft, label/tooltip unchanged.
- [x] Glider-context test asserts V_dive absent.
- [x] Non-glider tests continue to assert V_dive present.
- [x] Other chips (V_min_sink, V_x, V_y) unchanged.
- [x] `npm run test:unit` passes.
- [x] `npm run deps:check` passes.
- [ ] Manual smoke (pending).

## Out of scope

`VnDiagram.tsx:130` also draws a V_dive vertical line on the V-n diagram — call out for a separate ticket if the V-n diagram surfaces for gliders today (this PR only addresses the chip row).

Closes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)