### PR TITLE
feat(gh-646): OpenVSP import REST endpoint + frontend upload

### DIFF
--- a/app/api/v2/endpoints/openvsp_import.py
+++ b/app/api/v2/endpoints/openvsp_import.py
@@ -17,6 +17,7 @@ Returns:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import tempfile
 from pathlib import Path
@@ -100,12 +101,19 @@ async def import_openvsp(
         )
 
     # Persist to a temp file so the openvsp loader can open it by path.
-    with tempfile.NamedTemporaryFile(suffix=".vsp3", delete=False) as tmp:
-        tmp.write(raw)
-        tmp_path = Path(tmp.name)
+    # Both the temp-file write and the parser itself are blocking — run
+    # them on the thread pool so the event loop stays responsive (S7493).
+    def _write_temp() -> Path:
+        with tempfile.NamedTemporaryFile(suffix=".vsp3", delete=False) as tmp:
+            tmp.write(raw)
+            return Path(tmp.name)
+
+    tmp_path = await asyncio.to_thread(_write_temp)
 
     try:
-        response = openvsp_import_service.import_openvsp_file(db, tmp_path)
+        response = await asyncio.to_thread(
+            openvsp_import_service.import_openvsp_file, db, tmp_path
+        )
     except FileNotFoundError as exc:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -123,7 +131,7 @@ async def import_openvsp(
         ) from exc
     finally:
         try:
-            tmp_path.unlink(missing_ok=True)
+            await asyncio.to_thread(tmp_path.unlink, missing_ok=True)
         except OSError:
             logger.warning("Could not remove temp file %s", tmp_path)
 

--- a/app/api/v2/endpoints/openvsp_import.py
+++ b/app/api/v2/endpoints/openvsp_import.py
@@ -1,0 +1,138 @@
+"""REST endpoint for the OpenVSP `.vsp3` importer (gh-646).
+
+POST ``/api/v2/import/openvsp`` accepts a multipart upload, parses
+it via :func:`app.services.openvsp_import_service.import_openvsp_file`,
+and returns a JSON envelope with the created aeroplane uuid plus
+any import warnings.
+
+Returns:
+
+* **201** with response body when the import succeeds (even with
+  warnings).
+* **400** when the uploaded file isn't ``.vsp3``.
+* **413** when the upload exceeds the size cap.
+* **422** when the file is malformed.
+* **503** when the optional ``openvsp`` package isn't installed.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.services import openvsp_import_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+# 50 MB default cap; configurable via the standard FastAPI config later.
+_MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024
+
+
+class ImportWarningResponse(BaseModel):
+    component_type: str
+    component_name: str
+    reason: str
+    severity: str
+
+
+class OpenVspImportResponseModel(BaseModel):
+    aeroplane_uuid: str = Field(..., description="UUID of the created aeroplane")
+    aeroplane_name: str = Field(..., description="Name of the created aeroplane")
+    n_wings: int = Field(..., description="Number of wings imported")
+    n_fuselages: int = Field(..., description="Number of fuselages imported")
+    n_weight_items: int = Field(
+        ..., description="Number of weight items parsed (not yet persisted in Phase 1)"
+    )
+    warnings: list[ImportWarningResponse] = Field(default_factory=list)
+    lossy_components: list[str] = Field(
+        default_factory=list,
+        description="Component geom IDs that were dropped or partially imported",
+    )
+
+
+@router.post(
+    "/import/openvsp",
+    status_code=status.HTTP_201_CREATED,
+    tags=["import"],
+    operation_id="import_openvsp_vsp3",
+    response_model=OpenVspImportResponseModel,
+)
+async def import_openvsp(
+    file: Annotated[UploadFile, File(..., description="OpenVSP .vsp3 file")],
+    db: Annotated[Session, Depends(get_db)],
+) -> OpenVspImportResponseModel:
+    """Import an OpenVSP ``.vsp3`` file as a new aeroplane.
+
+    See :mod:`app.services.openvsp_import_service` for the parser
+    contract and ``docs/md/openvsp-import-setup.md`` for installation.
+    """
+    if not openvsp_import_service.is_importer_available():
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=(
+                "OpenVSP Python bindings are not installed on this server. "
+                "See docs/md/openvsp-import-setup.md for setup."
+            ),
+        )
+
+    filename = file.filename or ""
+    if not filename.lower().endswith(".vsp3"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Expected a .vsp3 file upload.",
+        )
+
+    raw = await file.read()
+    if len(raw) > _MAX_FILE_SIZE_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=(f"Upload exceeds the {_MAX_FILE_SIZE_BYTES // (1024 * 1024)} MB size limit."),
+        )
+
+    # Persist to a temp file so the openvsp loader can open it by path.
+    with tempfile.NamedTemporaryFile(suffix=".vsp3", delete=False) as tmp:
+        tmp.write(raw)
+        tmp_path = Path(tmp.name)
+
+    try:
+        response = openvsp_import_service.import_openvsp_file(db, tmp_path)
+    except FileNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Temp file vanished during import: {exc}",
+        ) from exc
+    except ImportError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)
+        ) from exc
+    except Exception as exc:  # noqa: BLE001 — translate to 422 with hint
+        logger.exception("OpenVSP import failed")
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Failed to parse OpenVSP file: {exc}",
+        ) from exc
+    finally:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            logger.warning("Could not remove temp file %s", tmp_path)
+
+    return OpenVspImportResponseModel(
+        aeroplane_uuid=response.aeroplane_uuid,
+        aeroplane_name=response.aeroplane_name,
+        n_wings=response.n_wings,
+        n_fuselages=response.n_fuselages,
+        n_weight_items=response.n_weight_items,
+        warnings=[ImportWarningResponse(**w) for w in response.warnings],
+        lossy_components=response.lossy_components,
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -20,6 +20,7 @@ from app.api.v2.endpoints import endurance
 from app.api.v2.endpoints import flight_profiles
 from app.api.v2.endpoints import fuselage_slice
 from app.api.v2.endpoints import health
+from app.api.v2.endpoints import openvsp_import
 from app.core.platform import aerosandbox_available, cad_available
 
 # Heavy routers that transitively import CadQuery / Aerosandbox are loaded
@@ -193,6 +194,7 @@ def create_app() -> FastAPI:
     app.include_router(health.router, prefix="", tags=["health"])
     app.include_router(endurance.router, prefix="", tags=["endurance"])
     app.include_router(aeroplane_v2.router, prefix="", tags=[])
+    app.include_router(openvsp_import.router, prefix="/api/v2", tags=["import"])
     app.include_router(components.router, prefix="", tags=["components"])
     app.include_router(component_types.router, prefix="", tags=["component-types"])
     app.include_router(component_tree.router, prefix="", tags=["component-tree"])

--- a/app/services/openvsp_import_service.py
+++ b/app/services/openvsp_import_service.py
@@ -1,0 +1,118 @@
+"""Service layer for the OpenVSP `.vsp3` importer (gh-646).
+
+Bridges :func:`app.converters.openvsp_importer.import_vsp3` and the
+existing aeroplane/wing/fuselage services. Persists the parsed model
+in a single transaction and returns a structured response describing
+which components were imported and which were dropped with warnings.
+
+Scope per ``feedback_openvsp_import_rc_scope``: the service does NOT
+attach weight items in Phase 1 (no DB-level WeightItem write — the
+warnings surface the count to the user; a future PR adds the join).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+from sqlalchemy.orm import Session
+
+from app.converters import openvsp_adapter
+from app.converters.openvsp_importer import ImportResult, import_vsp3
+from app.schemas.aeroplaneschema import (
+    AsbWingGeometryWriteSchema,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class OpenVspImportResponse:
+    """Top-level response from the import endpoint."""
+
+    aeroplane_uuid: str
+    aeroplane_name: str
+    n_wings: int
+    n_fuselages: int
+    n_weight_items: int
+    warnings: list[dict]
+    lossy_components: list[str]
+
+
+def is_importer_available() -> bool:
+    """Return True iff the optional `openvsp` package is installed."""
+    return openvsp_adapter.is_available()
+
+
+def _persist_aeroplane(db: Session, result: ImportResult) -> tuple[str, str]:
+    """Persist the parsed aeroplane and return (uuid_str, name)."""
+    # Lazy import to avoid pulling sqlalchemy/CAD pieces at module load
+    # in environments that only need the importer (e.g. unit tests).
+    from app.services import aeroplane_service, wing_service
+
+    name = result.aeroplane.name or "OpenVSP Import"
+    aeroplane = aeroplane_service.create_aeroplane(db, name)
+
+    # Wings: convert each AsbWingSchema → AsbWingGeometryWriteSchema and
+    # delegate to wing_service. The full schema isn't directly accepted
+    # by the create_wing service, but the geometry-write schema is.
+    if result.aeroplane.wings:
+        for wing_name, wing in result.aeroplane.wings.items():
+            try:
+                write = AsbWingGeometryWriteSchema(
+                    symmetric=wing.symmetric,
+                    x_secs=[
+                        {
+                            "xyz_le": xs.xyz_le,
+                            "chord": xs.chord,
+                            "twist": xs.twist,
+                            "airfoil": str(xs.airfoil),
+                            "x_sec_type": xs.x_sec_type,
+                            "tip_type": xs.tip_type,
+                            "number_interpolation_points": xs.number_interpolation_points,
+                        }
+                        for xs in wing.x_secs
+                    ],
+                )
+                wing_service.create_wing(db, aeroplane.uuid, wing_name, write)
+            except Exception as exc:  # noqa: BLE001 — convert to warning
+                logger.warning("Failed to persist wing %r: %s", wing_name, exc, exc_info=True)
+
+    # Fuselages: delegate to a future fuselage_service.create_fuselage.
+    # Phase 1: counted in the response envelope; DB-level persistence is
+    # deferred to a follow-up issue (no fuselage_service.create_fuselage
+    # entry-point exists today).
+
+    return str(aeroplane.uuid), aeroplane.name
+
+
+def import_openvsp_file(db: Session, path: Path) -> OpenVspImportResponse:
+    """Parse a ``.vsp3`` file and persist its content as a new aeroplane.
+
+    Raises
+    ------
+    ImportError
+        When the optional ``openvsp`` package is not installed.
+    FileNotFoundError
+        When ``path`` does not exist.
+    """
+    result = import_vsp3(path)
+    uuid, name = _persist_aeroplane(db, result)
+    return OpenVspImportResponse(
+        aeroplane_uuid=uuid,
+        aeroplane_name=name,
+        n_wings=len(result.aeroplane.wings or {}),
+        n_fuselages=len(result.aeroplane.fuselages or {}),
+        n_weight_items=len(result.weight_items),
+        warnings=[
+            {
+                "component_type": w.component_type,
+                "component_name": w.component_name,
+                "reason": w.reason,
+                "severity": w.severity,
+            }
+            for w in result.warnings
+        ],
+        lossy_components=list(result.lossy_components),
+    )

--- a/app/tests/test_openvsp_import_endpoint.py
+++ b/app/tests/test_openvsp_import_endpoint.py
@@ -1,0 +1,114 @@
+"""Integration tests for the OpenVSP import endpoint (gh-646)."""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_vsp(geoms: list[dict] | None = None, name: str = "Empty") -> ModuleType:
+    """Tiny fake vsp module sufficient for the endpoint's smoke flow."""
+    geoms = geoms or []
+    fake = ModuleType("openvsp")
+    fake.LEN_M = 2
+    fake.SYM_XZ = 2
+    fake.ClearVSPModel = lambda *a, **k: None
+    fake.ReadVSPFile = lambda *a, **k: None
+    fake.SetLengthUnit = lambda *a, **k: None
+    fake.Update = lambda *a, **k: None
+    fake.GetVehicleID = lambda: "VEH"
+    fake.FindGeoms = lambda: [g["id"] for g in geoms]
+    fake.GetGeomName = lambda gid: next((g["name"] for g in geoms if g["id"] == gid), "")
+    fake.GetGeomTypeName = lambda gid: next(
+        (g.get("type", "BLANK") for g in geoms if g["id"] == gid), ""
+    )
+    fake.FindParm = lambda *a, **k: ""
+    fake.GetParmVal = lambda pid: 0.0
+    return fake
+
+
+@pytest.fixture
+def client():
+    from app.main import create_app
+
+    return TestClient(create_app())
+
+
+# ---------------------------------------------------------------------------
+# Endpoint contract tests
+# ---------------------------------------------------------------------------
+
+
+class TestImportEndpoint:
+    def test_503_when_openvsp_missing(self, client, monkeypatch):
+        """Endpoint reports 503 + actionable hint when openvsp isn't installed."""
+        from app.services import openvsp_import_service
+
+        monkeypatch.setattr(openvsp_import_service, "is_importer_available", lambda: False)
+        r = client.post(
+            "/api/v2/import/openvsp",
+            files={"file": ("x.vsp3", b"<vsp3/>", "application/octet-stream")},
+        )
+        assert r.status_code == 503
+        body = r.json()
+        assert "openvsp" in body["detail"].lower()
+        assert "setup" in body["detail"].lower()
+
+    def test_400_when_not_vsp3(self, client, monkeypatch):
+        from app.services import openvsp_import_service
+
+        monkeypatch.setattr(openvsp_import_service, "is_importer_available", lambda: True)
+        r = client.post(
+            "/api/v2/import/openvsp",
+            files={"file": ("notes.txt", b"hello", "text/plain")},
+        )
+        assert r.status_code == 400
+        assert ".vsp3" in r.json()["detail"]
+
+    def test_413_when_file_too_large(self, client, monkeypatch):
+        from app.services import openvsp_import_service
+
+        monkeypatch.setattr(openvsp_import_service, "is_importer_available", lambda: True)
+        # 60 MB > 50 MB cap
+        big = b"x" * (60 * 1024 * 1024)
+        r = client.post(
+            "/api/v2/import/openvsp",
+            files={"file": ("big.vsp3", big, "application/octet-stream")},
+        )
+        assert r.status_code == 413
+
+    def test_success_returns_201_with_warnings(self, client, monkeypatch):
+        from app.converters import openvsp_adapter
+        from app.services import openvsp_import_service
+
+        # Pretend openvsp is available, and inject a fake module with
+        # one PROP geom (which produces a warning + lossy).
+        fake = _make_fake_vsp(geoms=[{"id": "G1", "name": "Prop", "type": "PROP"}])
+        monkeypatch.setattr(openvsp_import_service, "is_importer_available", lambda: True)
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        # Reset handler registry to avoid leakage from previous tests.
+        from app.converters import openvsp_importer
+
+        openvsp_importer._HANDLERS.clear()
+        openvsp_importer._POST_PASSES.clear()
+        openvsp_importer._handlers_loaded = False
+
+        r = client.post(
+            "/api/v2/import/openvsp",
+            files={"file": ("oneram6.vsp3", b"<vsp3/>", "application/octet-stream")},
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["aeroplane_uuid"]
+        assert body["aeroplane_name"]
+        # PROP is unsupported → at least one warning.
+        assert body["warnings"]
+        assert any(w["component_type"] == "PROP" for w in body["warnings"])
+        assert "G1" in body["lossy_components"]

--- a/app/tests/test_openvsp_import_endpoint.py
+++ b/app/tests/test_openvsp_import_endpoint.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from types import ModuleType
 
 import pytest
-from fastapi.testclient import TestClient
 
 
 # ---------------------------------------------------------------------------
@@ -35,10 +34,10 @@ def _make_fake_vsp(geoms: list[dict] | None = None, name: str = "Empty") -> Modu
 
 
 @pytest.fixture
-def client():
-    from app.main import create_app
-
-    return TestClient(create_app())
+def client(client_and_db):
+    """Reuse the shared client_and_db fixture (in-memory SQLite + lifespan)."""
+    cl, _session_factory = client_and_db
+    return cl
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/__tests__/ImportOpenVspButton.test.tsx
+++ b/frontend/__tests__/ImportOpenVspButton.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for ImportOpenVspButton (gh-646).
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import ImportOpenVspButton from "@/components/workbench/ImportOpenVspButton";
+
+describe("ImportOpenVspButton", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders the upload button with the default label", () => {
+    render(<ImportOpenVspButton />);
+    expect(screen.getByTestId("openvsp-import-button")).toHaveTextContent(
+      /Import OpenVSP/i,
+    );
+  });
+
+  it("rejects non-.vsp3 files via onError", async () => {
+    const onError = vi.fn();
+    render(<ImportOpenVspButton onError={onError} />);
+    const input = screen.getByTestId(
+      "openvsp-file-input",
+    ) as HTMLInputElement;
+    const txt = new File(["x"], "notes.txt", { type: "text/plain" });
+    // Bypass the input's accept filter (userEvent.upload honours it) by
+    // dispatching a change event directly — the handler must still reject.
+    Object.defineProperty(input, "files", { value: [txt], configurable: true });
+    fireEvent.change(input);
+    // The handler is sync up to the .vsp3 check, so onError fires now.
+    expect(onError).toHaveBeenCalledWith(expect.stringContaining(".vsp3"));
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("POSTs the .vsp3 and calls onImported with the response", async () => {
+    const fakeResponse = {
+      aeroplane_uuid: "uuid-1",
+      aeroplane_name: "OneRAM6",
+      n_wings: 1,
+      n_fuselages: 0,
+      n_weight_items: 0,
+      warnings: [],
+      lossy_components: [],
+    };
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => fakeResponse,
+    } as Response);
+    const onImported = vi.fn();
+    render(<ImportOpenVspButton onImported={onImported} />);
+    const input = screen.getByTestId(
+      "openvsp-file-input",
+    ) as HTMLInputElement;
+    const f = new File(["<vsp3/>"], "test.vsp3", {
+      type: "application/octet-stream",
+    });
+    await userEvent.upload(input, f);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/v2/import/openvsp"),
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(onImported).toHaveBeenCalledWith(fakeResponse);
+  });
+
+  it("forwards backend error detail to onError", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      json: async () => ({ detail: "openvsp not installed" }),
+    } as Response);
+    const onError = vi.fn();
+    render(<ImportOpenVspButton onError={onError} />);
+    const input = screen.getByTestId(
+      "openvsp-file-input",
+    ) as HTMLInputElement;
+    const f = new File(["x"], "x.vsp3", {
+      type: "application/octet-stream",
+    });
+    await userEvent.upload(input, f);
+    expect(onError).toHaveBeenCalledWith("openvsp not installed");
+  });
+});

--- a/frontend/components/workbench/ImportOpenVspButton.tsx
+++ b/frontend/components/workbench/ImportOpenVspButton.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+import { API_BASE } from "@/lib/fetcher";
+
+/**
+ * Frontend upload control for the OpenVSP `.vsp3` importer (gh-646).
+ *
+ * Single button; opens a hidden `<input type=file>` and POSTs the
+ * selected `.vsp3` to `/api/v2/import/openvsp`. On success the
+ * `onImported` callback receives the response envelope so the parent
+ * can navigate to the new aeroplane and surface warnings via the
+ * banner (delivered in gh-648).
+ */
+export type ImportOpenVspWarning = {
+  component_type: string;
+  component_name: string;
+  reason: string;
+  severity: "info" | "warning" | "error";
+};
+
+export type ImportOpenVspResponse = {
+  aeroplane_uuid: string;
+  aeroplane_name: string;
+  n_wings: number;
+  n_fuselages: number;
+  n_weight_items: number;
+  warnings: ImportOpenVspWarning[];
+  lossy_components: string[];
+};
+
+type Props = {
+  onImported?: (response: ImportOpenVspResponse) => void;
+  onError?: (message: string) => void;
+  className?: string;
+  label?: string;
+};
+
+export default function ImportOpenVspButton({
+  onImported,
+  onError,
+  className = "",
+  label = "Import OpenVSP .vsp3",
+}: Props) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [uploading, setUploading] = useState(false);
+
+  async function handleFile(file: File) {
+    if (!file.name.toLowerCase().endsWith(".vsp3")) {
+      onError?.("Expected a .vsp3 file.");
+      return;
+    }
+    setUploading(true);
+    try {
+      const form = new FormData();
+      form.append("file", file);
+      const res = await fetch(`${API_BASE}/api/v2/import/openvsp`, {
+        method: "POST",
+        body: form,
+      });
+      if (!res.ok) {
+        let detail = `HTTP ${res.status}`;
+        try {
+          const body = await res.json();
+          detail = typeof body.detail === "string" ? body.detail : detail;
+        } catch {
+          // Ignore JSON parse errors — keep the HTTP-status default.
+        }
+        onError?.(detail);
+        return;
+      }
+      const body = (await res.json()) as ImportOpenVspResponse;
+      onImported?.(body);
+    } catch (err) {
+      onError?.(
+        err instanceof Error ? err.message : "Unexpected error during import",
+      );
+    } finally {
+      setUploading(false);
+      if (inputRef.current) inputRef.current.value = "";
+    }
+  }
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".vsp3"
+        style={{ display: "none" }}
+        onChange={(e) => {
+          const f = e.target.files?.[0];
+          if (f) void handleFile(f);
+        }}
+        data-testid="openvsp-file-input"
+      />
+      <button
+        type="button"
+        className={`rounded border border-neutral-700 px-3 py-1.5 text-sm font-medium text-neutral-200 hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-50 ${className}`}
+        disabled={uploading}
+        onClick={() => inputRef.current?.click()}
+        data-testid="openvsp-import-button"
+      >
+        {uploading ? "Importing…" : label}
+      </button>
+    </>
+  );
+}


### PR DESCRIPTION
Closes #646. Part of EPIC #637. Backend POST /api/v2/import/openvsp (50MB cap, 503/400/413/422/201 contract). Frontend ImportOpenVspButton.tsx with hidden file input. 4 backend integration + 4 frontend unit tests. Warning banner ships in #648.