### PR TITLE
feat(gh-580): add Motorsegler (motor glider) mission preset

### DIFF
--- a/alembic/versions/e7387f35f31e_seed_motor_glider_mission_preset.py
+++ b/alembic/versions/e7387f35f31e_seed_motor_glider_mission_preset.py
@@ -1,0 +1,75 @@
+"""seed motor_glider mission preset
+
+Revision ID: e7387f35f31e
+Revises: 294aeab71af5
+Create Date: 2026-05-20 23:35:00.000000
+
+Adds the Motorsegler (motor glider) mission preset (gh-580). Self-launching
+sailplane geometry with a small climb-only powerplant. Idempotent: skips
+the insert if the preset id already exists (e.g. when the row was already
+created at startup by ``seed_mission_presets``).
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "e7387f35f31e"
+down_revision: Union[str, None] = "294aeab71af5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_MOTOR_GLIDER_ID = "motor_glider"
+
+
+def upgrade() -> None:
+    """Insert the motor_glider preset row if missing.
+
+    The row is idempotent: re-running upgrade() on a DB that already
+    has the row (typically because the app started and ran
+    ``seed_mission_presets``) is a no-op.
+    """
+    conn = op.get_bind()
+    existing = conn.execute(
+        sa.text("SELECT id FROM mission_presets WHERE id = :id"),
+        {"id": _MOTOR_GLIDER_ID},
+    ).fetchone()
+    if existing is not None:
+        return
+
+    from app.services.mission_preset_seed import SEED_PRESETS
+
+    preset = next(p for p in SEED_PRESETS if p.id == _MOTOR_GLIDER_ID)
+
+    op.bulk_insert(
+        sa.table(
+            "mission_presets",
+            sa.column("id", sa.String),
+            sa.column("label", sa.String),
+            sa.column("description", sa.String),
+            sa.column("target_polygon", sa.JSON),
+            sa.column("axis_ranges", sa.JSON),
+            sa.column("suggested_estimates", sa.JSON),
+        ),
+        [
+            {
+                "id": preset.id,
+                "label": preset.label,
+                "description": preset.description,
+                "target_polygon": preset.target_polygon,
+                "axis_ranges": {k: list(v) for k, v in preset.axis_ranges.items()},
+                "suggested_estimates": preset.suggested_estimates.model_dump(),
+            }
+        ],
+    )
+
+
+def downgrade() -> None:
+    """Remove the motor_glider preset row."""
+    op.execute(
+        sa.text("DELETE FROM mission_presets WHERE id = :id").bindparams(id=_MOTOR_GLIDER_ID)
+    )

--- a/app/services/mission_preset_seed.py
+++ b/app/services/mission_preset_seed.py
@@ -226,4 +226,51 @@ SEED_PRESETS: list[MissionPreset] = [
             prop_efficiency=0.0,
         ),
     ),
+    MissionPreset(
+        id="motor_glider",
+        label="Motorsegler (Motor Glider)",
+        description=(
+            "Self-launching motor glider — high-AR sailplane geometry with a "
+            "small climb-only powerplant (folding or retractable prop). "
+            "Aspect ratio default 15 (range 14–22): Stemme S10 ≈ 22 (upper "
+            "end), ASK-21 Mi ≈ 16, Grob G109 ≈ 16.6. Wing loading mid "
+            "(~35 g/dm² typical for RC; ~30–45 kg/m² full-scale). "
+            "Power-to-weight 80–150 W/kg covers self-launch climb. "
+            "Caveat: prop_efficiency=0.65 reflects the climb segment with a "
+            "folding/feathering prop; in glide the prop is stowed and the "
+            "drag contribution is implicit (≈ 0). The current schema carries "
+            "a single value, so 0.65 is the climb assumption. "
+            "g_limit=5.3 cites CS-22.337 utility-category ultimate factor "
+            "(1.5 × +3.5 limit) for sailplanes and powered sailplanes. "
+            "Note: L/D ≥ 20 is a market convention (FAI Self-Launching "
+            "Glider classification), NOT a CS-22 requirement; the achieved "
+            "L/D depends on the cleanly retracted-prop polar and must be "
+            "verified post-VLM."
+        ),
+        target_polygon={
+            "stall_safety": 0.65,
+            "glide": 0.85,
+            "climb": 0.50,
+            "cruise": 0.55,
+            "maneuver": 0.30,
+            "wing_loading": 0.45,
+            "field_friendliness": 0.60,
+        },
+        axis_ranges={
+            "stall_safety": (1.3, 2.0),
+            "glide": (15.0, 30.0),
+            "climb": (5.0, 25.0),
+            "cruise": (15.0, 35.0),
+            "maneuver": (3.0, 6.0),
+            "wing_loading": (20.0, 80.0),
+            "field_friendliness": (3.0, 100.0),
+        },
+        suggested_estimates=MissionPresetEstimates(
+            g_limit=5.3,
+            target_static_margin=0.10,
+            cl_max=1.4,
+            power_to_weight=100.0,
+            prop_efficiency=0.65,
+        ),
+    ),
 ]

--- a/app/tests/test_mission_objective_service.py
+++ b/app/tests/test_mission_objective_service.py
@@ -68,7 +68,7 @@ def test_upsert_creates_then_updates(client_and_db):
 
 
 def test_list_mission_presets_returns_all_seeded(client_and_db):
-    """gh-582: slope_soarer is in the seeded library alongside the original six."""
+    """gh-580: motor_glider is in the seeded library alongside the original seven."""
     _, SessionLocal = client_and_db
     with SessionLocal() as db:
         presets = list_mission_presets(db)
@@ -81,6 +81,7 @@ def test_list_mission_presets_returns_all_seeded(client_and_db):
         "acro_3d",
         "stol_bush",
         "slope_soarer",
+        "motor_glider",
     }
 
 
@@ -186,6 +187,40 @@ def test_upsert_slope_soarer_writes_unpowered_estimates(client_and_db):
         assert rows["cl_max"].estimate_value == 1.1
         assert rows["power_to_weight"].estimate_value == 0.0
         assert rows["prop_efficiency"].estimate_value == 0.0
+
+
+def test_upsert_motor_glider_writes_powered_estimates(client_and_db):
+    """gh-580: switching to motor_glider writes power_to_weight=100 so downstream
+    ``is_glider = p_to_w <= 0`` correctly treats it as a powered aircraft
+    (V_max chip and other powered-only outputs remain enabled)."""
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        from app.tests.conftest import make_aeroplane
+        from app.services.design_assumptions_service import seed_defaults
+        from app.models.aeroplanemodel import DesignAssumptionModel
+
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aircraft_id = aeroplane.id
+
+    with SessionLocal() as db:
+        upsert_mission_objective(db, aircraft_id, _make_objective(mission_type="motor_glider"))
+        db.commit()
+
+    with SessionLocal() as db:
+        rows = {
+            r.parameter_name: r
+            for r in db.query(DesignAssumptionModel).filter_by(aeroplane_id=aircraft_id).all()
+        }
+        # motor_glider preset values from app/services/mission_preset_seed.py
+        assert rows["g_limit"].estimate_value == 5.3
+        assert rows["target_static_margin"].estimate_value == 0.10
+        assert rows["cl_max"].estimate_value == 1.4
+        assert rows["power_to_weight"].estimate_value == 100.0
+        assert rows["prop_efficiency"].estimate_value == 0.65
+        # Critical: powered → is_glider=False downstream
+        assert rows["power_to_weight"].estimate_value > 0
 
 
 def test_upsert_no_change_in_mission_type_does_not_rewrite_estimates(client_and_db):

--- a/app/tests/test_mission_objectives_endpoint.py
+++ b/app/tests/test_mission_objectives_endpoint.py
@@ -49,7 +49,7 @@ def test_put_mission_objectives_persists(client_and_db):
 
 
 def test_get_mission_presets_returns_all_seeded(client_and_db):
-    """gh-582: seven seeded presets including the new slope_soarer."""
+    """gh-580: eight seeded presets including the new motor_glider."""
     client, _ = client_and_db
     r = client.get("/mission-presets")
     assert r.status_code == 200
@@ -62,6 +62,7 @@ def test_get_mission_presets_returns_all_seeded(client_and_db):
         "acro_3d",
         "stol_bush",
         "slope_soarer",
+        "motor_glider",
     }
 
 
@@ -77,6 +78,21 @@ def test_get_mission_presets_exposes_slope_soarer_payload(client_and_db):
     assert est["target_static_margin"] == 0.08
     assert est["cl_max"] == 1.1
     assert est["g_limit"] == 6.0
+
+
+def test_get_mission_presets_exposes_motor_glider_payload(client_and_db):
+    """gh-580: the Motorsegler preset surfaces via the public API with expected fields."""
+    client, _ = client_and_db
+    r = client.get("/mission-presets")
+    assert r.status_code == 200
+    preset = next(p for p in r.json() if p["id"] == "motor_glider")
+    assert preset["label"] == "Motorsegler (Motor Glider)"
+    est = preset["suggested_estimates"]
+    assert est["power_to_weight"] == 100.0
+    assert est["prop_efficiency"] == 0.65
+    assert est["target_static_margin"] == 0.10
+    assert est["cl_max"] == 1.4
+    assert est["g_limit"] == 5.3
 
 
 def test_get_mission_kpis_returns_seven_axes(client_and_db):

--- a/app/tests/test_mission_preset_seed.py
+++ b/app/tests/test_mission_preset_seed.py
@@ -6,7 +6,7 @@ from app.services.mission_preset_seed import SEED_PRESETS
 
 
 def test_seed_presets_exist():
-    """gh-582: slope_soarer added to the canonical preset set."""
+    """gh-580: motor_glider added to the canonical preset set."""
     ids = {p.id for p in SEED_PRESETS}
     assert ids == {
         "trainer",
@@ -16,6 +16,7 @@ def test_seed_presets_exist():
         "acro_3d",
         "stol_bush",
         "slope_soarer",
+        "motor_glider",
     }
 
 
@@ -39,6 +40,57 @@ def test_slope_soarer_preset_defaults():
     lo, hi = preset.axis_ranges["wing_loading"]
     assert lo == 50.0
     assert hi == 150.0
+
+
+def test_motor_glider_preset_defaults():
+    """gh-580: Motorsegler carries the Scholz-review-verified defaults."""
+    preset = next(p for p in SEED_PRESETS if p.id == "motor_glider")
+    assert preset.label == "Motorsegler (Motor Glider)"
+    est = preset.suggested_estimates
+    # Powered: power_to_weight=100 W/kg covers self-launch climb (80–150 range)
+    assert est.power_to_weight == 100.0
+    # Climb-segment prop efficiency for folding/feathering prop
+    assert est.prop_efficiency == 0.65
+    # Slightly more stable than sport, conservative for cross-country glide
+    assert est.target_static_margin == 0.10
+    # Cambered laminar profile, no stall protection needed
+    assert est.cl_max == 1.4
+    # CS-22.337 utility-category ultimate factor (1.5 × +3.5 limit)
+    assert est.g_limit == 5.3
+    # KPI polygon: high glide, mid climb/cruise/stall, low maneuver
+    polygon = preset.target_polygon
+    assert polygon["glide"] >= 0.8
+    assert polygon["stall_safety"] == 0.65
+    assert polygon["climb"] == 0.50
+    assert polygon["cruise"] == 0.55
+    assert polygon["maneuver"] <= 0.35
+    assert polygon["wing_loading"] == 0.45
+    assert polygon["field_friendliness"] == 0.60
+
+
+def test_motor_glider_is_powered_for_is_glider_flag():
+    """gh-580: motor_glider has power_to_weight > 0 so downstream
+    ``is_glider = p_to_w <= 0`` correctly treats it as a powered aircraft.
+    This is the key behavioural distinction from the unpowered ``sailplane``
+    and ``slope_soarer`` presets."""
+    preset = next(p for p in SEED_PRESETS if p.id == "motor_glider")
+    assert preset.suggested_estimates.power_to_weight > 0
+    # Sanity: compare with the unpowered presets
+    sailplane = next(p for p in SEED_PRESETS if p.id == "sailplane")
+    slope_soarer = next(p for p in SEED_PRESETS if p.id == "slope_soarer")
+    assert sailplane.suggested_estimates.power_to_weight == 0.0
+    assert slope_soarer.suggested_estimates.power_to_weight == 0.0
+
+
+def test_motor_glider_description_cites_cs22_and_clarifies_ld_market_convention():
+    """gh-580 (Scholz review): the description must (a) cite CS-22.337 for
+    g_limit and (b) explicitly state that L/D ≥ 20 is market convention,
+    NOT a CS-22 requirement, to avoid propagating the regulatory myth."""
+    preset = next(p for p in SEED_PRESETS if p.id == "motor_glider")
+    description = preset.description
+    assert "CS-22.337" in description
+    assert "market convention" in description.lower()
+    assert "L/D" in description
 
 
 def test_each_preset_covers_all_seven_axes():

--- a/frontend/__tests__/MissionObjectivesPanel.test.tsx
+++ b/frontend/__tests__/MissionObjectivesPanel.test.tsx
@@ -25,6 +25,7 @@ vi.mock("@/hooks/useMissionPresets", () => ({
       { id: "trainer", label: "Trainer", description: "", target_polygon: {}, axis_ranges: {}, suggested_estimates: { g_limit: 4, target_static_margin: 0.12, cl_max: 1.4, power_to_weight: 0.4, prop_efficiency: 0.6 } },
       { id: "sailplane", label: "Sailplane", description: "", target_polygon: {}, axis_ranges: {}, suggested_estimates: { g_limit: 2, target_static_margin: 0.18, cl_max: 1.2, power_to_weight: 0.0, prop_efficiency: 0.0 } },
       { id: "slope_soarer", label: "Slope Soarer", description: "", target_polygon: {}, axis_ranges: {}, suggested_estimates: { g_limit: 6, target_static_margin: 0.08, cl_max: 1.1, power_to_weight: 0.0, prop_efficiency: 0.0 } },
+      { id: "motor_glider", label: "Motorsegler (Motor Glider)", description: "", target_polygon: {}, axis_ranges: {}, suggested_estimates: { g_limit: 5.3, target_static_margin: 0.10, cl_max: 1.4, power_to_weight: 100, prop_efficiency: 0.65 } },
     ],
     isLoading: false, error: null,
   }),
@@ -37,6 +38,8 @@ describe("MissionObjectivesPanel", () => {
     expect(screen.getByRole("option", { name: /Sailplane/ })).toBeInTheDocument();
     // gh-582: slope_soarer surfaces in the selector once the backend seeds it.
     expect(screen.getByRole("option", { name: /Slope Soarer/ })).toBeInTheDocument();
+    // gh-580: motor_glider (Motorsegler) surfaces in the selector once seeded.
+    expect(screen.getByRole("option", { name: /Motorsegler/ })).toBeInTheDocument();
   });
 
   it("renders the field-performance section", () => {


### PR DESCRIPTION
## Summary

Adds a **Motorsegler** mission preset — self-launching sailplane with a
small climb-only powerplant. Mirrors the slope_soarer pattern from #595:
new `SEED_PRESETS` row + idempotent Alembic data migration + targeted
tests. The existing `/mission-presets` endpoint and dropdown selector
pick up the new row automatically once it is seeded.

The `motor_glider` enum value already exists in `FlightProfileType`, so
this PR is purely a preset addition (no schema migration of geometry
fields — they remain embedded in the description text per the existing
convention).

## Review-verified defaults (Scholz expert review on #580)

| Parameter | Value | Notes |
|---|---|---|
| `power_to_weight` | **100 W/kg** | self-launch climb (range 80–150) |
| `prop_efficiency` | **0.65** | climb-segment folding/feathering prop |
| `target_static_margin` | **0.10** | conservative cross-country glide |
| `cl_max` | **1.4** | cambered laminar profile (clean) |
| `g_limit` | **5.3** | CS-22.337 utility ultimate factor (1.5 × +3.5) |

KPI polygon (7 axes, 0–1): stall_safety 0.65 / glide 0.85 / climb 0.50 /
cruise 0.55 / maneuver 0.30 / wing_loading 0.45 / field_friendliness 0.60.

## Scholz review corrections (vs. the original ticket draft)

1. **AR default = 15 (was 18)**, range 14–22 (was 14–25). AR 18 was
   structurally aggressive; Stemme S10 ≈ 22 is the upper bound, ASK-21 Mi
   ≈ 16 and Grob G109 ≈ 16.6 sit closer to the new default. AR is
   embedded in description text (schema doesn't carry geometry fields).
2. **L/D ≥ 20 is market convention (FAI Self-Launching Glider), NOT a
   CS-22 requirement.** Description text states this explicitly to avoid
   propagating the regulatory myth. Achieved L/D depends on the
   retracted-prop polar and must be verified post-VLM.
3. **`prop_efficiency=0.65` caveat:** the schema carries a single value;
   0.65 reflects the climb segment with a folding/feathering prop. In
   glide the prop is stowed and the drag contribution is implicit (≈ 0).
   Documented in the description.

## Changes

- `app/services/mission_preset_seed.py` — new
  `MissionPreset(id="motor_glider", ...)` row.
- `alembic/versions/e7387f35f31e_seed_motor_glider_mission_preset.py` —
  idempotent data migration (skips insert if the row already exists).
- Backend tests:
  - `test_mission_preset_seed.py`: widened existence check to 8 ids;
    new `test_motor_glider_preset_defaults`,
    `test_motor_glider_is_powered_for_is_glider_flag`,
    `test_motor_glider_description_cites_cs22_and_clarifies_ld_market_convention`.
  - `test_mission_objectives_endpoint.py`: widened existence check to 8
    ids; new `test_get_mission_presets_exposes_motor_glider_payload`.
  - `test_mission_objective_service.py`: widened existence check to 8
    ids; new `test_upsert_motor_glider_writes_powered_estimates` —
    guarantees `power_to_weight=100` flows into `DesignAssumption`, so
    downstream `is_glider = p_to_w <= 0` correctly returns False (V_max
    chip and other powered-only outputs stay enabled).
- Frontend test:
  - `MissionObjectivesPanel.test.tsx` — adds `motor_glider` to the
    mocked preset list and asserts "Motorsegler" renders in the dropdown.

## Departures from `sailplane`

- **Powered** (`power_to_weight=100`) — distinguishes from the unpowered
  `sailplane` preset; downstream `is_glider` auto-detection sees it as a
  powered aircraft.
- **More cruise / climb weight** in the target polygon to reflect the
  self-launch mission.
- **Higher wing_loading axis range** (20–80 vs 10–50) to reflect the
  engine + battery / fuel mass penalty.

## Out of scope (per ticket notes)

- Schema fields for `aspect_ratio` / `dihedral_deg` / `airfoil_hints` —
  embedded in description string (same convention as #595).
- Separate `prop_efficiency` for climb vs. glide (single value today;
  documented as climb assumption).
- Post-VLM L/D verification test (acceptance criterion noted in ticket
  but a real VLM run is too heavy for a unit test; tracked as follow-up).
- CG-with-engine-at-nose computation (generic, not type-specific).

## Test plan

- [x] `poetry run pytest -m "not slow"` — 3632 passed.
- [x] `poetry run ruff check .` / `ruff format --check` on touched files — clean.
- [x] `poetry run pyright` on touched files — 0 errors, 0 warnings.
- [x] `cd frontend && npm run test:unit` — 811 passed.
- [x] `cd frontend && npm run lint` — 0 errors.
- [x] `cd frontend && npm run deps:check` — 0 errors.
- [x] `poetry run alembic heads` — single head `e7387f35f31e`.

References EPIC #578 and the Scholz expert review comment on #580.

Closes #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)