### PR TITLE
fix(gh-687): wire workbench refresh button to a real force-recompute

### DIFF
--- a/app/api/v2/endpoints/aeroplane/design_assumptions.py
+++ b/app/api/v2/endpoints/aeroplane/design_assumptions.py
@@ -194,6 +194,40 @@ async def get_recompute_status(
     }
 
 
+@router.post(
+    "/aeroplanes/{aeroplane_id}/recompute",
+    status_code=status.HTTP_202_ACCEPTED,
+    tags=["design-assumptions"],
+    operation_id="trigger_recompute",
+    summary="Force a recompute of the assumption computation context",
+    responses={404: {"description": "Aeroplane not found"}},
+)
+async def trigger_recompute(
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    db: Annotated[Session, Depends(get_db)],
+) -> dict[str, str | None]:
+    """Enqueue the same background job that AssumptionChanged /
+    GeometryChanged events enqueue. Used by the workbench refresh
+    button and the tail-sizing pencil-action to force a fresh
+    computation when no upstream event has fired."""
+    from app.core.background_jobs import job_tracker
+
+    aeroplane = _resolve_aeroplane(db, aeroplane_id)
+    job_tracker.schedule_recompute_assumptions(aeroplane.id)
+    job = job_tracker.get_recompute_job(aeroplane.id)
+    if job is None:
+        # No event loop was available to schedule the task — return
+        # idle so the client can decide whether to retry. We still
+        # 202 because the request itself was accepted.
+        return {"status": "idle", "started_at": None, "finished_at": None, "error": None}
+    return {
+        "status": job.status.value.lower(),
+        "started_at": job.started_at.isoformat() if job.started_at else None,
+        "finished_at": job.finished_at.isoformat() if job.finished_at else None,
+        "error": job.error,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Computation-context endpoint
 # ---------------------------------------------------------------------------

--- a/app/tests/test_recompute_endpoint.py
+++ b/app/tests/test_recompute_endpoint.py
@@ -1,0 +1,54 @@
+"""Tests for POST /aeroplanes/{id}/recompute — manual recompute trigger.
+
+The recompute button on the workbench info-chip row and the tail-sizing
+pencil-action both rely on this endpoint to enqueue the same background
+job that AssumptionChanged / GeometryChanged events enqueue.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+from app.tests.conftest import make_aeroplane
+
+
+class TestRecomputeEndpoint:
+    def test_returns_202_and_schedules_recompute(self, client_and_db):
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            aeroplane_uuid = str(aeroplane.uuid)
+            aeroplane_pk = aeroplane.id
+
+        with patch(
+            "app.core.background_jobs.job_tracker.schedule_recompute_assumptions"
+        ) as mock_schedule:
+            resp = client.post(f"/aeroplanes/{aeroplane_uuid}/recompute")
+
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["status"] in {"debouncing", "computing", "idle"}
+        mock_schedule.assert_called_once_with(aeroplane_pk)
+
+    def test_returns_404_for_missing_aeroplane(self, client_and_db):
+        client, _ = client_and_db
+        resp = client.post(f"/aeroplanes/{uuid.uuid4()}/recompute")
+        assert resp.status_code == 404
+
+    def test_repeated_calls_reschedule(self, client_and_db):
+        """Pressing the button twice must enqueue twice — debounce inside
+        the job tracker collapses the work, but the endpoint must not
+        silently drop the second call."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            aeroplane_uuid = str(aeroplane.uuid)
+
+        with patch(
+            "app.core.background_jobs.job_tracker.schedule_recompute_assumptions"
+        ) as mock_schedule:
+            client.post(f"/aeroplanes/{aeroplane_uuid}/recompute")
+            client.post(f"/aeroplanes/{aeroplane_uuid}/recompute")
+
+        assert mock_schedule.call_count == 2

--- a/frontend/__tests__/InfoChipRow.test.tsx
+++ b/frontend/__tests__/InfoChipRow.test.tsx
@@ -360,9 +360,12 @@ describe("Info Chip Row", () => {
     expect(bRefChip.textContent).toMatch(/=\s*–/);
   });
 
-  // gh-575: refresh button invokes mutate (SWR revalidation) on click.
-  it("renders a refresh button that calls mutate when clicked", async () => {
-    const mutate = vi.fn();
+  // gh-687: refresh button must force a recompute (POST /recompute),
+  // not just re-fetch the cached context. Previously it only called
+  // mutate() on the SWR key, which made the button feel like a no-op
+  // because the backend cached context never changed.
+  it("renders a force-recompute button that POSTs to /recompute and revalidates", async () => {
+    const mutate = vi.fn().mockResolvedValue(undefined);
     (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
       data: { v_cruise_mps: 18.0, reynolds: 230000, mac_m: 0.21, x_np_m: 0.085, target_static_margin: 0.12, cg_agg_m: 0.092 },
       isLoading: false,
@@ -370,19 +373,36 @@ describe("Info Chip Row", () => {
       mutate,
     });
 
-    const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
-    render(<InfoChipRow aeroplaneId="42" cgAero={0.073} />);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 202 }));
 
-    const button = screen.getByRole("button", { name: /refresh computation context/i });
-    expect(button).toBeInTheDocument();
-    expect(button).not.toBeDisabled();
+    try {
+      const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
+      render(<InfoChipRow aeroplaneId="42" cgAero={0.073} />);
 
-    fireEvent.click(button);
-    expect(mutate).toHaveBeenCalledTimes(1);
+      const button = screen.getByRole("button", { name: /force recompute/i });
+      expect(button).toBeInTheDocument();
+      expect(button).not.toBeDisabled();
+
+      fireEvent.click(button);
+      // Wait for the awaited fetch + mutate chain to settle.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(String(url)).toMatch(/\/aeroplanes\/42\/recompute$/);
+      expect(init?.method).toBe("POST");
+      expect(mutate).toHaveBeenCalledTimes(1);
+    } finally {
+      fetchMock.mockRestore();
+    }
   });
 
-  // gh-575: refresh button is disabled while a recompute is in flight.
-  it("disables refresh button while isRecomputing is true", async () => {
+  // gh-575/gh-687: button is disabled (and does not POST) while a
+  // recompute is already in flight.
+  it("disables force-recompute button while isRecomputing is true", async () => {
     const mutate = vi.fn();
     (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
       data: { v_cruise_mps: 18.0, reynolds: 230000, mac_m: 0.21, x_np_m: 0.085, target_static_margin: 0.12, cg_agg_m: 0.092 },
@@ -391,14 +411,23 @@ describe("Info Chip Row", () => {
       mutate,
     });
 
-    const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
-    render(<InfoChipRow aeroplaneId="42" cgAero={0.073} isRecomputing />);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 202 }),
+    );
 
-    const button = screen.getByRole("button", { name: /refresh computation context/i });
-    expect(button).toBeDisabled();
+    try {
+      const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
+      render(<InfoChipRow aeroplaneId="42" cgAero={0.073} isRecomputing />);
 
-    fireEvent.click(button);
-    expect(mutate).not.toHaveBeenCalled();
+      const button = screen.getByRole("button", { name: /force recompute/i });
+      expect(button).toBeDisabled();
+
+      fireEvent.click(button);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(mutate).not.toHaveBeenCalled();
+    } finally {
+      fetchMock.mockRestore();
+    }
   });
 
   // gh-579: SM chip must render for tailless aircraft.

--- a/frontend/components/workbench/InfoChipRow.tsx
+++ b/frontend/components/workbench/InfoChipRow.tsx
@@ -7,6 +7,7 @@ import { GeometryChipRow } from "@/components/workbench/GeometryChipRow";
 import { PolarChipRow } from "@/components/workbench/PolarChipRow";
 import { StabilityChipRow } from "@/components/workbench/StabilityChipRow";
 import { TaillessBanner } from "./TaillessBanner";
+import { API_BASE } from "@/lib/fetcher";
 
 interface Props {
   readonly aeroplaneId: string | null;
@@ -19,6 +20,22 @@ export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: P
   const { data: ctx, mutate } = useComputationContext(aeroplaneId, { isRecomputing });
   const recomputing = !!isRecomputing;
   const isTailless = !!ctx?.is_tailless;
+
+  // gh-687: refresh button must force a recompute, not just re-fetch
+  // the cached context. POST /aeroplanes/{id}/recompute schedules the
+  // same background job that AssumptionChanged events schedule;
+  // useRecomputeStatus then flips isRecomputing=true and the chip row
+  // polls computation-context every 1.5s until the job finishes.
+  const handleForceRecompute = async () => {
+    if (!aeroplaneId) return;
+    try {
+      await fetch(`${API_BASE}/aeroplanes/${aeroplaneId}/recompute`, {
+        method: "POST",
+      });
+    } finally {
+      await mutate();
+    }
+  };
 
   // gh-575: Recomputing pill + refresh button live in Row 1's rightSlot
   // so the in-flight state is co-located with the action that triggered it.
@@ -35,9 +52,9 @@ export function InfoChipRow({ aeroplaneId, cgAero, isRecomputing, rightSlot }: P
       )}
       <button
         type="button"
-        aria-label="Refresh computation context"
-        onClick={() => mutate()}
-        disabled={recomputing}
+        aria-label="Force recompute"
+        onClick={handleForceRecompute}
+        disabled={recomputing || !aeroplaneId}
         className="flex items-center gap-1 rounded-full bg-card-muted px-2.5 py-1.5 text-muted-foreground hover:bg-muted hover:text-foreground focus:outline-none focus-visible:ring-1 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50"
       >
         <RefreshCw size={12} />


### PR DESCRIPTION
## Summary

- Workbench refresh button was a no-op: it only called SWR `mutate()` on the **cached** computation-context endpoint, so users perceived "nothing happens" when clicking it.
- Add `POST /aeroplanes/{id}/recompute` that enqueues the same background job `AssumptionChanged` / `GeometryChanged` events enqueue (`job_tracker.schedule_recompute_assumptions`).
- Frontend button now POSTs the endpoint, then `mutate()`s the cached context. `useRecomputeStatus` polling flips `isRecomputing=true` while the job runs, so the chip row resumes its 1.5 s polling and the "Recomputing…" pill appears automatically.
- Bonus: `useTailSizing.recomputeOnce()` already expected this endpoint — its pencil-action becomes functional too.

Closes #687

## Test plan

- [x] `poetry run pytest app/tests/test_recompute_endpoint.py` — 3 new tests cover 202 + scheduling, 404, and repeated calls.
- [x] `poetry run pytest -m "not slow"` — 3860 passed, no regressions.
- [x] `cd frontend && npx vitest run __tests__/InfoChipRow.test.tsx` — 17/17 passed (button now asserts POST + revalidate, plus disabled-state).
- [x] `poetry run ruff check` on touched backend files — clean.
- [ ] Manual: click the refresh button in the workbench → expect a `Recomputing…` pill, chip values refreshed after the job completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)