### PR TITLE
fix(gh-755): wing import respects VSP's RelativeDihedralFlag + RelativeTwistFlag

### DIFF
--- a/app/converters/openvsp_wing_handler.py
+++ b/app/converters/openvsp_wing_handler.py
@@ -136,6 +136,32 @@ def _read_symmetric(vsp: ModuleType, wing_gid: str) -> bool:
     return bool(flag & sym_xz)
 
 
+def _read_relative_flag(vsp: ModuleType, wing_gid: str, parm_name: str) -> bool:
+    """gh-755: read a ``Relative*Flag`` parm on the Wing container.
+
+    OpenVSP carries ``RelativeDihedralFlag`` and ``RelativeTwistFlag``
+    on the WING container (constructor: ``m_*.Init(name, m_Name, ...)``
+    in WingGeom.cpp). Default ``0`` (= ABSOLUTE; per-section parm is
+    world-frame). Value ``1`` switches to RELATIVE (per-section parm
+    is incremental over the prior section).
+
+    The container's group name has varied across VSP versions, so we
+    try a handful of known group strings — the parm name itself is
+    stable, so any positive ``FindParm`` hit wins.
+
+    Returns ``False`` when the parm is absent (= old VSP file without
+    the flag, or pre-fix import test stub — treat as absolute).
+    """
+    for grp in ("WingGeom", "Wing"):
+        pid = vsp.FindParm(wing_gid, parm_name, grp)
+        if pid:
+            try:
+                return bool(int(vsp.GetParmVal(pid)))
+            except Exception:
+                return False
+    return False
+
+
 def _read_xform_parm(vsp: ModuleType, gid: str, name: str) -> float:
     """Read a single XForm parm; 0.0 if not present."""
     pid = vsp.FindParm(gid, name, "XForm")
@@ -464,9 +490,24 @@ def _handle_wing(
         )
     )
 
+    # gh-755: read the per-Wing Relative*Flag parms so we know
+    # whether the per-section dihedral/twist parms are absolute
+    # (world-frame, VSP default) or relative (incremental over prior
+    # section). Pre-fix, both flags were silently ignored —
+    # ``RelativeDihedralFlag=1`` profiles (e.g. DG-101G) collapsed
+    # the chained dihedral on Section 2+ to flat-horizontal, visible
+    # as a kink at the Section 1/2 boundary.
+    relative_dihedral = _read_relative_flag(vsp, gid, "RelativeDihedralFlag")
+    relative_twist = _read_relative_flag(vsp, gid, "RelativeTwistFlag")
+
     cum_x = 0.0
     cum_y = 0.0
     cum_z = 0.0
+    # Cumulative dihedral / twist in degrees. Tracked alongside the
+    # per-section values so the absolute branch can override them
+    # cheaply on each iteration.
+    cum_dihedral_deg = 0.0
+    cum_twist_deg = 0.0
     prev_chord = root_chord
 
     for i in range(1, n_sec + 1):
@@ -474,8 +515,8 @@ def _handle_wing(
         tip_chord = _read_section_parm(vsp, gid, i, "Tip_Chord")
         sweep_xref = _read_section_parm(vsp, gid, i, "Sweep")
         sweep_loc = _read_section_parm(vsp, gid, i, "Sweep_Location")
-        dihedral = _read_section_parm(vsp, gid, i, "Dihedral")
-        twist = _read_section_parm(vsp, gid, i, "Twist")
+        dihedral_parm = _read_section_parm(vsp, gid, i, "Dihedral")
+        twist_parm = _read_section_parm(vsp, gid, i, "Twist")
 
         if span <= 0:
             ctx.add_warning(
@@ -487,8 +528,24 @@ def _handle_wing(
             ctx.mark_lossy(gid)
             continue
 
+        # gh-755: resolve absolute dihedral / twist for this section.
+        # In RELATIVE mode the parm is added to the carried-over
+        # cumulative angle (matching VSP's ``GetSumDihedral(i)``).
+        # In ABSOLUTE mode the parm IS the world-frame angle, so it
+        # replaces (not adds to) the carried-over value.
+        if relative_dihedral:
+            cum_dihedral_deg += dihedral_parm
+        else:
+            cum_dihedral_deg = dihedral_parm
+        if relative_twist:
+            cum_twist_deg += twist_parm
+        else:
+            cum_twist_deg = twist_parm
+
         # Convert sweep to LE reference so we can advance the LE point.
         # (Internal record uses c/4 if a downstream consumer wants it.)
+        # Sweep stays absolute per section in VSP — no flag, no
+        # accumulation; see WingGeom.cpp line 1111.
         le_sweep = sweep_at_le(
             sweep_xref_deg=sweep_xref,
             xref=sweep_loc,
@@ -497,9 +554,13 @@ def _handle_wing(
             c_tip=tip_chord,
         )
 
+        # gh-755: y-step now follows VSP's own formula
+        # (``rad*cos(angle)``) rather than the small-angle
+        # approximation ``cum_y += span`` — visible on winglets and
+        # V-tail surfaces where the dihedral exceeds ~5°.
         cum_x += span * math.tan(math.radians(le_sweep))
-        cum_y += span
-        cum_z += span * math.tan(math.radians(dihedral))
+        cum_y += span * math.cos(math.radians(cum_dihedral_deg))
+        cum_z += span * math.sin(math.radians(cum_dihedral_deg))
 
         # Mark intermediate xsecs as `segment`; final xsec is terminal
         # and must have no segment-specific fields (Pydantic validator
@@ -509,7 +570,7 @@ def _handle_wing(
             WingXSecSchema(
                 xyz_le=[cum_x, cum_y, cum_z],
                 chord=tip_chord if tip_chord > 0 else prev_chord,
-                twist=twist,
+                twist=cum_twist_deg,
                 airfoil=_airfoil_for(i),
                 x_sec_type=None if is_last else "segment",
             )

--- a/app/tests/test_openvsp_wing_handler.py
+++ b/app/tests/test_openvsp_wing_handler.py
@@ -198,10 +198,12 @@ class TestSingleSectionTrapezoidal:
         root = wing.x_secs[0]
         assert root.xyz_le == pytest.approx([0.0, 0.0, 0.0])
         assert root.chord == pytest.approx(1.0)
-        # Tip xsec — y = span, z = span*tan(dihedral)
+        # Tip xsec — y = span·cos(dihedral), z = span·sin(dihedral)
+        # gh-755: switched from tan-approximation to the sin/cos
+        # form VSP's WingGeom.cpp itself uses (line 1108-1109).
         tip = wing.x_secs[1]
-        assert tip.xyz_le[1] == pytest.approx(5.0, rel=1e-6)
-        assert tip.xyz_le[2] == pytest.approx(5.0 * math.tan(math.radians(3.0)), rel=1e-6)
+        assert tip.xyz_le[1] == pytest.approx(5.0 * math.cos(math.radians(3.0)), rel=1e-6)
+        assert tip.xyz_le[2] == pytest.approx(5.0 * math.sin(math.radians(3.0)), rel=1e-6)
         assert tip.chord == pytest.approx(0.5)
         # Twist on the tip xsec
         assert tip.twist == pytest.approx(2.0)
@@ -261,16 +263,20 @@ class TestMultiSectionWing:
         wing = result.aeroplane.wings["MainWing"]
         # n_sec sections → n_sec+1 xsecs.
         assert len(wing.x_secs) == 3
-        # Cumulative span at each xsec along Y.
+        # Cumulative span at each xsec along Y. gh-755: Y now uses
+        # cos(dihedral) per section. Inner panel has 0° dihedral so
+        # y advances by full span = 2.0. Outer panel has 4° dihedral
+        # so y advances by 3·cos(4°) ≈ 2.9927 (not the bare 3.0).
         ys = [xs.xyz_le[1] for xs in wing.x_secs]
-        assert ys == pytest.approx([0.0, 2.0, 5.0], rel=1e-6)
-        # Cumulative Z due to dihedral.
-        # Inner panel dihedral 0 → z stays 0 at xsec 1.
-        # Outer panel dihedral 4° → tip z = inner_tip_z + 3*tan(4°)
+        assert ys[0] == pytest.approx(0.0, abs=1e-9)
+        assert ys[1] == pytest.approx(2.0, rel=1e-6)
+        assert ys[2] == pytest.approx(2.0 + 3.0 * math.cos(math.radians(4.0)), rel=1e-6)
+        # Cumulative Z due to dihedral. gh-755: Z uses sin (not tan)
+        # of the cumulative dihedral, matching VSP's WingGeom.cpp.
         zs = [xs.xyz_le[2] for xs in wing.x_secs]
         assert zs[0] == pytest.approx(0.0)
-        assert zs[1] == pytest.approx(0.0)
-        assert zs[2] == pytest.approx(3.0 * math.tan(math.radians(4.0)), rel=1e-6)
+        assert zs[1] == pytest.approx(0.0)  # inner panel 0° dihedral
+        assert zs[2] == pytest.approx(3.0 * math.sin(math.radians(4.0)), rel=1e-6)
 
 
 class TestSweepLocationConversion:

--- a/app/tests/test_openvsp_wing_relative_dihedral_twist.py
+++ b/app/tests/test_openvsp_wing_relative_dihedral_twist.py
@@ -92,9 +92,14 @@ class _VspStub:
         # come from the placeholder which is unique per xsec via the
         # monkey-patched _airfoil_for in the test wiring).
         class _P:
-            x = lambda self: 0.0
-            y = lambda self: 0.0
-            z = lambda self: 0.0
+            def x(self) -> float:
+                return 0.0
+
+            def y(self) -> float:
+                return 0.0
+
+            def z(self) -> float:
+                return 0.0
 
         return _P()
 
@@ -181,11 +186,16 @@ class TestReadRelativeFlag:
         assert _read_relative_flag(vsp, "wing-gid", "RelativeDihedralFlag") is True
 
     def test_value_0_returns_false(self):
-        # Parm exists but is set to 0 — same effect as absent.
-        # NB: our stub only registers the parm when value != 0 (the
-        # ``_build_parms`` helper skips zero defaults). Instead we
-        # construct the absent case directly.
-        vsp = _VspStub(n_xsec=2, parms={})
+        # Parm EXISTS but is set to 0.0 — must take the
+        # ``int(GetParmVal) → False`` path, not the early ``return
+        # False`` for an absent parm. The pre-fix bug was symmetric
+        # in both paths, but a future change to ``_read_relative_flag``
+        # could regress one without the other; this test pins the
+        # value-0 path explicitly. Bypass the ``_build_parms`` helper
+        # so the parm is registered even with zero value.
+        vsp = _VspStub(
+            n_xsec=2, parms={("RelativeTwistFlag", "WingGeom"): 0.0}
+        )
         assert _read_relative_flag(vsp, "wing-gid", "RelativeTwistFlag") is False
 
 

--- a/app/tests/test_openvsp_wing_relative_dihedral_twist.py
+++ b/app/tests/test_openvsp_wing_relative_dihedral_twist.py
@@ -1,0 +1,438 @@
+"""gh-755 — wing import respects VSP's ``RelativeDihedralFlag`` and
+``RelativeTwistFlag``.
+
+OpenVSP carries two per-Wing flags that switch the per-section
+``Dihedral`` and ``Twist`` parms between **absolute** (world-frame,
+VSP default) and **relative** (chained off the previous section).
+Pre-fix, ``_handle_wing`` ignored both flags and always interpreted
+the parms as absolute. A ``.vsp3`` designed with
+``RelativeDihedralFlag = 1`` (e.g. the DG-101G glider, where the user
+sets Section 2 = "0° dihedral" meaning "continue with the carried-
+over 3°") collapsed Section 2 onto a flat-horizontal Z, producing a
+visible kink at the Section 1/2 boundary.
+
+These tests use a minimal VSP stub that exposes the parm calls the
+handler relies on. Verified geometric invariants (DG-style cumulative
+dihedral, cosine-correct y-step at large angles, Cessna-style flat
+wing no-regression) are pinned against analytical values.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from app.converters.openvsp_importer import (
+    AeroplaneSchema,
+    ImportContext,
+)
+from app.converters.openvsp_wing_handler import (
+    _handle_wing,
+    _read_relative_flag,
+)
+
+
+# ---------------------------------------------------------------------------
+# VSP stub — just enough surface to drive ``_handle_wing``.
+# ---------------------------------------------------------------------------
+
+
+class _VspStub:
+    """Configurable VSP stub. ``parms`` is a flat dict keyed by
+    ``(parm_name, group)`` so the handler's ``FindParm`` calls
+    deterministically resolve. ``XSec_<i>`` parms live under group
+    ``XSec_<i>``; ``RelativeDihedralFlag`` / ``RelativeTwistFlag``
+    live under ``WingGeom``; ``Sym_Planar_Flag`` under ``Sym``;
+    XForm parms under ``XForm``.
+    """
+
+    SYM_XZ = 2
+
+    def __init__(self, n_xsec: int, parms: dict[tuple[str, str], float]):
+        self._n_xsec = n_xsec
+        self._parms = parms
+        # ``GetXSec`` returns the xs_index; the handler only stores it
+        # in a local and passes it to ``import_airfoil_from_xsec``, which
+        # we monkey-patch out via a stubbed _airfoil_for path. We don't
+        # need a real ID — int works.
+        self.GetXSecSurf = lambda gid, surf_id: "xsurf-mock"
+        self.GetNumXSec = lambda xsurf: self._n_xsec
+        # Stub for CompPnt01 — never called when the wing has no
+        # same-airfoil pairs (the gh-753 augmenter short-circuits).
+        # Provided so ``hasattr(vsp, 'CompPnt01')`` returns True.
+
+    def GetXSec(self, xsurf, xs_index):
+        return ("xs", xs_index)
+
+    def FindParm(self, gid: str, parm: str, group: str) -> int:
+        # Encode a fake non-zero parm id by hashing (gid, parm, group).
+        # The handler only checks truthiness + later calls GetParmVal,
+        # so any deterministic non-zero int works.
+        if (parm, group) in self._parms:
+            return hash((gid, parm, group)) or 1
+        return 0
+
+    def GetParmVal(self, pid: int) -> float:
+        # Reverse-lookup via the same hash. Since we only need to
+        # round-trip a single call, store a (pid → value) map by
+        # rebuilding from ``parms`` on demand.
+        # Simpler: iterate the parms dict and return the first match
+        # whose ``hash((gid, parm, group))`` equals pid. For tests
+        # the parms dict is tiny so the linear scan is acceptable.
+        for (parm, group), value in self._parms.items():
+            for gid in ("wing-gid",):  # stub only ever uses this gid
+                if (hash((gid, parm, group)) or 1) == pid:
+                    return float(value)
+        raise KeyError(f"unknown pid {pid}")
+
+    def CompPnt01(self, gid, surf, u, w):
+        # Return a stub point — gh-753 augmenter is short-circuited
+        # by all-different airfoils in these tests (the airfoils
+        # come from the placeholder which is unique per xsec via the
+        # monkey-patched _airfoil_for in the test wiring).
+        class _P:
+            x = lambda self: 0.0
+            y = lambda self: 0.0
+            z = lambda self: 0.0
+
+        return _P()
+
+
+def _build_parms(
+    *,
+    n_xsec: int,
+    sections: list[dict[str, float]],
+    relative_dihedral: int = 0,
+    relative_twist: int = 0,
+    sym_xz: bool = False,
+    xform_translation: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    xform_rotation: tuple[float, float, float] = (0.0, 0.0, 0.0),
+) -> dict[tuple[str, str], float]:
+    """Assemble the parm dict that ``_VspStub`` consumes.
+
+    ``sections`` is a list of N-1 dicts (one per planform-section),
+    each carrying ``Span``, ``Tip_Chord``, ``Sweep``, ``Sweep_Location``,
+    ``Dihedral``, ``Twist``. The first section additionally needs
+    ``Root_Chord``.
+    """
+    parms: dict[tuple[str, str], float] = {}
+    for i, sec in enumerate(sections, start=1):
+        for k, v in sec.items():
+            parms[(k, f"XSec_{i}")] = v
+    if relative_dihedral:
+        parms[("RelativeDihedralFlag", "WingGeom")] = float(relative_dihedral)
+    if relative_twist:
+        parms[("RelativeTwistFlag", "WingGeom")] = float(relative_twist)
+    if sym_xz:
+        parms[("Sym_Planar_Flag", "Sym")] = float(_VspStub.SYM_XZ)
+    if any(xform_translation):
+        for k, v in zip(("X_Location", "Y_Location", "Z_Location"), xform_translation, strict=True):
+            parms[(k, "XForm")] = v
+    if any(xform_rotation):
+        for k, v in zip(("X_Rotation", "Y_Rotation", "Z_Rotation"), xform_rotation, strict=True):
+            parms[(k, "XForm")] = v
+    return parms
+
+
+@pytest.fixture
+def aeroplane() -> AeroplaneSchema:
+    return AeroplaneSchema(name="test-aeroplane")
+
+
+@pytest.fixture
+def ctx() -> ImportContext:
+    return ImportContext()
+
+
+# Patch the airfoil resolution so each xsec gets a UNIQUE airfoil
+# reference — the gh-753 augmenter then short-circuits all same-airfoil
+# pairs and doesn't add interpolated xsecs. Keeps these tests focused
+# on the gh-755 dihedral/twist logic alone.
+@pytest.fixture(autouse=True)
+def _patch_airfoil_resolution(monkeypatch):
+    from app.converters import openvsp_airfoil
+
+    counter = {"i": 0}
+
+    def _unique_airfoil(*args, **kwargs):
+        counter["i"] += 1
+        return f"./components/airfoils/test_unique_{counter['i']}.dat"
+
+    monkeypatch.setattr(
+        openvsp_airfoil, "import_airfoil_from_xsec", _unique_airfoil
+    )
+
+
+# ---------------------------------------------------------------------------
+# _read_relative_flag
+# ---------------------------------------------------------------------------
+
+
+class TestReadRelativeFlag:
+    def test_absent_returns_false(self):
+        vsp = _VspStub(n_xsec=2, parms={})
+        assert _read_relative_flag(vsp, "wing-gid", "RelativeDihedralFlag") is False
+
+    def test_value_1_returns_true(self):
+        vsp = _VspStub(
+            n_xsec=2, parms={("RelativeDihedralFlag", "WingGeom"): 1.0}
+        )
+        assert _read_relative_flag(vsp, "wing-gid", "RelativeDihedralFlag") is True
+
+    def test_value_0_returns_false(self):
+        # Parm exists but is set to 0 — same effect as absent.
+        # NB: our stub only registers the parm when value != 0 (the
+        # ``_build_parms`` helper skips zero defaults). Instead we
+        # construct the absent case directly.
+        vsp = _VspStub(n_xsec=2, parms={})
+        assert _read_relative_flag(vsp, "wing-gid", "RelativeTwistFlag") is False
+
+
+# ---------------------------------------------------------------------------
+# Cessna 172 — flat wing, both flags 0, no regression.
+# ---------------------------------------------------------------------------
+
+
+class TestCessnaFlatWingNoRegression:
+    """Cessna 172: 1 section, 0° dihedral, 0° twist, both flags 0
+    (default). Pre-fix code computed (cum_y = span, cum_z = 0). Post-
+    fix must produce identical values."""
+
+    def test_single_section_flat_wing(self, aeroplane, ctx):
+        parms = _build_parms(
+            n_xsec=2,
+            sections=[
+                {
+                    "Root_Chord": 1.5,
+                    "Tip_Chord": 1.0,
+                    "Span": 5.0,
+                    "Sweep": 0.0,
+                    "Sweep_Location": 0.25,
+                    "Dihedral": 0.0,
+                    "Twist": 0.0,
+                }
+            ],
+        )
+        _handle_wing("wing-gid", "MainWing", aeroplane, ctx, _VspStub(2, parms))
+        wing = aeroplane.wings["MainWing"]
+        # Root + tip — 2 xsecs.
+        assert len(wing.x_secs) == 2
+        tip = wing.x_secs[-1]
+        # 0° Dihedral → y = span = 5.0, z = 0.
+        assert tip.xyz_le[1] == pytest.approx(5.0, abs=1e-9)
+        assert tip.xyz_le[2] == pytest.approx(0.0, abs=1e-9)
+        # x = small positive (LE sweep induced by 0° quarter-chord
+        # sweep on a tapered wing — that's the existing
+        # ``sweep_at_le`` conversion at work, not the gh-755 change).
+        assert tip.xyz_le[0] == pytest.approx(0.125, rel=1e-9)
+        # Twist 0° → tip twist 0°.
+        assert tip.twist == 0.0
+
+
+# ---------------------------------------------------------------------------
+# DG-101G — RelativeDihedralFlag=1, cumulative dihedral
+# ---------------------------------------------------------------------------
+
+
+class TestDgRelativeDihedral:
+    """DG-101G-style: 2 sections, ``RelativeDihedralFlag=1``,
+    Section 1 = 3°, Section 2 = 0° (relative → continues 3°).
+    Pre-fix Section 2's z stayed flat. Post-fix must rise per
+    sin(3°) along the second section."""
+
+    def test_section_2_continues_carried_over_dihedral(self, aeroplane, ctx):
+        parms = _build_parms(
+            n_xsec=3,
+            sections=[
+                {
+                    "Root_Chord": 1.0,
+                    "Tip_Chord": 0.8,
+                    "Span": 4.5,
+                    "Sweep": 0.0,
+                    "Sweep_Location": 0.25,
+                    "Dihedral": 3.0,
+                    "Twist": 0.0,
+                },
+                {
+                    "Tip_Chord": 0.4,
+                    "Span": 3.0,
+                    "Sweep": 0.0,
+                    "Sweep_Location": 0.25,
+                    "Dihedral": 0.0,  # relative → continue 3°
+                    "Twist": 0.0,
+                },
+            ],
+            relative_dihedral=1,
+        )
+        _handle_wing("wing-gid", "MainWing", aeroplane, ctx, _VspStub(3, parms))
+        wing = aeroplane.wings["MainWing"]
+        assert len(wing.x_secs) == 3
+
+        # Section 1: y = 4.5 · cos(3°), z = 4.5 · sin(3°).
+        s1 = wing.x_secs[1]
+        assert s1.xyz_le[1] == pytest.approx(4.5 * math.cos(math.radians(3.0)), rel=1e-9)
+        assert s1.xyz_le[2] == pytest.approx(4.5 * math.sin(math.radians(3.0)), rel=1e-9)
+
+        # Section 2: cumulative dihedral stays 3°. Y += 3·cos(3°),
+        # Z += 3·sin(3°). Pre-fix bug: Z stayed at Section 1's value.
+        s2 = wing.x_secs[2]
+        expected_y = 4.5 * math.cos(math.radians(3.0)) + 3.0 * math.cos(math.radians(3.0))
+        expected_z = 4.5 * math.sin(math.radians(3.0)) + 3.0 * math.sin(math.radians(3.0))
+        assert s2.xyz_le[1] == pytest.approx(expected_y, rel=1e-9)
+        assert s2.xyz_le[2] == pytest.approx(expected_z, rel=1e-9), (
+            f"Section 2 z must continue carried-over 3° dihedral; "
+            f"pre-fix bug would give z = {4.5 * math.sin(math.radians(3.0)):.4f}"
+        )
+
+
+class TestAbsoluteDihedralStillWorks:
+    """Same geometry but with ``RelativeDihedralFlag=0`` (absolute):
+    Section 2 = "0°" means flat-horizontal, so Z stays at Section 1's
+    value. Pin this so the absolute branch doesn't regress."""
+
+    def test_section_2_flat_when_absolute(self, aeroplane, ctx):
+        parms = _build_parms(
+            n_xsec=3,
+            sections=[
+                {
+                    "Root_Chord": 1.0,
+                    "Tip_Chord": 0.8,
+                    "Span": 4.5,
+                    "Sweep": 0.0,
+                    "Sweep_Location": 0.25,
+                    "Dihedral": 3.0,
+                    "Twist": 0.0,
+                },
+                {
+                    "Tip_Chord": 0.4,
+                    "Span": 3.0,
+                    "Sweep": 0.0,
+                    "Sweep_Location": 0.25,
+                    "Dihedral": 0.0,  # absolute → flat-horizontal
+                    "Twist": 0.0,
+                },
+            ],
+        )
+        _handle_wing("wing-gid", "MainWing", aeroplane, ctx, _VspStub(3, parms))
+        wing = aeroplane.wings["MainWing"]
+        s1 = wing.x_secs[1]
+        s2 = wing.x_secs[2]
+        # Section 1: z = 4.5·sin(3°). Section 2: z stays the same
+        # (cum_dihedral resets to absolute 0°).
+        assert s2.xyz_le[2] == pytest.approx(s1.xyz_le[2], rel=1e-9), (
+            "absolute mode: Section 2 with 0° dihedral must NOT carry the prior section's slope"
+        )
+        # y advances by span exactly (cos(0°) = 1).
+        assert s2.xyz_le[1] == pytest.approx(s1.xyz_le[1] + 3.0, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Twist relative / absolute
+# ---------------------------------------------------------------------------
+
+
+class TestRelativeTwist:
+    """Same flag pattern for Twist. ``RelativeTwistFlag=1`` →
+    each XSec's twist is incremental over the previous; in absolute
+    mode it replaces."""
+
+    def test_relative_twist_accumulates(self, aeroplane, ctx):
+        parms = _build_parms(
+            n_xsec=3,
+            sections=[
+                {
+                    "Root_Chord": 1.0,
+                    "Tip_Chord": 0.8,
+                    "Span": 1.0,
+                    "Sweep": 0.0,
+                    "Sweep_Location": 0.25,
+                    "Dihedral": 0.0,
+                    "Twist": 2.0,
+                },
+                {
+                    "Tip_Chord": 0.5,
+                    "Span": 1.0,
+                    "Sweep": 0.0,
+                    "Sweep_Location": 0.25,
+                    "Dihedral": 0.0,
+                    "Twist": -3.0,
+                },
+            ],
+            relative_twist=1,
+        )
+        _handle_wing("wing-gid", "MainWing", aeroplane, ctx, _VspStub(3, parms))
+        wing = aeroplane.wings["MainWing"]
+        # Section 1 twist: 2°. Section 2 twist: 2° + (-3°) = -1°.
+        assert wing.x_secs[1].twist == pytest.approx(2.0, rel=1e-9)
+        assert wing.x_secs[2].twist == pytest.approx(-1.0, rel=1e-9)
+
+    def test_absolute_twist_replaces(self, aeroplane, ctx):
+        # Same parms but flag absent → absolute mode.
+        parms = _build_parms(
+            n_xsec=3,
+            sections=[
+                {
+                    "Root_Chord": 1.0,
+                    "Tip_Chord": 0.8,
+                    "Span": 1.0,
+                    "Sweep": 0.0,
+                    "Sweep_Location": 0.25,
+                    "Dihedral": 0.0,
+                    "Twist": 2.0,
+                },
+                {
+                    "Tip_Chord": 0.5,
+                    "Span": 1.0,
+                    "Sweep": 0.0,
+                    "Sweep_Location": 0.25,
+                    "Dihedral": 0.0,
+                    "Twist": -3.0,
+                },
+            ],
+        )
+        _handle_wing("wing-gid", "MainWing", aeroplane, ctx, _VspStub(3, parms))
+        wing = aeroplane.wings["MainWing"]
+        # Each XSec's twist replaces, not adds.
+        assert wing.x_secs[1].twist == pytest.approx(2.0, rel=1e-9)
+        assert wing.x_secs[2].twist == pytest.approx(-3.0, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Cosine-correct Y-step (winglet / V-tail at high dihedral)
+# ---------------------------------------------------------------------------
+
+
+class TestCosineCorrectYStep:
+    """Pre-fix code used ``cum_y += span`` (small-angle approximation,
+    ≈ correct up to ~5°). At 60° dihedral the error is large:
+    real Y-step is span · cos(60°) = 0.5 · span. Pin that against the
+    analytical value so winglets / V-tail surfaces import accurately."""
+
+    def test_60deg_dihedral_y_step_uses_cosine(self, aeroplane, ctx):
+        parms = _build_parms(
+            n_xsec=2,
+            sections=[
+                {
+                    "Root_Chord": 0.3,
+                    "Tip_Chord": 0.2,
+                    "Span": 1.0,
+                    "Sweep": 0.0,
+                    "Sweep_Location": 0.25,
+                    "Dihedral": 60.0,
+                    "Twist": 0.0,
+                }
+            ],
+        )
+        _handle_wing(
+            "wing-gid", "Winglet", aeroplane, ctx, _VspStub(2, parms)
+        )
+        wing = aeroplane.wings["Winglet"]
+        tip = wing.x_secs[1]
+        # Y must be span · cos(60°) = 0.5. Pre-fix gave 1.0 (the bare span).
+        assert tip.xyz_le[1] == pytest.approx(0.5, rel=1e-9), (
+            "y-step on a 60° dihedral surface must use cos(60°); "
+            "pre-fix bug would give y = 1.0 (raw span)"
+        )
+        # Z = span · sin(60°) ≈ 0.866.
+        assert tip.xyz_le[2] == pytest.approx(math.sin(math.radians(60.0)), rel=1e-9)


### PR DESCRIPTION
## Summary

User reported a dihedral kink at the Section 1/2 boundary on DG-101G glider imports. VSP carries ``RelativeDihedralFlag`` and ``RelativeTwistFlag`` on each Wing geom (default 0 = ABSOLUTE / world-frame, value 1 = RELATIVE / chained). The DG-101G has the dihedral flag = 1; pre-fix the importer silently ignored both flags and always treated the per-section parm as absolute.

Verified against the VSP source (``WingGeom.cpp::GetSumDihedral(i)`` lines 2314+, ``UpdateSurf()`` lines 1108-1198) via web-research agent.

**Three changes:**

1. ``_read_relative_flag`` helper reads the per-Wing flag from container group ``WingGeom`` (with fallback to ``Wing``). Absent → False (= absolute, pre-fix behaviour).
2. Section-loop tracks ``cum_dihedral_deg`` and ``cum_twist_deg``. RELATIVE mode adds the per-section parm; ABSOLUTE mode replaces. Matches VSP's own accumulator exactly.
3. Y/Z step switches from ``span/span·tan(angle)`` to ``span·cos(angle)/span·sin(angle)`` — the form VSP itself uses. Negligible at ≤5°, critical for winglets/V-tail.

Sweep stays absolute (no ``RelativeSweepFlag`` in VSP) — no change needed there.

## Test plan

- [x] 9 new tests in ``test_openvsp_wing_relative_dihedral_twist.py`` covering flag read, Cessna-flat no-regression, DG-cumulative-dihedral, absolute-mode no-regression, relative-twist accumulation, absolute-twist replacement, 60° winglet cosine
- [x] 2 pre-existing tests in ``test_openvsp_wing_handler.py`` updated from ``tan`` to ``sin/cos`` analytical values
- [x] 328/328 fast openvsp tests pass (was 319; +9 new)
- [ ] Manual smoke test: re-import DG-101G — Section 2's dihedral now continues the carried-over 3°; no kink at the section boundary

Closes #755

🤖 Generated with [Claude Code](https://claude.com/claude-code)