### PR TITLE
fix(gh-706): fuselage axes — ASB-converter no longer rotates xsec 90°

### DIFF
--- a/app/converters/model_schema_converters.py
+++ b/app/converters/model_schema_converters.py
@@ -353,13 +353,18 @@ def _scale_asb_wing_geometry_schema(
 def _asb_fuselage_xsecs_from_schema(
     fuselage: schemas.FuselageSchema,
 ) -> List[FuselageXSec]:
+    # Axis convention (gh-706): schema.a = Y-half-axis = ASB.width,
+    # schema.b = Z-half-axis = ASB.height. ASB's own ellipse equation is
+    # ``(y/width)^n + (z/height)^n = 1`` — so a goes to width, b to
+    # height. The pre-fix code had these swapped, rotating every
+    # non-circular fuselage by 90° around the spine.
     return [
         FuselageXSec(
             xyz_c=[float(value) for value in x_sec.xyz],
             xyz_normal=[1.0, 0.0, 0.0],
             radius=None,
-            height=float(x_sec.a),
-            width=float(x_sec.b),
+            width=float(x_sec.a),
+            height=float(x_sec.b),
             shape=float(x_sec.n),
         )
         for x_sec in fuselage.x_secs
@@ -381,6 +386,8 @@ def fuselage_model_to_fuselage_config(
     fuselage: FuselageModel,
 ) -> FuselageConfiguration:
     fuselage_config = FuselageConfiguration(name=fuselage.name)
+    # See ``_asb_fuselage_xsecs_from_schema`` for axis-convention (gh-706):
+    # schema.a → ASB.width (Y), schema.b → ASB.height (Z).
     fuselage_config.asb_fuselage = asb.Fuselage(
         name=fuselage.name,
         xsecs=[
@@ -388,8 +395,8 @@ def fuselage_model_to_fuselage_config(
                 xyz_c=[float(value) for value in x_sec.xyz],
                 xyz_normal=[1.0, 0.0, 0.0],
                 radius=None,
-                height=float(x_sec.a),
-                width=float(x_sec.b),
+                width=float(x_sec.a),
+                height=float(x_sec.b),
                 shape=float(x_sec.n),
             )
             for x_sec in (fuselage.x_secs or [])

--- a/app/schemas/aeroplaneschema.py
+++ b/app/schemas/aeroplaneschema.py
@@ -566,6 +566,19 @@ class AsbWingGeometryWriteSchema(BaseModel):
 
 
 class FuselageXSecSuperEllipseSchema(BaseModel):
+    """Super-ellipse cross-section of a fuselage.
+
+    The shape obeys ``|y/a|^n + |z/b|^n = 1`` in the cross-section plane
+    (Y = lateral, Z = vertical). ``a`` and ``b`` are **half-axes**, not
+    full diameters; pick them to match VSP's ``Ellipse_Width/2`` and
+    ``Ellipse_Height/2`` respectively.
+
+    Axis convention (gh-706) — keep consistent across the stack:
+
+    * ``a`` → ASB ``FuselageXSec.width``  (Y, lateral / left-right)
+    * ``b`` → ASB ``FuselageXSec.height`` (Z, vertical / up-down)
+    """
+
     xyz: list[float] = Field(
         ...,
         description="Coordinates of the center of the cross-section in the local coordinate system",
@@ -573,12 +586,18 @@ class FuselageXSecSuperEllipseSchema(BaseModel):
     )
     a: float = Field(
         ...,
-        description="Semi-major axis of the superellipse in meters",
+        description=(
+            "Y-direction half-axis (semi-width) of the superellipse in metres. "
+            "Maps to ASB FuselageXSec.width."
+        ),
         examples=[0.5, 0.6],
     )
     b: float = Field(
         ...,
-        description="Semi-minor axis of the superellipse in meters",
+        description=(
+            "Z-direction half-axis (semi-height) of the superellipse in metres. "
+            "Maps to ASB FuselageXSec.height."
+        ),
         examples=[0.5, 0.4],
     )
     n: float = Field(

--- a/app/tests/test_model_schema_converters.py
+++ b/app/tests/test_model_schema_converters.py
@@ -673,7 +673,79 @@ def test_fuselage_model_to_fuselage_config():
     assert fuselage_config.name == "fuselage-a"
     assert fuselage_config.asb_fuselage is not None
     assert len(fuselage_config.asb_fuselage.xsecs) == 2
-    assert fuselage_config.asb_fuselage.xsecs[1].height == pytest.approx(0.06)
+    # Axis convention (gh-706): schema.a = Y-half-axis (ASB.width),
+    # schema.b = Z-half-axis (ASB.height). The second xsec has a=0.06, b=0.05.
+    assert fuselage_config.asb_fuselage.xsecs[1].width == pytest.approx(0.06)
+    assert fuselage_config.asb_fuselage.xsecs[1].height == pytest.approx(0.05)
+
+
+# ---------------------------------------------------------------------------
+# gh-706: Fuselage axis convention regression
+# ---------------------------------------------------------------------------
+
+
+class TestFuselageAxisConvention:
+    """The schema's ``a``/``b`` fields map to ASB's ``width``/``height`` via:
+
+        a  →  ASB.width   (Y half-axis, lateral / sideways)
+        b  →  ASB.height  (Z half-axis, vertical / up-down)
+
+    ASB's own ellipse equation is ``(y/width)^n + (z/height)^n = 1``.
+
+    These tests use deliberately **asymmetric** cross-sections (a ≠ b) so
+    that any axis swap is immediately visible — symmetric (round)
+    cross-sections would silently pass even under the pre-fix bug.
+    """
+
+    def test_asymmetric_xsec_through_fuselage_schema_converter(self):
+        """Roundtrip: a wider-than-tall fuselage stays wider than tall."""
+        from app.converters.model_schema_converters import (
+            _asb_fuselage_xsecs_from_schema,
+        )
+
+        wide_fuselage = schemas.FuselageSchema(
+            name="wide-glider-cabin",
+            x_secs=[
+                schemas.FuselageXSecSuperEllipseSchema(
+                    xyz=[0.0, 0.0, 0.0], a=0.0, b=0.0, n=2.0
+                ),
+                # Source body: 2 m wide (Y), 1 m tall (Z) → a=1.0, b=0.5.
+                schemas.FuselageXSecSuperEllipseSchema(
+                    xyz=[0.5, 0.0, 0.0], a=1.0, b=0.5, n=2.0
+                ),
+            ],
+        )
+
+        xsecs = _asb_fuselage_xsecs_from_schema(wide_fuselage)
+
+        assert xsecs[1].width == pytest.approx(1.0)
+        assert xsecs[1].height == pytest.approx(0.5)
+        assert xsecs[1].width > xsecs[1].height, (
+            f"Source body was wider than tall (a=1.0 > b=0.5); after the "
+            f"converter the ASB xsec must still satisfy width > height, "
+            f"got width={xsecs[1].width}, height={xsecs[1].height}."
+        )
+
+    def test_asymmetric_xsec_through_model_converter(self):
+        """Same invariant via the model→config path used by analysis runs."""
+        fuselage_model = FuselageModel.from_dict(
+            name="oblong",
+            data={
+                "x_secs": [
+                    {"xyz": [0.0, 0.0, 0.0], "a": 0.0, "b": 0.0, "n": 2.0},
+                    # 0.4 m Y-half, 0.1 m Z-half: a much wider than b.
+                    {"xyz": [0.5, 0.0, 0.0], "a": 0.4, "b": 0.1, "n": 2.0},
+                ]
+            },
+        )
+
+        fuselage_config = fuselage_model_to_fuselage_config(fuselage_model)
+
+        assert fuselage_config.asb_fuselage is not None
+        xs = fuselage_config.asb_fuselage.xsecs[1]
+        assert xs.width == pytest.approx(0.4)
+        assert xs.height == pytest.approx(0.1)
+        assert xs.width > xs.height
 
 
 class TestBuildAsbAirfoil:


### PR DESCRIPTION
## Summary

- Closes #706
- ASB-converter swapped schema `a`/`b` to ASB `height`/`width` — rotates every non-circular fuselage 90° around the spine
- Swap to the correct mapping: `width = a` (Y, lateral), `height = b` (Z, vertical)
- Schema docstring rewritten with explicit axis names so the next converter can't silently make the same mistake

## Why this matters

Was hidden by Cessna 172 (nearly circular xsecs), surfaces immediately for any oblong fuselage (glider cabin, teardrop, anything with `Width ≠ Height` in OpenVSP). AeroBuildup drag estimates and CAD-derived wetted area both get the frontal area wrong by the ratio `a/b`.

## Test plan

- [x] New `TestFuselageAxisConvention` (2 cases, asymmetric xsecs) — failing on main, passing after fix
- [x] Adjusted `test_fuselage_model_to_fuselage_config` which encoded the buggy mapping
- [x] `poetry run pytest -k "fuselage or openvsp or converter"` → 325 passed
- [x] `ruff check` clean
- [ ] Manual: re-import an OpenVSP file with non-round fuselage, eyeball workbench 3D viewer — out of scope for the fix PR, will verify when #693 lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)