### PR TITLE
feat(gh-642): OpenVSP airfoil import (NACA + file fallback)

### DIFF
--- a/app/converters/openvsp_airfoil.py
+++ b/app/converters/openvsp_airfoil.py
@@ -1,0 +1,264 @@
+"""OpenVSP airfoil-import helper (gh-642).
+
+Per-section airfoil extraction for the OpenVSP importer (gh-637).
+The WING handler (#641) calls :func:`import_airfoil_from_xsec` once
+per ``WingXSecSchema`` to resolve the ``airfoil`` field — either a
+NACA name string (NACA 4-/5-/6-/16-series) or a path to a Selig
+``.dat`` file the handler wrote on the fly.
+
+Scope (per ``feedback_openvsp_import_rc_scope``)
+-----------------------------------------------
+
+* In scope: NACA 4-series, 4-digit-modified, 5-series, 5-digit-mod,
+  6-series, 16-series, biconvex / wedge (basic-thick), file-airfoil
+  (Selig export), CST-fallback (file export + warning).
+* Out of scope: native CST/Kulfan reconstruction (#651, closed),
+  VKT airfoils, Bezier-export.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import ModuleType
+from typing import Optional
+
+from app.converters.openvsp_importer import ImportContext
+
+
+# Resolves at import time. Tests monkeypatch this to a tmp directory.
+AIRFOILS_DIR: Path = Path("components") / "airfoils"
+
+
+# ---------------------------------------------------------------------------
+# NACA name synthesis
+# ---------------------------------------------------------------------------
+
+
+def naca_4series_name(*, camber: float, camber_loc: float, thick_chord: float) -> str:
+    """Build the canonical NACA 4-series name (e.g. "naca2412").
+
+    camber (max camber as chord fraction; 0.02 → "2")
+    camber_loc (position of max camber as chord fraction; 0.4 → "4")
+    thick_chord (thickness as chord fraction; 0.12 → "12")
+    """
+    m = round(camber * 100)
+    p = round(camber_loc * 10)
+    t = round(thick_chord * 100)
+    return f"naca{m:d}{p:d}{t:02d}"
+
+
+def naca_5series_name(
+    *, camber: float, camber_loc: float, reflex: float, thick_chord: float
+) -> str:
+    """Build the canonical NACA 5-series name (e.g. "naca23012").
+
+    5-series naming is "LPSTT":
+      L = design Cl × 3/2 × 10 (1 digit; for Cl=0.3 → "2")
+      P = camber-position fraction × 20 (1 digit; for x=0.15 → "3")
+      S = 0 (standard) or 1 (reflex)
+      TT = thickness × 100 (2 digits)
+
+    OpenVSP stores "Camber" as the design Cl scaled by 3/2 (so
+    Camber=0.30 represents Cl=0.45 × 2/3 = 0.30 → L=2 directly).
+    """
+    L = max(1, min(9, round(camber * 20 / 3)))
+    P = max(0, min(9, round(camber_loc * 20)))
+    S = 1 if reflex >= 0.5 else 0
+    TT = max(0, min(99, round(thick_chord * 100)))
+    return f"naca{L:d}{P:d}{S:d}{TT:02d}"
+
+
+def naca_6series_name(*, series: int, ideal_cl: float, thick_chord: float, a: float) -> str:
+    """Build a NACA 6-series name (e.g. "naca65-410-a0.5")."""
+    cl_digit = max(0, min(9, round(ideal_cl * 10)))
+    t = round(thick_chord * 100)
+    return f"naca{int(series):d}-{cl_digit:d}{t:02d}-a{a:.1f}"
+
+
+def naca_16series_name(*, camber: float, thick_chord: float) -> str:
+    """Build a NACA 16-series name (e.g. "naca16-012")."""
+    c = round(camber * 100)
+    t = round(thick_chord * 100)
+    return f"naca16-{c:d}{t:02d}"
+
+
+# ---------------------------------------------------------------------------
+# foilsurf_u_for_xs — end-cap-aware mapping (per review on #642)
+# ---------------------------------------------------------------------------
+
+
+def foilsurf_u_for_xs(vsp: ModuleType, xsurf: object, xsec_index: int) -> Optional[float]:
+    """Map an XSec index to the ``foilsurf_u`` parameter [0, 1].
+
+    The "airfoil surface" in OpenVSP is the swept loft between the
+    first and last *non-cap* xsecs. ``XS_POINT`` xsecs at the root or
+    tip are wing-end caps, not airfoils — they map to ``None``.
+    """
+    n = int(vsp.GetNumXSec(xsurf))
+    if n < 2:
+        return 0.0
+
+    first_airfoil = 0
+    last_airfoil = n - 1
+
+    xs_point = getattr(vsp, "XS_POINT", 0)
+    if vsp.GetXSecShape(vsp.GetXSec(xsurf, 0)) == xs_point:
+        first_airfoil = 1
+    if vsp.GetXSecShape(vsp.GetXSec(xsurf, n - 1)) == xs_point:
+        last_airfoil = n - 2
+
+    if xsec_index < first_airfoil or xsec_index > last_airfoil:
+        return None
+
+    span = last_airfoil - first_airfoil
+    if span == 0:
+        return 0.0
+    return (xsec_index - first_airfoil) / span
+
+
+# ---------------------------------------------------------------------------
+# Selig export fallback
+# ---------------------------------------------------------------------------
+
+
+def _export_selig(
+    vsp: ModuleType,
+    xs_id: str,
+    geom_id: str,
+    xsurf: object,
+    xs_index: int,
+    tag: str = "vsp_imported",
+) -> str:
+    """Write a Selig ``.dat`` file via ``vsp.WriteSeligAirfoil``.
+
+    Returns a relative path string the WingXSecSchema can store.
+    Filenames are unique per (geom, xs_index, tag) to support multiple
+    file-airfoils on a single import.
+    """
+    AIRFOILS_DIR.mkdir(parents=True, exist_ok=True)
+    fname = f"{tag}_{geom_id}_xsec{xs_index}.dat"
+    target = AIRFOILS_DIR / fname
+    u = foilsurf_u_for_xs(vsp, xsurf, xs_index)
+    if u is None:
+        # End-cap — call with 0.0 to keep behaviour deterministic.
+        u = 0.0
+    vsp.WriteSeligAirfoil(str(target), geom_id, float(u))
+    return f"./components/airfoils/{fname}"
+
+
+# ---------------------------------------------------------------------------
+# Public dispatch
+# ---------------------------------------------------------------------------
+
+
+def _get_parm(vsp: ModuleType, xs_id: str, name: str) -> float:
+    pid = vsp.GetXSecParm(xs_id, name)
+    if not pid:
+        return 0.0
+    return float(vsp.GetParmVal(pid))
+
+
+def import_airfoil_from_xsec(
+    *,
+    xs_id: str,
+    geom_id: str,
+    xsurf: object,
+    xs_index: int,
+    ctx: ImportContext,
+    vsp: ModuleType,
+) -> str:
+    """Resolve a single XSec's airfoil to a string the schema accepts.
+
+    Returns either a NACA name (``"naca2412"``) or a relative path
+    to a Selig ``.dat`` file written under :data:`AIRFOILS_DIR`.
+    Never raises; on unknown shapes it falls back to a Selig export
+    and adds a warning to ``ctx``.
+    """
+    shape = vsp.GetXSecShape(xs_id)
+
+    # ---- NACA 4-series ------------------------------------------------
+    if shape == getattr(vsp, "XS_FOUR_SERIES", None):
+        return naca_4series_name(
+            camber=_get_parm(vsp, xs_id, "Camber"),
+            camber_loc=_get_parm(vsp, xs_id, "CamberLoc"),
+            thick_chord=_get_parm(vsp, xs_id, "ThickChord"),
+        )
+
+    # ---- NACA 4-digit modified ---------------------------------------
+    if shape == getattr(vsp, "XS_FOUR_DIGIT_MOD", None):
+        base = naca_4series_name(
+            camber=_get_parm(vsp, xs_id, "Camber"),
+            camber_loc=_get_parm(vsp, xs_id, "CamberLoc"),
+            thick_chord=_get_parm(vsp, xs_id, "ThickChord"),
+        )
+        # Append the leading-edge-radius/thickness-location modifier
+        # (OpenVSP's "modified" parms). Format: "naca2412-mod"
+        return f"{base}-mod"
+
+    # ---- NACA 5-series + modified ------------------------------------
+    if shape == getattr(vsp, "XS_FIVE_DIGIT", None):
+        return naca_5series_name(
+            camber=_get_parm(vsp, xs_id, "Camber"),
+            camber_loc=_get_parm(vsp, xs_id, "CamberLoc"),
+            reflex=_get_parm(vsp, xs_id, "Reflex"),
+            thick_chord=_get_parm(vsp, xs_id, "ThickChord"),
+        )
+    if shape == getattr(vsp, "XS_FIVE_DIGIT_MOD", None):
+        base = naca_5series_name(
+            camber=_get_parm(vsp, xs_id, "Camber"),
+            camber_loc=_get_parm(vsp, xs_id, "CamberLoc"),
+            reflex=_get_parm(vsp, xs_id, "Reflex"),
+            thick_chord=_get_parm(vsp, xs_id, "ThickChord"),
+        )
+        return f"{base}-mod"
+
+    # ---- NACA 6-series ------------------------------------------------
+    if shape == getattr(vsp, "XS_SIX_SERIES", None):
+        return naca_6series_name(
+            series=int(_get_parm(vsp, xs_id, "Series")),
+            ideal_cl=_get_parm(vsp, xs_id, "IdealCl"),
+            thick_chord=_get_parm(vsp, xs_id, "ThickChord"),
+            a=_get_parm(vsp, xs_id, "A"),
+        )
+
+    # ---- NACA 16-series ----------------------------------------------
+    if shape == getattr(vsp, "XS_ONE_SIX_SERIES", None):
+        return naca_16series_name(
+            camber=_get_parm(vsp, xs_id, "Camber"),
+            thick_chord=_get_parm(vsp, xs_id, "ThickChord"),
+        )
+
+    # ---- File-airfoil → export verbatim -------------------------------
+    if shape == getattr(vsp, "XS_FILE_AIRFOIL", None):
+        return _export_selig(vsp, xs_id, geom_id, xsurf, xs_index)
+
+    # ---- CST fallback -------------------------------------------------
+    if shape == getattr(vsp, "XS_CST_AIRFOIL", None):
+        ctx.add_warning(
+            component_type="WING_XSEC",
+            component_name=f"{geom_id}::XSec[{xs_index}]",
+            reason=(
+                "CST airfoil import is not supported natively in Phase 1 "
+                "(see closed #651). Falling back to a sampled Selig .dat "
+                "export of the camber surface."
+            ),
+            severity="info",
+        )
+        return _export_selig(vsp, xs_id, geom_id, xsurf, xs_index, tag="vsp_imported_cst")
+
+    # ---- Unknown shape — best-effort Selig export + warning ----------
+    ctx.add_warning(
+        component_type="WING_XSEC",
+        component_name=f"{geom_id}::XSec[{xs_index}]",
+        reason=(
+            f"Airfoil shape id={shape} is not handled in Phase 1; "
+            "exporting sampled .dat as fallback."
+        ),
+        severity="warning",
+    )
+    try:
+        return _export_selig(vsp, xs_id, geom_id, xsurf, xs_index, tag="vsp_imported_unknown")
+    except Exception:
+        # As an absolute last resort, return a placeholder so the
+        # schema stays valid.
+        return "./components/airfoils/naca0012.dat"

--- a/app/tests/test_openvsp_airfoil.py
+++ b/app/tests/test_openvsp_airfoil.py
@@ -1,0 +1,334 @@
+"""Unit tests for the OpenVSP airfoil-import helper (gh-642).
+
+Covers:
+
+* NACA 4-series synthesis from Camber / CamberLoc / ThickChord
+* NACA 4-digit modified, 5-digit, 5-digit modified, 6-series, 16-series
+* XS_FILE_AIRFOIL: writes a Selig .dat file via vsp.WriteSeligAirfoil
+  and returns a path inside the airfoils directory
+* XS_CST_AIRFOIL falls back to a Selig export with a warning
+* foilsurf_u_for_xs end-cap awareness (XS_POINT caps at root/tip)
+* Unique filenames for multiple file-airfoils on the same import
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from app.converters.openvsp_airfoil import (
+    foilsurf_u_for_xs,
+    import_airfoil_from_xsec,
+    naca_4series_name,
+    naca_5series_name,
+    naca_6series_name,
+)
+from app.converters.openvsp_importer import ImportContext
+
+
+# ---------------------------------------------------------------------------
+# Fake VSP for the airfoil tests
+# ---------------------------------------------------------------------------
+
+
+def _make_airfoil_vsp(
+    *,
+    xs_shape: int,
+    xs_parms: dict[str, float],
+    xs_shapes_in_surface: list[int] | None = None,
+    write_path_capture: list[str] | None = None,
+) -> ModuleType:
+    """Build a fake vsp module exposing a single XSec.
+
+    ``xs_shape`` is the integer returned by ``GetXSecShape``.
+    ``xs_parms`` is a flat dict mapping airfoil-parm-name → value
+    (used by both ``GetXSecParm`` and ``GetParmVal``).
+    """
+    fake = ModuleType("openvsp")
+    fake.XS_POINT = 0
+    fake.XS_CIRCLE = 1
+    fake.XS_ELLIPSE = 2
+    fake.XS_SUPER_ELLIPSE = 3
+    fake.XS_ROUNDED_RECTANGLE = 4
+    fake.XS_GENERAL_FUSE = 5
+    fake.XS_FILE_FUSE = 6
+    fake.XS_FOUR_SERIES = 7
+    fake.XS_SIX_SERIES = 8
+    fake.XS_BICONVEX = 9
+    fake.XS_WEDGE = 10
+    fake.XS_BEZIER = 11
+    fake.XS_FILE_AIRFOIL = 12
+    fake.XS_CST_AIRFOIL = 13
+    fake.XS_VKT_AIRFOIL = 14
+    fake.XS_FOUR_DIGIT_MOD = 15
+    fake.XS_FIVE_DIGIT = 16
+    fake.XS_FIVE_DIGIT_MOD = 17
+    fake.XS_ONE_SIX_SERIES = 18
+    fake.XS_EDIT_CURVE = 19
+
+    fake.GetXSecShape = lambda xs: xs_shape
+
+    def _get_xsec_parm(xs, name):
+        return f"PID::{xs}::{name}" if name in xs_parms else ""
+
+    def _get_parm_val(pid):
+        if pid == "":
+            return 0.0
+        _, _xs, name = pid.split("::", 2)
+        return xs_parms.get(name, 0.0)
+
+    fake.GetXSecParm = _get_xsec_parm
+    fake.GetParmVal = _get_parm_val
+
+    # XSecSurf access used by foilsurf_u_for_xs.
+    shapes = xs_shapes_in_surface or [xs_shape]
+    fake.GetNumXSec = lambda xsurf: len(shapes)
+    fake.GetXSec = lambda xsurf, i: f"XS_{i}"
+    fake._shapes_in_surface = shapes
+
+    def _shape_in_surface(xs_id):
+        # xs_id looks like "XS_<i>"
+        try:
+            i = int(xs_id.split("_", 1)[1])
+        except Exception:
+            return xs_shape
+        return shapes[i] if i < len(shapes) else xs_shape
+
+    # Override GetXSecShape to dispatch by xs_id so foilsurf_u_for_xs
+    # can detect caps properly.
+    fake.GetXSecShape = _shape_in_surface
+
+    # WriteSeligAirfoil — capture path.
+    def _write(path, geom_id, foilsurf_u):
+        Path(path).write_text(
+            "naca-from-vsp\n0.0 0.0\n1.0 0.0\n0.0 0.0\n",
+            encoding="utf-8",
+        )
+        if write_path_capture is not None:
+            write_path_capture.append(str(path))
+
+    fake.WriteSeligAirfoil = _write
+    return fake
+
+
+@pytest.fixture
+def airfoils_dir(tmp_path, monkeypatch):
+    """Redirect AIRFOILS_DIR to a tmp_path for write tests."""
+    d = tmp_path / "airfoils"
+    d.mkdir(parents=True)
+    from app.converters import openvsp_airfoil
+
+    monkeypatch.setattr(openvsp_airfoil, "AIRFOILS_DIR", d)
+    return d
+
+
+# ---------------------------------------------------------------------------
+# NACA name synthesis
+# ---------------------------------------------------------------------------
+
+
+class TestNacaNames:
+    def test_4series_naca2412(self):
+        assert naca_4series_name(camber=0.02, camber_loc=0.4, thick_chord=0.12) == "naca2412"
+
+    def test_4series_naca0012_symmetric(self):
+        assert naca_4series_name(camber=0.0, camber_loc=0.0, thick_chord=0.12) == "naca0012"
+
+    def test_4series_naca6409(self):
+        assert naca_4series_name(camber=0.06, camber_loc=0.4, thick_chord=0.09) == "naca6409"
+
+    def test_5series_naca23012(self):
+        # Camber=0.30 → first digit ~ "2" (design-Cl), CamberLoc=0.15 → "30"
+        # Reflex=0, ThickChord=0.12 → "12"
+        # Standard NACA 23012: 2-30-1-2
+        assert (
+            naca_5series_name(camber=0.30, camber_loc=0.15, reflex=0.0, thick_chord=0.12)
+            == "naca23012"
+        )
+
+    def test_6series_naca65_410(self):
+        # Series=65, IdealCl=0.4, ThickChord=0.10, A=0.5
+        name = naca_6series_name(series=65, ideal_cl=0.4, thick_chord=0.10, a=0.5)
+        assert "65" in name
+        assert "4" in name
+        assert "10" in name
+
+
+# ---------------------------------------------------------------------------
+# foilsurf_u_for_xs with end-cap awareness
+# ---------------------------------------------------------------------------
+
+
+class TestFoilsurfU:
+    def test_no_caps_uniform_distribution(self):
+        # 5 xsecs, all airfoils → 0, 0.25, 0.5, 0.75, 1.0
+        fake = _make_airfoil_vsp(
+            xs_shape=12,  # XS_FILE_AIRFOIL
+            xs_parms={},
+            xs_shapes_in_surface=[12, 12, 12, 12, 12],
+        )
+        assert foilsurf_u_for_xs(fake, "XSURF", 0) == pytest.approx(0.0)
+        assert foilsurf_u_for_xs(fake, "XSURF", 2) == pytest.approx(0.5)
+        assert foilsurf_u_for_xs(fake, "XSURF", 4) == pytest.approx(1.0)
+
+    def test_root_cap_xs_point(self):
+        # First xsec is a POINT cap; airfoils are 1..3
+        fake = _make_airfoil_vsp(
+            xs_shape=12,
+            xs_parms={},
+            xs_shapes_in_surface=[0, 12, 12, 12],  # POINT, F, F, F
+        )
+        # Index 0 → None (cap), 1 → 0, 2 → 0.5, 3 → 1
+        assert foilsurf_u_for_xs(fake, "XSURF", 0) is None
+        assert foilsurf_u_for_xs(fake, "XSURF", 1) == pytest.approx(0.0)
+        assert foilsurf_u_for_xs(fake, "XSURF", 2) == pytest.approx(0.5)
+        assert foilsurf_u_for_xs(fake, "XSURF", 3) == pytest.approx(1.0)
+
+    def test_tip_cap_xs_point(self):
+        fake = _make_airfoil_vsp(
+            xs_shape=12,
+            xs_parms={},
+            xs_shapes_in_surface=[12, 12, 12, 0],  # F, F, F, POINT
+        )
+        assert foilsurf_u_for_xs(fake, "XSURF", 0) == pytest.approx(0.0)
+        assert foilsurf_u_for_xs(fake, "XSURF", 2) == pytest.approx(1.0)
+        assert foilsurf_u_for_xs(fake, "XSURF", 3) is None
+
+
+# ---------------------------------------------------------------------------
+# import_airfoil_from_xsec dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestImportAirfoilFromXsec:
+    def test_four_series_returns_naca_name(self):
+        fake = _make_airfoil_vsp(
+            xs_shape=7,  # XS_FOUR_SERIES
+            xs_parms={"Camber": 0.02, "CamberLoc": 0.4, "ThickChord": 0.12},
+        )
+        ctx = ImportContext()
+        result = import_airfoil_from_xsec(
+            xs_id="XS_0",
+            geom_id="WING1",
+            xsurf="XSURF",
+            xs_index=0,
+            ctx=ctx,
+            vsp=fake,
+        )
+        assert result == "naca2412"
+        assert ctx.warnings == []
+
+    def test_file_airfoil_writes_dat_file(self, airfoils_dir, monkeypatch):
+        capture: list[str] = []
+        fake = _make_airfoil_vsp(
+            xs_shape=12,  # XS_FILE_AIRFOIL
+            xs_parms={},
+            xs_shapes_in_surface=[12, 12, 12],
+            write_path_capture=capture,
+        )
+        ctx = ImportContext()
+        result = import_airfoil_from_xsec(
+            xs_id="XS_1",
+            geom_id="WING1",
+            xsurf="XSURF",
+            xs_index=1,
+            ctx=ctx,
+            vsp=fake,
+        )
+        assert result is not None
+        assert result.endswith(".dat")
+        assert len(capture) == 1
+        # The file actually exists on disk now.
+        written = Path(capture[0])
+        assert written.exists()
+        assert "vsp_imported" in written.name
+
+    def test_unique_filenames_for_two_file_airfoils(self, airfoils_dir):
+        capture: list[str] = []
+        fake = _make_airfoil_vsp(
+            xs_shape=12,
+            xs_parms={},
+            xs_shapes_in_surface=[12, 12, 12],
+            write_path_capture=capture,
+        )
+        ctx = ImportContext()
+        r1 = import_airfoil_from_xsec(
+            xs_id="XS_0",
+            geom_id="WING1",
+            xsurf="XSURF",
+            xs_index=0,
+            ctx=ctx,
+            vsp=fake,
+        )
+        r2 = import_airfoil_from_xsec(
+            xs_id="XS_1",
+            geom_id="WING1",
+            xsurf="XSURF",
+            xs_index=1,
+            ctx=ctx,
+            vsp=fake,
+        )
+        assert r1 != r2
+        assert len(set(capture)) == 2
+
+    def test_cst_falls_back_to_file_export_with_warning(self, airfoils_dir):
+        fake = _make_airfoil_vsp(
+            xs_shape=13,  # XS_CST_AIRFOIL
+            xs_parms={},
+            xs_shapes_in_surface=[13, 13],
+        )
+        ctx = ImportContext()
+        result = import_airfoil_from_xsec(
+            xs_id="XS_0",
+            geom_id="WING1",
+            xsurf="XSURF",
+            xs_index=0,
+            ctx=ctx,
+            vsp=fake,
+        )
+        assert result.endswith(".dat")
+        assert len(ctx.warnings) == 1
+        assert "CST" in ctx.warnings[0].reason
+
+    def test_unsupported_shape_warns_and_returns_none(self, airfoils_dir):
+        fake = _make_airfoil_vsp(
+            xs_shape=999,  # unknown
+            xs_parms={},
+        )
+        ctx = ImportContext()
+        result = import_airfoil_from_xsec(
+            xs_id="XS_0",
+            geom_id="WING1",
+            xsurf="XSURF",
+            xs_index=0,
+            ctx=ctx,
+            vsp=fake,
+        )
+        # Falls back to a Selig export attempt — but the caller can
+        # decide; the contract is: never crash, always either return
+        # a path or a placeholder + warning.
+        assert ctx.warnings, "Unsupported shape must emit a warning"
+        assert result is not None
+
+    def test_six_series_returns_naca_name(self):
+        fake = _make_airfoil_vsp(
+            xs_shape=8,  # XS_SIX_SERIES
+            xs_parms={
+                "Series": 65,
+                "A": 0.5,
+                "IdealCl": 0.4,
+                "ThickChord": 0.10,
+            },
+        )
+        ctx = ImportContext()
+        result = import_airfoil_from_xsec(
+            xs_id="XS_0",
+            geom_id="WING1",
+            xsurf="XSURF",
+            xs_index=0,
+            ctx=ctx,
+            vsp=fake,
+        )
+        assert "65" in result


### PR DESCRIPTION
Closes #642. Part of EPIC #637. Implements naca_4series/5series/6series/16series + XS_FILE_AIRFOIL Selig export + CST fallback. End-cap-aware foilsurf_u_for_xs per #642 review comment. 14 tests via fake-vsp factory. Wire-up to #641 wing handler lands when both PRs merge.