### PR TITLE
feat(gh-613): Phase A — CS-25 honesty in Matching Chart modal + per-constraint relevance badges

### DIFF
--- a/frontend/__tests__/MatchingChartTab.test.tsx
+++ b/frontend/__tests__/MatchingChartTab.test.tsx
@@ -1310,6 +1310,321 @@ describe("findInsufficientThrustConstraint (gh-606)", () => {
   });
 });
 
+// ── gh-613 Phase A: CS-25 honesty in the info modal ──────────────────────────
+
+describe("MatchingChartTab — gh-613 Phase A CS-25 callout", () => {
+  beforeEach(() => {
+    hookReturn = MOCK_OK_STATE;
+    mockAssumptions = [];
+    mockCtx = null;
+  });
+
+  it("constraints section shows CS-25 provenance callout when modal is open", () => {
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    act(() => {
+      fireEvent.click(screen.getByTestId("info-modal-trigger"));
+    });
+    const callout = screen.getByTestId("info-section-cs25-callout");
+    expect(callout).toBeInTheDocument();
+    expect(callout.textContent).toMatch(/Scholz\/Loftin CS-25 methodology/);
+    expect(callout.textContent).toMatch(/multi-engine transport aircraft/);
+    expect(callout.textContent).toMatch(/Second-Segment Climb \(OEI\)/);
+    expect(callout.textContent).toMatch(/Missed-Approach Climb/);
+    expect(callout.textContent).toMatch(/CS-25 conformance bands, not RC requirements/);
+  });
+
+  it("CS-25 callout precedes the constraints list inside the constraints section", () => {
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    act(() => {
+      fireEvent.click(screen.getByTestId("info-modal-trigger"));
+    });
+    const constraintsSection = screen.getByTestId("info-section-constraints");
+    const callout = screen.getByTestId("info-section-cs25-callout");
+    // Callout must live inside the constraints section
+    expect(constraintsSection.contains(callout)).toBe(true);
+    // Callout must come before the <ul> of constraints
+    const ul = constraintsSection.querySelector("ul");
+    expect(ul).toBeTruthy();
+    expect(
+      callout.compareDocumentPosition(ul!) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeGreaterThan(0);
+  });
+});
+
+describe("MatchingChartTab — gh-613 Phase A relevance badges", () => {
+  beforeEach(() => {
+    hookReturn = MOCK_OK_STATE;
+    mockAssumptions = [];
+    mockCtx = null;
+  });
+
+  function openModal() {
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    act(() => {
+      fireEvent.click(screen.getByTestId("info-modal-trigger"));
+    });
+  }
+
+  it("Stall constraint has Universal badge", () => {
+    openModal();
+    const badge = screen.getByTestId("constraint-badge-stall");
+    expect(badge).toHaveAttribute("data-relevance", "universal");
+    expect(badge.textContent).toMatch(/Universal/);
+    expect(badge).toHaveAttribute("title", "Universal — pure aerodynamics");
+  });
+
+  it("Takeoff field length has Conditional badge", () => {
+    openModal();
+    const badge = screen.getByTestId("constraint-badge-takeoff");
+    expect(badge).toHaveAttribute("data-relevance", "conditional");
+    expect(badge.textContent).toMatch(/Conditional/);
+    expect(badge).toHaveAttribute("title", "Wheeled takeoff only");
+  });
+
+  it("Second-segment climb has CS-25-only badge", () => {
+    openModal();
+    const badge = screen.getByTestId("constraint-badge-second-segment");
+    expect(badge).toHaveAttribute("data-relevance", "cs25-only");
+    expect(badge.textContent).toMatch(/CS-25-only/);
+    expect(badge).toHaveAttribute(
+      "title",
+      "CS-25 multi-engine — single-engine N/A",
+    );
+  });
+
+  it("Missed-approach climb has CS-25-only badge", () => {
+    openModal();
+    const badge = screen.getByTestId("constraint-badge-missed-approach");
+    expect(badge).toHaveAttribute("data-relevance", "cs25-only");
+    expect(badge.textContent).toMatch(/CS-25-only/);
+    expect(badge).toHaveAttribute(
+      "title",
+      "CS-25 multi-engine — single-engine N/A",
+    );
+  });
+
+  it("Cruise has Universal badge with slack tooltip", () => {
+    openModal();
+    const badge = screen.getByTestId("constraint-badge-cruise");
+    expect(badge).toHaveAttribute("data-relevance", "universal");
+    expect(badge.textContent).toMatch(/Universal/);
+    expect(badge).toHaveAttribute(
+      "title",
+      "Universal — slack constraint, iterated via fuel mass",
+    );
+  });
+
+  it("Landing field length has Conditional badge", () => {
+    openModal();
+    const badge = screen.getByTestId("constraint-badge-landing");
+    expect(badge).toHaveAttribute("data-relevance", "conditional");
+    expect(badge.textContent).toMatch(/Conditional/);
+    expect(badge).toHaveAttribute("title", "Runway landing only");
+  });
+});
+
+// ── gh-613 Phase A: relax insufficient-T/W warning (skip OEI / Missed-Approach) ──
+
+describe("MatchingChartTab — gh-613 Phase A insufficient-T/W skips OEI", () => {
+  it("does NOT render warning when only an OEI Second-Segment constraint is violated", async () => {
+    const data: MatchingChartData = {
+      ...MOCK_CESSNA,
+      constraints: [
+        // Only the OEI constraint is binding/violated — everything else is OK.
+        {
+          name: "Second-Segment Climb (OEI)",
+          t_w_points: Array(200).fill(0.5),
+          ws_max: null,
+          color: "#E5484D",
+          binding: true,
+          hover_text: "OEI segment-2",
+        },
+        {
+          name: "Cruise",
+          t_w_points: Array(200).fill(0.05),
+          ws_max: null,
+          color: "#30A46C",
+          binding: false,
+          hover_text: "Cruise",
+        },
+      ],
+      design_point: { ws_n_m2: 400, t_w: 0.5 },
+    };
+    hookReturn = { ...MOCK_OK_STATE, data };
+    mockAssumptions = [
+      { parameter_name: "mass", effective_value: 40 },
+      { parameter_name: "t_static_N", effective_value: 30 }, // T/W ≈ 0.076
+    ];
+    mockCtx = { s_ref_m2: 1.0, b_ref_m: 3.0, is_glider: false };
+
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // OEI was the only "binding" violator — warning must be suppressed.
+    expect(screen.queryByTestId("insufficient-thrust-callout")).toBeNull();
+  });
+
+  it("does NOT render warning when only Missed-Approach constraint is violated", async () => {
+    const data: MatchingChartData = {
+      ...MOCK_CESSNA,
+      constraints: [
+        {
+          name: "Missed-Approach Climb",
+          t_w_points: Array(200).fill(0.5),
+          ws_max: null,
+          color: "#E5484D",
+          binding: true,
+          hover_text: "Missed approach",
+        },
+      ],
+      design_point: { ws_n_m2: 400, t_w: 0.5 },
+    };
+    hookReturn = { ...MOCK_OK_STATE, data };
+    mockAssumptions = [
+      { parameter_name: "mass", effective_value: 40 },
+      { parameter_name: "t_static_N", effective_value: 30 },
+    ];
+    mockCtx = { s_ref_m2: 1.0, b_ref_m: 3.0, is_glider: false };
+
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByTestId("insufficient-thrust-callout")).toBeNull();
+  });
+
+  it("DOES render warning when a non-OEI constraint (e.g. Stall climb) is violated", async () => {
+    const data: MatchingChartData = {
+      ...MOCK_CESSNA,
+      constraints: [
+        // OEI exists but is satisfied (low requirement) — should still be skipped from warning anyway
+        {
+          name: "Second-Segment Climb (OEI)",
+          t_w_points: Array(200).fill(0.02),
+          ws_max: null,
+          color: "#888",
+          binding: false,
+          hover_text: "OEI segment-2",
+        },
+        // Stall (T/W requirement) is genuinely violated
+        {
+          name: "Stall Climb",
+          t_w_points: Array(200).fill(0.5),
+          ws_max: null,
+          color: "#E5484D",
+          binding: true,
+          hover_text: "Stall climb",
+        },
+      ],
+      design_point: { ws_n_m2: 400, t_w: 0.5 },
+    };
+    hookReturn = { ...MOCK_OK_STATE, data };
+    mockAssumptions = [
+      { parameter_name: "mass", effective_value: 40 },
+      { parameter_name: "t_static_N", effective_value: 30 },
+    ];
+    mockCtx = { s_ref_m2: 1.0, b_ref_m: 3.0, is_glider: false };
+
+    render(<MatchingChartTab aeroplaneId="test-id" />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const callout = screen.getByTestId("insufficient-thrust-callout");
+    expect(callout).toBeInTheDocument();
+    // The non-OEI constraint name should appear (Stall Climb), not the OEI one.
+    expect(callout.textContent).toMatch(/Stall Climb/);
+    expect(callout.textContent).not.toMatch(/Second-Segment Climb \(OEI\)/);
+  });
+});
+
+describe("findInsufficientThrustConstraint — gh-613 Phase A skipOei flag", () => {
+  const wsRange = Array.from({ length: 100 }, (_, i) => 100 + i * 10);
+
+  it("skipOei=true ignores 'Second-Segment Climb (OEI)' constraint", () => {
+    const constraints: ConstraintLine[] = [
+      {
+        name: "Second-Segment Climb (OEI)",
+        t_w_points: Array(100).fill(0.5),
+        ws_max: null,
+        color: "#E5484D",
+        binding: true,
+        hover_text: null,
+      },
+    ];
+    // T/W = 0.05 violates the OEI constraint; with skipOei it should be ignored.
+    expect(
+      findInsufficientThrustConstraint(500, 0.05, wsRange, constraints, true),
+    ).toBeNull();
+    // Without the flag (or with skipOei=false) the constraint is still considered.
+    expect(
+      findInsufficientThrustConstraint(500, 0.05, wsRange, constraints, false),
+    ).toBe("Second-Segment Climb (OEI)");
+  });
+
+  it("skipOei=true ignores 'Missed-Approach Climb' constraint", () => {
+    const constraints: ConstraintLine[] = [
+      {
+        name: "Missed-Approach Climb",
+        t_w_points: Array(100).fill(0.5),
+        ws_max: null,
+        color: "#E5484D",
+        binding: true,
+        hover_text: null,
+      },
+    ];
+    expect(
+      findInsufficientThrustConstraint(500, 0.05, wsRange, constraints, true),
+    ).toBeNull();
+  });
+
+  it("skipOei=true still flags genuine non-OEI binding constraints", () => {
+    const constraints: ConstraintLine[] = [
+      {
+        name: "Second-Segment Climb (OEI)",
+        t_w_points: Array(100).fill(0.5),
+        ws_max: null,
+        color: "#E5484D",
+        binding: true,
+        hover_text: null,
+      },
+      {
+        name: "Climb",
+        t_w_points: Array(100).fill(0.4),
+        ws_max: null,
+        color: "#E5484D",
+        binding: false,
+        hover_text: null,
+      },
+    ];
+    // T/W = 0.05 violates Climb (non-OEI) — should still report it.
+    expect(
+      findInsufficientThrustConstraint(500, 0.05, wsRange, constraints, true),
+    ).toBe("Climb");
+  });
+
+  it("default (no skipOei argument) preserves previous behavior", () => {
+    // Backwards compat: callers that don't pass the flag get the old behavior.
+    const constraints: ConstraintLine[] = [
+      {
+        name: "Second-Segment Climb (OEI)",
+        t_w_points: Array(100).fill(0.5),
+        ws_max: null,
+        color: "#E5484D",
+        binding: true,
+        hover_text: null,
+      },
+    ];
+    // No 5th arg → undefined → falsy → OEI not skipped → bindingName returned.
+    expect(
+      findInsufficientThrustConstraint(500, 0.05, wsRange, constraints),
+    ).toBe("Second-Segment Climb (OEI)");
+  });
+});
+
 describe("buildCurrentDesignPointTrace (gh-606)", () => {
   it("produces a Plotly trace with the expected shape", () => {
     const trace = buildCurrentDesignPointTrace({

--- a/frontend/components/workbench/MatchingChartTab.tsx
+++ b/frontend/components/workbench/MatchingChartTab.tsx
@@ -335,6 +335,15 @@ export function findBindingConstraintAtPoint(
   return bindingName;
 }
 
+/** Pattern matching CS-25-only constraint names that don't apply to
+ * single-engine RC / UAV aircraft: Second-Segment Climb (OEI), Missed-Approach.
+ *
+ * gh-613 Phase A: these CS-25 multi-engine bands are still drawn on the chart
+ * for conformance-band reference, but they must not trigger the
+ * "insufficient T/W" warning for single-engine designs.
+ */
+const CS25_ONLY_CONSTRAINT_PATTERN = /segment.?2|second.?segment|missed.?approach|oei/i;
+
 /** Return the name of the most-violated **t_w_points** constraint at the
  * given (ws, tw) point, or null if none is violated.
  *
@@ -345,12 +354,18 @@ export function findBindingConstraintAtPoint(
  *
  * gh-606: Scholz review substantive finding — turn the chart from
  * decorative to diagnostic by flagging insufficient T/W.
+ *
+ * gh-613 Phase A: when `skipOei` is true, constraints whose name matches
+ * the CS-25-only pattern (Second-Segment Climb, Missed-Approach, generic
+ * OEI bands) are excluded from the binding-selection logic. The constraint
+ * curves are still drawn on the chart — only the warning text is gated.
  */
 export function findInsufficientThrustConstraint(
   ws: number,
   tw: number,
   wsRange: number[],
   constraints: ConstraintLine[],
+  skipOei: boolean = false,
 ): string | null {
   if (!wsRange.length) return null;
   const nearestIdx = _nearestWsIdx(ws, wsRange);
@@ -358,6 +373,7 @@ export function findInsufficientThrustConstraint(
   let maxRatio = 0;
   for (const c of constraints) {
     if (!c.t_w_points) continue;
+    if (skipOei && CS25_ONLY_CONSTRAINT_PATTERN.test(c.name)) continue;
     const twReq = c.t_w_points[nearestIdx];
     if (twReq <= 0) continue;
     const ratio = (twReq - tw) / twReq;
@@ -397,6 +413,54 @@ export function computeAspectRatio(bRefM: number | null | undefined, sRefM2: num
 interface InfoModalProps {
   readonly open: boolean;
   readonly onClose: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// gh-613 Phase A — CS-25 honesty: per-constraint relevance badges
+// ---------------------------------------------------------------------------
+
+type ConstraintRelevance = "universal" | "conditional" | "cs25-only";
+
+const RELEVANCE_LABEL: Record<ConstraintRelevance, string> = {
+  universal: "✅ Universal",
+  conditional: "⚠️ Conditional",
+  "cs25-only": "❌ CS-25-only",
+};
+
+const RELEVANCE_CLASS: Record<ConstraintRelevance, string> = {
+  universal:
+    "inline-flex items-center gap-1 rounded bg-green-500/15 px-1.5 py-0.5 text-[10px] text-green-400",
+  conditional:
+    "inline-flex items-center gap-1 rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] text-amber-400",
+  "cs25-only":
+    "inline-flex items-center gap-1 rounded bg-red-500/15 px-1.5 py-0.5 text-[10px] text-red-400",
+};
+
+/** Small inline badge tagging each constraint row in the info modal with its
+ * relevance to single-engine RC / UAV designs.
+ *
+ * gh-613 Phase A: helps the user separate "CS-25 conformance band" curves
+ * (Second-Segment OEI, Missed-Approach) from RC-applicable constraints.
+ */
+function RelevanceBadge({
+  relevance,
+  tooltip,
+  testId,
+}: Readonly<{
+  relevance: ConstraintRelevance;
+  tooltip: string;
+  testId: string;
+}>) {
+  return (
+    <span
+      className={RELEVANCE_CLASS[relevance]}
+      title={tooltip}
+      data-relevance={relevance}
+      data-testid={testId}
+    >
+      {RELEVANCE_LABEL[relevance]}
+    </span>
+  );
 }
 
 /** Modal explaining the matching-chart methodology per Loftin / Scholz §5 /
@@ -517,14 +581,76 @@ function InfoModal({ open, onClose }: InfoModalProps) {
             <h4 className="mb-1 text-[12px] font-semibold uppercase tracking-wider text-muted-foreground">
               Constraints (curves)
             </h4>
-            <ul className="list-disc pl-5">
-              <li><strong>Stall</strong> &mdash; vertical line at maximum W/S that still hits V<sub>s</sub> target.</li>
-              <li><strong>Take-off field</strong> &mdash; rising-with-W/S curve; binds at small fields and high W/S.</li>
-              <li><strong>Second-segment climb</strong> &mdash; CS-25 / FAR-25-style climb-gradient floor.</li>
-              <li><strong>Missed-approach climb</strong> &mdash; landing-config climb-gradient floor.</li>
-              <li>
-                <strong>Cruise</strong> <em>(typically slack)</em> &mdash; matched iteratively via fuel mass, not enforced
-                on the chart per Sadraey §4.3. Drawn for reference, not selection.
+            {/* gh-613 Phase A: CS-25 provenance callout — drawn BEFORE the
+                constraint list so the user knows the methodology pedigree
+                before scanning the per-row badges. */}
+            <div
+              className="mb-2 border-l-4 border-amber-500/50 bg-amber-500/5 p-3 text-[12px]"
+              data-testid="info-section-cs25-callout"
+            >
+              <em>
+                This chart&apos;s constraint curves follow the Scholz/Loftin CS-25
+                methodology, originally calibrated for multi-engine transport
+                aircraft. For single-engine RC and UAV applications, the chart
+                format (W/S vs T/W, feasibility region, design-point derivation)
+                translates directly, but some constraints &mdash; specifically
+                Second-Segment Climb (OEI) and Missed-Approach Climb &mdash; assume
+                an engine-out condition that single-engine aircraft cannot
+                experience. Read those curves as CS-25 conformance bands, not RC
+                requirements.
+              </em>
+            </div>
+            <ul className="flex list-disc flex-col gap-1.5 pl-5">
+              <li className="flex flex-wrap items-center gap-2">
+                <span><strong>Stall</strong> &mdash; vertical line at maximum W/S that still hits V<sub>s</sub> target.</span>
+                <RelevanceBadge
+                  relevance="universal"
+                  tooltip="Universal — pure aerodynamics"
+                  testId="constraint-badge-stall"
+                />
+              </li>
+              <li className="flex flex-wrap items-center gap-2">
+                <span><strong>Take-off field</strong> &mdash; rising-with-W/S curve; binds at small fields and high W/S.</span>
+                <RelevanceBadge
+                  relevance="conditional"
+                  tooltip="Wheeled takeoff only"
+                  testId="constraint-badge-takeoff"
+                />
+              </li>
+              <li className="flex flex-wrap items-center gap-2">
+                <span><strong>Second-segment climb (OEI)</strong> &mdash; CS-25 / FAR-25-style climb-gradient floor.</span>
+                <RelevanceBadge
+                  relevance="cs25-only"
+                  tooltip="CS-25 multi-engine — single-engine N/A"
+                  testId="constraint-badge-second-segment"
+                />
+              </li>
+              <li className="flex flex-wrap items-center gap-2">
+                <span><strong>Missed-approach climb</strong> &mdash; landing-config climb-gradient floor.</span>
+                <RelevanceBadge
+                  relevance="cs25-only"
+                  tooltip="CS-25 multi-engine — single-engine N/A"
+                  testId="constraint-badge-missed-approach"
+                />
+              </li>
+              <li className="flex flex-wrap items-center gap-2">
+                <span>
+                  <strong>Cruise</strong> <em>(typically slack)</em> &mdash; matched iteratively via fuel mass, not enforced
+                  on the chart per Sadraey §4.3. Drawn for reference, not selection.
+                </span>
+                <RelevanceBadge
+                  relevance="universal"
+                  tooltip="Universal — slack constraint, iterated via fuel mass"
+                  testId="constraint-badge-cruise"
+                />
+              </li>
+              <li className="flex flex-wrap items-center gap-2">
+                <span><strong>Landing field</strong> &mdash; landing distance constraint; vertical W/S limit at the runway.</span>
+                <RelevanceBadge
+                  relevance="conditional"
+                  tooltip="Runway landing only"
+                  testId="constraint-badge-landing"
+                />
               </li>
             </ul>
           </section>
@@ -1048,13 +1174,14 @@ function MatchingChartContent({
             Matching chart is jet/powered-only &mdash; gliders are sized by sink-rate polar, not T/W vs W/S.
           </div>
         )}
-        {/* gh-606: insufficient-thrust callout per Scholz review substantive finding */}
+        {/* gh-606: insufficient-thrust callout per Scholz review substantive finding.
+            gh-613 Phase A: warning excludes single-engine-irrelevant OEI bands. */}
         {!isGlider && currentDp && insufficientConstraintName && (
           <div
             className="absolute right-3 top-3 max-w-[360px] rounded bg-red-900/70 px-2 py-1 text-[10px] text-red-200"
             data-testid="insufficient-thrust-callout"
           >
-            Your assumed T/W = {currentDp.t_w.toFixed(3)} is insufficient for the {insufficientConstraintName} constraint at the current W/S.
+            Your assumed T/W = {currentDp.t_w.toFixed(3)} is insufficient for the {insufficientConstraintName} constraint at the current W/S (excluding single-engine-irrelevant OEI bands).
           </div>
         )}
       </div>
@@ -1138,6 +1265,9 @@ export function MatchingChartTab({ aeroplaneId }: Props) {
   }, [isGlider, massKg, sRefM2, tStaticN, aspectRatio]);
 
   // gh-606: insufficient-thrust diagnostic (substantive finding in Scholz review).
+  // gh-613 Phase A: skip CS-25-only OEI constraints when selecting the binding
+  // constraint. Those curves are still drawn (as CS-25 conformance bands) but
+  // do not raise a warning for single-engine RC / UAV designs.
   const insufficientConstraintName = useMemo(() => {
     if (!data || !currentDp) return null;
     return findInsufficientThrustConstraint(
@@ -1145,6 +1275,7 @@ export function MatchingChartTab({ aeroplaneId }: Props) {
       currentDp.t_w,
       data.ws_range_n_m2,
       data.constraints,
+      true, // skipOei
     );
   }, [data, currentDp]);
 


### PR DESCRIPTION
## Summary

Phase A of #613 only — Phase B (backend profile-aware constraint set + new RC-additive constraints like Mission-Min T/W, WCL, Power-Loading) is a separate follow-up PR.

Three frontend-only pieces:

1. **CS-25 provenance callout** in the existing info-modal (added by PR #614). Amber-bordered card stating the methodology origin and that OEI bands don't apply to single-engine RC/UAV.
2. **Per-constraint relevance badges** (✅ Universal / ⚠️ Conditional / ❌ CS-25-only) next to each constraint row in the modal.
3. **Insufficient-T/W warning** filtered to skip CS-25-only constraints (OEI Second-Segment / Missed-Approach) when computing "binding".

Constraint curves on the chart itself are unchanged — Phase A is text + warning-logic only.

## Test plan

- [x] `npm run test:unit -- MatchingChartTab` — 117/117 pass (was 102 pre-#613 Phase A)
- [x] `npm run lint` — 0 errors (10 pre-existing warnings in unrelated files)
- [x] `npm run deps:check` — 0 errors (7 pre-existing warnings)

Part 1 of #613 — Phase A. Phase B (backend refactor) follows in a separate PR.