### PR TITLE
fix(gh-758): wing xsec augmentation clamps inserts clear of VSP tip cap

### DIFF
--- a/app/converters/openvsp_wing_handler.py
+++ b/app/converters/openvsp_wing_handler.py
@@ -368,6 +368,78 @@ def _find_cap_safe_u_max(vsp: ModuleType, gid: str) -> float:
 _DEDUP_EPS: float = 1e-6
 
 
+# gh-758: outcomes of attempting a single insert. Splits the previous
+# single "cap_truncated" counter into two distinct paths so the user
+# can tell whether a slightly-polygonal wing came from the tip-cap
+# clamp (expected, harmless) or from the LE-dedup safety net (worth
+# investigating if it ever fires on a wing without a cap).
+_OUTCOME_INSERTED = "inserted"
+_OUTCOME_CAP_CLAMPED = "cap_clamped"  # u > u_max — known cap region
+_OUTCOME_DEDUPED = "deduped"  # LE within _DEDUP_EPS of previous xsec
+_OUTCOME_FAILED = "failed"  # CompPnt01 raised or chord <= 0
+
+
+def _try_emit_one_insert(
+    vsp: ModuleType,
+    gid: str,
+    u: float,
+    u_max: float,
+    twist_deg: float,
+    airfoil: object,
+    out: list[WingXSecSchema],
+) -> str:
+    """Attempt to compute and append one interpolated xsec at spanwise
+    ``u``. Returns one of the ``_OUTCOME_*`` strings so the caller can
+    bookkeep cap-clamps, dedupes, and CompPnt01 failures separately.
+
+    Extracted from :func:`_augment_same_airfoil_pairs` to keep the
+    outer loop's cognitive complexity below SonarQube's ``python:S3776``
+    threshold (= 15). Each early-return represents one decision branch
+    that would otherwise have lived in the loop body.
+    """
+    # gh-758 #1: clamp u against the cap boundary. u_max is verified
+    # distinct from the tip by _find_cap_safe_u_max, so `u > u_max` is
+    # tighter than `u >= u_max` while remaining safe.
+    if u > u_max:
+        return _OUTCOME_CAP_CLAMPED
+
+    # gh-753: CompPnt01 may raise on a specific u (one VSP version
+    # with a known edge-case bug). Skip just this u — the renderer
+    # sees one fewer xsec, and the count diff is surfaced as a warning
+    # by the caller.
+    try:
+        le_xyz, te_xyz = _sample_le_te_at(vsp, gid, u)
+    except Exception:
+        return _OUTCOME_FAILED
+
+    chord = _chord_from_le_te(le_xyz, te_xyz)
+    if chord <= 0:
+        return _OUTCOME_FAILED
+
+    # gh-758 #2: defensive LE-dedup. The cap-probe in
+    # _find_cap_safe_u_max can miss narrow / non-monotonic caps; if
+    # the augmenter ever produces a duplicate LE despite the clamp,
+    # drop it here so the DB never has consecutive identical xyz_le
+    # rows (the Spitfire 8/9/10 evidence in the issue body).
+    prev_le = out[-1].xyz_le
+    ddx = le_xyz[0] - prev_le[0]
+    ddy = le_xyz[1] - prev_le[1]
+    ddz = le_xyz[2] - prev_le[2]
+    if math.sqrt(ddx * ddx + ddy * ddy + ddz * ddz) < _DEDUP_EPS:
+        return _OUTCOME_DEDUPED
+
+    out.append(
+        WingXSecSchema(
+            xyz_le=list(le_xyz),
+            chord=chord,
+            twist=twist_deg,
+            airfoil=airfoil,
+            x_sec_type="segment",
+        )
+    )
+    return _OUTCOME_INSERTED
+
+
 def _augment_same_airfoil_pairs(
     x_secs: list[WingXSecSchema],
     vsp: ModuleType,
@@ -405,12 +477,15 @@ def _augment_same_airfoil_pairs(
     If ``vsp.CompPnt01`` is unavailable (very old VSP build or a
     test stub), the original ``x_secs`` list is returned unchanged.
 
-    Emits ``ctx.add_warning`` (severity=info) for two distinct cases:
+    Emits ``ctx.add_warning`` (severity=info) for three distinct cases
+    — split per review on PR #759 so the user can tell the causes
+    apart in the import report:
+    - gh-758 "tip-cap clamp" — inserts skipped because u > u_max
+      (expected on any wing with a round / flat cap)
+    - gh-758 "LE dedup" — inserts skipped because LE clustered to the
+      previous xsec (worth investigating; means probe missed a cap)
     - gh-753 "CompPnt01 failure" — inserts skipped because CompPnt01
       raised or returned a degenerate chord
-    - gh-758 "tip-cap truncation" — inserts skipped because their u
-      fell inside the wing's tip-cap region; user can correlate the
-      visual symptom (slightly polygonal tip section) with the cause.
     """
     if not hasattr(vsp, "CompPnt01") or len(x_secs) < 2:
         return x_secs
@@ -420,8 +495,12 @@ def _augment_same_airfoil_pairs(
     n_anchors = len(x_secs)
     out: list[WingXSecSchema] = []
     expected_inserts = 0
-    actual_inserts = 0
-    cap_truncated = 0  # gh-758: inserts dropped because u ≥ u_max
+    counts: dict[str, int] = {
+        _OUTCOME_INSERTED: 0,
+        _OUTCOME_CAP_CLAMPED: 0,
+        _OUTCOME_DEDUPED: 0,
+        _OUTCOME_FAILED: 0,
+    }
 
     for i, anchor in enumerate(x_secs):
         out.append(anchor)
@@ -440,61 +519,59 @@ def _augment_same_airfoil_pairs(
 
         for k in range(1, _N_INTERP_PER_PAIR + 1):
             u = u_lo + k * step
-            if u >= u_max:
-                # gh-758: u landed in the tip-cap region where CompPnt01
-                # converges to a single point. Skipping here keeps the
-                # outer tip section slightly polygonal rather than
-                # producing duplicate xsecs at the cap centerline.
-                cap_truncated += 1
-                continue
-            try:
-                le_xyz, te_xyz = _sample_le_te_at(vsp, gid, u)
-            except Exception:
-                # CompPnt01 raised — skip this u and continue. A noisy
-                # raise here would mask the more common surrounding
-                # cases (e.g. one VSP version missing the call); the
-                # workbench renderer just sees one fewer xsec, and the
-                # mismatch is logged below as an info-warning.
-                continue
-            chord = _chord_from_le_te(le_xyz, te_xyz)
-            if chord <= 0:
-                continue
-            # gh-758 defensive dedup: skip if this insert's LE is
-            # geometrically identical to the previously appended xsec.
-            # Catches u-mapping edge cases the cap probe misses.
-            prev_le = out[-1].xyz_le
-            ddx = le_xyz[0] - prev_le[0]
-            ddy = le_xyz[1] - prev_le[1]
-            ddz = le_xyz[2] - prev_le[2]
-            if math.sqrt(ddx * ddx + ddy * ddy + ddz * ddz) < _DEDUP_EPS:
-                cap_truncated += 1
-                continue
             # Linear interpolation of twist between the bracketing
             # anchors at fractional position t = k / (N_INTERP + 1).
             t = k / float(_N_INTERP_PER_PAIR + 1)
             twist_deg = twist_lo + (twist_hi - twist_lo) * t
-            out.append(
-                WingXSecSchema(
-                    xyz_le=list(le_xyz),
-                    chord=chord,
-                    twist=twist_deg,
-                    airfoil=anchor.airfoil,
-                    x_sec_type="segment",
-                )
+            outcome = _try_emit_one_insert(
+                vsp=vsp,
+                gid=gid,
+                u=u,
+                u_max=u_max,
+                twist_deg=twist_deg,
+                airfoil=anchor.airfoil,
+                out=out,
             )
-            actual_inserts += 1
+            counts[outcome] += 1
 
-    if cap_truncated > 0:
-        # gh-758: distinct from the gh-753 warning below — the user can
-        # tell whether the wing is slightly polygonal because of a tip
-        # cap (expected, harmless) or because CompPnt01 failed (real
-        # importer problem worth investigating).
+    _emit_augmentation_warnings(
+        ctx=ctx,
+        geom_name=geom_name,
+        u_max=u_max,
+        expected_inserts=expected_inserts,
+        counts=counts,
+    )
+
+    return out
+
+
+def _emit_augmentation_warnings(
+    *,
+    ctx: ImportContext,
+    geom_name: str,
+    u_max: float,
+    expected_inserts: int,
+    counts: dict[str, int],
+) -> None:
+    """Surface per-outcome counts as info-warnings on the import context.
+
+    Each cause gets its own warning string so a future debugger can
+    tell whether a polygonal wing came from the cap clamp (expected),
+    the LE dedup (rare — probe missed a cap), or a true CompPnt01
+    failure (worth investigating).
+    """
+    cap_clamped = counts[_OUTCOME_CAP_CLAMPED]
+    deduped = counts[_OUTCOME_DEDUPED]
+    inserted = counts[_OUTCOME_INSERTED]
+    real_failures = expected_inserts - inserted - cap_clamped - deduped
+
+    if cap_clamped > 0:
         ctx.add_warning(
             component_type="WING",
             component_name=geom_name,
             reason=(
-                f"WING {geom_name!r}: gh-758 tip-cap truncation skipped "
-                f"{cap_truncated} insert(s) whose u-parameter landed in "
+                f"WING {geom_name!r}: gh-758 tip-cap clamp skipped "
+                f"{cap_clamped} insert(s) whose u-parameter landed in "
                 f"the wing's implicit tip-cap region (u_max={u_max:.3f}). "
                 "The outer tip section will be slightly less smooth than "
                 "the rest of the wing — this is expected behaviour for "
@@ -503,28 +580,39 @@ def _augment_same_airfoil_pairs(
             severity="info",
         )
 
-    real_failures = expected_inserts - actual_inserts - cap_truncated
+    if deduped > 0:
+        ctx.add_warning(
+            component_type="WING",
+            component_name=geom_name,
+            reason=(
+                f"WING {geom_name!r}: gh-758 LE-dedup safety net "
+                f"skipped {deduped} insert(s) whose LE clustered within "
+                f"{_DEDUP_EPS:.0e} m of the previous xsec. The cap-probe "
+                "should have caught these — this means the probe table "
+                "missed a narrow / non-monotonic cap region. Wing is "
+                "rendered correctly, but the probe coverage may need "
+                "extending."
+            ),
+            severity="info",
+        )
+
     if real_failures > 0:
-        # PR #754 review finding #2: a silently-incomplete augmentation
-        # used to look like a polygonal wing without explanation.
-        # Surface the count diff so the user can correlate the visual
-        # symptom with a real importer event. gh-758: cap-truncated
-        # inserts are excluded from this count — they get their own
-        # warning above so the two causes don't get conflated.
+        # PR #754 review finding #2 (gh-753): silently-incomplete
+        # augmentation used to look polygonal without explanation.
+        # Surface count diff so the user can correlate the visual
+        # symptom with a real importer event.
         ctx.add_warning(
             component_type="WING",
             component_name=geom_name,
             reason=(
                 f"WING {geom_name!r}: gh-753 xsec augmentation produced "
-                f"{actual_inserts}/{expected_inserts} expected inserts. "
+                f"{inserted}/{expected_inserts} expected inserts. "
                 "Some CompPnt01 samples failed or returned a degenerate "
                 "chord — the wing will render with fewer intermediate "
                 "xsecs than designed."
             ),
             severity="info",
         )
-
-    return out
 
 
 # ---------------------------------------------------------------------------

--- a/app/converters/openvsp_wing_handler.py
+++ b/app/converters/openvsp_wing_handler.py
@@ -280,9 +280,7 @@ def _sample_le_te_at(
     )
 
 
-def _chord_from_le_te(
-    le: tuple[float, float, float], te: tuple[float, float, float]
-) -> float:
+def _chord_from_le_te(le: tuple[float, float, float], te: tuple[float, float, float]) -> float:
     """Straight-line distance LE→TE in 3D (= planform chord, in metres).
 
     Twist is NOT derived from these points — they're in the VSP body
@@ -302,6 +300,72 @@ def _chord_from_le_te(
     if chord < 1e-9:
         return 0.0
     return chord
+
+
+# gh-758: probe-distance threshold for declaring two CompPnt01 samples
+# "distinct". 1e-4 m = 0.1 mm — well below the smallest meaningful wing
+# anchor spacing (the Spitfire's anchors are ~1 m apart) but well above
+# any floating-point rounding noise in VSP's spline evaluator.
+_CAP_PROBE_EPS: float = 1e-4
+
+# gh-758: candidate u-values to probe, walked from highest (just below
+# the tip) to lower. Returns the FIRST u whose LE differs from u=1.0 by
+# more than _CAP_PROBE_EPS — that's the largest "safe" u (i.e. clear of
+# VSP's implicit tip cap which converges to a single point as u → 1).
+_CAP_PROBE_US: tuple[float, ...] = (0.99, 0.98, 0.97, 0.95, 0.92, 0.90, 0.85, 0.80, 0.70)
+
+
+def _find_cap_safe_u_max(vsp: ModuleType, gid: str) -> float:
+    """Return the largest spanwise ``u`` for which ``CompPnt01`` on the
+    wing main surface still returns a point geometrically distinct from
+    the tip (``u = 1.0``).
+
+    VSP wings have an implicit tip cap (round / flat / etc., controlled
+    by ``Cap_Tip`` parms) that occupies a small u-range near 1.0. Within
+    that range, ``CompPnt01(gid, 0, u, w)`` returns points that converge
+    to the cap centerline as u → 1, regardless of the chordwise ``w``.
+    Inserting interpolated xsecs into this range produces (a) duplicate
+    ``xyz_le`` rows and (b) Z-lifted xsecs that visually break the wing
+    render — the gh-758 Cessna 172 + Spitfire reproductions.
+
+    Method: sample LE at ``u = 1.0`` and at the values in
+    :data:`_CAP_PROBE_US` (highest first). The first probe whose LE
+    distance from the tip exceeds :data:`_CAP_PROBE_EPS` is returned —
+    that's our largest "safe" u. If every probe converges (degenerate
+    surface) or ``CompPnt01`` is unusable, return ``1.0`` so the caller
+    falls back to its existing per-u failure path.
+    """
+    if not hasattr(vsp, "CompPnt01"):
+        return 1.0
+    try:
+        le_at_tip, _ = _sample_le_te_at(vsp, gid, 1.0)
+    except Exception:
+        # CompPnt01 raised on the tip probe — no cap detection possible;
+        # the augmenter's per-u except will handle individual failures.
+        return 1.0
+
+    for u_probe in _CAP_PROBE_US:
+        try:
+            le_probe, _ = _sample_le_te_at(vsp, gid, u_probe)
+        except Exception:
+            continue
+        dx = le_at_tip[0] - le_probe[0]
+        dy = le_at_tip[1] - le_probe[1]
+        dz = le_at_tip[2] - le_probe[2]
+        if math.sqrt(dx * dx + dy * dy + dz * dz) > _CAP_PROBE_EPS:
+            return u_probe
+    # Every probe converged (or raised) — wing is degenerate in u.
+    # Returning the smallest tried probe is safer than 1.0 because we
+    # know u-values up to that point are also converged; clamp inserts
+    # well clear of them.
+    return _CAP_PROBE_US[-1]
+
+
+# gh-758: dedup threshold for consecutive output xsecs. 1e-6 m = 1 μm —
+# defensively skips inserts whose LE is geometrically identical to the
+# previous one. Guards against narrow caps or other VSP edge cases the
+# probe might miss. Real wing anchors differ by ≥ millimetres.
+_DEDUP_EPS: float = 1e-6
 
 
 def _augment_same_airfoil_pairs(
@@ -332,22 +396,32 @@ def _augment_same_airfoil_pairs(
     XForm pass) so the interpolated xsecs are transformed by the
     same pipeline as the anchors.
 
+    gh-758: inserts are clamped to stay clear of VSP's implicit tip
+    cap (see :func:`_find_cap_safe_u_max`). A defensive xyz_le-dedup
+    guards against narrow caps or u-mapping edge cases the probe
+    misses — duplicate xyz_le rows in the DB are the smoking gun the
+    issue body cites for the Spitfire / Cessna 172 breakage.
+
     If ``vsp.CompPnt01`` is unavailable (very old VSP build or a
     test stub), the original ``x_secs`` list is returned unchanged.
 
-    Emits a single ``ctx.add_warning`` (severity=info) when ≥1
-    expected insert silently failed (e.g. ``CompPnt01`` raised or
-    returned a degenerate chord) so a corrupted geom is visible in
-    the import report instead of just looking like a polygonal
-    wing without explanation.
+    Emits ``ctx.add_warning`` (severity=info) for two distinct cases:
+    - gh-753 "CompPnt01 failure" — inserts skipped because CompPnt01
+      raised or returned a degenerate chord
+    - gh-758 "tip-cap truncation" — inserts skipped because their u
+      fell inside the wing's tip-cap region; user can correlate the
+      visual symptom (slightly polygonal tip section) with the cause.
     """
     if not hasattr(vsp, "CompPnt01") or len(x_secs) < 2:
         return x_secs
+
+    u_max = _find_cap_safe_u_max(vsp, gid)
 
     n_anchors = len(x_secs)
     out: list[WingXSecSchema] = []
     expected_inserts = 0
     actual_inserts = 0
+    cap_truncated = 0  # gh-758: inserts dropped because u ≥ u_max
 
     for i, anchor in enumerate(x_secs):
         out.append(anchor)
@@ -366,6 +440,13 @@ def _augment_same_airfoil_pairs(
 
         for k in range(1, _N_INTERP_PER_PAIR + 1):
             u = u_lo + k * step
+            if u >= u_max:
+                # gh-758: u landed in the tip-cap region where CompPnt01
+                # converges to a single point. Skipping here keeps the
+                # outer tip section slightly polygonal rather than
+                # producing duplicate xsecs at the cap centerline.
+                cap_truncated += 1
+                continue
             try:
                 le_xyz, te_xyz = _sample_le_te_at(vsp, gid, u)
             except Exception:
@@ -377,6 +458,16 @@ def _augment_same_airfoil_pairs(
                 continue
             chord = _chord_from_le_te(le_xyz, te_xyz)
             if chord <= 0:
+                continue
+            # gh-758 defensive dedup: skip if this insert's LE is
+            # geometrically identical to the previously appended xsec.
+            # Catches u-mapping edge cases the cap probe misses.
+            prev_le = out[-1].xyz_le
+            ddx = le_xyz[0] - prev_le[0]
+            ddy = le_xyz[1] - prev_le[1]
+            ddz = le_xyz[2] - prev_le[2]
+            if math.sqrt(ddx * ddx + ddy * ddy + ddz * ddz) < _DEDUP_EPS:
+                cap_truncated += 1
                 continue
             # Linear interpolation of twist between the bracketing
             # anchors at fractional position t = k / (N_INTERP + 1).
@@ -393,11 +484,33 @@ def _augment_same_airfoil_pairs(
             )
             actual_inserts += 1
 
-    if expected_inserts > 0 and actual_inserts < expected_inserts:
+    if cap_truncated > 0:
+        # gh-758: distinct from the gh-753 warning below — the user can
+        # tell whether the wing is slightly polygonal because of a tip
+        # cap (expected, harmless) or because CompPnt01 failed (real
+        # importer problem worth investigating).
+        ctx.add_warning(
+            component_type="WING",
+            component_name=geom_name,
+            reason=(
+                f"WING {geom_name!r}: gh-758 tip-cap truncation skipped "
+                f"{cap_truncated} insert(s) whose u-parameter landed in "
+                f"the wing's implicit tip-cap region (u_max={u_max:.3f}). "
+                "The outer tip section will be slightly less smooth than "
+                "the rest of the wing — this is expected behaviour for "
+                "VSP wings with a round / flat tip cap."
+            ),
+            severity="info",
+        )
+
+    real_failures = expected_inserts - actual_inserts - cap_truncated
+    if real_failures > 0:
         # PR #754 review finding #2: a silently-incomplete augmentation
         # used to look like a polygonal wing without explanation.
         # Surface the count diff so the user can correlate the visual
-        # symptom with a real importer event.
+        # symptom with a real importer event. gh-758: cap-truncated
+        # inserts are excluded from this count — they get their own
+        # warning above so the two causes don't get conflated.
         ctx.add_warning(
             component_type="WING",
             component_name=geom_name,

--- a/app/converters/openvsp_wing_handler.py
+++ b/app/converters/openvsp_wing_handler.py
@@ -464,9 +464,13 @@ def _augment_same_airfoil_pairs(
       geometry. The body-frame ``atan2(le.z-te.z, te.x-le.x)``
       mixes dihedral into twist (PR #754 review finding #1).
 
-    The augmentation runs in the VSP body frame (before the Geom
-    XForm pass) so the interpolated xsecs are transformed by the
-    same pipeline as the anchors.
+    The augmenter operates in the **world frame**: anchors must
+    already be XForm-applied at call time. CompPnt01 returns
+    world-frame coordinates (the Geom XForm is baked into the VSP
+    surface), so the inserts naturally compose with post-XForm
+    anchors. The caller (``_handle_wing``) applies XForm BEFORE
+    this function (gh-758 #2) — the previous order (augment first,
+    XForm second) silently double-transformed every insert.
 
     gh-758: inserts are clamped to stay clear of VSP's implicit tip
     cap (see :func:`_find_cap_safe_u_max`). A defensive xyz_le-dedup
@@ -788,23 +792,32 @@ def _handle_wing(
         ctx.mark_lossy(gid)
         return
 
-    # gh-753: insert interpolated xsecs between consecutive anchors
-    # that share the same airfoil reference, so wings with few VSP-
-    # defined XSecs (Spitfire 4-anchor elliptical wing → looks
-    # pentagonal pre-augmentation) render as smooth splines. Runs in
-    # the VSP body frame before XForm so the new xsecs are
-    # transformed alongside the anchors.
-    x_secs = _augment_same_airfoil_pairs(x_secs, vsp, gid, ctx, name)
-
     # Apply Geom-level XForm (translation + intrinsic XYZ rotation) to every
-    # xyz_le so that wings end up at their world-frame position and orientation.
-    # Critical for HTP (aft translation) and VTP (90°-X rotation that stands
-    # the wing upright). See gh-698 for the Cessna 172 regression that
-    # surfaced this gap.
+    # anchor's xyz_le so that wings end up at their world-frame position and
+    # orientation. Critical for HTP (aft translation) and VTP (90°-X rotation
+    # that stands the wing upright). See gh-698 for the Cessna 172 regression
+    # that surfaced this gap.
+    #
+    # gh-758 #2: XForm MUST happen BEFORE augmentation (was: after). Reason:
+    # VSP's CompPnt01 returns coordinates in the WORLD FRAME (XForm already
+    # baked into the surface), so for the augmenter's inserts to match the
+    # anchors in frame, the anchors need to be world-frame too at that point.
+    # The old order (augment first, then XForm) silently DOUBLE-XFORMED every
+    # insert — visible on the Cessna 172 as "disconnected wing pieces" with
+    # xsec rows showing xyz_le = 2 × translation (e.g. z = 1.42 m when the
+    # wing's Z_Location is 0.71 m).
     translation, rotation_deg = _read_geom_xform(vsp, gid)
     if any(translation) or any(rotation_deg):
         for xs in x_secs:
             xs.xyz_le = _apply_xform(xs.xyz_le, translation, rotation_deg)
+
+    # gh-753: insert interpolated xsecs between consecutive anchors that
+    # share the same airfoil reference, so wings with few VSP-defined XSecs
+    # (Spitfire 4-anchor elliptical wing → looks pentagonal pre-augmentation)
+    # render as smooth splines. Runs in WORLD frame post-XForm — CompPnt01
+    # returns world-frame coordinates so the inserts compose directly with
+    # the post-XForm anchors. No further transform is applied to the inserts.
+    x_secs = _augment_same_airfoil_pairs(x_secs, vsp, gid, ctx, name)
 
     wing = AsbWingSchema(
         name=name,

--- a/app/tests/test_openvsp_wing_xsec_augmentation.py
+++ b/app/tests/test_openvsp_wing_xsec_augmentation.py
@@ -29,6 +29,7 @@ from app.converters.openvsp_wing_handler import (
     _W_TE,
     _augment_same_airfoil_pairs,
     _chord_from_le_te,
+    _find_cap_safe_u_max,
     _sample_le_te_at,
 )
 from app.schemas.aeroplaneschema import WingXSecSchema
@@ -273,9 +274,7 @@ class TestTwistInterpolation:
             _xsec(airfoil="naca2412", twist=0.0, t="root"),
             _xsec(airfoil="naca2412", twist=-4.0, t=None),
         ]
-        out = _augment_same_airfoil_pairs(
-            anchors, _ellipse_vsp(), "wing-gid", _ctx(), "wing"
-        )
+        out = _augment_same_airfoil_pairs(anchors, _ellipse_vsp(), "wing-gid", _ctx(), "wing")
         inserts = out[1:-1]
         expected = [-0.8, -1.6, -2.4, -3.2]
         for ins, exp in zip(inserts, expected, strict=True):
@@ -291,9 +290,7 @@ class TestTwistInterpolation:
             _xsec(airfoil="naca2412", twist=0.0, t="root"),
             _xsec(airfoil="naca2412", twist=0.0, t=None),
         ]
-        out = _augment_same_airfoil_pairs(
-            anchors, _ellipse_vsp(), "wing-gid", _ctx(), "wing"
-        )
+        out = _augment_same_airfoil_pairs(anchors, _ellipse_vsp(), "wing-gid", _ctx(), "wing")
         for ins in out[1:-1]:
             assert ins.twist == 0.0
 
@@ -322,9 +319,7 @@ class TestTwistInterpolation:
             _xsec(airfoil="naca2412", twist=0.0, t="root"),
             _xsec(airfoil="naca2412", twist=0.0, t=None),
         ]
-        out = _augment_same_airfoil_pairs(
-            anchors, _DihedralStub(), "wing-gid", _ctx(), "wing"
-        )
+        out = _augment_same_airfoil_pairs(anchors, _DihedralStub(), "wing-gid", _ctx(), "wing")
         # Anchor twists are 0 → every insert twist must be 0 even
         # though the body-frame LE/TE has a 0.5 m vertical offset.
         for ins in out[1:-1]:
@@ -356,15 +351,11 @@ class TestLossyWarning:
             _xsec(airfoil="naca2412", t="root"),
             _xsec(airfoil="naca2412", t=None),
         ]
-        out = _augment_same_airfoil_pairs(
-            anchors, _AlwaysRaises(), "wing-gid", ctx, "main_wing"
-        )
+        out = _augment_same_airfoil_pairs(anchors, _AlwaysRaises(), "wing-gid", ctx, "main_wing")
         # No inserts succeeded → 2 anchors only.
         assert len(out) == 2
         # Exactly one info-warning emitted with the count diff.
-        info_warnings = [
-            w for w in ctx.warnings if w.severity == "info" and "gh-753" in w.reason
-        ]
+        info_warnings = [w for w in ctx.warnings if w.severity == "info" and "gh-753" in w.reason]
         assert len(info_warnings) == 1
         assert info_warnings[0].component_name == "main_wing"
         assert "0/4" in info_warnings[0].reason
@@ -389,9 +380,7 @@ class TestLossyWarning:
             _xsec(airfoil="naca2412", t="root"),
             _xsec(airfoil="naca2412", t=None),
         ]
-        out = _augment_same_airfoil_pairs(
-            anchors, _FlakyAtMidU(), "wing-gid", ctx, "main_wing"
-        )
+        out = _augment_same_airfoil_pairs(anchors, _FlakyAtMidU(), "wing-gid", ctx, "main_wing")
         # 3 successful inserts + 2 anchors = 5
         assert len(out) == 5
         info_warnings = [w for w in ctx.warnings if "gh-753" in w.reason]
@@ -406,9 +395,7 @@ class TestLossyWarning:
             _xsec(airfoil="naca2412", t="root"),
             _xsec(airfoil="naca2412", t=None),
         ]
-        _augment_same_airfoil_pairs(
-            anchors, _ellipse_vsp(), "wing-gid", ctx, "main_wing"
-        )
+        _augment_same_airfoil_pairs(anchors, _ellipse_vsp(), "wing-gid", ctx, "main_wing")
         info_warnings = [w for w in ctx.warnings if "gh-753" in w.reason]
         assert info_warnings == []
 
@@ -460,9 +447,207 @@ class TestDegenerateInputs:
             _xsec(airfoil="naca2412", t="root"),
             _xsec(airfoil="naca2412", t=None),
         ]
-        out = _augment_same_airfoil_pairs(
-            anchors, _FlakyVsp(), "wing-gid", _ctx(), "wing"
-        )
+        out = _augment_same_airfoil_pairs(anchors, _FlakyVsp(), "wing-gid", _ctx(), "wing")
         # The u≈0.4 insert is skipped; the other 3 succeed.
         # Total: 2 anchors + 3 successful inserts = 5
         assert len(out) == 5
+
+
+# ---------------------------------------------------------------------------
+# gh-758 — Tip-cap-aware augmentation
+# ---------------------------------------------------------------------------
+#
+# Real VSP wings have an implicit tip cap (round / flat / etc.) which
+# occupies an u-range near 1.0 on the main wing surface. Within this
+# range, ``CompPnt01(gid, 0, u, w)`` returns near-identical points that
+# converge to the cap centerline as u → 1.0 — see the gh-758 issue body
+# for the Cessna 172 + Spitfire reproductions where DB rows 8/9/10 had
+# exactly identical ``xyz_le = [-0.055, 5.243, 0.510]`` after
+# augmentation.
+#
+# The fix introduces ``_find_cap_safe_u_max`` to probe the surface for
+# the largest non-convergent u, and the augmenter skips any insert
+# whose u exceeds that threshold. A defensive xyz_le-dedup catches any
+# edge case the probe might miss.
+
+
+def _capped_vsp(
+    half_span: float = 6.0,
+    root_chord: float = 2.0,
+    u_cap_start: float = 0.90,
+    cap_z: float = 0.5,
+):
+    """Build a VSP stub whose CompPnt01 simulates a real wing surface
+    WITH a tip cap. For u < u_cap_start, behaves like the ellipse stub
+    (smoothly varying LE/TE). For u >= u_cap_start, all points converge
+    to the cap centerline at (0, half_span * u_cap_start, cap_z),
+    mimicking how a rounded VSP tip cap collapses to its centerline as
+    u → 1.0.
+
+    This stub is what makes the gh-758 bug REPRODUCIBLE in unit tests:
+    the pre-fix augmenter inserts xsecs whose u lands in the cap region,
+    producing the duplicate-xyz_le + Z-lifted-xsec symptoms reported on
+    the Spitfire and Cessna 172.
+    """
+
+    class _Stub:
+        @staticmethod
+        def CompPnt01(_gid: str, _surf: int, u: float, w: float) -> _Pnt:
+            if u >= u_cap_start:
+                # Cap region: all points converge to centerline.
+                return _Pnt(0.0, half_span * u_cap_start, cap_z)
+            y = half_span * u
+            chord = root_chord * math.sqrt(max(0.0, 1.0 - u * u))
+            if abs(w - _W_LE) < 1e-9:
+                return _Pnt(-chord / 2.0, y, 0.0)
+            if abs(w - _W_TE) < 1e-9:
+                return _Pnt(+chord / 2.0, y, 0.0)
+            return _Pnt(-chord / 2.0, y, 0.0)
+
+    return _Stub()
+
+
+class TestFindCapSafeUMax:
+    """Probe-based detection of the largest u for which CompPnt01
+    still returns a distinct (= non-cap) point. The augmenter clamps
+    inserts to stay clear of this boundary."""
+
+    def test_no_cap_returns_high_u(self):
+        """The plain ellipse stub has no cap — every u ∈ [0, 1] gives
+        a distinct point. The probe returns ~1.0 (or the largest probe
+        value that's still distinct from u=1.0)."""
+        u_max = _find_cap_safe_u_max(_ellipse_vsp(), "wing-gid")
+        assert u_max >= 0.95
+
+    def test_capped_returns_below_cap_start(self):
+        """A capped stub with u_cap_start=0.90 → probe must return a
+        u_max <= 0.90 so that inserts stay clear of the cap region."""
+        u_max = _find_cap_safe_u_max(_capped_vsp(u_cap_start=0.90), "wing-gid")
+        assert u_max <= 0.90
+
+    def test_no_comppnt01_returns_one(self):
+        """No CompPnt01 → probe is unusable; return 1.0 (= no clamping,
+        the augmenter's early-return covers the actual call sites)."""
+
+        class _StubWithoutCompPnt:
+            pass
+
+        u_max = _find_cap_safe_u_max(_StubWithoutCompPnt(), "wing-gid")
+        assert u_max == 1.0
+
+    def test_raising_comppnt01_returns_one(self):
+        """If CompPnt01 raises on the tip probe, fall back to 1.0
+        (= no clamping; let the augmenter's per-u exception path
+        handle individual failures)."""
+
+        class _AlwaysRaises:
+            @staticmethod
+            def CompPnt01(_gid, _surf, _u, _w):
+                raise RuntimeError("synthetic")
+
+        u_max = _find_cap_safe_u_max(_AlwaysRaises(), "wing-gid")
+        assert u_max == 1.0
+
+
+class TestCapAwareAugmentation:
+    """gh-758 acceptance criterion: a wing with a tip cap must NOT
+    produce duplicate xyz_le rows in the augmented xsec list, and no
+    insert must land on the cap surface (which would visually lift
+    the wing into a z-kink)."""
+
+    def test_no_duplicate_xyz_le_with_tip_cap(self):
+        """A 4-anchor wing on a capped stub must produce 0 duplicate
+        consecutive xyz_le values. This is the direct DB-inspection
+        criterion from the issue body."""
+        anchors = [
+            _xsec(airfoil="naca2213", xyz_le=(0.0, 0.0, 0.0), chord=2.0, t="root"),
+            _xsec(airfoil="naca2213", xyz_le=(0.0, 2.0, 0.0), chord=1.8, t="segment"),
+            _xsec(airfoil="naca2213", xyz_le=(0.0, 4.0, 0.0), chord=1.2, t="segment"),
+            _xsec(airfoil="naca2213", xyz_le=(0.0, 5.4, 0.0), chord=0.4, t=None),
+        ]
+        out = _augment_same_airfoil_pairs(
+            anchors, _capped_vsp(u_cap_start=0.90), "wing-gid", _ctx(), "wing"
+        )
+        # Walk the output and assert no two consecutive xsecs share
+        # an xyz_le within 1e-6 m (= 1 μm — far below any meaningful
+        # wing geometry resolution).
+        for prev, curr in zip(out, out[1:], strict=False):
+            d = math.sqrt(sum((a - b) ** 2 for a, b in zip(prev.xyz_le, curr.xyz_le, strict=True)))
+            assert d > 1e-6, f"Duplicate xyz_le detected: {prev.xyz_le} == {curr.xyz_le}"
+
+    def test_no_insert_lands_on_cap_z(self):
+        """Inserts must not pick up the cap's Z-offset (which causes
+        the 'tip-caps parked at z≈1' visual symptom). Anchors all have
+        z=0; inserts must keep z near 0 too."""
+        anchors = [
+            _xsec(airfoil="naca2213", xyz_le=(0.0, 0.0, 0.0), chord=2.0, t="root"),
+            _xsec(airfoil="naca2213", xyz_le=(0.0, 5.4, 0.0), chord=0.4, t=None),
+        ]
+        out = _augment_same_airfoil_pairs(
+            anchors, _capped_vsp(u_cap_start=0.90, cap_z=0.5), "wing-gid", _ctx(), "wing"
+        )
+        # All inserts (everything except first/last anchors) must have
+        # z ≈ 0 (the non-cap surface), not z = 0.5 (the cap centerline).
+        for ins in out[1:-1]:
+            assert abs(ins.xyz_le[2]) < 1e-6, (
+                f"Insert picked up cap Z: xyz_le={ins.xyz_le} — "
+                "augmenter should have skipped this cap-region u"
+            )
+
+    def test_emits_cap_truncation_warning(self):
+        """When inserts are skipped due to the cap region, the
+        augmenter must surface that via ctx.add_warning so the user
+        can correlate the visual symptom (fewer-than-expected xsecs
+        near the tip) with an import event. Phrased differently from
+        the existing 'CompPnt01 failure' warning so the two are
+        distinguishable in the import report.
+
+        Setup mirrors the Spitfire's 4-anchor wing — the gh-758 bug
+        reproducer — where the outer pair's outer inserts land in
+        the cap region.
+        """
+        ctx = _ctx()
+        anchors = [
+            _xsec(airfoil="naca2213", xyz_le=(0.0, 0.0, 0.0), chord=2.0, t="root"),
+            _xsec(airfoil="naca2213", xyz_le=(0.0, 2.0, 0.0), chord=1.8, t="segment"),
+            _xsec(airfoil="naca2213", xyz_le=(0.0, 4.0, 0.0), chord=1.2, t="segment"),
+            _xsec(airfoil="naca2213", xyz_le=(0.0, 5.4, 0.0), chord=0.4, t=None),
+        ]
+        _augment_same_airfoil_pairs(
+            anchors, _capped_vsp(u_cap_start=0.90), "wing-gid", ctx, "main_wing"
+        )
+        # Look for a gh-758 cap-truncation warning specifically.
+        cap_warnings = [w for w in ctx.warnings if w.severity == "info" and "gh-758" in w.reason]
+        assert len(cap_warnings) == 1
+        assert cap_warnings[0].component_name == "main_wing"
+
+    def test_no_cap_warning_for_no_cap_wing(self):
+        """A wing with no cap (ellipse stub, u_max ≈ 1.0) must NOT
+        emit the cap-truncation warning — would be noise on healthy
+        imports."""
+        ctx = _ctx()
+        anchors = [
+            _xsec(airfoil="naca2213", xyz_le=(0.0, 0.0, 0.0), chord=2.0, t="root"),
+            _xsec(airfoil="naca2213", xyz_le=(0.0, 6.0, 0.0), chord=0.0, t=None),
+        ]
+        _augment_same_airfoil_pairs(anchors, _ellipse_vsp(), "wing-gid", ctx, "main_wing")
+        cap_warnings = [w for w in ctx.warnings if "gh-758" in w.reason]
+        assert cap_warnings == []
+
+    def test_inserts_remain_in_non_cap_segments(self):
+        """The first segments of a multi-anchor wing (root→mid) are far
+        from the tip cap. Their inserts must still happen normally — the
+        clamp only affects the outermost segment."""
+        anchors = [
+            _xsec(airfoil="naca2213", xyz_le=(0.0, 0.0, 0.0), chord=2.0, t="root"),
+            _xsec(airfoil="naca2213", xyz_le=(0.0, 2.0, 0.0), chord=1.8, t="segment"),
+            _xsec(airfoil="naca2213", xyz_le=(0.0, 5.4, 0.0), chord=0.4, t=None),
+        ]
+        out = _augment_same_airfoil_pairs(
+            anchors, _capped_vsp(u_cap_start=0.90), "wing-gid", _ctx(), "wing"
+        )
+        # First segment (root → mid): 4 inserts expected (u ∈ [0, 0.5]
+        # — well below the cap start).
+        # Second segment (mid → tip): some inserts may be dropped.
+        # Total must be at least 3 anchors + 4 first-segment inserts = 7.
+        assert len(out) >= 7

--- a/app/tests/test_openvsp_wing_xsec_augmentation.py
+++ b/app/tests/test_openvsp_wing_xsec_augmentation.py
@@ -476,26 +476,39 @@ def _capped_vsp(
     root_chord: float = 2.0,
     u_cap_start: float = 0.90,
     cap_z: float = 0.5,
+    cap_chord: float = 0.05,
 ):
     """Build a VSP stub whose CompPnt01 simulates a real wing surface
     WITH a tip cap. For u < u_cap_start, behaves like the ellipse stub
-    (smoothly varying LE/TE). For u >= u_cap_start, all points converge
-    to the cap centerline at (0, half_span * u_cap_start, cap_z),
-    mimicking how a rounded VSP tip cap collapses to its centerline as
-    u → 1.0.
+    (smoothly varying LE/TE). For u >= u_cap_start, the LE clusters to
+    the cap centerline at (-cap_chord/2, half_span * u_cap_start, cap_z)
+    while the TE clusters to (+cap_chord/2, ..., cap_z) — preserving a
+    small non-zero ``cap_chord`` distance so the augmenter's
+    ``chord <= 0`` check does NOT fire.
 
-    This stub is what makes the gh-758 bug REPRODUCIBLE in unit tests:
-    the pre-fix augmenter inserts xsecs whose u lands in the cap region,
-    producing the duplicate-xyz_le + Z-lifted-xsec symptoms reported on
-    the Spitfire and Cessna 172.
+    That distinction matters: review on PR #759 caught that a stub where
+    cap-region LE == TE made the existing ``if chord <= 0: continue``
+    silently drop every cap-region insert pre-fix, so the regression
+    tests "passed" against the pre-fix code. Real VSP CompPnt01 returns
+    distinct-but-clustered LE/TE in the cap region — the Spitfire DB
+    evidence (rows 8/9/10 with identical xyz_le but non-zero chord)
+    is exactly this shape. This stub models that faithfully so the
+    tests actually pin the regression they claim to.
     """
 
     class _Stub:
         @staticmethod
         def CompPnt01(_gid: str, _surf: int, u: float, w: float) -> _Pnt:
             if u >= u_cap_start:
-                # Cap region: all points converge to centerline.
-                return _Pnt(0.0, half_span * u_cap_start, cap_z)
+                # Cap region: LE/TE cluster to the cap centerline ±
+                # cap_chord/2 — identical for every u in the cap, but
+                # LE != TE so chord > 0 (matches Spitfire DB evidence).
+                y_cap = half_span * u_cap_start
+                if abs(w - _W_LE) < 1e-9:
+                    return _Pnt(-cap_chord / 2.0, y_cap, cap_z)
+                if abs(w - _W_TE) < 1e-9:
+                    return _Pnt(+cap_chord / 2.0, y_cap, cap_z)
+                return _Pnt(-cap_chord / 2.0, y_cap, cap_z)
             y = half_span * u
             chord = root_chord * math.sqrt(max(0.0, 1.0 - u * u))
             if abs(w - _W_LE) < 1e-9:
@@ -522,7 +535,7 @@ class TestFindCapSafeUMax:
     def test_capped_returns_below_cap_start(self):
         """A capped stub with u_cap_start=0.90 → probe must return a
         u_max <= 0.90 so that inserts stay clear of the cap region."""
-        u_max = _find_cap_safe_u_max(_capped_vsp(u_cap_start=0.90), "wing-gid")
+        u_max = _find_cap_safe_u_max(_capped_vsp(u_cap_start=0.85), "wing-gid")
         assert u_max <= 0.90
 
     def test_no_comppnt01_returns_one(self):
@@ -566,7 +579,7 @@ class TestCapAwareAugmentation:
             _xsec(airfoil="naca2213", xyz_le=(0.0, 5.4, 0.0), chord=0.4, t=None),
         ]
         out = _augment_same_airfoil_pairs(
-            anchors, _capped_vsp(u_cap_start=0.90), "wing-gid", _ctx(), "wing"
+            anchors, _capped_vsp(u_cap_start=0.85), "wing-gid", _ctx(), "wing"
         )
         # Walk the output and assert no two consecutive xsecs share
         # an xyz_le within 1e-6 m (= 1 μm — far below any meaningful
@@ -578,13 +591,20 @@ class TestCapAwareAugmentation:
     def test_no_insert_lands_on_cap_z(self):
         """Inserts must not pick up the cap's Z-offset (which causes
         the 'tip-caps parked at z≈1' visual symptom). Anchors all have
-        z=0; inserts must keep z near 0 too."""
+        z=0; inserts must keep z near 0 too.
+
+        4-anchor setup so the last pair's outer inserts (u ≈ 0.867,
+        0.933) actually exercise the cap region pre-fix — that's the
+        regression reported in the gh-758 issue body.
+        """
         anchors = [
             _xsec(airfoil="naca2213", xyz_le=(0.0, 0.0, 0.0), chord=2.0, t="root"),
-            _xsec(airfoil="naca2213", xyz_le=(0.0, 5.4, 0.0), chord=0.4, t=None),
+            _xsec(airfoil="naca2213", xyz_le=(0.0, 2.0, 0.0), chord=1.8, t="segment"),
+            _xsec(airfoil="naca2213", xyz_le=(0.0, 4.0, 0.0), chord=1.2, t="segment"),
+            _xsec(airfoil="naca2213", xyz_le=(0.0, 5.1, 0.0), chord=0.4, t=None),
         ]
         out = _augment_same_airfoil_pairs(
-            anchors, _capped_vsp(u_cap_start=0.90, cap_z=0.5), "wing-gid", _ctx(), "wing"
+            anchors, _capped_vsp(u_cap_start=0.85, cap_z=0.5), "wing-gid", _ctx(), "wing"
         )
         # All inserts (everything except first/last anchors) must have
         # z ≈ 0 (the non-cap surface), not z = 0.5 (the cap centerline).
@@ -614,7 +634,7 @@ class TestCapAwareAugmentation:
             _xsec(airfoil="naca2213", xyz_le=(0.0, 5.4, 0.0), chord=0.4, t=None),
         ]
         _augment_same_airfoil_pairs(
-            anchors, _capped_vsp(u_cap_start=0.90), "wing-gid", ctx, "main_wing"
+            anchors, _capped_vsp(u_cap_start=0.85), "wing-gid", ctx, "main_wing"
         )
         # Look for a gh-758 cap-truncation warning specifically.
         cap_warnings = [w for w in ctx.warnings if w.severity == "info" and "gh-758" in w.reason]
@@ -644,10 +664,122 @@ class TestCapAwareAugmentation:
             _xsec(airfoil="naca2213", xyz_le=(0.0, 5.4, 0.0), chord=0.4, t=None),
         ]
         out = _augment_same_airfoil_pairs(
-            anchors, _capped_vsp(u_cap_start=0.90), "wing-gid", _ctx(), "wing"
+            anchors, _capped_vsp(u_cap_start=0.85), "wing-gid", _ctx(), "wing"
         )
         # First segment (root → mid): 4 inserts expected (u ∈ [0, 0.5]
         # — well below the cap start).
         # Second segment (mid → tip): some inserts may be dropped.
         # Total must be at least 3 anchors + 4 first-segment inserts = 7.
         assert len(out) >= 7
+
+    def test_dedup_safety_net_fires_when_probe_misses_cluster(self):
+        """The LE-dedup is a belt-and-suspenders safety net for the
+        cap probe. This test pins the dedup-only path: probe sees
+        distinct LE at u=0.99 (so u_max≈0.99, no cap clamp), but a
+        mid-range cluster (u ∈ [0.35, 0.65]) makes consecutive inserts
+        share an LE — the dedup must drop the duplicate.
+
+        Per review on PR #759: without this test, the dedup branch
+        has no coverage of its own (the original cap-region tests
+        triggered the u-clamp before the dedup ever ran).
+        """
+
+        def _clustered_mid_vsp():
+            class _Stub:
+                @staticmethod
+                def CompPnt01(_gid, _surf, u, w):
+                    if 0.35 < u < 0.65:
+                        # Mid-range cluster: same LE/TE for every u
+                        # in this band → dedup must fire on the 2nd
+                        # consecutive insert.
+                        if abs(w - _W_LE) < 1e-9:
+                            return _Pnt(-0.5, 3.0, 0.0)
+                        return _Pnt(+0.5, 3.0, 0.0)
+                    y = 6.0 * u
+                    chord = 2.0 * math.sqrt(max(0.0, 1.0 - u * u))
+                    if abs(w - _W_LE) < 1e-9:
+                        return _Pnt(-chord / 2.0, y, 0.0)
+                    return _Pnt(+chord / 2.0, y, 0.0)
+
+            return _Stub()
+
+        ctx = _ctx()
+        anchors = [
+            _xsec(airfoil="naca2213", xyz_le=(0.0, 0.0, 0.0), chord=2.0, t="root"),
+            _xsec(airfoil="naca2213", xyz_le=(0.0, 6.0, 0.0), chord=0.0, t=None),
+        ]
+        out = _augment_same_airfoil_pairs(anchors, _clustered_mid_vsp(), "wing-gid", ctx, "wing")
+        # No duplicate consecutive xyz_le in the output.
+        for prev, curr in zip(out, out[1:], strict=False):
+            d = math.sqrt(sum((a - b) ** 2 for a, b in zip(prev.xyz_le, curr.xyz_le, strict=True)))
+            assert d > 1e-6, f"Dedup failed to catch cluster: {prev.xyz_le}"
+        # A dedup-specific warning must fire (distinct from cap-clamp).
+        dedup_warnings = [
+            w for w in ctx.warnings if "gh-758" in w.reason and "LE-dedup" in w.reason
+        ]
+        assert len(dedup_warnings) == 1, "Dedup safety net fired but no LE-dedup warning emitted"
+
+    def test_narrow_cap_at_u_098(self):
+        """Some VSP cap configurations occupy only a tiny u-range near
+        the tip (e.g. flat-cut cap, u ≥ 0.98). The probe's first
+        entry (0.99) lands inside the cap → walk down → return 0.98
+        or 0.97. Inserts at u ≤ 0.95 must still succeed normally.
+
+        Pins the high-end of the probe table (review nit #8 on
+        PR #759)."""
+        anchors = [
+            _xsec(airfoil="naca2213", xyz_le=(0.0, 0.0, 0.0), chord=2.0, t="root"),
+            _xsec(airfoil="naca2213", xyz_le=(0.0, 5.88, 0.0), chord=0.0, t=None),
+        ]
+        out = _augment_same_airfoil_pairs(
+            anchors, _capped_vsp(u_cap_start=0.98), "wing-gid", _ctx(), "wing"
+        )
+        # 2 anchors + N inserts. With u_cap_start=0.98 and inserts at
+        # u = 0.2 / 0.4 / 0.6 / 0.8, all 4 fall below cap_start → all
+        # inserts succeed. No clamping, no dedup.
+        assert len(out) == 2 + _N_INTERP_PER_PAIR
+        # And no duplicate xyz_le.
+        for prev, curr in zip(out, out[1:], strict=False):
+            d = math.sqrt(sum((a - b) ** 2 for a, b in zip(prev.xyz_le, curr.xyz_le, strict=True)))
+            assert d > 1e-6
+
+    def test_dihedral_with_cap_does_not_kink_at_tip(self):
+        """gh-758 DG-101G evidence: a dihedral wing with a tip cap
+        used to render a Z-jump kink near the tip. The fix's u-clamp
+        keeps inserts clear of the cap, and the augmenter's twist
+        interpolation continues to ignore body-frame Z (PR #754).
+        Combined: no kink, no false twist."""
+
+        def _dihedral_capped_vsp():
+            class _Stub:
+                @staticmethod
+                def CompPnt01(_gid, _surf, u, w):
+                    if u >= 0.85:
+                        # Cap region: LE clusters at cap_z. Pre-fix
+                        # would lift the tip section to z=0.5.
+                        if abs(w - _W_LE) < 1e-9:
+                            return _Pnt(-0.025, 5.1, 0.5)
+                        return _Pnt(+0.025, 5.1, 0.5)
+                    # Non-cap: LE is dihedral'd (z = 0.1 * u).
+                    y = 6.0 * u
+                    z = 0.1 * u
+                    chord = 2.0 * math.sqrt(max(0.0, 1.0 - u * u))
+                    if abs(w - _W_LE) < 1e-9:
+                        return _Pnt(-chord / 2.0, y, z)
+                    return _Pnt(+chord / 2.0, y, z)
+
+            return _Stub()
+
+        anchors = [
+            _xsec(airfoil="naca2213", xyz_le=(0.0, 0.0, 0.0), chord=2.0, twist=0.0, t="root"),
+            _xsec(airfoil="naca2213", xyz_le=(0.0, 6.0, 0.6), chord=0.0, twist=0.0, t=None),
+        ]
+        out = _augment_same_airfoil_pairs(
+            anchors, _dihedral_capped_vsp(), "wing-gid", _ctx(), "wing"
+        )
+        # No insert may carry the cap z-offset (0.5).
+        for ins in out[1:-1]:
+            assert ins.xyz_le[2] < 0.4, f"Cap Z leaked into a dihedral wing insert: {ins.xyz_le}"
+        # And twist stays 0 (no atan2 from body-frame Z).
+        for ins in out[1:-1]:
+            assert ins.twist == 0.0


### PR DESCRIPTION
## Summary

- Fixes the gh-753 augmentation walking into VSP's implicit tip-cap u-range, which produced duplicate `xyz_le` rows and Z-lifted xsecs (Cessna 172 disconnected wing, Spitfire DB 8/9/10 identical xyz_le, DG-101G tip-cap kink — all reported in #758)
- Adds `_find_cap_safe_u_max` — probes the wing main surface for the largest u whose LE is geometrically distinct from u=1.0, identifying VSP's implicit cap boundary
- Augmenter now skips any insert whose u ≥ u_max, tracked separately from CompPnt01 failures so the user can tell the two causes apart in the import report
- Adds defensive xyz_le-dedup (1 μm tolerance) as belt+suspenders against edge cases the probe might miss

## Why

The pre-fix `_augment_same_airfoil_pairs` mapped anchor `i` to `u = i/(n_anchors-1)`, sending the last anchor pair's inserts into u ∈ (0.667, 1.0] for a 4-anchor wing — which is squarely inside VSP's tip-cap region for typical `Cap_Tip = round` settings. `CompPnt01(gid, 0, u, w)` there returns near-identical points converging to the cap centerline, hence the duplicate xyz_le and the Z-lift visual symptom.

The probe-based approach was chosen over reading VSP's cap parms directly because the parm names vary across VSP versions and the probe is robust to whatever cap geometry VSP actually emits.

## Test plan

- [x] 29/29 unit tests pass — 20 pre-existing gh-753 + 9 new gh-758
- [x] Full backend fast suite: 4182 passed, 0 failed
- [x] `ruff check` + `ruff format --check` clean
- [ ] Manual smoke test on worktree: import Cessna 172, Spitfire, DG-101G — verify wings render as continuous surfaces, no z-lift at tips, DB shows no consecutive duplicate `xyz_le`
- [ ] Code review

Closes #758

🤖 Generated with [Claude Code](https://claude.com/claude-code)