### PR TITLE
fix(gh-770): revalidate mission-kpis after objective update (live radar)

### DIFF
--- a/frontend/__tests__/missionHooks.test.tsx
+++ b/frontend/__tests__/missionHooks.test.tsx
@@ -200,6 +200,76 @@ describe("useMissionObjectives", () => {
     expect(String(putUrl)).toContain("/aeroplanes/aero-2/mission-objectives");
     expect(putInit).toMatchObject({ method: "PUT" });
   });
+
+  it("revalidates the mission-kpis cache after update() so the radar updates live (gh-770)", async () => {
+    const objective = {
+      mission_type: "trainer",
+      target_cruise_mps: 20,
+      target_stall_safety: 1.3,
+      target_maneuver_n: 4,
+      target_glide_ld: 10,
+      target_climb_energy: 5,
+      target_wing_loading_n_m2: 200,
+      target_field_length_m: 50,
+      available_runway_m: 100,
+      runway_type: "grass" as const,
+      t_static_N: 30,
+      takeoff_mode: "runway" as const,
+    };
+    const updated = { ...objective, target_cruise_mps: 25 };
+    const kpis = {
+      aeroplane_uuid: "aero-3",
+      ist_polygon: {},
+      target_polygons: [],
+      active_mission_id: "trainer",
+      computed_at: "now",
+      context_hash: "x",
+    };
+
+    let kpiGetCount = 0;
+    vi.spyOn(global, "fetch").mockImplementation((input, init) => {
+      const url = String(input);
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url.includes("/mission-kpis")) {
+        kpiGetCount += 1;
+        return Promise.resolve(
+          new Response(JSON.stringify(kpis), { status: 200 }),
+        );
+      }
+      if (url.includes("/mission-objectives")) {
+        const body = method === "PUT" ? updated : objective;
+        return Promise.resolve(
+          new Response(JSON.stringify(body), { status: 200 }),
+        );
+      }
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    });
+
+    // Render both hooks in the SAME SWR cache so a global revalidation from
+    // the objectives hook is visible to the kpis cache entry.
+    const { result } = renderHook(
+      () => ({
+        kpis: useMissionKpis("aero-3", ["trainer"]),
+        obj: useMissionObjectives("aero-3"),
+      }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.obj.data).toEqual(objective));
+    await waitFor(() => expect(result.current.kpis.data).toBeTruthy());
+
+    const kpiGetsBeforeUpdate = kpiGetCount;
+
+    await act(async () => {
+      await result.current.obj.update(updated);
+    });
+
+    // The PUT must trigger a fresh mission-kpis fetch (live radar refresh),
+    // not leave the stale payload until a page reload.
+    await waitFor(() =>
+      expect(kpiGetCount).toBeGreaterThan(kpiGetsBeforeUpdate),
+    );
+  });
 });
 
 describe("useMissionPresets", () => {

--- a/frontend/hooks/useMissionObjectives.ts
+++ b/frontend/hooks/useMissionObjectives.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import useSWR from "swr";
+import useSWR, { useSWRConfig } from "swr";
 import { fetcher, putJson } from "@/lib/fetcher";
 
 // gh-477: backend ``LandingSurface`` literal — keep in lock-step with
@@ -35,6 +35,7 @@ export interface MissionObjective {
 }
 
 export function useMissionObjectives(aeroplaneId: string | null) {
+  const { mutate: globalMutate } = useSWRConfig();
   const path = aeroplaneId
     ? `/aeroplanes/${encodeURIComponent(aeroplaneId)}/mission-objectives`
     : null;
@@ -49,6 +50,15 @@ export function useMissionObjectives(aeroplaneId: string | null) {
     if (!aeroplaneId || !path) return null;
     const updated = await putJson<MissionObjective>(path, payload);
     await mutate(updated, { revalidate: false });
+    // gh-770: the spider chart's Soll polygon (and Ist) is computed server-side
+    // in /mission-kpis from the persisted objective (since gh-767). Revalidate
+    // every mission-kpis cache entry for this aeroplane so the radar refreshes
+    // live instead of only after a page reload. Prefix match because the key
+    // carries a `?missions=…` query that varies with the active/comparison set.
+    const kpiPrefix = `/aeroplanes/${encodeURIComponent(aeroplaneId)}/mission-kpis`;
+    await globalMutate(
+      (key) => typeof key === "string" && key.startsWith(kpiPrefix),
+    );
     return updated;
   };
 

--- a/frontend/hooks/useMissionObjectives.ts
+++ b/frontend/hooks/useMissionObjectives.ts
@@ -55,10 +55,19 @@ export function useMissionObjectives(aeroplaneId: string | null) {
     // every mission-kpis cache entry for this aeroplane so the radar refreshes
     // live instead of only after a page reload. Prefix match because the key
     // carries a `?missions=…` query that varies with the active/comparison set.
+    //
+    // The PUT already succeeded and the objectives cache is updated above, so a
+    // failed radar refresh must not reject update() (callers fire-and-forget
+    // via `void update(...)` — an unhandled rejection would surface). Log it
+    // instead of swallowing it silently.
     const kpiPrefix = `/aeroplanes/${encodeURIComponent(aeroplaneId)}/mission-kpis`;
-    await globalMutate(
-      (key) => typeof key === "string" && key.startsWith(kpiPrefix),
-    );
+    try {
+      await globalMutate(
+        (key) => typeof key === "string" && key.startsWith(kpiPrefix),
+      );
+    } catch (err) {
+      console.warn("mission-kpis revalidation after objective update failed", err);
+    }
     return updated;
   };
 


### PR DESCRIPTION
## What & Why

Editing a value in the **Mission Objectives** panel only updated the **Spiderweb / Mission-Compliance radar** after a full page reload.

Since #767, the radar's Soll polygon (and Ist) is computed server-side in `/mission-kpis` from the persisted `MissionObjective`, and `MissionRadarChart` renders it from that payload. But `useMissionObjectives.update()` only refreshed the `mission-objectives` SWR cache (`mutate(updated, { revalidate: false })`) and never invalidated the `mission-kpis` cache — so the radar kept serving the stale KPI payload until a reload.

## Fix

After the PUT, revalidate every `mission-kpis` cache entry for the aeroplane via the global SWR mutate with a key-prefix matcher:

```ts
const kpiPrefix = `/aeroplanes/${encodeURIComponent(aeroplaneId)}/mission-kpis`;
await globalMutate((key) => typeof key === "string" && key.startsWith(kpiPrefix));
```

Prefix match because the key carries a `?missions=…` query that varies with the active/comparison selection. The 300 ms debounce in the panel coalesces rapid edits; the KPI endpoint is closed-form (no AeroBuildup rerun).

## Tests

- `missionHooks.test.tsx`: new `revalidates the mission-kpis cache after update() so the radar updates live (gh-770)` — renders `useMissionKpis` + `useMissionObjectives` in one SWR cache, asserts a fresh `mission-kpis` fetch fires after `update()`. RED before the fix, green after.
- Broader mission frontend suite: 63 passed. `eslint` clean.

Closes #770 · follow-up to #767

🤖 Generated with [Claude Code](https://claude.com/claude-code)
