### PR TITLE
chore: english-only mission preset labels

### DIFF
--- a/app/services/mission_preset_seed.py
+++ b/app/services/mission_preset_seed.py
@@ -228,7 +228,7 @@ SEED_PRESETS: list[MissionPreset] = [
     ),
     MissionPreset(
         id="motor_glider",
-        label="Motorsegler (Motor Glider)",
+        label="Motor Glider",
         description=(
             "Self-launching motor glider — high-AR sailplane geometry with a "
             "small climb-only powerplant (folding or retractable prop). "
@@ -275,9 +275,9 @@ SEED_PRESETS: list[MissionPreset] = [
     ),
     MissionPreset(
         id="flying_wing",
-        label="Flying Wing (Nurflügler)",
+        label="Flying Wing",
         description=(
-            "Tailless RC flying wing (Nurflügler) — longitudinal trim via "
+            "Tailless RC flying wing — longitudinal trim via "
             "sweep + washout + reflex airfoil. Tail-volume sizing not "
             "applicable; static-margin corridor tightened (5–10 % MAC, "
             "default 7.5 %) per #579 — this is a dynamic-stability / "
@@ -300,7 +300,7 @@ SEED_PRESETS: list[MissionPreset] = [
             "MH64). PREFERRED STRATEGY: HYBRID (moderate reflex + moderate "
             "sweep + moderate washout) per Apogee — best modern flying "
             "wings. Symmetric-airfoil caveat: dx/dα = 0 from the section "
-            "alone, so a symmetric airfoil on a Nurflügler requires "
+            "alone, so a symmetric airfoil on a flying wing requires "
             "CG BELOW the wing chord plane (pendulum stability) — "
             "otherwise the wing is not statically stable. Penalty of "
             "reflex sections per Apogee: −9–15 % cl_max, −5 % minimum "

--- a/app/tests/test_flight_profile_schema.py
+++ b/app/tests/test_flight_profile_schema.py
@@ -76,7 +76,7 @@ def test_schema_accepts_slope_soarer_profile_type():
 
 
 def test_flight_profile_type_includes_flying_wing():
-    """gh-581: flying_wing is a first-class profile type for the Nurflügler preset."""
+    """gh-581: flying_wing is a first-class profile type for the flying wing preset."""
     assert FlightProfileType.flying_wing == "flying_wing"
     assert FlightProfileType("flying_wing") is FlightProfileType.flying_wing
 

--- a/app/tests/test_mission_objectives_endpoint.py
+++ b/app/tests/test_mission_objectives_endpoint.py
@@ -82,12 +82,12 @@ def test_get_mission_presets_exposes_slope_soarer_payload(client_and_db):
 
 
 def test_get_mission_presets_exposes_motor_glider_payload(client_and_db):
-    """gh-580: the Motorsegler preset surfaces via the public API with expected fields."""
+    """gh-580: the motor glider preset surfaces via the public API with expected fields."""
     client, _ = client_and_db
     r = client.get("/mission-presets")
     assert r.status_code == 200
     preset = next(p for p in r.json() if p["id"] == "motor_glider")
-    assert preset["label"] == "Motorsegler (Motor Glider)"
+    assert preset["label"] == "Motor Glider"
     est = preset["suggested_estimates"]
     assert est["power_to_weight"] == 100.0
     assert est["prop_efficiency"] == 0.65
@@ -97,12 +97,12 @@ def test_get_mission_presets_exposes_motor_glider_payload(client_and_db):
 
 
 def test_get_mission_presets_exposes_flying_wing_payload(client_and_db):
-    """gh-581: the Nurflügler preset surfaces via the public API with expected fields."""
+    """gh-581: the flying wing preset surfaces via the public API with expected fields."""
     client, _ = client_and_db
     r = client.get("/mission-presets")
     assert r.status_code == 200
     preset = next(p for p in r.json() if p["id"] == "flying_wing")
-    assert preset["label"] == "Flying Wing (Nurflügler)"
+    assert preset["label"] == "Flying Wing"
     est = preset["suggested_estimates"]
     # Tighter SM corridor for tailless (5–10 % MAC, default 7.5 %) — see #579
     assert est["target_static_margin"] == 0.075

--- a/app/tests/test_mission_preset_seed.py
+++ b/app/tests/test_mission_preset_seed.py
@@ -44,9 +44,9 @@ def test_slope_soarer_preset_defaults():
 
 
 def test_motor_glider_preset_defaults():
-    """gh-580: Motorsegler carries the Scholz-review-verified defaults."""
+    """gh-580: the motor glider preset carries the Scholz-review-verified defaults."""
     preset = next(p for p in SEED_PRESETS if p.id == "motor_glider")
-    assert preset.label == "Motorsegler (Motor Glider)"
+    assert preset.label == "Motor Glider"
     est = preset.suggested_estimates
     # Powered: power_to_weight=100 W/kg covers self-launch climb (80–150 range)
     assert est.power_to_weight == 100.0
@@ -95,9 +95,9 @@ def test_motor_glider_description_cites_cs22_and_clarifies_ld_market_convention(
 
 
 def test_flying_wing_preset_defaults():
-    """gh-581: Nurflügler carries the review-verified defaults (Scholz + Anderson + Apogee + Lennon)."""
+    """gh-581: the flying wing preset carries the review-verified defaults (Scholz + Anderson + Apogee + Lennon)."""
     preset = next(p for p in SEED_PRESETS if p.id == "flying_wing")
-    assert preset.label == "Flying Wing (Nurflügler)"
+    assert preset.label == "Flying Wing"
     est = preset.suggested_estimates
     # Tighter SM corridor for tailless (range 5–10 %, default 7.5 %) — see #579
     assert est.target_static_margin == 0.075

--- a/frontend/__tests__/MissionObjectivesPanel.test.tsx
+++ b/frontend/__tests__/MissionObjectivesPanel.test.tsx
@@ -25,8 +25,8 @@ vi.mock("@/hooks/useMissionPresets", () => ({
       { id: "trainer", label: "Trainer", description: "", target_polygon: {}, axis_ranges: {}, suggested_estimates: { g_limit: 4, target_static_margin: 0.12, cl_max: 1.4, power_to_weight: 0.4, prop_efficiency: 0.6 } },
       { id: "sailplane", label: "Sailplane", description: "", target_polygon: {}, axis_ranges: {}, suggested_estimates: { g_limit: 2, target_static_margin: 0.18, cl_max: 1.2, power_to_weight: 0.0, prop_efficiency: 0.0 } },
       { id: "slope_soarer", label: "Slope Soarer", description: "", target_polygon: {}, axis_ranges: {}, suggested_estimates: { g_limit: 6, target_static_margin: 0.08, cl_max: 1.1, power_to_weight: 0.0, prop_efficiency: 0.0 } },
-      { id: "motor_glider", label: "Motorsegler (Motor Glider)", description: "", target_polygon: {}, axis_ranges: {}, suggested_estimates: { g_limit: 5.3, target_static_margin: 0.10, cl_max: 1.4, power_to_weight: 100, prop_efficiency: 0.65 } },
-      { id: "flying_wing", label: "Flying Wing (Nurflügler)", description: "", target_polygon: {}, axis_ranges: {}, suggested_estimates: { g_limit: 5.0, target_static_margin: 0.075, cl_max: 1.0, power_to_weight: 100, prop_efficiency: 0.65 } },
+      { id: "motor_glider", label: "Motor Glider", description: "", target_polygon: {}, axis_ranges: {}, suggested_estimates: { g_limit: 5.3, target_static_margin: 0.10, cl_max: 1.4, power_to_weight: 100, prop_efficiency: 0.65 } },
+      { id: "flying_wing", label: "Flying Wing", description: "", target_polygon: {}, axis_ranges: {}, suggested_estimates: { g_limit: 5.0, target_static_margin: 0.075, cl_max: 1.0, power_to_weight: 100, prop_efficiency: 0.65 } },
     ],
     isLoading: false, error: null,
   }),
@@ -39,9 +39,9 @@ describe("MissionObjectivesPanel", () => {
     expect(screen.getByRole("option", { name: /Sailplane/ })).toBeInTheDocument();
     // gh-582: slope_soarer surfaces in the selector once the backend seeds it.
     expect(screen.getByRole("option", { name: /Slope Soarer/ })).toBeInTheDocument();
-    // gh-580: motor_glider (Motorsegler) surfaces in the selector once seeded.
-    expect(screen.getByRole("option", { name: /Motorsegler/ })).toBeInTheDocument();
-    // gh-581: flying_wing (Nurflügler) surfaces in the selector once seeded.
+    // gh-580: motor_glider surfaces in the selector once seeded.
+    expect(screen.getByRole("option", { name: /Motor Glider/ })).toBeInTheDocument();
+    // gh-581: flying_wing surfaces in the selector once seeded.
     expect(screen.getByRole("option", { name: /Flying Wing/ })).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary

Drop the German parentheticals from the user-facing mission preset labels:

- \"Motorsegler (Motor Glider)\" → **Motor Glider**
- \"Flying Wing (Nurflügler)\" → **Flying Wing**

Per user request: consistent English-only naming for the Mission Type selector dropdown. Internal enum values (\`motor_glider\`, \`flying_wing\`) remain unchanged — purely a UI label cleanup.

Also cleaned up a couple of test docstrings + one preset description sentence that still mentioned the German terms in free text. The behavioural defaults from the gh-578 EPIC (#580 / #581) stay untouched.

## Files changed

- \`app/services/mission_preset_seed.py\` — label + description text
- \`app/tests/test_mission_preset_seed.py\` — assertion strings + docstrings
- \`app/tests/test_mission_objectives_endpoint.py\` — assertion strings + docstrings
- \`app/tests/test_flight_profile_schema.py\` — docstring
- \`frontend/__tests__/MissionObjectivesPanel.test.tsx\` — mock label + regex

## Test plan

- [x] \`poetry run pytest -m \"not slow\"\` — 3645 passed, 0 regressions
- [x] \`poetry run ruff check .\` — clean
- [x] \`poetry run pyright\` on touched files — 0 errors
- [x] \`npm run test:unit -- MissionObjectivesPanel\` — 3/3 pass
- [ ] Manual smoke: workbench Mission tab → confirm dropdown reads \"Motor Glider\" and \"Flying Wing\" without parentheses

🤖 Generated with [Claude Code](https://claude.com/claude-code)