### PR TITLE
fix(gh-711): fuselage XSec positions — GetXSecParm instead of FindParm

### DIFF
--- a/app/converters/openvsp_fuselage_handler.py
+++ b/app/converters/openvsp_fuselage_handler.py
@@ -190,13 +190,17 @@ def _read_loc_pct(
 ) -> float:
     """Read ``{X,Y,Z}LocPercent`` from an XSec container.
 
-    These parms live on the XSec itself in group ``XSec`` (OpenVSP
-    3.50 convention) — NOT on the parent fuselage with an index
-    suffix. Fallback when missing: an evenly-spaced fraction
-    ``i / (n_xsec - 1)`` so we at least lay xsecs out along the
-    spine for X and produce 0 for Y/Z.
+    OpenVSP 3.50 convention (gh-711): the position parms live on the
+    XSec container in group ``XSec``, but ``FindParm(xs_id, …, "XSec")``
+    silently returns ``""`` for XSec containers. The only reliable
+    access path is ``GetXSecParm`` — the same family we use for shape
+    parms (``Circle_Diameter``, ``Super_Width`` …).
+
+    Fallback when the parm genuinely isn't there (rare — should only
+    happen for degenerate stub fuselages): an evenly-spaced fraction
+    ``i / (n_xsec - 1)`` for X, ``0`` for Y/Z.
     """
-    pid = vsp.FindParm(xs_id, f"{axis}LocPercent", "XSec")
+    pid = vsp.GetXSecParm(xs_id, f"{axis}LocPercent")
     if not pid:
         if axis == "X" and n_xsec > 1:
             return i / (n_xsec - 1)

--- a/app/tests/test_openvsp_fuselage_handler.py
+++ b/app/tests/test_openvsp_fuselage_handler.py
@@ -134,10 +134,14 @@ def _make_fuse_vsp(
     fake.GetXSecWidth = lambda xs_id: _xsec_dim(xs_id, "W")
     fake.GetXSecHeight = lambda xs_id: _xsec_dim(xs_id, "H")
 
-    # Parm routing per OpenVSP 3.50 convention (gh-702): Length lives on
-    # the fuselage container in group Design; XLocPercent/YLocPercent/
-    # ZLocPercent live on EACH XSec container in group XSec; XForm
-    # translation/rotation live on the fuselage container in group XForm.
+    # Parm routing per OpenVSP 3.50 convention (gh-711): Length lives on
+    # the fuselage container in group Design; XForm translation/rotation
+    # live on the fuselage container in group XForm. The per-XSec
+    # position parms (XLocPercent etc.) cannot be reached via
+    # ``FindParm(xs_id, ..., "XSec")`` — real OpenVSP 3.50 returns ""
+    # for that call. They are only reachable via ``GetXSecParm`` (see
+    # ``_get_xsec_parm`` stub above, which already routes ``x_pct``/
+    # ``y_pct``/``z_pct`` through the right XSec keys).
     xform = xform or {}
     XFORM_PARMS = {
         "X_Location", "Y_Location", "Z_Location",
@@ -151,15 +155,24 @@ def _make_fuse_vsp(
             return "PFUSE::Length"
         if container == fuse_id and group == "XForm" and parm in XFORM_PARMS:
             return f"PXFORM::{parm}"
-        if container.startswith("XS_") and group == "XSec" and parm in _LOC_KEY:
-            # Mirror real OpenVSP: return "" when the test dict doesn't
-            # declare the corresponding *_pct key, so the handler's
-            # fallback path is exercised.
-            idx = int(container.split("_", 1)[1])
-            if _LOC_KEY[parm] not in xsecs[idx]:
-                return ""
-            return f"PXSEC::{container}::{parm}"
+        # XSec-position parms: real OpenVSP 3.50 returns "" here — the
+        # handler must reach them via GetXSecParm instead.
         return ""
+
+    # Route GetXSecParm so position parms (XLocPercent/YLocPercent/
+    # ZLocPercent) work via the same key lookup as the shape parms.
+    _orig_get_xsec_parm = fake.GetXSecParm
+
+    def _get_xsec_parm_routed(xs_id: str, name: str) -> str:
+        if name in _LOC_KEY:
+            idx = int(xs_id.split("_", 1)[1])
+            loc_key = _LOC_KEY[name]
+            if loc_key not in xsecs[idx]:
+                return ""
+            return f"PXSEC::{xs_id}::{name}"
+        return _orig_get_xsec_parm(xs_id, name)
+
+    fake.GetXSecParm = _get_xsec_parm_routed
 
     def _get_parm_val_router(pid):
         if not pid:
@@ -399,6 +412,55 @@ class TestCessna172FuselageRegression:
         bodies = fuse.x_secs[1:-1]
         for left, right in zip(bodies, bodies[1:], strict=False):
             assert (left.a, left.b) != (right.a, right.b)
+
+    def test_real_cessna_xsec_positions_match(self, tmp_path, monkeypatch):
+        """gh-711: every xsec X/Z position must match the real Cessna
+        172 values within 1 mm, not the ``i/(n-1)``-fallback evenly
+        spaced grid the broken FindParm path produced.
+        """
+        f = tmp_path / "cessna_pos.vsp3"
+        f.write_text("")
+        length = 7.23
+        # (XLocPercent, ZLocPercent) probed from cessna172.vsp3.
+        positions = [
+            (0.0000, 0.0000),
+            (0.0567, 0.0000),
+            (0.0747, -0.0069),
+            (0.1494, -0.0221),
+            (0.2102, -0.0194),
+            (0.2752, 0.0124),
+            (0.5076, 0.0194),
+            (0.5864, 0.0097),
+            (0.9862, 0.0429),
+            (1.0000, 0.0429),
+        ]
+        # Minimal xsec list — only the position parms matter here, shape
+        # values are stubs sufficient for the bounding reader to return
+        # something non-degenerate.
+        xsecs = [
+            {
+                "shape": "SUPER_ELLIPSE", "x_pct": x, "z_pct": z,
+                "Super_Width": 0.5, "Super_Height": 0.5,
+                "Super_M": 2.0, "Super_N": 2.0,
+            }
+            for x, z in positions
+        ]
+        fake = _make_fuse_vsp(xsecs=xsecs, length=length)
+        monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: fake)
+        result = import_vsp3(f)
+
+        fuse = (result.aeroplane.fuselages or {})["Fuselage"]
+        for i, (x_pct, z_pct) in enumerate(positions):
+            expected_x = x_pct * length
+            expected_z = z_pct * length
+            assert fuse.x_secs[i].xyz[0] == pytest.approx(expected_x, abs=1e-3), (
+                f"xsec[{i}] X drift: expected {expected_x:.4f} m, "
+                f"got {fuse.x_secs[i].xyz[0]:.4f} m"
+            )
+            assert fuse.x_secs[i].xyz[2] == pytest.approx(expected_z, abs=1e-3), (
+                f"xsec[{i}] Z versatz lost: expected {expected_z:+.4f} m, "
+                f"got {fuse.x_secs[i].xyz[2]:+.4f} m"
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Closes #711
- `FindParm(xs_id, "XLocPercent", "XSec")` silently returns `""` for XSec containers in OpenVSP 3.50.4 — every imported fuselage fell back to `i/(n-1)` evenly-spaced X and `0` Y/Z
- Fix: use `GetXSecParm` (same API the handler already uses for shape parms like `Circle_Diameter`)
- Cessna 172 now matches VSP within 1 mm on both X and Z — every xsec, including the cockpit dip (z = −0.16 m) and the tail rise (z = +0.31 m)

## Verification

Side-by-side after the fix (all WORLD coordinates, Length = 7.23 m, XForm trans = −2.42 m):

| i | shape | VSP X | Z | unser X | Z | OK |
|---|---|---|---|---|---|---|
| 0 | SHIFT_LE | −2.420 | +0.000 | −2.420 | +0.000 | ✓ |
| 2 | SUPER_ELLIPSE | −1.880 | −0.050 | −1.880 | −0.050 | ✓ |
| 3 | SUPER_ELLIPSE | −1.340 | −0.160 | −1.340 | −0.160 | ✓ |
| 5 | GENERAL_FUSE | −0.430 | +0.090 | −0.430 | +0.090 | ✓ |
| 8 | SUPER_ELLIPSE | +4.710 | +0.310 | +4.710 | +0.310 | ✓ |
| 9 | SHIFT_LE | +4.810 | +0.310 | +4.810 | +0.310 | ✓ |

(Full 10-row table in the issue description.)

## Test plan

- [x] New `test_real_cessna_xsec_positions_match`: replays the 10 real (XLoc%, ZLoc%) tuples, asserts 1 mm match
- [x] Test stub now mirrors real OpenVSP 3.50: `FindParm` for XSec → `""`, positions via `GetXSecParm` only
- [x] 24 fuselage-handler tests pass, 298 fuselage+openvsp tests pass
- [x] `ruff check` clean
- [ ] Manual: re-import cessna172.vsp3 in workbench, verify the fuselage now tracks the orange original

## Followup

GENERAL_FUSE xsecs are still bounding-ellipse approximations with `n = 2`. xsec[5] has up to 26 cm radial error vs. the real Mansardendach-shape outline. Fitting a free `n` exponent against `ComputeXSecPnt` samples is tracked separately as #712.

🤖 Generated with [Claude Code](https://claude.com/claude-code)