### PR TITLE
fix(gh-617): move active mission label into Mission Radar tooltip header

### DIFF
--- a/frontend/__tests__/MissionRadarChart.test.tsx
+++ b/frontend/__tests__/MissionRadarChart.test.tsx
@@ -204,6 +204,83 @@ describe("MissionRadarChart", () => {
     expect(text).toMatch(/Soll/);
   });
 
+  it("renders active mission label in the tooltip header, not on the Soll row (gh-617)", () => {
+    const ksetCruise = {
+      ...kset,
+      ist_polygon: { ...kset.ist_polygon, cruise: cruiseKpi },
+    };
+    const { getByTestId } = render(
+      <MissionRadarChart
+        kpis={ksetCruise}
+        activeMissions={[preset("trainer")]}
+        onAxisClick={() => undefined}
+      />,
+    );
+    fireEvent.mouseEnter(getByTestId("hover-wedge-cruise"));
+
+    // Header has axis name AND the active mission label, separated by " · ".
+    const header = getByTestId("axis-tooltip-cruise-header");
+    const headerText = header.textContent ?? "";
+    expect(headerText).toMatch(/Cruise/);
+    expect(headerText).toMatch(/trainer/);
+    // Both pieces are present with a "·" separator (regardless of order).
+    expect(headerText).toMatch(/·/);
+
+    // Soll row contains only value + unit (no trailing parenthesised label).
+    // Spans are inline; textContent concatenates without spaces between them,
+    // hence "Soll:17.50 m/s". The `$` anchor verifies no trailing "(...)".
+    const sollRow = getByTestId("axis-tooltip-cruise-soll");
+    const sollText = (sollRow.textContent ?? "").trim();
+    expect(sollText).toMatch(/^Soll:\s*\d+\.\d+\s+m\/s$/);
+    // No trailing "(trainer)" suffix on the Soll row.
+    expect(sollText).not.toMatch(/\(trainer\)/);
+  });
+
+  it("header degrades to just the axis name when no active mission is selected (gh-617)", () => {
+    const ksetCruise = {
+      ...kset,
+      ist_polygon: { ...kset.ist_polygon, cruise: cruiseKpi },
+    };
+    const { getByTestId } = render(
+      <MissionRadarChart
+        kpis={ksetCruise}
+        activeMissions={[]}
+        onAxisClick={() => undefined}
+      />,
+    );
+    fireEvent.mouseEnter(getByTestId("hover-wedge-cruise"));
+    const header = getByTestId("axis-tooltip-cruise-header");
+    const headerText = (header.textContent ?? "").trim();
+    expect(headerText).toBe("Cruise");
+    // No separator when no active mission is present.
+    expect(headerText).not.toMatch(/·/);
+  });
+
+  it("ghost rows still carry their own per-row profile label (gh-617)", () => {
+    const ghost = preset("sailplane");
+    ghost.target_polygon.cruise = 0.8;
+    ghost.axis_ranges.cruise = [10, 30]; // 10 + 0.8 × 20 = 26
+    const { getByTestId } = render(
+      <MissionRadarChart
+        kpis={kset}
+        activeMissions={[preset("trainer"), ghost]}
+        onAxisClick={() => undefined}
+      />,
+    );
+    fireEvent.mouseEnter(getByTestId("hover-wedge-cruise"));
+
+    // Header carries the ACTIVE mission only ("trainer"), not the ghost.
+    const header = getByTestId("axis-tooltip-cruise-header");
+    expect(header.textContent ?? "").toMatch(/trainer/);
+    expect(header.textContent ?? "").not.toMatch(/sailplane/);
+
+    // Ghost row preserves the "<label>: <value> <unit>" format.
+    const tooltip = getByTestId("axis-tooltip-cruise");
+    const text = tooltip.textContent ?? "";
+    // Format: "sailplane: 26.00 m/s"
+    expect(text).toMatch(/sailplane:\s*26\.00\s+m\/s/);
+  });
+
   it("hides tooltip on mouseleave (gh-601)", () => {
     const { getByTestId, queryByTestId } = render(
       <MissionRadarChart

--- a/frontend/components/workbench/mission/MissionRadarChart.tsx
+++ b/frontend/components/workbench/mission/MissionRadarChart.tsx
@@ -384,8 +384,17 @@ function AxisTooltip({ axis, kpis, active, ghosts }: AxisTooltipProps) {
           transformOrigin,
         }}
       >
-        <div className="mb-1 font-semibold text-orange-400">
+        <div
+          data-testid={`axis-tooltip-${axis}-header`}
+          className="mb-1 font-semibold text-orange-400"
+        >
           {AXIS_LABELS[axis]}
+          {active && (
+            <span className="ml-1 font-normal text-muted-foreground">
+              {" · "}
+              {active.label}
+            </span>
+          )}
         </div>
 
         <div className="flex items-center justify-between gap-2">
@@ -406,13 +415,13 @@ function AxisTooltip({ axis, kpis, active, ghosts }: AxisTooltipProps) {
         </div>
 
         {active && sollValue !== null && (
-          <div className="flex items-center justify-between gap-2">
+          <div
+            data-testid={`axis-tooltip-${axis}-soll`}
+            className="flex items-center justify-between gap-2"
+          >
             <span className="text-muted-foreground">Soll:</span>
             <span className="tabular-nums">
               {fmt(sollValue)} {unit}
-            </span>
-            <span className="text-[9px] text-muted-foreground">
-              ({active.label})
             </span>
           </div>
         )}


### PR DESCRIPTION
## Summary

After #609 fixed the tooltip clipping, the per-axis hover tooltip's **Soll row** still wrapped because the active-mission profile label was appended after the value+unit, exceeding the tooltip's `max-width`.

The fix is **information architecture**, not layout stretching: move the active mission label into the tooltip header alongside the axis name; keep the tooltip's width and quadrant-aware positioning untouched.

### Before

```
                  Cruise
Ist:    10.20 m/s  *
Soll:   14.50
        m/s  (Sailplane)   <- wrapped
```

### After

```
Cruise * Sailplane          <- header: axis + muted active profile
Ist:    10.20 m/s  *
Soll:   14.50 m/s
Ghost (Trainer): X.X m/s    <- ghosts keep per-row label
```

## Changes

- `MissionRadarChart.tsx` (`AxisTooltip` only):
  - Header renders `<Axis> * <Active Label>` when an active mission is selected. The profile label is muted (`text-muted-foreground`, `font-normal`), not in the orange axis-name color, so the header reads as `<bold axis> * <muted profile>`.
  - Degrades to just the axis name when no active mission is present.
  - Soll row drops the trailing `(<active.label>)` suffix; value + unit only.
  - Ghost rows untouched: still `<ghost.label>: <value> <unit>`.
  - Quadrant-aware `data-x-align` / `data-y-align` from #609 unchanged.
  - Tooltip `max-width` unchanged.
  - Added `data-testid` hooks on header and Soll rows for targeted assertions.

- `MissionRadarChart.test.tsx`:
  - New: header contains axis name AND active mission label separated by `*`; Soll row contains only value+unit (no trailing parenthesised label).
  - New: header degrades to just the axis name when `activeMissions` is empty.
  - New: ghost rows preserve their per-row `<label>: <value> <unit>` format; the active profile name does **not** leak onto ghost rows.
  - Existing gh-601 tests preserved without weakening (Iron Law 4).

Single-file production change.

## Test plan

- [x] `npm run test:unit -- MissionRadarChart` (20 tests, all pass)
- [x] `npm run test:unit` (926 tests, all pass; +3 new vs main's 923)
- [x] `npm run lint` (0 errors)
- [x] `npm run deps:check` (0 errors)
- [ ] Manual smoke: hover any axis on the Mission Radar with an active profile + at least one ghost - header reads `<axis> * <profile>`; Ist, Soll rows are each one line; Ghost row shows its own profile label.

Closes #617

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>