### PR TITLE
feat(gh-610): per-field info tooltips on Mission Tab inputs

### DIFF
--- a/frontend/__tests__/InfoLabel.test.tsx
+++ b/frontend/__tests__/InfoLabel.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { InfoLabel } from "@/components/workbench/InfoLabel";
+
+describe("InfoLabel", () => {
+  it("renders the label text", () => {
+    render(<InfoLabel label="Target Cruise" description="Cruise speed in m/s." />);
+    expect(screen.getByText("Target Cruise")).toBeInTheDocument();
+  });
+
+  it("renders a tooltip element with the description when provided", () => {
+    render(
+      <InfoLabel
+        label="Target Cruise"
+        description="Cruise speed in m/s."
+      />,
+    );
+    const tip = screen.getByRole("tooltip", { hidden: true });
+    expect(tip).toBeInTheDocument();
+    expect(tip).toHaveTextContent("Cruise speed in m/s.");
+  });
+
+  it("tooltip is hidden by default (Tailwind `hidden` class)", () => {
+    render(
+      <InfoLabel label="A" description="hidden-by-default" />,
+    );
+    const tip = screen.getByRole("tooltip", { hidden: true });
+    expect(tip.className).toContain("hidden");
+    expect(tip.className).toContain("group-hover/info:block");
+    expect(tip.className).toContain("group-focus-within/info:block");
+  });
+
+  it("renders a focusable HelpCircle icon when a description is provided", () => {
+    const { container } = render(
+      <InfoLabel label="Foo" description="hello" />,
+    );
+    // The icon is the only tabIndex=0 element inside the label.
+    const focusable = container.querySelector("[tabindex='0']");
+    expect(focusable).not.toBeNull();
+  });
+
+  it("links the label to a form control via htmlFor", () => {
+    const { container } = render(
+      <InfoLabel label="Foo" description="bar" htmlFor="my-input" />,
+    );
+    const label = container.querySelector("label");
+    expect(label?.getAttribute("for")).toBe("my-input");
+  });
+
+  it("renders a plain label without icon/tooltip when no description is given", () => {
+    const { container } = render(<InfoLabel label="Bare" htmlFor="x" />);
+    expect(screen.getByText("Bare")).toBeInTheDocument();
+    expect(container.querySelector("[role='tooltip']")).toBeNull();
+    expect(container.querySelector("[tabindex='0']")).toBeNull();
+  });
+
+  it("renders a plain label without icon/tooltip when description is empty string", () => {
+    const { container } = render(<InfoLabel label="Bare" description="" />);
+    expect(screen.getByText("Bare")).toBeInTheDocument();
+    expect(container.querySelector("[role='tooltip']")).toBeNull();
+  });
+
+  it("plain label still respects htmlFor", () => {
+    const { container } = render(<InfoLabel label="Bare" htmlFor="y" />);
+    const label = container.querySelector("label");
+    expect(label?.getAttribute("for")).toBe("y");
+  });
+});

--- a/frontend/__tests__/MissionObjectivesPanel.test.tsx
+++ b/frontend/__tests__/MissionObjectivesPanel.test.tsx
@@ -236,6 +236,57 @@ describe("MissionObjectivesPanel", () => {
     });
   });
 
+  // Coverage for each per-field onChange closure (gh-610). Firing a value
+  // change exercises the inline `(v) => set("...", v)` handler on every
+  // NumField/SelectField, ensuring the description-prop refactor did not
+  // silently break wiring.
+  describe("per-field onChange handlers (gh-610 coverage)", () => {
+    it.each([
+      ["Target Cruise", "21"],
+      ["Stall Safety", "1.6"],
+      ["Max Maneuver", "4"],
+      ["Min Glide (L/D)", "14"],
+      ["Climb Energy", "20"],
+      ["Target Wing Load", "300"],
+      ["Available Runway", "75"],
+      ["Static Thrust", "12"],
+    ])("NumField %s onChange wires through to draft", (label, newValue) => {
+      render(<MissionObjectivesPanel aeroplaneId="x"/>);
+      // Use exact-string match so labels with regex metachars like "Min Glide (L/D)"
+      // do not get parsed as regex groups.
+      const input = screen.getByLabelText(label, { exact: true }) as HTMLInputElement;
+      fireEvent.change(input, { target: { value: newValue } });
+      expect(input.value).toBe(newValue);
+    });
+
+    it.each([
+      ["Runway Type", "asphalt"],
+      ["Takeoff Mode", "hand_launch"],
+    ])("SelectField %s onChange wires through to draft", (label, newValue) => {
+      render(<MissionObjectivesPanel aeroplaneId="x"/>);
+      const select = screen.getByLabelText(label, { exact: true }) as HTMLSelectElement;
+      fireEvent.change(select, { target: { value: newValue } });
+      expect(select.value).toBe(newValue);
+    });
+
+    it("debounced update() fires 300 ms after a value change", () => {
+      vi.useFakeTimers();
+      try {
+        render(<MissionObjectivesPanel aeroplaneId="x"/>);
+        const input = screen.getByLabelText(/Target Cruise/i) as HTMLInputElement;
+        fireEvent.change(input, { target: { value: "33" } });
+        // Before the debounce fires, update() has not been called.
+        expect(updateMock).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(350);
+        expect(updateMock).toHaveBeenCalled();
+        const arg = updateMock.mock.calls[updateMock.mock.calls.length - 1][0];
+        expect(arg.target_cruise_mps).toBe(33);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   it("preserves in-flight draft edits across SWR revalidations for the SAME aeroplaneId (gh-602)", () => {
     setMissionData("a", { ...defaultMissionData, target_cruise_mps: 10 });
 

--- a/frontend/__tests__/MissionObjectivesPanel.test.tsx
+++ b/frontend/__tests__/MissionObjectivesPanel.test.tsx
@@ -181,6 +181,61 @@ describe("MissionObjectivesPanel", () => {
     expect(inputB.value).not.toBe("18");
   });
 
+  describe("per-field info tooltips (gh-610)", () => {
+    // The 11 expected tooltip texts. Keep in lockstep with FIELD_DESCRIPTIONS
+    // in MissionObjectivesPanel — if the prod copy changes, this test should
+    // fail and surface the divergence.
+    const TOOLTIPS: Record<string, string> = {
+      "Mission Type":
+        "Preset that suggests defaults for the editable performance targets and the design assumptions. Changing the preset applies its suggested values via the banner Apply button.",
+      "Target Cruise":
+        "Design cruise speed at altitude. Drives propeller selection, drag analysis, and the cruise-constraint curve on the matching chart.",
+      "Stall Safety":
+        "Safety factor on stall speed (×); e.g. 1.8 means landing approach at 1.8 × V_stall. Lower = closer to stall = more demanding pilot skill.",
+      "Max Maneuver":
+        "Limit load factor n_max (g). Sets structural g-loading; CS-22 utility category = 5.3, aerobatic = 6+.",
+      "Min Glide (L/D)":
+        "Minimum lift-to-drag ratio in the cruise polar. Sailplanes ≥ 20; sport ≥ 10; trainer ≥ 8.",
+      "Climb Energy":
+        "Energy-per-time proxy for climb performance: rate-of-climb × g-load. Higher = stronger powerplant relative to weight.",
+      "Target Wing Load":
+        "Design wing loading W/S (N/m²). Sets stall speed and the W/S-axis position on the matching chart. Higher = smaller wing but higher stall speed.",
+      "Available Runway":
+        "Hard ground length available for take-off / landing (m). Sets the take-off and landing constraint curves on the matching chart.",
+      "Runway Type":
+        "Surface affecting rolling friction (grass higher, asphalt lower) and crash-landing tolerance (belly = no gear).",
+      "Static Thrust":
+        "Powertrain static thrust at zero airspeed (N). Sets the T/W ratio on the matching chart. For gliders, 0.",
+      "Takeoff Mode":
+        "runway = wheeled take-off; hand_launch = thrown by hand (RC); bungee = elastic catapult (gliders); catapult = launched device.",
+    };
+
+    it("renders 11 tooltip elements — one per editable input + Mission Type", () => {
+      render(<MissionObjectivesPanel aeroplaneId="x" />);
+      // role="tooltip" elements are hidden via Tailwind `hidden` class but
+      // still in the DOM so screen readers and `screen.getAllByRole` find them.
+      const tips = screen.getAllByRole("tooltip", { hidden: true });
+      expect(tips.length).toBe(11);
+    });
+
+    it("each tooltip text matches the spec exactly", () => {
+      render(<MissionObjectivesPanel aeroplaneId="x" />);
+      const tipTexts = screen
+        .getAllByRole("tooltip", { hidden: true })
+        .map((el) => el.textContent ?? "");
+      for (const expected of Object.values(TOOLTIPS)) {
+        expect(tipTexts).toContain(expected);
+      }
+    });
+
+    it("Mission Type dropdown has its info tooltip", () => {
+      render(<MissionObjectivesPanel aeroplaneId="x" />);
+      const tips = screen.getAllByRole("tooltip", { hidden: true });
+      const has = tips.some((t) => t.textContent === TOOLTIPS["Mission Type"]);
+      expect(has).toBe(true);
+    });
+  });
+
   it("preserves in-flight draft edits across SWR revalidations for the SAME aeroplaneId (gh-602)", () => {
     setMissionData("a", { ...defaultMissionData, target_cruise_mps: 10 });
 

--- a/frontend/components/workbench/InfoLabel.tsx
+++ b/frontend/components/workbench/InfoLabel.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { HelpCircle } from "lucide-react";
+
+interface Props {
+  readonly label: string;
+  readonly description?: string;
+  readonly htmlFor?: string;
+}
+
+/**
+ * Form-field label with an optional info-icon that reveals a dark-themed
+ * tooltip on hover or keyboard focus. Mirrors the InfoChipRow chip-tooltip
+ * pattern (`group-hover/info:block group-focus-within/info:block`) for
+ * visual consistency across the workbench.
+ *
+ * The icon is keyboard-focusable (`tabIndex={0}`) so the tooltip is
+ * surfaceable without a pointing device.
+ */
+export function InfoLabel({ label, description, htmlFor }: Props) {
+  if (!description) {
+    return (
+      <label
+        htmlFor={htmlFor}
+        className="block text-xs text-muted-foreground mb-1"
+      >
+        {label}
+      </label>
+    );
+  }
+  return (
+    <label
+      htmlFor={htmlFor}
+      className="group/info relative mb-1 flex items-center gap-1 text-xs text-muted-foreground"
+    >
+      <span>{label}</span>
+      <span
+        tabIndex={0}
+        data-testid="info-icon"
+        className="inline-flex cursor-help items-center focus:outline-none focus-visible:text-foreground"
+      >
+        <HelpCircle
+          size={11}
+          className="text-muted-foreground/60"
+          aria-hidden="true"
+        />
+        <span className="sr-only">Info</span>
+      </span>
+      <span
+        role="tooltip"
+        className="pointer-events-none absolute bottom-full left-0 z-50 mb-1.5 hidden w-max max-w-[280px] -translate-y-1 rounded-lg border border-border bg-card px-2.5 py-1.5 text-[10px] font-normal leading-snug text-foreground shadow-lg group-hover/info:block group-focus-within/info:block"
+      >
+        {description}
+      </span>
+    </label>
+  );
+}

--- a/frontend/components/workbench/mission/MissionObjectivesPanel.tsx
+++ b/frontend/components/workbench/mission/MissionObjectivesPanel.tsx
@@ -4,10 +4,41 @@ import React, { useRef, useState } from "react";
 import { useMissionObjectives, type MissionObjective } from "@/hooks/useMissionObjectives";
 import { useMissionPresets, type MissionPreset, type AxisName } from "@/hooks/useMissionPresets";
 import { normalizedToRaw } from "@/lib/missionScale";
+import { InfoLabel } from "@/components/workbench/InfoLabel";
 
 interface Props {
   readonly aeroplaneId: string;
 }
+
+/**
+ * Per-field info-tooltip copy for the Mission Tab inputs (gh-610).
+ * Tooltips surface on hover OR keyboard focus to keep the panel
+ * discoverable without overwhelming users who already know the fields.
+ */
+const FIELD_DESCRIPTIONS = {
+  mission_type:
+    "Preset that suggests defaults for the editable performance targets and the design assumptions. Changing the preset applies its suggested values via the banner Apply button.",
+  target_cruise_mps:
+    "Design cruise speed at altitude. Drives propeller selection, drag analysis, and the cruise-constraint curve on the matching chart.",
+  target_stall_safety:
+    "Safety factor on stall speed (×); e.g. 1.8 means landing approach at 1.8 × V_stall. Lower = closer to stall = more demanding pilot skill.",
+  target_maneuver_n:
+    "Limit load factor n_max (g). Sets structural g-loading; CS-22 utility category = 5.3, aerobatic = 6+.",
+  target_glide_ld:
+    "Minimum lift-to-drag ratio in the cruise polar. Sailplanes ≥ 20; sport ≥ 10; trainer ≥ 8.",
+  target_climb_energy:
+    "Energy-per-time proxy for climb performance: rate-of-climb × g-load. Higher = stronger powerplant relative to weight.",
+  target_wing_loading_n_m2:
+    "Design wing loading W/S (N/m²). Sets stall speed and the W/S-axis position on the matching chart. Higher = smaller wing but higher stall speed.",
+  available_runway_m:
+    "Hard ground length available for take-off / landing (m). Sets the take-off and landing constraint curves on the matching chart.",
+  runway_type:
+    "Surface affecting rolling friction (grass higher, asphalt lower) and crash-landing tolerance (belly = no gear).",
+  t_static_N:
+    "Powertrain static thrust at zero airspeed (N). Sets the T/W ratio on the matching chart. For gliders, 0.",
+  takeoff_mode:
+    "runway = wheeled take-off; hand_launch = thrown by hand (RC); bungee = elastic catapult (gliders); catapult = launched device.",
+} as const;
 
 /** Per-axis → MissionObjective target-field mapping (gh-601). */
 const AXIS_TO_TARGET_FIELD: Partial<Record<AxisName, keyof MissionObjective>> = {
@@ -204,9 +235,11 @@ export function MissionObjectivesPanel({ aeroplaneId }: Props) {
       )}
 
       <div className="space-y-2">
-        <label htmlFor="mission-type" className="block text-xs text-muted-foreground">
-          Mission Type
-        </label>
+        <InfoLabel
+          label="Mission Type"
+          description={FIELD_DESCRIPTIONS.mission_type}
+          htmlFor="mission-type"
+        />
         <select
           id="mission-type" aria-label="Mission Type"
           className="w-full rounded bg-background border border-border px-2 py-1.5 text-sm"
@@ -221,32 +254,32 @@ export function MissionObjectivesPanel({ aeroplaneId }: Props) {
         Performance Targets
       </div>
       <div className="grid grid-cols-2 gap-2">
-        <NumField label="Target Cruise" suffix="m/s" value={draft.target_cruise_mps} onChange={(v) => set("target_cruise_mps", v)}/>
-        <NumField label="Stall Safety" suffix="–" value={draft.target_stall_safety} onChange={(v) => set("target_stall_safety", v)}/>
-        <NumField label="Max Maneuver" suffix="g" value={draft.target_maneuver_n} onChange={(v) => set("target_maneuver_n", v)}/>
-        <NumField label="Min Glide (L/D)" suffix="–" value={draft.target_glide_ld} onChange={(v) => set("target_glide_ld", v)}/>
-        <NumField label="Climb Energy" suffix="–" value={draft.target_climb_energy} onChange={(v) => set("target_climb_energy", v)}/>
-        <NumField label="Target Wing Load" suffix="N/m²" value={draft.target_wing_loading_n_m2} onChange={(v) => set("target_wing_loading_n_m2", v)}/>
+        <NumField label="Target Cruise" suffix="m/s" value={draft.target_cruise_mps} onChange={(v) => set("target_cruise_mps", v)} description={FIELD_DESCRIPTIONS.target_cruise_mps}/>
+        <NumField label="Stall Safety" suffix="–" value={draft.target_stall_safety} onChange={(v) => set("target_stall_safety", v)} description={FIELD_DESCRIPTIONS.target_stall_safety}/>
+        <NumField label="Max Maneuver" suffix="g" value={draft.target_maneuver_n} onChange={(v) => set("target_maneuver_n", v)} description={FIELD_DESCRIPTIONS.target_maneuver_n}/>
+        <NumField label="Min Glide (L/D)" suffix="–" value={draft.target_glide_ld} onChange={(v) => set("target_glide_ld", v)} description={FIELD_DESCRIPTIONS.target_glide_ld}/>
+        <NumField label="Climb Energy" suffix="–" value={draft.target_climb_energy} onChange={(v) => set("target_climb_energy", v)} description={FIELD_DESCRIPTIONS.target_climb_energy}/>
+        <NumField label="Target Wing Load" suffix="N/m²" value={draft.target_wing_loading_n_m2} onChange={(v) => set("target_wing_loading_n_m2", v)} description={FIELD_DESCRIPTIONS.target_wing_loading_n_m2}/>
       </div>
 
       <div className="text-[10px] uppercase tracking-wider text-muted-foreground border-b border-border pb-1 mt-2">
         Field Performance
       </div>
       <div className="grid grid-cols-2 gap-2">
-        <NumField label="Available Runway" suffix="m" value={draft.available_runway_m} onChange={(v) => set("available_runway_m", v)}/>
-        <SelectField label="Runway Type" value={draft.runway_type} options={["grass", "asphalt", "belly"]} onChange={(v) => set("runway_type", v as MissionObjective["runway_type"])}/>
-        <NumField label="Static Thrust" suffix="N" value={draft.t_static_N} onChange={(v) => set("t_static_N", v)}/>
-        <SelectField label="Takeoff Mode" value={draft.takeoff_mode} options={["runway", "hand_launch", "bungee", "catapult"]} onChange={(v) => set("takeoff_mode", v as MissionObjective["takeoff_mode"])}/>
+        <NumField label="Available Runway" suffix="m" value={draft.available_runway_m} onChange={(v) => set("available_runway_m", v)} description={FIELD_DESCRIPTIONS.available_runway_m}/>
+        <SelectField label="Runway Type" value={draft.runway_type} options={["grass", "asphalt", "belly"]} onChange={(v) => set("runway_type", v as MissionObjective["runway_type"])} description={FIELD_DESCRIPTIONS.runway_type}/>
+        <NumField label="Static Thrust" suffix="N" value={draft.t_static_N} onChange={(v) => set("t_static_N", v)} description={FIELD_DESCRIPTIONS.t_static_N}/>
+        <SelectField label="Takeoff Mode" value={draft.takeoff_mode} options={["runway", "hand_launch", "bungee", "catapult"]} onChange={(v) => set("takeoff_mode", v as MissionObjective["takeoff_mode"])} description={FIELD_DESCRIPTIONS.takeoff_mode}/>
       </div>
     </div>
   );
 }
 
-function NumField(props: { label: string; suffix: string; value: number; onChange: (v: number) => void }) {
+function NumField(props: { label: string; suffix: string; value: number; onChange: (v: number) => void; description?: string }) {
   const id = `f-${props.label.replace(/\s+/g, "-").toLowerCase()}`;
   return (
     <div>
-      <label htmlFor={id} className="block text-xs text-muted-foreground mb-1">{props.label}</label>
+      <InfoLabel label={props.label} description={props.description} htmlFor={id} />
       <div className="flex">
         <input
           id={id} aria-label={props.label} type="number"
@@ -262,11 +295,11 @@ function NumField(props: { label: string; suffix: string; value: number; onChang
   );
 }
 
-function SelectField(props: { label: string; value: string; options: string[]; onChange: (v: string) => void }) {
+function SelectField(props: { label: string; value: string; options: string[]; onChange: (v: string) => void; description?: string }) {
   const id = `f-${props.label.replace(/\s+/g, "-").toLowerCase()}`;
   return (
     <div>
-      <label htmlFor={id} className="block text-xs text-muted-foreground mb-1">{props.label}</label>
+      <InfoLabel label={props.label} description={props.description} htmlFor={id} />
       <select id={id} aria-label={props.label}
         className="w-full rounded bg-background border border-border px-2 py-1.5 text-sm"
         value={props.value} onChange={(e) => props.onChange(e.target.value)}>


### PR DESCRIPTION
## Summary

- Adds a reusable `<InfoLabel>` component (`frontend/components/workbench/InfoLabel.tsx`) that renders a small `HelpCircle` icon next to a form-field label and surfaces a dark-themed tooltip on hover or keyboard focus. Mirrors the existing `InfoChipRow` chip-tooltip pattern (`group-hover/info:block` + `group-focus-within/info:block`) for visual consistency across the workbench.
- Wires per-field descriptive copy onto every editable input in `MissionObjectivesPanel` — the Mission Type dropdown plus the six Performance Targets and the four Field Performance controls. `NumField` and `SelectField` accept an optional `description` prop; when present, the label upgrades to `<InfoLabel>`, otherwise the original plain-label markup is preserved.
- Adds 8 unit tests for `InfoLabel` (with/without description, htmlFor plumbing, focusable icon, hidden-by-default tooltip, role=tooltip semantics) and 3 panel-level tests asserting the 11 tooltips render with the exact spec copy.

## Field tooltip copy

| Field            | Tooltip text |
|------------------|---|
| Mission Type     | Preset that suggests defaults for the editable performance targets and the design assumptions. Changing the preset applies its suggested values via the banner Apply button. |
| Target Cruise    | Design cruise speed at altitude. Drives propeller selection, drag analysis, and the cruise-constraint curve on the matching chart. |
| Stall Safety     | Safety factor on stall speed (×); e.g. 1.8 means landing approach at 1.8 × V_stall. Lower = closer to stall = more demanding pilot skill. |
| Max Maneuver     | Limit load factor n_max (g). Sets structural g-loading; CS-22 utility category = 5.3, aerobatic = 6+. |
| Min Glide (L/D)  | Minimum lift-to-drag ratio in the cruise polar. Sailplanes ≥ 20; sport ≥ 10; trainer ≥ 8. |
| Climb Energy     | Energy-per-time proxy for climb performance: rate-of-climb × g-load. Higher = stronger powerplant relative to weight. |
| Target Wing Load | Design wing loading W/S (N/m²). Sets stall speed and the W/S-axis position on the matching chart. Higher = smaller wing but higher stall speed. |
| Available Runway | Hard ground length available for take-off / landing (m). Sets the take-off and landing constraint curves on the matching chart. |
| Runway Type     | Surface affecting rolling friction (grass higher, asphalt lower) and crash-landing tolerance (belly = no gear). |
| Static Thrust    | Powertrain static thrust at zero airspeed (N). Sets the T/W ratio on the matching chart. For gliders, 0. |
| Takeoff Mode     | runway = wheeled take-off; hand_launch = thrown by hand (RC); bungee = elastic catapult (gliders); catapult = launched device. |

## Test plan

- [x] `npm run test:unit` — full 862-test suite green locally
- [x] `npm run lint` — 0 errors (warnings unchanged from main)
- [x] `npm run deps:check` — 0 errors (warnings unchanged from main)
- [x] `InfoLabel.test.tsx` — 8 unit tests cover every render branch (with/without description, htmlFor, hidden-by-default, focusable icon)
- [x] `MissionObjectivesPanel.test.tsx` — new `per-field info tooltips (gh-610)` describe block asserts all 11 tooltips render with the exact spec copy
- [x] Apply-banner flow from #605 (`applies all 6 target fields when Apply is clicked`, `does not apply targets when Dismiss is clicked`) untouched and still passing
- [x] gh-602 aeroplane-switch logic untouched

Closes #610

🤖 Generated with [Claude Code](https://claude.com/claude-code)