### PR TITLE
fix(gh-634): PolarRejectionBadge crashes on undefined rejection for pre-gh-630 aeroplanes

### DIFF
--- a/frontend/__tests__/PolarRejectionBadge.test.tsx
+++ b/frontend/__tests__/PolarRejectionBadge.test.tsx
@@ -52,6 +52,13 @@ describe("PolarRejectionBadge", () => {
     expect(container.firstChild).toBeNull();
   });
 
+  // gh-634: pre-gh-630 aeroplanes have polar_by_config without a rejection
+  // key — runtime value is undefined, not null. The badge must not crash.
+  it("renders nothing when rejection is undefined (legacy data)", () => {
+    const { container } = render(<PolarRejectionBadge rejection={undefined} />);
+    expect(container.firstChild).toBeNull();
+  });
+
   it.each([
     ["sweep", sweepRejection],
     ["data", dataRejection],

--- a/frontend/components/workbench/PolarRejectionBadge.tsx
+++ b/frontend/components/workbench/PolarRejectionBadge.tsx
@@ -5,19 +5,22 @@ import { AlertTriangle } from "lucide-react";
 import type { PolarRejection } from "@/hooks/useComputationContext";
 
 export interface PolarRejectionBadgeProps {
-  rejection: PolarRejection | null;
+  // gh-634: legacy aeroplanes (pre-gh-630) store polar_by_config without
+  // the `rejection` key, so the runtime value can be `undefined` even
+  // though Pydantic's model_dump() emits `null` for new records.
+  rejection: PolarRejection | null | undefined;
 }
 
 /**
  * gh-630: surface aerodynamically implausible polar-fit rejections
  * (k <= 0, e_oswald outside (0.4, 1.0]) to the user as a design warning.
  *
- * Renders nothing for `null` or for non-`design` categories — sweep, data,
- * and consistency rejections are internal-only. Callers should pass
- * `rejection` directly without category-routing.
+ * Renders nothing for `null`/`undefined` or for non-`design` categories —
+ * sweep, data, and consistency rejections are internal-only. Callers
+ * should pass `rejection` directly without category-routing.
  */
 export function PolarRejectionBadge({ rejection }: PolarRejectionBadgeProps) {
-  if (rejection === null || rejection.category !== "design") {
+  if (!rejection || rejection.category !== "design") {
     return null;
   }
   return (

--- a/frontend/components/workbench/PolarRejectionBadge.tsx
+++ b/frontend/components/workbench/PolarRejectionBadge.tsx
@@ -20,7 +20,7 @@ export interface PolarRejectionBadgeProps {
  * should pass `rejection` directly without category-routing.
  */
 export function PolarRejectionBadge({ rejection }: PolarRejectionBadgeProps) {
-  if (!rejection || rejection.category !== "design") {
+  if (rejection?.category !== "design") {
     return null;
   }
   return (


### PR DESCRIPTION
## Summary

Hot-fix for the runtime crash on the Analysis page (reported just minutes after #633 merged):

\`\`\`
Cannot read properties of undefined (reading 'category')
  at PolarRejectionBadge (PolarRejectionBadge.tsx:20:39)
\`\`\`

## Root cause

Aeroplanes whose \`assumption_computation_context\` JSON was written before gh-630 was merged don't have the \`rejection\` key inside per-config polar dicts. JSON deserialisation produces \`undefined\`, but the badge's strict \`=== null\` guard only short-circuited on \`null\`. React reached \`rejection.category\` and crashed.

## Fix

Two-line change in \`PolarRejectionBadge.tsx\`:
- Widen prop type: \`PolarRejection | null\` → \`PolarRejection | null | undefined\` (honest the type for legacy data)
- Change guard: \`rejection === null\` → \`!rejection\` (catches both null and undefined)

Regression test added: \`rejection={undefined}\` → renders nothing.

## Test plan
- [x] \`cd frontend && npm run test:unit -- PolarRejectionBadge AssumptionsPanel\` — **39/39 pass** including the new undefined-regression case.
- [ ] Manual: load Analysis page for an aeroplane created before gh-630 — should render without crashing.

Closes #634