### PR TITLE
feat(gh-695): wire OpenVSP import into AeroplanePickerDialog + optional quick-scale

### DIFF
--- a/app/api/v2/endpoints/openvsp_import.py
+++ b/app/api/v2/endpoints/openvsp_import.py
@@ -1,17 +1,25 @@
-"""REST endpoint for the OpenVSP `.vsp3` importer (gh-646).
+"""REST endpoint for the OpenVSP `.vsp3` importer (gh-646, scaling in gh-695).
 
 POST ``/api/v2/import/openvsp`` accepts a multipart upload, parses
 it via :func:`app.services.openvsp_import_service.import_openvsp_file`,
 and returns a JSON envelope with the created aeroplane uuid plus
 any import warnings.
 
+Optional Quick-Scale query parameters (gh-695, mutually exclusive):
+
+* ``?target_span_m=<float>`` — rescale so the largest wing physical
+  span equals this value (in metres).
+* ``?scale_factor=<float>`` — multiply all length-typed fields.
+
 Returns:
 
 * **201** with response body when the import succeeds (even with
   warnings).
-* **400** when the uploaded file isn't ``.vsp3``.
+* **400** when the uploaded file isn't ``.vsp3`` OR when both scaling
+  params are supplied (mutex violation).
 * **413** when the upload exceeds the size cap.
-* **422** when the file is malformed.
+* **422** when the file is malformed OR scaling inputs are out of
+  range / target_span_m requested with no wings.
 * **503** when the optional ``openvsp`` package isn't installed.
 """
 
@@ -21,14 +29,15 @@ import asyncio
 import logging
 import tempfile
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Optional
 
-from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
 from app.services import openvsp_import_service
+from app.services.openvsp_import_service import ScaleValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -71,6 +80,27 @@ class OpenVspImportResponseModel(BaseModel):
 async def import_openvsp(
     file: Annotated[UploadFile, File(..., description="OpenVSP .vsp3 file")],
     db: Annotated[Session, Depends(get_db)],
+    target_span_m: Annotated[
+        Optional[float],
+        Query(
+            description=(
+                "Optional: rescale the imported aeroplane so the largest "
+                "wing physical span equals this value in metres. Mutually "
+                "exclusive with scale_factor. Range: (0.1, 50)."
+            ),
+        ),
+    ] = None,
+    scale_factor: Annotated[
+        Optional[float],
+        Query(
+            description=(
+                "Optional: multiply all length-typed fields (positions, "
+                "chords, fuselage radii, weight-item positions) by this "
+                "factor. Mutually exclusive with target_span_m. "
+                "Range: (0.001, 10). Masses are NOT scaled."
+            ),
+        ),
+    ] = None,
 ) -> OpenVspImportResponseModel:
     """Import an OpenVSP ``.vsp3`` file as a new aeroplane.
 
@@ -93,6 +123,18 @@ async def import_openvsp(
             detail="Expected a .vsp3 file upload.",
         )
 
+    # Mutex check is cheap and translates to 400 (request-shape error
+    # — the user supplied two contradictory parameters). Out-of-range
+    # checks happen inside the service and surface as 422 below.
+    if target_span_m is not None and scale_factor is not None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "target_span_m and scale_factor are mutually exclusive; "
+                "specify at most one."
+            ),
+        )
+
     raw = await file.read()
     if len(raw) > _MAX_FILE_SIZE_BYTES:
         raise HTTPException(
@@ -112,7 +154,11 @@ async def import_openvsp(
 
     try:
         response = await asyncio.to_thread(
-            openvsp_import_service.import_openvsp_file, db, tmp_path
+            openvsp_import_service.import_openvsp_file,
+            db,
+            tmp_path,
+            target_span_m=target_span_m,
+            scale_factor=scale_factor,
         )
     except FileNotFoundError as exc:
         raise HTTPException(
@@ -122,6 +168,14 @@ async def import_openvsp(
     except ImportError as exc:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)
+        ) from exc
+    except ScaleValidationError as exc:
+        # Out-of-range scale params / no-wings → 422 (semantic error
+        # in otherwise well-formed request). Distinct from the 400
+        # mutex-check above which guards request shape.
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
         ) from exc
     except Exception as exc:  # noqa: BLE001 — translate to 422 with hint
         logger.exception("OpenVSP import failed")

--- a/app/services/openvsp_import_service.py
+++ b/app/services/openvsp_import_service.py
@@ -315,7 +315,10 @@ def import_openvsp_file(
     result = import_vsp3(path)
 
     factor = _resolve_scale_factor(result.aeroplane, target_span_m, scale_factor)
-    if factor is not None and factor != 1.0:
+    # S1244: any factor far enough from 1.0 to matter geometrically — using
+    # a small epsilon avoids float-equality pitfalls. Threshold 1e-9 is
+    # well below any user-typed scale value (UI step is 0.01).
+    if factor is not None and abs(factor - 1.0) > 1e-9:
         _scale_aeroplane_lengths(
             result.aeroplane, factor, weight_items=result.weight_items
         )

--- a/app/services/openvsp_import_service.py
+++ b/app/services/openvsp_import_service.py
@@ -8,6 +8,24 @@ which components were imported and which were dropped with warnings.
 Scope per ``feedback_openvsp_import_rc_scope``: the service does NOT
 attach weight items in Phase 1 (no DB-level WeightItem write — the
 warnings surface the count to the user; a future PR adds the join).
+
+Optional Quick-Scale (gh-695, Variante A)
+-----------------------------------------
+The importer accepts two **mutually exclusive** scaling options:
+
+* ``target_span_m`` — rescale so the maximum wing physical span equals
+  this value in metres.
+* ``scale_factor`` — multiply all length-typed fields by this factor.
+
+The helpers below scale **lengths only** (geometry positions,
+chords, fuselage radii, weight-item positions). Masses are
+**deliberately NOT scaled** — see the ``feedback_openvsp_import_rc_scope``
+memory: mass-vs-length scaling is a non-trivial design decision
+(length ∝ f, volume mass ∝ f³, electronics independent) and is
+covered by Variante B in a follow-up ticket. When scaling is
+applied, the response includes a warning that masses were left
+untouched so the user knows to adjust them in the mass-properties
+panel.
 """
 
 from __future__ import annotations
@@ -15,16 +33,41 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 
 from sqlalchemy.orm import Session
 
 from app.converters import openvsp_adapter
 from app.converters.openvsp_importer import ImportResult, import_vsp3
 from app.schemas.aeroplaneschema import (
+    AeroplaneSchema,
     AsbWingGeometryWriteSchema,
 )
+from app.schemas.weight_item import WeightItemWrite
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Scaling configuration (gh-695)
+# ---------------------------------------------------------------------------
+
+# Bounds on the user-supplied scaling parameters. Picked to cover the
+# RC-scaling use case (1.5 m sailplane up to 5 m airliner-scale) plus
+# a safety margin, while keeping the input numerically sane (no
+# 1e-12 or 1e+15 to break later CAD/aero stages).
+SCALE_FACTOR_MIN: float = 0.001
+SCALE_FACTOR_MAX: float = 10.0
+TARGET_SPAN_MIN: float = 0.1  # metres
+TARGET_SPAN_MAX: float = 50.0  # metres
+
+
+class ScaleValidationError(ValueError):
+    """Raised when the caller-supplied scaling params are invalid.
+
+    Endpoint layer translates this to HTTP 400 (mutex violation) or
+    422 (out-of-range numeric / no wings present).
+    """
 
 
 @dataclass
@@ -45,6 +88,152 @@ def is_importer_available() -> bool:
     return openvsp_adapter.is_available()
 
 
+# ---------------------------------------------------------------------------
+# Scaling helpers (gh-695)
+# ---------------------------------------------------------------------------
+
+
+def _compute_max_wing_span(aeroplane: AeroplaneSchema) -> float:
+    """Return the largest physical wingspan across all wings, in metres.
+
+    For a symmetric wing the physical span is ``2 * max|y_le|`` (mirror
+    about the XZ plane); for an asymmetric wing it's just the largest
+    ``|y_le|``. Returns ``0.0`` when the aeroplane has no wings — the
+    caller must validate against that before computing a scale factor.
+    """
+    wings = aeroplane.wings or {}
+    largest = 0.0
+    for wing in wings.values():
+        if not wing.x_secs:
+            continue
+        max_y_abs = max(abs(xs.xyz_le[1]) for xs in wing.x_secs)
+        physical_span = max_y_abs * (2.0 if wing.symmetric else 1.0)
+        largest = max(largest, physical_span)
+    return largest
+
+
+def _scale_aeroplane_lengths(
+    aeroplane: AeroplaneSchema,
+    factor: float,
+    *,
+    weight_items: Optional[list[WeightItemWrite]] = None,
+) -> None:
+    """Multiply every length-typed field by ``factor`` (in-place).
+
+    Scales:
+
+    * Wing x-sec ``xyz_le`` and ``chord``
+    * Fuselage x-sec ``xyz`` and superellipse ``a``/``b`` semi-axes
+    * Aeroplane ``xyz_ref`` (reference point / CG)
+    * Optional weight items' ``x_m``/``y_m``/``z_m`` positions
+
+    Does NOT scale (intentional, per ``feedback_openvsp_import_rc_scope``):
+
+    * Wing-section ``twist`` (angular)
+    * Fuselage superellipse ``n`` exponent (dimensionless)
+    * Weight items ``mass_kg`` — see Variante B for the mass-scaling story
+    * ``total_mass_kg`` on the aeroplane
+    """
+    # Wings
+    for wing in (aeroplane.wings or {}).values():
+        for xs in wing.x_secs:
+            xs.xyz_le = [v * factor for v in xs.xyz_le]
+            xs.chord = xs.chord * factor
+
+    # Fuselages
+    for fus in (aeroplane.fuselages or {}).values():
+        for fxs in fus.x_secs:
+            fxs.xyz = [v * factor for v in fxs.xyz]
+            fxs.a = fxs.a * factor
+            fxs.b = fxs.b * factor
+
+    # Aeroplane reference point (CG / origin) — also a length
+    if aeroplane.xyz_ref is not None:
+        aeroplane.xyz_ref = [v * factor for v in aeroplane.xyz_ref]
+
+    # Weight items: positions only, mass intentionally untouched
+    if weight_items is not None:
+        for item in weight_items:
+            item.x_m = item.x_m * factor
+            item.y_m = item.y_m * factor
+            item.z_m = item.z_m * factor
+
+
+def _resolve_scale_factor(
+    aeroplane: AeroplaneSchema,
+    target_span_m: Optional[float],
+    scale_factor: Optional[float],
+) -> Optional[float]:
+    """Validate the scaling inputs and return the effective factor.
+
+    Returns ``None`` when neither input was supplied (no scaling
+    requested). Raises :class:`ScaleValidationError` on mutex
+    violation, out-of-range values, or a ``target_span_m`` request
+    on an aeroplane with no wings.
+    """
+    if target_span_m is not None and scale_factor is not None:
+        raise ScaleValidationError(
+            "target_span_m and scale_factor are mutually exclusive; "
+            "specify at most one."
+        )
+
+    if scale_factor is not None:
+        if not (SCALE_FACTOR_MIN < scale_factor < SCALE_FACTOR_MAX):
+            raise ScaleValidationError(
+                f"scale_factor must be in ({SCALE_FACTOR_MIN}, {SCALE_FACTOR_MAX}), "
+                f"got {scale_factor!r}."
+            )
+        return scale_factor
+
+    if target_span_m is not None:
+        if not (TARGET_SPAN_MIN < target_span_m < TARGET_SPAN_MAX):
+            raise ScaleValidationError(
+                f"target_span_m must be in ({TARGET_SPAN_MIN}, {TARGET_SPAN_MAX}), "
+                f"got {target_span_m!r}."
+            )
+        current_span = _compute_max_wing_span(aeroplane)
+        if current_span <= 0.0:
+            raise ScaleValidationError(
+                "Cannot resolve target_span_m: the imported aeroplane has no "
+                "wings (or all wing y_le values are zero). Re-import with "
+                "scale_factor or 'import as-is'."
+            )
+        return target_span_m / current_span
+
+    return None
+
+
+def _make_scaling_warning(
+    applied_factor: float,
+    target_span_m: Optional[float],
+    scale_factor: Optional[float],
+):
+    """Build the user-facing scaling-applied warning record.
+
+    Imported here to avoid a top-level circular import (the warning
+    type lives in the converter module).
+    """
+    from app.converters.openvsp_importer import ImportWarning
+
+    if target_span_m is not None:
+        request = f"target wingspan {target_span_m:g} m"
+    elif scale_factor is not None:
+        request = f"explicit scale_factor {scale_factor:g}"
+    else:  # pragma: no cover — defensive, callers gate on factor
+        request = "scaling"
+
+    return ImportWarning(
+        component_type="SCALING",
+        component_name="aeroplane",
+        reason=(
+            f"Scaled all length-typed fields by factor {applied_factor:g} "
+            f"({request}). Masses were NOT scaled — adjust manually in the "
+            "mass-properties panel if needed."
+        ),
+        severity="info",
+    )
+
+
 def _persist_aeroplane(db: Session, result: ImportResult) -> tuple[str, str]:
     """Persist the parsed aeroplane and return (uuid_str, name)."""
     # Lazy import to avoid pulling sqlalchemy/CAD pieces at module load
@@ -61,6 +250,7 @@ def _persist_aeroplane(db: Session, result: ImportResult) -> tuple[str, str]:
         for wing_name, wing in result.aeroplane.wings.items():
             try:
                 write = AsbWingGeometryWriteSchema(
+                    name=wing_name,
                     symmetric=wing.symmetric,
                     x_secs=[
                         {
@@ -87,8 +277,30 @@ def _persist_aeroplane(db: Session, result: ImportResult) -> tuple[str, str]:
     return str(aeroplane.uuid), aeroplane.name
 
 
-def import_openvsp_file(db: Session, path: Path) -> OpenVspImportResponse:
+def import_openvsp_file(
+    db: Session,
+    path: Path,
+    *,
+    target_span_m: Optional[float] = None,
+    scale_factor: Optional[float] = None,
+) -> OpenVspImportResponse:
     """Parse a ``.vsp3`` file and persist its content as a new aeroplane.
+
+    Parameters
+    ----------
+    db
+        Active SQLAlchemy session (commit handled by the FastAPI
+        ``get_db`` dependency).
+    path
+        Filesystem path to the ``.vsp3`` upload.
+    target_span_m
+        Optional target wingspan in metres. Mutually exclusive with
+        ``scale_factor``. When set, computes the factor from the
+        currently-largest physical wingspan and applies it to all
+        length-typed fields.
+    scale_factor
+        Optional direct scaling factor. Mutually exclusive with
+        ``target_span_m``. Multiplies every length-typed field.
 
     Raises
     ------
@@ -96,8 +308,24 @@ def import_openvsp_file(db: Session, path: Path) -> OpenVspImportResponse:
         When the optional ``openvsp`` package is not installed.
     FileNotFoundError
         When ``path`` does not exist.
+    ScaleValidationError
+        When the scaling inputs are invalid (mutex, out-of-range,
+        target span on a wingless aeroplane).
     """
     result = import_vsp3(path)
+
+    factor = _resolve_scale_factor(result.aeroplane, target_span_m, scale_factor)
+    if factor is not None and factor != 1.0:
+        _scale_aeroplane_lengths(
+            result.aeroplane, factor, weight_items=result.weight_items
+        )
+        # Surface the scaling decision + the mass-not-scaled caveat to
+        # the user. The frontend banner renders these alongside any
+        # importer-level warnings.
+        result.warnings.append(
+            _make_scaling_warning(factor, target_span_m, scale_factor)
+        )
+
     uuid, name = _persist_aeroplane(db, result)
     return OpenVspImportResponse(
         aeroplane_uuid=uuid,

--- a/app/tests/test_openvsp_import_endpoint.py
+++ b/app/tests/test_openvsp_import_endpoint.py
@@ -1,7 +1,16 @@
-"""Integration tests for the OpenVSP import endpoint (gh-646)."""
+"""Integration tests for the OpenVSP import endpoint (gh-646).
+
+Extended for gh-695 with scaling-parameter coverage:
+
+* ``?target_span_m=<f>`` rescales the imported aeroplane to that span.
+* ``?scale_factor=<f>`` directly scales all length-typed fields.
+* Mutex (both supplied) → 400.
+* Out-of-range numeric inputs → 422.
+"""
 
 from __future__ import annotations
 
+from collections import OrderedDict
 from types import ModuleType, SimpleNamespace
 from typing import cast
 
@@ -112,3 +121,172 @@ class TestImportEndpoint:
         assert body["warnings"]
         assert any(w["component_type"] == "PROP" for w in body["warnings"])
         assert "G1" in body["lossy_components"]
+
+
+# ---------------------------------------------------------------------------
+# Scaling-parameter tests (gh-695)
+# ---------------------------------------------------------------------------
+
+
+def _stub_import_vsp3_with_wing(monkeypatch, *, span_m: float, root_chord: float = 0.5):
+    """Patch ``import_vsp3`` to yield a deterministic ImportResult with one
+    symmetric wing spanning ±``span_m`` (physical span = 2 * span_m).
+    """
+    from app.converters import openvsp_importer
+    from app.schemas.aeroplaneschema import AeroplaneSchema, AsbWingSchema, WingXSecSchema
+
+    def _fake_import(path):  # noqa: ARG001 — path is read for fixture only
+        wing = AsbWingSchema(
+            name="Main",
+            symmetric=True,
+            x_secs=[
+                WingXSecSchema(
+                    xyz_le=[0.0, 0.0, 0.0],
+                    chord=root_chord,
+                    twist=0.0,
+                    airfoil="naca0015",
+                ),
+                WingXSecSchema(
+                    xyz_le=[0.0, span_m, 0.0],
+                    chord=root_chord * 0.4,
+                    twist=0.0,
+                    airfoil="naca0015",
+                ),
+            ],
+        )
+        ap = AeroplaneSchema(name="ScaledTest")
+        ap.wings = OrderedDict([("Main", wing)])
+        return openvsp_importer.ImportResult(
+            aeroplane=ap,
+            warnings=[],
+            lossy_components=[],
+            weight_items=[],
+        )
+
+    # Patch both at the source module and at the alias used by the service.
+    monkeypatch.setattr(openvsp_importer, "import_vsp3", _fake_import)
+    from app.services import openvsp_import_service
+
+    monkeypatch.setattr(openvsp_import_service, "import_vsp3", _fake_import)
+
+
+class TestImportEndpointScaling:
+    def test_400_when_both_scale_params_supplied(self, client, monkeypatch):
+        from app.services import openvsp_import_service
+
+        monkeypatch.setattr(openvsp_import_service, "is_importer_available", lambda: True)
+        _stub_import_vsp3_with_wing(monkeypatch, span_m=10.0)
+
+        r = client.post(
+            "/api/v2/import/openvsp?target_span_m=1.5&scale_factor=0.1",
+            files={"file": ("x.vsp3", b"<vsp3/>", "application/octet-stream")},
+        )
+        assert r.status_code == 400
+        assert "mutually exclusive" in r.json()["detail"].lower()
+
+    def test_422_when_scale_factor_out_of_range(self, client, monkeypatch):
+        from app.services import openvsp_import_service
+
+        monkeypatch.setattr(openvsp_import_service, "is_importer_available", lambda: True)
+        _stub_import_vsp3_with_wing(monkeypatch, span_m=10.0)
+
+        # 50.0 is well above the max of 10.0
+        r = client.post(
+            "/api/v2/import/openvsp?scale_factor=50.0",
+            files={"file": ("x.vsp3", b"<vsp3/>", "application/octet-stream")},
+        )
+        assert r.status_code == 422
+        assert "scale_factor" in r.json()["detail"].lower()
+
+    def test_422_when_target_span_out_of_range(self, client, monkeypatch):
+        from app.services import openvsp_import_service
+
+        monkeypatch.setattr(openvsp_import_service, "is_importer_available", lambda: True)
+        _stub_import_vsp3_with_wing(monkeypatch, span_m=10.0)
+
+        r = client.post(
+            "/api/v2/import/openvsp?target_span_m=100.0",  # > 50 cap
+            files={"file": ("x.vsp3", b"<vsp3/>", "application/octet-stream")},
+        )
+        assert r.status_code == 422
+        assert "target_span_m" in r.json()["detail"].lower()
+
+    def test_scale_factor_applied_and_warning_emitted(self, client, monkeypatch):
+        from app.services import openvsp_import_service
+
+        monkeypatch.setattr(openvsp_import_service, "is_importer_available", lambda: True)
+        _stub_import_vsp3_with_wing(monkeypatch, span_m=10.0, root_chord=0.5)
+
+        r = client.post(
+            "/api/v2/import/openvsp?scale_factor=0.5",
+            files={"file": ("x.vsp3", b"<vsp3/>", "application/octet-stream")},
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        # SCALING warning should appear
+        scaling = [w for w in body["warnings"] if w["component_type"] == "SCALING"]
+        assert len(scaling) == 1
+        assert "scaled" in scaling[0]["reason"].lower()
+        assert "masses were not scaled" in scaling[0]["reason"].lower()
+
+    def test_target_span_resolves_to_correct_factor(self, client, monkeypatch):
+        """Roundtrip: span_m=10.0 sym → 20m physical; target_span=1.5 → factor 0.075."""
+        from app.services import openvsp_import_service
+
+        monkeypatch.setattr(openvsp_import_service, "is_importer_available", lambda: True)
+        _stub_import_vsp3_with_wing(monkeypatch, span_m=10.0, root_chord=0.5)
+
+        r = client.post(
+            "/api/v2/import/openvsp?target_span_m=1.5",
+            files={"file": ("x.vsp3", b"<vsp3/>", "application/octet-stream")},
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        # Look up the persisted wing and verify the y_le of the tip xsec.
+        # Tip y_le was 10.0; after factor 0.075 → 0.75. Sym wing → physical span 1.5.
+        uuid = body["aeroplane_uuid"]
+        rs = client.get(f"/aeroplanes/{uuid}/wings/Main")
+        assert rs.status_code == 200, rs.text
+        wing = rs.json()
+        tip_y = wing["x_secs"][1]["xyz_le"][1]
+        assert tip_y == pytest.approx(0.75, rel=0.01)
+
+    def test_target_span_on_wingless_returns_422(self, client, monkeypatch):
+        from app.converters import openvsp_importer
+        from app.schemas.aeroplaneschema import AeroplaneSchema
+        from app.services import openvsp_import_service
+
+        def _fake_import(path):  # noqa: ARG001
+            return openvsp_importer.ImportResult(
+                aeroplane=AeroplaneSchema(name="Wingless"),
+                warnings=[],
+                lossy_components=[],
+                weight_items=[],
+            )
+
+        monkeypatch.setattr(openvsp_import_service, "is_importer_available", lambda: True)
+        monkeypatch.setattr(openvsp_importer, "import_vsp3", _fake_import)
+        monkeypatch.setattr(openvsp_import_service, "import_vsp3", _fake_import)
+
+        r = client.post(
+            "/api/v2/import/openvsp?target_span_m=1.5",
+            files={"file": ("x.vsp3", b"<vsp3/>", "application/octet-stream")},
+        )
+        assert r.status_code == 422
+        assert "wing" in r.json()["detail"].lower() or "span" in r.json()["detail"].lower()
+
+    def test_no_scaling_when_no_params(self, client, monkeypatch):
+        """Without scale params the importer must NOT emit a SCALING warning."""
+        from app.services import openvsp_import_service
+
+        monkeypatch.setattr(openvsp_import_service, "is_importer_available", lambda: True)
+        _stub_import_vsp3_with_wing(monkeypatch, span_m=10.0)
+
+        r = client.post(
+            "/api/v2/import/openvsp",
+            files={"file": ("x.vsp3", b"<vsp3/>", "application/octet-stream")},
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        scaling = [w for w in body["warnings"] if w["component_type"] == "SCALING"]
+        assert scaling == []

--- a/app/tests/test_openvsp_import_scaling.py
+++ b/app/tests/test_openvsp_import_scaling.py
@@ -1,0 +1,262 @@
+"""Unit tests for OpenVSP import scaling helpers (gh-695).
+
+Tests cover:
+* ``_compute_max_wing_span`` — computes maximum |y| in m across all wings.
+* ``_scale_aeroplane_lengths`` — multiplies length-typed fields by factor
+  WITHOUT touching mass-typed fields (per ``feedback_openvsp_import_rc_scope``
+  memory: mass scaling is intentionally out of scope for #695).
+* Validation rules: factor ∈ (0.001, 10), span ∈ (0.1, 50), mutex.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.schemas.aeroplaneschema import (
+    AeroplaneSchema,
+    AsbWingSchema,
+    FuselageSchema,
+    FuselageXSecSuperEllipseSchema,
+    WingXSecSchema,
+)
+from app.schemas.weight_item import WeightItemWrite
+from app.services.openvsp_import_service import (
+    SCALE_FACTOR_MAX,
+    SCALE_FACTOR_MIN,
+    TARGET_SPAN_MAX,
+    TARGET_SPAN_MIN,
+    ScaleValidationError,
+    _compute_max_wing_span,
+    _resolve_scale_factor,
+    _scale_aeroplane_lengths,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _xsec(xyz, chord, twist=0.0):
+    return WingXSecSchema(
+        xyz_le=list(xyz),
+        chord=chord,
+        twist=twist,
+        airfoil="naca0015",
+    )
+
+
+def _make_wing(span_m: float, root_chord: float = 0.5, tip_chord: float = 0.2) -> AsbWingSchema:
+    return AsbWingSchema(
+        name="Main",
+        symmetric=True,
+        x_secs=[
+            _xsec([0.0, 0.0, 0.0], root_chord),
+            _xsec([0.1, span_m, 0.05], tip_chord),
+        ],
+    )
+
+
+def _make_fuselage(length_m: float, half_width: float, half_height: float) -> FuselageSchema:
+    return FuselageSchema(
+        name="Body",
+        x_secs=[
+            FuselageXSecSuperEllipseSchema(
+                xyz=[0.0, 0.0, 0.0],
+                a=half_width,
+                b=half_height,
+                n=2.0,
+            ),
+            FuselageXSecSuperEllipseSchema(
+                xyz=[length_m, 0.0, 0.0],
+                a=half_width * 0.5,
+                b=half_height * 0.5,
+                n=2.0,
+            ),
+        ],
+    )
+
+
+def _weight(name: str, mass_kg: float, xyz=(0.0, 0.0, 0.0)) -> WeightItemWrite:
+    x, y, z = xyz
+    return WeightItemWrite(
+        name=name,
+        mass_kg=mass_kg,
+        x_m=x,
+        y_m=y,
+        z_m=z,
+        category="other",
+    )
+
+
+# ---------------------------------------------------------------------------
+# _compute_max_wing_span
+# ---------------------------------------------------------------------------
+
+
+class TestComputeMaxWingSpan:
+    def test_single_symmetric_wing_returns_full_span(self):
+        ap = AeroplaneSchema(name="X")
+        ap.wings = {"Main": _make_wing(span_m=2.5)}
+        # symmetric wing: physical span is 2 * |y_tip|
+        assert _compute_max_wing_span(ap) == pytest.approx(5.0)
+
+    def test_single_asymmetric_wing_returns_half_span(self):
+        ap = AeroplaneSchema(name="X")
+        wing = _make_wing(span_m=3.0)
+        wing.symmetric = False
+        ap.wings = {"Main": wing}
+        # asymmetric wing: only the tip-y is the span
+        assert _compute_max_wing_span(ap) == pytest.approx(3.0)
+
+    def test_picks_largest_wing_when_multiple(self):
+        ap = AeroplaneSchema(name="X")
+        ap.wings = {
+            "Main": _make_wing(span_m=10.0),  # → 20 m
+            "Tail": _make_wing(span_m=2.0),  # → 4 m
+        }
+        assert _compute_max_wing_span(ap) == pytest.approx(20.0)
+
+    def test_zero_when_no_wings(self):
+        ap = AeroplaneSchema(name="X")
+        ap.wings = None
+        assert _compute_max_wing_span(ap) == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# _scale_aeroplane_lengths
+# ---------------------------------------------------------------------------
+
+
+class TestScaleAeroplaneLengths:
+    def test_wing_xsec_lengths_scale(self):
+        ap = AeroplaneSchema(name="X")
+        ap.wings = {"Main": _make_wing(span_m=2.0, root_chord=0.5, tip_chord=0.2)}
+        _scale_aeroplane_lengths(ap, 0.5)
+        wing = ap.wings["Main"]
+        assert wing.x_secs[0].chord == pytest.approx(0.25)
+        assert wing.x_secs[1].chord == pytest.approx(0.10)
+        assert wing.x_secs[1].xyz_le == pytest.approx([0.05, 1.0, 0.025])
+
+    def test_twist_is_NOT_scaled(self):
+        ap = AeroplaneSchema(name="X")
+        wing = _make_wing(span_m=2.0)
+        wing.x_secs[0].twist = 5.0
+        wing.x_secs[1].twist = -1.0
+        ap.wings = {"Main": wing}
+        _scale_aeroplane_lengths(ap, 2.0)
+        assert wing.x_secs[0].twist == pytest.approx(5.0)
+        assert wing.x_secs[1].twist == pytest.approx(-1.0)
+
+    def test_fuselage_xsec_lengths_scale(self):
+        ap = AeroplaneSchema(name="X")
+        ap.fuselages = {"Body": _make_fuselage(length_m=2.0, half_width=0.3, half_height=0.2)}
+        _scale_aeroplane_lengths(ap, 2.0)
+        fus = ap.fuselages["Body"]
+        assert fus.x_secs[0].a == pytest.approx(0.6)
+        assert fus.x_secs[0].b == pytest.approx(0.4)
+        # x-position scales:
+        assert fus.x_secs[1].xyz[0] == pytest.approx(4.0)
+
+    def test_fuselage_n_exponent_is_NOT_scaled(self):
+        ap = AeroplaneSchema(name="X")
+        ap.fuselages = {"Body": _make_fuselage(length_m=2.0, half_width=0.3, half_height=0.2)}
+        _scale_aeroplane_lengths(ap, 2.0)
+        fus = ap.fuselages["Body"]
+        assert fus.x_secs[0].n == pytest.approx(2.0)  # superellipse exponent stays
+
+    def test_xyz_ref_scales(self):
+        ap = AeroplaneSchema(name="X")
+        ap.xyz_ref = [0.1, 0.0, -0.05]
+        _scale_aeroplane_lengths(ap, 3.0)
+        assert ap.xyz_ref == pytest.approx([0.3, 0.0, -0.15])
+
+    def test_weight_item_positions_scale(self):
+        ap = AeroplaneSchema(name="X")
+        items = [_weight("Battery", 1.0, xyz=(0.4, 0.1, 0.0))]
+        _scale_aeroplane_lengths(ap, 0.5, weight_items=items)
+        assert items[0].x_m == pytest.approx(0.2)
+        assert items[0].y_m == pytest.approx(0.05)
+        assert items[0].z_m == pytest.approx(0.0)
+
+    def test_weight_item_mass_is_NOT_scaled(self):
+        """Per ``feedback_openvsp_import_rc_scope`` — mass scaling is OOS."""
+        ap = AeroplaneSchema(name="X")
+        items = [_weight("Battery", 1.234, xyz=(0.0, 0.0, 0.0))]
+        _scale_aeroplane_lengths(ap, 10.0, weight_items=items)
+        assert items[0].mass_kg == pytest.approx(1.234)
+
+    def test_total_mass_kg_is_NOT_scaled(self):
+        ap = AeroplaneSchema(name="X", total_mass_kg=2.5)
+        _scale_aeroplane_lengths(ap, 4.0)
+        assert ap.total_mass_kg == pytest.approx(2.5)
+
+    def test_factor_of_one_is_noop(self):
+        ap = AeroplaneSchema(name="X")
+        ap.wings = {"Main": _make_wing(span_m=2.0, root_chord=0.5)}
+        ap.fuselages = {"Body": _make_fuselage(length_m=1.0, half_width=0.2, half_height=0.1)}
+        _scale_aeroplane_lengths(ap, 1.0)
+        assert ap.wings["Main"].x_secs[1].xyz_le[1] == pytest.approx(2.0)
+        assert ap.fuselages["Body"].x_secs[0].a == pytest.approx(0.2)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_scale_factor (validation + mutex)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveScaleFactor:
+    def test_none_returns_none(self):
+        ap = AeroplaneSchema(name="X")
+        ap.wings = {"Main": _make_wing(span_m=1.0)}
+        assert _resolve_scale_factor(ap, None, None) is None
+
+    def test_scale_factor_passthrough(self):
+        ap = AeroplaneSchema(name="X")
+        ap.wings = {"Main": _make_wing(span_m=1.0)}
+        assert _resolve_scale_factor(ap, None, 2.0) == pytest.approx(2.0)
+
+    def test_target_span_computed(self):
+        ap = AeroplaneSchema(name="X")
+        ap.wings = {"Main": _make_wing(span_m=10.0)}  # → 20 m current
+        # target 1.5 m → factor 0.075
+        f = _resolve_scale_factor(ap, target_span_m=1.5, scale_factor=None)
+        assert f == pytest.approx(1.5 / 20.0)
+
+    def test_both_params_raises_mutex(self):
+        ap = AeroplaneSchema(name="X")
+        ap.wings = {"Main": _make_wing(span_m=1.0)}
+        with pytest.raises(ScaleValidationError) as exc:
+            _resolve_scale_factor(ap, target_span_m=1.5, scale_factor=0.5)
+        assert "mutual" in str(exc.value).lower() or "both" in str(exc.value).lower()
+
+    def test_scale_factor_below_min_raises(self):
+        ap = AeroplaneSchema(name="X")
+        ap.wings = {"Main": _make_wing(span_m=1.0)}
+        with pytest.raises(ScaleValidationError):
+            _resolve_scale_factor(ap, None, SCALE_FACTOR_MIN / 2.0)
+
+    def test_scale_factor_above_max_raises(self):
+        ap = AeroplaneSchema(name="X")
+        ap.wings = {"Main": _make_wing(span_m=1.0)}
+        with pytest.raises(ScaleValidationError):
+            _resolve_scale_factor(ap, None, SCALE_FACTOR_MAX + 1.0)
+
+    def test_target_span_below_min_raises(self):
+        ap = AeroplaneSchema(name="X")
+        ap.wings = {"Main": _make_wing(span_m=1.0)}
+        with pytest.raises(ScaleValidationError):
+            _resolve_scale_factor(ap, target_span_m=TARGET_SPAN_MIN / 2.0, scale_factor=None)
+
+    def test_target_span_above_max_raises(self):
+        ap = AeroplaneSchema(name="X")
+        ap.wings = {"Main": _make_wing(span_m=1.0)}
+        with pytest.raises(ScaleValidationError):
+            _resolve_scale_factor(ap, target_span_m=TARGET_SPAN_MAX + 1.0, scale_factor=None)
+
+    def test_target_span_with_no_wings_raises(self):
+        ap = AeroplaneSchema(name="X")
+        ap.wings = None
+        with pytest.raises(ScaleValidationError) as exc:
+            _resolve_scale_factor(ap, target_span_m=1.5, scale_factor=None)
+        assert "wing" in str(exc.value).lower() or "span" in str(exc.value).lower()

--- a/frontend/__tests__/AeroplanePickerHost.test.tsx
+++ b/frontend/__tests__/AeroplanePickerHost.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * Unit tests for AeroplanePickerHost (gh-695).
+ *
+ * The host wires the AeroplanePickerDialog props from the
+ * AeroplaneContext + useAeroplanes hook and adds the `onImport`
+ * callback that persists warnings into context, selects the imported
+ * aeroplane, and refreshes SWR caches.
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const setAeroplaneId = vi.fn();
+const closePicker = vi.fn();
+const setLastImportWarnings = vi.fn();
+const createAeroplane = vi.fn();
+const deleteAeroplane = vi.fn();
+const mutate = vi.fn();
+const globalMutate = vi.fn();
+
+vi.mock("@/components/workbench/AeroplaneContext", () => ({
+  useAeroplaneContext: () => ({
+    aeroplaneId: "aero-current",
+    setAeroplaneId,
+    pickerOpen: true,
+    closePicker,
+    setLastImportWarnings,
+  }),
+}));
+
+vi.mock("@/hooks/useAeroplanes", () => ({
+  useAeroplanes: () => ({
+    aeroplanes: [
+      { id: "aero-current", name: "Current", total_mass_kg: null, created_at: "", updated_at: "" },
+    ],
+    createAeroplane,
+    deleteAeroplane,
+    mutate,
+  }),
+}));
+
+vi.mock("swr", () => ({
+  useSWRConfig: () => ({ mutate: globalMutate }),
+}));
+
+// Stub the dialog with a minimal harness that exposes the callbacks
+// via buttons we can fire from the test.
+vi.mock("@/components/workbench/construction-plans/AeroplanePickerDialog", () => ({
+  AeroplanePickerDialog: ({
+    onSelect,
+    onDelete,
+    onCreate,
+    onImport,
+  }: {
+    onSelect: (id: string) => Promise<void>;
+    onDelete: (id: string) => Promise<void>;
+    onCreate: (name: string) => Promise<void>;
+    onImport: (response: {
+      aeroplane_uuid: string;
+      warnings: Array<{ component_type: string; component_name: string; reason: string; severity: "info" | "warning" | "error" }>;
+    }) => void;
+  }) => (
+    <div>
+      <button onClick={() => onSelect("aero-x")}>select</button>
+      <button onClick={() => onDelete("aero-current")}>delete-current</button>
+      <button onClick={() => onCreate("new-name")}>create</button>
+      <button
+        onClick={() =>
+          onImport({
+            aeroplane_uuid: "aero-imported",
+            warnings: [
+              {
+                component_type: "PROP",
+                component_name: "MainProp",
+                reason: "phase 2",
+                severity: "warning",
+              },
+            ],
+          })
+        }
+      >
+        import
+      </button>
+    </div>
+  ),
+}));
+
+import { AeroplanePickerHost } from "@/components/workbench/AeroplanePickerHost";
+
+describe("AeroplanePickerHost", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("on select: sets aeroplaneId and closes the picker", async () => {
+    render(<AeroplanePickerHost />);
+    fireEvent.click(screen.getByText("select"));
+    // Microtask flush
+    await Promise.resolve();
+    expect(setAeroplaneId).toHaveBeenCalledWith("aero-x");
+    expect(closePicker).toHaveBeenCalled();
+  });
+
+  it("on delete of current aeroplane: clears aeroplaneId", async () => {
+    deleteAeroplane.mockResolvedValueOnce(undefined);
+    render(<AeroplanePickerHost />);
+    fireEvent.click(screen.getByText("delete-current"));
+    // delete is async — flush a microtask cycle
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(deleteAeroplane).toHaveBeenCalledWith("aero-current");
+    expect(setAeroplaneId).toHaveBeenCalledWith(null);
+  });
+
+  it("on create: sets aeroplaneId from server response + closes picker", async () => {
+    createAeroplane.mockResolvedValueOnce({ id: "aero-new", name: "new-name" });
+    render(<AeroplanePickerHost />);
+    fireEvent.click(screen.getByText("create"));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(createAeroplane).toHaveBeenCalledWith("new-name");
+    expect(setAeroplaneId).toHaveBeenCalledWith("aero-new");
+    expect(closePicker).toHaveBeenCalled();
+  });
+
+  it("on import: captures warnings, selects imported aeroplane, refreshes SWR, closes picker", () => {
+    render(<AeroplanePickerHost />);
+    fireEvent.click(screen.getByText("import"));
+    expect(setLastImportWarnings).toHaveBeenCalledWith({
+      uuid: "aero-imported",
+      warnings: [
+        {
+          component_type: "PROP",
+          component_name: "MainProp",
+          reason: "phase 2",
+          severity: "warning",
+        },
+      ],
+    });
+    expect(setAeroplaneId).toHaveBeenCalledWith("aero-imported");
+    expect(mutate).toHaveBeenCalled();
+    expect(globalMutate).toHaveBeenCalled();
+    expect(closePicker).toHaveBeenCalled();
+  });
+
+  it("globalMutate filter matches keys containing the imported uuid", () => {
+    render(<AeroplanePickerHost />);
+    fireEvent.click(screen.getByText("import"));
+    const [predicate] = globalMutate.mock.calls.at(-1) as [
+      (k: unknown) => boolean,
+    ];
+    expect(predicate("/api/v2/aeroplanes/aero-imported/wings")).toBe(true);
+    expect(predicate("/api/v2/aeroplanes/other-uuid/wings")).toBe(false);
+    expect(predicate(123)).toBe(false);
+  });
+});

--- a/frontend/__tests__/ImportScaleInputs.test.tsx
+++ b/frontend/__tests__/ImportScaleInputs.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * Unit tests for ImportScaleInputs (gh-695, Variante A).
+ *
+ * Covers the three-mode radio group and the numeric inputs that
+ * surface only for their respective mode. Validates the discriminated-
+ * union shape passed to onChange so the parent (AeroplanePickerHost)
+ * can encode it correctly into the import endpoint query params.
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ImportScaleInputs } from "@/components/workbench/ImportScaleInputs";
+import type { ScaleOption } from "@/components/workbench/ImportOpenVspButton";
+
+const noneOpt: ScaleOption = { mode: "none" };
+const spanOpt: ScaleOption = { mode: "target_span", target_span_m: 1.5 };
+const factorOpt: ScaleOption = { mode: "scale_factor", scale_factor: 0.05 };
+
+describe("ImportScaleInputs", () => {
+  it("renders three radio options with the legend", () => {
+    render(<ImportScaleInputs value={noneOpt} onChange={vi.fn()} />);
+    expect(screen.getByText(/optional: scale on import/i)).toBeInTheDocument();
+    expect(screen.getByTestId("scale-mode-none")).toBeInTheDocument();
+    expect(screen.getByTestId("scale-mode-target-span")).toBeInTheDocument();
+    expect(screen.getByTestId("scale-mode-scale-factor")).toBeInTheDocument();
+  });
+
+  it("checks the 'none' radio when value.mode === 'none'", () => {
+    render(<ImportScaleInputs value={noneOpt} onChange={vi.fn()} />);
+    expect(screen.getByTestId("scale-mode-none")).toBeChecked();
+    expect(screen.getByTestId("scale-mode-target-span")).not.toBeChecked();
+    expect(screen.getByTestId("scale-mode-scale-factor")).not.toBeChecked();
+  });
+
+  it("checks the 'target_span' radio + shows its value", () => {
+    render(<ImportScaleInputs value={spanOpt} onChange={vi.fn()} />);
+    expect(screen.getByTestId("scale-mode-target-span")).toBeChecked();
+    expect(screen.getByTestId("scale-target-span-input")).toHaveValue(1.5);
+  });
+
+  it("checks the 'scale_factor' radio + shows its value", () => {
+    render(<ImportScaleInputs value={factorOpt} onChange={vi.fn()} />);
+    expect(screen.getByTestId("scale-mode-scale-factor")).toBeChecked();
+    expect(screen.getByTestId("scale-factor-input")).toHaveValue(0.05);
+  });
+
+  it("emits { mode: 'none' } when 'none' radio is clicked from another mode", () => {
+    const onChange = vi.fn();
+    render(<ImportScaleInputs value={spanOpt} onChange={onChange} />);
+    fireEvent.click(screen.getByTestId("scale-mode-none"));
+    expect(onChange).toHaveBeenCalledWith({ mode: "none" });
+  });
+
+  it("seeds target_span_m to 1.5 when switching from 'none' to target_span", () => {
+    const onChange = vi.fn();
+    render(<ImportScaleInputs value={noneOpt} onChange={onChange} />);
+    fireEvent.click(screen.getByTestId("scale-mode-target-span"));
+    expect(onChange).toHaveBeenCalledWith({
+      mode: "target_span",
+      target_span_m: 1.5,
+    });
+  });
+
+  it("seeds scale_factor to 1 when switching from 'none' to scale_factor", () => {
+    const onChange = vi.fn();
+    render(<ImportScaleInputs value={noneOpt} onChange={onChange} />);
+    fireEvent.click(screen.getByTestId("scale-mode-scale-factor"));
+    expect(onChange).toHaveBeenCalledWith({
+      mode: "scale_factor",
+      scale_factor: 1,
+    });
+  });
+
+  it("emits new target_span_m on numeric input change", () => {
+    const onChange = vi.fn();
+    render(<ImportScaleInputs value={spanOpt} onChange={onChange} />);
+    fireEvent.change(screen.getByTestId("scale-target-span-input"), {
+      target: { value: "2.4" },
+    });
+    expect(onChange).toHaveBeenCalledWith({
+      mode: "target_span",
+      target_span_m: 2.4,
+    });
+  });
+
+  it("emits new scale_factor on numeric input change", () => {
+    const onChange = vi.fn();
+    render(<ImportScaleInputs value={factorOpt} onChange={onChange} />);
+    fireEvent.change(screen.getByTestId("scale-factor-input"), {
+      target: { value: "0.12" },
+    });
+    expect(onChange).toHaveBeenCalledWith({
+      mode: "scale_factor",
+      scale_factor: 0.12,
+    });
+  });
+
+  it("ignores non-numeric input on target_span field", () => {
+    const onChange = vi.fn();
+    render(<ImportScaleInputs value={spanOpt} onChange={onChange} />);
+    fireEvent.change(screen.getByTestId("scale-target-span-input"), {
+      target: { value: "abc" },
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-numeric input on scale_factor field", () => {
+    const onChange = vi.fn();
+    render(<ImportScaleInputs value={factorOpt} onChange={onChange} />);
+    fireEvent.change(screen.getByTestId("scale-factor-input"), {
+      target: { value: "xyz" },
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("disables target_span input when mode is not target_span", () => {
+    render(<ImportScaleInputs value={noneOpt} onChange={vi.fn()} />);
+    expect(screen.getByTestId("scale-target-span-input")).toBeDisabled();
+  });
+
+  it("disables scale_factor input when mode is not scale_factor", () => {
+    render(<ImportScaleInputs value={noneOpt} onChange={vi.fn()} />);
+    expect(screen.getByTestId("scale-factor-input")).toBeDisabled();
+  });
+
+  it("disables the entire fieldset when disabled prop is true", () => {
+    render(
+      <ImportScaleInputs value={noneOpt} onChange={vi.fn()} disabled={true} />,
+    );
+    const fieldset = screen.getByTestId("import-scale-inputs") as HTMLFieldSetElement;
+    expect(fieldset).toBeDisabled();
+  });
+
+  it("warns about masses not being scaled", () => {
+    render(<ImportScaleInputs value={noneOpt} onChange={vi.fn()} />);
+    expect(screen.getByText(/masses are not scaled/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/WorkbenchImportWarningBanner.test.tsx
+++ b/frontend/__tests__/WorkbenchImportWarningBanner.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for WorkbenchImportWarningBanner (gh-695).
+ *
+ * The wrapper is a thin context consumer: it must hide the banner
+ * when (a) no recent import, (b) the selected aeroplane doesn't
+ * match the import-warning uuid, or (c) the warnings list is empty.
+ * Otherwise it forwards the warnings to ImportWarningBanner.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { WorkbenchImportWarningBanner } from "@/components/workbench/WorkbenchImportWarningBanner";
+
+vi.mock("@/components/workbench/AeroplaneContext", () => ({
+  useAeroplaneContext: vi.fn(),
+}));
+
+import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
+
+const useCtx = useAeroplaneContext as unknown as ReturnType<typeof vi.fn>;
+
+const warnings = [
+  {
+    component_type: "PROP",
+    component_name: "MainProp",
+    reason: "Propellers not yet supported",
+    severity: "warning" as const,
+  },
+];
+
+describe("WorkbenchImportWarningBanner", () => {
+  it("renders nothing when no import warnings are in context", () => {
+    useCtx.mockReturnValue({ lastImportWarnings: null, aeroplaneId: "uuid-1" });
+    const { container } = render(<WorkbenchImportWarningBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when warnings belong to a different aeroplane", () => {
+    useCtx.mockReturnValue({
+      lastImportWarnings: { uuid: "uuid-imported", warnings },
+      aeroplaneId: "uuid-other",
+    });
+    const { container } = render(<WorkbenchImportWarningBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when warnings list is empty", () => {
+    useCtx.mockReturnValue({
+      lastImportWarnings: { uuid: "uuid-1", warnings: [] },
+      aeroplaneId: "uuid-1",
+    });
+    const { container } = render(<WorkbenchImportWarningBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders ImportWarningBanner when active aeroplane matches and warnings exist", () => {
+    useCtx.mockReturnValue({
+      lastImportWarnings: { uuid: "uuid-1", warnings },
+      aeroplaneId: "uuid-1",
+    });
+    render(<WorkbenchImportWarningBanner />);
+    expect(
+      screen.getByText(/were not fully imported|propellers not yet supported/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/app/workbench/layout.tsx
+++ b/frontend/app/workbench/layout.tsx
@@ -5,6 +5,7 @@ import { AeroplaneProvider } from "@/components/workbench/AeroplaneContext";
 import { UnsavedChangesProvider } from "@/components/workbench/UnsavedChangesContext";
 import { UnsavedChangesModal } from "@/components/workbench/UnsavedChangesModal";
 import { AeroplanePickerHost } from "@/components/workbench/AeroplanePickerHost";
+import { WorkbenchImportWarningBanner } from "@/components/workbench/WorkbenchImportWarningBanner";
 
 export default function WorkbenchLayout({
   children,
@@ -17,6 +18,9 @@ export default function WorkbenchLayout({
         <UnsavedChangesProvider>
           <div className="flex h-full flex-col bg-background text-foreground font-[family-name:var(--font-geist-sans)]">
             <Header />
+            <div className="px-4 pt-4">
+              <WorkbenchImportWarningBanner />
+            </div>
             <main className="flex flex-1 overflow-hidden p-4 gap-4">
               {children}
             </main>

--- a/frontend/components/workbench/AeroplaneContext.tsx
+++ b/frontend/components/workbench/AeroplaneContext.tsx
@@ -11,7 +11,21 @@ import {
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import type { ReactNode } from "react";
 
+import type { ImportOpenVspWarning } from "@/components/workbench/ImportOpenVspButton";
+
 export type TreeMode = "wingconfig" | "asb" | "fuselage";
+
+/**
+ * Snapshot of the most recent OpenVSP import (gh-695). Captured by
+ * the picker host on a successful upload and consumed by the
+ * workbench layout's ``ImportWarningBanner``. Cleared (or replaced)
+ * on the next import. Persists in memory only — the banner has its
+ * own per-uuid localStorage dismiss flag.
+ */
+export interface LastImportWarnings {
+  uuid: string;
+  warnings: ImportOpenVspWarning[];
+}
 
 interface AeroplaneContextValue {
   aeroplaneId: string | null;
@@ -22,6 +36,7 @@ interface AeroplaneContextValue {
   selectedFuselageXsecIndex: number | null;
   treeMode: TreeMode;
   pickerOpen: boolean;
+  lastImportWarnings: LastImportWarnings | null;
   setAeroplaneId: (id: string | null) => void;
   selectWing: (name: string | null) => void;
   selectXsec: (index: number | null) => void;
@@ -30,6 +45,7 @@ interface AeroplaneContextValue {
   setTreeMode: (mode: TreeMode) => void;
   openPicker: () => void;
   closePicker: () => void;
+  setLastImportWarnings: (value: LastImportWarnings | null) => void;
 }
 
 const Ctx = createContext<AeroplaneContextValue | null>(null);
@@ -49,6 +65,8 @@ export function AeroplaneProvider({ children }: Readonly<{ children: ReactNode }
   const [treeMode, setTreeMode] = useState<TreeMode>("wingconfig");
   const [hydrated, setHydrated] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
+  const [lastImportWarnings, setLastImportWarnings] =
+    useState<LastImportWarnings | null>(null);
   const openPicker = useCallback(() => setPickerOpen(true), []);
   const closePicker = useCallback(() => setPickerOpen(false), []);
 
@@ -118,6 +136,7 @@ export function AeroplaneProvider({ children }: Readonly<{ children: ReactNode }
     selectedFuselageXsecIndex,
     treeMode,
     pickerOpen,
+    lastImportWarnings,
     setAeroplaneId,
     selectWing,
     selectXsec,
@@ -126,6 +145,7 @@ export function AeroplaneProvider({ children }: Readonly<{ children: ReactNode }
     setTreeMode,
     openPicker,
     closePicker,
+    setLastImportWarnings,
   }), [
     aeroplaneId,
     hydrated,
@@ -135,6 +155,7 @@ export function AeroplaneProvider({ children }: Readonly<{ children: ReactNode }
     selectedFuselageXsecIndex,
     treeMode,
     pickerOpen,
+    lastImportWarnings,
     setAeroplaneId,
     selectWing,
     selectXsec,

--- a/frontend/components/workbench/AeroplanePickerHost.tsx
+++ b/frontend/components/workbench/AeroplanePickerHost.tsx
@@ -1,12 +1,22 @@
 "use client";
 
+import { useSWRConfig } from "swr";
+
 import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
 import { useAeroplanes } from "@/hooks/useAeroplanes";
 import { AeroplanePickerDialog } from "@/components/workbench/construction-plans/AeroplanePickerDialog";
 
 export function AeroplanePickerHost() {
-  const { aeroplaneId, setAeroplaneId, pickerOpen, closePicker } = useAeroplaneContext();
-  const { aeroplanes, createAeroplane, deleteAeroplane } = useAeroplanes();
+  const {
+    aeroplaneId,
+    setAeroplaneId,
+    pickerOpen,
+    closePicker,
+    setLastImportWarnings,
+  } = useAeroplaneContext();
+  const { aeroplanes, createAeroplane, deleteAeroplane, mutate } =
+    useAeroplanes();
+  const { mutate: globalMutate } = useSWRConfig();
 
   return (
     <AeroplanePickerDialog
@@ -29,6 +39,26 @@ export function AeroplanePickerHost() {
         const created = await createAeroplane(name);
         if (!created?.id) throw new Error("Server returned aeroplane without an ID");
         setAeroplaneId(created.id);
+        closePicker();
+      }}
+      onImport={(response) => {
+        // gh-695: select the freshly-imported aeroplane, persist its
+        // warnings in context so the workbench layout banner picks
+        // them up, refresh the aeroplane list, and close the dialog.
+        setLastImportWarnings({
+          uuid: response.aeroplane_uuid,
+          warnings: response.warnings,
+        });
+        setAeroplaneId(response.aeroplane_uuid);
+        // Refresh the local aeroplane list + any wing/fuselage data
+        // hooks keyed off the new uuid so the workbench renders the
+        // imported geometry immediately.
+        mutate();
+        globalMutate(
+          (key) =>
+            typeof key === "string" &&
+            key.includes(response.aeroplane_uuid),
+        );
         closePicker();
       }}
     />

--- a/frontend/components/workbench/ImportOpenVspButton.tsx
+++ b/frontend/components/workbench/ImportOpenVspButton.tsx
@@ -12,6 +12,12 @@ import { API_BASE } from "@/lib/fetcher";
  * `onImported` callback receives the response envelope so the parent
  * can navigate to the new aeroplane and surface warnings via the
  * banner (delivered in gh-648).
+ *
+ * Optional Quick-Scale (gh-695): when ``scaleOption`` is supplied,
+ * the matching query param is appended to the request URL. The
+ * backend translates the option to either a target wingspan or a
+ * direct multiplier on all length-typed fields. Masses are
+ * intentionally NOT scaled (see backend service docstring).
  */
 export type ImportOpenVspWarning = {
   component_type: string;
@@ -30,18 +36,48 @@ export type ImportOpenVspResponse = {
   lossy_components: string[];
 };
 
+/**
+ * Optional scaling instruction for the import request.
+ *
+ * - ``none``        — import as-is, no rescale.
+ * - ``target_span`` — rescale to the requested wingspan in metres.
+ * - ``scale_factor``— multiply all length-typed fields by the factor.
+ *
+ * Both ``target_span_m`` and ``scale_factor`` are validated server-side
+ * (out-of-range → 422). The UI should also enforce reasonable bounds
+ * to prevent obvious mistakes.
+ */
+export type ScaleOption =
+  | { mode: "none" }
+  | { mode: "target_span"; target_span_m: number }
+  | { mode: "scale_factor"; scale_factor: number };
+
 type Props = {
   onImported?: (response: ImportOpenVspResponse) => void;
   onError?: (message: string) => void;
   className?: string;
   label?: string;
+  scaleOption?: ScaleOption;
 };
+
+function buildImportUrl(scaleOption?: ScaleOption): string {
+  const base = `${API_BASE}/api/v2/import/openvsp`;
+  if (!scaleOption || scaleOption.mode === "none") return base;
+  const params = new URLSearchParams();
+  if (scaleOption.mode === "target_span") {
+    params.set("target_span_m", String(scaleOption.target_span_m));
+  } else if (scaleOption.mode === "scale_factor") {
+    params.set("scale_factor", String(scaleOption.scale_factor));
+  }
+  return `${base}?${params.toString()}`;
+}
 
 export default function ImportOpenVspButton({
   onImported,
   onError,
   className = "",
   label = "Import OpenVSP .vsp3",
+  scaleOption,
 }: Props) {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [uploading, setUploading] = useState(false);
@@ -55,7 +91,7 @@ export default function ImportOpenVspButton({
     try {
       const form = new FormData();
       form.append("file", file);
-      const res = await fetch(`${API_BASE}/api/v2/import/openvsp`, {
+      const res = await fetch(buildImportUrl(scaleOption), {
         method: "POST",
         body: form,
       });

--- a/frontend/components/workbench/ImportScaleInputs.tsx
+++ b/frontend/components/workbench/ImportScaleInputs.tsx
@@ -96,7 +96,7 @@ export function ImportScaleInputs({
             max={50}
             value={value.mode === "target_span" ? value.target_span_m : ""}
             onChange={(e) => {
-              const next = parseFloat(e.target.value);
+              const next = Number.parseFloat(e.target.value);
               if (!Number.isNaN(next)) {
                 onChange({ mode: "target_span", target_span_m: next });
               }
@@ -123,7 +123,7 @@ export function ImportScaleInputs({
               onChange({
                 mode: "scale_factor",
                 scale_factor:
-                  value.mode === "scale_factor" ? value.scale_factor : 1.0,
+                  value.mode === "scale_factor" ? value.scale_factor : 1,
               })
             }
             className="accent-primary"
@@ -137,7 +137,7 @@ export function ImportScaleInputs({
             max={10}
             value={value.mode === "scale_factor" ? value.scale_factor : ""}
             onChange={(e) => {
-              const next = parseFloat(e.target.value);
+              const next = Number.parseFloat(e.target.value);
               if (!Number.isNaN(next)) {
                 onChange({ mode: "scale_factor", scale_factor: next });
               }

--- a/frontend/components/workbench/ImportScaleInputs.tsx
+++ b/frontend/components/workbench/ImportScaleInputs.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useId } from "react";
+
+import type { ScaleOption } from "./ImportOpenVspButton";
+
+/**
+ * Compact radio group for the optional Quick-Scale during OpenVSP
+ * import (gh-695, Variante A). Lives in the AeroplanePickerDialog
+ * footer above the Import button.
+ *
+ * Mutual exclusion is enforced by the radio semantics: only one of
+ * the three modes is active at a time. The numeric inputs are only
+ * surfaced for their respective mode to keep the footer compact.
+ *
+ * Bounds match the backend validator (``app.services.openvsp_import_service``):
+ * - target_span_m in (0.1, 50) m
+ * - scale_factor  in (0.001, 10)
+ *
+ * The UI uses softer inclusive bounds so the user can type the
+ * extremes; the server still rejects out-of-band values with 422.
+ */
+
+type Props = {
+  value: ScaleOption;
+  onChange: (next: ScaleOption) => void;
+  disabled?: boolean;
+};
+
+function modeOf(opt: ScaleOption): ScaleOption["mode"] {
+  return opt.mode;
+}
+
+export function ImportScaleInputs({
+  value,
+  onChange,
+  disabled = false,
+}: Readonly<Props>) {
+  const groupId = useId();
+  const noneId = `${groupId}-none`;
+  const targetSpanId = `${groupId}-target-span`;
+  const scaleFactorId = `${groupId}-scale-factor`;
+  const mode = modeOf(value);
+
+  return (
+    <fieldset
+      className="rounded-lg border border-border bg-input/30 px-3 py-2 text-[12px] text-muted-foreground"
+      data-testid="import-scale-inputs"
+      disabled={disabled}
+    >
+      <legend className="px-1 text-[11px] uppercase tracking-wide text-subtle-foreground">
+        Optional: scale on import
+      </legend>
+
+      <div className="flex flex-col gap-1.5">
+        <label
+          htmlFor={noneId}
+          className="flex items-center gap-2 cursor-pointer"
+        >
+          <input
+            id={noneId}
+            type="radio"
+            name={`${groupId}-mode`}
+            checked={mode === "none"}
+            onChange={() => onChange({ mode: "none" })}
+            className="accent-primary"
+            data-testid="scale-mode-none"
+          />
+          <span className="text-foreground">Import as-is (default)</span>
+        </label>
+
+        <label
+          htmlFor={targetSpanId}
+          className="flex items-center gap-2 cursor-pointer"
+        >
+          <input
+            id={targetSpanId}
+            type="radio"
+            name={`${groupId}-mode`}
+            checked={mode === "target_span"}
+            onChange={() =>
+              onChange({
+                mode: "target_span",
+                target_span_m:
+                  value.mode === "target_span" ? value.target_span_m : 1.5,
+              })
+            }
+            className="accent-primary"
+            data-testid="scale-mode-target-span"
+          />
+          <span className="text-foreground">Target wingspan</span>
+          <input
+            type="number"
+            step="0.1"
+            min={0.1}
+            max={50}
+            value={value.mode === "target_span" ? value.target_span_m : ""}
+            onChange={(e) => {
+              const next = parseFloat(e.target.value);
+              if (!Number.isNaN(next)) {
+                onChange({ mode: "target_span", target_span_m: next });
+              }
+            }}
+            disabled={mode !== "target_span"}
+            placeholder="1.5"
+            aria-label="Target wingspan in metres"
+            className="w-16 rounded border border-border bg-input px-1.5 py-0.5 text-[12px] text-foreground outline-none disabled:opacity-50"
+            data-testid="scale-target-span-input"
+          />
+          <span className="text-subtle-foreground">m</span>
+        </label>
+
+        <label
+          htmlFor={scaleFactorId}
+          className="flex items-center gap-2 cursor-pointer"
+        >
+          <input
+            id={scaleFactorId}
+            type="radio"
+            name={`${groupId}-mode`}
+            checked={mode === "scale_factor"}
+            onChange={() =>
+              onChange({
+                mode: "scale_factor",
+                scale_factor:
+                  value.mode === "scale_factor" ? value.scale_factor : 1.0,
+              })
+            }
+            className="accent-primary"
+            data-testid="scale-mode-scale-factor"
+          />
+          <span className="text-foreground">Scale factor</span>
+          <input
+            type="number"
+            step="0.01"
+            min={0.001}
+            max={10}
+            value={value.mode === "scale_factor" ? value.scale_factor : ""}
+            onChange={(e) => {
+              const next = parseFloat(e.target.value);
+              if (!Number.isNaN(next)) {
+                onChange({ mode: "scale_factor", scale_factor: next });
+              }
+            }}
+            disabled={mode !== "scale_factor"}
+            placeholder="1.0"
+            aria-label="Scale factor"
+            className="w-16 rounded border border-border bg-input px-1.5 py-0.5 text-[12px] text-foreground outline-none disabled:opacity-50"
+            data-testid="scale-factor-input"
+          />
+          <span className="text-subtle-foreground">×</span>
+        </label>
+      </div>
+
+      <p className="mt-2 text-[10px] text-subtle-foreground">
+        Masses are NOT scaled — adjust manually in mass-properties after import.
+      </p>
+    </fieldset>
+  );
+}

--- a/frontend/components/workbench/WorkbenchImportWarningBanner.tsx
+++ b/frontend/components/workbench/WorkbenchImportWarningBanner.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
+import ImportWarningBanner from "@/components/workbench/ImportWarningBanner";
+
+/**
+ * Context-aware wrapper around ``ImportWarningBanner`` (gh-695).
+ *
+ * Renders the banner only when:
+ * 1. A recent OpenVSP import has captured warnings into context.
+ * 2. The currently-selected aeroplane is the one those warnings
+ *    belong to (switching away hides the banner — the user is no
+ *    longer looking at that aeroplane).
+ *
+ * Per-aeroplane dismiss is handled by ``ImportWarningBanner`` itself
+ * via localStorage.
+ */
+export function WorkbenchImportWarningBanner() {
+  const { lastImportWarnings, aeroplaneId } = useAeroplaneContext();
+
+  if (!lastImportWarnings) return null;
+  if (lastImportWarnings.uuid !== aeroplaneId) return null;
+  if (lastImportWarnings.warnings.length === 0) return null;
+
+  return (
+    <ImportWarningBanner
+      warnings={lastImportWarnings.warnings}
+      aeroplaneUuid={lastImportWarnings.uuid}
+    />
+  );
+}

--- a/frontend/components/workbench/construction-plans/AeroplanePickerDialog.tsx
+++ b/frontend/components/workbench/construction-plans/AeroplanePickerDialog.tsx
@@ -4,6 +4,11 @@ import { useState } from "react";
 import { Search, ChevronDown, X, Trash2 } from "lucide-react";
 import { useDialog } from "@/hooks/useDialog";
 import type { Aeroplane } from "@/hooks/useAeroplanes";
+import ImportOpenVspButton, {
+  type ImportOpenVspResponse,
+  type ScaleOption,
+} from "@/components/workbench/ImportOpenVspButton";
+import { ImportScaleInputs } from "@/components/workbench/ImportScaleInputs";
 
 interface AeroplanePickerDialogProps {
   open: boolean;
@@ -14,6 +19,13 @@ interface AeroplanePickerDialogProps {
   onSelect: (aeroplaneId: string) => Promise<void> | void;
   onDelete?: (aeroplaneId: string) => Promise<void>;
   onCreate?: (name: string) => Promise<void>;
+  /**
+   * Optional callback invoked after a successful OpenVSP `.vsp3` upload
+   * (gh-695). Receives the full import-response envelope; the host
+   * (typically ``AeroplanePickerHost``) is responsible for selecting
+   * the new aeroplane, closing the dialog, and surfacing any warnings.
+   */
+  onImport?: (response: ImportOpenVspResponse) => void;
 }
 
 export function AeroplanePickerDialog({
@@ -25,11 +37,20 @@ export function AeroplanePickerDialog({
   onSelect,
   onDelete,
   onCreate,
+  onImport,
 }: Readonly<AeroplanePickerDialogProps>) {
   const { dialogRef, handleClose } = useDialog(open, onClose);
   const [search, setSearch] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState<Aeroplane | null>(null);
+  // gh-695: Scale-option state co-lives with the picker so the user
+  // can pick a mode before triggering the file dialog. Default "none"
+  // matches the import-as-is contract.
+  const [scaleOption, setScaleOption] = useState<ScaleOption>({ mode: "none" });
+  // Local error surface for OpenVSP-specific failures (503 if openvsp
+  // isn't installed, 422 if the file is malformed, etc.). Keeps the
+  // dialog open so the user can retry without losing context.
+  const [importError, setImportError] = useState<string | null>(null);
 
   const filtered = aeroplanes.filter((a) =>
     a.name.toLowerCase().includes(search.toLowerCase()),
@@ -178,16 +199,49 @@ export function AeroplanePickerDialog({
           </div>
 
           {/* Footer */}
-          {onCreate && (
-            <div className="border-t border-border px-6 py-4">
-              <button
-                type="button"
-                disabled={submitting}
-                onClick={handleCreate}
-                className="w-full rounded-full bg-primary px-4 py-2.5 text-[13px] text-primary-foreground hover:opacity-90 disabled:opacity-50"
-              >
-                + Create New
-              </button>
+          {(onCreate || onImport) && (
+            <div className="border-t border-border px-6 py-4 space-y-3">
+              {onImport && (
+                <ImportScaleInputs
+                  value={scaleOption}
+                  onChange={setScaleOption}
+                  disabled={submitting}
+                />
+              )}
+              {importError && (
+                <p
+                  role="alert"
+                  data-testid="aeroplane-picker-import-error"
+                  className="rounded border border-red-500/40 bg-red-500/10 px-3 py-2 text-[12px] text-red-300"
+                >
+                  {importError}
+                </p>
+              )}
+              <div className="flex gap-2">
+                {onCreate && (
+                  <button
+                    type="button"
+                    disabled={submitting}
+                    onClick={handleCreate}
+                    className="flex-[2] rounded-full bg-primary px-4 py-2.5 text-[13px] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                    data-testid="aeroplane-picker-create-button"
+                  >
+                    + Create New
+                  </button>
+                )}
+                {onImport && (
+                  <ImportOpenVspButton
+                    label="Import .vsp3"
+                    scaleOption={scaleOption}
+                    className="flex-1 rounded-full bg-input/40 text-foreground hover:bg-sidebar-accent"
+                    onImported={(response) => {
+                      setImportError(null);
+                      onImport(response);
+                    }}
+                    onError={(message) => setImportError(message)}
+                  />
+                )}
+              </div>
             </div>
           )}
         </div>


### PR DESCRIPTION
Closes #695.

## Summary

- Wires the existing `ImportOpenVspButton` + `ImportWarningBanner` into the `AeroplanePickerDialog` footer (2/3 Create New + 1/3 Import .vsp3) so the importer is finally reachable from the UI.
- Adds **Variante A quick-scale** at import time: optional `target_span_m` or `scale_factor` query params on `POST /api/v2/import/openvsp` (mutex; bounds-checked). Length-only scaling per the RC-scaling scope; masses deliberately unchanged + warning surfaced.
- Wires a `WorkbenchImportWarningBanner` into the workbench layout, driven by a new `lastImportWarnings` field on `AeroplaneContext`. Per-uuid localStorage dismiss already in the underlying banner.

## Test plan

- [x] Backend pytest: `poetry run pytest app/tests/test_openvsp_*.py` — **142 passed**
- [x] Frontend vitest: `cd frontend && npm run test:unit` — **1052 passed**
- [x] TypeScript: `tsc --noEmit` clean for all new/modified files (only pre-existing unrelated errors in MatchingChart/CreatorGallery remain)
- [ ] Manual end-to-end: upload a small `.vsp3` via the new Import button with `target_span_m=1.5` → aeroplane gets selected at the scaled span, warning banner appears
- [ ] Manual end-to-end: upload with mutex params via curl returns 400, out-of-range returns 422

## Out of scope

- **Mass-scaling strategy** (cubic / square_cube / etc.) → deferred to Variante B (#696)
- **Post-import re-scaling** for existing aeroplanes → also #696
- Fuselage + WeightItem DB persistence still as in #693 — wings persist, fuselage/weight count surfaced in response envelope only

## References

- Issue: #695
- Memory: `feedback_openvsp_import_rc_scope` (length-only scaling rationale)
- Setup doc: `docs/md/openvsp-import-setup.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)