### PR TITLE
feat(gh-700): generate missing NACA 4-digit .dat files at OpenVSP import

### DIFF
--- a/app/converters/openvsp_airfoil.py
+++ b/app/converters/openvsp_airfoil.py
@@ -18,6 +18,7 @@ Scope (per ``feedback_openvsp_import_rc_scope``)
 
 from __future__ import annotations
 
+import math
 from pathlib import Path
 from types import ModuleType
 from typing import Optional
@@ -27,6 +28,10 @@ from app.converters.openvsp_importer import ImportContext
 
 # Resolves at import time. Tests monkeypatch this to a tmp directory.
 AIRFOILS_DIR: Path = Path("components") / "airfoils"
+
+# Cosine-spaced default resolution for generated NACA .dat files.
+# Matches the density of the hand-curated files in components/airfoils.
+_NACA_DAT_HALF_POINTS = 80
 
 
 # ---------------------------------------------------------------------------
@@ -80,6 +85,114 @@ def naca_16series_name(*, camber: float, thick_chord: float) -> str:
     c = round(camber * 100)
     t = round(thick_chord * 100)
     return f"naca16-{c:d}{t:02d}"
+
+
+# ---------------------------------------------------------------------------
+# NACA 4-digit .dat generation (gh-700)
+# ---------------------------------------------------------------------------
+
+
+def _naca4_thickness_offset(x: float, thickness: float) -> float:
+    """Standard NACA 4-digit half-thickness distribution.
+
+    Uses the open-TE coefficient (-0.1015) consistent with Selig data;
+    callers that need a closed TE can chop the last point or use
+    -0.1036 instead.
+    """
+    return 5 * thickness * (
+        0.2969 * math.sqrt(max(x, 0.0))
+        - 0.1260 * x
+        - 0.3516 * x * x
+        + 0.2843 * x * x * x
+        - 0.1015 * x * x * x * x
+    )
+
+
+def _naca4_camber_line(
+    x: float, camber: float, camber_loc: float
+) -> tuple[float, float]:
+    """Returns ``(y_camber, dy/dx)`` for the NACA 4-digit camber line.
+
+    Symmetric airfoils (camber == 0) and the degenerate case
+    camber_loc == 0 both produce ``(0.0, 0.0)``. The piecewise quadratic
+    matches the canonical NACA definition.
+    """
+    if camber == 0 or camber_loc == 0:
+        return 0.0, 0.0
+    if x <= camber_loc:
+        yc = (camber / (camber_loc ** 2)) * (2 * camber_loc * x - x * x)
+        dyc = (2 * camber / (camber_loc ** 2)) * (camber_loc - x)
+    else:
+        denom = (1 - camber_loc) ** 2
+        yc = (camber / denom) * ((1 - 2 * camber_loc) + 2 * camber_loc * x - x * x)
+        dyc = (2 * camber / denom) * (camber_loc - x)
+    return yc, dyc
+
+
+def naca4_coordinates(
+    *,
+    camber: float,
+    camber_loc: float,
+    thick_chord: float,
+    n_half: int = _NACA_DAT_HALF_POINTS,
+) -> list[tuple[float, float]]:
+    """Generate Selig-format coordinates for a NACA 4-digit airfoil.
+
+    Returns ``n_half * 2 + 1`` points (cosine-spaced over each surface,
+    sharing the LE point). Order: TE → upper → LE → lower → TE — the
+    Selig convention all existing files in ``components/airfoils`` use.
+    """
+    upper: list[tuple[float, float]] = []
+    lower: list[tuple[float, float]] = []
+    for i in range(n_half + 1):
+        beta = math.pi * i / n_half
+        x = 0.5 * (1.0 - math.cos(beta))
+        yt = _naca4_thickness_offset(x, thick_chord)
+        yc, dyc = _naca4_camber_line(x, camber, camber_loc)
+        theta = math.atan(dyc)
+        sin_t = math.sin(theta)
+        cos_t = math.cos(theta)
+        upper.append((x - yt * sin_t, yc + yt * cos_t))
+        lower.append((x + yt * sin_t, yc - yt * cos_t))
+    # Selig: TE → upper-surface → LE → lower-surface → TE.
+    # Reverse upper so we walk from TE to LE; share the LE point.
+    return list(reversed(upper)) + lower[1:]
+
+
+def ensure_naca4_dat(
+    *,
+    name: str,
+    camber: float,
+    camber_loc: float,
+    thick_chord: float,
+    airfoils_dir: Path | None = None,
+) -> Path:
+    """Write ``{airfoils_dir}/{name}.dat`` if it doesn't already exist.
+
+    Idempotent: returns the path either way. Never raises — on write
+    failure (e.g. read-only fs) it logs nothing and returns the path
+    the caller should record; the downstream renderer will degrade
+    gracefully when the file is missing.
+    """
+    target_dir = airfoils_dir if airfoils_dir is not None else AIRFOILS_DIR
+    target = target_dir / f"{name}.dat"
+    if target.exists():
+        return target
+    try:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        coords = naca4_coordinates(
+            camber=camber, camber_loc=camber_loc, thick_chord=thick_chord
+        )
+        # Header: airfoil name on its own line (XFOIL / Selig convention).
+        header = name.upper().replace("NACA", "NACA ") if name.lower().startswith("naca") else name
+        lines = [header.strip()]
+        for x, y in coords:
+            lines.append(f"{x:.6f}  {y:.6f}")
+        target.write_text("\n".join(lines) + "\n")
+    except OSError:
+        # Read-only fs / permission error — don't crash the import.
+        pass
+    return target
 
 
 # ---------------------------------------------------------------------------
@@ -177,22 +290,44 @@ def import_airfoil_from_xsec(
 
     # ---- NACA 4-series ------------------------------------------------
     if shape == getattr(vsp, "XS_FOUR_SERIES", None):
-        return naca_4series_name(
-            camber=_get_parm(vsp, xs_id, "Camber"),
-            camber_loc=_get_parm(vsp, xs_id, "CamberLoc"),
-            thick_chord=_get_parm(vsp, xs_id, "ThickChord"),
+        camber = _get_parm(vsp, xs_id, "Camber")
+        camber_loc = _get_parm(vsp, xs_id, "CamberLoc")
+        thick_chord = _get_parm(vsp, xs_id, "ThickChord")
+        name = naca_4series_name(
+            camber=camber, camber_loc=camber_loc, thick_chord=thick_chord
         )
+        # gh-700: write a .dat for this NACA-4 profile so the renderer
+        # has something to draw, regardless of whether it's in our
+        # curated airfoil library.
+        ensure_naca4_dat(
+            name=name,
+            camber=camber,
+            camber_loc=camber_loc,
+            thick_chord=thick_chord,
+        )
+        return name
 
     # ---- NACA 4-digit modified ---------------------------------------
     if shape == getattr(vsp, "XS_FOUR_DIGIT_MOD", None):
+        camber = _get_parm(vsp, xs_id, "Camber")
+        camber_loc = _get_parm(vsp, xs_id, "CamberLoc")
+        thick_chord = _get_parm(vsp, xs_id, "ThickChord")
         base = naca_4series_name(
-            camber=_get_parm(vsp, xs_id, "Camber"),
-            camber_loc=_get_parm(vsp, xs_id, "CamberLoc"),
-            thick_chord=_get_parm(vsp, xs_id, "ThickChord"),
+            camber=camber, camber_loc=camber_loc, thick_chord=thick_chord
         )
         # Append the leading-edge-radius/thickness-location modifier
         # (OpenVSP's "modified" parms). Format: "naca2412-mod"
-        return f"{base}-mod"
+        name = f"{base}-mod"
+        # Generate the base 4-digit .dat so the modified-profile at
+        # least has a renderable fallback; the LE/thickness modifiers
+        # are not encoded in the analytical thickness polynomial.
+        ensure_naca4_dat(
+            name=name,
+            camber=camber,
+            camber_loc=camber_loc,
+            thick_chord=thick_chord,
+        )
+        return name
 
     # ---- NACA 5-series + modified ------------------------------------
     if shape == getattr(vsp, "XS_FIVE_DIGIT", None):

--- a/app/tests/test_openvsp_naca4_generation.py
+++ b/app/tests/test_openvsp_naca4_generation.py
@@ -1,0 +1,216 @@
+"""Unit tests for the NACA 4-digit .dat generator (gh-700).
+
+Closes the gap where OpenVSP-imported wings reference NACA 4-digit
+airfoils that aren't in our curated ``components/airfoils`` library
+(Cessna 172: naca0212, naca0209, naca0206 — none shipped). The
+generator writes a Selig-format .dat on demand from the analytical
+NACA 4-digit equation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.converters.openvsp_airfoil import (
+    _naca4_camber_line,
+    _naca4_thickness_offset,
+    ensure_naca4_dat,
+    naca4_coordinates,
+)
+
+
+# ---------------------------------------------------------------------------
+# _naca4_thickness_offset
+# ---------------------------------------------------------------------------
+
+
+class TestThicknessOffset:
+    def test_zero_at_le_and_te(self):
+        # LE and TE: thickness offset is 0 (LE has sqrt(0)=0; TE is by
+        # design close to 0 but the open-TE coefficient leaves ~0.001).
+        assert _naca4_thickness_offset(0.0, 0.12) == 0.0
+        # TE is not exactly zero with the open-TE coefficient, but small.
+        te = _naca4_thickness_offset(1.0, 0.12)
+        assert abs(te) < 0.002
+
+    def test_peak_near_30pct_chord(self):
+        # Standard NACA 4-digit thickness peaks at ~30% chord at value
+        # = thickness/2 (since the polynomial is the half-thickness).
+        # For NACA 0012: peak half-thickness ≈ 0.06.
+        peak = max(_naca4_thickness_offset(x, 0.12) for x in [0.25, 0.30, 0.35])
+        assert peak == pytest.approx(0.06, abs=0.005)
+
+    def test_scales_linearly_with_thickness(self):
+        x = 0.30
+        t1 = _naca4_thickness_offset(x, 0.12)
+        t2 = _naca4_thickness_offset(x, 0.24)
+        assert t2 == pytest.approx(2 * t1, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# _naca4_camber_line
+# ---------------------------------------------------------------------------
+
+
+class TestCamberLine:
+    def test_symmetric_when_camber_zero(self):
+        yc, dyc = _naca4_camber_line(0.5, camber=0.0, camber_loc=0.4)
+        assert yc == 0.0
+        assert dyc == 0.0
+
+    def test_symmetric_when_camber_loc_zero(self):
+        # Degenerate input: avoid division-by-zero.
+        yc, dyc = _naca4_camber_line(0.5, camber=0.02, camber_loc=0.0)
+        assert yc == 0.0
+        assert dyc == 0.0
+
+    def test_naca_2412_peak_camber_at_40pct(self):
+        # NACA 2412: max camber 2% at x=0.4.
+        yc_peak, dyc_peak = _naca4_camber_line(0.4, camber=0.02, camber_loc=0.4)
+        assert yc_peak == pytest.approx(0.02, rel=1e-9)
+        # At the peak, dy/dx is zero (the parabola apex).
+        assert dyc_peak == pytest.approx(0.0, abs=1e-12)
+
+    def test_camber_is_zero_at_le_and_te(self):
+        # 2412 camber line passes through (0, 0) and (1, 0).
+        assert _naca4_camber_line(0.0, 0.02, 0.4)[0] == pytest.approx(0.0)
+        assert _naca4_camber_line(1.0, 0.02, 0.4)[0] == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# naca4_coordinates
+# ---------------------------------------------------------------------------
+
+
+class TestCoordinates:
+    def test_returns_2n_plus_1_points(self):
+        coords = naca4_coordinates(camber=0, camber_loc=0, thick_chord=0.12, n_half=20)
+        # 21 upper (incl. LE) + 20 lower (LE shared) = 41
+        assert len(coords) == 41
+
+    def test_starts_and_ends_at_te(self):
+        coords = naca4_coordinates(camber=0, camber_loc=0, thick_chord=0.12, n_half=20)
+        # First and last point are at x ≈ 1.0 (TE), within thickness-offset
+        # rotation tolerance for symmetric profiles.
+        assert coords[0][0] == pytest.approx(1.0, abs=0.01)
+        assert coords[-1][0] == pytest.approx(1.0, abs=0.01)
+
+    def test_le_at_origin_for_symmetric(self):
+        coords = naca4_coordinates(camber=0, camber_loc=0, thick_chord=0.12, n_half=20)
+        # Middle point should be at the LE (x ≈ 0).
+        middle = coords[len(coords) // 2]
+        assert middle[0] == pytest.approx(0.0, abs=0.001)
+        assert middle[1] == pytest.approx(0.0, abs=0.001)
+
+    def test_naca_0012_max_thickness(self):
+        coords = naca4_coordinates(camber=0, camber_loc=0, thick_chord=0.12, n_half=80)
+        # Maximum y across all upper points: 0.06 (half-thickness for 12%)
+        max_y = max(y for _x, y in coords)
+        assert max_y == pytest.approx(0.06, abs=0.003)
+
+    def test_naca_2412_max_camber_offset_at_40pct(self):
+        coords = naca4_coordinates(camber=0.02, camber_loc=0.4, thick_chord=0.12, n_half=80)
+        # The MEAN of upper+lower y at each x is the camber line.
+        # Easiest sanity: at x≈0.4, mean(yu, yl) should ≈ 0.02 (max camber)
+        # Find the pair of points closest to x=0.4 on upper + lower
+        n = len(coords)
+        upper = coords[: n // 2 + 1]   # TE → LE
+        lower = coords[n // 2 :]       # LE → TE
+        # closest to x=0.4 on each side
+        u_at_04 = min(upper, key=lambda p: abs(p[0] - 0.4))
+        l_at_04 = min(lower, key=lambda p: abs(p[0] - 0.4))
+        mean_y = (u_at_04[1] + l_at_04[1]) / 2
+        assert mean_y == pytest.approx(0.02, abs=0.003)
+
+    def test_naca_2412_camber_positive(self):
+        # Cambered profile: upper surface y > 0 in the middle.
+        coords = naca4_coordinates(camber=0.02, camber_loc=0.4, thick_chord=0.12, n_half=40)
+        # x near 0.5: y on upper surface should be clearly above 0
+        for x, y in coords[: len(coords) // 2]:
+            if abs(x - 0.5) < 0.05:
+                assert y > 0.04   # camber + half-thickness
+
+
+# ---------------------------------------------------------------------------
+# ensure_naca4_dat — file I/O
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureDat:
+    def test_writes_dat_when_missing(self, tmp_path: Path):
+        path = ensure_naca4_dat(
+            name="naca0212",
+            camber=0.0,
+            camber_loc=0.2,
+            thick_chord=0.12,
+            airfoils_dir=tmp_path,
+        )
+        assert path == tmp_path / "naca0212.dat"
+        assert path.exists()
+        text = path.read_text()
+        # Header + many coord lines.
+        assert text.splitlines()[0].startswith("NACA")
+        assert len(text.splitlines()) > 50
+
+    def test_idempotent_does_not_overwrite(self, tmp_path: Path):
+        target = tmp_path / "naca0012.dat"
+        target.write_text("HAND-WRITTEN\n0 0\n1 0\n")
+        original = target.read_text()
+        ensure_naca4_dat(
+            name="naca0012",
+            camber=0,
+            camber_loc=0,
+            thick_chord=0.12,
+            airfoils_dir=tmp_path,
+        )
+        # File unchanged.
+        assert target.read_text() == original
+
+    def test_creates_airfoils_dir_if_missing(self, tmp_path: Path):
+        nested = tmp_path / "nested" / "airfoils"
+        ensure_naca4_dat(
+            name="naca0008",
+            camber=0,
+            camber_loc=0,
+            thick_chord=0.08,
+            airfoils_dir=nested,
+        )
+        assert (nested / "naca0008.dat").exists()
+
+    def test_silent_on_readonly_filesystem(self, tmp_path: Path, monkeypatch):
+        # Simulate OSError on write — function must not raise.
+        def boom(*_a, **_kw):  # noqa: ANN002,ANN003
+            raise OSError("read-only")
+
+        target = tmp_path / "naca0010.dat"
+        monkeypatch.setattr(Path, "write_text", boom)
+        # Should not raise; returns the planned path.
+        result = ensure_naca4_dat(
+            name="naca0010",
+            camber=0,
+            camber_loc=0,
+            thick_chord=0.10,
+            airfoils_dir=tmp_path,
+        )
+        assert result == target
+        assert not target.exists()
+
+    def test_dat_lines_well_formed(self, tmp_path: Path):
+        """Generated file is readable as plain text — header + coord pairs."""
+        path = ensure_naca4_dat(
+            name="naca0012",
+            camber=0,
+            camber_loc=0,
+            thick_chord=0.12,
+            airfoils_dir=tmp_path,
+        )
+        lines = path.read_text().splitlines()
+        assert lines[0].startswith("NACA")
+        # Every non-header line is "x  y" with two floats.
+        for line in lines[1:]:
+            parts = line.split()
+            assert len(parts) == 2
+            float(parts[0])  # raises ValueError on garbage
+            float(parts[1])


### PR DESCRIPTION
Closes #700. Follow-up to #698 (after which the Cessna 172 wings were correctly positioned but their tails had no visible airfoils because naca0212/naca0209/naca0206 weren't in our library).

## Summary

- New helpers in \`openvsp_airfoil.py\`: \`_naca4_thickness_offset\`, \`_naca4_camber_line\`, \`naca4_coordinates\` (Selig-format), \`ensure_naca4_dat\` (idempotent file writer).
- Wired into the NACA-4-series and NACA-4-digit-mod handlers so missing .dat files are generated on import.
- Existing curated .dat files are NEVER overwritten (idempotent check).
- 18 new tests pin the math + file-I/O semantics.

## Test plan

- [x] Backend pytest: \`poetry run pytest app/tests/test_openvsp_*.py\` — **176 passed (+18 new)**
- [x] Manual cessna172.vsp3 import → \`naca0212/0209/0206.dat\` generated; \`naca2412.dat\` untouched
- [ ] Manual: re-import via frontend, confirm tail surfaces render with airfoils

## Out of scope

- NACA 5-Digit generator (more complex; separate ticket if needed)
- NACA 6-Series (needs interpolation tables; not analytical)
- NACA 16-Series (separate ticket)

## References

- Issue: #700
- File: \`app/converters/openvsp_airfoil.py\`
- Earlier fix: #698 / PR #699 (wing XForm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)