### PR TITLE
fix(gh-602): reload MissionObjectives draft when switching aeroplane

### DIFF
--- a/frontend/__tests__/MissionObjectivesPanel.test.tsx
+++ b/frontend/__tests__/MissionObjectivesPanel.test.tsx
@@ -25,17 +25,30 @@ const fullAxisRanges = {
   field_friendliness: [3, 100] as [number, number],
 };
 
+// Default mission-objective payload — individual tests can override
+// the per-aeroplane payload via `setMissionData(id, data)` (gh-602).
+const defaultMissionData = {
+  mission_type: "trainer",
+  target_cruise_mps: 18, target_stall_safety: 1.8,
+  target_maneuver_n: 3, target_glide_ld: 12,
+  target_climb_energy: 22, target_wing_loading_n_m2: 412,
+  target_field_length_m: 50,
+  available_runway_m: 50, runway_type: "grass",
+  t_static_N: 18, takeoff_mode: "runway",
+};
+
+// Per-aeroplaneId mission-data store used by the mock.
+const missionDataById = new Map<string, typeof defaultMissionData>();
+const setMissionData = (id: string, data: typeof defaultMissionData) => {
+  missionDataById.set(id, data);
+};
+const resetMissionData = () => {
+  missionDataById.clear();
+};
+
 vi.mock("@/hooks/useMissionObjectives", () => ({
-  useMissionObjectives: () => ({
-    data: {
-      mission_type: "trainer",
-      target_cruise_mps: 18, target_stall_safety: 1.8,
-      target_maneuver_n: 3, target_glide_ld: 12,
-      target_climb_energy: 22, target_wing_loading_n_m2: 412,
-      target_field_length_m: 50,
-      available_runway_m: 50, runway_type: "grass",
-      t_static_N: 18, takeoff_mode: "runway",
-    },
+  useMissionObjectives: (aeroplaneId: string | null) => ({
+    data: missionDataById.get(aeroplaneId ?? "") ?? defaultMissionData,
     update: updateMock,
     isLoading: false, error: null,
   }),
@@ -57,6 +70,7 @@ vi.mock("@/hooks/useMissionPresets", () => ({
 describe("MissionObjectivesPanel", () => {
   beforeEach(() => {
     updateMock.mockClear();
+    resetMissionData();
   });
 
   it("renders the mission type dropdown with all presets", () => {
@@ -149,5 +163,42 @@ describe("MissionObjectivesPanel", () => {
       expect(arg.target_cruise_mps).toBe(18);
       expect(arg.target_glide_ld).toBe(12);
     }
+  });
+
+  it("reloads draft from new persisted data when aeroplaneId changes (gh-602)", () => {
+    setMissionData("a", { ...defaultMissionData, target_cruise_mps: 18 });
+    setMissionData("b", { ...defaultMissionData, target_cruise_mps: 42 });
+
+    const { rerender } = render(<MissionObjectivesPanel aeroplaneId="a"/>);
+    // Aeroplane A's cruise value (18) is shown.
+    const inputA = screen.getByLabelText(/Target Cruise/i) as HTMLInputElement;
+    expect(inputA.value).toBe("18");
+
+    // User switches to aeroplane B — its persisted data differs.
+    rerender(<MissionObjectivesPanel aeroplaneId="b"/>);
+    const inputB = screen.getByLabelText(/Target Cruise/i) as HTMLInputElement;
+    expect(inputB.value).toBe("42");
+    expect(inputB.value).not.toBe("18");
+  });
+
+  it("preserves in-flight draft edits across SWR revalidations for the SAME aeroplaneId (gh-602)", () => {
+    setMissionData("a", { ...defaultMissionData, target_cruise_mps: 10 });
+
+    const { rerender } = render(<MissionObjectivesPanel aeroplaneId="a"/>);
+    const input = screen.getByLabelText(/Target Cruise/i) as HTMLInputElement;
+    expect(input.value).toBe("10");
+
+    // User edits the cruise value to 99.
+    fireEvent.change(input, { target: { value: "99" } });
+    expect(input.value).toBe("99");
+
+    // SWR revalidates the SAME aeroplane — server still returns 10
+    // (the user's 99 hasn't been persisted yet). The draft must NOT be
+    // clobbered by this revalidation.
+    setMissionData("a", { ...defaultMissionData, target_cruise_mps: 10 });
+    rerender(<MissionObjectivesPanel aeroplaneId="a"/>);
+
+    const inputAfter = screen.getByLabelText(/Target Cruise/i) as HTMLInputElement;
+    expect(inputAfter.value).toBe("99");
   });
 });

--- a/frontend/components/workbench/mission/MissionObjectivesPanel.tsx
+++ b/frontend/components/workbench/mission/MissionObjectivesPanel.tsx
@@ -78,12 +78,21 @@ export function MissionObjectivesPanel({ aeroplaneId }: Props) {
   const [draft, setDraft] = useState<MissionObjective | null>(null);
   const [bannerKey, setBannerKey] = useState<string | null>(null);
   const [bannerVisible, setBannerVisible] = useState<boolean>(false);
+  const [lastAeroplaneId, setLastAeroplaneId] = useState<string | null>(null);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // "Adjust state when a prop changes" pattern — avoids useEffect+setState
-  // (which react-hooks/set-state-in-effect forbids). Seed draft once on first
-  // server response; subsequent SWR revalidations are intentionally ignored so
-  // the user's in-flight edits are not clobbered.
+  // (which react-hooks/set-state-in-effect forbids). When the aeroplaneId
+  // changes (user switched aeroplane), drop the previous draft so the next
+  // server response for the new aeroplane re-seeds it — otherwise the panel
+  // would render aeroplane A's data while writes target aeroplane B's URL
+  // (gh-602, data-corruption risk). For the SAME aeroplane, the draft is
+  // seeded once on the first server response; subsequent SWR revalidations
+  // are intentionally ignored so the user's in-flight edits are not clobbered.
+  if (lastAeroplaneId !== aeroplaneId) {
+    setLastAeroplaneId(aeroplaneId);
+    setDraft(null);
+  }
   if (persisted && !draft) setDraft({ ...persisted });
 
   if (!draft || !presets) return <div className="text-muted-foreground text-sm">Loading…</div>;


### PR DESCRIPTION
## Summary

- Fixes a **data-corruption** bug in `MissionObjectivesPanel`: when the user switched aeroplane (A → B), the panel kept rendering A's mission objective values while writes via `update()` targeted B's URL — so editing on the Mission tab silently overwrote B's record with a mutated copy of A's payload.
- Root cause: the seed-once guard `if (persisted && !draft) setDraft({ ...persisted })` (intentionally preserves in-flight edits against SWR revalidations) had no concept of "the prop changed".
- Fix: track the previously seen `aeroplaneId` in component state and, on mismatch, reset `draft` to `null` so the next render re-seeds it from the new aeroplane's persisted data. Uses the React 19 "compare props during render" pattern via `useState` (not `useRef` — keeps `react-hooks/refs` clean).

### Before / after

```diff
+ const [lastAeroplaneId, setLastAeroplaneId] = useState<string | null>(null);

+ if (lastAeroplaneId !== aeroplaneId) {
+   setLastAeroplaneId(aeroplaneId);
+   setDraft(null);
+ }
  if (persisted && !draft) setDraft({ ...persisted });
```

In-flight edits on the *same* `aeroplaneId` are still preserved against SWR revalidations (existing semantics — covered explicitly by a new test).

## Test plan

- [x] `npm run test:unit -- MissionObjectivesPanel` — 8/8 green (6 existing + 2 new):
  - new: `reloads draft from new persisted data when aeroplaneId changes (gh-602)`
  - new: `preserves in-flight draft edits across SWR revalidations for the SAME aeroplaneId (gh-602)`
- [x] `npm run test:unit` — 851/851 green (verified across 3 consecutive full runs to rule out flakes)
- [x] `npm run lint` — 0 errors (10 pre-existing warnings in unrelated files)
- [x] `npm run deps:check` — 0 errors (7 pre-existing warnings in unrelated files)
- [ ] Manual smoke (recommended on staging): switch aeroplane A→B with Mission tab open, verify fields refresh; edit a field on B, wait for SWR revalidation, verify the edit isn't clobbered.

Closes #602

🤖 Generated with [Claude Code](https://claude.com/claude-code)