### PR TITLE
feat(gh-581): Nurflügler (flying wing) mission preset + tailless UX banner

### DIFF
--- a/alembic/versions/5a0f2c4a9b52_seed_flying_wing_mission_preset.py
+++ b/alembic/versions/5a0f2c4a9b52_seed_flying_wing_mission_preset.py
@@ -1,0 +1,74 @@
+"""seed flying_wing mission preset
+
+Revision ID: 5a0f2c4a9b52
+Revises: e7387f35f31e
+Create Date: 2026-05-21 09:00:00.000000
+
+Adds the Nurflügler (flying wing) mission preset (gh-581). Tailless RC
+flying wing with tighter SM corridor, smaller AR, moderate sweep, and
+airfoil-paired washout defaults. Idempotent: skips the insert if the
+preset id already exists (e.g. when the row was already created at
+startup by ``seed_mission_presets``).
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "5a0f2c4a9b52"
+down_revision: Union[str, None] = "e7387f35f31e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_FLYING_WING_ID = "flying_wing"
+
+
+def upgrade() -> None:
+    """Insert the flying_wing preset row if missing.
+
+    The row is idempotent: re-running upgrade() on a DB that already
+    has the row (typically because the app started and ran
+    ``seed_mission_presets``) is a no-op.
+    """
+    conn = op.get_bind()
+    existing = conn.execute(
+        sa.text("SELECT id FROM mission_presets WHERE id = :id"),
+        {"id": _FLYING_WING_ID},
+    ).fetchone()
+    if existing is not None:
+        return
+
+    from app.services.mission_preset_seed import SEED_PRESETS
+
+    preset = next(p for p in SEED_PRESETS if p.id == _FLYING_WING_ID)
+
+    op.bulk_insert(
+        sa.table(
+            "mission_presets",
+            sa.column("id", sa.String),
+            sa.column("label", sa.String),
+            sa.column("description", sa.String),
+            sa.column("target_polygon", sa.JSON),
+            sa.column("axis_ranges", sa.JSON),
+            sa.column("suggested_estimates", sa.JSON),
+        ),
+        [
+            {
+                "id": preset.id,
+                "label": preset.label,
+                "description": preset.description,
+                "target_polygon": preset.target_polygon,
+                "axis_ranges": {k: list(v) for k, v in preset.axis_ranges.items()},
+                "suggested_estimates": preset.suggested_estimates.model_dump(),
+            }
+        ],
+    )
+
+
+def downgrade() -> None:
+    """Remove the flying_wing preset row."""
+    op.execute(sa.text("DELETE FROM mission_presets WHERE id = :id").bindparams(id=_FLYING_WING_ID))

--- a/app/schemas/flight_profile.py
+++ b/app/schemas/flight_profile.py
@@ -25,6 +25,7 @@ class FlightProfileType(str, Enum):
     glider = "glider"
     motor_glider = "motor_glider"
     slope_soarer = "slope_soarer"
+    flying_wing = "flying_wing"
     custom = "custom"
 
 

--- a/app/services/mission_preset_seed.py
+++ b/app/services/mission_preset_seed.py
@@ -273,4 +273,67 @@ SEED_PRESETS: list[MissionPreset] = [
             prop_efficiency=0.65,
         ),
     ),
+    MissionPreset(
+        id="flying_wing",
+        label="Flying Wing (Nurflügler)",
+        description=(
+            "Tailless RC flying wing (Nurflügler) — longitudinal trim via "
+            "sweep + washout + reflex airfoil. Tail-volume sizing not "
+            "applicable; static-margin corridor tightened (5–10 % MAC, "
+            "default 7.5 %) per #579 — this is a dynamic-stability / "
+            "control-power floor, NOT a static-aerodynamic limit (C_m,q "
+            "pitch damping is much smaller without a tail moment arm). "
+            "Aspect ratio default 8 (range 6–12). Sweep default 25° "
+            "leading-edge sweep (range 20–35°); sweep convention is "
+            "LE-sweep, NOT c/4 — the two differ by ~5° for typical taper. "
+            "Washout default 5° at the mid (range varies by airfoil): "
+            "**3–5° for symmetric** sections (NACA 0012-class), "
+            "**5–9° for reflex** sections (E184/E230, MH-series) — reflex "
+            "sections have less inherent stabilising camber and need MORE "
+            "washout, not less (Lennon Ch. 23 + NACA tunnel data). "
+            "Taper ratio default 0.5 — HARD CONSTRAINT 0.4 ≤ λ ≤ 0.6 to "
+            "avoid tip-stall + nose-up pitch break (Lennon: avoid 4:1 "
+            "taper; Sadraey converges). Stability guard: simultaneously "
+            "sweep < 20° AND washout < 3° is rejected (C_m,q margin "
+            "phugoid-divergent). Airfoil hints: **classic** Eppler E184 "
+            "(root) / E230 (tip); **modern** MH-series (MH45, MH60, MH61, "
+            "MH64). PREFERRED STRATEGY: HYBRID (moderate reflex + moderate "
+            "sweep + moderate washout) per Apogee — best modern flying "
+            "wings. Symmetric-airfoil caveat: dx/dα = 0 from the section "
+            "alone, so a symmetric airfoil on a Nurflügler requires "
+            "CG BELOW the wing chord plane (pendulum stability) — "
+            "otherwise the wing is not statically stable. Penalty of "
+            "reflex sections per Apogee: −9–15 % cl_max, −5 % minimum "
+            "profile drag (so cl_max = 1.0 is conservative: 1.25 cambered "
+            "× 0.85–0.91). YAW STABILITY is out of scope here — drag "
+            "rudders / split rudders / vertical fins / winglets are a "
+            "separate ticket; see Sadraey §12.2 and Apogee for design "
+            "guidance."
+        ),
+        target_polygon={
+            "stall_safety": 0.40,
+            "glide": 0.55,
+            "climb": 0.50,
+            "cruise": 0.65,
+            "maneuver": 0.75,
+            "wing_loading": 0.55,
+            "field_friendliness": 0.50,
+        },
+        axis_ranges={
+            "stall_safety": (1.3, 2.0),
+            "glide": (6.0, 18.0),
+            "climb": (8.0, 30.0),
+            "cruise": (15.0, 40.0),
+            "maneuver": (4.0, 8.0),
+            "wing_loading": (40.0, 150.0),
+            "field_friendliness": (3.0, 100.0),
+        },
+        suggested_estimates=MissionPresetEstimates(
+            g_limit=5.0,
+            target_static_margin=0.075,
+            cl_max=1.0,
+            power_to_weight=100.0,
+            prop_efficiency=0.65,
+        ),
+    ),
 ]

--- a/app/tests/test_flight_profile_schema.py
+++ b/app/tests/test_flight_profile_schema.py
@@ -73,3 +73,17 @@ def test_schema_accepts_slope_soarer_profile_type():
     payload["type"] = "slope_soarer"
     profile = RCFlightProfileCreate.model_validate(payload)
     assert profile.type == FlightProfileType.slope_soarer
+
+
+def test_flight_profile_type_includes_flying_wing():
+    """gh-581: flying_wing is a first-class profile type for the Nurflügler preset."""
+    assert FlightProfileType.flying_wing == "flying_wing"
+    assert FlightProfileType("flying_wing") is FlightProfileType.flying_wing
+
+
+def test_schema_accepts_flying_wing_profile_type():
+    """gh-581: payload with type='flying_wing' validates successfully."""
+    payload = valid_profile_payload()
+    payload["type"] = "flying_wing"
+    profile = RCFlightProfileCreate.model_validate(payload)
+    assert profile.type == FlightProfileType.flying_wing

--- a/app/tests/test_mission_objective_service.py
+++ b/app/tests/test_mission_objective_service.py
@@ -68,7 +68,7 @@ def test_upsert_creates_then_updates(client_and_db):
 
 
 def test_list_mission_presets_returns_all_seeded(client_and_db):
-    """gh-580: motor_glider is in the seeded library alongside the original seven."""
+    """gh-581: flying_wing is in the seeded library alongside the original eight."""
     _, SessionLocal = client_and_db
     with SessionLocal() as db:
         presets = list_mission_presets(db)
@@ -82,6 +82,7 @@ def test_list_mission_presets_returns_all_seeded(client_and_db):
         "stol_bush",
         "slope_soarer",
         "motor_glider",
+        "flying_wing",
     }
 
 
@@ -217,6 +218,40 @@ def test_upsert_motor_glider_writes_powered_estimates(client_and_db):
         assert rows["g_limit"].estimate_value == 5.3
         assert rows["target_static_margin"].estimate_value == 0.10
         assert rows["cl_max"].estimate_value == 1.4
+        assert rows["power_to_weight"].estimate_value == 100.0
+        assert rows["prop_efficiency"].estimate_value == 0.65
+        # Critical: powered → is_glider=False downstream
+        assert rows["power_to_weight"].estimate_value > 0
+
+
+def test_upsert_flying_wing_writes_estimates(client_and_db):
+    """gh-581: switching to flying_wing writes the tailless-tuned estimates —
+    tighter SM (0.075), reduced cl_max (1.0 due to reflex penalty), and
+    powered defaults (most RC flying wings are EDF / prop)."""
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        from app.tests.conftest import make_aeroplane
+        from app.services.design_assumptions_service import seed_defaults
+        from app.models.aeroplanemodel import DesignAssumptionModel
+
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aircraft_id = aeroplane.id
+
+    with SessionLocal() as db:
+        upsert_mission_objective(db, aircraft_id, _make_objective(mission_type="flying_wing"))
+        db.commit()
+
+    with SessionLocal() as db:
+        rows = {
+            r.parameter_name: r
+            for r in db.query(DesignAssumptionModel).filter_by(aeroplane_id=aircraft_id).all()
+        }
+        # flying_wing preset values from app/services/mission_preset_seed.py
+        assert rows["g_limit"].estimate_value == 5.0
+        assert rows["target_static_margin"].estimate_value == 0.075
+        assert rows["cl_max"].estimate_value == 1.0
         assert rows["power_to_weight"].estimate_value == 100.0
         assert rows["prop_efficiency"].estimate_value == 0.65
         # Critical: powered → is_glider=False downstream

--- a/app/tests/test_mission_objectives_endpoint.py
+++ b/app/tests/test_mission_objectives_endpoint.py
@@ -49,7 +49,7 @@ def test_put_mission_objectives_persists(client_and_db):
 
 
 def test_get_mission_presets_returns_all_seeded(client_and_db):
-    """gh-580: eight seeded presets including the new motor_glider."""
+    """gh-581: nine seeded presets including the new flying_wing."""
     client, _ = client_and_db
     r = client.get("/mission-presets")
     assert r.status_code == 200
@@ -63,6 +63,7 @@ def test_get_mission_presets_returns_all_seeded(client_and_db):
         "stol_bush",
         "slope_soarer",
         "motor_glider",
+        "flying_wing",
     }
 
 
@@ -93,6 +94,23 @@ def test_get_mission_presets_exposes_motor_glider_payload(client_and_db):
     assert est["target_static_margin"] == 0.10
     assert est["cl_max"] == 1.4
     assert est["g_limit"] == 5.3
+
+
+def test_get_mission_presets_exposes_flying_wing_payload(client_and_db):
+    """gh-581: the Nurflügler preset surfaces via the public API with expected fields."""
+    client, _ = client_and_db
+    r = client.get("/mission-presets")
+    assert r.status_code == 200
+    preset = next(p for p in r.json() if p["id"] == "flying_wing")
+    assert preset["label"] == "Flying Wing (Nurflügler)"
+    est = preset["suggested_estimates"]
+    # Tighter SM corridor for tailless (5–10 % MAC, default 7.5 %) — see #579
+    assert est["target_static_margin"] == 0.075
+    # Reflex/symmetric penalty per Apogee (9–15 % cl_max loss)
+    assert est["cl_max"] == 1.0
+    assert est["g_limit"] == 5.0
+    assert est["power_to_weight"] == 100.0
+    assert est["prop_efficiency"] == 0.65
 
 
 def test_get_mission_kpis_returns_seven_axes(client_and_db):

--- a/app/tests/test_mission_preset_seed.py
+++ b/app/tests/test_mission_preset_seed.py
@@ -6,7 +6,7 @@ from app.services.mission_preset_seed import SEED_PRESETS
 
 
 def test_seed_presets_exist():
-    """gh-580: motor_glider added to the canonical preset set."""
+    """gh-581: flying_wing added to the canonical preset set."""
     ids = {p.id for p in SEED_PRESETS}
     assert ids == {
         "trainer",
@@ -17,6 +17,7 @@ def test_seed_presets_exist():
         "stol_bush",
         "slope_soarer",
         "motor_glider",
+        "flying_wing",
     }
 
 
@@ -91,6 +92,118 @@ def test_motor_glider_description_cites_cs22_and_clarifies_ld_market_convention(
     assert "CS-22.337" in description
     assert "market convention" in description.lower()
     assert "L/D" in description
+
+
+def test_flying_wing_preset_defaults():
+    """gh-581: Nurflügler carries the review-verified defaults (Scholz + Anderson + Apogee + Lennon)."""
+    preset = next(p for p in SEED_PRESETS if p.id == "flying_wing")
+    assert preset.label == "Flying Wing (Nurflügler)"
+    est = preset.suggested_estimates
+    # Tighter SM corridor for tailless (range 5–10 %, default 7.5 %) — see #579
+    assert est.target_static_margin == 0.075
+    # Reflex/symmetric airfoils lose 9–15 % cl_max vs. cambered (Apogee)
+    assert est.cl_max == 1.0
+    # Sport-class g-limit for RC flying wings
+    assert est.g_limit == 5.0
+    # Powered default: most RC flying wings are EDF or prop
+    assert est.power_to_weight == 100.0
+    assert est.prop_efficiency == 0.65
+    # KPI polygon: high maneuver USP, mid cruise, low stall-safety
+    polygon = preset.target_polygon
+    assert polygon["stall_safety"] == 0.40
+    assert polygon["glide"] == 0.55
+    assert polygon["climb"] == 0.50
+    assert polygon["cruise"] == 0.65
+    assert polygon["maneuver"] == 0.75
+    assert polygon["wing_loading"] == 0.55
+    assert polygon["field_friendliness"] == 0.50
+
+
+def test_flying_wing_description_documents_washout_airfoil_pairing_correctly():
+    """gh-581 CRITICAL: the description must pair washout with airfoil family in the
+    CORRECT direction (3–5° symmetric / 5–9° reflex). The draft inverted it, and
+    if shipped reversed would cause tip-stall + nose-up pitch break on reflex
+    sections (the exact failure mode Northrop's LE slots were invented for)."""
+    preset = next(p for p in SEED_PRESETS if p.id == "flying_wing")
+    desc = preset.description
+    # Both ranges must appear in the description
+    assert "3–5°" in desc, "symmetric washout range missing"
+    assert "5–9°" in desc, "reflex washout range missing"
+    # The pairing must be present in the description text
+    assert "symmetric" in desc.lower()
+    assert "reflex" in desc.lower()
+    # Reflex sections need MORE washout (not less) — pin the wording so a future
+    # edit can't quietly re-invert the pairing without tripping this guard
+    assert "MORE washout" in desc or "more washout" in desc.lower()
+
+
+def test_flying_wing_description_documents_sweep_convention():
+    """gh-581 (Anderson review): sweep convention (LE vs c/4) must be explicit
+    in the description — they differ by ~5° for typical taper."""
+    preset = next(p for p in SEED_PRESETS if p.id == "flying_wing")
+    desc = preset.description
+    assert "LE-sweep" in desc or "leading-edge" in desc.lower()
+
+
+def test_flying_wing_description_documents_taper_hard_constraint():
+    """gh-581: taper 0.4 ≤ λ ≤ 0.6 is a HARD CONSTRAINT for tailless, not just
+    the default — Lennon + Sadraey converge on tip-stall risk above 4:1."""
+    preset = next(p for p in SEED_PRESETS if p.id == "flying_wing")
+    desc = preset.description
+    assert "0.4" in desc
+    assert "0.6" in desc
+    assert "HARD CONSTRAINT" in desc or "hard constraint" in desc.lower()
+
+
+def test_flying_wing_description_documents_pendulum_caveat():
+    """gh-581 (Apogee review): symmetric airfoil on a tailless wing requires
+    CG below the chord plane (dx/dα = 0 from the section alone, so the wing
+    is statically unstable without pendulum effect). Must be in the
+    description so users see the caveat in the UI."""
+    preset = next(p for p in SEED_PRESETS if p.id == "flying_wing")
+    desc = preset.description
+    assert "pendulum" in desc.lower()
+    assert "below" in desc.lower()
+    # dx/dα framework explicitly cited
+    assert "dx/dα" in desc
+
+
+def test_flying_wing_description_prefers_hybrid_strategy():
+    """gh-581 (Apogee review): hybrid strategy (moderate reflex + sweep + washout)
+    is the preferred default per Apogee — best modern flying wings. The
+    description must surface this as the recommended pick."""
+    preset = next(p for p in SEED_PRESETS if p.id == "flying_wing")
+    desc = preset.description
+    assert "HYBRID" in desc or "hybrid" in desc.lower()
+    assert "preferred" in desc.lower()
+
+
+def test_flying_wing_description_documents_stability_guard():
+    """gh-581: sweep<20° AND washout<3° simultaneously is rejected — the
+    stability guard must be documented in the description so users know
+    the rule before encountering it."""
+    preset = next(p for p in SEED_PRESETS if p.id == "flying_wing")
+    desc = preset.description
+    assert "sweep < 20°" in desc or "sweep<20°" in desc.lower().replace(" ", "")
+    assert "washout < 3°" in desc or "washout<3°" in desc.lower().replace(" ", "")
+
+
+def test_flying_wing_description_documents_yaw_oos():
+    """gh-581: yaw stability (drag rudders / split rudders / vertical fins) is
+    explicitly OOS — must be flagged in the description so users know to plan
+    yaw separately."""
+    preset = next(p for p in SEED_PRESETS if p.id == "flying_wing")
+    desc = preset.description
+    assert "yaw" in desc.lower()
+    assert "out of scope" in desc.lower() or "separate ticket" in desc.lower()
+
+
+def test_flying_wing_is_powered_by_default():
+    """gh-581: most RC flying wings are powered (EDF / prop). The preset
+    defaults to powered so downstream ``is_glider = p_to_w <= 0`` returns
+    False (V_max chip and other powered-only chips remain enabled)."""
+    preset = next(p for p in SEED_PRESETS if p.id == "flying_wing")
+    assert preset.suggested_estimates.power_to_weight > 0
 
 
 def test_each_preset_covers_all_seven_axes():

--- a/frontend/__tests__/InfoChipRow.test.tsx
+++ b/frontend/__tests__/InfoChipRow.test.tsx
@@ -21,6 +21,8 @@ vi.mock("lucide-react", () => {
     RefreshCw: icon,
     Square: icon,
     ArrowLeftRight: icon,
+    // gh-581: TaillessBanner uses Info icon when ctx.is_tailless is true.
+    Info: icon,
   };
 });
 
@@ -407,6 +409,52 @@ describe("Info Chip Row", () => {
     expect(smChip).toBeInTheDocument();
     // 0.075 → 8% (rounds to 0 decimals via .toFixed(0))
     expect(smChip.textContent).toMatch(/8%/);
+  });
+
+  // gh-581: Tailless UX banner surfaces when backend reports is_tailless=true.
+  // Banner explains tail-volume sizing is N/A, SM corridor is tighter, and that
+  // trim comes from sweep + washout + reflex (hybrid preferred per Apogee).
+  it("renders the TaillessBanner when ctx.is_tailless is true", async () => {
+    (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        is_tailless: true,
+        v_cruise_mps: 18.0,
+        reynolds: 230000,
+        mac_m: 0.21,
+        x_np_m: 0.085,
+        target_static_margin: 0.075,
+        cg_agg_m: 0.078,
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
+    render(<InfoChipRow aeroplaneId="42" cgAero={0.078} />);
+
+    expect(screen.getByTestId("tailless-banner")).toBeInTheDocument();
+    expect(screen.getByText(/Tailless configuration/i)).toBeInTheDocument();
+  });
+
+  // gh-581: Conventional aircraft must NOT see the tailless banner.
+  it("does not render the TaillessBanner when ctx.is_tailless is false or missing", async () => {
+    (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        v_cruise_mps: 18.0,
+        reynolds: 230000,
+        mac_m: 0.21,
+        x_np_m: 0.085,
+        target_static_margin: 0.12,
+        cg_agg_m: 0.092,
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
+    render(<InfoChipRow aeroplaneId="42" cgAero={0.073} />);
+
+    expect(screen.queryByTestId("tailless-banner")).not.toBeInTheDocument();
   });
 
   // gh-540: aria-label is humanized (no literal underscores spoken).

--- a/frontend/__tests__/MissionObjectivesPanel.test.tsx
+++ b/frontend/__tests__/MissionObjectivesPanel.test.tsx
@@ -26,6 +26,7 @@ vi.mock("@/hooks/useMissionPresets", () => ({
       { id: "sailplane", label: "Sailplane", description: "", target_polygon: {}, axis_ranges: {}, suggested_estimates: { g_limit: 2, target_static_margin: 0.18, cl_max: 1.2, power_to_weight: 0.0, prop_efficiency: 0.0 } },
       { id: "slope_soarer", label: "Slope Soarer", description: "", target_polygon: {}, axis_ranges: {}, suggested_estimates: { g_limit: 6, target_static_margin: 0.08, cl_max: 1.1, power_to_weight: 0.0, prop_efficiency: 0.0 } },
       { id: "motor_glider", label: "Motorsegler (Motor Glider)", description: "", target_polygon: {}, axis_ranges: {}, suggested_estimates: { g_limit: 5.3, target_static_margin: 0.10, cl_max: 1.4, power_to_weight: 100, prop_efficiency: 0.65 } },
+      { id: "flying_wing", label: "Flying Wing (Nurflügler)", description: "", target_polygon: {}, axis_ranges: {}, suggested_estimates: { g_limit: 5.0, target_static_margin: 0.075, cl_max: 1.0, power_to_weight: 100, prop_efficiency: 0.65 } },
     ],
     isLoading: false, error: null,
   }),
@@ -40,6 +41,8 @@ describe("MissionObjectivesPanel", () => {
     expect(screen.getByRole("option", { name: /Slope Soarer/ })).toBeInTheDocument();
     // gh-580: motor_glider (Motorsegler) surfaces in the selector once seeded.
     expect(screen.getByRole("option", { name: /Motorsegler/ })).toBeInTheDocument();
+    // gh-581: flying_wing (Nurflügler) surfaces in the selector once seeded.
+    expect(screen.getByRole("option", { name: /Flying Wing/ })).toBeInTheDocument();
   });
 
   it("renders the field-performance section", () => {

--- a/frontend/__tests__/TaillessBanner.test.tsx
+++ b/frontend/__tests__/TaillessBanner.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => ({
+  Info: (props: Record<string, unknown>) => (
+    <svg data-testid="info-icon" {...props} />
+  ),
+}));
+
+import { TaillessBanner } from "../components/workbench/TaillessBanner";
+
+describe("TaillessBanner (gh-581)", () => {
+  it("renders the tailless UX banner with the expected design copy", () => {
+    render(<TaillessBanner />);
+    // Anchor sentence — flags the configuration to the user
+    expect(screen.getByText(/Tailless configuration/i)).toBeInTheDocument();
+    // Tail-volume sizing not applicable — explains the missing UI
+    expect(
+      screen.getByText(/Tail-volume\s+sizing not applicable/i),
+    ).toBeInTheDocument();
+    // Pitch-trim mechanisms call-out (hybrid preferred per Apogee)
+    expect(screen.getByText(/hybrid \(preferred\)/i)).toBeInTheDocument();
+    // Tighter SM corridor (5–10 % MAC) — see #579
+    expect(screen.getByText(/SM target 5–10 % MAC/i)).toBeInTheDocument();
+  });
+
+  it("uses the status role so screen readers announce it without blocking", () => {
+    render(<TaillessBanner />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("exposes a stable test id for higher-level integration tests", () => {
+    render(<TaillessBanner />);
+    expect(screen.getByTestId("tailless-banner")).toBeInTheDocument();
+  });
+});

--- a/frontend/components/workbench/InfoChipRow.tsx
+++ b/frontend/components/workbench/InfoChipRow.tsx
@@ -18,6 +18,7 @@ import {
 import { useComputationContext } from "@/hooks/useComputationContext";
 import { renderSymbol } from "@/components/workbench/renderSymbol";
 import { cgDivergenceColor } from "./stability-overlay/divergence-color";
+import { TaillessBanner } from "./TaillessBanner";
 
 interface Props {
   readonly aeroplaneId: string | null;
@@ -110,10 +111,21 @@ export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: P
     </>
   );
 
+  // gh-581: surface the tailless UX banner above the chip rows when
+  // backend-derived `is_tailless = true` (no horizontal-tail wing). The
+  // banner explains that tail-volume sizing is not applicable and the
+  // SM corridor is tighter (see #579 + Apogee hybrid-strategy guidance).
+  const isTailless = !!ctx?.is_tailless;
+
   // gh-575: split the chips into two rows (envelope speeds + aero geometry)
   // with a user-triggered refresh button on row 1.
   return (
     <div className="flex flex-col gap-2 border-t border-border bg-card px-4 py-3">
+      {isTailless && (
+        <div className="flex">
+          <TaillessBanner />
+        </div>
+      )}
       {/* Row 1 — envelope speeds (gh-476: extended chip set) */}
       <div
         data-testid="chip-row-speeds"

--- a/frontend/components/workbench/TaillessBanner.tsx
+++ b/frontend/components/workbench/TaillessBanner.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { Info } from "lucide-react";
+
+/**
+ * gh-581: Banner surfaced on the workbench when the active aeroplane has
+ * no horizontal tail (`is_tailless = true` in the computation context).
+ *
+ * Explains the design implications:
+ *  - Tail-volume sizing is not applicable.
+ *  - Longitudinal trim must come from sweep + washout + reflex airfoil
+ *    (Apogee's hybrid approach is the preferred default).
+ *  - The static-margin corridor is tighter (5–10 % MAC, default 7.5 %)
+ *    per #579 — this is a dynamic-stability / control-power floor, not
+ *    a static-aerodynamic limit (C_m,q pitch damping is much smaller
+ *    without a tail moment arm).
+ *  - CG envelope is ~50 % narrower; mass-fixed items should mount on the
+ *    CG axis.
+ */
+export function TaillessBanner() {
+  return (
+    <div
+      role="status"
+      data-testid="tailless-banner"
+      className="flex items-start gap-2 rounded-full bg-orange-500/15 px-3 py-1.5 text-orange-400"
+    >
+      <Info size={12} className="mt-0.5 shrink-0" />
+      <span className="font-[family-name:var(--font-geist-sans)] text-[11px] leading-snug">
+        <span className="font-semibold">Tailless configuration</span> — Tail-volume
+        sizing not applicable. Pitch trim via sweep + washout, reflex airfoil,
+        or hybrid (preferred). SM target 5–10 % MAC (narrower CG envelope than
+        conventional, ~50 % less travel; mount mass-fixed items on CG axis).
+      </span>
+    </div>
+  );
+}

--- a/frontend/hooks/useComputationContext.ts
+++ b/frontend/hooks/useComputationContext.ts
@@ -26,6 +26,10 @@ export interface ComputationContext {
   x_np_m: number;
   target_static_margin: number;
   cg_agg_m: number | null;
+  // gh-581: tailless configuration flag — derived backend-side from geometry
+  // (no horizontal-tail wing). Used to surface the tailless UX banner and to
+  // gate tail-volume-related UI off when true.
+  is_tailless?: boolean;
   computed_at: string;
 }
 


### PR DESCRIPTION
## Summary

Adds the **Flying Wing (Nurflügler)** mission preset and a workbench UX banner that surfaces whenever the active aeroplane is tailless (`is_tailless = true` in the computation context). Completes the EPIC #578 sequence after #594 (gh-579 SM sizing), #595 (gh-582 Slope Soarer), #597 (gh-580 Motorsegler), #596 (gh-592 Trefftz spinner), and #598 (gh-593 Sref/Bref chips).

This is the largest ticket of the EPIC because it lands the tailless-specific design picture in one place — Lennon's classic RC Nurflügler defaults, Apogee's hybrid-strategy preference, Anderson's mechanism caveats, and Scholz's stability-derivative floors — converged onto a single preset row + a single UI banner.

## Review-verified defaults (all four authorities converged)

| Parameter | Value | Range | Source |
|---|---|---|---|
| `aspect_ratio` (in description) | 8 | 6–12 | RC sweptback typical |
| `sweep_angle` (LE) (in description) | 25° | 20–35° | Lennon 2:1 taper |
| `washout` (in description) | 5° mid | **3–5° symm / 5–9° reflex** ⚠ | Lennon Ch. 23 + NACA tunnel |
| `taper_ratio` (in description) | 0.5 | **0.4–0.6 HARD CONSTRAINT** | Lennon + Sadraey converge |
| `target_static_margin` | **0.075** | 0.05–0.10 | #579 backend |
| `cl_max` | **1.0** | 0.8–1.2 | Reflex penalty: -9 to -15 % per Apogee |
| `g_limit` | **5.0** | 4–7 | RC sport flying wing |
| `power_to_weight` | **100 W/kg** | — | Powered default (EDF / prop) |
| `prop_efficiency` | **0.65** | — | Folding/feathering climb prop |

KPI polygon (7 axes, 0–1): stall_safety 0.40 / glide 0.55 / climb 0.50 / cruise 0.65 / maneuver 0.75 / wing_loading 0.55 / field_friendliness 0.50.

## ⚠ CRITICAL: washout-airfoil pairing in the CORRECT direction

The original ticket draft had this **inverted** and would have caused tip-stall + nose-up pitch break on reflex sections — exactly the failure mode Northrop's LE slots were invented for. This PR ships the **correctly-paired** values, locked in by `test_flying_wing_description_documents_washout_airfoil_pairing_correctly`:

| Airfoil family | Washout |
|---|---|
| **Symmetric** (NACA 0012-class) | **3–5°** (less, because section has no destabilising camber) |
| **Reflex** (E184/E230, MH-series) | **5–9°** (MORE, because reflex sections have less inherent stabilising camber) |

The test pins the wording "MORE washout" so a future edit cannot quietly re-invert the pairing.

## Hybrid strategy = preferred default (Apogee)

Per Apogee Newsletter `[[flying-wing-reflex-airfoil]]`: "best modern flying wings often use a hybrid approach, combining moderate reflex sections with some sweep and washout." The preset description calls this out as the PREFERRED STRATEGY, locked in by `test_flying_wing_description_prefers_hybrid_strategy`.

## Pendulum-stability caveat for symmetric airfoils

Per Apogee `[[flying-wing-pitching-moment-stability]]`: symmetric / flat-plate sections have `dx/dα = 0` — the section alone cannot stabilise. Symmetric + tailless requires **CG below the wing chord plane** (pendulum stability). The description spells this out, locked in by `test_flying_wing_description_documents_pendulum_caveat`.

## Other review findings landed

- **Sweep convention** — LE-sweep, not c/4 (they differ ~5° for typical taper); test `test_flying_wing_description_documents_sweep_convention`.
- **Taper hard constraint** 0.4 ≤ λ ≤ 0.6 (not just default); test `test_flying_wing_description_documents_taper_hard_constraint`.
- **Stability guard** documented: `sweep < 20° AND washout < 3°` simultaneously rejected (C_m,q phugoid-divergent). Schema has no per-preset validation hook today, so the rule lives in the description text + locked in by a test guard.
- **Yaw OOS** flagged with vault anchors for the follow-up ticket: `[[flying-wing-yaw-control-drag-rudder]]`, `[[flying-wing-vertical-fin-placement]]`, `[[flying-wing-toe-in-weathercock]]`.
- **5 % SM floor** is dynamic-stability / control-power heuristic, NOT static-aerodynamic — called out in the description so users understand the floor.

## Frontend — Tailless UX banner

New `TaillessBanner` (`frontend/components/workbench/TaillessBanner.tsx`) surfaces above the InfoChipRow chip rows when `ctx.is_tailless = true`. Copy:

> Tailless configuration — Tail-volume sizing not applicable. Pitch trim via sweep + washout, reflex airfoil, or hybrid (preferred). SM target 5–10 % MAC (narrower CG envelope than conventional, ~50 % less travel; mount mass-fixed items on CG axis).

`ComputationContext` interface gains an optional `is_tailless` field — the backend already serves it in the JSON payload (part of the cached `assumption_computation_context` blob), so this is a type-only frontend change.

## Out of scope (per ticket notes)

- Yaw stability (drag rudders / split rudders / vertical fins / winglets) — vault anchors in description for the follow-up ticket.
- Schema fields for `aspect_ratio` / `sweep_angle` / `washout` / `taper_ratio` — embedded in description string (same convention as #595, #597).
- Per-preset schema-level validators for the stability guard and taper hard constraint — schema has no validation expression today.
- Symmetric-airfoil pendulum runtime warning — future ticket.
- Washout-hint pop-up per airfoil family — future Airfoil-Selector ticket.
- Post-VLM verification test (`C_m,α < 0` AND `|C_m,q| > 3·|C_m,α|`) — needs a real VLM run, too heavy for a unit test.

## Test plan

- [x] `poetry run pytest -m "not slow"` — 3645 passed, 2 xfailed.
- [x] `poetry run ruff check .` — All checks passed.
- [x] `poetry run ruff format` on touched files — clean.
- [x] `poetry run pyright` on touched files — 0 errors, 0 warnings.
- [x] `cd frontend && npm run test:unit` — 820 passed.
- [x] `cd frontend && npm run lint` — 0 errors.
- [x] `cd frontend && npm run deps:check` — 0 errors.
- [x] `poetry run alembic heads` — single head `5a0f2c4a9b52`.

References EPIC #578 and the three-expert review on #581 (Scholz / Anderson / Lennon) + Apogee Newsletter #15 vault update.

Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)