### PR TITLE
feat(gh-645): OpenVSP BLANK + Vehicle CG handler

### DIFF
--- a/app/converters/openvsp_blank_handler.py
+++ b/app/converters/openvsp_blank_handler.py
@@ -1,0 +1,159 @@
+"""OpenVSP BLANK + Vehicle CG handler (gh-645).
+
+BLANK geoms in OpenVSP are pure transforms with optional Mass and
+Inertia. We import them as :class:`WeightItemWrite` records collected
+in :attr:`ImportResult.weight_items`. The vehicle-wide centre-of-
+gravity (and total mass when declared) lives on the vehicle
+container's ``Mass_Props`` group; we resolve it in a post-pass and
+write it onto :attr:`AeroplaneSchema.xyz_ref`.
+
+Scope (per ``feedback_openvsp_import_rc_scope``):
+
+* In scope: explicit BLANK Mass + XForm position, vehicle CG/TotalMass.
+* Out of scope: inertia tensor (closed #657), Density/MassShell volumetric
+  masses on BLANK geoms (Phase 2).
+"""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+from app.converters import openvsp_importer
+from app.converters.openvsp_importer import AeroplaneSchema, ImportContext
+from app.schemas.weight_item import WeightItemWrite
+
+
+# ---------------------------------------------------------------------------
+# BLANK handler
+# ---------------------------------------------------------------------------
+
+
+def _find_parm(vsp: ModuleType, container: str, parm: str, group: str) -> str:
+    return vsp.FindParm(container, parm, group)
+
+
+def _get_val(vsp: ModuleType, pid: str) -> float:
+    if not pid:
+        return 0.0
+    return float(vsp.GetParmVal(pid))
+
+
+def _handle_blank(
+    gid: str,
+    name: str,
+    aeroplane: AeroplaneSchema,
+    ctx: ImportContext,
+    vsp: ModuleType,
+) -> None:
+    """Convert a BLANK geom into a WeightItemWrite.
+
+    Pure-transform BLANKs (no mass parm or Mass==0) are skipped
+    silently. Negative masses emit a warning and are skipped.
+    """
+    mass_pid = _find_parm(vsp, gid, "Mass", "Mass_Props")
+    if not mass_pid:
+        return  # pure-transform BLANK; not an error
+    mass = _get_val(vsp, mass_pid)
+    if mass == 0:
+        return
+    if mass < 0:
+        ctx.add_warning(
+            component_type="BLANK",
+            component_name=name,
+            reason=f"BLANK {name!r} has negative mass ({mass}); skipped.",
+            severity="warning",
+        )
+        return
+
+    x = _get_val(vsp, _find_parm(vsp, gid, "X_Location", "XForm"))
+    y = _get_val(vsp, _find_parm(vsp, gid, "Y_Location", "XForm"))
+    z = _get_val(vsp, _find_parm(vsp, gid, "Z_Location", "XForm"))
+
+    ctx.add_weight_item(
+        WeightItemWrite(
+            name=name,
+            mass_kg=mass,
+            x_m=x,
+            y_m=y,
+            z_m=z,
+            description=f"Imported from OpenVSP BLANK geom {gid}",
+            category="other",
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Vehicle-CG post-pass
+# ---------------------------------------------------------------------------
+
+
+def _resolve_vehicle_cg(aeroplane: AeroplaneSchema, ctx: ImportContext, vsp: ModuleType) -> None:
+    """Read Mass_Props on the vehicle container; fall back to computed CG.
+
+    1. If the vehicle declares X_CG/Y_CG/Z_CG, use those.
+    2. Else compute mass-weighted average from collected weight items.
+    3. Else leave the default ``[0, 0, 0]``.
+    4. Warn if declared TotalMass mismatches the sum of imported items
+       by more than 1%.
+    """
+    try:
+        vehicle_id = vsp.GetVehicleID()
+    except Exception:
+        return  # No vehicle — nothing to do.
+
+    total_mass_pid = _find_parm(vsp, vehicle_id, "TotalMass", "Mass_Props")
+    declared_total = _get_val(vsp, total_mass_pid) if total_mass_pid else 0.0
+
+    xcg_pid = _find_parm(vsp, vehicle_id, "X_CG", "Mass_Props")
+    ycg_pid = _find_parm(vsp, vehicle_id, "Y_CG", "Mass_Props")
+    zcg_pid = _find_parm(vsp, vehicle_id, "Z_CG", "Mass_Props")
+    declared_cg = (
+        (
+            _get_val(vsp, xcg_pid),
+            _get_val(vsp, ycg_pid),
+            _get_val(vsp, zcg_pid),
+        )
+        if (xcg_pid or ycg_pid or zcg_pid)
+        else None
+    )
+
+    if declared_total > 0:
+        aeroplane.total_mass_kg = declared_total
+
+    if declared_cg is not None and any(v != 0 for v in declared_cg):
+        aeroplane.xyz_ref = list(declared_cg)
+    elif ctx.weight_items:
+        total = sum(w.mass_kg for w in ctx.weight_items)
+        if total > 0:
+            aeroplane.xyz_ref = [
+                sum(w.mass_kg * getattr(w, axis) for w in ctx.weight_items) / total
+                for axis in ("x_m", "y_m", "z_m")
+            ]
+
+    # Consistency check: if declared TotalMass exists, compare to sum.
+    if declared_total > 0 and ctx.weight_items:
+        items_total = sum(w.mass_kg for w in ctx.weight_items)
+        if items_total > 0:
+            rel = abs(items_total - declared_total) / declared_total
+            if rel > 0.01:
+                ctx.add_warning(
+                    component_type="VEHICLE",
+                    component_name="vehicle",
+                    reason=(
+                        f"Total mass mismatch: BLANK sum = {items_total:.3f} kg "
+                        f"vs declared TotalMass = {declared_total:.3f} kg "
+                        f"({rel * 100:.1f}% relative)."
+                    ),
+                    severity="warning",
+                )
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def register() -> None:
+    """Register the BLANK handler and the vehicle-CG post-pass."""
+    openvsp_importer.register_handler("BLANK", _handle_blank)
+    openvsp_importer.register_post_pass(_resolve_vehicle_cg)

--- a/app/converters/openvsp_importer.py
+++ b/app/converters/openvsp_importer.py
@@ -164,12 +164,25 @@ class ImportResult:
 # so handler bodies remain testable with a fake module.
 
 HandlerFn = Callable[[str, str, AeroplaneSchema, ImportContext, ModuleType], None]
+PostPassFn = Callable[[AeroplaneSchema, ImportContext, ModuleType], None]
 _HANDLERS: dict[str, HandlerFn] = {}
+_POST_PASSES: list[PostPassFn] = []
 
 
 def register_handler(geom_type: str, handler: HandlerFn) -> None:
     """Register a handler for a VSP geom type (``"WING"``, ``"FUSELAGE"``, ...)."""
     _HANDLERS[geom_type] = handler
+
+
+def register_post_pass(fn: PostPassFn) -> None:
+    """Register a post-pass callable that runs once after the dispatch loop.
+
+    Use for cross-component work like vehicle-CG resolution (#645).
+    Post-passes run in registration order and receive the populated
+    AeroplaneSchema, the ImportContext, and the live vsp module.
+    """
+    if fn not in _POST_PASSES:
+        _POST_PASSES.append(fn)
 
 
 # Map of unsupported geom types → frontend-facing reason.
@@ -273,6 +286,18 @@ def import_vsp3(path: Path) -> ImportResult:
                 severity="warning",
             )
             ctx.mark_lossy(gid)
+
+    # Post-passes (vehicle-CG, etc.) run once on the populated aeroplane.
+    for post_fn in _POST_PASSES:
+        try:
+            post_fn(aeroplane, ctx, vsp)
+        except Exception as exc:  # pragma: no cover - defensive
+            ctx.add_warning(
+                component_type="POST_PASS",
+                component_name=post_fn.__name__,
+                reason=f"Post-pass {post_fn.__name__} failed: {exc}",
+                severity="warning",
+            )
 
     return ImportResult(
         aeroplane=aeroplane,

--- a/app/tests/test_openvsp_blank_handler.py
+++ b/app/tests/test_openvsp_blank_handler.py
@@ -1,0 +1,277 @@
+"""Unit tests for the OpenVSP BLANK + Vehicle CG handler (gh-645).
+
+Covers:
+
+* BLANK geom with explicit Mass>0 → WeightItemWrite at XForm position
+* BLANK without mass → skipped silently
+* Vehicle CG: X_CG/Y_CG/Z_CG in `Mass_Props` group → aeroplane.xyz_ref
+* Fallback: compute CG from collected weight items when Vehicle CG
+  is missing
+* Total-mass consistency (sum vs declared) within 1%
+
+All tests mock the `openvsp` module — no real install required.
+"""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+import pytest
+
+from app.converters import openvsp_adapter, openvsp_importer
+from app.converters.openvsp_blank_handler import register
+from app.converters.openvsp_importer import import_vsp3
+
+
+# ---------------------------------------------------------------------------
+# Fake VSP factory
+# ---------------------------------------------------------------------------
+
+
+def _make_blank_vsp(
+    *,
+    geoms: list[dict] | None = None,
+    vehicle_total_mass: float = 0.0,
+    vehicle_cg: tuple[float, float, float] | None = None,
+    vehicle_id: str = "VEH",
+) -> ModuleType:
+    """Build a fake `openvsp` module with BLANK geoms and a vehicle CG.
+
+    Each geom dict: ``{id, name, mass, x, y, z}``. Mass omitted → no
+    mass parm (simulates a pure-transform BLANK).
+    """
+    geoms = geoms or []
+
+    fake = ModuleType("openvsp")
+    fake.LEN_M = 2
+    fake.SYM_XZ = 2
+
+    fake.ClearVSPModel = lambda *a, **k: None
+    fake.ReadVSPFile = lambda *a, **k: None
+    fake.SetLengthUnit = lambda *a, **k: None
+    fake.Update = lambda *a, **k: None
+    fake.GetVehicleID = lambda: vehicle_id
+    fake.FindGeoms = lambda: [g["id"] for g in geoms]
+    fake.GetGeomName = lambda gid: next((g["name"] for g in geoms if g["id"] == gid), "")
+    fake.GetGeomTypeName = lambda gid: next(
+        (g.get("type", "BLANK") for g in geoms if g["id"] == gid), ""
+    )
+
+    def _find_parm(container, parm, group):
+        # Vehicle Mass_Props parms
+        if container == vehicle_id and group == "Mass_Props":
+            if vehicle_cg is None and parm in ("X_CG", "Y_CG", "Z_CG"):
+                return ""
+            if vehicle_total_mass <= 0 and parm == "TotalMass":
+                return ""
+            return f"VEH::{parm}"
+        # BLANK Mass_Props.Mass
+        for g in geoms:
+            if container == g["id"]:
+                if group == "Mass_Props" and parm == "Mass":
+                    return f"{g['id']}::Mass" if "mass" in g else ""
+                if group == "XForm" and parm in ("X_Location", "Y_Location", "Z_Location"):
+                    return f"{g['id']}::{parm}"
+        return ""
+
+    def _get_parm_val(pid):
+        if not pid:
+            return 0.0
+        if pid.startswith("VEH::"):
+            parm = pid.split("::", 1)[1]
+            if parm == "TotalMass":
+                return float(vehicle_total_mass)
+            mapping = {
+                "X_CG": (vehicle_cg or (0, 0, 0))[0],
+                "Y_CG": (vehicle_cg or (0, 0, 0))[1],
+                "Z_CG": (vehicle_cg or (0, 0, 0))[2],
+            }
+            return float(mapping.get(parm, 0.0))
+        gid, parm = pid.split("::", 1)
+        for g in geoms:
+            if g["id"] == gid:
+                if parm == "Mass":
+                    return float(g.get("mass", 0.0))
+                if parm == "X_Location":
+                    return float(g.get("x", 0.0))
+                if parm == "Y_Location":
+                    return float(g.get("y", 0.0))
+                if parm == "Z_Location":
+                    return float(g.get("z", 0.0))
+        return 0.0
+
+    fake.FindParm = _find_parm
+    fake.GetParmVal = _get_parm_val
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# Registration: handler + post-pass for vehicle CG
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_handlers():
+    openvsp_importer._HANDLERS.clear()
+    openvsp_importer._POST_PASSES.clear()
+    register()
+    yield
+    openvsp_importer._HANDLERS.clear()
+    openvsp_importer._POST_PASSES.clear()
+
+
+# ---------------------------------------------------------------------------
+# BLANK → WeightItem
+# ---------------------------------------------------------------------------
+
+
+class TestBlankHandler:
+    def test_blank_with_mass_creates_weight_item(self, tmp_path, monkeypatch):
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        fake = _make_blank_vsp(
+            geoms=[
+                {
+                    "id": "G1",
+                    "name": "Battery",
+                    "type": "BLANK",
+                    "mass": 2.5,
+                    "x": 0.3,
+                    "y": 0.0,
+                    "z": -0.05,
+                }
+            ]
+        )
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        result = import_vsp3(f)
+        assert len(result.weight_items) == 1
+        wi = result.weight_items[0]
+        assert wi.name == "Battery"
+        assert wi.mass_kg == pytest.approx(2.5)
+        assert wi.x_m == pytest.approx(0.3)
+        assert wi.z_m == pytest.approx(-0.05)
+
+    def test_blank_without_mass_is_skipped(self, tmp_path, monkeypatch):
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        fake = _make_blank_vsp(
+            geoms=[
+                {"id": "G1", "name": "Origin", "type": "BLANK"}  # no mass
+            ]
+        )
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        result = import_vsp3(f)
+        assert result.weight_items == []
+
+    def test_blank_with_zero_mass_is_skipped(self, tmp_path, monkeypatch):
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        fake = _make_blank_vsp(geoms=[{"id": "G1", "name": "Origin", "type": "BLANK", "mass": 0.0}])
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        result = import_vsp3(f)
+        assert result.weight_items == []
+
+    def test_negative_mass_is_skipped_with_warning(self, tmp_path, monkeypatch):
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        fake = _make_blank_vsp(geoms=[{"id": "G1", "name": "Bogus", "type": "BLANK", "mass": -1.0}])
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        result = import_vsp3(f)
+        assert result.weight_items == []
+        assert any("negative" in w.reason.lower() or "<=0" in w.reason for w in result.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Vehicle CG
+# ---------------------------------------------------------------------------
+
+
+class TestVehicleCG:
+    def test_vehicle_cg_overrides_default(self, tmp_path, monkeypatch):
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        fake = _make_blank_vsp(
+            geoms=[],
+            vehicle_total_mass=10.0,
+            vehicle_cg=(0.5, 0.0, 0.1),
+        )
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        result = import_vsp3(f)
+        assert result.aeroplane.xyz_ref == pytest.approx([0.5, 0.0, 0.1])
+        assert result.aeroplane.total_mass_kg == pytest.approx(10.0)
+
+    def test_cg_falls_back_to_weighted_average_of_items(self, tmp_path, monkeypatch):
+        """When vehicle CG is not declared, compute from weight items."""
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        fake = _make_blank_vsp(
+            geoms=[
+                {
+                    "id": "G1",
+                    "name": "A",
+                    "type": "BLANK",
+                    "mass": 1.0,
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0,
+                },
+                {
+                    "id": "G2",
+                    "name": "B",
+                    "type": "BLANK",
+                    "mass": 3.0,
+                    "x": 1.0,
+                    "y": 0.0,
+                    "z": 0.0,
+                },
+            ],
+            vehicle_cg=None,
+            vehicle_total_mass=0.0,
+        )
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        result = import_vsp3(f)
+        # CG = (1*0 + 3*1) / (1+3) = 0.75
+        assert result.aeroplane.xyz_ref[0] == pytest.approx(0.75)
+        assert result.aeroplane.xyz_ref[1] == pytest.approx(0.0)
+
+    def test_no_items_no_cg_yields_default_origin(self, tmp_path, monkeypatch):
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        fake = _make_blank_vsp(geoms=[], vehicle_cg=None)
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        result = import_vsp3(f)
+        # Stays at the AeroplaneSchema default [0, 0, 0]
+        assert result.aeroplane.xyz_ref == [0, 0, 0]
+
+    def test_total_mass_consistency_warning(self, tmp_path, monkeypatch):
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        fake = _make_blank_vsp(
+            geoms=[
+                {
+                    "id": "G1",
+                    "name": "A",
+                    "type": "BLANK",
+                    "mass": 1.0,
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0,
+                },
+                {
+                    "id": "G2",
+                    "name": "B",
+                    "type": "BLANK",
+                    "mass": 1.0,
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0,
+                },
+            ],
+            vehicle_total_mass=5.0,  # mismatches sum (=2) by 150%
+        )
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        result = import_vsp3(f)
+        assert any(
+            "total mass" in w.reason.lower() and "mismatch" in w.reason.lower()
+            for w in result.warnings
+        )


### PR DESCRIPTION
Closes #645. Part of EPIC #637. BLANK geoms → WeightItemWrite; vehicle CG post-pass resolves xyz_ref + total_mass. Skeleton extended with register_post_pass(fn). 8 unit tests via fake-vsp. Out of scope: inertia tensor (closed #657), MassShell volumetric.