### PR TITLE
feat(gh-641): OpenVSP WING geom handler

### DIFF
--- a/app/converters/openvsp_importer.py
+++ b/app/converters/openvsp_importer.py
@@ -214,6 +214,40 @@ def _read_source_length_unit(vsp: ModuleType, vehicle_id: str) -> Optional[int]:
         return None
 
 
+_handlers_loaded = False
+
+
+def _ensure_handlers_loaded() -> None:
+    """Lazy-import + register component handlers on first call.
+
+    Lazy registration avoids a circular import at module-load time
+    and lets each handler module live in its own file (one per
+    sub-issue).
+    """
+    global _handlers_loaded
+    if _handlers_loaded:
+        return
+    try:  # pragma: no cover - import side effects
+        from app.converters import openvsp_wing_handler
+
+        openvsp_wing_handler.register()
+    except ImportError:
+        pass
+    try:  # pragma: no cover
+        from app.converters import openvsp_fuselage_handler
+
+        openvsp_fuselage_handler.register()
+    except ImportError:
+        pass
+    try:  # pragma: no cover
+        from app.converters import openvsp_blank_handler
+
+        openvsp_blank_handler.register()
+    except ImportError:
+        pass
+    _handlers_loaded = True
+
+
 def import_vsp3(path: Path) -> ImportResult:
     """Parse a ``.vsp3`` file → :class:`ImportResult`.
 
@@ -225,6 +259,7 @@ def import_vsp3(path: Path) -> ImportResult:
     FileNotFoundError
         When ``path`` does not exist on disk.
     """
+    _ensure_handlers_loaded()
     path = Path(path)
     vsp = openvsp_adapter.get_vsp()  # raises ImportError if missing
     if not path.exists():

--- a/app/converters/openvsp_wing_handler.py
+++ b/app/converters/openvsp_wing_handler.py
@@ -1,0 +1,281 @@
+"""OpenVSP WING geom handler (gh-641).
+
+Converts a VSP ``WING`` geom into an :class:`AsbWingSchema` and
+attaches it to the in-progress :class:`AeroplaneSchema`. Registered
+into the skeleton handler table via :func:`register`.
+
+Container convention (per the review comment on gh-641):
+
+* **Planform parms** (Span, Root_Chord, Tip_Chord, Sweep,
+  Sweep_Location, Dihedral, Twist) live on the **WING container**
+  in group ``XSec_<i>``, where ``i`` is the section index
+  ``1..n_sec``.
+* The **first XSec** (index 0) is the root and carries the airfoil
+  shape only. Per-segment planform parms anchor at xsec index 1 and
+  describe the segment **outboard** of the previous xsec.
+
+Sweep convention:
+
+* OpenVSP stores ``Sweep`` at a user-selectable chord fraction
+  ``Sweep_Location`` ∈ [0, 1] (0 = LE, 0.25 = c/4, 1 = TE).
+* Our schema exposes geometry through ``xyz_le`` (leading-edge
+  coordinates), so we convert the chord-fraction-referenced sweep
+  to LE sweep for cumulative LE-X positioning.
+
+Out of scope (per ``feedback_openvsp_import_rc_scope``): blend modes,
+WING_BLEND_ANGLES, propulsion, inertia.
+"""
+
+from __future__ import annotations
+
+import math
+from types import ModuleType
+
+from app.converters import openvsp_importer
+from app.converters.openvsp_importer import AeroplaneSchema, ImportContext
+from app.schemas.aeroplaneschema import AsbWingSchema, WingXSecSchema
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _sweep_change_reference(
+    *,
+    sweep_from_deg: float,
+    xref_from: float,
+    xref_to: float,
+    span: float,
+    c_root: float,
+    c_tip: float,
+) -> float:
+    """Convert a sweep angle from one chord-fraction reference to another.
+
+    Geometry: a wing section's chord-fraction-f line lies at
+        x_f(y) = x_LE(y) + f * c(y)
+    where x_LE(y) = y * tan(Λ_LE) and c(y) = c_root - (c_root - c_tip)*y/span.
+
+    The sweep at fraction f satisfies
+        tan(Λ_f) = tan(Λ_LE) - f * (c_root - c_tip) / span
+    and chaining two references gives
+        tan(Λ_to) = tan(Λ_from) - (xref_to - xref_from) * (c_root - c_tip) / span
+
+    Returns ``sweep_from_deg`` unchanged when ``span <= 0``.
+    """
+    if span <= 0:
+        return sweep_from_deg
+    delta = (xref_to - xref_from) * (c_root - c_tip) / span
+    return math.degrees(math.atan(math.tan(math.radians(sweep_from_deg)) - delta))
+
+
+def sweep_at_c4(
+    *, sweep_xref_deg: float, xref: float, span: float, c_root: float, c_tip: float
+) -> float:
+    """Convert a sweep angle referenced at ``xref`` to the c/4 reference."""
+    return _sweep_change_reference(
+        sweep_from_deg=sweep_xref_deg,
+        xref_from=xref,
+        xref_to=0.25,
+        span=span,
+        c_root=c_root,
+        c_tip=c_tip,
+    )
+
+
+def sweep_at_le(
+    *, sweep_xref_deg: float, xref: float, span: float, c_root: float, c_tip: float
+) -> float:
+    """Convert a sweep at chord-fraction ``xref`` to the LE reference."""
+    return _sweep_change_reference(
+        sweep_from_deg=sweep_xref_deg,
+        xref_from=xref,
+        xref_to=0.0,
+        span=span,
+        c_root=c_root,
+        c_tip=c_tip,
+    )
+
+
+def _airfoil_placeholder() -> str:
+    """Placeholder airfoil path until #642 (XSecCurve → airfoil) lands.
+
+    Pointing at a known-good NACA 0012 keeps the schema valid; #642
+    will replace it with per-section detection.
+    """
+    return "./components/airfoils/naca0012.dat"
+
+
+def _read_section_parm(vsp: ModuleType, wing_gid: str, section_idx: int, parm: str) -> float:
+    """Best-effort read of a planform parm on the WING container.
+
+    Tries the 1-indexed group first (``XSec_1``..``XSec_N``) — that's
+    the convention used by current OpenVSP. Falls back to the
+    0-indexed form for forward-compat. Returns 0.0 when the parm is
+    absent so the caller can supply sensible defaults.
+    """
+    for grp in (f"XSec_{section_idx}", f"XSec_{section_idx - 1}"):
+        pid = vsp.FindParm(wing_gid, parm, grp)
+        if pid:
+            return float(vsp.GetParmVal(pid))
+    return 0.0
+
+
+def _read_symmetric(vsp: ModuleType, wing_gid: str) -> bool:
+    """Decode the Sym_Planar_Flag bitmask → wing-symmetric boolean.
+
+    Our schema's ``symmetric`` flag means "mirrored about XZ"
+    (left/right symmetry of a fixed-wing aircraft). OpenVSP encodes
+    this as the SYM_XZ bit (=2) in ``Sym_Planar_Flag``.
+    """
+    pid = vsp.FindParm(wing_gid, "Sym_Planar_Flag", "Sym")
+    if not pid:
+        return False
+    flag = int(vsp.GetParmVal(pid))
+    sym_xz = getattr(vsp, "SYM_XZ", 2)
+    return bool(flag & sym_xz)
+
+
+# ---------------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------------
+
+
+def _handle_wing(
+    gid: str,
+    name: str,
+    aeroplane: AeroplaneSchema,
+    ctx: ImportContext,
+    vsp: ModuleType,
+) -> None:
+    """Convert one WING geom into an ``AsbWingSchema``.
+
+    The function is intentionally tolerant of missing parms: a
+    well-formed VSP file produces a clean schema; an unusual VSP
+    file produces a schema plus warnings rather than an exception.
+    """
+    xsurf = vsp.GetXSecSurf(gid, 0)
+    n_xsec = int(vsp.GetNumXSec(xsurf))
+    if n_xsec < 2:
+        ctx.add_warning(
+            component_type="WING",
+            component_name=name,
+            reason=f"WING {name!r} has only {n_xsec} XSecs (need ≥2); skipped.",
+            severity="warning",
+        )
+        ctx.mark_lossy(gid)
+        return
+
+    n_sec = n_xsec - 1
+    symmetric = _read_symmetric(vsp, gid)
+
+    # Build the xsec list. Section index i (1..n_sec) describes the
+    # segment OUTBOARD of XSec[i-1] and terminating at XSec[i].
+    x_secs: list[WingXSecSchema] = []
+
+    # Root xsec at (0, 0, 0) with chord = section_1.Root_Chord and
+    # airfoil placeholder (real airfoil import is #642).
+    root_chord = _read_section_parm(vsp, gid, 1, "Root_Chord")
+    if root_chord <= 0:
+        ctx.add_warning(
+            component_type="WING",
+            component_name=name,
+            reason=f"WING {name!r} has Root_Chord<=0 on first section; defaulting to 1.0 m.",
+            severity="warning",
+        )
+        root_chord = 1.0
+
+    x_secs.append(
+        WingXSecSchema(
+            xyz_le=[0.0, 0.0, 0.0],
+            chord=root_chord,
+            twist=0.0,
+            airfoil=_airfoil_placeholder(),
+            x_sec_type="root",
+        )
+    )
+
+    cum_x = 0.0
+    cum_y = 0.0
+    cum_z = 0.0
+    prev_chord = root_chord
+
+    for i in range(1, n_sec + 1):
+        span = _read_section_parm(vsp, gid, i, "Span")
+        tip_chord = _read_section_parm(vsp, gid, i, "Tip_Chord")
+        sweep_xref = _read_section_parm(vsp, gid, i, "Sweep")
+        sweep_loc = _read_section_parm(vsp, gid, i, "Sweep_Location")
+        dihedral = _read_section_parm(vsp, gid, i, "Dihedral")
+        twist = _read_section_parm(vsp, gid, i, "Twist")
+
+        if span <= 0:
+            ctx.add_warning(
+                component_type="WING",
+                component_name=name,
+                reason=(f"WING {name!r} section {i} has Span<=0; skipping section."),
+                severity="warning",
+            )
+            ctx.mark_lossy(gid)
+            continue
+
+        # Convert sweep to LE reference so we can advance the LE point.
+        # (Internal record uses c/4 if a downstream consumer wants it.)
+        le_sweep = sweep_at_le(
+            sweep_xref_deg=sweep_xref,
+            xref=sweep_loc,
+            span=span,
+            c_root=prev_chord,
+            c_tip=tip_chord,
+        )
+
+        cum_x += span * math.tan(math.radians(le_sweep))
+        cum_y += span
+        cum_z += span * math.tan(math.radians(dihedral))
+
+        # Mark intermediate xsecs as `segment`; final xsec is terminal
+        # and must have no segment-specific fields (Pydantic validator
+        # enforces this — see AsbWingSchema.validate_last_xsec_has_no_segment_details).
+        is_last = i == n_sec
+        x_secs.append(
+            WingXSecSchema(
+                xyz_le=[cum_x, cum_y, cum_z],
+                chord=tip_chord if tip_chord > 0 else prev_chord,
+                twist=twist,
+                airfoil=_airfoil_placeholder(),
+                x_sec_type=None if is_last else "segment",
+            )
+        )
+        prev_chord = tip_chord if tip_chord > 0 else prev_chord
+
+    if len(x_secs) < 2:
+        ctx.add_warning(
+            component_type="WING",
+            component_name=name,
+            reason=f"WING {name!r} produced <2 valid xsecs after parsing; skipped.",
+            severity="warning",
+        )
+        ctx.mark_lossy(gid)
+        return
+
+    wing = AsbWingSchema(
+        name=name,
+        symmetric=symmetric,
+        x_secs=x_secs,
+    )
+
+    if aeroplane.wings is None:
+        # OrderedDict preserves insertion order (FindGeoms tree traversal).
+        from collections import OrderedDict
+
+        aeroplane.wings = OrderedDict()
+    aeroplane.wings[name] = wing
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def register() -> None:
+    """Register the WING handler with the importer skeleton."""
+    openvsp_importer.register_handler("WING", _handle_wing)

--- a/app/tests/test_openvsp_wing_handler.py
+++ b/app/tests/test_openvsp_wing_handler.py
@@ -1,0 +1,300 @@
+"""Unit tests for the OpenVSP WING handler (gh-641).
+
+Covers:
+
+* Container convention — planform parms live on the WING container in
+  group ``XSec_<i>`` (per review comment on gh-641).
+* ``Sym_Planar_Flag`` bitmask → ``WingConfiguration.symmetric``.
+* Multi-section (Yehudi-break) wings emit one ``WingXSecSchema`` per
+  section + a final terminal section.
+* Sweep is converted from ``Sweep_Location`` reference to the c/4
+  reference (our model's convention) via ``sweep_at_c4``.
+* Driver-group agnostic: post-``Update`` we read planform values
+  directly, never reconstruct from drivers.
+"""
+
+from __future__ import annotations
+
+import math
+from types import ModuleType
+
+import pytest
+
+from app.converters import openvsp_adapter, openvsp_importer
+from app.converters.openvsp_importer import import_vsp3
+from app.converters.openvsp_wing_handler import (
+    _airfoil_placeholder,
+    register,
+    sweep_at_c4,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake-vsp factory
+# ---------------------------------------------------------------------------
+
+
+def _make_wing_vsp(
+    *,
+    wing_id: str = "WING1",
+    name: str = "MainWing",
+    n_sec: int = 1,
+    symmetric_flag: int = 2,  # SYM_XZ
+    section_parms: list[dict[str, float]] | None = None,
+) -> ModuleType:
+    """Build a fake `openvsp` module describing a single WING geom.
+
+    ``section_parms[i]`` describes section *i* with keys:
+      Span, Root_Chord, Tip_Chord, Sweep, Sweep_Location, Dihedral, Twist
+    The skeleton dispatch loop expects geom-type "WING".
+    """
+    section_parms = section_parms or [
+        {
+            "Span": 5.0,
+            "Root_Chord": 1.0,
+            "Tip_Chord": 0.5,
+            "Sweep": 10.0,
+            "Sweep_Location": 0.25,  # c/4 reference
+            "Dihedral": 3.0,
+            "Twist": 2.0,
+        }
+    ]
+
+    fake = ModuleType("openvsp")
+    fake.LEN_MM, fake.LEN_CM, fake.LEN_M = 0, 1, 2
+    fake.LEN_IN, fake.LEN_FT, fake.LEN_YD, fake.LEN_UNITLESS = 3, 4, 5, 6
+    fake.SYM_XY, fake.SYM_XZ, fake.SYM_YZ = 1, 2, 4
+    fake.XS_FOUR_SERIES = 7  # arbitrary
+
+    fake.ClearVSPModel = lambda *a, **k: None
+    fake.ReadVSPFile = lambda *a, **k: None
+    fake.SetLengthUnit = lambda *a, **k: None
+    fake.Update = lambda *a, **k: None
+    fake.GetVehicleID = lambda: "VEH"
+    fake.FindGeoms = lambda: [wing_id]
+    fake.GetGeomName = lambda gid: name if gid == wing_id else ""
+    fake.GetGeomTypeName = lambda gid: "WING" if gid == wing_id else ""
+
+    # XSecSurf bookkeeping
+    XSURF = "XSURF_WING"
+    fake.GetXSecSurf = lambda gid, _idx: XSURF
+    fake.GetNumXSec = lambda xs: n_sec + 1  # n sections → n+1 xsecs
+
+    def _get_xsec(xs, i):
+        return f"XS_{i}"
+
+    fake.GetXSec = _get_xsec
+
+    # Per-section planform parms in group XSec_<i> on the wing container.
+    # We also need Sym_Planar_Flag on the wing container in group "Sym".
+    fake._parms: dict[tuple[str, str, str], float] = {  # type: ignore[attr-defined]
+        (wing_id, "Sym_Planar_Flag", "Sym"): float(symmetric_flag),
+    }
+    # Section 0 is the root XSec — segment parms anchor on sections 1..n.
+    # Per review comment: group naming is "XSec_<i>" for i in 1..n_sec.
+    for i, sp in enumerate(section_parms, start=1):
+        for k, v in sp.items():
+            fake._parms[(wing_id, k, f"XSec_{i}")] = v
+
+    def _find_parm(container, parm, group):
+        return f"{container}::{group}::{parm}" if (container, parm, group) in fake._parms else ""
+
+    def _get_parm_val(pid):
+        if pid == "":
+            return 0.0
+        container, group, parm = pid.split("::", 2)
+        return fake._parms.get((container, parm, group), 0.0)
+
+    fake.FindParm = _find_parm
+    fake.GetParmVal = _get_parm_val
+
+    # Airfoil shape lookup — return XS_FOUR_SERIES so the placeholder is used.
+    fake.GetXSecShape = lambda xs: fake.XS_FOUR_SERIES
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# sweep_at_c4 helper
+# ---------------------------------------------------------------------------
+
+
+class TestSweepAtC4:
+    def test_pass_through_when_reference_is_quarter_chord(self):
+        assert sweep_at_c4(
+            sweep_xref_deg=15.0, xref=0.25, span=5.0, c_root=1.0, c_tip=0.5
+        ) == pytest.approx(15.0)
+
+    def test_le_sweep_converts_to_smaller_c4_sweep(self):
+        # For a tapered wing (c_root > c_tip), the c/4 line is LESS swept
+        # than the leading edge: tan(Λ_c/4) = tan(Λ_LE) - 0.25*(c_root-c_tip)/span.
+        # With c_root=1, c_tip=0.5, span=5: delta = 0.25*0.5/5 = 0.025
+        # tan(15°) = 0.2679; tan(Λ_c/4) = 0.2679 - 0.025 = 0.2429
+        # Λ_c/4 ≈ 13.66°.
+        le = 15.0
+        c4 = sweep_at_c4(sweep_xref_deg=le, xref=0.0, span=5.0, c_root=1.0, c_tip=0.5)
+        expected = math.degrees(math.atan(math.tan(math.radians(le)) - 0.25 * (1.0 - 0.5) / 5.0))
+        assert c4 == pytest.approx(expected)
+        assert c4 < le, "c/4 sweep should be smaller than LE sweep on a tapered wing"
+
+    def test_zero_span_returns_input(self):
+        assert sweep_at_c4(
+            sweep_xref_deg=20.0, xref=0.5, span=0.0, c_root=1.0, c_tip=1.0
+        ) == pytest.approx(20.0)
+
+
+# ---------------------------------------------------------------------------
+# Airfoil placeholder — until #642 lands.
+# ---------------------------------------------------------------------------
+
+
+class TestAirfoilPlaceholder:
+    def test_returns_valid_path(self):
+        p = _airfoil_placeholder()
+        # Must be a string that the WingXSecSchema accepts (file path).
+        assert isinstance(p, str)
+        assert p.endswith(".dat")
+
+
+# ---------------------------------------------------------------------------
+# Integration via import_vsp3 + register()
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_handlers():
+    """Each test starts with the WING handler freshly registered."""
+    # Clear handlers + reset state.
+    openvsp_importer._HANDLERS.clear()
+    register()
+    yield
+    openvsp_importer._HANDLERS.clear()
+
+
+class TestSingleSectionTrapezoidal:
+    def test_basic_geometry(self, tmp_path, monkeypatch):
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        fake = _make_wing_vsp(
+            section_parms=[
+                {
+                    "Span": 5.0,
+                    "Root_Chord": 1.0,
+                    "Tip_Chord": 0.5,
+                    "Sweep": 10.0,
+                    "Sweep_Location": 0.25,
+                    "Dihedral": 3.0,
+                    "Twist": 2.0,
+                }
+            ]
+        )
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        result = import_vsp3(f)
+        assert "MainWing" in (result.aeroplane.wings or {})
+        wing = result.aeroplane.wings["MainWing"]
+        assert wing.symmetric is True
+        assert len(wing.x_secs) == 2  # root + tip
+        # Root xsec at origin
+        root = wing.x_secs[0]
+        assert root.xyz_le == pytest.approx([0.0, 0.0, 0.0])
+        assert root.chord == pytest.approx(1.0)
+        # Tip xsec — y = span, z = span*tan(dihedral)
+        tip = wing.x_secs[1]
+        assert tip.xyz_le[1] == pytest.approx(5.0, rel=1e-6)
+        assert tip.xyz_le[2] == pytest.approx(5.0 * math.tan(math.radians(3.0)), rel=1e-6)
+        assert tip.chord == pytest.approx(0.5)
+        # Twist on the tip xsec
+        assert tip.twist == pytest.approx(2.0)
+
+
+class TestSymmetryFlag:
+    @pytest.mark.parametrize(
+        "flag, expected",
+        [
+            (0, False),
+            (1, False),  # SYM_XY only — wing not mirrored about XZ
+            (2, True),  # SYM_XZ — left/right mirror
+            (4, False),  # SYM_YZ — fore/aft (not how wings mirror)
+            (2 | 1, True),  # combination including SYM_XZ
+        ],
+    )
+    def test_symmetric_inferred_from_sym_xz_bit(self, flag, expected, tmp_path, monkeypatch):
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        fake = _make_wing_vsp(symmetric_flag=flag)
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        result = import_vsp3(f)
+        wing = result.aeroplane.wings["MainWing"]
+        assert wing.symmetric is expected
+
+
+class TestMultiSectionWing:
+    def test_yehudi_break(self, tmp_path, monkeypatch):
+        """Two sections — inner (large chord, low sweep) + outer (cranked)."""
+        sections = [
+            # Inner panel
+            {
+                "Span": 2.0,
+                "Root_Chord": 1.0,
+                "Tip_Chord": 0.8,
+                "Sweep": 5.0,
+                "Sweep_Location": 0.25,
+                "Dihedral": 0.0,
+                "Twist": 0.0,
+            },
+            # Outer panel
+            {
+                "Span": 3.0,
+                "Root_Chord": 0.8,  # matches inner tip
+                "Tip_Chord": 0.4,
+                "Sweep": 20.0,
+                "Sweep_Location": 0.25,
+                "Dihedral": 4.0,
+                "Twist": -3.0,
+            },
+        ]
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        fake = _make_wing_vsp(n_sec=2, section_parms=sections)
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        result = import_vsp3(f)
+        wing = result.aeroplane.wings["MainWing"]
+        # n_sec sections → n_sec+1 xsecs.
+        assert len(wing.x_secs) == 3
+        # Cumulative span at each xsec along Y.
+        ys = [xs.xyz_le[1] for xs in wing.x_secs]
+        assert ys == pytest.approx([0.0, 2.0, 5.0], rel=1e-6)
+        # Cumulative Z due to dihedral.
+        # Inner panel dihedral 0 → z stays 0 at xsec 1.
+        # Outer panel dihedral 4° → tip z = inner_tip_z + 3*tan(4°)
+        zs = [xs.xyz_le[2] for xs in wing.x_secs]
+        assert zs[0] == pytest.approx(0.0)
+        assert zs[1] == pytest.approx(0.0)
+        assert zs[2] == pytest.approx(3.0 * math.tan(math.radians(4.0)), rel=1e-6)
+
+
+class TestSweepLocationConversion:
+    def test_le_sweep_input_converted_to_c4(self, tmp_path, monkeypatch):
+        """Sweep_Location=0 means input sweep is LE-referenced."""
+        sections = [
+            {
+                "Span": 5.0,
+                "Root_Chord": 1.0,
+                "Tip_Chord": 0.5,
+                "Sweep": 15.0,  # LE sweep
+                "Sweep_Location": 0.0,
+                "Dihedral": 0.0,
+                "Twist": 0.0,
+            }
+        ]
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        fake = _make_wing_vsp(section_parms=sections)
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        result = import_vsp3(f)
+        wing = result.aeroplane.wings["MainWing"]
+        # Tip leading-edge X comes from c/4 sweep on the inboard quarter-chord,
+        # but we expose the geometry via xyz_le, so the LE-X follows the LE
+        # sweep angle directly: tan(LE_sweep) * span.
+        tip = wing.x_secs[1]
+        expected_x = 5.0 * math.tan(math.radians(15.0))
+        assert tip.xyz_le[0] == pytest.approx(expected_x, rel=1e-6)


### PR DESCRIPTION
Closes #641. Part of EPIC #637. Converts VSP WING geom → AsbWingSchema; planform parms from group XSec_<i>, Sym_Planar_Flag → symmetric, multi-section Yehudi support, sweep-reference conversion helpers, airfoil placeholder until #642. 12 tests via fake-vsp factory. Unblocks #644.