### PR TITLE
fix(gh-627): stop writing solver_path string into trim_residuals dict[str, float]

### DIFF
--- a/app/services/operating_point_generator_service.py
+++ b/app/services/operating_point_generator_service.py
@@ -827,16 +827,18 @@ def _trim_or_estimate_point(
         best_alpha = float(opti_solution["alpha_deg"])
         best_beta = float(opti_solution["beta_deg"])
         best_controls = dict(opti_solution["controls"])
-        # gh-528: surface solver_path on the success path so consumers
-        # can branch consistently with the fallback path.
+        # gh-627: solver_path lives on trim_method, NOT in trim_residuals.
+        # trim_residuals is typed as dict[str, float] (Pydantic-validated in
+        # TrimEnrichment) and rejects string values. The earlier
+        # `best_residuals["solver_path"] = "opti"` line (gh-528) broke
+        # every OP enrichment until removed.
         best_residuals = dict(opti_solution.get("metrics", {}))
-        best_residuals["solver_path"] = "opti"
         best_method = "opti"
 
     # gh-528 / epic gh-525 finding C3: grid-search fallback updates BOTH
-    # alpha AND velocity post-trim. Records solver_path in trim_residuals
-    # so downstream consumers (UI, AVL replay) can distinguish a confident
-    # Opti convergence from an estimated grid result.
+    # alpha AND velocity post-trim. The solver-path branch label lives on
+    # `trim_method` (gh-627) — NOT inside trim_residuals, which is typed
+    # dict[str, float] and Pydantic-rejects any string value.
     if best_score > 0.35:
         gs_score, gs_alpha, gs_beta, gs_velocity, gs_controls = _grid_search_trim(
             asb_airplane,
@@ -854,7 +856,6 @@ def _trim_or_estimate_point(
                 gs_controls,
             )
             best_residuals = {
-                "solver_path": "grid_fallback",
                 "final_residual": float(gs_score),
                 "grid_velocity_mps": float(gs_velocity),
                 "target_velocity_mps": float(velocity),

--- a/app/tests/test_operating_point_generator_service.py
+++ b/app/tests/test_operating_point_generator_service.py
@@ -538,30 +538,9 @@ def test_grid_fallback_surfaces_trim_method_for_audit():
     assert point.trim_residuals.get("target_velocity_mps") == pytest.approx(14.0)
 
 
-def test_trim_residuals_round_trip_through_TrimEnrichment_schema():
-    """gh-627 regression: trim_residuals from the producer must be a
-    pure dict[str, float] (no string values), because it flows into
-    ``TrimEnrichment(trim_residuals=...)`` which Pydantic-validates
-    against ``dict[str, float]`` and rejects any string entry.
-
-    Failure mode pre-fix: the producer wrote ``solver_path: "opti"``
-    (or ``"grid_fallback"``) into ``trim_residuals``, causing every
-    OP enrichment to fail with ``ValidationError`` and the request to
-    silently return 200 OK with empty enrichment data.
-
-    This test exercises *both* the Opti-success path and the
-    grid-fallback path through ``_trim_or_estimate_point`` and
-    asserts:
-      1. every value in ``trim_residuals`` is numeric;
-      2. ``solver_path`` is NOT a key (it lives on ``trim_method``);
-      3. constructing ``TrimEnrichment(trim_residuals=...)`` raises
-         no ``ValidationError``.
-    """
-    from app.services.operating_point_generator_service import _trim_or_estimate_point
-    from app.schemas.aeroanalysisschema import TrimEnrichment
-
-    airplane = _mock_airplane_with_controls("[elevator]Elevator")
-    target = {
+def _cruise_target() -> dict:
+    """Shared OP-target fixture for the gh-627 regression tests."""
+    return {
         "name": "cruise",
         "config": "clean",
         "velocity": 18.0,
@@ -571,7 +550,44 @@ def test_trim_residuals_round_trip_through_TrimEnrichment_schema():
         "flap_deflection_deg": 0.0,
     }
 
-    # --- Opti-success path -------------------------------------------------
+
+def _assert_trim_residuals_round_trip_clean(point) -> None:
+    """gh-627 contract: trim_residuals is a pure dict[str, float].
+
+    Asserts (1) `solver_path` is NOT a key, (2) every value is numeric,
+    (3) constructing TrimEnrichment(trim_residuals=…) does not raise —
+    the Pydantic round-trip that production hits and that the OLD test
+    bypassed by inspecting the dict directly.
+    """
+    from app.schemas.aeroanalysisschema import TrimEnrichment
+
+    assert point.trim_residuals is not None
+    assert "solver_path" not in point.trim_residuals, (
+        f"solver_path must live on trim_method, not in trim_residuals; "
+        f"got {point.trim_residuals!r}"
+    )
+    assert all(isinstance(v, (int, float)) for v in point.trim_residuals.values()), (
+        f"trim_residuals must contain only numeric values; "
+        f"got {point.trim_residuals!r}"
+    )
+    # The Pydantic constructor that production hits — pre-fix this raises.
+    TrimEnrichment(
+        analysis_goal=f"{point.name} check",
+        trim_method=point.trim_method,
+        trim_score=point.trim_score,
+        trim_residuals=point.trim_residuals,
+    )
+
+
+def test_trim_residuals_round_trip_opti_path():
+    """gh-627: Opti-success path produces trim_residuals that round-trip
+    cleanly through TrimEnrichment. Pre-fix this path wrote
+    ``solver_path: "opti"`` into trim_residuals → ValidationError →
+    silent enrichment drop on every OP.
+    """
+    from app.services.operating_point_generator_service import _trim_or_estimate_point
+
+    airplane = _mock_airplane_with_controls("[elevator]Elevator")
     opti_solution = {
         "score": 0.05,
         "alpha_deg": 3.2,
@@ -592,30 +608,24 @@ def test_trim_residuals_round_trip_through_TrimEnrichment_schema():
         point = _trim_or_estimate_point(
             asb_airplane=airplane,
             aircraft=SimpleNamespace(id=1, total_mass_kg=1.5),
-            target=target,
+            target=_cruise_target(),
             constraints={"max_alpha_deg": 18.0, "max_beta_deg": 12.0},
             capabilities={"available_controls": ["[elevator]Elevator"]},
             effective_mass_kg=1.5,
         )
 
     assert point.trim_method == "opti"
-    assert point.trim_residuals is not None
-    assert "solver_path" not in point.trim_residuals, (
-        f"solver_path must live on trim_method, not in trim_residuals; "
-        f"got {point.trim_residuals!r}"
-    )
-    assert all(isinstance(v, (int, float)) for v in point.trim_residuals.values()), (
-        f"trim_residuals must contain only numeric values; got {point.trim_residuals!r}"
-    )
-    # The actual Pydantic round-trip that production hits — pre-fix this raises.
-    TrimEnrichment(
-        analysis_goal="cruise check",
-        trim_method=point.trim_method,
-        trim_score=point.trim_score,
-        trim_residuals=point.trim_residuals,
-    )
+    _assert_trim_residuals_round_trip_clean(point)
 
-    # --- Grid-fallback path ------------------------------------------------
+
+def test_trim_residuals_round_trip_grid_fallback_path():
+    """gh-627: Grid-fallback path produces trim_residuals that round-trip
+    cleanly through TrimEnrichment. Pre-fix this path wrote
+    ``solver_path: "grid_fallback"`` into trim_residuals.
+    """
+    from app.services.operating_point_generator_service import _trim_or_estimate_point
+
+    airplane = _mock_airplane_with_controls("[elevator]Elevator")
     with (
         patch(
             "app.services.operating_point_generator_service._solve_trim_candidate_with_opti",
@@ -633,28 +643,14 @@ def test_trim_residuals_round_trip_through_TrimEnrichment_schema():
         point = _trim_or_estimate_point(
             asb_airplane=airplane,
             aircraft=SimpleNamespace(id=1, total_mass_kg=1.5),
-            target=target,
+            target=_cruise_target(),
             constraints={"max_alpha_deg": 18.0, "max_beta_deg": 12.0},
             capabilities={"available_controls": ["[elevator]Elevator"]},
             effective_mass_kg=1.5,
         )
 
     assert point.trim_method == "grid_fallback"
-    assert point.trim_residuals is not None
-    assert "solver_path" not in point.trim_residuals, (
-        f"solver_path must live on trim_method, not in trim_residuals; "
-        f"got {point.trim_residuals!r}"
-    )
-    assert all(isinstance(v, (int, float)) for v in point.trim_residuals.values()), (
-        f"trim_residuals must contain only numeric values; got {point.trim_residuals!r}"
-    )
-    # The actual Pydantic round-trip that production hits — pre-fix this raises.
-    TrimEnrichment(
-        analysis_goal="cruise check (grid)",
-        trim_method=point.trim_method,
-        trim_score=point.trim_score,
-        trim_residuals=point.trim_residuals,
-    )
+    _assert_trim_residuals_round_trip_clean(point)
 
 
 def test_opti_success_keeps_trim_method_opti_and_target_velocity():

--- a/app/tests/test_operating_point_generator_service.py
+++ b/app/tests/test_operating_point_generator_service.py
@@ -486,10 +486,11 @@ def test_grid_search_updates_velocity_from_grid_result():
     )
 
 
-def test_grid_fallback_records_solver_path_in_trim_enrichment():
-    """gh-528 AC: trim_residuals / trim_enrichment must surface
-    a ``solver_path`` field so downstream consumers can audit which
-    branch produced each OP."""
+def test_grid_fallback_surfaces_trim_method_for_audit():
+    """gh-528 AC (revised gh-627): downstream consumers must be able to
+    audit which trim branch produced each OP. The branch label lives on
+    ``trim_method`` (a dedicated str field), NOT inside ``trim_residuals``
+    (which is dict[str, float] and Pydantic-rejects strings — gh-627)."""
     from app.services.operating_point_generator_service import _trim_or_estimate_point
 
     airplane = _mock_airplane_with_controls("[elevator]Elevator")
@@ -526,10 +527,134 @@ def test_grid_fallback_records_solver_path_in_trim_enrichment():
             effective_mass_kg=1.5,
         )
 
-    # trim_residuals receives the structured fallback metadata so
-    # downstream tools (UI, AVL replay) can branch on solver_path.
+    # gh-627: trim_method carries the branch label; trim_residuals stays
+    # numeric-only so the downstream TrimEnrichment Pydantic validation passes.
+    assert point.trim_method == "grid_fallback"
     assert point.trim_residuals is not None
-    assert point.trim_residuals.get("solver_path") == "grid_fallback"
+    assert "solver_path" not in point.trim_residuals
+    # Structured fallback metadata is still present, just without the string.
+    assert point.trim_residuals.get("final_residual") == pytest.approx(0.30)
+    assert point.trim_residuals.get("grid_velocity_mps") == pytest.approx(13.8)
+    assert point.trim_residuals.get("target_velocity_mps") == pytest.approx(14.0)
+
+
+def test_trim_residuals_round_trip_through_TrimEnrichment_schema():
+    """gh-627 regression: trim_residuals from the producer must be a
+    pure dict[str, float] (no string values), because it flows into
+    ``TrimEnrichment(trim_residuals=...)`` which Pydantic-validates
+    against ``dict[str, float]`` and rejects any string entry.
+
+    Failure mode pre-fix: the producer wrote ``solver_path: "opti"``
+    (or ``"grid_fallback"``) into ``trim_residuals``, causing every
+    OP enrichment to fail with ``ValidationError`` and the request to
+    silently return 200 OK with empty enrichment data.
+
+    This test exercises *both* the Opti-success path and the
+    grid-fallback path through ``_trim_or_estimate_point`` and
+    asserts:
+      1. every value in ``trim_residuals`` is numeric;
+      2. ``solver_path`` is NOT a key (it lives on ``trim_method``);
+      3. constructing ``TrimEnrichment(trim_residuals=...)`` raises
+         no ``ValidationError``.
+    """
+    from app.services.operating_point_generator_service import _trim_or_estimate_point
+    from app.schemas.aeroanalysisschema import TrimEnrichment
+
+    airplane = _mock_airplane_with_controls("[elevator]Elevator")
+    target = {
+        "name": "cruise",
+        "config": "clean",
+        "velocity": 18.0,
+        "altitude": 0.0,
+        "beta_target_deg": 0.0,
+        "n_target": 1.0,
+        "flap_deflection_deg": 0.0,
+    }
+
+    # --- Opti-success path -------------------------------------------------
+    opti_solution = {
+        "score": 0.05,
+        "alpha_deg": 3.2,
+        "beta_deg": 0.0,
+        "controls": {"[elevator]Elevator": -1.2},
+        "metrics": {"final_residual": 0.05, "alpha_residual": 0.01},
+    }
+    with (
+        patch(
+            "app.services.operating_point_generator_service._solve_trim_candidate_with_opti",
+            return_value=opti_solution,
+        ),
+        patch(
+            "app.services.operating_point_generator_service._cl_target_for_velocity",
+            return_value=0.45,
+        ),
+    ):
+        point = _trim_or_estimate_point(
+            asb_airplane=airplane,
+            aircraft=SimpleNamespace(id=1, total_mass_kg=1.5),
+            target=target,
+            constraints={"max_alpha_deg": 18.0, "max_beta_deg": 12.0},
+            capabilities={"available_controls": ["[elevator]Elevator"]},
+            effective_mass_kg=1.5,
+        )
+
+    assert point.trim_method == "opti"
+    assert point.trim_residuals is not None
+    assert "solver_path" not in point.trim_residuals, (
+        f"solver_path must live on trim_method, not in trim_residuals; "
+        f"got {point.trim_residuals!r}"
+    )
+    assert all(isinstance(v, (int, float)) for v in point.trim_residuals.values()), (
+        f"trim_residuals must contain only numeric values; got {point.trim_residuals!r}"
+    )
+    # The actual Pydantic round-trip that production hits — pre-fix this raises.
+    TrimEnrichment(
+        analysis_goal="cruise check",
+        trim_method=point.trim_method,
+        trim_score=point.trim_score,
+        trim_residuals=point.trim_residuals,
+    )
+
+    # --- Grid-fallback path ------------------------------------------------
+    with (
+        patch(
+            "app.services.operating_point_generator_service._solve_trim_candidate_with_opti",
+            return_value=None,
+        ),
+        patch(
+            "app.services.operating_point_generator_service._grid_search_trim",
+            return_value=(0.30, 8.0, 0.0, 17.5, {"[elevator]Elevator": -4.0}),
+        ),
+        patch(
+            "app.services.operating_point_generator_service._cl_target_for_velocity",
+            return_value=0.45,
+        ),
+    ):
+        point = _trim_or_estimate_point(
+            asb_airplane=airplane,
+            aircraft=SimpleNamespace(id=1, total_mass_kg=1.5),
+            target=target,
+            constraints={"max_alpha_deg": 18.0, "max_beta_deg": 12.0},
+            capabilities={"available_controls": ["[elevator]Elevator"]},
+            effective_mass_kg=1.5,
+        )
+
+    assert point.trim_method == "grid_fallback"
+    assert point.trim_residuals is not None
+    assert "solver_path" not in point.trim_residuals, (
+        f"solver_path must live on trim_method, not in trim_residuals; "
+        f"got {point.trim_residuals!r}"
+    )
+    assert all(isinstance(v, (int, float)) for v in point.trim_residuals.values()), (
+        f"trim_residuals must contain only numeric values; got {point.trim_residuals!r}"
+    )
+    # The actual Pydantic round-trip that production hits — pre-fix this raises.
+    TrimEnrichment(
+        analysis_goal="cruise check (grid)",
+        trim_method=point.trim_method,
+        trim_score=point.trim_score,
+        trim_residuals=point.trim_residuals,
+    )
 
 
 def test_opti_success_keeps_trim_method_opti_and_target_velocity():


### PR DESCRIPTION
Closes #627.

## Summary

Stops the OP-generator from writing the string `"opti"` / `"grid_fallback"` into `trim_residuals`, which is typed as `dict[str, float]` and Pydantic-rejected on every `TrimEnrichment` construction. Pre-fix: `POST /aeroplanes/{uuid}/operating-pointsets/generate-default` returned `200 OK` with `generated=12` while silently dropping every OP's trim enrichment data.

## Root cause

`operating_point_generator_service.py:833` and `:857` (added in **gh-528**) wrote the solver-branch label into `trim_residuals`:

```python
best_residuals["solver_path"] = "opti"          # ← schema-breaking
...
best_residuals = {
    "solver_path": "grid_fallback",             # ← schema-breaking
    ...
}
```

But the schema (`aeroanalysisschema.py:507`) is `trim_residuals: dict[str, float]` — every value must be numeric. And the schema *already has* a dedicated `trim_method: str` field (`:503`) documented exactly for this label. `best_method` was set correctly in both code paths — the dict mutation was redundant **and** schema-breaking.

## The fix

Two lines deleted, comments updated to reference gh-627:

```diff
- best_residuals["solver_path"] = "opti"
```

```diff
  best_residuals = {
-     "solver_path": "grid_fallback",
      "final_residual": float(gs_score),
      "grid_velocity_mps": float(gs_velocity),
      "target_velocity_mps": float(velocity),
  }
```

`trim_method = "opti"` / `"grid_fallback"` continues to carry the branch label correctly — same audit signal, but via the schema-correct field.

## Why this rotted past tests

The existing test (`test_grid_fallback_records_solver_path_in_trim_enrichment`) asserted `point.trim_residuals.get("solver_path") == "grid_fallback"` **directly on the dataclass** without ever passing through the `TrimEnrichment(...)` Pydantic constructor that production hits. The test was passing the bad pattern through.

## Tests

**New** — `test_trim_residuals_round_trip_through_TrimEnrichment_schema`:
- exercises BOTH the Opti-success path AND the grid-fallback path through `_trim_or_estimate_point`
- asserts `solver_path` is NOT a key in `trim_residuals`
- asserts all `trim_residuals` values are numeric
- **constructs `TrimEnrichment(trim_residuals=point.trim_residuals, ...)` end-to-end** — the Pydantic round-trip that production hits. Pre-fix this raises; post-fix it passes.

**Updated** — `test_grid_fallback_records_solver_path_in_trim_enrichment` renamed to `test_grid_fallback_surfaces_trim_method_for_audit`; asserts the audit signal via `trim_method` (and continues to assert the numeric structured fallback metadata is still present).

**Results:** 442 / 442 trim/OP/enrichment tests pass ✅.

## Severity / impact

**Major.** The endpoint silently lost trim enrichment data (deflection reserves, design warnings, effectiveness, stability classification, mixer values, result summary) on **every** OP for **every** aircraft since gh-528 landed. The 200 OK + `generated=12` log line hid the failure.

## Acceptance criteria (from #627)

- [x] OPG no longer writes `solver_path` into `trim_residuals`
- [x] `compute_enrichment(...)` round-trips successfully (Pydantic passes) for both paths
- [x] Grid-fallback test asserts via `trim_method` rather than `trim_residuals["solver_path"]`
- [x] New test constructs `TrimEnrichment` end-to-end with both paths' payloads — no Pydantic error
- [x] The misleading enrichment-failed warning no longer surfaces in the happy path
- [x] `poetry run pytest` passes for the OPG + trim/enrichment scope (442 tests)

## Why this got past static analysis (separate follow-up)

Pyright is installed (`pyright = "^1.1.409"` in `pyproject.toml`, `pyrightconfig.json` present, `typeCheckingMode: "basic"`) — but it's **not** wired into CI or any pre-commit hook. IDE-only diagnostics → if the developer doesn't look, nothing gates them.

User declined a separate chore ticket for this; noted for future hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
