### PR TITLE
feat(gh-643): OpenVSP FUSELAGE handler (super-ellipse family)

### DIFF
--- a/app/converters/openvsp_fuselage_handler.py
+++ b/app/converters/openvsp_fuselage_handler.py
@@ -1,0 +1,216 @@
+"""OpenVSP FUSELAGE geom handler (gh-643).
+
+Maps a VSP ``FUSELAGE`` geom into a :class:`FuselageSchema` whose
+cross-sections are ``FuselageXSecSuperEllipseSchema`` entries.
+
+Supported XSec shapes (super-ellipse family):
+
+* ``XS_CIRCLE`` — diameter / 2 → a=b, n=2
+* ``XS_ELLIPSE`` — width/2, height/2, n=2
+* ``XS_SUPER_ELLIPSE`` — a=Super_Width/2, b=Super_Height/2,
+  n=(Super_M + Super_N)/2 (with a warning if M != N)
+* ``XS_ROUNDED_RECTANGLE`` — approximated by a super-ellipse with a
+  high ``n`` (≈ 2..50 depending on corner radius)
+* ``XS_POINT`` — nose/tail cap → a=b=0, n=2
+
+Scope (per ``feedback_openvsp_import_rc_scope``):
+
+* In scope: super-ellipse-family shapes above.
+* Out of scope: ``XS_GENERAL_FUSE``, ``XS_FILE_FUSE``,
+  ``XS_EDIT_CURVE`` (Phase 2 / B5), POD and BODYOFREVOLUTION as
+  fuselages (Phase 2 / B4).
+
+Container convention (verified empirically during implementation —
+documented here as the source of truth for downstream handlers):
+
+* Length lives on the FUSELAGE container, group ``Design``, parm
+  ``Length``.
+* Station positions live on the FUSELAGE container, group ``XSec``,
+  parm ``XLocPercent_<i>`` (and ``YLocPercent_<i>``,
+  ``ZLocPercent_<i>``).
+* XSec-curve shape parms (Circle_Diameter, Ellipse_Width, etc.) live
+  on the XSec curve container, accessed via
+  ``vsp.GetXSecParm(xs_id, "Circle_Diameter")``.
+"""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+from app.converters import openvsp_importer
+from app.converters.openvsp_importer import AeroplaneSchema, ImportContext
+from app.schemas.aeroplaneschema import (
+    FuselageSchema,
+    FuselageXSecSuperEllipseSchema,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_xsec_parm(vsp: ModuleType, xs_id: str, name: str) -> float:
+    pid = vsp.GetXSecParm(xs_id, name)
+    if not pid:
+        return 0.0
+    return float(vsp.GetParmVal(pid))
+
+
+def _rounded_rect_to_n(*, width: float, height: float, radius: float) -> float:
+    """Approximate a rounded rectangle as a super-ellipse exponent.
+
+    Heuristic: r=0 (sharp corner) → n=50, r=min(w,h)/2 (perfect circle)
+    → n=2. Linear interpolation in between. Caller already extracts
+    width/height for the a, b axes.
+    """
+    r_max = min(width, height) / 2.0
+    if r_max <= 0:
+        return 2.0
+    f = max(0.0, min(1.0, radius / r_max))
+    n_high = 50.0
+    n_low = 2.0
+    return n_low + (n_high - n_low) * (1.0 - f)
+
+
+def _shape_to_super_ellipse(
+    vsp: ModuleType, xs_id: str, shape: int, ctx: ImportContext
+) -> tuple[float, float, float]:
+    """Map an XSec shape to (a, b, n) for a super-ellipse representation.
+
+    Returns ``(0, 0, 2)`` for unsupported shapes (caller can decide
+    whether to emit a warning).
+    """
+    if shape == getattr(vsp, "XS_CIRCLE", -1):
+        d = _get_xsec_parm(vsp, xs_id, "Circle_Diameter")
+        return d / 2.0, d / 2.0, 2.0
+
+    if shape == getattr(vsp, "XS_ELLIPSE", -1):
+        w = _get_xsec_parm(vsp, xs_id, "Ellipse_Width")
+        h = _get_xsec_parm(vsp, xs_id, "Ellipse_Height")
+        return w / 2.0, h / 2.0, 2.0
+
+    if shape == getattr(vsp, "XS_SUPER_ELLIPSE", -1):
+        w = _get_xsec_parm(vsp, xs_id, "Super_Width")
+        h = _get_xsec_parm(vsp, xs_id, "Super_Height")
+        m = _get_xsec_parm(vsp, xs_id, "Super_M")
+        n_exp = _get_xsec_parm(vsp, xs_id, "Super_N")
+        if abs(m - n_exp) > 0.01:
+            ctx.add_warning(
+                component_type="FUSELAGE_XSEC",
+                component_name=xs_id,
+                reason=(
+                    f"SUPER_ELLIPSE has asymmetric M={m} vs N={n_exp}; "
+                    f"using arithmetic mean {(m + n_exp) / 2.0:.3f}."
+                ),
+                severity="info",
+            )
+        return w / 2.0, h / 2.0, (m + n_exp) / 2.0
+
+    if shape == getattr(vsp, "XS_ROUNDED_RECTANGLE", -1):
+        w = _get_xsec_parm(vsp, xs_id, "RoundedRect_Width")
+        h = _get_xsec_parm(vsp, xs_id, "RoundedRect_Height")
+        r = _get_xsec_parm(vsp, xs_id, "RoundedRect_Radius")
+        n = _rounded_rect_to_n(width=w, height=h, radius=r)
+        ctx.add_warning(
+            component_type="FUSELAGE_XSEC",
+            component_name=xs_id,
+            reason=(
+                f"ROUNDED_RECTANGLE approximated as super-ellipse with "
+                f"n={n:.2f}; corner radius={r:.3f}."
+            ),
+            severity="info",
+        )
+        return w / 2.0, h / 2.0, n
+
+    if shape == getattr(vsp, "XS_POINT", -1):
+        return 0.0, 0.0, 2.0
+
+    # Unsupported shape — emit warning, return a defensible bounding ellipse.
+    ctx.add_warning(
+        component_type="FUSELAGE_XSEC",
+        component_name=xs_id,
+        reason=(
+            f"XSec shape id={shape} not supported in Phase 1; "
+            "falling back to a=b=0.5, n=2 placeholder."
+        ),
+        severity="warning",
+    )
+    return 0.5, 0.5, 2.0
+
+
+def _read_length(vsp: ModuleType, fuse_gid: str) -> float:
+    pid = vsp.FindParm(fuse_gid, "Length", "Design")
+    if not pid:
+        return 0.0
+    return float(vsp.GetParmVal(pid))
+
+
+def _read_x_pct(vsp: ModuleType, fuse_gid: str, i: int) -> float:
+    pid = vsp.FindParm(fuse_gid, f"XLocPercent_{i}", "XSec")
+    if not pid:
+        return float(i)  # fall back to evenly-spaced index proxy
+    return float(vsp.GetParmVal(pid))
+
+
+# ---------------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------------
+
+
+def _handle_fuselage(
+    gid: str,
+    name: str,
+    aeroplane: AeroplaneSchema,
+    ctx: ImportContext,
+    vsp: ModuleType,
+) -> None:
+    """Convert one FUSELAGE geom into a ``FuselageSchema``."""
+    xsurf = vsp.GetXSecSurf(gid, 0)
+    n_xsec = int(vsp.GetNumXSec(xsurf))
+    if n_xsec < 2:
+        ctx.add_warning(
+            component_type="FUSELAGE",
+            component_name=name,
+            reason=(f"FUSELAGE {name!r} has only {n_xsec} xsecs (need >=2); skipped."),
+            severity="warning",
+        )
+        ctx.mark_lossy(gid)
+        return
+
+    length = _read_length(vsp, gid)
+    if length <= 0:
+        # Use a sensible default so we don't collapse the X axis.
+        length = 1.0
+
+    xsecs: list[FuselageXSecSuperEllipseSchema] = []
+    for i in range(n_xsec):
+        xs_id = vsp.GetXSec(xsurf, i)
+        shape = vsp.GetXSecShape(xs_id)
+        x_pct = _read_x_pct(vsp, gid, i)
+        a, b, n = _shape_to_super_ellipse(vsp, xs_id, shape, ctx)
+        xsecs.append(
+            FuselageXSecSuperEllipseSchema(
+                xyz=[x_pct * length, 0.0, 0.0],
+                a=max(a, 0.0),
+                b=max(b, 0.0),
+                n=max(n, 1.0),
+            )
+        )
+
+    fuse = FuselageSchema(name=name, x_secs=xsecs)
+    if aeroplane.fuselages is None:
+        from collections import OrderedDict
+
+        aeroplane.fuselages = OrderedDict()
+    aeroplane.fuselages[name] = fuse
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def register() -> None:
+    """Register the FUSELAGE handler with the importer skeleton."""
+    openvsp_importer.register_handler("FUSELAGE", _handle_fuselage)

--- a/app/tests/test_openvsp_fuselage_handler.py
+++ b/app/tests/test_openvsp_fuselage_handler.py
@@ -240,7 +240,7 @@ class TestRoundedRectToN:
             _rounded_rect_to_n(width=2.0, height=2.0, radius=r) for r in (0.0, 0.25, 0.5, 0.75, 1.0)
         ]
         # decreasing as radius increases
-        for a, b in zip(ns, ns[1:]):
+        for a, b in zip(ns, ns[1:], strict=False):
             assert a >= b
 
 

--- a/app/tests/test_openvsp_fuselage_handler.py
+++ b/app/tests/test_openvsp_fuselage_handler.py
@@ -1,0 +1,345 @@
+"""Unit tests for the OpenVSP FUSELAGE handler (gh-643).
+
+Covers super-ellipse-family XSec shape mapping (CIRCLE, ELLIPSE,
+SUPER_ELLIPSE, ROUNDED_RECTANGLE, POINT) and the integration via
+``import_vsp3``.
+
+All tests run without the real OpenVSP package — they mock the
+`openvsp` module via a fake factory.
+"""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+import pytest
+
+from app.converters import openvsp_adapter, openvsp_importer
+from app.converters.openvsp_fuselage_handler import (
+    _rounded_rect_to_n,
+    _shape_to_super_ellipse,
+    register,
+)
+from app.converters.openvsp_importer import ImportContext, import_vsp3
+
+
+# ---------------------------------------------------------------------------
+# Fake vsp factory for FUSELAGE tests
+# ---------------------------------------------------------------------------
+
+
+# Map of xsec shape names → integer constants matching common OpenVSP defs.
+_SHAPES = {
+    "POINT": 0,
+    "CIRCLE": 1,
+    "ELLIPSE": 2,
+    "SUPER_ELLIPSE": 3,
+    "ROUNDED_RECTANGLE": 4,
+    "GENERAL_FUSE": 5,
+    "FILE_FUSE": 6,
+}
+
+
+def _make_fuse_vsp(
+    *,
+    fuse_id: str = "FUSE1",
+    name: str = "Fuselage",
+    length: float = 10.0,
+    xsecs: list[dict] | None = None,
+) -> ModuleType:
+    """Build a fake `openvsp` module describing one FUSELAGE geom.
+
+    ``xsecs`` is a list of dicts with keys:
+      shape (str), x_pct (float), and shape-specific parms
+      (Circle_Diameter, Ellipse_Width/Height, Super_Width/Height/M/N,
+       RoundedRect_Width/Height/Radius).
+    """
+    xsecs = xsecs or []
+    fake = ModuleType("openvsp")
+    fake.LEN_M = 2
+    fake.SYM_XZ = 2
+    for n, v in _SHAPES.items():
+        setattr(fake, f"XS_{n}", v)
+
+    fake.ClearVSPModel = lambda *a, **k: None
+    fake.ReadVSPFile = lambda *a, **k: None
+    fake.SetLengthUnit = lambda *a, **k: None
+    fake.Update = lambda *a, **k: None
+    fake.GetVehicleID = lambda: "VEH"
+    fake.FindGeoms = lambda: [fuse_id]
+    fake.GetGeomName = lambda gid: name if gid == fuse_id else ""
+    fake.GetGeomTypeName = lambda gid: "FUSELAGE" if gid == fuse_id else ""
+
+    XSURF = "XSURF_FUSE"
+    fake.GetXSecSurf = lambda gid, _i: XSURF
+    fake.GetNumXSec = lambda xs: len(xsecs)
+    fake.GetXSec = lambda xs, i: f"XS_{i}"
+
+    def _shape_for(xs_id: str) -> int:
+        idx = int(xs_id.split("_", 1)[1])
+        return _SHAPES[xsecs[idx]["shape"]]
+
+    fake.GetXSecShape = _shape_for
+
+    # Per-xsec parms accessed via GetXSecParm + GetParmVal.
+    def _get_xsec_parm(xs_id: str, name: str) -> str:
+        idx = int(xs_id.split("_", 1)[1])
+        return f"PID::{xs_id}::{name}" if name in xsecs[idx] else ""
+
+    def _get_parm_val(pid: str) -> float:
+        if not pid:
+            return 0.0
+        _, xs_id, name = pid.split("::", 2)
+        idx = int(xs_id.split("_", 1)[1])
+        return float(xsecs[idx].get(name, 0.0))
+
+    fake.GetXSecParm = _get_xsec_parm
+
+    # Per-fuselage parms (Length, XLocPercent_<i>) accessed via FindParm.
+    def _find_parm(container, parm, group):
+        if container == fuse_id:
+            if parm == "Length" and group == "Design":
+                return "PFUSE::Length"
+            if parm.startswith("XLocPercent_"):
+                return f"PFUSE::{parm}"
+        return ""
+
+    def _get_parm_val_router(pid):
+        if not pid:
+            return 0.0
+        if pid == "PFUSE::Length":
+            return float(length)
+        if pid.startswith("PFUSE::XLocPercent_"):
+            idx = int(pid.split("_", 1)[1])
+            return float(xsecs[idx].get("x_pct", 0.0))
+        return _get_parm_val(pid)
+
+    fake.FindParm = _find_parm
+    fake.GetParmVal = _get_parm_val_router
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# _shape_to_super_ellipse — pure mapping (no real vsp module needed)
+# ---------------------------------------------------------------------------
+
+
+class TestShapeToSuperEllipse:
+    def test_circle(self):
+        fake = _make_fuse_vsp(xsecs=[{"shape": "CIRCLE", "x_pct": 0.5, "Circle_Diameter": 2.0}])
+        ctx = ImportContext()
+        a, b, n = _shape_to_super_ellipse(fake, "XS_0", _SHAPES["CIRCLE"], ctx)
+        assert a == pytest.approx(1.0)
+        assert b == pytest.approx(1.0)
+        assert n == pytest.approx(2.0)
+
+    def test_ellipse(self):
+        fake = _make_fuse_vsp(
+            xsecs=[
+                {
+                    "shape": "ELLIPSE",
+                    "x_pct": 0.5,
+                    "Ellipse_Width": 3.0,
+                    "Ellipse_Height": 2.0,
+                }
+            ]
+        )
+        ctx = ImportContext()
+        a, b, n = _shape_to_super_ellipse(fake, "XS_0", _SHAPES["ELLIPSE"], ctx)
+        assert a == pytest.approx(1.5)
+        assert b == pytest.approx(1.0)
+        assert n == pytest.approx(2.0)
+
+    def test_super_ellipse_symmetric(self):
+        fake = _make_fuse_vsp(
+            xsecs=[
+                {
+                    "shape": "SUPER_ELLIPSE",
+                    "x_pct": 0.5,
+                    "Super_Width": 4.0,
+                    "Super_Height": 2.0,
+                    "Super_M": 3.0,
+                    "Super_N": 3.0,
+                }
+            ]
+        )
+        ctx = ImportContext()
+        a, b, n = _shape_to_super_ellipse(fake, "XS_0", _SHAPES["SUPER_ELLIPSE"], ctx)
+        assert a == pytest.approx(2.0)
+        assert b == pytest.approx(1.0)
+        assert n == pytest.approx(3.0)
+        assert ctx.warnings == []  # symmetric M/N → no warning
+
+    def test_super_ellipse_asymmetric_warns(self):
+        fake = _make_fuse_vsp(
+            xsecs=[
+                {
+                    "shape": "SUPER_ELLIPSE",
+                    "x_pct": 0.5,
+                    "Super_Width": 4.0,
+                    "Super_Height": 2.0,
+                    "Super_M": 2.0,
+                    "Super_N": 4.0,
+                }
+            ]
+        )
+        ctx = ImportContext()
+        a, b, n = _shape_to_super_ellipse(fake, "XS_0", _SHAPES["SUPER_ELLIPSE"], ctx)
+        assert n == pytest.approx(3.0)  # arithmetic mean
+        assert len(ctx.warnings) == 1
+        assert "asymmetric" in ctx.warnings[0].reason.lower()
+
+    def test_rounded_rectangle_approximation(self):
+        fake = _make_fuse_vsp(
+            xsecs=[
+                {
+                    "shape": "ROUNDED_RECTANGLE",
+                    "x_pct": 0.5,
+                    "RoundedRect_Width": 4.0,
+                    "RoundedRect_Height": 2.0,
+                    "RoundedRect_Radius": 0.4,
+                }
+            ]
+        )
+        ctx = ImportContext()
+        a, b, n = _shape_to_super_ellipse(fake, "XS_0", _SHAPES["ROUNDED_RECTANGLE"], ctx)
+        assert a == pytest.approx(2.0)
+        assert b == pytest.approx(1.0)
+        # n should be > 2 (squarer than ellipse).
+        assert n > 2.0
+        # Should have a warning about the approximation.
+        assert any("approxim" in w.reason.lower() for w in ctx.warnings)
+
+    def test_point(self):
+        fake = _make_fuse_vsp(xsecs=[{"shape": "POINT", "x_pct": 0.0}])
+        ctx = ImportContext()
+        a, b, n = _shape_to_super_ellipse(fake, "XS_0", _SHAPES["POINT"], ctx)
+        assert a == 0.0
+        assert b == 0.0
+        assert n == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# _rounded_rect_to_n heuristic
+# ---------------------------------------------------------------------------
+
+
+class TestRoundedRectToN:
+    def test_zero_radius_returns_high_exponent(self):
+        # r=0 means perfect rectangle → very high n
+        n = _rounded_rect_to_n(width=2.0, height=2.0, radius=0.0)
+        assert n >= 10.0  # sufficient "squareness"
+
+    def test_max_radius_returns_ellipse_exponent(self):
+        # r = min(w,h)/2 — perfect circle/ellipse → n=2
+        n = _rounded_rect_to_n(width=2.0, height=2.0, radius=1.0)
+        assert n == pytest.approx(2.0, abs=0.5)
+
+    def test_monotonic(self):
+        ns = [
+            _rounded_rect_to_n(width=2.0, height=2.0, radius=r) for r in (0.0, 0.25, 0.5, 0.75, 1.0)
+        ]
+        # decreasing as radius increases
+        for a, b in zip(ns, ns[1:]):
+            assert a >= b
+
+
+# ---------------------------------------------------------------------------
+# Integration via import_vsp3
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_handlers():
+    openvsp_importer._HANDLERS.clear()
+    register()
+    yield
+    openvsp_importer._HANDLERS.clear()
+
+
+class TestFuselageImport:
+    def test_tube_and_wing_constant_circle(self, tmp_path, monkeypatch):
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        xsecs = [
+            {"shape": "CIRCLE", "x_pct": 0.0, "Circle_Diameter": 0.5},
+            {"shape": "CIRCLE", "x_pct": 0.3, "Circle_Diameter": 1.0},
+            {"shape": "CIRCLE", "x_pct": 0.7, "Circle_Diameter": 1.0},
+            {"shape": "CIRCLE", "x_pct": 1.0, "Circle_Diameter": 0.2},
+        ]
+        fake = _make_fuse_vsp(xsecs=xsecs, length=10.0)
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        result = import_vsp3(f)
+        assert "Fuselage" in (result.aeroplane.fuselages or {})
+        fuse = result.aeroplane.fuselages["Fuselage"]
+        assert len(fuse.x_secs) == 4
+        # Station X positions = x_pct * length
+        xs_x = [xs.xyz[0] for xs in fuse.x_secs]
+        assert xs_x == pytest.approx([0.0, 3.0, 7.0, 10.0])
+        # Centre xsec is a constant 1.0 m diameter → a=b=0.5, n=2
+        mid = fuse.x_secs[1]
+        assert mid.a == pytest.approx(0.5)
+        assert mid.b == pytest.approx(0.5)
+        assert mid.n == pytest.approx(2.0)
+
+    def test_tapered_super_ellipse(self, tmp_path, monkeypatch):
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        xsecs = [
+            {"shape": "POINT", "x_pct": 0.0},
+            {
+                "shape": "SUPER_ELLIPSE",
+                "x_pct": 0.4,
+                "Super_Width": 2.0,
+                "Super_Height": 1.5,
+                "Super_M": 2.5,
+                "Super_N": 2.5,
+            },
+            {
+                "shape": "SUPER_ELLIPSE",
+                "x_pct": 0.6,
+                "Super_Width": 2.0,
+                "Super_Height": 1.5,
+                "Super_M": 2.5,
+                "Super_N": 2.5,
+            },
+            {"shape": "POINT", "x_pct": 1.0},
+        ]
+        fake = _make_fuse_vsp(xsecs=xsecs, length=12.0)
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        result = import_vsp3(f)
+        fuse = result.aeroplane.fuselages["Fuselage"]
+        # First and last are POINTs (a=b=0, n=2) — caps closed.
+        assert fuse.x_secs[0].a == 0.0
+        assert fuse.x_secs[-1].a == 0.0
+        # Middle two are super-ellipses.
+        assert fuse.x_secs[1].n == pytest.approx(2.5)
+        assert fuse.x_secs[2].a == pytest.approx(1.0)
+
+    def test_rounded_rect_emits_approximation_warning(self, tmp_path, monkeypatch):
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        xsecs = [
+            {"shape": "POINT", "x_pct": 0.0},
+            {
+                "shape": "ROUNDED_RECTANGLE",
+                "x_pct": 0.5,
+                "RoundedRect_Width": 2.0,
+                "RoundedRect_Height": 1.0,
+                "RoundedRect_Radius": 0.1,
+            },
+            {"shape": "POINT", "x_pct": 1.0},
+        ]
+        fake = _make_fuse_vsp(xsecs=xsecs, length=10.0)
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        result = import_vsp3(f)
+        assert any("approxim" in w.reason.lower() for w in result.warnings)
+
+    def test_too_few_xsecs_skips_with_warning(self, tmp_path, monkeypatch):
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        fake = _make_fuse_vsp(xsecs=[{"shape": "POINT", "x_pct": 0.0}])
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        result = import_vsp3(f)
+        assert result.aeroplane.fuselages is None or not result.aeroplane.fuselages
+        assert result.warnings


### PR DESCRIPTION
Closes #643. Part of EPIC #637. Maps VSP FUSELAGE geom → FuselageSchema. Supports CIRCLE/ELLIPSE/SUPER_ELLIPSE/ROUNDED_RECTANGLE/POINT with asymmetric M/N warning + rounded-rect heuristic. 13 unit tests via fake-vsp factory. Out of scope per scope memory: GENERAL_FUSE/FILE_FUSE/EDIT_CURVE (B5), POD/BOR (closed #652).