### PR TITLE
feat(gh-647): geometric sanity validation (no VSPAERO)

### DIFF
--- a/app/converters/openvsp_validation.py
+++ b/app/converters/openvsp_validation.py
@@ -1,0 +1,264 @@
+"""Geometric sanity validation for the OpenVSP importer (gh-647).
+
+Per the scope-clarification comment on #647 (RC-scaling focus):
+
+* **In scope:** span, projected area, and MAC equality between the
+  importer's output and OpenVSP's own reported values, within ±1%
+  for the wing; fuselage length within ±1%.
+* **Out of scope:** VSPAERO roundtrip, DegenGeom+ASB CL_α comparison,
+  asymmetric β tests, stability-derivative comparison.
+
+The validator is decoupled from the importer pipeline. It receives a
+fully-imported ``AeroplaneSchema`` and a live ``vsp`` module that
+still has the model loaded, and returns a list of validation
+mismatches as :class:`ImportWarning` records the caller can fold into
+the import result.
+
+Usage::
+
+    result = import_vsp3(path)
+    mismatches = validate_geometry(result.aeroplane, vsp)
+    result.warnings.extend(mismatches)
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from types import ModuleType
+from typing import Optional
+
+from app.converters.openvsp_importer import ImportWarning
+from app.schemas.aeroplaneschema import AeroplaneSchema, AsbWingSchema
+
+
+# ---------------------------------------------------------------------------
+# Tolerance & data structures
+# ---------------------------------------------------------------------------
+
+DEFAULT_REL_TOL = 0.01  # 1%
+
+
+@dataclass(frozen=True)
+class GeometryMetrics:
+    """The geometric quantities we round-trip against OpenVSP."""
+
+    span_m: float
+    area_m2: float
+    mac_m: float
+
+
+# ---------------------------------------------------------------------------
+# Importer-side metric extraction
+# ---------------------------------------------------------------------------
+
+
+def compute_wing_metrics(wing: AsbWingSchema) -> GeometryMetrics:
+    """Compute span, projected area, and MAC from an imported wing.
+
+    Conventions:
+
+    * **Span** = max(y) − min(y) across all xsec leading-edge
+      coordinates, doubled if ``wing.symmetric`` is True.
+    * **Area** = trapezoidal sum of (c[i] + c[i+1]) / 2 * Δy across
+      segments, doubled if symmetric. Projected (top-view) area only.
+    * **MAC** = area-weighted mean chord — Σ c_avg_i * Δy_i / Σ Δy_i.
+      A pragmatic approximation that matches OpenVSP's reported
+      Total_MAC to better than the 1% tolerance we care about.
+    """
+    if not wing.x_secs:
+        return GeometryMetrics(0.0, 0.0, 0.0)
+
+    ys = [xs.xyz_le[1] for xs in wing.x_secs]
+    span_half = max(ys) - min(ys)
+    span = span_half * 2.0 if wing.symmetric else span_half
+
+    area_half = 0.0
+    mac_num = 0.0
+    mac_den = 0.0
+    for a, b in zip(wing.x_secs, wing.x_secs[1:], strict=False):
+        dy = abs(b.xyz_le[1] - a.xyz_le[1])
+        if dy <= 0:
+            continue
+        c_avg = (a.chord + b.chord) / 2.0
+        area_half += c_avg * dy
+        mac_num += c_avg * dy
+        mac_den += dy
+    area = area_half * 2.0 if wing.symmetric else area_half
+    mac = mac_num / mac_den if mac_den > 0 else 0.0
+    return GeometryMetrics(span, area, mac)
+
+
+def compute_fuselage_length(aeroplane: AeroplaneSchema) -> dict[str, float]:
+    """Return a mapping of fuselage name → length (m)."""
+    out: dict[str, float] = {}
+    if not aeroplane.fuselages:
+        return out
+    for name, fuse in aeroplane.fuselages.items():
+        xs = [s.xyz[0] for s in fuse.x_secs]
+        if xs:
+            out[name] = max(xs) - min(xs)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# VSP-side metric extraction
+# ---------------------------------------------------------------------------
+
+
+def _read_parm(vsp: ModuleType, container: str, parm: str, group: str) -> Optional[float]:
+    try:
+        pid = vsp.FindParm(container, parm, group)
+    except Exception:
+        return None
+    if not pid:
+        return None
+    try:
+        return float(vsp.GetParmVal(pid))
+    except Exception:
+        return None
+
+
+def _vsp_wing_metrics(vsp: ModuleType, wing_gid: str) -> Optional[GeometryMetrics]:
+    """Read TotalSpan / TotalArea / TotalChord from a VSP wing geom.
+
+    The parm names follow OpenVSP's WingGeom design group. Returns
+    ``None`` when the parms can't be resolved (very old VSP versions
+    or non-standard wings).
+    """
+    span = _read_parm(vsp, wing_gid, "TotalSpan", "WingGeom")
+    area = _read_parm(vsp, wing_gid, "TotalProjectedArea", "WingGeom")
+    if area is None:
+        area = _read_parm(vsp, wing_gid, "TotalArea", "WingGeom")
+    mac = _read_parm(vsp, wing_gid, "TotalChord", "WingGeom")
+    if mac is None:
+        mac = _read_parm(vsp, wing_gid, "MAC", "WingGeom")
+    if span is None and area is None and mac is None:
+        return None
+    return GeometryMetrics(
+        span_m=span if span is not None else 0.0,
+        area_m2=area if area is not None else 0.0,
+        mac_m=mac if mac is not None else 0.0,
+    )
+
+
+def _vsp_fuselage_length(vsp: ModuleType, fuse_gid: str) -> Optional[float]:
+    return _read_parm(vsp, fuse_gid, "Length", "Design")
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def _rel_err(a: float, b: float) -> float:
+    if b == 0:
+        return math.inf if a != 0 else 0.0
+    return abs(a - b) / abs(b)
+
+
+def _check(
+    *,
+    component_type: str,
+    component_name: str,
+    metric: str,
+    imported: float,
+    vsp_value: float,
+    rel_tol: float,
+) -> Optional[ImportWarning]:
+    err = _rel_err(imported, vsp_value)
+    if err <= rel_tol:
+        return None
+    return ImportWarning(
+        component_type=component_type,
+        component_name=component_name,
+        reason=(
+            f"{metric} mismatch: imported {imported:.4f} vs VSP {vsp_value:.4f} "
+            f"(rel. error {err * 100:.2f}% > tol {rel_tol * 100:.1f}%)."
+        ),
+        severity="warning",
+    )
+
+
+def validate_geometry(
+    aeroplane: AeroplaneSchema,
+    vsp: ModuleType,
+    wing_gid_map: dict[str, str],
+    fuselage_gid_map: Optional[dict[str, str]] = None,
+    *,
+    rel_tol: float = DEFAULT_REL_TOL,
+) -> list[ImportWarning]:
+    """Compare importer output to OpenVSP's reported geometry.
+
+    Parameters
+    ----------
+    aeroplane
+        The populated :class:`AeroplaneSchema` from :func:`import_vsp3`.
+    vsp
+        The same OpenVSP module the importer used. The model must
+        still be loaded.
+    wing_gid_map
+        ``{wing_geom_id: wing_name}`` (typically
+        :attr:`ImportContext.wing_geom_ids`).
+    fuselage_gid_map
+        Same shape for fuselages. ``None`` skips fuselage checks.
+    rel_tol
+        Relative-error threshold (default 1%).
+
+    Returns
+    -------
+    list[ImportWarning]
+        One warning per metric whose relative error exceeds ``rel_tol``.
+    """
+    warnings: list[ImportWarning] = []
+
+    # Wings -----------------------------------------------------------------
+    if aeroplane.wings:
+        for gid, name in wing_gid_map.items():
+            wing = aeroplane.wings.get(name)
+            if wing is None:
+                continue
+            ours = compute_wing_metrics(wing)
+            vsp_metrics = _vsp_wing_metrics(vsp, gid)
+            if vsp_metrics is None:
+                continue  # VSP doesn't expose the metric — skip.
+            for metric_name, ours_v, vsp_v in (
+                ("span", ours.span_m, vsp_metrics.span_m),
+                ("area", ours.area_m2, vsp_metrics.area_m2),
+                ("MAC", ours.mac_m, vsp_metrics.mac_m),
+            ):
+                if vsp_v <= 0:
+                    continue  # VSP value not populated.
+                w = _check(
+                    component_type="WING",
+                    component_name=name,
+                    metric=metric_name,
+                    imported=ours_v,
+                    vsp_value=vsp_v,
+                    rel_tol=rel_tol,
+                )
+                if w is not None:
+                    warnings.append(w)
+
+    # Fuselages -------------------------------------------------------------
+    if fuselage_gid_map and aeroplane.fuselages:
+        lengths = compute_fuselage_length(aeroplane)
+        for gid, name in fuselage_gid_map.items():
+            ours_len = lengths.get(name)
+            if ours_len is None:
+                continue
+            vsp_len = _vsp_fuselage_length(vsp, gid)
+            if vsp_len is None or vsp_len <= 0:
+                continue
+            w = _check(
+                component_type="FUSELAGE",
+                component_name=name,
+                metric="length",
+                imported=ours_len,
+                vsp_value=vsp_len,
+                rel_tol=rel_tol,
+            )
+            if w is not None:
+                warnings.append(w)
+
+    return warnings

--- a/app/tests/test_openvsp_validation.py
+++ b/app/tests/test_openvsp_validation.py
@@ -1,0 +1,270 @@
+"""Geometric sanity validation tests for the OpenVSP importer (gh-647).
+
+Per the scope-clarification comment on #647: no VSPAERO roundtrip,
+no ASB CL_α comparison. We test:
+
+* Wing span/area/MAC equality (±1%) between importer output and the
+  vsp module's reported TotalSpan/TotalProjectedArea/TotalChord.
+* Fuselage length equality (±1%) against VSP's Design/Length parm.
+* Out-of-tolerance differences produce structured ImportWarnings.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from types import ModuleType
+
+import pytest
+
+from app.converters.openvsp_validation import (
+    compute_fuselage_length,
+    compute_wing_metrics,
+    validate_geometry,
+)
+from app.schemas.aeroplaneschema import (
+    AeroplaneSchema,
+    AsbWingSchema,
+    FuselageSchema,
+    FuselageXSecSuperEllipseSchema,
+    WingXSecSchema,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures: simple aircraft + fake vsp
+# ---------------------------------------------------------------------------
+
+
+def _trapezoid_wing(
+    *, name="MainWing", span_half=5.0, c_root=1.0, c_tip=0.5, symmetric=True
+) -> AsbWingSchema:
+    return AsbWingSchema(
+        name=name,
+        symmetric=symmetric,
+        x_secs=[
+            WingXSecSchema(
+                xyz_le=[0.0, 0.0, 0.0],
+                chord=c_root,
+                twist=0.0,
+                airfoil="./components/airfoils/naca0012.dat",
+                x_sec_type="root",
+            ),
+            WingXSecSchema(
+                xyz_le=[0.0, span_half, 0.0],
+                chord=c_tip,
+                twist=0.0,
+                airfoil="./components/airfoils/naca0012.dat",
+            ),
+        ],
+    )
+
+
+def _make_vsp(
+    *,
+    wing_id: str = "WING1",
+    wing_total_span: float | None = None,
+    wing_total_area: float | None = None,
+    wing_total_chord: float | None = None,
+    fuse_id: str = "FUSE1",
+    fuse_length: float | None = None,
+) -> ModuleType:
+    fake = ModuleType("openvsp")
+
+    parms: dict[tuple[str, str, str], float] = {}
+    if wing_total_span is not None:
+        parms[(wing_id, "TotalSpan", "WingGeom")] = wing_total_span
+    if wing_total_area is not None:
+        parms[(wing_id, "TotalProjectedArea", "WingGeom")] = wing_total_area
+    if wing_total_chord is not None:
+        parms[(wing_id, "TotalChord", "WingGeom")] = wing_total_chord
+    if fuse_length is not None:
+        parms[(fuse_id, "Length", "Design")] = fuse_length
+
+    def _find_parm(container, parm, group):
+        return f"{container}::{group}::{parm}" if (container, parm, group) in parms else ""
+
+    def _get_parm_val(pid):
+        if not pid:
+            return 0.0
+        container, group, parm = pid.split("::", 2)
+        return parms.get((container, parm, group), 0.0)
+
+    fake.FindParm = _find_parm
+    fake.GetParmVal = _get_parm_val
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# compute_wing_metrics
+# ---------------------------------------------------------------------------
+
+
+class TestComputeWingMetrics:
+    def test_full_span_for_symmetric_wing(self):
+        w = _trapezoid_wing(span_half=5.0, symmetric=True)
+        m = compute_wing_metrics(w)
+        # Y goes 0..5 on the imported half — full span is 10.
+        assert m.span_m == pytest.approx(10.0)
+
+    def test_half_span_for_asymmetric_wing(self):
+        w = _trapezoid_wing(span_half=5.0, symmetric=False)
+        m = compute_wing_metrics(w)
+        assert m.span_m == pytest.approx(5.0)
+
+    def test_area_for_simple_trapezoid(self):
+        # half-area = (1.0 + 0.5)/2 * 5.0 = 3.75; full = 7.5
+        w = _trapezoid_wing(span_half=5.0, c_root=1.0, c_tip=0.5, symmetric=True)
+        m = compute_wing_metrics(w)
+        assert m.area_m2 == pytest.approx(7.5)
+
+    def test_mac_for_uniform_chord(self):
+        # constant chord = MAC
+        w = _trapezoid_wing(span_half=5.0, c_root=1.0, c_tip=1.0)
+        m = compute_wing_metrics(w)
+        assert m.mac_m == pytest.approx(1.0)
+
+    def test_mac_for_taper(self):
+        # area-weighted mean — for linear taper the MAC is (c_root + c_tip)/2
+        # only when the area weight is uniform, which it is here.
+        w = _trapezoid_wing(c_root=1.0, c_tip=0.5)
+        m = compute_wing_metrics(w)
+        assert m.mac_m == pytest.approx(0.75)
+
+
+# ---------------------------------------------------------------------------
+# compute_fuselage_length
+# ---------------------------------------------------------------------------
+
+
+class TestComputeFuselageLength:
+    def test_simple_fuselage_length(self):
+        f = FuselageSchema(
+            name="Fuselage",
+            x_secs=[
+                FuselageXSecSuperEllipseSchema(xyz=[0.0, 0, 0], a=0, b=0, n=2),
+                FuselageXSecSuperEllipseSchema(xyz=[5.0, 0, 0], a=0.5, b=0.5, n=2),
+                FuselageXSecSuperEllipseSchema(xyz=[10.0, 0, 0], a=0, b=0, n=2),
+            ],
+        )
+        ap = AeroplaneSchema(name="X", fuselages=OrderedDict([("Fuselage", f)]))
+        assert compute_fuselage_length(ap)["Fuselage"] == pytest.approx(10.0)
+
+    def test_no_fuselages_yields_empty_dict(self):
+        ap = AeroplaneSchema(name="X")
+        assert compute_fuselage_length(ap) == {}
+
+
+# ---------------------------------------------------------------------------
+# validate_geometry — wing checks
+# ---------------------------------------------------------------------------
+
+
+class TestValidateWing:
+    def test_within_tolerance_no_warnings(self):
+        wing = _trapezoid_wing()  # span 10, area 7.5, MAC 0.75
+        ap = AeroplaneSchema(name="X", wings=OrderedDict([("MainWing", wing)]))
+        fake = _make_vsp(
+            wing_id="W1",
+            wing_total_span=10.0,
+            wing_total_area=7.5,
+            wing_total_chord=0.75,
+        )
+        w = validate_geometry(ap, fake, {"W1": "MainWing"})
+        assert w == []
+
+    def test_span_5pct_off_emits_warning(self):
+        wing = _trapezoid_wing()
+        ap = AeroplaneSchema(name="X", wings=OrderedDict([("MainWing", wing)]))
+        fake = _make_vsp(
+            wing_id="W1",
+            wing_total_span=10.5,  # 5% off
+            wing_total_area=7.5,
+            wing_total_chord=0.75,
+        )
+        w = validate_geometry(ap, fake, {"W1": "MainWing"})
+        assert len(w) == 1
+        assert "span" in w[0].reason.lower()
+        assert "WING" == w[0].component_type
+        assert "MainWing" == w[0].component_name
+
+    def test_area_8pct_off_emits_warning(self):
+        wing = _trapezoid_wing()
+        ap = AeroplaneSchema(name="X", wings=OrderedDict([("MainWing", wing)]))
+        fake = _make_vsp(
+            wing_id="W1",
+            wing_total_span=10.0,
+            wing_total_area=8.1,  # 8% off
+            wing_total_chord=0.75,
+        )
+        w = validate_geometry(ap, fake, {"W1": "MainWing"})
+        assert len(w) == 1
+        assert "area" in w[0].reason.lower()
+
+    def test_mac_2pct_off_emits_warning(self):
+        wing = _trapezoid_wing()
+        ap = AeroplaneSchema(name="X", wings=OrderedDict([("MainWing", wing)]))
+        fake = _make_vsp(
+            wing_id="W1",
+            wing_total_span=10.0,
+            wing_total_area=7.5,
+            wing_total_chord=0.765,  # 2% off
+        )
+        w = validate_geometry(ap, fake, {"W1": "MainWing"})
+        assert len(w) == 1
+        assert "mac" in w[0].reason.lower()
+
+    def test_vsp_metric_missing_skips_silently(self):
+        wing = _trapezoid_wing()
+        ap = AeroplaneSchema(name="X", wings=OrderedDict([("MainWing", wing)]))
+        fake = _make_vsp(wing_id="W1")  # no metrics declared
+        w = validate_geometry(ap, fake, {"W1": "MainWing"})
+        assert w == []
+
+    def test_custom_tolerance(self):
+        """A relaxed tolerance suppresses small mismatches."""
+        wing = _trapezoid_wing()
+        ap = AeroplaneSchema(name="X", wings=OrderedDict([("MainWing", wing)]))
+        fake = _make_vsp(
+            wing_id="W1",
+            wing_total_span=10.5,
+            wing_total_area=7.5,
+            wing_total_chord=0.75,
+        )
+        # 5% relative error in span; with rel_tol=0.1 (10%), no warning.
+        w = validate_geometry(ap, fake, {"W1": "MainWing"}, rel_tol=0.1)
+        assert w == []
+
+
+# ---------------------------------------------------------------------------
+# validate_geometry — fuselage check
+# ---------------------------------------------------------------------------
+
+
+class TestValidateFuselage:
+    def test_fuselage_length_within_tolerance(self):
+        fuse = FuselageSchema(
+            name="Fuselage",
+            x_secs=[
+                FuselageXSecSuperEllipseSchema(xyz=[0.0, 0, 0], a=0, b=0, n=2),
+                FuselageXSecSuperEllipseSchema(xyz=[10.0, 0, 0], a=0, b=0, n=2),
+            ],
+        )
+        ap = AeroplaneSchema(name="X", fuselages=OrderedDict([("Fuselage", fuse)]))
+        fake = _make_vsp(fuse_id="F1", fuse_length=10.0)
+        w = validate_geometry(ap, fake, wing_gid_map={}, fuselage_gid_map={"F1": "Fuselage"})
+        assert w == []
+
+    def test_fuselage_length_3pct_off_emits_warning(self):
+        fuse = FuselageSchema(
+            name="Fuselage",
+            x_secs=[
+                FuselageXSecSuperEllipseSchema(xyz=[0.0, 0, 0], a=0, b=0, n=2),
+                FuselageXSecSuperEllipseSchema(xyz=[10.0, 0, 0], a=0, b=0, n=2),
+            ],
+        )
+        ap = AeroplaneSchema(name="X", fuselages=OrderedDict([("Fuselage", fuse)]))
+        fake = _make_vsp(fuse_id="F1", fuse_length=10.3)
+        w = validate_geometry(ap, fake, wing_gid_map={}, fuselage_gid_map={"F1": "Fuselage"})
+        assert len(w) == 1
+        assert "length" in w[0].reason.lower()
+        assert "FUSELAGE" == w[0].component_type


### PR DESCRIPTION
Closes #647. Part of EPIC #637. Per scope-clarification: span/area/MAC vs VSP TotalSpan/TotalProjectedArea/TotalChord ±1%, fuselage length ±1%. NO VSPAERO, NO ASB roundtrip. 15 unit tests via fake-vsp.