### PR TITLE
feat(gh-477): landing field length — mission inputs + L_landing chip

### DIFF
--- a/alembic/versions/3b58409a0f04_gh_477_add_landing_field_inputs_to_.py
+++ b/alembic/versions/3b58409a0f04_gh_477_add_landing_field_inputs_to_.py
@@ -1,0 +1,39 @@
+"""gh-477 add landing field inputs to mission objectives
+
+Revision ID: 3b58409a0f04
+Revises: b5297a4b135a
+Create Date: 2026-05-27 01:26:34.872233
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '3b58409a0f04'
+down_revision: Union[str, None] = 'b5297a4b135a'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add the three optional landing-field inputs to mission_objectives.
+
+    All three are nullable with no DB-layer default — the service layer
+    fills in grass_short / 1.5 / None when the user has not set them.
+    See gh-477 acceptance criteria.
+    """
+    with op.batch_alter_table("mission_objectives") as batch_op:
+        batch_op.add_column(sa.Column("landing_surface", sa.String(), nullable=True))
+        batch_op.add_column(sa.Column("landing_safety_factor", sa.Float(), nullable=True))
+        batch_op.add_column(sa.Column("available_field_length_m", sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop the three columns added by the upgrade."""
+    with op.batch_alter_table("mission_objectives") as batch_op:
+        batch_op.drop_column("available_field_length_m")
+        batch_op.drop_column("landing_safety_factor")
+        batch_op.drop_column("landing_surface")

--- a/app/models/mission_objective.py
+++ b/app/models/mission_objective.py
@@ -35,4 +35,12 @@ class MissionObjectiveModel(Base):
     t_static_N = Column(Float, nullable=False, default=18.0)
     takeoff_mode = Column(String, nullable=False, default="runway")
 
+    # gh-477: Landing-field-length inputs. Optional — when unset the
+    # service falls back to grass-short / safety=1.5 / no length check.
+    # See LANDING_SURFACE_MU in assumption_compute_service.py for the
+    # μ_eff lookup table.
+    landing_surface = Column(String, nullable=True)
+    landing_safety_factor = Column(Float, nullable=True)
+    available_field_length_m = Column(Float, nullable=True)
+
     aeroplane = relationship("AeroplaneModel", back_populates="mission_objective")

--- a/app/schemas/mission_objective.py
+++ b/app/schemas/mission_objective.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -10,6 +10,20 @@ from app.schemas.mission_kpi import AxisName
 
 RunwayType = Literal["grass", "asphalt", "belly"]
 TakeoffMode = Literal["runway", "hand_launch", "bungee", "catapult"]
+
+# gh-477: surface taxonomy for landing-field-length computation. μ_eff
+# lookup lives in assumption_compute_service.LANDING_SURFACE_MU. The
+# six surfaces span the realistic RC / UAV operations envelope; brake-
+# equipped paved is out of scope until a per-aircraft brake flag exists
+# (see "Out of Scope" on gh-477).
+LandingSurface = Literal[
+    "grass_short",
+    "grass_long",
+    "hard_paved",
+    "soft_soil",
+    "belly_grass",
+    "net_recovery",
+]
 
 
 class MissionObjective(BaseModel):
@@ -31,6 +45,25 @@ class MissionObjective(BaseModel):
     runway_type: RunwayType
     t_static_N: float = Field(..., ge=0, description="Static thrust at V=0")
     takeoff_mode: TakeoffMode
+
+    # gh-477: landing-field-length inputs. All optional — the service
+    # falls back to grass-short / safety=1.5 / no length check when
+    # absent.
+    landing_surface: Optional[LandingSurface] = Field(
+        None,
+        description="Expected landing surface — drives μ_eff for s_ground",
+    )
+    landing_safety_factor: Optional[float] = Field(
+        None,
+        ge=1.0,
+        le=3.0,
+        description="Multiplier applied to (s_flare + s_ground). Typical 1.5–2.0.",
+    )
+    available_field_length_m: Optional[float] = Field(
+        None,
+        ge=0,
+        description="Length of the planned landing field (meters) — sizing check input.",
+    )
 
 
 class MissionPresetEstimates(BaseModel):

--- a/app/services/assumption_compute_service.py
+++ b/app/services/assumption_compute_service.py
@@ -35,6 +35,7 @@ from app.models.computation_config import (
     AircraftComputationConfigModel,
     COMPUTATION_CONFIG_DEFAULTS,
 )
+from app.models.mission_objective import MissionObjectiveModel
 from app.schemas.AeroplaneRequest import AnalysisToolUrlType
 from app.schemas.aeroanalysisschema import OperatingPointSchema
 from app.schemas.design_assumption import PARAMETER_DEFAULTS
@@ -596,6 +597,39 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
         "polar_by_config": polar_by_config,
         "computed_at": datetime.now(timezone.utc).isoformat(),
     }
+
+    # gh-477: required landing field length from the energy balance
+    # using the landing-config CL_max (with flaps), the user's chosen
+    # surface (or grass_short default), and safety factor. Compared
+    # against ``available_field_length_m`` from the mission spec so the
+    # UI can render the chip green / red / neutral.
+    mission_obj = (
+        db.query(MissionObjectiveModel).filter_by(aeroplane_id=aircraft.id).first()
+    )
+    landing_field_m, surface_used = _compute_landing_field_length(
+        mass_kg=mass,
+        s_ref_m2=s_ref,
+        cl_max_landing=polar_by_config["landing"]["cl_max"],
+        landing_surface=mission_obj.landing_surface if mission_obj is not None else None,
+        landing_safety_factor=(
+            mission_obj.landing_safety_factor if mission_obj is not None else None
+        ),
+    )
+    available = (
+        mission_obj.available_field_length_m if mission_obj is not None else None
+    )
+    landing_field_sufficient: bool | None
+    if landing_field_m is None or available is None:
+        landing_field_sufficient = None
+    else:
+        landing_field_sufficient = available >= landing_field_m
+
+    context["landing_field_length_m"] = (
+        round(landing_field_m, 1) if landing_field_m is not None else None
+    )
+    context["landing_surface_used"] = surface_used
+    context["landing_field_sufficient"] = landing_field_sufficient
+
     enrich_context_with_cg_envelope(
         ctx=context,
         cg_loading_fwd_m=_loading["cg_loading_fwd_m"],
@@ -1433,6 +1467,77 @@ def _stall_speed(
     cl_max_safe = max(cl_max, 0.5)
     weight_n = mass_kg * g
     return float(np.sqrt(2.0 * weight_n / (rho * s_ref_m2 * cl_max_safe)))
+
+
+# gh-477: μ_eff for the landing-field-length energy balance. Values
+# come from operational RC / UAV practice (the issue's "References /
+# Formula derivation" section). Not from Anderson — aircraft
+# performance is a separate textbook domain (Raymer ch. 17, Roskam P.7).
+LANDING_SURFACE_MU: dict[str, float] = {
+    "grass_short": 0.15,
+    "grass_long": 0.22,
+    "hard_paved": 0.07,  # no-brake default; brake flag is a future ticket
+    "soft_soil": 0.30,
+    "belly_grass": 0.40,
+    "net_recovery": 0.0,  # special-cased to s_ground=0 below
+}
+
+_LANDING_FLARE_M: float = 15.0
+_LANDING_SAFETY_DEFAULT: float = 1.5
+_LANDING_SURFACE_DEFAULT: str = "grass_short"
+_V_TD_OVER_V_S0: float = 1.15  # touchdown speed = 1.15 · V_S0 (RC rule of thumb)
+
+
+def _compute_landing_field_length(
+    mass_kg: float | None,
+    s_ref_m2: float | None,
+    cl_max_landing: float | None,
+    landing_surface: str | None,
+    landing_safety_factor: float | None,
+    rho: float = 1.225,
+    g: float = 9.81,
+) -> tuple[float | None, str | None]:
+    """Required landing field length (gh-477).
+
+    Returns ``(L_landing_m, surface_used)``. Both are ``None`` when any
+    of ``cl_max_landing``, ``mass_kg`` or ``s_ref_m2`` is missing or
+    non-positive — the caller renders no chip in that case.
+
+    Energy balance: ½·m·V_TD² = μ_eff·m·g·s_ground ⇒
+    ``s_ground = V_TD² / (2·g·μ_eff)``. The mass cancels — the result
+    depends only on V_TD (from V_S0 from physics) and surface friction.
+
+    Special case: ``net_recovery`` is a catch / arrester — there is no
+    ground roll, so ``L_landing`` collapses to the safety-padded flare.
+    """
+    if mass_kg is None or s_ref_m2 is None or cl_max_landing is None:
+        return (None, None)
+    if mass_kg <= 0 or s_ref_m2 <= 0 or cl_max_landing <= 0:
+        return (None, None)
+
+    surface_key = landing_surface if landing_surface in LANDING_SURFACE_MU else _LANDING_SURFACE_DEFAULT
+    safety = (
+        landing_safety_factor
+        if landing_safety_factor is not None and landing_safety_factor >= 1.0
+        else _LANDING_SAFETY_DEFAULT
+    )
+
+    v_s0 = _stall_speed(mass_kg, s_ref_m2, cl_max_landing, rho=rho, g=g)
+    if v_s0 is None:
+        return (None, None)
+    v_td = _V_TD_OVER_V_S0 * v_s0
+
+    if surface_key == "net_recovery":
+        s_ground = 0.0
+    else:
+        mu = LANDING_SURFACE_MU[surface_key]
+        # mu==0 would mean infinite roll — defensive, even though the
+        # table has no such entry outside net_recovery.
+        if mu <= 0:
+            return (None, surface_key)
+        s_ground = (v_td * v_td) / (2.0 * g * mu)
+
+    return (float(safety * (_LANDING_FLARE_M + s_ground)), surface_key)
 
 
 def _main_wing_aspect_ratio(asb_airplane) -> float | None:

--- a/app/tests/test_landing_field_length.py
+++ b/app/tests/test_landing_field_length.py
@@ -1,0 +1,255 @@
+"""gh-477 — landing field length from physics + mission inputs.
+
+The helper ``_compute_landing_field_length`` lives in
+``assumption_compute_service`` next to the other speed/length helpers
+(``_stall_speed``, ``_min_drag_speed``). These tests pin the four
+operationally meaningful cases from the issue spec (trainer / sport /
+UAV / Großmodell on hard paved) plus edge cases (no CL_max, net
+recovery, missing mass).
+
+The numbers come straight from the issue's "Acceptance Criteria >
+Backend" section. They are intentionally loose (±10%) — μ_eff and the
+flare are operational constants, not Anderson-grade physics.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from app.services.assumption_compute_service import (
+    LANDING_SURFACE_MU,
+    _compute_landing_field_length,
+)
+
+
+# ---------------------------------------------------------------------------
+# Sanity: the surface table covers the schema literal exactly.
+# ---------------------------------------------------------------------------
+
+def test_surface_table_matches_schema_literal():
+    """The compute service's LANDING_SURFACE_MU must enumerate exactly the
+    surfaces the schema accepts — otherwise a user-set surface from the
+    Mission page would silently fall back to grass_short and the chip
+    would lie."""
+    from app.schemas.mission_objective import LandingSurface
+
+    # Literal -> set of legal values
+    legal = set(LandingSurface.__args__)
+    assert set(LANDING_SURFACE_MU) == legal, (
+        f"surface table out of sync with schema: "
+        f"table={set(LANDING_SURFACE_MU)}, schema={legal}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reference cases from the issue spec (trainer / sport / UAV / Großmodell).
+# Mass / V_S0 / surface -> expected L_landing ± 10%.
+# ---------------------------------------------------------------------------
+
+
+def _solve_s_ref_for_v_s0(mass_kg: float, v_s0_mps: float, cl_max: float) -> float:
+    """Invert V_S0 = sqrt(2W / (rho·S·CL_max)) to derive the wing area
+    that gives the issue's target stall speed for the given mass. Lets
+    each reference case stay a one-line test instead of carrying its
+    own area number."""
+    rho = 1.225
+    g = 9.81
+    return float(2.0 * mass_kg * g / (rho * v_s0_mps * v_s0_mps * cl_max))
+
+
+class TestReferenceCasesFromIssueSpec:
+    """The four numerical anchors gh-477's "Acceptance Criteria" lists."""
+
+    def test_trainer_rc_grass_short_about_50m(self):
+        # m=2 kg, V_S0=6 m/s, grass_short → ~50 m
+        s_ref = _solve_s_ref_for_v_s0(mass_kg=2.0, v_s0_mps=6.0, cl_max=1.4)
+        l_land, surface = _compute_landing_field_length(
+            mass_kg=2.0,
+            s_ref_m2=s_ref,
+            cl_max_landing=1.4,
+            landing_surface="grass_short",
+            landing_safety_factor=1.5,
+        )
+        assert surface == "grass_short"
+        assert l_land is not None
+        assert math.isclose(l_land, 50.0, rel_tol=0.10), f"trainer L = {l_land:.1f} m"
+
+    def test_sport_rc_grass_short_about_75m(self):
+        # m=3 kg, V_S0=9 m/s, grass_short → ~75 m
+        s_ref = _solve_s_ref_for_v_s0(mass_kg=3.0, v_s0_mps=9.0, cl_max=1.4)
+        l_land, _ = _compute_landing_field_length(
+            mass_kg=3.0,
+            s_ref_m2=s_ref,
+            cl_max_landing=1.4,
+            landing_surface="grass_short",
+            landing_safety_factor=1.5,
+        )
+        assert l_land is not None
+        assert math.isclose(l_land, 75.0, rel_tol=0.15), f"sport L = {l_land:.1f} m"
+
+    def test_uav_grass_short_about_140m(self):
+        # m=5 kg, V_S0=13 m/s, grass_short → ~140 m
+        s_ref = _solve_s_ref_for_v_s0(mass_kg=5.0, v_s0_mps=13.0, cl_max=1.4)
+        l_land, _ = _compute_landing_field_length(
+            mass_kg=5.0,
+            s_ref_m2=s_ref,
+            cl_max_landing=1.4,
+            landing_surface="grass_short",
+            landing_safety_factor=1.5,
+        )
+        assert l_land is not None
+        assert math.isclose(l_land, 140.0, rel_tol=0.15), f"UAV L = {l_land:.1f} m"
+
+    def test_grossmodell_hard_paved_no_brake(self):
+        """m=15 kg, V_S0=12 m/s, hard_paved (μ=0.07 no brake), safety=1.5.
+
+        Closed-form: V_TD = 1.15·12 = 13.8; s_ground = 13.8²/(2·9.81·0.07)
+        ≈ 138.6 m; L = 1.5·(15+138.6) ≈ 230 m.
+
+        Note: the issue's "~370 m" target appears inconsistent with its
+        own μ table at safety=1.5 (the target only reaches ~370 m when
+        safety≈2.4 or μ≈0.04). My number follows the issue's derivation
+        block ("F_decel = μ_eff·m·g; s_ground = V_TD²/(2·g·μ_eff)") and
+        the published μ=0.07 verbatim. Pinning the *formula* output, not
+        the issue body's anchor — when the discrepancy is resolved
+        upstream we update one constant here.
+        """
+        s_ref = _solve_s_ref_for_v_s0(mass_kg=15.0, v_s0_mps=12.0, cl_max=1.4)
+        l_land, surface = _compute_landing_field_length(
+            mass_kg=15.0,
+            s_ref_m2=s_ref,
+            cl_max_landing=1.4,
+            landing_surface="hard_paved",
+            landing_safety_factor=1.5,
+        )
+        assert surface == "hard_paved"
+        assert l_land is not None
+        assert math.isclose(l_land, 230.0, rel_tol=0.10), (
+            f"Großmodell hard-paved no-brake L = {l_land:.1f} m"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Edge cases — what the chip surface must NOT crash on.
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_returns_none_when_cl_max_missing(self):
+        """No landing-config CL_max yet → no L_landing chip; both
+        return values None so the UI renders nothing."""
+        l_land, surface = _compute_landing_field_length(
+            mass_kg=3.0,
+            s_ref_m2=0.5,
+            cl_max_landing=None,
+            landing_surface="grass_short",
+            landing_safety_factor=1.5,
+        )
+        assert l_land is None
+        assert surface is None
+
+    def test_returns_none_when_mass_missing(self):
+        l_land, _ = _compute_landing_field_length(
+            mass_kg=None,
+            s_ref_m2=0.5,
+            cl_max_landing=1.4,
+            landing_surface="grass_short",
+            landing_safety_factor=1.5,
+        )
+        assert l_land is None
+
+    def test_returns_none_when_s_ref_non_positive(self):
+        l_land, _ = _compute_landing_field_length(
+            mass_kg=3.0,
+            s_ref_m2=0.0,
+            cl_max_landing=1.4,
+            landing_surface="grass_short",
+            landing_safety_factor=1.5,
+        )
+        assert l_land is None
+
+    def test_net_recovery_short_circuits_to_safety_padded_flare(self):
+        """Net / arrester: no ground roll. L_landing collapses to the
+        safety-padded flare. With flare=15 m and safety=1.5 the result
+        is 22.5 m regardless of mass / wing area / CL_max."""
+        l_land, surface = _compute_landing_field_length(
+            mass_kg=15.0,
+            s_ref_m2=0.5,
+            cl_max_landing=1.4,
+            landing_surface="net_recovery",
+            landing_safety_factor=1.5,
+        )
+        assert surface == "net_recovery"
+        assert l_land is not None
+        assert math.isclose(l_land, 22.5, rel_tol=0.02), (
+            f"net_recovery L should be 1.5·15.0 = 22.5 m, got {l_land}"
+        )
+
+    def test_unknown_surface_falls_back_to_grass_short(self):
+        """An unknown / future surface label must not crash — fall back
+        to the median RC surface and surface the choice back to the
+        caller so the UI can show 'grass_short' rather than the bogus
+        label."""
+        s_ref = _solve_s_ref_for_v_s0(mass_kg=2.0, v_s0_mps=6.0, cl_max=1.4)
+        l_land, surface = _compute_landing_field_length(
+            mass_kg=2.0,
+            s_ref_m2=s_ref,
+            cl_max_landing=1.4,
+            landing_surface="moon_regolith",  # not in the table
+            landing_safety_factor=1.5,
+        )
+        assert surface == "grass_short", "must surface the fallback choice"
+        # Same result as the trainer case above.
+        assert l_land is not None
+        assert math.isclose(l_land, 50.0, rel_tol=0.10)
+
+    def test_safety_factor_below_one_falls_back_to_default(self):
+        """Defensive: a corrupt safety factor < 1.0 (somehow past the
+        Pydantic ge=1.0 gate) must fall back to 1.5, not produce a
+        deceptively-short L_landing."""
+        s_ref = _solve_s_ref_for_v_s0(mass_kg=2.0, v_s0_mps=6.0, cl_max=1.4)
+        l_land_bad, _ = _compute_landing_field_length(
+            mass_kg=2.0,
+            s_ref_m2=s_ref,
+            cl_max_landing=1.4,
+            landing_surface="grass_short",
+            landing_safety_factor=0.5,
+        )
+        l_land_default, _ = _compute_landing_field_length(
+            mass_kg=2.0,
+            s_ref_m2=s_ref,
+            cl_max_landing=1.4,
+            landing_surface="grass_short",
+            landing_safety_factor=None,
+        )
+        assert l_land_bad == pytest.approx(l_land_default)
+
+    def test_none_surface_falls_back_to_grass_short(self):
+        """Surface unset (no mission spec yet) → grass_short median."""
+        s_ref = _solve_s_ref_for_v_s0(mass_kg=2.0, v_s0_mps=6.0, cl_max=1.4)
+        _, surface = _compute_landing_field_length(
+            mass_kg=2.0,
+            s_ref_m2=s_ref,
+            cl_max_landing=1.4,
+            landing_surface=None,
+            landing_safety_factor=1.5,
+        )
+        assert surface == "grass_short"
+
+    def test_long_grass_is_shorter_than_hard_paved_no_brake(self):
+        """Sanity: long grass (μ=0.22) decelerates harder than no-brake
+        paved (μ=0.07) — the chip must show the long-grass field as
+        shorter, not longer. Catches sign-flip / table-swap regressions."""
+        s_ref = _solve_s_ref_for_v_s0(mass_kg=3.0, v_s0_mps=9.0, cl_max=1.4)
+        l_grass, _ = _compute_landing_field_length(
+            mass_kg=3.0, s_ref_m2=s_ref, cl_max_landing=1.4,
+            landing_surface="grass_long", landing_safety_factor=1.5,
+        )
+        l_paved, _ = _compute_landing_field_length(
+            mass_kg=3.0, s_ref_m2=s_ref, cl_max_landing=1.4,
+            landing_surface="hard_paved", landing_safety_factor=1.5,
+        )
+        assert l_grass is not None and l_paved is not None
+        assert l_grass < l_paved, f"grass_long {l_grass} should beat paved-no-brake {l_paved}"

--- a/frontend/__tests__/AnalysisWingGate.test.tsx
+++ b/frontend/__tests__/AnalysisWingGate.test.tsx
@@ -23,6 +23,8 @@ vi.mock("lucide-react", () => {
     RefreshCw: icon,
     Square: icon,
     ArrowLeftRight: icon,
+    // gh-477: GeometryChipRow's new L_landing chip uses MapPin.
+    MapPin: icon,
   };
 });
 

--- a/frontend/__tests__/GeometryChipRow.test.tsx
+++ b/frontend/__tests__/GeometryChipRow.test.tsx
@@ -4,7 +4,13 @@ import React from "react";
 
 vi.mock("lucide-react", () => {
   const icon = (p: Record<string, unknown>) => React.createElement("span", p);
-  return { Square: icon, Ruler: icon, ArrowLeftRight: icon, Gauge: icon };
+  return {
+    Square: icon,
+    Ruler: icon,
+    ArrowLeftRight: icon,
+    Gauge: icon,
+    MapPin: icon,
+  };
 });
 
 import { GeometryChipRow } from "@/components/workbench/GeometryChipRow";
@@ -40,7 +46,91 @@ describe("GeometryChipRow", () => {
   });
 
   it("ctx=null → all dashes", () => {
+    // gh-477: row gained an L_landing chip → 5 dashes (was 4).
     render(<GeometryChipRow ctx={null} isRecomputing={false} />);
-    expect(screen.getAllByText("–").length).toBe(4);
+    expect(screen.getAllByText("–").length).toBe(5);
+  });
+
+  // -------------------------------------------------------------------------
+  // gh-477: L_landing chip — green / red / neutral.
+  // -------------------------------------------------------------------------
+
+  describe("L_landing chip (gh-477)", () => {
+    const baseCtx = {
+      s_ref_m2: 0.4,
+      mac_m: 0.21,
+      b_ref_m: 2,
+      aspect_ratio: 10.0,
+    } as const;
+
+    it("renders 'NN m ✓' in emerald when the planned field is long enough", () => {
+      render(
+        <GeometryChipRow
+          ctx={{
+            ...baseCtx,
+            landing_field_length_m: 48,
+            landing_surface_used: "grass_short",
+            landing_field_sufficient: true,
+          } as unknown as ComputationContext}
+          isRecomputing={false}
+        />,
+      );
+      const valueEl = screen.getByText(/48 m ✓/);
+      expect(valueEl).toBeInTheDocument();
+      expect(valueEl.className).toContain("emerald");
+    });
+
+    it("renders 'NN m ✗' in red when the planned field is too short", () => {
+      render(
+        <GeometryChipRow
+          ctx={{
+            ...baseCtx,
+            landing_field_length_m: 48,
+            landing_surface_used: "grass_short",
+            landing_field_sufficient: false,
+          } as unknown as ComputationContext}
+          isRecomputing={false}
+        />,
+      );
+      const valueEl = screen.getByText(/48 m ✗/);
+      expect(valueEl).toBeInTheDocument();
+      expect(valueEl.className).toContain("red");
+    });
+
+    it("renders 'NN m' (no marker, no color) when available_field_length_m is unset", () => {
+      render(
+        <GeometryChipRow
+          ctx={{
+            ...baseCtx,
+            landing_field_length_m: 48,
+            landing_surface_used: "grass_short",
+            landing_field_sufficient: null,
+          } as unknown as ComputationContext}
+          isRecomputing={false}
+        />,
+      );
+      // No ✓ / ✗ marker and no emerald/red colour class.
+      expect(screen.getByText(/^48 m$/)).toBeInTheDocument();
+      expect(screen.queryByText(/48 m ✓/)).toBeNull();
+      expect(screen.queryByText(/48 m ✗/)).toBeNull();
+    });
+
+    it("renders '–' when landing_field_length_m is null (no CL_max yet)", () => {
+      // The chip should show a dash, NOT crash, when the backend
+      // returns null (e.g. CL_max_landing not yet available).
+      render(
+        <GeometryChipRow
+          ctx={{
+            ...baseCtx,
+            landing_field_length_m: null,
+            landing_surface_used: null,
+            landing_field_sufficient: null,
+          } as unknown as ComputationContext}
+          isRecomputing={false}
+        />,
+      );
+      // At least the L_landing dash exists (others have values).
+      expect(screen.getAllByText("–").length).toBeGreaterThanOrEqual(1);
+    });
   });
 });

--- a/frontend/__tests__/InfoChipRow.test.tsx
+++ b/frontend/__tests__/InfoChipRow.test.tsx
@@ -23,6 +23,8 @@ vi.mock("lucide-react", () => {
     ArrowLeftRight: icon,
     // gh-581: TaillessBanner uses Info icon when ctx.is_tailless is true.
     Info: icon,
+    // gh-477: GeometryChipRow's new L_landing chip uses MapPin.
+    MapPin: icon,
   };
 });
 

--- a/frontend/__tests__/MissionObjectivesPanel.test.tsx
+++ b/frontend/__tests__/MissionObjectivesPanel.test.tsx
@@ -210,12 +210,14 @@ describe("MissionObjectivesPanel", () => {
         "runway = wheeled take-off; hand_launch = thrown by hand (RC); bungee = elastic catapult (gliders); catapult = launched device.",
     };
 
-    it("renders 11 tooltip elements — one per editable input + Mission Type", () => {
+    it("renders 14 tooltip elements — one per editable input + Mission Type", () => {
+      // gh-477: added three landing-field inputs (Landing Surface,
+      // Landing Safety Factor, Available Landing Field) → 11 + 3 = 14.
       render(<MissionObjectivesPanel aeroplaneId="x" />);
       // role="tooltip" elements are hidden via Tailwind `hidden` class but
       // still in the DOM so screen readers and `screen.getAllByRole` find them.
       const tips = screen.getAllByRole("tooltip", { hidden: true });
-      expect(tips.length).toBe(11);
+      expect(tips.length).toBe(14);
     });
 
     it("each tooltip text matches the spec exactly", () => {

--- a/frontend/components/workbench/GeometryChipRow.tsx
+++ b/frontend/components/workbench/GeometryChipRow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Square, Ruler, ArrowLeftRight, Gauge } from "lucide-react";
+import { Square, Ruler, ArrowLeftRight, Gauge, MapPin } from "lucide-react";
 import { Chip } from "@/components/workbench/Chip";
 import type { ComputationContext } from "@/hooks/useComputationContext";
 
@@ -13,8 +13,35 @@ function fmt(v: number | null | undefined, decimals: number, suffix = "") {
   return v != null ? `${v.toFixed(decimals)}${suffix}` : "–";
 }
 
+// gh-477: format the landing-field chip value with a "/ NN m available"
+// suffix when the mission spec has an ``available_field_length_m``. The
+// suffix and the ``sufficient`` flag drive the green / red / neutral
+// styling below — keep them in lock-step.
+function fmtLandingField(ctx: ComputationContext | null | undefined): string {
+  const l = ctx?.landing_field_length_m;
+  if (l == null) return "–";
+  const sufficient = ctx?.landing_field_sufficient;
+  // We don't have the raw available_field_length_m on the context (only
+  // the boolean comparison result), so the chip shows the L_landing
+  // number and uses the sufficient flag for colour. The mission page
+  // surfaces the available length for the user to verify directly.
+  if (sufficient === null || sufficient === undefined) {
+    return `${l.toFixed(0)} m`;
+  }
+  return sufficient ? `${l.toFixed(0)} m ✓` : `${l.toFixed(0)} m ✗`;
+}
+
 export function GeometryChipRow({ ctx, isRecomputing }: Props) {
   const stale = isRecomputing;
+  const landingSurface = ctx?.landing_surface_used ?? null;
+  // gh-477: green when the planned field is long enough, red when not,
+  // default (no class) when the user hasn't set ``available_field_length_m``.
+  let landingFieldClassName: string | undefined;
+  if (ctx?.landing_field_sufficient === true) {
+    landingFieldClassName = "text-emerald-400";
+  } else if (ctx?.landing_field_sufficient === false) {
+    landingFieldClassName = "text-red-400";
+  }
   return (
     <div
       data-testid="chip-row-geometry"
@@ -47,6 +74,17 @@ export function GeometryChipRow({ ctx, isRecomputing }: Props) {
         description="Aspect ratio = b² / S_ref (main wing). Higher AR ⇒ less induced drag."
         value={fmt(ctx?.aspect_ratio, 2)}
         stale={stale}
+      />
+      <Chip
+        icon={MapPin}
+        symbol="L_landing"
+        description={
+          "Required landing field length — safety · (15 m flare + V_TD² / (2·g·μ_eff))" +
+          (landingSurface ? `. Surface used: ${landingSurface}.` : "")
+        }
+        value={fmtLandingField(ctx)}
+        stale={stale}
+        valueColorClassName={landingFieldClassName}
       />
       <div className="flex-1" />
     </div>

--- a/frontend/components/workbench/mission/MissionObjectivesPanel.tsx
+++ b/frontend/components/workbench/mission/MissionObjectivesPanel.tsx
@@ -38,7 +38,26 @@ const FIELD_DESCRIPTIONS = {
     "Powertrain static thrust at zero airspeed (N). Sets the T/W ratio on the matching chart. For gliders, 0.",
   takeoff_mode:
     "runway = wheeled take-off; hand_launch = thrown by hand (RC); bungee = elastic catapult (gliders); catapult = launched device.",
+  // gh-477: landing-field-length inputs. The three feed
+  // ``computation_context.landing_field_length_m`` + the L_landing chip.
+  landing_surface:
+    "Expected landing surface. Drives μ_eff: short grass μ=0.15, long grass μ=0.22, hard paved (no brake) μ=0.07, soft soil μ=0.30, belly on grass μ=0.40, net/cable recovery → no ground roll.",
+  landing_safety_factor:
+    "Safety multiplier applied to the computed landing length (s_flare + s_ground). Typical 1.5–2.0. Higher = more conservative field-length recommendation.",
+  available_field_length_m:
+    "Length of the planned landing field (m). When set, the L_landing chip turns green (sufficient) or red (insufficient). Leave at 0 to suppress the comparison and show only the required length.",
 } as const;
+
+// gh-477: landing-surface options for the dropdown. Plain-English
+// labels for the user, kebab-case values for the backend literal.
+const LANDING_SURFACE_OPTIONS: { value: string; label: string }[] = [
+  { value: "grass_short", label: "Short grass" },
+  { value: "grass_long", label: "Long grass" },
+  { value: "hard_paved", label: "Hard paved (no brake)" },
+  { value: "soft_soil", label: "Soft soil" },
+  { value: "belly_grass", label: "Belly landing on grass" },
+  { value: "net_recovery", label: "Net / cable recovery" },
+];
 
 /** Per-axis → MissionObjective target-field mapping (gh-601). */
 const AXIS_TO_TARGET_FIELD: Partial<Record<AxisName, keyof MissionObjective>> = {
@@ -159,7 +178,7 @@ export function MissionObjectivesPanel({ aeroplaneId }: Props) {
     }
     const next = { ...draft };
     for (const row of suggestedTargets) {
-      (next as Record<string, number>)[row.field as string] = row.suggested;
+      (next as unknown as Record<string, number>)[row.field as string] = row.suggested;
     }
     setDraft(next);
     void update(next);
@@ -271,6 +290,69 @@ export function MissionObjectivesPanel({ aeroplaneId }: Props) {
         <NumField label="Static Thrust" suffix="N" value={draft.t_static_N} onChange={(v) => set("t_static_N", v)} description={FIELD_DESCRIPTIONS.t_static_N}/>
         <SelectField label="Takeoff Mode" value={draft.takeoff_mode} options={["runway", "hand_launch", "bungee", "catapult"]} onChange={(v) => set("takeoff_mode", v as MissionObjective["takeoff_mode"])} description={FIELD_DESCRIPTIONS.takeoff_mode}/>
       </div>
+
+      <div className="text-[10px] uppercase tracking-wider text-muted-foreground border-b border-border pb-1 mt-2">
+        Landing Field (L_landing chip)
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <LabelledSelectField
+          label="Landing Surface"
+          value={draft.landing_surface ?? "grass_short"}
+          options={LANDING_SURFACE_OPTIONS}
+          onChange={(v) => set("landing_surface", v as MissionObjective["landing_surface"])}
+          description={FIELD_DESCRIPTIONS.landing_surface}
+        />
+        <NumField
+          label="Landing Safety Factor"
+          suffix="×"
+          value={draft.landing_safety_factor ?? 1.5}
+          onChange={(v) => set("landing_safety_factor", v)}
+          description={FIELD_DESCRIPTIONS.landing_safety_factor}
+        />
+        <NumField
+          label="Available Landing Field"
+          suffix="m"
+          value={draft.available_field_length_m ?? 0}
+          onChange={(v) =>
+            // 0 → null so the backend skips the green/red comparison and the
+            // chip renders only the required length (issue: "available unset
+            // → don't render the comparison").
+            set("available_field_length_m", (v > 0 ? v : null) as unknown as number)
+          }
+          description={FIELD_DESCRIPTIONS.available_field_length_m}
+        />
+      </div>
+    </div>
+  );
+}
+
+// gh-477: variant of SelectField that takes labelled options (the
+// landing-surface dropdown's value is a kebab-case literal but the
+// user reads a plain-English label).
+function LabelledSelectField(props: {
+  label: string;
+  value: string;
+  options: { value: string; label: string }[];
+  onChange: (v: string) => void;
+  description?: string;
+}) {
+  const id = `f-${props.label.replace(/\s+/g, "-").toLowerCase()}`;
+  return (
+    <div>
+      <InfoLabel label={props.label} description={props.description} htmlFor={id} />
+      <select
+        id={id}
+        aria-label={props.label}
+        className="w-full rounded bg-background border border-border px-2 py-1.5 text-sm"
+        value={props.value}
+        onChange={(e) => props.onChange(e.target.value)}
+      >
+        {props.options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
     </div>
   );
 }

--- a/frontend/hooks/useComputationContext.ts
+++ b/frontend/hooks/useComputationContext.ts
@@ -85,6 +85,14 @@ export interface ComputationContext {
   computed_at: string;
   // gh-630 + gh-636: per-config polars + empirical L/D max + e provenance.
   polar_by_config?: PolarByConfig;
+  // gh-477: required landing field length from physics + mission surface.
+  // ``landing_field_length_m`` is null when CL_max_landing, mass, or S_ref
+  // is not yet known. ``landing_field_sufficient`` compares against the
+  // mission's ``available_field_length_m``; null when one of the two is
+  // absent (chip renders neutral).
+  landing_field_length_m?: number | null;
+  landing_surface_used?: string | null;
+  landing_field_sufficient?: boolean | null;
 }
 
 export function useComputationContext(

--- a/frontend/hooks/useMissionObjectives.ts
+++ b/frontend/hooks/useMissionObjectives.ts
@@ -3,6 +3,17 @@
 import useSWR from "swr";
 import { fetcher, putJson } from "@/lib/fetcher";
 
+// gh-477: backend ``LandingSurface`` literal — keep in lock-step with
+// ``app/schemas/mission_objective.py``. The mission page uses these
+// values verbatim in the dropdown.
+export type LandingSurface =
+  | "grass_short"
+  | "grass_long"
+  | "hard_paved"
+  | "soft_soil"
+  | "belly_grass"
+  | "net_recovery";
+
 export interface MissionObjective {
   mission_type: string;
   target_cruise_mps: number;
@@ -16,6 +27,11 @@ export interface MissionObjective {
   runway_type: "grass" | "asphalt" | "belly";
   t_static_N: number;
   takeoff_mode: "runway" | "hand_launch" | "bungee" | "catapult";
+  // gh-477: landing-field-length inputs. All optional — the service
+  // falls back to grass-short / safety=1.5 / no length check when absent.
+  landing_surface?: LandingSurface | null;
+  landing_safety_factor?: number | null;
+  available_field_length_m?: number | null;
 }
 
 export function useMissionObjectives(aeroplaneId: string | null) {


### PR DESCRIPTION
## Summary

End-to-end ``L_landing`` feature: mission spec → physics-based compute → green / red / neutral chip.

- ``MissionObjective`` schema + ``MissionObjectiveModel`` table + Alembic migration add three optional fields: ``landing_surface``, ``landing_safety_factor``, ``available_field_length_m``.
- ``assumption_compute_service._compute_landing_field_length`` evaluates ``L = safety·(s_flare + V_TD²/(2·g·μ_eff))`` with ``V_TD = 1.15·V_S0(physics)``. Injected into ``computation_context`` as ``landing_field_length_m``, ``landing_surface_used``, ``landing_field_sufficient``.
- ``GeometryChipRow`` renders the L_landing chip (``MapPin`` icon) with emerald / red / neutral colour driven by the ``sufficient`` flag. Mission Tab gains a "Landing Field (L_landing chip)" section with surface dropdown + safety + available length inputs.

## Test plan

- [x] ``test_landing_field_length.py`` — 13 tests (4 issue reference cases + 7 edge cases + 2 sanity checks). The Großmodell anchor is pinned at the *formula* output (≈230 m) with a note explaining why the issue body's "~370 m" is inconsistent with its own μ=0.07 at safety=1.5.
- [x] Fast pytest suite: 3554/3554 pass
- [x] Frontend vitest suite: 1092/1092 pass (109 files)
- [x] Mission Objectives Panel tooltip count: 11 → 14 (three new inputs)

Closes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)