### PR TITLE
fix(gh-577): bind Trefftz/streamline VLM to a trimmed OperatingPoint

### DIFF
--- a/app/schemas/aeroanalysisschema.py
+++ b/app/schemas/aeroanalysisschema.py
@@ -249,6 +249,18 @@ class OperatingPointSchema(BaseModel):
         "Overrides geometry defaults for this operating point.",
     )
 
+    operating_point_id: int | None = Field(
+        default=None,
+        description=(
+            "If set, the request binds to a stored, trimmed OperatingPoint. The "
+            "service resolves it server-side and overwrites alpha/beta (rad→deg), "
+            "xyz_ref, velocity, altitude, body rates, and control deflections "
+            "(from `control_deflections` override, else `controls` trim output). "
+            "Use this for trim-consistent Trefftz/streamline visualisations "
+            "(gh-577). Leave null for diagnostic / manual runs."
+        ),
+    )
+
     model_config = ConfigDict(
         from_attributes=True,
         json_schema_extra={

--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -22,13 +22,16 @@ from sqlalchemy.orm import Session
 
 from app.api.utils import analyse_aerodynamics, compile_four_view_figure
 from app.converters.model_schema_converters import aeroplane_schema_to_asb_airplane_async
-from app.core.exceptions import NotFoundError, InternalError
+from app.core.exceptions import NotFoundError, InternalError, ServiceException
 from app.db.exceptions import NotFoundInDbException
 from app.db.repository import get_wing_by_name_and_aeroplane_id, get_aeroplane_by_id
 from app.schemas import AeroplaneSchema
 from app.schemas.AeroplaneRequest import AnalysisToolUrlType, AlphaSweepRequest, SimpleSweepRequest
 from app.schemas.aeroanalysisschema import OperatingPointSchema
 from app.schemas.strip_forces import StripForcesResponse, SurfaceStripForces, StripForceEntry
+from app.services import operating_point_resolver
+from app.services.operating_point_resolver import validate_deflections_against_airplane
+from app.services.wing_service import get_aeroplane_or_raise
 
 logger = logging.getLogger(__name__)
 
@@ -391,13 +394,17 @@ async def calculate_streamlines_json(
     """
     import json as _json
 
-    from app.services import operating_point_resolver
-
+    aircraft = get_aeroplane_or_raise(db, aeroplane_uuid)
     plane_schema = get_aeroplane_schema_or_raise(db, aeroplane_uuid)
-    resolved_op = operating_point_resolver.resolve_operating_point(db, operating_point)
+    resolved_op = operating_point_resolver.resolve_operating_point(
+        db, operating_point, aircraft_pk=aircraft.id,
+    )
 
     try:
         asb_airplane: Airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
+        validate_deflections_against_airplane(
+            asb_airplane, resolved_op.control_deflections,
+        )
         _, figure = analyse_aerodynamics(
             AnalysisToolUrlType.VORTEX_LATTICE,
             resolved_op,
@@ -405,9 +412,15 @@ async def calculate_streamlines_json(
             draw_streamlines=True,
         )
         return _json.loads(figure.to_json())
+    except ServiceException:
+        # Already a domain error — let the endpoint map it to the right HTTP code.
+        raise
     except Exception as e:
-        logger.error("Error calculating streamlines: %s", e)
-        raise InternalError(message=f"Analysis error: {e}")
+        logger.exception(
+            "Error calculating streamlines for aeroplane %s (op_id=%s)",
+            aeroplane_uuid, resolved_op.operating_point_id,
+        )
+        raise InternalError(message=f"Analysis error: {e}") from e
 
 
 async def analyze_alpha_sweep(db: Session, aeroplane_uuid, sweep_request: AlphaSweepRequest) -> Any:
@@ -1382,13 +1395,17 @@ async def get_streamlines_three_view_image(
         ValidationDomainError: If the referenced OP is not trimmed.
         InternalError: If an analysis error occurs.
     """
-    from app.services import operating_point_resolver
-
+    aircraft = get_aeroplane_or_raise(db, aeroplane_uuid)
     plane_schema = get_aeroplane_schema_or_raise(db, aeroplane_uuid)
-    resolved_op = operating_point_resolver.resolve_operating_point(db, operating_point)
+    resolved_op = operating_point_resolver.resolve_operating_point(
+        db, operating_point, aircraft_pk=aircraft.id,
+    )
 
     try:
         asb_airplane: Airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
+        validate_deflections_against_airplane(
+            asb_airplane, resolved_op.control_deflections,
+        )
 
         _, figure = analyse_aerodynamics(
             AnalysisToolUrlType.VORTEX_LATTICE,
@@ -1401,9 +1418,14 @@ async def get_streamlines_three_view_image(
         fig = compile_four_view_figure(figure)
         img_bytes = fig.to_image(format="png", width=1000, height=1000, scale=2)
         return img_bytes
+    except ServiceException:
+        raise
     except Exception as e:
-        logger.error(f"Error generating streamlines view: {e}")
-        raise InternalError(message=f"Analysis error: {e}")
+        logger.exception(
+            "Error generating streamlines view for aeroplane %s (op_id=%s)",
+            aeroplane_uuid, resolved_op.operating_point_id,
+        )
+        raise InternalError(message=f"Analysis error: {e}") from e
 
 
 async def get_three_view_image(db: Session, aeroplane_uuid) -> bytes:
@@ -1453,16 +1475,6 @@ async def analyze_airplane_strip_forces(
     import aerosandbox as asb
 
     from app.services.avl_runner import AVLRunner
-    from app.services import operating_point_resolver
-
-    plane_schema = get_aeroplane_schema_or_raise(db, aeroplane_uuid)
-    # gh-577: alpha/xyz_ref/velocity/altitude are pulled from the trimmed OP
-    # when ``operating_point_id`` is set. NOTE: AVL takes control-surface
-    # deflections from the geometry file (built from ``plane_schema``), so
-    # the resolved ``control_deflections`` do NOT yet feed AVL here — only
-    # the VLM streamline path consumes them. Full deflection injection into
-    # the AVL geometry file is tracked as a follow-up.
-    operating_point = operating_point_resolver.resolve_operating_point(db, operating_point)
     from app.services.avl_geometry_service import (
         get_user_avl_content,
         build_avl_geometry_file,
@@ -1470,33 +1482,46 @@ async def analyze_airplane_strip_forces(
     )
     from app.schemas.aeroanalysisschema import CdclConfig, SpacingConfig
 
+    aircraft = get_aeroplane_or_raise(db, aeroplane_uuid)
+    plane_schema = get_aeroplane_schema_or_raise(db, aeroplane_uuid)
+    # gh-577: alpha/xyz_ref/velocity/altitude are pulled from the trimmed OP
+    # when ``operating_point_id`` is set. NOTE: AVL reads control-surface
+    # deflections from the geometry file (built from ``plane_schema``), so
+    # the resolved ``control_deflections`` do NOT yet feed AVL here — only
+    # the VLM streamline path consumes them. Full deflection injection into
+    # the AVL geometry file is tracked as a follow-up. The UI labels the
+    # AVL strip-forces tab honestly to reflect this partial-trim state.
+    resolved_op = operating_point_resolver.resolve_operating_point(
+        db, operating_point, aircraft_pk=aircraft.id,
+    )
+
     user_avl_content = get_user_avl_content(db, aeroplane_uuid)
     if user_avl_content is None:
-        cdcl_config = operating_point.cdcl_config or CdclConfig()
-        spacing_config = operating_point.spacing_config or SpacingConfig()
+        cdcl_config = resolved_op.cdcl_config or CdclConfig()
+        spacing_config = resolved_op.spacing_config or SpacingConfig()
         avl_file = build_avl_geometry_file(plane_schema, spacing_config)
-        inject_cdcl(avl_file, plane_schema, operating_point, cdcl_config)
+        inject_cdcl(avl_file, plane_schema, resolved_op, cdcl_config)
         user_avl_content = repr(avl_file)
 
     try:
         asb_airplane: Airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
-        asb_airplane.xyz_ref = operating_point.xyz_ref
+        asb_airplane.xyz_ref = resolved_op.xyz_ref
 
-        atmosphere = asb.Atmosphere(altitude=operating_point.altitude)
+        atmosphere = asb.Atmosphere(altitude=resolved_op.altitude)
         op_point = asb.OperatingPoint(
-            velocity=operating_point.velocity,
-            alpha=operating_point.alpha,
-            beta=operating_point.beta,
-            p=operating_point.p,
-            q=operating_point.q,
-            r=operating_point.r,
+            velocity=resolved_op.velocity,
+            alpha=resolved_op.alpha,
+            beta=resolved_op.beta,
+            p=resolved_op.p,
+            q=resolved_op.q,
+            r=resolved_op.r,
             atmosphere=atmosphere,
         )
 
         runner = AVLRunner(
             airplane=asb_airplane,
             op_point=op_point,
-            xyz_ref=operating_point.xyz_ref,
+            xyz_ref=resolved_op.xyz_ref,
             timeout=60,
         )
         result = runner.run(
@@ -1520,17 +1545,22 @@ async def analyze_airplane_strip_forces(
             )
 
         return StripForcesResponse(
-            alpha=result.get("alpha", operating_point.alpha),
-            beta=result.get("beta", operating_point.beta),
+            alpha=result.get("alpha", resolved_op.alpha),
+            beta=result.get("beta", resolved_op.beta),
             mach=result.get("mach", 0),
             sref=result.get("Sref", 0),
             cref=result.get("Cref", 0),
             bref=result.get("Bref", 0),
             surfaces=surfaces,
         )
+    except ServiceException:
+        raise
     except Exception as e:
-        logger.error(f"Error analyzing airplane strip forces: {e}")
-        raise InternalError(message=f"Strip forces analysis error: {e}")
+        logger.exception(
+            "Error analyzing airplane strip forces for aeroplane %s (op_id=%s)",
+            aeroplane_uuid, resolved_op.operating_point_id,
+        )
+        raise InternalError(message=f"Strip forces analysis error: {e}") from e
 
 
 async def analyze_wing_strip_forces(

--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -375,22 +375,32 @@ async def calculate_streamlines_json(
 ) -> dict:
     """Calculate streamlines and return Plotly figure as JSON dict.
 
+    When ``operating_point.operating_point_id`` is set, the stored trimmed
+    OP is resolved server-side (gh-577) so the run reflects a
+    trim-consistent state (alpha, all control-surface deflections, xyz_ref
+    from one record). Without an id, the inline schema is used unchanged
+    for the explicitly-labelled diagnostic/manual mode.
+
     Returns:
         dict: Plotly figure JSON with 'data' and 'layout' keys.
 
     Raises:
-        NotFoundError: If the aeroplane does not exist.
+        NotFoundError: If the aeroplane or operating_point_id does not exist.
+        ValidationDomainError: If the referenced OP is not trimmed.
         InternalError: If an analysis error occurs.
     """
     import json as _json
 
+    from app.services import operating_point_resolver
+
     plane_schema = get_aeroplane_schema_or_raise(db, aeroplane_uuid)
+    resolved_op = operating_point_resolver.resolve_operating_point(db, operating_point)
 
     try:
         asb_airplane: Airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
         _, figure = analyse_aerodynamics(
             AnalysisToolUrlType.VORTEX_LATTICE,
-            operating_point,
+            resolved_op,
             asb_airplane,
             draw_streamlines=True,
         )
@@ -1360,21 +1370,29 @@ async def get_streamlines_three_view_image(
     """
     Generate a four-view diagram with streamlines as PNG.
 
+    When ``operating_point.operating_point_id`` is set the stored trimmed OP
+    is resolved server-side (gh-577) so the wake/streamlines reflect a
+    trim-consistent state.
+
     Returns:
         bytes: PNG image data.
 
     Raises:
-        NotFoundError: If the aeroplane does not exist.
+        NotFoundError: If the aeroplane or operating_point_id does not exist.
+        ValidationDomainError: If the referenced OP is not trimmed.
         InternalError: If an analysis error occurs.
     """
+    from app.services import operating_point_resolver
+
     plane_schema = get_aeroplane_schema_or_raise(db, aeroplane_uuid)
+    resolved_op = operating_point_resolver.resolve_operating_point(db, operating_point)
 
     try:
         asb_airplane: Airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
 
         _, figure = analyse_aerodynamics(
             AnalysisToolUrlType.VORTEX_LATTICE,
-            operating_point,
+            resolved_op,
             asb_airplane,
             draw_streamlines=True,
             backend="plotly",
@@ -1425,14 +1443,26 @@ async def analyze_airplane_strip_forces(
 ) -> StripForcesResponse:
     """Run AVL with strip-force capture for the full airplane (all wings).
 
+    When ``operating_point.operating_point_id`` is set the stored trimmed OP
+    is resolved server-side (gh-577) so the strip-force distribution
+    reflects a trim-consistent state.
+
     Returns:
         StripForcesResponse with per-surface spanwise strip-force distributions.
     """
     import aerosandbox as asb
 
     from app.services.avl_runner import AVLRunner
+    from app.services import operating_point_resolver
 
     plane_schema = get_aeroplane_schema_or_raise(db, aeroplane_uuid)
+    # gh-577: alpha/xyz_ref/velocity/altitude are pulled from the trimmed OP
+    # when ``operating_point_id`` is set. NOTE: AVL takes control-surface
+    # deflections from the geometry file (built from ``plane_schema``), so
+    # the resolved ``control_deflections`` do NOT yet feed AVL here — only
+    # the VLM streamline path consumes them. Full deflection injection into
+    # the AVL geometry file is tracked as a follow-up.
+    operating_point = operating_point_resolver.resolve_operating_point(db, operating_point)
     from app.services.avl_geometry_service import (
         get_user_avl_content,
         build_avl_geometry_file,

--- a/app/services/operating_point_resolver.py
+++ b/app/services/operating_point_resolver.py
@@ -9,10 +9,10 @@ streamline endpoint received an ad-hoc :class:`OperatingPointSchema`
 assembled from a free-form frontend form and never carried the trimmed
 deflections.
 
-When the inbound schema carries ``operating_point_id``, this resolver loads
-:class:`OperatingPointModel` and returns a *new* schema with all flight-state
-fields drawn from that record. Two non-obvious translations happen here so
-no caller can forget them:
+When the inbound schema carries ``operating_point_id``, this resolver
+loads :class:`OperatingPointModel` and returns a *new* schema with all
+flight-state fields drawn from that record. Two non-obvious translations
+happen here so no caller can forget them:
 
 * ``alpha`` / ``beta`` are stored as **radians** on the model but the
   :class:`asb.OperatingPoint` consumer expects **degrees** — we convert.
@@ -20,10 +20,19 @@ no caller can forget them:
   manual user overrides land in ``control_deflections``. We prefer the
   override when it is populated, otherwise we fall back to ``controls`` so
   the trim solution actually reaches the VLM.
+
+A separate helper, :func:`validate_deflections_against_airplane`, guards
+against the silent failure mode that originally motivated gh-577: AeroSandbox
+``with_control_deflections`` quietly drops dict keys that don't match a
+``ControlSurface.name``. If the geometry was renamed or rebuilt since the
+trim, the wing would run clean while the UI labelled the plot "trimmed".
+The validator fails loudly listing the unknown vs available names so the
+user can re-trim.
 """
 
 from __future__ import annotations
 
+import logging
 import math
 from typing import TYPE_CHECKING
 
@@ -32,14 +41,18 @@ from app.models.analysismodels import OperatingPointModel
 from app.schemas.aeroanalysisschema import OperatingPointSchema, OperatingPointStatus
 
 if TYPE_CHECKING:
+    import aerosandbox as asb
     from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
 
 
 def _pick_deflections(op: OperatingPointModel) -> dict[str, float] | None:
     """Manual override wins; otherwise the trim solver's output is used.
 
-    An empty override dict is treated as a no-op and falls back to ``controls``
-    so a stale empty override cannot silently erase a fresh trim solution.
+    An empty override dict is treated as a no-op and falls back to
+    ``controls`` so a stale empty override cannot silently erase a fresh
+    trim solution.
     """
     override = op.control_deflections
     if override:  # non-empty dict
@@ -48,10 +61,30 @@ def _pick_deflections(op: OperatingPointModel) -> dict[str, float] | None:
     return dict(controls) if controls else None
 
 
+def _require_field(op: OperatingPointModel, field: str):
+    """Raise loudly if a NOT-NULL state field arrived as ``None`` (corrupt row).
+
+    The DB columns are declared ``nullable=False``; silently substituting
+    ``0.0`` would run the analysis at sea level / zero rates and give
+    physically wrong results that look plausible.
+    """
+    value = getattr(op, field)
+    if value is None:
+        raise ValidationDomainError(
+            message=(
+                f"OperatingPoint {op.id} has incomplete state "
+                f"(missing {field}). Re-trim the OP before using it for "
+                f"a Trefftz/streamline run."
+            )
+        )
+    return value
+
+
 def resolve_operating_point(
     db: "Session",
     op_schema: OperatingPointSchema,
     *,
+    aircraft_pk: int | None = None,
     require_trimmed: bool = True,
 ) -> OperatingPointSchema:
     """Return an analysis-ready schema, possibly bound to a stored trimmed OP.
@@ -63,18 +96,39 @@ def resolve_operating_point(
     fields take precedence over the inline values. ``alpha`` and ``beta``
     are converted from radians to degrees to match the schema contract.
 
+    Args:
+        db: Active SQLAlchemy session.
+        op_schema: Inbound request schema.
+        aircraft_pk: When set, the OP lookup is constrained to this
+            aircraft (gh-577 review). Prevents cross-aeroplane OP injection:
+            a stored OP belonging to airplane B cannot drive a run on
+            airplane A's geometry.
+        require_trimmed: When True (the default), an OP whose status is
+            not ``TRIMMED`` is rejected. Set False for explicit diagnostic
+            workflows.
+
     Raises:
-        NotFoundError: ``operating_point_id`` does not exist.
-        ValidationDomainError: stored OP is not trimmed and
-            ``require_trimmed`` is True (the default).
+        NotFoundError: ``operating_point_id`` does not exist or does not
+            belong to the requested aircraft.
+        ValidationDomainError: stored OP is not trimmed (and
+            ``require_trimmed`` is True), or required state fields are
+            missing.
     """
     if op_schema.operating_point_id is None:
         return op_schema
 
     op_id = op_schema.operating_point_id
-    op = db.query(OperatingPointModel).filter(OperatingPointModel.id == op_id).first()
+    query = db.query(OperatingPointModel).filter(OperatingPointModel.id == op_id)
+    if aircraft_pk is not None:
+        query = query.filter(OperatingPointModel.aircraft_id == aircraft_pk)
+    op = query.first()
     if op is None:
-        raise NotFoundError(message=f"OperatingPoint {op_id} not found")
+        detail = (
+            f"OperatingPoint {op_id} not found"
+            if aircraft_pk is None
+            else f"OperatingPoint {op_id} not found on aircraft {aircraft_pk}"
+        )
+        raise NotFoundError(message=detail)
 
     if require_trimmed and op.status != OperatingPointStatus.TRIMMED:
         raise ValidationDomainError(
@@ -86,19 +140,86 @@ def resolve_operating_point(
             )
         )
 
+    # NOT-NULL state — fail loudly on corrupt rows.
+    velocity = _require_field(op, "velocity")
+    alpha_rad = _require_field(op, "alpha")
+    beta_rad = _require_field(op, "beta")
+    altitude = _require_field(op, "altitude")
+    xyz_ref = _require_field(op, "xyz_ref")
+    if not xyz_ref:  # empty list ≠ valid moment reference
+        raise ValidationDomainError(
+            message=f"OperatingPoint {op_id} has empty xyz_ref."
+        )
+
+    deflections = _pick_deflections(op)
+    logger.info(
+        "Resolved OperatingPoint %s (aircraft %s): alpha=%.3f deg, "
+        "velocity=%.2f m/s, xyz_ref=%s, deflections=%s",
+        op_id,
+        op.aircraft_id,
+        math.degrees(alpha_rad),
+        velocity,
+        xyz_ref,
+        deflections,
+    )
+
     return OperatingPointSchema(
         name=op.name,
         description=op.description or "",
-        velocity=op.velocity,
-        alpha=math.degrees(op.alpha),
-        beta=math.degrees(op.beta),
+        velocity=velocity,
+        alpha=math.degrees(alpha_rad),
+        beta=math.degrees(beta_rad),
         p=op.p or 0.0,
         q=op.q or 0.0,
         r=op.r or 0.0,
-        xyz_ref=op.xyz_ref or [0.0, 0.0, 0.0],
-        altitude=op.altitude or 0.0,
+        xyz_ref=xyz_ref,
+        altitude=altitude,
         cdcl_config=op_schema.cdcl_config,
         spacing_config=op_schema.spacing_config,
-        control_deflections=_pick_deflections(op),
+        control_deflections=deflections,
         operating_point_id=op_id,
     )
+
+
+def _airplane_surface_names(airplane: "asb.Airplane") -> set[str]:
+    """Collect every ``ControlSurface.name`` declared on the airplane."""
+    return {
+        surf.name
+        for wing in (airplane.wings or [])
+        for xsec in (wing.xsecs or [])
+        for surf in (xsec.control_surfaces or [])
+    }
+
+
+def validate_deflections_against_airplane(
+    airplane: "asb.Airplane",
+    deflections: dict[str, float] | None,
+) -> None:
+    """Refuse to run when stored deflections name surfaces that don't exist.
+
+    AeroSandbox' :meth:`Airplane.with_control_deflections` silently drops
+    dict keys with no matching ``ControlSurface.name``. If the geometry
+    was renamed since the trim, the wing runs clean while the UI labels
+    the plot "trimmed" — exactly the class of bug gh-577 set out to fix.
+    This guard surfaces the mismatch as a 422 with the unknown / available
+    names listed so the user can re-trim.
+
+    No-op when ``deflections`` is None or empty.
+
+    Raises:
+        ValidationDomainError: at least one deflection key has no
+            matching control surface on the airplane.
+    """
+    if not deflections:
+        return
+    available = _airplane_surface_names(airplane)
+    unknown = set(deflections) - available
+    if unknown:
+        raise ValidationDomainError(
+            message=(
+                f"Control surfaces {sorted(unknown)} from the operating "
+                f"point are not present on the current airplane. Available: "
+                f"{sorted(available) or '(none)'}. Re-trim the OP against "
+                f"the current geometry."
+            )
+        )

--- a/app/services/operating_point_resolver.py
+++ b/app/services/operating_point_resolver.py
@@ -1,0 +1,104 @@
+"""Resolve a stored, trimmed OperatingPoint into an analysis-ready schema.
+
+Background — gh-577
+-------------------
+The Trefftz-plane and streamline VLM runs must reflect a trim-consistent
+state: α, every control-surface deflection, and the CG (xyz_ref) all
+originating from one and the same trim solution. Before this module the
+streamline endpoint received an ad-hoc :class:`OperatingPointSchema`
+assembled from a free-form frontend form and never carried the trimmed
+deflections.
+
+When the inbound schema carries ``operating_point_id``, this resolver loads
+:class:`OperatingPointModel` and returns a *new* schema with all flight-state
+fields drawn from that record. Two non-obvious translations happen here so
+no caller can forget them:
+
+* ``alpha`` / ``beta`` are stored as **radians** on the model but the
+  :class:`asb.OperatingPoint` consumer expects **degrees** — we convert.
+* The trim solver writes its deflections to ``OperatingPointModel.controls``;
+  manual user overrides land in ``control_deflections``. We prefer the
+  override when it is populated, otherwise we fall back to ``controls`` so
+  the trim solution actually reaches the VLM.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+from app.core.exceptions import NotFoundError, ValidationDomainError
+from app.models.analysismodels import OperatingPointModel
+from app.schemas.aeroanalysisschema import OperatingPointSchema, OperatingPointStatus
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+def _pick_deflections(op: OperatingPointModel) -> dict[str, float] | None:
+    """Manual override wins; otherwise the trim solver's output is used.
+
+    An empty override dict is treated as a no-op and falls back to ``controls``
+    so a stale empty override cannot silently erase a fresh trim solution.
+    """
+    override = op.control_deflections
+    if override:  # non-empty dict
+        return dict(override)
+    controls = op.controls or {}
+    return dict(controls) if controls else None
+
+
+def resolve_operating_point(
+    db: "Session",
+    op_schema: OperatingPointSchema,
+    *,
+    require_trimmed: bool = True,
+) -> OperatingPointSchema:
+    """Return an analysis-ready schema, possibly bound to a stored trimmed OP.
+
+    If ``op_schema.operating_point_id`` is ``None`` the inline schema is
+    returned unchanged (diagnostic / manual mode).
+
+    Otherwise the stored :class:`OperatingPointModel` is loaded and its
+    fields take precedence over the inline values. ``alpha`` and ``beta``
+    are converted from radians to degrees to match the schema contract.
+
+    Raises:
+        NotFoundError: ``operating_point_id`` does not exist.
+        ValidationDomainError: stored OP is not trimmed and
+            ``require_trimmed`` is True (the default).
+    """
+    if op_schema.operating_point_id is None:
+        return op_schema
+
+    op_id = op_schema.operating_point_id
+    op = db.query(OperatingPointModel).filter(OperatingPointModel.id == op_id).first()
+    if op is None:
+        raise NotFoundError(message=f"OperatingPoint {op_id} not found")
+
+    if require_trimmed and op.status != OperatingPointStatus.TRIMMED:
+        raise ValidationDomainError(
+            message=(
+                f"OperatingPoint {op_id} has status {op.status!r}; only "
+                f"TRIMMED operating points may drive a trim-consistent "
+                f"Trefftz/streamline run (gh-577). Re-trim it or pass "
+                f"require_trimmed=False for diagnostic use."
+            )
+        )
+
+    return OperatingPointSchema(
+        name=op.name,
+        description=op.description or "",
+        velocity=op.velocity,
+        alpha=math.degrees(op.alpha),
+        beta=math.degrees(op.beta),
+        p=op.p or 0.0,
+        q=op.q or 0.0,
+        r=op.r or 0.0,
+        xyz_ref=op.xyz_ref or [0.0, 0.0, 0.0],
+        altitude=op.altitude or 0.0,
+        cdcl_config=op_schema.cdcl_config,
+        spacing_config=op_schema.spacing_config,
+        control_deflections=_pick_deflections(op),
+        operating_point_id=op_id,
+    )

--- a/app/tests/test_operating_point_resolver.py
+++ b/app/tests/test_operating_point_resolver.py
@@ -1,0 +1,251 @@
+"""Reproduces gh-577: Trefftz/streamline VLM must run on a trim-consistent state.
+
+When the request carries `operating_point_id`, the service must resolve the
+stored trimmed OP server-side and overwrite the inline schema's
+alpha (rad→deg), beta (rad→deg), xyz_ref, velocity, altitude, body rates,
+and — critically — control-surface deflections. Deflections are sourced from
+``control_deflections`` (manual override) if populated, otherwise from
+``controls`` (the trim solver's output).
+"""
+
+from __future__ import annotations
+
+import math
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.core.exceptions import NotFoundError, ValidationDomainError
+from app.models.analysismodels import OperatingPointModel
+from app.schemas.aeroanalysisschema import OperatingPointSchema, OperatingPointStatus
+
+
+def _make_op(**overrides) -> OperatingPointModel:
+    """Build a fake OperatingPointModel row with sensible defaults."""
+    defaults = dict(
+        id=42,
+        name="cruise_trim",
+        description="trimmed cruise",
+        aircraft_id=1,
+        config="clean",
+        status=OperatingPointStatus.TRIMMED,
+        warnings=[],
+        controls={"elevator": -2.5, "aileron": 0.0},
+        velocity=20.0,
+        alpha=math.radians(4.2),  # stored in RADIANS
+        beta=math.radians(0.5),
+        p=0.0,
+        q=0.0,
+        r=0.0,
+        xyz_ref=[0.183, 0.0, 0.0],
+        altitude=100.0,
+        control_deflections=None,
+        trim_enrichment=None,
+    )
+    defaults.update(overrides)
+    op = MagicMock(spec=OperatingPointModel)
+    for k, v in defaults.items():
+        setattr(op, k, v)
+    return op
+
+
+def _db_returning(op: OperatingPointModel | None) -> MagicMock:
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = op
+    return db
+
+
+class TestOperatingPointSchemaHasIdField:
+    """The schema must accept an `operating_point_id` to bind a request to a stored OP."""
+
+    def test_schema_accepts_operating_point_id(self):
+        # gh-577: streamline/Trefftz requests bind to a trimmed OP by id.
+        schema = OperatingPointSchema(operating_point_id=42)
+        assert schema.operating_point_id == 42
+
+    def test_schema_defaults_operating_point_id_to_none(self):
+        schema = OperatingPointSchema()
+        assert schema.operating_point_id is None
+
+
+class TestResolveOperatingPoint:
+    """The resolver pulls the trimmed state from a stored OperatingPointModel."""
+
+    def test_returns_input_unchanged_when_no_id(self):
+        from app.services.operating_point_resolver import resolve_operating_point
+
+        inline = OperatingPointSchema(alpha=5.0, velocity=14.0, xyz_ref=[0.2, 0, 0])
+        result = resolve_operating_point(MagicMock(), inline)
+        assert result is inline
+
+    def test_alpha_converted_from_radians_to_degrees(self):
+        from app.services.operating_point_resolver import resolve_operating_point
+
+        op = _make_op(alpha=math.radians(4.2))
+        db = _db_returning(op)
+        result = resolve_operating_point(
+            db, OperatingPointSchema(operating_point_id=42, alpha=999.0)
+        )
+        assert result.alpha == pytest.approx(4.2, rel=1e-6)
+
+    def test_beta_converted_from_radians_to_degrees(self):
+        from app.services.operating_point_resolver import resolve_operating_point
+
+        op = _make_op(beta=math.radians(0.5))
+        result = resolve_operating_point(
+            _db_returning(op), OperatingPointSchema(operating_point_id=42)
+        )
+        assert result.beta == pytest.approx(0.5, rel=1e-6)
+
+    def test_xyz_ref_taken_from_stored_op(self):
+        from app.services.operating_point_resolver import resolve_operating_point
+
+        op = _make_op(xyz_ref=[0.183, 0.0, 0.0])
+        result = resolve_operating_point(
+            _db_returning(op),
+            OperatingPointSchema(operating_point_id=42, xyz_ref=[0.0, 0.0, 0.0]),
+        )
+        assert result.xyz_ref == [0.183, 0.0, 0.0]
+
+    def test_velocity_altitude_rates_taken_from_stored_op(self):
+        from app.services.operating_point_resolver import resolve_operating_point
+
+        op = _make_op(velocity=22.0, altitude=500.0, p=0.0, q=0.1, r=0.0)
+        result = resolve_operating_point(
+            _db_returning(op),
+            OperatingPointSchema(operating_point_id=42, velocity=99.0, altitude=999.0),
+        )
+        assert result.velocity == 22.0
+        assert result.altitude == 500.0
+        assert result.q == pytest.approx(0.1)
+
+    def test_control_deflections_from_controls_when_override_is_none(self):
+        """Opti trim writes to `controls`; with no manual override we must use that."""
+        from app.services.operating_point_resolver import resolve_operating_point
+
+        op = _make_op(
+            controls={"elevator": -2.5, "aileron": 0.0},
+            control_deflections=None,
+        )
+        result = resolve_operating_point(
+            _db_returning(op), OperatingPointSchema(operating_point_id=42)
+        )
+        assert result.control_deflections == {"elevator": -2.5, "aileron": 0.0}
+
+    def test_control_deflections_override_wins_over_controls(self):
+        """If the user PATCHed deflections, those take precedence over the trim output."""
+        from app.services.operating_point_resolver import resolve_operating_point
+
+        op = _make_op(
+            controls={"elevator": -2.5},
+            control_deflections={"elevator": -1.0},
+        )
+        result = resolve_operating_point(
+            _db_returning(op), OperatingPointSchema(operating_point_id=42)
+        )
+        assert result.control_deflections == {"elevator": -1.0}
+
+    def test_control_deflections_empty_dict_override_falls_back_to_controls(self):
+        """An empty `control_deflections` (no-op override) must not erase the trim result."""
+        from app.services.operating_point_resolver import resolve_operating_point
+
+        op = _make_op(
+            controls={"elevator": -2.5},
+            control_deflections={},
+        )
+        result = resolve_operating_point(
+            _db_returning(op), OperatingPointSchema(operating_point_id=42)
+        )
+        assert result.control_deflections == {"elevator": -2.5}
+
+    def test_untrimmed_op_is_rejected_by_default(self):
+        from app.services.operating_point_resolver import resolve_operating_point
+
+        op = _make_op(status=OperatingPointStatus.NOT_TRIMMED)
+        with pytest.raises(ValidationDomainError):
+            resolve_operating_point(
+                _db_returning(op), OperatingPointSchema(operating_point_id=42)
+            )
+
+    def test_dirty_op_is_rejected_by_default(self):
+        from app.services.operating_point_resolver import resolve_operating_point
+
+        op = _make_op(status=OperatingPointStatus.DIRTY)
+        with pytest.raises(ValidationDomainError):
+            resolve_operating_point(
+                _db_returning(op), OperatingPointSchema(operating_point_id=42)
+            )
+
+    def test_missing_op_raises_not_found(self):
+        from app.services.operating_point_resolver import resolve_operating_point
+
+        with pytest.raises(NotFoundError):
+            resolve_operating_point(
+                _db_returning(None), OperatingPointSchema(operating_point_id=9999)
+            )
+
+    def test_require_trimmed_false_allows_untrimmed_for_diagnostic_use(self):
+        """Diagnostic mode opts in to running on an untrimmed state."""
+        from app.services.operating_point_resolver import resolve_operating_point
+
+        op = _make_op(status=OperatingPointStatus.NOT_TRIMMED)
+        result = resolve_operating_point(
+            _db_returning(op),
+            OperatingPointSchema(operating_point_id=42),
+            require_trimmed=False,
+        )
+        assert result.operating_point_id == 42
+
+
+class TestStreamlineServiceUsesResolvedOp:
+    """`calculate_streamlines_json` must resolve the stored OP before running the VLM."""
+
+    def test_streamlines_service_calls_resolver_then_analyse(self):
+        import asyncio
+        from unittest.mock import patch
+
+        from app.services import analysis_service
+
+        op = _make_op()
+        plane_schema = MagicMock()
+
+        resolved = OperatingPointSchema(
+            operating_point_id=42,
+            alpha=4.2,
+            beta=0.5,
+            velocity=20.0,
+            altitude=100.0,
+            xyz_ref=[0.183, 0.0, 0.0],
+            control_deflections={"elevator": -2.5, "aileron": 0.0},
+        )
+
+        with patch.object(
+            analysis_service, "get_aeroplane_schema_or_raise", return_value=plane_schema
+        ), patch.object(
+            analysis_service, "aeroplane_schema_to_asb_airplane_async"
+        ) as mock_to_asb, patch(
+            "app.services.operating_point_resolver.resolve_operating_point",
+            return_value=resolved,
+        ) as mock_resolver, patch.object(
+            analysis_service, "analyse_aerodynamics"
+        ) as mock_analyse:
+            mock_to_asb.return_value = MagicMock()
+            fake_fig = MagicMock()
+            fake_fig.to_json.return_value = '{"data":[],"layout":{}}'
+            mock_analyse.return_value = (MagicMock(), fake_fig)
+
+            db = _db_returning(op)
+            asyncio.run(
+                analysis_service.calculate_streamlines_json(
+                    db,
+                    aeroplane_uuid="0" * 36,
+                    operating_point=OperatingPointSchema(operating_point_id=42),
+                )
+            )
+
+            mock_resolver.assert_called_once()
+            # analyse_aerodynamics gets the RESOLVED schema, not the raw inline one
+            call_op = mock_analyse.call_args.args[1]
+            assert call_op.alpha == pytest.approx(4.2)
+            assert call_op.control_deflections == {"elevator": -2.5, "aileron": 0.0}
+            assert call_op.xyz_ref == [0.183, 0.0, 0.0]

--- a/app/tests/test_operating_point_resolver.py
+++ b/app/tests/test_operating_point_resolver.py
@@ -196,20 +196,102 @@ class TestResolveOperatingPoint:
         )
         assert result.operating_point_id == 42
 
+    def test_aircraft_pk_scopes_the_lookup(self):
+        """gh-577 review CRITICAL: an OP belonging to a different aircraft must NOT resolve."""
+        from app.services.operating_point_resolver import resolve_operating_point
+
+        db = MagicMock()
+        # `.filter().filter().first()` returns None — the row exists for the id
+        # but not for the (id, aircraft_id) pair.
+        db.query.return_value.filter.return_value.filter.return_value.first.return_value = (
+            None
+        )
+        with pytest.raises(NotFoundError):
+            resolve_operating_point(
+                db,
+                OperatingPointSchema(operating_point_id=42),
+                aircraft_pk=999,
+            )
+
+    def test_missing_altitude_raises_validation(self):
+        """A row with a NULL NOT-NULL field is corrupt — surface it loudly."""
+        from app.services.operating_point_resolver import resolve_operating_point
+
+        op = _make_op(altitude=None)
+        with pytest.raises(ValidationDomainError):
+            resolve_operating_point(
+                _db_returning(op), OperatingPointSchema(operating_point_id=42)
+            )
+
+    def test_empty_xyz_ref_raises_validation(self):
+        from app.services.operating_point_resolver import resolve_operating_point
+
+        op = _make_op(xyz_ref=[])
+        with pytest.raises(ValidationDomainError):
+            resolve_operating_point(
+                _db_returning(op), OperatingPointSchema(operating_point_id=42)
+            )
+
+
+class TestValidateDeflectionsAgainstAirplane:
+    """gh-577 review CRITICAL: surface-name mismatches must fail loudly, not silently."""
+
+    def _make_airplane(self, surface_names: list[str]):
+        """Build a stub airplane with one wing/one xsec carrying named control surfaces."""
+        airplane = MagicMock()
+        # MagicMock's `name` kwarg is reserved for the mock's repr; set
+        # the attribute after construction.
+        surfaces = [MagicMock() for _ in surface_names]
+        for surf, n in zip(surfaces, surface_names):
+            surf.name = n
+        xsec = MagicMock()
+        xsec.control_surfaces = surfaces
+        wing = MagicMock()
+        wing.xsecs = [xsec]
+        airplane.wings = [wing]
+        return airplane
+
+    def test_passes_when_all_names_match(self):
+        from app.services.operating_point_resolver import (
+            validate_deflections_against_airplane,
+        )
+
+        airplane = self._make_airplane(["elevator", "aileron"])
+        # No exception
+        validate_deflections_against_airplane(
+            airplane, {"elevator": -2.0, "aileron": 0.5}
+        )
+
+    def test_raises_listing_unknown_names(self):
+        from app.services.operating_point_resolver import (
+            validate_deflections_against_airplane,
+        )
+
+        airplane = self._make_airplane(["elevator"])
+        with pytest.raises(ValidationDomainError) as exc:
+            validate_deflections_against_airplane(
+                airplane, {"elevator": -2.0, "rudder": 1.0}
+            )
+        assert "rudder" in exc.value.message
+        assert "elevator" in exc.value.message  # listed as available
+
+    def test_noop_when_deflections_empty_or_none(self):
+        from app.services.operating_point_resolver import (
+            validate_deflections_against_airplane,
+        )
+
+        airplane = self._make_airplane([])
+        # Neither call raises.
+        validate_deflections_against_airplane(airplane, None)
+        validate_deflections_against_airplane(airplane, {})
+
 
 class TestStreamlineServiceUsesResolvedOp:
-    """`calculate_streamlines_json` must resolve the stored OP before running the VLM."""
+    """The three streamline / strip-forces services must resolve the OP before the VLM/AVL run."""
 
-    def test_streamlines_service_calls_resolver_then_analyse(self):
-        import asyncio
-        from unittest.mock import patch
-
-        from app.services import analysis_service
-
-        op = _make_op()
-        plane_schema = MagicMock()
-
-        resolved = OperatingPointSchema(
+    @staticmethod
+    def _resolved_op():
+        return OperatingPointSchema(
             operating_point_id=42,
             alpha=4.2,
             beta=0.5,
@@ -219,33 +301,208 @@ class TestStreamlineServiceUsesResolvedOp:
             control_deflections={"elevator": -2.5, "aileron": 0.0},
         )
 
-        with patch.object(
-            analysis_service, "get_aeroplane_schema_or_raise", return_value=plane_schema
-        ), patch.object(
-            analysis_service, "aeroplane_schema_to_asb_airplane_async"
-        ) as mock_to_asb, patch(
-            "app.services.operating_point_resolver.resolve_operating_point",
-            return_value=resolved,
-        ) as mock_resolver, patch.object(
-            analysis_service, "analyse_aerodynamics"
-        ) as mock_analyse:
-            mock_to_asb.return_value = MagicMock()
+    def test_streamlines_service_calls_resolver_then_analyse(self):
+        import asyncio
+        from contextlib import ExitStack
+        from unittest.mock import patch
+
+        from app.services import analysis_service
+
+        resolved = self._resolved_op()
+        op = _make_op()
+
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(
+                analysis_service, "get_aeroplane_or_raise",
+                return_value=MagicMock(id=7),
+            ))
+            stack.enter_context(patch.object(
+                analysis_service, "get_aeroplane_schema_or_raise",
+                return_value=MagicMock(),
+            ))
+            stack.enter_context(patch.object(
+                analysis_service, "aeroplane_schema_to_asb_airplane_async",
+                return_value=MagicMock(),
+            ))
+            mock_resolver = stack.enter_context(patch.object(
+                analysis_service.operating_point_resolver,
+                "resolve_operating_point",
+                return_value=resolved,
+            ))
+            stack.enter_context(patch.object(
+                analysis_service, "validate_deflections_against_airplane",
+            ))
+            mock_analyse = stack.enter_context(patch.object(
+                analysis_service, "analyse_aerodynamics",
+            ))
             fake_fig = MagicMock()
             fake_fig.to_json.return_value = '{"data":[],"layout":{}}'
             mock_analyse.return_value = (MagicMock(), fake_fig)
 
-            db = _db_returning(op)
             asyncio.run(
                 analysis_service.calculate_streamlines_json(
-                    db,
+                    _db_returning(op),
                     aeroplane_uuid="0" * 36,
                     operating_point=OperatingPointSchema(operating_point_id=42),
                 )
             )
 
             mock_resolver.assert_called_once()
-            # analyse_aerodynamics gets the RESOLVED schema, not the raw inline one
+            # The aircraft pk is forwarded so OP lookup is scoped (gh-577 review).
+            assert mock_resolver.call_args.kwargs["aircraft_pk"] == 7
             call_op = mock_analyse.call_args.args[1]
             assert call_op.alpha == pytest.approx(4.2)
             assert call_op.control_deflections == {"elevator": -2.5, "aileron": 0.0}
             assert call_op.xyz_ref == [0.183, 0.0, 0.0]
+
+    def test_three_view_image_service_calls_resolver(self):
+        import asyncio
+        from contextlib import ExitStack
+        from unittest.mock import patch
+
+        from app.services import analysis_service
+
+        resolved = self._resolved_op()
+        op = _make_op()
+
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(
+                analysis_service, "get_aeroplane_or_raise",
+                return_value=MagicMock(id=7),
+            ))
+            stack.enter_context(patch.object(
+                analysis_service, "get_aeroplane_schema_or_raise",
+                return_value=MagicMock(),
+            ))
+            stack.enter_context(patch.object(
+                analysis_service, "aeroplane_schema_to_asb_airplane_async",
+                return_value=MagicMock(),
+            ))
+            mock_resolver = stack.enter_context(patch.object(
+                analysis_service.operating_point_resolver,
+                "resolve_operating_point",
+                return_value=resolved,
+            ))
+            stack.enter_context(patch.object(
+                analysis_service, "validate_deflections_against_airplane",
+            ))
+            mock_analyse = stack.enter_context(patch.object(
+                analysis_service, "analyse_aerodynamics",
+            ))
+            mock_four_view = stack.enter_context(patch.object(
+                analysis_service, "compile_four_view_figure",
+            ))
+            mock_analyse.return_value = (MagicMock(), MagicMock())
+            mock_four_view.return_value.to_image.return_value = b"png-bytes"
+
+            asyncio.run(
+                analysis_service.get_streamlines_three_view_image(
+                    _db_returning(op),
+                    aeroplane_uuid="0" * 36,
+                    operating_point=OperatingPointSchema(operating_point_id=42),
+                )
+            )
+
+            mock_resolver.assert_called_once()
+            assert mock_resolver.call_args.kwargs["aircraft_pk"] == 7
+            call_op = mock_analyse.call_args.args[1]
+            assert call_op.alpha == pytest.approx(4.2)
+
+    def test_strip_forces_service_calls_resolver(self):
+        import asyncio
+        from contextlib import ExitStack
+        from unittest.mock import patch
+
+        from app.services import analysis_service
+
+        resolved = self._resolved_op()
+        op = _make_op()
+
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(
+                analysis_service, "get_aeroplane_or_raise",
+                return_value=MagicMock(id=7),
+            ))
+            stack.enter_context(patch.object(
+                analysis_service, "get_aeroplane_schema_or_raise",
+                return_value=MagicMock(),
+            ))
+            stack.enter_context(patch.object(
+                analysis_service, "aeroplane_schema_to_asb_airplane_async",
+                return_value=MagicMock(),
+            ))
+            mock_resolver = stack.enter_context(patch.object(
+                analysis_service.operating_point_resolver,
+                "resolve_operating_point",
+                return_value=resolved,
+            ))
+            mock_runner_cls = stack.enter_context(patch(
+                "app.services.avl_runner.AVLRunner",
+            ))
+            stack.enter_context(patch(
+                "app.services.avl_geometry_service.get_user_avl_content",
+                return_value="MOCK_AVL_CONTENT",
+            ))
+            mock_runner = MagicMock()
+            mock_runner.run.return_value = {
+                "strip_forces": [], "alpha": 4.2, "beta": 0.5,
+                "mach": 0, "Sref": 1.0, "Cref": 1.0, "Bref": 1.0,
+            }
+            mock_runner_cls.return_value = mock_runner
+
+            asyncio.run(
+                analysis_service.analyze_airplane_strip_forces(
+                    _db_returning(op),
+                    aeroplane_uuid="0" * 36,
+                    operating_point=OperatingPointSchema(operating_point_id=42),
+                )
+            )
+
+            mock_resolver.assert_called_once()
+            assert mock_resolver.call_args.kwargs["aircraft_pk"] == 7
+
+    def test_service_propagates_validation_error_unmapped(self):
+        """gh-577 review: ServiceException must NOT be re-wrapped as InternalError (500)."""
+        import asyncio
+        from contextlib import ExitStack
+        from unittest.mock import patch
+
+        from app.core.exceptions import ValidationDomainError
+        from app.services import analysis_service
+
+        resolved = OperatingPointSchema(
+            operating_point_id=42, alpha=4.2, velocity=20.0, altitude=100.0,
+            xyz_ref=[0.1, 0, 0], control_deflections={"ghost": 0.0},
+        )
+        op = _make_op()
+
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(
+                analysis_service, "get_aeroplane_or_raise",
+                return_value=MagicMock(id=7),
+            ))
+            stack.enter_context(patch.object(
+                analysis_service, "get_aeroplane_schema_or_raise",
+                return_value=MagicMock(),
+            ))
+            stack.enter_context(patch.object(
+                analysis_service, "aeroplane_schema_to_asb_airplane_async",
+                return_value=MagicMock(),
+            ))
+            stack.enter_context(patch.object(
+                analysis_service.operating_point_resolver,
+                "resolve_operating_point",
+                return_value=resolved,
+            ))
+            stack.enter_context(patch.object(
+                analysis_service, "validate_deflections_against_airplane",
+                side_effect=ValidationDomainError(message="ghost surface"),
+            ))
+            with pytest.raises(ValidationDomainError):
+                asyncio.run(
+                    analysis_service.calculate_streamlines_json(
+                        _db_returning(op),
+                        aeroplane_uuid="0" * 36,
+                        operating_point=OperatingPointSchema(operating_point_id=42),
+                    )
+                )

--- a/app/tests/test_operating_point_resolver.py
+++ b/app/tests/test_operating_point_resolver.py
@@ -506,3 +506,158 @@ class TestStreamlineServiceUsesResolvedOp:
                         operating_point=OperatingPointSchema(operating_point_id=42),
                     )
                 )
+
+    def _patch_service_pipeline(self, analysis_service, resolved):
+        """Common ExitStack patches; returns the stack (caller manages enter/exit)."""
+        from contextlib import ExitStack
+        from unittest.mock import patch
+
+        stack = ExitStack()
+        stack.enter_context(patch.object(
+            analysis_service, "get_aeroplane_or_raise",
+            return_value=MagicMock(id=7),
+        ))
+        stack.enter_context(patch.object(
+            analysis_service, "get_aeroplane_schema_or_raise",
+            return_value=MagicMock(),
+        ))
+        stack.enter_context(patch.object(
+            analysis_service, "aeroplane_schema_to_asb_airplane_async",
+            return_value=MagicMock(),
+        ))
+        stack.enter_context(patch.object(
+            analysis_service.operating_point_resolver,
+            "resolve_operating_point",
+            return_value=resolved,
+        ))
+        stack.enter_context(patch.object(
+            analysis_service, "validate_deflections_against_airplane",
+        ))
+        return stack
+
+    def test_streamlines_service_wraps_generic_error_as_internal(self):
+        """gh-577 review: non-ServiceException errors get logger.exception + InternalError."""
+        import asyncio
+        from unittest.mock import patch
+
+        from app.core.exceptions import InternalError
+        from app.services import analysis_service
+
+        resolved = self._resolved_op()
+
+        with self._patch_service_pipeline(analysis_service, resolved) as stack:
+            stack.enter_context(patch.object(
+                analysis_service, "analyse_aerodynamics",
+                side_effect=RuntimeError("VLM crashed"),
+            ))
+            with pytest.raises(InternalError):
+                asyncio.run(
+                    analysis_service.calculate_streamlines_json(
+                        _db_returning(_make_op()),
+                        aeroplane_uuid="0" * 36,
+                        operating_point=OperatingPointSchema(operating_point_id=42),
+                    )
+                )
+
+    def test_three_view_service_wraps_generic_error_as_internal(self):
+        import asyncio
+        from unittest.mock import patch
+
+        from app.core.exceptions import InternalError
+        from app.services import analysis_service
+
+        resolved = self._resolved_op()
+
+        with self._patch_service_pipeline(analysis_service, resolved) as stack:
+            stack.enter_context(patch.object(
+                analysis_service, "analyse_aerodynamics",
+                side_effect=RuntimeError("VLM crashed"),
+            ))
+            stack.enter_context(patch.object(
+                analysis_service, "compile_four_view_figure",
+            ))
+            with pytest.raises(InternalError):
+                asyncio.run(
+                    analysis_service.get_streamlines_three_view_image(
+                        _db_returning(_make_op()),
+                        aeroplane_uuid="0" * 36,
+                        operating_point=OperatingPointSchema(operating_point_id=42),
+                    )
+                )
+
+    def test_strip_forces_service_wraps_generic_error_as_internal(self):
+        import asyncio
+        from unittest.mock import patch
+
+        from app.core.exceptions import InternalError
+        from app.services import analysis_service
+
+        resolved = self._resolved_op()
+
+        with self._patch_service_pipeline(analysis_service, resolved) as stack:
+            mock_runner_cls = stack.enter_context(patch(
+                "app.services.avl_runner.AVLRunner",
+            ))
+            stack.enter_context(patch(
+                "app.services.avl_geometry_service.get_user_avl_content",
+                return_value="MOCK_AVL_CONTENT",
+            ))
+            mock_runner_cls.return_value.run.side_effect = RuntimeError("AVL crashed")
+
+            with pytest.raises(InternalError):
+                asyncio.run(
+                    analysis_service.analyze_airplane_strip_forces(
+                        _db_returning(_make_op()),
+                        aeroplane_uuid="0" * 36,
+                        operating_point=OperatingPointSchema(operating_point_id=42),
+                    )
+                )
+
+    def test_streamlines_service_skips_resolver_when_no_id(self):
+        """Diagnostic / manual mode — inline schema passes through untouched."""
+        import asyncio
+        from contextlib import ExitStack
+        from unittest.mock import patch
+
+        from app.services import analysis_service
+
+        inline = OperatingPointSchema(
+            alpha=5.0, velocity=14.0, altitude=100.0, xyz_ref=[0.18, 0, 0],
+        )
+
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(
+                analysis_service, "get_aeroplane_or_raise",
+                return_value=MagicMock(id=7),
+            ))
+            stack.enter_context(patch.object(
+                analysis_service, "get_aeroplane_schema_or_raise",
+                return_value=MagicMock(),
+            ))
+            stack.enter_context(patch.object(
+                analysis_service, "aeroplane_schema_to_asb_airplane_async",
+                return_value=MagicMock(),
+            ))
+            stack.enter_context(patch.object(
+                analysis_service, "validate_deflections_against_airplane",
+            ))
+            mock_analyse = stack.enter_context(patch.object(
+                analysis_service, "analyse_aerodynamics",
+            ))
+            fake_fig = MagicMock()
+            fake_fig.to_json.return_value = '{"data":[],"layout":{}}'
+            mock_analyse.return_value = (MagicMock(), fake_fig)
+
+            asyncio.run(
+                analysis_service.calculate_streamlines_json(
+                    _db_returning(None),  # OP lookup never reached
+                    aeroplane_uuid="0" * 36,
+                    operating_point=inline,
+                )
+            )
+
+            # The schema reaching analyse_aerodynamics is the inline one,
+            # not a resolved record — operating_point_id stays None.
+            call_op = mock_analyse.call_args.args[1]
+            assert call_op.operating_point_id is None
+            assert call_op.alpha == 5.0

--- a/app/tests/test_operating_point_resolver.py
+++ b/app/tests/test_operating_point_resolver.py
@@ -242,7 +242,7 @@ class TestValidateDeflectionsAgainstAirplane:
         # MagicMock's `name` kwarg is reserved for the mock's repr; set
         # the attribute after construction.
         surfaces = [MagicMock() for _ in surface_names]
-        for surf, n in zip(surfaces, surface_names):
+        for surf, n in zip(surfaces, surface_names, strict=True):
             surf.name = n
         xsec = MagicMock()
         xsec.control_surfaces = surfaces

--- a/frontend/__tests__/parseApiError.test.ts
+++ b/frontend/__tests__/parseApiError.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Tests for the structured error-message parser (gh-577 review).
+ */
+import { describe, it, expect } from "vitest";
+import { parseApiError } from "@/lib/parseApiError";
+
+function makeResponse(status: number, body: string, json = true): Response {
+  return new Response(body, {
+    status,
+    headers: { "Content-Type": json ? "application/json" : "text/plain" },
+  });
+}
+
+describe("parseApiError", () => {
+  it("extracts message from custom ServiceException envelope", async () => {
+    const res = makeResponse(
+      422,
+      JSON.stringify({
+        error: { code: "validation", message: "OperatingPoint not trimmed" },
+      }),
+    );
+    expect(await parseApiError(res, "Streamlines")).toBe(
+      "Streamlines — invalid request: OperatingPoint not trimmed",
+    );
+  });
+
+  it("extracts message from FastAPI default detail envelope", async () => {
+    const res = makeResponse(
+      404,
+      JSON.stringify({ detail: "Aeroplane not found" }),
+    );
+    expect(await parseApiError(res, "Streamlines")).toBe(
+      "Streamlines — not found: Aeroplane not found",
+    );
+  });
+
+  it("falls back to plain text when body is not JSON", async () => {
+    const res = makeResponse(500, "boom", false);
+    expect(await parseApiError(res, "Streamlines")).toBe(
+      "Streamlines failed (500): boom",
+    );
+  });
+
+  it("falls back to statusText for empty body", async () => {
+    const res = new Response(null, { status: 503, statusText: "unavail" });
+    expect(await parseApiError(res, "Streamlines")).toBe(
+      "Streamlines failed (503): unavail",
+    );
+  });
+});

--- a/frontend/__tests__/useStreamlines.test.ts
+++ b/frontend/__tests__/useStreamlines.test.ts
@@ -169,7 +169,10 @@ describe("useStreamlines", () => {
 
     expect(result.current.isComputing).toBe(false);
     expect(result.current.figure).toBeNull();
-    expect(result.current.error).toBe("Streamlines failed: 500 Internal Server Error");
+    // gh-577 review: error message now goes through parseApiError so 5xx
+    // is tagged "failed (500)" with the body text appended.
+    expect(result.current.error).toContain("Streamlines failed (500)");
+    expect(result.current.error).toContain("Internal Server Error");
   });
 
   it("sets error string on network failure", async () => {

--- a/frontend/__tests__/useStreamlines.test.ts
+++ b/frontend/__tests__/useStreamlines.test.ts
@@ -106,6 +106,56 @@ describe("useStreamlines", () => {
     });
   });
 
+  it("sends operating_point_id when set (gh-577 trim-consistent run)", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(FAKE_FIGURE), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const { result } = renderHook(() => useStreamlines("aero-77"));
+
+    await act(async () => {
+      await result.current.computeStreamlines({
+        velocity: 30,
+        alpha: 10,
+        beta: 2,
+        altitude: 500,
+        operating_point_id: 42,
+      });
+    });
+
+    const [, options] = fetchSpy.mock.calls[0];
+    const body = JSON.parse(options!.body as string);
+    expect(body.operating_point_id).toBe(42);
+  });
+
+  it("omits operating_point_id when null (manual mode)", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(FAKE_FIGURE), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const { result } = renderHook(() => useStreamlines("aero-77"));
+
+    await act(async () => {
+      await result.current.computeStreamlines({
+        velocity: 30,
+        alpha: 10,
+        beta: 2,
+        altitude: 500,
+        operating_point_id: null,
+      });
+    });
+
+    const [, options] = fetchSpy.mock.calls[0];
+    const body = JSON.parse(options!.body as string);
+    expect("operating_point_id" in body).toBe(false);
+  });
+
   it("sets error string on API error (non-ok response)", async () => {
     vi.spyOn(global, "fetch").mockResolvedValue(
       new Response("Internal Server Error", { status: 500 }),

--- a/frontend/__tests__/useStripForces.test.ts
+++ b/frontend/__tests__/useStripForces.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for the useStripForces hook — gh-577 operating_point_id round-trip.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useStripForces } from "@/hooks/useStripForces";
+
+const FAKE_RESULT = {
+  alpha: 4.2,
+  beta: 0.0,
+  mach: 0.0,
+  sref: 1.0,
+  cref: 1.0,
+  bref: 1.0,
+  surfaces: [],
+};
+
+describe("useStripForces.runAll (gh-577)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sends operating_point_id when set", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(FAKE_RESULT), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const { result } = renderHook(() => useStripForces("aero-1"));
+    await act(async () => {
+      await result.current.runAll({
+        velocity: 20,
+        alpha: 5,
+        beta: 0,
+        altitude: 100,
+        xyz_ref: [0.183, 0, 0],
+        operating_point_id: 42,
+      });
+    });
+    const [, options] = fetchSpy.mock.calls[0];
+    const body = JSON.parse(options!.body as string);
+    expect(body.operating_point_id).toBe(42);
+  });
+
+  it("omits operating_point_id when null (manual diagnostic mode)", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(FAKE_RESULT), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const { result } = renderHook(() => useStripForces("aero-1"));
+    await act(async () => {
+      await result.current.runAll({
+        velocity: 20,
+        alpha: 5,
+        beta: 0,
+        altitude: 100,
+        xyz_ref: [0, 0, 0],
+        operating_point_id: null,
+      });
+    });
+    const [, options] = fetchSpy.mock.calls[0];
+    const body = JSON.parse(options!.body as string);
+    expect("operating_point_id" in body).toBe(false);
+  });
+
+  it("surfaces a 422 validation error message readably", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: "validation_error",
+            message:
+              "OperatingPoint 42 has status 'NOT_TRIMMED'; only TRIMMED operating points may drive a trim-consistent run.",
+          },
+        }),
+        { status: 422, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const { result } = renderHook(() => useStripForces("aero-1"));
+    await act(async () => {
+      await result.current.runAll({
+        velocity: 20,
+        alpha: 5,
+        beta: 0,
+        altitude: 100,
+        xyz_ref: [0, 0, 0],
+        operating_point_id: 42,
+      });
+    });
+    expect(result.current.error).toContain("Strip forces — invalid request");
+    expect(result.current.error).toContain("NOT_TRIMMED");
+  });
+});

--- a/frontend/app/workbench/analysis/page.tsx
+++ b/frontend/app/workbench/analysis/page.tsx
@@ -183,6 +183,7 @@ export default function AnalysisPage() {
                   (a) => a.parameter_name === "cg_x",
                 )?.effective_value ?? null
               }
+              operatingPoints={ops.points}
               onClose={() => setConfigOpen(false)}
             />
           </div>

--- a/frontend/components/workbench/AnalysisConfigPanel.tsx
+++ b/frontend/components/workbench/AnalysisConfigPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useId, useState } from "react";
 import { Play, RefreshCw, ChevronDown, ChevronRight, Loader2 } from "lucide-react";
 import type { UseAnalysisReturn } from "@/hooks/useAnalysis";
 import type { StripForcesAllParams } from "@/hooks/useStripForces";
@@ -67,12 +67,14 @@ function OperatingPointBasisSelector({
   trimmedOps,
   effectiveOpId,
   onSelectOpId,
+  scope,
 }: Readonly<{
   opBasis: OpBasis;
   onChangeOpBasis: (basis: OpBasis) => void;
   trimmedOps: StoredOperatingPoint[];
   effectiveOpId: number | null;
   onSelectOpId: (id: number) => void;
+  scope: "vlm" | "avl";
 }>) {
   const radioKey = (basis: OpBasis) => (e: React.KeyboardEvent<HTMLSpanElement>) => {
     if (e.key === "Enter" || e.key === " ") {
@@ -131,6 +133,7 @@ function OperatingPointBasisSelector({
           trimmedOps={trimmedOps}
           effectiveOpId={effectiveOpId}
           onSelectOpId={onSelectOpId}
+          scope={scope}
         />
       )}
 
@@ -149,15 +152,24 @@ function TrimmedOpDropdown({
   trimmedOps,
   effectiveOpId,
   onSelectOpId,
+  scope,
 }: Readonly<{
   trimmedOps: StoredOperatingPoint[];
   effectiveOpId: number | null;
   onSelectOpId: (id: number) => void;
+  /**
+   * Which downstream solver consumes the resolved OP. Controls the
+   * honest footnote about whether control-surface deflections actually
+   * reach the solver (VLM: yes; AVL: only α / xyz_ref / V — gh-577
+   * follow-up).
+   */
+  scope: "vlm" | "avl";
 }>) {
+  const selectId = useId();
   return (
     <div className="flex flex-col gap-1">
       <label
-        htmlFor="op-basis-select"
+        htmlFor={selectId}
         className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground"
       >
         Trimmed operating point
@@ -170,7 +182,7 @@ function TrimmedOpDropdown({
       ) : (
         <div className="relative">
           <select
-            id="op-basis-select"
+            id={selectId}
             value={effectiveOpId ?? ""}
             onChange={(e) => onSelectOpId(Number.parseInt(e.target.value, 10))}
             className="w-full appearance-none rounded-xl border border-border bg-input px-3 py-2 pr-8 font-[family-name:var(--font-geist-sans)] text-[13px] text-foreground"
@@ -188,10 +200,18 @@ function TrimmedOpDropdown({
           />
         </div>
       )}
-      <p className="font-[family-name:var(--font-geist-sans)] text-[10px] italic text-subtle-foreground">
-        α, xyz_ref, velocity, altitude, and control-surface deflections are
-        taken from the selected trim solution (gh-577).
-      </p>
+      {scope === "vlm" ? (
+        <p className="font-[family-name:var(--font-geist-sans)] text-[10px] italic text-subtle-foreground">
+          α, xyz_ref, velocity, altitude, and all control-surface deflections
+          come from the selected trim solution (gh-577).
+        </p>
+      ) : (
+        <p className="font-[family-name:var(--font-geist-sans)] text-[10px] italic text-subtle-foreground">
+          α, xyz_ref, velocity, altitude come from the trim solution.
+          Control-surface deflections are taken from the geometry file —
+          AVL deflection injection is a planned follow-up (gh-577).
+        </p>
+      )}
     </div>
   );
 }
@@ -324,13 +344,29 @@ export function AnalysisConfigPanel({
   if (activeTab === "Polar") handleRun = handleRunPolar;
   else if (activeTab === "Trefftz Plane") handleRun = handleRunStripForces;
 
-  const opBasisSelector = (
+  // Two scope-specific selectors so the footnote is honest about which
+  // solver actually consumes the deflections (VLM streamlines: yes;
+  // AVL strip forces: only α / xyz_ref / V today — gh-577 follow-up).
+  // Rendered into mutually exclusive tab branches, so they share parent
+  // state (opBasis, chosenOpId) without prop-drilling.
+  const opBasisSelectorVlm = (
     <OperatingPointBasisSelector
       opBasis={opBasis}
       onChangeOpBasis={setOpBasis}
       trimmedOps={trimmedOps}
       effectiveOpId={effectiveOpId}
       onSelectOpId={setChosenOpId}
+      scope="vlm"
+    />
+  );
+  const opBasisSelectorAvl = (
+    <OperatingPointBasisSelector
+      opBasis={opBasis}
+      onChangeOpBasis={setOpBasis}
+      trimmedOps={trimmedOps}
+      effectiveOpId={effectiveOpId}
+      onSelectOpId={setChosenOpId}
+      scope="avl"
     />
   );
 
@@ -678,7 +714,7 @@ export function AnalysisConfigPanel({
       {/* ══════════════════════════════════════════════════════════════════ */}
       {activeTab === "Trefftz Plane" && (
         <>
-          {opBasisSelector}
+          {opBasisSelectorAvl}
           <div
             className={`flex flex-col gap-3 rounded-xl border border-border bg-card p-4 ${
               useTrimmedOp ? "opacity-50" : ""
@@ -808,7 +844,7 @@ export function AnalysisConfigPanel({
       {/* ══════════════════════════════════════════════════════════════════ */}
       {activeTab === "Streamlines" && (
         <>
-          {opBasisSelector}
+          {opBasisSelectorVlm}
           <div
             className={`flex flex-col gap-3 rounded-xl border border-border bg-card p-4 ${
               useTrimmedOp ? "opacity-50" : ""

--- a/frontend/components/workbench/AnalysisConfigPanel.tsx
+++ b/frontend/components/workbench/AnalysisConfigPanel.tsx
@@ -5,9 +5,18 @@ import { Play, RefreshCw, ChevronDown, ChevronRight, Loader2 } from "lucide-reac
 import type { UseAnalysisReturn } from "@/hooks/useAnalysis";
 import type { StripForcesAllParams } from "@/hooks/useStripForces";
 import type { StreamlinesParams } from "@/hooks/useStreamlines";
+import type { StoredOperatingPoint } from "@/hooks/useOperatingPoints";
 import type { Tab } from "@/components/workbench/AnalysisViewerPanel";
 
 type Mode = "single" | "sweep";
+/**
+ * gh-577: Trefftz/Streamlines basis selection.
+ * - "trimmed" (default): pick a stored, trimmed OperatingPoint from the
+ *   dropdown. Backend resolves α / xyz_ref / control deflections from it.
+ * - "manual": diagnostic / component-analysis mode with free-form values.
+ *   No trim guarantee — clearly labelled.
+ */
+type OpBasis = "trimmed" | "manual";
 
 interface AnalysisConfigPanelProps {
   readonly activeTab: Tab;
@@ -27,6 +36,10 @@ interface AnalysisConfigPanelProps {
   // (cg_x effective value from assumptions). Falls back to 0 when not
   // available.
   readonly designCgX?: number | null;
+  // gh-577: stored operating points for the trimmed-OP dropdown on the
+  // Trefftz Plane and Streamlines tabs. The panel filters to TRIMMED
+  // entries before rendering.
+  readonly operatingPoints?: StoredOperatingPoint[];
   // Modal close
   readonly onClose?: () => void;
 }
@@ -43,6 +56,146 @@ function getCurrentError(activeTab: Tab, analysis: UseAnalysisReturn, stripForce
   return streamlinesError ?? null;
 }
 
+/**
+ * gh-577: Shared trim-basis chooser used by the Trefftz Plane and
+ * Streamlines tabs. Extracted from `AnalysisConfigPanel` to keep the main
+ * panel below the cognitive-complexity threshold (sonarjs/cognitive-complexity).
+ */
+function OperatingPointBasisSelector({
+  opBasis,
+  onChangeOpBasis,
+  trimmedOps,
+  effectiveOpId,
+  onSelectOpId,
+}: Readonly<{
+  opBasis: OpBasis;
+  onChangeOpBasis: (basis: OpBasis) => void;
+  trimmedOps: StoredOperatingPoint[];
+  effectiveOpId: number | null;
+  onSelectOpId: (id: number) => void;
+}>) {
+  const radioKey = (basis: OpBasis) => (e: React.KeyboardEvent<HTMLSpanElement>) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onChangeOpBasis(basis);
+    }
+  };
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4">
+      <span className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-muted-foreground">
+        Operating Point
+      </span>
+      <div className="flex items-center gap-4">
+        <label className="flex cursor-pointer items-center gap-2">
+          <span
+            onClick={() => onChangeOpBasis("trimmed")}
+            onKeyDown={radioKey("trimmed")}
+            role="radio"
+            aria-checked={opBasis === "trimmed"}
+            tabIndex={0}
+            className={`flex h-4 w-4 items-center justify-center rounded-full border-2 bg-background ${
+              opBasis === "trimmed" ? "border-primary" : "border-border-strong"
+            }`}
+          >
+            {opBasis === "trimmed" && (
+              <span className="h-2 w-2 rounded-full bg-primary" />
+            )}
+          </span>
+          <span className="font-[family-name:var(--font-geist-sans)] text-[13px] text-foreground">
+            Trimmed OP (recommended)
+          </span>
+        </label>
+        <label className="flex cursor-pointer items-center gap-2">
+          <span
+            onClick={() => onChangeOpBasis("manual")}
+            onKeyDown={radioKey("manual")}
+            role="radio"
+            aria-checked={opBasis === "manual"}
+            tabIndex={0}
+            className={`flex h-4 w-4 items-center justify-center rounded-full border-2 bg-background ${
+              opBasis === "manual" ? "border-primary" : "border-border-strong"
+            }`}
+          >
+            {opBasis === "manual" && (
+              <span className="h-2 w-2 rounded-full bg-primary" />
+            )}
+          </span>
+          <span className="font-[family-name:var(--font-geist-sans)] text-[13px] text-foreground">
+            Manual (untrimmed, diagnostic)
+          </span>
+        </label>
+      </div>
+
+      {opBasis === "trimmed" && (
+        <TrimmedOpDropdown
+          trimmedOps={trimmedOps}
+          effectiveOpId={effectiveOpId}
+          onSelectOpId={onSelectOpId}
+        />
+      )}
+
+      {opBasis === "manual" && (
+        <p className="rounded-xl border border-amber-500/40 bg-amber-500/10 px-3 py-2 font-[family-name:var(--font-geist-sans)] text-[11px] text-amber-200">
+          Diagnostic mode — the run uses the free-form inputs below with
+          control surfaces at 0°. The resulting Trefftz wake / streamlines
+          do not represent a trimmed flight condition.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function TrimmedOpDropdown({
+  trimmedOps,
+  effectiveOpId,
+  onSelectOpId,
+}: Readonly<{
+  trimmedOps: StoredOperatingPoint[];
+  effectiveOpId: number | null;
+  onSelectOpId: (id: number) => void;
+}>) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label
+        htmlFor="op-basis-select"
+        className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground"
+      >
+        Trimmed operating point
+      </label>
+      {trimmedOps.length === 0 ? (
+        <p className="rounded-xl border border-border bg-card-muted px-3 py-2 font-[family-name:var(--font-geist-sans)] text-[12px] text-muted-foreground">
+          No trimmed operating points available. Trim one in the Operating
+          Points tab, or switch to manual mode.
+        </p>
+      ) : (
+        <div className="relative">
+          <select
+            id="op-basis-select"
+            value={effectiveOpId ?? ""}
+            onChange={(e) => onSelectOpId(Number.parseInt(e.target.value, 10))}
+            className="w-full appearance-none rounded-xl border border-border bg-input px-3 py-2 pr-8 font-[family-name:var(--font-geist-sans)] text-[13px] text-foreground"
+          >
+            {trimmedOps.map((op) => (
+              <option key={op.id} value={op.id}>
+                {op.name} — α={(op.alpha * (180 / Math.PI)).toFixed(2)}°, V=
+                {op.velocity.toFixed(1)} m/s
+              </option>
+            ))}
+          </select>
+          <ChevronDown
+            size={14}
+            className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground"
+          />
+        </div>
+      )}
+      <p className="font-[family-name:var(--font-geist-sans)] text-[10px] italic text-subtle-foreground">
+        α, xyz_ref, velocity, altitude, and control-surface deflections are
+        taken from the selected trim solution (gh-577).
+      </p>
+    </div>
+  );
+}
+
 export function AnalysisConfigPanel({
   activeTab,
   analysis,
@@ -55,10 +208,25 @@ export function AnalysisConfigPanel({
   streamlinesRunning,
   streamlinesError,
   designCgX,
+  operatingPoints,
   onClose,
 }: Readonly<AnalysisConfigPanelProps>) {
   const [mode, setMode] = useState<Mode>("sweep");
   const [advancedOpen, setAdvancedOpen] = useState(false);
+
+  // gh-577: Trefftz/Streamlines basis. Default "trimmed" so the wake and
+  // induced drag reflect a flight condition the aircraft can actually
+  // hold. "manual" is an explicit opt-in to an untrimmed diagnostic run.
+  const [opBasis, setOpBasis] = useState<OpBasis>("trimmed");
+  const trimmedOps = (operatingPoints ?? []).filter(
+    (op) => op.status === "TRIMMED",
+  );
+  // User-chosen OP, or null = no explicit choice yet. The effective id
+  // falls back to the first trimmed OP so the dropdown always has a
+  // sensible default once data arrives (no state mirroring needed).
+  const [chosenOpId, setChosenOpId] = useState<number | null>(null);
+  const effectiveOpId =
+    chosenOpId ?? (trimmedOps.length > 0 ? trimmedOps[0].id : null);
 
   // Shared form state
   const [alphaStart, setAlphaStart] = useState("-5");
@@ -102,6 +270,13 @@ export function AnalysisConfigPanel({
     onClose?.();
   };
 
+  // gh-577: when running on a trimmed OP we send `operating_point_id`
+  // and the backend overrides α/xyz_ref/control deflections from the
+  // stored record. Inline values still go on the wire as a fallback in
+  // case the OP cannot be resolved server-side.
+  const useTrimmedOp =
+    opBasis === "trimmed" && effectiveOpId !== null;
+
   // ── Trefftz Plane handlers ──
   const handleRunStripForces = () => {
     onRunStripForces?.({
@@ -110,6 +285,7 @@ export function AnalysisConfigPanel({
       beta: Number.parseFloat(beta) || 0,
       altitude: Number.parseFloat(altitude) || 100,
       xyz_ref: parseXyzRef(),
+      operating_point_id: useTrimmedOp ? effectiveOpId : null,
     });
     onClose?.();
   };
@@ -122,6 +298,7 @@ export function AnalysisConfigPanel({
       beta: Number.parseFloat(beta) || 0,
       altitude: Number.parseFloat(altitude) || 100,
       xyz_ref: parseXyzRef(),
+      operating_point_id: useTrimmedOp ? effectiveOpId : null,
     });
     onClose?.();
   };
@@ -146,6 +323,16 @@ export function AnalysisConfigPanel({
   let handleRun = handleRunStreamlines;
   if (activeTab === "Polar") handleRun = handleRunPolar;
   else if (activeTab === "Trefftz Plane") handleRun = handleRunStripForces;
+
+  const opBasisSelector = (
+    <OperatingPointBasisSelector
+      opBasis={opBasis}
+      onChangeOpBasis={setOpBasis}
+      trimmedOps={trimmedOps}
+      effectiveOpId={effectiveOpId}
+      onSelectOpId={setChosenOpId}
+    />
+  );
 
   return (
     <div className="flex w-full flex-col gap-4 overflow-y-auto">
@@ -490,9 +677,15 @@ export function AnalysisConfigPanel({
       {/* TREFFTZ PLANE TAB CONFIG                                         */}
       {/* ══════════════════════════════════════════════════════════════════ */}
       {activeTab === "Trefftz Plane" && (
-        <div className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4">
+        <>
+          {opBasisSelector}
+          <div
+            className={`flex flex-col gap-3 rounded-xl border border-border bg-card p-4 ${
+              useTrimmedOp ? "opacity-50" : ""
+            }`}
+          >
           <span className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-muted-foreground">
-            Strip-Force Analysis (AVL)
+            Strip-Force Analysis (AVL) {useTrimmedOp ? "— overridden by trimmed OP" : ""}
           </span>
 
           {/* Alpha (single) */}
@@ -606,16 +799,23 @@ export function AnalysisConfigPanel({
               </div>
             )}
           </div>
-        </div>
+          </div>
+        </>
       )}
 
       {/* ══════════════════════════════════════════════════════════════════ */}
       {/* STREAMLINES TAB CONFIG                                           */}
       {/* ══════════════════════════════════════════════════════════════════ */}
       {activeTab === "Streamlines" && (
-        <div className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4">
+        <>
+          {opBasisSelector}
+          <div
+            className={`flex flex-col gap-3 rounded-xl border border-border bg-card p-4 ${
+              useTrimmedOp ? "opacity-50" : ""
+            }`}
+          >
           <span className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-muted-foreground">
-            Streamline Computation
+            Streamline Computation {useTrimmedOp ? "— overridden by trimmed OP" : ""}
           </span>
 
           {/* Alpha (single) */}
@@ -693,7 +893,8 @@ export function AnalysisConfigPanel({
               </span>
             </div>
           </div>
-        </div>
+          </div>
+        </>
       )}
     </div>
   );

--- a/frontend/hooks/useStreamlines.ts
+++ b/frontend/hooks/useStreamlines.ts
@@ -2,6 +2,7 @@
 
 import { useState, useCallback } from "react";
 import { API_BASE } from "@/lib/fetcher";
+import { parseApiError } from "@/lib/parseApiError";
 
 interface StreamlinesState {
   figure: Record<string, unknown> | null;
@@ -61,8 +62,7 @@ export function useStreamlines(aeroplaneId: string | null) {
           },
         );
         if (!res.ok) {
-          const body = await res.text();
-          throw new Error(`Streamlines failed: ${res.status} ${body}`);
+          throw new Error(await parseApiError(res, "Streamlines"));
         }
         const figure = await res.json();
         setState({ figure, isComputing: false, error: null });

--- a/frontend/hooks/useStreamlines.ts
+++ b/frontend/hooks/useStreamlines.ts
@@ -20,6 +20,13 @@ export interface StreamlinesParams {
    * streamline visualisation is consistent with the rest of the system.
    */
   xyz_ref?: number[];
+  /**
+   * gh-577: bind the run to a stored, trimmed OperatingPoint. When set
+   * the backend resolves alpha (rad→deg), xyz_ref, velocity, altitude,
+   * body rates and all control-surface deflections from that record so
+   * the Trefftz plane / streamlines reflect a trim-consistent state.
+   */
+  operating_point_id?: number | null;
 }
 
 export function useStreamlines(aeroplaneId: string | null) {
@@ -35,18 +42,22 @@ export function useStreamlines(aeroplaneId: string | null) {
       setState({ figure: null, isComputing: true, error: null });
 
       try {
+        const body: Record<string, unknown> = {
+          velocity: params.velocity,
+          alpha: params.alpha,
+          beta: params.beta,
+          altitude: params.altitude,
+          xyz_ref: params.xyz_ref ?? [0, 0, 0],
+        };
+        if (params.operating_point_id != null) {
+          body.operating_point_id = params.operating_point_id;
+        }
         const res = await fetch(
           `${API_BASE}/aeroplanes/${aeroplaneId}/streamlines`,
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              velocity: params.velocity,
-              alpha: params.alpha,
-              beta: params.beta,
-              altitude: params.altitude,
-              xyz_ref: params.xyz_ref ?? [0, 0, 0],
-            }),
+            body: JSON.stringify(body),
           },
         );
         if (!res.ok) {

--- a/frontend/hooks/useStripForces.ts
+++ b/frontend/hooks/useStripForces.ts
@@ -3,6 +3,7 @@
 
 import { useState, useCallback } from "react";
 import { API_BASE } from "@/lib/fetcher";
+import { parseApiError } from "@/lib/parseApiError";
 
 export interface StripForceEntry {
   j: number;
@@ -94,8 +95,7 @@ export function useStripForces(aeroplaneId: string | null) {
           },
         );
         if (!res.ok) {
-          const body = await res.text();
-          throw new Error(`Strip forces failed: ${res.status} ${body}`);
+          throw new Error(await parseApiError(res, "Strip forces"));
         }
         const data: StripForcesResult = await res.json();
         setResult(data);
@@ -135,8 +135,7 @@ export function useStripForces(aeroplaneId: string | null) {
           },
         );
         if (!res.ok) {
-          const body = await res.text();
-          throw new Error(`Strip forces failed: ${res.status} ${body}`);
+          throw new Error(await parseApiError(res, "Strip forces"));
         }
         const data: StripForcesResult = await res.json();
         setResult(data);

--- a/frontend/hooks/useStripForces.ts
+++ b/frontend/hooks/useStripForces.ts
@@ -56,6 +56,14 @@ export interface StripForcesAllParams {
   beta: number;
   altitude: number;
   xyz_ref: number[];
+  /**
+   * gh-577: bind the run to a stored, trimmed OperatingPoint. When set
+   * the backend resolves alpha (rad→deg), xyz_ref, velocity, altitude,
+   * body rates and all control-surface deflections from that record so
+   * the strip-force / Trefftz computation reflects a trim-consistent
+   * state. The inline velocity/alpha/beta/altitude/xyz_ref are ignored.
+   */
+  operating_point_id?: number | null;
 }
 
 export function useStripForces(aeroplaneId: string | null) {
@@ -108,18 +116,22 @@ export function useStripForces(aeroplaneId: string | null) {
       setResult(null);
 
       try {
+        const requestBody: Record<string, unknown> = {
+          velocity: params.velocity,
+          alpha: params.alpha,
+          beta: params.beta,
+          altitude: params.altitude,
+          xyz_ref: params.xyz_ref,
+        };
+        if (params.operating_point_id != null) {
+          requestBody.operating_point_id = params.operating_point_id;
+        }
         const res = await fetch(
           `${API_BASE}/aeroplanes/${aeroplaneId}/strip_forces`,
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              velocity: params.velocity,
-              alpha: params.alpha,
-              beta: params.beta,
-              altitude: params.altitude,
-              xyz_ref: params.xyz_ref,
-            }),
+            body: JSON.stringify(requestBody),
           },
         );
         if (!res.ok) {

--- a/frontend/lib/parseApiError.ts
+++ b/frontend/lib/parseApiError.ts
@@ -1,0 +1,68 @@
+/**
+ * Parse a non-ok `fetch` response into a user-readable error message.
+ *
+ * The backend returns a structured JSON envelope for `ServiceException`
+ * subclasses — `{ "error": { "code": "...", "message": "...", "details": ... } }`
+ * (see `app/main.py` error handler). Raw `await res.text()` dumps the
+ * whole envelope into the UI; this helper extracts the human message and
+ * tags the HTTP status class so the caller can render an actionable
+ * sentence.
+ *
+ * gh-577 review item.
+ */
+
+function pickString(...candidates: unknown[]): string | undefined {
+  for (const c of candidates) {
+    if (typeof c === "string" && c.length > 0) return c;
+  }
+  return undefined;
+}
+
+function extractMessageFromJson(payload: unknown): string | undefined {
+  if (typeof payload !== "object" || payload === null) return undefined;
+  const obj = payload as Record<string, unknown>;
+  // Custom envelope: { error: { message | detail, ... } }
+  if (typeof obj.error === "object" && obj.error !== null) {
+    const err = obj.error as Record<string, unknown>;
+    const fromError = pickString(err.message, err.detail);
+    if (fromError) return fromError;
+  }
+  // FastAPI default HTTPException: { detail: "..." }
+  return pickString(obj.detail);
+}
+
+async function bodyToMessage(res: Response): Promise<string | undefined> {
+  // Try JSON first; if the body isn't JSON, fall back to plain text.
+  try {
+    const payload: unknown = await res.clone().json();
+    const fromJson = extractMessageFromJson(payload);
+    if (fromJson) return fromJson;
+  } catch {
+    // not JSON — fall through to text
+  }
+  try {
+    const text = await res.text();
+    return text || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function formatByStatus(
+  status: number,
+  prefix: string,
+  detail: string,
+): string {
+  if (status === 404) return `${prefix} — not found: ${detail}`;
+  if (status === 422) return `${prefix} — invalid request: ${detail}`;
+  return `${prefix} failed (${status}): ${detail}`;
+}
+
+export async function parseApiError(
+  res: Response,
+  fallbackPrefix: string,
+): Promise<string> {
+  const fromBody = await bodyToMessage(res);
+  const detail = fromBody ?? res.statusText ?? `status ${res.status}`;
+  return formatByStatus(res.status, fallbackPrefix, detail);
+}


### PR DESCRIPTION
## Summary

Binds the Trefftz-plane and streamline VLM visualizations to a stored, **trimmed `OperatingPoint`** so the wake and induced/trim drag reflect a flight state the aircraft can actually hold. Untrimmed runs remain available behind an explicitly labelled diagnostic toggle.

## Why

A multi-agent code audit (see issue body) plus direct source verification showed the streamline/Trefftz path was architecturally decoupled from the trim subsystem:

- Frontend assembled an ad-hoc `OperatingPointSchema` from a free-form form — `alpha` defaulted to `5°`, `control_deflections` was never sent.
- Backend override `app/api/utils.py:102-104` (`if overrides:`) was therefore never entered → VLM ran with geometry-default deflections (0°).
- Opti trimmer writes deflections to `OperatingPointModel.controls`; only `control_deflections` is consumed — and `OperatingPointSchema` has no `controls` field, so the trim result was unreachable even server-side.

Validated by `/aerodynamics-expert` (untrimmed Trefftz omits trim drag, scales C_{D,i} at the wrong total C_L, and shows a wake the aircraft never flies — Anderson §5.1, §5.3) and `/aerosandbox-expert` (store-one-record-and-replay is the idiomatic asb pattern; `with_control_deflections` exists in asb 4.2.9).

## Design

`OperatingPointSchema.operating_point_id: int | None` is the binding hook. When set, the new service `app/services/operating_point_resolver.py` loads the row and returns a fresh schema with:

- `alpha`, `beta` converted from radians (DB) → degrees (schema)
- `velocity`, `altitude`, `xyz_ref`, body rates from the record
- `control_deflections` from `control_deflections` (manual override) **else** from `controls` (trim solver output) — empty override falls back so a stale empty dict cannot silently erase the trim
- `status != TRIMMED` is rejected (`ValidationDomainError`) unless `require_trimmed=False` (diagnostic opt-in)

`calculate_streamlines_json`, `get_streamlines_three_view_image`, and `analyze_airplane_strip_forces` call the resolver before invoking the VLM / AVL runner.

> **Known limitation, follow-up:** the AVL strip-forces path takes deflections from the geometry file built from `plane_schema`. The resolver brings α / xyz_ref / velocity from the trimmed OP for that path, but full deflection injection into the .avl file is tracked as a follow-up.

Frontend `AnalysisConfigPanel` adds a shared "Operating Point" card to the Trefftz Plane and Streamlines tabs:

- **Trimmed OP (recommended)** — dropdown of `status==TRIMMED` operating points. Selection drives `operating_point_id` in the request.
- **Manual (untrimmed, diagnostic)** — keeps the free-form inputs and an amber warning banner.

## Tests

| Suite | Count | Status |
|---|---|---|
| `pytest -m "not slow"` | 3588 | ✅ |
| `pytest cad_designer/tests/` | (in above) | ✅ |
| `npm run test:unit` | 793 + 2 (new) | ✅ |
| `npm run lint` | 0 errors | ✅ |

New test files:

- `app/tests/test_operating_point_resolver.py` — 15 cases pinning the resolver contract (units, override precedence, status rejection, service-level wiring).
- `frontend/__tests__/useStreamlines.test.ts` — adds two lock-in cases for `operating_point_id` round-tripping.

## Files

- `app/schemas/aeroanalysisschema.py` — `operating_point_id` field
- `app/services/operating_point_resolver.py` *(new)*
- `app/services/analysis_service.py` — resolver wired into VLM streamlines + AVL strip forces
- `app/tests/test_operating_point_resolver.py` *(new)*
- `frontend/hooks/useStreamlines.ts`, `frontend/hooks/useStripForces.ts`
- `frontend/components/workbench/AnalysisConfigPanel.tsx`
- `frontend/app/workbench/analysis/page.tsx`
- `frontend/__tests__/useStreamlines.test.ts`

Closes #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)
