### PR TITLE
fix(gh-587): convert alpha/beta rad→deg in retrim path via shared helper

### DIFF
--- a/app/schemas/aeroanalysisschema.py
+++ b/app/schemas/aeroanalysisschema.py
@@ -263,28 +263,27 @@ class OperatingPointSchema(BaseModel):
 
     @field_validator("alpha", "beta")
     @classmethod
-    def _validate_degrees_range(cls, value):
+    def _validate_degrees_range(cls, value: float | list[float]) -> float | list[float]:
         """Reject values whose magnitude exceeds 180 — they are almost certainly radians.
 
         alpha/beta must be in **degrees**. Values > 180 indicate an unconverted
         radians value passed through (see gh-577/gh-587). When alpha is a list
         (sweep), each element is checked individually.
         """
-        if isinstance(value, list):
-            for element in value:
-                if abs(element) > 180:
-                    raise ValueError(
-                        f"alpha/beta must be in degrees; element {element!r} exceeds ±180. "
-                        f"A value this large almost certainly means radians were passed "
-                        f"instead of degrees (gh-577/gh-587). Convert with math.degrees()."
-                    )
-        else:
-            if abs(value) > 180:
+
+        def _check(v: float) -> None:
+            if abs(v) > 180:
                 raise ValueError(
-                    f"alpha/beta must be in degrees; {value!r} exceeds ±180. "
+                    f"alpha/beta must be in degrees; {v!r} exceeds ±180. "
                     f"A value this large almost certainly means radians were passed "
                     f"instead of degrees (gh-577/gh-587). Convert with math.degrees()."
                 )
+
+        if isinstance(value, list):
+            for element in value:
+                _check(element)
+        else:
+            _check(value)
         return value
 
     model_config = ConfigDict(

--- a/app/schemas/aeroanalysisschema.py
+++ b/app/schemas/aeroanalysisschema.py
@@ -261,6 +261,32 @@ class OperatingPointSchema(BaseModel):
         ),
     )
 
+    @field_validator("alpha", "beta")
+    @classmethod
+    def _validate_degrees_range(cls, value):
+        """Reject values whose magnitude exceeds 180 — they are almost certainly radians.
+
+        alpha/beta must be in **degrees**. Values > 180 indicate an unconverted
+        radians value passed through (see gh-577/gh-587). When alpha is a list
+        (sweep), each element is checked individually.
+        """
+        if isinstance(value, list):
+            for element in value:
+                if abs(element) > 180:
+                    raise ValueError(
+                        f"alpha/beta must be in degrees; element {element!r} exceeds ±180. "
+                        f"A value this large almost certainly means radians were passed "
+                        f"instead of degrees (gh-577/gh-587). Convert with math.degrees()."
+                    )
+        else:
+            if abs(value) > 180:
+                raise ValueError(
+                    f"alpha/beta must be in degrees; {value!r} exceeds ±180. "
+                    f"A value this large almost certainly means radians were passed "
+                    f"instead of degrees (gh-577/gh-587). Convert with math.degrees()."
+                )
+        return value
+
     model_config = ConfigDict(
         from_attributes=True,
         json_schema_extra={

--- a/app/services/operating_point_resolver.py
+++ b/app/services/operating_point_resolver.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 import logging
 import math
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from app.core.exceptions import NotFoundError, ValidationDomainError
 from app.models.analysismodels import OperatingPointModel
@@ -66,7 +66,7 @@ def _pick_deflections(op: OperatingPointModel) -> dict[str, float] | None:
     return dict(controls) if controls else None
 
 
-def _require_field(op: OperatingPointModel, field: str):
+def _require_field(op: OperatingPointModel, field: str) -> Any:
     """Raise loudly if a NOT-NULL state field arrived as ``None`` (corrupt row).
 
     The DB columns are declared ``nullable=False``; silently substituting

--- a/app/services/operating_point_resolver.py
+++ b/app/services/operating_point_resolver.py
@@ -38,7 +38,12 @@ from typing import TYPE_CHECKING
 
 from app.core.exceptions import NotFoundError, ValidationDomainError
 from app.models.analysismodels import OperatingPointModel
-from app.schemas.aeroanalysisschema import OperatingPointSchema, OperatingPointStatus
+from app.schemas.aeroanalysisschema import (
+    CdclConfig,
+    OperatingPointSchema,
+    OperatingPointStatus,
+    SpacingConfig,
+)
 
 if TYPE_CHECKING:
     import aerosandbox as asb
@@ -83,8 +88,8 @@ def _require_field(op: OperatingPointModel, field: str):
 def operating_point_model_to_schema(
     op: OperatingPointModel,
     *,
-    cdcl_config=None,
-    spacing_config=None,
+    cdcl_config: CdclConfig | None = None,
+    spacing_config: SpacingConfig | None = None,
 ) -> OperatingPointSchema:
     """Convert an :class:`OperatingPointModel` DB row to an analysis-ready schema.
 

--- a/app/services/operating_point_resolver.py
+++ b/app/services/operating_point_resolver.py
@@ -80,6 +80,56 @@ def _require_field(op: OperatingPointModel, field: str):
     return value
 
 
+def operating_point_model_to_schema(
+    op: OperatingPointModel,
+    *,
+    cdcl_config=None,
+    spacing_config=None,
+) -> OperatingPointSchema:
+    """Convert an :class:`OperatingPointModel` DB row to an analysis-ready schema.
+
+    Single source of truth for model→schema conversion (gh-587). Both
+    :func:`resolve_operating_point` and :mod:`app.services.retrim_service`
+    delegate here so the rad→deg conversion and the ``_require_field`` guards
+    are never duplicated.
+
+    ``alpha`` / ``beta`` are stored as **radians** on the model; the schema
+    and every downstream ``asb.OperatingPoint`` consumer expect **degrees**.
+
+    ``cdcl_config`` / ``spacing_config`` are caller-supplied because the DB
+    row does not own these — they come from the inbound request schema.
+    """
+    velocity = _require_field(op, "velocity")
+    alpha_rad = _require_field(op, "alpha")
+    beta_rad = _require_field(op, "beta")
+    p = _require_field(op, "p")
+    q = _require_field(op, "q")
+    r = _require_field(op, "r")
+    altitude = _require_field(op, "altitude")
+    xyz_ref = _require_field(op, "xyz_ref")
+    if not xyz_ref:  # empty list ≠ valid moment reference
+        raise ValidationDomainError(message=f"OperatingPoint {op.id} has empty xyz_ref.")
+
+    deflections = _pick_deflections(op)
+
+    return OperatingPointSchema(
+        name=op.name,
+        description=op.description or "",
+        velocity=velocity,
+        alpha=math.degrees(alpha_rad),
+        beta=math.degrees(beta_rad),
+        p=p,
+        q=q,
+        r=r,
+        xyz_ref=xyz_ref,
+        altitude=altitude,
+        cdcl_config=cdcl_config,
+        spacing_config=spacing_config,
+        control_deflections=deflections,
+        operating_point_id=op.id,
+    )
+
+
 def resolve_operating_point(
     db: "Session",
     op_schema: OperatingPointSchema,
@@ -140,45 +190,22 @@ def resolve_operating_point(
             )
         )
 
-    # NOT-NULL state — fail loudly on corrupt rows.
-    velocity = _require_field(op, "velocity")
-    alpha_rad = _require_field(op, "alpha")
-    beta_rad = _require_field(op, "beta")
-    altitude = _require_field(op, "altitude")
-    xyz_ref = _require_field(op, "xyz_ref")
-    if not xyz_ref:  # empty list ≠ valid moment reference
-        raise ValidationDomainError(
-            message=f"OperatingPoint {op_id} has empty xyz_ref."
-        )
-
-    deflections = _pick_deflections(op)
+    result = operating_point_model_to_schema(
+        op,
+        cdcl_config=op_schema.cdcl_config,
+        spacing_config=op_schema.spacing_config,
+    )
     logger.info(
         "Resolved OperatingPoint %s (aircraft %s): alpha=%.3f deg, "
         "velocity=%.2f m/s, xyz_ref=%s, deflections=%s",
         op_id,
         op.aircraft_id,
-        math.degrees(alpha_rad),
-        velocity,
-        xyz_ref,
-        deflections,
+        result.alpha,
+        result.velocity,
+        result.xyz_ref,
+        result.control_deflections,
     )
-
-    return OperatingPointSchema(
-        name=op.name,
-        description=op.description or "",
-        velocity=velocity,
-        alpha=math.degrees(alpha_rad),
-        beta=math.degrees(beta_rad),
-        p=op.p or 0.0,
-        q=op.q or 0.0,
-        r=op.r or 0.0,
-        xyz_ref=xyz_ref,
-        altitude=altitude,
-        cdcl_config=op_schema.cdcl_config,
-        spacing_config=op_schema.spacing_config,
-        control_deflections=deflections,
-        operating_point_id=op_id,
-    )
+    return result
 
 
 def _airplane_surface_names(airplane: "asb.Airplane") -> set[str]:

--- a/app/services/retrim_service.py
+++ b/app/services/retrim_service.py
@@ -14,12 +14,10 @@ from app.models.aeroplanemodel import (
     WingXSecTrailingEdgeDeviceModel,
 )
 from app.models.analysismodels import OperatingPointModel
-from app.schemas.aeroanalysisschema import (
-    AeroBuildupTrimRequest,
-    OperatingPointSchema,
-)
+from app.schemas.aeroanalysisschema import AeroBuildupTrimRequest
 from app.schemas.AeroplaneRequest import AnalysisToolUrlType
 from app.services.aerobuildup_trim_service import trim_with_aerobuildup
+from app.services.operating_point_resolver import operating_point_model_to_schema
 from app.services.stability_service import get_stability_summary
 
 if TYPE_CHECKING:
@@ -49,23 +47,6 @@ def _find_pitch_control_name(db: Session, aeroplane_id: int) -> str | None:
     return row[0] if row else None
 
 
-def _op_model_to_schema(op: OperatingPointModel) -> OperatingPointSchema:
-    """Convert an OperatingPointModel row to an OperatingPointSchema."""
-    return OperatingPointSchema(
-        name=op.name,
-        description=op.description or "",
-        velocity=op.velocity,
-        alpha=op.alpha,
-        beta=op.beta,
-        p=op.p or 0.0,
-        q=op.q or 0.0,
-        r=op.r or 0.0,
-        xyz_ref=op.xyz_ref or [0.0, 0.0, 0.0],
-        altitude=op.altitude or 0.0,
-        control_deflections=op.control_deflections,
-    )
-
-
 async def retrim_dirty_ops(aeroplane_id: int) -> None:
     """Re-trim all DIRTY operating points for an aeroplane.
 
@@ -89,9 +70,7 @@ async def retrim_dirty_ops(aeroplane_id: int) -> None:
             return
 
         dirty_ops = (
-            db.query(OperatingPointModel)
-            .filter_by(aircraft_id=aeroplane_id, status="DIRTY")
-            .all()
+            db.query(OperatingPointModel).filter_by(aircraft_id=aeroplane_id, status="DIRTY").all()
         )
         if not dirty_ops:
             logger.debug("Retrim: no dirty OPs for aeroplane %d", aeroplane_id)
@@ -105,7 +84,7 @@ async def retrim_dirty_ops(aeroplane_id: int) -> None:
             db.flush()
 
             try:
-                op_schema = _op_model_to_schema(op)
+                op_schema = operating_point_model_to_schema(op)
                 request = AeroBuildupTrimRequest(
                     operating_point=op_schema,
                     trim_variable=pitch_control,
@@ -135,12 +114,10 @@ async def retrim_dirty_ops(aeroplane_id: int) -> None:
             db.flush()
 
         if any_trimmed:
-            first_trimmed = next(
-                (op for op in dirty_ops if op.status == "TRIMMED"), None
-            )
+            first_trimmed = next((op for op in dirty_ops if op.status == "TRIMMED"), None)
             if first_trimmed:
                 try:
-                    op_schema = _op_model_to_schema(first_trimmed)
+                    op_schema = operating_point_model_to_schema(first_trimmed)
                     await get_stability_summary(
                         db, aeroplane_uuid, op_schema, AnalysisToolUrlType.AEROBUILDUP
                     )

--- a/app/tests/test_aeroanalysis.py
+++ b/app/tests/test_aeroanalysis.py
@@ -4,6 +4,7 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from fastapi import HTTPException, Request
 
@@ -475,21 +476,15 @@ class TestOperatingPointSchemaAlphaBetaValidator:
     """gh-587/gh-577: alpha and beta must be in degrees; values > 180 are radians in disguise."""
 
     def test_alpha_above_180_rejected(self):
-        import pydantic
-
-        with pytest.raises(pydantic.ValidationError):
+        with pytest.raises(ValidationError):
             OperatingPointSchema(alpha=999.0)
 
     def test_beta_above_180_rejected(self):
-        import pydantic
-
-        with pytest.raises(pydantic.ValidationError):
+        with pytest.raises(ValidationError):
             OperatingPointSchema(beta=999.0)
 
     def test_alpha_list_with_element_above_180_rejected(self):
-        import pydantic
-
-        with pytest.raises(pydantic.ValidationError):
+        with pytest.raises(ValidationError):
             OperatingPointSchema(alpha=[1.0, 999.0])
 
     def test_alpha_exactly_180_accepted(self):
@@ -517,9 +512,7 @@ class TestOperatingPointSchemaAlphaBetaValidator:
         assert schema.beta == -180.0
 
     def test_error_message_mentions_degrees_and_gh(self):
-        import pydantic
-
-        with pytest.raises(pydantic.ValidationError) as exc_info:
+        with pytest.raises(ValidationError) as exc_info:
             OperatingPointSchema(alpha=999.0)
         msg = str(exc_info.value)
         assert "degree" in msg.lower() or "gh-577" in msg or "gh-587" in msg

--- a/app/tests/test_aeroanalysis.py
+++ b/app/tests/test_aeroanalysis.py
@@ -3,6 +3,8 @@ import unittest
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from fastapi import HTTPException, Request
 
 from app.api.v2.endpoints.aeroanalysis import (
@@ -38,7 +40,10 @@ class TestAeroanalysis(unittest.TestCase):
         mock_db = MagicMock()
         expected = {"ok": True}
 
-        with patch("app.api.v2.endpoints.aeroanalysis.analysis_service.analyze_wing", new=AsyncMock(return_value=expected)) as mock_analyze:
+        with patch(
+            "app.api.v2.endpoints.aeroanalysis.analysis_service.analyze_wing",
+            new=AsyncMock(return_value=expected),
+        ) as mock_analyze:
             result = asyncio.run(
                 analyze_wing_post(
                     aeroplane_id=self.test_plane_id,
@@ -83,7 +88,10 @@ class TestAeroanalysis(unittest.TestCase):
         mock_db = MagicMock()
         expected = {"lift": 123}
 
-        with patch("app.api.v2.endpoints.aeroanalysis.analysis_service.analyze_airplane", new=AsyncMock(return_value=expected)) as mock_analyze:
+        with patch(
+            "app.api.v2.endpoints.aeroanalysis.analysis_service.analyze_airplane",
+            new=AsyncMock(return_value=expected),
+        ) as mock_analyze:
             result = asyncio.run(
                 analyze_airplane_post(
                     aeroplane_id=self.test_plane_id,
@@ -241,10 +249,13 @@ class TestAeroanalysis(unittest.TestCase):
         mock_settings = MagicMock()
         mock_settings.base_url = "http://example.com"
 
-        with patch(
-            "app.api.v2.endpoints.aeroanalysis.analysis_service.get_streamlines_three_view_image",
-            new=AsyncMock(return_value=b"png"),
-        ) as mock_image, patch("app.api.v2.endpoints.aeroanalysis.uuid4") as mock_uuid:
+        with (
+            patch(
+                "app.api.v2.endpoints.aeroanalysis.analysis_service.get_streamlines_three_view_image",
+                new=AsyncMock(return_value=b"png"),
+            ) as mock_image,
+            patch("app.api.v2.endpoints.aeroanalysis.uuid4") as mock_uuid,
+        ):
             mock_uuid.return_value = MagicMock(hex="abc123")
 
             result = asyncio.run(
@@ -258,7 +269,11 @@ class TestAeroanalysis(unittest.TestCase):
             )
 
         self.assertIsInstance(result, StaticUrlResponse)
-        self.assertTrue(result.url.endswith(f"/static/{self.test_plane_id}/png/streamlines_three_view_abc123.png"))
+        self.assertTrue(
+            result.url.endswith(
+                f"/static/{self.test_plane_id}/png/streamlines_three_view_abc123.png"
+            )
+        )
         mock_image.assert_awaited_once_with(mock_db, self.test_plane_id, self.test_operating_point)
 
     def test_get_aeroplane_three_view_success(self):
@@ -268,10 +283,13 @@ class TestAeroanalysis(unittest.TestCase):
         mock_settings = MagicMock()
         mock_settings.base_url = "http://example.com"
 
-        with patch(
-            "app.api.v2.endpoints.aeroanalysis.analysis_service.get_three_view_image",
-            new=AsyncMock(return_value=b"png"),
-        ) as mock_image, patch("app.api.v2.endpoints.aeroanalysis.uuid4") as mock_uuid:
+        with (
+            patch(
+                "app.api.v2.endpoints.aeroanalysis.analysis_service.get_three_view_image",
+                new=AsyncMock(return_value=b"png"),
+            ) as mock_image,
+            patch("app.api.v2.endpoints.aeroanalysis.uuid4") as mock_uuid,
+        ):
             mock_uuid.return_value = MagicMock(hex="def456")
 
             result = asyncio.run(
@@ -284,7 +302,9 @@ class TestAeroanalysis(unittest.TestCase):
             )
 
         self.assertIsInstance(result, StaticUrlResponse)
-        self.assertTrue(result.url.endswith(f"/static/{self.test_plane_id}/png/three_view_def456.png"))
+        self.assertTrue(
+            result.url.endswith(f"/static/{self.test_plane_id}/png/three_view_def456.png")
+        )
         mock_image.assert_awaited_once_with(mock_db, self.test_plane_id)
 
     def test_calculate_streamlines_json_success(self):
@@ -358,8 +378,13 @@ class TestAnalysisServiceAwaitContract(unittest.TestCase):
         self.mock_plane_schema.name = "TestPlane"
         self.mock_plane_schema.wings = {}
         self.test_operating_point = OperatingPointSchema.model_construct(
-            velocity=10.0, alpha=5.0, beta=0.0,
-            p=0.0, q=0.0, r=0.0, xyz_ref=[0.0, 0.0, 0.0],
+            velocity=10.0,
+            alpha=5.0,
+            beta=0.0,
+            p=0.0,
+            q=0.0,
+            r=0.0,
+            xyz_ref=[0.0, 0.0, 0.0],
         )
 
     def _make_mock_result(self):
@@ -381,9 +406,16 @@ class TestAnalysisServiceAwaitContract(unittest.TestCase):
 
         mock_result = self._make_mock_result()
         sweep_request = AlphaSweepRequest.model_construct(
-            altitude=1000.0, velocity=30.0,
-            alpha_start=-5, alpha_end=15, alpha_num=3,
-            beta=0.0, p=0.0, q=0.0, r=0.0, xyz_ref=[0, 0, 0],
+            altitude=1000.0,
+            velocity=30.0,
+            alpha_start=-5,
+            alpha_end=15,
+            alpha_num=3,
+            beta=0.0,
+            p=0.0,
+            q=0.0,
+            r=0.0,
+            xyz_ref=[0, 0, 0],
         )
 
         with (
@@ -429,12 +461,68 @@ class TestAnalysisServiceAwaitContract(unittest.TestCase):
         ):
             result = asyncio.run(
                 analyze_airplane(
-                    self.mock_db, self.test_plane_id,
-                    self.test_operating_point, AnalysisToolUrlType.AEROBUILDUP,
+                    self.mock_db,
+                    self.test_plane_id,
+                    self.test_operating_point,
+                    AnalysisToolUrlType.AEROBUILDUP,
                 )
             )
 
         self.assertEqual(result, mock_result)
+
+
+class TestOperatingPointSchemaAlphaBetaValidator:
+    """gh-587/gh-577: alpha and beta must be in degrees; values > 180 are radians in disguise."""
+
+    def test_alpha_above_180_rejected(self):
+        import pydantic
+
+        with pytest.raises(pydantic.ValidationError):
+            OperatingPointSchema(alpha=999.0)
+
+    def test_beta_above_180_rejected(self):
+        import pydantic
+
+        with pytest.raises(pydantic.ValidationError):
+            OperatingPointSchema(beta=999.0)
+
+    def test_alpha_list_with_element_above_180_rejected(self):
+        import pydantic
+
+        with pytest.raises(pydantic.ValidationError):
+            OperatingPointSchema(alpha=[1.0, 999.0])
+
+    def test_alpha_exactly_180_accepted(self):
+        schema = OperatingPointSchema(alpha=180.0)
+        assert schema.alpha == 180.0
+
+    def test_alpha_negative_180_accepted(self):
+        schema = OperatingPointSchema(alpha=-180.0)
+        assert schema.alpha == -180.0
+
+    def test_normal_alpha_accepted(self):
+        schema = OperatingPointSchema(alpha=4.2)
+        assert schema.alpha == pytest.approx(4.2)
+
+    def test_normal_beta_accepted(self):
+        schema = OperatingPointSchema(beta=2.0)
+        assert schema.beta == pytest.approx(2.0)
+
+    def test_alpha_list_all_valid_accepted(self):
+        schema = OperatingPointSchema(alpha=[0.0, 5.0, -10.0, 180.0])
+        assert schema.alpha == [0.0, 5.0, -10.0, 180.0]
+
+    def test_beta_exactly_minus_180_accepted(self):
+        schema = OperatingPointSchema(beta=-180.0)
+        assert schema.beta == -180.0
+
+    def test_error_message_mentions_degrees_and_gh(self):
+        import pydantic
+
+        with pytest.raises(pydantic.ValidationError) as exc_info:
+            OperatingPointSchema(alpha=999.0)
+        msg = str(exc_info.value)
+        assert "degree" in msg.lower() or "gh-577" in msg or "gh-587" in msg
 
 
 if __name__ == "__main__":

--- a/app/tests/test_operating_point_resolver.py
+++ b/app/tests/test_operating_point_resolver.py
@@ -84,7 +84,7 @@ class TestResolveOperatingPoint:
         op = _make_op(alpha=math.radians(4.2))
         db = _db_returning(op)
         result = resolve_operating_point(
-            db, OperatingPointSchema(operating_point_id=42, alpha=999.0)
+            db, OperatingPointSchema(operating_point_id=42, alpha=99.0)
         )
         assert result.alpha == pytest.approx(4.2, rel=1e-6)
 
@@ -163,18 +163,14 @@ class TestResolveOperatingPoint:
 
         op = _make_op(status=OperatingPointStatus.NOT_TRIMMED)
         with pytest.raises(ValidationDomainError):
-            resolve_operating_point(
-                _db_returning(op), OperatingPointSchema(operating_point_id=42)
-            )
+            resolve_operating_point(_db_returning(op), OperatingPointSchema(operating_point_id=42))
 
     def test_dirty_op_is_rejected_by_default(self):
         from app.services.operating_point_resolver import resolve_operating_point
 
         op = _make_op(status=OperatingPointStatus.DIRTY)
         with pytest.raises(ValidationDomainError):
-            resolve_operating_point(
-                _db_returning(op), OperatingPointSchema(operating_point_id=42)
-            )
+            resolve_operating_point(_db_returning(op), OperatingPointSchema(operating_point_id=42))
 
     def test_missing_op_raises_not_found(self):
         from app.services.operating_point_resolver import resolve_operating_point
@@ -203,9 +199,7 @@ class TestResolveOperatingPoint:
         db = MagicMock()
         # `.filter().filter().first()` returns None — the row exists for the id
         # but not for the (id, aircraft_id) pair.
-        db.query.return_value.filter.return_value.filter.return_value.first.return_value = (
-            None
-        )
+        db.query.return_value.filter.return_value.filter.return_value.first.return_value = None
         with pytest.raises(NotFoundError):
             resolve_operating_point(
                 db,
@@ -219,18 +213,116 @@ class TestResolveOperatingPoint:
 
         op = _make_op(altitude=None)
         with pytest.raises(ValidationDomainError):
-            resolve_operating_point(
-                _db_returning(op), OperatingPointSchema(operating_point_id=42)
-            )
+            resolve_operating_point(_db_returning(op), OperatingPointSchema(operating_point_id=42))
 
     def test_empty_xyz_ref_raises_validation(self):
         from app.services.operating_point_resolver import resolve_operating_point
 
         op = _make_op(xyz_ref=[])
         with pytest.raises(ValidationDomainError):
-            resolve_operating_point(
-                _db_returning(op), OperatingPointSchema(operating_point_id=42)
-            )
+            resolve_operating_point(_db_returning(op), OperatingPointSchema(operating_point_id=42))
+
+
+class TestOperatingPointModelToSchema:
+    """Unit tests for the shared operating_point_model_to_schema helper (gh-587).
+
+    The helper is the single source of truth for model→schema conversion and
+    must apply the rad→deg conversion that was missing in retrim_service.
+    """
+
+    def test_alpha_converted_rad_to_deg(self):
+        from app.services.operating_point_resolver import operating_point_model_to_schema
+
+        op = _make_op(alpha=math.radians(45.0))
+        schema = operating_point_model_to_schema(op)
+        assert schema.alpha == pytest.approx(45.0, rel=1e-6)
+
+    def test_beta_converted_rad_to_deg(self):
+        from app.services.operating_point_resolver import operating_point_model_to_schema
+
+        op = _make_op(beta=math.radians(2.0))
+        schema = operating_point_model_to_schema(op)
+        assert schema.beta == pytest.approx(2.0, rel=1e-6)
+
+    def test_operating_point_id_set_on_schema(self):
+        from app.services.operating_point_resolver import operating_point_model_to_schema
+
+        op = _make_op(id=99)
+        schema = operating_point_model_to_schema(op)
+        assert schema.operating_point_id == 99
+
+    def test_velocity_altitude_body_rates_passed_through(self):
+        from app.services.operating_point_resolver import operating_point_model_to_schema
+
+        op = _make_op(velocity=30.0, altitude=500.0, p=0.1, q=0.2, r=0.0)
+        schema = operating_point_model_to_schema(op)
+        assert schema.velocity == 30.0
+        assert schema.altitude == 500.0
+        assert schema.p == pytest.approx(0.1)
+        assert schema.q == pytest.approx(0.2)
+        assert schema.r == pytest.approx(0.0)
+
+    def test_deflections_from_controls_when_override_none(self):
+        from app.services.operating_point_resolver import operating_point_model_to_schema
+
+        op = _make_op(controls={"elevator": -2.0}, control_deflections=None)
+        schema = operating_point_model_to_schema(op)
+        assert schema.control_deflections == {"elevator": -2.0}
+
+    def test_manual_override_wins_over_controls(self):
+        from app.services.operating_point_resolver import operating_point_model_to_schema
+
+        op = _make_op(
+            controls={"elevator": -2.0},
+            control_deflections={"elevator": -1.0},
+        )
+        schema = operating_point_model_to_schema(op)
+        assert schema.control_deflections == {"elevator": -1.0}
+
+    def test_cdcl_config_and_spacing_config_forwarded(self):
+        from app.schemas.aeroanalysisschema import CdclConfig, SpacingConfig
+        from app.services.operating_point_resolver import operating_point_model_to_schema
+
+        cdcl = CdclConfig()
+        spacing = SpacingConfig()
+        op = _make_op()
+        schema = operating_point_model_to_schema(op, cdcl_config=cdcl, spacing_config=spacing)
+        assert schema.cdcl_config is cdcl
+        assert schema.spacing_config is spacing
+
+    def test_missing_altitude_raises_validation_error(self):
+        from app.core.exceptions import ValidationDomainError
+        from app.services.operating_point_resolver import operating_point_model_to_schema
+
+        op = _make_op(altitude=None)
+        with pytest.raises(ValidationDomainError):
+            operating_point_model_to_schema(op)
+
+    def test_missing_alpha_raises_validation_error(self):
+        from app.core.exceptions import ValidationDomainError
+        from app.services.operating_point_resolver import operating_point_model_to_schema
+
+        op = _make_op(alpha=None)
+        with pytest.raises(ValidationDomainError):
+            operating_point_model_to_schema(op)
+
+    def test_empty_xyz_ref_raises_validation_error(self):
+        from app.core.exceptions import ValidationDomainError
+        from app.services.operating_point_resolver import operating_point_model_to_schema
+
+        op = _make_op(xyz_ref=[])
+        with pytest.raises(ValidationDomainError):
+            operating_point_model_to_schema(op)
+
+    def test_p_q_r_zero_not_rejected_by_require_field(self):
+        """Genuine 0.0 body rates (not None) must pass _require_field."""
+        from app.services.operating_point_resolver import operating_point_model_to_schema
+
+        op = _make_op(p=0.0, q=0.0, r=0.0)
+        schema = operating_point_model_to_schema(op)
+        assert schema.p == 0.0
+        assert schema.q == 0.0
+        assert schema.r == 0.0
 
 
 class TestValidateDeflectionsAgainstAirplane:
@@ -258,9 +350,7 @@ class TestValidateDeflectionsAgainstAirplane:
 
         airplane = self._make_airplane(["elevator", "aileron"])
         # No exception
-        validate_deflections_against_airplane(
-            airplane, {"elevator": -2.0, "aileron": 0.5}
-        )
+        validate_deflections_against_airplane(airplane, {"elevator": -2.0, "aileron": 0.5})
 
     def test_raises_listing_unknown_names(self):
         from app.services.operating_point_resolver import (
@@ -269,9 +359,7 @@ class TestValidateDeflectionsAgainstAirplane:
 
         airplane = self._make_airplane(["elevator"])
         with pytest.raises(ValidationDomainError) as exc:
-            validate_deflections_against_airplane(
-                airplane, {"elevator": -2.0, "rudder": 1.0}
-            )
+            validate_deflections_against_airplane(airplane, {"elevator": -2.0, "rudder": 1.0})
         assert "rudder" in exc.value.message
         assert "elevator" in exc.value.message  # listed as available
 
@@ -312,29 +400,46 @@ class TestStreamlineServiceUsesResolvedOp:
         op = _make_op()
 
         with ExitStack() as stack:
-            stack.enter_context(patch.object(
-                analysis_service, "get_aeroplane_or_raise",
-                return_value=MagicMock(id=7),
-            ))
-            stack.enter_context(patch.object(
-                analysis_service, "get_aeroplane_schema_or_raise",
-                return_value=MagicMock(),
-            ))
-            stack.enter_context(patch.object(
-                analysis_service, "aeroplane_schema_to_asb_airplane_async",
-                return_value=MagicMock(),
-            ))
-            mock_resolver = stack.enter_context(patch.object(
-                analysis_service.operating_point_resolver,
-                "resolve_operating_point",
-                return_value=resolved,
-            ))
-            stack.enter_context(patch.object(
-                analysis_service, "validate_deflections_against_airplane",
-            ))
-            mock_analyse = stack.enter_context(patch.object(
-                analysis_service, "analyse_aerodynamics",
-            ))
+            stack.enter_context(
+                patch.object(
+                    analysis_service,
+                    "get_aeroplane_or_raise",
+                    return_value=MagicMock(id=7),
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    analysis_service,
+                    "get_aeroplane_schema_or_raise",
+                    return_value=MagicMock(),
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    analysis_service,
+                    "aeroplane_schema_to_asb_airplane_async",
+                    return_value=MagicMock(),
+                )
+            )
+            mock_resolver = stack.enter_context(
+                patch.object(
+                    analysis_service.operating_point_resolver,
+                    "resolve_operating_point",
+                    return_value=resolved,
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    analysis_service,
+                    "validate_deflections_against_airplane",
+                )
+            )
+            mock_analyse = stack.enter_context(
+                patch.object(
+                    analysis_service,
+                    "analyse_aerodynamics",
+                )
+            )
             fake_fig = MagicMock()
             fake_fig.to_json.return_value = '{"data":[],"layout":{}}'
             mock_analyse.return_value = (MagicMock(), fake_fig)
@@ -366,32 +471,52 @@ class TestStreamlineServiceUsesResolvedOp:
         op = _make_op()
 
         with ExitStack() as stack:
-            stack.enter_context(patch.object(
-                analysis_service, "get_aeroplane_or_raise",
-                return_value=MagicMock(id=7),
-            ))
-            stack.enter_context(patch.object(
-                analysis_service, "get_aeroplane_schema_or_raise",
-                return_value=MagicMock(),
-            ))
-            stack.enter_context(patch.object(
-                analysis_service, "aeroplane_schema_to_asb_airplane_async",
-                return_value=MagicMock(),
-            ))
-            mock_resolver = stack.enter_context(patch.object(
-                analysis_service.operating_point_resolver,
-                "resolve_operating_point",
-                return_value=resolved,
-            ))
-            stack.enter_context(patch.object(
-                analysis_service, "validate_deflections_against_airplane",
-            ))
-            mock_analyse = stack.enter_context(patch.object(
-                analysis_service, "analyse_aerodynamics",
-            ))
-            mock_four_view = stack.enter_context(patch.object(
-                analysis_service, "compile_four_view_figure",
-            ))
+            stack.enter_context(
+                patch.object(
+                    analysis_service,
+                    "get_aeroplane_or_raise",
+                    return_value=MagicMock(id=7),
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    analysis_service,
+                    "get_aeroplane_schema_or_raise",
+                    return_value=MagicMock(),
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    analysis_service,
+                    "aeroplane_schema_to_asb_airplane_async",
+                    return_value=MagicMock(),
+                )
+            )
+            mock_resolver = stack.enter_context(
+                patch.object(
+                    analysis_service.operating_point_resolver,
+                    "resolve_operating_point",
+                    return_value=resolved,
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    analysis_service,
+                    "validate_deflections_against_airplane",
+                )
+            )
+            mock_analyse = stack.enter_context(
+                patch.object(
+                    analysis_service,
+                    "analyse_aerodynamics",
+                )
+            )
+            mock_four_view = stack.enter_context(
+                patch.object(
+                    analysis_service,
+                    "compile_four_view_figure",
+                )
+            )
             mock_analyse.return_value = (MagicMock(), MagicMock())
             mock_four_view.return_value.to_image.return_value = b"png-bytes"
 
@@ -425,34 +550,54 @@ class TestStreamlineServiceUsesResolvedOp:
             # ``.name`` attribute — we have to assign it after construction.
             aircraft_mock = MagicMock(id=7)
             aircraft_mock.name = "test_plane"
-            stack.enter_context(patch.object(
-                analysis_service, "get_aeroplane_or_raise",
-                return_value=aircraft_mock,
-            ))
-            stack.enter_context(patch.object(
-                analysis_service, "get_aeroplane_schema_or_raise",
-                return_value=MagicMock(),
-            ))
-            stack.enter_context(patch.object(
-                analysis_service, "aeroplane_schema_to_asb_airplane_async",
-                return_value=MagicMock(),
-            ))
-            mock_resolver = stack.enter_context(patch.object(
-                analysis_service.operating_point_resolver,
-                "resolve_operating_point",
-                return_value=resolved,
-            ))
-            mock_runner_cls = stack.enter_context(patch(
-                "app.services.avl_runner.AVLRunner",
-            ))
-            stack.enter_context(patch(
-                "app.services.avl_geometry_service.get_user_avl_content",
-                return_value="MOCK_AVL_CONTENT",
-            ))
+            stack.enter_context(
+                patch.object(
+                    analysis_service,
+                    "get_aeroplane_or_raise",
+                    return_value=aircraft_mock,
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    analysis_service,
+                    "get_aeroplane_schema_or_raise",
+                    return_value=MagicMock(),
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    analysis_service,
+                    "aeroplane_schema_to_asb_airplane_async",
+                    return_value=MagicMock(),
+                )
+            )
+            mock_resolver = stack.enter_context(
+                patch.object(
+                    analysis_service.operating_point_resolver,
+                    "resolve_operating_point",
+                    return_value=resolved,
+                )
+            )
+            mock_runner_cls = stack.enter_context(
+                patch(
+                    "app.services.avl_runner.AVLRunner",
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "app.services.avl_geometry_service.get_user_avl_content",
+                    return_value="MOCK_AVL_CONTENT",
+                )
+            )
             mock_runner = MagicMock()
             mock_runner.run.return_value = {
-                "strip_forces": [], "alpha": 4.2, "beta": 0.5,
-                "mach": 0, "Sref": 1.0, "Cref": 1.0, "Bref": 1.0,
+                "strip_forces": [],
+                "alpha": 4.2,
+                "beta": 0.5,
+                "mach": 0,
+                "Sref": 1.0,
+                "Cref": 1.0,
+                "Bref": 1.0,
             }
             mock_runner_cls.return_value = mock_runner
 
@@ -477,33 +622,51 @@ class TestStreamlineServiceUsesResolvedOp:
         from app.services import analysis_service
 
         resolved = OperatingPointSchema(
-            operating_point_id=42, alpha=4.2, velocity=20.0, altitude=100.0,
-            xyz_ref=[0.1, 0, 0], control_deflections={"ghost": 0.0},
+            operating_point_id=42,
+            alpha=4.2,
+            velocity=20.0,
+            altitude=100.0,
+            xyz_ref=[0.1, 0, 0],
+            control_deflections={"ghost": 0.0},
         )
         op = _make_op()
 
         with ExitStack() as stack:
-            stack.enter_context(patch.object(
-                analysis_service, "get_aeroplane_or_raise",
-                return_value=MagicMock(id=7),
-            ))
-            stack.enter_context(patch.object(
-                analysis_service, "get_aeroplane_schema_or_raise",
-                return_value=MagicMock(),
-            ))
-            stack.enter_context(patch.object(
-                analysis_service, "aeroplane_schema_to_asb_airplane_async",
-                return_value=MagicMock(),
-            ))
-            stack.enter_context(patch.object(
-                analysis_service.operating_point_resolver,
-                "resolve_operating_point",
-                return_value=resolved,
-            ))
-            stack.enter_context(patch.object(
-                analysis_service, "validate_deflections_against_airplane",
-                side_effect=ValidationDomainError(message="ghost surface"),
-            ))
+            stack.enter_context(
+                patch.object(
+                    analysis_service,
+                    "get_aeroplane_or_raise",
+                    return_value=MagicMock(id=7),
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    analysis_service,
+                    "get_aeroplane_schema_or_raise",
+                    return_value=MagicMock(),
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    analysis_service,
+                    "aeroplane_schema_to_asb_airplane_async",
+                    return_value=MagicMock(),
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    analysis_service.operating_point_resolver,
+                    "resolve_operating_point",
+                    return_value=resolved,
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    analysis_service,
+                    "validate_deflections_against_airplane",
+                    side_effect=ValidationDomainError(message="ghost surface"),
+                )
+            )
             with pytest.raises(ValidationDomainError):
                 asyncio.run(
                     analysis_service.calculate_streamlines_json(
@@ -519,26 +682,40 @@ class TestStreamlineServiceUsesResolvedOp:
         from unittest.mock import patch
 
         stack = ExitStack()
-        stack.enter_context(patch.object(
-            analysis_service, "get_aeroplane_or_raise",
-            return_value=MagicMock(id=7),
-        ))
-        stack.enter_context(patch.object(
-            analysis_service, "get_aeroplane_schema_or_raise",
-            return_value=MagicMock(),
-        ))
-        stack.enter_context(patch.object(
-            analysis_service, "aeroplane_schema_to_asb_airplane_async",
-            return_value=MagicMock(),
-        ))
-        stack.enter_context(patch.object(
-            analysis_service.operating_point_resolver,
-            "resolve_operating_point",
-            return_value=resolved,
-        ))
-        stack.enter_context(patch.object(
-            analysis_service, "validate_deflections_against_airplane",
-        ))
+        stack.enter_context(
+            patch.object(
+                analysis_service,
+                "get_aeroplane_or_raise",
+                return_value=MagicMock(id=7),
+            )
+        )
+        stack.enter_context(
+            patch.object(
+                analysis_service,
+                "get_aeroplane_schema_or_raise",
+                return_value=MagicMock(),
+            )
+        )
+        stack.enter_context(
+            patch.object(
+                analysis_service,
+                "aeroplane_schema_to_asb_airplane_async",
+                return_value=MagicMock(),
+            )
+        )
+        stack.enter_context(
+            patch.object(
+                analysis_service.operating_point_resolver,
+                "resolve_operating_point",
+                return_value=resolved,
+            )
+        )
+        stack.enter_context(
+            patch.object(
+                analysis_service,
+                "validate_deflections_against_airplane",
+            )
+        )
         return stack
 
     def test_streamlines_service_wraps_generic_error_as_internal(self):
@@ -552,10 +729,13 @@ class TestStreamlineServiceUsesResolvedOp:
         resolved = self._resolved_op()
 
         with self._patch_service_pipeline(analysis_service, resolved) as stack:
-            stack.enter_context(patch.object(
-                analysis_service, "analyse_aerodynamics",
-                side_effect=RuntimeError("VLM crashed"),
-            ))
+            stack.enter_context(
+                patch.object(
+                    analysis_service,
+                    "analyse_aerodynamics",
+                    side_effect=RuntimeError("VLM crashed"),
+                )
+            )
             with pytest.raises(InternalError):
                 asyncio.run(
                     analysis_service.calculate_streamlines_json(
@@ -575,13 +755,19 @@ class TestStreamlineServiceUsesResolvedOp:
         resolved = self._resolved_op()
 
         with self._patch_service_pipeline(analysis_service, resolved) as stack:
-            stack.enter_context(patch.object(
-                analysis_service, "analyse_aerodynamics",
-                side_effect=RuntimeError("VLM crashed"),
-            ))
-            stack.enter_context(patch.object(
-                analysis_service, "compile_four_view_figure",
-            ))
+            stack.enter_context(
+                patch.object(
+                    analysis_service,
+                    "analyse_aerodynamics",
+                    side_effect=RuntimeError("VLM crashed"),
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    analysis_service,
+                    "compile_four_view_figure",
+                )
+            )
             with pytest.raises(InternalError):
                 asyncio.run(
                     analysis_service.get_streamlines_three_view_image(
@@ -601,13 +787,17 @@ class TestStreamlineServiceUsesResolvedOp:
         resolved = self._resolved_op()
 
         with self._patch_service_pipeline(analysis_service, resolved) as stack:
-            mock_runner_cls = stack.enter_context(patch(
-                "app.services.avl_runner.AVLRunner",
-            ))
-            stack.enter_context(patch(
-                "app.services.avl_geometry_service.get_user_avl_content",
-                return_value="MOCK_AVL_CONTENT",
-            ))
+            mock_runner_cls = stack.enter_context(
+                patch(
+                    "app.services.avl_runner.AVLRunner",
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "app.services.avl_geometry_service.get_user_avl_content",
+                    return_value="MOCK_AVL_CONTENT",
+                )
+            )
             mock_runner_cls.return_value.run.side_effect = RuntimeError("AVL crashed")
 
             with pytest.raises(InternalError):
@@ -628,28 +818,46 @@ class TestStreamlineServiceUsesResolvedOp:
         from app.services import analysis_service
 
         inline = OperatingPointSchema(
-            alpha=5.0, velocity=14.0, altitude=100.0, xyz_ref=[0.18, 0, 0],
+            alpha=5.0,
+            velocity=14.0,
+            altitude=100.0,
+            xyz_ref=[0.18, 0, 0],
         )
 
         with ExitStack() as stack:
-            stack.enter_context(patch.object(
-                analysis_service, "get_aeroplane_or_raise",
-                return_value=MagicMock(id=7),
-            ))
-            stack.enter_context(patch.object(
-                analysis_service, "get_aeroplane_schema_or_raise",
-                return_value=MagicMock(),
-            ))
-            stack.enter_context(patch.object(
-                analysis_service, "aeroplane_schema_to_asb_airplane_async",
-                return_value=MagicMock(),
-            ))
-            stack.enter_context(patch.object(
-                analysis_service, "validate_deflections_against_airplane",
-            ))
-            mock_analyse = stack.enter_context(patch.object(
-                analysis_service, "analyse_aerodynamics",
-            ))
+            stack.enter_context(
+                patch.object(
+                    analysis_service,
+                    "get_aeroplane_or_raise",
+                    return_value=MagicMock(id=7),
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    analysis_service,
+                    "get_aeroplane_schema_or_raise",
+                    return_value=MagicMock(),
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    analysis_service,
+                    "aeroplane_schema_to_asb_airplane_async",
+                    return_value=MagicMock(),
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    analysis_service,
+                    "validate_deflections_against_airplane",
+                )
+            )
+            mock_analyse = stack.enter_context(
+                patch.object(
+                    analysis_service,
+                    "analyse_aerodynamics",
+                )
+            )
             fake_fig = MagicMock()
             fake_fig.to_json.return_value = '{"data":[],"layout":{}}'
             mock_analyse.return_value = (MagicMock(), fake_fig)

--- a/app/tests/test_retrim_service.py
+++ b/app/tests/test_retrim_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import math
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -35,7 +36,11 @@ class TestFindPitchControlName:
         db.add(wing)
         db.flush()
         xsec = WingXSecModel(
-            wing_id=wing.id, xyz_le=[0, 0, 0], chord=0.2, twist=0, airfoil="naca0012",
+            wing_id=wing.id,
+            xyz_le=[0, 0, 0],
+            chord=0.2,
+            twist=0,
+            airfoil="naca0012",
             sort_index=0,
         )
         db.add(xsec)
@@ -44,7 +49,9 @@ class TestFindPitchControlName:
         db.add(detail)
         db.flush()
         ted = WingXSecTrailingEdgeDeviceModel(
-            wing_xsec_detail_id=detail.id, name="elevator", role="elevator",
+            wing_xsec_detail_id=detail.id,
+            name="elevator",
+            role="elevator",
         )
         db.add(ted)
         db.commit()
@@ -60,7 +67,9 @@ class TestFindPitchControlName:
         db = SessionLocal()
         aeroplane = make_aeroplane(db, name="elevon-test")
         from app.models.aeroplanemodel import (
-            WingModel, WingXSecModel, WingXSecDetailModel,
+            WingModel,
+            WingXSecModel,
+            WingXSecDetailModel,
             WingXSecTrailingEdgeDeviceModel,
         )
 
@@ -68,7 +77,11 @@ class TestFindPitchControlName:
         db.add(wing)
         db.flush()
         xsec = WingXSecModel(
-            wing_id=wing.id, xyz_le=[0, 0, 0], chord=0.3, twist=0, airfoil="naca0012",
+            wing_id=wing.id,
+            xyz_le=[0, 0, 0],
+            chord=0.3,
+            twist=0,
+            airfoil="naca0012",
             sort_index=0,
         )
         db.add(xsec)
@@ -77,7 +90,9 @@ class TestFindPitchControlName:
         db.add(detail)
         db.flush()
         ted = WingXSecTrailingEdgeDeviceModel(
-            wing_xsec_detail_id=detail.id, name="elevon", role="elevon",
+            wing_xsec_detail_id=detail.id,
+            name="elevon",
+            role="elevon",
         )
         db.add(ted)
         db.commit()
@@ -102,7 +117,9 @@ class TestFindPitchControlName:
         db = SessionLocal()
         aeroplane = make_aeroplane(db, name="aileron-only")
         from app.models.aeroplanemodel import (
-            WingModel, WingXSecModel, WingXSecDetailModel,
+            WingModel,
+            WingXSecModel,
+            WingXSecDetailModel,
             WingXSecTrailingEdgeDeviceModel,
         )
 
@@ -110,7 +127,11 @@ class TestFindPitchControlName:
         db.add(wing)
         db.flush()
         xsec = WingXSecModel(
-            wing_id=wing.id, xyz_le=[0, 0, 0], chord=0.3, twist=0, airfoil="naca0012",
+            wing_id=wing.id,
+            xyz_le=[0, 0, 0],
+            chord=0.3,
+            twist=0,
+            airfoil="naca0012",
             sort_index=0,
         )
         db.add(xsec)
@@ -119,7 +140,9 @@ class TestFindPitchControlName:
         db.add(detail)
         db.flush()
         ted = WingXSecTrailingEdgeDeviceModel(
-            wing_xsec_detail_id=detail.id, name="aileron", role="aileron",
+            wing_xsec_detail_id=detail.id,
+            name="aileron",
+            role="aileron",
         )
         db.add(ted)
         db.commit()
@@ -156,7 +179,9 @@ class TestRetrimDirtyOps:
         aeroplane = make_aeroplane(db, name="trim-test")
 
         from app.models.aeroplanemodel import (
-            WingModel, WingXSecModel, WingXSecDetailModel,
+            WingModel,
+            WingXSecModel,
+            WingXSecDetailModel,
             WingXSecTrailingEdgeDeviceModel,
         )
 
@@ -164,7 +189,11 @@ class TestRetrimDirtyOps:
         db.add(wing)
         db.flush()
         xsec = WingXSecModel(
-            wing_id=wing.id, xyz_le=[0, 0, 0], chord=0.2, twist=0, airfoil="naca0012",
+            wing_id=wing.id,
+            xyz_le=[0, 0, 0],
+            chord=0.2,
+            twist=0,
+            airfoil="naca0012",
             sort_index=0,
         )
         db.add(xsec)
@@ -173,7 +202,9 @@ class TestRetrimDirtyOps:
         db.add(detail)
         db.flush()
         ted = WingXSecTrailingEdgeDeviceModel(
-            wing_xsec_detail_id=detail.id, name="elevator", role="elevator",
+            wing_xsec_detail_id=detail.id,
+            name="elevator",
+            role="elevator",
         )
         db.add(ted)
         db.commit()
@@ -217,7 +248,9 @@ class TestRetrimDirtyOps:
         aeroplane = make_aeroplane(db, name="partial-fail")
 
         from app.models.aeroplanemodel import (
-            WingModel, WingXSecModel, WingXSecDetailModel,
+            WingModel,
+            WingXSecModel,
+            WingXSecDetailModel,
             WingXSecTrailingEdgeDeviceModel,
         )
 
@@ -225,7 +258,11 @@ class TestRetrimDirtyOps:
         db.add(wing)
         db.flush()
         xsec = WingXSecModel(
-            wing_id=wing.id, xyz_le=[0, 0, 0], chord=0.2, twist=0, airfoil="naca0012",
+            wing_id=wing.id,
+            xyz_le=[0, 0, 0],
+            chord=0.2,
+            twist=0,
+            airfoil="naca0012",
             sort_index=0,
         )
         db.add(xsec)
@@ -234,7 +271,9 @@ class TestRetrimDirtyOps:
         db.add(detail)
         db.flush()
         ted = WingXSecTrailingEdgeDeviceModel(
-            wing_xsec_detail_id=detail.id, name="elevator", role="elevator",
+            wing_xsec_detail_id=detail.id,
+            name="elevator",
+            role="elevator",
         )
         db.add(ted)
         db.commit()
@@ -289,7 +328,9 @@ class TestRetrimDirtyOps:
         aeroplane = make_aeroplane(db, name="limit-test")
 
         from app.models.aeroplanemodel import (
-            WingModel, WingXSecModel, WingXSecDetailModel,
+            WingModel,
+            WingXSecModel,
+            WingXSecDetailModel,
             WingXSecTrailingEdgeDeviceModel,
         )
 
@@ -297,7 +338,11 @@ class TestRetrimDirtyOps:
         db.add(wing)
         db.flush()
         xsec = WingXSecModel(
-            wing_id=wing.id, xyz_le=[0, 0, 0], chord=0.2, twist=0, airfoil="naca0012",
+            wing_id=wing.id,
+            xyz_le=[0, 0, 0],
+            chord=0.2,
+            twist=0,
+            airfoil="naca0012",
             sort_index=0,
         )
         db.add(xsec)
@@ -306,7 +351,9 @@ class TestRetrimDirtyOps:
         db.add(detail)
         db.flush()
         ted = WingXSecTrailingEdgeDeviceModel(
-            wing_xsec_detail_id=detail.id, name="elevator", role="elevator",
+            wing_xsec_detail_id=detail.id,
+            name="elevator",
+            role="elevator",
         )
         db.add(ted)
         db.commit()
@@ -362,7 +409,9 @@ class TestRetrimDirtyOps:
         aeroplane = make_aeroplane(db, name="stability-test")
 
         from app.models.aeroplanemodel import (
-            WingModel, WingXSecModel, WingXSecDetailModel,
+            WingModel,
+            WingXSecModel,
+            WingXSecDetailModel,
             WingXSecTrailingEdgeDeviceModel,
         )
 
@@ -370,7 +419,11 @@ class TestRetrimDirtyOps:
         db.add(wing)
         db.flush()
         xsec = WingXSecModel(
-            wing_id=wing.id, xyz_le=[0, 0, 0], chord=0.2, twist=0, airfoil="naca0012",
+            wing_id=wing.id,
+            xyz_le=[0, 0, 0],
+            chord=0.2,
+            twist=0,
+            airfoil="naca0012",
             sort_index=0,
         )
         db.add(xsec)
@@ -379,7 +432,9 @@ class TestRetrimDirtyOps:
         db.add(detail)
         db.flush()
         ted = WingXSecTrailingEdgeDeviceModel(
-            wing_xsec_detail_id=detail.id, name="elevator", role="elevator",
+            wing_xsec_detail_id=detail.id,
+            name="elevator",
+            role="elevator",
         )
         db.add(ted)
         db.commit()
@@ -411,7 +466,6 @@ class TestRetrimDirtyOps:
 
         mock_stability.assert_called_once()
 
-
     def test_aeroplane_deleted_before_retrim(self, client_and_db):
         """Finding 9: aeroplane deleted between schedule and execution."""
         _, SessionLocal = client_and_db
@@ -436,7 +490,9 @@ class TestRetrimDirtyOps:
         aeroplane = make_aeroplane(db, name="merge-test")
 
         from app.models.aeroplanemodel import (
-            WingModel, WingXSecModel, WingXSecDetailModel,
+            WingModel,
+            WingXSecModel,
+            WingXSecDetailModel,
             WingXSecTrailingEdgeDeviceModel,
         )
 
@@ -444,7 +500,11 @@ class TestRetrimDirtyOps:
         db.add(wing)
         db.flush()
         xsec = WingXSecModel(
-            wing_id=wing.id, xyz_le=[0, 0, 0], chord=0.2, twist=0, airfoil="naca0012",
+            wing_id=wing.id,
+            xyz_le=[0, 0, 0],
+            chord=0.2,
+            twist=0,
+            airfoil="naca0012",
             sort_index=0,
         )
         db.add(xsec)
@@ -453,13 +513,18 @@ class TestRetrimDirtyOps:
         db.add(detail)
         db.flush()
         ted = WingXSecTrailingEdgeDeviceModel(
-            wing_xsec_detail_id=detail.id, name="elevator", role="elevator",
+            wing_xsec_detail_id=detail.id,
+            name="elevator",
+            role="elevator",
         )
         db.add(ted)
         db.commit()
 
         make_operating_point(
-            db, aircraft_id=aeroplane.id, name="cruise", status="DIRTY",
+            db,
+            aircraft_id=aeroplane.id,
+            name="cruise",
+            status="DIRTY",
             control_deflections={"aileron": 5.0},
         )
         db.close()
@@ -499,7 +564,9 @@ class TestRetrimDirtyOps:
         aeroplane = make_aeroplane(db, name="stab-fail")
 
         from app.models.aeroplanemodel import (
-            WingModel, WingXSecModel, WingXSecDetailModel,
+            WingModel,
+            WingXSecModel,
+            WingXSecDetailModel,
             WingXSecTrailingEdgeDeviceModel,
         )
 
@@ -507,7 +574,11 @@ class TestRetrimDirtyOps:
         db.add(wing)
         db.flush()
         xsec = WingXSecModel(
-            wing_id=wing.id, xyz_le=[0, 0, 0], chord=0.2, twist=0, airfoil="naca0012",
+            wing_id=wing.id,
+            xyz_le=[0, 0, 0],
+            chord=0.2,
+            twist=0,
+            airfoil="naca0012",
             sort_index=0,
         )
         db.add(xsec)
@@ -516,7 +587,9 @@ class TestRetrimDirtyOps:
         db.add(detail)
         db.flush()
         ted = WingXSecTrailingEdgeDeviceModel(
-            wing_xsec_detail_id=detail.id, name="elevator", role="elevator",
+            wing_xsec_detail_id=detail.id,
+            name="elevator",
+            role="elevator",
         )
         db.add(ted)
         db.commit()
@@ -553,6 +626,137 @@ class TestRetrimDirtyOps:
         db2.close()
 
 
+class TestOpModelToSchemaRadDegConversion:
+    """gh-587 regression: retrim path must convert alpha/beta from rad→deg.
+
+    Before gh-587 the retrim seeded the solver with alpha in radians (≈ 0 °
+    for small angles), discarding the converged trim. These tests pin the fix.
+    """
+
+    def _make_op_mock(self, **overrides) -> MagicMock:
+        from app.models.analysismodels import OperatingPointModel
+        from app.schemas.aeroanalysisschema import OperatingPointStatus
+
+        defaults = dict(
+            id=7,
+            name="cruise",
+            description="",
+            aircraft_id=1,
+            status=OperatingPointStatus.TRIMMED,
+            warnings=[],
+            controls={"elevator": -2.5},
+            velocity=20.0,
+            alpha=math.pi / 4,  # 45° stored as radians
+            beta=math.radians(3.0),
+            p=0.0,
+            q=0.0,
+            r=0.0,
+            xyz_ref=[0.18, 0.0, 0.0],
+            altitude=100.0,
+            control_deflections=None,
+            trim_enrichment=None,
+        )
+        defaults.update(overrides)
+        op = MagicMock(spec=OperatingPointModel)
+        for k, v in defaults.items():
+            setattr(op, k, v)
+        return op
+
+    def test_retrim_schema_alpha_is_degrees_not_radians(self):
+        """Alpha stored as π/4 rad must arrive as 45° on the schema."""
+        from app.services.operating_point_resolver import operating_point_model_to_schema
+
+        op = self._make_op_mock(alpha=math.pi / 4)
+        schema = operating_point_model_to_schema(op)
+        assert schema.alpha == pytest.approx(45.0, rel=1e-6)
+
+    def test_retrim_schema_beta_is_degrees_not_radians(self):
+        """Beta stored as radians must be converted to degrees on the schema."""
+        from app.services.operating_point_resolver import operating_point_model_to_schema
+
+        op = self._make_op_mock(beta=math.radians(3.0))
+        schema = operating_point_model_to_schema(op)
+        assert schema.beta == pytest.approx(3.0, rel=1e-6)
+
+    def test_retrim_service_calls_operating_point_model_to_schema(self, client_and_db):
+        """retrim_dirty_ops must use operating_point_model_to_schema (not _op_model_to_schema)."""
+        _, SessionLocal = client_and_db
+        db = SessionLocal()
+        aeroplane = make_aeroplane(db, name="rad-deg-test")
+
+        from app.models.aeroplanemodel import (
+            WingModel,
+            WingXSecDetailModel,
+            WingXSecModel,
+            WingXSecTrailingEdgeDeviceModel,
+        )
+
+        wing = WingModel(name="h-stab", aeroplane_id=aeroplane.id, symmetric=True)
+        db.add(wing)
+        db.flush()
+        xsec = WingXSecModel(
+            wing_id=wing.id,
+            xyz_le=[0, 0, 0],
+            chord=0.2,
+            twist=0,
+            airfoil="naca0012",
+            sort_index=0,
+        )
+        db.add(xsec)
+        db.flush()
+        detail = WingXSecDetailModel(wing_xsec_id=xsec.id)
+        db.add(detail)
+        db.flush()
+        ted = WingXSecTrailingEdgeDeviceModel(
+            wing_xsec_detail_id=detail.id,
+            name="elevator",
+            role="elevator",
+        )
+        db.add(ted)
+        db.commit()
+
+        # Store alpha as π/4 radians — after the fix, the schema must get 45°
+        make_operating_point(
+            db,
+            aircraft_id=aeroplane.id,
+            name="cruise",
+            status="DIRTY",
+            alpha=math.pi / 4,
+        )
+        db.close()
+
+        captured_schemas: list = []
+
+        async def _capture_trim(db, uuid, request):
+            captured_schemas.append(request.operating_point)
+            result = MagicMock()
+            result.converged = True
+            result.trimmed_deflection = -2.0
+            return result
+
+        with (
+            patch("app.services.retrim_service.SessionLocal", SessionLocal),
+            patch(
+                "app.services.retrim_service.trim_with_aerobuildup",
+                side_effect=_capture_trim,
+            ),
+            patch(
+                "app.services.retrim_service.get_stability_summary",
+                new_callable=AsyncMock,
+            ),
+        ):
+            from app.services.retrim_service import retrim_dirty_ops
+
+            asyncio.run(retrim_dirty_ops(aeroplane.id))
+
+        assert len(captured_schemas) == 1, "Expected exactly one trim call"
+        schema = captured_schemas[0]
+        # The schema must carry 45°, not ≈0.785 (radians value)
+        assert schema.alpha == pytest.approx(45.0, rel=1e-3), (
+            f"alpha was {schema.alpha!r} — expected 45.0° (gh-587 regression)"
+        )
+
+
 class TestStartupRegistration:
     """Verify trim function is registered at app startup."""
 
@@ -571,7 +775,9 @@ class TestRetrimIntegration:
         aeroplane = make_aeroplane(db, name="integration-test")
 
         from app.models.aeroplanemodel import (
-            WingModel, WingXSecModel, WingXSecDetailModel,
+            WingModel,
+            WingXSecModel,
+            WingXSecDetailModel,
             WingXSecTrailingEdgeDeviceModel,
         )
 
@@ -579,7 +785,11 @@ class TestRetrimIntegration:
         db.add(wing)
         db.flush()
         xsec = WingXSecModel(
-            wing_id=wing.id, xyz_le=[0, 0, 0], chord=0.2, twist=0, airfoil="naca0012",
+            wing_id=wing.id,
+            xyz_le=[0, 0, 0],
+            chord=0.2,
+            twist=0,
+            airfoil="naca0012",
             sort_index=0,
         )
         db.add(xsec)
@@ -588,16 +798,24 @@ class TestRetrimIntegration:
         db.add(detail)
         db.flush()
         ted = WingXSecTrailingEdgeDeviceModel(
-            wing_xsec_detail_id=detail.id, name="elevator", role="elevator",
+            wing_xsec_detail_id=detail.id,
+            name="elevator",
+            role="elevator",
         )
         db.add(ted)
         db.commit()
 
         make_operating_point(
-            db, aircraft_id=aeroplane.id, name="cruise", status="TRIMMED",
+            db,
+            aircraft_id=aeroplane.id,
+            name="cruise",
+            status="TRIMMED",
         )
         make_operating_point(
-            db, aircraft_id=aeroplane.id, name="stall", status="TRIMMED",
+            db,
+            aircraft_id=aeroplane.id,
+            name="stall",
+            status="TRIMMED",
         )
         db.close()
 


### PR DESCRIPTION
## Summary

Fixes #587 — a unit-conversion bug in the background auto-retrim path.

`retrim_service._op_model_to_schema` copied `OperatingPointModel.alpha`/`.beta`
(stored in **radians**) straight into `OperatingPointSchema` (consumed in
**degrees** by `asb.OperatingPoint`). Effect: `trim_with_aerobuildup` inside
`retrim_dirty_ops` was seeded with α ≈ 0° on **every** retrim — a ~57×
under-statement — silently discarding the previous converged trim. Latent on
clean linear-`C_L(α)` aircraft; bites near stall, on multiple-equilibrium
configs (T-tail/canard/tandem), and for engine-out β trim.

The parallel streamline path was already fixed for the same bug class in
gh-577 via `operating_point_resolver.py`.

## Changes

- **New shared helper** `operating_point_model_to_schema()` in
  `operating_point_resolver.py` — single source of truth for the
  `OperatingPointModel` → `OperatingPointSchema` conversion. `α/β` converted
  via `math.degrees`; every NOT-NULL column routed through the existing
  `_require_field` fail-loud guard (no more silent `or 0.0` fallbacks);
  deflections via `_pick_deflections`.
- `resolve_operating_point` now delegates to the helper (behaviour unchanged).
- `retrim_service._op_model_to_schema` **removed**; both call sites call the
  shared helper. The bug class has now bitten twice on parallel paths
  (gh-577, gh-587) — a third is prevented structurally.
- **New `@field_validator("alpha", "beta")`** on `OperatingPointSchema`
  rejecting `abs(value) > 180` (handles the `alpha: float | list[float]`
  sweep case) — a radians value reaching the schema unconverted now lands as
  a 422 instead of a silent miscalculation.

## Test plan

- New regression test in `test_retrim_service.py`: a model row with
  `alpha = π/4` rad drives the retrim path and the schema reaching
  `trim_with_aerobuildup` carries `alpha ≈ 45.0°` (not `0.785`).
- New helper unit tests in `test_operating_point_resolver.py`.
- New validator tests in `test_aeroanalysis.py` (reject 999, list-element
  reject, ±180 boundary accepted).
- Fast suite green: **3700 passed**, 163 deselected, 2 xfailed.
- TDD throughout; spec-compliance + code-quality review passed.

Closes #587

🤖 Generated with [Claude Code](https://claude.com/claude-code)