### PR TITLE
perf(gh-690): vectorize AeroBuildup sweeps in assumption_compute_service

### DIFF
--- a/app/services/assumption_compute_service.py
+++ b/app/services/assumption_compute_service.py
@@ -871,7 +871,12 @@ def _stability_run_at_cruise(asb_airplane, v_cruise: float) -> tuple[float, floa
 def _coarse_alpha_sweep(
     asb_airplane, v_cruise: float, config: AircraftComputationConfigModel
 ) -> float:
-    """Returns approximate stall_alpha_deg (alpha where CL peaks)."""
+    """Returns approximate stall_alpha_deg (alpha where CL peaks).
+
+    gh-690: vectorised — one ``AeroBuildup.run()`` call over the whole α
+    sweep. AeroSandbox 4.2.x accepts numpy-array op-points and returns
+    same-shape result fields.
+    """
     import aerosandbox as asb
 
     alphas = np.arange(
@@ -880,12 +885,12 @@ def _coarse_alpha_sweep(
         config.coarse_alpha_step_deg,
     )
     xyz_ref = list(asb_airplane.xyz_ref) if asb_airplane.xyz_ref is not None else [0.0, 0.0, 0.0]
-    cls: list[float] = []
-    for a in alphas:
-        op = asb.OperatingPoint(velocity=v_cruise, alpha=float(a))
-        abu = asb.AeroBuildup(airplane=asb_airplane, op_point=op, xyz_ref=xyz_ref)
-        r = abu.run()
-        cls.append(_extract_scalar(r, "CL", default=0.0))
+    op = asb.OperatingPoint(
+        velocity=np.full_like(alphas, v_cruise, dtype=float),
+        alpha=alphas.astype(float),
+    )
+    r = asb.AeroBuildup(airplane=asb_airplane, op_point=op, xyz_ref=xyz_ref).run()
+    cls = _extract_array(r, "CL", n=len(alphas), default=0.0)
     return float(alphas[int(np.argmax(cls))])
 
 
@@ -918,39 +923,34 @@ def _fine_sweep_cl_max(
 
     xyz_ref = list(asb_airplane.xyz_ref) if asb_airplane.xyz_ref is not None else [0.0, 0.0, 0.0]
     s_ref = float(asb_airplane.s_ref)
-    cl_max = -float("inf")
-    cl_list: list[float] = []
-    cd_list: list[float] = []
-    v_list: list[float] = []
-    cdi_list: list[float] = []
-    for v in velocities:
-        for a in alphas:
-            op = asb.OperatingPoint(velocity=float(v), alpha=float(a))
-            abu = asb.AeroBuildup(airplane=asb_airplane, op_point=op, xyz_ref=xyz_ref)
-            r = abu.run()
-            cl = _extract_scalar(r, "CL", default=0.0)
-            cd = _extract_scalar(r, "CD", default=0.0)
-            # gh-636: D_induced is exposed by AeroBuildup per op-point.
-            # CDi = D_induced / (q · S_ref). NaN/missing → fall back to NaN so
-            # the consumer can detect and skip these entries.
-            d_induced = _extract_scalar(r, "D_induced", default=float("nan"))
-            q = 0.5 * 1.225 * float(v) ** 2  # ISA sea-level rho; consistent with op
-            cdi = (
-                d_induced / (q * s_ref) if (s_ref > 0 and np.isfinite(d_induced)) else float("nan")
-            )
-            cl_list.append(cl)
-            cd_list.append(cd)
-            v_list.append(float(v))
-            cdi_list.append(cdi)
-            if cl > cl_max:
-                cl_max = cl
-    return (
-        float(cl_max),
-        np.asarray(cl_list, dtype=float),
-        np.asarray(cd_list, dtype=float),
-        np.asarray(v_list, dtype=float),
-        np.asarray(cdi_list, dtype=float),
-    )
+
+    # gh-690: one vectorised .run() over the flattened V × α grid (was
+    # ~150 calls per polar config). meshgrid + indexing="xy" gives
+    # V-outer / α-inner ravel order, which matches the pre-refactor
+    # nested-loop order that downstream consumers index against.
+    a_grid, v_grid = np.meshgrid(alphas, velocities, indexing="xy")
+    v_flat = v_grid.ravel().astype(float)
+    a_flat = a_grid.ravel().astype(float)
+    n_pts = v_flat.size
+    op = asb.OperatingPoint(velocity=v_flat, alpha=a_flat)
+    r = asb.AeroBuildup(airplane=asb_airplane, op_point=op, xyz_ref=xyz_ref).run()
+
+    cl_arr = _extract_array(r, "CL", n=n_pts, default=0.0)
+    cd_arr = _extract_array(r, "CD", n=n_pts, default=0.0)
+    # gh-636: D_induced exposed per op-point. CDi = D_induced / (q · S_ref).
+    # Keep NaNs where AeroBuildup returned NaN/missing so the consumer can
+    # detect and skip these entries (same contract as the pre-refactor code).
+    d_induced = _extract_array(r, "D_induced", n=n_pts, default=float("nan"))
+    q = 0.5 * 1.225 * v_flat ** 2  # ISA sea-level rho; consistent with op
+    with np.errstate(invalid="ignore", divide="ignore"):
+        cdi_arr = np.where(
+            (s_ref > 0) & np.isfinite(d_induced),
+            d_induced / (q * s_ref),
+            np.nan,
+        )
+
+    cl_max = float(np.max(cl_arr)) if cl_arr.size > 0 else -float("inf")
+    return (cl_max, cl_arr, cd_arr, v_flat, cdi_arr)
 
 
 def _extract_cl_alpha_from_linear_sweep(
@@ -981,15 +981,14 @@ def _extract_cl_alpha_from_linear_sweep(
     alphas_deg = np.arange(alpha_min_deg, alpha_max_deg + 0.01, alpha_step_deg)
     alphas_rad = np.deg2rad(alphas_deg)
 
-    cls: list[float] = []
-    for a in alphas_deg:
-        op = asb.OperatingPoint(velocity=v_cruise, alpha=float(a))
-        abu = asb.AeroBuildup(airplane=asb_airplane, op_point=op, xyz_ref=xyz_ref)
-        r = abu.run()
-        cls.append(_extract_scalar(r, "CL", default=float("nan")))
-
-    alphas_arr = np.array(alphas_rad)
-    cls_arr = np.array(cls)
+    # gh-690: vectorised — one AeroBuildup.run over the whole α sweep.
+    op = asb.OperatingPoint(
+        velocity=np.full_like(alphas_deg, v_cruise, dtype=float),
+        alpha=alphas_deg.astype(float),
+    )
+    r = asb.AeroBuildup(airplane=asb_airplane, op_point=op, xyz_ref=xyz_ref).run()
+    cls_arr = _extract_array(r, "CL", n=len(alphas_deg), default=float("nan"))
+    alphas_arr = np.asarray(alphas_rad)
 
     # Discard NaN points (convergence failures)
     mask = np.isfinite(cls_arr)
@@ -1057,6 +1056,32 @@ def _extract_scalar(result: Any, key: str, *, default: float) -> float:
         val = getattr(result, key, None)
     scalar = _scalar(val)
     return float(scalar) if scalar is not None else default
+
+
+def _extract_array(result: Any, key: str, *, n: int, default: float) -> np.ndarray:
+    """Extract a length-``n`` 1-D float array from a vectorised AeroBuildup result.
+
+    gh-690 companion to ``_extract_scalar``: when ``AeroBuildup.run()`` is
+    called with an array-shaped ``OperatingPoint``, each result field is a
+    same-shape array (or a 0-D array if the array happened to be length 1
+    on certain CasADi paths). Always return a 1-D ``np.ndarray`` of length
+    ``n``, filling with ``default`` on missing keys or non-array values to
+    preserve the contract of the pre-refactor per-point loop.
+    """
+    if isinstance(result, dict):
+        val = result.get(key)
+    else:
+        val = getattr(result, key, None)
+    if val is None:
+        return np.full(n, default, dtype=float)
+    arr = np.asarray(val, dtype=float).ravel()
+    if arr.size == n:
+        return arr
+    if arr.size == 1 and n == 1:
+        return arr.reshape(1)
+    # Shape mismatch (shouldn't happen with current ASB) — fall back to
+    # default so a downstream NaN-aware consumer can still proceed.
+    return np.full(n, default, dtype=float)
 
 
 def _build_rejection(

--- a/app/tests/test_aerobuildup_sweep_vectorization.py
+++ b/app/tests/test_aerobuildup_sweep_vectorization.py
@@ -1,0 +1,346 @@
+"""Tests for gh-690 vectorization of AeroBuildup sweeps.
+
+The three sweep functions in ``app/services/assumption_compute_service.py``
+historically called ``asb.AeroBuildup(...).run()`` once per (V, α) point.
+gh-690 collapses each one into a single vectorised call over the full grid.
+
+Two test layers:
+
+1. **Single-call** — pins the refactor itself. Counts ``AeroBuildup.run``
+   invocations per sweep-function call: must be exactly 1. FAILS before
+   the refactor, PASSES after.
+
+2. **Equivalence** — pins the *output* against an inlined point-by-point
+   serial reference computed in the test itself. Catches regressions if
+   anyone later tweaks the vectorised implementation.
+
+The fixture is a tiny rectangular wing built directly with the AeroSandbox
+API (no DB / no conftest factory) so the whole file runs in well under
+the slow-test budget. AeroBuildup is deterministic, so vectorised vs.
+serial should agree to machine precision (``atol=1e-9``).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+asb = pytest.importorskip("aerosandbox")
+
+from app.models.computation_config import COMPUTATION_CONFIG_DEFAULTS  # noqa: E402
+from app.services.assumption_compute_service import (  # noqa: E402
+    _coarse_alpha_sweep,
+    _extract_cl_alpha_from_linear_sweep,
+    _extract_scalar,
+    _fine_sweep_cl_max,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+class _SweepConfig:
+    """Tiny stand-in for AircraftComputationConfigModel.
+
+    ``_coarse_alpha_sweep`` and ``_fine_sweep_cl_max`` only read attribute
+    values — no SQLAlchemy machinery needed. Defaults match
+    COMPUTATION_CONFIG_DEFAULTS exactly so behaviour matches production.
+    """
+
+    def __init__(self, **overrides):
+        for k, v in COMPUTATION_CONFIG_DEFAULTS.items():
+            setattr(self, k, v)
+        for k, v in overrides.items():
+            setattr(self, k, v)
+
+
+@pytest.fixture(scope="module")
+def tiny_airplane():
+    """A minimal rectangular wing — enough to exercise AeroBuildup / NeuralFoil.
+
+    Module-scoped so the airfoil's NeuralFoil cache is built once.
+    """
+    naca = asb.Airfoil("naca2412")
+    wing = asb.Wing(
+        symmetric=True,
+        xsecs=[
+            asb.WingXSec(xyz_le=[0.0, 0.0, 0.0], chord=0.25, airfoil=naca),
+            asb.WingXSec(xyz_le=[0.0, 1.0, 0.0], chord=0.25, airfoil=naca),
+        ],
+    )
+    plane = asb.Airplane(wings=[wing], xyz_ref=[0.0, 0.0, 0.0])
+    plane.s_ref = 0.5  # 2 × 1.0 × 0.25
+    plane.b_ref = 2.0
+    plane.c_ref = 0.25
+    return plane
+
+
+@pytest.fixture
+def sweep_config():
+    """Reduced-grid config so the tests stay fast.
+
+    Smaller than the production default, large enough to exercise the
+    array-flattening path (and reveal any V-outer / α-inner ordering bug).
+    """
+    return _SweepConfig(
+        coarse_alpha_min_deg=-2.0,
+        coarse_alpha_max_deg=8.0,
+        coarse_alpha_step_deg=2.0,  # → 6 α points
+        fine_alpha_margin_deg=2.0,
+        fine_alpha_step_deg=1.0,  # → 5 α points around the coarse peak
+        fine_velocity_count=3,  # → 3 velocities
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper: count AeroBuildup.run() invocations during a callable
+# ---------------------------------------------------------------------------
+
+
+def _count_runs(monkeypatch):
+    """Wrap ``asb.AeroBuildup.run`` with a counter. Returns the counter dict."""
+    counter = {"n": 0}
+    original = asb.AeroBuildup.run
+
+    def counted_run(self, *args, **kwargs):
+        counter["n"] += 1
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(asb.AeroBuildup, "run", counted_run)
+    return counter
+
+
+# ---------------------------------------------------------------------------
+# 1. Single-call tests (FAIL before refactor, PASS after)
+# ---------------------------------------------------------------------------
+
+
+class TestSingleAeroBuildupCall:
+    def test_coarse_alpha_sweep_makes_one_run_call(
+        self, tiny_airplane, sweep_config, monkeypatch
+    ):
+        counter = _count_runs(monkeypatch)
+        _coarse_alpha_sweep(tiny_airplane, v_cruise=15.0, config=sweep_config)
+        assert counter["n"] == 1
+
+    def test_fine_sweep_cl_max_makes_one_run_call(
+        self, tiny_airplane, sweep_config, monkeypatch
+    ):
+        counter = _count_runs(monkeypatch)
+        _fine_sweep_cl_max(
+            tiny_airplane,
+            stall_alpha_deg=10.0,
+            v_cruise=15.0,
+            v_max=25.0,
+            config=sweep_config,
+        )
+        assert counter["n"] == 1
+
+    def test_cl_alpha_linear_sweep_makes_one_run_call(
+        self, tiny_airplane, monkeypatch
+    ):
+        counter = _count_runs(monkeypatch)
+        _extract_cl_alpha_from_linear_sweep(
+            tiny_airplane,
+            v_cruise=15.0,
+            alpha_min_deg=-2.0,
+            alpha_max_deg=6.0,
+            alpha_step_deg=2.0,
+        )
+        assert counter["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 2. Equivalence tests against inlined point-by-point serial references
+# ---------------------------------------------------------------------------
+
+
+def _serial_coarse_alpha_sweep(asb_airplane, v_cruise, config):
+    """Point-by-point baseline mirroring the pre-refactor implementation."""
+    xyz_ref = (
+        list(asb_airplane.xyz_ref) if asb_airplane.xyz_ref is not None else [0.0, 0.0, 0.0]
+    )
+    alphas = np.arange(
+        config.coarse_alpha_min_deg,
+        config.coarse_alpha_max_deg + 0.01,
+        config.coarse_alpha_step_deg,
+    )
+    cls = []
+    for a in alphas:
+        op = asb.OperatingPoint(velocity=v_cruise, alpha=float(a))
+        r = asb.AeroBuildup(airplane=asb_airplane, op_point=op, xyz_ref=xyz_ref).run()
+        cls.append(_extract_scalar(r, "CL", default=0.0))
+    return float(alphas[int(np.argmax(cls))])
+
+
+def _serial_fine_sweep_cl_max(asb_airplane, stall_alpha_deg, v_cruise, v_max, config):
+    """Point-by-point baseline mirroring the pre-refactor implementation."""
+    xyz_ref = (
+        list(asb_airplane.xyz_ref) if asb_airplane.xyz_ref is not None else [0.0, 0.0, 0.0]
+    )
+    s_ref = float(asb_airplane.s_ref)
+    alpha_min = stall_alpha_deg - config.fine_alpha_margin_deg
+    alpha_max = stall_alpha_deg + config.fine_alpha_margin_deg
+    alphas = np.arange(alpha_min, alpha_max + 0.01, config.fine_alpha_step_deg)
+    velocities = np.linspace(max(v_cruise * 0.5, 3.0), v_max, config.fine_velocity_count)
+    cl_list, cd_list, v_list, cdi_list = [], [], [], []
+    cl_max = -float("inf")
+    for v in velocities:
+        for a in alphas:
+            op = asb.OperatingPoint(velocity=float(v), alpha=float(a))
+            r = asb.AeroBuildup(airplane=asb_airplane, op_point=op, xyz_ref=xyz_ref).run()
+            cl = _extract_scalar(r, "CL", default=0.0)
+            cd = _extract_scalar(r, "CD", default=0.0)
+            d_ind = _extract_scalar(r, "D_induced", default=float("nan"))
+            q = 0.5 * 1.225 * float(v) ** 2
+            cdi = d_ind / (q * s_ref) if (s_ref > 0 and np.isfinite(d_ind)) else float("nan")
+            cl_list.append(cl)
+            cd_list.append(cd)
+            v_list.append(float(v))
+            cdi_list.append(cdi)
+            if cl > cl_max:
+                cl_max = cl
+    return (
+        float(cl_max),
+        np.asarray(cl_list, dtype=float),
+        np.asarray(cd_list, dtype=float),
+        np.asarray(v_list, dtype=float),
+        np.asarray(cdi_list, dtype=float),
+    )
+
+
+def _serial_cl_alpha_linear_sweep(
+    asb_airplane, v_cruise, alpha_min_deg, alpha_max_deg, alpha_step_deg
+):
+    """Point-by-point baseline mirroring the pre-refactor implementation."""
+    xyz_ref = (
+        list(asb_airplane.xyz_ref) if asb_airplane.xyz_ref is not None else [0.0, 0.0, 0.0]
+    )
+    alphas_deg = np.arange(alpha_min_deg, alpha_max_deg + 0.01, alpha_step_deg)
+    cls = []
+    for a in alphas_deg:
+        op = asb.OperatingPoint(velocity=v_cruise, alpha=float(a))
+        r = asb.AeroBuildup(airplane=asb_airplane, op_point=op, xyz_ref=xyz_ref).run()
+        cls.append(_extract_scalar(r, "CL", default=float("nan")))
+    return alphas_deg, np.asarray(cls, dtype=float)
+
+
+class TestEquivalenceAgainstSerialBaseline:
+    def test_coarse_alpha_sweep_matches_serial(self, tiny_airplane, sweep_config):
+        vectorised = _coarse_alpha_sweep(tiny_airplane, v_cruise=15.0, config=sweep_config)
+        serial = _serial_coarse_alpha_sweep(tiny_airplane, v_cruise=15.0, config=sweep_config)
+        # Both return a peak α picked from the same grid → exact equality.
+        assert vectorised == serial
+
+    def test_fine_sweep_cl_max_matches_serial(self, tiny_airplane, sweep_config):
+        cl_max_v, cl_v, cd_v, v_v, cdi_v = _fine_sweep_cl_max(
+            tiny_airplane,
+            stall_alpha_deg=10.0,
+            v_cruise=15.0,
+            v_max=25.0,
+            config=sweep_config,
+        )
+        cl_max_s, cl_s, cd_s, v_s, cdi_s = _serial_fine_sweep_cl_max(
+            tiny_airplane,
+            stall_alpha_deg=10.0,
+            v_cruise=15.0,
+            v_max=25.0,
+            config=sweep_config,
+        )
+        assert abs(cl_max_v - cl_max_s) < 1e-9
+        np.testing.assert_allclose(cl_v, cl_s, rtol=0, atol=1e-9)
+        np.testing.assert_allclose(cd_v, cd_s, rtol=0, atol=1e-9)
+        np.testing.assert_allclose(v_v, v_s, rtol=0, atol=1e-9)
+        # NaN positions in CDi must align element-by-element.
+        nan_mask_v = np.isnan(cdi_v)
+        nan_mask_s = np.isnan(cdi_s)
+        assert np.array_equal(nan_mask_v, nan_mask_s)
+        np.testing.assert_allclose(
+            cdi_v[~nan_mask_v], cdi_s[~nan_mask_s], rtol=0, atol=1e-9
+        )
+
+    def test_cl_alpha_linear_sweep_matches_serial(self, tiny_airplane):
+        vectorised = _extract_cl_alpha_from_linear_sweep(
+            tiny_airplane,
+            v_cruise=15.0,
+            alpha_min_deg=-2.0,
+            alpha_max_deg=6.0,
+            alpha_step_deg=2.0,
+        )
+
+        alphas_deg, cls = _serial_cl_alpha_linear_sweep(
+            tiny_airplane,
+            v_cruise=15.0,
+            alpha_min_deg=-2.0,
+            alpha_max_deg=6.0,
+            alpha_step_deg=2.0,
+        )
+        alphas_rad = np.deg2rad(alphas_deg)
+        mask = np.isfinite(cls)
+        a_mat = np.column_stack([alphas_rad[mask], np.ones_like(alphas_rad[mask])])
+        coeffs, *_ = np.linalg.lstsq(a_mat, cls[mask], rcond=None)
+        serial_cl_alpha = float(coeffs[0])
+
+        # Both either produce a number or both reject via the R² gate.
+        if vectorised is None:
+            # If the vectorised path rejected, the serial fit on the same
+            # data should also produce a low R². We don't recompute R² here
+            # — leave the rejection to the production-side gate.
+            pytest.skip("vectorised CL_α extraction rejected via R² gate")
+        assert abs(vectorised - serial_cl_alpha) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# 3. Performance smoke test (marked slow)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+class TestPerformanceSmoke:
+    """Lower bound on the speedup from vectorisation.
+
+    Same hardware, same fixture, deterministic ratio — avoids brittle
+    absolute wall-clock thresholds. With the production-default grid
+    (~160 ops for the fine sweep, ~15 for the coarse sweep), the speedup
+    is expected ~10–50×; the assertion is a loose 3× to leave headroom
+    for noisy CI runners.
+    """
+
+    def test_fine_sweep_speedup_at_least_3x_over_serial(self, tiny_airplane):
+        from time import perf_counter
+
+        # Production-default sweep grid — the configuration that dominates
+        # real recompute wall-clock.
+        config = _SweepConfig()  # all defaults
+
+        # Warm the NeuralFoil cache for this airfoil so the first sweep
+        # doesn't pay the one-shot setup cost on top of its loop work.
+        _coarse_alpha_sweep(tiny_airplane, v_cruise=15.0, config=config)
+
+        serial_start = perf_counter()
+        _serial_fine_sweep_cl_max(
+            tiny_airplane,
+            stall_alpha_deg=12.0,
+            v_cruise=15.0,
+            v_max=25.0,
+            config=config,
+        )
+        serial_dt = perf_counter() - serial_start
+
+        vec_start = perf_counter()
+        _fine_sweep_cl_max(
+            tiny_airplane,
+            stall_alpha_deg=12.0,
+            v_cruise=15.0,
+            v_max=25.0,
+            config=config,
+        )
+        vec_dt = perf_counter() - vec_start
+
+        speedup = serial_dt / vec_dt if vec_dt > 0 else float("inf")
+        assert speedup >= 3.0, (
+            f"Expected ≥3× speedup from vectorisation, got {speedup:.1f}× "
+            f"(serial={serial_dt * 1000:.0f} ms, vectorised={vec_dt * 1000:.0f} ms)"
+        )

--- a/app/tests/test_gust_envelope.py
+++ b/app/tests/test_gust_envelope.py
@@ -915,27 +915,23 @@ class TestExtractClAlphaFromLinearSweep:
 
     def test_success_path_returns_positive_cl_alpha(self):
         """Happy path: linear CL data → returns positive CL_α in rad⁻¹."""
-        import math
         from types import SimpleNamespace
         from unittest.mock import patch
 
-        from app.services.assumption_compute_service import _extract_cl_alpha_from_linear_sweep
-
-        # Simulate 9 alpha points [-2, -1, ..., 6] with CL = 5.7 * alpha_rad
         import numpy as np
 
+        from app.services.assumption_compute_service import _extract_cl_alpha_from_linear_sweep
+
+        # gh-690: AeroBuildup is now called ONCE with array op-points; the
+        # mock returns a single result whose CL is the full per-α array.
         alphas_deg = np.arange(-2.0, 6.01, 1.0)
         alphas_rad = np.deg2rad(alphas_deg)
         cl_true = 5.7 * alphas_rad  # perfect linear, CL_α = 5.7 rad⁻¹
-
-        results_iter = iter([SimpleNamespace(CL=cl, CD=0.03) for cl in cl_true])
-
-        def fake_run(self_):
-            return next(results_iter)
+        vec_result = SimpleNamespace(CL=cl_true, CD=np.full_like(cl_true, 0.03))
 
         asb_airplane = self._make_fake_airplane()
 
-        with patch("aerosandbox.AeroBuildup.run", fake_run):
+        with patch("aerosandbox.AeroBuildup.run", lambda self_: vec_result):
             result = _extract_cl_alpha_from_linear_sweep(asb_airplane, v_cruise=18.0)
 
         assert result is not None
@@ -959,29 +955,6 @@ class TestExtractClAlphaFromLinearSweep:
 
     def test_low_r2_returns_none(self):
         """When R² < threshold (nonlinear lift curve), returns None."""
-        import math
-        import random
-        from types import SimpleNamespace
-        from unittest.mock import patch
-
-        from app.services.assumption_compute_service import _extract_cl_alpha_from_linear_sweep
-
-        asb_airplane = self._make_fake_airplane()
-
-        # Highly nonlinear CL values: zigzag pattern → very low R²
-        # 9 alpha points: [-2, -1, 0, 1, 2, 3, 4, 5, 6]
-        # Give alternating high/low values so regression is terrible
-        cl_values = [1.0, -1.0, 1.5, -1.5, 2.0, -2.0, 1.0, -1.0, 0.5]
-        results = iter([SimpleNamespace(CL=cl, CD=0.03) for cl in cl_values])
-
-        with patch("aerosandbox.AeroBuildup.run", lambda self_: next(results)):
-            result = _extract_cl_alpha_from_linear_sweep(asb_airplane, v_cruise=18.0)
-
-        assert result is None
-
-    def test_negative_slope_returns_none(self):
-        """When fitted CL_α ≤ 0 (inverted lift curve), returns None."""
-        import math
         from types import SimpleNamespace
         from unittest.mock import patch
 
@@ -991,14 +964,34 @@ class TestExtractClAlphaFromLinearSweep:
 
         asb_airplane = self._make_fake_airplane()
 
-        # CL decreasing with alpha → negative slope
+        # gh-690: vectorised mock — zigzag CL pattern over the full 9-α grid
+        # so regression R² stays well below the 0.995 threshold.
+        cl_values = np.array([1.0, -1.0, 1.5, -1.5, 2.0, -2.0, 1.0, -1.0, 0.5])
+        vec_result = SimpleNamespace(CL=cl_values, CD=np.full_like(cl_values, 0.03))
+
+        with patch("aerosandbox.AeroBuildup.run", lambda self_: vec_result):
+            result = _extract_cl_alpha_from_linear_sweep(asb_airplane, v_cruise=18.0)
+
+        assert result is None
+
+    def test_negative_slope_returns_none(self):
+        """When fitted CL_α ≤ 0 (inverted lift curve), returns None."""
+        from types import SimpleNamespace
+        from unittest.mock import patch
+
+        import numpy as np
+
+        from app.services.assumption_compute_service import _extract_cl_alpha_from_linear_sweep
+
+        asb_airplane = self._make_fake_airplane()
+
+        # gh-690: vectorised mock — perfect negative slope CL = -5.0·α_rad.
         alphas_deg = np.arange(-2.0, 6.01, 1.0)
         alphas_rad = np.deg2rad(alphas_deg)
-        # Perfect negative slope: CL = -5.0 * alpha_rad
-        cl_values = list(-5.0 * alphas_rad)
-        results = iter([SimpleNamespace(CL=cl, CD=0.03) for cl in cl_values])
+        cl_values = -5.0 * alphas_rad
+        vec_result = SimpleNamespace(CL=cl_values, CD=np.full_like(cl_values, 0.03))
 
-        with patch("aerosandbox.AeroBuildup.run", lambda self_: next(results)):
+        with patch("aerosandbox.AeroBuildup.run", lambda self_: vec_result):
             result = _extract_cl_alpha_from_linear_sweep(asb_airplane, v_cruise=18.0)
 
         assert result is None
@@ -1030,16 +1023,17 @@ class TestExtractClAlphaFromLinearSweep:
 
         asb_airplane = self._make_fake_airplane()
 
-        # 9 alpha points: 3 valid, 6 NaN
+        # gh-690: vectorised mock — exactly 3 valid CLs, the rest NaN.
         alphas_deg = np.arange(-2.0, 6.01, 1.0)
         alphas_rad = np.deg2rad(alphas_deg)
-        # Only first 3 get real values, rest NaN
-        cl_values = list(5.7 * alphas_rad[:3]) + [float("nan")] * (len(alphas_rad) - 3)
-        results = iter([SimpleNamespace(CL=cl, CD=0.03) for cl in cl_values])
+        cl_values = np.concatenate(
+            [5.7 * alphas_rad[:3], np.full(len(alphas_rad) - 3, np.nan)]
+        )
+        vec_result = SimpleNamespace(CL=cl_values, CD=np.full_like(cl_values, 0.03))
 
-        with patch("aerosandbox.AeroBuildup.run", lambda self_: next(results)):
+        with patch("aerosandbox.AeroBuildup.run", lambda self_: vec_result):
             # With only 3 points R² might be perfect (3 points → perfect line)
-            # but the result will be some float (not None from the <3 check)
+            # but the result will be some float (not None from the <3 check).
             result = _extract_cl_alpha_from_linear_sweep(asb_airplane, v_cruise=18.0)
         # Result may be None (low R² or negative slope) or a float — either is acceptable.
         # Key thing: the < 3 guard did NOT fire for exactly 3 valid points.


### PR DESCRIPTION
## Summary

- Three sweep helpers in `app/services/assumption_compute_service.py` called `asb.AeroBuildup(...).run()` once per (V, α) point — **~600 total `.run()` calls** per recompute at production defaults. Each call carried ~14–50 ms of Python/CasADi/NeuralFoil-setup overhead that dwarfed the actual aero work.
- After #687 wired the workbench refresh button to a real recompute, the resulting 5–15 s wall-clock latency became directly user-visible.
- AeroSandbox 4.2.x already accepts numpy-array `OperatingPoint`s and returns same-shape result fields, so each sweep collapses to a **single** `.run()` call over the flattened grid.

## What changed

- `_coarse_alpha_sweep`: 1 vectorised `.run()` over the α grid.
- `_fine_sweep_cl_max`: 1 vectorised `.run()` over the V × α grid via `np.meshgrid(..., indexing="xy")` + `.ravel()`, **preserving** the previous V-outer / α-inner ordering that downstream consumers (parabolic fit, gh-636 `e_oswald`-from-CDi extraction, Re-table builder) iterate against.
- `_extract_cl_alpha_from_linear_sweep`: 1 vectorised `.run()` over the α grid.
- New helper `_extract_array` mirrors `_extract_scalar` for vectorised results. NaN positions in `D_induced` → `CDi` are preserved by a masked `np.where`, so the downstream "NaN means skip" contract still holds.

## Benchmark

Local micro-benchmark, NACA2412 rectangular wing, 360-op fine sweep (8 V × 45 α — slightly bigger than production default):

| | calls | time | ms/op |
|---|---|---|---|
| serial (pre-refactor) | 360 | **2234 ms** | 6.2 |
| vectorised | 1 | **14 ms** | 0.04 |
| **speedup** | | **~160×** | |

Real-airplane recomputes are expected ~10–50× faster (strips/NeuralFoil scale, but fixed-cost dominates).

## Test plan

New file `app/tests/test_aerobuildup_sweep_vectorization.py`:

- [x] **Single-call tests** count `AeroBuildup.run` invocations per sweep function: exactly **1** each. These were RED before the refactor (6/15/5 calls), GREEN after.
- [x] **Equivalence tests** pin the new output against an **inlined point-by-point serial reference** computed in the test (faithful copy of the pre-refactor loop, not a copy of the new code). `atol=1e-9` for `cl_arr`/`cd_arr`/`v_arr`, plus element-wise NaN-mask equality for `cdi_arr`.
- [x] **Perf-smoke test** (`@pytest.mark.slow`) asserts **≥3×** speedup vs the serial reference on the production-default grid (loose threshold; observed ~160× locally).

Updated `app/tests/test_gust_envelope.py::TestExtractClAlphaFromLinearSweep` (4 of 6 tests):

- Old mock pattern fed `AeroBuildup.run` a per-call iterator (`iter([Namespace(CL=cl, CD=...) for cl in cl_values])`). After vectorisation, `run` is called **once** with an array op-point, so the mock now returns a **single** `SimpleNamespace` whose `CL` is the full per-α array.
- `test_success_path_returns_positive_cl_alpha` was failing (mock consumed 1 of 9 iter values → all-NaN fallback → no valid fit). Fixed.
- `test_low_r2_returns_none`, `test_negative_slope_returns_none`, `test_exactly_3_valid_points_passes_threshold` were silently passing for the wrong reason (all-NaN fallback instead of their named scenario). Updated to actually exercise their documented behaviour. The two unchanged tests (`test_nan_handling`, `test_exception`) still verify correctly.

## Verified

- `poetry run pytest -m "not slow"` — **3866 passed**, 1 skipped, 2 xfailed.
- `poetry run pytest app/tests/test_polar_fit_integration.py app/tests/test_aerobuildup_sweep_vectorization.py -m slow` — **16 passed in 13.87 s**. The real-AeroBuildup polar-fit roundtrip on the conventional T-tail fixture still produces `cd0`, `e_oswald`, `cl_max` that pass the same downstream gates (R² > 0.95, `cd0 ∈ [0.010, 0.060]`, `e ∈ [0.6, 1.0]`).
- `poetry run ruff check` on touched files — clean.
- Independent code review — APPROVED (0 BLOCKER/MAJOR/MINOR findings, 1 NIT).

Closes #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)