### PR TITLE
chore(gh-613): cast SQLAlchemy columns to plain types at matching-chart endpoint boundary

### DIFF
--- a/app/api/v2/endpoints/aeroplane/matching_chart.py
+++ b/app/api/v2/endpoints/aeroplane/matching_chart.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Annotated, Any, NoReturn
+from typing import Annotated, Any, NoReturn, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
 from pydantic import UUID4
@@ -62,18 +62,24 @@ def _resolve_aircraft_params(
     -------
     dict ready to pass to ``compute_chart`` as the *aircraft* argument.
     """
-    ctx: dict[str, Any] = plane.assumption_computation_context or {}
+    # Materialise SQLAlchemy columns to plain types at the boundary so
+    # downstream helpers (typed as int / dict) type-check cleanly under
+    # Pyright. SQLAlchemy's legacy declarative columns appear as Column[T]
+    # rather than Mapped[T]; typing.cast is the right idiom here. Same
+    # pattern as #579's _ctx_dict fix in sm_sizing_service.py.
+    plane_id: int = cast(int, plane.id)
+    ctx: dict[str, Any] = cast(dict[str, Any], plane.assumption_computation_context or {})
 
     mass_kg = float(
-        get_effective_assumption(db, plane.id, "mass") or PARAMETER_DEFAULTS["mass"]
+        get_effective_assumption(db, plane_id, "mass") or PARAMETER_DEFAULTS["mass"]
     )
     cl_max = float(
-        get_effective_assumption(db, plane.id, "cl_max") or PARAMETER_DEFAULTS["cl_max"]
+        get_effective_assumption(db, plane_id, "cl_max") or PARAMETER_DEFAULTS["cl_max"]
     )
     cd0 = float(
-        get_effective_assumption(db, plane.id, "cd0") or PARAMETER_DEFAULTS.get("cd0", 0.03)
+        get_effective_assumption(db, plane_id, "cd0") or PARAMETER_DEFAULTS.get("cd0", 0.03)
     )
-    t_static_raw = get_effective_assumption(db, plane.id, "t_static_N")
+    t_static_raw = get_effective_assumption(db, plane_id, "t_static_N")
     t_static_n = float(t_static_raw) if t_static_raw and float(t_static_raw) > 0 else 0.0
 
     s_ref_m2: float | None = ctx.get("s_ref_m2")


### PR DESCRIPTION
## Summary

Follow-up to #620 (#613 Phase B). After that PR merged, `poetry run pyright app/api/v2/endpoints/aeroplane/matching_chart.py` reports 5 real errors — the endpoint reads `plane.id` (SQLAlchemy `Column[int]`) and passes it to `get_effective_assumption(db, aeroplane_id: int, …)`, and assigns `plane.assumption_computation_context` (`Column[Any] | dict`) to a `dict[str, Any]` variable.

This is the same Pyright-boundary issue we fixed in #579 (`_ctx_dict` helper in `sm_sizing_service.py`). Legacy SQLAlchemy declarative columns expose `Column[T]` not `Mapped[T]`; `int()` and dict-assignment don't apply because the protocols aren't there. The runtime values are plain ints/dicts, but Pyright correctly refuses the implicit cast.

Fix: materialise the columns via `typing.cast` at the function boundary.

## Diff

```python
-    ctx: dict[str, Any] = plane.assumption_computation_context or {}
-    mass_kg = float(get_effective_assumption(db, plane.id, "mass") or …)
+    plane_id: int = cast(int, plane.id)
+    ctx: dict[str, Any] = cast(dict[str, Any], plane.assumption_computation_context or {})
+    mass_kg = float(get_effective_assumption(db, plane_id, "mass") or …)
```

12 lines changed in one file.

## Verification

- `poetry run pyright app/api/v2/endpoints/aeroplane/matching_chart.py` → 0 errors, 0 warnings.
- `poetry run pytest app/tests/test_matching_chart_endpoint.py app/tests/test_matching_chart.py` → 121 / 121 pass.
- `poetry run ruff check` → clean.

No behavior change. Pure type-hint cleanup.