### PR TITLE
feat(gh-693): persist fuselages + weight items in OpenVSP importer

### DIFF
--- a/app/services/openvsp_import_service.py
+++ b/app/services/openvsp_import_service.py
@@ -1,13 +1,15 @@
-"""Service layer for the OpenVSP `.vsp3` importer (gh-646).
+"""Service layer for the OpenVSP `.vsp3` importer (gh-646, gh-693).
 
 Bridges :func:`app.converters.openvsp_importer.import_vsp3` and the
-existing aeroplane/wing/fuselage services. Persists the parsed model
-in a single transaction and returns a structured response describing
-which components were imported and which were dropped with warnings.
+existing aeroplane/wing/fuselage/weight-item services. Persists the
+parsed model in a single transaction and returns a structured
+response describing which components were imported and which were
+dropped with warnings.
 
-Scope per ``feedback_openvsp_import_rc_scope``: the service does NOT
-attach weight items in Phase 1 (no DB-level WeightItem write — the
-warnings surface the count to the user; a future PR adds the join).
+Phase 1.5 (gh-693): the importer now persists **all** four component
+types — Aeroplane, Wings, Fuselages, and Weight Items. Each component
+write is wrapped in its own try/except; a failure on one record adds
+a warning instead of rolling back the whole import.
 
 Optional Quick-Scale (gh-695, Variante A)
 -----------------------------------------
@@ -38,7 +40,7 @@ from typing import Optional
 from sqlalchemy.orm import Session
 
 from app.converters import openvsp_adapter
-from app.converters.openvsp_importer import ImportResult, import_vsp3
+from app.converters.openvsp_importer import ImportResult, ImportWarning, import_vsp3
 from app.schemas.aeroplaneschema import (
     AeroplaneSchema,
     AsbWingGeometryWriteSchema,
@@ -269,6 +271,36 @@ def _resolve_aeroplane_name(
     return "OpenVSP Import"
 
 
+def _record_persist_failure(
+    result: ImportResult,
+    *,
+    component_type: str,
+    component_name: str,
+    exc: Exception,
+) -> None:
+    """Log a per-component persistence failure and surface it as a
+    user-visible warning so the importer banner can show it.
+
+    One failure must not roll back the whole import: the rest of the
+    aeroplane (other wings/fuselages/weight items) stays usable.
+    """
+    logger.warning(
+        "Failed to persist %s %r: %s",
+        component_type.lower(),
+        component_name,
+        exc,
+        exc_info=True,
+    )
+    result.warnings.append(
+        ImportWarning(
+            component_type=component_type,
+            component_name=component_name,
+            reason=f"Failed to persist {component_type.lower()} to database: {exc}",
+            severity="warning",
+        )
+    )
+
+
 def _persist_aeroplane(
     db: Session,
     result: ImportResult,
@@ -276,10 +308,22 @@ def _persist_aeroplane(
     name: Optional[str] = None,
     source_filename: Optional[str] = None,
 ) -> tuple[str, str]:
-    """Persist the parsed aeroplane and return (uuid_str, name)."""
+    """Persist the parsed aeroplane and return (uuid_str, name).
+
+    Writes (gh-693): Aeroplane + Wings + Fuselages + WeightItems. Each
+    component is wrapped in its own try/except — a failure on one
+    record records a warning but lets the rest of the import succeed,
+    so the user never loses an entire aeroplane to a single broken
+    fuselage or weight item.
+    """
     # Lazy import to avoid pulling sqlalchemy/CAD pieces at module load
     # in environments that only need the importer (e.g. unit tests).
-    from app.services import aeroplane_service, wing_service
+    from app.services import (
+        aeroplane_service,
+        fuselage_service,
+        weight_items_service,
+        wing_service,
+    )
 
     resolved_name = _resolve_aeroplane_name(
         explicit_name=name,
@@ -312,12 +356,32 @@ def _persist_aeroplane(
                 )
                 wing_service.create_wing(db, aeroplane.uuid, wing_name, write)
             except Exception as exc:  # noqa: BLE001 — convert to warning
-                logger.warning("Failed to persist wing %r: %s", wing_name, exc, exc_info=True)
+                _record_persist_failure(
+                    result, component_type="WING", component_name=wing_name, exc=exc
+                )
 
-    # Fuselages: delegate to a future fuselage_service.create_fuselage.
-    # Phase 1: counted in the response envelope; DB-level persistence is
-    # deferred to a follow-up issue (no fuselage_service.create_fuselage
-    # entry-point exists today).
+    # Fuselages (gh-693): persist each fuselage via fuselage_service.
+    # FuselageSchema fields are already in metres (no unit conversion
+    # needed — different from wings which are mm-in-schema).
+    if result.aeroplane.fuselages:
+        for fuse_name, fuse in result.aeroplane.fuselages.items():
+            try:
+                fuselage_service.create_fuselage(db, aeroplane.uuid, fuse_name, fuse)
+            except Exception as exc:  # noqa: BLE001
+                _record_persist_failure(
+                    result, component_type="FUSELAGE", component_name=fuse_name, exc=exc
+                )
+
+    # Weight items (gh-693): persist each WeightItemWrite via the same
+    # entry point the manual mass-properties UI uses, so categories,
+    # CG-recompute hooks, and validation stay aligned.
+    for item in result.weight_items:
+        try:
+            weight_items_service.create_weight_item(db, aeroplane.uuid, item)
+        except Exception as exc:  # noqa: BLE001
+            _record_persist_failure(
+                result, component_type="WEIGHT_ITEM", component_name=item.name, exc=exc
+            )
 
     return str(aeroplane.uuid), aeroplane.name
 

--- a/app/tests/test_openvsp_import_endpoint.py
+++ b/app/tests/test_openvsp_import_endpoint.py
@@ -368,3 +368,191 @@ class TestImportEndpointAeroplaneName:
         )
         assert r.status_code == 201, r.text
         assert r.json()["aeroplane_name"] == "Cessna 172"
+
+
+# ---------------------------------------------------------------------------
+# gh-693: Phase 1.5 — Fuselage + WeightItem DB persistence
+# ---------------------------------------------------------------------------
+
+
+def _stub_import_vsp3_with_fuselage_and_weights(monkeypatch):
+    """Patch ``import_vsp3`` to yield an ImportResult with one wing,
+    one fuselage (3 super-ellipse xsecs), and 2 weight items.
+    """
+    from app.converters import openvsp_importer
+    from app.schemas.aeroplaneschema import (
+        AeroplaneSchema,
+        AsbWingSchema,
+        FuselageSchema,
+        FuselageXSecSuperEllipseSchema,
+        WingXSecSchema,
+    )
+    from app.schemas.weight_item import WeightItemWrite
+
+    def _fake_import(path):  # noqa: ARG001 — fixture-only path
+        wing = AsbWingSchema(
+            name="Main",
+            symmetric=True,
+            x_secs=[
+                WingXSecSchema(
+                    xyz_le=[0.0, 0.0, 0.0],
+                    chord=0.5,
+                    twist=0.0,
+                    airfoil="naca0015",
+                ),
+                WingXSecSchema(
+                    xyz_le=[0.0, 5.0, 0.0],
+                    chord=0.2,
+                    twist=0.0,
+                    airfoil="naca0015",
+                ),
+            ],
+        )
+        fuse = FuselageSchema(
+            name="Fuselage",
+            x_secs=[
+                FuselageXSecSuperEllipseSchema(
+                    xyz=[0.0, 0.0, 0.0], a=0.0, b=0.0, n=2.0
+                ),
+                FuselageXSecSuperEllipseSchema(
+                    xyz=[1.0, 0.0, 0.0], a=0.4, b=0.3, n=2.0
+                ),
+                FuselageXSecSuperEllipseSchema(
+                    xyz=[2.0, 0.0, 0.0], a=0.0, b=0.0, n=2.0
+                ),
+            ],
+        )
+        ap = AeroplaneSchema(name="WithFuse")
+        ap.wings = OrderedDict([("Main", wing)])
+        ap.fuselages = OrderedDict([("Fuselage", fuse)])
+
+        return openvsp_importer.ImportResult(
+            aeroplane=ap,
+            warnings=[],
+            lossy_components=[],
+            weight_items=[
+                WeightItemWrite(
+                    name="Battery",
+                    mass_kg=1.5,
+                    x_m=0.3,
+                    y_m=0.0,
+                    z_m=0.05,
+                    category="other",
+                ),
+                WeightItemWrite(
+                    name="ESC",
+                    mass_kg=0.08,
+                    x_m=0.5,
+                    y_m=0.1,
+                    z_m=0.0,
+                    category="other",
+                ),
+            ],
+        )
+
+    from app.services import openvsp_import_service
+
+    monkeypatch.setattr(openvsp_importer, "import_vsp3", _fake_import)
+    monkeypatch.setattr(openvsp_import_service, "import_vsp3", _fake_import)
+
+
+class TestImportEndpointPersistence:
+    """After a successful import the DB must contain the parsed
+    fuselages and weight items — not just the wing.
+
+    Pre-gh-693 the importer counted them in the response envelope but
+    silently dropped them on the way to the DB, leaving the user with
+    a wing-only aeroplane that couldn't be scaled or analysed end-to-end.
+    """
+
+    def test_fuselage_persisted_after_import(self, client, monkeypatch):
+        from app.services import openvsp_import_service
+
+        monkeypatch.setattr(openvsp_import_service, "is_importer_available", lambda: True)
+        _stub_import_vsp3_with_fuselage_and_weights(monkeypatch)
+
+        r = client.post(
+            "/api/v2/import/openvsp",
+            files={"file": ("x.vsp3", b"<vsp3/>", "application/octet-stream")},
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["n_fuselages"] == 1
+
+        # Fuselage must be retrievable through the REST API.
+        uuid = body["aeroplane_uuid"]
+        rs = client.get(f"/aeroplanes/{uuid}/fuselages/Fuselage")
+        assert rs.status_code == 200, rs.text
+        fuse = rs.json()
+        assert fuse["name"] == "Fuselage"
+        assert len(fuse["x_secs"]) == 3
+        # Middle xsec carries the non-trivial geometry.
+        mid = fuse["x_secs"][1]
+        assert mid["a"] == pytest.approx(0.4)
+        assert mid["b"] == pytest.approx(0.3)
+        assert mid["xyz"] == [pytest.approx(1.0), pytest.approx(0.0), pytest.approx(0.0)]
+
+    def test_weight_items_persisted_after_import(self, client, monkeypatch):
+        from app.services import openvsp_import_service
+
+        monkeypatch.setattr(openvsp_import_service, "is_importer_available", lambda: True)
+        _stub_import_vsp3_with_fuselage_and_weights(monkeypatch)
+
+        r = client.post(
+            "/api/v2/import/openvsp",
+            files={"file": ("x.vsp3", b"<vsp3/>", "application/octet-stream")},
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["n_weight_items"] == 2
+
+        # Weight items must be readable via the existing weight-items
+        # endpoint. The list-endpoint returns a WeightSummary envelope
+        # ``{items, total_mass_kg, cg_x_m, cg_y_m, cg_z_m}``.
+        uuid = body["aeroplane_uuid"]
+        rs = client.get(f"/aeroplanes/{uuid}/weight-items")
+        assert rs.status_code == 200, rs.text
+        summary = rs.json()
+        items = summary["items"]
+        assert len(items) == 2
+        names = sorted(it["name"] for it in items)
+        assert names == ["Battery", "ESC"]
+        battery = next(it for it in items if it["name"] == "Battery")
+        assert battery["mass_kg"] == pytest.approx(1.5)
+        assert battery["x_m"] == pytest.approx(0.3)
+        assert battery["category"] == "other"
+        # CG of (1.5 kg @ x=0.3) + (0.08 kg @ x=0.5) ≈ 0.31013 m. The
+        # endpoint rounds to 6 decimals — keep the tolerance loose.
+        assert summary["total_mass_kg"] == pytest.approx(1.58)
+        expected_cg = (1.5 * 0.3 + 0.08 * 0.5) / 1.58
+        assert summary["cg_x_m"] == pytest.approx(expected_cg, abs=1e-5)
+
+    def test_fuselage_failure_becomes_warning_not_crash(self, client, monkeypatch):
+        """A broken fuselage write must not roll back the whole import —
+        the wing should still land, and the failure must surface as an
+        importer warning so the user sees what happened.
+        """
+        from app.services import fuselage_service, openvsp_import_service
+
+        monkeypatch.setattr(openvsp_import_service, "is_importer_available", lambda: True)
+        _stub_import_vsp3_with_fuselage_and_weights(monkeypatch)
+
+        def _boom(*_a, **_kw):
+            raise RuntimeError("simulated DB failure on fuselage write")
+
+        monkeypatch.setattr(fuselage_service, "create_fuselage", _boom)
+
+        r = client.post(
+            "/api/v2/import/openvsp",
+            files={"file": ("x.vsp3", b"<vsp3/>", "application/octet-stream")},
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        # Wing still landed.
+        uuid = body["aeroplane_uuid"]
+        rs = client.get(f"/aeroplanes/{uuid}/wings/Main")
+        assert rs.status_code == 200, rs.text
+        # Failure surfaced as a FUSELAGE-typed warning.
+        fuse_warnings = [w for w in body["warnings"] if w["component_type"] == "FUSELAGE"]
+        assert fuse_warnings, body["warnings"]
+        assert "simulated DB failure" in fuse_warnings[0]["reason"]


### PR DESCRIPTION
## Summary

- Closes #693
- Wires `fuselage_service.create_fuselage` + `weight_items_service.create_weight_item` into the importer's `_persist_aeroplane`
- Per-component try/except → failures surface as `ImportWarning` in the banner instead of crashing the whole import
- New helper `_record_persist_failure` keeps the wing/fuselage/weight-item failure paths symmetric (previously wings logged silently)

## Why this matters

An imported aeroplane can now actually be scaled to RC — fuselage geometry needed for ASB drag (gh-707 fixed the axes), and mass items needed for the CG target.

## Test plan

- [x] 3 new endpoint tests (`TestImportEndpointPersistence`): fuselage persisted, weight items persisted, fuselage-failure-becomes-warning
- [x] 188 OpenVSP tests pass (was 185)
- [x] 224 fuselage/weight-item-related tests pass (no regression)
- [x] `ruff check` clean
- [ ] Manual: re-import `cessna172.vsp3`, eyeball the fuselage in the workbench 3D viewer + check the mass-properties panel for the weight items

🤖 Generated with [Claude Code](https://claude.com/claude-code)