### PR TITLE
fix(gh-588): tighten _NACA_RE to integer-only — strip-forces 500 on decimal-named airfoils

### DIFF
--- a/app/services/avl_geometry_service.py
+++ b/app/services/avl_geometry_service.py
@@ -35,9 +35,21 @@ from app.schemas.avl_geometry import AvlGeometryResponse
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Regex for detecting NACA 4/5-digit airfoil names
+# Regex for detecting valid NACA 4-/5-digit airfoil names.
+#
+# Must be **integer** digit groups only — the NACA series itself is defined
+# with integer-valued parameters (e.g. NACA 2412, NACA 23012). AVL's ``NACA``
+# keyword expects an integer code and raises ``Read error`` on any decimal
+# value. Decimal-bearing names such as ``naca23013.5`` are custom airfoils
+# that exist as ``.dat`` files under ``components/airfoils/`` — they fall
+# through to file resolution (``_resolve_airfoil_reference`` → ``AFIL``)
+# instead of being passed verbatim to AVL's NACA generator.
+#
+# gh-588: the previous pattern ``\d{4,5}(?:\.\d+)?`` (from gh-409) over-matched
+# and routed ``naca23013.5`` into ``AvlNaca``, crashing AVL with
+# ``Read error on line N`` during ``Building surface: main_wing``.
 # ---------------------------------------------------------------------------
-_NACA_RE = _re.compile(r"^naca\s*(\d{4,5}(?:\.\d+)?)$", _re.IGNORECASE)
+_NACA_RE = _re.compile(r"^naca\s*(\d{4,5})$", _re.IGNORECASE)
 
 
 # ---------------------------------------------------------------------------

--- a/app/tests/test_avl_generator_integration.py
+++ b/app/tests/test_avl_generator_integration.py
@@ -191,21 +191,49 @@ class TestBuildAirfoilNode:
         assert result.digits == "0012"
 
 
-    def test_naca_decimal_thickness(self):
-        from app.avl.geometry import AvlNaca
+    def test_naca_decimal_thickness_falls_through_to_file(self):
+        """gh-588 (regression of gh-409): a decimal in a NACA-style name is NOT
+        a valid 4-/5-digit NACA designation. AVL's ``NACA`` keyword expects an
+        integer code (e.g. 2412, 23012) and crashes with ``Read error`` on a
+        decimal value. The generator must therefore route ``naca23013.5`` to
+        the file-resolution branch (``AFIL <path/naca23013.5.dat>``), which
+        AVL accepts.
+        """
+        from app.avl.geometry import AvlAfile
         from app.services.avl_geometry_service import _build_airfoil_node
 
         result = _build_airfoil_node("naca23013.5")
-        assert isinstance(result, AvlNaca)
-        assert result.digits == "23013.5"
+        assert isinstance(result, AvlAfile), (
+            "Decimal-named airfoils must resolve to AFIL so AVL can parse the "
+            "geometry; emitting NACA with a decimal designation triggers a "
+            "Read error on the AVL side (gh-588)."
+        )
+        assert result.filepath.endswith("naca23013.5.dat")
 
-    def test_naca_decimal_thickness_case_insensitive(self):
-        from app.avl.geometry import AvlNaca
+    def test_naca_decimal_thickness_case_insensitive_falls_through_to_file(self):
+        """gh-588: same as above with upper-case spelling."""
+        from app.avl.geometry import AvlAfile
         from app.services.avl_geometry_service import _build_airfoil_node
 
         result = _build_airfoil_node("NACA23013.5")
-        assert isinstance(result, AvlNaca)
-        assert result.digits == "23013.5"
+        assert isinstance(result, AvlAfile)
+        assert result.filepath.endswith("naca23013.5.dat")
+
+    def test_generated_avl_uses_afil_not_naca_for_decimal_airfoil(self):
+        """gh-588 end-to-end: the serialised ``.avl`` content for a decimal-named
+        airfoil must contain ``AFIL <path>`` and must NOT contain a bare
+        ``NACA\\n23013.5`` line that AVL would reject.
+        """
+        from app.services.avl_geometry_service import _build_airfoil_node
+
+        node = _build_airfoil_node("naca23013.5")
+        serialised = repr(node)
+        assert "AFIL" in serialised
+        assert "naca23013.5.dat" in serialised
+        # The bare decimal designation must not appear on its own line — AVL's
+        # NACA-keyword parser would choke on it.
+        assert "NACA\n23013.5" not in serialised
+        assert "23013.5\n" != serialised  # not a stand-alone integer line
 
 
 class TestBuildGeometryEdgeCases:


### PR DESCRIPTION
## Summary

Tightens `_NACA_RE` in `app/services/avl_geometry_service.py` to **integer-only** digit groups so airfoil refs like `naca23013.5` fall through to file resolution (`AFIL <path>`) instead of being passed verbatim to AVL's `NACA` keyword, which only accepts integer 4-/5-digit codes.

## Bug

Aircraft with a decimal-named NACA airfoil (the local default **RV-7** is one) cannot run **Strip-Force Analysis** (Trefftz Plane tab) — HTTP 500 with the misleading hint `Building surface: rudder`. The truncated stdout in `avl_runner.py:352` (`stderr_text[:500]`) cut off the actual diagnostic; running AVL directly on the same `.avl` shows:

```
   Building surface: main_wing
 ** Read error on line   77 ...
 23013.5
```

NACA digit groups are integer-valued by definition (e.g. 2412, 23012); AVL's parser rejects the decimal value.

## Why this regex now

Introducing commit `86ed1233 fix(gh-409): resolve 500 error on strip_forces with decimal NACA airfoils (#410)` relaxed the pattern from `\d{4,5}` to `\d{4,5}(?:\.\d+)?` to "support" decimal-named airfoils. That over-corrected at the wrong layer. The correct path for decimal-named refs is `_resolve_airfoil_reference` → `AvlAfile`, which is what every other section of the same wing was already doing.

## Fix

```diff
-_NACA_RE = _re.compile(r"^naca\s*(\d{4,5}(?:\.\d+)?)$", _re.IGNORECASE)
+_NACA_RE = _re.compile(r"^naca\s*(\d{4,5})$", _re.IGNORECASE)
```

A docstring above the constant now explains the invariant.

## Tests

| | |
|---|---|
| Inverted | `test_naca_decimal_thickness` (asserted `AvlNaca` — wrong contract) |
| Inverted | `test_naca_decimal_thickness_case_insensitive` |
| Added | `test_naca_decimal_thickness_falls_through_to_file` — asserts `AvlAfile` with `.filepath.endswith("naca23013.5.dat")` |
| Added | `test_naca_decimal_thickness_case_insensitive_falls_through_to_file` |
| Added | `test_generated_avl_uses_afil_not_naca_for_decimal_airfoil` — asserts the serialised `.avl` contains `AFIL` and not `NACA\n23013.5` |
| Untouched | `test_naca_airfoil` (`naca2412` → `AvlNaca`) — still passes |
| Untouched | `test_naca5_airfoil` (`NACA23012` → `AvlNaca`) — still passes |

## Verification

- `pytest app/tests/test_avl_*.py test_neuralfoil_cdcl_service test_aeroanalysis test_operating_point_resolver test_elevator_authority_avl` — **256 passed**, 5 deselected.
- `ruff check`: clean.
- Empirical: patching the user's RV-7 `.avl` `NACA\n23013.5` → `AFIL\n.../naca23013.5.dat` lets AVL build all surfaces without `Read error`.

## Side note (not in scope)

`avl_runner.py:352` truncates the AVL stdout to `[:500]` chars — that cut off the actual `Read error on line N` line in this case. Widening the slice (or taking the tail instead of the head) would have made the original bug self-diagnosing. Tracked as a follow-up if desired.

Closes #588

🤖 Generated with [Claude Code](https://claude.com/claude-code)
