### PR TITLE
fix(gh-702): fuselage import — XSec position container + Geom XForm

### DIFF
--- a/app/converters/openvsp_fuselage_handler.py
+++ b/app/converters/openvsp_fuselage_handler.py
@@ -20,17 +20,24 @@ Scope (per ``feedback_openvsp_import_rc_scope``):
   ``XS_EDIT_CURVE`` (Phase 2 / B5), POD and BODYOFREVOLUTION as
   fuselages (Phase 2 / B4).
 
-Container convention (verified empirically during implementation —
-documented here as the source of truth for downstream handlers):
+Container convention (corrected after gh-702 — earlier docstring was
+wrong; OpenVSP 3.50 keeps these on the XSec itself, not the parent
+fuselage):
 
 * Length lives on the FUSELAGE container, group ``Design``, parm
   ``Length``.
-* Station positions live on the FUSELAGE container, group ``XSec``,
-  parm ``XLocPercent_<i>`` (and ``YLocPercent_<i>``,
-  ``ZLocPercent_<i>``).
+* Per-XSec **position** parms live on the **XSec container** in
+  group ``XSec``: ``XLocPercent``, ``YLocPercent``, ``ZLocPercent``
+  (no per-index suffix). Values are fractions of the fuselage length.
 * XSec-curve shape parms (Circle_Diameter, Ellipse_Width, etc.) live
   on the XSec curve container, accessed via
   ``vsp.GetXSecParm(xs_id, "Circle_Diameter")``.
+
+Geom-level XForm (translation + intrinsic XYZ rotation) is applied
+after the local-frame loop, identical pattern to the wing handler
+(``openvsp_wing_handler._apply_xform``). Parent-chain traversal for
+child-of-BLANK geoms (NoseFairing etc.) is out of scope here — a
+separate ticket.
 """
 
 from __future__ import annotations
@@ -39,6 +46,10 @@ from types import ModuleType
 
 from app.converters import openvsp_importer
 from app.converters.openvsp_importer import AeroplaneSchema, ImportContext
+from app.converters.openvsp_wing_handler import (
+    _apply_xform,
+    _read_geom_xform,
+)
 from app.schemas.aeroplaneschema import (
     FuselageSchema,
     FuselageXSecSuperEllipseSchema,
@@ -146,10 +157,22 @@ def _read_length(vsp: ModuleType, fuse_gid: str) -> float:
     return float(vsp.GetParmVal(pid))
 
 
-def _read_x_pct(vsp: ModuleType, fuse_gid: str, i: int) -> float:
-    pid = vsp.FindParm(fuse_gid, f"XLocPercent_{i}", "XSec")
+def _read_loc_pct(
+    vsp: ModuleType, xs_id: str, axis: str, i: int, n_xsec: int
+) -> float:
+    """Read ``{X,Y,Z}LocPercent`` from an XSec container.
+
+    These parms live on the XSec itself in group ``XSec`` (OpenVSP
+    3.50 convention) — NOT on the parent fuselage with an index
+    suffix. Fallback when missing: an evenly-spaced fraction
+    ``i / (n_xsec - 1)`` so we at least lay xsecs out along the
+    spine for X and produce 0 for Y/Z.
+    """
+    pid = vsp.FindParm(xs_id, f"{axis}LocPercent", "XSec")
     if not pid:
-        return float(i)  # fall back to evenly-spaced index proxy
+        if axis == "X" and n_xsec > 1:
+            return i / (n_xsec - 1)
+        return 0.0
     return float(vsp.GetParmVal(pid))
 
 
@@ -187,16 +210,27 @@ def _handle_fuselage(
     for i in range(n_xsec):
         xs_id = vsp.GetXSec(xsurf, i)
         shape = vsp.GetXSecShape(xs_id)
-        x_pct = _read_x_pct(vsp, gid, i)
+        x_pct = _read_loc_pct(vsp, xs_id, "X", i, n_xsec)
+        y_pct = _read_loc_pct(vsp, xs_id, "Y", i, n_xsec)
+        z_pct = _read_loc_pct(vsp, xs_id, "Z", i, n_xsec)
         a, b, n = _shape_to_super_ellipse(vsp, xs_id, shape, ctx)
         xsecs.append(
             FuselageXSecSuperEllipseSchema(
-                xyz=[x_pct * length, 0.0, 0.0],
+                xyz=[x_pct * length, y_pct * length, z_pct * length],
                 a=max(a, 0.0),
                 b=max(b, 0.0),
                 n=max(n, 1.0),
             )
         )
+
+    # Apply Geom-level XForm (translation + intrinsic XYZ rotation) to
+    # every xsec position — same pattern as the wing handler post-gh-698.
+    # Critical for Cessna 172 sub-fuselages (Struts rotated 90° about Z,
+    # MainStrut rotated -90°/MainFairing/etc.).
+    translation, rotation_deg = _read_geom_xform(vsp, gid)
+    if any(translation) or any(rotation_deg):
+        for xs in xsecs:
+            xs.xyz = _apply_xform(xs.xyz, translation, rotation_deg)
 
     fuse = FuselageSchema(name=name, x_secs=xsecs)
     if aeroplane.fuselages is None:

--- a/app/tests/test_openvsp_fuselage_handler.py
+++ b/app/tests/test_openvsp_fuselage_handler.py
@@ -47,6 +47,7 @@ def _make_fuse_vsp(
     name: str = "Fuselage",
     length: float = 10.0,
     xsecs: list[dict] | None = None,
+    xform: dict | None = None,
 ) -> ModuleType:
     """Build a fake `openvsp` module describing one FUSELAGE geom.
 
@@ -96,13 +97,31 @@ def _make_fuse_vsp(
 
     fake.GetXSecParm = _get_xsec_parm
 
-    # Per-fuselage parms (Length, XLocPercent_<i>) accessed via FindParm.
+    # Parm routing per OpenVSP 3.50 convention (gh-702): Length lives on
+    # the fuselage container in group Design; XLocPercent/YLocPercent/
+    # ZLocPercent live on EACH XSec container in group XSec; XForm
+    # translation/rotation live on the fuselage container in group XForm.
+    xform = xform or {}
+    XFORM_PARMS = {
+        "X_Location", "Y_Location", "Z_Location",
+        "X_Rotation", "Y_Rotation", "Z_Rotation",
+    }
+
+    _LOC_KEY = {"XLocPercent": "x_pct", "YLocPercent": "y_pct", "ZLocPercent": "z_pct"}
+
     def _find_parm(container, parm, group):
-        if container == fuse_id:
-            if parm == "Length" and group == "Design":
-                return "PFUSE::Length"
-            if parm.startswith("XLocPercent_"):
-                return f"PFUSE::{parm}"
+        if container == fuse_id and parm == "Length" and group == "Design":
+            return "PFUSE::Length"
+        if container == fuse_id and group == "XForm" and parm in XFORM_PARMS:
+            return f"PXFORM::{parm}"
+        if container.startswith("XS_") and group == "XSec" and parm in _LOC_KEY:
+            # Mirror real OpenVSP: return "" when the test dict doesn't
+            # declare the corresponding *_pct key, so the handler's
+            # fallback path is exercised.
+            idx = int(container.split("_", 1)[1])
+            if _LOC_KEY[parm] not in xsecs[idx]:
+                return ""
+            return f"PXSEC::{container}::{parm}"
         return ""
 
     def _get_parm_val_router(pid):
@@ -110,9 +129,13 @@ def _make_fuse_vsp(
             return 0.0
         if pid == "PFUSE::Length":
             return float(length)
-        if pid.startswith("PFUSE::XLocPercent_"):
-            idx = int(pid.split("_", 1)[1])
-            return float(xsecs[idx].get("x_pct", 0.0))
+        if pid.startswith("PXFORM::"):
+            return float(xform.get(pid.split("::", 1)[1], 0.0))
+        if pid.startswith("PXSEC::"):
+            _, xs_id, name = pid.split("::", 2)
+            idx = int(xs_id.split("_", 1)[1])
+            key = {"XLocPercent": "x_pct", "YLocPercent": "y_pct", "ZLocPercent": "z_pct"}[name]
+            return float(xsecs[idx].get(key, 0.0))
         return _get_parm_val(pid)
 
     fake.FindParm = _find_parm
@@ -344,3 +367,119 @@ class TestFuselageImport:
         result = import_vsp3(f)
         assert result.aeroplane.fuselages is None or not result.aeroplane.fuselages
         assert result.warnings
+
+
+class TestFuselageXForm:
+    """gh-702: Geom-level XForm (translation + intrinsic XYZ rotation)
+    must be applied to every xsec xyz, identical pattern to the wing
+    handler post-gh-698."""
+
+    def test_pure_translation_offsets_all_xsecs(self, tmp_path, monkeypatch):
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        xsecs = [
+            {"shape": "CIRCLE", "x_pct": 0.0, "Circle_Diameter": 0.5},
+            {"shape": "CIRCLE", "x_pct": 1.0, "Circle_Diameter": 0.5},
+        ]
+        fake = _make_fuse_vsp(
+            xsecs=xsecs,
+            length=5.0,
+            xform={"X_Location": 10.0, "Y_Location": -2.0, "Z_Location": 3.0},
+        )
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        result = import_vsp3(f)
+        fuse = (result.aeroplane.fuselages or {})["Fuselage"]
+        # Every xsec is translated by (10, -2, 3) on top of its local xyz.
+        assert fuse.x_secs[0].xyz == pytest.approx([10.0, -2.0, 3.0])
+        assert fuse.x_secs[1].xyz == pytest.approx([15.0, -2.0, 3.0])
+
+    def test_z_rotation_90_rotates_about_world_z(self, tmp_path, monkeypatch):
+        # A fuselage laid along +X rotated 90° about Z should point along +Y.
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        xsecs = [
+            {"shape": "CIRCLE", "x_pct": 0.0, "Circle_Diameter": 0.2},
+            {"shape": "CIRCLE", "x_pct": 1.0, "Circle_Diameter": 0.2},
+        ]
+        fake = _make_fuse_vsp(
+            xsecs=xsecs, length=4.0, xform={"Z_Rotation": 90.0}
+        )
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        result = import_vsp3(f)
+        fuse = (result.aeroplane.fuselages or {})["Fuselage"]
+        # Local (4, 0, 0) → after Rz(90°) → (0, 4, 0)
+        assert fuse.x_secs[1].xyz == pytest.approx([0.0, 4.0, 0.0], abs=1e-9)
+
+    def test_y_rotation_neg80_with_translation_cessna_nose_strut(
+        self, tmp_path, monkeypatch
+    ):
+        # Mirrors NoseStrut from the Cessna 172 file: translated to
+        # (-1.22, 0, -1.0) and rotated by Y=-80°. A xsec at local
+        # (1.5, 0, 0) → after Ry(-80°): (cos(-80)·1.5, 0, -sin(-80)·1.5)
+        # = (0.260, 0, 1.477) → + translation = (-0.960, 0, 0.477).
+        import math
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        xsecs = [
+            {"shape": "CIRCLE", "x_pct": 0.0, "Circle_Diameter": 0.1},
+            {"shape": "CIRCLE", "x_pct": 1.0, "Circle_Diameter": 0.1},
+        ]
+        fake = _make_fuse_vsp(
+            xsecs=xsecs,
+            length=1.5,
+            xform={
+                "X_Location": -1.22,
+                "Z_Location": -1.0,
+                "Y_Rotation": -80.0,
+            },
+        )
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        result = import_vsp3(f)
+        fuse = (result.aeroplane.fuselages or {})["Fuselage"]
+        # Local tip at (1.5, 0, 0). Ry(-80°): x→cos(-80)*1.5, z→-sin(-80)*1.5
+        cos_t = math.cos(math.radians(-80.0))
+        sin_t = math.sin(math.radians(-80.0))
+        expected = [
+            -1.22 + cos_t * 1.5,
+            0.0,
+            -1.0 + (-sin_t * 1.5),
+        ]
+        assert fuse.x_secs[1].xyz == pytest.approx(expected, abs=1e-9)
+
+
+class TestFuselagePositionParms:
+    """gh-702: per-XSec position parms live on the XSec, not on the
+    parent fuselage with an _<i> suffix (corrects the earlier docstring
+    + handler convention)."""
+
+    def test_xsec_x_y_z_loc_percent_all_read(self, tmp_path, monkeypatch):
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        xsecs = [
+            {"shape": "CIRCLE", "x_pct": 0.0, "y_pct": 0.0, "z_pct": 0.0, "Circle_Diameter": 0.5},
+            {"shape": "CIRCLE", "x_pct": 0.4, "y_pct": 0.05, "z_pct": -0.02, "Circle_Diameter": 0.5},
+        ]
+        fake = _make_fuse_vsp(xsecs=xsecs, length=10.0)
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        result = import_vsp3(f)
+        fuse = (result.aeroplane.fuselages or {})["Fuselage"]
+        assert fuse.x_secs[0].xyz == pytest.approx([0.0, 0.0, 0.0])
+        assert fuse.x_secs[1].xyz == pytest.approx([4.0, 0.5, -0.2])
+
+    def test_missing_position_parms_falls_back_to_even_spacing(
+        self, tmp_path, monkeypatch
+    ):
+        # Provide xsec dicts WITHOUT any *_pct keys → handler falls
+        # back to i/(n-1) for X, 0 for Y/Z. With length=8.0 and
+        # n=5, the 3rd xsec (index 2) lands at 2/4 * 8 = 4.0.
+        f = tmp_path / "x.vsp3"
+        f.write_text("")
+        xsecs = [{"shape": "CIRCLE", "Circle_Diameter": 0.5} for _ in range(5)]
+        fake = _make_fuse_vsp(xsecs=xsecs, length=8.0)
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        result = import_vsp3(f)
+        fuse = (result.aeroplane.fuselages or {})["Fuselage"]
+        xs_x = [xs.xyz[0] for xs in fuse.x_secs]
+        assert xs_x == pytest.approx([0.0, 2.0, 4.0, 6.0, 8.0])
+        # Y / Z all zero.
+        assert all(xs.xyz[1] == 0.0 and xs.xyz[2] == 0.0 for xs in fuse.x_secs)


### PR DESCRIPTION
Closes #702. Surfaced during real Cessna 172 testing after #698 fixed the wing case.

## Summary

- Fuselage XSec position parms live on the XSec, not on the parent — fixed \`_read_x_pct\` → \`_read_loc_pct\` reading from XSec.
- Garbage \`float(i)\` fallback replaced with \`i / (n_xsec - 1)\`.
- Geom-level XForm (translation + intrinsic XYZ rotation) now applied to every xsec — reuses helpers from \`openvsp_wing_handler\`.

## Test plan

- [x] Backend pytest: \`poetry run pytest app/tests/test_openvsp_*.py\` — **181 passed (+5 new)**
- [x] Manual Cessna 172 import:
  - Fuselage: 7.23m (was 65m), starts at x=-2.42
  - Struts/NoseStrut/MainStrut all rotated correctly
- [ ] Manual: re-import via frontend, confirm fuselage + sub-fuselages render at correct positions

## Out of scope

- Parent-chain XForm traversal — landing-gear sub-fuselages (NoseFairing/NoseStrut/MainFairing/MainStrut) have parent=BLANK. Currently OK because Cessna's landing-gear BLANKs are at origin; will need traversal once a non-trivial .vsp3 puts them elsewhere.

## References

- Issue: #702
- File: \`app/converters/openvsp_fuselage_handler.py\`
- Memory: \`project_openvsp_api_discoveries_350.md\` section #7 added
- Earlier fix: #698 / PR #699 (wing XForm — same helpers re-used here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)