### PR TITLE
fix(gh-624): retrim validates control deflections against current geometry

### DIFF
--- a/app/services/aerobuildup_trim_service.py
+++ b/app/services/aerobuildup_trim_service.py
@@ -82,6 +82,21 @@ async def trim_with_aerobuildup(
     asb_airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
     asb_airplane.xyz_ref = op.xyz_ref
 
+    # gh-624: guard against stale control-deflection keys on the OP.
+    # ``Airplane.with_control_deflections`` silently drops keys that
+    # don't match any ``ControlSurface.name`` on the airplane — so a
+    # renamed elevator (``elevator`` → ``elev_pitch``) would let a
+    # retrim run cleanly on a pruned deflection set and mark the OP
+    # ``TRIMMED`` on a result that no longer applies. Validating
+    # here closes the gap for **both** entry points: endpoint callers
+    # (Trefftz / streamline) AND the background ``retrim_dirty_ops``.
+    # The validator is a no-op when ``control_deflections`` is empty.
+    from app.services.operating_point_resolver import (
+        validate_deflections_against_airplane,
+    )
+
+    validate_deflections_against_airplane(asb_airplane, op.control_deflections)
+
     atmosphere = asb.Atmosphere(altitude=op.altitude)
     op_point = asb.OperatingPoint(
         velocity=op.velocity,

--- a/app/tests/test_aerobuildup_trim_validates_deflections.py
+++ b/app/tests/test_aerobuildup_trim_validates_deflections.py
@@ -1,0 +1,151 @@
+"""Regression test for gh-624: ``trim_with_aerobuildup`` must validate
+``operating_point.control_deflections`` against the actual airplane's
+``ControlSurface.name`` set, otherwise stale keys (e.g. ``elevator``
+after a rename to ``elev_pitch``) get silently dropped by AeroSandbox
+and the OP is marked ``TRIMMED`` on a deflection set that no longer
+applies.
+
+The fix puts the guard inside ``trim_with_aerobuildup`` so both call
+sites — endpoint handlers AND the background ``retrim_dirty_ops`` —
+benefit. We test by injecting an OP with a known-stale deflection
+key and asserting a ``ValidationDomainError`` with the expected list
+of unknown surfaces.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from app.core.exceptions import ValidationDomainError
+from app.tests.conftest import make_aeroplane
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _build_aeroplane_with_elevator(db, name: str = "trim-validate"):
+    """Build a minimal aeroplane with a wing + a TED named ``elevator``
+    so that the airplane has exactly one control surface."""
+    from app.models.aeroplanemodel import (
+        WingModel,
+        WingXSecModel,
+        WingXSecDetailModel,
+        WingXSecTrailingEdgeDeviceModel,
+    )
+
+    aeroplane = make_aeroplane(db, name=name)
+    wing = WingModel(name="h-stab", aeroplane_id=aeroplane.id, symmetric=True)
+    db.add(wing)
+    db.flush()
+    for i, x in enumerate([0.0, 0.5]):
+        xsec = WingXSecModel(
+            wing_id=wing.id,
+            xyz_le=[0, x, 0],
+            chord=0.2,
+            twist=0.0,
+            airfoil="naca0012",
+            sort_index=i,
+        )
+        db.add(xsec)
+        db.flush()
+        if i == 0:  # The TED lives on the root xsec.
+            detail = WingXSecDetailModel(wing_xsec_id=xsec.id)
+            db.add(detail)
+            db.flush()
+            ted = WingXSecTrailingEdgeDeviceModel(
+                wing_xsec_detail_id=detail.id,
+                name="elevator",
+                role="elevator",
+            )
+            db.add(ted)
+    db.commit()
+    return aeroplane
+
+
+def test_trim_raises_when_op_has_unknown_deflection_keys(client_and_db):
+    """The fix: ``trim_with_aerobuildup`` rejects an OP whose stored
+    ``control_deflections`` reference surfaces that don't exist."""
+    _, SessionLocal = client_and_db
+    db = SessionLocal()
+    aeroplane = _build_aeroplane_with_elevator(db, name="stale-deflections")
+
+    from app.schemas.aeroanalysisschema import (
+        AeroBuildupTrimRequest,
+        OperatingPointSchema,
+    )
+
+    op_schema = OperatingPointSchema(
+        velocity=30.0,
+        alpha=2.0,
+        beta=0.0,
+        p=0.0, q=0.0, r=0.0,
+        altitude=500.0,
+        xyz_ref=[0.0, 0.0, 0.0],
+        # Stale name — geometry has "elevator" but the OP was trimmed
+        # before a rename and still references "elev_pitch".
+        control_deflections={"elev_pitch": -2.5},
+    )
+    request = AeroBuildupTrimRequest(
+        operating_point=op_schema,
+        trim_variable="elevator",
+        target_coefficient="Cm",
+        target_value=0.0,
+    )
+
+    from app.services.aerobuildup_trim_service import trim_with_aerobuildup
+
+    with pytest.raises(ValidationDomainError) as exc_info:
+        _run(trim_with_aerobuildup(db, aeroplane.uuid, request))
+
+    msg = str(exc_info.value)
+    assert "elev_pitch" in msg
+    # Validator lists the surfaces available on the airplane so the
+    # user sees what's expected.
+    assert "elevator" in msg
+    db.close()
+
+
+def test_trim_passes_when_op_has_no_deflections(client_and_db):
+    """No-op when ``control_deflections`` is empty — the validator must
+    not error out. We mock the aero solver so the test stays fast and
+    doesn't depend on a working AeroBuildup compute."""
+    _, SessionLocal = client_and_db
+    db = SessionLocal()
+    aeroplane = _build_aeroplane_with_elevator(db, name="empty-deflections")
+
+    from app.schemas.aeroanalysisschema import (
+        AeroBuildupTrimRequest,
+        OperatingPointSchema,
+    )
+
+    op_schema = OperatingPointSchema(
+        velocity=30.0,
+        alpha=2.0,
+        beta=0.0,
+        p=0.0, q=0.0, r=0.0,
+        altitude=500.0,
+        xyz_ref=[0.0, 0.0, 0.0],
+        control_deflections=None,
+    )
+    request = AeroBuildupTrimRequest(
+        operating_point=op_schema,
+        trim_variable="elevator",
+        target_coefficient="Cm",
+        target_value=0.0,
+    )
+
+    # Mock the inner aero call so the test stays quick. We only care
+    # that the validator doesn't reject an empty dict.
+    with patch(
+        "app.services.aerobuildup_trim_service._run_single_aerobuildup",
+        return_value={"Cm": 0.0, "CL": 0.4, "CD": 0.03},
+    ):
+        from app.services.aerobuildup_trim_service import trim_with_aerobuildup
+
+        result = _run(trim_with_aerobuildup(db, aeroplane.uuid, request))
+        assert result is not None  # got past the validator + ran the mocked solver
+    db.close()


### PR DESCRIPTION
## Summary

Closes the silent-failure where the background ``retrim_dirty_ops`` path
trims OPs whose stored ``control_deflections`` reference surfaces that
no longer exist (e.g. renamed elevator). AeroSandbox silently drops
unknown deflection keys; the OP got marked ``TRIMMED`` on a pruned set.

## Fix

Validate ``op.control_deflections`` against the live airplane inside
``trim_with_aerobuildup`` — both endpoint callers and the retrim
background job now go through the same guard.

## Test plan

- [x] New ``test_aerobuildup_trim_validates_deflections.py`` — 2 tests
- [x] Existing 49 retrim/resolver tests pass
- [ ] Manual: rename a control surface, mark an OP dirty, observe ``NOT_TRIMMED`` status (vs silent ``TRIMMED``)

Closes #624

🤖 Generated with [Claude Code](https://claude.com/claude-code)