### PR TITLE
feat(gh-640): OpenVSP importer skeleton + unit handling

### DIFF
--- a/app/converters/openvsp_importer.py
+++ b/app/converters/openvsp_importer.py
@@ -1,0 +1,284 @@
+"""OpenVSP ``.vsp3`` importer skeleton (gh-640).
+
+This module is the **grundgerüst** of the OpenVSP importer (epic
+gh-637). It provides:
+
+* :class:`ImportWarning` — structured, frontend-displayable record of
+  something that did not import cleanly.
+* :class:`ImportContext` — collector passed through the pipeline so
+  individual handlers don't need to manage cross-cutting state.
+* :class:`ImportResult` — the top-level return value: parsed
+  ``AeroplaneSchema`` + collected weight items + warnings.
+* :func:`import_vsp3` — public entry point.
+* ``_HANDLERS`` — dispatch table the component PRs (#641 WING,
+  #643 FUSELAGE, #645 BLANK, ...) register their handlers into.
+
+Scope
+-----
+
+This module deliberately does **not** implement WING/FUSELAGE/BLANK
+import. Those handlers live in their own PRs and are registered via
+:func:`register_handler` so the component work can land in any order.
+
+Out of scope (per ``feedback_openvsp_import_rc_scope`` memory): no
+propulsion, no inertia, no CSGroup gains, no VSPAERO validation —
+this importer is for RC-model scaling inspiration only.
+
+Unit handling
+-------------
+
+The OpenVSP file format declares its length unit in the Vehicle_Info
+container. We:
+
+1. Read the source unit before doing anything else.
+2. Call ``vsp.SetLengthUnit(LEN_M)`` to ask OpenVSP to rescale all
+   length-typed parms to metres.
+3. Also expose the source-unit metadata
+   (:attr:`ImportResult.source_length_unit` /
+   :attr:`ImportResult.source_scale_to_meters`) for handlers that
+   need to do their own conversion as a belt-and-braces fallback
+   (some VSP-side parms don't always honour SetLengthUnit reliably —
+   see review comment on gh-640).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import ModuleType
+from typing import Callable, Literal, Optional
+
+from app.converters import openvsp_adapter
+from app.schemas.aeroplaneschema import AeroplaneSchema
+from app.schemas.weight_item import WeightItemWrite
+
+
+# ---------------------------------------------------------------------------
+# Unit table
+# ---------------------------------------------------------------------------
+
+# Maps OpenVSP `LEN_UNITS` enum integer → metres-per-unit scale.
+# See ``vsp.LEN_MM`` through ``vsp.LEN_YD`` and ``vsp.LEN_UNITLESS``.
+# Used as primary conversion when ``SetLengthUnit`` doesn't propagate.
+LEN_UNIT_TO_METERS: dict[int, float] = {
+    0: 0.001,  # LEN_MM
+    1: 0.01,  # LEN_CM
+    2: 1.0,  # LEN_M
+    3: 0.0254,  # LEN_IN
+    4: 0.3048,  # LEN_FT
+    5: 0.9144,  # LEN_YD
+    6: 1.0,  # LEN_UNITLESS — treat as metres
+}
+
+
+_VALID_SEVERITIES = ("info", "warning", "error")
+Severity = Literal["info", "warning", "error"]
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ImportWarning:
+    """A single non-fatal issue surfaced during import.
+
+    Designed to round-trip cleanly to the JSON envelope returned by
+    the ``/api/v2/import/openvsp`` endpoint (#646) and rendered by
+    the frontend banner (#648).
+    """
+
+    component_type: str
+    component_name: str
+    reason: str
+    severity: Severity = "warning"
+
+
+@dataclass
+class ImportContext:
+    """Mutable collector threaded through the importer pipeline."""
+
+    warnings: list[ImportWarning] = field(default_factory=list)
+    lossy_components: list[str] = field(default_factory=list)
+    weight_items: list[WeightItemWrite] = field(default_factory=list)
+    source_length_unit: Optional[int] = None
+    source_scale_to_meters: Optional[float] = None
+
+    def add_warning(
+        self,
+        *,
+        component_type: str,
+        component_name: str,
+        reason: str,
+        severity: Severity = "warning",
+    ) -> None:
+        if severity not in _VALID_SEVERITIES:
+            raise ValueError(f"severity must be one of {_VALID_SEVERITIES}, got {severity!r}")
+        self.warnings.append(
+            ImportWarning(
+                component_type=component_type,
+                component_name=component_name,
+                reason=reason,
+                severity=severity,
+            )
+        )
+
+    def mark_lossy(self, gid: str) -> None:
+        """Record a geom id as not fully imported (de-duplicated)."""
+        if gid not in self.lossy_components:
+            self.lossy_components.append(gid)
+
+    def add_weight_item(self, item: WeightItemWrite) -> None:
+        self.weight_items.append(item)
+
+
+@dataclass
+class ImportResult:
+    """Top-level return value of :func:`import_vsp3`.
+
+    ``aeroplane`` is the parsed geometry. ``weight_items`` is kept
+    separate because the persistence layer (#646) attaches them to
+    the ``AeroplaneModel`` rather than the schema.
+    """
+
+    aeroplane: AeroplaneSchema
+    warnings: list[ImportWarning] = field(default_factory=list)
+    lossy_components: list[str] = field(default_factory=list)
+    weight_items: list[WeightItemWrite] = field(default_factory=list)
+    source_length_unit: Optional[int] = None
+    source_scale_to_meters: Optional[float] = None
+
+
+# ---------------------------------------------------------------------------
+# Handler registry
+# ---------------------------------------------------------------------------
+
+# Component PRs (#641 WING, #643 FUSELAGE, #645 BLANK, ...) register
+# themselves here. Signature:
+#
+#     handler(gid: str, name: str, aeroplane: AeroplaneSchema,
+#             ctx: ImportContext, vsp: ModuleType) -> None
+#
+# The vsp module is passed in (rather than imported at module top)
+# so handler bodies remain testable with a fake module.
+
+HandlerFn = Callable[[str, str, AeroplaneSchema, ImportContext, ModuleType], None]
+_HANDLERS: dict[str, HandlerFn] = {}
+
+
+def register_handler(geom_type: str, handler: HandlerFn) -> None:
+    """Register a handler for a VSP geom type (``"WING"``, ``"FUSELAGE"``, ...)."""
+    _HANDLERS[geom_type] = handler
+
+
+# Map of unsupported geom types → frontend-facing reason.
+# Sub-issue #648 takes the warning structure and renders it.
+_UNSUPPORTED_REASONS: dict[str, str] = {
+    "PROP": "Propellers not yet supported (Phase 2 — see issue #649)",
+    "DISK": "Actuator disks not yet supported (Phase 2)",
+    "MESH": "Imported meshes not yet supported (Phase 2)",
+    "CUSTOM": "Custom Geoms (AngelScript) cannot be imported parametrically",
+    "CONFORMAL": "Conformal Geoms not yet supported (Phase 2)",
+    "NGON_MESH": "N-Gon Mesh imports come in Phase 2",
+    "HUMAN": "Human pilot geoms are not part of the aerodynamic model",
+    "POD": "Pod/Body-of-Revolution geoms not yet supported (see issue #652)",
+    "BOR": "Body-of-Revolution geoms not yet supported (see issue #652)",
+    "STACK": "Stack geoms not yet supported in Phase 1",
+    "ELLIPSOID": "Ellipsoid geoms not yet supported in Phase 1",
+    "WIRE_FRAME": "Wire-frame geoms not part of the aerodynamic model",
+    "HINGE": "Hinge geoms not part of the aerodynamic model",
+    "PT_CLOUD": "Point-cloud geoms not yet supported",
+    "GEAR": "Landing-gear geoms not yet supported",
+}
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def _read_source_length_unit(vsp: ModuleType, vehicle_id: str) -> Optional[int]:
+    """Try to read the source-file length unit.
+
+    Returns ``None`` when the parm group cannot be found (e.g. very
+    old VSP versions or stub vehicles). Callers must tolerate ``None``.
+    """
+    try:
+        pid = vsp.FindParm(vehicle_id, "LengthUnit", "Vehicle_Info")
+        if pid == "":
+            return None
+        return int(vsp.GetParmVal(pid))
+    except Exception:
+        # Defensive: never crash because of unit-discovery failure.
+        return None
+
+
+def import_vsp3(path: Path) -> ImportResult:
+    """Parse a ``.vsp3`` file → :class:`ImportResult`.
+
+    Raises
+    ------
+    ImportError
+        When the optional ``openvsp`` package is not installed.
+        Message includes install hint (see ``openvsp_adapter``).
+    FileNotFoundError
+        When ``path`` does not exist on disk.
+    """
+    path = Path(path)
+    vsp = openvsp_adapter.get_vsp()  # raises ImportError if missing
+    if not path.exists():
+        raise FileNotFoundError(f"OpenVSP file not found: {path}")
+
+    # Critical sequence (see gh-640 acceptance criteria): clear → read
+    # → set unit → update. Skipping ClearVSPModel makes ReadVSPFile
+    # merge into whatever state is already loaded.
+    vsp.ClearVSPModel()
+    vsp.ReadVSPFile(str(path))
+
+    # Read original unit BEFORE asking OpenVSP to rescale.
+    vehicle_id = vsp.GetVehicleID()
+    source_unit = _read_source_length_unit(vsp, vehicle_id)
+    source_scale = LEN_UNIT_TO_METERS.get(source_unit) if source_unit is not None else None
+
+    # Ask OpenVSP to rescale all length parms to metres.
+    vsp.SetLengthUnit(vsp.LEN_M)
+    vsp.Update()
+
+    ctx = ImportContext(
+        source_length_unit=source_unit,
+        source_scale_to_meters=source_scale,
+    )
+
+    aeroplane = AeroplaneSchema(name=path.stem)
+
+    # Dispatch loop. Component PRs register handlers via
+    # ``register_handler``. Unknown / unsupported geoms become
+    # warnings (#648 surfaces them in the UI).
+    for gid in vsp.FindGeoms():
+        type_name = vsp.GetGeomTypeName(gid)
+        name = vsp.GetGeomName(gid) or gid
+        handler = _HANDLERS.get(type_name)
+        if handler is not None:
+            handler(gid, name, aeroplane, ctx, vsp)
+        else:
+            reason = _UNSUPPORTED_REASONS.get(
+                type_name,
+                f"Geom type {type_name!r} is not supported in Phase 1",
+            )
+            ctx.add_warning(
+                component_type=type_name,
+                component_name=name,
+                reason=reason,
+                severity="warning",
+            )
+            ctx.mark_lossy(gid)
+
+    return ImportResult(
+        aeroplane=aeroplane,
+        warnings=list(ctx.warnings),
+        lossy_components=list(ctx.lossy_components),
+        weight_items=list(ctx.weight_items),
+        source_length_unit=ctx.source_length_unit,
+        source_scale_to_meters=ctx.source_scale_to_meters,
+    )

--- a/app/tests/test_openvsp_importer.py
+++ b/app/tests/test_openvsp_importer.py
@@ -1,0 +1,351 @@
+"""Unit tests for the OpenVSP importer skeleton (gh-640).
+
+This module covers the **grundgerüst** — module-level entry point,
+warning collection, unit-conversion table, geom-dispatch loop — but
+deliberately stops at the component handlers (#641 WING, #643
+FUSELAGE, #645 BLANK). Those handlers are added in their own PRs and
+this skeleton calls **registered handler callbacks**, so the
+component PRs can land in any order without touching the skeleton.
+
+All tests use the `openvsp_adapter` shim from gh-639 and mock the
+`vsp` module — no real OpenVSP installation required.
+"""
+
+from __future__ import annotations
+
+from types import ModuleType
+from unittest.mock import patch
+
+import pytest
+
+from app.converters import openvsp_adapter, openvsp_importer
+from app.converters.openvsp_importer import (
+    LEN_UNIT_TO_METERS,
+    ImportContext,
+    ImportResult,
+    ImportWarning,
+    import_vsp3,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake VSP module factory
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_vsp(
+    geoms: list[tuple[str, str, str]] | None = None,
+    length_unit: int = 2,  # LEN_M
+    vehicle_id: str = "VEH",
+    parm_values: dict[tuple[str, str, str], float] | None = None,
+) -> ModuleType:
+    """Build a minimal stand-in for the `openvsp` module.
+
+    ``geoms`` is a list of ``(gid, name, type_name)`` triples. Calls
+    that retrieve a parm value can be satisfied via ``parm_values``,
+    a dict keyed by ``(container_id, parm_name, group_name)``.
+    """
+    geoms = geoms or []
+    parm_values = parm_values or {}
+
+    fake = ModuleType("openvsp")
+
+    # Enum-like constants used by the skeleton.
+    fake.LEN_MM = 0
+    fake.LEN_CM = 1
+    fake.LEN_M = 2
+    fake.LEN_IN = 3
+    fake.LEN_FT = 4
+    fake.LEN_YD = 5
+    fake.LEN_UNITLESS = 6
+    fake.SYM_XY = 1
+    fake.SYM_XZ = 2
+    fake.SYM_YZ = 4
+
+    # Bookkeeping for the test asserts.
+    fake.calls: list[tuple[str, tuple]] = []  # type: ignore[attr-defined]
+
+    def record(name):
+        def _impl(*args, **kwargs):
+            fake.calls.append((name, args))  # type: ignore[attr-defined]
+
+        return _impl
+
+    fake.ClearVSPModel = record("ClearVSPModel")
+    fake.ReadVSPFile = record("ReadVSPFile")
+    fake.Update = record("Update")
+
+    def _set_length_unit(unit):
+        fake.calls.append(("SetLengthUnit", (unit,)))  # type: ignore[attr-defined]
+
+    fake.SetLengthUnit = _set_length_unit
+
+    fake.GetVehicleID = lambda: vehicle_id
+    fake.FindGeoms = lambda: [gid for gid, _name, _t in geoms]
+    fake.GetGeomName = lambda gid: next((n for g, n, _t in geoms if g == gid), "")
+    fake.GetGeomTypeName = lambda gid: next((t for g, _n, t in geoms if g == gid), "")
+
+    # Parm-system stubs — keyed by (container, parm, group).
+    fake._parm_registry = parm_values  # type: ignore[attr-defined]
+
+    def _find_parm(container_id, parm_name, group_name):
+        key = (container_id, parm_name, group_name)
+        if key in parm_values:
+            return f"PID::{container_id}::{group_name}::{parm_name}"
+        return ""
+
+    def _get_parm_val(pid):
+        if pid == "":
+            return 0.0
+        # PID encoding: PID::<container>::<group>::<parm>
+        _, container, group, parm = pid.split("::", 3)
+        return parm_values.get((container, parm, group), 0.0)
+
+    fake.FindParm = _find_parm
+    fake.GetParmVal = _get_parm_val
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# LEN_UNIT_TO_METERS
+# ---------------------------------------------------------------------------
+
+
+class TestLenUnitToMeters:
+    def test_table_has_all_known_units(self):
+        # mm, cm, m, in, ft, yd, unitless
+        for unit in (0, 1, 2, 3, 4, 5, 6):
+            assert unit in LEN_UNIT_TO_METERS
+
+    @pytest.mark.parametrize(
+        "unit, scale",
+        [
+            (0, 0.001),  # mm
+            (1, 0.01),  # cm
+            (2, 1.0),  # m
+            (3, 0.0254),  # in
+            (4, 0.3048),  # ft
+            (5, 0.9144),  # yd
+            (6, 1.0),  # unitless → treat as m
+        ],
+    )
+    def test_each_factor_matches_si_definition(self, unit, scale):
+        assert LEN_UNIT_TO_METERS[unit] == pytest.approx(scale, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# ImportWarning + ImportContext + ImportResult
+# ---------------------------------------------------------------------------
+
+
+class TestImportContext:
+    def test_add_warning_appends(self):
+        ctx = ImportContext()
+        ctx.add_warning(
+            component_type="PROP",
+            component_name="MainProp",
+            reason="Propellers not supported in Phase 1",
+            severity="warning",
+        )
+        assert len(ctx.warnings) == 1
+        w = ctx.warnings[0]
+        assert isinstance(w, ImportWarning)
+        assert w.component_type == "PROP"
+        assert w.component_name == "MainProp"
+        assert w.severity == "warning"
+
+    def test_mark_lossy_unique(self):
+        ctx = ImportContext()
+        ctx.mark_lossy("GEOM1")
+        ctx.mark_lossy("GEOM1")  # duplicate ignored
+        ctx.mark_lossy("GEOM2")
+        assert ctx.lossy_components == ["GEOM1", "GEOM2"]
+
+    def test_severity_must_be_known(self):
+        ctx = ImportContext()
+        with pytest.raises(ValueError, match="severity"):
+            ctx.add_warning(
+                component_type="X",
+                component_name="Y",
+                reason="z",
+                severity="catastrophic",  # not allowed
+            )
+
+
+class TestImportResult:
+    def test_default_fields(self):
+        from app.schemas.aeroplaneschema import AeroplaneSchema
+
+        ap = AeroplaneSchema(name="Empty")
+        r = ImportResult(aeroplane=ap)
+        assert r.aeroplane is ap
+        assert r.warnings == []
+        assert r.lossy_components == []
+        assert r.weight_items == []
+
+
+# ---------------------------------------------------------------------------
+# import_vsp3 — adapter wiring + ClearVSPModel + Read + Update
+# ---------------------------------------------------------------------------
+
+
+class TestImportVsp3OpenVspMissing:
+    def test_raises_clear_import_error(self, tmp_path):
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        with patch.object(openvsp_adapter, "_attempt_import", return_value=None):
+            openvsp_adapter.reset_for_tests()
+            # Force ImportError path.
+            with patch.object(
+                openvsp_adapter.importlib,
+                "import_module",
+                side_effect=ImportError("missing"),
+            ):
+                with pytest.raises(ImportError) as exc_info:
+                    import_vsp3(f)
+        assert "openvsp" in str(exc_info.value).lower()
+
+
+class TestImportVsp3FileMissing:
+    def test_raises_file_not_found(self, tmp_path):
+        path = tmp_path / "no_such_file.vsp3"
+        fake = _make_fake_vsp()
+        with patch.object(openvsp_adapter, "get_vsp", return_value=fake):
+            with pytest.raises(FileNotFoundError):
+                import_vsp3(path)
+
+
+class TestImportVsp3Empty:
+    def test_no_geoms_yields_empty_aeroplane(self, tmp_path):
+        f = tmp_path / "empty.vsp3"
+        f.write_text("")
+        fake = _make_fake_vsp(geoms=[])
+        with patch.object(openvsp_adapter, "get_vsp", return_value=fake):
+            result = import_vsp3(f)
+        assert result.aeroplane.name == "empty"  # filename stem
+        assert result.warnings == []
+        assert result.weight_items == []
+        # The skeleton MUST have called these in order on the fake vsp:
+        names = [c[0] for c in fake.calls]
+        assert names[0] == "ClearVSPModel"
+        assert names[1] == "ReadVSPFile"
+        assert "SetLengthUnit" in names
+        assert "Update" in names
+
+    def test_set_length_unit_called_with_meters(self, tmp_path):
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        fake = _make_fake_vsp(geoms=[])
+        with patch.object(openvsp_adapter, "get_vsp", return_value=fake):
+            import_vsp3(f)
+        slu = [c for c in fake.calls if c[0] == "SetLengthUnit"]
+        assert slu, "SetLengthUnit must be called"
+        assert slu[0][1] == (fake.LEN_M,)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch loop — unhandled geom types produce warnings, not crashes
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchUnknownGeoms:
+    @pytest.mark.parametrize(
+        "vsp_type",
+        ["PROP", "DISK", "MESH", "CUSTOM", "CONFORMAL", "NGON_MESH", "HUMAN"],
+    )
+    def test_unsupported_geom_emits_warning(self, vsp_type, tmp_path):
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        fake = _make_fake_vsp(
+            geoms=[(f"GID_{vsp_type}", f"Some{vsp_type}", vsp_type)],
+        )
+        with patch.object(openvsp_adapter, "get_vsp", return_value=fake):
+            result = import_vsp3(f)
+        assert len(result.warnings) == 1
+        w = result.warnings[0]
+        assert w.component_type == vsp_type
+        assert w.component_name == f"Some{vsp_type}"
+        assert w.severity in ("info", "warning")
+        # The component is recorded as lossy / non-imported.
+        assert f"GID_{vsp_type}" in result.lossy_components
+
+
+class TestDispatchRegisteredHandler:
+    """The skeleton dispatches WING/FUSELAGE/BLANK to handlers.
+
+    The component PRs (#641, #643, #645) register their own handlers.
+    Here we verify the dispatch contract by registering fakes.
+    """
+
+    def test_wing_handler_is_invoked(self, tmp_path, monkeypatch):
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        fake = _make_fake_vsp(geoms=[("GID1", "MainWing", "WING")])
+
+        recorded: list[tuple[str, str]] = []
+
+        def _wing_handler(gid, name, aeroplane, ctx, vsp):
+            recorded.append((gid, name))
+
+        monkeypatch.setitem(openvsp_importer._HANDLERS, "WING", _wing_handler)
+        with patch.object(openvsp_adapter, "get_vsp", return_value=fake):
+            import_vsp3(f)
+        assert recorded == [("GID1", "MainWing")]
+
+    def test_blank_handler_receives_weight_items_sink(self, tmp_path, monkeypatch):
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        fake = _make_fake_vsp(geoms=[("B1", "Battery", "BLANK")])
+
+        def _blank_handler(gid, name, aeroplane, ctx, vsp):
+            # Skeleton must pass an `ImportContext` that has a way to
+            # add weight items so the handler doesn't need to manage
+            # cross-cutting state itself.
+            from app.schemas.weight_item import WeightItemWrite
+
+            ctx.add_weight_item(WeightItemWrite(name=name, mass_kg=1.5, x_m=0.3))
+
+        monkeypatch.setitem(openvsp_importer._HANDLERS, "BLANK", _blank_handler)
+        with patch.object(openvsp_adapter, "get_vsp", return_value=fake):
+            result = import_vsp3(f)
+        assert len(result.weight_items) == 1
+        assert result.weight_items[0].name == "Battery"
+        assert result.weight_items[0].mass_kg == 1.5
+
+
+# ---------------------------------------------------------------------------
+# Unit handling — read original LengthUnit + rescale
+# ---------------------------------------------------------------------------
+
+
+class TestUnitHandling:
+    @pytest.mark.parametrize(
+        "source_unit_name, unit_value",
+        [
+            ("mm", 0),
+            ("cm", 1),
+            ("m", 2),
+            ("in", 3),
+            ("ft", 4),
+            ("yd", 5),
+        ],
+    )
+    def test_source_unit_is_read_before_set_length_unit(
+        self, source_unit_name, unit_value, tmp_path
+    ):
+        """The skeleton must read the source unit *before* rescaling."""
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        fake = _make_fake_vsp(
+            geoms=[],
+            parm_values={("VEH", "LengthUnit", "Vehicle_Info"): float(unit_value)},
+        )
+        with patch.object(openvsp_adapter, "get_vsp", return_value=fake):
+            result = import_vsp3(f)
+        # The ImportContext records the source unit for downstream
+        # handlers that need to do their own scaling (esp. when
+        # SetLengthUnit doesn't propagate to a particular parm).
+        assert result.source_length_unit == unit_value
+        assert result.source_scale_to_meters == pytest.approx(
+            LEN_UNIT_TO_METERS[unit_value], rel=1e-9
+        )


### PR DESCRIPTION
Closes #640. Part of EPIC #637.

## Summary

Lays the grundgerüst for the OpenVSP `.vsp3` importer that the
component PRs (#641 WING, #642 airfoil, #643 FUSELAGE, #644
SS_CONTROL, #645 BLANK) will plug into.

- `app/converters/openvsp_importer.py`:
  - `ImportWarning` (frozen dataclass), `ImportContext` (mutable
    collector with `add_warning` / `mark_lossy` / `add_weight_item`),
    `ImportResult` (top-level return).
  - `import_vsp3(path)` entry: ClearVSPModel → ReadVSPFile → read
    source LengthUnit → SetLengthUnit(LEN_M) → Update → dispatch.
  - `LEN_UNIT_TO_METERS` table for all 7 VSP LEN_UNITS values, per
    the review comment on gh-640 — primary conversion so handlers
    have a belt-and-braces fallback.
  - `register_handler(geom_type, fn)` so component PRs can land in
    any order.
  - `_UNSUPPORTED_REASONS` map renders all out-of-scope geom types
    (PROP, DISK, CUSTOM, NGON_MESH, etc.) as structured warnings
    rather than crashing — feeds #648 banner.
- `app/tests/test_openvsp_importer.py`: 31 unit tests via a fake-vsp
  module factory; no real OpenVSP needed.

## Why a handler registry

The component PRs (#641, #643, #645, #644) can land in any order and
in parallel without touching this skeleton. Each component PR adds
its own `register_handler("WING", _import_wing)` call (probably in
its module's import side-effect or via an explicit `register()` call
from `app/main.py`). The skeleton is closed for modification and
open for extension.

## Scope guard

Per `feedback_openvsp_import_rc_scope` memory: this importer is for
RC-model scaling inspiration only — no propulsion, no inertia, no
CSGroup gains, no VSPAERO validation. The `_UNSUPPORTED_REASONS` map
explicitly marks PROP/DISK/etc. as Phase 2.

## Test plan

- [x] `poetry run pytest app/tests/test_openvsp_importer.py -v` — 31 passed
- [x] `poetry run pytest -m "not slow"` — 3733+31 = 3764 passed, 1 skipped, 163 deselected, 2 xfailed
- [x] `poetry run ruff check` clean on changed files
- [x] `poetry run ruff format --check` clean on changed files

## Unblocks

This PR unblocks the parallel component batch: #641, #642, #643,
#645 (all blocked by A2). #644 chains off #641; #647 and #646 wait
on the component handlers.