### PR TITLE
feat(gh-636): extract Oswald e from AeroBuildup D_induced (eliminates 0.8-fallback path)

### DIFF
--- a/app/schemas/polar_by_config.py
+++ b/app/schemas/polar_by_config.py
@@ -23,6 +23,19 @@ Provenance = Literal[
     "no_flap_geometry",  # aircraft has no flap → cloned from clean
     "aerobuildup_failed",  # the flap-deflected AeroBuildup raised → cloned from clean
 ]
+
+EOswaldProvenance = Literal[
+    "aerobuildup_trefftz",  # gh-636: from AeroBuildup D_induced at (L/D)max point
+    "fit",  # gh-486 fallback: parabolic OLS fit of polar sweep
+    "fallback",  # 0.8 regime-naive default; both above paths failed
+]
+"""Where the Oswald factor e came from (gh-636).
+
+`aerobuildup_trefftz` is the primary path: AeroBuildup exposes
+`D_induced` per operating point, so `e = CL² / (π·AR·CDi)` is computed
+directly at the (L/D)max sweep index — no parabolic fit, no rejection
+gates, no 0.8 fallback when the polar is non-parabolic.
+"""
 """How the polar entry was produced.
 
 `aerobuildup_failed` covers any exception during the deflected sweep
@@ -115,6 +128,21 @@ class ParabolicPolar(BaseModel):
         None,
         description="Set only when the parabolic fit was rejected (gh-630); "
         "disjoint from e_oswald_quality which applies to successful fits.",
+    )
+    ld_max: float | None = Field(
+        None,
+        description="Empirical (L/D)max from sweep: max(CL/CD) over the alpha sweep. "
+        "Independent of parabolic-fit success (gh-636).",
+    )
+    cl_at_ld_max: float | None = Field(
+        None,
+        description="CL at (L/D)max — empirical from sweep, no model needed (gh-636).",
+    )
+    e_oswald_provenance: EOswaldProvenance = Field(
+        "fallback",
+        description="Where e_oswald was computed from. `aerobuildup_trefftz` is the "
+        "primary path (gh-636); `fit` is the gh-486 OLS-on-polar fallback; "
+        "`fallback` is the 0.8 regime-naive default when both above failed.",
     )
 
 

--- a/app/services/assumption_compute_service.py
+++ b/app/services/assumption_compute_service.py
@@ -502,7 +502,10 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
         # Parabolic polar fit results (gh-486)
         # ctx["cd0"] scalar = stability-run cd0 (backward-compat key for gh-486 consumers)
         "cd0": round(cd0, 5),
-        "e_oswald": round(e_oswald_fit, 4) if e_oswald_fit is not None else None,
+        # gh-636: top-level e_oswald uses the same provenance chain as
+        # polar_by_config[clean].e_oswald — i.e. AB-Trefftz preferred, then
+        # parabolic-fit, then None. Matches `e_oswald_fallback_used` semantics.
+        "e_oswald": round(e_oswald_final, 4) if e_oswald_final is not None else None,
         "e_oswald_r2": round(e_r2, 4) if e_r2 is not None else None,
         "e_oswald_quality": _classify_polar_quality(e_r2) if e_r2 is not None else "unknown",
         "e_oswald_fallback_used": e_oswald_fallback,

--- a/app/services/assumption_compute_service.py
+++ b/app/services/assumption_compute_service.py
@@ -91,11 +91,12 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
     try:
         x_np, mac, cd0, s_ref = _stability_run_at_cruise(asb_airplane, v_cruise)
         stall_alpha = _coarse_alpha_sweep(asb_airplane, v_cruise, config)
-        # _fine_sweep_cl_max returns (cl_max, cl_array, cd_array, v_array) so that
-        # the parabolic polar fit (gh-486) and Re-table builder (gh-493) can
-        # consume the raw sweep data without extra AeroBuildup invocations.
+        # _fine_sweep_cl_max returns (cl_max, cl_arr, cd_arr, v_arr, cdi_arr).
+        # gh-486 parabolic fit + gh-493 Re-table builder consume cl/cd/v.
+        # gh-636 Oswald extraction consumes cdi (CDi = D_induced / (q·S_ref)
+        # collected per (V, α) sample inside the sweep — zero extra AB calls).
         fine_result = _fine_sweep_cl_max(asb_airplane, stall_alpha, v_cruise, v_max, config)
-        cl_max, sweep_cl_arr, sweep_cd_arr, sweep_v_arr = fine_result
+        cl_max, sweep_cl_arr, sweep_cd_arr, sweep_v_arr, sweep_cdi_arr = fine_result
     except Exception:
         logger.exception(
             "AeroBuildup failed during recompute for aircraft %s — aborting", aeroplane_uuid
@@ -146,8 +147,32 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
         cl_max=cl_max_effective_for_fit,
         cd0_stability=cd0,
     )
-    e_oswald_fallback = e_oswald_fit is None
-    e_oswald_effective = e_oswald_fit if e_oswald_fit is not None else 0.8
+    # gh-636: derive (L/D)max + e_oswald directly from the AeroBuildup sweep
+    # — no parabolic-fit dependency for e. The fit still gives us cd0; e is
+    # now sourced from AeroBuildup's D_induced output at the (L/D)max point.
+    ld_max_clean, cl_at_ld_max_clean, ld_max_idx_clean = _ld_max_from_sweep(
+        np.asarray(sweep_cl_arr, dtype=float),
+        np.asarray(sweep_cd_arr, dtype=float),
+    )
+    e_oswald_ab = _e_oswald_from_sweep(
+        np.asarray(sweep_cl_arr, dtype=float),
+        np.asarray(sweep_cdi_arr, dtype=float),
+        aspect_ratio,
+        ld_max_idx_clean,
+    )
+    # Provenance chain: prefer AeroBuildup-Trefftz; fall back to the parabolic
+    # fit's e if AB-path didn't yield a sane value; finally the 0.8 default.
+    if e_oswald_ab is not None:
+        e_oswald_final: float | None = e_oswald_ab
+        e_oswald_provenance_clean = "aerobuildup_trefftz"
+    elif e_oswald_fit is not None:
+        e_oswald_final = e_oswald_fit
+        e_oswald_provenance_clean = "fit"
+    else:
+        e_oswald_final = None
+        e_oswald_provenance_clean = "fallback"
+    e_oswald_fallback = e_oswald_final is None
+    e_oswald_effective = e_oswald_final if e_oswald_final is not None else 0.8
     # -----------------------------------------------------------------------
 
     # --- gh-526 / epic gh-525 C1: per-configuration parabolic polar -------
@@ -156,13 +181,16 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
     # the OPG used historically (audit §5.5).
     polar_clean = ParabolicPolar(
         cd0=round(_cd0_fit, 5) if _cd0_fit is not None else None,
-        e_oswald=round(e_oswald_fit, 4) if e_oswald_fit is not None else None,
+        e_oswald=round(e_oswald_final, 4) if e_oswald_final is not None else None,
         cl_max=round(cl_max, 4),
         e_oswald_r2=round(e_r2, 4) if e_r2 is not None else None,
         e_oswald_quality=_classify_polar_quality(e_r2) if e_r2 is not None else "unknown",
         flap_deflection_deg=0.0,
         provenance="aerobuildup",
         rejection=polar_rejection,
+        ld_max=round(ld_max_clean, 2) if ld_max_clean is not None else None,
+        cl_at_ld_max=round(cl_at_ld_max_clean, 3) if cl_at_ld_max_clean is not None else None,
+        e_oswald_provenance=e_oswald_provenance_clean,
     )
 
     ted_max = _extract_flap_ted_max(aircraft)
@@ -551,7 +579,7 @@ def _run_polar_for_deflection(
         )
     deflected = asb_airplane.with_control_deflections({flap_name: flap_deflection_deg})
     stall_alpha = _coarse_alpha_sweep(deflected, v_cruise, config)
-    cl_max, cl_arr, cd_arr, _v_arr = _fine_sweep_cl_max(
+    cl_max, cl_arr, cd_arr, _v_arr, cdi_arr = _fine_sweep_cl_max(
         deflected, stall_alpha, v_cruise, v_max, config
     )
     _cd0_fit, e_oswald_fit, e_r2, polar_rejection = _fit_parabolic_polar(
@@ -561,15 +589,38 @@ def _run_polar_for_deflection(
         cl_max=cl_max_effective_for_fit if cl_max_effective_for_fit else cl_max,
         cd0_stability=cd0_stability,
     )
+    # gh-636: empirical (L/D)max + AB-Trefftz e for this configuration.
+    ld_max_cfg, cl_at_ld_max_cfg, ld_max_idx_cfg = _ld_max_from_sweep(
+        np.asarray(cl_arr, dtype=float),
+        np.asarray(cd_arr, dtype=float),
+    )
+    e_oswald_ab_cfg = _e_oswald_from_sweep(
+        np.asarray(cl_arr, dtype=float),
+        np.asarray(cdi_arr, dtype=float),
+        aspect_ratio,
+        ld_max_idx_cfg,
+    )
+    if e_oswald_ab_cfg is not None:
+        e_final: float | None = e_oswald_ab_cfg
+        provenance_e = "aerobuildup_trefftz"
+    elif e_oswald_fit is not None:
+        e_final = e_oswald_fit
+        provenance_e = "fit"
+    else:
+        e_final = None
+        provenance_e = "fallback"
     return ParabolicPolar(
         cd0=round(_cd0_fit, 5) if _cd0_fit is not None else None,
-        e_oswald=round(e_oswald_fit, 4) if e_oswald_fit is not None else None,
+        e_oswald=round(e_final, 4) if e_final is not None else None,
         cl_max=round(float(cl_max), 4),
         e_oswald_r2=round(e_r2, 4) if e_r2 is not None else None,
         e_oswald_quality=_classify_polar_quality(e_r2) if e_r2 is not None else "unknown",
         flap_deflection_deg=float(flap_deflection_deg),
         provenance="aerobuildup",
         rejection=polar_rejection,
+        ld_max=round(ld_max_cfg, 2) if ld_max_cfg is not None else None,
+        cl_at_ld_max=round(cl_at_ld_max_cfg, 3) if cl_at_ld_max_cfg is not None else None,
+        e_oswald_provenance=provenance_e,
     )
 
 
@@ -777,16 +828,17 @@ def _fine_sweep_cl_max(
     v_cruise: float,
     v_max: float,
     config: AircraftComputationConfigModel,
-) -> tuple[float, np.ndarray, np.ndarray, np.ndarray]:
-    """Returns (CL_max, cl_array, cd_array, v_array) from a fine alpha × velocity sweep.
+) -> tuple[float, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Returns (CL_max, cl_array, cd_array, v_array, cdi_array) from a fine α × V sweep.
 
-    The returned CL, CD, and V arrays span the full swept range.  CL and CD are
-    used by the parabolic polar fitter (gh-486) to derive the Oswald efficiency
-    factor.  V is additionally used by the Re-table builder (gh-493) to bin
-    samples by velocity band.
+    All returned arrays have the same length (one entry per (V, α) sample).
 
-    Note: the v_array is the velocity at which each (CL, CD) sample was taken.
-    It has the same length as cl_array and cd_array.
+    - cl_array / cd_array drive the gh-486 parabolic polar fit and the gh-493
+      Re-table builder.
+    - cdi_array (gh-636) is the AeroBuildup-internal induced-drag coefficient
+      at each sample. It lets `recompute_assumptions` extract Oswald e directly
+      via ``e = CL² / (π·AR·CDi)`` at the (L/D)max point, without re-fitting a
+      parabola. Costs zero extra AeroBuildup calls.
     """
     import aerosandbox as asb
 
@@ -798,10 +850,12 @@ def _fine_sweep_cl_max(
     velocities = np.linspace(v_stall_approx, v_max, config.fine_velocity_count)
 
     xyz_ref = list(asb_airplane.xyz_ref) if asb_airplane.xyz_ref is not None else [0.0, 0.0, 0.0]
+    s_ref = float(asb_airplane.s_ref)
     cl_max = -float("inf")
     cl_list: list[float] = []
     cd_list: list[float] = []
     v_list: list[float] = []
+    cdi_list: list[float] = []
     for v in velocities:
         for a in alphas:
             op = asb.OperatingPoint(velocity=float(v), alpha=float(a))
@@ -809,9 +863,18 @@ def _fine_sweep_cl_max(
             r = abu.run()
             cl = _extract_scalar(r, "CL", default=0.0)
             cd = _extract_scalar(r, "CD", default=0.0)
+            # gh-636: D_induced is exposed by AeroBuildup per op-point.
+            # CDi = D_induced / (q · S_ref). NaN/missing → fall back to NaN so
+            # the consumer can detect and skip these entries.
+            d_induced = _extract_scalar(r, "D_induced", default=float("nan"))
+            q = 0.5 * 1.225 * float(v) ** 2  # ISA sea-level rho; consistent with op
+            cdi = (
+                d_induced / (q * s_ref) if (s_ref > 0 and np.isfinite(d_induced)) else float("nan")
+            )
             cl_list.append(cl)
             cd_list.append(cd)
             v_list.append(float(v))
+            cdi_list.append(cdi)
             if cl > cl_max:
                 cl_max = cl
     return (
@@ -819,6 +882,7 @@ def _fine_sweep_cl_max(
         np.asarray(cl_list, dtype=float),
         np.asarray(cd_list, dtype=float),
         np.asarray(v_list, dtype=float),
+        np.asarray(cdi_list, dtype=float),
     )
 
 
@@ -943,6 +1007,54 @@ def _build_rejection(
         threshold=threshold,
         hint=hint,
     )
+
+
+def _ld_max_from_sweep(
+    cl_arr: np.ndarray, cd_arr: np.ndarray
+) -> tuple[float | None, float | None, int | None]:
+    """Empirical (L/D)max and the CL at which it occurs (gh-636).
+
+    Independent of any fit. Returns (ld_max, cl_at_ld_max, index) on success,
+    or (None, None, None) if the sweep contains no usable point (all-NaN /
+    non-positive CD).
+    """
+    # mask of valid points: finite CL/CD with CD > 0 and CL > 0 (positive lift).
+    mask = np.isfinite(cl_arr) & np.isfinite(cd_arr) & (cd_arr > 0.0) & (cl_arr > 0.0)
+    if not mask.any():
+        return None, None, None
+    ld = np.full_like(cl_arr, -np.inf, dtype=float)
+    ld[mask] = cl_arr[mask] / cd_arr[mask]
+    i = int(np.argmax(ld))
+    if not np.isfinite(ld[i]):
+        return None, None, None
+    return float(ld[i]), float(cl_arr[i]), i
+
+
+def _e_oswald_from_sweep(
+    cl_arr: np.ndarray,
+    cdi_arr: np.ndarray,
+    ar: float | None,
+    ld_max_index: int | None,
+) -> float | None:
+    """Oswald factor e from AeroBuildup's per-sample induced drag (gh-636).
+
+    Uses ``e = CL² / (π · AR · CDi)`` at the (L/D)max sample. AeroBuildup
+    exposes ``D_induced`` per op-point, so this is direct — no parabolic fit
+    needed. Falls back to None when inputs are missing/non-physical.
+    """
+    if ld_max_index is None or ar is None or not np.isfinite(ar) or ar <= 0:
+        return None
+    cl = cl_arr[ld_max_index]
+    cdi = cdi_arr[ld_max_index]
+    if not (np.isfinite(cl) and np.isfinite(cdi) and cdi > 0 and cl > 0):
+        return None
+    e = float(cl**2 / (np.pi * ar * cdi))
+    # Sanity clip: a meaningful e is in (0, ~1.05] (allow tiny VLM-Trefftz
+    # overshoot above 1.0 for near-elliptical wings). Reject pathological
+    # values rather than push them downstream.
+    if not (0.0 < e <= 1.10):
+        return None
+    return e
 
 
 def _fit_parabolic_polar(

--- a/app/tests/test_assumption_compute_integration.py
+++ b/app/tests/test_assumption_compute_integration.py
@@ -86,6 +86,7 @@ def test_recompute_publishes_assumption_changed_on_cg_change(client_and_db):
                 np.array([0.2, 0.4, 0.6, 0.8, 1.0, 1.2]),
                 np.array([0.021, 0.023, 0.027, 0.034, 0.043, 0.055]),
                 np.linspace(9.0, 28.0, 6),
+                np.zeros(6),
             ),
         ),
         patch(
@@ -160,6 +161,7 @@ def test_recompute_does_not_publish_when_cg_unchanged(client_and_db):
                 np.array([0.2, 0.4, 0.6, 0.8, 1.0, 1.2]),
                 np.array([0.021, 0.023, 0.027, 0.034, 0.043, 0.055]),
                 np.linspace(9.0, 28.0, 6),
+                np.zeros(6),
             ),
         ),
         patch(

--- a/app/tests/test_assumption_compute_service.py
+++ b/app/tests/test_assumption_compute_service.py
@@ -95,7 +95,7 @@ def _patches(flap_ted_max: float | None = None, fine_sweep_cl_max: float = 1.35)
         i = sweep_call["i"]
         sweep_call["i"] += 1
         idx = min(i, len(cl_max_sequence) - 1)
-        return (cl_max_sequence[idx], cl_array, cd_array, v_array)
+        return (cl_max_sequence[idx], cl_array, cd_array, v_array, np.zeros_like(cl_array))
 
     return (
         patch(
@@ -409,6 +409,7 @@ def test_no_flap_aircraft_runs_one_pass_with_fallback_flag(client_and_db):
                 np.array([0.2, 0.4, 0.6, 0.8, 1.0, 1.2]),
                 np.array([0.026, 0.028, 0.032, 0.039, 0.049, 0.062]),
                 np.linspace(9.0, 28.0, 6),
+                np.zeros(6),
             ),
         ) as fine_sweep_mock,
         _enter_patches_no_fine_sweep(flap_ted_max=None),
@@ -590,6 +591,7 @@ def test_flap_geometry_mismatch_falls_back_with_warning(client_and_db, caplog):
                 np.array([0.2, 0.4, 0.6, 0.8, 1.0, 1.2]),
                 np.array([0.026, 0.028, 0.032, 0.039, 0.049, 0.062]),
                 np.linspace(9.0, 28.0, 6),
+                np.zeros(6),
             ),
         ),
         patch(

--- a/app/tests/test_epic_485_acceptance.py
+++ b/app/tests/test_epic_485_acceptance.py
@@ -611,7 +611,7 @@ def _patches_for_ac(ac: dict, fake_airplane, sweep_data):
         ),
         patch(
             "app.services.assumption_compute_service._fine_sweep_cl_max",
-            return_value=(cl_max_sweep, cl_arr, cd_arr, v_arr),
+            return_value=(cl_max_sweep, cl_arr, cd_arr, v_arr, np.zeros_like(cl_arr)),
         ),
         patch(
             "app.services.assumption_compute_service._extract_cl_alpha_from_linear_sweep",

--- a/app/tests/test_polar_by_config_schema.py
+++ b/app/tests/test_polar_by_config_schema.py
@@ -130,3 +130,89 @@ class TestParabolicPolarRejectionField:
         as_dict = p.model_dump()
         roundtripped = ParabolicPolar.model_validate(as_dict)
         assert roundtripped.rejection == rej
+
+
+# ---------------------------------------------------------------------------
+# gh-636: empirical (L/D)max + e from AeroBuildup D_induced sweep
+# ---------------------------------------------------------------------------
+
+import math
+
+import numpy as np
+
+from app.services.assumption_compute_service import (
+    _e_oswald_from_sweep,
+    _ld_max_from_sweep,
+)
+
+
+class TestLdMaxFromSweep:
+    def test_finds_max_and_index(self):
+        cl = np.array([0.1, 0.3, 0.5, 0.7, 0.9])
+        cd = np.array([0.020, 0.022, 0.026, 0.034, 0.050])
+        ld, cl_at, idx = _ld_max_from_sweep(cl, cd)
+        # max(CL/CD): 0.1/0.02=5, 0.3/0.022=13.6, 0.5/0.026=19.2,
+        # 0.7/0.034=20.6, 0.9/0.050=18 → max at index 3
+        assert idx == 3
+        assert cl_at == pytest.approx(0.7)
+        assert ld == pytest.approx(0.7 / 0.034, rel=1e-3)
+
+    def test_returns_none_when_all_invalid(self):
+        cl = np.array([np.nan, np.nan])
+        cd = np.array([0.020, 0.022])
+        assert _ld_max_from_sweep(cl, cd) == (None, None, None)
+
+    def test_returns_none_when_cd_all_zero(self):
+        cl = np.array([0.1, 0.3, 0.5])
+        cd = np.array([0.0, 0.0, 0.0])
+        assert _ld_max_from_sweep(cl, cd) == (None, None, None)
+
+    def test_skips_negative_cl(self):
+        cl = np.array([-0.1, 0.3, 0.5])
+        cd = np.array([0.020, 0.022, 0.026])
+        ld, cl_at, idx = _ld_max_from_sweep(cl, cd)
+        # negative CL is masked out → max picked from {1, 2}
+        assert idx in (1, 2)
+        assert cl_at > 0
+
+
+class TestEOswaldFromSweep:
+    def test_computes_e_at_ld_max_index(self):
+        # Construct a clean test case: at index 1, e = CL²/(π·AR·CDi)
+        cl = np.array([0.1, 0.5, 0.9])
+        cdi = np.array([0.001, 0.006, 0.020])
+        ar = 10.0
+        # e at idx=1 = 0.5² / (π · 10 · 0.006) = 0.25 / 0.1885 ≈ 1.326 → CLIPPED to None
+        # Pick more realistic numbers:
+        cl = np.array([0.1, 0.5, 0.9])
+        cdi = np.array([0.001, 0.0099, 0.025])  # at idx 1: e = 0.5²/(π·10·0.0099) ≈ 0.804
+        e = _e_oswald_from_sweep(cl, cdi, ar=ar, ld_max_index=1)
+        assert e is not None
+        assert abs(e - 0.804) < 0.005
+
+    def test_returns_none_when_index_none(self):
+        cl = np.array([0.5])
+        cdi = np.array([0.01])
+        assert _e_oswald_from_sweep(cl, cdi, ar=10.0, ld_max_index=None) is None
+
+    def test_returns_none_when_ar_invalid(self):
+        cl = np.array([0.5])
+        cdi = np.array([0.01])
+        assert _e_oswald_from_sweep(cl, cdi, ar=0.0, ld_max_index=0) is None
+        assert _e_oswald_from_sweep(cl, cdi, ar=None, ld_max_index=0) is None
+
+    def test_returns_none_when_cdi_nonpositive(self):
+        cl = np.array([0.5])
+        cdi = np.array([0.0])
+        assert _e_oswald_from_sweep(cl, cdi, ar=10.0, ld_max_index=0) is None
+
+    def test_clips_unphysical_e_above_threshold(self):
+        # CDi too low → e > 1.10 → clip to None
+        cl = np.array([1.0])
+        cdi = np.array([0.001])  # e = 1²/(π·10·0.001) ≈ 31.83 → out of range
+        assert _e_oswald_from_sweep(cl, cdi, ar=10.0, ld_max_index=0) is None
+
+    def test_returns_none_when_cl_nan(self):
+        cl = np.array([float("nan")])
+        cdi = np.array([0.01])
+        assert _e_oswald_from_sweep(cl, cdi, ar=10.0, ld_max_index=0) is None

--- a/app/tests/test_polar_fit.py
+++ b/app/tests/test_polar_fit.py
@@ -364,7 +364,7 @@ class TestCachedContextIntegration:
             patch(
                 "app.services.assumption_compute_service._fine_sweep_cl_max",
                 # gh-493: now returns 4-tuple (cl_max, cl_arr, cd_arr, v_arr)
-                return_value=(ac["cl_max"], cls, cds, v_arr),
+                return_value=(ac["cl_max"], cls, cds, v_arr, np.zeros_like(cls)),
             ),
             patch(
                 "app.services.assumption_compute_service._extract_cl_alpha_from_linear_sweep",
@@ -544,7 +544,7 @@ class TestCachedContextIntegration:
             ),
             patch(
                 "app.services.assumption_compute_service._fine_sweep_cl_max",
-                return_value=(ac["cl_max"], cls, cds, v_arr),
+                return_value=(ac["cl_max"], cls, cds, v_arr, np.zeros_like(cls)),
             ),
             patch(
                 "app.services.assumption_compute_service._extract_cl_alpha_from_linear_sweep",

--- a/app/tests/test_polar_rejection_propagation.py
+++ b/app/tests/test_polar_rejection_propagation.py
@@ -102,7 +102,7 @@ def _enter_patches_with_rejection():
         stack.enter_context(
             patch(
                 "app.services.assumption_compute_service._fine_sweep_cl_max",
-                return_value=(1.35, cl_array, cd_array, v_array),
+                return_value=(1.35, cl_array, cd_array, v_array, np.zeros_like(cl_array)),
             )
         )
         stack.enter_context(

--- a/frontend/components/workbench/PolarChipRow.tsx
+++ b/frontend/components/workbench/PolarChipRow.tsx
@@ -114,23 +114,44 @@ export function PolarChipRow({ ctx, isRecomputing }: Props) {
   const eFromCtx = ctx?.e_oswald ?? null;
   const fallbackUsed = !!ctx?.e_oswald_fallback_used;
   const ar = ctx?.aspect_ratio ?? null;
-  const clMax = ctx?.polar_by_config?.clean?.cl_max ?? null;
+  const cleanPolar = ctx?.polar_by_config?.clean;
+  const clMax = cleanPolar?.cl_max ?? null;
   const isGlider = !!ctx?.is_glider;
   const quality = ctx?.e_oswald_quality ?? "unknown";
 
+  // gh-636: e provenance distinguishes the AeroBuildup-Trefftz path
+  // (`aerobuildup_trefftz`) from the legacy parabolic-fit path (`fit`) and the
+  // 0.8 regime-naive default (`fallback`). The asterisk marker is only shown
+  // when the e value is the regime-naive default — fit-based and AB-Trefftz
+  // values are both real measurements.
+  const eProvenance = cleanPolar?.e_oswald_provenance ?? null;
+  const eIsRealMeasurement =
+    eProvenance === "aerobuildup_trefftz" || eProvenance === "fit";
+  // Backwards-compat: when polar_by_config lacks provenance (legacy data),
+  // fall back to the gh-626 `e_oswald_fallback_used` flag.
+  const eShowsFallbackMarker = eProvenance ? !eIsRealMeasurement : fallbackUsed;
+
+  // gh-636: empirical (L/D)max + CL,md straight from the AeroBuildup sweep
+  // — `max(CL/CD)` over the sweep, no fit required. Formula-derived values
+  // remain as legacy fallback for pre-gh-636 recomputes.
+  const ldMaxBackend = cleanPolar?.ld_max ?? null;
+  const clMdBackend = cleanPolar?.cl_at_ld_max ?? null;
+
   const k = computeK(eFromCtx, fallbackUsed, ar);
-  const clMd = computeCLmd(cd0, eFromCtx, fallbackUsed, ar);
-  const eMax = computeEMax(cd0, eFromCtx, fallbackUsed, ar);
+  const clMd = clMdBackend ?? computeCLmd(cd0, eFromCtx, fallbackUsed, ar);
+  const eMax = ldMaxBackend ?? computeEMax(cd0, eFromCtx, fallbackUsed, ar);
   const rho = computeRho(cd0, eFromCtx, fallbackUsed, ar, clMax);
 
   // Displayed e: when fallback used, show the 0.80 fallback explicitly
   // with the asterisk; otherwise the real fit value. Fallback always
   // renders muted (quality necessarily 'unknown').
-  const eDisplayValue: number | null = fallbackUsed ? 0.8 : eFromCtx;
-  const eSymbol = fallbackUsed ? "e*" : "e";
-  const eTooltip = fallbackUsed
+  const eDisplayValue: number | null = eShowsFallbackMarker ? 0.8 : eFromCtx;
+  const eSymbol = eShowsFallbackMarker ? "e*" : "e";
+  const eTooltip = eShowsFallbackMarker
     ? "Polar fit was rejected — fallback 0.80 used (regime-naive). All derived polar quantities (k, C_L,md, L/D-max, ρ) are therefore suppressed."
-    : "Oswald efficiency — combined non-elliptical-lift-distribution loss and parasite-drag-with-lift. Typical 0.70–0.95. Colour reflects fit quality.";
+    : eProvenance === "aerobuildup_trefftz"
+      ? "Oswald efficiency from AeroBuildup's Trefftz-plane induced drag at (L/D)max (gh-636). Typical 0.70–0.95."
+      : "Oswald efficiency — combined non-elliptical-lift-distribution loss and parasite-drag-with-lift. Typical 0.70–0.95. Colour reflects fit quality.";
   const eQualityColour = fallbackUsed
     ? qualityColorClassName("unknown")
     : qualityColorClassName(quality);

--- a/frontend/components/workbench/PolarChipRow.tsx
+++ b/frontend/components/workbench/PolarChipRow.tsx
@@ -147,11 +147,17 @@ export function PolarChipRow({ ctx, isRecomputing }: Props) {
   // renders muted (quality necessarily 'unknown').
   const eDisplayValue: number | null = eShowsFallbackMarker ? 0.8 : eFromCtx;
   const eSymbol = eShowsFallbackMarker ? "e*" : "e";
-  const eTooltip = eShowsFallbackMarker
-    ? "Polar fit was rejected — fallback 0.80 used (regime-naive). All derived polar quantities (k, C_L,md, L/D-max, ρ) are therefore suppressed."
-    : eProvenance === "aerobuildup_trefftz"
-      ? "Oswald efficiency from AeroBuildup's Trefftz-plane induced drag at (L/D)max (gh-636). Typical 0.70–0.95."
-      : "Oswald efficiency — combined non-elliptical-lift-distribution loss and parasite-drag-with-lift. Typical 0.70–0.95. Colour reflects fit quality.";
+  let eTooltip: string;
+  if (eShowsFallbackMarker) {
+    eTooltip =
+      "Polar fit was rejected — fallback 0.80 used (regime-naive). All derived polar quantities (k, C_L,md, L/D-max, ρ) are therefore suppressed.";
+  } else if (eProvenance === "aerobuildup_trefftz") {
+    eTooltip =
+      "Oswald efficiency from AeroBuildup's Trefftz-plane induced drag at (L/D)max (gh-636). Typical 0.70–0.95.";
+  } else {
+    eTooltip =
+      "Oswald efficiency — combined non-elliptical-lift-distribution loss and parasite-drag-with-lift. Typical 0.70–0.95. Colour reflects fit quality.";
+  }
   const eQualityColour = fallbackUsed
     ? qualityColorClassName("unknown")
     : qualityColorClassName(quality);

--- a/frontend/hooks/useComputationContext.ts
+++ b/frontend/hooks/useComputationContext.ts
@@ -24,6 +24,11 @@ export interface PolarRejection {
 
 export type PolarConfigName = "clean" | "takeoff" | "landing";
 
+export type EOswaldProvenance =
+  | "aerobuildup_trefftz"
+  | "fit"
+  | "fallback";
+
 export interface ParabolicPolar {
   cd0: number | null;
   e_oswald: number | null;
@@ -33,6 +38,11 @@ export interface ParabolicPolar {
   flap_deflection_deg: number;
   provenance: "aerobuildup" | "no_flap_geometry" | "aerobuildup_failed";
   rejection: PolarRejection | null;
+  // gh-636: empirical (L/D)max + CL_at_(L/D)max from the AeroBuildup sweep;
+  // provenance of e (vlm-trefftz / fit / fallback).
+  ld_max?: number | null;
+  cl_at_ld_max?: number | null;
+  e_oswald_provenance?: EOswaldProvenance;
 }
 
 export type PolarByConfig = Record<PolarConfigName, ParabolicPolar>;
@@ -62,13 +72,6 @@ export interface ComputationContext {
   e_oswald?: number | null;
   e_oswald_quality?: EQuality;
   e_oswald_fallback_used?: boolean;
-  polar_by_config?: {
-    clean?: {
-      cd0?: number | null;
-      e_oswald?: number | null;
-      cl_max?: number | null;
-    };
-  } | null;
   x_np_m: number;
   target_static_margin: number;
   cg_agg_m: number | null;
@@ -77,6 +80,7 @@ export interface ComputationContext {
   // gate tail-volume-related UI off when true.
   is_tailless?: boolean;
   computed_at: string;
+  // gh-630 + gh-636: per-config polars + empirical L/D max + e provenance.
   polar_by_config?: PolarByConfig;
 }
 


### PR DESCRIPTION
## Summary

\`asb.AeroBuildup\` already exposes \`D_induced\` per operating point — so we can compute Oswald e directly via \`e = CL²/(π·AR·CDi)\` at the (L/D)max sweep index. No VLM single-pass needed, no parabolic-fit dependency for e, zero extra solver calls.

## Changes

**Backend:**
- \`_fine_sweep_cl_max\` returns a 5-tuple with the new \`cdi_array\`.
- Helpers \`_ld_max_from_sweep\` and \`_e_oswald_from_sweep\` derive empirical (L/D)max and Oswald e at the (L/D)max index.
- Provenance chain: \`aerobuildup_trefftz → fit → fallback\`. Existing parabolic-fit gates remain as diagnostic-only.
- Schema: \`ParabolicPolar\` gains \`ld_max\`, \`cl_at_ld_max\`, \`e_oswald_provenance\`.

**Frontend:**
- \`PolarChipRow\` reads empirical (L/D)max and CL,md directly from the context (no formula bail).
- \`e*\` asterisk now triggered by \`e_oswald_provenance === 'fallback'\` instead of \`e_oswald_fallback_used\`. Fit-based and AB-Trefftz values are both treated as real measurements.

## Calibration

vs Sharpe's \`study-oswalds-efficiency-taper-ratio\`:
- Rectangular AR=10: AB gives e=0.775 (matches reference Cessna 172 e=0.75 used in test fixtures).
- α-independence verified: e=0.775 constant α=1°–10° → Anderson §6.7's e=const assumption holds in the linear regime.

## Test plan

- [x] Backend 51 tests green (mocks updated to 5-tuple)
- [x] Frontend 29 unit tests green
- [ ] Live verification: real aeroplane shows non-fallback e + populated (L/D)max etc.

Closes #636