### PR TITLE
feat(gh-582): add Slope Soarer mission preset

### DIFF
--- a/alembic/versions/294aeab71af5_seed_slope_soarer_mission_preset.py
+++ b/alembic/versions/294aeab71af5_seed_slope_soarer_mission_preset.py
@@ -1,0 +1,75 @@
+"""seed slope_soarer mission preset
+
+Revision ID: 294aeab71af5
+Revises: 6063db4db84f
+Create Date: 2026-05-20 09:00:00.000000
+
+Adds the Slope Soarer mission preset (gh-582). RC-specific unpowered
+high-wing-loading mission for slope/ridge soaring. Idempotent: skips
+the insert if the preset id already exists (e.g. when the row was
+already created at startup by ``seed_mission_presets``).
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "294aeab71af5"
+down_revision: Union[str, None] = "6063db4db84f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_SLOPE_SOARER_ID = "slope_soarer"
+
+
+def upgrade() -> None:
+    """Insert the slope_soarer preset row if missing.
+
+    The row is idempotent: re-running upgrade() on a DB that already
+    has the row (typically because the app started and ran
+    ``seed_mission_presets``) is a no-op.
+    """
+    conn = op.get_bind()
+    existing = conn.execute(
+        sa.text("SELECT id FROM mission_presets WHERE id = :id"),
+        {"id": _SLOPE_SOARER_ID},
+    ).fetchone()
+    if existing is not None:
+        return
+
+    from app.services.mission_preset_seed import SEED_PRESETS
+
+    preset = next(p for p in SEED_PRESETS if p.id == _SLOPE_SOARER_ID)
+
+    op.bulk_insert(
+        sa.table(
+            "mission_presets",
+            sa.column("id", sa.String),
+            sa.column("label", sa.String),
+            sa.column("description", sa.String),
+            sa.column("target_polygon", sa.JSON),
+            sa.column("axis_ranges", sa.JSON),
+            sa.column("suggested_estimates", sa.JSON),
+        ),
+        [
+            {
+                "id": preset.id,
+                "label": preset.label,
+                "description": preset.description,
+                "target_polygon": preset.target_polygon,
+                "axis_ranges": {k: list(v) for k, v in preset.axis_ranges.items()},
+                "suggested_estimates": preset.suggested_estimates.model_dump(),
+            }
+        ],
+    )
+
+
+def downgrade() -> None:
+    """Remove the slope_soarer preset row."""
+    op.execute(
+        sa.text("DELETE FROM mission_presets WHERE id = :id").bindparams(id=_SLOPE_SOARER_ID)
+    )

--- a/app/schemas/flight_profile.py
+++ b/app/schemas/flight_profile.py
@@ -24,6 +24,7 @@ class FlightProfileType(str, Enum):
     three_d = "3d"
     glider = "glider"
     motor_glider = "motor_glider"
+    slope_soarer = "slope_soarer"
     custom = "custom"
 
 
@@ -144,7 +145,10 @@ class Goals(BaseModel):
 
     @model_validator(mode="after")
     def validate_speed_relationship(self):
-        if self.max_level_speed_mps is not None and self.max_level_speed_mps <= self.cruise_speed_mps:
+        if (
+            self.max_level_speed_mps is not None
+            and self.max_level_speed_mps <= self.cruise_speed_mps
+        ):
             raise ValueError("max_level_speed_mps must be greater than cruise_speed_mps.")
         return self
 
@@ -187,7 +191,10 @@ class Handling(BaseModel):
 
     @model_validator(mode="after")
     def apply_agile_default_roll_rate(self):
-        if self.stability_preference == StabilityPreference.agile and self.roll_rate_target_dps is None:
+        if (
+            self.stability_preference == StabilityPreference.agile
+            and self.roll_rate_target_dps is None
+        ):
             self.roll_rate_target_dps = DEFAULT_AGILE_ROLL_RATE_DPS
         return self
 

--- a/app/services/mission_preset_seed.py
+++ b/app/services/mission_preset_seed.py
@@ -190,4 +190,40 @@ SEED_PRESETS: list[MissionPreset] = [
             prop_efficiency=0.7,
         ),
     ),
+    MissionPreset(
+        id="slope_soarer",
+        label="Slope Soarer",
+        description=(
+            "Unpowered RC slope soarer — higher wing loading (50–150 g/dm²) "
+            "than thermal gliders for stable penetration in gusty ridge lift. "
+            "Hand-launched, aerobatic-capable, low dihedral (0–2°) for roll "
+            "responsiveness. Airfoil hints: RG14, RG15, NACA 0012, HN-354, "
+            "HN-1033, SD7037. AR range 5–12 covers sport through F3F racers."
+        ),
+        target_polygon={
+            "stall_safety": 0.45,
+            "glide": 0.50,
+            "climb": 0.30,
+            "cruise": 0.75,
+            "maneuver": 0.80,
+            "wing_loading": 0.70,
+            "field_friendliness": 0.85,
+        },
+        axis_ranges={
+            "stall_safety": (1.3, 2.0),
+            "glide": (10.0, 25.0),
+            "climb": (5.0, 25.0),
+            "cruise": (15.0, 45.0),
+            "maneuver": (5.0, 8.0),
+            "wing_loading": (50.0, 150.0),
+            "field_friendliness": (3.0, 100.0),
+        },
+        suggested_estimates=MissionPresetEstimates(
+            g_limit=6.0,
+            target_static_margin=0.08,
+            cl_max=1.1,
+            power_to_weight=0.0,
+            prop_efficiency=0.0,
+        ),
+    ),
 ]

--- a/app/tests/test_flight_profile_schema.py
+++ b/app/tests/test_flight_profile_schema.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import ValidationError
 
-from app.schemas.flight_profile import RCFlightProfileCreate
+from app.schemas.flight_profile import FlightProfileType, RCFlightProfileCreate
 
 
 def valid_profile_payload() -> dict:
@@ -59,3 +59,17 @@ def test_schema_rejects_turn_n_above_bank_limit():
     payload["constraints"]["max_bank_deg"] = 45
     with pytest.raises(ValidationError):
         RCFlightProfileCreate.model_validate(payload)
+
+
+def test_flight_profile_type_includes_slope_soarer():
+    """gh-582: slope_soarer is a first-class profile type."""
+    assert FlightProfileType.slope_soarer == "slope_soarer"
+    assert FlightProfileType("slope_soarer") is FlightProfileType.slope_soarer
+
+
+def test_schema_accepts_slope_soarer_profile_type():
+    """gh-582: payload with type='slope_soarer' validates successfully."""
+    payload = valid_profile_payload()
+    payload["type"] = "slope_soarer"
+    profile = RCFlightProfileCreate.model_validate(payload)
+    assert profile.type == FlightProfileType.slope_soarer

--- a/app/tests/test_mission_objective_service.py
+++ b/app/tests/test_mission_objective_service.py
@@ -1,4 +1,5 @@
 """Tests for app.services.mission_objective_service (gh-546)."""
+
 from __future__ import annotations
 
 from app.schemas.mission_objective import MissionObjective
@@ -13,11 +14,17 @@ from app.tests.conftest import make_aeroplane
 def _make_objective(**overrides):
     payload = dict(
         mission_type="trainer",
-        target_cruise_mps=18.0, target_stall_safety=1.8,
-        target_maneuver_n=3.0, target_glide_ld=12.0,
-        target_climb_energy=22.0, target_wing_loading_n_m2=412.0,
-        target_field_length_m=50.0, available_runway_m=50.0,
-        runway_type="grass", t_static_N=18.0, takeoff_mode="runway",
+        target_cruise_mps=18.0,
+        target_stall_safety=1.8,
+        target_maneuver_n=3.0,
+        target_glide_ld=12.0,
+        target_climb_energy=22.0,
+        target_wing_loading_n_m2=412.0,
+        target_field_length_m=50.0,
+        available_runway_m=50.0,
+        runway_type="grass",
+        t_static_N=18.0,
+        takeoff_mode="runway",
     )
     payload.update(overrides)
     return MissionObjective(**payload)
@@ -60,12 +67,21 @@ def test_upsert_creates_then_updates(client_and_db):
         assert obj.target_cruise_mps == 25.0
 
 
-def test_list_mission_presets_returns_six_seeded(client_and_db):
+def test_list_mission_presets_returns_all_seeded(client_and_db):
+    """gh-582: slope_soarer is in the seeded library alongside the original six."""
     _, SessionLocal = client_and_db
     with SessionLocal() as db:
         presets = list_mission_presets(db)
         ids = {p.id for p in presets}
-    assert ids == {"trainer", "sport", "sailplane", "wing_racer", "acro_3d", "stol_bush"}
+    assert ids == {
+        "trainer",
+        "sport",
+        "sailplane",
+        "wing_racer",
+        "acro_3d",
+        "stol_bush",
+        "slope_soarer",
+    }
 
 
 def test_upsert_changes_mission_type_writes_suggested_estimates(client_and_db):
@@ -88,8 +104,7 @@ def test_upsert_changes_mission_type_writes_suggested_estimates(client_and_db):
     with SessionLocal() as db:
         rows = {
             r.parameter_name: r
-            for r in db.query(DesignAssumptionModel)
-            .filter_by(aeroplane_id=aircraft_id).all()
+            for r in db.query(DesignAssumptionModel).filter_by(aeroplane_id=aircraft_id).all()
         }
         # Sailplane preset values from app/services/mission_preset_seed.py
         assert rows["g_limit"].estimate_value == 5.3
@@ -135,11 +150,42 @@ def test_upsert_does_not_touch_calculated_value_when_changing_mission(client_and
             .one()
         )
         # estimate_value was overwritten by the preset
-        assert cl_max_row.estimate_value == 1.3   # sailplane preset
+        assert cl_max_row.estimate_value == 1.3  # sailplane preset
         # calculated_value preserved
         assert cl_max_row.calculated_value == 1.62
         # active_source preserved (CALCULATED takes precedence per existing convention)
         assert cl_max_row.active_source == "CALCULATED"
+
+
+def test_upsert_slope_soarer_writes_unpowered_estimates(client_and_db):
+    """gh-582: switching to slope_soarer writes power_to_weight=0 so downstream
+    is_glider auto-detection sees an unpowered aircraft."""
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        from app.tests.conftest import make_aeroplane
+        from app.services.design_assumptions_service import seed_defaults
+        from app.models.aeroplanemodel import DesignAssumptionModel
+
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aircraft_id = aeroplane.id
+
+    with SessionLocal() as db:
+        upsert_mission_objective(db, aircraft_id, _make_objective(mission_type="slope_soarer"))
+        db.commit()
+
+    with SessionLocal() as db:
+        rows = {
+            r.parameter_name: r
+            for r in db.query(DesignAssumptionModel).filter_by(aeroplane_id=aircraft_id).all()
+        }
+        # slope_soarer preset values from app/services/mission_preset_seed.py
+        assert rows["g_limit"].estimate_value == 6.0
+        assert rows["target_static_margin"].estimate_value == 0.08
+        assert rows["cl_max"].estimate_value == 1.1
+        assert rows["power_to_weight"].estimate_value == 0.0
+        assert rows["prop_efficiency"].estimate_value == 0.0
 
 
 def test_upsert_no_change_in_mission_type_does_not_rewrite_estimates(client_and_db):
@@ -182,4 +228,4 @@ def test_upsert_no_change_in_mission_type_does_not_rewrite_estimates(client_and_
             .filter_by(aeroplane_id=aircraft_id, parameter_name="g_limit")
             .one()
         )
-        assert row.estimate_value == 4.5   # user override preserved
+        assert row.estimate_value == 4.5  # user override preserved

--- a/app/tests/test_mission_objectives_endpoint.py
+++ b/app/tests/test_mission_objectives_endpoint.py
@@ -1,4 +1,5 @@
 """Endpoint tests for Mission Objectives + Mission Presets (gh-546)."""
+
 from __future__ import annotations
 
 from app.tests.conftest import make_aeroplane
@@ -27,11 +28,17 @@ def test_put_mission_objectives_persists(client_and_db):
 
     payload = {
         "mission_type": "sailplane",
-        "target_cruise_mps": 14.0, "target_stall_safety": 1.6,
-        "target_maneuver_n": 4.0, "target_glide_ld": 25.0,
-        "target_climb_energy": 45.0, "target_wing_loading_n_m2": 200.0,
-        "target_field_length_m": 60.0, "available_runway_m": 80.0,
-        "runway_type": "grass", "t_static_N": 0.0, "takeoff_mode": "bungee",
+        "target_cruise_mps": 14.0,
+        "target_stall_safety": 1.6,
+        "target_maneuver_n": 4.0,
+        "target_glide_ld": 25.0,
+        "target_climb_energy": 45.0,
+        "target_wing_loading_n_m2": 200.0,
+        "target_field_length_m": 60.0,
+        "available_runway_m": 80.0,
+        "runway_type": "grass",
+        "t_static_N": 0.0,
+        "takeoff_mode": "bungee",
     }
     r = client.put(f"/aeroplanes/{uuid}/mission-objectives", json=payload)
     assert r.status_code == 200
@@ -41,12 +48,35 @@ def test_put_mission_objectives_persists(client_and_db):
     assert r2.json()["target_glide_ld"] == 25.0
 
 
-def test_get_mission_presets_returns_six(client_and_db):
+def test_get_mission_presets_returns_all_seeded(client_and_db):
+    """gh-582: seven seeded presets including the new slope_soarer."""
     client, _ = client_and_db
     r = client.get("/mission-presets")
     assert r.status_code == 200
     ids = {p["id"] for p in r.json()}
-    assert ids == {"trainer", "sport", "sailplane", "wing_racer", "acro_3d", "stol_bush"}
+    assert ids == {
+        "trainer",
+        "sport",
+        "sailplane",
+        "wing_racer",
+        "acro_3d",
+        "stol_bush",
+        "slope_soarer",
+    }
+
+
+def test_get_mission_presets_exposes_slope_soarer_payload(client_and_db):
+    """gh-582: the new preset surfaces via the public API with expected fields."""
+    client, _ = client_and_db
+    r = client.get("/mission-presets")
+    assert r.status_code == 200
+    preset = next(p for p in r.json() if p["id"] == "slope_soarer")
+    assert preset["label"] == "Slope Soarer"
+    est = preset["suggested_estimates"]
+    assert est["power_to_weight"] == 0.0
+    assert est["target_static_margin"] == 0.08
+    assert est["cl_max"] == 1.1
+    assert est["g_limit"] == 6.0
 
 
 def test_get_mission_kpis_returns_seven_axes(client_and_db):
@@ -96,9 +126,7 @@ def test_get_mission_kpis_multi_mission_param(client_and_db):
         aeroplane = make_aeroplane(db)
         uuid = str(aeroplane.uuid)
 
-    r = client.get(
-        f"/aeroplanes/{uuid}/mission-kpis?missions=trainer&missions=sailplane"
-    )
+    r = client.get(f"/aeroplanes/{uuid}/mission-kpis?missions=trainer&missions=sailplane")
     assert r.status_code == 200
     body = r.json()
     assert {p["mission_id"] for p in body["target_polygons"]} == {

--- a/app/tests/test_mission_preset_seed.py
+++ b/app/tests/test_mission_preset_seed.py
@@ -1,18 +1,55 @@
 """Tests for the seeded Mission Presets (gh-546)."""
+
 from __future__ import annotations
 
 from app.services.mission_preset_seed import SEED_PRESETS
 
 
-def test_six_seed_presets_exist():
+def test_seed_presets_exist():
+    """gh-582: slope_soarer added to the canonical preset set."""
     ids = {p.id for p in SEED_PRESETS}
-    assert ids == {"trainer", "sport", "sailplane", "wing_racer", "acro_3d", "stol_bush"}
+    assert ids == {
+        "trainer",
+        "sport",
+        "sailplane",
+        "wing_racer",
+        "acro_3d",
+        "stol_bush",
+        "slope_soarer",
+    }
+
+
+def test_slope_soarer_preset_defaults():
+    """gh-582: RC slope soarer carries the review-verified defaults."""
+    preset = next(p for p in SEED_PRESETS if p.id == "slope_soarer")
+    assert preset.label == "Slope Soarer"
+    est = preset.suggested_estimates
+    assert est.power_to_weight == 0.0  # unpowered → is_glider auto
+    assert est.prop_efficiency == 0.0
+    assert est.target_static_margin == 0.08
+    assert est.cl_max == 1.1
+    assert est.g_limit == 6.0
+    # KPI polygon: high maneuver + high cruise + mid stall + high field-friendliness
+    polygon = preset.target_polygon
+    assert polygon["maneuver"] >= 0.7
+    assert polygon["cruise"] >= 0.7
+    assert polygon["field_friendliness"] >= 0.8
+    assert 0.3 <= polygon["stall_safety"] <= 0.6
+    # Wing-loading axis covers RC slope range 50–150 g/dm² (in N/m²-equivalent scale)
+    lo, hi = preset.axis_ranges["wing_loading"]
+    assert lo == 50.0
+    assert hi == 150.0
 
 
 def test_each_preset_covers_all_seven_axes():
     expected_axes = {
-        "stall_safety", "glide", "climb", "cruise",
-        "maneuver", "wing_loading", "field_friendliness",
+        "stall_safety",
+        "glide",
+        "climb",
+        "cruise",
+        "maneuver",
+        "wing_loading",
+        "field_friendliness",
     }
     for p in SEED_PRESETS:
         assert set(p.target_polygon.keys()) == expected_axes, f"{p.id} target_polygon"

--- a/frontend/__tests__/MissionObjectivesPanel.test.tsx
+++ b/frontend/__tests__/MissionObjectivesPanel.test.tsx
@@ -24,6 +24,7 @@ vi.mock("@/hooks/useMissionPresets", () => ({
     data: [
       { id: "trainer", label: "Trainer", description: "", target_polygon: {}, axis_ranges: {}, suggested_estimates: { g_limit: 4, target_static_margin: 0.12, cl_max: 1.4, power_to_weight: 0.4, prop_efficiency: 0.6 } },
       { id: "sailplane", label: "Sailplane", description: "", target_polygon: {}, axis_ranges: {}, suggested_estimates: { g_limit: 2, target_static_margin: 0.18, cl_max: 1.2, power_to_weight: 0.0, prop_efficiency: 0.0 } },
+      { id: "slope_soarer", label: "Slope Soarer", description: "", target_polygon: {}, axis_ranges: {}, suggested_estimates: { g_limit: 6, target_static_margin: 0.08, cl_max: 1.1, power_to_weight: 0.0, prop_efficiency: 0.0 } },
     ],
     isLoading: false, error: null,
   }),
@@ -34,6 +35,8 @@ describe("MissionObjectivesPanel", () => {
     render(<MissionObjectivesPanel aeroplaneId="x"/>);
     expect(screen.getByRole("option", { name: /Trainer/ })).toBeInTheDocument();
     expect(screen.getByRole("option", { name: /Sailplane/ })).toBeInTheDocument();
+    // gh-582: slope_soarer surfaces in the selector once the backend seeds it.
+    expect(screen.getByRole("option", { name: /Slope Soarer/ })).toBeInTheDocument();
   });
 
   it("renders the field-performance section", () => {


### PR DESCRIPTION
## Summary

Adds a **Slope Soarer** mission preset — unpowered, high-wing-loading RC ridge/slope soaring. Pure schema + seed addition (no new physics): the existing `/mission-presets` endpoint and the existing dropdown selector pick up the new row automatically once it is seeded.

**Authority caveat:** RC-specific. `/rc-aircraft-designer` (RCPlaneDesigner.com) is the lead authority for this ticket, since the values come from RC slope-soaring practice (F3F-racer ballasted range, ridge-gust penetration) — not from Scholz/Sadraey full-scale-glider methodology.

## Changes

- `app/schemas/flight_profile.py` — `FlightProfileType.slope_soarer = "slope_soarer"`.
- `app/services/mission_preset_seed.py` — new `MissionPreset(id="slope_soarer", ...)` row.
- `alembic/versions/294aeab71af5_seed_slope_soarer_mission_preset.py` — idempotent data migration. Skips the insert if the row already exists (the row is also created on startup by `seed_mission_presets`).
- Backend tests:
  - `test_mission_preset_seed.py`: `test_seed_presets_exist` widened to 7 ids; new `test_slope_soarer_preset_defaults`.
  - `test_mission_objectives_endpoint.py`: `test_get_mission_presets_returns_all_seeded` (renamed from `..._returns_six`); new `test_get_mission_presets_exposes_slope_soarer_payload`.
  - `test_mission_objective_service.py`: `test_list_mission_presets_returns_all_seeded` (renamed); new `test_upsert_slope_soarer_writes_unpowered_estimates` — guarantees `power_to_weight=0` flows into `DesignAssumption`, which makes downstream `is_glider = p_to_w <= 0` fire.
  - `test_flight_profile_schema.py`: new `test_flight_profile_type_includes_slope_soarer` + `test_schema_accepts_slope_soarer_profile_type`.
- Frontend test:
  - `MissionObjectivesPanel.test.tsx` — adds `slope_soarer` to the mocked preset list and asserts it renders in the dropdown.

## Review-verified defaults

| Parameter | Value | Notes |
|---|---|---|
| `power_to_weight` | **0** | unpowered → `is_glider` auto-detected downstream |
| `prop_efficiency` | 0 | no propulsion |
| `target_static_margin` | **0.08** | less than thermal glider — favours maneuver |
| `cl_max` | **1.1** | symmetric / weakly-cambered RC slope airfoils |
| `g_limit` | **6** | aerobatic-capable |
| `wing_loading` axis | (50, 150) N/m² | covers F3F-racer ballasted range |
| `target_polygon` | high maneuver (0.80) + cruise (0.75) + field-friendliness (0.85), mid stall-safety (0.45), low climb (0.30) | RC slope-specific weighting |

## Slope-specific departures from `glider`

- **Higher wing loading** — gust penetration on ridge lift, not still-air thermal flight.
- **Low dihedral target** (0–2°, documented in `description`) — roll responsiveness over spiral stability.
- **High `maneuver` KPI weight** — F3F / aerobatic slope flying.
- **Hand-launch friendly** — `field_friendliness` axis weighted high.

## Out of scope (per ticket notes)

- New `aspect_ratio` / `wing_loading_g_dm2` / `dihedral_deg` / `airfoil_hints` schema fields. The current `MissionPreset` schema only carries `g_limit` / `target_static_margin` / `cl_max` / `power_to_weight` / `prop_efficiency`. The remaining RC slope geometry hints (AR 5–12, dihedral 1°, airfoils RG14 / RG15 / NACA 0012 / HN-354 / HN-1033 / SD7037) are embedded in the preset `description` string — visible to users via the existing UI without requiring a schema migration.
- Ballast capability flag (separate future issue).
- Slope-lift atmosphere / wind-profile modelling.

## Test plan

- [x] `poetry run pytest -m "not slow"` — 3615 passed.
- [x] `poetry run ruff check` / `ruff format --check` — clean on touched files.
- [x] `cd frontend && npm run test:unit` — 802 passed.
- [x] `cd frontend && npm run lint` — 0 errors.
- [x] `cd frontend && npm run deps:check` — 0 errors.
- [x] `alembic heads` — single head `294aeab71af5`.

Closes #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)