### PR TITLE
fix(gh-590): bump AVL Nspan to satisfy section-density constraint

### DIFF
--- a/app/avl/spacing.py
+++ b/app/avl/spacing.py
@@ -40,6 +40,40 @@ def _has_centreline_break(surface: AvlSurface) -> bool:
     return False
 
 
+def _required_nspan_for_section_density(
+    surface: AvlSurface, safety_margin: int = 2
+) -> int:
+    """Minimum ``Nspan`` that lets AVL allocate ≥ 1 panel per inter-section gap.
+
+    AVL refuses with ``Cannot adjust spanwise spacing at section N`` /
+    ``Insufficient number of spanwise vortices to work with`` when the
+    surface-level ``Nspan`` cannot fit a panel into the tightest
+    inter-section gap. The binding threshold matches ``ceil(span / min_gap)``
+    empirically (gh-590), regardless of the ``s_space`` choice — cosine
+    edge-concentration doesn't loosen the constraint.
+
+    Coincident sections (chord-/twist-discontinuity at the same Y) are
+    ignored when picking the smallest gap so they don't force ``Nspan`` to
+    infinity. Surfaces with < 2 sections or zero span return 0 (no
+    constraint).
+    """
+    if len(surface.sections) < 2:
+        return 0
+    y_positions = sorted(sec.xyz_le[1] for sec in surface.sections)
+    span = y_positions[-1] - y_positions[0]
+    if span <= 0:
+        return 0
+    gaps = [
+        b - a
+        for a, b in zip(y_positions, y_positions[1:], strict=False)
+        if b - a > 1e-9
+    ]
+    if not gaps:
+        return 0
+    min_gap = min(gaps)
+    return math.ceil(span / min_gap) + safety_margin
+
+
 def optimise_surface_spacing(surface: AvlSurface, config: SpacingConfig) -> AvlSurface:
     """Apply intelligent spacing rules to a surface, returning a modified copy.
 
@@ -50,6 +84,10 @@ def optimise_surface_spacing(surface: AvlSurface, config: SpacingConfig) -> AvlS
     - Unswept wing without a centreline break: switch spanwise spacing to
       -sine (``s_space = -2.0``) which concentrates panels at tip and root
       where induced drag gradients are steepest.
+    - **Tight section density** (gh-590): bump ``n_span`` to satisfy AVL's
+      per-section panel constraint so wings with near-coincident sections
+      at spar / control-surface boundaries don't crash with
+      ``Cannot adjust spanwise spacing at section N``.
     """
     result = copy.copy(surface)
     result.n_chord = config.n_chord
@@ -67,5 +105,8 @@ def optimise_surface_spacing(surface: AvlSurface, config: SpacingConfig) -> AvlS
     # Rule: unswept wings without centreline break use -sine spacing
     if _is_unswept(surface) and not _has_centreline_break(surface):
         result.s_space = -2.0
+
+    # Rule: bump Nspan if tight section gaps would crash AVL (gh-590)
+    result.n_span = max(result.n_span, _required_nspan_for_section_density(surface))
 
     return result

--- a/app/tests/test_avl_spacing.py
+++ b/app/tests/test_avl_spacing.py
@@ -187,3 +187,109 @@ class TestHelperFunctions:
             ],
         )
         assert not _is_unswept(surface)
+
+
+class TestSectionDensityNspanBump:
+    """gh-590: AVL refuses with 'Cannot adjust spanwise spacing at section N'
+    when the surface-level Nspan cannot fit at least one spanwise panel into
+    the tightest inter-section gap. The optimiser must bump Nspan to satisfy
+    AVL whenever the configured value is too low for the actual geometry.
+    """
+
+    def _rv7_like_wing(self, *, n_span: int = 20):
+        """Six-section main wing mirroring the RV-7 layout: two near-coincident
+        section pairs at root (Y=0, Y=0.005) and tip (Y=0.399, Y=0.409) on a
+        semispan of 0.409 m. min_gap / span = 1.2 % → AVL needs Nspan ≥ 82.
+        """
+        ys = [0.0, 0.005, 0.070, 0.235, 0.399, 0.409]
+        return AvlSurface(
+            name="main_wing",
+            n_chord=16,
+            c_space=1.0,
+            n_span=n_span,
+            s_space=-2.0,
+            sections=[AvlSection(xyz_le=(0.19, y, 0.0), chord=0.183) for y in ys],
+        )
+
+    def test_bumps_nspan_when_sections_too_tight(self):
+        from app.avl.spacing import optimise_surface_spacing
+
+        surface = self._rv7_like_wing(n_span=20)
+        config = SpacingConfig(n_span=20, auto_optimise=True)
+        result = optimise_surface_spacing(surface, config)
+        # span = 0.409, min_gap = 0.005 → ceil(span/min_gap) + 2 = 84
+        assert result.n_span >= 82, (
+            f"Optimiser must bump Nspan to satisfy AVL's section-density "
+            f"constraint; got {result.n_span}, need >= 82 for this geometry."
+        )
+
+    def test_does_not_lower_user_configured_nspan(self):
+        """If the caller already configured a generous Nspan, don't downgrade."""
+        from app.avl.spacing import optimise_surface_spacing
+
+        # Clean wing — only 2 sections, no tight gaps. Required is small.
+        surface = AvlSurface(
+            name="W",
+            n_chord=16,
+            c_space=1.0,
+            n_span=200,
+            s_space=1.0,
+            sections=[
+                AvlSection(xyz_le=(0, 0, 0), chord=0.3),
+                AvlSection(xyz_le=(0, 1, 0), chord=0.2),
+            ],
+        )
+        config = SpacingConfig(n_span=200, auto_optimise=True)
+        result = optimise_surface_spacing(surface, config)
+        assert result.n_span == 200
+
+    def test_no_bump_for_clean_wing(self):
+        from app.avl.spacing import optimise_surface_spacing
+
+        # Uniformly-spaced 3-section wing — min_gap / span = 0.5 → Nspan=20 plenty.
+        surface = AvlSurface(
+            name="W",
+            n_chord=16,
+            c_space=1.0,
+            n_span=20,
+            s_space=1.0,
+            sections=[
+                AvlSection(xyz_le=(0, 0.0, 0), chord=0.3),
+                AvlSection(xyz_le=(0, 0.5, 0), chord=0.25),
+                AvlSection(xyz_le=(0, 1.0, 0), chord=0.2),
+            ],
+        )
+        config = SpacingConfig(n_span=20, auto_optimise=True)
+        result = optimise_surface_spacing(surface, config)
+        assert result.n_span == 20
+
+    def test_auto_optimise_false_honours_user_nspan(self):
+        from app.avl.spacing import optimise_surface_spacing
+
+        surface = self._rv7_like_wing(n_span=20)
+        config = SpacingConfig(n_span=20, auto_optimise=False)
+        result = optimise_surface_spacing(surface, config)
+        assert result.n_span == 20  # opt-out: no bump even if AVL would crash
+
+    def test_coincident_sections_are_ignored_in_min_gap(self):
+        """Two sections at exactly the same Y (chord/twist change) must not
+        produce min_gap=0 → infinite Nspan. They're ignored in the calculation.
+        """
+        from app.avl.spacing import optimise_surface_spacing
+
+        surface = AvlSurface(
+            name="W",
+            n_chord=16,
+            c_space=1.0,
+            n_span=20,
+            s_space=1.0,
+            sections=[
+                AvlSection(xyz_le=(0, 0.0, 0), chord=0.3),
+                AvlSection(xyz_le=(0, 0.0, 0), chord=0.25),  # coincident
+                AvlSection(xyz_le=(0, 1.0, 0), chord=0.2),
+            ],
+        )
+        config = SpacingConfig(n_span=20, auto_optimise=True)
+        result = optimise_surface_spacing(surface, config)
+        # Real min_gap is 1.0, span is 1.0 → bump not required; stay at 20.
+        assert result.n_span == 20

--- a/app/tests/test_avl_spacing.py
+++ b/app/tests/test_avl_spacing.py
@@ -293,3 +293,44 @@ class TestSectionDensityNspanBump:
         result = optimise_surface_spacing(surface, config)
         # Real min_gap is 1.0, span is 1.0 → bump not required; stay at 20.
         assert result.n_span == 20
+
+
+class TestRequiredNspanHelper:
+    """Direct coverage of the early-return branches in
+    ``_required_nspan_for_section_density`` so SonarQube ``new_coverage`` lands
+    above the 80 % gate. The main paths are exercised end-to-end by
+    ``TestSectionDensityNspanBump`` above; these tests pin the corner cases.
+    """
+
+    def test_returns_zero_for_empty_surface(self):
+        from app.avl.spacing import _required_nspan_for_section_density
+
+        surface = AvlSurface(name="W", n_chord=12, c_space=1.0, sections=[])
+        assert _required_nspan_for_section_density(surface) == 0
+
+    def test_returns_zero_for_single_section(self):
+        from app.avl.spacing import _required_nspan_for_section_density
+
+        surface = AvlSurface(
+            name="W",
+            n_chord=12,
+            c_space=1.0,
+            sections=[AvlSection(xyz_le=(0, 0, 0), chord=0.2)],
+        )
+        assert _required_nspan_for_section_density(surface) == 0
+
+    def test_returns_zero_for_zero_span_surface(self):
+        """All sections at the same Y (e.g. a rudder declared as two coincident
+        sections) → no spanwise constraint to satisfy."""
+        from app.avl.spacing import _required_nspan_for_section_density
+
+        surface = AvlSurface(
+            name="rudder",
+            n_chord=12,
+            c_space=1.0,
+            sections=[
+                AvlSection(xyz_le=(0, 0.0, 0), chord=0.2),
+                AvlSection(xyz_le=(0, 0.0, 0.3), chord=0.18),
+            ],
+        )
+        assert _required_nspan_for_section_density(surface) == 0


### PR DESCRIPTION
## Summary

`optimise_surface_spacing` now bumps `Nspan` to satisfy AVL's per-section panel constraint so wings with near-coincident sections at spar / control-surface boundaries don't crash AVL with `Cannot adjust spanwise spacing at section N`.

## Bug

After [#588](https://github.com/szymansk/da3Dalus/pull/589) (NACA decimal fix), Strip-Force Analysis on the local RV-7 still returns HTTP 500. The truncated stdout in `avl_runner.py:352` keeps hinting "Building surface: rudder", but running the regenerated `.avl` directly through AVL reveals AVL now fails on `main_wing`:

```
   Building surface: main_wing
 *** Cannot adjust spanwise spacing at section  2, on surface main_wing
 *** Insufficient number of spanwise vortices to work with
```

The RV-7 wing has six sections with two near-coincident pairs:

| Y (m) | 0.000 | 0.005 | 0.070 | 0.235 | 0.399 | 0.409 |
|---|---|---|---|---|---|---|
| gap to next | **0.005** | 0.065 | 0.165 | 0.164 | **0.010** | — |

Semispan = 0.409 m, smallest gap = 0.005 m (1.2 % of semispan). AVL can't fit a panel into that gap with Nspan = 20.

## Empirical threshold

| Nspan | Result |
|---|---|
| 20, 40, 60 | FAIL |
| **80** | **OK** |
| 100 | OK |

Independent of `s_space` (cosine vs uniform — same threshold). Matches the analytic bound `Nspan ≥ ceil(span / min_gap)` ≈ 82.

## Fix

```python
def _required_nspan_for_section_density(surface, safety_margin=2) -> int:
    """Minimum Nspan that lets AVL allocate ≥ 1 panel per inter-section gap."""
    if len(surface.sections) < 2: return 0
    y_positions = sorted(sec.xyz_le[1] for sec in surface.sections)
    span = y_positions[-1] - y_positions[0]
    if span <= 0: return 0
    gaps = [b - a for a, b in zip(y_positions, y_positions[1:], strict=False) if b - a > 1e-9]
    if not gaps: return 0
    return math.ceil(span / min(gaps)) + safety_margin

# in optimise_surface_spacing:
result.n_span = max(result.n_span, _required_nspan_for_section_density(surface))
```

Invariants:
- Coincident-Y sections (chord/twist change at same Y) ignored when picking `min_gap` — won't force `Nspan → ∞`.
- User-configured `Nspan` larger than the minimum is honoured (never downgraded).
- `auto_optimise=False` disables the bump.

## Tests

5 new cases in `app/tests/test_avl_spacing.py`:

| Case | Asserts |
|---|---|
| `test_bumps_nspan_when_sections_too_tight` | RV-7-like 6-section wing → `n_span ≥ 82` |
| `test_does_not_lower_user_configured_nspan` | Clean wing with caller-set `Nspan=200` → stays 200 |
| `test_no_bump_for_clean_wing` | 3 evenly-spaced sections, Nspan=20 → stays 20 |
| `test_auto_optimise_false_honours_user_nspan` | RV-7-like wing with `auto_optimise=False` → no bump |
| `test_coincident_sections_are_ignored_in_min_gap` | Two sections at same Y → no divide-by-zero, no infinite bump |

## Verification

- `pytest -m "not slow" app/tests/test_avl_*.py app/tests/test_aeroanalysis*.py app/tests/test_operating_point_resolver.py app/tests/test_elevator_authority_avl.py`: **276 passed**, 5 deselected.
- `ruff check`: clean.
- Empirical: AVL run on RV-7 `.avl` at Nspan=80 succeeds (no `Cannot adjust spanwise spacing`). The fix produces Nspan = 82 + 2 = 84 for this wing, comfortably above the threshold.

## User impact

Together with #589 (gh-588), this unblocks **Strip-Force Analysis** on the RV-7 — the user's reporting aircraft. Any aircraft with a wing-section gap below ~5 % of the semispan (common for spar / control-boundary sections) was affected.

## Side note (not in scope)

`avl_runner.py:352` truncates AVL stdout to `[:500]` chars, which consistently hides the actual `*** Cannot adjust ...` line under "Building surface: rudder". Worth a tiny separate ticket to take the tail of stdout instead, so geometry errors are self-diagnosing.

Closes #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)
