### PR TITLE
fix(gh-767): derive Soll polygon from user's MissionObjective targets

### DIFF
--- a/app/services/mission_kpi_service.py
+++ b/app/services/mission_kpi_service.py
@@ -35,6 +35,7 @@ from app.schemas.mission_kpi import (
     MissionKpiSet,
     MissionTargetPolygon,
 )
+from app.schemas.mission_objective import MissionObjective
 
 # Module-level import so the symbol exists for both runtime calls and
 # `unittest.mock.patch("app.services.mission_kpi_service.compute_field_lengths_for_aeroplane", ...)`.
@@ -351,6 +352,40 @@ def _kpi_field_friendliness(
     )
 
 
+# ----- Soll polygon from user targets (gh-767) ------------------------------
+
+
+def _objective_target_scores(
+    objective: MissionObjective,
+    axis_ranges: dict[AxisName, tuple[float, float]],
+) -> dict[AxisName, float]:
+    """Soll-polygon scores derived from the user's editable mission targets.
+
+    gh-767: each score is normalised with the *same* ``_normalise_score`` and
+    ``axis_ranges`` the matching Ist axis uses, so the white Soll line and the
+    orange Ist polygon stay directly comparable on the radar.
+
+    ``field_friendliness`` is special: its Ist axis is
+    ``target_field_length_m / effective`` (an achievement ratio), not a
+    range-normalised physical value. Meeting the user's declared target field
+    length is therefore full score by construction (``1.0``) — the Ist polygon
+    shows how close the aircraft actually gets.
+    """
+    return {
+        "stall_safety": _normalise_score(
+            objective.target_stall_safety, *axis_ranges["stall_safety"]
+        ),
+        "glide": _normalise_score(objective.target_glide_ld, *axis_ranges["glide"]),
+        "climb": _normalise_score(objective.target_climb_energy, *axis_ranges["climb"]),
+        "cruise": _normalise_score(objective.target_cruise_mps, *axis_ranges["cruise"]),
+        "maneuver": _normalise_score(objective.target_maneuver_n, *axis_ranges["maneuver"]),
+        "wing_loading": _normalise_score(
+            objective.target_wing_loading_n_m2, *axis_ranges["wing_loading"]
+        ),
+        "field_friendliness": 1.0,
+    }
+
+
 # ----- Aggregator -----------------------------------------------------------
 
 
@@ -432,17 +467,25 @@ def compute_mission_kpis(
         ),
     }
 
-    # Build target polygons (Soll for each active mission preset)
+    # Build target polygons (Soll for each active mission preset). gh-767:
+    # the polygon for the user's own mission (objective.mission_type) is
+    # derived from their editable MissionObjective targets so the white Soll
+    # line tracks live edits; comparison overlays keep their static preset
+    # polygon (no per-aeroplane targets exist for them).
     targets: list[MissionTargetPolygon] = []
     for mid in active_mission_ids:
         preset = presets.get(mid)
         if preset is None:
             continue
+        if mid == objective.mission_type:
+            scores = _objective_target_scores(objective, preset.axis_ranges)
+        else:
+            scores = preset.target_polygon
         targets.append(
             MissionTargetPolygon(
                 mission_id=preset.id,
                 label=preset.label,
-                scores_0_1=preset.target_polygon,
+                scores_0_1=scores,
             )
         )
 

--- a/app/tests/test_mission_kpi_service.py
+++ b/app/tests/test_mission_kpi_service.py
@@ -583,6 +583,66 @@ def test_comparison_target_polygons_keep_preset_defaults(client_and_db):
     assert sailplane_soll.scores_0_1 == presets["sailplane"].target_polygon
 
 
+def test_objective_override_follows_mission_type_not_primary(client_and_db):
+    """gh-767: the objective targets land on objective.mission_type's polygon
+    even when a *different* mission is the primary/active one — they describe
+    the user's own mission, not whichever id happens to be first."""
+    from app.services.mission_objective_service import list_mission_presets
+
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db, total_mass_kg=2.0)
+        aircraft_id = aeroplane.id
+    _seed_context(SessionLocal, aircraft_id)
+    # User's stored mission is trainer; cruise 22 → trainer range (10,25) → 0.8.
+    _persist_objective(SessionLocal, aircraft_id, mission_type="trainer", target_cruise_mps=22.0)
+
+    with patch(
+        "app.services.mission_kpi_service._compute_field_length_score",
+        return_value=(45.0, 1.0, None),
+    ):
+        with SessionLocal() as db:
+            presets = {p.id: p for p in list_mission_presets(db)}
+            # sailplane is primary, trainer is only a comparison overlay.
+            kset = compute_mission_kpis(db, aircraft_id, ["sailplane", "trainer"])
+
+    trainer_soll = next(p for p in kset.target_polygons if p.mission_id == "trainer")
+    sailplane_soll = next(p for p in kset.target_polygons if p.mission_id == "sailplane")
+    # The objective mission (trainer) is objective-derived even though not primary…
+    assert trainer_soll.scores_0_1["cruise"] == pytest.approx(0.8)
+    # …and the primary-but-non-objective mission keeps its static preset polygon.
+    assert sailplane_soll.scores_0_1 == presets["sailplane"].target_polygon
+
+
+def test_objective_target_scores_clip_out_of_range(client_and_db):
+    """gh-767: targets outside the axis range clip to [0,1] exactly like the
+    matching Ist axis (guards against a future raw (v-lo)/(hi-lo) regression)."""
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db, total_mass_kg=2.0)
+        aircraft_id = aeroplane.id
+    _seed_context(SessionLocal, aircraft_id)
+    # trainer cruise range (10,25); stall_safety range (1.3,2.5).
+    _persist_objective(
+        SessionLocal,
+        aircraft_id,
+        mission_type="trainer",
+        target_cruise_mps=999.0,  # >> hi → clip to 1.0
+        target_stall_safety=1.0,  # < lo → clip to 0.0
+    )
+
+    with patch(
+        "app.services.mission_kpi_service._compute_field_length_score",
+        return_value=(45.0, 1.0, None),
+    ):
+        with SessionLocal() as db:
+            kset = compute_mission_kpis(db, aircraft_id, ["trainer"])
+
+    soll = next(p for p in kset.target_polygons if p.mission_id == "trainer")
+    assert soll.scores_0_1["cruise"] == 1.0
+    assert soll.scores_0_1["stall_safety"] == 0.0
+
+
 # ---------------------------------------------------------------------------
 # Warning propagation (#562 review fix — surface t_static_N / recompute hints
 # via MissionAxisKpi.warning now that FieldLengthsPanel is gone).

--- a/app/tests/test_mission_kpi_service.py
+++ b/app/tests/test_mission_kpi_service.py
@@ -492,6 +492,98 @@ def test_compute_mission_kpis_raises_when_presets_table_empty(client_and_db):
 
 
 # ---------------------------------------------------------------------------
+# gh-767: the active Soll polygon must reflect the user's editable
+# MissionObjective targets, not the static preset.target_polygon.
+# ---------------------------------------------------------------------------
+
+
+def _persist_objective(SessionLocal, aircraft_id: int, **overrides) -> None:
+    """Upsert a MissionObjective with sensible defaults + per-test overrides."""
+    from app.schemas.mission_objective import MissionObjective
+    from app.services.mission_objective_service import upsert_mission_objective
+
+    base = MissionObjective(
+        mission_type="trainer",
+        target_cruise_mps=18.0,
+        target_stall_safety=1.8,
+        target_maneuver_n=3.0,
+        target_glide_ld=12.0,
+        target_climb_energy=22.0,
+        target_wing_loading_n_m2=50.0,
+        target_field_length_m=50.0,
+        available_runway_m=80.0,
+        runway_type="grass",
+        t_static_N=20.0,
+        takeoff_mode="runway",
+    )
+    with SessionLocal() as db:
+        upsert_mission_objective(db, aircraft_id, base.model_copy(update=overrides))
+        db.commit()
+
+
+def test_active_target_polygon_reflects_objective_targets(client_and_db):
+    """gh-767: the active Soll polygon is normalised from the user's
+    MissionObjective targets, not copied from preset.target_polygon."""
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db, total_mass_kg=2.0)
+        aircraft_id = aeroplane.id
+    _seed_context(SessionLocal, aircraft_id)
+
+    # Trainer preset cruise target_polygon == 0.3 with axis range (10, 25).
+    # A 22 m/s target normalises to (22-10)/(25-10) = 0.8 — clearly distinct.
+    _persist_objective(
+        SessionLocal,
+        aircraft_id,
+        mission_type="trainer",
+        target_cruise_mps=22.0,
+        target_stall_safety=1.9,  # range (1.3, 2.5) -> 0.5
+        target_glide_ld=18.0,  # range (5, 18) -> 1.0
+    )
+
+    with patch(
+        "app.services.mission_kpi_service._compute_field_length_score",
+        return_value=(45.0, 1.0, None),
+    ):
+        with SessionLocal() as db:
+            kset = compute_mission_kpis(db, aircraft_id, ["trainer"])
+
+    soll = next(p for p in kset.target_polygons if p.mission_id == "trainer")
+    # cruise reflects the user's target (0.8), NOT the preset's hardcoded 0.3.
+    assert soll.scores_0_1["cruise"] == pytest.approx(0.8)
+    assert soll.scores_0_1["stall_safety"] == pytest.approx(0.5)
+    assert soll.scores_0_1["glide"] == pytest.approx(1.0)
+    # field_friendliness: Ist is target/effective, so meeting the declared
+    # target field length == full score.
+    assert soll.scores_0_1["field_friendliness"] == pytest.approx(1.0)
+
+
+def test_comparison_target_polygons_keep_preset_defaults(client_and_db):
+    """gh-767: only the active mission's Soll is objective-derived; comparison
+    overlays keep their static preset polygon (no per-aeroplane targets exist
+    for them)."""
+    from app.services.mission_objective_service import list_mission_presets
+
+    _, SessionLocal = client_and_db
+    with SessionLocal() as db:
+        aeroplane = make_aeroplane(db, total_mass_kg=2.0)
+        aircraft_id = aeroplane.id
+    _seed_context(SessionLocal, aircraft_id)
+    _persist_objective(SessionLocal, aircraft_id, mission_type="trainer")
+
+    with patch(
+        "app.services.mission_kpi_service._compute_field_length_score",
+        return_value=(45.0, 1.0, None),
+    ):
+        with SessionLocal() as db:
+            presets = {p.id: p for p in list_mission_presets(db)}
+            kset = compute_mission_kpis(db, aircraft_id, ["trainer", "sailplane"])
+
+    sailplane_soll = next(p for p in kset.target_polygons if p.mission_id == "sailplane")
+    assert sailplane_soll.scores_0_1 == presets["sailplane"].target_polygon
+
+
+# ---------------------------------------------------------------------------
 # Warning propagation (#562 review fix — surface t_static_N / recompute hints
 # via MissionAxisKpi.warning now that FieldLengthsPanel is gone).
 # ---------------------------------------------------------------------------

--- a/frontend/__tests__/MissionRadarChart.test.tsx
+++ b/frontend/__tests__/MissionRadarChart.test.tsx
@@ -466,6 +466,40 @@ describe("MissionRadarChart", () => {
     expect(sollRow.textContent ?? "").toMatch(/17\.50/);
   });
 
+  it("derives ghost polygon values from kpis.target_polygons too (gh-767)", () => {
+    // A backend target_polygons entry for the ghost (sailplane) mission must
+    // override its static preset value in the tooltip ghost row.
+    const fullScores = {
+      stall_safety: 0.5,
+      glide: 0.5,
+      climb: 0.5,
+      cruise: 0.9, // sailplane preset cruise range [10,25] → 10 + 0.9×15 = 23.50
+      maneuver: 0.5,
+      wing_loading: 0.5,
+      field_friendliness: 1.0,
+    };
+    const ksetWithGhostTarget: MissionKpiSet = {
+      ...kset,
+      ist_polygon: { ...kset.ist_polygon, cruise: cruiseKpi },
+      target_polygons: [
+        { mission_id: "trainer", label: "trainer", scores_0_1: { ...fullScores, cruise: 0.4 } },
+        { mission_id: "sailplane", label: "sailplane", scores_0_1: fullScores },
+      ],
+    };
+    const { getByTestId } = render(
+      <MissionRadarChart
+        kpis={ksetWithGhostTarget}
+        activeMissions={[preset("trainer"), preset("sailplane")]}
+        onAxisClick={() => undefined}
+      />,
+    );
+    fireEvent.mouseEnter(getByTestId("hover-wedge-cruise"));
+    const text = getByTestId("axis-tooltip-cruise").textContent ?? "";
+    // Ghost row reflects backend score 0.9 → 23.50, NOT the preset's 0.5 → 17.50.
+    expect(text).toMatch(/sailplane:\s*23\.50/);
+    expect(text).not.toMatch(/sailplane:\s*17\.50/);
+  });
+
   it("includes ghost mission values in tooltip (gh-601)", () => {
     const ghost = preset("sailplane");
     // Set a distinctive cruise score on the ghost so we can locate it.

--- a/frontend/__tests__/MissionRadarChart.test.tsx
+++ b/frontend/__tests__/MissionRadarChart.test.tsx
@@ -408,6 +408,64 @@ describe("MissionRadarChart", () => {
     }
   });
 
+  it("derives the Soll line from kpis.target_polygons, not the static preset (gh-767)", () => {
+    // Backend supplies an objective-derived Soll: cruise score 0.8.
+    // trainer preset cruise range [10,25] → 10 + 0.8×15 = 22.00.
+    // The static preset's cruise target_polygon is 0.5 → 17.50 (the stale value).
+    const ksetWithTargets: MissionKpiSet = {
+      ...kset,
+      ist_polygon: { ...kset.ist_polygon, cruise: cruiseKpi },
+      target_polygons: [
+        {
+          mission_id: "trainer",
+          label: "trainer",
+          scores_0_1: {
+            stall_safety: 0.5,
+            glide: 0.5,
+            climb: 0.5,
+            cruise: 0.8,
+            maneuver: 0.5,
+            wing_loading: 0.5,
+            field_friendliness: 1.0,
+          },
+        },
+      ],
+    };
+    const { getByTestId } = render(
+      <MissionRadarChart
+        kpis={ksetWithTargets}
+        activeMissions={[preset("trainer")]}
+        onAxisClick={() => undefined}
+      />,
+    );
+    fireEvent.mouseEnter(getByTestId("hover-wedge-cruise"));
+    const sollRow = getByTestId("axis-tooltip-cruise-soll");
+    const text = sollRow.textContent ?? "";
+    // Reflects the backend (user-target) score 0.8 → 22.00 …
+    expect(text).toMatch(/22\.00/);
+    // … and NOT the static preset value 0.5 → 17.50.
+    expect(text).not.toMatch(/17\.50/);
+  });
+
+  it("falls back to the preset polygon when the backend supplies no target score (gh-767)", () => {
+    // Empty target_polygons → keep using the static preset (legacy behaviour).
+    const ksetCruise = {
+      ...kset,
+      ist_polygon: { ...kset.ist_polygon, cruise: cruiseKpi },
+    };
+    const { getByTestId } = render(
+      <MissionRadarChart
+        kpis={ksetCruise}
+        activeMissions={[preset("trainer")]}
+        onAxisClick={() => undefined}
+      />,
+    );
+    fireEvent.mouseEnter(getByTestId("hover-wedge-cruise"));
+    const sollRow = getByTestId("axis-tooltip-cruise-soll");
+    // preset cruise 0.5 → 10 + 0.5×15 = 17.50.
+    expect(sollRow.textContent ?? "").toMatch(/17\.50/);
+  });
+
   it("includes ghost mission values in tooltip (gh-601)", () => {
     const ghost = preset("sailplane");
     // Set a distinctive cruise score on the ghost so we can locate it.

--- a/frontend/__tests__/missionScale.test.ts
+++ b/frontend/__tests__/missionScale.test.ts
@@ -217,3 +217,45 @@ describe("computeAxisRanges with Ist KPIs (gh-601 Part C)", () => {
     expect(ranges.field_friendliness[1]).toBeGreaterThanOrEqual(120);
   });
 });
+
+describe("resolveSollScore (gh-767)", () => {
+  const kset = (
+    targets: MissionKpiSet["target_polygons"],
+  ): MissionKpiSet => ({
+    aeroplane_uuid: "x",
+    ist_polygon: {} as MissionKpiSet["ist_polygon"],
+    target_polygons: targets,
+    active_mission_id: "trainer",
+    computed_at: "",
+    context_hash: "0".repeat(64),
+  });
+
+  it("prefers the backend target_polygons score over the preset", async () => {
+    const { resolveSollScore } = await import("@/lib/missionScale");
+    const kpis = kset([
+      {
+        mission_id: "trainer",
+        label: "Trainer",
+        scores_0_1: { cruise: 0.8 },
+      },
+    ]);
+    // preset trainer cruise score is 0.3 — backend 0.8 must win.
+    expect(resolveSollScore(kpis, trainer, "cruise")).toBe(0.8);
+  });
+
+  it("falls back to the preset score per-axis when the backend omits it", async () => {
+    const { resolveSollScore } = await import("@/lib/missionScale");
+    // Backend entry exists for trainer but carries only cruise — glide must
+    // fall back to the preset (0.4).
+    const kpis = kset([
+      { mission_id: "trainer", label: "Trainer", scores_0_1: { cruise: 0.8 } },
+    ]);
+    expect(resolveSollScore(kpis, trainer, "glide")).toBe(0.4);
+  });
+
+  it("falls back to the preset polygon when no backend entry matches", async () => {
+    const { resolveSollScore } = await import("@/lib/missionScale");
+    const kpis = kset([]);
+    expect(resolveSollScore(kpis, trainer, "cruise")).toBe(0.3);
+  });
+});

--- a/frontend/components/workbench/mission/MissionRadarChart.tsx
+++ b/frontend/components/workbench/mission/MissionRadarChart.tsx
@@ -10,6 +10,7 @@ import {
   normalizedToRaw,
   polarToCartesian,
   renormalise,
+  resolveSollScore,
 } from "@/lib/missionScale";
 
 interface Props {
@@ -115,16 +116,6 @@ export function MissionRadarChart({
   // the aircraft's KPI band (gh-601).
   const globalRanges = computeAxisRanges(activeMissions, kpis);
 
-  // gh-767: the Soll polygon scores come from the backend `target_polygons`
-  // (which the active mission derives from the user's editable MissionObjective
-  // targets), keyed by mission id. Fall back per-axis to the static preset
-  // polygon when the backend supplies no score for that mission/axis.
-  const targetScoresById = new Map(
-    kpis.target_polygons.map((tp) => [tp.mission_id, tp.scores_0_1]),
-  );
-  const sollScore = (m: MissionPreset, axis: AxisName): number =>
-    targetScoresById.get(m.id)?.[axis] ?? m.target_polygon[axis];
-
   const istPoints = AXES.map((axis, i) => {
     const k = kpis.ist_polygon[axis];
     const local: [number, number] = [k.range_min, k.range_max];
@@ -137,7 +128,7 @@ export function MissionRadarChart({
 
   const sollPoints = active
     ? AXES.map((axis, i) => {
-        const localScore = sollScore(active, axis);
+        const localScore = resolveSollScore(kpis, active, axis);
         const local = active.axis_ranges[axis];
         const global = renormalise(localScore, local, globalRanges[axis]);
         return polarToCartesian(i, global, R);
@@ -146,7 +137,7 @@ export function MissionRadarChart({
 
   const ghostPolygons = ghosts.map((g) =>
     AXES.map((axis, i) => {
-      const score = sollScore(g, axis);
+      const score = resolveSollScore(kpis, g, axis);
       const local = g.axis_ranges[axis];
       const global = renormalise(score, local, globalRanges[axis]);
       return polarToCartesian(i, global, R);
@@ -343,23 +334,15 @@ function AxisTooltip({ axis, kpis, active, ghosts }: AxisTooltipProps) {
       ? normalizedToRaw(k.score_0_1, [k.range_min, k.range_max])
       : null;
 
-  // gh-767: mirror the chart's Soll source — prefer the backend
-  // target_polygons score (objective-derived for the active mission), with a
-  // per-axis fallback to the static preset polygon.
-  const targetScoresById = new Map(
-    kpis.target_polygons.map((tp) => [tp.mission_id, tp.scores_0_1]),
-  );
-  const sollScore = (m: MissionPreset): number =>
-    targetScoresById.get(m.id)?.[axis] ?? m.target_polygon[axis];
-
+  // gh-767: mirror the chart's Soll source via the shared resolver.
   const sollValue = active
-    ? normalizedToRaw(sollScore(active), active.axis_ranges[axis])
+    ? normalizedToRaw(resolveSollScore(kpis, active, axis), active.axis_ranges[axis])
     : null;
 
   const ghostValues = ghosts.map((g, idx) => ({
     label: g.label,
     color: GHOST_COLORS[idx % GHOST_COLORS.length],
-    value: normalizedToRaw(sollScore(g), g.axis_ranges[axis]),
+    value: normalizedToRaw(resolveSollScore(kpis, g, axis), g.axis_ranges[axis]),
   }));
 
   // Position the tooltip box. Width/height are estimates; we offset so the

--- a/frontend/components/workbench/mission/MissionRadarChart.tsx
+++ b/frontend/components/workbench/mission/MissionRadarChart.tsx
@@ -115,6 +115,16 @@ export function MissionRadarChart({
   // the aircraft's KPI band (gh-601).
   const globalRanges = computeAxisRanges(activeMissions, kpis);
 
+  // gh-767: the Soll polygon scores come from the backend `target_polygons`
+  // (which the active mission derives from the user's editable MissionObjective
+  // targets), keyed by mission id. Fall back per-axis to the static preset
+  // polygon when the backend supplies no score for that mission/axis.
+  const targetScoresById = new Map(
+    kpis.target_polygons.map((tp) => [tp.mission_id, tp.scores_0_1]),
+  );
+  const sollScore = (m: MissionPreset, axis: AxisName): number =>
+    targetScoresById.get(m.id)?.[axis] ?? m.target_polygon[axis];
+
   const istPoints = AXES.map((axis, i) => {
     const k = kpis.ist_polygon[axis];
     const local: [number, number] = [k.range_min, k.range_max];
@@ -127,7 +137,7 @@ export function MissionRadarChart({
 
   const sollPoints = active
     ? AXES.map((axis, i) => {
-        const localScore = active.target_polygon[axis];
+        const localScore = sollScore(active, axis);
         const local = active.axis_ranges[axis];
         const global = renormalise(localScore, local, globalRanges[axis]);
         return polarToCartesian(i, global, R);
@@ -136,7 +146,7 @@ export function MissionRadarChart({
 
   const ghostPolygons = ghosts.map((g) =>
     AXES.map((axis, i) => {
-      const score = g.target_polygon[axis];
+      const score = sollScore(g, axis);
       const local = g.axis_ranges[axis];
       const global = renormalise(score, local, globalRanges[axis]);
       return polarToCartesian(i, global, R);
@@ -333,14 +343,23 @@ function AxisTooltip({ axis, kpis, active, ghosts }: AxisTooltipProps) {
       ? normalizedToRaw(k.score_0_1, [k.range_min, k.range_max])
       : null;
 
+  // gh-767: mirror the chart's Soll source — prefer the backend
+  // target_polygons score (objective-derived for the active mission), with a
+  // per-axis fallback to the static preset polygon.
+  const targetScoresById = new Map(
+    kpis.target_polygons.map((tp) => [tp.mission_id, tp.scores_0_1]),
+  );
+  const sollScore = (m: MissionPreset): number =>
+    targetScoresById.get(m.id)?.[axis] ?? m.target_polygon[axis];
+
   const sollValue = active
-    ? normalizedToRaw(active.target_polygon[axis], active.axis_ranges[axis])
+    ? normalizedToRaw(sollScore(active), active.axis_ranges[axis])
     : null;
 
   const ghostValues = ghosts.map((g, idx) => ({
     label: g.label,
     color: GHOST_COLORS[idx % GHOST_COLORS.length],
-    value: normalizedToRaw(g.target_polygon[axis], g.axis_ranges[axis]),
+    value: normalizedToRaw(sollScore(g), g.axis_ranges[axis]),
   }));
 
   // Position the tooltip box. Width/height are estimates; we offset so the

--- a/frontend/lib/missionScale.ts
+++ b/frontend/lib/missionScale.ts
@@ -96,6 +96,23 @@ export function normalizedToRaw(score: number, range: AxisRange): number {
   return range[0] + clamped * (range[1] - range[0]);
 }
 
+/**
+ * Resolve the Soll-polygon score for one mission/axis (gh-767).
+ *
+ * Prefers the backend `target_polygons` score (which the active mission derives
+ * from the user's editable MissionObjective targets), keyed by mission id, with
+ * a per-axis fallback to the static `preset.target_polygon` when the backend
+ * supplies no score for that mission/axis.
+ */
+export function resolveSollScore(
+  kpis: MissionKpiSet,
+  preset: MissionPreset,
+  axis: AxisName,
+): number {
+  const tp = kpis.target_polygons.find((t) => t.mission_id === preset.id);
+  return tp?.scores_0_1[axis] ?? preset.target_polygon[axis];
+}
+
 /** Display unit for each axis — used by the radar hover tooltip. */
 export const AXIS_UNITS: Record<AxisName, string> = {
   stall_safety: "×",


### PR DESCRIPTION
## What & Why

Editing the numeric **Mission Objectives** targets did not move the white dashed **Soll** line in the Mission-Compliance spider chart — it stayed locked to the static `MissionPreset` polygon. Since the user is no longer on the default values, the Soll line should reflect *their* targets.

Fixes the disconnect at both layers:

- **Backend** (`mission_kpi_service.py`): the `MissionTargetPolygon` for the user's own mission (`objective.mission_type`) is now derived from the persisted `MissionObjective.target_*` values, normalised with the **same** `_normalise_score` + `axis_ranges` the matching **Ist** axis uses (so Ist and Soll stay directly comparable). Comparison overlays keep their static preset polygon.
- **Frontend** (`MissionRadarChart.tsx`): the Soll line, ghost polygons, and axis tooltips now consume `kpis.target_polygons` (keyed by `mission_id`), with a per-axis fallback to `preset.target_polygon` when the backend supplies no score.

### `field_friendliness` note

This axis maps to a full score (**1.0**) by construction. Its Ist axis is `target_field_length_m / effective_field_length` (an achievement ratio), not a range-normalised physical value — so "meet your declared target field length" is full score, and the orange Ist polygon shows how close the aircraft actually gets.

## Tests

- **Backend** (`test_mission_kpi_service.py`): `test_active_target_polygon_reflects_objective_targets` (cruise 22 m/s → score 0.8, not preset 0.3; field_friendliness 1.0) + `test_comparison_target_polygons_keep_preset_defaults`. Full file: 37 passed.
- **Frontend** (`MissionRadarChart.test.tsx`): `derives the Soll line from kpis.target_polygons` + per-axis preset fallback. Full file: 22 passed.
- Wider mission suites: backend 76 passed, frontend 47 passed. `ruff` + `eslint` clean.

## Root cause & detail

See #767.

Closes #767

🤖 Generated with [Claude Code](https://claude.com/claude-code)
