### PR TITLE
fix(gh-698): apply Geom-level XForm to wing xyz_le (Cessna 172 regression)

### DIFF
--- a/app/converters/openvsp_wing_handler.py
+++ b/app/converters/openvsp_wing_handler.py
@@ -136,6 +136,67 @@ def _read_symmetric(vsp: ModuleType, wing_gid: str) -> bool:
     return bool(flag & sym_xz)
 
 
+def _read_xform_parm(vsp: ModuleType, gid: str, name: str) -> float:
+    """Read a single XForm parm; 0.0 if not present."""
+    pid = vsp.FindParm(gid, name, "XForm")
+    if not pid:
+        return 0.0
+    try:
+        return float(vsp.GetParmVal(pid))
+    except Exception:
+        return 0.0
+
+
+def _read_geom_xform(
+    vsp: ModuleType, gid: str
+) -> tuple[tuple[float, float, float], tuple[float, float, float]]:
+    """Read the Geom-level XForm: (translation, rotation_deg).
+
+    Prefers the absolute ``*_Location`` / ``*_Rotation`` parms over the
+    relative ``*_Rel_*`` variants. Returns ``((0,0,0), (0,0,0))`` when
+    no XForm parms are present (e.g. very old VSP files or stubbed
+    test fakes).
+
+    Discovered necessary for gh-698: WING handler previously rendered
+    all wings at the origin in the X–Y plane, which broke Cessna 172
+    imports (HTP overlapped with main wing, VTP rendered flat).
+    """
+    translation = (
+        _read_xform_parm(vsp, gid, "X_Location"),
+        _read_xform_parm(vsp, gid, "Y_Location"),
+        _read_xform_parm(vsp, gid, "Z_Location"),
+    )
+    rotation_deg = (
+        _read_xform_parm(vsp, gid, "X_Rotation"),
+        _read_xform_parm(vsp, gid, "Y_Rotation"),
+        _read_xform_parm(vsp, gid, "Z_Rotation"),
+    )
+    return translation, rotation_deg
+
+
+def _apply_xform(
+    pt: list[float] | tuple[float, float, float],
+    translation: tuple[float, float, float],
+    rotation_deg: tuple[float, float, float],
+) -> list[float]:
+    """Apply OpenVSP's intrinsic XYZ rotation + translation to a 3D point.
+
+    OpenVSP applies rotations in the local frame in the order X → Y → Z
+    (intrinsic), then translates in the world frame. We mirror that
+    here so that ``StabVer`` (Cessna 172) with ``X_Rotation=90°`` correctly
+    rotates the wing's span axis from Y onto +Z.
+    """
+    x, y, z = pt
+    rx, ry, rz = (math.radians(a) for a in rotation_deg)
+    # Rx
+    y, z = y * math.cos(rx) - z * math.sin(rx), y * math.sin(rx) + z * math.cos(rx)
+    # Ry
+    x, z = x * math.cos(ry) + z * math.sin(ry), -x * math.sin(ry) + z * math.cos(ry)
+    # Rz
+    x, y = x * math.cos(rz) - y * math.sin(rz), x * math.sin(rz) + y * math.cos(rz)
+    return [x + translation[0], y + translation[1], z + translation[2]]
+
+
 # ---------------------------------------------------------------------------
 # Handler
 # ---------------------------------------------------------------------------
@@ -273,6 +334,16 @@ def _handle_wing(
         )
         ctx.mark_lossy(gid)
         return
+
+    # Apply Geom-level XForm (translation + intrinsic XYZ rotation) to every
+    # xyz_le so that wings end up at their world-frame position and orientation.
+    # Critical for HTP (aft translation) and VTP (90°-X rotation that stands
+    # the wing upright). See gh-698 for the Cessna 172 regression that
+    # surfaced this gap.
+    translation, rotation_deg = _read_geom_xform(vsp, gid)
+    if any(translation) or any(rotation_deg):
+        for xs in x_secs:
+            xs.xyz_le = _apply_xform(xs.xyz_le, translation, rotation_deg)
 
     wing = AsbWingSchema(
         name=name,

--- a/app/tests/test_openvsp_wing_xform.py
+++ b/app/tests/test_openvsp_wing_xform.py
@@ -1,0 +1,157 @@
+"""Unit tests for the WING-handler XForm helpers (gh-698).
+
+The wing handler must read each Geom's world-frame translation +
+rotation (Cessna 172 regression: HTP was overlapping the main wing,
+VTP was rendered flat in the X-Y plane). These tests pin the
+rotation order (intrinsic XYZ) and the translation handling.
+"""
+
+from __future__ import annotations
+
+import math
+from types import ModuleType, SimpleNamespace
+from typing import cast
+
+import pytest
+
+from app.converters.openvsp_wing_handler import (
+    _apply_xform,
+    _read_geom_xform,
+    _read_xform_parm,
+)
+
+
+# ---------------------------------------------------------------------------
+# _read_xform_parm / _read_geom_xform
+# ---------------------------------------------------------------------------
+
+
+def _make_xform_vsp(parms: dict[tuple[str, str], float]) -> ModuleType:
+    """Tiny fake vsp module that exposes only FindParm/GetParmVal,
+    backed by a ``{(name, group): value}`` dict.
+    """
+    fake = SimpleNamespace()
+    fake.FindParm = lambda gid, name, group: (
+        f"{gid}:{name}:{group}" if (name, group) in parms else ""
+    )
+    fake.GetParmVal = lambda pid: parms[(pid.split(":")[1], pid.split(":")[2])]
+    return cast(ModuleType, fake)
+
+
+class TestReadXformParm:
+    def test_returns_zero_when_parm_missing(self):
+        vsp = _make_xform_vsp({})
+        assert _read_xform_parm(vsp, "GID", "X_Location") == 0.0
+
+    def test_returns_value_when_present(self):
+        vsp = _make_xform_vsp({("X_Location", "XForm"): 4.2})
+        assert _read_xform_parm(vsp, "GID", "X_Location") == 4.2
+
+    def test_coerces_to_float(self):
+        vsp = _make_xform_vsp({("Y_Location", "XForm"): 1})
+        assert _read_xform_parm(vsp, "GID", "Y_Location") == 1.0
+        assert isinstance(_read_xform_parm(vsp, "GID", "Y_Location"), float)
+
+
+class TestReadGeomXform:
+    def test_all_zero_when_no_parms(self):
+        vsp = _make_xform_vsp({})
+        translation, rotation = _read_geom_xform(vsp, "GID")
+        assert translation == (0.0, 0.0, 0.0)
+        assert rotation == (0.0, 0.0, 0.0)
+
+    def test_reads_full_xform(self):
+        # Mirrors the StabVer values from the Cessna 172 regression case.
+        vsp = _make_xform_vsp(
+            {
+                ("X_Location", "XForm"): 2.09,
+                ("Y_Location", "XForm"): 0.0,
+                ("Z_Location", "XForm"): 0.13,
+                ("X_Rotation", "XForm"): 90.0,
+                ("Y_Rotation", "XForm"): 0.0,
+                ("Z_Rotation", "XForm"): 0.0,
+            }
+        )
+        translation, rotation = _read_geom_xform(vsp, "GID")
+        assert translation == (2.09, 0.0, 0.13)
+        assert rotation == (90.0, 0.0, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# _apply_xform — rotation pinning
+# ---------------------------------------------------------------------------
+
+
+def _approx_eq(a: list[float], b: list[float], tol: float = 1e-9) -> bool:
+    return all(abs(x - y) < tol for x, y in zip(a, b, strict=True))
+
+
+class TestApplyXform:
+    def test_identity(self):
+        out = _apply_xform([1.0, 2.0, 3.0], (0, 0, 0), (0, 0, 0))
+        assert _approx_eq(out, [1.0, 2.0, 3.0])
+
+    def test_pure_translation(self):
+        out = _apply_xform([1.0, 2.0, 3.0], (10, 20, 30), (0, 0, 0))
+        assert _approx_eq(out, [11.0, 22.0, 33.0])
+
+    def test_rx_90_maps_y_to_z(self):
+        """X-rotation of +90° rotates +Y onto +Z (right-hand rule).
+
+        This is the Cessna 172 VTP case: a flat wing whose span is +Y
+        becomes a vertical wing whose span is +Z.
+        """
+        out = _apply_xform([0.0, 1.0, 0.0], (0, 0, 0), (90.0, 0, 0))
+        assert _approx_eq(out, [0.0, 0.0, 1.0])
+
+    def test_rx_90_maps_z_to_negative_y(self):
+        """+Z under Rx(+90°) goes to −Y (right-hand rule).
+
+        Pairs with ``test_rx_90_maps_y_to_z`` to pin the chirality.
+        """
+        out = _apply_xform([0.0, 0.0, 1.0], (0, 0, 0), (90.0, 0, 0))
+        assert _approx_eq(out, [0.0, -1.0, 0.0])
+
+    def test_ry_90_maps_z_to_x(self):
+        """+Z under Ry(+90°) goes to +X."""
+        out = _apply_xform([0.0, 0.0, 1.0], (0, 0, 0), (0, 90.0, 0))
+        assert _approx_eq(out, [1.0, 0.0, 0.0])
+
+    def test_rz_90_maps_x_to_y(self):
+        """+X under Rz(+90°) goes to +Y."""
+        out = _apply_xform([1.0, 0.0, 0.0], (0, 0, 0), (0, 0, 90.0))
+        assert _approx_eq(out, [0.0, 1.0, 0.0])
+
+    def test_rotation_then_translation(self):
+        """Cessna 172 StabVer-style XForm: translate to (2.09, 0, 0.13)
+        + 90° X-rotation. A point at (0, 1, 0) — the local-frame span
+        tip — should end up at (2.09, 0, 1.13)."""
+        out = _apply_xform(
+            [0.0, 1.0, 0.0], (2.09, 0.0, 0.13), (90.0, 0.0, 0.0)
+        )
+        assert _approx_eq(out, [2.09, 0.0, 1.13])
+
+    def test_intrinsic_xyz_order(self):
+        """Pin rotation order: intrinsic X → Y → Z.
+
+        Sequence (Rx(90°), Ry(90°)) applied to (1, 0, 0):
+            Rx(90°)(1,0,0)        = (1, 0, 0)            (X is the axis)
+            Ry(90°)(1,0,0)        = (0, 0, -1)           (+X → −Z)
+        Sequence (Rx(90°), Ry(90°)) applied to (0, 1, 0):
+            Rx(90°)(0,1,0)        = (0, 0, 1)
+            Ry(90°)(0,0,1)        = (1, 0, 0)            (+Z → +X)
+        """
+        out = _apply_xform([0.0, 1.0, 0.0], (0, 0, 0), (90.0, 90.0, 0.0))
+        assert _approx_eq(out, [1.0, 0.0, 0.0])
+
+    @pytest.mark.parametrize(
+        "rot_deg,inp,expected",
+        [
+            ((45.0, 0, 0), [0, math.sqrt(2), 0], [0, 1.0, 1.0]),
+            ((-90.0, 0, 0), [0, 1, 0], [0, 0, -1]),  # opposite rotation
+            ((0, 0, 180.0), [1, 0, 0], [-1, 0, 0]),  # 180° around Z
+        ],
+    )
+    def test_various_rotations(self, rot_deg, inp, expected):
+        out = _apply_xform(inp, (0, 0, 0), rot_deg)
+        assert _approx_eq(out, expected, tol=1e-9)


### PR DESCRIPTION
Closes #698.

## Summary

- HTP/VTP wings were rendered at the origin in the X-Y plane because the wing handler never read the Geom-level XForm parms (`X_Location` / `Y_Location` / `Z_Location` + `X_Rotation` / `Y_Rotation` / `Z_Rotation`).
- New helpers `_read_xform_parm`, `_read_geom_xform`, `_apply_xform` (intrinsic XYZ rotation then translation, matching OpenVSP) — applied to every `xyz_le` after the local-frame loop.

## Test plan

- [x] Backend pytest: `poetry run pytest app/tests/test_openvsp_*.py` — **158 passed (+16 new in `test_openvsp_wing_xform.py`)**
- [x] Manual Cessna 172 import:
    - Wing root at (-0.42, 0, 0.71) ✓
    - StabHor root at (4.00, 0, 0.35) ✓
    - StabVer root at (2.09, 0, 0.13), tip at (5.05, 0, 1.91) ✓ vertical
- [ ] Manual: re-import cessna172.vsp3 via frontend, confirm HTP visible at ~4m aft and VTP stands upright

## Out of scope

- Parent-chain XForm traversal for child Geoms (Cessna's wings are all parent=NONE; nested cases will get their own ticket if/when they appear)
- Fuselage XForm — separate handler, same gap probably exists but Cessna's fuselage is rooted at origin so wasn't surfaced

## References

- Issue: #698
- Memory: `project_openvsp_api_discoveries_350.md` extended with XForm rule
- File: `app/converters/openvsp_wing_handler.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)