### PR TITLE
feat(gh-592): Trefftz Plane proper spinner + complete compute parameters in Plotly annotation

### DIFF
--- a/app/schemas/strip_forces.py
+++ b/app/schemas/strip_forces.py
@@ -1,5 +1,10 @@
 """Pydantic schemas for AVL strip-force distribution responses."""
 
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal, Optional
+
 from pydantic import BaseModel, Field
 
 
@@ -40,3 +45,39 @@ class StripForcesResponse(BaseModel):
     cref: float = Field(..., description="Reference chord (m)")
     bref: float = Field(..., description="Reference span (m)")
     surfaces: list[SurfaceStripForces] = Field(..., description="Per-surface strip forces")
+
+    # gh-592: full compute-parameter echo so the Trefftz-Plane Plotly annotation
+    # can display every input that produced the run. New fields are optional for
+    # backward-compatibility with any existing consumers, but the analysis
+    # service always populates them.
+    velocity_mps: Optional[float] = Field(
+        None, description="Freestream velocity (m/s) used for the run"
+    )
+    altitude_m: Optional[float] = Field(
+        None, description="Altitude (m) used to set the atmosphere"
+    )
+    xyz_ref_m: Optional[list[float]] = Field(
+        None,
+        description="Moment/CG reference point [x, y, z] in metres",
+        min_length=3,
+        max_length=3,
+    )
+    wing_name: Optional[str] = Field(
+        None,
+        description="Wing/aeroplane identifier the strip-forces were computed for",
+    )
+    reynolds: Optional[float] = Field(
+        None,
+        description="Reynolds number based on V, Cref, and the kinematic viscosity at altitude",
+    )
+    aero_model: Optional[Literal["AVL", "ASB"]] = Field(
+        "AVL",
+        description="Aerodynamic solver that produced the strip forces (today fixed to AVL)",
+    )
+    computed_at: Optional[datetime] = Field(
+        None, description="UTC timestamp when the run completed (ISO-8601)"
+    )
+    operating_point_label: Optional[str] = Field(
+        None,
+        description="Human-readable label of the bound stored operating point, if any",
+    )

--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -8,7 +8,7 @@ separated from HTTP concerns for better testability and reusability.
 import io
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from urllib.parse import urljoin
 from typing import Any, List, Optional
 from uuid import uuid4
@@ -1458,6 +1458,62 @@ async def get_three_view_image(db: Session, aeroplane_uuid) -> bytes:
         raise InternalError(message=f"Error generating diagram: {e}")
 
 
+def _reynolds_from_atmosphere(velocity: float, cref: float, altitude: float) -> float:
+    """Compute the chord-based Reynolds number for the strip-forces echo.
+
+    Uses Aerosandbox's standard atmosphere to get the kinematic viscosity at
+    ``altitude``. Returns ``0.0`` if any required input is non-positive or if
+    Aerosandbox is unavailable, so the strip-forces response can always be
+    built (gh-592).
+    """
+    if velocity <= 0.0 or cref <= 0.0:
+        return 0.0
+    try:
+        import aerosandbox as asb
+
+        nu = float(asb.Atmosphere(altitude=altitude).kinematic_viscosity())
+        if nu <= 0.0:
+            return 0.0
+        return float(velocity * cref / nu)
+    except Exception:  # pragma: no cover - defensive: aerosandbox missing
+        logger.exception("Failed to compute Reynolds number for strip-forces echo")
+        return 0.0
+
+
+def _build_strip_forces_response(
+    *,
+    avl_result: dict[str, Any],
+    surfaces: list[SurfaceStripForces],
+    resolved_op: OperatingPointSchema,
+    wing_name: str,
+    aero_model: str = "AVL",
+) -> StripForcesResponse:
+    """Construct the StripForcesResponse with full compute-parameter echo (gh-592)."""
+    cref = float(avl_result.get("Cref", 0) or 0)
+    reynolds = _reynolds_from_atmosphere(
+        velocity=float(resolved_op.velocity),
+        cref=cref,
+        altitude=float(resolved_op.altitude),
+    )
+    return StripForcesResponse(
+        alpha=avl_result.get("alpha", resolved_op.alpha),
+        beta=avl_result.get("beta", resolved_op.beta),
+        mach=avl_result.get("mach", 0),
+        sref=avl_result.get("Sref", 0),
+        cref=cref,
+        bref=avl_result.get("Bref", 0),
+        surfaces=surfaces,
+        velocity_mps=float(resolved_op.velocity),
+        altitude_m=float(resolved_op.altitude),
+        xyz_ref_m=[float(v) for v in resolved_op.xyz_ref],
+        wing_name=wing_name,
+        reynolds=reynolds,
+        aero_model=aero_model,
+        computed_at=datetime.now(timezone.utc),
+        operating_point_label=resolved_op.name,
+    )
+
+
 async def analyze_airplane_strip_forces(
     db: Session,
     aeroplane_uuid,
@@ -1544,14 +1600,11 @@ async def analyze_airplane_strip_forces(
                 )
             )
 
-        return StripForcesResponse(
-            alpha=result.get("alpha", resolved_op.alpha),
-            beta=result.get("beta", resolved_op.beta),
-            mach=result.get("mach", 0),
-            sref=result.get("Sref", 0),
-            cref=result.get("Cref", 0),
-            bref=result.get("Bref", 0),
+        return _build_strip_forces_response(
+            avl_result=result,
             surfaces=surfaces,
+            resolved_op=resolved_op,
+            wing_name=aircraft.name,
         )
     except ServiceException:
         raise
@@ -1637,14 +1690,11 @@ async def analyze_wing_strip_forces(
                 )
             )
 
-        return StripForcesResponse(
-            alpha=result.get("alpha", operating_point.alpha),
-            beta=result.get("beta", operating_point.beta),
-            mach=result.get("mach", 0),
-            sref=result.get("Sref", 0),
-            cref=result.get("Cref", 0),
-            bref=result.get("Bref", 0),
+        return _build_strip_forces_response(
+            avl_result=result,
             surfaces=surfaces,
+            resolved_op=operating_point,
+            wing_name=wing_name,
         )
     except Exception as e:
         logger.error(f"Error analyzing wing strip forces: {e}")

--- a/app/tests/test_analysis_service.py
+++ b/app/tests/test_analysis_service.py
@@ -965,3 +965,142 @@ class TestAnalyzeAlphaSweep:
         cp = result["characteristic_points"]
         assert cp["maximum_lift_coefficient_point"] is not None
         assert cp["trim_point_cm_equals_zero"] is not None
+
+
+# =========================================================================
+# gh-592: StripForcesResponse compute-parameter echo
+# =========================================================================
+
+
+class TestReynoldsFromAtmosphere:
+    """Reynolds helper used by the strip-forces response builder (gh-592)."""
+
+    def test_returns_zero_when_velocity_is_non_positive(self):
+        from app.services.analysis_service import _reynolds_from_atmosphere
+
+        assert _reynolds_from_atmosphere(0.0, 0.5, 0.0) == 0.0
+        assert _reynolds_from_atmosphere(-1.0, 0.5, 0.0) == 0.0
+
+    def test_returns_zero_when_cref_is_non_positive(self):
+        from app.services.analysis_service import _reynolds_from_atmosphere
+
+        assert _reynolds_from_atmosphere(15.0, 0.0, 0.0) == 0.0
+        assert _reynolds_from_atmosphere(15.0, -0.2, 0.0) == 0.0
+
+    def test_returns_positive_for_valid_inputs(self):
+        from app.services.analysis_service import _reynolds_from_atmosphere
+
+        # Sea-level air, V=15 m/s, c=0.5 m → Re ~ 5e5 (kinematic viscosity ~1.46e-5)
+        re = _reynolds_from_atmosphere(15.0, 0.5, 0.0)
+        assert re > 1e5
+        assert re < 1e7
+
+    def test_swallows_aerosandbox_import_failure(self, monkeypatch):
+        """If aerosandbox is unavailable, helper returns 0.0 rather than raise."""
+        import builtins as _builtins
+        from app.services import analysis_service as svc
+
+        real_import = _builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "aerosandbox":
+                raise ImportError("simulated missing aerosandbox")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(_builtins, "__import__", fake_import)
+        assert svc._reynolds_from_atmosphere(15.0, 0.5, 0.0) == 0.0
+
+
+class TestBuildStripForcesResponse:
+    """The response builder echoes every compute input back to the frontend."""
+
+    def _resolved_op(self):
+        from app.schemas.aeroanalysisschema import OperatingPointSchema
+
+        return OperatingPointSchema(
+            name="level_cruise",
+            velocity=15.0,
+            alpha=2.5,
+            beta=0.0,
+            altitude=500.0,
+            xyz_ref=[0.25, 0.0, 0.0],
+        )
+
+    def _avl_result(self):
+        return {
+            "alpha": 2.5,
+            "beta": 0.0,
+            "mach": 0.044,
+            "Sref": 0.6,
+            "Cref": 0.25,
+            "Bref": 2.4,
+        }
+
+    def test_populates_every_gh592_field(self):
+        from app.services.analysis_service import _build_strip_forces_response
+
+        resp = _build_strip_forces_response(
+            avl_result=self._avl_result(),
+            surfaces=[],
+            resolved_op=self._resolved_op(),
+            wing_name="main_wing",
+        )
+
+        assert resp.velocity_mps == pytest.approx(15.0)
+        assert resp.altitude_m == pytest.approx(500.0)
+        assert resp.xyz_ref_m == [pytest.approx(0.25), pytest.approx(0.0), pytest.approx(0.0)]
+        assert resp.wing_name == "main_wing"
+        assert resp.aero_model == "AVL"
+        assert resp.operating_point_label == "level_cruise"
+        assert resp.computed_at is not None
+        # Reynolds > 0 for valid V and Cref
+        assert resp.reynolds is not None
+        assert resp.reynolds > 0.0
+
+    def test_echoes_existing_fields_from_avl_result(self):
+        from app.services.analysis_service import _build_strip_forces_response
+
+        resp = _build_strip_forces_response(
+            avl_result=self._avl_result(),
+            surfaces=[],
+            resolved_op=self._resolved_op(),
+            wing_name="main_wing",
+        )
+
+        assert resp.alpha == pytest.approx(2.5)
+        assert resp.beta == pytest.approx(0.0)
+        assert resp.mach == pytest.approx(0.044)
+        assert resp.sref == pytest.approx(0.6)
+        assert resp.cref == pytest.approx(0.25)
+        assert resp.bref == pytest.approx(2.4)
+
+    def test_operating_point_label_none_when_unnamed(self):
+        from app.schemas.aeroanalysisschema import OperatingPointSchema
+        from app.services.analysis_service import _build_strip_forces_response
+
+        op = OperatingPointSchema(
+            velocity=20.0,
+            alpha=0.0,
+            beta=0.0,
+            altitude=0.0,
+            xyz_ref=[0.0, 0.0, 0.0],
+        )
+        resp = _build_strip_forces_response(
+            avl_result=self._avl_result(),
+            resolved_op=op,
+            surfaces=[],
+            wing_name="ac",
+        )
+        assert resp.operating_point_label is None
+
+    def test_aero_model_is_pluggable(self):
+        from app.services.analysis_service import _build_strip_forces_response
+
+        resp = _build_strip_forces_response(
+            avl_result=self._avl_result(),
+            surfaces=[],
+            resolved_op=self._resolved_op(),
+            wing_name="main_wing",
+            aero_model="ASB",
+        )
+        assert resp.aero_model == "ASB"

--- a/app/tests/test_operating_point_resolver.py
+++ b/app/tests/test_operating_point_resolver.py
@@ -419,9 +419,15 @@ class TestStreamlineServiceUsesResolvedOp:
         op = _make_op()
 
         with ExitStack() as stack:
+            # gh-592: aircraft.name now feeds the StripForcesResponse wing_name
+            # echo, so the mock must expose a real string. Note: passing
+            # ``name="..."`` to MagicMock() sets the mock's repr name, not the
+            # ``.name`` attribute — we have to assign it after construction.
+            aircraft_mock = MagicMock(id=7)
+            aircraft_mock.name = "test_plane"
             stack.enter_context(patch.object(
                 analysis_service, "get_aeroplane_or_raise",
-                return_value=MagicMock(id=7),
+                return_value=aircraft_mock,
             ))
             stack.enter_context(patch.object(
                 analysis_service, "get_aeroplane_schema_or_raise",

--- a/frontend/__tests__/TrefftzPlaneTabContent.test.tsx
+++ b/frontend/__tests__/TrefftzPlaneTabContent.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * gh-592: tests for the Trefftz-Plane spinner + compute-parameter annotation.
+ *
+ * Covers the two coordinated UX changes:
+ *  1. Loading state renders a Loader2 spinner (not the old plain text).
+ *  2. `buildTrefftzAnnotationText` produces a 4-line, structured readout
+ *     containing every echoed compute parameter.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import React from "react";
+import type { StripForcesResult } from "@/hooks/useStripForces";
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) =>
+    React.createElement("span", { ...props, "data-testid": "lucide-icon" });
+  return {
+    Maximize2: icon,
+    Minimize2: icon,
+    Settings: icon,
+    Wind: icon,
+    Ruler: icon,
+    Target: icon,
+    Navigation: icon,
+    Gauge: icon,
+    AlertTriangle: icon,
+    SlidersHorizontal: icon,
+    Activity: icon,
+    Loader2: icon,
+    Plane: icon,
+    TrendingUp: icon,
+    Zap: icon,
+    RefreshCw: icon,
+  };
+});
+
+// Some descendant components of AnalysisViewerPanel may import the dynamic
+// Plotly bundle at module load. We don't render TrefftzPlaneChart in these
+// tests (only the loading / empty branches and the annotation helper), but a
+// defensive mock keeps the test environment hermetic.
+vi.mock("plotly.js-gl3d-dist-min", () => ({
+  default: { react: vi.fn(), purge: vi.fn() },
+  react: vi.fn(),
+  purge: vi.fn(),
+}));
+
+function makeStripForces(overrides: Partial<StripForcesResult> = {}): StripForcesResult {
+  return {
+    alpha: 2.5,
+    beta: 0.0,
+    mach: 0.044,
+    sref: 0.6,
+    cref: 0.25,
+    bref: 2.4,
+    surfaces: [],
+    velocity_mps: 15.0,
+    altitude_m: 500,
+    xyz_ref_m: [0.25, 0.0, 0.0],
+    wing_name: "main_wing",
+    reynolds: 5.1e5,
+    aero_model: "AVL",
+    computed_at: "2026-05-19T14:07:00Z",
+    operating_point_label: "level_cruise",
+    ...overrides,
+  };
+}
+
+describe("buildTrefftzAnnotationText (gh-592)", () => {
+  it("emits four <br>-separated lines", async () => {
+    const { buildTrefftzAnnotationText } = await import(
+      "@/components/workbench/AnalysisViewerPanel"
+    );
+    const text = buildTrefftzAnnotationText(makeStripForces());
+    expect(text.split("<br>")).toHaveLength(4);
+  });
+
+  it("includes flow / geometry / reference / run sections", async () => {
+    const { buildTrefftzAnnotationText } = await import(
+      "@/components/workbench/AnalysisViewerPanel"
+    );
+    const text = buildTrefftzAnnotationText(makeStripForces());
+    expect(text).toMatch(/Flow/);
+    expect(text).toMatch(/Geometry/);
+    expect(text).toMatch(/Reference/);
+    expect(text).toMatch(/Run/);
+  });
+
+  it("renders every echoed compute parameter", async () => {
+    const { buildTrefftzAnnotationText } = await import(
+      "@/components/workbench/AnalysisViewerPanel"
+    );
+    const text = buildTrefftzAnnotationText(makeStripForces());
+    // Flow line
+    expect(text).toContain("α = 2.50°");
+    expect(text).toContain("β = 0.00°");
+    expect(text).toContain("V = 15.0 m/s");
+    expect(text).toContain("Mach = 0.044");
+    expect(text).toContain("Alt = 500 m");
+    // Geometry line
+    expect(text).toContain("Wing: main_wing");
+    expect(text).toContain("S_ref = 0.6000 m²");
+    expect(text).toContain("C_ref = 0.2500 m");
+    expect(text).toContain("B_ref = 2.4000 m");
+    // Reference line
+    expect(text).toContain("x_cg = (0.250, 0.000, 0.000) m");
+    expect(text).toContain("Re = 5.10e+5");
+    expect(text).toContain("Model: AVL");
+    // Run line
+    expect(text).toContain("2026-05-19T14:07:00Z");
+    expect(text).toContain("OP: level_cruise");
+  });
+
+  it("falls back to em-dash for missing fields", async () => {
+    const { buildTrefftzAnnotationText } = await import(
+      "@/components/workbench/AnalysisViewerPanel"
+    );
+    const partial: StripForcesResult = {
+      alpha: 0,
+      beta: 0,
+      mach: 0,
+      sref: 0,
+      cref: 0,
+      bref: 0,
+      surfaces: [],
+    };
+    const text = buildTrefftzAnnotationText(partial);
+    // Wing name + computed_at fall back to em-dash
+    expect(text).toContain("Wing: —");
+    expect(text).toMatch(/Run\s+—/);
+    // xyz_ref_m missing falls back to em-dash
+    expect(text).toContain("x_cg = —");
+    // OP label section absent
+    expect(text).not.toContain("OP:");
+  });
+
+  it("omits the OP-label suffix when operating_point_label is null", async () => {
+    const { buildTrefftzAnnotationText } = await import(
+      "@/components/workbench/AnalysisViewerPanel"
+    );
+    const text = buildTrefftzAnnotationText(
+      makeStripForces({ operating_point_label: null })
+    );
+    expect(text).not.toContain("OP:");
+  });
+
+  it("uses AVL as the default aero model when missing", async () => {
+    const { buildTrefftzAnnotationText } = await import(
+      "@/components/workbench/AnalysisViewerPanel"
+    );
+    const text = buildTrefftzAnnotationText(
+      makeStripForces({ aero_model: undefined })
+    );
+    expect(text).toContain("Model: AVL");
+  });
+});
+
+describe("TrefftzPlaneTabContent loading state (gh-592)", () => {
+  it("renders the Loader2 spinner under the data-testid hook when loading", async () => {
+    const { TrefftzPlaneTabContent } = await import(
+      "@/components/workbench/AnalysisViewerPanel"
+    );
+    const { getByTestId, getByText } = render(
+      <TrefftzPlaneTabContent stripForcesLoading={true} stripForces={null} />,
+    );
+    const spinner = getByTestId("trefftz-spinner");
+    expect(spinner).not.toBeNull();
+    // The Loader2 icon (mocked above with data-testid="lucide-icon") lives
+    // inside the spinner container.
+    expect(spinner.querySelector('[data-testid="lucide-icon"]')).not.toBeNull();
+    expect(getByText(/Running strip-force analysis/)).not.toBeNull();
+  });
+
+  it("renders empty-state copy when not loading and no surfaces", async () => {
+    const { TrefftzPlaneTabContent } = await import(
+      "@/components/workbench/AnalysisViewerPanel"
+    );
+    const { queryByTestId, getByText } = render(
+      <TrefftzPlaneTabContent stripForcesLoading={false} stripForces={null} />,
+    );
+    expect(queryByTestId("trefftz-spinner")).toBeNull();
+    expect(getByText(/Run an analysis to see strip-force distributions/)).not.toBeNull();
+  });
+});

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo, useRef, useEffect } from "react";
-import { Maximize2, Minimize2, Settings } from "lucide-react";
+import { Loader2, Maximize2, Minimize2, Settings } from "lucide-react";
 import { InfoChipRow } from "@/components/workbench/InfoChipRow";
 import type { AnalysisResult } from "@/hooks/useAnalysis";
 import type { StripForcesResult } from "@/hooks/useStripForces";
@@ -402,6 +402,42 @@ function buildSegmentMarkerTrace(
   };
 }
 
+// -- Trefftz Plane Compute-Parameter Annotation (gh-592) ------------------
+
+// gh-592: build the multi-line metadata text the Trefftz Plotly annotation
+// renders in the top-left of the figure. All compute parameters live INSIDE
+// the figure — no surrounding chrome. `<br>` is Plotly's line-break in
+// annotation text. Exported for direct unit testing.
+export function buildTrefftzAnnotationText(stripForces: StripForcesResult): string {
+  const fmtFixed = (value: number | undefined | null, digits: number, fallback = "—") =>
+    value == null || Number.isNaN(value) ? fallback : value.toFixed(digits);
+  const fmtExp = (value: number | undefined | null, digits: number, fallback = "—") =>
+    value == null || Number.isNaN(value) || value === 0 ? fallback : value.toExponential(digits);
+  const xyz = stripForces.xyz_ref_m ?? [];
+  const xyzStr = xyz.length >= 3
+    ? `(${fmtFixed(xyz[0], 3)}, ${fmtFixed(xyz[1], 3)}, ${fmtFixed(xyz[2], 3)}) m`
+    : "—";
+  const opLabel = stripForces.operating_point_label
+    ? `  ·  OP: ${stripForces.operating_point_label}`
+    : "";
+  const lines = [
+    `Flow      α = ${fmtFixed(stripForces.alpha, 2)}°  ·  ` +
+      `β = ${fmtFixed(stripForces.beta, 2)}°  ·  ` +
+      `V = ${fmtFixed(stripForces.velocity_mps, 1)} m/s  ·  ` +
+      `Mach = ${fmtFixed(stripForces.mach, 3)}  ·  ` +
+      `Alt = ${fmtFixed(stripForces.altitude_m, 0)} m`,
+    `Geometry  Wing: ${stripForces.wing_name ?? "—"}  ·  ` +
+      `S_ref = ${fmtFixed(stripForces.sref, 4)} m²  ·  ` +
+      `C_ref = ${fmtFixed(stripForces.cref, 4)} m  ·  ` +
+      `B_ref = ${fmtFixed(stripForces.bref, 4)} m`,
+    `Reference x_cg = ${xyzStr}  ·  ` +
+      `Re = ${fmtExp(stripForces.reynolds, 2)}  ·  ` +
+      `Model: ${stripForces.aero_model ?? "AVL"}`,
+    `Run       ${stripForces.computed_at ?? "—"}${opLabel}`,
+  ];
+  return lines.join("<br>");
+}
+
 // -- Trefftz Plane Combined Chart -----------------------------------------
 
 function TrefftzPlaneChart({
@@ -435,18 +471,15 @@ function TrefftzPlaneChart({
       }
 
       const shapes: PlotlyShape[] = [];
+      // gh-592: multi-line, structured compute-parameter readout. All metadata
+      // (flow / geometry / reference / run) stays INSIDE the Plotly figure \u2014
+      // no surrounding chrome (sidebar, header, footer).
       const annotations = [{
         x: 0.01, y: 0.98, xref: "paper", yref: "paper",
         xanchor: "left", yanchor: "top", showarrow: false,
+        align: "left",
         font: { color: "#71717A", family: "JetBrains Mono, monospace", size: 10 },
-        text: [
-          `\u03B1 = ${stripForces.alpha.toFixed(2)}\u00B0`,
-          `\u03B2 = ${stripForces.beta.toFixed(2)}\u00B0`,
-          `Mach = ${stripForces.mach.toFixed(3)}`,
-          `Sref = ${stripForces.sref.toFixed(4)} m\u00B2`,
-          `Cref = ${stripForces.cref.toFixed(4)} m`,
-          `Bref = ${stripForces.bref.toFixed(4)} m`,
-        ].join("  \u00B7  "),
+        text: buildTrefftzAnnotationText(stripForces),
       }];
 
       const layout = {
@@ -501,7 +534,8 @@ function TrefftzPlaneChart({
 
 // -- Tab Content Helpers --------------------------------------------------
 
-function TrefftzPlaneTabContent({
+// Exported for direct unit testing (gh-592).
+export function TrefftzPlaneTabContent({
   stripForcesLoading,
   stripForces,
   wingXSecs,
@@ -515,9 +549,15 @@ function TrefftzPlaneTabContent({
   if (stripForcesLoading) {
     return (
       <div className="flex flex-1 items-center justify-center">
-        <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-muted-foreground">
-          Running AVL strip-force analysis...
-        </span>
+        <div
+          className="flex items-center gap-2 text-muted-foreground"
+          data-testid="trefftz-spinner"
+        >
+          <Loader2 size={14} className="animate-spin" />
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px]">
+            Running strip-force analysis…
+          </span>
+        </div>
       </div>
     );
   }

--- a/frontend/hooks/useStripForces.ts
+++ b/frontend/hooks/useStripForces.ts
@@ -40,6 +40,17 @@ export interface StripForcesResult {
   cref: number;
   bref: number;
   surfaces: SurfaceStripForces[];
+  // gh-592: full compute-parameter echo for the Trefftz-Plane Plotly annotation.
+  // Optional for backward-compatibility — the backend always populates them now,
+  // but old cached responses or unit-test stubs may omit them.
+  velocity_mps?: number;
+  altitude_m?: number;
+  xyz_ref_m?: number[];
+  wing_name?: string;
+  reynolds?: number;
+  aero_model?: "AVL" | "ASB";
+  computed_at?: string;
+  operating_point_label?: string | null;
 }
 
 export interface StripForcesParams {


### PR DESCRIPTION
## Summary

Closes #592 — two coordinated UX fixes for the Analysis → Trefftz Plane view:

- **Real loading affordance.** Plain-text "Running AVL strip-force analysis…" replaced by `Loader2` + `animate-spin` (same pattern as the Recomputing pill in `InfoChipRow` from #575), wrapped in a `data-testid="trefftz-spinner"` container.
- **Complete compute-parameter readout inside the Plotly figure.** The single-line annotation (α, β, Mach, S_ref, C_ref, B_ref) is replaced by a structured four-line block:
  - `Flow      α · β · V · Mach · Alt`
  - `Geometry  Wing · S_ref · C_ref · B_ref`
  - `Reference x_cg · Re · Model`
  - `Run       <ISO timestamp>  ·  OP: <label>`

All metadata stays **inside** the Plotly figure — no surrounding chrome (sidebar / header / footer) — per the user preference noted in `feedback_plotly_inline_metadata.md`.

## Backend

- `StripForcesResponse` echoes every compute input back to the frontend: `velocity_mps`, `altitude_m`, `xyz_ref_m`, `wing_name`, `reynolds`, `aero_model` (Literal `"AVL" | "ASB"` for future-proofing), `computed_at`, `operating_point_label`. All optional for backward-compatibility.
- `_reynolds_from_atmosphere` computes Re from `V × Cref / ν(altitude)` via AeroSandbox's standard atmosphere, returning `0.0` on missing inputs or import failure.
- `_build_strip_forces_response` centralises response construction for both `analyze_airplane_strip_forces` and `analyze_wing_strip_forces`.

## Frontend

- `StripForcesResult` interface extended with the new optional echo fields.
- `buildTrefftzAnnotationText` helper assembles the multi-line metadata block with em-dash fallbacks for missing fields, exponential format for Re, and suppresses the `OP: …` suffix when no operating-point label is bound.
- `TrefftzPlaneTabContent` exported for direct unit testing.
- `Loader2` added to the `lucide-react` imports.

## Tests

- **Backend (8 new pytest cases):** `_reynolds_from_atmosphere` (zero / invalid / valid / aerosandbox-missing) and `_build_strip_forces_response` (every gh-592 field populated, AVL echo fields preserved, OP-label None handling, pluggable aero model). Full fast suite green: **3618 passed, 2 xfailed**.
- **Frontend (8 new vitest cases):** 4 for the annotation helper (structure / sections / every field / em-dash fallbacks / OP-suffix absent / default model), 2 for `TrefftzPlaneTabContent` loading / empty branches. Full suite green: **810 passed**.
- `test_strip_forces_service_calls_resolver`: mock setup updated to give `aircraft.name` a real string so the new `wing_name` echo passes Pydantic validation.

## Test plan

- [x] `poetry run pytest -m "not slow"` — 3618 passed
- [x] `cd frontend && npm run test:unit` — 810 passed
- [x] `cd frontend && npm run lint` — 0 errors, 8 pre-existing warnings
- [x] `cd frontend && npm run deps:check` — 0 errors, 6 pre-existing warnings
- [x] `poetry run ruff check` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)