### PR TITLE
feat(gh-575): two-row InfoChipRow, drop "No data", add refresh button

### DIFF
--- a/frontend/__tests__/AnalysisWingGate.test.tsx
+++ b/frontend/__tests__/AnalysisWingGate.test.tsx
@@ -20,6 +20,7 @@ vi.mock("lucide-react", () => {
     Plane: icon,
     TrendingUp: icon,
     Zap: icon,
+    RefreshCw: icon,
   };
 });
 

--- a/frontend/__tests__/InfoChipRow.test.tsx
+++ b/frontend/__tests__/InfoChipRow.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 
 vi.mock("lucide-react", () => {
@@ -18,6 +18,7 @@ vi.mock("lucide-react", () => {
     Plane: icon,
     TrendingUp: icon,
     Zap: icon,
+    RefreshCw: icon,
   };
 });
 
@@ -177,6 +178,91 @@ describe("Info Chip Row", () => {
     expect(subTexts).toContain("min,sink");
     expect(subTexts).toContain("x");
     expect(subTexts).toContain("dive");
+  });
+
+  // gh-575: chip row splits into two rows (envelope speeds, aero geometry).
+  it("splits envelope speeds and aero geometry into two separate rows", async () => {
+    (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        v_cruise_mps: 18.0,
+        v_stall_mps: 8.0,
+        v_min_sink_mps: 13.2,
+        v_md_mps: 14.0,
+        v_x_mps: 12.0,
+        v_y_mps: 15.5,
+        v_a_mps: 17.5,
+        v_max_mps: 25.0,
+        v_dive_mps: 30.0,
+        reynolds: 230000,
+        mac_m: 0.21,
+        x_np_m: 0.085,
+        target_static_margin: 0.12,
+        cg_agg_m: 0.092,
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
+    render(<InfoChipRow aeroplaneId="42" cgAero={0.073} />);
+
+    const speedsRow = screen.getByTestId("chip-row-speeds");
+    const geometryRow = screen.getByTestId("chip-row-geometry");
+
+    // Envelope speeds belong to row 1.
+    expect(speedsRow).toContainElement(screen.getByRole("group", { name: /^V stall:/ }));
+    expect(speedsRow).toContainElement(screen.getByRole("group", { name: /V min sink/ }));
+    expect(speedsRow).toContainElement(screen.getByRole("group", { name: /^V max:/ }));
+
+    // Aero geometry belongs to row 2.
+    expect(geometryRow).toContainElement(screen.getByRole("group", { name: /^Re:/ }));
+    expect(geometryRow).toContainElement(screen.getByRole("group", { name: /^MAC:/ }));
+    expect(geometryRow).toContainElement(screen.getByRole("group", { name: /^CG:/ }));
+
+    // No chip is placed in the wrong row.
+    expect(geometryRow).not.toContainElement(screen.getByRole("group", { name: /^V stall:/ }));
+    expect(speedsRow).not.toContainElement(screen.getByRole("group", { name: /^Re:/ }));
+  });
+
+  // gh-575: refresh button invokes mutate (SWR revalidation) on click.
+  it("renders a refresh button that calls mutate when clicked", async () => {
+    const mutate = vi.fn();
+    (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: { v_cruise_mps: 18.0, reynolds: 230000, mac_m: 0.21, x_np_m: 0.085, target_static_margin: 0.12, cg_agg_m: 0.092 },
+      isLoading: false,
+      error: null,
+      mutate,
+    });
+
+    const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
+    render(<InfoChipRow aeroplaneId="42" cgAero={0.073} />);
+
+    const button = screen.getByRole("button", { name: /refresh computation context/i });
+    expect(button).toBeInTheDocument();
+    expect(button).not.toBeDisabled();
+
+    fireEvent.click(button);
+    expect(mutate).toHaveBeenCalledTimes(1);
+  });
+
+  // gh-575: refresh button is disabled while a recompute is in flight.
+  it("disables refresh button while isRecomputing is true", async () => {
+    const mutate = vi.fn();
+    (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: { v_cruise_mps: 18.0, reynolds: 230000, mac_m: 0.21, x_np_m: 0.085, target_static_margin: 0.12, cg_agg_m: 0.092 },
+      isLoading: false,
+      error: null,
+      mutate,
+    });
+
+    const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
+    render(<InfoChipRow aeroplaneId="42" cgAero={0.073} isRecomputing />);
+
+    const button = screen.getByRole("button", { name: /refresh computation context/i });
+    expect(button).toBeDisabled();
+
+    fireEvent.click(button);
+    expect(mutate).not.toHaveBeenCalled();
   });
 
   // gh-540: aria-label is humanized (no literal underscores spoken).

--- a/frontend/__tests__/buildAnalysisRightSlot.test.tsx
+++ b/frontend/__tests__/buildAnalysisRightSlot.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) => React.createElement("span", props);
+  return {
+    Maximize2: icon,
+    Minimize2: icon,
+    Settings: icon,
+    Wind: icon,
+    Ruler: icon,
+    Target: icon,
+    Navigation: icon,
+    Gauge: icon,
+    AlertTriangle: icon,
+    SlidersHorizontal: icon,
+    Activity: icon,
+    Loader2: icon,
+    Plane: icon,
+    TrendingUp: icon,
+    Zap: icon,
+    RefreshCw: icon,
+  };
+});
+
+import { buildAnalysisRightSlot } from "@/components/workbench/AnalysisViewerPanel";
+
+describe("buildAnalysisRightSlot (gh-575)", () => {
+  it("returns null when neither point count nor run timestamp is present", () => {
+    expect(buildAnalysisRightSlot(null, null, null)).toBeNull();
+    expect(buildAnalysisRightSlot(null, undefined, undefined)).toBeNull();
+  });
+
+  it("renders only the points segment when no run timestamp", () => {
+    const node = buildAnalysisRightSlot(42, null, null);
+    expect(node).not.toBeNull();
+    const { container } = render(<>{node}</>);
+    expect(container.textContent).toBe("42 points");
+  });
+
+  it("renders only the last-run segment when no point count", () => {
+    const t = new Date("2026-05-19T14:07:00Z");
+    const node = buildAnalysisRightSlot(null, t, 1234);
+    expect(node).not.toBeNull();
+    const { container } = render(<>{node}</>);
+    expect(container.textContent).toMatch(/Last run: \d\d:\d\d · 1234 ms/);
+  });
+
+  it("joins both segments with bullet separator when both present", () => {
+    const t = new Date("2026-05-19T14:07:00Z");
+    const node = buildAnalysisRightSlot(7, t, 950);
+    expect(node).not.toBeNull();
+    const { container } = render(<>{node}</>);
+    expect(container.textContent).toMatch(/^7 points · Last run: \d\d:\d\d · 950 ms$/);
+  });
+
+  it("omits last-run segment when only the timestamp is present (duration missing)", () => {
+    const t = new Date("2026-05-19T14:07:00Z");
+    expect(buildAnalysisRightSlot(null, t, null)).toBeNull();
+    expect(buildAnalysisRightSlot(null, t, undefined)).toBeNull();
+  });
+});

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -22,7 +22,8 @@ export { TABS };
 // gh-575: build the chip-row rightSlot from optional analysis-run metadata.
 // Returns null when neither segment is present, so the "No data" sentinel
 // the previous implementation rendered is dropped entirely.
-function buildAnalysisRightSlot(
+// Exported for direct unit testing.
+export function buildAnalysisRightSlot(
   pointCount: number | null,
   lastRunTime: Date | null | undefined,
   lastRunDurationMs: number | null | undefined,

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -19,6 +19,32 @@ const TABS = ["Assumptions", "Operating Points", "Polar", "Trefftz Plane", "Stre
 export type Tab = (typeof TABS)[number];
 export { TABS };
 
+// gh-575: build the chip-row rightSlot from optional analysis-run metadata.
+// Returns null when neither segment is present, so the "No data" sentinel
+// the previous implementation rendered is dropped entirely.
+function buildAnalysisRightSlot(
+  pointCount: number | null,
+  lastRunTime: Date | null | undefined,
+  lastRunDurationMs: number | null | undefined,
+): React.ReactNode {
+  const parts: string[] = [];
+  if (pointCount != null) parts.push(`${pointCount} points`);
+  if (lastRunTime && lastRunDurationMs != null) {
+    const time = lastRunTime.toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+    parts.push(`Last run: ${time} · ${lastRunDurationMs} ms`);
+  }
+  if (parts.length === 0) return null;
+  return (
+    <span className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+      {parts.join(" · ")}
+    </span>
+  );
+}
+
 interface WingXSec {
   readonly xyz_le: readonly number[];
   readonly chord: number;
@@ -849,34 +875,18 @@ export function AnalysisViewerPanel({
         </div>
       )}
 
-      {/* Info Chip Row \u2014 gh-575: drop the "No data" sentinel; render nothing
-          for the points segment when no charts have been computed yet. */}
-      {(() => {
-        const parts: string[] = [];
-        if (charts) parts.push(`${charts.alpha.length} points`);
-        if (lastRunTime && lastRunDurationMs != null) {
-          const time = lastRunTime.toLocaleTimeString([], {
-            hour: "2-digit",
-            minute: "2-digit",
-            hour12: false,
-          });
-          parts.push(`Last run: ${time} \u00B7 ${lastRunDurationMs} ms`);
-        }
-        const rightSlot =
-          parts.length > 0 ? (
-            <span className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
-              {parts.join(" \u00B7 ")}
-            </span>
-          ) : null;
-        return (
-          <InfoChipRow
-            aeroplaneId={aeroplaneId}
-            cgAero={cgAero}
-            isRecomputing={recomputeStatus.isRecomputing}
-            rightSlot={rightSlot}
-          />
-        );
-      })()}
+      {/* Info Chip Row \u2014 gh-575: rightSlot built from optional analysis metadata;
+          renders null when neither charts nor a last-run timestamp is present. */}
+      <InfoChipRow
+        aeroplaneId={aeroplaneId}
+        cgAero={cgAero}
+        isRecomputing={recomputeStatus.isRecomputing}
+        rightSlot={buildAnalysisRightSlot(
+          charts ? charts.alpha.length : null,
+          lastRunTime,
+          lastRunDurationMs,
+        )}
+      />
     </div>
   );
 }

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -849,29 +849,34 @@ export function AnalysisViewerPanel({
         </div>
       )}
 
-      {/* Info Chip Row */}
-      <InfoChipRow
-        aeroplaneId={aeroplaneId}
-        cgAero={cgAero}
-        isRecomputing={recomputeStatus.isRecomputing}
-        rightSlot={
-          <span className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
-            {charts ? `${charts.alpha.length} points` : "No data"}
-            {lastRunTime && lastRunDurationMs != null && (
-              <>
-                {" "}
-                {"\u00B7"} Last run:{" "}
-                {lastRunTime.toLocaleTimeString([], {
-                  hour: "2-digit",
-                  minute: "2-digit",
-                  hour12: false,
-                })}{" "}
-                {"\u00B7"} {lastRunDurationMs} ms
-              </>
-            )}
-          </span>
+      {/* Info Chip Row \u2014 gh-575: drop the "No data" sentinel; render nothing
+          for the points segment when no charts have been computed yet. */}
+      {(() => {
+        const parts: string[] = [];
+        if (charts) parts.push(`${charts.alpha.length} points`);
+        if (lastRunTime && lastRunDurationMs != null) {
+          const time = lastRunTime.toLocaleTimeString([], {
+            hour: "2-digit",
+            minute: "2-digit",
+            hour12: false,
+          });
+          parts.push(`Last run: ${time} \u00B7 ${lastRunDurationMs} ms`);
         }
-      />
+        const rightSlot =
+          parts.length > 0 ? (
+            <span className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+              {parts.join(" \u00B7 ")}
+            </span>
+          ) : null;
+        return (
+          <InfoChipRow
+            aeroplaneId={aeroplaneId}
+            cgAero={cgAero}
+            isRecomputing={recomputeStatus.isRecomputing}
+            rightSlot={rightSlot}
+          />
+        );
+      })()}
     </div>
   );
 }

--- a/frontend/components/workbench/InfoChipRow.tsx
+++ b/frontend/components/workbench/InfoChipRow.tsx
@@ -9,6 +9,7 @@ import {
   AlertTriangle,
   Loader2,
   Plane,
+  RefreshCw,
   TrendingUp,
   Zap,
 } from "lucide-react";
@@ -74,7 +75,7 @@ function Chip({
 }
 
 export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: Props) {
-  const { data: ctx } = useComputationContext(aeroplaneId, { isRecomputing });
+  const { data: ctx, mutate } = useComputationContext(aeroplaneId, { isRecomputing });
 
   const fmt = (v: number | null | undefined, decimals: number, suffix = "") =>
     v != null ? `${v.toFixed(decimals)}${suffix}` : "–";
@@ -107,139 +108,162 @@ export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: P
     </>
   );
 
+  // gh-575: split the chips into two rows (envelope speeds + aero geometry)
+  // with a user-triggered refresh button on row 1.
   return (
-    <div className="flex flex-wrap items-center gap-2 border-t border-border bg-card px-4 py-3">
-      {/* Envelope speeds (gh-476: extended chip set) */}
-      <Chip
-        icon={AlertTriangle}
-        symbol="V_stall"
-        description="Stall speed in clean configuration at 1 g"
-        value={fmt(ctx?.v_stall_mps, 1, " m/s")}
-        stale={stale}
-      />
-      <Chip
-        icon={Wind}
-        symbol="V_min_sink"
-        description="Speed for minimum sink rate — best endurance / longest glide time"
-        value={fmt(ctx?.v_min_sink_mps, 1, " m/s")}
-        stale={stale}
-      />
-      <Chip
-        icon={Wind}
-        symbol="V_md"
-        description="Minimum-drag speed — best L/D, longest glide distance"
-        value={fmt(ctx?.v_md_mps, 1, " m/s")}
-        stale={stale}
-      />
-      <Chip
-        icon={Wind}
-        symbol={ctx?.v_cruise_auto ? "V_cruise*" : "V_cruise"}
-        description={
-          ctx?.v_cruise_auto
-            ? "Design cruise speed (auto-derived from cruise sizing — asterisk)"
-            : "Design cruise speed"
-        }
-        value={fmt(ctx?.v_cruise_mps, 1, " m/s")}
-        stale={stale}
-      />
-      <Chip
-        icon={TrendingUp}
-        symbol="V_x"
-        description="Best angle-of-climb speed — steepest altitude gain per unit ground distance"
-        value={fmt(ctx?.v_x_mps, 1, " m/s")}
-        stale={stale}
-      />
-      <Chip
-        icon={Plane}
-        symbol="V_y"
-        description="Best rate-of-climb speed — fastest altitude gain per unit time"
-        value={fmt(ctx?.v_y_mps, 1, " m/s")}
-        stale={stale}
-      />
-      {/* V_a hidden for gliders — they use V_RA per CS-22 (separate ticket). */}
-      {!ctx?.is_glider && (
+    <div className="flex flex-col gap-2 border-t border-border bg-card px-4 py-3">
+      {/* Row 1 — envelope speeds (gh-476: extended chip set) */}
+      <div
+        data-testid="chip-row-speeds"
+        className="flex flex-wrap items-center gap-2"
+      >
         <Chip
-          icon={Gauge}
-          symbol="V_a"
-          description="Design manoeuvring speed — structural limit at full control deflection"
-          value={fmt(ctx?.v_a_mps, 1, " m/s")}
+          icon={AlertTriangle}
+          symbol="V_stall"
+          description="Stall speed in clean configuration at 1 g"
+          value={fmt(ctx?.v_stall_mps, 1, " m/s")}
           stale={stale}
         />
-      )}
-      {/* V_max hidden for gliders — gh-563: no powertrain to define V_max, and
-          V_NE is a CS-22 placard speed with no user input. */}
-      {!ctx?.is_glider && (
         <Chip
-          icon={Gauge}
-          symbol="V_max"
-          description="Maximum operating speed"
-          value={fmt(ctx?.v_max_mps, 1, " m/s")}
+          icon={Wind}
+          symbol="V_min_sink"
+          description="Speed for minimum sink rate — best endurance / longest glide time"
+          value={fmt(ctx?.v_min_sink_mps, 1, " m/s")}
           stale={stale}
         />
-      )}
-      {/* V_dive hidden for gliders — gh-573: the 1.4 × V_max heuristic is invalid
-          without V_max (hidden by gh-563); CS-22 V_D is a placard value. */}
-      {!ctx?.is_glider && (
         <Chip
-          icon={Zap}
-          symbol="V_dive"
-          description="Design dive speed (heuristic: 1.4 × V_max)"
-          value={fmt(ctx?.v_dive_mps, 1, " m/s")}
+          icon={Wind}
+          symbol="V_md"
+          description="Minimum-drag speed — best L/D, longest glide distance"
+          value={fmt(ctx?.v_md_mps, 1, " m/s")}
           stale={stale}
         />
-      )}
-      {/* Divider between envelope speeds and aero geometry */}
-      <div className="h-5 w-px bg-border" />
-      <Chip
-        icon={Wind}
-        symbol="Re"
-        description="Reynolds number at cruise, characteristic length = MAC"
-        value={fmtRe(ctx?.reynolds)}
-        stale={stale}
-      />
-      <Chip
-        icon={Ruler}
-        symbol="MAC"
-        description="Mean Aerodynamic Chord — reference length for force and moment coefficients"
-        value={fmt(ctx?.mac_m, 2, " m")}
-        stale={stale}
-      />
-      <Chip
-        icon={Target}
-        symbol="NP"
-        description="Neutral point — aerodynamic centre of the whole aircraft"
-        value={fmt(ctx?.x_np_m, 3, " m")}
-        stale={stale}
-      />
-      <Chip
-        icon={Navigation}
-        symbol="SM"
-        description="Static margin = (NP − CG) / MAC — target value used for trim balancing"
-        value={
-          ctx?.target_static_margin != null
-            ? (ctx.target_static_margin * 100).toFixed(0) + "%"
-            : "–"
-        }
-        stale={stale}
-      />
-      <Chip
-        icon={Navigation}
-        symbol="CG"
-        description={cgDescription}
-        valueNode={cgValueNode}
-        stale={stale}
-      />
-      <div className="flex-1" />
-      {isRecomputing && (
-        <span
-          className="flex items-center gap-1 rounded-full bg-orange-500/15 px-2 py-1 text-[11px] text-orange-400"
-          data-testid="recomputing-chip"
+        <Chip
+          icon={Wind}
+          symbol={ctx?.v_cruise_auto ? "V_cruise*" : "V_cruise"}
+          description={
+            ctx?.v_cruise_auto
+              ? "Design cruise speed (auto-derived from cruise sizing — asterisk)"
+              : "Design cruise speed"
+          }
+          value={fmt(ctx?.v_cruise_mps, 1, " m/s")}
+          stale={stale}
+        />
+        <Chip
+          icon={TrendingUp}
+          symbol="V_x"
+          description="Best angle-of-climb speed — steepest altitude gain per unit ground distance"
+          value={fmt(ctx?.v_x_mps, 1, " m/s")}
+          stale={stale}
+        />
+        <Chip
+          icon={Plane}
+          symbol="V_y"
+          description="Best rate-of-climb speed — fastest altitude gain per unit time"
+          value={fmt(ctx?.v_y_mps, 1, " m/s")}
+          stale={stale}
+        />
+        {/* V_a hidden for gliders — they use V_RA per CS-22 (separate ticket). */}
+        {!ctx?.is_glider && (
+          <Chip
+            icon={Gauge}
+            symbol="V_a"
+            description="Design manoeuvring speed — structural limit at full control deflection"
+            value={fmt(ctx?.v_a_mps, 1, " m/s")}
+            stale={stale}
+          />
+        )}
+        {/* V_max hidden for gliders — gh-563: no powertrain to define V_max, and
+            V_NE is a CS-22 placard speed with no user input. */}
+        {!ctx?.is_glider && (
+          <Chip
+            icon={Gauge}
+            symbol="V_max"
+            description="Maximum operating speed"
+            value={fmt(ctx?.v_max_mps, 1, " m/s")}
+            stale={stale}
+          />
+        )}
+        {/* V_dive hidden for gliders — gh-573: the 1.4 × V_max heuristic is invalid
+            without V_max (hidden by gh-563); CS-22 V_D is a placard value. */}
+        {!ctx?.is_glider && (
+          <Chip
+            icon={Zap}
+            symbol="V_dive"
+            description="Design dive speed (heuristic: 1.4 × V_max)"
+            value={fmt(ctx?.v_dive_mps, 1, " m/s")}
+            stale={stale}
+          />
+        )}
+        <div className="flex-1" />
+        {/* gh-575: refresh button revalidates the SWR-cached computation context. */}
+        <button
+          type="button"
+          aria-label="Refresh computation context"
+          onClick={() => mutate()}
+          disabled={isRecomputing}
+          className="flex items-center gap-1 rounded-full bg-card-muted px-2.5 py-1.5 text-muted-foreground hover:text-foreground focus:outline-none focus-visible:ring-1 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50"
         >
-          <Loader2 size={11} className="animate-spin" />
-          Recomputing…
-        </span>
-      )}
-      {rightSlot}
+          <RefreshCw size={12} />
+        </button>
+      </div>
+
+      {/* Row 2 — aero geometry */}
+      <div
+        data-testid="chip-row-geometry"
+        className="flex flex-wrap items-center gap-2"
+      >
+        <Chip
+          icon={Wind}
+          symbol="Re"
+          description="Reynolds number at cruise, characteristic length = MAC"
+          value={fmtRe(ctx?.reynolds)}
+          stale={stale}
+        />
+        <Chip
+          icon={Ruler}
+          symbol="MAC"
+          description="Mean Aerodynamic Chord — reference length for force and moment coefficients"
+          value={fmt(ctx?.mac_m, 2, " m")}
+          stale={stale}
+        />
+        <Chip
+          icon={Target}
+          symbol="NP"
+          description="Neutral point — aerodynamic centre of the whole aircraft"
+          value={fmt(ctx?.x_np_m, 3, " m")}
+          stale={stale}
+        />
+        <Chip
+          icon={Navigation}
+          symbol="SM"
+          description="Static margin = (NP − CG) / MAC — target value used for trim balancing"
+          value={
+            ctx?.target_static_margin != null
+              ? (ctx.target_static_margin * 100).toFixed(0) + "%"
+              : "–"
+          }
+          stale={stale}
+        />
+        <Chip
+          icon={Navigation}
+          symbol="CG"
+          description={cgDescription}
+          valueNode={cgValueNode}
+          stale={stale}
+        />
+        <div className="flex-1" />
+        {isRecomputing && (
+          <span
+            className="flex items-center gap-1 rounded-full bg-orange-500/15 px-2 py-1 text-[11px] text-orange-400"
+            data-testid="recomputing-chip"
+          >
+            <Loader2 size={11} className="animate-spin" />
+            Recomputing…
+          </span>
+        )}
+        {rightSlot}
+      </div>
     </div>
   );
 }

--- a/frontend/components/workbench/InfoChipRow.tsx
+++ b/frontend/components/workbench/InfoChipRow.tsx
@@ -196,13 +196,24 @@ export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: P
           />
         )}
         <div className="flex-1" />
+        {/* gh-575: Recomputing pill kept next to the refresh button so users see
+            the in-flight state co-located with the action that triggered it. */}
+        {isRecomputing && (
+          <span
+            className="flex items-center gap-1 rounded-full bg-orange-500/15 px-2 py-1 text-[11px] text-orange-400"
+            data-testid="recomputing-chip"
+          >
+            <Loader2 size={11} className="animate-spin" />
+            Recomputing…
+          </span>
+        )}
         {/* gh-575: refresh button revalidates the SWR-cached computation context. */}
         <button
           type="button"
           aria-label="Refresh computation context"
           onClick={() => mutate()}
           disabled={isRecomputing}
-          className="flex items-center gap-1 rounded-full bg-card-muted px-2.5 py-1.5 text-muted-foreground hover:text-foreground focus:outline-none focus-visible:ring-1 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50"
+          className="flex items-center gap-1 rounded-full bg-card-muted px-2.5 py-1.5 text-muted-foreground hover:bg-muted hover:text-foreground focus:outline-none focus-visible:ring-1 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50"
         >
           <RefreshCw size={12} />
         </button>
@@ -253,15 +264,6 @@ export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: P
           stale={stale}
         />
         <div className="flex-1" />
-        {isRecomputing && (
-          <span
-            className="flex items-center gap-1 rounded-full bg-orange-500/15 px-2 py-1 text-[11px] text-orange-400"
-            data-testid="recomputing-chip"
-          >
-            <Loader2 size={11} className="animate-spin" />
-            Recomputing…
-          </span>
-        )}
         {rightSlot}
       </div>
     </div>


### PR DESCRIPTION
## Summary

Three coordinated UI changes to the workbench envelope chip row (spec in #575):

1. **Two-row layout** — envelope speeds (V_*) on row 1, aero geometry (Re · MAC · NP · SM · CG) on row 2. Inline vertical divider removed.
2. **Drop "No data" text** — `AnalysisViewerPanel.tsx` no longer renders the literal `"No data"` in `InfoChipRow`'s rightSlot when no analysis charts exist. Last-run timestamp still renders independently; segments joined with " · " only when both present.
3. **Refresh button** — `RefreshCw` icon on row 1 that calls `mutate()` from `useComputationContext` (existing SWR hook, just newly surfaced). Disabled while `isRecomputing`, `aria-label="Refresh computation context"`, keyboard-focusable.

## Files changed

| File | Change |
|------|--------|
| `frontend/components/workbench/InfoChipRow.tsx` | Two-row JSX restructure, RefreshCw import, mutate destructure, refresh button. |
| `frontend/components/workbench/AnalysisViewerPanel.tsx` | rightSlot rewritten as IIFE building parts array; "No data" branch removed. |
| `frontend/__tests__/InfoChipRow.test.tsx` | +3 specs: two-row testid layout, refresh button click → mutate, disabled-during-recompute. |
| `frontend/__tests__/AnalysisWingGate.test.tsx` | Added `RefreshCw` to local lucide-react mock (sibling test imports through AnalysisViewerPanel → InfoChipRow). |

## Test plan

- [x] `npm run test:unit -- InfoChipRow` (10/10 pass — 7 existing + 3 new for gh-575)
- [x] `npm run test:unit` full suite (788/788 pass)
- [x] `npm run lint` (0 errors, 8 pre-existing warnings in unrelated files)
- [x] `npm run deps:check` (0 errors, 6 pre-existing warnings in unrelated files)
- [ ] Manual smoke: workbench Mission Tab + Analysis Tab — confirm two rows render, refresh button works (chip values re-flicker via brief loading state), "No data" no longer appears next to chip row, rows wrap independently on narrow viewport.

## Acceptance criteria (from #575)

- [x] Envelope speed chips render on a separate row above aero geometry chips.
- [x] Inline vertical divider removed.
- [x] On narrow viewports each row still wraps within itself (each row is its own flex-wrap container).
- [x] No literal "No data" in `AnalysisViewerPanel` for the points indicator; "X points" still renders when chart data is present; "Last run: …" still renders independently.
- [x] Refresh button visible with `RefreshCw` icon.
- [x] Click triggers SWR revalidation (`mutate()`).
- [x] Button disabled + visually muted (`disabled:opacity-50 disabled:cursor-not-allowed`) when `isRecomputing`.
- [x] `aria-label="Refresh computation context"`, keyboard-focusable (`focus-visible:ring-1`).
- [x] Tests updated: dashes test still passes; new tests for button click, disabled state, two-row structure.
- [x] `npm run test:unit` passes.
- [x] `npm run lint` no new warnings/errors.
- [x] `npm run deps:check` passes.
- [ ] Manual smoke (pending).

Closes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)