### PR TITLE
fix(gh-763): clear MissionObjectivesPanel debounce timer on unmount

### DIFF
--- a/frontend/__tests__/MissionObjectivesPanel.test.tsx
+++ b/frontend/__tests__/MissionObjectivesPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import React from "react";
 import { MissionObjectivesPanel } from "@/components/workbench/mission/MissionObjectivesPanel";
 
@@ -287,6 +287,32 @@ describe("MissionObjectivesPanel", () => {
         vi.useRealTimers();
       }
     });
+  });
+
+  // gh-763: the 300 ms debounce scheduled by set() (e.g. on a mission_type
+  // change) must be cleared when the component unmounts. Otherwise the
+  // orphaned timer fires after unmount and issues a stale-closure update()
+  // for an aeroplane the user has navigated away from — a data-write bug in
+  // production, and the source of cross-test timer leakage that flakes the
+  // full suite (the leaked call carries the pre-change draft and lands after
+  // a later test's assertions).
+  it("does not call update() after unmount when a debounce is pending (gh-763)", () => {
+    vi.useFakeTimers();
+    try {
+      const { unmount } = render(<MissionObjectivesPanel aeroplaneId="x" />);
+      const select = screen.getByLabelText(/Mission Type/i) as HTMLSelectElement;
+      fireEvent.change(select, { target: { value: "motor_glider" } });
+      // A 300 ms debounced update() is now pending. Unmount before it fires.
+      unmount();
+      // Advance well past the debounce window.
+      act(() => {
+        vi.advanceTimersByTime(400);
+      });
+      // The orphaned timer must have been cleared on unmount.
+      expect(updateMock).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("preserves in-flight draft edits across SWR revalidations for the SAME aeroplaneId (gh-602)", () => {

--- a/frontend/components/workbench/mission/MissionObjectivesPanel.tsx
+++ b/frontend/components/workbench/mission/MissionObjectivesPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useMissionObjectives, type MissionObjective } from "@/hooks/useMissionObjectives";
 import { useMissionPresets, type MissionPreset, type AxisName } from "@/hooks/useMissionPresets";
 import { normalizedToRaw } from "@/lib/missionScale";
@@ -130,6 +130,19 @@ export function MissionObjectivesPanel({ aeroplaneId }: Props) {
   const [bannerVisible, setBannerVisible] = useState<boolean>(false);
   const [lastAeroplaneId, setLastAeroplaneId] = useState<string | null>(null);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // gh-763: clear any pending debounce on unmount. Without this, the 300 ms
+  // timer scheduled by set() fires after the component is gone and issues a
+  // stale-closure update() for an aeroplane the user already left — a spurious
+  // write in production, and the source of cross-test timer leakage that flakes
+  // the unit suite. Cleanup-only effect (no setState), so it does not run afoul
+  // of the react-hooks/set-state-in-effect constraint noted below.
+  useEffect(
+    () => () => {
+      if (timer.current) clearTimeout(timer.current);
+    },
+    [],
+  );
 
   // "Adjust state when a prop changes" pattern — avoids useEffect+setState
   // (which react-hooks/set-state-in-effect forbids). When the aeroplaneId


### PR DESCRIPTION
## Summary

Fixes the non-deterministic flake in the frontend `vitest` suite that intermittently turns the CI `frontend` check red (observed blocking PR #748).

**Root cause:** `MissionObjectivesPanel` schedules a 300 ms `setTimeout` debounce in `set()` (every field / `mission_type` change), stored in a `useRef`, but **never clears it on unmount**. The orphaned timer fires after the component is gone and issues a stale-closure `update()` PUT — a spurious production write for an aeroplane the user already left. In tests, leaked timers survive RTL's auto-unmount and fire during a later async test, appending a stale `target_cruise_mps: 18` call after the Apply call (`26`), so `MissionObjectivesPanel.test.tsx > applies all 6 target fields` reads the wrong "last call" → `expected 18 to be close to 26`.

**Fix:** a cleanup-only `useEffect` that clears the pending timer on unmount. Fixes the production write bug and deterministically removes the cross-test timer leak.

## Testing
- New test `does not call update() after unmount when a debounce is pending (gh-763)` — RED before fix (`update()` called once with stale `18`), GREEN after.
- Full `npm run test:unit` green 3×3 on Node 22 (CI version), 1096 tests.
- `npm run lint` — 0 errors.

## Related (not in scope — see #763 body)
- Sibling uncleared-timer pattern in `AssumptionRow`, `CreateWingDialog`, `usePreviewState`, `useTessellation` — recommend an audit.
- No `.nvmrc`/`engines`: Node ≥24 shadows jsdom `localStorage`, breaking localStorage tests locally (CI pins Node 22, unaffected).

Closes #763

🤖 Generated with [Claude Code](https://claude.com/claude-code)