### PR TITLE
feat(gh-601): apply preset targets via banner button + radar polygon hover tooltips

### DIFF
--- a/frontend/__tests__/MissionObjectivesPanel.test.tsx
+++ b/frontend/__tests__/MissionObjectivesPanel.test.tsx
@@ -1,7 +1,29 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import React from "react";
 import { MissionObjectivesPanel } from "@/components/workbench/mission/MissionObjectivesPanel";
+
+const updateMock = vi.fn().mockResolvedValue(undefined);
+
+const fullPolygon = {
+  stall_safety: 1,
+  glide: 0.5,
+  climb: 0.5,
+  cruise: 0.5,
+  maneuver: 0.5,
+  wing_loading: 0.5,
+  field_friendliness: 0.5,
+};
+
+const fullAxisRanges = {
+  stall_safety: [1.3, 2.0] as [number, number],
+  glide: [15, 35] as [number, number],
+  climb: [5, 25] as [number, number],
+  cruise: [22, 30] as [number, number], // → 0.5 maps to 26.0
+  maneuver: [3.0, 4.8] as [number, number], // → 0.5 maps to 3.9
+  wing_loading: [20, 80] as [number, number],
+  field_friendliness: [3, 100] as [number, number],
+};
 
 vi.mock("@/hooks/useMissionObjectives", () => ({
   useMissionObjectives: () => ({
@@ -14,7 +36,7 @@ vi.mock("@/hooks/useMissionObjectives", () => ({
       available_runway_m: 50, runway_type: "grass",
       t_static_N: 18, takeoff_mode: "runway",
     },
-    update: vi.fn().mockResolvedValue(undefined),
+    update: updateMock,
     isLoading: false, error: null,
   }),
 }));
@@ -22,17 +44,21 @@ vi.mock("@/hooks/useMissionObjectives", () => ({
 vi.mock("@/hooks/useMissionPresets", () => ({
   useMissionPresets: () => ({
     data: [
-      { id: "trainer", label: "Trainer", description: "", target_polygon: {}, axis_ranges: {}, suggested_estimates: { g_limit: 4, target_static_margin: 0.12, cl_max: 1.4, power_to_weight: 0.4, prop_efficiency: 0.6 } },
-      { id: "sailplane", label: "Sailplane", description: "", target_polygon: {}, axis_ranges: {}, suggested_estimates: { g_limit: 2, target_static_margin: 0.18, cl_max: 1.2, power_to_weight: 0.0, prop_efficiency: 0.0 } },
-      { id: "slope_soarer", label: "Slope Soarer", description: "", target_polygon: {}, axis_ranges: {}, suggested_estimates: { g_limit: 6, target_static_margin: 0.08, cl_max: 1.1, power_to_weight: 0.0, prop_efficiency: 0.0 } },
-      { id: "motor_glider", label: "Motor Glider", description: "", target_polygon: {}, axis_ranges: {}, suggested_estimates: { g_limit: 5.3, target_static_margin: 0.10, cl_max: 1.4, power_to_weight: 100, prop_efficiency: 0.65 } },
-      { id: "flying_wing", label: "Flying Wing", description: "", target_polygon: {}, axis_ranges: {}, suggested_estimates: { g_limit: 5.0, target_static_margin: 0.075, cl_max: 1.0, power_to_weight: 100, prop_efficiency: 0.65 } },
+      { id: "trainer", label: "Trainer", description: "", target_polygon: fullPolygon, axis_ranges: fullAxisRanges, suggested_estimates: { g_limit: 4, target_static_margin: 0.12, cl_max: 1.4, power_to_weight: 0.4, prop_efficiency: 0.6 } },
+      { id: "sailplane", label: "Sailplane", description: "", target_polygon: fullPolygon, axis_ranges: fullAxisRanges, suggested_estimates: { g_limit: 2, target_static_margin: 0.18, cl_max: 1.2, power_to_weight: 0.0, prop_efficiency: 0.0 } },
+      { id: "slope_soarer", label: "Slope Soarer", description: "", target_polygon: fullPolygon, axis_ranges: fullAxisRanges, suggested_estimates: { g_limit: 6, target_static_margin: 0.08, cl_max: 1.1, power_to_weight: 0.0, prop_efficiency: 0.0 } },
+      { id: "motor_glider", label: "Motor Glider", description: "", target_polygon: fullPolygon, axis_ranges: fullAxisRanges, suggested_estimates: { g_limit: 5.3, target_static_margin: 0.10, cl_max: 1.4, power_to_weight: 100, prop_efficiency: 0.65 } },
+      { id: "flying_wing", label: "Flying Wing", description: "", target_polygon: fullPolygon, axis_ranges: fullAxisRanges, suggested_estimates: { g_limit: 5.0, target_static_margin: 0.075, cl_max: 1.0, power_to_weight: 100, prop_efficiency: 0.65 } },
     ],
     isLoading: false, error: null,
   }),
 }));
 
 describe("MissionObjectivesPanel", () => {
+  beforeEach(() => {
+    updateMock.mockClear();
+  });
+
   it("renders the mission type dropdown with all presets", () => {
     render(<MissionObjectivesPanel aeroplaneId="x"/>);
     expect(screen.getByRole("option", { name: /Trainer/ })).toBeInTheDocument();
@@ -51,10 +77,77 @@ describe("MissionObjectivesPanel", () => {
     expect(screen.getByLabelText(/Available Runway/i)).toBeInTheDocument();
   });
 
-  it("shows the auto-apply banner after mission_type change", () => {
+  it("shows the apply banner after mission_type change with English copy (gh-601)", () => {
     render(<MissionObjectivesPanel aeroplaneId="x"/>);
     const select = screen.getByLabelText(/Mission Type/i) as HTMLSelectElement;
-    fireEvent.change(select, { target: { value: "sailplane" } });
-    expect(screen.getByText(/Estimates angepasst/i)).toBeInTheDocument();
+    fireEvent.change(select, { target: { value: "motor_glider" } });
+
+    const banner = screen.getByTestId("mission-apply-banner");
+    expect(banner).toBeInTheDocument();
+
+    // English banner copy — no remaining German.
+    expect(banner.textContent ?? "").toMatch(/Mission set to/i);
+    expect(banner.textContent ?? "").not.toMatch(/Mission auf/i);
+    expect(banner.textContent ?? "").not.toMatch(/angepasst/i);
+  });
+
+  it("shows a diff row for target_cruise_mps after Motor Glider preset change (gh-601)", () => {
+    render(<MissionObjectivesPanel aeroplaneId="x"/>);
+    const select = screen.getByLabelText(/Mission Type/i) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "motor_glider" } });
+
+    // cruise: 18 → 26.0 (0.5 × (22, 30))
+    expect(screen.getByTestId("diff-row-target_cruise_mps")).toBeInTheDocument();
+  });
+
+  it("applies all 6 target fields when Apply is clicked (gh-601)", async () => {
+    render(<MissionObjectivesPanel aeroplaneId="x"/>);
+    const select = screen.getByLabelText(/Mission Type/i) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "motor_glider" } });
+
+    const applyBtn = screen.getByRole("button", { name: /^Apply$/ });
+    fireEvent.click(applyBtn);
+
+    // Banner is dismissed
+    expect(screen.queryByTestId("mission-apply-banner")).not.toBeInTheDocument();
+
+    // update() was called with all 6 target fields set to preset-derived values
+    await waitFor(() => {
+      expect(updateMock).toHaveBeenCalled();
+    });
+    const lastCallArg = updateMock.mock.calls[updateMock.mock.calls.length - 1][0];
+    expect(lastCallArg.target_cruise_mps).toBeCloseTo(26.0, 3);
+    expect(lastCallArg.target_maneuver_n).toBeCloseTo(3.9, 3);
+    // stall_safety: preset score is 1.0 → range[1] = 2.0
+    expect(lastCallArg.target_stall_safety).toBeCloseTo(2.0, 3);
+    // glide: 0.5 × (15, 35) = 25
+    expect(lastCallArg.target_glide_ld).toBeCloseTo(25.0, 3);
+    // climb: 0.5 × (5, 25) = 15
+    expect(lastCallArg.target_climb_energy).toBeCloseTo(15.0, 3);
+    // wing_loading: 0.5 × (20, 80) = 50
+    expect(lastCallArg.target_wing_loading_n_m2).toBeCloseTo(50.0, 3);
+    // mission_type carries through
+    expect(lastCallArg.mission_type).toBe("motor_glider");
+  });
+
+  it("does not apply targets when Dismiss is clicked (gh-601)", () => {
+    render(<MissionObjectivesPanel aeroplaneId="x"/>);
+    const select = screen.getByLabelText(/Mission Type/i) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "motor_glider" } });
+
+    const dismissBtn = screen.getByRole("button", { name: /Dismiss/ });
+    fireEvent.click(dismissBtn);
+
+    expect(screen.queryByTestId("mission-apply-banner")).not.toBeInTheDocument();
+
+    // The only update() call so far is from the debounced mission_type set
+    // (debounce timer hasn't fired in synchronous test). It must NOT contain
+    // the preset target overrides.
+    for (const call of updateMock.mock.calls) {
+      const arg = call[0];
+      // Targets remain at the original (trainer) values.
+      expect(arg.target_cruise_mps).toBe(18);
+      expect(arg.target_glide_ld).toBe(12);
+    }
   });
 });

--- a/frontend/__tests__/MissionRadarChart.test.tsx
+++ b/frontend/__tests__/MissionRadarChart.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render } from "@testing-library/react";
+import { render, fireEvent } from "@testing-library/react";
 import React from "react";
 import { MissionRadarChart } from "@/components/workbench/mission/MissionRadarChart";
 import type { MissionKpiSet, MissionAxisKpi } from "@/hooks/useMissionKpis";
@@ -16,6 +16,18 @@ const baseKpi = (axis: AxisName, score: number): MissionAxisKpi => ({
   formula: "-",
   warning: null,
 });
+
+const cruiseKpi: MissionAxisKpi = {
+  axis: "cruise",
+  value: 18.2,
+  unit: "m/s",
+  score_0_1: 0.5,
+  range_min: 10,
+  range_max: 25,
+  provenance: "computed",
+  formula: "-",
+  warning: null,
+};
 
 const kset: MissionKpiSet = {
   aeroplane_uuid: "x",
@@ -106,5 +118,125 @@ describe("MissionRadarChart", () => {
       new MouseEvent("click", { bubbles: true }),
     );
     expect(onAxisClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a hover wedge per axis (gh-601)", () => {
+    const { container } = render(
+      <MissionRadarChart
+        kpis={kset}
+        activeMissions={[preset("trainer")]}
+        onAxisClick={() => undefined}
+      />,
+    );
+    const wedges = container.querySelectorAll('[data-testid^="hover-wedge-"]');
+    expect(wedges.length).toBe(7);
+  });
+
+  it("shows tooltip with raw cruise value on axis hover (gh-601)", () => {
+    const ksetCruise = { ...kset, ist_polygon: { ...kset.ist_polygon, cruise: cruiseKpi } };
+    const { getByTestId, queryByTestId } = render(
+      <MissionRadarChart
+        kpis={ksetCruise}
+        activeMissions={[preset("trainer")]}
+        onAxisClick={() => undefined}
+      />,
+    );
+    expect(queryByTestId("axis-tooltip-cruise")).not.toBeInTheDocument();
+
+    fireEvent.mouseEnter(getByTestId("hover-wedge-cruise"));
+
+    const tooltip = getByTestId("axis-tooltip-cruise");
+    expect(tooltip).toBeInTheDocument();
+    const text = tooltip.textContent ?? "";
+    // Ist: 10 + 0.5 × (25 − 10) = 17.50
+    expect(text).toMatch(/17\.50/);
+    expect(text).toMatch(/m\/s/);
+    // Soll for trainer preset: 10 + 0.5 × (25 − 10) = 17.50
+    expect(text).toMatch(/Soll/);
+  });
+
+  it("hides tooltip on mouseleave (gh-601)", () => {
+    const { getByTestId, queryByTestId } = render(
+      <MissionRadarChart
+        kpis={kset}
+        activeMissions={[preset("trainer")]}
+        onAxisClick={() => undefined}
+      />,
+    );
+    const wedge = getByTestId("hover-wedge-cruise");
+    fireEvent.mouseEnter(wedge);
+    expect(queryByTestId("axis-tooltip-cruise")).toBeInTheDocument();
+    fireEvent.mouseLeave(wedge);
+    expect(queryByTestId("axis-tooltip-cruise")).not.toBeInTheDocument();
+  });
+
+  it("does not collapse Ist polygon when preset's axis_ranges are narrower than the actual KPI (gh-601 Part C)", () => {
+    // Wing-Racer style preset with cruise range [25, 40].
+    const wingRacer = preset("wing_racer");
+    wingRacer.axis_ranges = {
+      stall_safety: [1.3, 2.5],
+      glide: [5, 18],
+      climb: [5, 25],
+      cruise: [25, 40],
+      maneuver: [2, 5],
+      wing_loading: [20, 80],
+      field_friendliness: [3, 100],
+    };
+    // Aircraft cruises at 18 m/s — below the Wing-Racer preset's lower bound.
+    const ksetLowCruise: MissionKpiSet = {
+      ...kset,
+      ist_polygon: {
+        ...kset.ist_polygon,
+        cruise: {
+          axis: "cruise",
+          value: 18,
+          unit: "m/s",
+          score_0_1: 0.4,
+          range_min: 10,
+          range_max: 30,
+          provenance: "computed",
+          formula: "-",
+          warning: null,
+        },
+      },
+    };
+    const { container } = render(
+      <MissionRadarChart
+        kpis={ksetLowCruise}
+        activeMissions={[wingRacer]}
+        onAxisClick={() => undefined}
+      />,
+    );
+    const ist = container.querySelector("polygon.radar-ist");
+    expect(ist).not.toBeNull();
+    const pointsAttr = ist!.getAttribute("points") ?? "";
+    // Parse points and ensure at least one vertex is > 5 px from origin.
+    const distances = pointsAttr
+      .trim()
+      .split(/\s+/)
+      .map((p) => p.split(",").map(Number))
+      .map(([x, y]) => Math.hypot(x, y));
+    expect(Math.max(...distances)).toBeGreaterThan(5);
+  });
+
+  it("includes ghost mission values in tooltip (gh-601)", () => {
+    const ghost = preset("sailplane");
+    // Set a distinctive cruise score on the ghost so we can locate it.
+    ghost.target_polygon.cruise = 0.8;
+    ghost.axis_ranges.cruise = [10, 30]; // 10 + 0.8 × 20 = 26
+    const { getByTestId } = render(
+      <MissionRadarChart
+        kpis={kset}
+        activeMissions={[preset("trainer"), ghost]}
+        onAxisClick={() => undefined}
+      />,
+    );
+    fireEvent.mouseEnter(getByTestId("hover-wedge-cruise"));
+    const tooltip = getByTestId("axis-tooltip-cruise");
+    const text = tooltip.textContent ?? "";
+    // Ghost label "sailplane" is present
+    expect(text).toMatch(/sailplane/);
+    // Ghost value 26.00
+    expect(text).toMatch(/26\.00/);
   });
 });

--- a/frontend/__tests__/missionScale.test.ts
+++ b/frontend/__tests__/missionScale.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { computeAxisRanges } from "@/lib/missionScale";
-import type { MissionPreset } from "@/hooks/useMissionPresets";
+import {
+  AXIS_UNITS,
+  computeAxisRanges,
+  normalizedToRaw,
+} from "@/lib/missionScale";
+import type { MissionPreset, AxisName } from "@/hooks/useMissionPresets";
+import type { MissionKpiSet, MissionAxisKpi } from "@/hooks/useMissionKpis";
 
 const trainer: MissionPreset = {
   id: "trainer",
@@ -58,5 +63,157 @@ describe("computeAxisRanges", () => {
     expect(ranges.glide).toEqual([5, 35]);
     expect(ranges.stall_safety).toEqual([1.3, 2.5]);
     expect(ranges.wing_loading).toEqual([10, 80]);
+  });
+});
+
+describe("normalizedToRaw (gh-601)", () => {
+  it("maps 0 to range minimum", () => {
+    expect(normalizedToRaw(0, [10, 25])).toBeCloseTo(10);
+  });
+
+  it("maps 1 to range maximum", () => {
+    expect(normalizedToRaw(1, [10, 25])).toBeCloseTo(25);
+  });
+
+  it("interpolates linearly inside the range", () => {
+    expect(normalizedToRaw(0.5, [10, 25])).toBeCloseTo(17.5);
+    expect(normalizedToRaw(0.5, [22, 30])).toBeCloseTo(26.0);
+    expect(normalizedToRaw(0.5, [3.0, 4.8])).toBeCloseTo(3.9);
+  });
+
+  it("clamps scores above 1 to range maximum", () => {
+    expect(normalizedToRaw(1.5, [10, 25])).toBeCloseTo(25);
+  });
+
+  it("clamps negative scores to range minimum", () => {
+    expect(normalizedToRaw(-0.2, [10, 25])).toBeCloseTo(10);
+  });
+
+  it("handles inverted ranges (max < min) by linear interpolation", () => {
+    // For inverted ranges we still return range[0] + score × (range[1] − range[0]);
+    // callers should pass [lo, hi] in non-decreasing order.
+    expect(normalizedToRaw(0.25, [10, 0])).toBeCloseTo(7.5);
+  });
+});
+
+describe("AXIS_UNITS (gh-601)", () => {
+  it("provides a unit string for every axis", () => {
+    expect(AXIS_UNITS.cruise).toBe("m/s");
+    expect(AXIS_UNITS.maneuver).toBe("g");
+    expect(AXIS_UNITS.wing_loading).toBe("N/m²");
+    expect(AXIS_UNITS.glide).toBe("L/D");
+    expect(AXIS_UNITS.stall_safety).toBe("×");
+  });
+});
+
+// gh-601 Part C: computeAxisRanges should union the Ist KPI ranges/values
+// so the Ist polygon doesn't collapse to the center when an active mission's
+// axis_ranges are narrower than the aircraft's actual KPIs.
+const wingRacer: MissionPreset = {
+  ...trainer,
+  id: "wing_racer",
+  axis_ranges: {
+    stall_safety: [1.3, 2.5],
+    glide: [5, 18],
+    climb: [5, 25],
+    cruise: [25, 40], // narrower than the actual aircraft (18 m/s)
+    maneuver: [2, 5],
+    wing_loading: [20, 80],
+    field_friendliness: [3, 100],
+  },
+};
+
+const kpi = (
+  axis: AxisName,
+  value: number,
+  range: [number, number],
+  provenance: "computed" | "estimated" | "missing" = "computed",
+): MissionAxisKpi => ({
+  axis,
+  value,
+  unit: "-",
+  score_0_1: (value - range[0]) / (range[1] - range[0]),
+  range_min: range[0],
+  range_max: range[1],
+  provenance,
+  formula: "-",
+  warning: null,
+});
+
+const istKpiSet = (cruiseValue: number, cruiseRange: [number, number]): MissionKpiSet => ({
+  aeroplane_uuid: "x",
+  ist_polygon: {
+    stall_safety: kpi("stall_safety", 1.6, [1.3, 2.5]),
+    glide: kpi("glide", 10, [5, 18]),
+    climb: kpi("climb", 12, [5, 25]),
+    cruise: kpi("cruise", cruiseValue, cruiseRange),
+    maneuver: kpi("maneuver", 3, [2, 5]),
+    wing_loading: kpi("wing_loading", 40, [20, 80]),
+    field_friendliness: kpi("field_friendliness", 30, [3, 100]),
+  },
+  target_polygons: [],
+  active_mission_id: "wing_racer",
+  computed_at: "",
+  context_hash: "0".repeat(64),
+});
+
+describe("computeAxisRanges with Ist KPIs (gh-601 Part C)", () => {
+  it("widens the active mission range to include the Ist KPI's actual value", () => {
+    const ist = istKpiSet(18, [10, 25]);
+    const ranges = computeAxisRanges([wingRacer], ist);
+    // Wing-Racer cruise range is [25, 40]; aircraft cruises at 18 → the
+    // returned range must include 18 (and the KPI reference upper bound 25).
+    expect(ranges.cruise[0]).toBeLessThanOrEqual(18);
+    expect(ranges.cruise[1]).toBeGreaterThanOrEqual(40);
+  });
+
+  it("widens the range upward when the Ist value exceeds the preset upper bound", () => {
+    const ist = istKpiSet(50, [10, 60]);
+    const ranges = computeAxisRanges([wingRacer], ist);
+    expect(ranges.cruise[1]).toBeGreaterThanOrEqual(50);
+  });
+
+  it("is backward compatible when no Ist KPI is supplied", () => {
+    const ranges = computeAxisRanges([wingRacer]);
+    expect(ranges.cruise).toEqual([25, 40]);
+  });
+
+  it("skips axes whose Ist provenance is missing (no stale-zero pollution)", () => {
+    const ist = istKpiSet(0, [0, 1]);
+    ist.ist_polygon.cruise = {
+      ...ist.ist_polygon.cruise,
+      provenance: "missing",
+      score_0_1: null,
+      value: null,
+      range_min: 0,
+      range_max: 0,
+    };
+    const ranges = computeAxisRanges([wingRacer], ist);
+    // Cruise range should remain the preset's own [25, 40] since the Ist is
+    // missing.
+    expect(ranges.cruise).toEqual([25, 40]);
+  });
+
+  it("widens ranges across ALL 7 axes when Ist values fall outside", () => {
+    const ist: MissionKpiSet = {
+      ...istKpiSet(50, [10, 60]),
+      ist_polygon: {
+        stall_safety: kpi("stall_safety", 3.0, [0.5, 3.0]),
+        glide: kpi("glide", 25, [5, 30]),
+        climb: kpi("climb", 30, [5, 35]),
+        cruise: kpi("cruise", 50, [10, 60]),
+        maneuver: kpi("maneuver", 6.0, [1, 6.5]),
+        wing_loading: kpi("wing_loading", 100, [10, 120]),
+        field_friendliness: kpi("field_friendliness", 120, [3, 150]),
+      },
+    };
+    const ranges = computeAxisRanges([wingRacer], ist);
+    expect(ranges.stall_safety[1]).toBeGreaterThanOrEqual(3.0);
+    expect(ranges.glide[1]).toBeGreaterThanOrEqual(25);
+    expect(ranges.climb[1]).toBeGreaterThanOrEqual(30);
+    expect(ranges.cruise[1]).toBeGreaterThanOrEqual(50);
+    expect(ranges.maneuver[1]).toBeGreaterThanOrEqual(6.0);
+    expect(ranges.wing_loading[1]).toBeGreaterThanOrEqual(100);
+    expect(ranges.field_friendliness[1]).toBeGreaterThanOrEqual(120);
   });
 });

--- a/frontend/components/workbench/mission/MissionObjectivesPanel.tsx
+++ b/frontend/components/workbench/mission/MissionObjectivesPanel.tsx
@@ -2,17 +2,82 @@
 
 import React, { useRef, useState } from "react";
 import { useMissionObjectives, type MissionObjective } from "@/hooks/useMissionObjectives";
-import { useMissionPresets } from "@/hooks/useMissionPresets";
+import { useMissionPresets, type MissionPreset, type AxisName } from "@/hooks/useMissionPresets";
+import { normalizedToRaw } from "@/lib/missionScale";
 
 interface Props {
   readonly aeroplaneId: string;
 }
+
+/** Per-axis → MissionObjective target-field mapping (gh-601). */
+const AXIS_TO_TARGET_FIELD: Partial<Record<AxisName, keyof MissionObjective>> = {
+  stall_safety: "target_stall_safety",
+  glide: "target_glide_ld",
+  climb: "target_climb_energy",
+  cruise: "target_cruise_mps",
+  maneuver: "target_maneuver_n",
+  wing_loading: "target_wing_loading_n_m2",
+  // field_friendliness — no direct target field (out of scope per #601).
+};
+
+const TARGET_FIELD_LABELS: Record<string, string> = {
+  target_stall_safety: "Stall Safety",
+  target_glide_ld: "Glide (L/D)",
+  target_climb_energy: "Climb Energy",
+  target_cruise_mps: "Cruise (m/s)",
+  target_maneuver_n: "Maneuver (g)",
+  target_wing_loading_n_m2: "Wing Loading (N/m²)",
+};
+
+/** Suggested target value computed from a preset's polygon × axis ranges. */
+interface SuggestedTarget {
+  readonly axis: AxisName;
+  readonly field: keyof MissionObjective;
+  readonly label: string;
+  readonly current: number;
+  readonly suggested: number;
+}
+
+function computeSuggestedTargets(
+  preset: MissionPreset,
+  draft: MissionObjective,
+): SuggestedTarget[] {
+  const out: SuggestedTarget[] = [];
+  for (const [axis, field] of Object.entries(AXIS_TO_TARGET_FIELD) as [
+    AxisName,
+    keyof MissionObjective,
+  ][]) {
+    const score = preset.target_polygon[axis];
+    const range = preset.axis_ranges[axis];
+    if (score === undefined || range === undefined) continue;
+    const suggested = normalizedToRaw(score, range);
+    const current = draft[field] as number;
+    out.push({
+      axis,
+      field,
+      label: TARGET_FIELD_LABELS[field] ?? field,
+      current,
+      suggested,
+    });
+  }
+  return out;
+}
+
+/** Row is shown only when the relative delta exceeds 0.5%. */
+function isMeaningfulDiff(current: number, suggested: number): boolean {
+  const denom = Math.max(Math.abs(current), Math.abs(suggested), 1e-9);
+  return Math.abs(current - suggested) / denom > 0.005;
+}
+
+const fmt = (n: number): string =>
+  Number.isInteger(n) ? n.toFixed(1) : n.toFixed(2);
 
 export function MissionObjectivesPanel({ aeroplaneId }: Props) {
   const { data: persisted, update } = useMissionObjectives(aeroplaneId);
   const { data: presets } = useMissionPresets();
   const [draft, setDraft] = useState<MissionObjective | null>(null);
   const [bannerKey, setBannerKey] = useState<string | null>(null);
+  const [bannerVisible, setBannerVisible] = useState<boolean>(false);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // "Adjust state when a prop changes" pattern — avoids useEffect+setState
@@ -34,21 +99,97 @@ export function MissionObjectivesPanel({ aeroplaneId }: Props) {
   const onMissionTypeChange = (id: string) => {
     set("mission_type", id);
     setBannerKey(id);
+    setBannerVisible(true);
   };
 
   const activePreset = presets.find((p) => p.id === draft.mission_type);
+
+  const suggestedTargets =
+    activePreset && bannerKey ? computeSuggestedTargets(activePreset, draft) : [];
+  const diffRows = suggestedTargets.filter((r) => isMeaningfulDiff(r.current, r.suggested));
+
+  const handleApply = () => {
+    if (!activePreset) return;
+    // Snapshot the current draft and apply all suggested targets at once.
+    // We cancel any pending debounced update synchronously here so the older
+    // (mission_type-only) PUT cannot race past this one.
+    if (timer.current) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
+    const next = { ...draft };
+    for (const row of suggestedTargets) {
+      (next as Record<string, number>)[row.field as string] = row.suggested;
+    }
+    setDraft(next);
+    void update(next);
+    setBannerVisible(false);
+  };
+
+  const handleDismiss = () => {
+    setBannerVisible(false);
+  };
+
+  const showBanner = bannerVisible && bannerKey && activePreset;
 
   return (
     <div className="flex h-full flex-col gap-3">
       <h3 className="text-sm font-semibold text-orange-500">⊙ Mission Objectives</h3>
 
-      {bannerKey && activePreset && (
-        <div className="rounded border-l-2 border-orange-500 bg-orange-500/10 p-3 text-xs">
+      {showBanner && (
+        <div
+          className="rounded border-l-2 border-orange-500 bg-orange-500/10 p-3 text-xs"
+          data-testid="mission-apply-banner"
+        >
           <div className="font-semibold text-orange-500">
-            ⚡ Mission auf <span className="text-white">{activePreset.label}</span> gesetzt — Estimates angepasst
+            ⚡ Mission set to <span className="text-white">{activePreset.label}</span> — estimates applied
           </div>
           <div className="mt-1 font-mono text-[10px] text-foreground/80">
-            {Object.entries(activePreset.suggested_estimates).map(([k, v]) => `${k}=${v}`).join(" · ")}
+            {Object.entries(activePreset.suggested_estimates)
+              .map(([k, v]) => `${k}=${v}`)
+              .join(" · ")}
+          </div>
+
+          {diffRows.length > 0 && (
+            <div className="mt-2">
+              <div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">
+                Suggested Performance Targets
+              </div>
+              <table className="w-full font-mono text-[10px]">
+                <tbody>
+                  {diffRows.map((row) => (
+                    <tr key={row.field} data-testid={`diff-row-${row.field}`}>
+                      <td className="py-0.5 pr-2 text-foreground/80">{row.label}</td>
+                      <td className="py-0.5 pr-2 text-right text-muted-foreground tabular-nums">
+                        {fmt(row.current)}
+                      </td>
+                      <td className="py-0.5 pr-1 text-muted-foreground">→</td>
+                      <td className="py-0.5 text-right text-orange-300 tabular-nums">
+                        {fmt(row.suggested)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          <div className="mt-2 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={handleDismiss}
+              className="rounded border border-border bg-transparent px-3 py-1 text-[11px] text-muted-foreground hover:bg-card hover:text-foreground"
+            >
+              Dismiss
+            </button>
+            <button
+              type="button"
+              onClick={handleApply}
+              disabled={diffRows.length === 0}
+              className="rounded bg-orange-500 px-3 py-1 text-[11px] font-semibold text-black hover:bg-orange-400 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Apply
+            </button>
           </div>
         </div>
       )}

--- a/frontend/components/workbench/mission/MissionRadarChart.tsx
+++ b/frontend/components/workbench/mission/MissionRadarChart.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import type { MissionKpiSet } from "@/hooks/useMissionKpis";
 import type { MissionPreset, AxisName } from "@/hooks/useMissionPresets";
 import {
   AXES,
+  AXIS_UNITS,
   computeAxisRanges,
+  normalizedToRaw,
   polarToCartesian,
   renormalise,
 } from "@/lib/missionScale";
@@ -38,12 +40,34 @@ const badgeColor = (p: "computed" | "estimated" | "missing"): string => {
 const toPointsAttr = (pts: { x: number; y: number }[]): string =>
   pts.map((p) => `${p.x},${p.y}`).join(" ");
 
+const fmt = (n: number): string =>
+  Math.abs(n) >= 100 ? n.toFixed(0) : n.toFixed(2);
+
+/** SVG path for the radial hit-wedge at axis index `i` (out of N). */
+function wedgePath(i: number, n: number, outerRadius: number): string {
+  const half = Math.PI / n; // half of the angular slice
+  const center = (Math.PI * 2 * i) / n - Math.PI / 2;
+  const a0 = center - half;
+  const a1 = center + half;
+  const x0 = Math.cos(a0) * outerRadius;
+  const y0 = Math.sin(a0) * outerRadius;
+  const x1 = Math.cos(a1) * outerRadius;
+  const y1 = Math.sin(a1) * outerRadius;
+  // sweep = 1 (clockwise in SVG); large-arc = 0 since slice < 180°
+  return `M 0 0 L ${x0} ${y0} A ${outerRadius} ${outerRadius} 0 0 1 ${x1} ${y1} Z`;
+}
+
 export function MissionRadarChart({
   kpis,
   activeMissions,
   onAxisClick,
 }: Props) {
-  const globalRanges = computeAxisRanges(activeMissions);
+  const [hoveredAxis, setHoveredAxis] = useState<AxisName | null>(null);
+  // Pass the Ist kpis in so axis ranges include the aircraft's actual
+  // values; this prevents the orange polygon collapsing to the chart
+  // center when the active mission's `axis_ranges` are narrower than
+  // the aircraft's KPI band (gh-601).
+  const globalRanges = computeAxisRanges(activeMissions, kpis);
 
   const istPoints = AXES.map((axis, i) => {
     const k = kpis.ist_polygon[axis];
@@ -215,6 +239,133 @@ export function MissionRadarChart({
           </g>
         );
       })}
+
+      {/* Invisible hover wedges — one per axis. Sits on top of polygons so
+          mouse events are captured. Fill is transparent but pointer-events
+          are enabled. */}
+      {AXES.map((axis, i) => (
+        <path
+          key={`wedge-${axis}`}
+          data-testid={`hover-wedge-${axis}`}
+          d={wedgePath(i, AXES.length, R * 1.4)}
+          fill="transparent"
+          stroke="none"
+          style={{ pointerEvents: "all", cursor: "pointer" }}
+          onMouseEnter={() => setHoveredAxis(axis)}
+          onMouseLeave={() => setHoveredAxis(null)}
+        />
+      ))}
+
+      {/* Hover tooltip — anchored near the hovered axis label. */}
+      {hoveredAxis && (
+        <AxisTooltip
+          axis={hoveredAxis}
+          kpis={kpis}
+          active={active}
+          ghosts={ghosts}
+        />
+      )}
     </svg>
+  );
+}
+
+interface AxisTooltipProps {
+  readonly axis: AxisName;
+  readonly kpis: MissionKpiSet;
+  readonly active: MissionPreset | undefined;
+  readonly ghosts: MissionPreset[];
+}
+
+function AxisTooltip({ axis, kpis, active, ghosts }: AxisTooltipProps) {
+  const i = AXES.indexOf(axis);
+  const anchor = polarToCartesian(i, 1.55, R);
+  const unit = AXIS_UNITS[axis];
+
+  const k = kpis.ist_polygon[axis];
+  const istValue =
+    k.score_0_1 !== null
+      ? normalizedToRaw(k.score_0_1, [k.range_min, k.range_max])
+      : null;
+
+  const sollValue = active
+    ? normalizedToRaw(active.target_polygon[axis], active.axis_ranges[axis])
+    : null;
+
+  const ghostValues = ghosts.map((g, idx) => ({
+    label: g.label,
+    color: GHOST_COLORS[idx % GHOST_COLORS.length],
+    value: normalizedToRaw(g.target_polygon[axis], g.axis_ranges[axis]),
+  }));
+
+  // Position the tooltip box. Width/height are estimates; we offset so the
+  // tooltip stays inside the SVG viewport for all axes.
+  const boxW = 150;
+  const baseH = 56;
+  const extraH = 14 * ghostValues.length;
+  const boxH = baseH + extraH;
+  const tx = anchor.x < 0 ? anchor.x - boxW : anchor.x;
+  const ty = anchor.y < 0 ? anchor.y - boxH : anchor.y;
+
+  return (
+    <foreignObject
+      x={tx}
+      y={ty}
+      width={boxW}
+      height={boxH}
+      style={{ pointerEvents: "none" }}
+      data-testid={`axis-tooltip-${axis}`}
+    >
+      <div
+        // xmlns required so React renders HTML inside foreignObject
+        xmlns="http://www.w3.org/1999/xhtml"
+        className="rounded border border-border bg-background/95 p-1.5 font-mono text-[10px] leading-tight text-foreground shadow-lg"
+        style={{ width: "100%", boxSizing: "border-box" }}
+      >
+        <div className="mb-1 font-semibold text-orange-400">
+          {AXIS_LABELS[axis]}
+        </div>
+
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-muted-foreground">Ist:</span>
+          <span className="tabular-nums">
+            {istValue === null ? "—" : `${fmt(istValue)} ${unit}`}
+          </span>
+          <span
+            aria-hidden="true"
+            style={{
+              display: "inline-block",
+              width: 6,
+              height: 6,
+              borderRadius: "50%",
+              background: badgeColor(k.provenance),
+            }}
+          />
+        </div>
+
+        {active && sollValue !== null && (
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-muted-foreground">Soll:</span>
+            <span className="tabular-nums">
+              {fmt(sollValue)} {unit}
+            </span>
+            <span className="text-[9px] text-muted-foreground">
+              ({active.label})
+            </span>
+          </div>
+        )}
+
+        {ghostValues.map((g) => (
+          <div
+            key={g.label}
+            className="flex items-center justify-between gap-2"
+          >
+            <span style={{ color: g.color }}>{g.label}:</span>
+            <span className="tabular-nums">
+              {fmt(g.value)} {unit}
+            </span>
+          </div>
+        ))}
+      </div>
+    </foreignObject>
   );
 }

--- a/frontend/lib/missionScale.ts
+++ b/frontend/lib/missionScale.ts
@@ -1,4 +1,5 @@
 import type { MissionPreset, AxisName } from "@/hooks/useMissionPresets";
+import type { MissionKpiSet } from "@/hooks/useMissionKpis";
 
 export const AXES: AxisName[] = [
   "stall_safety",
@@ -13,14 +14,8 @@ export const AXES: AxisName[] = [
 export type AxisRange = [number, number];
 export type AxisRanges = Record<AxisName, AxisRange>;
 
-/**
- * Combine multiple mission presets' per-axis ranges into one set.
- * For each axis, result = [min(all mins), max(all maxes)].
- */
-export function computeAxisRanges(activeMissions: MissionPreset[]): AxisRanges {
-  if (activeMissions.length === 0) {
-    return Object.fromEntries(AXES.map((a) => [a, [0, 1]])) as AxisRanges;
-  }
+/** Union the per-axis range across all supplied missions. */
+function unionMissionRanges(activeMissions: MissionPreset[]): AxisRanges {
   const out = {} as AxisRanges;
   for (const axis of AXES) {
     let lo = Infinity;
@@ -32,6 +27,46 @@ export function computeAxisRanges(activeMissions: MissionPreset[]): AxisRanges {
     }
     out[axis] = [lo, hi];
   }
+  return out;
+}
+
+/** Widen `out` so it covers the Ist KPI's reference range + actual value. */
+function widenWithIst(out: AxisRanges, ist: MissionKpiSet): void {
+  for (const axis of AXES) {
+    const k = ist.ist_polygon[axis];
+    if (!k || k.provenance === "missing") continue;
+    const score = k.score_0_1 ?? 0;
+    const istValue = k.range_min + score * (k.range_max - k.range_min);
+    const lo = Math.min(out[axis][0], k.range_min, istValue);
+    const hi = Math.max(out[axis][1], k.range_max, istValue);
+    out[axis] = [lo, hi];
+  }
+}
+
+/**
+ * Combine multiple mission presets' per-axis ranges (and, optionally, the
+ * Ist KPI's own ranges + values) into one set.
+ *
+ * Without `ist`: result for each axis = [min(all mins), max(all maxes)] across
+ * the supplied missions.
+ *
+ * With `ist` (gh-601): the union also includes the KPI's reference range
+ * AND the actual raw Ist value. This keeps the orange Ist polygon visible
+ * even when the active mission's `axis_ranges` are narrower than the
+ * aircraft's actual KPIs (e.g. a Wing-Racer preset with cruise range
+ * `[25, 40]` should not collapse the cruise vertex of an aircraft that
+ * actually cruises at 18 m/s). Axes whose Ist provenance is "missing" are
+ * skipped to avoid polluting the range with stale zeros.
+ */
+export function computeAxisRanges(
+  activeMissions: MissionPreset[],
+  ist?: MissionKpiSet,
+): AxisRanges {
+  if (activeMissions.length === 0) {
+    return Object.fromEntries(AXES.map((a) => [a, [0, 1]])) as AxisRanges;
+  }
+  const out = unionMissionRanges(activeMissions);
+  if (ist) widenWithIst(out, ist);
   return out;
 }
 
@@ -49,6 +84,28 @@ export function renormalise(
   if (span <= 0) return 0;
   return Math.max(0, Math.min(1, (localValue - globalRange[0]) / span));
 }
+
+/**
+ * Linearly map a 0..1 normalised score onto its axis range to recover the
+ * raw physical value: `range[0] + score × (range[1] − range[0])`.
+ *
+ * Clamps the score to [0, 1] to guard against out-of-band KPI readings.
+ */
+export function normalizedToRaw(score: number, range: AxisRange): number {
+  const clamped = Math.max(0, Math.min(1, score));
+  return range[0] + clamped * (range[1] - range[0]);
+}
+
+/** Display unit for each axis — used by the radar hover tooltip. */
+export const AXIS_UNITS: Record<AxisName, string> = {
+  stall_safety: "×",
+  glide: "L/D",
+  climb: "—",
+  cruise: "m/s",
+  maneuver: "g",
+  wing_loading: "N/m²",
+  field_friendliness: "—",
+};
 
 /** Convert a 0..1 score on a given axis-index (out of 7) into SVG (x, y). */
 export function polarToCartesian(


### PR DESCRIPTION
## Summary

Two coordinated UX additions to the Mission Tab plus an Ist-polygon visibility fix:

- **Apply-banner in `MissionObjectivesPanel`** — after a Mission Type change the banner now shows a diff table (current → suggested) for the six editable Performance Targets, derived from `preset.target_polygon[axis] × preset.axis_ranges[axis]`. Two buttons: **Apply** writes all six fields at once via a single update; **Dismiss** closes the banner. Banner copy is now fully English (the previous German strings are gone).
- **Per-axis hover tooltip in `MissionRadarChart`** — each axis gets an invisible radial hit-wedge that, on mouse enter, surfaces a tooltip with the raw (un-normalised) Ist, Soll and Ghost values plus their axis-specific unit (m/s, g, N/m², L/D, …). Provenance dot reuses the existing computed/estimated/missing palette.
- **Fixes Ist-polygon collapse to center when active mission's axis_ranges don't cover the aircraft's KPIs** — `computeAxisRanges` now unions the Ist KPI ranges in addition to the mission ranges. Concrete repro: a Wing-Racer preset with cruise range `[25, 40]` used to clamp the cruise vertex of an 18 m/s aircraft to zero (vertex at chart center). After the fix, the Ist KPI's own reference range + raw value are unioned in, so the orange polygon stays visible. Axes whose provenance is `"missing"` are skipped to avoid stale-zero pollution. Signature is backward compatible — `ist` is optional.

## Axis → MissionObjective field mapping

| Axis | Field |
|---|---|
| `stall_safety` | `target_stall_safety` |
| `glide` | `target_glide_ld` |
| `climb` | `target_climb_energy` |
| `cruise` | `target_cruise_mps` |
| `maneuver` | `target_maneuver_n` |
| `wing_loading` | `target_wing_loading_n_m2` |
| `field_friendliness` | — (no direct target field, out of scope) |

Note: `field_friendliness` still appears in the radar tooltip with its Soll/Ist raw value — it just has no apply effect.

## Test plan

- [x] `npx vitest run __tests__/missionScale.test.ts __tests__/MissionObjectivesPanel.test.tsx __tests__/MissionRadarChart.test.tsx` — 28 tests pass
- [x] `npm run test:unit` — full frontend suite (840 tests) green
- [x] `npm run lint` — 0 errors (8 pre-existing warnings on unrelated files)
- [x] `npm run deps:check` — exit 0
- [ ] Manual smoke: Mission Tab → change Mission Type → banner appears with diff list → Apply → Performance Target fields jump to preset values; hover over radar axis → tooltip with Ist/Soll values appears

Closes #601