### PR TITLE
fix(gh-681): _kpi_glide/_kpi_climb fall back through gh-636 provenance chain

### DIFF
--- a/app/services/mission_kpi_service.py
+++ b/app/services/mission_kpi_service.py
@@ -126,18 +126,61 @@ def _kpi_stall_safety(ctx: dict[str, Any], range_min: float, range_max: float) -
     )
 
 
-def _kpi_glide(ctx: dict[str, Any], range_min: float, range_max: float) -> MissionAxisKpi:
-    """Maximum lift-to-drag ratio from the clean polar."""
-    formula = "(L/D)_max = 0.5 · √(π · e · AR / C_D0)"
+def _resolve_polar_inputs(
+    ctx: dict[str, Any],
+) -> tuple[float | None, float | None, float | None, float | None]:
+    """gh-681: resolve (ld_max_empirical, cd0, e_oswald, ar) for the clean polar.
+
+    Provenance chain that survives parabolic-fit rejection:
+    - ``ld_max_empirical``: ``polar_by_config.clean.ld_max`` (gh-636 empirical
+      max(CL/CD) from the AeroBuildup sweep) if positive.
+    - ``cd0`` / ``e``: prefer ``polar_by_config.clean`` (post-fit values),
+      then fall back to top-level ``ctx['cd0']`` (always-written stability-run
+      cd0) and ``ctx['e_oswald']`` (gh-636 AB-Trefftz, populated independently
+      of the parabolic fit).
+    - ``ar``: ``ctx['aspect_ratio']``.
+    """
     polar = ctx.get("polar_by_config", {}).get("clean") if ctx.get("polar_by_config") else None
     ar = ctx.get("aspect_ratio")
-    if not polar or ar is None:
+    if ar is None or ar <= 0:
+        return None, None, None, None
+
+    ld_emp = polar.get("ld_max") if polar else None
+    if not isinstance(ld_emp, (int, float)) or ld_emp <= 0:
+        ld_emp = None
+
+    cd0 = polar.get("cd0") if polar else None
+    if cd0 is None or cd0 <= 0:
+        cd0 = ctx.get("cd0")
+        if cd0 is None or cd0 <= 0:
+            cd0 = None
+
+    e = polar.get("e_oswald") if polar else None
+    if e is None or e <= 0:
+        e = ctx.get("e_oswald")
+        if e is None or e <= 0:
+            e = None
+
+    return ld_emp, cd0, e, float(ar)
+
+
+def _kpi_glide(ctx: dict[str, Any], range_min: float, range_max: float) -> MissionAxisKpi:
+    """Maximum lift-to-drag ratio from the clean polar.
+
+    gh-681: prefer empirical (L/D)max from the sweep; if absent, use the
+    parabolic-polar formula with cd0/e_oswald via the provenance chain
+    that survives fit rejection (see ``_resolve_polar_inputs``).
+    """
+    formula = "(L/D)_max = 0.5 · √(π · e · AR / C_D0)"
+    ld_emp, cd0, e, ar = _resolve_polar_inputs(ctx)
+    if ar is None:
         return _missing("glide", range_min, range_max, formula)
-    cd0 = polar.get("cd0")
-    e = polar.get("e_oswald")
-    if cd0 is None or cd0 <= 0 or e is None or e <= 0 or ar <= 0:
+    if ld_emp is not None:
+        value = float(ld_emp)
+    elif cd0 is not None and e is not None:
+        value = 0.5 * math.sqrt(math.pi * e * ar / cd0)
+    else:
         return _missing("glide", range_min, range_max, formula)
-    value = 0.5 * math.sqrt(math.pi * e * ar / cd0)
     return MissionAxisKpi(
         axis="glide",
         value=value,
@@ -151,15 +194,15 @@ def _kpi_glide(ctx: dict[str, Any], range_min: float, range_max: float) -> Missi
 
 
 def _kpi_climb_energy(ctx: dict[str, Any], range_min: float, range_max: float) -> MissionAxisKpi:
-    """Climb-energy figure ``(C_L^1.5 / C_D)_max`` — relevant for thermalling and ROC."""
+    """Climb-energy figure ``(C_L^1.5 / C_D)_max`` — relevant for thermalling and ROC.
+
+    gh-681: uses the same provenance chain as ``_kpi_glide`` for cd0 / e_oswald.
+    No empirical equivalent for climb-energy yet (only ld_max is on the polar);
+    formula is the only path.
+    """
     formula = "(C_L^1.5 / C_D)_max = (3·π·e·AR)^0.75 / (4 · C_D0^0.25)"
-    polar = ctx.get("polar_by_config", {}).get("clean") if ctx.get("polar_by_config") else None
-    ar = ctx.get("aspect_ratio")
-    if not polar or ar is None:
-        return _missing("climb", range_min, range_max, formula)
-    cd0 = polar.get("cd0")
-    e = polar.get("e_oswald")
-    if cd0 is None or cd0 <= 0 or e is None or e <= 0 or ar <= 0:
+    _ld_emp_unused, cd0, e, ar = _resolve_polar_inputs(ctx)
+    if ar is None or cd0 is None or e is None:
         return _missing("climb", range_min, range_max, formula)
     # Closed-form maximum of CL^1.5/CD for the parabolic polar
     # CD = CD0 + CL^2/(π·e·AR). Setting d(CL^1.5/CD)/dCL = 0 gives

--- a/app/tests/test_mission_kpi_service.py
+++ b/app/tests/test_mission_kpi_service.py
@@ -115,6 +115,93 @@ def test_kpi_climb_energy_missing_when_no_polar():
     assert kpi.provenance == "missing"
 
 
+# gh-681: when the parabolic-fit was rejected, polar_by_config.clean.cd0 is
+# None but top-level ctx['cd0'] (stability run) and ctx['e_oswald'] (gh-636
+# AB-Trefftz) are still valid. Both KPIs must fall back to those instead of
+# returning missing.
+
+
+def test_kpi_glide_falls_back_to_top_level_cd0_when_fit_rejected():
+    """gh-681: rejected fit ⇒ polar.cd0=None; use ctx['cd0'] + ctx['e_oswald']."""
+    ctx = {
+        "aspect_ratio": 18.71,
+        "cd0": 0.0159,
+        "e_oswald": 0.808,
+        "polar_by_config": {
+            "clean": {
+                "cd0": None,
+                "e_oswald": 0.808,
+                "cl_max": 1.12,
+                "rejection": {
+                    "gate": "non_monotonic_polar",
+                    "category": "data",
+                    "fitted_value": -0.15,
+                    "threshold": "dCD/d(CL²) >= 0",
+                    "hint": "laminar bubble",
+                },
+            },
+        },
+    }
+    kpi = _kpi_glide(ctx, range_min=15.0, range_max=35.0)
+    expected = 0.5 * math.sqrt(math.pi * 0.808 * 18.71 / 0.0159)
+    assert kpi.provenance == "computed"
+    assert kpi.value == pytest.approx(expected, rel=1e-3)
+
+
+def test_kpi_glide_prefers_empirical_ld_max():
+    """gh-681: when polar.ld_max is set, prefer it over the formula."""
+    ctx = {
+        "aspect_ratio": 18.71,
+        "cd0": 0.0159,
+        "e_oswald": 0.808,
+        "polar_by_config": {
+            "clean": {
+                "cd0": None,
+                "e_oswald": 0.808,
+                "cl_max": 1.12,
+                "ld_max": 30.52,  # empirical, gh-636
+            },
+        },
+    }
+    kpi = _kpi_glide(ctx, range_min=15.0, range_max=35.0)
+    assert kpi.provenance == "computed"
+    # Empirical 30.52 should win over formula (~30.7) — small difference
+    # but exercised path is what matters; assert the empirical value.
+    assert kpi.value == pytest.approx(30.52, rel=1e-3)
+
+
+def test_kpi_climb_energy_falls_back_to_top_level_when_fit_rejected():
+    """gh-681: rejected fit ⇒ polar.cd0=None; use ctx['cd0'] + ctx['e_oswald']."""
+    ctx = {
+        "aspect_ratio": 18.71,
+        "cd0": 0.0159,
+        "e_oswald": 0.808,
+        "polar_by_config": {
+            "clean": {
+                "cd0": None,
+                "e_oswald": 0.808,
+                "cl_max": 1.12,
+            },
+        },
+    }
+    kpi = _kpi_climb_energy(ctx, range_min=15.0, range_max=60.0)
+    expected = (3.0 * math.pi * 0.808 * 18.71) ** 0.75 / (4.0 * 0.0159**0.25)
+    assert kpi.provenance == "computed"
+    assert kpi.value == pytest.approx(expected, rel=1e-3)
+
+
+def test_kpi_glide_missing_when_ar_none_even_with_fallback():
+    """Fallback only fires when AR is present and at least one cd0 source exists."""
+    ctx = {
+        "aspect_ratio": None,
+        "cd0": 0.0159,
+        "e_oswald": 0.808,
+        "polar_by_config": {"clean": {"cd0": None, "e_oswald": 0.808, "cl_max": 1.12}},
+    }
+    kpi = _kpi_glide(ctx, range_min=15.0, range_max=35.0)
+    assert kpi.provenance == "missing"
+
+
 def test_kpi_cruise_from_context():
     ctx = {"v_cruise_mps": 22.0}
     kpi = _kpi_cruise(ctx, range_min=10.0, range_max=25.0)


### PR DESCRIPTION
## Summary

After gh-636, the top-level \`ctx['cd0']\` (stability-run) and \`ctx['e_oswald']\` (AB-Trefftz) are valid even when the parabolic fit is rejected. Also \`polar_by_config.clean.ld_max\` is empirically populated. But \`_kpi_glide\` / \`_kpi_climb\` still bailed on \`polar_by_config.clean.cd0 = None\`.

New shared helper \`_resolve_polar_inputs(ctx)\` returns \`(ld_max_emp, cd0, e, ar)\` via this fallback chain:

| Field | Primary | Fallback |
|---|---|---|
| \`ld_max_emp\` | \`polar_by_config.clean.ld_max\` | n/a |
| \`cd0\` | \`polar_by_config.clean.cd0\` | \`ctx['cd0']\` (stability-run) |
| \`e\`   | \`polar_by_config.clean.e_oswald\` | \`ctx['e_oswald']\` (AB-Trefftz) |
| \`ar\`  | \`ctx['aspect_ratio']\` | n/a |

\`_kpi_glide\` prefers empirical \`ld_max\` when present; otherwise the parabolic-polar formula via fallback. \`_kpi_climb_energy\` uses the same fallback for cd0/e (no empirical equivalent).

## Live verification

Olek (\`389b5778\`, non_monotonic_polar rejection):

| KPI | Before | After |
|---|---|---|
| glide | missing | **computed (30.52)** — via empirical \`ld_max\` |
| climb | missing | **computed (29.03)** — via formula with fallback inputs |

## Test plan

- [x] 4 new TDD tests for the fallback paths
- [x] 5 existing glide/climb tests still pass (regress to second-choice path)
- [x] All 35 mission_kpi tests green
- [x] Live verified on Olek

Closes #681