### PR TITLE
feat(gh-644): OpenVSP SS_CONTROL → TrailingEdgeDevice + wire airfoil

### DIFF
--- a/app/converters/openvsp_importer.py
+++ b/app/converters/openvsp_importer.py
@@ -104,6 +104,10 @@ class ImportContext:
     weight_items: list[WeightItemWrite] = field(default_factory=list)
     source_length_unit: Optional[int] = None
     source_scale_to_meters: Optional[float] = None
+    # Map of WING geom-id → schema name. Populated by the WING handler
+    # and consumed by post-passes that need to walk wings (e.g.
+    # SS_CONTROL → TrailingEdgeDevice in gh-644).
+    wing_geom_ids: dict[str, str] = field(default_factory=dict)
 
     def add_warning(
         self,

--- a/app/converters/openvsp_ss_control.py
+++ b/app/converters/openvsp_ss_control.py
@@ -1,0 +1,172 @@
+"""OpenVSP SS_CONTROL → TrailingEdgeDevice handler (gh-644).
+
+Per the scope-clarification comment on #644 (RC-scaling focus): this
+handler does the **minimal** mapping from a VSP ``SS_CONTROL`` sub-
+surface to our :class:`TrailingEdgeDeviceDetailSchema`. The user
+edits role/mixing/etc. in the frontend.
+
+Explicitly **out of scope**:
+
+* CSGroup gain matrix
+* antisymmetric flag (each TED inherits `symmetric` from its wing)
+* Leading-edge devices (warn + skip)
+* Role inference (set to ``OTHER``; user can change in UI)
+
+Runs as a post-pass over the populated AeroplaneSchema so it doesn't
+need to know wing-handler internals. It re-queries the vsp module
+for each WING geom id recorded in :attr:`ImportContext.wing_geom_ids`.
+"""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+from app.converters import openvsp_importer
+from app.converters.openvsp_importer import AeroplaneSchema, ImportContext
+from app.schemas.aeroplaneschema import (
+    ControlSurfaceRole,
+    TrailingEdgeDeviceDetailSchema,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _u_to_segment_index(*, u: float, n_sec: int) -> int:
+    """Map a parametric u ∈ [0, 1] to a segment index 1..n_sec.
+
+    OpenVSP's wing u parameter spans the whole loft; we approximate it
+    as a linear distribution across the n_sec segments so the
+    inboard-half lands on segment 1, outboard-half on segment n.
+    """
+    if n_sec < 1:
+        return 1
+    if u <= 0.0:
+        return 1
+    if u >= 1.0:
+        return n_sec
+    return max(1, min(n_sec, int(u * n_sec) + 1))
+
+
+def _read_parm(vsp: ModuleType, container: str, parm: str, group: str) -> float:
+    pid = vsp.FindParm(container, parm, group)
+    if not pid:
+        return 0.0
+    return float(vsp.GetParmVal(pid))
+
+
+def _handle_wing_sub_surfaces(
+    wing_gid: str,
+    wing_name: str,
+    aeroplane: AeroplaneSchema,
+    ctx: ImportContext,
+    vsp: ModuleType,
+) -> None:
+    """Walk SS_CONTROL sub-surfaces on a wing and attach TEDs.
+
+    Skipped (with warning) when:
+    * The wing isn't in aeroplane.wings (probably failed earlier).
+    * LE_Flag is set (LE devices are out of scope per #644 clarification).
+    """
+    if not aeroplane.wings or wing_name not in aeroplane.wings:
+        return
+    wing = aeroplane.wings[wing_name]
+
+    try:
+        ss_ids = list(vsp.GetSubSurfIDVec(wing_gid))
+    except AttributeError:
+        return  # vsp version without sub-surface API; nothing to do.
+
+    ss_control = getattr(vsp, "SS_CONTROL", 3)
+    n_sec = max(1, len(wing.x_secs) - 1)
+
+    for sid in ss_ids:
+        if vsp.GetSubSurfType(sid) != ss_control:
+            continue
+        sub_index = vsp.GetSubSurfIndex(sid)
+        grp = f"SS_Control_{sub_index + 1}"
+
+        le_flag = _read_parm(vsp, wing_gid, "LE_Flag", grp) >= 0.5
+        if le_flag:
+            ctx.add_warning(
+                component_type="WING_SS_CONTROL",
+                component_name=f"{wing_name}::{vsp.GetSubSurfName(sid)}",
+                reason=(
+                    "Leading-edge sub-surface detected; LE devices are out of "
+                    "scope for the Phase 1 RC-scaling importer. Sub-surface skipped."
+                ),
+                severity="info",
+            )
+            continue
+
+        eta_flag = _read_parm(vsp, wing_gid, "EtaFlag", grp) >= 0.5
+        if eta_flag:
+            u_start = _read_parm(vsp, wing_gid, "EtaStart", grp)
+            u_end = _read_parm(vsp, wing_gid, "EtaEnd", grp)
+        else:
+            u_start = _read_parm(vsp, wing_gid, "UStart", grp)
+            u_end = _read_parm(vsp, wing_gid, "UEnd", grp)
+
+        # OpenVSP's Length_C_* is the chord fraction measured from
+        # the trailing edge towards the hinge; our rel_chord_* is
+        # measured from the leading edge.
+        c_root_le = 1.0 - _read_parm(vsp, wing_gid, "Length_C_Start", grp)
+        c_tip_le = 1.0 - _read_parm(vsp, wing_gid, "Length_C_End", grp)
+        deflection = _read_parm(vsp, wing_gid, "Deflection", grp)
+
+        ted = TrailingEdgeDeviceDetailSchema(
+            name=vsp.GetSubSurfName(sid),
+            role=ControlSurfaceRole.OTHER,
+            rel_chord_root=c_root_le,
+            rel_chord_tip=c_tip_le,
+            deflection_deg=deflection,
+            symmetric=wing.symmetric,
+        )
+
+        # Attach to the inboard xsec of the segment whose midpoint
+        # contains the SS_CONTROL midpoint. The Pydantic model stores
+        # TEDs on the xsec whose outgoing segment carries them.
+        u_mid = (u_start + u_end) / 2.0
+        seg_idx = _u_to_segment_index(u=u_mid, n_sec=n_sec)
+        # seg_idx is 1-based; corresponding inboard xsec index is seg_idx - 1
+        xsec_idx = seg_idx - 1
+        target = wing.x_secs[xsec_idx]
+        if target.trailing_edge_device is not None:
+            # Already has a TED — keep the existing one and warn.
+            ctx.add_warning(
+                component_type="WING_SS_CONTROL",
+                component_name=f"{wing_name}::{vsp.GetSubSurfName(sid)}",
+                reason=(
+                    f"Multiple SS_CONTROL sub-surfaces map to wing segment "
+                    f"{seg_idx}; only the first is imported as TED."
+                ),
+                severity="warning",
+            )
+            continue
+        target.trailing_edge_device = ted
+
+
+def _post_pass(aeroplane: AeroplaneSchema, ctx: ImportContext, vsp: ModuleType) -> None:
+    """Run SS_CONTROL → TED for every registered WING geom id."""
+    for gid, name in list(ctx.wing_geom_ids.items()):
+        try:
+            _handle_wing_sub_surfaces(gid, name, aeroplane, ctx, vsp)
+        except Exception as exc:  # pragma: no cover - defensive
+            ctx.add_warning(
+                component_type="WING_SS_CONTROL",
+                component_name=name,
+                reason=f"SS_CONTROL pass failed on wing {name}: {exc}",
+                severity="warning",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def register() -> None:
+    """Register the SS_CONTROL post-pass."""
+    openvsp_importer.register_post_pass(_post_pass)

--- a/app/converters/openvsp_wing_handler.py
+++ b/app/converters/openvsp_wing_handler.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 import math
 from types import ModuleType
 
-from app.converters import openvsp_importer
+from app.converters import openvsp_airfoil, openvsp_importer
 from app.converters.openvsp_importer import AeroplaneSchema, ImportContext
 from app.schemas.aeroplaneschema import AsbWingSchema, WingXSecSchema
 
@@ -169,12 +169,29 @@ def _handle_wing(
     n_sec = n_xsec - 1
     symmetric = _read_symmetric(vsp, gid)
 
+    def _airfoil_for(xs_index: int) -> str:
+        """Resolve airfoil via openvsp_airfoil; fall back to placeholder on error."""
+        try:
+            xs_id = vsp.GetXSec(xsurf, xs_index)
+        except Exception:
+            return _airfoil_placeholder()
+        try:
+            return openvsp_airfoil.import_airfoil_from_xsec(
+                xs_id=xs_id,
+                geom_id=gid,
+                xsurf=xsurf,
+                xs_index=xs_index,
+                ctx=ctx,
+                vsp=vsp,
+            )
+        except Exception:
+            return _airfoil_placeholder()
+
     # Build the xsec list. Section index i (1..n_sec) describes the
     # segment OUTBOARD of XSec[i-1] and terminating at XSec[i].
     x_secs: list[WingXSecSchema] = []
 
-    # Root xsec at (0, 0, 0) with chord = section_1.Root_Chord and
-    # airfoil placeholder (real airfoil import is #642).
+    # Root xsec at (0, 0, 0) with chord = section_1.Root_Chord.
     root_chord = _read_section_parm(vsp, gid, 1, "Root_Chord")
     if root_chord <= 0:
         ctx.add_warning(
@@ -190,7 +207,7 @@ def _handle_wing(
             xyz_le=[0.0, 0.0, 0.0],
             chord=root_chord,
             twist=0.0,
-            airfoil=_airfoil_placeholder(),
+            airfoil=_airfoil_for(0),
             x_sec_type="root",
         )
     )
@@ -241,7 +258,7 @@ def _handle_wing(
                 xyz_le=[cum_x, cum_y, cum_z],
                 chord=tip_chord if tip_chord > 0 else prev_chord,
                 twist=twist,
-                airfoil=_airfoil_placeholder(),
+                airfoil=_airfoil_for(i),
                 x_sec_type=None if is_last else "segment",
             )
         )
@@ -269,6 +286,8 @@ def _handle_wing(
 
         aeroplane.wings = OrderedDict()
     aeroplane.wings[name] = wing
+    # Record gid→name so SS_CONTROL post-pass (gh-644) can find this wing.
+    ctx.wing_geom_ids[gid] = name
 
 
 # ---------------------------------------------------------------------------

--- a/app/tests/test_openvsp_ss_control.py
+++ b/app/tests/test_openvsp_ss_control.py
@@ -1,0 +1,323 @@
+"""Unit tests for the OpenVSP SS_CONTROL → TrailingEdgeDevice handler (gh-644).
+
+Per the scope-clarification comment on #644 (RC-scaling focus):
+
+* In scope: basic SS_CONTROL → TrailingEdgeDevice mapping (rel_chord
+  root/tip, deflection, symmetric inherited from wing).
+* Out of scope: CSGroup-gain matrix, antisymmetric flag, role
+  inference, LE-devices (warn+skip), CSGroup naming heuristic.
+
+The handler is invoked from the WING handler — we test it through
+``import_vsp3`` with a fake-vsp that exposes both a WING geom and
+sub-surfaces on that geom.
+"""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+import pytest
+
+from app.converters import openvsp_adapter, openvsp_importer
+from app.converters.openvsp_importer import import_vsp3
+from app.converters.openvsp_ss_control import _u_to_segment_index, register
+from app.converters.openvsp_wing_handler import register as register_wing
+
+
+# ---------------------------------------------------------------------------
+# Fake vsp factory — wing geom + N sub-surfaces (some SS_CONTROL)
+# ---------------------------------------------------------------------------
+
+
+def _make_wing_with_sub_surfaces(
+    *,
+    wing_id: str = "WING1",
+    name: str = "MainWing",
+    n_sec: int = 2,
+    sub_surfaces: list[dict] | None = None,
+) -> ModuleType:
+    """Build fake vsp module with a WING and a list of sub-surfaces.
+
+    sub_surfaces entries: ``{id, name, type, u_start, u_end, c_root,
+    c_tip, deflection, le_flag, eta_flag, eta_start, eta_end}``.
+    type ∈ {SS_CONTROL, SS_LINE, ...}; only SS_CONTROL is processed.
+    """
+    sub_surfaces = sub_surfaces or []
+
+    fake = ModuleType("openvsp")
+    fake.LEN_M = 2
+    fake.SYM_XY = 1
+    fake.SYM_XZ = 2
+    fake.SYM_YZ = 4
+    fake.XS_FOUR_SERIES = 7
+    fake.XS_POINT = 0
+    fake.SS_LINE = 0
+    fake.SS_RECTANGLE = 1
+    fake.SS_ELLIPSE = 2
+    fake.SS_CONTROL = 3
+    fake.SS_FINITE_LINE = 4
+
+    fake.ClearVSPModel = lambda *a, **k: None
+    fake.ReadVSPFile = lambda *a, **k: None
+    fake.SetLengthUnit = lambda *a, **k: None
+    fake.Update = lambda *a, **k: None
+    fake.GetVehicleID = lambda: "VEH"
+    fake.FindGeoms = lambda: [wing_id]
+    fake.GetGeomName = lambda gid: name if gid == wing_id else ""
+    fake.GetGeomTypeName = lambda gid: "WING" if gid == wing_id else ""
+
+    XSURF = "XSURF_WING"
+    fake.GetXSecSurf = lambda gid, _i: XSURF
+    fake.GetNumXSec = lambda xs: n_sec + 1
+    fake.GetXSec = lambda xs, i: f"XS_{i}"
+    fake.GetXSecShape = lambda xs: fake.XS_FOUR_SERIES
+
+    # Sub-surfaces
+    fake.GetSubSurfIDVec = lambda gid: [s["id"] for s in sub_surfaces]
+    fake.GetSubSurfType = lambda sid: next(
+        (s.get("type", fake.SS_CONTROL) for s in sub_surfaces if s["id"] == sid),
+        fake.SS_CONTROL,
+    )
+    fake.GetSubSurfIndex = lambda sid: next(
+        (i for i, s in enumerate(sub_surfaces) if s["id"] == sid), 0
+    )
+    fake.GetSubSurfName = lambda sid: next((s["name"] for s in sub_surfaces if s["id"] == sid), "")
+
+    # Per-section planform parms.
+    section_default = {
+        "Span": 5.0,
+        "Root_Chord": 1.0,
+        "Tip_Chord": 0.5,
+        "Sweep": 0.0,
+        "Sweep_Location": 0.25,
+        "Dihedral": 0.0,
+        "Twist": 0.0,
+    }
+    parms: dict[tuple[str, str, str], float] = {
+        (wing_id, "Sym_Planar_Flag", "Sym"): float(fake.SYM_XZ),
+    }
+    for i in range(1, n_sec + 1):
+        for k, v in section_default.items():
+            parms[(wing_id, k, f"XSec_{i}")] = v
+
+    # SS_Control_<n> group parms: U/Eta extent, chord fractions, deflection, LE_Flag.
+    for s in sub_surfaces:
+        n = fake.GetSubSurfIndex(s["id"]) + 1
+        grp = f"SS_Control_{n}"
+        parms[(wing_id, "UStart", grp)] = float(s.get("u_start", 0.6))
+        parms[(wing_id, "UEnd", grp)] = float(s.get("u_end", 0.95))
+        parms[(wing_id, "EtaFlag", grp)] = 1.0 if s.get("eta_flag") else 0.0
+        parms[(wing_id, "EtaStart", grp)] = float(s.get("eta_start", 0.6))
+        parms[(wing_id, "EtaEnd", grp)] = float(s.get("eta_end", 0.95))
+        parms[(wing_id, "Length_C_Start", grp)] = float(s.get("c_root", 0.25))
+        parms[(wing_id, "Length_C_End", grp)] = float(s.get("c_tip", 0.25))
+        parms[(wing_id, "LE_Flag", grp)] = 1.0 if s.get("le_flag") else 0.0
+        parms[(wing_id, "Deflection", grp)] = float(s.get("deflection", 0.0))
+
+    def _find_parm(container, parm, group):
+        key = (container, parm, group)
+        if key in parms:
+            return f"PID::{container}::{group}::{parm}"
+        return ""
+
+    def _get_parm_val(pid):
+        if not pid:
+            return 0.0
+        _, container, group, parm = pid.split("::", 3)
+        return parms.get((container, parm, group), 0.0)
+
+    fake.FindParm = _find_parm
+    fake.GetParmVal = _get_parm_val
+    fake.GetXSecParm = lambda xs, name: ""  # no airfoil parms in this fake
+
+    return fake
+
+
+@pytest.fixture(autouse=True)
+def _clean_handlers():
+    openvsp_importer._HANDLERS.clear()
+    openvsp_importer._POST_PASSES.clear()
+    register_wing()
+    register()
+    yield
+    openvsp_importer._HANDLERS.clear()
+    openvsp_importer._POST_PASSES.clear()
+
+
+# ---------------------------------------------------------------------------
+# _u_to_segment_index helper
+# ---------------------------------------------------------------------------
+
+
+class TestUToSegmentIndex:
+    def test_u_at_segment_center_returns_that_segment(self):
+        # 2-segment wing → segment 1 covers u in [0, 0.5], segment 2 covers [0.5, 1].
+        # NB: u in OpenVSP is typically the parametric coordinate; we
+        # approximate by linear distribution.
+        assert _u_to_segment_index(u=0.25, n_sec=2) == 1
+        assert _u_to_segment_index(u=0.75, n_sec=2) == 2
+
+    def test_u_at_outermost_returns_last_segment(self):
+        assert _u_to_segment_index(u=1.0, n_sec=3) == 3
+
+    def test_u_at_root_returns_first_segment(self):
+        assert _u_to_segment_index(u=0.0, n_sec=3) == 1
+
+    def test_u_outside_range_clamps(self):
+        assert _u_to_segment_index(u=-0.5, n_sec=2) == 1
+        assert _u_to_segment_index(u=2.0, n_sec=2) == 2
+
+
+# ---------------------------------------------------------------------------
+# Aileron-like SS_CONTROL → TED
+# ---------------------------------------------------------------------------
+
+
+class TestSsControlImport:
+    def test_aileron_creates_ted_on_outer_segment(self, tmp_path, monkeypatch):
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        fake = _make_wing_with_sub_surfaces(
+            n_sec=2,
+            sub_surfaces=[
+                {
+                    "id": "SS_AIL",
+                    "name": "Aileron",
+                    "type": 3,  # SS_CONTROL
+                    "u_start": 0.7,
+                    "u_end": 0.95,
+                    "c_root": 0.25,
+                    "c_tip": 0.25,
+                    "deflection": 0.0,
+                    "le_flag": False,
+                }
+            ],
+        )
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        result = import_vsp3(f)
+        wing = result.aeroplane.wings["MainWing"]
+        # The aileron lands on the outer segment — xsec 1 (segment-2's
+        # inboard xsec) carries the TED.
+        outer_seg = wing.x_secs[1]
+        assert outer_seg.trailing_edge_device is not None
+        ted = outer_seg.trailing_edge_device
+        # rel_chord_* per scope: directly from Length_C_*.
+        assert ted.rel_chord_root == pytest.approx(1.0 - 0.25)
+        assert ted.rel_chord_tip == pytest.approx(1.0 - 0.25)
+        # Symmetric inherited from wing (SYM_XZ → True).
+        assert ted.symmetric is True
+        # No CSGroup gain inference per scope clarification — role is OTHER.
+        from app.schemas.aeroplaneschema import ControlSurfaceRole
+
+        assert ted.role == ControlSurfaceRole.OTHER
+
+    def test_le_device_emits_warning_and_skips(self, tmp_path, monkeypatch):
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        fake = _make_wing_with_sub_surfaces(
+            n_sec=2,
+            sub_surfaces=[
+                {
+                    "id": "SS_SLAT",
+                    "name": "Slat",
+                    "type": 3,
+                    "u_start": 0.7,
+                    "u_end": 0.95,
+                    "c_root": 0.25,
+                    "c_tip": 0.25,
+                    "le_flag": True,
+                }
+            ],
+        )
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        result = import_vsp3(f)
+        wing = result.aeroplane.wings["MainWing"]
+        # No TED on any xsec.
+        for xs in wing.x_secs:
+            assert xs.trailing_edge_device is None
+        # Warning about LE device.
+        assert any(
+            "leading" in w.reason.lower() or "le" in w.reason.lower() for w in result.warnings
+        )
+
+    def test_non_control_sub_surface_is_ignored(self, tmp_path, monkeypatch):
+        """SS_LINE / SS_RECTANGLE etc. are not processed."""
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        fake = _make_wing_with_sub_surfaces(
+            n_sec=1,
+            sub_surfaces=[
+                {"id": "SS_L", "name": "Marker", "type": 0},  # SS_LINE
+            ],
+        )
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        result = import_vsp3(f)
+        wing = result.aeroplane.wings["MainWing"]
+        for xs in wing.x_secs:
+            assert xs.trailing_edge_device is None
+
+    def test_eta_flag_uses_eta_extent(self, tmp_path, monkeypatch):
+        """When EtaFlag=1, U-extent is read from EtaStart/EtaEnd instead."""
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        fake = _make_wing_with_sub_surfaces(
+            n_sec=2,
+            sub_surfaces=[
+                {
+                    "id": "SS_F",
+                    "name": "Flap",
+                    "type": 3,
+                    "u_start": 0.0,  # wrong values — should be ignored
+                    "u_end": 0.1,
+                    "eta_flag": True,
+                    "eta_start": 0.7,
+                    "eta_end": 0.95,
+                    "c_root": 0.30,
+                    "c_tip": 0.30,
+                }
+            ],
+        )
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        result = import_vsp3(f)
+        wing = result.aeroplane.wings["MainWing"]
+        outer = wing.x_secs[1]
+        assert outer.trailing_edge_device is not None
+        ted = outer.trailing_edge_device
+        assert ted.rel_chord_root == pytest.approx(1.0 - 0.30)
+        assert ted.rel_chord_tip == pytest.approx(1.0 - 0.30)
+
+    def test_asymmetric_wing_yields_non_symmetric_ted(self, tmp_path, monkeypatch):
+        """If wing.symmetric=False (no SYM_XZ bit), TED inherits False."""
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        fake = _make_wing_with_sub_surfaces(
+            n_sec=1,
+            sub_surfaces=[
+                {
+                    "id": "SS_A",
+                    "name": "A",
+                    "type": 3,
+                    "u_start": 0.7,
+                    "u_end": 0.95,
+                    "c_root": 0.25,
+                    "c_tip": 0.25,
+                }
+            ],
+        )
+        # Override Sym_Planar_Flag to 0 (no symmetry) by patching
+        # GetParmVal directly — the FindParm closure cannot be reached.
+        original_get = fake.GetParmVal
+
+        def _patched_get(pid):
+            if pid.endswith("Sym_Planar_Flag"):
+                return 0.0
+            return original_get(pid)
+
+        fake.GetParmVal = _patched_get
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        result = import_vsp3(f)
+        wing = result.aeroplane.wings["MainWing"]
+        outer = wing.x_secs[0]  # n_sec=1 → root is xsec[0], TED on segment 1 (xsec[0])
+        # TED carries the wing's symmetric flag.
+        assert outer.trailing_edge_device is not None
+        assert outer.trailing_edge_device.symmetric is False


### PR DESCRIPTION
Closes #644. Part of EPIC #637. SS_CONTROL handler per scope-clarification — basic rel_chord/deflection/symmetric mapping; no CSGroup gains, no antisymmetric, no LE devices (warn+skip), role=OTHER (user edits in UI). Skeleton: ImportContext.wing_geom_ids registry + post-pass. Wing handler now uses openvsp_airfoil instead of placeholder. 9 unit tests; 93 openvsp tests total green.