### PR TITLE
feat(gh-606): Matching Chart info modal, current-design-point marker, live S/T readout

### DIFF
--- a/frontend/__tests__/MatchingChartTab.test.tsx
+++ b/frontend/__tests__/MatchingChartTab.test.tsx
@@ -17,12 +17,14 @@ vi.mock("lucide-react", () => {
     AlertTriangle: icon,
     Info: icon,
     Loader2: icon,
+    X: icon,
   };
 });
 
-// Plotly dynamic import — return a stub that does nothing
+// Plotly dynamic import — return a stub that captures calls so we can inspect traces
+const plotlyReactMock = vi.fn().mockResolvedValue(undefined);
 vi.mock("plotly.js-gl3d-dist-min", () => ({
-  react: vi.fn().mockResolvedValue(undefined),
+  react: plotlyReactMock,
   purge: vi.fn(),
 }));
 
@@ -37,7 +39,47 @@ vi.mock("@/hooks/useMatchingChart", () => ({
   useMatchingChart: () => hookReturn,
 }));
 
-import { MatchingChartTab, findBindingConstraintAtPoint } from "@/components/workbench/MatchingChartTab";
+// gh-606: mocks for design-assumptions + computation-context. Tests override
+// these per scenario via the let-binding pattern (mutable closure).
+type MockAssumption = {
+  parameter_name: string;
+  effective_value: number;
+};
+let mockAssumptions: MockAssumption[] = [];
+let mockCtx: { s_ref_m2?: number | null; b_ref_m?: number | null; is_glider?: boolean } | null = null;
+
+vi.mock("@/hooks/useDesignAssumptions", () => ({
+  useDesignAssumptions: () => ({
+    data: { assumptions: mockAssumptions, warnings_count: 0 },
+    isLoading: false,
+    isRecomputing: false,
+    error: null,
+    seedDefaults: vi.fn(),
+    updateEstimate: vi.fn(),
+    switchSource: vi.fn(),
+    mutate: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useComputationContext", () => ({
+  useComputationContext: () => ({
+    data: mockCtx,
+    error: null,
+    isLoading: false,
+    mutate: vi.fn(),
+  }),
+}));
+
+import {
+  MatchingChartTab,
+  findBindingConstraintAtPoint,
+  findInsufficientThrustConstraint,
+  formatSigFigs,
+  computeWingArea,
+  computeThrust,
+  computeAspectRatio,
+  buildCurrentDesignPointTrace,
+} from "@/components/workbench/MatchingChartTab";
 
 // ── Test data ─────────────────────────────────────────────────────────────────
 
@@ -115,6 +157,10 @@ const MOCK_INFEASIBLE: MatchingChartData = {
 describe("MatchingChartTab", () => {
   beforeEach(() => {
     hookReturn = MOCK_LOADING_STATE;
+    // gh-606: default empty assumptions + null ctx — current-design-point hidden
+    mockAssumptions = [];
+    mockCtx = null;
+    plotlyReactMock.mockClear();
   });
 
   it("shows loading spinner while fetching", () => {
@@ -208,10 +254,10 @@ describe("MatchingChartTab", () => {
     expect(screen.getByText(/Scholz/i)).toBeInTheDocument();
   });
 
-  it("shows drag hint info text when data is available", () => {
+  it("shows info-modal trigger button when data is available", () => {
     hookReturn = MOCK_OK_STATE;
     render(<MatchingChartTab aeroplaneId="test-id" />);
-    expect(screen.getByText(/drag design point/i)).toBeInTheDocument();
+    expect(screen.getByText(/How to read this chart/i)).toBeInTheDocument();
   });
 
   it("renders plot container with data-testid", () => {
@@ -826,5 +872,475 @@ describe("MatchingChartTab — async Plotly render (trace builders + buildLayout
     rerender(<MatchingChartTab aeroplaneId="test-id" />);
     await act(async () => { await Promise.resolve(); });
     expect(screen.getByText(/660/)).toBeInTheDocument();
+  });
+});
+
+// ── gh-606: Info modal ────────────────────────────────────────────────────────
+
+describe("MatchingChartTab — info modal (gh-606)", () => {
+  beforeEach(() => {
+    hookReturn = MOCK_OK_STATE;
+    mockAssumptions = [];
+    mockCtx = null;
+  });
+
+  it("info-modal trigger has aria-label and is keyboard-accessible", () => {
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    const trigger = screen.getByTestId("info-modal-trigger");
+    expect(trigger).toHaveAttribute("aria-label", "Open sizing methodology help");
+    expect(trigger.tagName).toBe("BUTTON");
+  });
+
+  it("modal is hidden initially", () => {
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    expect(screen.queryByTestId("matching-chart-info-modal")).toBeNull();
+  });
+
+  it("clicking trigger opens the modal with all 8 sections", () => {
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    act(() => {
+      fireEvent.click(screen.getByTestId("info-modal-trigger"));
+    });
+    expect(screen.getByTestId("matching-chart-info-modal")).toBeInTheDocument();
+    // Eight sections per Scholz-corrected spec
+    expect(screen.getByTestId("info-section-overview")).toBeInTheDocument();
+    expect(screen.getByTestId("info-section-glossary")).toBeInTheDocument();
+    expect(screen.getByTestId("info-section-axes")).toBeInTheDocument();
+    expect(screen.getByTestId("info-section-constraints")).toBeInTheDocument();
+    expect(screen.getByTestId("info-section-red-area")).toBeInTheDocument();
+    expect(screen.getByTestId("info-section-design-point")).toBeInTheDocument();
+    expect(screen.getByTestId("info-section-readoff")).toBeInTheDocument();
+    expect(screen.getByTestId("info-section-iteration")).toBeInTheDocument();
+  });
+
+  it("modal y-axis section names T_TO/W_TO and the static-thrust proxy", () => {
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    act(() => {
+      fireEvent.click(screen.getByTestId("info-modal-trigger"));
+    });
+    const axes = screen.getByTestId("info-section-axes");
+    // textContent strips <sub> tags, so T_TO/W_TO becomes TTO/WTO
+    expect(axes.textContent).toMatch(/TTO\/WTO/);
+    expect(axes.textContent).toMatch(/take-off thrust over take-off weight/);
+    expect(axes.textContent).toMatch(/proxy/);
+    // AR labelled as chart INPUT, not "held constant"
+    expect(axes.textContent).toMatch(/AR is a chart INPUT/);
+  });
+
+  it("modal glossary entry for T mentions the RC approximation", () => {
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    act(() => {
+      fireEvent.click(screen.getByTestId("info-modal-trigger"));
+    });
+    const glossary = screen.getByTestId("info-section-glossary");
+    expect(glossary.textContent).toMatch(/take-off thrust at sea level/);
+    expect(glossary.textContent).toMatch(/static-thrust input/);
+    expect(glossary.textContent).toMatch(/L\/D/);
+    expect(glossary.textContent).toMatch(/C/); // C_L,max
+  });
+
+  it("modal overview discloses 3-5 iteration outer loop and SI units", () => {
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    act(() => {
+      fireEvent.click(screen.getByTestId("info-modal-trigger"));
+    });
+    const overview = screen.getByTestId("info-section-overview");
+    expect(overview.textContent).toMatch(/3.{0,3}5 iteration/);
+    expect(overview.textContent).toMatch(/SI units/);
+  });
+
+  it("modal cruise is shown but called out as slack (parenthesised)", () => {
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    act(() => {
+      fireEvent.click(screen.getByTestId("info-modal-trigger"));
+    });
+    const constraints = screen.getByTestId("info-section-constraints");
+    expect(constraints.textContent).toMatch(/Cruise/);
+    expect(constraints.textContent).toMatch(/slack/);
+  });
+
+  it("modal includes Scholz Fig. 5.9 sketch reference", () => {
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    act(() => {
+      fireEvent.click(screen.getByTestId("info-modal-trigger"));
+    });
+    const dp = screen.getByTestId("info-section-design-point");
+    expect(dp.textContent).toMatch(/Fig\. 5\.9/);
+    expect(dp.textContent).toMatch(/intersection of the take-off line/);
+  });
+
+  it("ESC closes the modal", () => {
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    act(() => {
+      fireEvent.click(screen.getByTestId("info-modal-trigger"));
+    });
+    expect(screen.getByTestId("matching-chart-info-modal")).toBeInTheDocument();
+    act(() => {
+      fireEvent.keyDown(window, { key: "Escape" });
+    });
+    expect(screen.queryByTestId("matching-chart-info-modal")).toBeNull();
+  });
+
+  it("close button closes the modal", () => {
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    act(() => {
+      fireEvent.click(screen.getByTestId("info-modal-trigger"));
+    });
+    act(() => {
+      fireEvent.click(screen.getByTestId("info-modal-close"));
+    });
+    expect(screen.queryByTestId("matching-chart-info-modal")).toBeNull();
+  });
+});
+
+// ── gh-606: Current design point marker — powered ────────────────────────────
+
+describe("MatchingChartTab — current design point (powered, gh-606)", () => {
+  beforeEach(() => {
+    hookReturn = MOCK_OK_STATE;
+    mockAssumptions = [
+      { parameter_name: "mass", effective_value: 2.0 }, // 2 kg
+      { parameter_name: "t_static_N", effective_value: 30.0 }, // 30 N
+    ];
+    mockCtx = { s_ref_m2: 0.5, b_ref_m: 2.0, is_glider: false };
+  });
+
+  it("renders Current Design Point trace via Plotly.react", async () => {
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    await act(async () => { await Promise.resolve(); });
+    // Plotly.react should have been called; pull the traces argument
+    const calls = plotlyReactMock.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const traces = calls[calls.length - 1][1] as Array<{ name?: string }>;
+    const cdp = traces.find((t) => t.name === "Current Design Point");
+    expect(cdp).toBeDefined();
+  });
+
+  it("Current Design Point uses (W/S, T/W) = (39.2, 1.53) for 2kg/0.5m²/30N", async () => {
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    await act(async () => { await Promise.resolve(); });
+    const traces = plotlyReactMock.mock.calls.at(-1)![1] as Array<{
+      name?: string;
+      x?: number[];
+      y?: number[];
+    }>;
+    const cdp = traces.find((t) => t.name === "Current Design Point")!;
+    // W = 2 × 9.80665 = 19.6133 N. W/S = 19.6133 / 0.5 = 39.227. T/W = 30 / 19.6133 = 1.530.
+    expect(cdp.x![0]).toBeCloseTo(39.227, 2);
+    expect(cdp.y![0]).toBeCloseTo(1.530, 2);
+  });
+
+  it("Current Design Point marker uses teal #22dd99 and diamond symbol", async () => {
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    await act(async () => { await Promise.resolve(); });
+    const traces = plotlyReactMock.mock.calls.at(-1)![1] as Array<{
+      name?: string;
+      marker?: { symbol?: string; color?: string };
+    }>;
+    const cdp = traces.find((t) => t.name === "Current Design Point")!;
+    expect(cdp.marker?.symbol).toBe("diamond");
+    expect(cdp.marker?.color).toBe("#22dd99");
+  });
+
+  it("Current Design Point hover template names W as m_MTO·g", async () => {
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    await act(async () => { await Promise.resolve(); });
+    const traces = plotlyReactMock.mock.calls.at(-1)![1] as Array<{
+      name?: string;
+      hovertemplate?: string;
+    }>;
+    const cdp = traces.find((t) => t.name === "Current Design Point")!;
+    expect(cdp.hovertemplate).toMatch(/m_MTO/);
+    expect(cdp.hovertemplate).toMatch(/W\/S/);
+    expect(cdp.hovertemplate).toMatch(/T\/W/);
+    expect(cdp.hovertemplate).toMatch(/AR/);
+    expect(cdp.hovertemplate).toMatch(/assumed static thrust/);
+  });
+});
+
+// ── gh-606: Glider suppression ───────────────────────────────────────────────
+
+describe("MatchingChartTab — glider current design point suppressed (gh-606)", () => {
+  beforeEach(() => {
+    hookReturn = MOCK_OK_STATE;
+  });
+
+  it("no Current Design Point trace for glider context", async () => {
+    mockAssumptions = [
+      { parameter_name: "mass", effective_value: 2.0 },
+      { parameter_name: "t_static_N", effective_value: 0 },
+    ];
+    mockCtx = { s_ref_m2: 0.5, b_ref_m: 3.0, is_glider: true };
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    await act(async () => { await Promise.resolve(); });
+    const traces = plotlyReactMock.mock.calls.at(-1)![1] as Array<{ name?: string }>;
+    const cdp = traces.find((t) => t.name === "Current Design Point");
+    expect(cdp).toBeUndefined();
+  });
+
+  it("renders the glider callout", async () => {
+    mockAssumptions = [];
+    mockCtx = { s_ref_m2: 0.5, b_ref_m: 3.0, is_glider: true };
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    await act(async () => { await Promise.resolve(); });
+    const callout = screen.getByTestId("glider-callout");
+    expect(callout.textContent).toMatch(/jet\/powered-only/);
+    expect(callout.textContent).toMatch(/sink-rate polar/);
+  });
+
+  it("no Current Design Point trace when t_static_N = 0 (even non-glider flag)", async () => {
+    mockAssumptions = [
+      { parameter_name: "mass", effective_value: 2.0 },
+      { parameter_name: "t_static_N", effective_value: 0 },
+    ];
+    mockCtx = { s_ref_m2: 0.5, b_ref_m: 2.0, is_glider: false };
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    await act(async () => { await Promise.resolve(); });
+    const traces = plotlyReactMock.mock.calls.at(-1)![1] as Array<{ name?: string }>;
+    expect(traces.find((t) => t.name === "Current Design Point")).toBeUndefined();
+  });
+});
+
+// ── gh-606: Insufficient-thrust callout ──────────────────────────────────────
+
+describe("MatchingChartTab — insufficient thrust warning (gh-606)", () => {
+  it("renders callout when current marker T/W is below a constraint curve", async () => {
+    // Constraint at T/W = 0.5 across the board. Current T/W = 30 / (40 × 9.80665) = ~0.0765 — well below.
+    // mass = 40 kg, s_ref = 1.0 m² → W = 392 N, W/S = 392, T/W = 30/392 = 0.0765.
+    const customData: MatchingChartData = {
+      ...MOCK_CESSNA,
+      ws_range_n_m2: Array.from({ length: 200 }, (_, i) => 10 + (1490 / 199) * i),
+      constraints: [
+        {
+          name: "Climb",
+          t_w_points: Array(200).fill(0.5),
+          ws_max: null,
+          color: "#E5484D",
+          binding: true,
+          hover_text: "Insufficient climb thrust",
+        },
+      ],
+      design_point: { ws_n_m2: 400, t_w: 0.5 },
+    };
+    hookReturn = { ...MOCK_OK_STATE, data: customData };
+    mockAssumptions = [
+      { parameter_name: "mass", effective_value: 40 },
+      { parameter_name: "t_static_N", effective_value: 30 },
+    ];
+    mockCtx = { s_ref_m2: 1.0, b_ref_m: 3.0, is_glider: false };
+
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    await act(async () => { await Promise.resolve(); });
+
+    const callout = screen.getByTestId("insufficient-thrust-callout");
+    expect(callout.textContent).toMatch(/insufficient/i);
+    expect(callout.textContent).toMatch(/Climb/);
+  });
+
+  it("does NOT render callout when current marker is above all constraints", async () => {
+    const customData: MatchingChartData = {
+      ...MOCK_CESSNA,
+      constraints: [
+        {
+          name: "Climb",
+          t_w_points: Array(200).fill(0.05),
+          ws_max: null,
+          color: "#E5484D",
+          binding: false,
+          hover_text: "OK",
+        },
+      ],
+    };
+    hookReturn = { ...MOCK_OK_STATE, data: customData };
+    mockAssumptions = [
+      { parameter_name: "mass", effective_value: 2 },
+      { parameter_name: "t_static_N", effective_value: 30 },
+    ];
+    mockCtx = { s_ref_m2: 0.5, b_ref_m: 2.0, is_glider: false };
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    await act(async () => { await Promise.resolve(); });
+    expect(screen.queryByTestId("insufficient-thrust-callout")).toBeNull();
+  });
+});
+
+// ── gh-606: Live derived readout ─────────────────────────────────────────────
+
+describe("MatchingChartTab — live derived readout (gh-606)", () => {
+  beforeEach(() => {
+    hookReturn = MOCK_OK_STATE;
+    mockAssumptions = [
+      { parameter_name: "mass", effective_value: 2.0 }, // W = 19.6133 N
+      { parameter_name: "t_static_N", effective_value: 30.0 },
+    ];
+    mockCtx = { s_ref_m2: 0.5, b_ref_m: 2.0, is_glider: false };
+  });
+
+  it("readout shows derived S, T, W, and AR cells", () => {
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    // Initial design point W/S=660, T/W=0.178 → S = 19.6133/660 ≈ 0.0297, T = 0.178·19.6133 ≈ 3.49
+    const sCell = document.querySelector("[data-testid='dp-derived-s']");
+    const tCell = document.querySelector("[data-testid='dp-derived-t']");
+    const wCell = document.querySelector("[data-testid='dp-w']");
+    const arCell = document.querySelector("[data-testid='dp-ar']");
+    expect(sCell).toBeTruthy();
+    expect(tCell).toBeTruthy();
+    expect(wCell).toBeTruthy();
+    expect(arCell).toBeTruthy();
+    // W displayed in N
+    expect(wCell!.textContent).toMatch(/19\.6/);
+    // AR = b²/S = 4 / 0.5 = 8.00
+    expect(arCell!.textContent).toMatch(/8\.00/);
+  });
+
+  it("AR label uses 'AR (input — see info modal)' not 'AR (held)'", () => {
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    expect(screen.getByText(/AR \(input — see info modal\)/)).toBeInTheDocument();
+    expect(screen.queryByText(/AR \(held\)/)).toBeNull();
+  });
+
+  it("W label uses 'W (m_MTO · g)'", () => {
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    expect(screen.getByText(/W \(m_MTO · g\)/)).toBeInTheDocument();
+  });
+
+  it("derived S = W / (W/S) when dragging to (W/S = 100, T/W = 0.4)", async () => {
+    const customData: MatchingChartData = {
+      ...MOCK_CESSNA,
+      design_point: { ws_n_m2: 100, t_w: 0.4 },
+    };
+    hookReturn = { ...MOCK_OK_STATE, data: customData };
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    // W = 19.6133 N, so S = 19.6133 / 100 = 0.196 m²
+    const sCell = document.querySelector("[data-testid='dp-derived-s']");
+    expect(sCell!.textContent).toMatch(/0\.196/);
+    // T = 0.4 × 19.6133 = 7.85 N → 3 sig figs ≈ "7.85"
+    const tCell = document.querySelector("[data-testid='dp-derived-t']");
+    expect(tCell!.textContent).toMatch(/7\.85/);
+  });
+
+  it("derived cells show em dash when mass missing", () => {
+    mockAssumptions = []; // no mass
+    mockCtx = { s_ref_m2: 0.5, b_ref_m: 2.0, is_glider: false };
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    const sCell = document.querySelector("[data-testid='dp-derived-s']");
+    expect(sCell!.textContent).toMatch(/—/);
+  });
+});
+
+// ── gh-606: pure helpers ──────────────────────────────────────────────────────
+
+describe("formatSigFigs (gh-606)", () => {
+  it("formats 123 to 3 sig figs as '123'", () => {
+    expect(formatSigFigs(123, 3)).toBe("123");
+  });
+  it("formats 1234.56 to 3 sig figs", () => {
+    // toPrecision(3) on 1234.56 = "1.23e+3"
+    expect(formatSigFigs(1234.56, 3)).toMatch(/1\.23e\+3/);
+  });
+  it("formats 0.01234 to 3 sig figs", () => {
+    expect(formatSigFigs(0.01234, 3)).toBe("0.0123");
+  });
+  it("returns '0' for zero", () => {
+    expect(formatSigFigs(0, 3)).toBe("0");
+  });
+  it("returns em dash for non-finite", () => {
+    expect(formatSigFigs(Infinity, 3)).toBe("—");
+    expect(formatSigFigs(NaN, 3)).toBe("—");
+  });
+});
+
+describe("computeWingArea / computeThrust / computeAspectRatio (gh-606)", () => {
+  it("S = W / (W/S)", () => {
+    expect(computeWingArea(19.6133, 660)).toBeCloseTo(0.0297, 4);
+    expect(computeWingArea(19.6133, 100)).toBeCloseTo(0.196, 3);
+  });
+  it("computeWingArea returns NaN for W/S <= 0", () => {
+    expect(Number.isNaN(computeWingArea(100, 0))).toBe(true);
+    expect(Number.isNaN(computeWingArea(100, -1))).toBe(true);
+  });
+  it("T = T/W · W", () => {
+    expect(computeThrust(100, 0.5)).toBe(50);
+    expect(computeThrust(19.6133, 0.4)).toBeCloseTo(7.845, 3);
+  });
+  it("AR = b²/S", () => {
+    expect(computeAspectRatio(2, 0.5)).toBeCloseTo(8.0, 5);
+    expect(computeAspectRatio(3, 1)).toBe(9);
+  });
+  it("AR returns null on missing/invalid inputs", () => {
+    expect(computeAspectRatio(null, 1)).toBeNull();
+    expect(computeAspectRatio(2, null)).toBeNull();
+    expect(computeAspectRatio(2, 0)).toBeNull();
+    expect(computeAspectRatio(2, -1)).toBeNull();
+  });
+});
+
+describe("findInsufficientThrustConstraint (gh-606)", () => {
+  const wsRange = Array.from({ length: 100 }, (_, i) => 100 + i * 10);
+  const constraints: ConstraintLine[] = [
+    { name: "Takeoff", t_w_points: Array(100).fill(0.2), ws_max: null, color: "#FF8400", binding: true, hover_text: null },
+    { name: "Climb", t_w_points: Array(100).fill(0.5), ws_max: null, color: "#E5484D", binding: false, hover_text: null },
+    { name: "Stall", t_w_points: null, ws_max: 800, color: "#A78BFA", binding: false, hover_text: null },
+  ];
+
+  it("returns most-violated t_w_points constraint when below all", () => {
+    // T/W = 0.05 violates both Takeoff (0.2) and Climb (0.5). Climb has the larger ratio.
+    expect(findInsufficientThrustConstraint(500, 0.05, wsRange, constraints)).toBe("Climb");
+  });
+
+  it("returns null when current T/W is above all curves", () => {
+    expect(findInsufficientThrustConstraint(500, 0.8, wsRange, constraints)).toBeNull();
+  });
+
+  it("ignores ws_max-only constraints", () => {
+    const wsOnly: ConstraintLine[] = [
+      { name: "Stall", t_w_points: null, ws_max: 800, color: "#A78BFA", binding: false, hover_text: null },
+    ];
+    expect(findInsufficientThrustConstraint(900, 0.1, wsRange, wsOnly)).toBeNull();
+  });
+
+  it("returns null on empty wsRange", () => {
+    expect(findInsufficientThrustConstraint(500, 0.05, [], constraints)).toBeNull();
+  });
+
+  it("ignores zero-valued constraints to avoid divide-by-zero", () => {
+    const zero: ConstraintLine[] = [
+      { name: "Zero", t_w_points: Array(100).fill(0), ws_max: null, color: "#fff", binding: false, hover_text: null },
+    ];
+    expect(findInsufficientThrustConstraint(500, 0.1, wsRange, zero)).toBeNull();
+  });
+});
+
+describe("buildCurrentDesignPointTrace (gh-606)", () => {
+  it("produces a Plotly trace with the expected shape", () => {
+    const trace = buildCurrentDesignPointTrace({
+      ws_n_m2: 39.227,
+      t_w: 1.530,
+      mass_kg: 2,
+      s_m2: 0.5,
+      t_n: 30,
+      w_n: 19.6133,
+      ar: 8.0,
+    });
+    expect(trace.name).toBe("Current Design Point");
+    expect(trace.type).toBe("scatter");
+    expect(trace.mode).toBe("markers");
+    expect(trace.x).toEqual([39.227]);
+    expect(trace.y).toEqual([1.530]);
+    expect(trace.marker.symbol).toBe("diamond");
+    expect(trace.marker.color).toBe("#22dd99");
+    expect(trace.hovertemplate).toContain("m_MTO·g");
+  });
+
+  it("renders em-dash for AR when null", () => {
+    const trace = buildCurrentDesignPointTrace({
+      ws_n_m2: 100,
+      t_w: 0.2,
+      mass_kg: 1,
+      s_m2: 0.5,
+      t_n: 10,
+      w_n: 9.81,
+      ar: null,
+    });
+    expect(trace.hovertemplate).toContain("AR = —");
   });
 });

--- a/frontend/components/workbench/MatchingChartTab.tsx
+++ b/frontend/components/workbench/MatchingChartTab.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
-import { Loader2, AlertTriangle, Info } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Loader2, AlertTriangle, Info, X } from "lucide-react";
 import {
   useMatchingChart,
   type AircraftMode,
   type MatchingChartData,
   type ConstraintLine,
 } from "@/hooks/useMatchingChart";
+import { useDesignAssumptions } from "@/hooks/useDesignAssumptions";
+import { useComputationContext } from "@/hooks/useComputationContext";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -21,6 +23,18 @@ interface DragPoint {
   ws_n_m2: number;
   t_w: number;
 }
+
+interface CurrentDesignPoint {
+  readonly ws_n_m2: number;
+  readonly t_w: number;
+  readonly mass_kg: number;
+  readonly s_m2: number;
+  readonly t_n: number;
+  readonly w_n: number;
+  readonly ar: number | null;
+}
+
+const G_MPS2 = 9.80665;
 
 // ---------------------------------------------------------------------------
 // Mode labels
@@ -39,6 +53,22 @@ const MODE_DEFAULTS: Record<AircraftMode, { sRunway: number; vSTarget: number; g
   uav_runway: { sRunway: 200, vSTarget: 12, gamma: 4 },
   uav_belly_land: { sRunway: 200, vSTarget: 12, gamma: 4 },
 };
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+/** Format a number to N significant figures.
+ *
+ * gh-606: per Scholz review (minor finding), the T value in the readout
+ * panel should be 3 sig figs, not toFixed(1). Examples: 123.456 → "123",
+ * 1234.56 → "1.23e+3", 0.01234 → "0.0123". Exported for unit testing.
+ */
+export function formatSigFigs(value: number, sigFigs: number): string {
+  if (!isFinite(value)) return "—";
+  if (value === 0) return "0";
+  return value.toPrecision(sigFigs);
+}
 
 // ---------------------------------------------------------------------------
 // Plotly trace / shape builders (extracted to reduce function nesting depth)
@@ -92,7 +122,45 @@ function buildDesignPointTrace(
     },
     hovertemplate: (
       `<b>Design Point</b><br>W/S = ${ws_n_m2.toFixed(0)} N/m²<br>` +
-      `T/W = ${t_w.toFixed(4)}<br><i>T/W = T_static_SL / W_MTOW</i><extra></extra>`
+      `T/W = ${t_w.toFixed(4)}<br><i>y-axis: T_TO/W_TO (RC airframes: t_static_N proxy)</i><extra></extra>`
+    ),
+  };
+}
+
+/** Build the static current-design-point marker trace.
+ *
+ * gh-606: this is a separate trace from the (existing, draggable) "Design
+ * Point" — it visualises where the current aircraft (mass, s_ref, t_static)
+ * actually sits on the chart. Colour: teal (`#22dd99`) to distinguish from
+ * the orange explored point. Symbol: filled diamond.
+ *
+ * Tooltip labels W explicitly as `m_MTO·g` (per Scholz review substantive
+ * finding) and T as the user's *assumed* static thrust (RC proxy for
+ * T_TO at sea level). Exported for unit testing.
+ */
+export function buildCurrentDesignPointTrace(cdp: CurrentDesignPoint): PlotlyTrace {
+  const arStr = cdp.ar != null ? cdp.ar.toFixed(2) : "—";
+  return {
+    x: [cdp.ws_n_m2],
+    y: [cdp.t_w],
+    type: "scatter",
+    mode: "markers",
+    name: "Current Design Point",
+    marker: {
+      symbol: "diamond",
+      size: 12,
+      color: "#22dd99",
+      line: { color: "#0a0a0a", width: 1.5 },
+    },
+    hovertemplate: (
+      `<b>Current Design Point</b><br>` +
+      `W/S = ${cdp.ws_n_m2.toFixed(1)} N/m²<br>` +
+      `T/W = ${cdp.t_w.toFixed(3)}<br>` +
+      `S = ${cdp.s_m2.toFixed(2)} m²<br>` +
+      `T = ${formatSigFigs(cdp.t_n, 3)} N (your assumed static thrust)<br>` +
+      `W = m_MTO·g = ${cdp.w_n.toFixed(1)} N<br>` +
+      `AR = ${arStr}` +
+      `<extra></extra>`
     ),
   };
 }
@@ -196,7 +264,9 @@ function buildLayout(
         x: 0.01, y: 0.99, xref: "paper", yref: "paper",
         xanchor: "left", yanchor: "top", showarrow: false,
         font: { color: "#52525B", size: 9 },
-        text: "Convention: T/W = T_static_SL / W_MTOW · AR held constant",
+        // gh-606: Scholz review critical #1 — y-axis is T_TO/W_TO (sea-level
+        // take-off thrust); t_static_N is only an RC-airframe proxy.
+        text: "y-axis: T_TO/W_TO · RC airframes use static thrust as proxy · AR is a chart input",
       },
       {
         x: displayDp.ws_n_m2, y: displayDp.t_w, xref: "x", yref: "y",
@@ -265,6 +335,275 @@ export function findBindingConstraintAtPoint(
   return bindingName;
 }
 
+/** Return the name of the most-violated **t_w_points** constraint at the
+ * given (ws, tw) point, or null if none is violated.
+ *
+ * Unlike `findBindingConstraintAtPoint`, this does NOT report ws_max
+ * constraints (we only care about climb/takeoff insufficient-thrust
+ * diagnostics for the current-design-point callout). Exported for unit
+ * testing.
+ *
+ * gh-606: Scholz review substantive finding — turn the chart from
+ * decorative to diagnostic by flagging insufficient T/W.
+ */
+export function findInsufficientThrustConstraint(
+  ws: number,
+  tw: number,
+  wsRange: number[],
+  constraints: ConstraintLine[],
+): string | null {
+  if (!wsRange.length) return null;
+  const nearestIdx = _nearestWsIdx(ws, wsRange);
+  let bindingName: string | null = null;
+  let maxRatio = 0;
+  for (const c of constraints) {
+    if (!c.t_w_points) continue;
+    const twReq = c.t_w_points[nearestIdx];
+    if (twReq <= 0) continue;
+    const ratio = (twReq - tw) / twReq;
+    if (ratio > maxRatio) {
+      maxRatio = ratio;
+      bindingName = c.name;
+    }
+  }
+  return bindingName;
+}
+
+// ---------------------------------------------------------------------------
+// Derived value helpers (pure, exported for unit testing)
+// ---------------------------------------------------------------------------
+
+/** Compute S [m²] from weight [N] and wing loading [N/m²]. */
+export function computeWingArea(weightN: number, wsNm2: number): number {
+  if (wsNm2 <= 0) return NaN;
+  return weightN / wsNm2;
+}
+
+/** Compute T [N] from weight [N] and thrust-to-weight ratio. */
+export function computeThrust(weightN: number, tw: number): number {
+  return tw * weightN;
+}
+
+/** Compute aspect ratio from reference span [m] and reference area [m²]. */
+export function computeAspectRatio(bRefM: number | null | undefined, sRefM2: number | null | undefined): number | null {
+  if (bRefM == null || sRefM2 == null || sRefM2 <= 0) return null;
+  return (bRefM * bRefM) / sRefM2;
+}
+
+// ---------------------------------------------------------------------------
+// Info modal — Scholz/Sadraey sizing methodology explainer
+// ---------------------------------------------------------------------------
+
+interface InfoModalProps {
+  readonly open: boolean;
+  readonly onClose: () => void;
+}
+
+/** Modal explaining the matching-chart methodology per Loftin / Scholz §5 /
+ * Sadraey §4.3.1. English-only. Vault concepts referenced:
+ * `[[matching-chart-optimization]]`, `[[exam-matching-chart-design-point]]`,
+ * `[[preliminary-sizing-overview]]`. */
+function InfoModal({ open, onClose }: InfoModalProps) {
+  useEffect(() => {
+    if (!open) return;
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      data-testid="matching-chart-info-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="matching-chart-info-title"
+    >
+      <div className="max-h-[85vh] w-[680px] overflow-y-auto rounded-xl border border-border bg-card p-6">
+        <div className="mb-4 flex items-center justify-between">
+          <h3
+            id="matching-chart-info-title"
+            className="font-[family-name:var(--font-geist-sans)] text-[15px] font-medium text-foreground"
+          >
+            Matching Chart — sizing methodology
+          </h3>
+          <button
+            onClick={onClose}
+            className="text-muted-foreground hover:text-foreground"
+            aria-label="Close sizing methodology help"
+            data-testid="info-modal-close"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-4 font-[family-name:var(--font-geist-sans)] text-[12px] leading-relaxed text-foreground">
+
+          {/* 1. What you're doing */}
+          <section data-testid="info-section-overview">
+            <h4 className="mb-1 text-[12px] font-semibold uppercase tracking-wider text-muted-foreground">
+              What you&apos;re doing
+            </h4>
+            <p>
+              Preliminary sizing per Loftin / Scholz §5 / Sadraey §4.3.1. The goal is to find the
+              smallest (T, S) pair that satisfies every performance constraint. The chart visualises
+              the *feasible region* in (W/S, T/W)-space, and the optimum design point typically sits
+              at the intersection of the take-off requirement and the binding climb constraint.
+            </p>
+            <p className="mt-2 text-muted-foreground">
+              <strong>SI units throughout.</strong> Sizing is a <strong>3&ndash;5 iteration outer loop</strong>: a
+              single chart read is one pass. Each pass refines the polar (C<sub>D0</sub>,
+              C<sub>L,max</sub>) and the mass estimate; the chart is re-plotted; design point is
+              re-picked. Convergence comes from the loop, not from a single read.
+            </p>
+          </section>
+
+          {/* 2. Glossary */}
+          <section data-testid="info-section-glossary">
+            <h4 className="mb-1 text-[12px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Glossary
+            </h4>
+            <table className="w-full text-[11px]">
+              <thead>
+                <tr className="text-left text-[10px] uppercase tracking-wider text-muted-foreground">
+                  <th scope="col" className="py-0.5 pr-3 font-normal">Symbol</th>
+                  <th scope="col" className="py-0.5 font-normal">Meaning [units]</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td className="py-0.5 pr-3 font-mono text-foreground">S</td><td className="py-0.5">wing reference area [m²]</td></tr>
+                <tr>
+                  <td className="py-0.5 pr-3 font-mono text-foreground">T</td>
+                  <td className="py-0.5">
+                    take-off thrust at sea level [N] (approximated by your static-thrust input for RC airframes)
+                  </td>
+                </tr>
+                <tr><td className="py-0.5 pr-3 font-mono text-foreground">W</td><td className="py-0.5">total weight m<sub>MTO</sub>·g [N]</td></tr>
+                <tr><td className="py-0.5 pr-3 font-mono text-foreground">AR</td><td className="py-0.5">aspect ratio b²/S [-]</td></tr>
+                <tr><td className="py-0.5 pr-3 font-mono text-foreground">W/S</td><td className="py-0.5">wing loading [N/m²] — sets stall speed, landing distance, cruise efficiency</td></tr>
+                <tr><td className="py-0.5 pr-3 font-mono text-foreground">T/W</td><td className="py-0.5">thrust-to-weight ratio [-] — sets climb gradient, take-off distance, acceleration</td></tr>
+                <tr><td className="py-0.5 pr-3 font-mono text-foreground">L/D</td><td className="py-0.5">lift-to-drag ratio at the operating point [-] — drives cruise constraint</td></tr>
+                <tr><td className="py-0.5 pr-3 font-mono text-foreground">C<sub>L,max</sub></td><td className="py-0.5">maximum lift coefficient (clean, take-off, landing) [-] — drives stall and field-length constraints</td></tr>
+              </tbody>
+            </table>
+          </section>
+
+          {/* 3. Axes */}
+          <section data-testid="info-section-axes">
+            <h4 className="mb-1 text-[12px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Axes
+            </h4>
+            <p>
+              <strong>x-axis:</strong> W/S [N/m²]. <strong>y-axis:</strong> T<sub>TO</sub>/W<sub>TO</sub>
+              (take-off thrust over take-off weight at ISA sea level). For electric / prop RC
+              airframes the lapse from static thrust to lift-off is a few percent, so your
+              <span className="font-mono"> t_static_N</span> assumption is used as a proxy &mdash; the chart equates them, but
+              that is a <em>convention</em>, not a definition.
+            </p>
+            <p className="mt-2">
+              <strong>AR is a chart INPUT, not a slider.</strong> AR enters the Oswald factor
+              <span className="font-mono"> e</span>, the induced-drag term, and therefore every climb and cruise curve directly.
+              Changing AR upstream requires <em>re-plotting</em>; the chart does not auto-update from
+              the readout panel. AR adjustment lives in the 3&ndash;5-iteration outer loop.
+            </p>
+          </section>
+
+          {/* 4. Constraints */}
+          <section data-testid="info-section-constraints">
+            <h4 className="mb-1 text-[12px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Constraints (curves)
+            </h4>
+            <ul className="list-disc pl-5">
+              <li><strong>Stall</strong> &mdash; vertical line at maximum W/S that still hits V<sub>s</sub> target.</li>
+              <li><strong>Take-off field</strong> &mdash; rising-with-W/S curve; binds at small fields and high W/S.</li>
+              <li><strong>Second-segment climb</strong> &mdash; CS-25 / FAR-25-style climb-gradient floor.</li>
+              <li><strong>Missed-approach climb</strong> &mdash; landing-config climb-gradient floor.</li>
+              <li>
+                <strong>Cruise</strong> <em>(typically slack)</em> &mdash; matched iteratively via fuel mass, not enforced
+                on the chart per Sadraey §4.3. Drawn for reference, not selection.
+              </li>
+            </ul>
+          </section>
+
+          {/* 5. Red area */}
+          <section data-testid="info-section-red-area">
+            <h4 className="mb-1 text-[12px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Red area = infeasible
+            </h4>
+            <p>
+              The shaded red region marks combinations of (W/S, T/W) where <strong>at least one
+              constraint is violated</strong>. The unshaded region above all constraint curves
+              (and to the left of the stall line) is feasible. A larger feasible region is a
+              <em> permissible</em> design space, not yet an <em>optimum</em>.
+            </p>
+          </section>
+
+          {/* 6. Design point selection */}
+          <section data-testid="info-section-design-point">
+            <h4 className="mb-1 text-[12px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Picking the design point (Scholz Fig. 5.9)
+            </h4>
+            <p>
+              Scholz preference: <strong>primary</strong> &mdash; minimise T/W (engine cost / weight
+              drops). <strong>Secondary</strong> &mdash; maximise W/S (smaller wing, lighter
+              structure). The optimum is therefore at the <strong>intersection of the take-off line
+              and the binding climb constraint</strong> &mdash; then W/S is pushed rightward to the
+              landing / stall limit.
+            </p>
+            <pre
+              aria-hidden="true"
+              className="mt-2 rounded bg-card-muted p-2 font-mono text-[10px] leading-tight text-muted-foreground"
+            >
+{`  T/W ▲
+      │  climb (binding)
+      │  ╲
+      │   ╲ take-off
+      │    ╲╲
+      │   ★ ◀─── optimum
+      │     ──────────  cruise (slack)
+      │
+      └────────────▶  W/S
+                 ▲
+                 │ stall / landing limit`}
+            </pre>
+          </section>
+
+          {/* 7. Reading off results */}
+          <section data-testid="info-section-readoff">
+            <h4 className="mb-1 text-[12px] font-semibold uppercase tracking-wider text-muted-foreground">
+              How to read off results
+            </h4>
+            <p>
+              Once the design point (W/S)<sub>d</sub> and (T/W)<sub>d</sub> is chosen:
+            </p>
+            <ul className="mt-1 list-disc pl-5">
+              <li><span className="font-mono">S = W / (W/S)<sub>d</sub></span> &mdash; wing reference area follows from the current MTOW estimate.</li>
+              <li><span className="font-mono">T = (T/W)<sub>d</sub> · W</span> &mdash; required sea-level take-off thrust.</li>
+              <li>AR is held during the read-off but it was an <em>input</em> to the chart construction.</li>
+            </ul>
+          </section>
+
+          {/* 8. Iteration disclosure */}
+          <section data-testid="info-section-iteration">
+            <h4 className="mb-1 text-[12px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Iteration (3&ndash;5 passes)
+            </h4>
+            <p>
+              The matching chart is one step inside a larger sizing loop. Re-plot after each
+              update to mass, polar, AR, or cruise altitude until the design point converges.
+              Single-pass numbers from the readout are useful for orientation, not final sizing.
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Plotly chart renderer with drag support
 // ---------------------------------------------------------------------------
@@ -273,6 +612,7 @@ interface MatchingChartPlotProps {
   readonly data: MatchingChartData;
   readonly dragPoint: DragPoint | null;
   readonly isDragging: boolean;
+  readonly currentDp: CurrentDesignPoint | null;
   readonly onDragStart: (ws: number, tw: number) => void;
   readonly onDragMove: (ws: number, tw: number) => void;
   readonly onDragEnd: () => void;
@@ -282,6 +622,7 @@ function MatchingChartPlot({
   data,
   dragPoint,
   isDragging,
+  currentDp,
   onDragStart,
   onDragMove,
   onDragEnd,
@@ -374,6 +715,11 @@ function MatchingChartPlot({
         ...constraintTraces,
         buildDesignPointTrace(displayDp.ws_n_m2, displayDp.t_w, data.feasibility, isDragging),
       ];
+      // gh-606: include current-design-point trace when available (powered
+      // aircraft only — gliders are suppressed upstream in MatchingChartTab).
+      if (currentDp) {
+        allTraces.push(buildCurrentDesignPointTrace(currentDp));
+      }
       const layout = { ...buildLayout(ws, data, displayDp, isDragging), shapes };
 
       await Plotly.react(node, allTraces, layout, {
@@ -386,7 +732,7 @@ function MatchingChartPlot({
       disposed = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, displayDp.ws_n_m2, displayDp.t_w, isDragging, dragBindingName]);
+  }, [data, displayDp.ws_n_m2, displayDp.t_w, isDragging, dragBindingName, currentDp]);
 
   // Cleanup Plotly on unmount
   useEffect(() => {
@@ -459,56 +805,93 @@ interface DesignPointSummaryProps {
   readonly isDragging: boolean;
   readonly displayDp: { ws_n_m2: number; t_w: number } | undefined;
   readonly liveDragBinding: string | null;
+  readonly weightN: number | null;
+  readonly aspectRatio: number | null;
 }
 
-function DesignPointSummary({ data, isDragging, displayDp, liveDragBinding }: DesignPointSummaryProps) {
-  const activeColor = isDragging ? "#FF8400" : undefined;
-
+/** Single readout cell with optional title (tooltip) and testid. */
+function SummaryCell({
+  label,
+  value,
+  title,
+  color,
+  testId,
+}: Readonly<{
+  label: string;
+  value: string;
+  title?: string;
+  color?: string;
+  testId?: string;
+}>) {
   return (
-    <div className="flex flex-wrap gap-4 rounded-xl border border-border bg-card px-4 py-3">
+    <div className="flex flex-col gap-0.5">
+      <span
+        className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground"
+        title={title}
+      >
+        {label}
+      </span>
+      <span
+        className="font-[family-name:var(--font-jetbrains-mono)] text-[14px] font-semibold"
+        style={color ? { color } : undefined}
+        data-testid={testId}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+/** Format helpers — pulled out to flatten the JSX. */
+function fmtWs(displayDp: { ws_n_m2: number } | undefined): string {
+  return displayDp ? `${displayDp.ws_n_m2.toFixed(0)} N/m²` : "—";
+}
+function fmtTw(displayDp: { t_w: number } | undefined): string {
+  return displayDp ? displayDp.t_w.toFixed(3) : "—";
+}
+function fmtArea(area: number | null): string {
+  return area != null && isFinite(area) ? `${area.toFixed(3)} m²` : "—";
+}
+function fmtThrust(thrust: number | null): string {
+  return thrust != null && isFinite(thrust) ? `${formatSigFigs(thrust, 3)} N` : "—";
+}
+function fmtWeight(w: number | null): string {
+  return w != null && isFinite(w) ? `${w.toFixed(1)} N` : "—";
+}
+function fmtAr(ar: number | null): string {
+  return ar != null && isFinite(ar) ? ar.toFixed(2) : "—";
+}
+
+function BindingCells({
+  data,
+  isDragging,
+  liveDragBinding,
+}: Readonly<{
+  data: MatchingChartData;
+  isDragging: boolean;
+  liveDragBinding: string | null;
+}>) {
+  if (isDragging) {
+    if (!liveDragBinding) return null;
+    const color = data.constraints.find((c) => c.name === liveDragBinding)?.color ?? "#FF8400";
+    return (
       <div className="flex flex-col gap-0.5">
-        <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
-          {isDragging ? "Drag W/S" : "Design Point W/S"}
-        </span>
+        <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">Binding</span>
         <span
-          className="font-[family-name:var(--font-jetbrains-mono)] text-[14px] font-semibold"
-          style={{ color: activeColor }}
-          data-testid="dp-ws"
+          className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] font-semibold"
+          style={{ color }}
+          data-testid="drag-binding"
         >
-          {displayDp ? `${displayDp.ws_n_m2.toFixed(0)} N/m²` : "—"}
+          {liveDragBinding}
         </span>
       </div>
-      <div className="flex flex-col gap-0.5">
-        <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
-          {isDragging ? "Drag T/W" : "Design Point T/W"}
-        </span>
-        <span
-          className="font-[family-name:var(--font-jetbrains-mono)] text-[14px] font-semibold"
-          style={{ color: activeColor }}
-          data-testid="dp-tw"
-        >
-          {displayDp ? displayDp.t_w.toFixed(3) : "—"}
-        </span>
-      </div>
-      {isDragging && liveDragBinding && (
-        <div className="flex flex-col gap-0.5">
-          <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
-            Binding
-          </span>
-          <span
-            className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] font-semibold"
-            style={{ color: data.constraints.find((c) => c.name === liveDragBinding)?.color ?? "#FF8400" }}
-            data-testid="drag-binding"
-          >
-            {liveDragBinding}
-          </span>
-        </div>
-      )}
-      {!isDragging && data.constraints.filter((c) => c.binding).map((c) => (
+    );
+  }
+  return (
+    <>
+      {data.constraints.filter((c) => c.binding).map((c) => (
         <div key={c.name} className="flex flex-col gap-0.5">
-          <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
-            Binding
-          </span>
+          <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">Binding</span>
           <span
             className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] font-semibold"
             style={{ color: c.color }}
@@ -517,6 +900,65 @@ function DesignPointSummary({ data, isDragging, displayDp, liveDragBinding }: De
           </span>
         </div>
       ))}
+    </>
+  );
+}
+
+function DesignPointSummary({
+  data,
+  isDragging,
+  displayDp,
+  liveDragBinding,
+  weightN,
+  aspectRatio,
+}: DesignPointSummaryProps) {
+  const activeColor = isDragging ? "#FF8400" : undefined;
+  const hasMass = weightN != null && weightN > 0;
+  // gh-606: live-derived S = W/(W/S), T = T/W·W using the held W and AR.
+  const derivedS = displayDp && hasMass ? computeWingArea(weightN!, displayDp.ws_n_m2) : null;
+  const derivedT = displayDp && hasMass ? computeThrust(weightN!, displayDp.t_w) : null;
+
+  return (
+    <div className="flex flex-wrap gap-4 rounded-xl border border-border bg-card px-4 py-3">
+      <SummaryCell
+        label={isDragging ? "Drag W/S" : "Design Point W/S"}
+        value={fmtWs(displayDp)}
+        color={activeColor}
+        testId="dp-ws"
+      />
+      <SummaryCell
+        label={isDragging ? "Drag T/W" : "Design Point T/W"}
+        value={fmtTw(displayDp)}
+        color={activeColor}
+        testId="dp-tw"
+      />
+      <SummaryCell
+        label="S = W / (W/S)"
+        title="S = W / (W/S)"
+        value={fmtArea(derivedS)}
+        color={activeColor}
+        testId="dp-derived-s"
+      />
+      <SummaryCell
+        label="T = (T/W)·W"
+        title="T = (T/W) · W"
+        value={fmtThrust(derivedT)}
+        color={activeColor}
+        testId="dp-derived-t"
+      />
+      <SummaryCell
+        label="W (m_MTO · g)"
+        title="W = m_MTO · g, treated as constant during this chart read"
+        value={fmtWeight(weightN)}
+        testId="dp-w"
+      />
+      <SummaryCell
+        label="AR (input — see info modal)"
+        title="AR is a chart input — changing it requires re-plotting"
+        value={fmtAr(aspectRatio)}
+        testId="dp-ar"
+      />
+      <BindingCells data={data} isDragging={isDragging} liveDragBinding={liveDragBinding} />
     </div>
   );
 }
@@ -542,11 +984,27 @@ function FeasibilityBadge({ feasibility }: Readonly<{ feasibility: string }>) {
 // Chart + drag state (extracted to enable key-based reset when data changes)
 // ---------------------------------------------------------------------------
 
+interface MatchingChartContentProps {
+  readonly data: MatchingChartData;
+  readonly currentDp: CurrentDesignPoint | null;
+  readonly weightN: number | null;
+  readonly aspectRatio: number | null;
+  readonly isGlider: boolean;
+  readonly insufficientConstraintName: string | null;
+}
+
 /** Internal component that owns drag state for a given snapshot of chart data.
  * Rendered with key={data.design_point.ws_n_m2 + data.design_point.t_w} so that
  * when fresh server data arrives the drag state resets automatically via re-mount.
  */
-function MatchingChartContent({ data }: Readonly<{ data: MatchingChartData }>) {
+function MatchingChartContent({
+  data,
+  currentDp,
+  weightN,
+  aspectRatio,
+  isGlider,
+  insufficientConstraintName,
+}: MatchingChartContentProps) {
   const [dragPoint, setDragPoint] = useState<DragPoint | null>(null);
   const [isDragging, setIsDragging] = useState(false);
 
@@ -571,21 +1029,42 @@ function MatchingChartContent({ data }: Readonly<{ data: MatchingChartData }>) {
 
   return (
     <>
-      <div className="rounded-xl border border-border bg-card p-2">
+      <div className="relative rounded-xl border border-border bg-card p-2">
         <MatchingChartPlot
           data={data}
           dragPoint={dragPoint}
           isDragging={isDragging}
+          currentDp={currentDp}
           onDragStart={handleDragStart}
           onDragMove={handleDragMove}
           onDragEnd={handleDragEnd}
         />
+        {/* gh-606: glider suppression per Scholz review critical #3 */}
+        {isGlider && (
+          <div
+            className="absolute left-3 top-3 max-w-[420px] rounded bg-card-muted/90 px-2 py-1 text-[10px] text-muted-foreground"
+            data-testid="glider-callout"
+          >
+            Matching chart is jet/powered-only &mdash; gliders are sized by sink-rate polar, not T/W vs W/S.
+          </div>
+        )}
+        {/* gh-606: insufficient-thrust callout per Scholz review substantive finding */}
+        {!isGlider && currentDp && insufficientConstraintName && (
+          <div
+            className="absolute right-3 top-3 max-w-[360px] rounded bg-red-900/70 px-2 py-1 text-[10px] text-red-200"
+            data-testid="insufficient-thrust-callout"
+          >
+            Your assumed T/W = {currentDp.t_w.toFixed(3)} is insufficient for the {insufficientConstraintName} constraint at the current W/S.
+          </div>
+        )}
       </div>
       <DesignPointSummary
         data={data}
         isDragging={isDragging}
         displayDp={displayDp}
         liveDragBinding={liveDragBinding}
+        weightN={weightN}
+        aspectRatio={aspectRatio}
       />
     </>
   );
@@ -600,6 +1079,7 @@ export function MatchingChartTab({ aeroplaneId }: Props) {
   const [sRunway, setSRunway] = useState<number>(MODE_DEFAULTS[mode].sRunway);
   const [vSTarget, setVSTarget] = useState<number>(MODE_DEFAULTS[mode].vSTarget);
   const [gamma, setGamma] = useState<number>(MODE_DEFAULTS[mode].gamma);
+  const [infoOpen, setInfoOpen] = useState(false);
 
   function handleModeChange(newMode: AircraftMode) {
     setMode(newMode);
@@ -614,6 +1094,59 @@ export function MatchingChartTab({ aeroplaneId }: Props) {
     vSTarget,
     gammaClimbDeg: gamma,
   });
+
+  // gh-606: pull mass + t_static + s_ref + b_ref to compute the current
+  // (W/S, T/W) point and the live readout's "held" W and AR.
+  const { data: assumptionsData } = useDesignAssumptions(aeroplaneId);
+  const { data: ctx } = useComputationContext(aeroplaneId);
+
+  const massKg = useMemo(() => {
+    const a = assumptionsData?.assumptions.find((x) => x.parameter_name === "mass");
+    return a ? a.effective_value : null;
+  }, [assumptionsData]);
+
+  const tStaticN = useMemo(() => {
+    const a = assumptionsData?.assumptions.find((x) => x.parameter_name === "t_static_N");
+    return a ? a.effective_value : null;
+  }, [assumptionsData]);
+
+  const sRefM2 = ctx?.s_ref_m2 ?? null;
+  const bRefM = ctx?.b_ref_m ?? null;
+  const isGlider = ctx?.is_glider === true;
+
+  const weightN = massKg != null && massKg > 0 ? massKg * G_MPS2 : null;
+  const aspectRatio = computeAspectRatio(bRefM, sRefM2);
+
+  // gh-606: glider suppression — Scholz review critical #3. Drawing a phantom
+  // marker at T/W = 0 trains the user to misread the chart. Suppress entirely.
+  const currentDp: CurrentDesignPoint | null = useMemo(() => {
+    if (isGlider) return null;
+    if (massKg == null || sRefM2 == null || tStaticN == null) return null;
+    if (sRefM2 <= 0 || massKg <= 0 || tStaticN <= 0) return null;
+    const w = massKg * G_MPS2;
+    const ws = w / sRefM2;
+    const tw = tStaticN / w;
+    return {
+      ws_n_m2: ws,
+      t_w: tw,
+      mass_kg: massKg,
+      s_m2: sRefM2,
+      t_n: tStaticN,
+      w_n: w,
+      ar: aspectRatio,
+    };
+  }, [isGlider, massKg, sRefM2, tStaticN, aspectRatio]);
+
+  // gh-606: insufficient-thrust diagnostic (substantive finding in Scholz review).
+  const insufficientConstraintName = useMemo(() => {
+    if (!data || !currentDp) return null;
+    return findInsufficientThrustConstraint(
+      currentDp.ws_n_m2,
+      currentDp.t_w,
+      data.ws_range_n_m2,
+      data.constraints,
+    );
+  }, [data, currentDp]);
 
   // Stable key: changes only when the server returns a new design point.
   // This re-mounts MatchingChartContent and resets its internal drag state.
@@ -695,13 +1228,28 @@ export function MatchingChartTab({ aeroplaneId }: Props) {
           />
         </div>
 
-        <div className="ml-auto flex items-center gap-1.5 text-[10px] text-muted-foreground">
-          <Info size={11} />
-          <span className="font-[family-name:var(--font-geist-sans)]">
-            Drag design point to explore required S and T for fixed W and AR
+        {/* gh-606: Info button now opens the methodology modal. */}
+        <div className="ml-auto flex items-center gap-2 text-[10px] text-muted-foreground">
+          <button
+            type="button"
+            onClick={() => setInfoOpen(true)}
+            aria-label="Open sizing methodology help"
+            data-testid="info-modal-trigger"
+            className="inline-flex items-center gap-1 rounded-full border border-border px-2 py-1 hover:border-orange-400 hover:text-foreground"
+          >
+            <Info size={11} />
+            <span className="font-[family-name:var(--font-geist-sans)]">
+              How to read this chart
+            </span>
+          </button>
+          <span className="font-[family-name:var(--font-geist-sans)] hidden md:inline">
+            Drag the design point to explore S and T for the held W and AR
           </span>
         </div>
       </div>
+
+      {/* gh-606: Modal */}
+      <InfoModal open={infoOpen} onClose={() => setInfoOpen(false)} />
 
       {/* States */}
       {isLoading && (
@@ -727,7 +1275,15 @@ export function MatchingChartTab({ aeroplaneId }: Props) {
       {data && !isLoading && (
         <>
           {/* MatchingChartContent owns drag state; key forces reset on new server data */}
-          <MatchingChartContent key={contentKey} data={data} />
+          <MatchingChartContent
+            key={contentKey}
+            data={data}
+            currentDp={currentDp}
+            weightN={weightN}
+            aspectRatio={aspectRatio}
+            isGlider={isGlider}
+            insufficientConstraintName={insufficientConstraintName}
+          />
 
           {/* Warnings */}
           {data.warnings.length > 0 && (


### PR DESCRIPTION
## Summary

Adds three UX features to the Analysis → Sizing tab (Matching Chart), implementing the **Scholz-expert-reviewed** spec on #606 (APPROVE_WITH_CHANGES — original ticket body amended in the review comment):

1. **Info modal** explaining the methodology (Loftin / Scholz §5 / Sadraey §4.3.1) — eight sections (overview, glossary, axes, constraints, red area, design-point selection, read-off, iteration disclosure). Replaces the static `<Info>` icon + one-liner in `MatchingChartTab.tsx`.
2. **Current-design-point marker** — filled teal diamond (`#22dd99`), distinct from the orange explored point. Derived from `mass`, `s_ref_m2`, and `t_static_N`. Hover tooltip lists W as `m_MTO·g`, T as the user's assumed static thrust, plus S and AR.
3. **Live derived readout** — S = W/(W/S), T = (T/W)·W, held W = m_MTO·g, AR (input) updates continuously as the user drags the explored design point. T is formatted to 3 sig figs.

## Scholz review compliance

Implementation follows the Scholz expert review (APPROVE_WITH_CHANGES on #606); key corrections applied (not the original spec):

- **y-axis** labelled as T_TO/W_TO with `t_static_N` disclosed as RC airframe proxy, not silently equated.
- **AR** labelled as chart **input** (enters Oswald factor → induced drag → climb/cruise curves), not "held constant" — changing AR upstream requires re-plotting per the 3–5-iteration outer loop.
- **Gliders** suppress the current-design-point marker entirely (drawing it at T/W = 0 trains the user to misread the chart). Callout: *"Matching chart is jet/powered-only — gliders are sized by sink-rate polar, not T/W vs W/S."*
- **Tooltip warning**: when the assumed T/W lies above any constraint curve at the current W/S, surface *"Your assumed T/W = X is insufficient for the &lt;constraint&gt; constraint at the current W/S"* — chart becomes diagnostic, not decorative.

Modal copy also includes the SI-units disclosure, the 3–5-iteration outer-loop reminder, and a small ASCII sketch echoing Scholz Fig. 5.9 (intersection of take-off + binding climb → push W/S rightward to landing limit).

## Vault concepts referenced

`[[matching-chart-optimization]]`, `[[exam-matching-chart-design-point]]`, `[[preliminary-sizing-overview]]`, `[[engine-thrust-scaling-altitude-mach]]`, `[[permissible-design-vs-optimum-design]]`.

## Test plan

- [x] `npm run test:unit -- MatchingChartTab` — 102/102 pass (41 new tests).
- [x] `npm run test:unit` — full suite green except 1 pre-existing failure in `MissionObjectivesPanel.test.tsx` (unrelated to gh-606; same failure on `main`).
- [x] `npm run lint` — 0 errors in MatchingChartTab.
- [x] `npm run deps:check` — no new violations.
- [x] `poetry run pytest -m "not slow"` — 3645 passing.
- [ ] Manual smoke: Sizing tab → modal opens with 8 sections → ESC closes → current-design-point visible for powered aircraft → glider context shows callout instead → drag explored point → live S, T, W, AR cells update → assume-thrust-too-low surfaces the insufficient-thrust callout.

Closes #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)