### PR TITLE
fix(gh-765,gh-769): frame-pure fuselage refinement + scale xsecs and STEP to model scale

### DIFF
--- a/app/services/openvsp_import_service.py
+++ b/app/services/openvsp_import_service.py
@@ -449,7 +449,10 @@ def _try_slicer_refinement(
         # ``factor``) so the slice stations, X-dominance gate, and
         # symmetry-clip all reason in the STEP's own frame. Output is
         # rescaled by ``factor`` below. ``n`` is dimensionless.
-        inv = 1.0 / factor if factor else 1.0
+        # ``factor`` is validated to (0.001, 10) upstream; the guard keeps
+        # a stray non-positive value from zeroing or flipping the geometry.
+        safe_factor = factor if factor > 0.0 else 1.0
+        inv = 1.0 / safe_factor
         handler_xsec_dicts = [
             {
                 "xyz": [v * inv for v in xs.xyz],
@@ -540,8 +543,9 @@ def _try_slicer_refinement(
 
     # gh-765: the slicer output is in the full-size STEP frame (mm).
     # Convert mm→m and re-apply the import ``factor`` so the refined
-    # xsecs land at the same scale as the wings.
-    eff = _MM_TO_M * factor
+    # xsecs land at the same scale as the wings. (``safe_factor`` mirrors
+    # the non-positive guard used for ``inv`` above.)
+    eff = _MM_TO_M * safe_factor
     refined = []
     for xs in slicer_xsecs:
         refined.append(

--- a/app/services/openvsp_import_service.py
+++ b/app/services/openvsp_import_service.py
@@ -398,6 +398,7 @@ def _try_slicer_refinement(
     rel_step_path: str,
     handler_fuse,
     fuse_name: str,
+    factor: float = 1.0,
 ):
     """Slice the gh-729/731 STEP file into a finer xsec list (gh-732).
 
@@ -406,6 +407,14 @@ def _try_slicer_refinement(
     / the fuselage isn't X-dominant in world frame. Failure is **silent
     on purpose** — the slicer is a refinement, not a requirement, and
     the handler-built schema is always the fallback.
+
+    ``factor`` (gh-765) is the import scale factor already applied to
+    the handler schema. The STEP is exported from the **unscaled**
+    OpenVSP model, so the slicer runs in the full-size frame: the
+    handler anchors are divided by ``factor`` to recover the STEP's
+    coordinates, and the slicer's full-size output is multiplied back by
+    ``factor`` so the refined xsecs match the rest of the scaled
+    aeroplane. ``factor=1.0`` (no scaling requested) is a no-op.
     """
     from app.core.config import settings
     from app.schemas.aeroplaneschema import FuselageXSecSuperEllipseSchema
@@ -435,8 +444,19 @@ def _try_slicer_refinement(
     # actually curves. Falls back to cadquery's XZ-profile curvature
     # for the rare case where the handler list is empty / has < 2 xsecs.
     try:
+        # gh-765: the STEP is exported from the unscaled OpenVSP model.
+        # Recover the full-size handler anchors (divide out the import
+        # ``factor``) so the slice stations, X-dominance gate, and
+        # symmetry-clip all reason in the STEP's own frame. Output is
+        # rescaled by ``factor`` below. ``n`` is dimensionless.
+        inv = 1.0 / factor if factor else 1.0
         handler_xsec_dicts = [
-            {"xyz": list(xs.xyz), "a": xs.a, "b": xs.b, "n": xs.n}
+            {
+                "xyz": [v * inv for v in xs.xyz],
+                "a": xs.a * inv,
+                "b": xs.b * inv,
+                "n": xs.n,
+            }
             for xs in handler_fuse.x_secs
         ]
 
@@ -518,13 +538,17 @@ def _try_slicer_refinement(
         )
         return None
 
+    # gh-765: the slicer output is in the full-size STEP frame (mm).
+    # Convert mm→m and re-apply the import ``factor`` so the refined
+    # xsecs land at the same scale as the wings.
+    eff = _MM_TO_M * factor
     refined = []
     for xs in slicer_xsecs:
         refined.append(
             FuselageXSecSuperEllipseSchema(
-                xyz=[v * _MM_TO_M for v in xs["xyz"]],
-                a=max(float(xs["a"]) * _MM_TO_M, 0.0),
-                b=max(float(xs["b"]) * _MM_TO_M, 0.0),
+                xyz=[v * eff for v in xs["xyz"]],
+                a=max(float(xs["a"]) * eff, 0.0),
+                b=max(float(xs["b"]) * eff, 0.0),
                 n=max(float(xs["n"]), 1.0),
             )
         )
@@ -603,6 +627,7 @@ def _persist_aeroplane(
     name: Optional[str] = None,
     source_filename: Optional[str] = None,
     progress_cb: ProgressCallback = _noop_progress,
+    scale_factor: float = 1.0,
 ) -> tuple[str, str]:
     """Persist the parsed aeroplane and return (uuid_str, name).
 
@@ -757,7 +782,7 @@ def _persist_aeroplane(
             )
             slicer_source = rel_solid or rel_step
             refined_xsecs = _try_slicer_refinement(
-                slicer_source, fuse, fuse_name
+                slicer_source, fuse, fuse_name, scale_factor
             )
             if refined_xsecs is not None:
                 _replace_fuselage_xsecs(
@@ -858,6 +883,10 @@ def import_openvsp_file(
         name=name,
         source_filename=source_filename,
         progress_cb=progress_cb,
+        # gh-765: the fuselage slicer refinement reads a STEP exported
+        # from the unscaled OpenVSP model, so it needs the factor to
+        # rescale its output to match the already-scaled schema.
+        scale_factor=factor if factor is not None else 1.0,
     )
     progress_cb("finalising", 95, "Finalising aeroplane")
     return OpenVspImportResponse(

--- a/app/services/openvsp_import_service.py
+++ b/app/services/openvsp_import_service.py
@@ -57,6 +57,8 @@ from app.converters.openvsp_importer import ImportResult, ImportWarning, import_
 from app.schemas.aeroplaneschema import (
     AeroplaneSchema,
     AsbWingGeometryWriteSchema,
+    FuselageSchema,
+    FuselageXSecSuperEllipseSchema,
 )
 from app.schemas.weight_item import WeightItemWrite
 
@@ -169,7 +171,9 @@ def _scale_aeroplane_lengths(
             item.z_m = item.z_m * factor
 
 
-def _scale_fuselage_xsecs(x_secs, factor: float):
+def _scale_fuselage_xsecs(
+    x_secs: list[FuselageXSecSuperEllipseSchema], factor: float
+) -> list[FuselageXSecSuperEllipseSchema]:
     """Return a new xsec list scaled by ``factor`` (gh-765).
 
     Applied once in ``_persist_aeroplane`` after the slicer refinement,
@@ -177,8 +181,6 @@ def _scale_fuselage_xsecs(x_secs, factor: float):
     (``xyz`` position, ``a``/``b`` semi-axes); the dimensionless
     super-ellipse exponent ``n`` is left untouched.
     """
-    from app.schemas.aeroplaneschema import FuselageXSecSuperEllipseSchema
-
     return [
         FuselageXSecSuperEllipseSchema(
             xyz=[v * factor for v in xs.xyz],
@@ -412,9 +414,9 @@ def _is_x_dominant_fuselage(handler_xsec_dicts: list[dict]) -> bool:
 
 def _try_slicer_refinement(
     rel_step_path: str,
-    handler_fuse,
+    handler_fuse: FuselageSchema,
     fuse_name: str,
-):
+) -> list[FuselageXSecSuperEllipseSchema] | None:
     """Slice the gh-729/731 STEP file into a finer xsec list (gh-732).
 
     Returns a list of ``FuselageXSecSuperEllipseSchema`` in metres, or
@@ -430,7 +432,6 @@ def _try_slicer_refinement(
     and ``scale_geom_step`` (the stored STEP files).
     """
     from app.core.config import settings
-    from app.schemas.aeroplaneschema import FuselageXSecSuperEllipseSchema
 
     full_path = Path(settings.ARTIFACTS_BASE_DIR) / rel_step_path
     if not full_path.exists():
@@ -788,13 +789,13 @@ def _persist_aeroplane(
                         slicer_source, fuse, fuse_name
                     )
 
-            # gh-765: apply the import scale ONCE, after refinement. Persist
-            # the scaled xsecs whether they came from the slicer or the
-            # handler fallback. Skip the rewrite only when nothing changed
-            # (no refinement and no scaling) — ``create_fuselage`` already
-            # stored the unscaled handler xsecs in that case.
+            # gh-765: apply the import scale ONCE, after refinement (the
+            # slicer ran in the unscaled STEP frame). When scaling, persist
+            # the scaled xsecs — slicer output or handler fallback. When
+            # not scaling, only the slicer result needs writing; the
+            # handler xsecs are already correct from ``create_fuselage``.
             scaling = abs(scale_factor - 1.0) > 1e-9
-            if refined_xsecs is not None or scaling:
+            if scaling:
                 final_xsecs = refined_xsecs if refined_xsecs is not None else fuse.x_secs
                 _replace_fuselage_xsecs(
                     db,
@@ -802,11 +803,16 @@ def _persist_aeroplane(
                     fuse_name,
                     _scale_fuselage_xsecs(final_xsecs, scale_factor),
                 )
+            elif refined_xsecs is not None:
+                _replace_fuselage_xsecs(db, aeroplane.uuid, fuse_name, refined_xsecs)
 
             # gh-769: scale the stored STEP download files to model scale.
             # Done AFTER slicing (which needed the unscaled frame). The
             # precise STEP is what the user downloads / uses for internal
             # installations, so it must match the scaled aeroplane.
+            # ``scale_geom_step`` overwrites in place and returns the same
+            # path, so the DB row (set above) already points at the scaled
+            # file — only re-set on the (future-proof) chance it relocates.
             if scaling:
                 for setter, rel in (
                     (_set_fuselage_step_path, rel_step),
@@ -817,7 +823,7 @@ def _persist_aeroplane(
                     scaled_rel = openvsp_step_export_service.scale_geom_step(
                         rel, scale_factor, str(aeroplane.uuid)
                     )
-                    if scaled_rel:
+                    if scaled_rel and scaled_rel != rel:
                         setter(db, aeroplane.uuid, fuse_name, scaled_rel)
 
     # Weight items (gh-693): persist each WeightItemWrite via the same

--- a/app/services/openvsp_import_service.py
+++ b/app/services/openvsp_import_service.py
@@ -138,29 +138,24 @@ def _scale_aeroplane_lengths(
     Scales:
 
     * Wing x-sec ``xyz_le`` and ``chord``
-    * Fuselage x-sec ``xyz`` and superellipse ``a``/``b`` semi-axes
     * Aeroplane ``xyz_ref`` (reference point / CG)
     * Optional weight items' ``x_m``/``y_m``/``z_m`` positions
 
-    Does NOT scale (intentional, per ``feedback_openvsp_import_rc_scope``):
+    Does NOT scale here:
 
+    * **Fuselages** — scaled in ``_persist_aeroplane`` via
+      :func:`_scale_fuselage_xsecs`, *after* the slicer refinement which
+      must run in the unscaled STEP frame (gh-765). Scaling them here
+      would force the slicer to unscale/rescale around the import factor.
     * Wing-section ``twist`` (angular)
-    * Fuselage superellipse ``n`` exponent (dimensionless)
-    * Weight items ``mass_kg`` — see Variante B for the mass-scaling story
-    * ``total_mass_kg`` on the aeroplane
+    * Weight items ``mass_kg`` / ``total_mass_kg`` (per
+      ``feedback_openvsp_import_rc_scope`` — see Variante B)
     """
     # Wings
     for wing in (aeroplane.wings or {}).values():
         for xs in wing.x_secs:
             xs.xyz_le = [v * factor for v in xs.xyz_le]
             xs.chord = xs.chord * factor
-
-    # Fuselages
-    for fus in (aeroplane.fuselages or {}).values():
-        for fxs in fus.x_secs:
-            fxs.xyz = [v * factor for v in fxs.xyz]
-            fxs.a = fxs.a * factor
-            fxs.b = fxs.b * factor
 
     # Aeroplane reference point (CG / origin) — also a length
     if aeroplane.xyz_ref is not None:
@@ -172,6 +167,27 @@ def _scale_aeroplane_lengths(
             item.x_m = item.x_m * factor
             item.y_m = item.y_m * factor
             item.z_m = item.z_m * factor
+
+
+def _scale_fuselage_xsecs(x_secs, factor: float):
+    """Return a new xsec list scaled by ``factor`` (gh-765).
+
+    Applied once in ``_persist_aeroplane`` after the slicer refinement,
+    which runs in the unscaled STEP frame. Scales the length-typed fields
+    (``xyz`` position, ``a``/``b`` semi-axes); the dimensionless
+    super-ellipse exponent ``n`` is left untouched.
+    """
+    from app.schemas.aeroplaneschema import FuselageXSecSuperEllipseSchema
+
+    return [
+        FuselageXSecSuperEllipseSchema(
+            xyz=[v * factor for v in xs.xyz],
+            a=xs.a * factor,
+            b=xs.b * factor,
+            n=xs.n,
+        )
+        for xs in x_secs
+    ]
 
 
 def _resolve_scale_factor(
@@ -398,7 +414,6 @@ def _try_slicer_refinement(
     rel_step_path: str,
     handler_fuse,
     fuse_name: str,
-    factor: float = 1.0,
 ):
     """Slice the gh-729/731 STEP file into a finer xsec list (gh-732).
 
@@ -408,13 +423,11 @@ def _try_slicer_refinement(
     on purpose** — the slicer is a refinement, not a requirement, and
     the handler-built schema is always the fallback.
 
-    ``factor`` (gh-765) is the import scale factor already applied to
-    the handler schema. The STEP is exported from the **unscaled**
-    OpenVSP model, so the slicer runs in the full-size frame: the
-    handler anchors are divided by ``factor`` to recover the STEP's
-    coordinates, and the slicer's full-size output is multiplied back by
-    ``factor`` so the refined xsecs match the rest of the scaled
-    aeroplane. ``factor=1.0`` (no scaling requested) is a no-op.
+    Frame-pure (gh-765): both the handler anchors and the STEP are in the
+    **unscaled** OpenVSP frame, so this just converts the slicer's mm
+    output to metres. The import scale factor is applied once afterwards,
+    in :func:`_persist_aeroplane` via :func:`_scale_fuselage_xsecs` (xsecs)
+    and ``scale_geom_step`` (the stored STEP files).
     """
     from app.core.config import settings
     from app.schemas.aeroplaneschema import FuselageXSecSuperEllipseSchema
@@ -444,22 +457,8 @@ def _try_slicer_refinement(
     # actually curves. Falls back to cadquery's XZ-profile curvature
     # for the rare case where the handler list is empty / has < 2 xsecs.
     try:
-        # gh-765: the STEP is exported from the unscaled OpenVSP model.
-        # Recover the full-size handler anchors (divide out the import
-        # ``factor``) so the slice stations, X-dominance gate, and
-        # symmetry-clip all reason in the STEP's own frame. Output is
-        # rescaled by ``factor`` below. ``n`` is dimensionless.
-        # ``factor`` is validated to (0.001, 10) upstream; the guard keeps
-        # a stray non-positive value from zeroing or flipping the geometry.
-        safe_factor = factor if factor > 0.0 else 1.0
-        inv = 1.0 / safe_factor
         handler_xsec_dicts = [
-            {
-                "xyz": [v * inv for v in xs.xyz],
-                "a": xs.a * inv,
-                "b": xs.b * inv,
-                "n": xs.n,
-            }
+            {"xyz": list(xs.xyz), "a": xs.a, "b": xs.b, "n": xs.n}
             for xs in handler_fuse.x_secs
         ]
 
@@ -541,18 +540,13 @@ def _try_slicer_refinement(
         )
         return None
 
-    # gh-765: the slicer output is in the full-size STEP frame (mm).
-    # Convert mm→m and re-apply the import ``factor`` so the refined
-    # xsecs land at the same scale as the wings. (``safe_factor`` mirrors
-    # the non-positive guard used for ``inv`` above.)
-    eff = _MM_TO_M * safe_factor
     refined = []
     for xs in slicer_xsecs:
         refined.append(
             FuselageXSecSuperEllipseSchema(
-                xyz=[v * eff for v in xs["xyz"]],
-                a=max(float(xs["a"]) * eff, 0.0),
-                b=max(float(xs["b"]) * eff, 0.0),
+                xyz=[v * _MM_TO_M for v in xs["xyz"]],
+                a=max(float(xs["a"]) * _MM_TO_M, 0.0),
+                b=max(float(xs["b"]) * _MM_TO_M, 0.0),
                 n=max(float(xs["n"]), 1.0),
             )
         )
@@ -742,56 +736,89 @@ def _persist_aeroplane(
                     result, component_type="FUSELAGE", component_name=fuse_name, exc=exc
                 )
                 continue
+            # gh-765: STEP export + sewing + slicer refinement all run in
+            # the UNSCALED OpenVSP frame. The import scale is applied once
+            # afterwards — to the xsecs (``_scale_fuselage_xsecs``) and to
+            # the stored STEP download files (``scale_geom_step``, gh-769).
             gid = name_to_gid.get(fuse_name)
-            if vsp is None or gid is None:
-                continue
-            progress_cb(
-                "fuselage_step",
-                base_pct + int(fuselage_step_pct * 0.25),
-                f"{fuse_name}: exporting STEP",
-            )
-            rel_step = openvsp_step_export_service.export_geom_step(
-                vsp=vsp,
-                gid=gid,
-                geom_name=fuse_name,
-                aeroplane_uuid=str(aeroplane.uuid),
-            )
-            if not rel_step:
-                continue
-            _set_fuselage_step_path(db, aeroplane.uuid, fuse_name, rel_step)
-            progress_cb(
-                "fuselage_sew",
-                base_pct + int(fuselage_step_pct * 0.5),
-                f"{fuse_name}: sewing closed Solid",
-            )
-            rel_solid = openvsp_solid_sewing_service.sew_imported_geom_to_solid(
-                source_rel_step=rel_step,
-                aeroplane_uuid=str(aeroplane.uuid),
-                geom_name=fuse_name,
-            )
-            if rel_solid:
-                _set_fuselage_solid_step_path(
-                    db, aeroplane.uuid, fuse_name, rel_solid
+            rel_step: Optional[str] = None
+            rel_solid: Optional[str] = None
+            refined_xsecs = None
+            if vsp is not None and gid is not None:
+                progress_cb(
+                    "fuselage_step",
+                    base_pct + int(fuselage_step_pct * 0.25),
+                    f"{fuse_name}: exporting STEP",
+                )
+                rel_step = openvsp_step_export_service.export_geom_step(
+                    vsp=vsp,
+                    gid=gid,
+                    geom_name=fuse_name,
+                    aeroplane_uuid=str(aeroplane.uuid),
+                )
+                if rel_step:
+                    _set_fuselage_step_path(db, aeroplane.uuid, fuse_name, rel_step)
+                    progress_cb(
+                        "fuselage_sew",
+                        base_pct + int(fuselage_step_pct * 0.5),
+                        f"{fuse_name}: sewing closed Solid",
+                    )
+                    rel_solid = openvsp_solid_sewing_service.sew_imported_geom_to_solid(
+                        source_rel_step=rel_step,
+                        aeroplane_uuid=str(aeroplane.uuid),
+                        geom_name=fuse_name,
+                    )
+                    if rel_solid:
+                        _set_fuselage_solid_step_path(
+                            db, aeroplane.uuid, fuse_name, rel_solid
+                        )
+
+                    # gh-732: refine the schema's xsecs from the just-exported
+                    # (unscaled) STEP. Solid STEP gives the slicer a real
+                    # volume metric for logging; fall back to the Surface STEP
+                    # when sewing failed. The handler-built schema stays if the
+                    # slicer fails or produces too few points.
+                    progress_cb(
+                        "fuselage_slice",
+                        base_pct + int(fuselage_step_pct * 0.75),
+                        f"{fuse_name}: slicing for finer xsecs",
+                    )
+                    slicer_source = rel_solid or rel_step
+                    refined_xsecs = _try_slicer_refinement(
+                        slicer_source, fuse, fuse_name
+                    )
+
+            # gh-765: apply the import scale ONCE, after refinement. Persist
+            # the scaled xsecs whether they came from the slicer or the
+            # handler fallback. Skip the rewrite only when nothing changed
+            # (no refinement and no scaling) — ``create_fuselage`` already
+            # stored the unscaled handler xsecs in that case.
+            scaling = abs(scale_factor - 1.0) > 1e-9
+            if refined_xsecs is not None or scaling:
+                final_xsecs = refined_xsecs if refined_xsecs is not None else fuse.x_secs
+                _replace_fuselage_xsecs(
+                    db,
+                    aeroplane.uuid,
+                    fuse_name,
+                    _scale_fuselage_xsecs(final_xsecs, scale_factor),
                 )
 
-            # gh-732: refine the schema's xsecs from the just-exported
-            # STEP via the slicer. Solid STEP gives the slicer a real
-            # volume metric for logging; we fall back to the Surface
-            # STEP when sewing failed. The handler-built schema stays
-            # if the slicer fails or produces too few points.
-            progress_cb(
-                "fuselage_slice",
-                base_pct + int(fuselage_step_pct * 0.75),
-                f"{fuse_name}: slicing for finer xsecs",
-            )
-            slicer_source = rel_solid or rel_step
-            refined_xsecs = _try_slicer_refinement(
-                slicer_source, fuse, fuse_name, scale_factor
-            )
-            if refined_xsecs is not None:
-                _replace_fuselage_xsecs(
-                    db, aeroplane.uuid, fuse_name, refined_xsecs
-                )
+            # gh-769: scale the stored STEP download files to model scale.
+            # Done AFTER slicing (which needed the unscaled frame). The
+            # precise STEP is what the user downloads / uses for internal
+            # installations, so it must match the scaled aeroplane.
+            if scaling:
+                for setter, rel in (
+                    (_set_fuselage_step_path, rel_step),
+                    (_set_fuselage_solid_step_path, rel_solid),
+                ):
+                    if not rel:
+                        continue
+                    scaled_rel = openvsp_step_export_service.scale_geom_step(
+                        rel, scale_factor, str(aeroplane.uuid)
+                    )
+                    if scaled_rel:
+                        setter(db, aeroplane.uuid, fuse_name, scaled_rel)
 
     # Weight items (gh-693): persist each WeightItemWrite via the same
     # entry point the manual mass-properties UI uses, so categories,

--- a/app/services/openvsp_step_export_service.py
+++ b/app/services/openvsp_step_export_service.py
@@ -164,6 +164,57 @@ def export_geom_step(
         return None
 
 
+def scale_geom_step(
+    rel_step_path: str, factor: float, aeroplane_uuid: str
+) -> Optional[str]:
+    """Scale a stored STEP file uniformly by ``factor`` about the origin,
+    in place, and return its (unchanged) relative path (gh-769).
+
+    OpenVSP exports the STEP from the **unscaled** model; this brings the
+    precise download geometry to the same model scale as the rest of the
+    imported aeroplane (so it matches the scaled xsecs and is usable for
+    internal-installation work). Scaling the actual solid — rather than
+    fudging the STEP unit declaration — avoids the foot/metre
+    reader-interpretation footgun seen in gh-732.
+
+    ``factor == 1.0`` is a no-op (returns the path unchanged). Returns
+    ``None`` when CadQuery is unavailable or the transform/export fails;
+    the caller then keeps the unscaled file (best-effort, never aborts
+    the import). ``aeroplane_uuid`` is accepted for symmetry with
+    :func:`export_geom_step`.
+    """
+    if abs(factor - 1.0) < 1e-9:
+        return rel_step_path
+    try:
+        import cadquery as cq
+        from cadquery import exporters
+        from OCP.BRepBuilderAPI import BRepBuilderAPI_Transform
+        from OCP.gp import gp_Pnt, gp_Trsf
+    except Exception:  # noqa: BLE001 — CAD stack is optional on some platforms
+        logger.info("CadQuery unavailable — leaving STEP %r unscaled.", rel_step_path)
+        return None
+    try:
+        full_path = Path(settings.ARTIFACTS_BASE_DIR) / rel_step_path
+        if not full_path.exists():
+            return None
+        shape = cq.importers.importStep(str(full_path)).val()
+        trsf = gp_Trsf()
+        trsf.SetScale(gp_Pnt(0.0, 0.0, 0.0), float(factor))
+        scaled = cq.Shape.cast(
+            BRepBuilderAPI_Transform(shape.wrapped, trsf, True).Shape()
+        )
+        exporters.export(
+            cq.Workplane(obj=scaled), str(full_path), exporters.ExportTypes.STEP
+        )
+        return rel_step_path
+    except Exception as exc:  # noqa: BLE001 — best effort, never abort import
+        logger.warning(
+            "Failed to scale STEP %r by %g (%s) — keeping unscaled.",
+            rel_step_path, factor, exc,
+        )
+        return None
+
+
 def cleanup_aeroplane_step_files(aeroplane_uuid: str) -> None:
     """Best-effort removal of the per-aeroplane STEP directory on
     ``DELETE /aeroplanes/<uuid>``. Errors are logged but never raised

--- a/app/services/openvsp_step_export_service.py
+++ b/app/services/openvsp_step_export_service.py
@@ -190,22 +190,28 @@ def scale_geom_step(
         from cadquery import exporters
         from OCP.BRepBuilderAPI import BRepBuilderAPI_Transform
         from OCP.gp import gp_Pnt, gp_Trsf
-    except Exception:  # noqa: BLE001 — CAD stack is optional on some platforms
+    except ImportError:
         logger.info("CadQuery unavailable — leaving STEP %r unscaled.", rel_step_path)
         return None
     try:
         full_path = Path(settings.ARTIFACTS_BASE_DIR) / rel_step_path
         if not full_path.exists():
             return None
-        shape = cq.importers.importStep(str(full_path)).val()
+        # ``.vals()`` (not ``.val()``) so multi-shell STEPs — e.g. a
+        # symmetric fuselage whose export holds both halves — are scaled
+        # in full instead of silently dropping all but the first shell.
+        shapes = cq.importers.importStep(str(full_path)).vals()
+        if not shapes:
+            return None
         trsf = gp_Trsf()
         trsf.SetScale(gp_Pnt(0.0, 0.0, 0.0), float(factor))
-        scaled = cq.Shape.cast(
-            BRepBuilderAPI_Transform(shape.wrapped, trsf, True).Shape()
-        )
-        exporters.export(
-            cq.Workplane(obj=scaled), str(full_path), exporters.ExportTypes.STEP
-        )
+        scaled = [
+            cq.Shape.cast(BRepBuilderAPI_Transform(s.wrapped, trsf, True).Shape())
+            for s in shapes
+        ]
+        # ``exporters.export`` accepts a Shape or an iterable of Shapes.
+        out = scaled[0] if len(scaled) == 1 else scaled
+        exporters.export(out, str(full_path), exporters.ExportTypes.STEP)
         return rel_step_path
     except Exception as exc:  # noqa: BLE001 — best effort, never abort import
         logger.warning(

--- a/app/tests/test_openvsp_import_scaling.py
+++ b/app/tests/test_openvsp_import_scaling.py
@@ -148,22 +148,32 @@ class TestScaleAeroplaneLengths:
         assert wing.x_secs[0].twist == pytest.approx(5.0)
         assert wing.x_secs[1].twist == pytest.approx(-1.0)
 
-    def test_fuselage_xsec_lengths_scale(self):
+    def test_fuselages_are_not_scaled_here(self):
+        # gh-765: fuselage scaling moved out of _scale_aeroplane_lengths
+        # into the persist path (after the unscaled-frame slicer), via
+        # _scale_fuselage_xsecs. This helper must leave fuselages alone.
         ap = AeroplaneSchema(name="X")
         ap.fuselages = {"Body": _make_fuselage(length_m=2.0, half_width=0.3, half_height=0.2)}
         _scale_aeroplane_lengths(ap, 2.0)
         fus = ap.fuselages["Body"]
-        assert fus.x_secs[0].a == pytest.approx(0.6)
-        assert fus.x_secs[0].b == pytest.approx(0.4)
-        # x-position scales:
-        assert fus.x_secs[1].xyz[0] == pytest.approx(4.0)
+        assert fus.x_secs[0].a == pytest.approx(0.3)  # unchanged
+        assert fus.x_secs[1].xyz[0] == pytest.approx(2.0)  # unchanged
 
-    def test_fuselage_n_exponent_is_NOT_scaled(self):
-        ap = AeroplaneSchema(name="X")
-        ap.fuselages = {"Body": _make_fuselage(length_m=2.0, half_width=0.3, half_height=0.2)}
-        _scale_aeroplane_lengths(ap, 2.0)
-        fus = ap.fuselages["Body"]
-        assert fus.x_secs[0].n == pytest.approx(2.0)  # superellipse exponent stays
+
+class TestScaleFuselageXsecs:
+    """gh-765: the single fuselage-scaling step, applied in persist after
+    the (unscaled-frame) slicer refinement."""
+
+    def test_lengths_scale_exponent_does_not(self):
+        from app.services.openvsp_import_service import _scale_fuselage_xsecs
+
+        fus = _make_fuselage(length_m=2.0, half_width=0.3, half_height=0.2)
+        scaled = _scale_fuselage_xsecs(fus.x_secs, 2.0)
+        assert scaled[0].a == pytest.approx(0.6)
+        assert scaled[0].b == pytest.approx(0.4)
+        assert scaled[1].xyz[0] == pytest.approx(4.0)
+        # superellipse exponent is dimensionless — never scaled
+        assert scaled[0].n == pytest.approx(2.0)
 
     def test_xyz_ref_scales(self):
         ap = AeroplaneSchema(name="X")

--- a/app/tests/test_openvsp_import_slicer_scaling.py
+++ b/app/tests/test_openvsp_import_slicer_scaling.py
@@ -1,0 +1,146 @@
+"""Regression tests for fuselage slicer refinement under scaling (gh-765).
+
+Bug: importing a ``.vsp3`` with a custom wing span scaled the Python
+schema (wings + fuselage xsecs) correctly, but the fuselage slicer
+refinement (gh-732) re-derived xsecs from a STEP exported from the
+**unscaled** OpenVSP model and overwrote the scaled schema with
+full-size cross-sections — producing a giant out-of-scale fuselage.
+
+These tests pin down that ``_try_slicer_refinement``:
+  * slices the (full-size) STEP in the full-size frame — the x-stations
+    handed to the slicer are recovered from the scaled handler schema by
+    dividing out ``factor``;
+  * scales the slicer's full-size output back down by ``factor`` so the
+    refined xsecs match the rest of the scaled aeroplane.
+
+The CAD slicer is mocked so the test runs without OpenVSP / CadQuery.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.schemas.aeroplaneschema import (
+    FuselageSchema,
+    FuselageXSecSuperEllipseSchema,
+)
+
+
+def _scaled_handler_fuse(factor: float) -> FuselageSchema:
+    """A handler-built fuselage already scaled by ``factor``.
+
+    Full-size body: length 10 m, half-axes a=1.0 m / b=0.5 m. After the
+    schema-level scaling that runs before persistence, every length is
+    multiplied by ``factor``.
+    """
+    return FuselageSchema(
+        name="Body",
+        symmetric=False,
+        x_secs=[
+            FuselageXSecSuperEllipseSchema(
+                xyz=[0.0 * factor, 0.0, 0.0], a=0.2 * factor, b=0.1 * factor, n=2.0
+            ),
+            FuselageXSecSuperEllipseSchema(
+                xyz=[5.0 * factor, 0.0, 0.0], a=1.0 * factor, b=0.5 * factor, n=2.0
+            ),
+            FuselageXSecSuperEllipseSchema(
+                xyz=[10.0 * factor, 0.0, 0.0], a=0.2 * factor, b=0.1 * factor, n=2.0
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def mock_slicer(monkeypatch, tmp_path):
+    """Patch the CAD slicer module + artifacts dir.
+
+    ``slice_step_at_stations`` returns FULL-SIZE output (mm) — simulating
+    a slice of the unscaled STEP. The real ``vsp_anchored_x_stations`` is
+    replaced by a spy that just records the handler dicts it was given so
+    we can assert the frame they were computed in.
+    """
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "ARTIFACTS_BASE_DIR", str(tmp_path))
+    (tmp_path / "body.stp").write_text("dummy step")
+
+    # Full-size slicer output (mm): body half-axes 1000 mm / 500 mm at
+    # the mid station, tapering to 200 mm / 100 mm at the ends. Length
+    # 10 m == 10000 mm.
+    full_size_xsecs = [
+        {"xyz": [0.0, 0.0, 0.0], "a": 200.0, "b": 100.0, "n": 2.0},
+        {"xyz": [5000.0, 0.0, 0.0], "a": 1000.0, "b": 500.0, "n": 2.0},
+        {"xyz": [10000.0, 0.0, 0.0], "a": 200.0, "b": 100.0, "n": 2.0},
+    ]
+
+    slice_at_stations = MagicMock(return_value=(full_size_xsecs, {"area_ratio": 1.0}))
+    anchored_stations = MagicMock(return_value=[0.0, 5000.0, 10000.0])
+    slice_to_fuselage = MagicMock(return_value=(full_size_xsecs, {}))
+
+    fake_mod = types.ModuleType("cad_designer.aerosandbox.slicing")
+    fake_mod.slice_step_at_stations = slice_at_stations
+    fake_mod.slice_step_to_fuselage = slice_to_fuselage
+    fake_mod.vsp_anchored_x_stations = anchored_stations
+    monkeypatch.setitem(sys.modules, "cad_designer.aerosandbox.slicing", fake_mod)
+
+    return types.SimpleNamespace(
+        slice_at_stations=slice_at_stations,
+        anchored_stations=anchored_stations,
+    )
+
+
+def test_slicer_refinement_scales_output_by_factor(mock_slicer):
+    """Refined xsecs from a full-size STEP must be scaled by ``factor``.
+
+    With factor=0.1 the slicer returns a full-size body (a_mid = 1.0 m).
+    The refined schema must come back at the scaled size (a_mid = 0.1 m),
+    matching the scaled wings — NOT the full 1.0 m that caused the giant
+    fuselage in gh-765.
+    """
+    from app.services.openvsp_import_service import _try_slicer_refinement
+
+    factor = 0.1
+    refined = _try_slicer_refinement("body.stp", _scaled_handler_fuse(factor), "Body", factor)
+
+    assert refined is not None
+    a_values = sorted(xs.a for xs in refined)
+    # Mid-section half-width: full-size 1.0 m → scaled 0.1 m.
+    assert a_values[-1] == pytest.approx(1.0 * factor)
+    # Length: full-size 10 m → scaled 1.0 m.
+    x_span = max(xs.xyz[0] for xs in refined) - min(xs.xyz[0] for xs in refined)
+    assert x_span == pytest.approx(10.0 * factor)
+
+
+def test_slicer_refinement_slices_step_in_full_size_frame(mock_slicer):
+    """The slicer must operate in the unscaled STEP's frame.
+
+    The x-stations handed to ``slice_step_at_stations`` must be full-size
+    (≈10000 mm span), recovered from the scaled handler schema. Slicing a
+    full-size STEP at scaled (tiny) stations was the gh-765 defect.
+    """
+    from app.services.openvsp_import_service import _try_slicer_refinement
+
+    factor = 0.1
+    _try_slicer_refinement("body.stp", _scaled_handler_fuse(factor), "Body", factor)
+
+    # The handler dicts used to compute anchored stations must be in the
+    # full-size frame (mid xsec a ≈ 1.0 m), not the scaled 0.1 m frame.
+    args, kwargs = mock_slicer.anchored_stations.call_args
+    handler_dicts = args[0]
+    max_a = max(d["a"] for d in handler_dicts)
+    assert max_a == pytest.approx(1.0)
+
+
+def test_slicer_refinement_factor_one_is_identity(mock_slicer):
+    """factor=1.0 preserves the pre-gh-765 behaviour (plain mm→m)."""
+    from app.services.openvsp_import_service import _try_slicer_refinement
+
+    refined = _try_slicer_refinement("body.stp", _scaled_handler_fuse(1.0), "Body", 1.0)
+
+    assert refined is not None
+    a_values = sorted(xs.a for xs in refined)
+    assert a_values[-1] == pytest.approx(1.0)

--- a/app/tests/test_openvsp_import_slicer_scaling.py
+++ b/app/tests/test_openvsp_import_slicer_scaling.py
@@ -1,19 +1,15 @@
-"""Regression tests for fuselage slicer refinement under scaling (gh-765).
+"""Frame-pure fuselage refinement + post-refinement scaling (gh-765/769).
 
-Bug: importing a ``.vsp3`` with a custom wing span scaled the Python
-schema (wings + fuselage xsecs) correctly, but the fuselage slicer
-refinement (gh-732) re-derived xsecs from a STEP exported from the
-**unscaled** OpenVSP model and overwrote the scaled schema with
-full-size cross-sections — producing a giant out-of-scale fuselage.
+Clean architecture (supersedes the gh-766 ``factor``-in-slicer workaround):
 
-These tests pin down that ``_try_slicer_refinement``:
-  * slices the (full-size) STEP in the full-size frame — the x-stations
-    handed to the slicer are recovered from the scaled handler schema by
-    dividing out ``factor``;
-  * scales the slicer's full-size output back down by ``factor`` so the
-    refined xsecs match the rest of the scaled aeroplane.
+* ``_try_slicer_refinement`` runs entirely in the **unscaled** STEP frame
+  — it takes no scale factor and just converts the slicer's mm output to
+  metres.
+* The import scale is applied **once, after refinement**, by
+  ``_scale_fuselage_xsecs`` (xsec geometry) and ``scale_geom_step`` (the
+  stored STEP download files), so xsecs and STEP both land at model scale.
 
-The CAD slicer is mocked so the test runs without OpenVSP / CadQuery.
+The CAD slicer is mocked so these tests run without OpenVSP / CadQuery.
 """
 
 from __future__ import annotations
@@ -30,117 +26,127 @@ from app.schemas.aeroplaneschema import (
 )
 
 
-def _scaled_handler_fuse(factor: float) -> FuselageSchema:
-    """A handler-built fuselage already scaled by ``factor``.
-
-    Full-size body: length 10 m, half-axes a=1.0 m / b=0.5 m. After the
-    schema-level scaling that runs before persistence, every length is
-    multiplied by ``factor``.
-    """
+def _fuse() -> FuselageSchema:
+    """A handler-built (unscaled) fuselage: length 10 m, a=1.0/b=0.5 m mid."""
     return FuselageSchema(
         name="Body",
         symmetric=False,
         x_secs=[
-            FuselageXSecSuperEllipseSchema(
-                xyz=[0.0 * factor, 0.0, 0.0], a=0.2 * factor, b=0.1 * factor, n=2.0
-            ),
-            FuselageXSecSuperEllipseSchema(
-                xyz=[5.0 * factor, 0.0, 0.0], a=1.0 * factor, b=0.5 * factor, n=2.0
-            ),
-            FuselageXSecSuperEllipseSchema(
-                xyz=[10.0 * factor, 0.0, 0.0], a=0.2 * factor, b=0.1 * factor, n=2.0
-            ),
+            FuselageXSecSuperEllipseSchema(xyz=[0.0, 0.0, 0.0], a=0.2, b=0.1, n=2.0),
+            FuselageXSecSuperEllipseSchema(xyz=[5.0, 0.0, 0.0], a=1.0, b=0.5, n=2.0),
+            FuselageXSecSuperEllipseSchema(xyz=[10.0, 0.0, 0.0], a=0.2, b=0.1, n=2.0),
         ],
     )
 
 
+# --------------------------------------------------------------------------- #
+# _try_slicer_refinement — frame-pure (no scale factor)
+#
+# (``_scale_fuselage_xsecs`` and ``_scale_aeroplane_lengths`` are covered in
+# test_openvsp_import_scaling.py, the canonical scaling-helpers suite.)
+# --------------------------------------------------------------------------- #
+
+
 @pytest.fixture
 def mock_slicer(monkeypatch, tmp_path):
-    """Patch the CAD slicer module + artifacts dir.
-
-    ``slice_step_at_stations`` returns FULL-SIZE output (mm) — simulating
-    a slice of the unscaled STEP. The real ``vsp_anchored_x_stations`` is
-    replaced by a spy that just records the handler dicts it was given so
-    we can assert the frame they were computed in.
-    """
+    """Patch the CAD slicer; ``slice_step_at_stations`` returns mm output."""
     from app.core.config import settings
 
     monkeypatch.setattr(settings, "ARTIFACTS_BASE_DIR", str(tmp_path))
     (tmp_path / "body.stp").write_text("dummy step")
 
-    # Full-size slicer output (mm): body half-axes 1000 mm / 500 mm at
-    # the mid station, tapering to 200 mm / 100 mm at the ends. Length
-    # 10 m == 10000 mm.
-    full_size_xsecs = [
+    mm_xsecs = [
         {"xyz": [0.0, 0.0, 0.0], "a": 200.0, "b": 100.0, "n": 2.0},
         {"xyz": [5000.0, 0.0, 0.0], "a": 1000.0, "b": 500.0, "n": 2.0},
         {"xyz": [10000.0, 0.0, 0.0], "a": 200.0, "b": 100.0, "n": 2.0},
     ]
+    fake = types.ModuleType("cad_designer.aerosandbox.slicing")
+    fake.slice_step_at_stations = MagicMock(return_value=(mm_xsecs, {"area_ratio": 1.0}))
+    fake.slice_step_to_fuselage = MagicMock(return_value=(mm_xsecs, {}))
+    fake.vsp_anchored_x_stations = MagicMock(return_value=[0.0, 5000.0, 10000.0])
+    monkeypatch.setitem(sys.modules, "cad_designer.aerosandbox.slicing", fake)
+    return fake
 
-    slice_at_stations = MagicMock(return_value=(full_size_xsecs, {"area_ratio": 1.0}))
-    anchored_stations = MagicMock(return_value=[0.0, 5000.0, 10000.0])
-    slice_to_fuselage = MagicMock(return_value=(full_size_xsecs, {}))
 
-    fake_mod = types.ModuleType("cad_designer.aerosandbox.slicing")
-    fake_mod.slice_step_at_stations = slice_at_stations
-    fake_mod.slice_step_to_fuselage = slice_to_fuselage
-    fake_mod.vsp_anchored_x_stations = anchored_stations
-    monkeypatch.setitem(sys.modules, "cad_designer.aerosandbox.slicing", fake_mod)
+def test_slicer_refinement_is_frame_pure_mm_to_m(mock_slicer):
+    """Refinement converts mm→m only — no scale factor, no parameter."""
+    from app.services.openvsp_import_service import _try_slicer_refinement
 
-    return types.SimpleNamespace(
-        slice_at_stations=slice_at_stations,
-        anchored_stations=anchored_stations,
+    refined = _try_slicer_refinement("body.stp", _fuse(), "Body")
+
+    assert refined is not None
+    # Mid-section: 1000 mm → 1.0 m (NOT scaled by any import factor here).
+    assert max(xs.a for xs in refined) == pytest.approx(1.0)
+    x_span = max(xs.xyz[0] for xs in refined) - min(xs.xyz[0] for xs in refined)
+    assert x_span == pytest.approx(10.0)
+
+
+def test_slicer_refinement_takes_no_factor_argument():
+    """The gh-766 ``factor`` parameter is gone (frame-pure by construction)."""
+    import inspect
+
+    from app.services.openvsp_import_service import _try_slicer_refinement
+
+    params = inspect.signature(_try_slicer_refinement).parameters
+    assert "factor" not in params
+    assert "scale_factor" not in params
+
+
+# --------------------------------------------------------------------------- #
+# _scale_aeroplane_lengths — no longer touches fuselages (gh-765)
+# --------------------------------------------------------------------------- #
+
+
+def test_scale_aeroplane_lengths_leaves_fuselages_untouched():
+    """Fuselage scaling moved to the persist path; this helper must not
+    double-scale fuselages."""
+    from app.schemas.aeroplaneschema import AeroplaneSchema
+    from app.services.openvsp_import_service import _scale_aeroplane_lengths
+
+    ap = AeroplaneSchema(name="t")
+    ap.fuselages = {"Body": _fuse()}
+    _scale_aeroplane_lengths(ap, 0.1)
+
+    body = ap.fuselages["Body"]
+    assert body.x_secs[1].a == pytest.approx(1.0)  # unchanged
+    assert body.x_secs[-1].xyz[0] == pytest.approx(10.0)  # unchanged
+
+
+# --------------------------------------------------------------------------- #
+# scale_geom_step — scale the stored STEP download to model scale (gh-769)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.slow
+def test_scale_geom_step_scales_bounding_box(monkeypatch, tmp_path):
+    """A stored STEP is rewritten at model scale; its bbox shrinks by factor."""
+    cq = pytest.importorskip("cadquery")
+    from cadquery import exporters
+
+    from app.core.config import settings
+    from app.services import openvsp_step_export_service as step_svc
+
+    monkeypatch.setattr(settings, "ARTIFACTS_BASE_DIR", str(tmp_path))
+    rel = "openvsp_imports/uuid/body.stp"
+    src = tmp_path / rel
+    src.parent.mkdir(parents=True, exist_ok=True)
+    exporters.export(
+        cq.Workplane("XY").box(10, 4, 2), str(src), exporters.ExportTypes.STEP
     )
 
+    new_rel = step_svc.scale_geom_step(rel, 0.1, "uuid")
+    assert new_rel is not None
 
-def test_slicer_refinement_scales_output_by_factor(mock_slicer):
-    """Refined xsecs from a full-size STEP must be scaled by ``factor``.
-
-    With factor=0.1 the slicer returns a full-size body (a_mid = 1.0 m).
-    The refined schema must come back at the scaled size (a_mid = 0.1 m),
-    matching the scaled wings — NOT the full 1.0 m that caused the giant
-    fuselage in gh-765.
-    """
-    from app.services.openvsp_import_service import _try_slicer_refinement
-
-    factor = 0.1
-    refined = _try_slicer_refinement("body.stp", _scaled_handler_fuse(factor), "Body", factor)
-
-    assert refined is not None
-    a_values = sorted(xs.a for xs in refined)
-    # Mid-section half-width: full-size 1.0 m → scaled 0.1 m.
-    assert a_values[-1] == pytest.approx(1.0 * factor)
-    # Length: full-size 10 m → scaled 1.0 m.
-    x_span = max(xs.xyz[0] for xs in refined) - min(xs.xyz[0] for xs in refined)
-    assert x_span == pytest.approx(10.0 * factor)
+    scaled = cq.importers.importStep(str(tmp_path / new_rel)).val()
+    bb = scaled.BoundingBox()
+    assert bb.xlen == pytest.approx(1.0, abs=1e-3)
+    assert bb.ylen == pytest.approx(0.4, abs=1e-3)
+    assert bb.zlen == pytest.approx(0.2, abs=1e-3)
 
 
-def test_slicer_refinement_slices_step_in_full_size_frame(mock_slicer):
-    """The slicer must operate in the unscaled STEP's frame.
+def test_scale_geom_step_factor_one_returns_same_path(tmp_path, monkeypatch):
+    from app.core.config import settings
+    from app.services import openvsp_step_export_service as step_svc
 
-    The x-stations handed to ``slice_step_at_stations`` must be full-size
-    (≈10000 mm span), recovered from the scaled handler schema. Slicing a
-    full-size STEP at scaled (tiny) stations was the gh-765 defect.
-    """
-    from app.services.openvsp_import_service import _try_slicer_refinement
-
-    factor = 0.1
-    _try_slicer_refinement("body.stp", _scaled_handler_fuse(factor), "Body", factor)
-
-    # The handler dicts used to compute anchored stations must be in the
-    # full-size frame (mid xsec a ≈ 1.0 m), not the scaled 0.1 m frame.
-    args, kwargs = mock_slicer.anchored_stations.call_args
-    handler_dicts = args[0]
-    max_a = max(d["a"] for d in handler_dicts)
-    assert max_a == pytest.approx(1.0)
-
-
-def test_slicer_refinement_factor_one_is_identity(mock_slicer):
-    """factor=1.0 preserves the pre-gh-765 behaviour (plain mm→m)."""
-    from app.services.openvsp_import_service import _try_slicer_refinement
-
-    refined = _try_slicer_refinement("body.stp", _scaled_handler_fuse(1.0), "Body", 1.0)
-
-    assert refined is not None
-    a_values = sorted(xs.a for xs in refined)
-    assert a_values[-1] == pytest.approx(1.0)
+    monkeypatch.setattr(settings, "ARTIFACTS_BASE_DIR", str(tmp_path))
+    assert step_svc.scale_geom_step("x/y.stp", 1.0, "x") == "x/y.stp"

--- a/app/tests/test_openvsp_import_slicer_scaling.py
+++ b/app/tests/test_openvsp_import_slicer_scaling.py
@@ -16,11 +16,13 @@ from __future__ import annotations
 
 import sys
 import types
+from collections import OrderedDict
 from unittest.mock import MagicMock
 
 import pytest
 
 from app.schemas.aeroplaneschema import (
+    AeroplaneSchema,
     FuselageSchema,
     FuselageXSecSuperEllipseSchema,
 )
@@ -117,9 +119,13 @@ def test_scale_aeroplane_lengths_leaves_fuselages_untouched():
 # --------------------------------------------------------------------------- #
 
 
-@pytest.mark.slow
 def test_scale_geom_step_scales_bounding_box(monkeypatch, tmp_path):
-    """A stored STEP is rewritten at model scale; its bbox shrinks by factor."""
+    """A stored STEP is rewritten at model scale; its bbox shrinks by factor.
+
+    Uses real CadQuery (gated by ``importorskip`` — installed in the fast CI
+    tier, like the existing solid-sewing / step-export tests), so the
+    ``scale_geom_step`` body is exercised for coverage rather than mocked.
+    """
     cq = pytest.importorskip("cadquery")
     from cadquery import exporters
 
@@ -150,3 +156,115 @@ def test_scale_geom_step_factor_one_returns_same_path(tmp_path, monkeypatch):
 
     monkeypatch.setattr(settings, "ARTIFACTS_BASE_DIR", str(tmp_path))
     assert step_svc.scale_geom_step("x/y.stp", 1.0, "x") == "x/y.stp"
+
+
+def test_scale_geom_step_missing_file_returns_none(tmp_path, monkeypatch):
+    pytest.importorskip("cadquery")
+    from app.core.config import settings
+    from app.services import openvsp_step_export_service as step_svc
+
+    monkeypatch.setattr(settings, "ARTIFACTS_BASE_DIR", str(tmp_path))
+    assert step_svc.scale_geom_step("does/not/exist.stp", 0.5, "u") is None
+
+
+def test_scale_geom_step_invalid_step_returns_none(tmp_path, monkeypatch):
+    """A corrupt/unreadable STEP fails gracefully (best-effort): None, no raise."""
+    pytest.importorskip("cadquery")
+    from app.core.config import settings
+    from app.services import openvsp_step_export_service as step_svc
+
+    monkeypatch.setattr(settings, "ARTIFACTS_BASE_DIR", str(tmp_path))
+    (tmp_path / "bad.stp").write_text("this is not a STEP file")
+    assert step_svc.scale_geom_step("bad.stp", 0.5, "u") is None
+
+
+# --------------------------------------------------------------------------- #
+# _persist_aeroplane — fuselage scaling applied once, after refinement (gh-765)
+#
+# CAD-free: OpenVSP / CadQuery are mocked so these run in the `fast` CI job
+# (which excludes requires_cadquery/openvsp) and exercise the persist branches.
+# --------------------------------------------------------------------------- #
+
+
+def _import_result_with_fuselage(**geom_ids):
+    from app.converters.openvsp_importer import ImportResult
+
+    ap = AeroplaneSchema(name="F")
+    ap.fuselages = OrderedDict([("Body", _fuse())])
+    return ImportResult(aeroplane=ap, fuselage_geom_ids=dict(geom_ids))
+
+
+def _read_fuselage(db, uuid):
+    from app.models.aeroplanemodel import AeroplaneModel, FuselageModel
+
+    ap = db.query(AeroplaneModel).filter(AeroplaneModel.uuid == uuid).first()
+    return db.query(FuselageModel).filter(FuselageModel.aeroplane_id == ap.id).first()
+
+
+def test_persist_scales_fuselage_xsecs_when_vsp_unavailable(client_and_db, monkeypatch):
+    """vsp unavailable → no STEP path; the handler xsecs are scaled once."""
+    _client, SessionLocal = client_and_db
+    from app.converters import openvsp_adapter
+    from app.services import openvsp_import_service as svc
+
+    monkeypatch.setattr(openvsp_adapter, "is_available", lambda: False)
+
+    db = SessionLocal()
+    uuid, _name = svc._persist_aeroplane(
+        db, _import_result_with_fuselage(), scale_factor=0.5
+    )
+    db.commit()
+
+    f = _read_fuselage(db, uuid)
+    # _fuse() mid-section a=1.0 → scaled 0.5; length 10 m → 5 m.
+    assert max(s.a for s in f.x_secs) == pytest.approx(0.5)
+    xs = [s.xyz[0] for s in f.x_secs]
+    assert max(xs) - min(xs) == pytest.approx(5.0)
+    db.close()
+
+
+def test_persist_scales_refined_xsecs_and_step_with_vsp(client_and_db, monkeypatch):
+    """vsp present → STEP export/sew/slice (mocked); the refined xsecs and
+    the stored STEP files are both scaled by the import factor."""
+    _client, SessionLocal = client_and_db
+    from app.converters import openvsp_adapter
+    from app.services import openvsp_import_service as svc
+    from app.services import (
+        openvsp_solid_sewing_service as sew_svc,
+    )
+    from app.services import (
+        openvsp_step_export_service as step_svc,
+    )
+
+    monkeypatch.setattr(openvsp_adapter, "is_available", lambda: True)
+    monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: object())
+    monkeypatch.setattr(step_svc, "export_geom_step", lambda **kw: "imp/u/body.stp")
+    monkeypatch.setattr(
+        sew_svc, "sew_imported_geom_to_solid", lambda **kw: "imp/u/body_solid.stp"
+    )
+    scale_calls: list[tuple[str, float]] = []
+    monkeypatch.setattr(
+        step_svc,
+        "scale_geom_step",
+        lambda rel, factor, uuid: (scale_calls.append((rel, factor)) or rel),
+    )
+    # Slicer returns an UNSCALED refined list (mid a=2.0); persist scales it.
+    refined = [
+        FuselageXSecSuperEllipseSchema(xyz=[0.0, 0.0, 0.0], a=0.0, b=0.0, n=2.0),
+        FuselageXSecSuperEllipseSchema(xyz=[10.0, 0.0, 0.0], a=2.0, b=1.0, n=2.0),
+    ]
+    monkeypatch.setattr(svc, "_try_slicer_refinement", lambda *a, **k: refined)
+
+    db = SessionLocal()
+    uuid, _name = svc._persist_aeroplane(
+        db, _import_result_with_fuselage(GID1="Body"), scale_factor=0.5
+    )
+    db.commit()
+
+    f = _read_fuselage(db, uuid)
+    # refined mid a=2.0 → scaled 1.0 (proves slicer output, not handler, won).
+    assert max(s.a for s in f.x_secs) == pytest.approx(1.0)
+    # both stored STEP files were scaled by the same factor.
+    assert ("imp/u/body.stp", 0.5) in scale_calls
+    assert ("imp/u/body_solid.stp", 0.5) in scale_calls
+    db.close()


### PR DESCRIPTION
## Problem

Importing a `.vsp3` with a custom wing span produced a **giant, out-of-scale fuselage** (#765): wings scaled correctly but the fuselage stayed full-size. Root cause: the fuselage slicer-refinement (gh-732) ran in the **service after scaling** and re-derived xsecs from a STEP exported from the **unscaled** OpenVSP model, overwriting the scaled schema. Separately (#769), the stored STEP download files were never scaled, so the precise geometry didn't match the scaled aeroplane.

## Approach (clean architecture, agreed in design)

Keep the STEP slicer (it slices the precise STEP → a *consistent* low-fi xsec model for drag/layout), but run the whole CAD chain in **one frame** and scale **once**:

- **STEP export + sewing + slicer refinement run in the UNSCALED OpenVSP frame** — `_try_slicer_refinement` is frame-pure again (the gh-766 `factor` unscale/rescale juggling is removed).
- **`_scale_aeroplane_lengths` no longer scales fuselages** (wings/CG/weights only).
- **`_persist_aeroplane`** refines on the unscaled STEP, then applies the import scale exactly once via the new **`_scale_fuselage_xsecs`** — to the slicer output *or* the handler fallback, so every branch ends scaled.
- **#769:** the stored Surface + Solid **STEP files are scaled to model scale** via CadQuery (`scale_geom_step`, OCC `gp_Trsf.SetScale` about origin), **after** slicing. Scaling the actual solid avoids the foot/metre unit-declaration footgun from gh-732. `factor == 1.0` is a no-op everywhere.

Why not resurrect CompPnt01 surface sampling (the "do what the wing does" idea): it was already tried and reverted (gh-721/723/725) — world-frame bounding box conflates rotation with shape (Cessna sub-fuselages, area_ratio 0.232 vs the slicer's 0.927). The slicer is the proven redesign, and slicing the kept STEP guarantees the xsecs are a faithful low-fi version of the exact downloaded geometry.

## Verification

- New/updated unit tests (slicer mocked → CI-safe): frame-pure slicer (no `factor`), `_scale_fuselage_xsecs`, `_scale_aeroplane_lengths` leaves fuselages untouched, and `scale_geom_step` bbox (real CadQuery, `@slow`).
- 520 openvsp/fuselage/slicer tests pass; ruff clean.
- **E2E on `spitfire.vsp3` @ target span 1.5 m:** fuselage xsecs len **1.241 m** / height **0.203 m**, and the stored STEP bbox **1.245 m** — both at model scale and mutually consistent (was ~9 m before).

Closes #765
Closes #769

🤖 Generated with [Claude Code](https://claude.com/claude-code)