### PR TITLE
feat(gh-704): import — let user supply aeroplane name

### DIFF
--- a/app/api/v2/endpoints/openvsp_import.py
+++ b/app/api/v2/endpoints/openvsp_import.py
@@ -101,6 +101,17 @@ async def import_openvsp(
             ),
         ),
     ] = None,
+    name: Annotated[
+        Optional[str],
+        Query(
+            max_length=200,
+            description=(
+                "Optional: user-supplied aeroplane name. Overrides the "
+                "default (which is the uploaded filename's stem). "
+                "Whitespace-only values are treated as 'no override'."
+            ),
+        ),
+    ] = None,
 ) -> OpenVspImportResponseModel:
     """Import an OpenVSP ``.vsp3`` file as a new aeroplane.
 
@@ -159,6 +170,8 @@ async def import_openvsp(
             tmp_path,
             target_span_m=target_span_m,
             scale_factor=scale_factor,
+            name=name,
+            source_filename=file.filename,
         )
     except FileNotFoundError as exc:
         raise HTTPException(

--- a/app/services/openvsp_import_service.py
+++ b/app/services/openvsp_import_service.py
@@ -234,14 +234,59 @@ def _make_scaling_warning(
     )
 
 
-def _persist_aeroplane(db: Session, result: ImportResult) -> tuple[str, str]:
+def _resolve_aeroplane_name(
+    *,
+    explicit_name: Optional[str],
+    source_filename: Optional[str],
+    parsed_name: Optional[str],
+) -> str:
+    """Resolve the aeroplane name from the first non-empty source.
+
+    Precedence (each must be a non-empty trimmed string to count):
+
+    1. ``explicit_name`` — user-typed in the import dialog.
+    2. ``source_filename`` stem — the original upload's basename
+       (so ``cessna172.vsp3`` → ``cessna172``). Avoids leaking the
+       ``tmpXXXX`` name of the NamedTemporaryFile the endpoint writes.
+    3. ``parsed_name`` — whatever the converter recorded on the
+       parsed schema (legacy fallback, may itself be the tempfile
+       stem when called via the endpoint).
+    4. ``"OpenVSP Import"`` — final hard fallback.
+    """
+    explicit = (explicit_name or "").strip()
+    if explicit:
+        return explicit
+
+    if source_filename:
+        stem = Path(source_filename).stem.strip()
+        if stem:
+            return stem
+
+    parsed = (parsed_name or "").strip()
+    if parsed:
+        return parsed
+
+    return "OpenVSP Import"
+
+
+def _persist_aeroplane(
+    db: Session,
+    result: ImportResult,
+    *,
+    name: Optional[str] = None,
+    source_filename: Optional[str] = None,
+) -> tuple[str, str]:
     """Persist the parsed aeroplane and return (uuid_str, name)."""
     # Lazy import to avoid pulling sqlalchemy/CAD pieces at module load
     # in environments that only need the importer (e.g. unit tests).
     from app.services import aeroplane_service, wing_service
 
-    name = result.aeroplane.name or "OpenVSP Import"
-    aeroplane = aeroplane_service.create_aeroplane(db, name)
+    resolved_name = _resolve_aeroplane_name(
+        explicit_name=name,
+        source_filename=source_filename,
+        parsed_name=result.aeroplane.name,
+    )
+    aeroplane = aeroplane_service.create_aeroplane(db, resolved_name)
 
     # Wings: convert each AsbWingSchema → AsbWingGeometryWriteSchema and
     # delegate to wing_service. The full schema isn't directly accepted
@@ -283,6 +328,8 @@ def import_openvsp_file(
     *,
     target_span_m: Optional[float] = None,
     scale_factor: Optional[float] = None,
+    name: Optional[str] = None,
+    source_filename: Optional[str] = None,
 ) -> OpenVspImportResponse:
     """Parse a ``.vsp3`` file and persist its content as a new aeroplane.
 
@@ -301,6 +348,14 @@ def import_openvsp_file(
     scale_factor
         Optional direct scaling factor. Mutually exclusive with
         ``target_span_m``. Multiplies every length-typed field.
+    name
+        Optional user-typed aeroplane name from the import dialog. When
+        non-empty (after trim) it overrides every other name source.
+    source_filename
+        Original upload filename (``cessna172.vsp3``). Used as a sane
+        fallback for the persisted aeroplane name when ``name`` is not
+        supplied — without this the endpoint would persist the
+        ``NamedTemporaryFile`` stem (``tmpXXXX``).
 
     Raises
     ------
@@ -329,7 +384,9 @@ def import_openvsp_file(
             _make_scaling_warning(factor, target_span_m, scale_factor)
         )
 
-    uuid, name = _persist_aeroplane(db, result)
+    uuid, name = _persist_aeroplane(
+        db, result, name=name, source_filename=source_filename
+    )
     return OpenVspImportResponse(
         aeroplane_uuid=uuid,
         aeroplane_name=name,

--- a/app/tests/test_openvsp_import_endpoint.py
+++ b/app/tests/test_openvsp_import_endpoint.py
@@ -290,3 +290,81 @@ class TestImportEndpointScaling:
         body = r.json()
         scaling = [w for w in body["warnings"] if w["component_type"] == "SCALING"]
         assert scaling == []
+
+
+# ---------------------------------------------------------------------------
+# Aeroplane-name tests (post-MVP UX fix)
+# ---------------------------------------------------------------------------
+
+
+class TestImportEndpointAeroplaneName:
+    """The aeroplane name must come from (in order of precedence):
+
+    1. Explicit ``?name=`` query param (user-typed in the import dialog).
+    2. The original upload filename's stem (so ``cessna172.vsp3`` →
+       ``cessna172``).
+    3. The converter-supplied fallback (which uses ``path.stem`` —
+       previously surfaced as ``tmpXXXX`` because the endpoint writes
+       to a NamedTemporaryFile before parsing).
+    """
+
+    def test_explicit_name_query_param_overrides_filename(self, client, monkeypatch):
+        from app.services import openvsp_import_service
+
+        monkeypatch.setattr(openvsp_import_service, "is_importer_available", lambda: True)
+        _stub_import_vsp3_with_wing(monkeypatch, span_m=10.0)
+
+        r = client.post(
+            "/api/v2/import/openvsp?name=My%20Custom%20Plane",
+            files={"file": ("cessna172.vsp3", b"<vsp3/>", "application/octet-stream")},
+        )
+        assert r.status_code == 201, r.text
+        assert r.json()["aeroplane_name"] == "My Custom Plane"
+
+    def test_fallback_to_uploaded_filename_stem(self, client, monkeypatch):
+        """No explicit name → use the uploaded filename's stem, NOT the
+        tempfile stem the endpoint generates internally.
+        """
+        from app.services import openvsp_import_service
+
+        monkeypatch.setattr(openvsp_import_service, "is_importer_available", lambda: True)
+        _stub_import_vsp3_with_wing(monkeypatch, span_m=10.0)
+
+        r = client.post(
+            "/api/v2/import/openvsp",
+            files={"file": ("cessna172.vsp3", b"<vsp3/>", "application/octet-stream")},
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["aeroplane_name"] == "cessna172"
+        # Defensive: no `tmp` leaked-tempfile prefix.
+        assert not body["aeroplane_name"].startswith("tmp")
+
+    def test_blank_name_param_falls_back_to_filename(self, client, monkeypatch):
+        """An explicit empty-or-whitespace ``?name=`` is treated as 'no
+        override' so we still get a sane name from the upload filename.
+        """
+        from app.services import openvsp_import_service
+
+        monkeypatch.setattr(openvsp_import_service, "is_importer_available", lambda: True)
+        _stub_import_vsp3_with_wing(monkeypatch, span_m=10.0)
+
+        r = client.post(
+            "/api/v2/import/openvsp?name=%20%20",
+            files={"file": ("rv7.vsp3", b"<vsp3/>", "application/octet-stream")},
+        )
+        assert r.status_code == 201, r.text
+        assert r.json()["aeroplane_name"] == "rv7"
+
+    def test_name_param_is_trimmed(self, client, monkeypatch):
+        from app.services import openvsp_import_service
+
+        monkeypatch.setattr(openvsp_import_service, "is_importer_available", lambda: True)
+        _stub_import_vsp3_with_wing(monkeypatch, span_m=10.0)
+
+        r = client.post(
+            "/api/v2/import/openvsp?name=%20%20Cessna%20172%20%20",
+            files={"file": ("ignored.vsp3", b"<vsp3/>", "application/octet-stream")},
+        )
+        assert r.status_code == 201, r.text
+        assert r.json()["aeroplane_name"] == "Cessna 172"

--- a/frontend/__tests__/ImportOpenVspButton.test.tsx
+++ b/frontend/__tests__/ImportOpenVspButton.test.tsx
@@ -86,4 +86,86 @@ describe("ImportOpenVspButton", () => {
     await userEvent.upload(input, f);
     expect(onError).toHaveBeenCalledWith("openvsp not installed");
   });
+
+  it("appends ?name= when a customName is supplied", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        aeroplane_uuid: "u",
+        aeroplane_name: "Cessna 172",
+        n_wings: 0,
+        n_fuselages: 0,
+        n_weight_items: 0,
+        warnings: [],
+        lossy_components: [],
+      }),
+    } as Response);
+    render(<ImportOpenVspButton customName="Cessna 172" />);
+    const input = screen.getByTestId(
+      "openvsp-file-input",
+    ) as HTMLInputElement;
+    const f = new File(["<vsp3/>"], "x.vsp3", {
+      type: "application/octet-stream",
+    });
+    await userEvent.upload(input, f);
+    const calledUrl = vi.mocked(global.fetch).mock.calls[0][0] as string;
+    // URLSearchParams encodes spaces as '+'.
+    expect(calledUrl).toMatch(/[?&]name=Cessna\+172\b/);
+  });
+
+  it("omits ?name= when customName is empty or whitespace", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        aeroplane_uuid: "u",
+        aeroplane_name: "x",
+        n_wings: 0,
+        n_fuselages: 0,
+        n_weight_items: 0,
+        warnings: [],
+        lossy_components: [],
+      }),
+    } as Response);
+    render(<ImportOpenVspButton customName="   " />);
+    const input = screen.getByTestId(
+      "openvsp-file-input",
+    ) as HTMLInputElement;
+    const f = new File(["<vsp3/>"], "x.vsp3", {
+      type: "application/octet-stream",
+    });
+    await userEvent.upload(input, f);
+    const calledUrl = vi.mocked(global.fetch).mock.calls[0][0] as string;
+    expect(calledUrl).not.toMatch(/[?&]name=/);
+  });
+
+  it("combines customName with a scaleOption query param", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        aeroplane_uuid: "u",
+        aeroplane_name: "RV-7",
+        n_wings: 0,
+        n_fuselages: 0,
+        n_weight_items: 0,
+        warnings: [],
+        lossy_components: [],
+      }),
+    } as Response);
+    render(
+      <ImportOpenVspButton
+        customName="RV-7"
+        scaleOption={{ mode: "scale_factor", scale_factor: 0.5 }}
+      />,
+    );
+    const input = screen.getByTestId(
+      "openvsp-file-input",
+    ) as HTMLInputElement;
+    const f = new File(["<vsp3/>"], "x.vsp3", {
+      type: "application/octet-stream",
+    });
+    await userEvent.upload(input, f);
+    const calledUrl = vi.mocked(global.fetch).mock.calls[0][0] as string;
+    expect(calledUrl).toMatch(/scale_factor=0\.5/);
+    expect(calledUrl).toMatch(/name=RV-7/);
+  });
 });

--- a/frontend/components/workbench/ImportOpenVspButton.tsx
+++ b/frontend/components/workbench/ImportOpenVspButton.tsx
@@ -58,18 +58,29 @@ type Props = {
   className?: string;
   label?: string;
   scaleOption?: ScaleOption;
+  /**
+   * Optional user-supplied aeroplane name forwarded to the backend as
+   * ``?name=<value>``. Empty / whitespace-only values are dropped so
+   * the server falls back to the uploaded filename's stem (the
+   * desired default).
+   */
+  customName?: string;
 };
 
-function buildImportUrl(scaleOption?: ScaleOption): string {
+function buildImportUrl(scaleOption?: ScaleOption, customName?: string): string {
   const base = `${API_BASE}/api/v2/import/openvsp`;
-  if (!scaleOption || scaleOption.mode === "none") return base;
   const params = new URLSearchParams();
-  if (scaleOption.mode === "target_span") {
+  if (scaleOption?.mode === "target_span") {
     params.set("target_span_m", String(scaleOption.target_span_m));
-  } else if (scaleOption.mode === "scale_factor") {
+  } else if (scaleOption?.mode === "scale_factor") {
     params.set("scale_factor", String(scaleOption.scale_factor));
   }
-  return `${base}?${params.toString()}`;
+  const trimmedName = customName?.trim() ?? "";
+  if (trimmedName) {
+    params.set("name", trimmedName);
+  }
+  const qs = params.toString();
+  return qs ? `${base}?${qs}` : base;
 }
 
 export default function ImportOpenVspButton({
@@ -78,6 +89,7 @@ export default function ImportOpenVspButton({
   className = "",
   label = "Import OpenVSP .vsp3",
   scaleOption,
+  customName,
 }: Props) {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [uploading, setUploading] = useState(false);
@@ -91,7 +103,7 @@ export default function ImportOpenVspButton({
     try {
       const form = new FormData();
       form.append("file", file);
-      const res = await fetch(buildImportUrl(scaleOption), {
+      const res = await fetch(buildImportUrl(scaleOption, customName), {
         method: "POST",
         body: form,
       });

--- a/frontend/components/workbench/construction-plans/AeroplanePickerDialog.tsx
+++ b/frontend/components/workbench/construction-plans/AeroplanePickerDialog.tsx
@@ -47,6 +47,9 @@ export function AeroplanePickerDialog({
   // can pick a mode before triggering the file dialog. Default "none"
   // matches the import-as-is contract.
   const [scaleOption, setScaleOption] = useState<ScaleOption>({ mode: "none" });
+  // Optional user-typed name for the imported aeroplane. Empty string
+  // means "let the server use the upload filename's stem".
+  const [importName, setImportName] = useState("");
   // Local error surface for OpenVSP-specific failures (503 if openvsp
   // isn't installed, 422 if the file is malformed, etc.). Keeps the
   // dialog open so the user can retry without losing context.
@@ -202,11 +205,28 @@ export function AeroplanePickerDialog({
           {(onCreate || onImport) && (
             <div className="border-t border-border px-6 py-4 space-y-3">
               {onImport && (
-                <ImportScaleInputs
-                  value={scaleOption}
-                  onChange={setScaleOption}
-                  disabled={submitting}
-                />
+                <>
+                  <label className="flex flex-col gap-1">
+                    <span className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                      Aeroplane name (optional)
+                    </span>
+                    <input
+                      type="text"
+                      value={importName}
+                      onChange={(e) => setImportName(e.target.value)}
+                      placeholder="Defaults to the .vsp3 file name"
+                      maxLength={200}
+                      disabled={submitting}
+                      data-testid="aeroplane-picker-import-name"
+                      className="rounded-lg border border-border bg-input px-3 py-2 text-[13px] text-foreground outline-none placeholder:text-subtle-foreground focus:border-primary disabled:opacity-50"
+                    />
+                  </label>
+                  <ImportScaleInputs
+                    value={scaleOption}
+                    onChange={setScaleOption}
+                    disabled={submitting}
+                  />
+                </>
               )}
               {importError && (
                 <p
@@ -233,9 +253,11 @@ export function AeroplanePickerDialog({
                   <ImportOpenVspButton
                     label="Import .vsp3"
                     scaleOption={scaleOption}
+                    customName={importName}
                     className="flex-1 rounded-full bg-input/40 text-foreground hover:bg-sidebar-accent"
                     onImported={(response) => {
                       setImportError(null);
+                      setImportName("");
                       onImport(response);
                     }}
                     onError={(message) => setImportError(message)}


### PR DESCRIPTION
## Summary

- Closes #704
- Add optional `?name=` query param to `/api/v2/import/openvsp` and pipe through to the persisted aeroplane
- Replace the previous `path.stem` fallback (which leaked the `NamedTemporaryFile` name like `tmpdcws5iey`) with the original upload filename's stem
- Add an "Aeroplane name (optional)" text input to the `AeroplanePickerDialog` so users can override before triggering the upload

## Test plan

- [x] `poetry run pytest -k openvsp` — 185 passed
- [x] `npm run test:unit` — 1079 passed (including 3 new cases in `ImportOpenVspButton.test.tsx`)
- [x] Backend: explicit name overrides filename; blank name falls back to filename; trimming works
- [x] Manual: upload `cessna172.vsp3` → aeroplane named `cessna172`; upload with input set to `"My Plane"` → `"My Plane"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)