### PR TITLE
feat(gh-626): polar metrics chip-row — 8 chips with ρ-bail + profile thresholds

### DIFF
--- a/docs/superpowers/plans/2026-05-23-polar-metrics-chip-row.md
+++ b/docs/superpowers/plans/2026-05-23-polar-metrics-chip-row.md
@@ -1,0 +1,1670 @@
+# Polar Metrics Chip-Row Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a thematic Polar row to the workbench chip strip surfacing C_D0, e*, k, C_L,md, C_L,max, (L/D)_max, ρ with profile-aware traffic-light colours and a bail-rule for non-parabolic polars.
+
+**Architecture:** Refactor `InfoChipRow.tsx` (302 lines, monolithic) into a thin container + four sibling row components (`SpeedChipRow`, `GeometryChipRow`, `PolarChipRow`, `StabilityChipRow`) + a shared `Chip.tsx` primitive. Pure derivation helpers live in `frontend/lib/polar.ts`. All values are already cached server-side in `assumption_computation_context` — pure frontend change.
+
+**Tech Stack:** Next.js 16, React 19, TypeScript, Tailwind, vitest + React Testing Library, SWR, lucide-react icons.
+
+**Spec:** `docs/superpowers/specs/2026-05-23-polar-metrics-chip-row-design.md`
+
+---
+
+## File map
+
+| File | Action | Purpose |
+|---|---|---|
+| `frontend/components/workbench/Chip.tsx` | **Create** | Extracted primitive (icon, symbol, value, valueNode, description, stale, valueColorClassName) |
+| `frontend/components/workbench/SpeedChipRow.tsx` | **Create** | Row 1: V-speeds + refresh slot |
+| `frontend/components/workbench/GeometryChipRow.tsx` | **Create** | Row 2a: S_ref, MAC, B_ref, AR |
+| `frontend/components/workbench/PolarChipRow.tsx` | **Create** | Row 2b: Re, C_D0, e*, k, C_L,md, C_L,max, (L/D)_max, ρ |
+| `frontend/components/workbench/StabilityChipRow.tsx` | **Create** | Row 2c: NP, SM, CG + rightSlot |
+| `frontend/components/workbench/InfoChipRow.tsx` | **Modify** | Reduce to ≤ 80-line container |
+| `frontend/lib/polar.ts` | **Create** | Pure helpers: computeK, computeCLmd, computeEMax, computeRho, rhoThresholdsForProfile, qualityColorClassName, rhoColorClassName |
+| `frontend/hooks/useComputationContext.ts` | **Modify** | Extend `ComputationContext` with cd0, e_oswald, e_oswald_quality, e_oswald_fallback_used, polar_by_config |
+| `frontend/__tests__/Chip.test.tsx` | **Create** | Primitive tests |
+| `frontend/__tests__/SpeedChipRow.test.tsx` | **Create** | Speed row migrated cases |
+| `frontend/__tests__/GeometryChipRow.test.tsx` | **Create** | Geometry row + AR |
+| `frontend/__tests__/PolarChipRow.test.tsx` | **Create** | Polar row component tests (centre of effort) |
+| `frontend/__tests__/StabilityChipRow.test.tsx` | **Create** | Stability row migrated cases |
+| `frontend/__tests__/polar.test.ts` | **Create** | Pure-helper round-trip tests |
+| `frontend/__tests__/InfoChipRow.test.tsx` | **Modify** | Trim to container behaviour |
+
+---
+
+## Task 1 — Extract `Chip.tsx` primitive
+
+**Files:**
+- Create: `frontend/components/workbench/Chip.tsx`
+- Create: `frontend/__tests__/Chip.test.tsx`
+- Modify: `frontend/components/workbench/InfoChipRow.tsx:30-78` (remove inline `humanize` + `Chip` function, import from new module)
+
+- [ ] **Step 1: Write the failing test**
+
+`frontend/__tests__/Chip.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) =>
+    React.createElement("span", props);
+  return { Wind: icon };
+});
+
+import { Chip } from "@/components/workbench/Chip";
+import { Wind } from "lucide-react";
+
+describe("Chip primitive", () => {
+  it("renders symbol = value", () => {
+    render(<Chip icon={Wind} symbol="V_md" value="13.2 m/s" />);
+    expect(screen.getByText(/13\.2 m\/s/)).toBeInTheDocument();
+  });
+
+  it("renders valueNode in place of value when provided", () => {
+    render(
+      <Chip
+        icon={Wind}
+        symbol="CG"
+        valueNode={<span data-testid="rich">rich</span>}
+      />,
+    );
+    expect(screen.getByTestId("rich")).toBeInTheDocument();
+  });
+
+  it("applies stale red colour to value when stale=true", () => {
+    const { container } = render(
+      <Chip icon={Wind} symbol="V_md" value="13.2" stale />,
+    );
+    const valueSpan = container.querySelector("span.text-red-400");
+    expect(valueSpan).not.toBeNull();
+  });
+
+  it("applies valueColorClassName when not stale", () => {
+    const { container } = render(
+      <Chip
+        icon={Wind}
+        symbol="e"
+        value="0.80"
+        valueColorClassName="text-emerald-400"
+      />,
+    );
+    expect(container.querySelector("span.text-emerald-400")).not.toBeNull();
+  });
+
+  it("stale overrides valueColorClassName", () => {
+    const { container } = render(
+      <Chip
+        icon={Wind}
+        symbol="e"
+        value="0.80"
+        valueColorClassName="text-emerald-400"
+        stale
+      />,
+    );
+    expect(container.querySelector("span.text-red-400")).not.toBeNull();
+    expect(container.querySelector("span.text-emerald-400")).toBeNull();
+  });
+
+  it("renders tooltip description", () => {
+    render(
+      <Chip
+        icon={Wind}
+        symbol="V_md"
+        value="13.2"
+        description="Minimum-drag speed"
+      />,
+    );
+    expect(screen.getByText("Minimum-drag speed")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run __tests__/Chip.test.tsx`
+Expected: FAIL — module `@/components/workbench/Chip` not found.
+
+- [ ] **Step 3: Create `Chip.tsx`**
+
+`frontend/components/workbench/Chip.tsx`:
+
+```tsx
+"use client";
+
+import { renderSymbol } from "@/components/workbench/renderSymbol";
+
+function humanize(symbol: string): string {
+  return symbol.replace(/_/g, " ");
+}
+
+export function Chip({
+  icon: Icon,
+  symbol,
+  value,
+  valueNode,
+  description,
+  stale = false,
+  valueColorClassName,
+}: {
+  readonly icon: React.ComponentType<{ size: number; className: string }>;
+  readonly symbol: string;
+  readonly value?: string;
+  readonly valueNode?: React.ReactNode;
+  readonly description?: string;
+  readonly stale?: boolean;
+  readonly valueColorClassName?: string;
+}) {
+  // Stale (recompute in flight) always wins over caller-supplied colour:
+  // the chip's value is provisional and that fact dominates any quality
+  // / traffic-light signal.
+  const valueClass = stale
+    ? "text-red-400"
+    : (valueColorClassName ?? "text-foreground");
+  const ariaLabel = description
+    ? `${humanize(symbol)}: ${description}`
+    : humanize(symbol);
+  return (
+    <div
+      role="group"
+      tabIndex={0}
+      aria-label={ariaLabel}
+      className="group/chip relative flex items-center gap-1.5 rounded-full bg-card-muted px-3 py-1.5 focus:outline-none focus-visible:ring-1 focus-visible:ring-primary"
+    >
+      <Icon size={12} className="text-muted-foreground" />
+      <span className="font-[family-name:var(--font-geist-sans)] text-[12px] text-foreground">
+        {renderSymbol(symbol)}
+        {" = "}
+        {valueNode ?? <span className={valueClass}>{value}</span>}
+      </span>
+      {description && (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute bottom-full left-1/2 z-50 mb-1.5 hidden w-max max-w-[240px] -translate-x-1/2 rounded-lg border border-border bg-card px-2.5 py-1.5 text-[10px] font-normal leading-snug text-foreground shadow-lg group-hover/chip:block group-focus-within/chip:block"
+        >
+          {description}
+        </span>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run: `cd frontend && npx vitest run __tests__/Chip.test.tsx`
+Expected: PASS, 6/6.
+
+- [ ] **Step 5: Migrate `InfoChipRow.tsx` to import the primitive**
+
+Remove lines 30-78 (`humanize` + `Chip` function definitions) from `InfoChipRow.tsx`. Add at top with the other imports:
+
+```tsx
+import { Chip } from "@/components/workbench/Chip";
+```
+
+Run: `cd frontend && npx vitest run __tests__/InfoChipRow.test.tsx`
+Expected: PASS (no behaviour change).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/components/workbench/Chip.tsx \
+        frontend/__tests__/Chip.test.tsx \
+        frontend/components/workbench/InfoChipRow.tsx
+git commit -m "refactor(gh-626): extract Chip primitive from InfoChipRow
+
+Adds valueColorClassName prop (stale takes priority). No behaviour
+change in InfoChipRow.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2 — Extend `ComputationContext` type
+
+**Files:**
+- Modify: `frontend/hooks/useComputationContext.ts:6-34`
+
+- [ ] **Step 1: Add the new fields to the interface**
+
+After line 25 (`aspect_ratio?: number | null;`) add:
+
+```ts
+  // gh-626: polar metrics surfaced in PolarChipRow.
+  cd0?: number | null;
+  e_oswald?: number | null;
+  e_oswald_quality?: "high" | "medium" | "low" | "unknown";
+  e_oswald_fallback_used?: boolean;
+  polar_by_config?: {
+    clean?: {
+      cd0?: number | null;
+      e_oswald?: number | null;
+      cl_max?: number | null;
+    };
+  } | null;
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: PASS (no new errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/hooks/useComputationContext.ts
+git commit -m "types(gh-626): extend ComputationContext with polar fields
+
+Adds cd0, e_oswald, e_oswald_quality, e_oswald_fallback_used,
+polar_by_config. All fields are optional — the runtime payload
+already includes them when the recompute has run.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3 — Pure polar helpers in `frontend/lib/polar.ts`
+
+**Files:**
+- Create: `frontend/lib/polar.ts`
+- Create: `frontend/__tests__/polar.test.ts`
+
+- [ ] **Step 1: Write the failing tests** (covers §13.A from the spec)
+
+`frontend/__tests__/polar.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  computeK,
+  computeCLmd,
+  computeEMax,
+  computeRho,
+  rhoThresholdsForProfile,
+  qualityColorClassName,
+  rhoColorClassName,
+} from "@/lib/polar";
+
+describe("polar.computeCLmd", () => {
+  it("matches √(π·e·AR·CD0)", () => {
+    const v = computeCLmd(0.02, 0.8, false, 7);
+    expect(v).toBeCloseTo(Math.sqrt(Math.PI * 0.8 * 7 * 0.02), 4);
+    expect(v).toBeCloseTo(0.5937, 3);
+  });
+  it("returns null when fit was rejected (ρ-bail rule)", () => {
+    expect(computeCLmd(0.02, 0.8, true, 7)).toBeNull();
+  });
+  it("returns null on each null/zero/negative input", () => {
+    expect(computeCLmd(null, 0.8, false, 7)).toBeNull();
+    expect(computeCLmd(0.02, null, false, 7)).toBeNull();
+    expect(computeCLmd(0.02, 0.8, false, null)).toBeNull();
+    expect(computeCLmd(0, 0.8, false, 7)).toBeNull();
+    expect(computeCLmd(0.02, 0, false, 7)).toBeNull();
+    expect(computeCLmd(0.02, 0.8, false, 0)).toBeNull();
+    expect(computeCLmd(-0.01, 0.8, false, 7)).toBeNull();
+  });
+});
+
+describe("polar.computeEMax", () => {
+  it("matches ½·√(π·e·AR/CD0)", () => {
+    const v = computeEMax(0.02, 0.8, false, 7);
+    expect(v).toBeCloseTo(0.5 * Math.sqrt((Math.PI * 0.8 * 7) / 0.02), 3);
+    expect(v).toBeCloseTo(13.213, 2);
+  });
+  it("ρ-bail when fit rejected", () => {
+    expect(computeEMax(0.02, 0.8, true, 7)).toBeNull();
+  });
+});
+
+describe("polar.computeRho", () => {
+  it("matches CD0·π·e·AR / CL_max²", () => {
+    const v = computeRho(0.02, 0.8, false, 7, 1.4);
+    expect(v).toBeCloseTo((0.02 * Math.PI * 0.8 * 7) / (1.4 * 1.4), 4);
+    expect(v).toBeCloseTo(0.180, 2);
+  });
+  it("identity ρ = (CL_md/CL_max)² (fuzz, 10 cases)", () => {
+    for (let i = 0; i < 10; i++) {
+      const cd0 = 0.005 + Math.random() * 0.04;
+      const e = 0.6 + Math.random() * 0.4;
+      const ar = 5 + Math.random() * 20;
+      const clMax = 0.8 + Math.random() * 1.0;
+      const rho = computeRho(cd0, e, false, ar, clMax)!;
+      const clMd = computeCLmd(cd0, e, false, ar)!;
+      expect(rho).toBeCloseTo((clMd / clMax) ** 2, 6);
+    }
+  });
+  it("ρ-bail when fit rejected", () => {
+    expect(computeRho(0.02, 0.8, true, 7, 1.4)).toBeNull();
+  });
+});
+
+describe("polar.computeK", () => {
+  it("matches 1/(π·e·AR)", () => {
+    expect(computeK(0.8, false, 7)).toBeCloseTo(
+      1 / (Math.PI * 0.8 * 7),
+      6,
+    );
+  });
+  it("ρ-bail when fit rejected", () => {
+    expect(computeK(0.8, true, 7)).toBeNull();
+  });
+});
+
+describe("polar.rhoThresholdsForProfile", () => {
+  it("powered uses { amber: 1/3, red: 1.0 }", () => {
+    expect(rhoThresholdsForProfile(false)).toEqual({
+      amber: 1 / 3,
+      red: 1.0,
+    });
+  });
+  it("glider uses { amber: 2/3, red: 1.0 }", () => {
+    expect(rhoThresholdsForProfile(true)).toEqual({
+      amber: 2 / 3,
+      red: 1.0,
+    });
+  });
+});
+
+describe("polar.qualityColorClassName", () => {
+  it.each([
+    ["high", "text-emerald-400"],
+    ["medium", "text-amber-400"],
+    ["low", "text-orange-400"],
+    ["unknown", "text-muted-foreground"],
+  ] as const)("%s → %s", (q, cls) => {
+    expect(qualityColorClassName(q)).toBe(cls);
+  });
+  it("undefined quality → muted (defensive)", () => {
+    expect(qualityColorClassName(undefined)).toBe("text-muted-foreground");
+  });
+});
+
+describe("polar.rhoColorClassName", () => {
+  it("null ρ → muted", () => {
+    expect(rhoColorClassName(null, false)).toBe("text-muted-foreground");
+  });
+  it("powered: ρ < 1/3 → emerald", () => {
+    expect(rhoColorClassName(0.2, false)).toBe("text-emerald-400");
+  });
+  it("powered: ρ = 1/3 → amber (lower-inclusive)", () => {
+    expect(rhoColorClassName(1 / 3, false)).toBe("text-amber-400");
+  });
+  it("powered: ρ ∈ (1/3, 1) → amber", () => {
+    expect(rhoColorClassName(0.5, false)).toBe("text-amber-400");
+  });
+  it("powered: ρ = 1 → red (upper-inclusive)", () => {
+    expect(rhoColorClassName(1.0, false)).toBe("text-red-400");
+  });
+  it("powered: ρ > 1 → red", () => {
+    expect(rhoColorClassName(1.2, false)).toBe("text-red-400");
+  });
+  it("glider: ρ = 1/3 → still emerald (under 2/3 amber)", () => {
+    expect(rhoColorClassName(1 / 3, true)).toBe("text-emerald-400");
+  });
+  it("glider: ρ = 2/3 → amber", () => {
+    expect(rhoColorClassName(2 / 3, true)).toBe("text-amber-400");
+  });
+  it("glider: ρ = 1 → red", () => {
+    expect(rhoColorClassName(1.0, true)).toBe("text-red-400");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx vitest run __tests__/polar.test.ts`
+Expected: FAIL — module `@/lib/polar` not found.
+
+- [ ] **Step 3: Implement helpers**
+
+`frontend/lib/polar.ts`:
+
+```ts
+/**
+ * Pure derivation helpers for the parabolic polar
+ * `C_D = C_D0 + C_L²/(π·e·AR)` — Anderson §6.7.2.
+ *
+ * The ρ-bail rule (gh-626 spec §8.5): when the AeroBuildup parabolic
+ * fit was rejected (`e_oswald_fallback_used = true`), the polar is
+ * NOT parabolic. Computing parabolic-polar metrics on it produces
+ * measurement-shaped non-measurements, so every derived helper here
+ * bails to `null` in that case.
+ */
+
+export type EQuality = "high" | "medium" | "low" | "unknown";
+
+export type RhoThresholds = { readonly amber: number; readonly red: number };
+
+function valid(...vs: (number | null | undefined)[]): boolean {
+  return vs.every((v) => v != null && v > 0);
+}
+
+/** k = 1/(π·e·AR). Returns null on fit rejection or invalid inputs. */
+export function computeK(
+  eFromCtx: number | null | undefined,
+  fallbackUsed: boolean,
+  ar: number | null | undefined,
+): number | null {
+  if (fallbackUsed) return null;
+  if (!valid(eFromCtx, ar)) return null;
+  return 1 / (Math.PI * (eFromCtx as number) * (ar as number));
+}
+
+/** C_L,md = √(π·e·AR·C_D0). Lift coefficient at maximum L/D. */
+export function computeCLmd(
+  cd0: number | null | undefined,
+  eFromCtx: number | null | undefined,
+  fallbackUsed: boolean,
+  ar: number | null | undefined,
+): number | null {
+  if (fallbackUsed) return null;
+  if (!valid(cd0, eFromCtx, ar)) return null;
+  return Math.sqrt(
+    Math.PI * (eFromCtx as number) * (ar as number) * (cd0 as number),
+  );
+}
+
+/** (L/D)_max = ½·√(π·e·AR / C_D0). Canonical Scholz polar-quality scalar. */
+export function computeEMax(
+  cd0: number | null | undefined,
+  eFromCtx: number | null | undefined,
+  fallbackUsed: boolean,
+  ar: number | null | undefined,
+): number | null {
+  if (fallbackUsed) return null;
+  if (!valid(cd0, eFromCtx, ar)) return null;
+  return (
+    0.5 *
+    Math.sqrt((Math.PI * (eFromCtx as number) * (ar as number)) / (cd0 as number))
+  );
+}
+
+/**
+ * Degeneracy ratio ρ = C_D0·π·e·AR / C_L,max² = (C_L,md / C_L,max)².
+ * Anderson §6.7.2 derivation: ρ=1 ⇔ V_md=V_stall, ρ=1/3 ⇔ V_min,sink=V_stall.
+ */
+export function computeRho(
+  cd0: number | null | undefined,
+  eFromCtx: number | null | undefined,
+  fallbackUsed: boolean,
+  ar: number | null | undefined,
+  clMax: number | null | undefined,
+): number | null {
+  if (fallbackUsed) return null;
+  if (!valid(cd0, eFromCtx, ar, clMax)) return null;
+  const e = eFromCtx as number;
+  const c = clMax as number;
+  return ((cd0 as number) * Math.PI * e * (ar as number)) / (c * c);
+}
+
+/** Profile-aware ρ traffic-light thresholds (Scholz §5.7 +  rev 2 decision 9). */
+export function rhoThresholdsForProfile(isGlider: boolean): RhoThresholds {
+  return isGlider ? { amber: 2 / 3, red: 1.0 } : { amber: 1 / 3, red: 1.0 };
+}
+
+/** Maps the backend's e-fit quality label to a Tailwind value-colour class. */
+export function qualityColorClassName(
+  quality: EQuality | undefined | null,
+): string {
+  switch (quality) {
+    case "high":
+      return "text-emerald-400";
+    case "medium":
+      return "text-amber-400";
+    case "low":
+      return "text-orange-400";
+    case "unknown":
+    default:
+      return "text-muted-foreground";
+  }
+}
+
+/** ρ traffic-light colour. Lower-inclusive boundaries. */
+export function rhoColorClassName(rho: number | null, isGlider: boolean): string {
+  if (rho == null) return "text-muted-foreground";
+  const { amber, red } = rhoThresholdsForProfile(isGlider);
+  if (rho >= red) return "text-red-400";
+  if (rho >= amber) return "text-amber-400";
+  return "text-emerald-400";
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd frontend && npx vitest run __tests__/polar.test.ts`
+Expected: PASS, all assertions green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/lib/polar.ts frontend/__tests__/polar.test.ts
+git commit -m "feat(gh-626): pure polar helpers (computeK/CLmd/EMax/Rho + colours)
+
+Derivation helpers from Anderson §6.7.2 parabolic polar:
+- computeK: k = 1/(π·e·AR)
+- computeCLmd: √(π·e·AR·CD0)
+- computeEMax: ½·√(π·e·AR/CD0) — canonical Scholz §5.7 polar quality
+- computeRho: CD0·π·e·AR / CL_max² = (CL_md/CL_max)²
+- rhoThresholdsForProfile: powered {1/3, 1.0} vs glider {2/3, 1.0}
+- qualityColorClassName / rhoColorClassName: Tailwind class mapping
+
+All derived helpers bail to null on fit rejection (ρ-bail rule,
+spec §8.5). 100% test coverage of derivation identities, bail rule,
+and boundary semantics.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4 — `SpeedChipRow.tsx` (Row 1 extraction)
+
+**Files:**
+- Create: `frontend/components/workbench/SpeedChipRow.tsx`
+- Create: `frontend/__tests__/SpeedChipRow.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+`frontend/__tests__/SpeedChipRow.test.tsx`:
+
+```tsx
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (p: Record<string, unknown>) => React.createElement("span", p);
+  return {
+    Wind: icon, AlertTriangle: icon, Plane: icon, Gauge: icon,
+    TrendingUp: icon, Zap: icon,
+  };
+});
+
+import { vi } from "vitest";
+import { SpeedChipRow } from "@/components/workbench/SpeedChipRow";
+
+describe("SpeedChipRow", () => {
+  const base = {
+    v_cruise_mps: 18.0,
+    v_stall_mps: 13.2,
+    v_md_mps: 17.0,
+    v_min_sink_mps: 14.5,
+    v_max_mps: 25.0,
+    v_a_mps: 19.0,
+    v_dive_mps: 35.0,
+    v_x_mps: 12.0,
+    v_y_mps: 15.5,
+    is_glider: false,
+  };
+
+  it("renders all V-speed chips when context complete", () => {
+    render(<SpeedChipRow ctx={base as any} isRecomputing={false} />);
+    expect(screen.getByText(/13\.2 m\/s/)).toBeInTheDocument();
+    expect(screen.getByText(/18\.0 m\/s/)).toBeInTheDocument();
+    expect(screen.getByText(/35\.0 m\/s/)).toBeInTheDocument();
+  });
+
+  it("uses V_cruise* symbol when ctx.v_cruise_auto", () => {
+    render(
+      <SpeedChipRow
+        ctx={{ ...base, v_cruise_auto: true } as any}
+        isRecomputing={false}
+      />,
+    );
+    // V_cruise* — asterisk visible in rendered subscript output
+    expect(screen.getByText((t) => t.includes("V"))).toBeTruthy();
+  });
+
+  it("hides V_a, V_max, V_dive when is_glider=true", () => {
+    render(
+      <SpeedChipRow
+        ctx={{ ...base, is_glider: true } as any}
+        isRecomputing={false}
+      />,
+    );
+    // V_a description should be absent.
+    expect(screen.queryByText(/manoeuvring/)).toBeNull();
+  });
+
+  it("shows dashes when ctx is null", () => {
+    render(<SpeedChipRow ctx={null} isRecomputing={false} />);
+    const dashes = screen.getAllByText("–");
+    expect(dashes.length).toBeGreaterThanOrEqual(6);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `cd frontend && npx vitest run __tests__/SpeedChipRow.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `SpeedChipRow.tsx`**
+
+```tsx
+"use client";
+
+import {
+  Wind, AlertTriangle, Plane, Gauge, TrendingUp, Zap,
+} from "lucide-react";
+import { Chip } from "@/components/workbench/Chip";
+import type { ComputationContext } from "@/hooks/useComputationContext";
+
+interface Props {
+  readonly ctx: ComputationContext | null | undefined;
+  readonly isRecomputing: boolean;
+  readonly rightSlot?: React.ReactNode;
+}
+
+function fmt(v: number | null | undefined, decimals: number, suffix = "") {
+  return v != null ? `${v.toFixed(decimals)}${suffix}` : "–";
+}
+
+export function SpeedChipRow({ ctx, isRecomputing, rightSlot }: Props) {
+  const stale = isRecomputing;
+  return (
+    <div
+      data-testid="chip-row-speeds"
+      className="flex flex-wrap items-center gap-2"
+    >
+      <Chip
+        icon={AlertTriangle}
+        symbol="V_stall"
+        description="Stall speed in clean configuration at 1 g"
+        value={fmt(ctx?.v_stall_mps, 1, " m/s")}
+        stale={stale}
+      />
+      <Chip
+        icon={Wind}
+        symbol="V_min_sink"
+        description="Speed for minimum sink rate — best endurance / longest glide time"
+        value={fmt(ctx?.v_min_sink_mps, 1, " m/s")}
+        stale={stale}
+      />
+      <Chip
+        icon={Wind}
+        symbol="V_md"
+        description="Minimum-drag speed — best L/D, longest glide distance"
+        value={fmt(ctx?.v_md_mps, 1, " m/s")}
+        stale={stale}
+      />
+      <Chip
+        icon={Wind}
+        symbol={ctx?.v_cruise_auto ? "V_cruise*" : "V_cruise"}
+        description={
+          ctx?.v_cruise_auto
+            ? "Design cruise speed (auto-derived from cruise sizing — asterisk)"
+            : "Design cruise speed"
+        }
+        value={fmt(ctx?.v_cruise_mps, 1, " m/s")}
+        stale={stale}
+      />
+      <Chip
+        icon={TrendingUp}
+        symbol="V_x"
+        description="Best angle-of-climb speed — steepest altitude gain per unit ground distance"
+        value={fmt(ctx?.v_x_mps, 1, " m/s")}
+        stale={stale}
+      />
+      <Chip
+        icon={Plane}
+        symbol="V_y"
+        description="Best rate-of-climb speed — fastest altitude gain per unit time"
+        value={fmt(ctx?.v_y_mps, 1, " m/s")}
+        stale={stale}
+      />
+      {!ctx?.is_glider && (
+        <Chip
+          icon={Gauge}
+          symbol="V_a"
+          description="Design manoeuvring speed — structural limit at full control deflection"
+          value={fmt(ctx?.v_a_mps, 1, " m/s")}
+          stale={stale}
+        />
+      )}
+      {!ctx?.is_glider && (
+        <Chip
+          icon={Gauge}
+          symbol="V_max"
+          description="Maximum operating speed"
+          value={fmt(ctx?.v_max_mps, 1, " m/s")}
+          stale={stale}
+        />
+      )}
+      {!ctx?.is_glider && (
+        <Chip
+          icon={Zap}
+          symbol="V_dive"
+          description="Design dive speed (heuristic: 1.4 × V_max)"
+          value={fmt(ctx?.v_dive_mps, 1, " m/s")}
+          stale={stale}
+        />
+      )}
+      <div className="flex-1" />
+      {rightSlot}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+Run: `cd frontend && npx vitest run __tests__/SpeedChipRow.test.tsx`
+Expected: PASS, 4/4.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/components/workbench/SpeedChipRow.tsx \
+        frontend/__tests__/SpeedChipRow.test.tsx
+git commit -m "refactor(gh-626): extract SpeedChipRow component
+
+Pure renderer of Row 1 (V_stall, V_min_sink, V_md, V_cruise(*),
+V_x, V_y, and is_glider-gated V_a/V_max/V_dive). Accepts rightSlot
+for the container to inject refresh + recomputing pill.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5 — `GeometryChipRow.tsx` (Row 2a + AR)
+
+**Files:**
+- Create: `frontend/components/workbench/GeometryChipRow.tsx`
+- Create: `frontend/__tests__/GeometryChipRow.test.tsx`
+
+- [ ] **Step 1: Failing test**
+
+`frontend/__tests__/GeometryChipRow.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (p: Record<string, unknown>) => React.createElement("span", p);
+  return { Square: icon, Ruler: icon, ArrowLeftRight: icon, Gauge: icon };
+});
+
+import { GeometryChipRow } from "@/components/workbench/GeometryChipRow";
+
+describe("GeometryChipRow", () => {
+  it("renders S_ref, MAC, B_ref, AR", () => {
+    render(
+      <GeometryChipRow
+        ctx={{
+          s_ref_m2: 0.4,
+          mac_m: 0.21,
+          b_ref_m: 2.0,
+          aspect_ratio: 10.0,
+        } as any}
+        isRecomputing={false}
+      />,
+    );
+    expect(screen.getByText(/0\.400 m²/)).toBeInTheDocument();
+    expect(screen.getByText(/0\.21 m/)).toBeInTheDocument();
+    expect(screen.getByText(/2\.00 m/)).toBeInTheDocument();
+    expect(screen.getByText(/10\.00$/)).toBeInTheDocument();
+  });
+
+  it("AR=null → '–'", () => {
+    render(
+      <GeometryChipRow
+        ctx={{ s_ref_m2: 0.4, mac_m: 0.21, b_ref_m: 2, aspect_ratio: null } as any}
+        isRecomputing={false}
+      />,
+    );
+    expect(screen.getAllByText("–").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("ctx=null → all dashes", () => {
+    render(<GeometryChipRow ctx={null} isRecomputing={false} />);
+    expect(screen.getAllByText("–").length).toBe(4);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify fail**
+
+Run: `cd frontend && npx vitest run __tests__/GeometryChipRow.test.tsx`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```tsx
+"use client";
+
+import { Square, Ruler, ArrowLeftRight, Gauge } from "lucide-react";
+import { Chip } from "@/components/workbench/Chip";
+import type { ComputationContext } from "@/hooks/useComputationContext";
+
+interface Props {
+  readonly ctx: ComputationContext | null | undefined;
+  readonly isRecomputing: boolean;
+}
+
+function fmt(v: number | null | undefined, decimals: number, suffix = "") {
+  return v != null ? `${v.toFixed(decimals)}${suffix}` : "–";
+}
+
+export function GeometryChipRow({ ctx, isRecomputing }: Props) {
+  const stale = isRecomputing;
+  return (
+    <div
+      data-testid="chip-row-geometry"
+      className="flex flex-wrap items-center gap-2"
+    >
+      <Chip
+        icon={Square}
+        symbol="S_ref"
+        description="Reference area — projected wing area used to non-dimensionalize forces (C_L = L / (q · S_ref))"
+        value={fmt(ctx?.s_ref_m2, 3, " m²")}
+        stale={stale}
+      />
+      <Chip
+        icon={Ruler}
+        symbol="MAC"
+        description="Mean Aerodynamic Chord (= C_ref in AVL/ASB) — reference chord for pitching moment coefficient"
+        value={fmt(ctx?.mac_m, 2, " m")}
+        stale={stale}
+      />
+      <Chip
+        icon={ArrowLeftRight}
+        symbol="B_ref"
+        description="Reference span — wingspan used to non-dimensionalize roll and yaw moments"
+        value={fmt(ctx?.b_ref_m, 2, " m")}
+        stale={stale}
+      />
+      <Chip
+        icon={Gauge}
+        symbol="AR"
+        description="Aspect ratio = b² / S_ref (main wing). Higher AR ⇒ less induced drag."
+        value={fmt(ctx?.aspect_ratio, 2)}
+        stale={stale}
+      />
+      <div className="flex-1" />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+Run: `cd frontend && npx vitest run __tests__/GeometryChipRow.test.tsx`
+Expected: PASS, 3/3.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/components/workbench/GeometryChipRow.tsx \
+        frontend/__tests__/GeometryChipRow.test.tsx
+git commit -m "feat(gh-626): GeometryChipRow with S_ref, MAC, B_ref, AR
+
+AR chip is new (gh-626); the other three are migrated from Row 2.
+Pure renderer, no SWR.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6 — `StabilityChipRow.tsx` (NP, SM, CG)
+
+**Files:**
+- Create: `frontend/components/workbench/StabilityChipRow.tsx`
+- Create: `frontend/__tests__/StabilityChipRow.test.tsx`
+
+- [ ] **Step 1: Failing test**
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (p: Record<string, unknown>) => React.createElement("span", p);
+  return { Target: icon, Navigation: icon };
+});
+
+import { StabilityChipRow } from "@/components/workbench/StabilityChipRow";
+
+describe("StabilityChipRow", () => {
+  it("renders NP, SM, CG", () => {
+    render(
+      <StabilityChipRow
+        ctx={{
+          x_np_m: 0.085,
+          target_static_margin: 0.12,
+          cg_agg_m: 0.092,
+          mac_m: 0.21,
+        } as any}
+        cgAero={0.073}
+        isRecomputing={false}
+      />,
+    );
+    expect(screen.getByText(/0\.085 m/)).toBeInTheDocument();
+    expect(screen.getByText(/12%/)).toBeInTheDocument();
+    expect(screen.getByText(/0\.073 m/)).toBeInTheDocument();
+  });
+
+  it("ctx=null → dashes", () => {
+    render(<StabilityChipRow ctx={null} cgAero={null} isRecomputing={false} />);
+    expect(screen.getAllByText("–").length).toBeGreaterThanOrEqual(3);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd frontend && npx vitest run __tests__/StabilityChipRow.test.tsx`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```tsx
+"use client";
+
+import { Target, Navigation } from "lucide-react";
+import { Chip } from "@/components/workbench/Chip";
+import { cgDivergenceColor } from "./stability-overlay/divergence-color";
+import type { ComputationContext } from "@/hooks/useComputationContext";
+
+interface Props {
+  readonly ctx: ComputationContext | null | undefined;
+  readonly cgAero: number | null;
+  readonly isRecomputing: boolean;
+  readonly rightSlot?: React.ReactNode;
+}
+
+function fmt(v: number | null | undefined, decimals: number, suffix = "") {
+  return v != null ? `${v.toFixed(decimals)}${suffix}` : "–";
+}
+
+export function StabilityChipRow({ ctx, cgAero, isRecomputing, rightSlot }: Props) {
+  const stale = isRecomputing;
+  const cgValue = cgAero != null ? `${cgAero.toFixed(3)} m` : "–";
+  const cgDescription =
+    "Centre of gravity — aerodynamic balance value; component-derived value in parentheses when available";
+  const cgValueNode = (
+    <>
+      <span className={stale ? "text-red-400" : ""}>{cgValue}</span>
+      {cgAero != null && ctx?.cg_agg_m != null && ctx?.mac_m != null && (
+        <span
+          className={`ml-1 ${
+            stale
+              ? "text-red-400"
+              : cgDivergenceColor(cgAero, ctx.cg_agg_m, ctx.mac_m)
+          }`}
+        >
+          ({ctx.cg_agg_m.toFixed(3)})
+        </span>
+      )}
+    </>
+  );
+
+  return (
+    <div
+      data-testid="chip-row-stability"
+      className="flex flex-wrap items-center gap-2"
+    >
+      <Chip
+        icon={Target}
+        symbol="NP"
+        description="Neutral point — aerodynamic centre of the whole aircraft"
+        value={fmt(ctx?.x_np_m, 3, " m")}
+        stale={stale}
+      />
+      <Chip
+        icon={Navigation}
+        symbol="SM"
+        description="Static margin = (NP − CG) / MAC — target value used for trim balancing"
+        value={
+          ctx?.target_static_margin != null
+            ? (ctx.target_static_margin * 100).toFixed(0) + "%"
+            : "–"
+        }
+        stale={stale}
+      />
+      <Chip
+        icon={Navigation}
+        symbol="CG"
+        description={cgDescription}
+        valueNode={cgValueNode}
+        stale={stale}
+      />
+      <div className="flex-1" />
+      {rightSlot}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `cd frontend && npx vitest run __tests__/StabilityChipRow.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/components/workbench/StabilityChipRow.tsx \
+        frontend/__tests__/StabilityChipRow.test.tsx
+git commit -m "refactor(gh-626): extract StabilityChipRow component
+
+Pure renderer of NP, SM, CG (with cg_agg divergence colour). Migrated
+from InfoChipRow Row 2 lines 272-296.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7 — `PolarChipRow.tsx` (the new content)
+
+**Files:**
+- Create: `frontend/components/workbench/PolarChipRow.tsx`
+- Create: `frontend/__tests__/PolarChipRow.test.tsx`
+
+- [ ] **Step 1: Failing test** (spec §13.B)
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (p: Record<string, unknown>) => React.createElement("span", p);
+  return {
+    Wind: icon, Gauge: icon, Activity: icon,
+    Target: icon, TrendingUp: icon, AlertTriangle: icon,
+  };
+});
+
+import { PolarChipRow } from "@/components/workbench/PolarChipRow";
+
+// Healthy powered fixture: CD0=0.02, e=0.80, AR=7, CL_max=1.4
+// → ρ ≈ 0.180 emerald
+const HEALTHY = {
+  reynolds: 540000,
+  cd0: 0.02,
+  e_oswald: 0.80,
+  e_oswald_quality: "high" as const,
+  e_oswald_fallback_used: false,
+  aspect_ratio: 7,
+  polar_by_config: { clean: { cl_max: 1.4 } },
+  is_glider: false,
+};
+
+// Sailplane: CD0=0.008, e=0.95, AR=36, CL_max=1.5, is_glider=true
+// → ρ ≈ 0.382 — would be amber on powered thresholds, emerald on glider
+const SAILPLANE = {
+  reynolds: 1.2e6,
+  cd0: 0.008,
+  e_oswald: 0.95,
+  e_oswald_quality: "high" as const,
+  e_oswald_fallback_used: false,
+  aspect_ratio: 36,
+  polar_by_config: { clean: { cl_max: 1.5 } },
+  is_glider: true,
+};
+
+// Fit-rejected (gh-625 reproduction): e_oswald_fallback_used=true
+const REJECTED = {
+  reynolds: 230000,
+  cd0: 0.04,
+  e_oswald: null,
+  e_oswald_quality: "unknown" as const,
+  e_oswald_fallback_used: true,
+  aspect_ratio: 6,
+  polar_by_config: { clean: { cl_max: 1.0 } },
+  is_glider: false,
+};
+
+describe("PolarChipRow", () => {
+  it("healthy powered: all 8 chips populated, ρ emerald", () => {
+    const { container } = render(
+      <PolarChipRow ctx={HEALTHY as any} isRecomputing={false} />,
+    );
+    expect(screen.getByText(/5\.4e\+?5/)).toBeInTheDocument(); // Re
+    expect(screen.getByText(/0\.0200$/)).toBeInTheDocument();  // CD0
+    expect(screen.getByText(/0\.80$/)).toBeInTheDocument();    // e
+    expect(screen.getByText(/0\.0568$/)).toBeInTheDocument();  // k = 1/(π·0.8·7)
+    expect(screen.getByText(/0\.59$/)).toBeInTheDocument();    // C_L,md
+    expect(screen.getByText(/1\.40$/)).toBeInTheDocument();    // C_L,max
+    expect(screen.getByText(/13\.2$/)).toBeInTheDocument();    // (L/D)_max
+    expect(screen.getByText(/0\.18$/)).toBeInTheDocument();    // ρ
+    expect(container.querySelector(".text-emerald-400")).not.toBeNull();
+  });
+
+  it("sailplane: ρ ≈ 0.38 → emerald under glider thresholds (would be amber powered)", () => {
+    const { container } = render(
+      <PolarChipRow ctx={SAILPLANE as any} isRecomputing={false} />,
+    );
+    expect(screen.getByText(/0\.38$/)).toBeInTheDocument();
+    // ρ chip uses emerald (glider amber threshold = 2/3)
+    // Locate the ρ value span and check its colour.
+    const rho = screen.getByText(/0\.38$/);
+    expect(rho.className).toContain("text-emerald-400");
+  });
+
+  it("powered amber lower boundary (ρ = 1/3) → amber", () => {
+    // Need CD0·π·e·AR / CL_max² = 1/3 exactly.
+    // Pick CD0=1/(3·π·0.8·7)·1² ≈ 0.0189 with CL_max=1.0 e=0.8 AR=7.
+    const ctx = {
+      ...HEALTHY,
+      cd0: 1 / (3 * Math.PI * 0.8 * 7),
+      polar_by_config: { clean: { cl_max: 1.0 } },
+    };
+    render(<PolarChipRow ctx={ctx as any} isRecomputing={false} />);
+    const rho = screen.getByText(/0\.33$/);
+    expect(rho.className).toContain("text-amber-400");
+  });
+
+  it("powered red boundary (ρ = 1.00) → red", () => {
+    const ctx = {
+      ...HEALTHY,
+      cd0: 1.0 / (Math.PI * 0.8 * 7),  // → ρ = 1.0 exactly with CL_max=1
+      polar_by_config: { clean: { cl_max: 1.0 } },
+    };
+    render(<PolarChipRow ctx={ctx as any} isRecomputing={false} />);
+    const rho = screen.getByText(/^1\.00$/);
+    expect(rho.className).toContain("text-red-400");
+  });
+
+  it("glider amber lower boundary (ρ = 2/3, is_glider=true) → amber", () => {
+    const ctx = {
+      ...SAILPLANE,
+      cd0: (2 / 3) / (Math.PI * 0.95 * 36),  // → ρ = 2/3 with CL_max=1.0
+      polar_by_config: { clean: { cl_max: 1.0 } },
+    };
+    render(<PolarChipRow ctx={ctx as any} isRecomputing={false} />);
+    const rho = screen.getByText(/0\.67$/);
+    expect(rho.className).toContain("text-amber-400");
+  });
+
+  it("quality matrix on e: high/medium/low/unknown → emerald/amber/orange/muted", () => {
+    const colours = {
+      high: "text-emerald-400",
+      medium: "text-amber-400",
+      low: "text-orange-400",
+      unknown: "text-muted-foreground",
+    } as const;
+    for (const [q, cls] of Object.entries(colours)) {
+      const ctx = { ...HEALTHY, e_oswald_quality: q };
+      const { container, unmount } = render(
+        <PolarChipRow ctx={ctx as any} isRecomputing={false} />,
+      );
+      const eSpan = container.querySelector(`span.${cls.replace("text-", "")}`);
+      // Not all colour classes turn into clean selectors via classList; do a
+      // broader assert instead.
+      expect(container.innerHTML).toContain(cls);
+      unmount();
+    }
+  });
+
+  it("#625 reproduction: e* muted + k/CLmd/EMax/ρ all '–'", () => {
+    const { container } = render(
+      <PolarChipRow ctx={REJECTED as any} isRecomputing={false} />,
+    );
+    expect(container.innerHTML).toContain("V_cruise*".charAt(0)); // sanity
+    // e* renders with the muted class:
+    expect(container.innerHTML).toContain("text-muted-foreground");
+    // The four derived chips render '–'
+    expect(screen.getAllByText("–").length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("each null input nukes its dependents", () => {
+    const variants = [
+      { ...HEALTHY, cd0: null },
+      { ...HEALTHY, aspect_ratio: null },
+      { ...HEALTHY, polar_by_config: { clean: { cl_max: null } } },
+    ];
+    for (const ctx of variants) {
+      const { container, unmount } = render(
+        <PolarChipRow ctx={ctx as any} isRecomputing={false} />,
+      );
+      // ρ should always be '–' here.
+      const dashes = screen.getAllByText("–");
+      expect(dashes.length).toBeGreaterThanOrEqual(1);
+      unmount();
+    }
+  });
+
+  it("ctx=null → all '–'", () => {
+    render(<PolarChipRow ctx={null} isRecomputing={false} />);
+    expect(screen.getAllByText("–").length).toBeGreaterThanOrEqual(7);
+  });
+
+  it("ρ-red tooltip prescribes 'see Matching Chart'", () => {
+    const ctx = {
+      ...HEALTHY,
+      cd0: 1.0 / (Math.PI * 0.8 * 7),
+      polar_by_config: { clean: { cl_max: 1.0 } },
+    };
+    render(<PolarChipRow ctx={ctx as any} isRecomputing={false} />);
+    expect(screen.getByText(/see Matching Chart/i)).toBeInTheDocument();
+  });
+
+  it("(L/D)_max tooltip contains 'headline polar number'", () => {
+    render(<PolarChipRow ctx={HEALTHY as any} isRecomputing={false} />);
+    expect(screen.getByText(/headline polar number/i)).toBeInTheDocument();
+  });
+
+  it("bail-rule tooltip contains 'non-parabolic'", () => {
+    render(<PolarChipRow ctx={REJECTED as any} isRecomputing={false} />);
+    expect(screen.getByText(/non-parabolic/i)).toBeInTheDocument();
+  });
+
+  it("isRecomputing=true overrides colours with stale red", () => {
+    const { container } = render(
+      <PolarChipRow ctx={HEALTHY as any} isRecomputing={true} />,
+    );
+    expect(container.innerHTML).toContain("text-red-400");
+    // Emerald should NOT be present on the values because stale wins.
+    // (The emerald may still appear elsewhere, but the ρ value span is red.)
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd frontend && npx vitest run __tests__/PolarChipRow.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `PolarChipRow.tsx`**
+
+```tsx
+"use client";
+
+import { Wind, Gauge, Activity, Target, TrendingUp, AlertTriangle } from "lucide-react";
+import { Chip } from "@/components/workbench/Chip";
+import {
+  computeK, computeCLmd, computeEMax, computeRho,
+  qualityColorClassName, rhoColorClassName,
+} from "@/lib/polar";
+import type { ComputationContext } from "@/hooks/useComputationContext";
+
+interface Props {
+  readonly ctx: ComputationContext | null | undefined;
+  readonly isRecomputing: boolean;
+}
+
+function fmt(v: number | null, decimals: number, suffix = "") {
+  return v != null ? `${v.toFixed(decimals)}${suffix}` : "–";
+}
+function fmtRe(v: number | null | undefined) {
+  return v == null ? "–" : v.toExponential(1);
+}
+
+const BAIL_TOOLTIP =
+  "Parabolic polar fit was rejected (see e*). Derived polar quantities are not meaningful when the polar is non-parabolic.";
+
+function rhoTooltip(rho: number | null, isGlider: boolean): string {
+  if (rho == null) return BAIL_TOOLTIP;
+  const intuitiveForm = " ρ = (C_L,md/C_L,max)²";
+  if (rho >= 1.0) {
+    return (
+      "Polar health: L/D-max coincident with or past stall — polar is degenerate. " +
+      "Resize wing: raise AR or improve C_L,max — see Matching Chart." +
+      intuitiveForm
+    );
+  }
+  const amber = isGlider ? 2 / 3 : 1 / 3;
+  if (rho >= amber) {
+    return isGlider
+      ? "Polar health: tightening sailplane optimum. Still healthy for glider regime." +
+          intuitiveForm
+      : "Polar health: min-sink point at/below stall. L/D-max still reachable. " +
+          "Consider raising AR or lowering W/S — see Matching Chart." +
+          intuitiveForm;
+  }
+  return (
+    "Polar health: healthy. L/D-max sits comfortably above stall." + intuitiveForm
+  );
+}
+
+export function PolarChipRow({ ctx, isRecomputing }: Props) {
+  const stale = isRecomputing;
+
+  const cd0 = ctx?.cd0 ?? null;
+  const eFromCtx = ctx?.e_oswald ?? null;
+  const fallbackUsed = !!ctx?.e_oswald_fallback_used;
+  const ar = ctx?.aspect_ratio ?? null;
+  const clMax = ctx?.polar_by_config?.clean?.cl_max ?? null;
+  const isGlider = !!ctx?.is_glider;
+  const quality = ctx?.e_oswald_quality ?? "unknown";
+
+  const k = computeK(eFromCtx, fallbackUsed, ar);
+  const clMd = computeCLmd(cd0, eFromCtx, fallbackUsed, ar);
+  const eMax = computeEMax(cd0, eFromCtx, fallbackUsed, ar);
+  const rho = computeRho(cd0, eFromCtx, fallbackUsed, ar, clMax);
+
+  // The displayed e-value: when fallback used, show the fallback 0.80
+  // explicitly with the asterisk marker; otherwise show the real fit
+  // value. Both render with the quality colour (fallback ⇒ unknown ⇒ muted).
+  const eDisplayValue =
+    fallbackUsed ? 0.80 : eFromCtx;
+  const eSymbol = fallbackUsed ? "e*" : "e";
+  const eTooltip = fallbackUsed
+    ? "Polar fit was rejected — fallback 0.80 used (regime-naive). All derived polar quantities (k, C_L,md, L/D-max, ρ) are therefore suppressed."
+    : "Oswald efficiency — combined non-elliptical-lift-distribution loss and parasite-drag-with-lift. Typical 0.70–0.95. Colour reflects fit quality.";
+  const eQualityColour = fallbackUsed
+    ? qualityColorClassName("unknown")
+    : qualityColorClassName(quality);
+
+  return (
+    <div
+      data-testid="chip-row-polar"
+      className="flex flex-wrap items-center gap-2"
+    >
+      <Chip
+        icon={Wind}
+        symbol="Re"
+        description="Reynolds number at cruise (characteristic length = MAC). Polar shape is Re-dependent; this row's metrics describe cruise-Re behaviour."
+        value={fmtRe(ctx?.reynolds)}
+        stale={stale}
+      />
+      <Chip
+        icon={Gauge}
+        symbol="C_D0"
+        description="Zero-lift drag coefficient (parasite drag). Lower is better. ρ uses this together with e and AR. Source: stability run (single-CL eval)."
+        value={fmt(cd0, 4)}
+        stale={stale}
+      />
+      <Chip
+        icon={Activity}
+        symbol={eSymbol}
+        description={eTooltip}
+        value={fmt(eDisplayValue, 2)}
+        valueColorClassName={eQualityColour}
+        stale={stale}
+      />
+      <Chip
+        icon={Activity}
+        symbol="k"
+        description={k == null
+          ? BAIL_TOOLTIP
+          : "Induced-drag factor k = 1/(πeAR). Drag rises as k·C_L². Lower k = less induced drag at the same lift."}
+        value={fmt(k, 4)}
+        stale={stale}
+      />
+      <Chip
+        icon={Target}
+        symbol="C_L,md"
+        description={clMd == null
+          ? BAIL_TOOLTIP
+          : "Lift coefficient where L/D is maximum (best glide). Should sit well below C_L,max. If C_L,md ≥ C_L,max your wing must stall to reach best glide."}
+        value={fmt(clMd, 2)}
+        stale={stale}
+      />
+      <Chip
+        icon={AlertTriangle}
+        symbol="C_L,max"
+        description="Maximum lift coefficient (clean configuration, no flaps). From AeroBuildup — known to underestimate at Re < 3×10⁵; treat as conservative for RC."
+        value={fmt(clMax, 2)}
+        stale={stale}
+      />
+      <Chip
+        icon={TrendingUp}
+        symbol="(L/D)_max"
+        description={eMax == null
+          ? BAIL_TOOLTIP
+          : "Maximum lift-to-drag ratio. The headline polar number. Sailplane > 30 · GA 10–18 · jet transport 16–22 · trainer 8–12. Formula: ½·√(πeAR/C_D0)."}
+        value={fmt(eMax, 1)}
+        stale={stale}
+      />
+      <Chip
+        icon={Gauge}
+        symbol="ρ"
+        description={rhoTooltip(rho, isGlider)}
+        value={fmt(rho, 2)}
+        valueColorClassName={rhoColorClassName(rho, isGlider)}
+        stale={stale}
+      />
+      <div className="flex-1" />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `cd frontend && npx vitest run __tests__/PolarChipRow.test.tsx`
+Expected: PASS, all assertions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/components/workbench/PolarChipRow.tsx \
+        frontend/__tests__/PolarChipRow.test.tsx
+git commit -m "feat(gh-626): PolarChipRow with ρ-bail rule + profile thresholds
+
+Eight chips: Re, C_D0, e*, k, C_L,md, C_L,max, (L/D)_max, ρ. All
+derived chips bail to '–' when e_oswald_fallback_used=true. ρ uses
+profile-aware thresholds (powered 1/3 vs glider 2/3). Tooltips are
+consequence-first with Matching-Chart prescription on red.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8 — Slim `InfoChipRow.tsx` to a container + wire `PolarChipRow`
+
+**Files:**
+- Modify: `frontend/components/workbench/InfoChipRow.tsx` (replace bulk of file)
+- Modify: `frontend/__tests__/InfoChipRow.test.tsx` (keep container-level tests, remove migrated assertions)
+
+- [ ] **Step 1: Replace InfoChipRow body with container**
+
+`frontend/components/workbench/InfoChipRow.tsx` (full replacement):
+
+```tsx
+"use client";
+
+import { Loader2, RefreshCw } from "lucide-react";
+import { useComputationContext } from "@/hooks/useComputationContext";
+import { SpeedChipRow } from "@/components/workbench/SpeedChipRow";
+import { GeometryChipRow } from "@/components/workbench/GeometryChipRow";
+import { PolarChipRow } from "@/components/workbench/PolarChipRow";
+import { StabilityChipRow } from "@/components/workbench/StabilityChipRow";
+import { TaillessBanner } from "./TaillessBanner";
+
+interface Props {
+  readonly aeroplaneId: string | null;
+  readonly cgAero: number | null;
+  readonly isRecomputing?: boolean;
+  readonly rightSlot?: React.ReactNode;
+}
+
+export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: Props) {
+  const { data: ctx, mutate } = useComputationContext(aeroplaneId, { isRecomputing });
+  const recomputing = !!isRecomputing;
+  const isTailless = !!ctx?.is_tailless;
+
+  const refreshSlot = (
+    <>
+      {recomputing && (
+        <span
+          className="flex items-center gap-1 rounded-full bg-orange-500/15 px-2 py-1 text-[11px] text-orange-400"
+          data-testid="recomputing-chip"
+        >
+          <Loader2 size={11} className="animate-spin" />
+          Recomputing…
+        </span>
+      )}
+      <button
+        type="button"
+        aria-label="Refresh computation context"
+        onClick={() => mutate()}
+        disabled={recomputing}
+        className="flex items-center gap-1 rounded-full bg-card-muted px-2.5 py-1.5 text-muted-foreground hover:bg-muted hover:text-foreground focus:outline-none focus-visible:ring-1 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <RefreshCw size={12} />
+      </button>
+    </>
+  );
+
+  return (
+    <div className="flex flex-col gap-2 border-t border-border bg-card px-4 py-3">
+      {isTailless && (
+        <div className="flex">
+          <TaillessBanner />
+        </div>
+      )}
+      <SpeedChipRow ctx={ctx} isRecomputing={recomputing} rightSlot={refreshSlot} />
+      <GeometryChipRow ctx={ctx} isRecomputing={recomputing} />
+      <PolarChipRow ctx={ctx} isRecomputing={recomputing} />
+      <StabilityChipRow
+        ctx={ctx}
+        cgAero={cgAero}
+        isRecomputing={recomputing}
+        rightSlot={rightSlot}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Run existing test, verify still passes**
+
+Run: `cd frontend && npx vitest run __tests__/InfoChipRow.test.tsx`
+Expected: Most cases still pass. Some may fail (e.g. multi-row dash counts) because the row count changed. **Update the existing test** to assert four `data-testid` rows present and at least one expected chip value renders.
+
+Add a test:
+
+```tsx
+it("renders four chip rows in order: speeds / geometry / polar / stability", async () => {
+  (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
+    data: { v_cruise_mps: 18, reynolds: 5.4e5, mac_m: 0.21, x_np_m: 0.085,
+            target_static_margin: 0.12, cg_agg_m: 0.092, s_ref_m2: 0.4,
+            aspect_ratio: 7, cd0: 0.02, e_oswald: 0.8,
+            e_oswald_quality: "high", e_oswald_fallback_used: false,
+            polar_by_config: { clean: { cl_max: 1.4 } }, is_glider: false },
+    isLoading: false, error: null, mutate: vi.fn(),
+  });
+
+  const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
+  const { container } = render(<InfoChipRow aeroplaneId="42" cgAero={0.073} />);
+
+  expect(container.querySelector('[data-testid="chip-row-speeds"]')).not.toBeNull();
+  expect(container.querySelector('[data-testid="chip-row-geometry"]')).not.toBeNull();
+  expect(container.querySelector('[data-testid="chip-row-polar"]')).not.toBeNull();
+  expect(container.querySelector('[data-testid="chip-row-stability"]')).not.toBeNull();
+});
+```
+
+Adjust the existing `"shows dashes when no context"` test if the dash count assertion is too strict. The current minimum-4-dashes assertion should be raised to ≥ 10 (more chips now).
+
+Run: `cd frontend && npx vitest run __tests__/InfoChipRow.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 3: Run full frontend unit suite**
+
+Run: `cd frontend && npm run test:unit`
+Expected: All passing.
+
+- [ ] **Step 4: Verify line count of InfoChipRow.tsx ≤ 80**
+
+Run: `wc -l frontend/components/workbench/InfoChipRow.tsx`
+Expected: ≤ 80.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/components/workbench/InfoChipRow.tsx \
+        frontend/__tests__/InfoChipRow.test.tsx
+git commit -m "refactor(gh-626): InfoChipRow becomes thin container
+
+InfoChipRow now orchestrates four sibling row components and owns
+the refresh button + recomputing pill. Down from 302 lines to <80.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9 — Verification against acceptance criteria
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cd frontend && npm run test:unit`
+Expected: All tests green.
+
+- [ ] **Step 2: Run TypeScript compile**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 3: Run lint**
+
+Run: `cd frontend && npm run lint`
+Expected: No new warnings.
+
+- [ ] **Step 4: Verify ACs §12.A (Structural)**
+
+- `wc -l frontend/components/workbench/InfoChipRow.tsx` ≤ 80 ✓
+- Six new files exist: `Chip.tsx`, `SpeedChipRow.tsx`, `GeometryChipRow.tsx`, `PolarChipRow.tsx`, `StabilityChipRow.tsx`, `lib/polar.ts` ✓
+- Six new test files exist ✓
+- AR chip present in `GeometryChipRow.tsx` (grep) ✓
+
+- [ ] **Step 5: Verify ACs §12.B (Diagnostic value) via test output**
+
+The relevant test cases (already in §13.A/13.B) cover:
+- derivation identities ✓
+- powered traffic-light boundaries ✓
+- glider traffic-light boundaries ✓
+- healthy fixture ✓
+- sailplane no-false-alarm ✓
+- #625 reproduction ✓
+- empty context ✓
+
+- [ ] **Step 6: Verify ACs §12.C (Behaviour) via test output**
+
+- fallback marker test passes ✓
+- gliders show polar chips (negative assertion: no `is_glider` hide in PolarChipRow source — grep) ✓
+- isRecomputing stale red test passes ✓
+- ρ red tooltip "see Matching Chart" test passes ✓
+- `npm run test:unit` passes ✓
+
+- [ ] **Step 7: Visual verification in browser**
+
+Start the backend and frontend, browse to the workbench with an aeroplane that has run a recompute. Confirm the four chip rows render in order, the Polar row shows the eight chips, and at least the ρ chip shows traffic-light colouring.
+
+```bash
+# Backend (in a separate terminal):
+poetry run uvicorn app.main:app --port 8001 --reload
+
+# Frontend (in another terminal):
+cd frontend && npm run dev
+
+# Visit http://localhost:3000/workbench/<aeroplane-id>
+```
+
+Take a screenshot for the PR description.
+
+- [ ] **Step 8: Final commit & push**
+
+```bash
+git push -u github feat/gh-626-polar-metrics-chip-row
+```
+
+PR title: `feat(gh-626): polar metrics chip-row — eight chips + ρ-bail + profile thresholds`. Body references the spec doc and lists the spec's acceptance criteria as a checklist.
+
+---
+
+## Self-Review
+
+1. **Spec coverage:** every §-numbered chip and every §12 AC has a corresponding task or step. The ρ-bail rule (§8.5) is in `polar.ts` and tested in §13.A-7. Profile thresholds (§8.4) are in `rhoThresholdsForProfile` + tested at boundaries. Tooltip text is asserted via test cases (§13.B-18). ✓
+2. **Placeholder scan:** no TBD/TODO/"implement later" — every step has the actual code. ✓
+3. **Type consistency:** helper signatures (`computeRho(cd0, eFromCtx, fallbackUsed, ar, clMax)`) are identical across `polar.ts` definition, `polar.test.ts` imports, and `PolarChipRow.tsx` usage. ✓
+4. **Ambiguity:** the ρ-bail rule lives in the helpers themselves (not in the component), so any future caller automatically inherits the bail behaviour. ✓

--- a/docs/superpowers/specs/2026-05-23-polar-metrics-chip-row-design.md
+++ b/docs/superpowers/specs/2026-05-23-polar-metrics-chip-row-design.md
@@ -1,102 +1,159 @@
 # Polar metrics in the Workbench Chip-Row — design
 
-**Date:** 2026-05-23
+**Date:** 2026-05-23 (rev 2)
 **Status:** Draft (pending user review)
 **Type:** Frontend feature
-**Brainstorm transcript:** in-session, 2026-05-22 / 2026-05-23
+**GitHub issue:** #626
+**Reviewers (rev 1):**
+- `aerodynamics-expert` (Anderson §6.7.2) — *"Approve with minor changes"*; flagged 2 correctness items + 2 missing-physics items + minors.
+- `aircraft-design-scholz` (Scholz §5.7 / Sadraey §4) — *"Revise and re-review"*; flagged missing canonical figure of merit, weak design utility, profile-naive thresholds, weak ACs.
+
+Rev 2 addresses all 15 findings from those two reviews.
 
 ## 1 · Motivation
 
-The Mission Tab investigation on 2026-05-22 (see GitHub issue #625) surfaced a
-recurring difficulty: a user cannot tell from the workbench whether their
-*aerodynamic polar* is healthy or degenerate. Two symptoms today expose this
-gap:
+The Mission Tab investigation on 2026-05-22 (GitHub #625) showed that the
+workbench provides no quick way to tell whether an aircraft's polar is
+healthy or degenerate. The four governing scalars — `C_D0`, `e_oswald`,
+`AR`, `C_L,max` — are computed and cached in
+`assumption_computation_context` but never surfaced in the chip strip.
+Two downstream symptoms expose the gap:
 
-1. The Mission radar Ist polygon collapses on aircraft whose polar is
-   degenerate — `glide` and `climb` come back missing because
-   `_fit_parabolic_polar` rejected the OLS fit (`assumption_compute_service.py
-   :924-1032`).
-2. The V-speed chip-row reports physically impossible relationships
-   (`V_min,sink < V_stall`, `V_md == V_stall`) because the closed-form speeds
-   do not clamp to `V_stall` (tracked as Bug C in #625) — but the underlying
-   *cause* (a degenerate polar) is invisible to the user.
+1. The Mission radar `glide` and `climb` axes come back missing on
+   aircraft whose parabolic polar fit was rejected by
+   `_fit_parabolic_polar` (`assumption_compute_service.py:924-1032`).
+2. The chip-row V-speeds report physically impossible relationships
+   (`V_min,sink < V_stall`, `V_md = V_stall`) — those are downstream of
+   the same polar problem but the cause is invisible.
 
-Both symptoms stem from a polar where
-`C_D0 · π · e · AR ≈ C_L,max²` — i.e. the L/D optimum sits at or past the
-stall point. With the four governing scalars not displayed anywhere on the
-workbench header, the user has no fast way to diagnose which lever (`C_D0`,
-`e`, `AR`, `C_L,max`) is responsible.
+The canonical Scholz/Sadraey figure of merit for polar quality is
+`(L/D)_max`. The canonical Anderson §6.7.2 derivation shows the
+stall-margin of the L/D optimum collapses to a single dimensionless
+ratio. This feature surfaces both.
 
 ## 2 · Goal
 
-Surface the four polar/geometry scalars **plus a derived degeneracy ratio ρ**
-directly in the existing two-row chip strip at the top of the workbench, so
-the user can self-diagnose polar quality at a glance without leaving the
-screen.
+Surface a Scholz/Sadraey-grade polar summary in the workbench chip strip
+so the user can read polar health at a glance:
 
-## 3 · Scope
+- the **canonical figure of merit** `(L/D)_max`,
+- the **operating CL margin** via the pair `(C_L,md, C_L,max)`,
+- the **induced-drag factor** `k = 1/(πeAR)`,
+- a **degeneracy ratio** `ρ` with **profile-aware** traffic-light
+  thresholds and an actionable tooltip that points at the Matching
+  Chart.
+
+## 3 · The ρ derivation (self-contained)
+
+From Anderson §6.7.2 for a parabolic polar `C_D = C_D0 + C_L² / (π·e·AR)`:
+
+- Maximum L/D occurs at **`C_L,md = √(π·e·AR · C_D0)`** (induced drag
+  equals parasite drag — Anderson §6.7.2). At this CL,
+  `(L/D)_max = ½·√(π·e·AR / C_D0)`.
+- Minimum power required (minimum sink rate for a steady glide) occurs
+  at **`C_L,mp = √3 · C_L,md`** (Anderson §6.7.4).
+
+Define the dimensionless ratio
+
+> **ρ ≡ C_D0 · π·e·AR / C_L,max² = (C_L,md / C_L,max)²**
+
+Then:
+
+- `ρ = 1` ⇔ `C_L,md = C_L,max` ⇔ `V_md = V_stall` (L/D-max coincident
+  with stall).
+- `ρ = 1/3` ⇔ `C_L,mp = C_L,max` ⇔ `V_min,sink = V_stall`.
+
+The form `ρ = (C_L,md / C_L,max)²` is the intuitive one — the
+squared ratio of the L/D-max CL to the stall CL. ρ = 0.25 means
+"L/D-max is at half the stall CL — comfortable margin."
+
+ρ is evaluated at the cached **cruise Reynolds number**. Off-design
+Re (climb, landing approach) may differ; for low-Reynolds RC the polar
+shape can change appreciably between operating points. The ρ tooltip
+states this explicitly.
+
+## 4 · Scope
 
 ### In scope
 
-- Add four new chips: `C_D0`, `e_oswald`, `AR`, `C_L,max` (clean).
-- Add a fifth derived chip: `ρ = C_D0·π·e·AR / C_L,max²` with traffic-light
-  colouring.
-- Re-organise the existing second chip row into three thematic sections —
-  *Geometry*, *Polar*, *Stability* — so the chip strip stays scannable as
-  it grows from two to four logical rows.
-- Refactor `InfoChipRow.tsx` into a thin container plus four sibling row
-  components and a shared `Chip` primitive. Extract the existing chips into
-  their new homes without behaviour change.
+A new thematic **Polar** row with **eight chips**:
+
+```
+Re   C_D0   e*   k   C_L,md   C_L,max   (L/D)_max   ρ
+```
+
+Plus:
+
+- Refactor `InfoChipRow.tsx` into a thin container + four sibling row
+  components (Speed / Geometry / Polar / Stability) + a shared `Chip`
+  primitive.
+- Pure derivation helpers exported for testing: `computeK`,
+  `computeCLmd`, `computeEMax`, `computeRho`,
+  `rhoThresholdsForProfile`.
+- Profile-aware ρ thresholds (powered vs glider) using `ctx.is_glider`.
+- All derived quantities bail out to `—` when the parabolic fit was
+  rejected (`e_oswald_fallback_used = true`) — the polar is
+  non-parabolic and derived quantities are no longer meaningful.
+- Tooltips that lead with the *consequence* and end with the formula.
+- Tests for derivation identities, profile-aware thresholds, sailplane
+  no-false-alarm case, #625 reproduction case.
 
 ### Out of scope (separate follow-ups)
 
+- **`C_L,cruise`** — needs the aircraft mass; depends on #625 Bug B fix
+  (`mass_kg` not currently in `assumption_computation_context`). After
+  #625 lands, adding this chip is trivial.
 - **Per-configuration `C_L,max`** chips for takeoff / landing.
-- **Bug C** (clamping `V_md` and `V_min,sink` against `V_stall`) — separate
-  ticket already noted in #625.
-- **Color-blind alternative** to the ρ traffic light. The tooltip text
-  redundantly carries the threshold meaning, so the colour-blind degraded
-  experience is still informative; a richer fix is its own UX ticket.
-- **Backend changes.** All values are already cached in
-  `assumption_computation_context` by `recompute_assumptions`
-  (`assumption_compute_service.py:434-488`); only the consumer side moves.
+- **Bug C from #625** — clamping `V_md` / `V_min,sink` against `V_stall`.
+- **Mission-profile-aware thresholds beyond `is_glider`** (separate
+  bands for RC trainer / aerobatic / transport).
+- **Hobbyist "verb mode"** (`ρ: healthy / marginal / degenerate`).
+- **Matching-chart anchor / route** — the ρ tooltip *text* refers the
+  user to the Matching Chart; clicking the chip does not yet navigate.
+- **Color-blind alternative** to the traffic light.
+- **Regime-specific `e_oswald` fallback** (the 0.80 default is
+  jet-transport-naive).
+- **Backend changes.**
 
-## 4 · Architecture
+## 5 · Architecture
 
 ```
 frontend/components/workbench/
-  Chip.tsx                ← extracted primitive (existing internal Chip fn moves here)
-  SpeedChipRow.tsx        ← Row 1: V_stall, V_min,sink, V_md, V_cruise(*),
-                                   V_x, V_y, V_a, V_max, V_dive
-  GeometryChipRow.tsx     ← Row 2a: S_ref, MAC, B_ref, AR
-  PolarChipRow.tsx        ← Row 2b: Re, C_D0, e, C_L,max, ρ        [new content]
-  StabilityChipRow.tsx    ← Row 2c: NP, SM, CG
-  InfoChipRow.tsx         ← container: data fetch, refresh button,
-                            recomputing pill, renders the 4 rows
-  renderSymbol.tsx        (unchanged)
+  Chip.tsx                ← extracted primitive
+  SpeedChipRow.tsx        ← Row 1 (no behaviour change)
+  GeometryChipRow.tsx     ← Row 2a: S_ref, MAC, B_ref, AR    [AR is new]
+  PolarChipRow.tsx        ← Row 2b: Re, C_D0, e*, k, C_L,md, C_L,max,
+                                    (L/D)_max, ρ              [new]
+  StabilityChipRow.tsx    ← Row 2c (no behaviour change)
+  InfoChipRow.tsx         ← container ≤ 80 lines
+
+frontend/lib/
+  polar.ts                ← pure helpers (computeK / computeCLmd /
+                            computeEMax / computeRho /
+                            rhoThresholdsForProfile)
 
 frontend/__tests__/
-  Chip.test.tsx                ← new
-  SpeedChipRow.test.tsx        ← migrated cases
-  GeometryChipRow.test.tsx     ← migrated cases + AR
-  PolarChipRow.test.tsx        ← new, focus: ρ + empty-state + quality colours
-  StabilityChipRow.test.tsx    ← migrated cases
-  InfoChipRow.test.tsx         ← reduced to container behaviour
+  Chip.test.tsx
+  SpeedChipRow.test.tsx
+  GeometryChipRow.test.tsx
+  PolarChipRow.test.tsx               ← centre of test effort
+  StabilityChipRow.test.tsx
+  InfoChipRow.test.tsx
+  polar.test.ts                       ← pure-helper round-trip tests
 ```
 
 Each row component is a pure renderer with props
-`{ ctx: ComputationContext | null, isRecomputing: boolean }` plus, for
-`StabilityChipRow`, the existing CG-aggregation divergence inputs it
-already reads. No row component performs its own SWR call; the container
-remains the single source of truth.
+`{ ctx: ComputationContext | null, isRecomputing: boolean }`. The
+container owns SWR, refresh button, recomputing pill.
 
-## 5 · Data flow
+## 6 · Data flow
 
 ```
 GET /aeroplanes/{id}/assumptions/computation-context
         │
         ▼
 useComputationContext(aeroplaneId)
-        │   (TypeScript interface extended — see §6)
+        │   (TypeScript interface extended — see §7)
         ▼
 InfoChipRow (container)
         │
@@ -106,245 +163,363 @@ InfoChipRow (container)
         └─ StabilityChipRow  (ctx, isRecomputing, cgAggregation…)
 ```
 
-## 6 · TypeScript interface changes
+## 7 · TypeScript interface changes
 
 `frontend/hooks/useComputationContext.ts` — extend `ComputationContext`:
 
 ```ts
 interface ComputationContext {
-  // ... existing keys (v_cruise_mps, v_s1_mps, s_ref_m2, mac_m, b_ref_m,
-  // reynolds, aspect_ratio, x_np_m, target_static_margin, cg_agg_m,
-  // is_glider, is_tailless, v_cruise_auto, …) — unchanged
+  // ... existing keys unchanged ...
 
-  // Newly typed (already present in the JSON response):
   cd0: number | null;
   e_oswald: number | null;
   e_oswald_quality: "high" | "medium" | "low" | "unknown";
   e_oswald_fallback_used: boolean;
+  is_glider: boolean;          // already in the runtime payload
   polar_by_config: {
     clean: {
       cd0: number | null;
       e_oswald: number | null;
       cl_max: number | null;
-      // takeoff/landing also exist but are not consumed in this feature
     };
   } | null;
 }
 ```
 
-No runtime parser is added — the existing endpoint returns the raw JSON and
-TypeScript types are advisory.
+## 8 · PolarChipRow — details
 
-## 7 · PolarChipRow — details
+### 8.1 Chips
 
-### 7.1 Chips
-
-| Chip | Symbol | Source | Format | Default colour |
+| # | Chip | Source | Format | Notes |
 |---|---|---|---|---|
-| Reynolds | `Re` | `ctx.reynolds` | `toExponential(1)` | foreground |
-| Zero-lift drag | `C_D0` | `ctx.cd0` | `.toFixed(4)` | foreground |
-| Span efficiency | `e` or `e*` | `ctx.e_oswald` (or 0.80 fallback) | `.toFixed(2)` | derived from `e_oswald_quality` — see §7.3 |
-| Max lift (clean) | `C_L,max` | `ctx.polar_by_config?.clean?.cl_max` | `.toFixed(2)` | foreground |
-| Degeneracy ratio | `ρ` | computed — see §7.2 | `.toFixed(2)` | traffic light — see §7.4 |
+| 1 | `Re` | `ctx.reynolds` | `toExponential(1)` | At cruise (`MAC × V_cruise × ρ/μ`) |
+| 2 | `C_D0` | `ctx.cd0` | `.toFixed(4)` | Stability-run value (single-CL) |
+| 3 | `e` / `e*` | `ctx.e_oswald` or fallback `0.80` | `.toFixed(2)` | `*` when `e_oswald_fallback_used`; quality colour from `e_oswald_quality` (§8.3) |
+| 4 | `k` | `computeK(e, AR)` | `.toFixed(4)` | `—` under ρ-bail rule (§8.5) |
+| 5 | `C_L,md` | `computeCLmd(cd0, e, AR)` | `.toFixed(2)` | `—` under ρ-bail rule |
+| 6 | `C_L,max` | `ctx.polar_by_config?.clean?.cl_max` | `.toFixed(2)` | Clean configuration only (tooltip §9) |
+| 7 | `(L/D)_max` | `computeEMax(cd0, e, AR)` | `.toFixed(1)` | `—` under ρ-bail rule; **Scholz §5.7 canonical figure** |
+| 8 | `ρ` | `computeRho(cd0, e, AR, cl_max, fallbackUsed)` | `.toFixed(2)` | `—` under ρ-bail rule; profile-aware traffic-light colour (§8.4) |
 
-When a source is `null`, the value renders as `—` and the chip's tooltip
-explains why (see §9).
-
-### 7.2 ρ computation
-
-Pure helper exported from `PolarChipRow.tsx` for unit testing:
+### 8.2 Helpers (pure TS, exported)
 
 ```ts
+export function computeK(
+  eFromCtx: number | null, fallbackUsed: boolean, ar: number | null,
+): number | null {
+  if (fallbackUsed) return null;   // ρ-bail rule
+  if (eFromCtx == null || ar == null || eFromCtx <= 0 || ar <= 0) {
+    return null;
+  }
+  return 1 / (Math.PI * eFromCtx * ar);
+}
+
+export function computeCLmd(
+  cd0: number | null, eFromCtx: number | null,
+  fallbackUsed: boolean, ar: number | null,
+): number | null {
+  if (fallbackUsed) return null;   // ρ-bail rule
+  if (cd0 == null || eFromCtx == null || ar == null) return null;
+  if (cd0 <= 0 || eFromCtx <= 0 || ar <= 0) return null;
+  return Math.sqrt(Math.PI * eFromCtx * ar * cd0);
+}
+
+export function computeEMax(
+  cd0: number | null, eFromCtx: number | null,
+  fallbackUsed: boolean, ar: number | null,
+): number | null {
+  if (fallbackUsed) return null;   // ρ-bail rule
+  if (cd0 == null || eFromCtx == null || ar == null) return null;
+  if (cd0 <= 0 || eFromCtx <= 0 || ar <= 0) return null;
+  return 0.5 * Math.sqrt((Math.PI * eFromCtx * ar) / cd0);
+}
+
 export function computeRho(
-  cd0: number | null,
-  eFromCtx: number | null,
-  fallbackUsed: boolean,
-  ar: number | null,
+  cd0: number | null, eFromCtx: number | null,
+  fallbackUsed: boolean, ar: number | null,
   clMax: number | null,
 ): number | null {
-  const e = eFromCtx ?? (fallbackUsed ? 0.80 : null);
-  if (cd0 == null || e == null || ar == null || clMax == null) return null;
-  if (cd0 <= 0 || e <= 0 || ar <= 0 || clMax <= 0) return null;
-  return (cd0 * Math.PI * e * ar) / (clMax * clMax);
+  if (fallbackUsed) return null;   // ρ-bail rule
+  if (cd0 == null || eFromCtx == null || ar == null || clMax == null) {
+    return null;
+  }
+  if (cd0 <= 0 || eFromCtx <= 0 || ar <= 0 || clMax <= 0) return null;
+  return (cd0 * Math.PI * eFromCtx * ar) / (clMax * clMax);
+}
+
+export type RhoThresholds = { amber: number; red: number };
+
+export function rhoThresholdsForProfile(isGlider: boolean): RhoThresholds {
+  // Per Scholz/Sadraey: sailplanes intentionally operate near
+  // V_min,sink ≈ V_stall (ρ ≈ 1/3 is normal). Shift amber up.
+  // Red boundary stays at 1.0 (V_md = V_stall is bad for any aircraft).
+  return isGlider ? { amber: 2 / 3, red: 1.0 } : { amber: 1 / 3, red: 1.0 };
 }
 ```
 
-### 7.3 Quality colour mapping (applied to the `e` value)
+### 8.3 Quality colour mapping (applied to `e` value only)
 
 | `e_oswald_quality` | Tailwind class |
 |---|---|
 | `high` (R² > 0.99) | `text-emerald-400` |
 | `medium` (0.95 ≤ R² ≤ 0.99) | `text-amber-400` |
 | `low` (R² < 0.95) | `text-orange-400` |
-| `unknown` (fit not run / rejected) | `text-muted-foreground` |
+| `unknown` — **always when `e_oswald_fallback_used`** | `text-muted-foreground` |
 
-### 7.4 ρ traffic light
+When `e_oswald_fallback_used === true`, quality is necessarily `unknown`
+and the `e*` value renders muted. Tests assert this combination
+explicitly.
 
-| Range | Meaning | Tailwind class |
-|---|---|---|
-| `ρ < 1/3` | healthy polar | `text-emerald-400` |
-| `1/3 ≤ ρ < 1` | V_min,sink at or below V_stall | `text-amber-400` |
-| `ρ ≥ 1` | degenerate: V_md at stall | `text-red-400` |
+### 8.4 ρ traffic light (profile-aware)
 
-### 7.5 Fallback marker for `e`
+Powered (`is_glider === false`):
 
-When `ctx.e_oswald_fallback_used === true`:
+| Range | Tailwind class |
+|---|---|
+| `ρ < 1/3` | `text-emerald-400` |
+| `1/3 ≤ ρ < 1` | `text-amber-400` |
+| `ρ ≥ 1` | `text-red-400` |
 
-- Symbol becomes `e*` (asterisk handled by the existing `renderSymbol`
-  helper, mirroring the `V_cruise*` precedent).
-- Value displays the fallback `0.80`.
-- Tooltip is replaced by the fallback variant (see §8).
+Glider (`is_glider === true`):
 
-## 8 · Tooltips
+| Range | Tailwind class |
+|---|---|
+| `ρ < 2/3` | `text-emerald-400` |
+| `2/3 ≤ ρ < 1` | `text-amber-400` |
+| `ρ ≥ 1` | `text-red-400` |
 
-One concise sentence each, consistent with existing chip tooltips. ρ gets
-two lines because the threshold semantics are the actionable part.
+Boundaries are **lower-inclusive** in both bands — tested at
+`ρ = 1/3`, `ρ = 2/3`, `ρ = 1.00`.
+
+### 8.5 The ρ-bail rule (all derived quantities)
+
+When `e_oswald_fallback_used === true`, the parabolic OLS fit
+(`_fit_parabolic_polar`, `assumption_compute_service.py:924-1032`) was
+rejected for substantive physical reasons (laminar-bubble drag dip,
+`e` outside (0.4, 1.0], `cd0` deviation > 20 % from the stability run,
+non-monotonic `dCD/d(CL²)`, etc.). Every one of these signals that the
+polar **is not parabolic**.
+
+Computing a "parabolic-polar diagnostic" on a non-parabolic polar
+produces a number that *looks* like a measurement but is actually
+"what the metric would be *if* the polar were parabolic with the
+literature-average e = 0.80, which we established it isn't."
+
+The rule, applied uniformly to **k, C_L,md, (L/D)_max, ρ**:
+
+> If `e_oswald_fallback_used === true`, all four derived chips render
+> `—` with a tooltip explaining the polar is not parabolic.
+
+Raw chips (`Re`, `C_D0`, `e*`, `C_L,max`) remain visible. The `e*`
+asterisk + muted colour communicates "we know this polar isn't
+parabolic; the four derived quantities have therefore been suppressed."
+
+### 8.6 Chip primitive — new prop
+
+Extracted `Chip` keeps every existing prop (`icon`, `symbol`,
+`value | valueNode`, `description`, `stale`). One new optional prop:
+
+```ts
+valueColorClassName?: string;
+```
+
+Applied to the value span only; `stale = true` (recompute red) takes
+priority.
+
+## 9 · Tooltips (consequence-first)
+
+All tooltips lead with the consequence/meaning a designer cares about,
+then optionally include the formula on the same line.
 
 | Symbol | Tooltip |
 |---|---|
-| `Re` | (unchanged) *"Reynolds number at cruise (characteristic length = MAC)"* |
-| `C_D0` | *"Zero-lift drag coefficient from the parabolic polar fit (stability run)."* |
-| `e` | *"Oswald span efficiency from the parabolic polar fit."* |
-| `e*` | *"Polar fit was rejected — fallback value 0.80 used internally. Value colour reflects fit quality."* |
-| `C_L,max` | *"Maximum lift coefficient (clean configuration) from AeroBuildup."* |
-| `AR` | *"Aspect ratio = b² / S_ref (main wing)."* |
-| `ρ` | *"Polar degeneracy ρ = C_D0·π·e·AR / C_L,max². ρ<⅓ healthy · ⅓≤ρ<1 V_min,sink at/below stall · ρ≥1 V_md at stall."* |
+| `Re` | *"Reynolds number at cruise (characteristic length = MAC). Polar shape is Re-dependent; this row's metrics describe cruise-Re behaviour."* |
+| `C_D0` | *"Zero-lift drag coefficient (parasite drag). Lower is better. ρ uses this together with e and AR. Source: stability run (single-CL eval)."* |
+| `e` | *"Oswald efficiency — combined non-elliptical-lift-distribution loss and parasite-drag-with-lift. Typical 0.70–0.95. Colour reflects fit quality."* |
+| `e*` | *"Polar fit was rejected — fallback 0.80 used (regime-naive). All derived polar quantities (k, C_L,md, L/D-max, ρ) are therefore suppressed."* |
+| `k` | *"Induced-drag factor k = 1/(πeAR). Drag rises as k·C_L². Lower k = less induced drag at the same lift."* |
+| `C_L,md` | *"Lift coefficient where L/D is maximum (best glide). Should sit well below C_L,max. If C_L,md ≥ C_L,max your wing must stall to reach best glide."* |
+| `C_L,max` | *"Maximum lift coefficient (clean configuration, no flaps). From AeroBuildup — known to underestimate at Re < 3×10⁵; treat as conservative for RC."* |
+| `(L/D)_max` | *"Maximum lift-to-drag ratio. The headline polar number. Sailplane > 30 · GA 10–18 · jet transport 16–22 · trainer 8–12. Formula: ½·√(πeAR/C_D0)."* |
+| `ρ` (emerald) | *"Polar health: healthy. L/D-max sits comfortably above stall. ρ = (C_L,md/C_L,max)² ≤ threshold."* |
+| `ρ` (amber, powered) | *"Polar health: min-sink point at/below stall. L/D-max still reachable. Consider raising AR or lowering W/S — see Matching Chart. ρ = (C_L,md/C_L,max)²."* |
+| `ρ` (amber, glider) | *"Polar health: tightening sailplane optimum. Still healthy for glider regime. ρ = (C_L,md/C_L,max)²."* |
+| `ρ` (red) | *"Polar health: L/D-max coincident with or past stall — polar is degenerate. Resize wing: raise AR or improve C_L,max — see Matching Chart. ρ = (C_L,md/C_L,max)²."* |
+| Four derived chips when bail-rule fires | *"Parabolic polar fit was rejected (see e*). Derived polar quantities are not meaningful when the polar is non-parabolic."* |
 
-## 9 · Edge cases
+## 10 · Edge cases
 
 | Case | Behaviour |
 |---|---|
-| `ctx === null` (no recompute has run) | All chips show `—`; refresh button stays active |
-| Polar fit rejected (`e_oswald = null`, `e_oswald_fallback_used = true`) | `e*=0.80` with `text-muted-foreground`; ρ computed with fallback e *only when CD0 and CL_max are both present* |
-| `cd0 = null` | `C_D0=—`; ρ=`—` |
-| `cl_max = null` (clean polar missing entirely) | `C_L,max=—`; ρ=`—` |
-| `aspect_ratio = null` (geometry issue) | `AR=—` (in GeometryChipRow); ρ=`—` |
-| `is_glider === true` | **All five polar chips remain visible.** No conditional hide — polar health matters more, not less, for gliders |
-| `isRecomputing === true` | Stale red colour applies to all chip values; overrides quality and traffic-light colours |
+| `ctx === null` (no recompute) | All chips show `—`; refresh button stays active |
+| Polar fit rejected (`e_oswald_fallback_used = true`) | `e*=0.80` muted; **k, C_L,md, (L/D)_max, ρ all = `—`** with shared bail-rule tooltip |
+| `cd0 = null` | `C_D0=—`; all four derived = `—` |
+| `cl_max = null` (no clean polar) | `C_L,max=—`; `C_L,md` and `(L/D)_max` still computable; `ρ = —` |
+| `aspect_ratio = null` | `AR=—` in Geometry row; `k, C_L,md, (L/D)_max, ρ` all = `—` in Polar row |
+| `is_glider === true` | All chips visible; ρ uses `{ amber: 2/3, red: 1.0 }` threshold set |
+| `isRecomputing === true` | Stale red on all chip values overrides quality and traffic-light colours |
 
-## 10 · Chip primitive — new prop
+## 11 · Implementation order (TDD)
 
-The extracted `Chip` component keeps every existing prop (`icon`, `symbol`,
-`value | valueNode`, `description`, `stale`). One new optional prop is
-added:
+1. Extract `Chip.tsx` primitive (move existing inner function verbatim;
+   add `valueColorClassName`). `Chip.test.tsx` — RED → GREEN.
+2. Extract `SpeedChipRow.tsx`; migrate relevant tests. Verify.
+3. Extract `GeometryChipRow.tsx` (existing chips first, **without**
+   AR). Verify.
+4. Extract `StabilityChipRow.tsx`. Verify.
+5. Extend `ComputationContext` type with new fields.
+6. Add `AR` chip to `GeometryChipRow.tsx`. Add the test case.
+7. Create `frontend/lib/polar.ts` with the five pure helpers.
+   `polar.test.ts` covers derivation identities (§13.A). RED → GREEN.
+8. Write `PolarChipRow.test.tsx` (cases in §13.B). RED.
+9. Implement `PolarChipRow.tsx`. GREEN.
+10. Wire `PolarChipRow` into `InfoChipRow.tsx`. Adjust
+    `InfoChipRow.test.tsx` for four-row order. GREEN.
 
-```ts
-valueColorClassName?: string;   // Tailwind class applied to the value span only
-```
+## 12 · Acceptance criteria
 
-`stale` (recompute red) has priority over `valueColorClassName`. The primitive
-remains semantically neutral — colour meaning lives in the calling row
-component.
+### 12.A Structural
 
-## 11 · Testing strategy
+- [ ] `InfoChipRow.tsx` reduces to ≤ 80 lines (container only).
+- [ ] Six new component files + one helpers file (`lib/polar.ts`).
+- [ ] Six new test files (one per row + one for helpers).
+- [ ] `AR` chip appears in `GeometryChipRow`.
 
-`PolarChipRow.test.tsx` is the centre of the test effort. Required cases:
+### 12.B Diagnostic value
 
-1. Healthy context (CD0=0.01, e=0.85, AR=15, CL_max=1.2) → all five chips
-   render; ρ = 0.01·π·0.85·15 / 1.44 ≈ 0.28 with `text-emerald-400`.
-2. Threshold matrix for ρ — six cases pin inclusion semantics:
-   ρ ∈ {0.20, 1/3, 0.50, 0.99, 1.00, 1.20} → emerald, amber (lower
-   boundary inclusive), amber, amber, red (upper boundary inclusive),
-   red.
-3. Asterisk pathway: `e_oswald_fallback_used = true` → symbol `e*`, value
-   `0.80`, fallback tooltip.
-4. Quality matrix on `e`: `high` / `medium` / `low` / `unknown` → emerald /
-   amber / orange / muted.
-5. Each individual `null` input (`cd0`, `e`, `aspect_ratio`, `cl_max`)
-   propagates correctly: that chip and ρ both go to `—`.
-6. `ctx === null` → every chip `—`, no crashes.
-7. Tooltip text correctness — assert visible after hover/focus; ρ tooltip
-   contains the threshold breakdown.
-8. `isRecomputing = true` overrides quality and traffic-light colours with
-   `text-red-400`.
+- [ ] **Derivation identities:** `computeCLmd² = π·e·AR·C_D0`;
+      `(L/D)_max = (π·e·AR) / (4·C_L,md)`;
+      `ρ · C_L,max² = π·e·AR·C_D0`;
+      `ρ = (computeCLmd / cl_max)²` within float ε.
+- [ ] **Powered traffic-light:** `ρ = 1/3` → amber; `ρ = 1.00` → red.
+- [ ] **Glider traffic-light:** `ρ = 2/3` → amber; `ρ = 1.00` → red.
+- [ ] **Healthy aircraft fixture** (CD0=0.02, e=0.80, AR=7, CL_max=1.4,
+      is_glider=false) → ρ ≈ 0.180 emerald, all derived chips
+      populated.
+- [ ] **Sailplane no-false-alarm fixture** (CD0=0.008, e=0.95, AR=36,
+      CL_max=1.5, is_glider=true) → ρ ≈ 0.382 emerald under glider
+      thresholds (would be amber under powered).
+- [ ] **#625 reproduction** (e_oswald_fallback_used=true) → `e*=0.80`
+      muted; k, C_L,md, (L/D)_max, ρ all `—`; shared bail tooltip.
+- [ ] **Empty context** → all chips `—`, no crashes.
 
-`Chip.test.tsx`: render with `value`, with `valueNode`, `stale` red,
-`valueColorClassName` applied, `stale` overrides `valueColorClassName`.
+### 12.C Behaviour
 
-`SpeedChipRow.test.tsx`, `GeometryChipRow.test.tsx`,
-`StabilityChipRow.test.tsx`: migrate the relevant cases from the current
-`InfoChipRow.test.tsx`. No new behaviour — only sub-component scoping.
-
-`InfoChipRow.test.tsx` is reduced to container behaviour: renders all four
-rows in the expected order; refresh button calls SWR `mutate`; recomputing
-pill appears when `isRecomputing`.
-
-## 12 · Implementation order (TDD)
-
-The order minimises risk of regressing existing chip behaviour:
-
-1. Extract `Chip.tsx` (move existing inner function verbatim, add
-   `valueColorClassName`). Write `Chip.test.tsx`. Verify existing
-   `InfoChipRow.test.tsx` still passes after `InfoChipRow.tsx` imports the
-   primitive.
-2. Extract `SpeedChipRow.tsx`; migrate the relevant tests. Verify.
-3. Extract `GeometryChipRow.tsx` (existing chips first, **without** AR);
-   migrate tests. Verify.
-4. Extract `StabilityChipRow.tsx`; migrate tests. Verify.
-5. Extend `ComputationContext` type with the new fields.
-6. Add AR chip to `GeometryChipRow.tsx`; add the new test case.
-7. Write `PolarChipRow.test.tsx` (all 8 cases) — RED.
-8. Implement `PolarChipRow.tsx` and the `computeRho` helper — GREEN.
-9. Wire `PolarChipRow` into `InfoChipRow.tsx` between Geometry and
-   Stability. Update `InfoChipRow.test.tsx` to assert the four-row order.
-
-Each step is a self-contained commit. Step 8 is the only place where new
-visual logic lands; steps 1–6 are mechanical refactors.
-
-## 13 · Acceptance criteria
-
-- [ ] `InfoChipRow.tsx` is ≤ 80 lines (container only).
-- [ ] Four row components exist as sibling files, each with its own test
-      file.
-- [ ] A `PolarChipRow` row appears in the workbench between Geometry and
-      Stability.
-- [ ] For a healthy polar (R² > 0.95, ρ < 1/3), the row shows `Re`,
-      `C_D0`, `e`, `C_L,max`, `ρ` all populated, `ρ` in emerald.
-- [ ] For the reproduction aeroplane in #625 (polar fit rejected), the row
-      shows `Re=…`, `C_D0=—`, `e*=0.80` in muted grey, `C_L,max=—`,
-      `ρ=—`. Tooltips explain each `—`.
-- [ ] `ρ` traffic-light thresholds are unit-tested at the boundaries.
-- [ ] Tooltip on `ρ` contains the threshold meaning verbatim.
-- [ ] `is_glider === true` does **not** hide any polar chip.
-- [ ] During recompute, all chip values are red (existing stale pattern
-      continues to win).
+- [ ] `e_oswald_fallback_used = true` triggers `e*` + fallback tooltip
+      + muted colour.
+- [ ] Polar chips remain visible for gliders (no `!is_glider`
+      gating).
+- [ ] `isRecomputing = true` overrides quality and traffic-light
+      colours with stale red.
+- [ ] ρ red tooltip contains the literal phrase "see Matching Chart".
 - [ ] `npm run test:unit` passes.
 
-## 14 · Decisions taken during brainstorming
+## 13 · Test cases
 
-1. **All four values plus the derived ρ.** Plain values alone are not
-   sufficient for self-diagnosis; ρ does the interpretation.
-2. **Thematic split: Speed / Geometry / Polar / Stability — four rows.**
-   The Polar row gets its own thematic section rather than being appended
-   to Geometry (which would be eleven chips wide).
-3. **Annotation level = Diagnostic.** Asterisk on `e` when fallback, quality
-   colour on `e`, and the traffic-light ρ chip — all of these in one shot,
-   not staged.
-4. **Empty values render as `—` with an explanatory tooltip.** No hidden
-   chips; explicit absence is preferable to invisible omission (the same
-   principle that the Mission radar epic #561 is currently failing on).
-5. **Full split into five new components.** `InfoChipRow.tsx` becomes a
-   thin container. Three extracted rows have no behaviour change; the
-   Polar row introduces the new logic. The shared `Chip` primitive
-   eliminates the duplicate inner function and adds a single new prop.
-6. **Polar chips always visible.** Gliders specifically benefit from polar
-   transparency, so the `!is_glider` gating used by V_a / V_max / V_dive is
-   not extended.
-7. **Stale red overrides quality and traffic-light colours.** Single source
-   of visual truth during recompute; the user knows the values are
-   provisional.
+### 13.A `polar.test.ts` (helper round-trips)
+
+1. `computeCLmd(0.02, 0.80, false, 7) ≈ 0.594`
+   `= √(π·0.80·7·0.02)`.
+2. `computeEMax(0.02, 0.80, false, 7) ≈ 13.21`
+   `= ½·√(π·0.80·7/0.02)`.
+3. `computeRho(0.02, 0.80, false, 7, 1.4) ≈ 0.180`.
+4. `computeRho ≡ (computeCLmd / cl_max)²` — fuzz over 10 random
+   inputs.
+5. `computeK(0.80, false, 7) ≈ 0.0568`.
+6. `rhoThresholdsForProfile(false)` → `{ amber: 1/3, red: 1.0 }`;
+   `(true)` → `{ amber: 2/3, red: 1.0 }`.
+7. **Bail rule:** every helper returns `null` when `fallbackUsed=true`,
+   regardless of other inputs.
+8. Each negative / zero / null input on each helper → `null`.
+
+### 13.B `PolarChipRow.test.tsx` (component)
+
+9. **Healthy powered** — fixture from 12.B → all eight chips
+   populated, ρ emerald.
+10. **Sailplane** — fixture from 12.B → eight chips populated, ρ
+    emerald *despite* ρ ≈ 0.38 (would be amber on powered).
+11. **Powered amber lower boundary** — `ρ = 1/3` exact → amber.
+12. **Powered red boundary** — `ρ = 1.00` exact → red.
+13. **Glider amber lower boundary** — `ρ = 2/3` + `is_glider=true` →
+    amber.
+14. **Quality matrix on `e`:** high / medium / low / unknown →
+    emerald / amber / orange / muted.
+15. **#625 reproduction** — fallback → `e*=0.80` muted; k, C_L,md,
+    (L/D)_max, ρ render `—`.
+16. **Per-null input** (cd0=null, then cl_max=null, then AR=null) →
+    that chip + every dependent derived chip → `—`.
+17. **`ctx === null`** — all chips `—`.
+18. **Tooltip text:** `(L/D)_max` tooltip contains "headline polar
+    number"; ρ red tooltip contains "see Matching Chart"; bail tooltip
+    contains "non-parabolic".
+19. **`isRecomputing = true`** overrides all colours with stale red.
+
+## 14 · Decisions
+
+1. All four governing scalars plus the derived ρ.
+2. Four thematic rows (Speed / Geometry / Polar / Stability).
+3. Annotation level = Diagnostic.
+4. Empty values → `—` with explanatory tooltips.
+5. Full split into six new components.
+6. Polar chips always visible (no `is_glider` hide gating).
+7. Stale red overrides quality and traffic-light colours.
+
+**Rev-2 (post-expert-review):**
+
+8. **ρ-bail rule.** When `e_oswald_fallback_used = true`, all four
+   derived polar quantities render `—`. Reason — Aero #1: the metric
+   is only meaningful for parabolic polars; computing it on rejected
+   fits produces a measurement-shaped non-measurement.
+9. **Profile-aware ρ thresholds.** Glider `{ 2/3, 1.0 }`; powered
+   `{ 1/3, 1.0 }`. Reason — Scholz: high-performance sailplanes
+   intentionally operate with `V_min,sink ≈ V_stall`; flat ⅓ amber
+   generates false alarms on healthy gliders.
+10. **`(L/D)_max` is a first-class chip.** Scholz §5.7 canonical
+    figure of merit.
+11. **`C_L,md` is a first-class chip.** `C_D0` alone is not
+    interpretable; the `(C_L,md, C_L,max)` pair tells the
+    operating-CL story.
+12. **`k` is a first-class chip.** `k = 1/(πeAR)` is the canonical
+    induced-drag factor in Scholz / Sadraey notation.
+13. **`C_L,cruise` deferred** (depends on #625 mass-context fix).
+14. **Tooltips are consequence-first**, not formula-first.
+15. **ρ-red tooltip prescribes** ("see Matching Chart") — converts
+    passive diagnostic into actionable feedback.
+16. **Re-conditional caveat** in `Re` tooltip — this row describes
+    cruise-Re behaviour.
+17. **CL_max low-Re bias caveat** in `C_L,max` tooltip — AeroBuildup
+    conservative at Re < 3×10⁵.
+18. **Sailplane no-false-alarm fixture** in the test suite.
 
 ## 15 · References
 
-- **#625** — Mission Radar Ist polygon bug cluster (the trigger that surfaced
-  the diagnostic gap).
-- **#575** — InfoChipRow split into two rows / refresh button. This spec
-  refactors the same component.
-- **#545 / #550** — Mission Tab spider chart epic & component (the
-  downstream consumer of these polar values).
-- **`assumption_compute_service.py:434-488`** — backend writer of the
-  context keys this UI consumes.
-- **`field_length_service.py:322-335`** — gh-548 wiring that revealed the
-  mass-source mismatch. Adjacent context for #625 Bug B.
-- **Anderson, *Fundamentals of Aerodynamics* 6e, §6.7.2** — derivation of
-  L/D-max and the optimum-CL conditions used in the ρ formula.
+- **GitHub #625** — Mission Radar bug cluster (trigger).
+- **GitHub #575** — earlier InfoChipRow split.
+- **GitHub #545 / #550** — Mission Tab spider chart epic.
+- **`assumption_compute_service.py:434-488`** — backend writer.
+- **`assumption_compute_service.py:924-1032`** — `_fit_parabolic_polar`
+  rejection guards.
+- **Anderson, *Fundamentals of Aerodynamics* 6e, §6.7.2–§6.7.4** —
+  L/D-max and the optimum-CL conditions.
+- **Scholz, *Flugzeugentwurf* §5.6.2 / §5.7 / §5.8.**
+- **Sadraey, *Aircraft Design* §4** — induced-drag factor `k`.
+
+## 16 · Domain-expert-review record (rev 1 → rev 2)
+
+| # | Sev | Source | Action |
+|---|---|---|---|
+| 1 | MAJOR | Aero | **Addressed** — ρ-bail rule (§8.5, §10, §13.B-15). |
+| 2 | CRITICAL | Scholz | **Addressed** — `(L/D)_max` first-class chip (§8.1). |
+| 3 | CRITICAL | Scholz | **Addressed** — `C_L,md` first-class chip (§8.1). `C_L,cruise` deferred (§4 Out of scope). |
+| 4 | MAJOR | Aero | **Addressed** — amber tooltip reworded "min-sink at/below stall" (§9). |
+| 5 | MAJOR | Scholz | **Addressed** — profile-aware thresholds (§8.4, §13.A-6, §13.B-10/13). |
+| 6 | MAJOR | Scholz | **Addressed** — ρ-red tooltip prescribes "see Matching Chart" (§9). |
+| 7 | MAJOR | Aero | **Addressed** — Re-conditional caveat + ρ derivation §3. |
+| 8 | MAJOR | Aero | **Addressed** — CL_max low-Re bias caveat in tooltip (§9). |
+| 9 | MAJOR | Scholz | **Addressed** — AC §12.B tests diagnostic value (healthy / sailplane / #625). |
+| 10 | MINOR | Scholz | **Addressed** — consequence-first tooltips (§9). |
+| 11 | MINOR | Scholz | **Addressed** — `k` first-class chip (§8.1). |
+| 12 | NIT | Aero | **Addressed** — intuitive form `ρ = (C_L,md/C_L,max)²` (§3 + §9). |
+| 13 | NIT | Scholz | **Addressed** — ρ derivation self-contained in §3. |
+| 14 | MINOR | Aero | **Addressed** — `unknown` + fallback combination explicit (§8.3). |
+| 15 | MINOR | Scholz | **Addressed** — `C_L,max,clean` precision in tooltip (§9). |

--- a/docs/superpowers/specs/2026-05-23-polar-metrics-chip-row-design.md
+++ b/docs/superpowers/specs/2026-05-23-polar-metrics-chip-row-design.md
@@ -1,0 +1,350 @@
+# Polar metrics in the Workbench Chip-Row — design
+
+**Date:** 2026-05-23
+**Status:** Draft (pending user review)
+**Type:** Frontend feature
+**Brainstorm transcript:** in-session, 2026-05-22 / 2026-05-23
+
+## 1 · Motivation
+
+The Mission Tab investigation on 2026-05-22 (see GitHub issue #625) surfaced a
+recurring difficulty: a user cannot tell from the workbench whether their
+*aerodynamic polar* is healthy or degenerate. Two symptoms today expose this
+gap:
+
+1. The Mission radar Ist polygon collapses on aircraft whose polar is
+   degenerate — `glide` and `climb` come back missing because
+   `_fit_parabolic_polar` rejected the OLS fit (`assumption_compute_service.py
+   :924-1032`).
+2. The V-speed chip-row reports physically impossible relationships
+   (`V_min,sink < V_stall`, `V_md == V_stall`) because the closed-form speeds
+   do not clamp to `V_stall` (tracked as Bug C in #625) — but the underlying
+   *cause* (a degenerate polar) is invisible to the user.
+
+Both symptoms stem from a polar where
+`C_D0 · π · e · AR ≈ C_L,max²` — i.e. the L/D optimum sits at or past the
+stall point. With the four governing scalars not displayed anywhere on the
+workbench header, the user has no fast way to diagnose which lever (`C_D0`,
+`e`, `AR`, `C_L,max`) is responsible.
+
+## 2 · Goal
+
+Surface the four polar/geometry scalars **plus a derived degeneracy ratio ρ**
+directly in the existing two-row chip strip at the top of the workbench, so
+the user can self-diagnose polar quality at a glance without leaving the
+screen.
+
+## 3 · Scope
+
+### In scope
+
+- Add four new chips: `C_D0`, `e_oswald`, `AR`, `C_L,max` (clean).
+- Add a fifth derived chip: `ρ = C_D0·π·e·AR / C_L,max²` with traffic-light
+  colouring.
+- Re-organise the existing second chip row into three thematic sections —
+  *Geometry*, *Polar*, *Stability* — so the chip strip stays scannable as
+  it grows from two to four logical rows.
+- Refactor `InfoChipRow.tsx` into a thin container plus four sibling row
+  components and a shared `Chip` primitive. Extract the existing chips into
+  their new homes without behaviour change.
+
+### Out of scope (separate follow-ups)
+
+- **Per-configuration `C_L,max`** chips for takeoff / landing.
+- **Bug C** (clamping `V_md` and `V_min,sink` against `V_stall`) — separate
+  ticket already noted in #625.
+- **Color-blind alternative** to the ρ traffic light. The tooltip text
+  redundantly carries the threshold meaning, so the colour-blind degraded
+  experience is still informative; a richer fix is its own UX ticket.
+- **Backend changes.** All values are already cached in
+  `assumption_computation_context` by `recompute_assumptions`
+  (`assumption_compute_service.py:434-488`); only the consumer side moves.
+
+## 4 · Architecture
+
+```
+frontend/components/workbench/
+  Chip.tsx                ← extracted primitive (existing internal Chip fn moves here)
+  SpeedChipRow.tsx        ← Row 1: V_stall, V_min,sink, V_md, V_cruise(*),
+                                   V_x, V_y, V_a, V_max, V_dive
+  GeometryChipRow.tsx     ← Row 2a: S_ref, MAC, B_ref, AR
+  PolarChipRow.tsx        ← Row 2b: Re, C_D0, e, C_L,max, ρ        [new content]
+  StabilityChipRow.tsx    ← Row 2c: NP, SM, CG
+  InfoChipRow.tsx         ← container: data fetch, refresh button,
+                            recomputing pill, renders the 4 rows
+  renderSymbol.tsx        (unchanged)
+
+frontend/__tests__/
+  Chip.test.tsx                ← new
+  SpeedChipRow.test.tsx        ← migrated cases
+  GeometryChipRow.test.tsx     ← migrated cases + AR
+  PolarChipRow.test.tsx        ← new, focus: ρ + empty-state + quality colours
+  StabilityChipRow.test.tsx    ← migrated cases
+  InfoChipRow.test.tsx         ← reduced to container behaviour
+```
+
+Each row component is a pure renderer with props
+`{ ctx: ComputationContext | null, isRecomputing: boolean }` plus, for
+`StabilityChipRow`, the existing CG-aggregation divergence inputs it
+already reads. No row component performs its own SWR call; the container
+remains the single source of truth.
+
+## 5 · Data flow
+
+```
+GET /aeroplanes/{id}/assumptions/computation-context
+        │
+        ▼
+useComputationContext(aeroplaneId)
+        │   (TypeScript interface extended — see §6)
+        ▼
+InfoChipRow (container)
+        │
+        ├─ SpeedChipRow      (ctx, isRecomputing)
+        ├─ GeometryChipRow   (ctx, isRecomputing)
+        ├─ PolarChipRow      (ctx, isRecomputing)
+        └─ StabilityChipRow  (ctx, isRecomputing, cgAggregation…)
+```
+
+## 6 · TypeScript interface changes
+
+`frontend/hooks/useComputationContext.ts` — extend `ComputationContext`:
+
+```ts
+interface ComputationContext {
+  // ... existing keys (v_cruise_mps, v_s1_mps, s_ref_m2, mac_m, b_ref_m,
+  // reynolds, aspect_ratio, x_np_m, target_static_margin, cg_agg_m,
+  // is_glider, is_tailless, v_cruise_auto, …) — unchanged
+
+  // Newly typed (already present in the JSON response):
+  cd0: number | null;
+  e_oswald: number | null;
+  e_oswald_quality: "high" | "medium" | "low" | "unknown";
+  e_oswald_fallback_used: boolean;
+  polar_by_config: {
+    clean: {
+      cd0: number | null;
+      e_oswald: number | null;
+      cl_max: number | null;
+      // takeoff/landing also exist but are not consumed in this feature
+    };
+  } | null;
+}
+```
+
+No runtime parser is added — the existing endpoint returns the raw JSON and
+TypeScript types are advisory.
+
+## 7 · PolarChipRow — details
+
+### 7.1 Chips
+
+| Chip | Symbol | Source | Format | Default colour |
+|---|---|---|---|---|
+| Reynolds | `Re` | `ctx.reynolds` | `toExponential(1)` | foreground |
+| Zero-lift drag | `C_D0` | `ctx.cd0` | `.toFixed(4)` | foreground |
+| Span efficiency | `e` or `e*` | `ctx.e_oswald` (or 0.80 fallback) | `.toFixed(2)` | derived from `e_oswald_quality` — see §7.3 |
+| Max lift (clean) | `C_L,max` | `ctx.polar_by_config?.clean?.cl_max` | `.toFixed(2)` | foreground |
+| Degeneracy ratio | `ρ` | computed — see §7.2 | `.toFixed(2)` | traffic light — see §7.4 |
+
+When a source is `null`, the value renders as `—` and the chip's tooltip
+explains why (see §9).
+
+### 7.2 ρ computation
+
+Pure helper exported from `PolarChipRow.tsx` for unit testing:
+
+```ts
+export function computeRho(
+  cd0: number | null,
+  eFromCtx: number | null,
+  fallbackUsed: boolean,
+  ar: number | null,
+  clMax: number | null,
+): number | null {
+  const e = eFromCtx ?? (fallbackUsed ? 0.80 : null);
+  if (cd0 == null || e == null || ar == null || clMax == null) return null;
+  if (cd0 <= 0 || e <= 0 || ar <= 0 || clMax <= 0) return null;
+  return (cd0 * Math.PI * e * ar) / (clMax * clMax);
+}
+```
+
+### 7.3 Quality colour mapping (applied to the `e` value)
+
+| `e_oswald_quality` | Tailwind class |
+|---|---|
+| `high` (R² > 0.99) | `text-emerald-400` |
+| `medium` (0.95 ≤ R² ≤ 0.99) | `text-amber-400` |
+| `low` (R² < 0.95) | `text-orange-400` |
+| `unknown` (fit not run / rejected) | `text-muted-foreground` |
+
+### 7.4 ρ traffic light
+
+| Range | Meaning | Tailwind class |
+|---|---|---|
+| `ρ < 1/3` | healthy polar | `text-emerald-400` |
+| `1/3 ≤ ρ < 1` | V_min,sink at or below V_stall | `text-amber-400` |
+| `ρ ≥ 1` | degenerate: V_md at stall | `text-red-400` |
+
+### 7.5 Fallback marker for `e`
+
+When `ctx.e_oswald_fallback_used === true`:
+
+- Symbol becomes `e*` (asterisk handled by the existing `renderSymbol`
+  helper, mirroring the `V_cruise*` precedent).
+- Value displays the fallback `0.80`.
+- Tooltip is replaced by the fallback variant (see §8).
+
+## 8 · Tooltips
+
+One concise sentence each, consistent with existing chip tooltips. ρ gets
+two lines because the threshold semantics are the actionable part.
+
+| Symbol | Tooltip |
+|---|---|
+| `Re` | (unchanged) *"Reynolds number at cruise (characteristic length = MAC)"* |
+| `C_D0` | *"Zero-lift drag coefficient from the parabolic polar fit (stability run)."* |
+| `e` | *"Oswald span efficiency from the parabolic polar fit."* |
+| `e*` | *"Polar fit was rejected — fallback value 0.80 used internally. Value colour reflects fit quality."* |
+| `C_L,max` | *"Maximum lift coefficient (clean configuration) from AeroBuildup."* |
+| `AR` | *"Aspect ratio = b² / S_ref (main wing)."* |
+| `ρ` | *"Polar degeneracy ρ = C_D0·π·e·AR / C_L,max². ρ<⅓ healthy · ⅓≤ρ<1 V_min,sink at/below stall · ρ≥1 V_md at stall."* |
+
+## 9 · Edge cases
+
+| Case | Behaviour |
+|---|---|
+| `ctx === null` (no recompute has run) | All chips show `—`; refresh button stays active |
+| Polar fit rejected (`e_oswald = null`, `e_oswald_fallback_used = true`) | `e*=0.80` with `text-muted-foreground`; ρ computed with fallback e *only when CD0 and CL_max are both present* |
+| `cd0 = null` | `C_D0=—`; ρ=`—` |
+| `cl_max = null` (clean polar missing entirely) | `C_L,max=—`; ρ=`—` |
+| `aspect_ratio = null` (geometry issue) | `AR=—` (in GeometryChipRow); ρ=`—` |
+| `is_glider === true` | **All five polar chips remain visible.** No conditional hide — polar health matters more, not less, for gliders |
+| `isRecomputing === true` | Stale red colour applies to all chip values; overrides quality and traffic-light colours |
+
+## 10 · Chip primitive — new prop
+
+The extracted `Chip` component keeps every existing prop (`icon`, `symbol`,
+`value | valueNode`, `description`, `stale`). One new optional prop is
+added:
+
+```ts
+valueColorClassName?: string;   // Tailwind class applied to the value span only
+```
+
+`stale` (recompute red) has priority over `valueColorClassName`. The primitive
+remains semantically neutral — colour meaning lives in the calling row
+component.
+
+## 11 · Testing strategy
+
+`PolarChipRow.test.tsx` is the centre of the test effort. Required cases:
+
+1. Healthy context (CD0=0.01, e=0.85, AR=15, CL_max=1.2) → all five chips
+   render; ρ = 0.01·π·0.85·15 / 1.44 ≈ 0.28 with `text-emerald-400`.
+2. Threshold matrix for ρ — six cases pin inclusion semantics:
+   ρ ∈ {0.20, 1/3, 0.50, 0.99, 1.00, 1.20} → emerald, amber (lower
+   boundary inclusive), amber, amber, red (upper boundary inclusive),
+   red.
+3. Asterisk pathway: `e_oswald_fallback_used = true` → symbol `e*`, value
+   `0.80`, fallback tooltip.
+4. Quality matrix on `e`: `high` / `medium` / `low` / `unknown` → emerald /
+   amber / orange / muted.
+5. Each individual `null` input (`cd0`, `e`, `aspect_ratio`, `cl_max`)
+   propagates correctly: that chip and ρ both go to `—`.
+6. `ctx === null` → every chip `—`, no crashes.
+7. Tooltip text correctness — assert visible after hover/focus; ρ tooltip
+   contains the threshold breakdown.
+8. `isRecomputing = true` overrides quality and traffic-light colours with
+   `text-red-400`.
+
+`Chip.test.tsx`: render with `value`, with `valueNode`, `stale` red,
+`valueColorClassName` applied, `stale` overrides `valueColorClassName`.
+
+`SpeedChipRow.test.tsx`, `GeometryChipRow.test.tsx`,
+`StabilityChipRow.test.tsx`: migrate the relevant cases from the current
+`InfoChipRow.test.tsx`. No new behaviour — only sub-component scoping.
+
+`InfoChipRow.test.tsx` is reduced to container behaviour: renders all four
+rows in the expected order; refresh button calls SWR `mutate`; recomputing
+pill appears when `isRecomputing`.
+
+## 12 · Implementation order (TDD)
+
+The order minimises risk of regressing existing chip behaviour:
+
+1. Extract `Chip.tsx` (move existing inner function verbatim, add
+   `valueColorClassName`). Write `Chip.test.tsx`. Verify existing
+   `InfoChipRow.test.tsx` still passes after `InfoChipRow.tsx` imports the
+   primitive.
+2. Extract `SpeedChipRow.tsx`; migrate the relevant tests. Verify.
+3. Extract `GeometryChipRow.tsx` (existing chips first, **without** AR);
+   migrate tests. Verify.
+4. Extract `StabilityChipRow.tsx`; migrate tests. Verify.
+5. Extend `ComputationContext` type with the new fields.
+6. Add AR chip to `GeometryChipRow.tsx`; add the new test case.
+7. Write `PolarChipRow.test.tsx` (all 8 cases) — RED.
+8. Implement `PolarChipRow.tsx` and the `computeRho` helper — GREEN.
+9. Wire `PolarChipRow` into `InfoChipRow.tsx` between Geometry and
+   Stability. Update `InfoChipRow.test.tsx` to assert the four-row order.
+
+Each step is a self-contained commit. Step 8 is the only place where new
+visual logic lands; steps 1–6 are mechanical refactors.
+
+## 13 · Acceptance criteria
+
+- [ ] `InfoChipRow.tsx` is ≤ 80 lines (container only).
+- [ ] Four row components exist as sibling files, each with its own test
+      file.
+- [ ] A `PolarChipRow` row appears in the workbench between Geometry and
+      Stability.
+- [ ] For a healthy polar (R² > 0.95, ρ < 1/3), the row shows `Re`,
+      `C_D0`, `e`, `C_L,max`, `ρ` all populated, `ρ` in emerald.
+- [ ] For the reproduction aeroplane in #625 (polar fit rejected), the row
+      shows `Re=…`, `C_D0=—`, `e*=0.80` in muted grey, `C_L,max=—`,
+      `ρ=—`. Tooltips explain each `—`.
+- [ ] `ρ` traffic-light thresholds are unit-tested at the boundaries.
+- [ ] Tooltip on `ρ` contains the threshold meaning verbatim.
+- [ ] `is_glider === true` does **not** hide any polar chip.
+- [ ] During recompute, all chip values are red (existing stale pattern
+      continues to win).
+- [ ] `npm run test:unit` passes.
+
+## 14 · Decisions taken during brainstorming
+
+1. **All four values plus the derived ρ.** Plain values alone are not
+   sufficient for self-diagnosis; ρ does the interpretation.
+2. **Thematic split: Speed / Geometry / Polar / Stability — four rows.**
+   The Polar row gets its own thematic section rather than being appended
+   to Geometry (which would be eleven chips wide).
+3. **Annotation level = Diagnostic.** Asterisk on `e` when fallback, quality
+   colour on `e`, and the traffic-light ρ chip — all of these in one shot,
+   not staged.
+4. **Empty values render as `—` with an explanatory tooltip.** No hidden
+   chips; explicit absence is preferable to invisible omission (the same
+   principle that the Mission radar epic #561 is currently failing on).
+5. **Full split into five new components.** `InfoChipRow.tsx` becomes a
+   thin container. Three extracted rows have no behaviour change; the
+   Polar row introduces the new logic. The shared `Chip` primitive
+   eliminates the duplicate inner function and adds a single new prop.
+6. **Polar chips always visible.** Gliders specifically benefit from polar
+   transparency, so the `!is_glider` gating used by V_a / V_max / V_dive is
+   not extended.
+7. **Stale red overrides quality and traffic-light colours.** Single source
+   of visual truth during recompute; the user knows the values are
+   provisional.
+
+## 15 · References
+
+- **#625** — Mission Radar Ist polygon bug cluster (the trigger that surfaced
+  the diagnostic gap).
+- **#575** — InfoChipRow split into two rows / refresh button. This spec
+  refactors the same component.
+- **#545 / #550** — Mission Tab spider chart epic & component (the
+  downstream consumer of these polar values).
+- **`assumption_compute_service.py:434-488`** — backend writer of the
+  context keys this UI consumes.
+- **`field_length_service.py:322-335`** — gh-548 wiring that revealed the
+  mass-source mismatch. Adjacent context for #625 Bug B.
+- **Anderson, *Fundamentals of Aerodynamics* 6e, §6.7.2** — derivation of
+  L/D-max and the optimum-CL conditions used in the ρ formula.

--- a/frontend/__tests__/Chip.test.tsx
+++ b/frontend/__tests__/Chip.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) =>
+    React.createElement("span", props);
+  return { Wind: icon };
+});
+
+import { Chip } from "@/components/workbench/Chip";
+import { Wind } from "lucide-react";
+
+describe("Chip primitive", () => {
+  it("renders symbol = value", () => {
+    render(<Chip icon={Wind} symbol="V_md" value="13.2 m/s" />);
+    expect(screen.getByText(/13\.2 m\/s/)).toBeInTheDocument();
+  });
+
+  it("renders valueNode in place of value when provided", () => {
+    render(
+      <Chip
+        icon={Wind}
+        symbol="CG"
+        valueNode={<span data-testid="rich">rich</span>}
+      />,
+    );
+    expect(screen.getByTestId("rich")).toBeInTheDocument();
+  });
+
+  it("applies stale red colour to value when stale=true", () => {
+    const { container } = render(
+      <Chip icon={Wind} symbol="V_md" value="13.2" stale />,
+    );
+    const valueSpan = container.querySelector("span.text-red-400");
+    expect(valueSpan).not.toBeNull();
+  });
+
+  it("applies valueColorClassName when not stale", () => {
+    const { container } = render(
+      <Chip
+        icon={Wind}
+        symbol="e"
+        value="0.80"
+        valueColorClassName="text-emerald-400"
+      />,
+    );
+    expect(container.querySelector("span.text-emerald-400")).not.toBeNull();
+  });
+
+  it("stale overrides valueColorClassName", () => {
+    const { container } = render(
+      <Chip
+        icon={Wind}
+        symbol="e"
+        value="0.80"
+        valueColorClassName="text-emerald-400"
+        stale
+      />,
+    );
+    expect(container.querySelector("span.text-red-400")).not.toBeNull();
+    expect(container.querySelector("span.text-emerald-400")).toBeNull();
+  });
+
+  it("renders tooltip description", () => {
+    render(
+      <Chip
+        icon={Wind}
+        symbol="V_md"
+        value="13.2"
+        description="Minimum-drag speed"
+      />,
+    );
+    expect(screen.getByText("Minimum-drag speed")).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/GeometryChipRow.test.tsx
+++ b/frontend/__tests__/GeometryChipRow.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (p: Record<string, unknown>) => React.createElement("span", p);
+  return { Square: icon, Ruler: icon, ArrowLeftRight: icon, Gauge: icon };
+});
+
+import { GeometryChipRow } from "@/components/workbench/GeometryChipRow";
+import type { ComputationContext } from "@/hooks/useComputationContext";
+
+describe("GeometryChipRow", () => {
+  it("renders S_ref, MAC, B_ref, AR", () => {
+    render(
+      <GeometryChipRow
+        ctx={{
+          s_ref_m2: 0.4,
+          mac_m: 0.21,
+          b_ref_m: 2.0,
+          aspect_ratio: 10.0,
+        } as unknown as ComputationContext}
+        isRecomputing={false}
+      />,
+    );
+    expect(screen.getByText(/0\.400 m²/)).toBeInTheDocument();
+    expect(screen.getByText(/0\.21 m/)).toBeInTheDocument();
+    expect(screen.getByText(/2\.00 m/)).toBeInTheDocument();
+    expect(screen.getByText(/10\.00$/)).toBeInTheDocument();
+  });
+
+  it("AR=null → '–'", () => {
+    render(
+      <GeometryChipRow
+        ctx={{ s_ref_m2: 0.4, mac_m: 0.21, b_ref_m: 2, aspect_ratio: null } as unknown as ComputationContext}
+        isRecomputing={false}
+      />,
+    );
+    expect(screen.getAllByText("–").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("ctx=null → all dashes", () => {
+    render(<GeometryChipRow ctx={null} isRecomputing={false} />);
+    expect(screen.getAllByText("–").length).toBe(4);
+  });
+});

--- a/frontend/__tests__/InfoChipRow.test.tsx
+++ b/frontend/__tests__/InfoChipRow.test.tsx
@@ -184,9 +184,9 @@ describe("Info Chip Row", () => {
     expect(subTexts).toContain("dive");
   });
 
-  // gh-575: chip row splits into two rows (envelope speeds, aero geometry).
-  // gh-593: geometry row now includes S_ref and B_ref alongside MAC.
-  it("splits envelope speeds and aero geometry into two separate rows", async () => {
+  // gh-626: chip row splits into FOUR thematic rows
+  // (speeds / geometry / polar / stability).
+  it("splits chips into four thematic rows: speeds / geometry / polar / stability", async () => {
     (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
       data: {
         v_cruise_mps: 18.0,
@@ -202,12 +202,20 @@ describe("Info Chip Row", () => {
         mac_m: 0.21,
         s_ref_m2: 0.42,
         b_ref_m: 2.0,
+        aspect_ratio: 10.0,
+        cd0: 0.02,
+        e_oswald: 0.8,
+        e_oswald_quality: "high",
+        e_oswald_fallback_used: false,
+        polar_by_config: { clean: { cl_max: 1.4 } },
         x_np_m: 0.085,
         target_static_margin: 0.12,
         cg_agg_m: 0.092,
+        is_glider: false,
       },
       isLoading: false,
       error: null,
+      mutate: vi.fn(),
     });
 
     const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
@@ -215,22 +223,34 @@ describe("Info Chip Row", () => {
 
     const speedsRow = screen.getByTestId("chip-row-speeds");
     const geometryRow = screen.getByTestId("chip-row-geometry");
+    const polarRow = screen.getByTestId("chip-row-polar");
+    const stabilityRow = screen.getByTestId("chip-row-stability");
 
-    // Envelope speeds belong to row 1.
+    // Envelope speeds in row 1.
     expect(speedsRow).toContainElement(screen.getByRole("group", { name: /^V stall:/ }));
-    expect(speedsRow).toContainElement(screen.getByRole("group", { name: /V min sink/ }));
     expect(speedsRow).toContainElement(screen.getByRole("group", { name: /^V max:/ }));
 
-    // Aero geometry belongs to row 2 (gh-593: includes S_ref + B_ref).
-    expect(geometryRow).toContainElement(screen.getByRole("group", { name: /^Re:/ }));
+    // Geometry row (gh-626: AR added here, Re moved to polar row).
     expect(geometryRow).toContainElement(screen.getByRole("group", { name: /^S ref:/ }));
     expect(geometryRow).toContainElement(screen.getByRole("group", { name: /^MAC:/ }));
     expect(geometryRow).toContainElement(screen.getByRole("group", { name: /^B ref:/ }));
-    expect(geometryRow).toContainElement(screen.getByRole("group", { name: /^CG:/ }));
+    expect(geometryRow).toContainElement(screen.getByRole("group", { name: /^AR:/ }));
+
+    // Polar row (gh-626 NEW: Re, C_D0, e, k, C_L,md, C_L,max, (L/D)_max, ρ).
+    expect(polarRow).toContainElement(screen.getByRole("group", { name: /^Re:/ }));
+    expect(polarRow).toContainElement(screen.getByRole("group", { name: /^C D0:/ }));
+    expect(polarRow).toContainElement(screen.getByRole("group", { name: /^e:/ }));
+    expect(polarRow).toContainElement(screen.getByRole("group", { name: /^ρ:/ }));
+
+    // Stability row.
+    expect(stabilityRow).toContainElement(screen.getByRole("group", { name: /^CG:/ }));
+    expect(stabilityRow).toContainElement(screen.getByRole("group", { name: /^NP:/ }));
 
     // No chip is placed in the wrong row.
     expect(geometryRow).not.toContainElement(screen.getByRole("group", { name: /^V stall:/ }));
     expect(speedsRow).not.toContainElement(screen.getByRole("group", { name: /^Re:/ }));
+    expect(geometryRow).not.toContainElement(screen.getByRole("group", { name: /^Re:/ }));
+    expect(polarRow).not.toContainElement(screen.getByRole("group", { name: /^CG:/ }));
   });
 
   // gh-593: S_ref chip renders with the formatted area value (3 decimals + " m²").

--- a/frontend/__tests__/PolarChipRow.test.tsx
+++ b/frontend/__tests__/PolarChipRow.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import React from "react";
 
 vi.mock("lucide-react", () => {
@@ -52,13 +52,25 @@ const REJECTED = {
   is_glider: false,
 };
 
-function findRhoValueSpan(container: HTMLElement, rhoText: RegExp): HTMLElement {
-  // The ρ value span is inside the polar chip-row, with the rho text.
-  const matches = screen.getAllByText(rhoText);
-  // Return the last match — the chip's value span (the surrounding chip
-  // may render multiple matching texts on different lines; we want the
-  // actual value span which carries the colour).
-  return matches[matches.length - 1] as HTMLElement;
+function findRhoValueSpan(rhoText: RegExp): HTMLElement {
+  // Scope to the ρ chip (aria-label starts with "ρ:") so we don't pick up
+  // a coincidentally-matching number elsewhere in the polar row.
+  const polarRow = screen.getByTestId("chip-row-polar");
+  const rhoChip = within(polarRow).getByRole("group", { name: /^ρ:/ });
+  return within(rhoChip).getByText(rhoText) as HTMLElement;
+}
+
+function findEChipValueSpan(symbol: string, value: RegExp): HTMLElement {
+  // Scope assertions about the e / e* chip to the e chip itself so a
+  // coincidental match elsewhere in the row cannot pass the test.
+  const polarRow = screen.getByTestId("chip-row-polar");
+  // Both 'e' and 'e*' render with the aria-label "e: …" — renderSymbol
+  // keeps trailing non-word chars outside the subscript, but humanize()
+  // strips underscores only. So the label starts with "e:".
+  const eChip = symbol === "e*"
+    ? within(polarRow).getByRole("group", { name: /^e\*?:/ })
+    : within(polarRow).getByRole("group", { name: /^e:/ });
+  return within(eChip).getByText(value) as HTMLElement;
 }
 
 describe("PolarChipRow", () => {
@@ -87,7 +99,7 @@ describe("PolarChipRow", () => {
         isRecomputing={false}
       />,
     );
-    const rho = findRhoValueSpan(document.body, /^0\.38$/);
+    const rho = findRhoValueSpan(/^0\.38$/);
     expect(rho.className).toContain("text-emerald-400");
   });
 
@@ -105,7 +117,7 @@ describe("PolarChipRow", () => {
         isRecomputing={false}
       />,
     );
-    const rho = findRhoValueSpan(document.body, /^0\.33$/);
+    const rho = findRhoValueSpan(/^0\.33$/);
     expect(rho.className).toContain("text-amber-400");
   });
 
@@ -121,7 +133,7 @@ describe("PolarChipRow", () => {
         isRecomputing={false}
       />,
     );
-    const rho = findRhoValueSpan(document.body, /^1\.00$/);
+    const rho = findRhoValueSpan(/^1\.00$/);
     expect(rho.className).toContain("text-red-400");
   });
 
@@ -137,7 +149,7 @@ describe("PolarChipRow", () => {
         isRecomputing={false}
       />,
     );
-    const rho = findRhoValueSpan(document.body, /^0\.67$/);
+    const rho = findRhoValueSpan(/^0\.67$/);
     expect(rho.className).toContain("text-amber-400");
   });
 
@@ -146,32 +158,43 @@ describe("PolarChipRow", () => {
     ["medium", "text-amber-400"],
     ["low", "text-orange-400"],
     ["unknown", "text-muted-foreground"],
-  ] as const)("e-quality %s → %s", (q, cls) => {
+  ] as const)("e-quality %s → e value coloured %s", (q, cls) => {
     const ctx = { ...HEALTHY, e_oswald_quality: q };
-    const { container } = render(
+    render(
       <PolarChipRow
         ctx={ctx as unknown as ComputationContext}
         isRecomputing={false}
       />,
     );
-    expect(container.innerHTML).toContain(cls);
+    // Scope: the e chip specifically. innerHTML.contains would also pass
+    // when an unrelated chip happens to use the same Tailwind class.
+    const eValue = findEChipValueSpan("e", /^0\.80$/);
+    expect(eValue.className).toContain(cls);
   });
 
-  it("#625 reproduction: e* muted + k/CLmd/EMax/ρ all '–'", () => {
-    const { container } = render(
+  it("#625 reproduction: e*=0.80 muted + bail tooltip on exactly 4 derived chips", () => {
+    render(
       <PolarChipRow
         ctx={REJECTED as unknown as ComputationContext}
         isRecomputing={false}
       />,
     );
-    // e* muted
-    expect(container.innerHTML).toContain("text-muted-foreground");
-    // four derived chips render '–'
-    expect(screen.getAllByText("–").length).toBeGreaterThanOrEqual(4);
+    // e* chip: value is the fallback 0.80, value-span is muted.
+    const eValue = findEChipValueSpan("e*", /^0\.80$/);
+    expect(eValue.className).toContain("text-muted-foreground");
+    // Exactly four derived chips bail to '–' (k, C_L,md, (L/D)_max, ρ).
+    expect(screen.getAllByText("–").length).toBe(4);
+    // The bail tooltip text must appear on each of the four chips — and
+    // ONLY on those (not on Re/CD0/e*/CL,max which have their own
+    // non-bail descriptions).
+    expect(screen.getAllByText(/non-parabolic/i)).toHaveLength(4);
   });
 
   it("each null input nukes its dependents", () => {
-    const variants: Array<Partial<typeof HEALTHY>> = [
+    // Variant fixtures with one nullable input each — cast through
+    // `unknown` because typeof HEALTHY narrows the numeric fields to
+    // non-nullable based on the literal initialiser.
+    const variants: ReadonlyArray<unknown> = [
       { ...HEALTHY, cd0: null },
       { ...HEALTHY, aspect_ratio: null },
       { ...HEALTHY, polar_by_config: { clean: { cl_max: null } } },
@@ -179,7 +202,7 @@ describe("PolarChipRow", () => {
     for (const ctx of variants) {
       const { unmount } = render(
         <PolarChipRow
-          ctx={ctx as unknown as ComputationContext}
+          ctx={ctx as ComputationContext}
           isRecomputing={false}
         />,
       );
@@ -218,16 +241,17 @@ describe("PolarChipRow", () => {
     expect(screen.getByText(/headline polar number/i)).toBeInTheDocument();
   });
 
-  it("bail-rule tooltip contains 'non-parabolic'", () => {
-    render(
-      <PolarChipRow
-        ctx={REJECTED as unknown as ComputationContext}
-        isRecomputing={false}
-      />,
-    );
-    // Tooltip text appears in all 4 bailed derived chips (k, C_L,md,
-    // (L/D)_max, ρ) — assert at least one match exists.
-    expect(screen.getAllByText(/non-parabolic/i).length).toBeGreaterThanOrEqual(1);
+  it("missing-input tooltip distinguishes the cause from the bail rule", () => {
+    // gh-626 review #2: when rho is null because CD0 is missing (NOT
+    // because the fit was rejected), the tooltip must say "missing
+    // input" — NOT "fit rejected (see e*)" which would misdirect.
+    const ctx = { ...HEALTHY, cd0: null } as unknown as ComputationContext;
+    render(<PolarChipRow ctx={ctx} isRecomputing={false} />);
+    // No "non-parabolic" / "see e*" anywhere — the fit was not rejected.
+    expect(screen.queryByText(/non-parabolic/i)).toBeNull();
+    // The cause-distinguishing tooltip names the missing input.
+    expect(screen.getAllByText(/missing or non-physical input/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/C_D0/).length).toBeGreaterThan(0);
   });
 
   it("isRecomputing=true puts stale red on the ρ value (overrides emerald)", () => {
@@ -237,7 +261,7 @@ describe("PolarChipRow", () => {
         isRecomputing={true}
       />,
     );
-    const rho = findRhoValueSpan(document.body, /^0\.18$/);
+    const rho = findRhoValueSpan(/^0\.18$/);
     expect(rho.className).toContain("text-red-400");
   });
 });

--- a/frontend/__tests__/PolarChipRow.test.tsx
+++ b/frontend/__tests__/PolarChipRow.test.tsx
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (p: Record<string, unknown>) => React.createElement("span", p);
+  return {
+    Wind: icon, Gauge: icon, Activity: icon,
+    Target: icon, TrendingUp: icon, AlertTriangle: icon,
+  };
+});
+
+import { PolarChipRow } from "@/components/workbench/PolarChipRow";
+import type { ComputationContext } from "@/hooks/useComputationContext";
+
+// Healthy powered fixture: CD0=0.02, e=0.80, AR=7, CL_max=1.4
+// → ρ = 0.02·π·0.8·7/1.4² ≈ 0.180 emerald
+const HEALTHY = {
+  reynolds: 540000,
+  cd0: 0.02,
+  e_oswald: 0.80,
+  e_oswald_quality: "high" as const,
+  e_oswald_fallback_used: false,
+  aspect_ratio: 7,
+  polar_by_config: { clean: { cl_max: 1.4 } },
+  is_glider: false,
+};
+
+// Sailplane: CD0=0.008, e=0.95, AR=36, CL_max=1.5, is_glider=true
+// ρ = 0.008·π·0.95·36/1.5² ≈ 0.382 — amber on powered thresholds,
+// emerald on glider (amber boundary 2/3)
+const SAILPLANE = {
+  reynolds: 1.2e6,
+  cd0: 0.008,
+  e_oswald: 0.95,
+  e_oswald_quality: "high" as const,
+  e_oswald_fallback_used: false,
+  aspect_ratio: 36,
+  polar_by_config: { clean: { cl_max: 1.5 } },
+  is_glider: true,
+};
+
+// Fit-rejected (gh-625 reproduction): e_oswald_fallback_used=true
+const REJECTED = {
+  reynolds: 230000,
+  cd0: 0.04,
+  e_oswald: null,
+  e_oswald_quality: "unknown" as const,
+  e_oswald_fallback_used: true,
+  aspect_ratio: 6,
+  polar_by_config: { clean: { cl_max: 1.0 } },
+  is_glider: false,
+};
+
+function findRhoValueSpan(container: HTMLElement, rhoText: RegExp): HTMLElement {
+  // The ρ value span is inside the polar chip-row, with the rho text.
+  const matches = screen.getAllByText(rhoText);
+  // Return the last match — the chip's value span (the surrounding chip
+  // may render multiple matching texts on different lines; we want the
+  // actual value span which carries the colour).
+  return matches[matches.length - 1] as HTMLElement;
+}
+
+describe("PolarChipRow", () => {
+  it("healthy powered: all 8 chips populated, ρ emerald", () => {
+    const { container } = render(
+      <PolarChipRow
+        ctx={HEALTHY as unknown as ComputationContext}
+        isRecomputing={false}
+      />,
+    );
+    expect(screen.getByText(/5\.4e\+?5/)).toBeInTheDocument(); // Re
+    expect(screen.getByText(/^0\.0200$/)).toBeInTheDocument(); // CD0
+    expect(screen.getByText(/^0\.80$/)).toBeInTheDocument();   // e
+    expect(screen.getByText(/^0\.0568$/)).toBeInTheDocument(); // k = 1/(π·0.8·7)
+    expect(screen.getByText(/^0\.59$/)).toBeInTheDocument();   // C_L,md ≈ 0.5932 → 0.59
+    expect(screen.getByText(/^1\.40$/)).toBeInTheDocument();   // C_L,max
+    expect(screen.getByText(/^14\.8$/)).toBeInTheDocument();   // (L/D)_max ≈ 14.83
+    expect(screen.getByText(/^0\.18$/)).toBeInTheDocument();   // ρ
+    expect(container.querySelector(".text-emerald-400")).not.toBeNull();
+  });
+
+  it("sailplane: ρ ≈ 0.38 → emerald on glider thresholds", () => {
+    render(
+      <PolarChipRow
+        ctx={SAILPLANE as unknown as ComputationContext}
+        isRecomputing={false}
+      />,
+    );
+    const rho = findRhoValueSpan(document.body, /^0\.38$/);
+    expect(rho.className).toContain("text-emerald-400");
+  });
+
+  it("powered amber lower boundary (ρ = 1/3) → amber", () => {
+    // ρ = CD0·π·e·AR / CL_max² = 1/3.  e=0.8, AR=7, CL_max=1.0
+    // → CD0 = (1/3) · 1 / (π · 0.8 · 7) = 0.01895
+    const ctx = {
+      ...HEALTHY,
+      cd0: 1 / (3 * Math.PI * 0.8 * 7),
+      polar_by_config: { clean: { cl_max: 1.0 } },
+    };
+    render(
+      <PolarChipRow
+        ctx={ctx as unknown as ComputationContext}
+        isRecomputing={false}
+      />,
+    );
+    const rho = findRhoValueSpan(document.body, /^0\.33$/);
+    expect(rho.className).toContain("text-amber-400");
+  });
+
+  it("powered red boundary (ρ = 1.00) → red", () => {
+    const ctx = {
+      ...HEALTHY,
+      cd0: 1.0 / (Math.PI * 0.8 * 7), // ρ = 1.0 with CL_max=1
+      polar_by_config: { clean: { cl_max: 1.0 } },
+    };
+    render(
+      <PolarChipRow
+        ctx={ctx as unknown as ComputationContext}
+        isRecomputing={false}
+      />,
+    );
+    const rho = findRhoValueSpan(document.body, /^1\.00$/);
+    expect(rho.className).toContain("text-red-400");
+  });
+
+  it("glider amber lower boundary (ρ = 2/3, is_glider=true) → amber", () => {
+    const ctx = {
+      ...SAILPLANE,
+      cd0: (2 / 3) / (Math.PI * 0.95 * 36),
+      polar_by_config: { clean: { cl_max: 1.0 } },
+    };
+    render(
+      <PolarChipRow
+        ctx={ctx as unknown as ComputationContext}
+        isRecomputing={false}
+      />,
+    );
+    const rho = findRhoValueSpan(document.body, /^0\.67$/);
+    expect(rho.className).toContain("text-amber-400");
+  });
+
+  it.each([
+    ["high", "text-emerald-400"],
+    ["medium", "text-amber-400"],
+    ["low", "text-orange-400"],
+    ["unknown", "text-muted-foreground"],
+  ] as const)("e-quality %s → %s", (q, cls) => {
+    const ctx = { ...HEALTHY, e_oswald_quality: q };
+    const { container } = render(
+      <PolarChipRow
+        ctx={ctx as unknown as ComputationContext}
+        isRecomputing={false}
+      />,
+    );
+    expect(container.innerHTML).toContain(cls);
+  });
+
+  it("#625 reproduction: e* muted + k/CLmd/EMax/ρ all '–'", () => {
+    const { container } = render(
+      <PolarChipRow
+        ctx={REJECTED as unknown as ComputationContext}
+        isRecomputing={false}
+      />,
+    );
+    // e* muted
+    expect(container.innerHTML).toContain("text-muted-foreground");
+    // four derived chips render '–'
+    expect(screen.getAllByText("–").length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("each null input nukes its dependents", () => {
+    const variants: Array<Partial<typeof HEALTHY>> = [
+      { ...HEALTHY, cd0: null },
+      { ...HEALTHY, aspect_ratio: null },
+      { ...HEALTHY, polar_by_config: { clean: { cl_max: null } } },
+    ];
+    for (const ctx of variants) {
+      const { unmount } = render(
+        <PolarChipRow
+          ctx={ctx as unknown as ComputationContext}
+          isRecomputing={false}
+        />,
+      );
+      expect(screen.getAllByText("–").length).toBeGreaterThanOrEqual(1);
+      unmount();
+    }
+  });
+
+  it("ctx=null → at least 7 dashes (CD0, e, k, CLmd, CLmax, EMax, ρ)", () => {
+    render(<PolarChipRow ctx={null} isRecomputing={false} />);
+    expect(screen.getAllByText("–").length).toBeGreaterThanOrEqual(7);
+  });
+
+  it("ρ-red tooltip prescribes 'see Matching Chart'", () => {
+    const ctx = {
+      ...HEALTHY,
+      cd0: 1.0 / (Math.PI * 0.8 * 7),
+      polar_by_config: { clean: { cl_max: 1.0 } },
+    };
+    render(
+      <PolarChipRow
+        ctx={ctx as unknown as ComputationContext}
+        isRecomputing={false}
+      />,
+    );
+    expect(screen.getByText(/see Matching Chart/i)).toBeInTheDocument();
+  });
+
+  it("(L/D)_max tooltip contains 'headline polar number'", () => {
+    render(
+      <PolarChipRow
+        ctx={HEALTHY as unknown as ComputationContext}
+        isRecomputing={false}
+      />,
+    );
+    expect(screen.getByText(/headline polar number/i)).toBeInTheDocument();
+  });
+
+  it("bail-rule tooltip contains 'non-parabolic'", () => {
+    render(
+      <PolarChipRow
+        ctx={REJECTED as unknown as ComputationContext}
+        isRecomputing={false}
+      />,
+    );
+    // Tooltip text appears in all 4 bailed derived chips (k, C_L,md,
+    // (L/D)_max, ρ) — assert at least one match exists.
+    expect(screen.getAllByText(/non-parabolic/i).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("isRecomputing=true puts stale red on the ρ value (overrides emerald)", () => {
+    render(
+      <PolarChipRow
+        ctx={HEALTHY as unknown as ComputationContext}
+        isRecomputing={true}
+      />,
+    );
+    const rho = findRhoValueSpan(document.body, /^0\.18$/);
+    expect(rho.className).toContain("text-red-400");
+  });
+});

--- a/frontend/__tests__/SpeedChipRow.test.tsx
+++ b/frontend/__tests__/SpeedChipRow.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (p: Record<string, unknown>) => React.createElement("span", p);
+  return {
+    Wind: icon, AlertTriangle: icon, Plane: icon, Gauge: icon,
+    TrendingUp: icon, Zap: icon,
+  };
+});
+
+import { SpeedChipRow } from "@/components/workbench/SpeedChipRow";
+import type { ComputationContext } from "@/hooks/useComputationContext";
+
+const baseCtx = {
+  v_cruise_mps: 18.0,
+  v_stall_mps: 13.2,
+  v_md_mps: 17.0,
+  v_min_sink_mps: 14.5,
+  v_max_mps: 25.0,
+  v_a_mps: 19.0,
+  v_dive_mps: 35.0,
+  v_x_mps: 12.0,
+  v_y_mps: 15.5,
+  is_glider: false,
+};
+
+describe("SpeedChipRow", () => {
+  it("renders all V-speed chips when context complete", () => {
+    render(<SpeedChipRow ctx={baseCtx as unknown as ComputationContext} isRecomputing={false} />);
+    expect(screen.getByText(/13\.2 m\/s/)).toBeInTheDocument();
+    expect(screen.getByText(/18\.0 m\/s/)).toBeInTheDocument();
+    expect(screen.getByText(/35\.0 m\/s/)).toBeInTheDocument();
+  });
+
+  it("V_cruise* tooltip indicates auto-derived", () => {
+    render(
+      <SpeedChipRow
+        ctx={{ ...baseCtx, v_cruise_auto: true } as unknown as ComputationContext}
+        isRecomputing={false}
+      />,
+    );
+    expect(screen.getByText(/auto-derived from cruise sizing/i)).toBeInTheDocument();
+  });
+
+  it("hides V_a, V_max, V_dive when is_glider=true", () => {
+    render(
+      <SpeedChipRow
+        ctx={{ ...baseCtx, is_glider: true } as unknown as ComputationContext}
+        isRecomputing={false}
+      />,
+    );
+    expect(screen.queryByText(/manoeuvring speed/i)).toBeNull();
+    expect(screen.queryByText(/Maximum operating speed/i)).toBeNull();
+    expect(screen.queryByText(/dive speed/i)).toBeNull();
+  });
+
+  it("shows dashes when ctx is null", () => {
+    render(<SpeedChipRow ctx={null} isRecomputing={false} />);
+    const dashes = screen.getAllByText("–");
+    expect(dashes.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it("rightSlot renders next to the speed chips", () => {
+    render(
+      <SpeedChipRow
+        ctx={baseCtx as unknown as ComputationContext}
+        isRecomputing={false}
+        rightSlot={<button data-testid="my-slot">slot</button>}
+      />,
+    );
+    expect(screen.getByTestId("my-slot")).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/StabilityChipRow.test.tsx
+++ b/frontend/__tests__/StabilityChipRow.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => {
+  const icon = (p: Record<string, unknown>) => React.createElement("span", p);
+  return { Target: icon, Navigation: icon };
+});
+
+import { StabilityChipRow } from "@/components/workbench/StabilityChipRow";
+import type { ComputationContext } from "@/hooks/useComputationContext";
+
+describe("StabilityChipRow", () => {
+  it("renders NP, SM, CG", () => {
+    render(
+      <StabilityChipRow
+        ctx={{
+          x_np_m: 0.085,
+          target_static_margin: 0.12,
+          cg_agg_m: 0.092,
+          mac_m: 0.21,
+        } as unknown as ComputationContext}
+        cgAero={0.073}
+        isRecomputing={false}
+      />,
+    );
+    expect(screen.getByText(/0\.085 m/)).toBeInTheDocument();
+    expect(screen.getByText(/12%/)).toBeInTheDocument();
+    expect(screen.getByText(/0\.073 m/)).toBeInTheDocument();
+  });
+
+  it("ctx=null → dashes", () => {
+    render(<StabilityChipRow ctx={null} cgAero={null} isRecomputing={false} />);
+    expect(screen.getAllByText("–").length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/frontend/__tests__/polar.test.ts
+++ b/frontend/__tests__/polar.test.ts
@@ -27,6 +27,18 @@ describe("polar.computeCLmd", () => {
     expect(computeCLmd(0.02, 0.8, false, 0)).toBeNull();
     expect(computeCLmd(-0.01, 0.8, false, 7)).toBeNull();
   });
+  it("rejects non-finite inputs (Infinity / -Infinity / NaN)", () => {
+    // Corrupt-payload guard — a backend `np.inf` from a degenerate fit
+    // would otherwise propagate through .toFixed(2) as "Infinity" in the
+    // chip rather than the documented "—" bail state.
+    expect(computeCLmd(Infinity, 0.8, false, 7)).toBeNull();
+    expect(computeCLmd(0.02, Infinity, false, 7)).toBeNull();
+    expect(computeCLmd(0.02, 0.8, false, Infinity)).toBeNull();
+    expect(computeCLmd(-Infinity, 0.8, false, 7)).toBeNull();
+    expect(computeCLmd(NaN, 0.8, false, 7)).toBeNull();
+    expect(computeCLmd(0.02, NaN, false, 7)).toBeNull();
+    expect(computeCLmd(0.02, 0.8, false, NaN)).toBeNull();
+  });
 });
 
 describe("polar.computeEMax", () => {
@@ -37,6 +49,34 @@ describe("polar.computeEMax", () => {
   });
   it("ρ-bail when fit rejected", () => {
     expect(computeEMax(0.02, 0.8, true, 7)).toBeNull();
+  });
+  it("rejects non-finite inputs", () => {
+    expect(computeEMax(Infinity, 0.8, false, 7)).toBeNull();
+    expect(computeEMax(0.02, NaN, false, 7)).toBeNull();
+    expect(computeEMax(0.02, 0.8, false, Infinity)).toBeNull();
+  });
+  it("cross-helper identity (L/D)_max · C_L,md = (π·e·AR) / 2 on the grid", () => {
+    // Cross-pin computeEMax against computeCLmd so a sign/factor regression
+    // in only one helper is caught even when both still match their own
+    // formula tests.  Anderson §6.7.2 derivation:
+    //   (L/D)_max = ½·√(π·e·AR / C_D0)
+    //   C_L,md    =      √(π·e·AR · C_D0)
+    //   ⇒ (L/D)_max · C_L,md = (π·e·AR) / 2
+    const cases: ReadonlyArray<[number, number, number]> = [
+      [0.008, 0.95, 36],
+      [0.02, 0.80, 7],
+      [0.04, 0.75, 6],
+      [0.012, 0.85, 18],
+      [0.025, 0.78, 10],
+      [0.015, 0.90, 25],
+    ];
+    for (const [cd0, e, ar] of cases) {
+      const eMax = computeEMax(cd0, e, false, ar);
+      const clMd = computeCLmd(cd0, e, false, ar);
+      expect(eMax).not.toBeNull();
+      expect(clMd).not.toBeNull();
+      expect(eMax! * clMd!).toBeCloseTo((Math.PI * e * ar) / 2, 6);
+    }
   });
 });
 
@@ -67,6 +107,11 @@ describe("polar.computeRho", () => {
   });
   it("ρ-bail when fit rejected", () => {
     expect(computeRho(0.02, 0.8, true, 7, 1.4)).toBeNull();
+  });
+  it("rejects non-finite inputs", () => {
+    expect(computeRho(Infinity, 0.8, false, 7, 1.4)).toBeNull();
+    expect(computeRho(0.02, 0.8, false, NaN, 1.4)).toBeNull();
+    expect(computeRho(0.02, 0.8, false, 7, Infinity)).toBeNull();
   });
 });
 
@@ -135,6 +180,9 @@ describe("polar.rhoColorClassName", () => {
   });
   it("glider: ρ = 2/3 → amber", () => {
     expect(rhoColorClassName(2 / 3, true)).toBe("text-amber-400");
+  });
+  it("glider: ρ ∈ (2/3, 1) → amber (interior)", () => {
+    expect(rhoColorClassName(0.85, true)).toBe("text-amber-400");
   });
   it("glider: ρ = 1 → red", () => {
     expect(rhoColorClassName(1.0, true)).toBe("text-red-400");

--- a/frontend/__tests__/polar.test.ts
+++ b/frontend/__tests__/polar.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeK,
+  computeCLmd,
+  computeEMax,
+  computeRho,
+  rhoThresholdsForProfile,
+  qualityColorClassName,
+  rhoColorClassName,
+} from "@/lib/polar";
+
+describe("polar.computeCLmd", () => {
+  it("matches √(π·e·AR·CD0)", () => {
+    const v = computeCLmd(0.02, 0.8, false, 7);
+    expect(v).toBeCloseTo(Math.sqrt(Math.PI * 0.8 * 7 * 0.02), 4);
+    expect(v).toBeCloseTo(0.5932, 3);
+  });
+  it("returns null when fit was rejected (ρ-bail rule)", () => {
+    expect(computeCLmd(0.02, 0.8, true, 7)).toBeNull();
+  });
+  it("returns null on each null/zero/negative input", () => {
+    expect(computeCLmd(null, 0.8, false, 7)).toBeNull();
+    expect(computeCLmd(0.02, null, false, 7)).toBeNull();
+    expect(computeCLmd(0.02, 0.8, false, null)).toBeNull();
+    expect(computeCLmd(0, 0.8, false, 7)).toBeNull();
+    expect(computeCLmd(0.02, 0, false, 7)).toBeNull();
+    expect(computeCLmd(0.02, 0.8, false, 0)).toBeNull();
+    expect(computeCLmd(-0.01, 0.8, false, 7)).toBeNull();
+  });
+});
+
+describe("polar.computeEMax", () => {
+  it("matches ½·√(π·e·AR/CD0)", () => {
+    const v = computeEMax(0.02, 0.8, false, 7);
+    expect(v).toBeCloseTo(0.5 * Math.sqrt((Math.PI * 0.8 * 7) / 0.02), 3);
+    expect(v).toBeCloseTo(14.83, 2);
+  });
+  it("ρ-bail when fit rejected", () => {
+    expect(computeEMax(0.02, 0.8, true, 7)).toBeNull();
+  });
+});
+
+describe("polar.computeRho", () => {
+  it("matches CD0·π·e·AR / CL_max²", () => {
+    const v = computeRho(0.02, 0.8, false, 7, 1.4);
+    expect(v).toBeCloseTo((0.02 * Math.PI * 0.8 * 7) / (1.4 * 1.4), 4);
+    expect(v).toBeCloseTo(0.18, 2);
+  });
+  it("identity ρ = (CL_md/CL_max)² across a deterministic grid", () => {
+    // Deterministic table — covers GA, RC, sailplane, and edge-of-range
+    // combinations of (CD0, e, AR, CL_max).
+    const cases: ReadonlyArray<[number, number, number, number]> = [
+      [0.008, 0.95, 36, 1.5],   // ASH-25-class sailplane
+      [0.02, 0.80, 7, 1.4],     // GA trainer
+      [0.04, 0.75, 6, 1.0],     // draggy RC trainer
+      [0.012, 0.85, 18, 1.3],   // motorglider
+      [0.025, 0.78, 10, 1.5],   // GA
+      [0.015, 0.90, 25, 1.4],   // high-performance glider
+    ];
+    for (const [cd0, e, ar, clMax] of cases) {
+      const rho = computeRho(cd0, e, false, ar, clMax);
+      const clMd = computeCLmd(cd0, e, false, ar);
+      expect(rho).not.toBeNull();
+      expect(clMd).not.toBeNull();
+      expect(rho!).toBeCloseTo((clMd! / clMax) ** 2, 6);
+    }
+  });
+  it("ρ-bail when fit rejected", () => {
+    expect(computeRho(0.02, 0.8, true, 7, 1.4)).toBeNull();
+  });
+});
+
+describe("polar.computeK", () => {
+  it("matches 1/(π·e·AR)", () => {
+    expect(computeK(0.8, false, 7)).toBeCloseTo(
+      1 / (Math.PI * 0.8 * 7),
+      6,
+    );
+  });
+  it("ρ-bail when fit rejected", () => {
+    expect(computeK(0.8, true, 7)).toBeNull();
+  });
+});
+
+describe("polar.rhoThresholdsForProfile", () => {
+  it("powered uses { amber: 1/3, red: 1.0 }", () => {
+    expect(rhoThresholdsForProfile(false)).toEqual({
+      amber: 1 / 3,
+      red: 1.0,
+    });
+  });
+  it("glider uses { amber: 2/3, red: 1.0 }", () => {
+    expect(rhoThresholdsForProfile(true)).toEqual({
+      amber: 2 / 3,
+      red: 1.0,
+    });
+  });
+});
+
+describe("polar.qualityColorClassName", () => {
+  it.each([
+    ["high", "text-emerald-400"],
+    ["medium", "text-amber-400"],
+    ["low", "text-orange-400"],
+    ["unknown", "text-muted-foreground"],
+  ] as const)("%s → %s", (q, cls) => {
+    expect(qualityColorClassName(q)).toBe(cls);
+  });
+  it("undefined quality → muted (defensive)", () => {
+    expect(qualityColorClassName(undefined)).toBe("text-muted-foreground");
+  });
+});
+
+describe("polar.rhoColorClassName", () => {
+  it("null ρ → muted", () => {
+    expect(rhoColorClassName(null, false)).toBe("text-muted-foreground");
+  });
+  it("powered: ρ < 1/3 → emerald", () => {
+    expect(rhoColorClassName(0.2, false)).toBe("text-emerald-400");
+  });
+  it("powered: ρ = 1/3 → amber (lower-inclusive)", () => {
+    expect(rhoColorClassName(1 / 3, false)).toBe("text-amber-400");
+  });
+  it("powered: ρ ∈ (1/3, 1) → amber", () => {
+    expect(rhoColorClassName(0.5, false)).toBe("text-amber-400");
+  });
+  it("powered: ρ = 1 → red (upper-inclusive)", () => {
+    expect(rhoColorClassName(1.0, false)).toBe("text-red-400");
+  });
+  it("powered: ρ > 1 → red", () => {
+    expect(rhoColorClassName(1.2, false)).toBe("text-red-400");
+  });
+  it("glider: ρ = 1/3 → still emerald (under 2/3 amber)", () => {
+    expect(rhoColorClassName(1 / 3, true)).toBe("text-emerald-400");
+  });
+  it("glider: ρ = 2/3 → amber", () => {
+    expect(rhoColorClassName(2 / 3, true)).toBe("text-amber-400");
+  });
+  it("glider: ρ = 1 → red", () => {
+    expect(rhoColorClassName(1.0, true)).toBe("text-red-400");
+  });
+});

--- a/frontend/components/workbench/Chip.tsx
+++ b/frontend/components/workbench/Chip.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { renderSymbol } from "@/components/workbench/renderSymbol";
+
+// Replace underscores with spaces so screen readers say
+// "V min sink" instead of "V underscore min underscore sink".
+function humanize(symbol: string): string {
+  return symbol.replace(/_/g, " ");
+}
+
+export function Chip({
+  icon: Icon,
+  symbol,
+  value,
+  valueNode,
+  description,
+  stale = false,
+  valueColorClassName,
+}: {
+  readonly icon: React.ComponentType<{ size: number; className: string }>;
+  readonly symbol: string;
+  readonly value?: string;
+  readonly valueNode?: React.ReactNode;
+  readonly description?: string;
+  readonly stale?: boolean;
+  readonly valueColorClassName?: string;
+}) {
+  // Stale (recompute in flight) always wins over caller-supplied colour:
+  // the chip's value is provisional and that fact dominates any quality
+  // / traffic-light signal.
+  const valueClass = stale
+    ? "text-red-400"
+    : (valueColorClassName ?? "text-foreground");
+  const ariaLabel = description
+    ? `${humanize(symbol)}: ${description}`
+    : humanize(symbol);
+  return (
+    <div
+      role="group"
+      tabIndex={0}
+      aria-label={ariaLabel}
+      className="group/chip relative flex items-center gap-1.5 rounded-full bg-card-muted px-3 py-1.5 focus:outline-none focus-visible:ring-1 focus-visible:ring-primary"
+    >
+      <Icon size={12} className="text-muted-foreground" />
+      <span className="font-[family-name:var(--font-geist-sans)] text-[12px] text-foreground">
+        {renderSymbol(symbol)}
+        {" = "}
+        {valueNode ?? <span className={valueClass}>{value}</span>}
+      </span>
+      {description && (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute bottom-full left-1/2 z-50 mb-1.5 hidden w-max max-w-[240px] -translate-x-1/2 rounded-lg border border-border bg-card px-2.5 py-1.5 text-[10px] font-normal leading-snug text-foreground shadow-lg group-hover/chip:block group-focus-within/chip:block"
+        >
+          {description}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/workbench/GeometryChipRow.tsx
+++ b/frontend/components/workbench/GeometryChipRow.tsx
@@ -30,14 +30,14 @@ export function GeometryChipRow({ ctx, isRecomputing }: Props) {
       <Chip
         icon={Ruler}
         symbol="MAC"
-        description="Mean Aerodynamic Chord (= C_ref in AVL/ASB) — reference chord for pitching moment coefficient"
+        description="Mean Aerodynamic Chord (= C_ref in AVL/ASB) — reference chord for pitching moment coefficient (C_m = M_pitch / (q · S_ref · C_ref))"
         value={fmt(ctx?.mac_m, 2, " m")}
         stale={stale}
       />
       <Chip
         icon={ArrowLeftRight}
         symbol="B_ref"
-        description="Reference span — wingspan used to non-dimensionalize roll and yaw moments"
+        description="Reference span — wingspan used to non-dimensionalize roll and yaw moments (C_l = M_roll / (q · S_ref · B_ref))"
         value={fmt(ctx?.b_ref_m, 2, " m")}
         stale={stale}
       />

--- a/frontend/components/workbench/GeometryChipRow.tsx
+++ b/frontend/components/workbench/GeometryChipRow.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Square, Ruler, ArrowLeftRight, Gauge } from "lucide-react";
+import { Chip } from "@/components/workbench/Chip";
+import type { ComputationContext } from "@/hooks/useComputationContext";
+
+interface Props {
+  readonly ctx: ComputationContext | null | undefined;
+  readonly isRecomputing: boolean;
+}
+
+function fmt(v: number | null | undefined, decimals: number, suffix = "") {
+  return v != null ? `${v.toFixed(decimals)}${suffix}` : "–";
+}
+
+export function GeometryChipRow({ ctx, isRecomputing }: Props) {
+  const stale = isRecomputing;
+  return (
+    <div
+      data-testid="chip-row-geometry"
+      className="flex flex-wrap items-center gap-2"
+    >
+      <Chip
+        icon={Square}
+        symbol="S_ref"
+        description="Reference area — projected wing area used to non-dimensionalize forces (C_L = L / (q · S_ref))"
+        value={fmt(ctx?.s_ref_m2, 3, " m²")}
+        stale={stale}
+      />
+      <Chip
+        icon={Ruler}
+        symbol="MAC"
+        description="Mean Aerodynamic Chord (= C_ref in AVL/ASB) — reference chord for pitching moment coefficient"
+        value={fmt(ctx?.mac_m, 2, " m")}
+        stale={stale}
+      />
+      <Chip
+        icon={ArrowLeftRight}
+        symbol="B_ref"
+        description="Reference span — wingspan used to non-dimensionalize roll and yaw moments"
+        value={fmt(ctx?.b_ref_m, 2, " m")}
+        stale={stale}
+      />
+      <Chip
+        icon={Gauge}
+        symbol="AR"
+        description="Aspect ratio = b² / S_ref (main wing). Higher AR ⇒ less induced drag."
+        value={fmt(ctx?.aspect_ratio, 2)}
+        stale={stale}
+      />
+      <div className="flex-1" />
+    </div>
+  );
+}

--- a/frontend/components/workbench/InfoChipRow.tsx
+++ b/frontend/components/workbench/InfoChipRow.tsx
@@ -1,23 +1,11 @@
 "use client";
 
-import {
-  Wind,
-  Ruler,
-  Target,
-  Navigation,
-  Gauge,
-  AlertTriangle,
-  Loader2,
-  Plane,
-  RefreshCw,
-  TrendingUp,
-  Zap,
-  Square,
-  ArrowLeftRight,
-} from "lucide-react";
+import { Loader2, RefreshCw } from "lucide-react";
 import { useComputationContext } from "@/hooks/useComputationContext";
-import { Chip } from "@/components/workbench/Chip";
-import { cgDivergenceColor } from "./stability-overlay/divergence-color";
+import { SpeedChipRow } from "@/components/workbench/SpeedChipRow";
+import { GeometryChipRow } from "@/components/workbench/GeometryChipRow";
+import { PolarChipRow } from "@/components/workbench/PolarChipRow";
+import { StabilityChipRow } from "@/components/workbench/StabilityChipRow";
 import { TaillessBanner } from "./TaillessBanner";
 
 interface Props {
@@ -29,46 +17,34 @@ interface Props {
 
 export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: Props) {
   const { data: ctx, mutate } = useComputationContext(aeroplaneId, { isRecomputing });
+  const recomputing = !!isRecomputing;
+  const isTailless = !!ctx?.is_tailless;
 
-  const fmt = (v: number | null | undefined, decimals: number, suffix = "") =>
-    v != null ? `${v.toFixed(decimals)}${suffix}` : "–";
-
-  const fmtRe = (v: number | null | undefined) => (v == null ? "–" : v.toExponential(1));
-
-  const cgValue = cgAero != null ? `${cgAero.toFixed(3)} m` : "–";
-  const cgDescription =
-    "Centre of gravity — aerodynamic balance value; component-derived value in parentheses when available";
-
-  // Values that depend on the geometry-driven recompute. While a job is
-  // in flight these are stale → render in red so the user knows not to
-  // trust them until the recompute settles.
-  const stale = !!isRecomputing;
-
-  const cgValueNode = (
+  // gh-575: Recomputing pill + refresh button live in Row 1's rightSlot
+  // so the in-flight state is co-located with the action that triggered it.
+  const refreshSlot = (
     <>
-      <span className={stale ? "text-red-400" : ""}>{cgValue}</span>
-      {cgAero != null && ctx?.cg_agg_m != null && ctx?.mac_m != null && (
+      {recomputing && (
         <span
-          className={`ml-1 ${
-            stale
-              ? "text-red-400"
-              : cgDivergenceColor(cgAero, ctx.cg_agg_m, ctx.mac_m)
-          }`}
+          className="flex items-center gap-1 rounded-full bg-orange-500/15 px-2 py-1 text-[11px] text-orange-400"
+          data-testid="recomputing-chip"
         >
-          ({ctx.cg_agg_m.toFixed(3)})
+          <Loader2 size={11} className="animate-spin" />
+          Recomputing…
         </span>
       )}
+      <button
+        type="button"
+        aria-label="Refresh computation context"
+        onClick={() => mutate()}
+        disabled={recomputing}
+        className="flex items-center gap-1 rounded-full bg-card-muted px-2.5 py-1.5 text-muted-foreground hover:bg-muted hover:text-foreground focus:outline-none focus-visible:ring-1 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <RefreshCw size={12} />
+      </button>
     </>
   );
 
-  // gh-581: surface the tailless UX banner above the chip rows when
-  // backend-derived `is_tailless = true` (no horizontal-tail wing). The
-  // banner explains that tail-volume sizing is not applicable and the
-  // SM corridor is tighter (see #579 + Apogee hybrid-strategy guidance).
-  const isTailless = !!ctx?.is_tailless;
-
-  // gh-575: split the chips into two rows (envelope speeds + aero geometry)
-  // with a user-triggered refresh button on row 1.
   return (
     <div className="flex flex-col gap-2 border-t border-border bg-card px-4 py-3">
       {isTailless && (
@@ -76,177 +52,15 @@ export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: P
           <TaillessBanner />
         </div>
       )}
-      {/* Row 1 — envelope speeds (gh-476: extended chip set) */}
-      <div
-        data-testid="chip-row-speeds"
-        className="flex flex-wrap items-center gap-2"
-      >
-        <Chip
-          icon={AlertTriangle}
-          symbol="V_stall"
-          description="Stall speed in clean configuration at 1 g"
-          value={fmt(ctx?.v_stall_mps, 1, " m/s")}
-          stale={stale}
-        />
-        <Chip
-          icon={Wind}
-          symbol="V_min_sink"
-          description="Speed for minimum sink rate — best endurance / longest glide time"
-          value={fmt(ctx?.v_min_sink_mps, 1, " m/s")}
-          stale={stale}
-        />
-        <Chip
-          icon={Wind}
-          symbol="V_md"
-          description="Minimum-drag speed — best L/D, longest glide distance"
-          value={fmt(ctx?.v_md_mps, 1, " m/s")}
-          stale={stale}
-        />
-        <Chip
-          icon={Wind}
-          symbol={ctx?.v_cruise_auto ? "V_cruise*" : "V_cruise"}
-          description={
-            ctx?.v_cruise_auto
-              ? "Design cruise speed (auto-derived from cruise sizing — asterisk)"
-              : "Design cruise speed"
-          }
-          value={fmt(ctx?.v_cruise_mps, 1, " m/s")}
-          stale={stale}
-        />
-        <Chip
-          icon={TrendingUp}
-          symbol="V_x"
-          description="Best angle-of-climb speed — steepest altitude gain per unit ground distance"
-          value={fmt(ctx?.v_x_mps, 1, " m/s")}
-          stale={stale}
-        />
-        <Chip
-          icon={Plane}
-          symbol="V_y"
-          description="Best rate-of-climb speed — fastest altitude gain per unit time"
-          value={fmt(ctx?.v_y_mps, 1, " m/s")}
-          stale={stale}
-        />
-        {/* V_a hidden for gliders — they use V_RA per CS-22 (separate ticket). */}
-        {!ctx?.is_glider && (
-          <Chip
-            icon={Gauge}
-            symbol="V_a"
-            description="Design manoeuvring speed — structural limit at full control deflection"
-            value={fmt(ctx?.v_a_mps, 1, " m/s")}
-            stale={stale}
-          />
-        )}
-        {/* V_max hidden for gliders — gh-563: no powertrain to define V_max, and
-            V_NE is a CS-22 placard speed with no user input. */}
-        {!ctx?.is_glider && (
-          <Chip
-            icon={Gauge}
-            symbol="V_max"
-            description="Maximum operating speed"
-            value={fmt(ctx?.v_max_mps, 1, " m/s")}
-            stale={stale}
-          />
-        )}
-        {/* V_dive hidden for gliders — gh-573: the 1.4 × V_max heuristic is invalid
-            without V_max (hidden by gh-563); CS-22 V_D is a placard value. */}
-        {!ctx?.is_glider && (
-          <Chip
-            icon={Zap}
-            symbol="V_dive"
-            description="Design dive speed (heuristic: 1.4 × V_max)"
-            value={fmt(ctx?.v_dive_mps, 1, " m/s")}
-            stale={stale}
-          />
-        )}
-        <div className="flex-1" />
-        {/* gh-575: Recomputing pill kept next to the refresh button so users see
-            the in-flight state co-located with the action that triggered it. */}
-        {isRecomputing && (
-          <span
-            className="flex items-center gap-1 rounded-full bg-orange-500/15 px-2 py-1 text-[11px] text-orange-400"
-            data-testid="recomputing-chip"
-          >
-            <Loader2 size={11} className="animate-spin" />
-            Recomputing…
-          </span>
-        )}
-        {/* gh-575: refresh button revalidates the SWR-cached computation context. */}
-        <button
-          type="button"
-          aria-label="Refresh computation context"
-          onClick={() => mutate()}
-          disabled={isRecomputing}
-          className="flex items-center gap-1 rounded-full bg-card-muted px-2.5 py-1.5 text-muted-foreground hover:bg-muted hover:text-foreground focus:outline-none focus-visible:ring-1 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          <RefreshCw size={12} />
-        </button>
-      </div>
-
-      {/* Row 2 — aero geometry */}
-      <div
-        data-testid="chip-row-geometry"
-        className="flex flex-wrap items-center gap-2"
-      >
-        <Chip
-          icon={Wind}
-          symbol="Re"
-          description="Reynolds number at cruise, characteristic length = MAC"
-          value={fmtRe(ctx?.reynolds)}
-          stale={stale}
-        />
-        {/* gh-593: reference triplet S_ref · MAC · B_ref grouped for visual
-            cohesion. All three are the AVL/ASB non-dimensionalisation
-            references for force and moment coefficients. */}
-        <Chip
-          icon={Square}
-          symbol="S_ref"
-          description="Reference area — projected wing area used to non-dimensionalize forces (C_L = L / (q · S_ref))"
-          value={fmt(ctx?.s_ref_m2, 3, " m²")}
-          stale={stale}
-        />
-        <Chip
-          icon={Ruler}
-          symbol="MAC"
-          description="Mean Aerodynamic Chord (= C_ref in AVL/ASB) — reference chord for pitching moment coefficient (C_m = M_pitch / (q · S_ref · C_ref))"
-          value={fmt(ctx?.mac_m, 2, " m")}
-          stale={stale}
-        />
-        <Chip
-          icon={ArrowLeftRight}
-          symbol="B_ref"
-          description="Reference span — wingspan used to non-dimensionalize roll and yaw moments (C_l = M_roll / (q · S_ref · B_ref))"
-          value={fmt(ctx?.b_ref_m, 2, " m")}
-          stale={stale}
-        />
-        <Chip
-          icon={Target}
-          symbol="NP"
-          description="Neutral point — aerodynamic centre of the whole aircraft"
-          value={fmt(ctx?.x_np_m, 3, " m")}
-          stale={stale}
-        />
-        <Chip
-          icon={Navigation}
-          symbol="SM"
-          description="Static margin = (NP − CG) / MAC — target value used for trim balancing"
-          value={
-            ctx?.target_static_margin != null
-              ? (ctx.target_static_margin * 100).toFixed(0) + "%"
-              : "–"
-          }
-          stale={stale}
-        />
-        <Chip
-          icon={Navigation}
-          symbol="CG"
-          description={cgDescription}
-          valueNode={cgValueNode}
-          stale={stale}
-        />
-        <div className="flex-1" />
-        {rightSlot}
-      </div>
+      <SpeedChipRow ctx={ctx} isRecomputing={recomputing} rightSlot={refreshSlot} />
+      <GeometryChipRow ctx={ctx} isRecomputing={recomputing} />
+      <PolarChipRow ctx={ctx} isRecomputing={recomputing} />
+      <StabilityChipRow
+        ctx={ctx}
+        cgAero={cgAero}
+        isRecomputing={recomputing}
+        rightSlot={rightSlot}
+      />
     </div>
   );
 }

--- a/frontend/components/workbench/InfoChipRow.tsx
+++ b/frontend/components/workbench/InfoChipRow.tsx
@@ -16,7 +16,7 @@ import {
   ArrowLeftRight,
 } from "lucide-react";
 import { useComputationContext } from "@/hooks/useComputationContext";
-import { renderSymbol } from "@/components/workbench/renderSymbol";
+import { Chip } from "@/components/workbench/Chip";
 import { cgDivergenceColor } from "./stability-overlay/divergence-color";
 import { TaillessBanner } from "./TaillessBanner";
 
@@ -25,56 +25,6 @@ interface Props {
   readonly cgAero: number | null;
   readonly isRecomputing?: boolean;
   readonly rightSlot?: React.ReactNode;
-}
-
-// Replace underscores with spaces so screen readers say
-// "V min sink" instead of "V underscore min underscore sink".
-function humanize(symbol: string): string {
-  return symbol.replace(/_/g, " ");
-}
-
-function Chip({
-  icon: Icon,
-  symbol,
-  value,
-  valueNode,
-  description,
-  stale = false,
-}: {
-  readonly icon: React.ComponentType<{ size: number; className: string }>;
-  readonly symbol: string;
-  readonly value?: string;
-  readonly valueNode?: React.ReactNode;
-  readonly description?: string;
-  readonly stale?: boolean;
-}) {
-  const valueClass = stale ? "text-red-400" : "text-foreground";
-  const ariaLabel = description
-    ? `${humanize(symbol)}: ${description}`
-    : humanize(symbol);
-  return (
-    <div
-      role="group"
-      tabIndex={0}
-      aria-label={ariaLabel}
-      className="group/chip relative flex items-center gap-1.5 rounded-full bg-card-muted px-3 py-1.5 focus:outline-none focus-visible:ring-1 focus-visible:ring-primary"
-    >
-      <Icon size={12} className="text-muted-foreground" />
-      <span className="font-[family-name:var(--font-geist-sans)] text-[12px] text-foreground">
-        {renderSymbol(symbol)}
-        {" = "}
-        {valueNode ?? <span className={valueClass}>{value}</span>}
-      </span>
-      {description && (
-        <span
-          aria-hidden="true"
-          className="pointer-events-none absolute bottom-full left-1/2 z-50 mb-1.5 hidden w-max max-w-[240px] -translate-x-1/2 rounded-lg border border-border bg-card px-2.5 py-1.5 text-[10px] font-normal leading-snug text-foreground shadow-lg group-hover/chip:block group-focus-within/chip:block"
-        >
-          {description}
-        </span>
-      )}
-    </div>
-  );
 }
 
 export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: Props) {

--- a/frontend/components/workbench/PolarChipRow.tsx
+++ b/frontend/components/workbench/PolarChipRow.tsx
@@ -4,7 +4,7 @@ import { Wind, Gauge, Activity, Target, TrendingUp, AlertTriangle } from "lucide
 import { Chip } from "@/components/workbench/Chip";
 import {
   computeK, computeCLmd, computeEMax, computeRho,
-  qualityColorClassName, rhoColorClassName,
+  qualityColorClassName, rhoColorClassName, rhoThresholdsForProfile,
 } from "@/lib/polar";
 import type { ComputationContext } from "@/hooks/useComputationContext";
 
@@ -13,11 +13,13 @@ interface Props {
   readonly isRecomputing: boolean;
 }
 
-function fmt(v: number | null, decimals: number, suffix = "") {
-  return v != null ? `${v.toFixed(decimals)}${suffix}` : "–";
+function fmt(v: number | null | undefined, decimals: number, suffix = "") {
+  if (v == null || !Number.isFinite(v)) return "–";
+  return `${v.toFixed(decimals)}${suffix}`;
 }
 function fmtRe(v: number | null | undefined) {
-  return v == null ? "–" : v.toExponential(1);
+  if (v == null || !Number.isFinite(v)) return "–";
+  return v.toExponential(1);
 }
 
 const BAIL_TOOLTIP =
@@ -25,8 +27,66 @@ const BAIL_TOOLTIP =
 
 const INTUITIVE_FORM = " ρ = (C_L,md/C_L,max)²";
 
-function rhoTooltip(rho: number | null, isGlider: boolean): string {
-  if (rho == null) return BAIL_TOOLTIP;
+/**
+ * Returns the human-readable reason a derived chip rendered `—`.
+ *
+ * Three cases are distinguished so we never blame the parabolic-fit
+ * rejection for a problem that is actually a missing/non-physical
+ * input (gh-626 review #2 + #3):
+ *
+ *   1. fallbackUsed         → BAIL_TOOLTIP (fit rejected)
+ *   2. ar / clMax / cd0 / e missing or non-physical → enumerate which
+ *   3. value computed fine  → caller passes the normal description
+ */
+function derivedChipTooltip(
+  fallbackUsed: boolean,
+  inputs: {
+    cd0: number | null;
+    e: number | null;
+    ar: number | null;
+    needsClMax: boolean;
+    clMax: number | null;
+  },
+  normalDescription: string,
+): string {
+  if (fallbackUsed) return BAIL_TOOLTIP;
+  const isBadNum = (v: number | null) =>
+    v == null || !Number.isFinite(v) || v <= 0;
+  const missing: string[] = [];
+  if (isBadNum(inputs.cd0)) missing.push("C_D0");
+  if (isBadNum(inputs.e)) missing.push("e");
+  if (isBadNum(inputs.ar)) missing.push("AR");
+  if (inputs.needsClMax && isBadNum(inputs.clMax)) missing.push("C_L,max");
+  if (missing.length > 0) {
+    return (
+      `Cannot compute — missing or non-physical input(s): ${missing.join(", ")}. ` +
+      "Trigger an assumption recompute or check the wing geometry."
+    );
+  }
+  return normalDescription;
+}
+
+function rhoTooltip(
+  rho: number | null,
+  isGlider: boolean,
+  fallbackUsed: boolean,
+  inputs: {
+    cd0: number | null;
+    e: number | null;
+    ar: number | null;
+    clMax: number | null;
+  },
+): string {
+  if (rho == null) {
+    return derivedChipTooltip(
+      fallbackUsed,
+      { ...inputs, needsClMax: true },
+      // Should not normally surface — rho==null implies one of the
+      // branches above. Defensive fallback string.
+      "Polar health metric not computable from current inputs.",
+    );
+  }
+  const { amber } = rhoThresholdsForProfile(isGlider);
   if (rho >= 1.0) {
     return (
       "Polar health: L/D-max coincident with or past stall — polar is degenerate. " +
@@ -34,7 +94,6 @@ function rhoTooltip(rho: number | null, isGlider: boolean): string {
       INTUITIVE_FORM
     );
   }
-  const amber = isGlider ? 2 / 3 : 1 / 3;
   if (rho >= amber) {
     return isGlider
       ? "Polar health: tightening sailplane optimum. Still healthy for glider regime." +
@@ -67,7 +126,7 @@ export function PolarChipRow({ ctx, isRecomputing }: Props) {
   // Displayed e: when fallback used, show the 0.80 fallback explicitly
   // with the asterisk; otherwise the real fit value. Fallback always
   // renders muted (quality necessarily 'unknown').
-  const eDisplayValue = fallbackUsed ? 0.8 : eFromCtx;
+  const eDisplayValue: number | null = fallbackUsed ? 0.8 : eFromCtx;
   const eSymbol = fallbackUsed ? "e*" : "e";
   const eTooltip = fallbackUsed
     ? "Polar fit was rejected — fallback 0.80 used (regime-naive). All derived polar quantities (k, C_L,md, L/D-max, ρ) are therefore suppressed."
@@ -75,6 +134,9 @@ export function PolarChipRow({ ctx, isRecomputing }: Props) {
   const eQualityColour = fallbackUsed
     ? qualityColorClassName("unknown")
     : qualityColorClassName(quality);
+
+  // Shared input bundle for the cause-distinguishing tooltip helpers.
+  const derivedInputs = { cd0, e: eFromCtx, ar };
 
   return (
     <div
@@ -106,24 +168,28 @@ export function PolarChipRow({ ctx, isRecomputing }: Props) {
       <Chip
         icon={Activity}
         symbol="k"
-        description={k == null
-          ? BAIL_TOOLTIP
-          : "Induced-drag factor k = 1/(πeAR). Drag rises as k·C_L². Lower k = less induced drag at the same lift."}
+        description={derivedChipTooltip(
+          fallbackUsed,
+          { ...derivedInputs, needsClMax: false, clMax: null },
+          "Induced-drag factor k = 1/(πeAR). Drag rises as k·C_L². Lower k = less induced drag at the same lift.",
+        )}
         value={fmt(k, 4)}
         stale={stale}
       />
       <Chip
         icon={Target}
-        symbol="C_L,md"
-        description={clMd == null
-          ? BAIL_TOOLTIP
-          : "Lift coefficient where L/D is maximum (best glide). Should sit well below C_L,max. If C_L,md ≥ C_L,max your wing must stall to reach best glide."}
+        symbol="C_L_md"
+        description={derivedChipTooltip(
+          fallbackUsed,
+          { ...derivedInputs, needsClMax: false, clMax: null },
+          "Lift coefficient where L/D is maximum (best glide). Should sit well below C_L,max. If C_L,md ≥ C_L,max your wing must stall to reach best glide.",
+        )}
         value={fmt(clMd, 2)}
         stale={stale}
       />
       <Chip
         icon={AlertTriangle}
-        symbol="C_L,max"
+        symbol="C_L_max"
         description="Maximum lift coefficient (clean configuration, no flaps). From AeroBuildup — known to underestimate at Re < 3×10⁵; treat as conservative for RC."
         value={fmt(clMax, 2)}
         stale={stale}
@@ -131,16 +197,20 @@ export function PolarChipRow({ ctx, isRecomputing }: Props) {
       <Chip
         icon={TrendingUp}
         symbol="(L/D)_max"
-        description={eMax == null
-          ? BAIL_TOOLTIP
-          : "Maximum lift-to-drag ratio. The headline polar number. Sailplane > 30 · GA 10–18 · jet transport 16–22 · trainer 8–12. Formula: ½·√(πeAR/C_D0)."}
+        description={derivedChipTooltip(
+          fallbackUsed,
+          { ...derivedInputs, needsClMax: false, clMax: null },
+          "Maximum lift-to-drag ratio. The headline polar number. Sailplane > 30 · GA 10–18 · jet transport 16–22 · trainer 8–12. Formula: ½·√(πeAR/C_D0).",
+        )}
         value={fmt(eMax, 1)}
         stale={stale}
       />
       <Chip
         icon={Gauge}
         symbol="ρ"
-        description={rhoTooltip(rho, isGlider)}
+        description={rhoTooltip(rho, isGlider, fallbackUsed, {
+          cd0, e: eFromCtx, ar, clMax,
+        })}
         value={fmt(rho, 2)}
         valueColorClassName={rhoColorClassName(rho, isGlider)}
         stale={stale}

--- a/frontend/components/workbench/PolarChipRow.tsx
+++ b/frontend/components/workbench/PolarChipRow.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { Wind, Gauge, Activity, Target, TrendingUp, AlertTriangle } from "lucide-react";
+import { Chip } from "@/components/workbench/Chip";
+import {
+  computeK, computeCLmd, computeEMax, computeRho,
+  qualityColorClassName, rhoColorClassName,
+} from "@/lib/polar";
+import type { ComputationContext } from "@/hooks/useComputationContext";
+
+interface Props {
+  readonly ctx: ComputationContext | null | undefined;
+  readonly isRecomputing: boolean;
+}
+
+function fmt(v: number | null, decimals: number, suffix = "") {
+  return v != null ? `${v.toFixed(decimals)}${suffix}` : "–";
+}
+function fmtRe(v: number | null | undefined) {
+  return v == null ? "–" : v.toExponential(1);
+}
+
+const BAIL_TOOLTIP =
+  "Parabolic polar fit was rejected (see e*). Derived polar quantities are not meaningful when the polar is non-parabolic.";
+
+const INTUITIVE_FORM = " ρ = (C_L,md/C_L,max)²";
+
+function rhoTooltip(rho: number | null, isGlider: boolean): string {
+  if (rho == null) return BAIL_TOOLTIP;
+  if (rho >= 1.0) {
+    return (
+      "Polar health: L/D-max coincident with or past stall — polar is degenerate. " +
+      "Resize wing: raise AR or improve C_L,max — see Matching Chart." +
+      INTUITIVE_FORM
+    );
+  }
+  const amber = isGlider ? 2 / 3 : 1 / 3;
+  if (rho >= amber) {
+    return isGlider
+      ? "Polar health: tightening sailplane optimum. Still healthy for glider regime." +
+          INTUITIVE_FORM
+      : "Polar health: min-sink point at/below stall. L/D-max still reachable. " +
+          "Consider raising AR or lowering W/S — see Matching Chart." +
+          INTUITIVE_FORM;
+  }
+  return (
+    "Polar health: healthy. L/D-max sits comfortably above stall." + INTUITIVE_FORM
+  );
+}
+
+export function PolarChipRow({ ctx, isRecomputing }: Props) {
+  const stale = isRecomputing;
+
+  const cd0 = ctx?.cd0 ?? null;
+  const eFromCtx = ctx?.e_oswald ?? null;
+  const fallbackUsed = !!ctx?.e_oswald_fallback_used;
+  const ar = ctx?.aspect_ratio ?? null;
+  const clMax = ctx?.polar_by_config?.clean?.cl_max ?? null;
+  const isGlider = !!ctx?.is_glider;
+  const quality = ctx?.e_oswald_quality ?? "unknown";
+
+  const k = computeK(eFromCtx, fallbackUsed, ar);
+  const clMd = computeCLmd(cd0, eFromCtx, fallbackUsed, ar);
+  const eMax = computeEMax(cd0, eFromCtx, fallbackUsed, ar);
+  const rho = computeRho(cd0, eFromCtx, fallbackUsed, ar, clMax);
+
+  // Displayed e: when fallback used, show the 0.80 fallback explicitly
+  // with the asterisk; otherwise the real fit value. Fallback always
+  // renders muted (quality necessarily 'unknown').
+  const eDisplayValue = fallbackUsed ? 0.8 : eFromCtx;
+  const eSymbol = fallbackUsed ? "e*" : "e";
+  const eTooltip = fallbackUsed
+    ? "Polar fit was rejected — fallback 0.80 used (regime-naive). All derived polar quantities (k, C_L,md, L/D-max, ρ) are therefore suppressed."
+    : "Oswald efficiency — combined non-elliptical-lift-distribution loss and parasite-drag-with-lift. Typical 0.70–0.95. Colour reflects fit quality.";
+  const eQualityColour = fallbackUsed
+    ? qualityColorClassName("unknown")
+    : qualityColorClassName(quality);
+
+  return (
+    <div
+      data-testid="chip-row-polar"
+      className="flex flex-wrap items-center gap-2"
+    >
+      <Chip
+        icon={Wind}
+        symbol="Re"
+        description="Reynolds number at cruise (characteristic length = MAC). Polar shape is Re-dependent; this row's metrics describe cruise-Re behaviour."
+        value={fmtRe(ctx?.reynolds)}
+        stale={stale}
+      />
+      <Chip
+        icon={Gauge}
+        symbol="C_D0"
+        description="Zero-lift drag coefficient (parasite drag). Lower is better. ρ uses this together with e and AR. Source: stability run (single-CL eval)."
+        value={fmt(cd0, 4)}
+        stale={stale}
+      />
+      <Chip
+        icon={Activity}
+        symbol={eSymbol}
+        description={eTooltip}
+        value={fmt(eDisplayValue, 2)}
+        valueColorClassName={eQualityColour}
+        stale={stale}
+      />
+      <Chip
+        icon={Activity}
+        symbol="k"
+        description={k == null
+          ? BAIL_TOOLTIP
+          : "Induced-drag factor k = 1/(πeAR). Drag rises as k·C_L². Lower k = less induced drag at the same lift."}
+        value={fmt(k, 4)}
+        stale={stale}
+      />
+      <Chip
+        icon={Target}
+        symbol="C_L,md"
+        description={clMd == null
+          ? BAIL_TOOLTIP
+          : "Lift coefficient where L/D is maximum (best glide). Should sit well below C_L,max. If C_L,md ≥ C_L,max your wing must stall to reach best glide."}
+        value={fmt(clMd, 2)}
+        stale={stale}
+      />
+      <Chip
+        icon={AlertTriangle}
+        symbol="C_L,max"
+        description="Maximum lift coefficient (clean configuration, no flaps). From AeroBuildup — known to underestimate at Re < 3×10⁵; treat as conservative for RC."
+        value={fmt(clMax, 2)}
+        stale={stale}
+      />
+      <Chip
+        icon={TrendingUp}
+        symbol="(L/D)_max"
+        description={eMax == null
+          ? BAIL_TOOLTIP
+          : "Maximum lift-to-drag ratio. The headline polar number. Sailplane > 30 · GA 10–18 · jet transport 16–22 · trainer 8–12. Formula: ½·√(πeAR/C_D0)."}
+        value={fmt(eMax, 1)}
+        stale={stale}
+      />
+      <Chip
+        icon={Gauge}
+        symbol="ρ"
+        description={rhoTooltip(rho, isGlider)}
+        value={fmt(rho, 2)}
+        valueColorClassName={rhoColorClassName(rho, isGlider)}
+        stale={stale}
+      />
+      <div className="flex-1" />
+    </div>
+  );
+}

--- a/frontend/components/workbench/SpeedChipRow.tsx
+++ b/frontend/components/workbench/SpeedChipRow.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import {
+  Wind, AlertTriangle, Plane, Gauge, TrendingUp, Zap,
+} from "lucide-react";
+import { Chip } from "@/components/workbench/Chip";
+import type { ComputationContext } from "@/hooks/useComputationContext";
+
+interface Props {
+  readonly ctx: ComputationContext | null | undefined;
+  readonly isRecomputing: boolean;
+  readonly rightSlot?: React.ReactNode;
+}
+
+function fmt(v: number | null | undefined, decimals: number, suffix = "") {
+  return v != null ? `${v.toFixed(decimals)}${suffix}` : "–";
+}
+
+export function SpeedChipRow({ ctx, isRecomputing, rightSlot }: Props) {
+  const stale = isRecomputing;
+  return (
+    <div
+      data-testid="chip-row-speeds"
+      className="flex flex-wrap items-center gap-2"
+    >
+      <Chip
+        icon={AlertTriangle}
+        symbol="V_stall"
+        description="Stall speed in clean configuration at 1 g"
+        value={fmt(ctx?.v_stall_mps, 1, " m/s")}
+        stale={stale}
+      />
+      <Chip
+        icon={Wind}
+        symbol="V_min_sink"
+        description="Speed for minimum sink rate — best endurance / longest glide time"
+        value={fmt(ctx?.v_min_sink_mps, 1, " m/s")}
+        stale={stale}
+      />
+      <Chip
+        icon={Wind}
+        symbol="V_md"
+        description="Minimum-drag speed — best L/D, longest glide distance"
+        value={fmt(ctx?.v_md_mps, 1, " m/s")}
+        stale={stale}
+      />
+      <Chip
+        icon={Wind}
+        symbol={ctx?.v_cruise_auto ? "V_cruise*" : "V_cruise"}
+        description={
+          ctx?.v_cruise_auto
+            ? "Design cruise speed (auto-derived from cruise sizing — asterisk)"
+            : "Design cruise speed"
+        }
+        value={fmt(ctx?.v_cruise_mps, 1, " m/s")}
+        stale={stale}
+      />
+      <Chip
+        icon={TrendingUp}
+        symbol="V_x"
+        description="Best angle-of-climb speed — steepest altitude gain per unit ground distance"
+        value={fmt(ctx?.v_x_mps, 1, " m/s")}
+        stale={stale}
+      />
+      <Chip
+        icon={Plane}
+        symbol="V_y"
+        description="Best rate-of-climb speed — fastest altitude gain per unit time"
+        value={fmt(ctx?.v_y_mps, 1, " m/s")}
+        stale={stale}
+      />
+      {!ctx?.is_glider && (
+        <Chip
+          icon={Gauge}
+          symbol="V_a"
+          description="Design manoeuvring speed — structural limit at full control deflection"
+          value={fmt(ctx?.v_a_mps, 1, " m/s")}
+          stale={stale}
+        />
+      )}
+      {!ctx?.is_glider && (
+        <Chip
+          icon={Gauge}
+          symbol="V_max"
+          description="Maximum operating speed"
+          value={fmt(ctx?.v_max_mps, 1, " m/s")}
+          stale={stale}
+        />
+      )}
+      {!ctx?.is_glider && (
+        <Chip
+          icon={Zap}
+          symbol="V_dive"
+          description="Design dive speed (heuristic: 1.4 × V_max)"
+          value={fmt(ctx?.v_dive_mps, 1, " m/s")}
+          stale={stale}
+        />
+      )}
+      <div className="flex-1" />
+      {rightSlot}
+    </div>
+  );
+}

--- a/frontend/components/workbench/StabilityChipRow.tsx
+++ b/frontend/components/workbench/StabilityChipRow.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { Target, Navigation } from "lucide-react";
+import { Chip } from "@/components/workbench/Chip";
+import { cgDivergenceColor } from "./stability-overlay/divergence-color";
+import type { ComputationContext } from "@/hooks/useComputationContext";
+
+interface Props {
+  readonly ctx: ComputationContext | null | undefined;
+  readonly cgAero: number | null;
+  readonly isRecomputing: boolean;
+  readonly rightSlot?: React.ReactNode;
+}
+
+function fmt(v: number | null | undefined, decimals: number, suffix = "") {
+  return v != null ? `${v.toFixed(decimals)}${suffix}` : "–";
+}
+
+export function StabilityChipRow({ ctx, cgAero, isRecomputing, rightSlot }: Props) {
+  const stale = isRecomputing;
+  const cgValue = cgAero != null ? `${cgAero.toFixed(3)} m` : "–";
+  const cgDescription =
+    "Centre of gravity — aerodynamic balance value; component-derived value in parentheses when available";
+  const cgValueNode = (
+    <>
+      <span className={stale ? "text-red-400" : ""}>{cgValue}</span>
+      {cgAero != null && ctx?.cg_agg_m != null && ctx?.mac_m != null && (
+        <span
+          className={`ml-1 ${
+            stale
+              ? "text-red-400"
+              : cgDivergenceColor(cgAero, ctx.cg_agg_m, ctx.mac_m)
+          }`}
+        >
+          ({ctx.cg_agg_m.toFixed(3)})
+        </span>
+      )}
+    </>
+  );
+
+  return (
+    <div
+      data-testid="chip-row-stability"
+      className="flex flex-wrap items-center gap-2"
+    >
+      <Chip
+        icon={Target}
+        symbol="NP"
+        description="Neutral point — aerodynamic centre of the whole aircraft"
+        value={fmt(ctx?.x_np_m, 3, " m")}
+        stale={stale}
+      />
+      <Chip
+        icon={Navigation}
+        symbol="SM"
+        description="Static margin = (NP − CG) / MAC — target value used for trim balancing"
+        value={
+          ctx?.target_static_margin != null
+            ? (ctx.target_static_margin * 100).toFixed(0) + "%"
+            : "–"
+        }
+        stale={stale}
+      />
+      <Chip
+        icon={Navigation}
+        symbol="CG"
+        description={cgDescription}
+        valueNode={cgValueNode}
+        stale={stale}
+      />
+      <div className="flex-1" />
+      {rightSlot}
+    </div>
+  );
+}

--- a/frontend/hooks/useComputationContext.ts
+++ b/frontend/hooks/useComputationContext.ts
@@ -2,6 +2,7 @@
 
 import useSWR from "swr";
 import { fetcher } from "@/lib/fetcher";
+import type { EQuality } from "@/lib/polar";
 
 export interface ComputationContext {
   v_cruise_mps: number;
@@ -26,7 +27,7 @@ export interface ComputationContext {
   // gh-626: polar metrics surfaced in PolarChipRow.
   cd0?: number | null;
   e_oswald?: number | null;
-  e_oswald_quality?: "high" | "medium" | "low" | "unknown";
+  e_oswald_quality?: EQuality;
   e_oswald_fallback_used?: boolean;
   polar_by_config?: {
     clean?: {

--- a/frontend/hooks/useComputationContext.ts
+++ b/frontend/hooks/useComputationContext.ts
@@ -23,6 +23,18 @@ export interface ComputationContext {
   // S_ref and MAC for coefficient non-dimensionalisation.
   b_ref_m?: number | null;
   aspect_ratio?: number | null;
+  // gh-626: polar metrics surfaced in PolarChipRow.
+  cd0?: number | null;
+  e_oswald?: number | null;
+  e_oswald_quality?: "high" | "medium" | "low" | "unknown";
+  e_oswald_fallback_used?: boolean;
+  polar_by_config?: {
+    clean?: {
+      cd0?: number | null;
+      e_oswald?: number | null;
+      cl_max?: number | null;
+    };
+  } | null;
   x_np_m: number;
   target_static_margin: number;
   cg_agg_m: number | null;

--- a/frontend/lib/polar.ts
+++ b/frontend/lib/polar.ts
@@ -1,0 +1,107 @@
+/**
+ * Pure derivation helpers for the parabolic polar
+ * `C_D = C_D0 + C_L²/(π·e·AR)` — Anderson §6.7.2.
+ *
+ * The ρ-bail rule (gh-626 spec §8.5): when the AeroBuildup parabolic
+ * fit was rejected (`e_oswald_fallback_used = true`), the polar is
+ * NOT parabolic. Computing parabolic-polar metrics on it produces
+ * measurement-shaped non-measurements, so every derived helper here
+ * bails to `null` in that case.
+ */
+
+export type EQuality = "high" | "medium" | "low" | "unknown";
+
+export type RhoThresholds = { readonly amber: number; readonly red: number };
+
+function valid(...vs: (number | null | undefined)[]): boolean {
+  return vs.every((v) => v != null && v > 0);
+}
+
+/** k = 1/(π·e·AR). Returns null on fit rejection or invalid inputs. */
+export function computeK(
+  eFromCtx: number | null | undefined,
+  fallbackUsed: boolean,
+  ar: number | null | undefined,
+): number | null {
+  if (fallbackUsed) return null;
+  if (!valid(eFromCtx, ar)) return null;
+  return 1 / (Math.PI * (eFromCtx as number) * (ar as number));
+}
+
+/** C_L,md = √(π·e·AR·C_D0). Lift coefficient at maximum L/D. */
+export function computeCLmd(
+  cd0: number | null | undefined,
+  eFromCtx: number | null | undefined,
+  fallbackUsed: boolean,
+  ar: number | null | undefined,
+): number | null {
+  if (fallbackUsed) return null;
+  if (!valid(cd0, eFromCtx, ar)) return null;
+  return Math.sqrt(
+    Math.PI * (eFromCtx as number) * (ar as number) * (cd0 as number),
+  );
+}
+
+/** (L/D)_max = ½·√(π·e·AR / C_D0). Canonical Scholz §5.7 polar-quality scalar. */
+export function computeEMax(
+  cd0: number | null | undefined,
+  eFromCtx: number | null | undefined,
+  fallbackUsed: boolean,
+  ar: number | null | undefined,
+): number | null {
+  if (fallbackUsed) return null;
+  if (!valid(cd0, eFromCtx, ar)) return null;
+  return (
+    0.5 *
+    Math.sqrt((Math.PI * (eFromCtx as number) * (ar as number)) / (cd0 as number))
+  );
+}
+
+/**
+ * Degeneracy ratio ρ = C_D0·π·e·AR / C_L,max² = (C_L,md / C_L,max)².
+ * Anderson §6.7.2 derivation: ρ=1 ⇔ V_md=V_stall, ρ=1/3 ⇔ V_min,sink=V_stall.
+ */
+export function computeRho(
+  cd0: number | null | undefined,
+  eFromCtx: number | null | undefined,
+  fallbackUsed: boolean,
+  ar: number | null | undefined,
+  clMax: number | null | undefined,
+): number | null {
+  if (fallbackUsed) return null;
+  if (!valid(cd0, eFromCtx, ar, clMax)) return null;
+  const e = eFromCtx as number;
+  const c = clMax as number;
+  return ((cd0 as number) * Math.PI * e * (ar as number)) / (c * c);
+}
+
+/** Profile-aware ρ traffic-light thresholds (Scholz §5.7 + spec rev 2 decision 9). */
+export function rhoThresholdsForProfile(isGlider: boolean): RhoThresholds {
+  return isGlider ? { amber: 2 / 3, red: 1.0 } : { amber: 1 / 3, red: 1.0 };
+}
+
+/** Maps the backend's e-fit quality label to a Tailwind value-colour class. */
+export function qualityColorClassName(
+  quality: EQuality | undefined | null,
+): string {
+  switch (quality) {
+    case "high":
+      return "text-emerald-400";
+    case "medium":
+      return "text-amber-400";
+    case "low":
+      return "text-orange-400";
+    case "unknown":
+    default:
+      return "text-muted-foreground";
+  }
+}
+
+/** ρ traffic-light colour. Lower-inclusive boundaries. */
+export function rhoColorClassName(rho: number | null, isGlider: boolean): string {
+  if (rho == null) return "text-muted-foreground";
+  const { amber, red } = rhoThresholdsForProfile(isGlider);
+  if (rho >= red) return "text-red-400";
+  if (rho >= amber) return "text-amber-400";
+  return "text-emerald-400";
+}

--- a/frontend/lib/polar.ts
+++ b/frontend/lib/polar.ts
@@ -14,7 +14,11 @@ export type EQuality = "high" | "medium" | "low" | "unknown";
 export type RhoThresholds = { readonly amber: number; readonly red: number };
 
 function valid(...vs: (number | null | undefined)[]): boolean {
-  return vs.every((v) => v != null && v > 0);
+  // Reject null / undefined / non-finite (NaN, ±Infinity) / non-positive.
+  // Non-finite inputs are a corrupt-payload symptom — a backend bug like
+  // `np.inf` from a degenerate fit would otherwise produce "Infinity" /
+  // "0" chip values instead of the documented "—" bail state.
+  return vs.every((v) => v != null && Number.isFinite(v) && v > 0);
 }
 
 /** k = 1/(π·e·AR). Returns null on fit rejection or invalid inputs. */


### PR DESCRIPTION
Closes #626.

## Summary

Adds a thematic **Polar** row to the workbench chip strip so the user can read polar health at a glance — eight chips with traffic-light ρ, profile-aware thresholds, and a bail-rule for non-parabolic polars.

```
Re   C_D0   e*   k   C_L,md   C_L,max   (L/D)_max   ρ
```

Refactors `InfoChipRow.tsx` from 302 → 66 lines: extracts a `Chip` primitive plus four sibling row components (Speed / Geometry / Polar / Stability). Pure derivation helpers (`computeK`, `computeCLmd`, `computeEMax`, `computeRho`, `rhoThresholdsForProfile`) live in `frontend/lib/polar.ts` for unit testing.

**Pure frontend change** — all values are already cached in `assumption_computation_context` by `recompute_assumptions`.

## What you get visually

For an aeroplane with a healthy polar (ρ < ⅓): all eight chips populate, ρ renders emerald.

For the gh-625 reproduction case (ASK-21 with rejected parabolic fit — live-verified): `e*=0.80` muted asterisk, and the four derived chips (`k`, `C_L,md`, `(L/D)_max`, `ρ`) render `—` with a tooltip explaining the polar is non-parabolic. The user immediately sees *why* the derived numbers are absent.

## Expert review

The spec went through two domain-expert critiques during brainstorming (`aerodynamics-expert` for Anderson §6.7.2 physics and `aircraft-design-scholz` for Scholz/Sadraey utility) — 15 findings (2 CRITICAL + 7 MAJOR + rest minor) addressed in rev 2. See `docs/superpowers/specs/2026-05-23-polar-metrics-chip-row-design.md` §16 for the full review-record table.

Key rev-2 decisions:
- **ρ-bail rule** — every derived metric renders `—` when `e_oswald_fallback_used = true` (computing a parabolic-polar metric on a non-parabolic polar produces a measurement-shaped non-measurement).
- **Profile-aware thresholds** — gliders use amber-from-⅔ (sailplanes intentionally operate near `V_min,sink ≈ V_stall`); powered uses amber-from-⅓.
- **Tooltips consequence-first**, not formula-first — bridges the hobbyist/professional audience gap.
- **ρ-red tooltip prescribes** — "see Matching Chart" — turns passive diagnostic into actionable feedback.

## Tests

- `__tests__/polar.test.ts` — 26 tests covering derivation identities, ρ-bail rule, boundary inclusion semantics, identity `ρ = (C_L,md/C_L,max)²` across a deterministic GA/RC/sailplane grid.
- `__tests__/PolarChipRow.test.tsx` — 16 tests covering all behaviour: healthy / sailplane no-false-alarm / boundary inclusion / quality matrix / #625 reproduction / null inputs / tooltip text / stale red.
- `__tests__/Chip.test.tsx` + `SpeedChipRow.test.tsx` + `GeometryChipRow.test.tsx` + `StabilityChipRow.test.tsx` + updated `InfoChipRow.test.tsx` for the new 4-row layout.

Full frontend suite: **1017 / 1017** ✅.

## Acceptance criteria (from #626)

- [x] `InfoChipRow.tsx` reduces to ≤ 80 lines (container only) — **66 lines**
- [x] Six new component files + helpers
- [x] Six new test files
- [x] AR chip in `GeometryChipRow`
- [x] `PolarChipRow` renders five+ chips with specified formatting + tooltips
- [x] ρ traffic-light boundaries tested at inclusion points (`ρ = 1/3` amber, `ρ = 1.00` red, `ρ = 2/3` amber for glider)
- [x] Healthy polar → all chips populated, ρ emerald
- [x] gh-625 reproduction → `e*=0.80` muted, k/C_L,md/(L/D)_max/ρ all `—`, bail tooltip
- [x] `e_oswald_fallback_used = true` triggers `e*` + fallback tooltip + muted colour
- [x] All polar chips visible for gliders (no `!is_glider` hide)
- [x] `isRecomputing = true` stale red overrides quality + traffic-light colours
- [x] `npm run test:unit` passes

## Out of scope (separate follow-ups)

- `C_L,cruise` chip — depends on #625 Bug B mass-context fix.
- Per-configuration `C_L,max` chips (takeoff/landing).
- Matching-chart anchor/navigation from the ρ-red tooltip.
- Hobbyist "verb mode" (`ρ: healthy/marginal/degenerate`).
- Color-blind alternative to the traffic light.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
