### PR TITLE
fix(gh-760): wing xsec augmenter uses VSP's actual anchor u-positions

### DIFF
--- a/app/converters/openvsp_wing_handler.py
+++ b/app/converters/openvsp_wing_handler.py
@@ -275,9 +275,11 @@ def _read_cap_option(vsp: ModuleType, gid: str, parm_name: str) -> int:
     rather than assuming no caps (which would degrade to the naïve
     pre-gh-760 u-mapping).
     """
+    if not hasattr(vsp, "FindParm"):
+        return -1
     try:
         pid = vsp.FindParm(gid, parm_name, "EndCap")
-    except (AttributeError, Exception):
+    except Exception:
         return -1
     if not pid:
         return -1
@@ -571,6 +573,14 @@ def _augment_same_airfoil_pairs(
     # wing with ``EndCap`` parms present. When the parms are absent
     # (``-1.0`` sentinel from ``_anchor_u_position``), fall back to
     # the gh-758 empirical probe.
+    #
+    # Note: in the formula path, ``u_max`` is the last anchor's u
+    # (NOT the cap-safe boundary). The per-insert ``u > u_max`` guard
+    # in ``_try_emit_one_insert`` is then a no-op — the augmenter's
+    # last insert is at ``u_lo + N_INTERP*step`` which is strictly
+    # less than ``u_hi = u_max_formula``. The guard remains relevant
+    # for the legacy-fallback path where ``u_max`` comes from the
+    # probe and may be tighter than the naïve mapping's range.
     u_max_formula = _anchor_u_position(vsp, gid, n_anchors - 1, n_anchors)
     use_formula_u = u_max_formula > 0
     u_max = u_max_formula if use_formula_u else _find_cap_safe_u_max(vsp, gid)

--- a/app/converters/openvsp_wing_handler.py
+++ b/app/converters/openvsp_wing_handler.py
@@ -259,6 +259,76 @@ _W_TE: float = 0.0
 _N_INTERP_PER_PAIR: int = 4
 
 
+# gh-760: VSP's per-anchor u-position depends on the wing's cap
+# configuration. ``CapUMinOption`` and ``CapUMaxOption`` on the Wing's
+# ``EndCap`` parm group control whether root/tip caps occupy a slice
+# of u-range. Any non-zero value = cap present (1=flat, 2=round, etc.).
+_CAP_OPTION_PARMS: tuple[str, str] = ("CapUMinOption", "CapUMaxOption")
+
+
+def _read_cap_option(vsp: ModuleType, gid: str, parm_name: str) -> int:
+    """Read ``CapUMinOption`` or ``CapUMaxOption`` from the Wing's
+    ``EndCap`` parm group. Returns the raw enum value (0 = no cap,
+    >0 = some cap type), or ``-1`` when the parm is absent / unreadable
+    (old VSP file or test stub without EndCap parms). The augmenter
+    treats ``-1`` as "unknown — fall back to the empirical probe"
+    rather than assuming no caps (which would degrade to the naïve
+    pre-gh-760 u-mapping).
+    """
+    try:
+        pid = vsp.FindParm(gid, parm_name, "EndCap")
+    except (AttributeError, Exception):
+        return -1
+    if not pid:
+        return -1
+    try:
+        return int(vsp.GetParmVal(pid))
+    except Exception:
+        return -1
+
+
+def _anchor_u_position(vsp: ModuleType, gid: str, anchor_index: int, n_xsec: int) -> float:
+    """Return VSP's actual ``u`` position for anchor ``anchor_index``
+    on the wing's main surface, or ``-1.0`` when the wing's ``EndCap``
+    parms are absent (caller should fall back to the empirical probe).
+
+    Empirically verified across 13 wings (Spitfire, Cessna 172,
+    DG-101G) via ``GetUWTess01``: VSP distributes anchors as
+
+        cap_min = 1 if CapUMinOption > 0 else 0
+        cap_max = 1 if CapUMaxOption > 0 else 0
+        total_segments = (n_xsec - 1) + cap_min + cap_max
+        anchor_u[i] = (i + cap_min) / total_segments
+
+    The gh-753 augmenter previously assumed ``u = i / (n_anchors - 1)``
+    which only happens to be correct when ``cap_min = cap_max = 0`` —
+    a configuration none of the canonical RC / GA aircraft samples use.
+    The mismatch produced the Spitfire xsec 5/6 collision (issue #760)
+    and the entirely-cap-clamped outer wing section.
+
+    For ``n_xsec < 2`` the wing is degenerate; return 0.0 so callers
+    don't divide-by-zero.
+
+    When BOTH ``CapU*Option`` parms are absent (``_read_cap_option``
+    returns -1), the formula cannot be evaluated safely — defaulting
+    cap_min/max to 0 would regress to the naïve mapping for any
+    capped wing. Return ``-1.0`` so the caller knows to fall back to
+    the gh-758 empirical probe instead.
+    """
+    if n_xsec < 2:
+        return 0.0
+    raw_min = _read_cap_option(vsp, gid, _CAP_OPTION_PARMS[0])
+    raw_max = _read_cap_option(vsp, gid, _CAP_OPTION_PARMS[1])
+    if raw_min < 0 and raw_max < 0:
+        return -1.0  # sentinel: caller falls back to empirical probe
+    cap_min = 1 if max(raw_min, 0) > 0 else 0
+    cap_max = 1 if max(raw_max, 0) > 0 else 0
+    total_segments = (n_xsec - 1) + cap_min + cap_max
+    if total_segments <= 0:
+        return 0.0
+    return (anchor_index + cap_min) / total_segments
+
+
 def _sample_le_te_at(
     vsp: ModuleType, gid: str, u: float
 ) -> tuple[tuple[float, float, float], tuple[float, float, float]]:
@@ -494,9 +564,16 @@ def _augment_same_airfoil_pairs(
     if not hasattr(vsp, "CompPnt01") or len(x_secs) < 2:
         return x_secs
 
-    u_max = _find_cap_safe_u_max(vsp, gid)
-
     n_anchors = len(x_secs)
+    # gh-760: u_max is the LAST anchor's u-position (formula-based).
+    # The formula is empirically verified across 13 wings (Spitfire,
+    # Cessna 172, DG-101G — see issue #760), so we trust it for any
+    # wing with ``EndCap`` parms present. When the parms are absent
+    # (``-1.0`` sentinel from ``_anchor_u_position``), fall back to
+    # the gh-758 empirical probe.
+    u_max_formula = _anchor_u_position(vsp, gid, n_anchors - 1, n_anchors)
+    use_formula_u = u_max_formula > 0
+    u_max = u_max_formula if use_formula_u else _find_cap_safe_u_max(vsp, gid)
     out: list[WingXSecSchema] = []
     expected_inserts = 0
     counts: dict[str, int] = {
@@ -514,8 +591,21 @@ def _augment_same_airfoil_pairs(
         if anchor.airfoil != nxt.airfoil:
             continue  # different profiles → skip (user-edit-ability)
 
-        u_lo = i / (n_anchors - 1)
-        u_hi = (i + 1) / (n_anchors - 1)
+        # gh-760: query VSP for each anchor's real u-position instead
+        # of the naive ``i / (n_anchors - 1)`` mapping. The cap-aware
+        # formula reads ``CapUMinOption`` / ``CapUMaxOption`` from the
+        # Wing's ``EndCap`` group — without this, the last insert in
+        # pair (n-2 → n-1) collides with Anchor n-1 (Spitfire xsec 5/6)
+        # and the inner-pair inserts fall into the root-cap region.
+        # When the EndCap parms are absent (test stubs / old VSP files),
+        # ``use_formula_u`` is False and we keep the legacy mapping —
+        # the gh-758 probe handles the cap region in that path.
+        if use_formula_u:
+            u_lo = _anchor_u_position(vsp, gid, i, n_anchors)
+            u_hi = _anchor_u_position(vsp, gid, i + 1, n_anchors)
+        else:
+            u_lo = i / (n_anchors - 1)
+            u_hi = (i + 1) / (n_anchors - 1)
         step = (u_hi - u_lo) / (_N_INTERP_PER_PAIR + 1)
         twist_lo = float(anchor.twist or 0.0)
         twist_hi = float(nxt.twist or 0.0)

--- a/app/tests/test_openvsp_wing_xsec_augmentation.py
+++ b/app/tests/test_openvsp_wing_xsec_augmentation.py
@@ -27,6 +27,7 @@ from app.converters.openvsp_wing_handler import (
     _N_INTERP_PER_PAIR,
     _W_LE,
     _W_TE,
+    _anchor_u_position,
     _augment_same_airfoil_pairs,
     _chord_from_le_te,
     _find_cap_safe_u_max,
@@ -497,6 +498,15 @@ def _capped_vsp(
     """
 
     class _Stub:
+        # gh-760: legacy capped stub keeps the gh-758 cap-probe path
+        # exercised by NOT exposing ``CapUMinOption`` / ``CapUMaxOption``
+        # parms. Returning 0 from ``FindParm`` for EndCap parms forces
+        # the augmenter to fall back to ``_find_cap_safe_u_max`` — the
+        # original behaviour these gh-758 tests pin.
+        @staticmethod
+        def FindParm(_gid: str, _parm: str, _group: str) -> int:
+            return 0
+
         @staticmethod
         def CompPnt01(_gid: str, _surf: int, u: float, w: float) -> _Pnt:
             if u >= u_cap_start:
@@ -783,3 +793,244 @@ class TestCapAwareAugmentation:
         # And twist stays 0 (no atan2 from body-frame Z).
         for ins in out[1:-1]:
             assert ins.twist == 0.0
+
+
+# ---------------------------------------------------------------------------
+# gh-760 — VSP anchor-u formula
+# ---------------------------------------------------------------------------
+#
+# Real VSP wings do not place anchors uniformly across u ∈ [0, 1]. The
+# anchor-u positions depend on the wing's cap configuration:
+#
+#     cap_min = 1 if CapUMinOption > 0 else 0     # root cap present?
+#     cap_max = 1 if CapUMaxOption > 0 else 0     # tip cap present?
+#     total_segments = (n_xsec - 1) + cap_min + cap_max
+#     anchor_u[i] = (i + cap_min) / total_segments
+#
+# Verified empirically via ``GetUWTess01`` across 13 wings in
+# Spitfire / Cessna 172 / DG-101G — see issue #760 for the dashboard
+# Phase 4 table. The pre-fix augmenter assumed ``u = i / (n_anchors - 1)``,
+# producing the Spitfire xsec 5/6 collision (insert at augmenter-u 0.6
+# landed on Anchor 2's real VSP u = 0.6).
+
+
+class _CappedWingStub:
+    """VSP stub that exposes ``CapUMinOption`` / ``CapUMaxOption``
+    via ``FindParm`` + ``GetParmVal`` so the new ``_anchor_u_position``
+    helper can read them. CompPnt01 simulates an ellipse with the
+    correct cap-aware u-parameterization: anchor i sits at u =
+    (i + cap_min) / total_segments.
+
+    cap_*_option is 0 for no cap, 1 for flat cap, 2 for round cap
+    (matching VSP's enum). Any non-zero value counts as cap_present=1.
+    """
+
+    def __init__(
+        self,
+        n_xsec: int,
+        cap_min_option: int = 1,
+        cap_max_option: int = 1,
+        half_span: float = 6.0,
+        root_chord: float = 2.0,
+    ):
+        self.n_xsec = n_xsec
+        self.cap_min_option = cap_min_option
+        self.cap_max_option = cap_max_option
+        self.half_span = half_span
+        self.root_chord = root_chord
+        cap_min = 1 if cap_min_option > 0 else 0
+        cap_max = 1 if cap_max_option > 0 else 0
+        self.total_segments = (n_xsec - 1) + cap_min + cap_max
+        self.cap_min = cap_min
+        self.cap_max = cap_max
+
+    # FindParm / GetParmVal — only resolve CapU*Option from EndCap group.
+    def FindParm(self, gid: str, parm: str, group: str) -> int:
+        if group == "EndCap" and parm == "CapUMinOption":
+            return 11
+        if group == "EndCap" and parm == "CapUMaxOption":
+            return 12
+        return 0
+
+    def GetParmVal(self, pid: int) -> float:
+        if pid == 11:
+            return float(self.cap_min_option)
+        if pid == 12:
+            return float(self.cap_max_option)
+        raise KeyError(pid)
+
+    # CompPnt01 — cap-aware ellipse. u_anchor[i] = (i+cap_min)/total.
+    # Between anchors → linear interpolation in y; in cap regions →
+    # converge to the root/tip anchor point (matches real VSP).
+    def CompPnt01(self, _gid: str, _surf: int, u: float, w: float) -> "_Pnt":
+        if self.cap_min and u < self.cap_min / self.total_segments:
+            # Root cap — converge to Anchor 0
+            return self._anchor_pnt(0, w)
+        if self.cap_max and u > (self.n_xsec - 1 + self.cap_min) / self.total_segments:
+            # Tip cap — converge to Anchor n-1
+            return self._anchor_pnt(self.n_xsec - 1, w)
+        # In a section: find which one, then interpolate
+        for i in range(self.n_xsec - 1):
+            u_lo = (i + self.cap_min) / self.total_segments
+            u_hi = (i + 1 + self.cap_min) / self.total_segments
+            if u_lo <= u <= u_hi + 1e-9:
+                # frac ∈ [0, 1] within the section
+                frac = (u - u_lo) / (u_hi - u_lo) if u_hi > u_lo else 0.0
+                y_lo = self.half_span * i / (self.n_xsec - 1)
+                y_hi = self.half_span * (i + 1) / (self.n_xsec - 1)
+                y = y_lo + frac * (y_hi - y_lo)
+                chord = self.root_chord * math.sqrt(max(0.0, 1.0 - (y / self.half_span) ** 2))
+                if abs(w - _W_LE) < 1e-9:
+                    return _Pnt(-chord / 2.0, y, 0.0)
+                if abs(w - _W_TE) < 1e-9:
+                    return _Pnt(+chord / 2.0, y, 0.0)
+                return _Pnt(-chord / 2.0, y, 0.0)
+        # Fallback for u slightly outside [0, 1]: return tip
+        return self._anchor_pnt(self.n_xsec - 1, w)
+
+    def _anchor_pnt(self, i: int, w: float) -> "_Pnt":
+        y = self.half_span * i / (self.n_xsec - 1)
+        chord = self.root_chord * math.sqrt(max(0.0, 1.0 - (y / self.half_span) ** 2))
+        if abs(w - _W_LE) < 1e-9:
+            return _Pnt(-chord / 2.0, y, 0.0)
+        if abs(w - _W_TE) < 1e-9:
+            return _Pnt(+chord / 2.0, y, 0.0)
+        return _Pnt(-chord / 2.0, y, 0.0)
+
+
+class TestAnchorUPosition:
+    """gh-760 contract — VSP's actual u-position per anchor depends on
+    cap configuration. Pin the formula across the four canonical cases:
+    both caps, neither cap, root-only, tip-only."""
+
+    def test_both_caps_present(self):
+        """Standard wing (Wing, Spitfire) — both ``CapUMinOption`` and
+        ``CapUMaxOption`` non-zero → anchor i at (i+1)/(n_xsec+1)."""
+        vsp = _CappedWingStub(n_xsec=4, cap_min_option=1, cap_max_option=1)
+        # 4 anchors, total_segments = 3 + 1 + 1 = 5
+        # Anchor i at (i + 1) / 5
+        for i, expected in enumerate([0.2, 0.4, 0.6, 0.8]):
+            assert _anchor_u_position(vsp, "wing-gid", i, 4) == pytest.approx(expected)
+
+    def test_no_caps(self):
+        """Edge case: both options = 0 → anchors span full u-range.
+        Anchor 0 at u=0, anchor n-1 at u=1."""
+        vsp = _CappedWingStub(n_xsec=3, cap_min_option=0, cap_max_option=0)
+        # total_segments = 2 + 0 + 0 = 2
+        # Anchor i at i / 2
+        for i, expected in enumerate([0.0, 0.5, 1.0]):
+            assert _anchor_u_position(vsp, "wing-gid", i, 3) == pytest.approx(expected)
+
+    def test_root_only_cap(self):
+        """``CapUMinOption > 0, CapUMaxOption = 0`` — anchors offset
+        forward; anchor n-1 sits at the tip (u=1)."""
+        vsp = _CappedWingStub(n_xsec=3, cap_min_option=1, cap_max_option=0)
+        # total_segments = 2 + 1 + 0 = 3
+        # Anchor i at (i + 1) / 3
+        for i, expected in enumerate([1 / 3, 2 / 3, 3 / 3]):
+            assert _anchor_u_position(vsp, "wing-gid", i, 3) == pytest.approx(expected)
+
+    def test_tip_only_cap_matches_dg_htail(self):
+        """``CapUMinOption = 0, CapUMaxOption > 0`` — the DG-101G H-Tail
+        edge case. Anchor 0 at u=0 (no root cap), anchor n-1 inboard
+        of tip cap."""
+        vsp = _CappedWingStub(n_xsec=2, cap_min_option=0, cap_max_option=2)
+        # total_segments = 1 + 0 + 1 = 2
+        # Anchor i at i / 2
+        assert _anchor_u_position(vsp, "wing-gid", 0, 2) == pytest.approx(0.0)
+        assert _anchor_u_position(vsp, "wing-gid", 1, 2) == pytest.approx(0.5)
+
+    def test_round_cap_option_2_counts_as_present(self):
+        """VSP's ``CapU*Option = 2`` (round cap) still means "cap
+        present". The helper treats any non-zero value as cap_present=1.
+        """
+        vsp = _CappedWingStub(n_xsec=3, cap_min_option=2, cap_max_option=2)
+        # Same as both_caps_present (round vs flat doesn't change u-position)
+        for i, expected in enumerate([0.25, 0.5, 0.75]):
+            assert _anchor_u_position(vsp, "wing-gid", i, 3) == pytest.approx(expected)
+
+
+class TestAugmenterUsesCorrectUMapping:
+    """gh-760: the regression scenario. Spitfire-like 4-anchor wing
+    with both caps. The pre-fix augmenter mapped anchor i to
+    u = i/(n_anchors-1), so the last insert in pair (n-2 → n-1) at
+    u_lo + 4·step = (n-2)/(n-1) + 4·(1/(n-1))/5 = (n-2)/(n-1) +
+    0.8/(n-1) landed at Anchor n-1's real VSP u for n=4 (= 0.6).
+
+    Post-fix, inserts in pair (i → i+1) span [u_anchor[i], u_anchor[i+1]]
+    which is BETWEEN the anchors' actual u-positions — no collision."""
+
+    def test_no_insert_collides_with_next_anchor(self):
+        """Pin the Spitfire 5/6 collision: with cap-aware u-mapping,
+        the last insert in pair (n-2 → n-1) sits BEFORE anchor n-1's
+        real u-position. Pre-fix the insert and the anchor had the
+        same xyz_le (the user's "oversized oval" near the tip)."""
+        anchors = [
+            _xsec(airfoil="naca2213", xyz_le=(-1.0, 0.0, 0.0), chord=2.0, t="root"),
+            _xsec(airfoil="naca2213", xyz_le=(-0.92, 2.0, 0.0), chord=1.83, t="segment"),
+            _xsec(airfoil="naca2213", xyz_le=(-0.60, 4.0, 0.0), chord=1.20, t="segment"),
+            _xsec(airfoil="naca2213", xyz_le=(-0.07, 5.5, 0.0), chord=0.14, t=None),
+        ]
+        vsp = _CappedWingStub(n_xsec=4, cap_min_option=1, cap_max_option=1)
+        out = _augment_same_airfoil_pairs(anchors, vsp, "wing-gid", _ctx(), "Wing")
+        # No consecutive xsecs share an xyz_le within 1 mm (= the
+        # gh-760 DB-evidence threshold; pre-fix the gap was ~1 mm).
+        for prev, curr in zip(out, out[1:], strict=False):
+            d = math.sqrt(sum((a - b) ** 2 for a, b in zip(prev.xyz_le, curr.xyz_le, strict=True)))
+            assert d > 1e-3, (
+                f"Insert collides with next anchor: prev={prev.xyz_le}, curr={curr.xyz_le} "
+                f"(distance {d * 1000:.2f} mm) — gh-760 u-mapping regression."
+            )
+
+    def test_outer_section_gets_inserts(self):
+        """Pre-fix, pair (n-2 → n-1) inserts mapped to u ∈ [0.667, 1.0]
+        (for 4 anchors) and were ALL cap-clamped by the gh-758 safety
+        net (u_max ≈ 0.7). Post-fix, they map to u ∈ [0.6, 0.8] which
+        is fully inside the wing surface — all 4 should INSERT."""
+        anchors = [
+            _xsec(airfoil="naca2213", xyz_le=(-1.0, 0.0, 0.0), chord=2.0, t="root"),
+            _xsec(airfoil="naca2213", xyz_le=(-0.92, 2.0, 0.0), chord=1.83, t="segment"),
+            _xsec(airfoil="naca2213", xyz_le=(-0.60, 4.0, 0.0), chord=1.20, t="segment"),
+            _xsec(airfoil="naca2213", xyz_le=(-0.07, 5.5, 0.0), chord=0.14, t=None),
+        ]
+        vsp = _CappedWingStub(n_xsec=4, cap_min_option=1, cap_max_option=1)
+        out = _augment_same_airfoil_pairs(anchors, vsp, "wing-gid", _ctx(), "Wing")
+        # 4 anchors + 4 inserts × 3 pairs = 16 expected when augmenter
+        # correctly maps anchor-u and the cap-clamp is reachable only
+        # for inserts truly in the cap region.
+        # Allow some slack — but ALL three pairs must contribute at
+        # least one insert (especially the outer one).
+        outer_pair_inserts = 0
+        # The outer pair's inserts sit between anchor 2 (y=4.0) and
+        # anchor 3 (y=5.5), so y ∈ (4.0, 5.5).
+        for xs in out:
+            if 4.0 < xs.xyz_le[1] < 5.5:
+                outer_pair_inserts += 1
+        assert outer_pair_inserts >= 2, (
+            f"Outer pair (anchor n-2 → n-1) got only {outer_pair_inserts} inserts "
+            "— pre-fix this section was entirely cap-clamped."
+        )
+
+    def test_inner_section_no_root_cap_dedup(self):
+        """Pre-fix, pair 0→1 inserts at augmenter-u ∈ (0, 0.333) landed
+        in VSP's root-cap region (u ∈ [0, 0.2] for both-caps wing) and
+        got DEDUPED. Post-fix, inserts map to u ∈ (0.2, 0.4) — clear
+        of the root cap."""
+        anchors = [
+            _xsec(airfoil="naca2213", xyz_le=(-1.0, 0.0, 0.0), chord=2.0, t="root"),
+            _xsec(airfoil="naca2213", xyz_le=(-0.92, 2.0, 0.0), chord=1.83, t=None),
+        ]
+        ctx = _ctx()
+        vsp = _CappedWingStub(n_xsec=2, cap_min_option=1, cap_max_option=1)
+        out = _augment_same_airfoil_pairs(anchors, vsp, "wing-gid", ctx, "Wing")
+        # 2 anchors + 4 inserts (none should dedup with cap-aware mapping).
+        assert len(out) == 2 + _N_INTERP_PER_PAIR
+        # The dedup safety-net warning must NOT fire — cap-aware
+        # u-mapping eliminates the root-cap collision.
+        dedup_warnings = [
+            w for w in ctx.warnings if "gh-758" in w.reason and "LE-dedup" in w.reason
+        ]
+        assert dedup_warnings == [], (
+            "LE-dedup fired on a cap-aware mapping — should be unreachable "
+            "in the no-pathological-cap case."
+        )

--- a/scripts/openvsp_import_trace.py
+++ b/scripts/openvsp_import_trace.py
@@ -1,0 +1,438 @@
+"""OpenVSP wing import phase-by-phase trace.
+
+Dev tool for debugging mis-imports of OpenVSP ``.vsp3`` files. Loads
+a VSP file, replays each phase of ``_handle_wing`` for every WING
+geom, and writes a Markdown dashboard with per-phase tables. Compares
+the augmenter's assumed u-mapping against VSP's actual surface
+parameterization so u-mismatches (a known limitation of the gh-753
+augmenter) are obvious at a glance.
+
+Usage:
+    poetry run python scripts/openvsp_import_trace.py <path.vsp3> [out.md]
+
+If ``out.md`` is omitted, prints to stdout.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import openvsp as vsp
+
+from app.converters.openvsp_wing_handler import (
+    _CAP_PROBE_EPS,
+    _CAP_PROBE_US,
+    _DEDUP_EPS,
+    _N_INTERP_PER_PAIR,
+    _W_LE,
+    _W_TE,
+    _airfoil_placeholder,
+    _apply_xform,
+    _chord_from_le_te,
+    _find_cap_safe_u_max,
+    _read_geom_xform,
+    _read_relative_flag,
+    _read_section_parm,
+    _sample_le_te_at,
+    sweep_at_le,
+)
+
+
+def _h(text: str, level: int = 2) -> str:
+    return f"{'#' * level} {text}\n\n"
+
+
+def _table(headers: list[str], rows: list[list[str]]) -> str:
+    out = "| " + " | ".join(headers) + " |\n"
+    out += "| " + " | ".join("---" for _ in headers) + " |\n"
+    for r in rows:
+        out += "| " + " | ".join(r) + " |\n"
+    return out + "\n"
+
+
+def _fmt(x: float, prec: int = 3) -> str:
+    return f"{x:.{prec}f}"
+
+
+def _probe_anchor_u(gid: str, n_xsec: int) -> list[float]:
+    """Probe VSP's actual u-position for each anchor by sampling
+    CompPnt01 in a dense grid and finding where each anchor's
+    spanwise (y) position aligns.
+
+    Returns a list of u-values, one per xsec. Anchor i's u-position
+    is where CompPnt01(u) matches the anchor's body-frame y stored
+    on the wing's XSec_<i>.Span cumulative walk.
+
+    VSP doesn't expose anchor-u directly — this is empirical.
+    """
+    # Sample 200 points along u
+    samples = []
+    for k in range(201):
+        u = k / 200.0
+        try:
+            p = vsp.CompPnt01(gid, 0, u, _W_LE)
+            samples.append((u, p.x(), p.y(), p.z()))
+        except Exception:
+            samples.append((u, 0.0, 0.0, 0.0))
+    return samples
+
+
+def _trace_wing_phases(gid: str, name: str) -> str:
+    out = _h(f"WING `{name}` (gid={gid})", level=2)
+
+    # ───────────────────────────── Phase 1: VSP raw parms
+    out += _h("Phase 1 — VSP section parms", level=3)
+    xsurf = vsp.GetXSecSurf(gid, 0)
+    n_xsec = int(vsp.GetNumXSec(xsurf))
+    n_sec = n_xsec - 1
+    out += f"`n_xsec = {n_xsec}` ({n_sec} planform sections)\n\n"
+
+    rows = []
+    for i in range(1, n_sec + 1):
+        row = [str(i)]
+        for parm in (
+            "Root_Chord",
+            "Span",
+            "Tip_Chord",
+            "Sweep",
+            "Sweep_Location",
+            "Dihedral",
+            "Twist",
+        ):
+            v = _read_section_parm(vsp, gid, i, parm)
+            row.append(_fmt(v))
+        rows.append(row)
+    out += _table(
+        [
+            "Section",
+            "Root_Chord",
+            "Span",
+            "Tip_Chord",
+            "Sweep°",
+            "Sweep_Loc",
+            "Dihedral°",
+            "Twist°",
+        ],
+        rows,
+    )
+
+    # XForm + relative flags
+    out += _h("Phase 1b — XForm + flags", level=3)
+    translation, rotation_deg = _read_geom_xform(vsp, gid)
+    rel_dih = _read_relative_flag(vsp, gid, "RelativeDihedralFlag")
+    rel_twist = _read_relative_flag(vsp, gid, "RelativeTwistFlag")
+    out += _table(
+        ["Parm", "Value"],
+        [
+            [
+                "Translation (X,Y,Z)",
+                f"({translation[0]:.3f}, {translation[1]:.3f}, {translation[2]:.3f})",
+            ],
+            [
+                "Rotation (X,Y,Z)°",
+                f"({rotation_deg[0]:.1f}, {rotation_deg[1]:.1f}, {rotation_deg[2]:.1f})",
+            ],
+            ["RelativeDihedralFlag", str(rel_dih)],
+            ["RelativeTwistFlag", str(rel_twist)],
+        ],
+    )
+
+    # ───────────────────────────── Phase 2: Anchor walk (body frame)
+    out += _h("Phase 2 — Anchor walk (BODY frame, pre-XForm)", level=3)
+    root_chord = _read_section_parm(vsp, gid, 1, "Root_Chord") or 1.0
+
+    anchors = [{"xyz": [0.0, 0.0, 0.0], "chord": root_chord, "twist": 0.0, "i_sec": 0}]
+    cum_x = cum_y = cum_z = 0.0
+    cum_dih = cum_tw = 0.0
+    prev_chord = root_chord
+
+    for i in range(1, n_sec + 1):
+        span = _read_section_parm(vsp, gid, i, "Span")
+        tip_chord = _read_section_parm(vsp, gid, i, "Tip_Chord")
+        sweep_xref = _read_section_parm(vsp, gid, i, "Sweep")
+        sweep_loc = _read_section_parm(vsp, gid, i, "Sweep_Location")
+        dih = _read_section_parm(vsp, gid, i, "Dihedral")
+        tw = _read_section_parm(vsp, gid, i, "Twist")
+
+        if span <= 0:
+            continue
+        if rel_dih:
+            cum_dih += dih
+        else:
+            cum_dih = dih
+        if rel_twist:
+            cum_tw += tw
+        else:
+            cum_tw = tw
+
+        le_sweep = sweep_at_le(
+            sweep_xref_deg=sweep_xref,
+            xref=sweep_loc,
+            span=span,
+            c_root=prev_chord,
+            c_tip=tip_chord,
+        )
+        cum_x += span * math.tan(math.radians(le_sweep))
+        cum_y += span * math.cos(math.radians(cum_dih))
+        cum_z += span * math.sin(math.radians(cum_dih))
+
+        anchors.append(
+            {
+                "xyz": [cum_x, cum_y, cum_z],
+                "chord": tip_chord if tip_chord > 0 else prev_chord,
+                "twist": cum_tw,
+                "i_sec": i,
+                "le_sweep": le_sweep,
+                "cum_dih": cum_dih,
+            }
+        )
+        prev_chord = tip_chord if tip_chord > 0 else prev_chord
+
+    rows = []
+    for j, a in enumerate(anchors):
+        rows.append(
+            [
+                str(j),
+                f"({_fmt(a['xyz'][0])}, {_fmt(a['xyz'][1])}, {_fmt(a['xyz'][2])})",
+                _fmt(a["chord"]),
+                _fmt(a["twist"], 1),
+            ]
+        )
+    out += _table(
+        ["Anchor #", "xyz (body)", "chord", "twist°"],
+        rows,
+    )
+
+    # ───────────────────────────── Phase 3: After XForm
+    out += _h("Phase 3 — Anchor xyz_le AFTER XForm (world frame)", level=3)
+    rows = []
+    world_anchors = []
+    for j, a in enumerate(anchors):
+        xyz_world = _apply_xform(a["xyz"], translation, rotation_deg)
+        world_anchors.append(xyz_world)
+        rows.append(
+            [
+                str(j),
+                f"({_fmt(xyz_world[0])}, {_fmt(xyz_world[1])}, {_fmt(xyz_world[2])})",
+                _fmt(a["chord"]),
+                _fmt(a["twist"], 1),
+            ]
+        )
+    out += _table(
+        ["Anchor #", "xyz_le (world)", "chord", "twist°"],
+        rows,
+    )
+
+    # ───────────────────────────── Phase 4: VSP's ACTUAL u-position for each anchor
+    out += _h("Phase 4 — VSP's actual u-position per anchor (empirical probe)", level=3)
+    out += "Compare augmenter's assumed `u = i/(n_anchors-1)` against VSP's real surface mapping.\n"
+    out += "Mismatch → inserts land at wrong spanwise positions.\n\n"
+
+    # Sample VSP surface at fine u-grid to find anchor positions
+    samples = []
+    for k in range(201):
+        u = k / 200.0
+        try:
+            p_le = vsp.CompPnt01(gid, 0, u, _W_LE)
+            samples.append((u, p_le.x(), p_le.y(), p_le.z()))
+        except Exception:
+            samples.append((u, 0.0, 0.0, 0.0))
+
+    # For each anchor, find the u whose LE-y best matches the world-frame anchor y
+    rows = []
+    for j, a in enumerate(world_anchors):
+        target_y = a[1]
+        # Find closest sample
+        best_u, best_d = 0.0, float("inf")
+        for u_s, _x_s, y_s, _z_s in samples:
+            d = abs(y_s - target_y)
+            if d < best_d:
+                best_d = d
+                best_u = u_s
+        u_naive = j / (len(world_anchors) - 1) if len(world_anchors) > 1 else 0.0
+        rows.append(
+            [
+                str(j),
+                _fmt(u_naive),
+                _fmt(best_u),
+                _fmt(best_u - u_naive, 3),
+                _fmt(target_y),
+            ]
+        )
+    out += _table(
+        ["Anchor #", "u (augmenter naïve)", "u (VSP actual)", "Δu", "target y (world)"],
+        rows,
+    )
+
+    # ───────────────────────────── Phase 5: u-probe table
+    out += _h("Phase 5 — Cap-safe u probe (gh-758 _find_cap_safe_u_max)", level=3)
+    u_max = _find_cap_safe_u_max(vsp, gid)
+    out += f"`u_max = {u_max:.4f}` — inserts with u ≥ u_max are skipped (tip-cap region).\n\n"
+    rows = []
+    try:
+        le_tip, _ = _sample_le_te_at(vsp, gid, 1.0)
+    except Exception:
+        le_tip = (0.0, 0.0, 0.0)
+    for u_p in _CAP_PROBE_US:
+        try:
+            le_p, te_p = _sample_le_te_at(vsp, gid, u_p)
+            d = math.sqrt(sum((le_tip[k] - le_p[k]) ** 2 for k in range(3)))
+            distinct = "✓" if d > _CAP_PROBE_EPS else "✗"
+            rows.append(
+                [
+                    _fmt(u_p),
+                    f"({_fmt(le_p[0])}, {_fmt(le_p[1])}, {_fmt(le_p[2])})",
+                    _fmt(d, 5),
+                    distinct,
+                ]
+            )
+        except Exception:
+            rows.append([_fmt(u_p), "(raised)", "—", "—"])
+    out += _table(["u probe", "LE @u", "dist to LE@1.0", "distinct?"], rows)
+
+    # ───────────────────────────── Phase 6: Augmenter simulation
+    out += _h("Phase 6 — Augmenter trace (per-insert outcome)", level=3)
+    n_anchors = len(world_anchors)
+    rows = []
+    out_xsecs = []
+    for j, xyz_world in enumerate(world_anchors):
+        out_xsecs.append(
+            {
+                "xyz_le": xyz_world,
+                "chord": anchors[j]["chord"],
+                "twist": anchors[j]["twist"],
+                "role": f"Anchor {j}",
+            }
+        )
+        if j == n_anchors - 1:
+            break
+        # Naive u-mapping
+        u_lo = j / (n_anchors - 1)
+        u_hi = (j + 1) / (n_anchors - 1)
+        step = (u_hi - u_lo) / (_N_INTERP_PER_PAIR + 1)
+        twist_lo = anchors[j]["twist"]
+        twist_hi = anchors[j + 1]["twist"]
+        for k in range(1, _N_INTERP_PER_PAIR + 1):
+            u = u_lo + k * step
+            t = k / float(_N_INTERP_PER_PAIR + 1)
+            twist_d = twist_lo + (twist_hi - twist_lo) * t
+            if u > u_max:
+                rows.append([f"{j}→{j + 1}", str(k), _fmt(u), "—", "—", "CAP-CLAMPED"])
+                continue
+            try:
+                le, te = _sample_le_te_at(vsp, gid, u)
+            except Exception:
+                rows.append([f"{j}→{j + 1}", str(k), _fmt(u), "—", "—", "FAILED (raised)"])
+                continue
+            chord = _chord_from_le_te(le, te)
+            if chord <= 0:
+                rows.append(
+                    [
+                        f"{j}→{j + 1}",
+                        str(k),
+                        _fmt(u),
+                        f"({_fmt(le[0])},{_fmt(le[1])},{_fmt(le[2])})",
+                        _fmt(chord),
+                        "FAILED (chord≤0)",
+                    ]
+                )
+                continue
+            prev_le = out_xsecs[-1]["xyz_le"]
+            d = math.sqrt(sum((le[m] - prev_le[m]) ** 2 for m in range(3)))
+            if d < _DEDUP_EPS:
+                rows.append(
+                    [
+                        f"{j}→{j + 1}",
+                        str(k),
+                        _fmt(u),
+                        f"({_fmt(le[0])},{_fmt(le[1])},{_fmt(le[2])})",
+                        _fmt(chord),
+                        "DEDUPED",
+                    ]
+                )
+                continue
+            out_xsecs.append(
+                {
+                    "xyz_le": list(le),
+                    "chord": chord,
+                    "twist": twist_d,
+                    "role": f"Insert {j}→{j + 1} #{k}",
+                }
+            )
+            rows.append(
+                [
+                    f"{j}→{j + 1}",
+                    str(k),
+                    _fmt(u),
+                    f"({_fmt(le[0])},{_fmt(le[1])},{_fmt(le[2])})",
+                    _fmt(chord),
+                    "INSERTED",
+                ]
+            )
+    out += _table(
+        ["Pair", "k", "u", "LE @u (world)", "chord", "outcome"],
+        rows,
+    )
+
+    # ───────────────────────────── Phase 7: Final xsec list (what gets persisted)
+    out += _h("Phase 7 — Final xsec list (what the DB stores)", level=3)
+    rows = []
+    prev_le_w = None
+    for s, xs in enumerate(out_xsecs):
+        le = xs["xyz_le"]
+        flag = ""
+        if prev_le_w is not None:
+            dy = le[1] - prev_le_w[1]
+            if dy < -1e-3:
+                flag = "⚠ y backwards"
+            elif abs(dy) < 1e-3 and abs(le[0] - prev_le_w[0]) < 1e-3:
+                flag = "⚠ near-duplicate"
+        rows.append(
+            [
+                str(s),
+                xs["role"],
+                f"({_fmt(le[0])}, {_fmt(le[1])}, {_fmt(le[2])})",
+                _fmt(xs["chord"]),
+                _fmt(xs["twist"], 1),
+                flag,
+            ]
+        )
+        prev_le_w = le
+    out += _table(["sort", "role", "xyz_le", "chord", "twist°", "flag"], rows)
+
+    return out
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+    vsp_path = Path(sys.argv[1]).resolve()
+    out_path = Path(sys.argv[2]).resolve() if len(sys.argv) > 2 else None
+
+    vsp.ClearVSPModel()
+    vsp.ReadVSPFile(str(vsp_path))
+
+    md = f"# OpenVSP import trace — `{vsp_path.name}`\n\n"
+    md += "_Generated by `scripts/openvsp_import_trace.py`_\n\n"
+
+    for gid in vsp.FindGeoms():
+        if vsp.GetGeomTypeName(gid) != "Wing":
+            continue
+        name = vsp.GetGeomName(gid)
+        md += "---\n\n"
+        md += _trace_wing_phases(gid, name)
+
+    if out_path:
+        out_path.write_text(md)
+        print(f"Wrote {out_path}")
+    else:
+        print(md)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Fixes the gh-753 augmenter's naïve `u = i / (n_anchors - 1)` mapping which assumed uniform VSP anchor distribution
- Verified empirically via `GetUWTess01(gid, surf_idx)` across 13 wings: VSP places anchors at `(i + cap_min) / (n_xsec - 1 + cap_min + cap_max)` where `cap_min/max` are derived from `CapUMinOption` / `CapUMaxOption` on the Wing's `EndCap` parm group
- Spitfire main wing was the smoking gun: pre-fix had sort 5/6 collision (xyz_le identical within 1 mm) at the augmenter-u 0.6 ↔ Anchor 2's real VSP u 0.6
- Adds `scripts/openvsp_import_trace.py` — dev tool producing a per-phase Markdown dashboard for any `.vsp3` (used to identify and verify the fix)

## Why

The gh-758 fix (PR #759) correctly handled cap-clamping and XForm ordering but did NOT address the underlying u-mapping. The smoke-test overlay against the real VSP Spitfire showed the wing form still deviated outboard of xsec 4, with sort 5/6 stacked at the same y-position. Investigation via `GetUWTess01` revealed VSP's actual u-distribution depends on cap configuration.

## Smoke test (already done)

Re-imported Spitfire + Cessna 172 + DG-101G via Playwright + DB inspection:

| Wing | pre-fix xsecs | post-fix xsecs | Spitfire 5/6 dup | gh-758 warnings |
|------|---------------|----------------|------------------|-----------------|
| Spitfire Wing | 9 (sort 5/6 dup) | 12 (smooth) | gone | none |
| Cessna 172 Wing | 25 (non-monotonic y) | 31 (monotone) | n/a | none |
| DG-101G | already ok (gh-755) | unchanged | n/a | none |

Visual rendering: smooth elliptical Spitfire wing, continuous Cessna outer-section taper, no z-kinks.

## Test plan

- [x] 40/40 unit tests in `test_openvsp_wing_xsec_augmentation.py` pass (32 pre-existing + 8 new)
- [x] Manual smoke test on worktree (Spitfire + Cessna, browser + DB)
- [ ] Full backend fast suite (running)
- [ ] `ruff check` + `ruff format --check` clean ✓
- [ ] Code review

Closes #760

🤖 Generated with [Claude Code](https://claude.com/claude-code)