### PR TITLE
feat(gh-692): surface min sink rate + hide V_x/V_y for pure gliders

### DIFF
--- a/app/services/assumption_compute_service.py
+++ b/app/services/assumption_compute_service.py
@@ -427,6 +427,13 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
     v_min_sink = _min_sink_speed(
         mass, s_ref, cd0_effective, aspect_ratio, oswald_e=e_oswald_effective
     )
+    # gh-692: w_min — vertical speed at V_min_sink, derived in closed form
+    # from the same parabolic-polar scalars. Picard iteration below refines
+    # V_min_sink by <5% for healthy polars; we keep w_min on the scalar
+    # average to match how pilots read it off the speed polar chart.
+    min_sink_rate = _min_sink_rate(
+        mass, s_ref, cd0_effective, aspect_ratio, oswald_e=e_oswald_effective
+    )
 
     # V_max from physics if powered (P/W > 0); otherwise fall back to
     # the user-set goal in the flight profile (gliders set max speed
@@ -529,6 +536,8 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
         "v_s0_mps": round(v_s0, 1) if v_s0 is not None else None,
         "v_md_mps": round(v_md, 1) if v_md is not None else None,
         "v_min_sink_mps": round(v_min_sink, 1) if v_min_sink is not None else None,
+        # gh-692: vertical speed at V_min_sink — Glider/Motorsegler chip.
+        "min_sink_rate_mps": round(min_sink_rate, 2) if min_sink_rate is not None else None,
         # gh-476: extended V-speed set surfaced on the chip row.
         # V_a, V_dive: physics / heuristic (provenance noted in field doc).
         # V_x, V_y: pulled from operating-point rows when they exist;
@@ -1545,6 +1554,37 @@ def _min_sink_speed(
         return None
     weight_n = mass_kg * g
     return float(np.sqrt(2.0 * weight_n / (rho * s_ref_m2 * cl_mp)))
+
+
+def _min_sink_rate(
+    mass_kg: float,
+    s_ref_m2: float,
+    cd0: float,
+    aspect_ratio: float | None,
+    rho: float = 1.225,
+    g: float = 9.81,
+    oswald_e: float = 0.8,
+) -> float | None:
+    """Sea-level minimum sink rate w_min [m/s] — vertical speed at V_min_sink.
+
+    gh-692: the value pilots read off the speed polar as "wieviel Höhe
+    verliere ich pro Sekunde am besten?". Derived in closed form from
+    Anderson §6.7.2 at the min-power point:
+
+        C_L_mp = sqrt(3·π·e·AR·C_D0)
+        C_D_mp = 4·C_D0   (induced drag = 3 × parasitic at this point)
+        (C_D/C_L)_mp = 4·sqrt(C_D0 / (3·π·e·AR))
+        w_min = V_min_sink · (C_D/C_L)_mp
+
+    Same degenerate-input contract as ``_min_sink_speed`` (no wing,
+    zero AR, zero CD0 → None).
+    """
+    v_ms = _min_sink_speed(mass_kg, s_ref_m2, cd0, aspect_ratio, rho=rho, g=g, oswald_e=oswald_e)
+    if v_ms is None:
+        return None
+    # aspect_ratio is guaranteed > 0 here (None / ≤ 0 already returned None above).
+    cd_over_cl = 4.0 * float(np.sqrt(cd0 / (3.0 * np.pi * oswald_e * aspect_ratio)))
+    return float(v_ms * cd_over_cl)
 
 
 def _picard_iterate_speed(

--- a/app/tests/test_assumption_compute_service.py
+++ b/app/tests/test_assumption_compute_service.py
@@ -929,6 +929,80 @@ def test_context_v_x_and_v_y_read_from_existing_ops(client_and_db):
     assert ctx["v_y_mps"] == 15.3
 
 
+# ---------------------------------------------------------------------------
+# gh-692: min sink rate (w_min) — vertical speed at V_min_sink
+# ---------------------------------------------------------------------------
+
+
+def test_context_includes_min_sink_rate_mps(client_and_db):
+    """gh-692: w_min is the vertical speed at V_min_sink — the value pilots
+    read off the speed polar. Derived in closed form from the polar (no
+    AeroBuildup call), so it must populate alongside v_min_sink_mps."""
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db)
+        seed_defaults(db, str(aeroplane.uuid))
+        db.commit()
+        aeroplane_uuid = str(aeroplane.uuid)
+        aeroplane_id = aeroplane.id
+
+    with _enter_patches(flap_ted_max=30.0):
+        with SessionLocal() as db:
+            recompute_assumptions(db, aeroplane_uuid)
+            db.commit()
+
+    ctx = _load_ctx(SessionLocal, aeroplane_id)
+    assert "min_sink_rate_mps" in ctx
+    w_min = ctx["min_sink_rate_mps"]
+    assert w_min is not None
+    # Plausible band for the default fixture (RC-scale clean trainer).
+    assert 0.3 <= w_min <= 2.0, f"w_min={w_min} m/s outside plausible [0.3, 2.0]"
+
+
+def test_min_sink_rate_helper_matches_closed_form_formula():
+    """gh-692: pin the formula directly on the helper, decoupled from the
+    recompute pipeline's effective-value resolution / Picard / clamp.
+
+        w_min = V_min_sink · (C_D/C_L)_mp
+        (C_D/C_L)_mp = 4 · sqrt(C_D0 / (3·π·e·AR))   (Anderson §6.7.2)
+    """
+    from app.services.assumption_compute_service import _min_sink_rate, _min_sink_speed
+
+    # Representative RC-scale trainer scalars.
+    mass = 1.5  # kg
+    s_ref = 0.30  # m²
+    cd0 = 0.025
+    ar = 8.0
+    e = 0.85
+    rho = 1.225
+    g = 9.81
+
+    v_ms = _min_sink_speed(mass, s_ref, cd0, ar, rho=rho, g=g, oswald_e=e)
+    w_min = _min_sink_rate(mass, s_ref, cd0, ar, rho=rho, g=g, oswald_e=e)
+
+    expected_ratio = 4.0 * np.sqrt(cd0 / (3.0 * np.pi * e * ar))
+    expected_w = v_ms * expected_ratio
+
+    # Both come from closed-form math → expect machine precision agreement.
+    assert abs(w_min - expected_w) < 1e-12, (
+        f"w_min={w_min}, expected={expected_w} from V_min_sink={v_ms}, "
+        f"CD0={cd0}, e={e}, AR={ar}, ratio={expected_ratio}"
+    )
+
+
+def test_min_sink_rate_null_when_degenerate_inputs(client_and_db):
+    """gh-692: when V_min_sink would be None (zero CD0 / no wing / etc.),
+    w_min must also be None — same degenerate-input contract."""
+    from app.services.assumption_compute_service import _min_sink_rate
+
+    # Direct unit test of the helper to cover degenerate paths the
+    # full-pipeline tests can't easily reach.
+    assert _min_sink_rate(mass_kg=1.0, s_ref_m2=0.0, cd0=0.02, aspect_ratio=8.0) is None
+    assert _min_sink_rate(mass_kg=1.0, s_ref_m2=0.3, cd0=0.0, aspect_ratio=8.0) is None
+    assert _min_sink_rate(mass_kg=1.0, s_ref_m2=0.3, cd0=0.02, aspect_ratio=None) is None
+    assert _min_sink_rate(mass_kg=1.0, s_ref_m2=0.3, cd0=0.02, aspect_ratio=0.0) is None
+
+
 @contextlib.contextmanager
 def _enter_patches_no_fine_sweep(flap_ted_max: float | None = None):
     """Variant: skip the fine_sweep patch so the test can supply its own

--- a/frontend/__tests__/InfoChipRow.test.tsx
+++ b/frontend/__tests__/InfoChipRow.test.tsx
@@ -137,6 +137,108 @@ describe("Info Chip Row", () => {
     expect(screen.getByRole("group", { name: /V min sink/ })).toBeInTheDocument();
   });
 
+  // gh-692: w_min chip renders the minimum sink rate next to V_min_sink.
+  it("renders w_min chip with min_sink_rate_mps value formatted to 2 dp m/s", async () => {
+    (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        v_cruise_mps: 18.0,
+        v_min_sink_mps: 13.2,
+        min_sink_rate_mps: 0.62,
+        reynolds: 230000,
+        mac_m: 0.21,
+        x_np_m: 0.085,
+        target_static_margin: 0.12,
+        cg_agg_m: 0.092,
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
+    render(<InfoChipRow aeroplaneId="42" cgAero={0.073} />);
+
+    const wMinChip = screen.getByRole("group", { name: /^w min:/ });
+    expect(wMinChip).toBeInTheDocument();
+    expect(wMinChip.textContent).toMatch(/0\.62 m\/s/);
+  });
+
+  it("renders w_min chip with dash when min_sink_rate_mps is missing", async () => {
+    (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        v_cruise_mps: 18.0,
+        // min_sink_rate_mps intentionally absent
+        reynolds: 230000,
+        mac_m: 0.21,
+        x_np_m: 0.085,
+        target_static_margin: 0.12,
+        cg_agg_m: 0.092,
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
+    render(<InfoChipRow aeroplaneId="42" cgAero={0.073} />);
+
+    const wMinChip = screen.getByRole("group", { name: /^w min:/ });
+    expect(wMinChip.textContent).toMatch(/=\s*–/);
+  });
+
+  // gh-692: V_x / V_y hidden for pure gliders (no motor → no climb speeds).
+  it("hides V_x and V_y chips when is_glider is true", async () => {
+    (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        v_cruise_mps: 30.0,
+        v_min_sink_mps: 22.0,
+        v_x_mps: null,
+        v_y_mps: null,
+        is_glider: true,
+        reynolds: 800000,
+        mac_m: 0.42,
+        x_np_m: 0.15,
+        target_static_margin: 0.12,
+        cg_agg_m: 0.13,
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
+    render(<InfoChipRow aeroplaneId="42" cgAero={0.13} />);
+
+    expect(screen.queryByRole("group", { name: /^V x:/ })).toBeNull();
+    expect(screen.queryByRole("group", { name: /^V y:/ })).toBeNull();
+  });
+
+  // gh-692 regression guard — Motorsegler (P/W > 0 → is_glider=false) MUST
+  // keep its V_x / V_y chips even though w_min is also shown.
+  it("renders V_x and V_y chips when is_glider is false", async () => {
+    (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        v_cruise_mps: 25.0,
+        v_min_sink_mps: 16.0,
+        min_sink_rate_mps: 0.85,
+        v_x_mps: 14.0,
+        v_y_mps: 18.0,
+        is_glider: false,
+        reynolds: 500000,
+        mac_m: 0.30,
+        x_np_m: 0.11,
+        target_static_margin: 0.12,
+        cg_agg_m: 0.10,
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    const { InfoChipRow } = await import("@/components/workbench/InfoChipRow");
+    render(<InfoChipRow aeroplaneId="42" cgAero={0.10} />);
+
+    expect(screen.getByRole("group", { name: /^V x:/ })).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: /^V y:/ })).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: /^w min:/ })).toBeInTheDocument();
+  });
+
   // gh-540: each chip exposes a hover description and is keyboard-focusable.
   it("renders hover-description tooltip and is keyboard focusable", async () => {
     (useComputationContext as ReturnType<typeof vi.fn>).mockReturnValue({

--- a/frontend/components/workbench/SpeedChipRow.tsx
+++ b/frontend/components/workbench/SpeedChipRow.tsx
@@ -39,6 +39,13 @@ export function SpeedChipRow({ ctx, isRecomputing, rightSlot }: Props) {
       />
       <Chip
         icon={Wind}
+        symbol="w_min"
+        description="Minimum sink rate — vertical speed at V_min_sink (best endurance descent)"
+        value={fmt(ctx?.min_sink_rate_mps, 2, " m/s")}
+        stale={stale}
+      />
+      <Chip
+        icon={Wind}
         symbol="V_md"
         description="Minimum-drag speed — best L/D, longest glide distance"
         value={fmt(ctx?.v_md_mps, 1, " m/s")}
@@ -55,20 +62,27 @@ export function SpeedChipRow({ ctx, isRecomputing, rightSlot }: Props) {
         value={fmt(ctx?.v_cruise_mps, 1, " m/s")}
         stale={stale}
       />
-      <Chip
-        icon={TrendingUp}
-        symbol="V_x"
-        description="Best angle-of-climb speed — steepest altitude gain per unit ground distance"
-        value={fmt(ctx?.v_x_mps, 1, " m/s")}
-        stale={stale}
-      />
-      <Chip
-        icon={Plane}
-        symbol="V_y"
-        description="Best rate-of-climb speed — fastest altitude gain per unit time"
-        value={fmt(ctx?.v_y_mps, 1, " m/s")}
-        stale={stale}
-      />
+      {/* gh-692: V_x / V_y exist only with a motor. Pure gliders (P/W = 0
+          → is_glider=true) get them hidden; Motorsegler (is_glider=false)
+          still see them. Same guard pattern as V_a / V_max / V_dive below. */}
+      {!ctx?.is_glider && (
+        <Chip
+          icon={TrendingUp}
+          symbol="V_x"
+          description="Best angle-of-climb speed — steepest altitude gain per unit ground distance"
+          value={fmt(ctx?.v_x_mps, 1, " m/s")}
+          stale={stale}
+        />
+      )}
+      {!ctx?.is_glider && (
+        <Chip
+          icon={Plane}
+          symbol="V_y"
+          description="Best rate-of-climb speed — fastest altitude gain per unit time"
+          value={fmt(ctx?.v_y_mps, 1, " m/s")}
+          stale={stale}
+        />
+      )}
       {!ctx?.is_glider && (
         <Chip
           icon={Gauge}

--- a/frontend/hooks/useComputationContext.ts
+++ b/frontend/hooks/useComputationContext.ts
@@ -55,6 +55,9 @@ export interface ComputationContext {
   v_md_mps?: number | null;
   // gh-476: extended V-speed set surfaced on the chip row.
   v_min_sink_mps?: number | null;
+  // gh-692: vertical speed at V_min_sink — minimum sink rate the polar can deliver.
+  // Glider/Motorsegler chip; powered aircraft also receive it for completeness.
+  min_sink_rate_mps?: number | null;
   v_a_mps?: number | null;
   v_dive_mps?: number | null;
   v_x_mps?: number | null;


### PR DESCRIPTION
## Summary

Two small, independent Glider / Motorsegler UX improvements to the workbench speed-chip row.

### 1. Min sink rate (w_min) [m/s]

The vertical-speed companion to V_min_sink — what pilots read off the speed-polar diagram as "wieviel Höhe verliere ich pro Sekunde am besten?". The chip row already showed *at what speed* you sink the least; it now also shows *how much*.

New helper `_min_sink_rate(...)` next to `_min_sink_speed`. Closed form from Anderson §6.7.2 at the minimum-power point:

```
C_L_mp       = sqrt(3·π·e·AR·C_D0)
(C_D/C_L)_mp = 4·sqrt(C_D0 / (3·π·e·AR))
w_min        = V_min_sink · (C_D/C_L)_mp
```

No new AeroBuildup call. Same degenerate-input contract as `_min_sink_speed` (no wing / zero AR / zero C_D0 → `None`).

### 2. Hide V_x / V_y for pure gliders

Sailplanes (`P/W = 0` → `is_glider=true`) physically have no best-angle / best-rate-of-climb speed. Chips used to render `–` which is meaningless noise — same situation V_a / V_max / V_dive already handle. Wrapped V_x and V_y in `{!ctx?.is_glider && (...)}` mirroring the existing V_a guard.

**Motorsegler (`P/W > 0` → `is_glider=false`) are not affected**: they keep their V_x / V_y chips *and* additionally get the new w_min chip (relevant for motor-off flight).

## Changes

| Layer | File | Change |
|---|---|---|
| Backend | `app/services/assumption_compute_service.py` | + `_min_sink_rate` helper; wire into `recompute_assumptions`; add `min_sink_rate_mps` to context dict |
| Backend | `app/tests/test_assumption_compute_service.py` | 3 new tests (integration + closed-form + degenerate) |
| Frontend | `frontend/hooks/useComputationContext.ts` | + `min_sink_rate_mps?: number \| null` |
| Frontend | `frontend/components/workbench/SpeedChipRow.tsx` | + `w_min` chip; V_x/V_y guard |
| Frontend | `frontend/__tests__/InfoChipRow.test.tsx` | 4 new tests (renders w_min, dash when null, V_x/V_y hidden for glider, V_x/V_y rendered for non-glider) |

## Test plan

- [x] `poetry run pytest -m "not slow"` — **3869 passed**, 1 skipped, 2 xfailed.
- [x] `poetry run pytest app/tests/test_assumption_compute_service.py -k min_sink_rate` — **3 passed**.
- [x] `cd frontend && npx vitest run __tests__/InfoChipRow.test.tsx` — **21 passed** (17 existing + 4 new).
- [x] `poetry run ruff check` on touched backend files — clean.
- [x] Independent code review — **APPROVED**, 0 BLOCKER/MAJOR/MINOR findings.
- [ ] Manual: open a sailplane fixture → see `w_min` chip with a number, no V_x/V_y chips.
- [ ] Manual: open a Motorsegler/powered aircraft → see `w_min` chip *and* V_x/V_y chips.

Closes #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)