### PR TITLE
feat(gh-593): add Sref and Bref chips to InfoChipRow

### DIFF
--- a/frontend/__tests__/AnalysisWingGate.test.tsx
+++ b/frontend/__tests__/AnalysisWingGate.test.tsx
@@ -21,6 +21,8 @@ vi.mock("lucide-react", () => {
     TrendingUp: icon,
     Zap: icon,
     RefreshCw: icon,
+    Square: icon,
+    ArrowLeftRight: icon,
   };
 });
 

--- a/frontend/__tests__/InfoChipRow.test.tsx
+++ b/frontend/__tests__/InfoChipRow.test.tsx
@@ -19,6 +19,8 @@ vi.mock("lucide-react", () => {
     TrendingUp: icon,
     Zap: icon,
     RefreshCw: icon,
+    Square: icon,
+    ArrowLeftRight: icon,
   };
 });
 
@@ -181,6 +183,7 @@ describe("Info Chip Row", () => {
   });
 
   // gh-575: chip row splits into two rows (envelope speeds, aero geometry).
+  // gh-593: geometry row now includes S_ref and B_ref alongside MAC.
   it("splits envelope speeds and aero geometry into two separate rows", async () => {
     (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
       data: {
@@ -195,6 +198,8 @@ describe("Info Chip Row", () => {
         v_dive_mps: 30.0,
         reynolds: 230000,
         mac_m: 0.21,
+        s_ref_m2: 0.42,
+        b_ref_m: 2.0,
         x_np_m: 0.085,
         target_static_margin: 0.12,
         cg_agg_m: 0.092,
@@ -214,14 +219,123 @@ describe("Info Chip Row", () => {
     expect(speedsRow).toContainElement(screen.getByRole("group", { name: /V min sink/ }));
     expect(speedsRow).toContainElement(screen.getByRole("group", { name: /^V max:/ }));
 
-    // Aero geometry belongs to row 2.
+    // Aero geometry belongs to row 2 (gh-593: includes S_ref + B_ref).
     expect(geometryRow).toContainElement(screen.getByRole("group", { name: /^Re:/ }));
+    expect(geometryRow).toContainElement(screen.getByRole("group", { name: /^S ref:/ }));
     expect(geometryRow).toContainElement(screen.getByRole("group", { name: /^MAC:/ }));
+    expect(geometryRow).toContainElement(screen.getByRole("group", { name: /^B ref:/ }));
     expect(geometryRow).toContainElement(screen.getByRole("group", { name: /^CG:/ }));
 
     // No chip is placed in the wrong row.
     expect(geometryRow).not.toContainElement(screen.getByRole("group", { name: /^V stall:/ }));
     expect(speedsRow).not.toContainElement(screen.getByRole("group", { name: /^Re:/ }));
+  });
+
+  // gh-593: S_ref chip renders with the formatted area value (3 decimals + " m²").
+  it("renders S_ref chip with the s_ref_m2 value formatted as area", async () => {
+    (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        reynolds: 230000,
+        mac_m: 0.21,
+        s_ref_m2: 0.42,
+        b_ref_m: 2.0,
+        x_np_m: 0.085,
+        target_static_margin: 0.12,
+        cg_agg_m: 0.092,
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
+    render(<InfoChipRow aeroplaneId="42" cgAero={0.073} />);
+
+    const sRefChip = screen.getByRole("group", { name: /^S ref:/ });
+    expect(sRefChip).toBeInTheDocument();
+    expect(sRefChip.textContent).toMatch(/0\.420 m²/);
+    // Tooltip explains the coefficient formula (drag/lift non-dim).
+    expect(sRefChip.getAttribute("aria-label")).toMatch(/Reference area/);
+    expect(sRefChip.getAttribute("aria-label")).toMatch(/C_L = L \/ \(q · S_ref\)/);
+  });
+
+  // gh-593: B_ref chip renders with the formatted span value (2 decimals + " m").
+  it("renders B_ref chip with the b_ref_m value formatted as length", async () => {
+    (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        reynolds: 230000,
+        mac_m: 0.21,
+        s_ref_m2: 0.42,
+        b_ref_m: 2.0,
+        x_np_m: 0.085,
+        target_static_margin: 0.12,
+        cg_agg_m: 0.092,
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
+    render(<InfoChipRow aeroplaneId="42" cgAero={0.073} />);
+
+    const bRefChip = screen.getByRole("group", { name: /^B ref:/ });
+    expect(bRefChip).toBeInTheDocument();
+    expect(bRefChip.textContent).toMatch(/2\.00 m/);
+    // Tooltip explains the moment-coefficient formula (roll/yaw non-dim).
+    expect(bRefChip.getAttribute("aria-label")).toMatch(/Reference span/);
+    expect(bRefChip.getAttribute("aria-label")).toMatch(
+      /C_l = M_roll \/ \(q · S_ref · B_ref\)/,
+    );
+  });
+
+  // gh-593: MAC tooltip explicitly calls out the C_ref alias used in AVL / ASB.
+  it("MAC chip description mentions C_ref alias", async () => {
+    (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        reynolds: 230000,
+        mac_m: 0.21,
+        s_ref_m2: 0.42,
+        b_ref_m: 2.0,
+        x_np_m: 0.085,
+        target_static_margin: 0.12,
+        cg_agg_m: 0.092,
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
+    render(<InfoChipRow aeroplaneId="42" cgAero={0.073} />);
+
+    const macChip = screen.getByRole("group", { name: /^MAC:/ });
+    expect(macChip.getAttribute("aria-label")).toMatch(/C_ref/);
+    // The tooltip should also still contain the pitching-moment formula.
+    expect(macChip.getAttribute("aria-label")).toMatch(
+      /C_m = M_pitch \/ \(q · S_ref · C_ref\)/,
+    );
+  });
+
+  // gh-593: when s_ref_m2 / b_ref_m are missing, chips render dash placeholders.
+  it("renders dashes for S_ref / B_ref when values are missing from context", async () => {
+    (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        reynolds: 230000,
+        mac_m: 0.21,
+        // s_ref_m2 / b_ref_m intentionally absent
+        x_np_m: 0.085,
+        target_static_margin: 0.12,
+        cg_agg_m: 0.092,
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
+    render(<InfoChipRow aeroplaneId="42" cgAero={0.073} />);
+
+    const sRefChip = screen.getByRole("group", { name: /^S ref:/ });
+    const bRefChip = screen.getByRole("group", { name: /^B ref:/ });
+    expect(sRefChip.textContent).toMatch(/=\s*–/);
+    expect(bRefChip.textContent).toMatch(/=\s*–/);
   });
 
   // gh-575: refresh button invokes mutate (SWR revalidation) on click.

--- a/frontend/__tests__/TrefftzPlaneTabContent.test.tsx
+++ b/frontend/__tests__/TrefftzPlaneTabContent.test.tsx
@@ -31,6 +31,8 @@ vi.mock("lucide-react", () => {
     TrendingUp: icon,
     Zap: icon,
     RefreshCw: icon,
+    Square: icon,
+    ArrowLeftRight: icon,
   };
 });
 

--- a/frontend/__tests__/buildAnalysisRightSlot.test.tsx
+++ b/frontend/__tests__/buildAnalysisRightSlot.test.tsx
@@ -21,6 +21,8 @@ vi.mock("lucide-react", () => {
     TrendingUp: icon,
     Zap: icon,
     RefreshCw: icon,
+    Square: icon,
+    ArrowLeftRight: icon,
   };
 });
 

--- a/frontend/components/workbench/InfoChipRow.tsx
+++ b/frontend/components/workbench/InfoChipRow.tsx
@@ -12,6 +12,8 @@ import {
   RefreshCw,
   TrendingUp,
   Zap,
+  Square,
+  ArrowLeftRight,
 } from "lucide-react";
 import { useComputationContext } from "@/hooks/useComputationContext";
 import { renderSymbol } from "@/components/workbench/renderSymbol";
@@ -231,11 +233,28 @@ export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: P
           value={fmtRe(ctx?.reynolds)}
           stale={stale}
         />
+        {/* gh-593: reference triplet S_ref · MAC · B_ref grouped for visual
+            cohesion. All three are the AVL/ASB non-dimensionalisation
+            references for force and moment coefficients. */}
+        <Chip
+          icon={Square}
+          symbol="S_ref"
+          description="Reference area — projected wing area used to non-dimensionalize forces (C_L = L / (q · S_ref))"
+          value={fmt(ctx?.s_ref_m2, 3, " m²")}
+          stale={stale}
+        />
         <Chip
           icon={Ruler}
           symbol="MAC"
-          description="Mean Aerodynamic Chord — reference length for force and moment coefficients"
+          description="Mean Aerodynamic Chord (= C_ref in AVL/ASB) — reference chord for pitching moment coefficient (C_m = M_pitch / (q · S_ref · C_ref))"
           value={fmt(ctx?.mac_m, 2, " m")}
+          stale={stale}
+        />
+        <Chip
+          icon={ArrowLeftRight}
+          symbol="B_ref"
+          description="Reference span — wingspan used to non-dimensionalize roll and yaw moments (C_l = M_roll / (q · S_ref · B_ref))"
+          value={fmt(ctx?.b_ref_m, 2, " m")}
           stale={stale}
         />
         <Chip

--- a/frontend/hooks/useComputationContext.ts
+++ b/frontend/hooks/useComputationContext.ts
@@ -19,6 +19,9 @@ export interface ComputationContext {
   reynolds: number;
   mac_m: number;
   s_ref_m2?: number | null;
+  // gh-593: reference span (main wing), surfaced as the B_ref chip alongside
+  // S_ref and MAC for coefficient non-dimensionalisation.
+  b_ref_m?: number | null;
   aspect_ratio?: number | null;
   x_np_m: number;
   target_static_margin: number;


### PR DESCRIPTION
## Summary

Adds the missing **S_ref** and **B_ref** chips to the workbench
`InfoChipRow` so the full AVL/ASB reference triplet
(`S_ref · MAC · B_ref`) is always visible alongside the existing
geometry chips — symmetric with the values already echoed in the
Trefftz-Plane plot annotation (#592).

Closes #593

## Changes

**Frontend**
- `useComputationContext`: TS interface gains `b_ref_m?: number | null`.
  Backend already returns the value (gh-491 sub-task in
  `assumption_compute_service.py:461`); only the TS type was lagging.
- `InfoChipRow` row 2 now renders:
  `Re · S_ref · MAC · B_ref · NP · SM · CG`. The three reference
  values are grouped for visual cohesion.
- Tooltips spell out the coefficient formulas:
  - **S_ref:** `C_L = L / (q · S_ref)`
  - **MAC:** `(= C_ref in AVL/ASB) … C_m = M_pitch / (q · S_ref · C_ref)`
  - **B_ref:** `C_l = M_roll / (q · S_ref · B_ref)`
- Icons: `Square` (S_ref) and `ArrowLeftRight` (B_ref) from `lucide-react`.

**Tests**
- New unit tests cover S_ref + B_ref chip rendering, the MAC tooltip
  `C_ref` mention, and dash placeholders when the values are missing.
- Existing `splits envelope speeds and aero geometry into two separate
  rows` (gh-575) assertion extended to include the two new chips.
- Lucide-react test mocks extended with `Square` + `ArrowLeftRight`
  in **four** test files — continues the mock-update pattern
  established by #575 / #592 (`InfoChipRow`, `AnalysisWingGate`,
  `buildAnalysisRightSlot`, `TrefftzPlaneTabContent`).

**Backend**
- No code change required. `b_ref_m` is already populated in
  `assumption_compute_service.py` (line 461) and covered by
  `test_b_ref_m_is_in_context_after_recompute`.

## Test plan

- [x] `npm run test:unit` — 815/815 pass
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm run deps:check` — 0 errors (pre-existing warnings only)
- [x] `poetry run pytest -m "not slow"` — 3627 pass
- [x] `poetry run ruff check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)