### PR TITLE
feat(gh-783): Geschwindigkeitspolare (speed polar) in Analysis-Polar with multi-mass comparison

### DIFF
--- a/alembic/versions/c3a5992b6f25_gh_772_ted_mix_gains_differential.py
+++ b/alembic/versions/c3a5992b6f25_gh_772_ted_mix_gains_differential.py
@@ -1,0 +1,36 @@
+"""gh-772 add mix gains + differential_ratio to trailing edge devices
+
+Revision ID: c3a5992b6f25
+Revises: 3b58409a0f04
+Create Date: 2026-05-30
+
+Additive, nullable-with-default columns for mixed control-surface support
+(elevon/flaperon/ruddervator mix gains + aileron differential ratio).
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "c3a5992b6f25"
+down_revision = "3b58409a0f04"
+branch_labels = None
+depends_on = None
+
+_TABLE = "wing_xsec_trailing_edge_devices"
+_COLUMNS = ("mix_gain_primary", "mix_gain_secondary", "differential_ratio")
+
+
+def upgrade() -> None:
+    with op.batch_alter_table(_TABLE) as batch_op:
+        for col in _COLUMNS:
+            batch_op.add_column(
+                sa.Column(col, sa.Float(), nullable=False, server_default="1.0")
+            )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table(_TABLE) as batch_op:
+        for col in _COLUMNS:
+            batch_op.drop_column(col)

--- a/app/converters/model_schema_converters.py
+++ b/app/converters/model_schema_converters.py
@@ -303,10 +303,51 @@ def _control_surface_for_xsec(
     return x_sec.control_surface
 
 
-def _asb_wing_xsecs_from_schema(wing: schemas.AsbWingSchema) -> List[asb.WingXSec]:
+def axes_for_xsec(
+    x_sec: schemas.WingXSecSchema,
+    wing_key: str,
+    xsec_index: int,
+) -> list:
+    """gh-772: decompose an xsec's control surface into its AVL control axes.
+
+    Dual-role surfaces (elevon/flaperon/ruddervator) yield TWO axes; single-axis
+    surfaces yield one with their existing name/sign preserved. Shared by the ASB
+    airplane builder and the AVL geometry builder so both agree on names/order.
+    """
+    from app.services.control_surface_mixing import (
+        control_axes_for_surface,
+        parse_role_tag,
+    )
+
+    cs = _control_surface_for_xsec(x_sec)
+    if cs is None:
+        return []
+    ted = x_sec.trailing_edge_device
+    if ted is not None and getattr(ted, "role", None) is not None:
+        role = ted.role.value if hasattr(ted.role, "value") else ted.role
+    else:
+        role = parse_role_tag(cs.name)[0]
+    gp = float(getattr(ted, "mix_gain_primary", 1.0) or 1.0) if ted is not None else 1.0
+    gs = float(getattr(ted, "mix_gain_secondary", 1.0) or 1.0) if ted is not None else 1.0
+    return control_axes_for_surface(
+        role=role,
+        tagged_name=cs.name,
+        symmetric=cs.symmetric,
+        hinge_point=cs.hinge_point,
+        deflection=cs.deflection,
+        mix_gain_primary=gp,
+        mix_gain_secondary=gs,
+        wing_key=wing_key,
+        xsec_index=xsec_index,
+    )
+
+
+def _asb_wing_xsecs_from_schema(
+    wing: schemas.AsbWingSchema, wing_key: str = "w"
+) -> List[asb.WingXSec]:
     xsecs: List[asb.WingXSec] = []
-    for x_sec in wing.x_secs:
-        control_surface = _control_surface_for_xsec(x_sec)
+    for xsec_index, x_sec in enumerate(wing.x_secs):
+        axes = axes_for_xsec(x_sec, wing_key, xsec_index)
         xsecs.append(
             asb.WingXSec(
                 xyz_le=x_sec.xyz_le,
@@ -315,15 +356,14 @@ def _asb_wing_xsecs_from_schema(wing: schemas.AsbWingSchema) -> List[asb.WingXSe
                 airfoil=_build_asb_airfoil(x_sec.airfoil),
                 control_surfaces=[
                     asb.ControlSurface(
-                        name=control_surface.name,
-                        symmetric=control_surface.symmetric,
-                        deflection=control_surface.deflection,
-                        hinge_point=control_surface.hinge_point,
+                        name=axis.name,
+                        symmetric=axis.symmetric,
+                        deflection=axis.deflection,
+                        hinge_point=axis.hinge_point,
                         trailing_edge=True,
                     )
-                ]
-                if control_surface
-                else [],
+                    for axis in axes
+                ],
             )
         )
     return xsecs
@@ -584,7 +624,9 @@ def aeroplane_schema_to_asb_airplane_async(plane_schema: AeroplaneSchema) -> "as
             Wing(
                 name=wing_name,
                 symmetric=wing.symmetric,
-                xsecs=list(_asb_wing_xsecs_from_schema(wing)) if wing.x_secs else None,
+                xsecs=list(_asb_wing_xsecs_from_schema(wing, wing_key=wing_name))
+                if wing.x_secs
+                else None,
             )
             for wing_name, wing in plane_schema.wings.items()
         ]
@@ -606,8 +648,8 @@ def aeroplane_schema_to_airplane_configuration_async(
         )
 
     wing_configs: List[WingConfiguration] = []
-    for wing in (plane_schema.wings or {}).values():
-        xsecs = _asb_wing_xsecs_from_schema(wing)
+    for wing_key, wing in (plane_schema.wings or {}).items():
+        xsecs = _asb_wing_xsecs_from_schema(wing, wing_key=wing_key)
         wing_config = WingConfiguration.from_asb(xsecs=xsecs, symmetric=wing.symmetric)
         _hydrate_wing_configuration_details(wing_config, wing)
         wing_configs.append(wing_config)
@@ -683,7 +725,9 @@ def asb_wing_schema_to_wing_config(
     been transported via pickle.
     """
     geometry_scaled_schema = _scale_asb_wing_geometry_schema(asb_wing, scale=scale)
-    xsecs = _asb_wing_xsecs_from_schema(geometry_scaled_schema)
+    xsecs = _asb_wing_xsecs_from_schema(
+        geometry_scaled_schema, wing_key=getattr(asb_wing, "name", "w") or "w"
+    )
     wing_config = WingConfiguration.from_asb(xsecs, geometry_scaled_schema.symmetric)
     _hydrate_wing_configuration_details(wing_config, asb_wing)
     return wing_config

--- a/app/models/aeroplanemodel.py
+++ b/app/models/aeroplanemodel.py
@@ -132,6 +132,10 @@ class WingXSecTrailingEdgeDeviceModel(Base):
     trailing_edge_offset_factor = Column(Float, nullable=True)
     hinge_type = Column(String, nullable=True)
     symmetric = Column(Boolean, nullable=True)
+    # gh-772: mixed control-surface mix gains + differential (reporting-only) ratio.
+    mix_gain_primary = Column(Float, nullable=False, default=1.0, server_default="1.0")
+    mix_gain_secondary = Column(Float, nullable=False, default=1.0, server_default="1.0")
+    differential_ratio = Column(Float, nullable=False, default=1.0, server_default="1.0")
     servo_index = Column(Integer, nullable=True)
 
     detail = relationship("WingXSecDetailModel", back_populates="trailing_edge_device")

--- a/app/schemas/AeroplaneRequest.py
+++ b/app/schemas/AeroplaneRequest.py
@@ -77,6 +77,11 @@ class AlphaSweepRequest(BaseModel):
         [0.0, 0.0, 0.0], description="xyz reference points for moments and rotation rates"
     )
     altitude: Optional[float] = Field(0.0, description="altitude in m")
+    masses_kg: Optional[List[float]] = Field(
+        None,
+        description="Extra aircraft masses [kg] for speed-polar comparison curves. "
+        "The effective design mass is always included.",
+    )
 
 
 class SimpleSweepRequest(BaseModel):

--- a/app/schemas/aeroanalysisschema.py
+++ b/app/schemas/aeroanalysisschema.py
@@ -494,9 +494,7 @@ class MixerValues(BaseModel):
     up-going side. Aileron is included because it carries differential too.
     """
 
-    symmetric_offset: float = Field(
-        ..., description="Symmetric (pitch/lift) component, degrees"
-    )
+    symmetric_offset: float = Field(..., description="Symmetric (pitch/lift) component, degrees")
     differential_throw: float = Field(
         ..., ge=0.0, description="Antisymmetric (roll/yaw) command magnitude, degrees"
     )
@@ -565,3 +563,29 @@ class AnalysisStatusResponse(BaseModel):
 AVLTrimResult.model_rebuild()
 AeroBuildupTrimResult.model_rebuild()
 StoredOperatingPointCreate.model_rebuild()
+
+
+class SpeedPolarCurve(BaseModel):
+    """One glide speed polar (sink rate w over forward speed V) for a mass."""
+
+    mass_kg: float = Field(..., description="Aircraft mass for this curve [kg]")
+    is_base: bool = Field(..., description="True if this is the effective design (assumption) mass")
+    V: List[float] = Field(..., description="Forward speed [m/s], ascending")
+    w: List[float] = Field(..., description="Sink rate [m/s], positive downward")
+    cl: List[float] = Field(..., description="Lift coefficient at each point")
+    cd: List[float] = Field(..., description="Drag coefficient at each point")
+    v_stall: Optional[float] = Field(None, description="Stall speed at CL_max [m/s]")
+    v_min_sink: Optional[float] = Field(None, description="Speed for minimum sink rate [m/s]")
+    w_min: Optional[float] = Field(None, description="Minimum sink rate [m/s]")
+    v_best_glide: Optional[float] = Field(None, description="Speed for best glide / max L/D [m/s]")
+    ld_max: Optional[float] = Field(None, description="Maximum lift-to-drag ratio")
+
+
+class SpeedPolar(BaseModel):
+    """Speed polar bundle: one curve per mass, derived from a drag polar."""
+
+    base_mass_kg: float = Field(..., description="Effective design mass [kg]")
+    s_ref: float = Field(..., description="Wing reference area [m^2]")
+    rho: float = Field(..., description="Air density used [kg/m^3]")
+    altitude: float = Field(..., description="Altitude used [m]")
+    curves: List[SpeedPolarCurve] = Field(..., description="Speed polar curves, ascending by mass")

--- a/app/schemas/aeroanalysisschema.py
+++ b/app/schemas/aeroanalysisschema.py
@@ -486,18 +486,33 @@ class StabilityClassification(BaseModel):
 
 
 class MixerValues(BaseModel):
-    """Symmetric/differential decomposition for dual-role surfaces."""
+    """Symmetric/antisymmetric decomposition + left/right physical angles (gh-772).
+
+    A mixed surface trims to a symmetric (pitch/lift) and an antisymmetric
+    (roll/yaw) component. The left/right physical deflections are reconstructed
+    by superposition with the (reporting-only) differential ratio applied to the
+    up-going side. Aileron is included because it carries differential too.
+    """
 
     symmetric_offset: float = Field(
-        ..., description="Average deflection of paired surfaces (degrees)"
+        ..., description="Symmetric (pitch/lift) component, degrees"
     )
     differential_throw: float = Field(
-        ..., ge=0.0, description="Half-difference of paired surfaces (degrees)"
+        ..., ge=0.0, description="Antisymmetric (roll/yaw) command magnitude, degrees"
+    )
+    deflection_left: float = Field(
+        0.0, description="Reconstructed left-surface physical deflection (degrees)"
+    )
+    deflection_right: float = Field(
+        0.0, description="Reconstructed right-surface physical deflection (degrees)"
+    )
+    differential_ratio: float = Field(
+        1.0, description="Up/down throw ratio applied to the up-going side (reporting-only)"
     )
     role: str = Field(
         ...,
-        description="Dual-role type: elevon, flaperon, ruddervator",
-        pattern="^(elevon|flaperon|ruddervator)$",
+        description="Mixed-surface role",
+        pattern="^(aileron|elevon|flaperon|ruddervator)$",
     )
 
 

--- a/app/schemas/aeroplaneschema.py
+++ b/app/schemas/aeroplaneschema.py
@@ -38,6 +38,45 @@ class ControlSurfaceRole(str, Enum):
     OTHER = "other"
 
 
+# gh-772: roles that combine a symmetric and an antisymmetric axis on ONE physical
+# surface — they get a SECOND AVL CONTROL line (a secondary mix gain).
+DUAL_ROLE_VALUES = {"elevon", "flaperon", "ruddervator"}
+# Roles whose antisymmetric (roll/yaw) throw can be made differential. Aileron is
+# single-axis but still supports differential; the dual roles carry it on their
+# antisymmetric component.
+DIFFERENTIAL_ROLE_VALUES = {"aileron", "elevon", "flaperon", "ruddervator"}
+
+
+def _validate_mix_fields(role, mix_gain_secondary, differential_ratio) -> None:
+    """Cross-validate gh-772 mix fields against the control-surface role.
+
+    differential_ratio only makes sense where an antisymmetric axis exists;
+    mix_gain_secondary only where a *second* (dual-role) axis exists. Raises
+    ``ValueError`` so Pydantic surfaces a clean validation error.
+    """
+    role_value = role.value if hasattr(role, "value") else role
+    if role_value is None:
+        return  # cannot cross-validate without a role (e.g. partial patch)
+    if (
+        differential_ratio is not None
+        and differential_ratio != 1.0
+        and role_value not in DIFFERENTIAL_ROLE_VALUES
+    ):
+        raise ValueError(
+            f"differential_ratio != 1.0 is only valid for roles with an "
+            f"antisymmetric axis {sorted(DIFFERENTIAL_ROLE_VALUES)}, not '{role_value}'"
+        )
+    if (
+        mix_gain_secondary is not None
+        and mix_gain_secondary != 1.0
+        and role_value not in DUAL_ROLE_VALUES
+    ):
+        raise ValueError(
+            f"mix_gain_secondary != 1.0 is only valid for dual-role surfaces "
+            f"{sorted(DUAL_ROLE_VALUES)}, not '{role_value}'"
+        )
+
+
 class AeroplaneSchema(BaseModel):
     name: str = Field(..., description="Aeroplane name", examples=["Vanilla"])
     total_mass_kg: Optional[float] = Field(
@@ -276,11 +315,44 @@ class TrailingEdgeDeviceDetailSchema(BaseModel):
         None,
         description="Whether deflection is symmetric between left/right wing",
     )
+    mix_gain_primary: float = Field(
+        1.0,
+        gt=0.0,
+        le=5.0,
+        description=(
+            "gh-772: AVL gain on the PRIMARY (symmetric: pitch/lift) control axis "
+            "(deg deflection per unit control variable)."
+        ),
+    )
+    mix_gain_secondary: float = Field(
+        1.0,
+        gt=0.0,
+        le=5.0,
+        description=(
+            "gh-772: AVL gain on the SECONDARY (antisymmetric: roll/yaw) axis of a "
+            "dual-role surface (elevon/flaperon/ruddervator)."
+        ),
+    )
+    differential_ratio: float = Field(
+        1.0,
+        gt=0.3,
+        le=3.0,
+        description=(
+            "gh-772: up/down throw ratio of the antisymmetric axis, applied as a "
+            "post-trim kinematic for left/right display only. 1.0 = symmetric throw; "
+            "does NOT alter the aero/trim solution."
+        ),
+    )
 
     @model_validator(mode="after")
     def _compute_name_from_role(self):
         if self.name is None and (self.label is not None or self.role != ControlSurfaceRole.OTHER):
             self.name = self.label if self.label else self.role.value
+        return self
+
+    @model_validator(mode="after")
+    def _validate_mix_fields(self):
+        _validate_mix_fields(self.role, self.mix_gain_secondary, self.differential_ratio)
         return self
 
     model_config = ConfigDict(from_attributes=True)
@@ -327,6 +399,15 @@ class TrailingEdgeDevicePatchSchema(BaseModel):
         None,
         description="Whether deflection is symmetric between left/right wing",
     )
+    mix_gain_primary: Optional[float] = Field(
+        None, gt=0.0, le=5.0, description="gh-772: primary (symmetric) axis AVL gain"
+    )
+    mix_gain_secondary: Optional[float] = Field(
+        None, gt=0.0, le=5.0, description="gh-772: secondary (antisymmetric) axis AVL gain"
+    )
+    differential_ratio: Optional[float] = Field(
+        None, gt=0.3, le=3.0, description="gh-772: antisymmetric up/down throw ratio (reporting-only)"
+    )
 
     @model_validator(mode="after")
     def validate_non_empty_patch(self):
@@ -350,9 +431,18 @@ class TrailingEdgeDevicePatchSchema(BaseModel):
                 self.trailing_edge_offset_factor,
                 self.hinge_type,
                 self.symmetric,
+                self.mix_gain_primary,
+                self.mix_gain_secondary,
+                self.differential_ratio,
             ]
         ):
             raise ValueError("TrailingEdgeDevicePatchSchema requires at least one field.")
+        return self
+
+    @model_validator(mode="after")
+    def _validate_mix_fields(self):
+        # Only cross-validate when a role is present on the patch.
+        _validate_mix_fields(self.role, self.mix_gain_secondary, self.differential_ratio)
         return self
 
     model_config = ConfigDict(extra="forbid")

--- a/app/services/aerobuildup_trim_service.py
+++ b/app/services/aerobuildup_trim_service.py
@@ -275,6 +275,7 @@ async def trim_with_aerobuildup(
     try:
         from app.services.trim_enrichment_service import (
             build_deflection_limits_from_schema,
+            build_mix_params_from_schema,
             compute_enrichment,
             parse_role_tag,
         )
@@ -303,6 +304,7 @@ async def trim_with_aerobuildup(
             alpha_deg=alpha_deg,
             stability_derivatives=derivs or None,
             aero_coefficients=aero or None,
+            mix_params=build_mix_params_from_schema(plane_schema),
         )
         trim_enrichment_data = enrichment
     except Exception:

--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -427,6 +427,146 @@ async def calculate_streamlines_json(
         raise InternalError(message=f"Analysis error: {e}") from e
 
 
+def _compute_speed_polar(
+    cl,
+    cd,
+    masses_kg,
+    base_mass_kg,
+    s_ref_m2,
+    rho,
+    altitude: float = 0.0,
+    g: float = 9.81,
+):
+    """Derive glide speed polars (sink rate ``w`` over forward speed ``V``) from
+    a drag polar (CL/CD), for one or more masses.
+
+    Aerodynamic coefficients are mass independent; only the speed required to
+    fly a given CL scales with mass. For each point with ``CL > 0``::
+
+        V = sqrt(2 * m * g / (rho * S_ref * CL))
+        w = V * (CD / CL)
+
+    Curves for different masses therefore scale as ``V, w ∝ sqrt(m)``. The
+    effective design mass (``base_mass_kg``) is always included and flagged
+    ``is_base``. Pure function — no DB or aero calls — so it is unit testable.
+    """
+    from app.schemas.aeroanalysisschema import SpeedPolar, SpeedPolarCurve
+
+    cl_arr = np.atleast_1d(np.asarray(cl, dtype=float))
+    cd_arr = np.atleast_1d(np.asarray(cd, dtype=float))
+    n = min(len(cl_arr), len(cd_arr))
+    cl_arr, cd_arr = cl_arr[:n], cd_arr[:n]
+
+    # Deduplicated, ascending mass set that always includes the base mass.
+    tol = 1e-9
+    masses: list[float] = [float(base_mass_kg)]
+    for m in masses_kg or []:
+        mf = float(m)
+        if mf > 0 and all(abs(mf - existing) > tol for existing in masses):
+            masses.append(mf)
+    masses.sort()
+
+    # Only positive-CL points describe a steady glide.
+    pos = cl_arr > 0
+    cl_pos = cl_arr[pos]
+    cd_pos = cd_arr[pos]
+    cl_max = float(np.max(cl_arr)) if cl_arr.size else 0.0
+    valid_geometry = s_ref_m2 > 0 and rho > 0
+
+    curves: list[SpeedPolarCurve] = []
+    for m in masses:
+        is_base = abs(m - float(base_mass_kg)) <= tol
+        if not valid_geometry or cl_pos.size == 0 or m <= 0:
+            curves.append(
+                SpeedPolarCurve(
+                    mass_kg=m,
+                    is_base=is_base,
+                    V=[],
+                    w=[],
+                    cl=[],
+                    cd=[],
+                    v_stall=None,
+                    v_min_sink=None,
+                    w_min=None,
+                    v_best_glide=None,
+                    ld_max=None,
+                )
+            )
+            continue
+        weight_n = m * g
+        v = np.sqrt(2.0 * weight_n / (rho * s_ref_m2 * cl_pos))
+        w = v * (cd_pos / cl_pos)
+        # Co-sort all parallel arrays ascending by V (higher CL -> lower V).
+        order = np.argsort(v)
+        v, w = v[order], w[order]
+        cl_s, cd_s = cl_pos[order], cd_pos[order]
+
+        i_min_sink = int(np.argmin(w))
+        ld = cl_s / cd_s  # equals V / w
+        i_best = int(np.argmax(ld))
+        v_stall = float(np.sqrt(2.0 * weight_n / (rho * s_ref_m2 * cl_max))) if cl_max > 0 else None
+        curves.append(
+            SpeedPolarCurve(
+                mass_kg=m,
+                is_base=is_base,
+                V=v.tolist(),
+                w=w.tolist(),
+                cl=cl_s.tolist(),
+                cd=cd_s.tolist(),
+                v_stall=v_stall,
+                v_min_sink=float(v[i_min_sink]),
+                w_min=float(w[i_min_sink]),
+                v_best_glide=float(v[i_best]),
+                ld_max=float(ld[i_best]),
+            )
+        )
+
+    return SpeedPolar(
+        base_mass_kg=float(base_mass_kg),
+        s_ref=float(s_ref_m2),
+        rho=float(rho),
+        altitude=float(altitude),
+        curves=curves,
+    )
+
+
+def _build_speed_polar(db, aeroplane_uuid, sweep_request, asb_airplane, cl_values, cd_values):
+    """Glue around :func:`_compute_speed_polar`: resolve effective mass, wing
+    reference area and air density, then build the speed polar. Returns ``None``
+    if no polar data is available or anything goes wrong (best-effort add-on)."""
+    if cl_values is None or cd_values is None:
+        return None
+    try:
+        import aerosandbox as asb
+
+        from app.core.exceptions import NotFoundError
+        from app.services.mass_cg_service import get_effective_assumption_value
+
+        try:
+            base_mass = float(get_effective_assumption_value(db, aeroplane_uuid, "mass"))
+        except NotFoundError:
+            base_mass = 1.0
+            logger.warning(
+                "No 'mass' assumption for %s; speed polar defaults to 1.0 kg",
+                aeroplane_uuid,
+            )
+        s_ref = float(getattr(asb_airplane, "s_ref", 0.0) or 0.0)
+        altitude = float(getattr(sweep_request, "altitude", 0.0) or 0.0)
+        rho = float(asb.Atmosphere(altitude=altitude).density())
+        return _compute_speed_polar(
+            cl=cl_values,
+            cd=cd_values,
+            masses_kg=getattr(sweep_request, "masses_kg", None) or [],
+            base_mass_kg=base_mass,
+            s_ref_m2=s_ref,
+            rho=rho,
+            altitude=altitude,
+        )
+    except Exception as e:  # pragma: no cover - defensive add-on
+        logger.error("Speed polar computation failed: %s", e)
+        return None
+
+
 async def analyze_alpha_sweep(db: Session, aeroplane_uuid, sweep_request: AlphaSweepRequest) -> Any:
     """
     Perform an angle of attack sweep.
@@ -464,9 +604,13 @@ async def analyze_alpha_sweep(db: Session, aeroplane_uuid, sweep_request: AlphaS
         characteristic_points = _compute_alpha_sweep_characteristic_points(
             alpha_array, cl_values, cd_values, cm_values
         )
+        speed_polar = _build_speed_polar(
+            db, aeroplane_uuid, sweep_request, asb_airplane, cl_values, cd_values
+        )
         return {
             "analysis": result,
             "characteristic_points": characteristic_points,
+            "speed_polar": speed_polar,
             "aircraft_name": getattr(plane_schema, "name", str(aeroplane_uuid)),
         }
     except Exception as e:

--- a/app/services/avl_geometry_service.py
+++ b/app/services/avl_geometry_service.py
@@ -114,33 +114,34 @@ def _build_section(
     )
 
 
-def _build_controls_for_wing(wing: AsbWingSchema) -> list[list[AvlControl]]:
+def _build_controls_for_wing(
+    wing: AsbWingSchema, wing_key: str = "w"
+) -> list[list[AvlControl]]:
     """Build per-section control lists replicating ASB's CONTROL duplication.
 
-    For each xsec[i] with a control surface, the CONTROL command is added to
-    both section i and section i+1 so AVL interpolates the deflection across
-    the panel strip.
+    For each xsec[i] with a control surface, the CONTROL command(s) are added to
+    both section i and section i+1 so AVL interpolates the deflection across the
+    panel strip. A dual-role surface (gh-772: elevon/flaperon/ruddervator) emits
+    TWO CONTROL variables per section (primary symmetric + secondary
+    antisymmetric); single-axis surfaces emit one, unchanged.
     """
-    from app.converters.model_schema_converters import _control_surface_for_xsec
+    from app.converters.model_schema_converters import axes_for_xsec
 
     n = len(wing.x_secs)
     controls_per_section: list[list[AvlControl]] = [[] for _ in range(n)]
 
     for i, xsec in enumerate(wing.x_secs):
-        cs = _control_surface_for_xsec(xsec)
-        if cs is None:
-            continue
-
-        ctrl = AvlControl(
-            name=cs.name,
-            gain=1.0,
-            xhinge=cs.hinge_point,
-            xyz_hvec=(0.0, 0.0, 0.0),
-            sgn_dup=1.0 if cs.symmetric else -1.0,
-        )
-        controls_per_section[i].append(ctrl)
-        if i + 1 < n:
-            controls_per_section[i + 1].append(ctrl)
+        for axis in axes_for_xsec(xsec, wing_key, i):
+            ctrl = AvlControl(
+                name=axis.name,
+                gain=axis.gain,
+                xhinge=axis.hinge_point,
+                xyz_hvec=(0.0, 0.0, 0.0),
+                sgn_dup=axis.sgn_dup,
+            )
+            controls_per_section[i].append(ctrl)
+            if i + 1 < n:
+                controls_per_section[i + 1].append(ctrl)
 
     return controls_per_section
 
@@ -151,7 +152,7 @@ def _build_surface(
     spacing_config: SpacingConfig,
 ) -> AvlSurface:
     """Build an AvlSurface from a wing schema."""
-    controls_per_section = _build_controls_for_wing(wing)
+    controls_per_section = _build_controls_for_wing(wing, wing_key=wing_name)
 
     sections = [_build_section(xsec, controls_per_section[i]) for i, xsec in enumerate(wing.x_secs)]
 

--- a/app/services/avl_trim_service.py
+++ b/app/services/avl_trim_service.py
@@ -145,6 +145,7 @@ async def trim_with_avl(
         try:
             from app.services.trim_enrichment_service import (
                 build_deflection_limits_from_schema,
+                build_mix_params_from_schema,
                 compute_enrichment,
             )
 
@@ -160,6 +161,7 @@ async def trim_with_avl(
                 alpha_deg=alpha_deg,
                 stability_derivatives=trimmed.stability_derivatives or None,
                 aero_coefficients=trimmed.aero_coefficients or None,
+                mix_params=build_mix_params_from_schema(plane_schema),
             )
             trimmed = trimmed.model_copy(update={"trim_enrichment": enrichment})
         except Exception:

--- a/app/services/control_surface_mixing.py
+++ b/app/services/control_surface_mixing.py
@@ -1,0 +1,165 @@
+"""gh-772 — role → control-axis decomposition for mixed control surfaces.
+
+Single source of truth shared by the AVL geometry builder, the AeroSandbox
+airplane builder, and the trim-enrichment service so all three agree on the
+control-variable NAMES, their AVL ``SgnDup`` signs, gains, and which axis is
+symmetric (pitch/lift) vs antisymmetric (roll/yaw).
+
+Key decisions (validated by AVL / AeroSandbox / flight-dynamics critique, gh-772):
+
+* A **dual-role** surface (elevon, flaperon, ruddervator) emits TWO AVL CONTROL
+  variables on the same section — a primary (symmetric, ``SgnDup=+1``) and a
+  secondary (antisymmetric, ``SgnDup=-1``) — so the trimmer drives each axis
+  independently. avl_doc §CONTROL (multiple CONTROL lines per section are summed).
+* ``SgnDup`` is a SIGN flag, never a differential magnitude. Differential is a
+  reporting-only kinematic handled in enrichment, never in the geometry.
+* Control-variable names must be globally unique (AVL silently collapses
+  same-named CONTROL variables into one DOF, avl_doc 778-789).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+_ROLE_TAG_RE = re.compile(r"^\[(\w+)\](.*)$")
+
+# Roles that combine a symmetric + an antisymmetric axis on one physical surface.
+# Order matters: primary (symmetric) axis first, secondary (antisymmetric) second.
+_DUAL_ROLE_AXES: dict[str, tuple[str, str]] = {
+    "elevon": ("pitch", "roll"),
+    "flaperon": ("lift", "roll"),
+    "ruddervator": ("pitch", "yaw"),
+}
+
+# Axis-label classification for the enrichment L/R reconstruction.
+PRIMARY_AXES = {"pitch", "lift"}      # symmetric component
+SECONDARY_AXES = {"roll", "yaw"}      # antisymmetric component
+
+
+@dataclass(frozen=True)
+class ControlAxis:
+    """One AVL control variable contributing to a physical surface's deflection."""
+
+    name: str          # globally-unique AVL/ASB control-variable name
+    sgn_dup: float     # +1 symmetric, -1 antisymmetric (NEVER a differential magnitude)
+    gain: float        # AVL gain column (deg deflection per control variable)
+    symmetric: bool    # True → pitch/lift axis; False → roll/yaw axis
+    hinge_point: float
+    deflection: float  # baseline deflection for this axis (antisym dual axis → 0 in ASB)
+    role: str
+    axis: str          # "pitch" | "lift" | "roll" | "yaw" | "" (single-axis)
+
+
+def is_dual_role(role: str | None) -> bool:
+    return (role or "") in _DUAL_ROLE_AXES
+
+
+def parse_role_tag(name: str) -> tuple[str | None, str]:
+    """Parse a ``[role]display`` tag; returns ``(role, display)`` or ``(None, name)``."""
+    m = _ROLE_TAG_RE.match(name)
+    if m:
+        return m.group(1), m.group(2)
+    return None, name
+
+
+def _sanitize(token: str) -> str:
+    """Make a token safe as an AVL control name (no whitespace, no brackets)."""
+    return re.sub(r"[^0-9A-Za-z_.-]", "_", token.strip())
+
+
+def surface_suffix(wing_key: str, xsec_index: int) -> str:
+    """The per-surface uniqueness suffix shared by naming and enrichment grouping."""
+    return f"{_sanitize(wing_key)}_{xsec_index}"
+
+
+def axis_control_name(role: str, axis: str, wing_key: str, xsec_index: int) -> str:
+    """Build a globally-unique, role-tag-parseable, AVL-safe control-variable name.
+
+    e.g. ``[ruddervator]pitch_htail_1``. Keeps the ``[role]`` prefix so
+    ``parse_role_tag`` still recovers the role for enrichment, and the
+    ``{axis}_{suffix}`` body so enrichment can regroup the two axes of one
+    physical surface.
+    """
+    return f"[{role}]{_sanitize(axis)}_{surface_suffix(wing_key, xsec_index)}"
+
+
+def control_axes_for_surface(
+    *,
+    role: str | None,
+    tagged_name: str,
+    symmetric: bool,
+    hinge_point: float,
+    deflection: float,
+    mix_gain_primary: float = 1.0,
+    mix_gain_secondary: float = 1.0,
+    wing_key: str,
+    xsec_index: int,
+) -> list[ControlAxis]:
+    """Decompose one physical control surface into its AVL control axes.
+
+    Single-axis roles (elevator/flap/stabilator/rudder/aileron/other) keep their
+    existing tagged name and ``±1`` SgnDup unchanged — exactly one axis. Dual
+    roles return two axes (primary symmetric, secondary antisymmetric) with
+    unique names; the secondary axis carries ``deflection=0`` so the AeroBuildup
+    fallback never feeds a roll/yaw deflection into the single-axis ASB model.
+    """
+    role_value = (role or "").lower()
+
+    if role_value in _DUAL_ROLE_AXES:
+        primary_axis, secondary_axis = _DUAL_ROLE_AXES[role_value]
+        return [
+            ControlAxis(
+                name=axis_control_name(role_value, primary_axis, wing_key, xsec_index),
+                sgn_dup=1.0,
+                gain=mix_gain_primary,
+                symmetric=True,
+                hinge_point=hinge_point,
+                deflection=deflection,
+                role=role_value,
+                axis=primary_axis,
+            ),
+            ControlAxis(
+                name=axis_control_name(role_value, secondary_axis, wing_key, xsec_index),
+                sgn_dup=-1.0,
+                gain=mix_gain_secondary,
+                symmetric=False,
+                hinge_point=hinge_point,
+                deflection=0.0,  # antisymmetric axis: 0 baseline (AeroBuildup fallback)
+                role=role_value,
+                axis=secondary_axis,
+            ),
+        ]
+
+    # Single-axis surface: preserve the existing name + sign convention verbatim.
+    return [
+        ControlAxis(
+            name=tagged_name,
+            sgn_dup=1.0 if symmetric else -1.0,
+            gain=mix_gain_primary,
+            symmetric=symmetric,
+            hinge_point=hinge_point,
+            deflection=deflection,
+            role=role_value or None,  # type: ignore[arg-type]
+            axis="",
+        )
+    ]
+
+
+def assert_unique_control_names(names: list[str]) -> None:
+    """Raise if any control-variable name repeats across the aircraft.
+
+    AVL collapses same-named CONTROL variables into a single DOF; an accidental
+    collision silently couples unrelated surfaces (avl_doc 778-789).
+    """
+    seen: set[str] = set()
+    dupes: set[str] = set()
+    for n in names:
+        if n in seen:
+            dupes.add(n)
+        seen.add(n)
+    if dupes:
+        raise ValueError(
+            f"Duplicate control-variable names would collapse into one AVL DOF: "
+            f"{sorted(dupes)}"
+        )

--- a/app/services/trim_enrichment_service.py
+++ b/app/services/trim_enrichment_service.py
@@ -216,45 +216,109 @@ def compute_control_effectiveness(
     return effectiveness
 
 
+def build_mix_params_from_schema(
+    plane_schema: Any,
+) -> dict[str, tuple[float, float, float]]:
+    """Per-surface ``(mix_gain_primary, mix_gain_secondary, differential_ratio)``.
+
+    Keyed by ``"{role}:{surface_suffix}"`` so :func:`decompose_dual_role` can look
+    up the gains and differential ratio of the two control variables belonging to
+    one physical surface. Mirrors the naming in ``control_surface_mixing``.
+    """
+    from app.services.control_surface_mixing import surface_suffix
+
+    params: dict[str, tuple[float, float, float]] = {}
+    if not plane_schema or not getattr(plane_schema, "wings", None):
+        return params
+
+    wings = plane_schema.wings
+    wing_items = wings.items() if isinstance(wings, dict) else enumerate(wings or [])
+
+    for wing_key, wing in wing_items:
+        xsecs = getattr(wing, "x_secs", None) or getattr(wing, "xsecs", None) or []
+        xsec_list = list(xsecs.values()) if isinstance(xsecs, dict) else list(xsecs)
+        for xsec_index, xsec in enumerate(xsec_list):
+            ted = getattr(xsec, "trailing_edge_device", None)
+            if ted is None:
+                continue
+            role = getattr(ted, "role", None)
+            role_value = role.value if hasattr(role, "value") else role
+            if not role_value:
+                continue
+            gp = float(getattr(ted, "mix_gain_primary", 1.0) or 1.0)
+            gs = float(getattr(ted, "mix_gain_secondary", 1.0) or 1.0)
+            diff = float(getattr(ted, "differential_ratio", 1.0) or 1.0)
+            if role_value in DUAL_ROLES:
+                key = f"{role_value}:{surface_suffix(str(wing_key), xsec_index)}"
+                params[key] = (gp, gs, diff)
+            elif role_value == "aileron":
+                # Single-axis aileron keeps its tagged name; key by display so the
+                # decomposition (which groups aileron by its display) can find it.
+                display = getattr(ted, "name", None) or "aileron"
+                params[f"aileron:{display}"] = (1.0, 1.0, diff)
+    return params
+
+
 def decompose_dual_role(
     controls: dict[str, float],
+    mix_params: dict[str, tuple[float, float, float]] | None = None,
 ) -> dict[str, MixerValues]:
-    """Decompose dual-role surface deflections into symmetric and differential components.
+    """Reconstruct per-surface symmetric/antisymmetric + left/right deflections.
 
-    Looks for paired surfaces with the same dual-role tag
-    (e.g. two ``[elevon]`` surfaces).
-    Symmetric = average, Differential = half the difference.
+    gh-772: a mixed surface now contributes TWO control variables
+    (``[role]pitch_<suffix>`` + ``[role]roll_<suffix>``), or one for an aileron.
+    The symmetric (pitch/lift) and antisymmetric (roll/yaw) components are
+    superposed into physical left/right angles; the (reporting-only) differential
+    ratio scales the up-going side. ``mix_params`` carries per-surface gains +
+    ratio (defaults: gains 1.0, ratio 1.0).
     """
+    from app.services.control_surface_mixing import PRIMARY_AXES, SECONDARY_AXES
+
+    mix_params = mix_params or {}
     mixer_values: dict[str, MixerValues] = {}
 
-    # Group controls by role
-    role_groups: dict[str, list[tuple[str, float]]] = {}
+    # Group the control variables of one physical surface together.
+    groups: dict[tuple[str, str], dict[str, float]] = {}
     for surface_name, deflection in controls.items():
-        role, _display = parse_role_tag(surface_name)
-        if role and role in DUAL_ROLES:
-            role_groups.setdefault(role, []).append((surface_name, deflection))
+        role, display = parse_role_tag(surface_name)
+        if role is None:
+            continue
+        if role in DUAL_ROLES:
+            axis, _, suffix = display.partition("_")
+            groups.setdefault((role, suffix), {})[axis] = float(deflection)
+        elif role == "aileron":
+            groups.setdefault((role, display), {})["roll"] = float(deflection)
 
-    for role, surfaces in role_groups.items():
-        if len(surfaces) >= 2:
-            # Paired surfaces: compute symmetric and differential
-            defl_values = [d for _, d in surfaces]
-            symmetric = sum(defl_values) / len(defl_values)
-            # Differential = half-difference between first two surfaces
-            differential = abs(defl_values[0] - defl_values[1]) / 2.0
-            group_key = f"{role}_mixer"
-            mixer_values[group_key] = MixerValues(
-                symmetric_offset=round(symmetric, 3),
-                differential_throw=round(differential, 3),
-                role=role,
-            )
-        elif len(surfaces) == 1:
-            # Single dual-role surface: symmetric = deflection, differential = 0
-            name, deflection = surfaces[0]
-            mixer_values[name] = MixerValues(
-                symmetric_offset=round(deflection, 3),
-                differential_throw=0.0,
-                role=role,
-            )
+    for (role, suffix), axes in groups.items():
+        primary_val = 0.0
+        secondary_val = 0.0
+        for axis, value in axes.items():
+            if axis in PRIMARY_AXES:
+                primary_val = value
+            elif axis in SECONDARY_AXES:
+                secondary_val = value
+
+        gp, gs, diff = mix_params.get(f"{role}:{suffix}", (1.0, 1.0, 1.0))
+        d_sym = gp * primary_val
+        d_anti = gs * secondary_val
+
+        # Superpose; apply differential to whichever side is going up (negative TE).
+        right = d_anti
+        left = -d_anti
+        if right < 0:
+            right *= diff
+        if left < 0:
+            left *= diff
+
+        group_key = f"{role}_{suffix}_mixer" if suffix else f"{role}_mixer"
+        mixer_values[group_key] = MixerValues(
+            symmetric_offset=round(d_sym, 3),
+            differential_throw=round(abs(d_anti), 3),
+            deflection_left=round(d_sym + left, 3),
+            deflection_right=round(d_sym + right, 3),
+            differential_ratio=diff,
+            role=role,
+        )
 
     return mixer_values
 
@@ -320,6 +384,7 @@ def compute_enrichment(
     reserve_critical_threshold: float = 0.95,
     margin_low_threshold: float = 0.05,
     margin_high_threshold: float = 0.30,
+    mix_params: dict[str, tuple[float, float, float]] | None = None,
 ) -> TrimEnrichment:
     """Compute full enrichment from trim results.
 
@@ -449,7 +514,24 @@ def compute_enrichment(
         effectiveness = compute_control_effectiveness(stability_derivatives, controls)
 
     # --- Dual-role decomposition ---
-    mixer_values = decompose_dual_role(controls)
+    mixer_values = decompose_dual_role(controls, mix_params)
+
+    # gh-772: the AeroBuildup/NeuralFoil model is single-axis — it cannot trim the
+    # antisymmetric (roll/yaw) component of a mixed surface. Warn loudly so AVL and
+    # AeroBuildup results for mixed-surface aircraft are never silently compared.
+    if trim_method == "aerobuildup" and mixer_values:
+        warnings.append(
+            DesignWarning(
+                level="warning",
+                category="solver",
+                surface=None,
+                message=(
+                    "Lateral-directional (roll/yaw) control of mixed surfaces is "
+                    "modeled in AVL only — this AeroBuildup trim solved the "
+                    "symmetric (pitch/lift) axis only."
+                ),
+            )
+        )
 
     # --- Result summary ---
     result_summary = generate_result_summary(

--- a/app/tests/test_control_surface_mixing.py
+++ b/app/tests/test_control_surface_mixing.py
@@ -1,0 +1,107 @@
+"""gh-772 #C — role→axis decomposition + unique naming for mixed control surfaces."""
+
+import pytest
+
+from app.services.control_surface_mixing import (
+    assert_unique_control_names,
+    axis_control_name,
+    control_axes_for_surface,
+    is_dual_role,
+    parse_role_tag,
+)
+
+
+def _axes(role, **kw):
+    defaults = dict(
+        role=role,
+        tagged_name=f"[{role}]Surf",
+        symmetric=(role not in {"aileron", "rudder"}),
+        hinge_point=0.75,
+        deflection=3.0,
+        wing_key="wing0",
+        xsec_index=1,
+    )
+    defaults.update(kw)
+    return control_axes_for_surface(**defaults)
+
+
+class TestSingleAxisUnchanged:
+    @pytest.mark.parametrize(
+        "role,symmetric,expected_sgn",
+        [
+            ("elevator", True, 1.0),
+            ("flap", True, 1.0),
+            ("stabilator", True, 1.0),
+            ("rudder", False, -1.0),
+            ("aileron", False, -1.0),
+        ],
+    )
+    def test_single_axis_keeps_name_and_sign(self, role, symmetric, expected_sgn):
+        axes = _axes(role, symmetric=symmetric, tagged_name=f"[{role}]X")
+        assert len(axes) == 1
+        ax = axes[0]
+        assert ax.name == f"[{role}]X"  # name preserved verbatim
+        assert ax.sgn_dup == expected_sgn
+        assert ax.gain == 1.0
+        assert ax.deflection == 3.0
+
+
+class TestDualRoleEmitsTwoAxes:
+    @pytest.mark.parametrize(
+        "role,primary_axis,secondary_axis",
+        [
+            ("elevon", "pitch", "roll"),
+            ("flaperon", "lift", "roll"),
+            ("ruddervator", "pitch", "yaw"),
+        ],
+    )
+    def test_two_axes_primary_symmetric_secondary_antisymmetric(
+        self, role, primary_axis, secondary_axis
+    ):
+        axes = _axes(role, mix_gain_primary=1.2, mix_gain_secondary=0.6)
+        assert len(axes) == 2
+        primary, secondary = axes
+        assert primary.symmetric is True and primary.sgn_dup == 1.0
+        assert primary.axis == primary_axis and primary.gain == 1.2
+        assert secondary.symmetric is False and secondary.sgn_dup == -1.0
+        assert secondary.axis == secondary_axis and secondary.gain == 0.6
+
+    def test_secondary_axis_baseline_deflection_is_zero(self):
+        # AeroBuildup fallback: never feed roll/yaw deflection into the single-axis ASB model.
+        axes = _axes("elevon", deflection=5.0)
+        assert axes[0].deflection == 5.0  # primary carries the symmetric deflection
+        assert axes[1].deflection == 0.0  # secondary axis zeroed
+
+    def test_names_are_unique_and_role_parseable(self):
+        axes = _axes("ruddervator")
+        names = [a.name for a in axes]
+        assert names[0] != names[1]
+        for a in axes:
+            role, _ = parse_role_tag(a.name)
+            assert role == "ruddervator"
+
+    def test_no_sgndup_other_than_unit(self):
+        # Differential must NEVER leak into geometry as a non-unit SgnDup.
+        axes = _axes("elevon")
+        assert all(abs(a.sgn_dup) == 1.0 for a in axes)
+
+
+class TestNaming:
+    def test_avl_safe_no_spaces(self):
+        name = axis_control_name("elevon", "pitch", "Left Wing", 2)
+        assert " " not in name
+        assert name.startswith("[elevon]")
+
+    def test_uniqueness_assertion_raises_on_collision(self):
+        with pytest.raises(ValueError, match="collapse"):
+            assert_unique_control_names(["[elevon]pitch_w_1", "[elevon]pitch_w_1"])
+
+    def test_uniqueness_assertion_passes_when_unique(self):
+        assert_unique_control_names(["a", "b", "c"])  # no raise
+
+    def test_is_dual_role(self):
+        assert is_dual_role("elevon")
+        assert is_dual_role("ruddervator")
+        assert not is_dual_role("aileron")
+        assert not is_dual_role("elevator")
+        assert not is_dual_role(None)

--- a/app/tests/test_decompose_dual_role.py
+++ b/app/tests/test_decompose_dual_role.py
@@ -1,0 +1,109 @@
+"""gh-772 #H — decompose_dual_role: L/R reconstruction + sign-branched differential."""
+
+from app.services.trim_enrichment_service import compute_enrichment, decompose_dual_role
+
+
+class TestRuddervatorPair:
+    def test_symmetric_no_differential(self):
+        controls = {
+            "[ruddervator]pitch_vtail_0": 3.0,
+            "[ruddervator]yaw_vtail_0": 2.0,
+        }
+        out = decompose_dual_role(controls)
+        mv = next(iter(out.values()))
+        assert mv.role == "ruddervator"
+        assert mv.symmetric_offset == 3.0
+        assert mv.differential_throw == 2.0
+        # left = 3 - 2 = 1, right = 3 + 2 = 5
+        assert mv.deflection_left == 1.0
+        assert mv.deflection_right == 5.0
+        assert mv.differential_ratio == 1.0
+
+    def test_two_axes_grouped_into_one_surface(self):
+        controls = {
+            "[ruddervator]pitch_vtail_0": 1.0,
+            "[ruddervator]yaw_vtail_0": 1.0,
+        }
+        out = decompose_dual_role(controls)
+        assert len(out) == 1  # not the old "needs 2 surfaces -> 0 differential" bug
+
+
+class TestDifferentialSignBranched:
+    def test_positive_command_up_going_side_throws_more(self):
+        controls = {"[elevon]pitch_w_0": 3.0, "[elevon]roll_w_0": 2.0}
+        mix = {"elevon:w_0": (1.0, 1.0, 2.0)}  # differential_ratio 2.0
+        mv = next(iter(decompose_dual_role(controls, mix).values()))
+        # right_anti=+2 (down, unscaled); left_anti=-2*2=-4 (up, scaled)
+        assert mv.deflection_right == 5.0   # 3 + 2
+        assert mv.deflection_left == -1.0   # 3 - 4
+        # up-going (left) carries the larger antisymmetric magnitude
+        assert abs(mv.deflection_left - mv.symmetric_offset) > abs(
+            mv.deflection_right - mv.symmetric_offset
+        )
+
+    def test_negative_command_up_going_side_flips_but_still_larger(self):
+        controls = {"[elevon]pitch_w_0": 3.0, "[elevon]roll_w_0": -2.0}
+        mix = {"elevon:w_0": (1.0, 1.0, 2.0)}
+        mv = next(iter(decompose_dual_role(controls, mix).values()))
+        # right_anti=-2 (up, scaled ->-4); left_anti=+2 (down, unscaled)
+        assert mv.deflection_right == -1.0  # 3 - 4
+        assert mv.deflection_left == 5.0    # 3 + 2
+        # for the opposite sign the up-going side is now the right
+        assert abs(mv.deflection_right - mv.symmetric_offset) > abs(
+            mv.deflection_left - mv.symmetric_offset
+        )
+
+
+class TestGains:
+    def test_gains_scale_components(self):
+        controls = {"[ruddervator]pitch_t_1": 2.0, "[ruddervator]yaw_t_1": 4.0}
+        mix = {"ruddervator:t_1": (1.5, 0.5, 1.0)}
+        mv = next(iter(decompose_dual_role(controls, mix).values()))
+        assert mv.symmetric_offset == 3.0   # 1.5 * 2
+        assert mv.differential_throw == 2.0  # 0.5 * 4
+
+
+class TestAileronDifferential:
+    def test_single_aileron_produces_left_right(self):
+        controls = {"[aileron]Aileron": 5.0}
+        mix = {"aileron:Aileron": (1.0, 1.0, 1.5)}
+        out = decompose_dual_role(controls, mix)
+        mv = next(iter(out.values()))
+        assert mv.role == "aileron"
+        assert mv.symmetric_offset == 0.0
+        # right_anti=+5 (down); left_anti=-5*1.5=-7.5 (up, scaled)
+        assert mv.deflection_right == 5.0
+        assert mv.deflection_left == -7.5
+
+    def test_aileron_default_ratio_symmetric(self):
+        out = decompose_dual_role({"[aileron]Aileron": 5.0})
+        mv = next(iter(out.values()))
+        assert mv.deflection_left == -5.0
+        assert mv.deflection_right == 5.0
+
+
+class TestNonMixedIgnored:
+    def test_elevator_not_decomposed(self):
+        out = decompose_dual_role({"[elevator]Elevator": -3.0})
+        assert out == {}
+
+
+class TestAeroBuildupMixedSurfaceWarning:
+    def _enrich(self, trim_method):
+        return compute_enrichment(
+            controls={"[ruddervator]pitch_t_0": 2.0, "[ruddervator]yaw_t_0": 1.0},
+            limits={},
+            trim_method=trim_method,
+            trim_score=None,
+            trim_residuals={},
+            op_name="cruise",
+            alpha_deg=2.0,
+        )
+
+    def test_aerobuildup_mixed_surface_emits_solver_warning(self):
+        enr = self._enrich("aerobuildup")
+        assert any(w.category == "solver" for w in enr.design_warnings)
+
+    def test_avl_mixed_surface_has_no_solver_warning(self):
+        enr = self._enrich("avl")
+        assert not any(w.category == "solver" for w in enr.design_warnings)

--- a/app/tests/test_mixed_control_surface_converter.py
+++ b/app/tests/test_mixed_control_surface_converter.py
@@ -1,0 +1,100 @@
+"""gh-772 #D/#G — dual-axis emission in the ASB airplane + AVL geometry builders.
+
+A dual-role surface (elevon/flaperon/ruddervator) must emit TWO control variables
+(primary symmetric + secondary antisymmetric) on BOTH paths, with identical unique
+names so the trim index map stays consistent. Single-axis surfaces are unchanged.
+Differential never enters the geometry (SgnDup stays ±1).
+"""
+
+import app.schemas.aeroplaneschema as schemas
+from app.converters.model_schema_converters import _asb_wing_xsecs_from_schema
+from app.services.avl_geometry_service import _build_controls_for_wing
+
+_AF = "./components/airfoils/mh32.dat"
+
+
+def _wing_with_ted(ted: schemas.TrailingEdgeDeviceDetailSchema) -> schemas.AsbWingSchema:
+    return schemas.AsbWingSchema(
+        name="surf",
+        symmetric=True,
+        x_secs=[
+            schemas.WingXSecSchema(
+                xyz_le=[0.0, 0.0, 0.0], chord=0.2, twist=0.0, airfoil=_AF,
+                trailing_edge_device=ted,
+            ),
+            schemas.WingXSecSchema(
+                xyz_le=[0.0, 0.5, 0.0], chord=0.16, twist=0.0, airfoil=_AF,
+            ),
+        ],
+    )
+
+
+class TestAsbDualAxis:
+    def test_ruddervator_emits_two_control_surfaces(self):
+        ted = schemas.TrailingEdgeDeviceDetailSchema(
+            role="ruddervator", rel_chord_root=0.7, deflection_deg=2.0,
+            mix_gain_primary=1.2, mix_gain_secondary=0.6,
+        )
+        xsecs = _asb_wing_xsecs_from_schema(_wing_with_ted(ted), wing_key="vtail")
+        cs = xsecs[0].control_surfaces
+        assert len(cs) == 2
+        primary, secondary = cs
+        assert primary.symmetric is True
+        assert secondary.symmetric is False
+        # secondary (yaw) axis baseline deflection zeroed for the AeroBuildup fallback
+        assert primary.deflection == 2.0
+        assert secondary.deflection == 0.0
+        # unique, role-tag-parseable names
+        assert primary.name != secondary.name
+        assert primary.name.startswith("[ruddervator]")
+        assert secondary.name.startswith("[ruddervator]")
+
+    def test_elevator_unchanged_single_surface(self):
+        ted = schemas.TrailingEdgeDeviceDetailSchema(
+            role="elevator", rel_chord_root=0.7, deflection_deg=1.0
+        )
+        xsecs = _asb_wing_xsecs_from_schema(_wing_with_ted(ted), wing_key="htail")
+        cs = xsecs[0].control_surfaces
+        assert len(cs) == 1
+        assert cs[0].symmetric is True
+        assert cs[0].name == "[elevator]elevator"
+
+
+class TestAvlDualAxis:
+    def test_ruddervator_two_control_lines_sgndup_signs(self):
+        ted = schemas.TrailingEdgeDeviceDetailSchema(
+            role="ruddervator", rel_chord_root=0.7,
+            mix_gain_primary=1.2, mix_gain_secondary=0.6,
+        )
+        per_section = _build_controls_for_wing(_wing_with_ted(ted), wing_key="vtail")
+        # both sections of the single panel carry both axes
+        assert len(per_section[0]) == 2
+        signs = sorted(c.sgn_dup for c in per_section[0])
+        assert signs == [-1.0, 1.0]
+        gains = sorted(c.gain for c in per_section[0])
+        assert gains == [0.6, 1.2]
+
+    def test_differential_ratio_never_enters_geometry(self):
+        ted = schemas.TrailingEdgeDeviceDetailSchema(
+            role="aileron", rel_chord_root=0.7, symmetric=False, differential_ratio=2.5
+        )
+        per_section = _build_controls_for_wing(_wing_with_ted(ted), wing_key="wing")
+        for ctrl in per_section[0]:
+            assert abs(ctrl.sgn_dup) == 1.0  # never 2.5
+        avl_text = repr(per_section[0][0])
+        assert "2.5" not in avl_text
+
+    def test_elevon_emits_two_lines(self):
+        ted = schemas.TrailingEdgeDeviceDetailSchema(role="elevon", rel_chord_root=0.75)
+        per_section = _build_controls_for_wing(_wing_with_ted(ted), wing_key="wing")
+        assert len(per_section[0]) == 2
+        names = {c.name for c in per_section[0]}
+        assert len(names) == 2  # distinct names
+
+    def test_single_axis_unchanged_name_and_gain(self):
+        ted = schemas.TrailingEdgeDeviceDetailSchema(role="flap", rel_chord_root=0.8)
+        per_section = _build_controls_for_wing(_wing_with_ted(ted), wing_key="wing")
+        assert len(per_section[0]) == 1
+        assert per_section[0][0].name == "[flap]flap"
+        assert per_section[0][0].gain == 1.0
+        assert per_section[0][0].sgn_dup == 1.0

--- a/app/tests/test_mixed_control_surface_schema.py
+++ b/app/tests/test_mixed_control_surface_schema.py
@@ -1,0 +1,97 @@
+"""Tests for gh-772 #A — TED mix-gain + differential_ratio schema fields & validators.
+
+Mixed control surfaces (aileron differential, elevon, flaperon, ruddervator) need
+per-axis mix gains and a differential ratio. differential_ratio is a reporting-only
+kinematic; mix_gain_secondary only exists for dual-role surfaces. The validators
+keep impossible combinations off axis-less roles.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.aeroplaneschema import (
+    ControlSurfaceRole,
+    TrailingEdgeDeviceDetailSchema,
+    TrailingEdgeDevicePatchSchema,
+)
+
+
+class TestMixFieldDefaults:
+    def test_defaults_are_unity(self):
+        ted = TrailingEdgeDeviceDetailSchema(role=ControlSurfaceRole.ELEVON)
+        assert ted.mix_gain_primary == 1.0
+        assert ted.mix_gain_secondary == 1.0
+        assert ted.differential_ratio == 1.0
+
+    def test_single_axis_role_unchanged(self):
+        ted = TrailingEdgeDeviceDetailSchema(role=ControlSurfaceRole.ELEVATOR)
+        assert ted.mix_gain_primary == 1.0
+        assert ted.differential_ratio == 1.0
+
+
+class TestRangeValidation:
+    @pytest.mark.parametrize("bad", [0.0, -1.0, 5.1])
+    def test_mix_gain_primary_out_of_range(self, bad):
+        with pytest.raises(ValidationError):
+            TrailingEdgeDeviceDetailSchema(
+                role=ControlSurfaceRole.ELEVON, mix_gain_primary=bad
+            )
+
+    @pytest.mark.parametrize("bad", [0.3, 0.2, 3.1, 0.0])
+    def test_differential_ratio_out_of_range(self, bad):
+        with pytest.raises(ValidationError):
+            TrailingEdgeDeviceDetailSchema(
+                role=ControlSurfaceRole.AILERON, differential_ratio=bad
+            )
+
+    def test_differential_ratio_in_range_ok(self):
+        ted = TrailingEdgeDeviceDetailSchema(
+            role=ControlSurfaceRole.AILERON, differential_ratio=2.0
+        )
+        assert ted.differential_ratio == 2.0
+
+
+class TestRoleAwareValidation:
+    @pytest.mark.parametrize(
+        "role", ["aileron", "elevon", "flaperon", "ruddervator"]
+    )
+    def test_differential_allowed_for_roles_with_antisymmetric_axis(self, role):
+        ted = TrailingEdgeDeviceDetailSchema(role=role, differential_ratio=1.5)
+        assert ted.differential_ratio == 1.5
+
+    @pytest.mark.parametrize("role", ["elevator", "flap", "stabilator", "rudder"])
+    def test_differential_rejected_for_axisless_roles(self, role):
+        with pytest.raises(ValidationError):
+            TrailingEdgeDeviceDetailSchema(role=role, differential_ratio=1.5)
+
+    @pytest.mark.parametrize("role", ["elevon", "flaperon", "ruddervator"])
+    def test_secondary_gain_allowed_for_dual_roles(self, role):
+        ted = TrailingEdgeDeviceDetailSchema(role=role, mix_gain_secondary=0.5)
+        assert ted.mix_gain_secondary == 0.5
+
+    @pytest.mark.parametrize("role", ["aileron", "elevator", "flap", "rudder"])
+    def test_secondary_gain_rejected_for_non_dual_roles(self, role):
+        with pytest.raises(ValidationError):
+            TrailingEdgeDeviceDetailSchema(role=role, mix_gain_secondary=0.5)
+
+
+class TestPatchSchema:
+    def test_patch_accepts_fields(self):
+        patch = TrailingEdgeDevicePatchSchema(
+            role=ControlSurfaceRole.ELEVON,
+            mix_gain_secondary=0.6,
+            differential_ratio=1.2,
+        )
+        assert patch.mix_gain_secondary == 0.6
+        assert patch.differential_ratio == 1.2
+
+    def test_patch_validates_when_role_present(self):
+        with pytest.raises(ValidationError):
+            TrailingEdgeDevicePatchSchema(
+                role=ControlSurfaceRole.ELEVATOR, differential_ratio=1.5
+            )
+
+    def test_patch_skips_role_validation_when_role_absent(self):
+        # Without a role on a patch we cannot cross-validate; range still applies.
+        patch = TrailingEdgeDevicePatchSchema(differential_ratio=1.5)
+        assert patch.differential_ratio == 1.5

--- a/app/tests/test_speed_polar.py
+++ b/app/tests/test_speed_polar.py
@@ -1,0 +1,135 @@
+"""Unit tests for the speed polar (Geschwindigkeitspolare) derivation.
+
+The speed polar derives sink rate ``w`` over forward speed ``V`` from a drag
+polar (CL/CD) for one or more masses. Aerodynamic coefficients are mass
+independent; only the speed required to fly a given CL scales with mass, so
+curves for different masses scale as ``V, w ∝ sqrt(m)``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from app.services.analysis_service import _compute_speed_polar
+
+G = 9.81
+
+
+def _v_of(mass: float, rho: float, s: float, cl: float) -> float:
+    return math.sqrt(2.0 * mass * G / (rho * s * cl))
+
+
+def test_single_base_curve_formula() -> None:
+    cl = np.array([0.5, 1.0])
+    cd = np.array([0.02, 0.05])
+    sp = _compute_speed_polar(
+        cl=cl, cd=cd, masses_kg=[], base_mass_kg=1.5, s_ref_m2=0.225, rho=1.225
+    )
+    assert len(sp.curves) == 1
+    curve = sp.curves[0]
+    assert curve.is_base is True
+    assert curve.mass_kg == pytest.approx(1.5)
+    # Arrays sorted ascending by V (higher CL -> lower V).
+    assert curve.V == sorted(curve.V)
+    # Spot-check the V and w formulas at CL = 1.0 (the lowest-V point).
+    v_expected = _v_of(1.5, 1.225, 0.225, 1.0)
+    idx = next(i for i, c in enumerate(curve.cl) if abs(c - 1.0) < 1e-9)
+    assert curve.V[idx] == pytest.approx(v_expected, rel=1e-9)
+    assert curve.w[idx] == pytest.approx(v_expected * (0.05 / 1.0), rel=1e-9)
+
+
+def test_sqrt_m_scaling() -> None:
+    """Quadrupling the mass scales V and w by exactly 2 (sqrt(4))."""
+    cl = np.array([0.4, 0.8, 1.2])
+    cd = np.array([0.018, 0.03, 0.06])
+    sp = _compute_speed_polar(
+        cl=cl, cd=cd, masses_kg=[1.0, 4.0], base_mass_kg=1.0, s_ref_m2=0.3, rho=1.225
+    )
+    by_mass = {c.mass_kg: c for c in sp.curves}
+    light, heavy = by_mass[1.0], by_mass[4.0]
+    for vl, vh in zip(light.V, heavy.V):
+        assert vh == pytest.approx(2.0 * vl, rel=1e-9)
+    for wl, wh in zip(light.w, heavy.w):
+        assert wh == pytest.approx(2.0 * wl, rel=1e-9)
+
+
+def test_filters_nonpositive_cl() -> None:
+    cl = np.array([-0.3, 0.0, 0.5, 1.0])
+    cd = np.array([0.04, 0.02, 0.02, 0.05])
+    sp = _compute_speed_polar(
+        cl=cl, cd=cd, masses_kg=[], base_mass_kg=2.0, s_ref_m2=0.225, rho=1.225
+    )
+    curve = sp.curves[0]
+    # Only CL = 0.5 and CL = 1.0 survive.
+    assert len(curve.V) == 2
+    assert all(c > 0 for c in curve.cl)
+
+
+def test_empty_masses_returns_base_only() -> None:
+    cl = np.array([0.5, 1.0])
+    cd = np.array([0.02, 0.05])
+    sp = _compute_speed_polar(
+        cl=cl, cd=cd, masses_kg=[], base_mass_kg=1.5, s_ref_m2=0.225, rho=1.225
+    )
+    assert [c.mass_kg for c in sp.curves] == [pytest.approx(1.5)]
+    assert sp.base_mass_kg == pytest.approx(1.5)
+
+
+def test_dedup_sort_and_base_flag() -> None:
+    cl = np.array([0.5, 1.0])
+    cd = np.array([0.02, 0.05])
+    sp = _compute_speed_polar(
+        cl=cl,
+        cd=cd,
+        masses_kg=[2.5, 1.5, 2.5],  # duplicate 2.5, base 1.5 not in list explicitly
+        base_mass_kg=1.5,
+        s_ref_m2=0.225,
+        rho=1.225,
+    )
+    masses = [c.mass_kg for c in sp.curves]
+    # Deduplicated, base included, ascending.
+    assert masses == [pytest.approx(1.5), pytest.approx(2.5)]
+    base_curves = [c for c in sp.curves if c.is_base]
+    assert len(base_curves) == 1
+    assert base_curves[0].mass_kg == pytest.approx(1.5)
+
+
+def test_characteristic_points_present() -> None:
+    # Parabolic polar so min-sink and best-glide land on distinct CL points
+    # (min-sink CL = sqrt(3) * best-glide CL for an ideal parabolic polar).
+    cd0, e, ar = 0.012, 0.85, 14.4
+    cl = np.linspace(0.1, 1.4, 200)
+    cd = cd0 + cl**2 / (math.pi * e * ar)
+    sp = _compute_speed_polar(
+        cl=cl, cd=cd, masses_kg=[], base_mass_kg=1.5, s_ref_m2=0.225, rho=1.225
+    )
+    curve = sp.curves[0]
+    assert curve.w_min is not None and curve.w_min > 0
+    assert curve.v_min_sink is not None and curve.v_min_sink > 0
+    assert curve.v_best_glide is not None and curve.v_best_glide > 0
+    assert curve.ld_max is not None
+    # Best glide L/D equals max(CL/CD) of the polar.
+    assert curve.ld_max == pytest.approx(float(np.max(cl / cd)), rel=1e-9)
+    # Min-sink speed is strictly below best-glide speed (classic glider ordering).
+    assert curve.v_min_sink < curve.v_best_glide
+
+
+def test_w_min_matches_closed_form() -> None:
+    """w_min from the discrete polar matches the closed-form _min_sink_rate."""
+    from app.services.assumption_compute_service import _min_sink_rate
+
+    cd0, e, ar = 0.012, 0.85, 14.4
+    mass, s_ref, rho = 1.5, 0.225, 1.225
+    cl = np.linspace(0.05, 1.4, 600)
+    cd = cd0 + cl**2 / (math.pi * e * ar)
+
+    sp = _compute_speed_polar(
+        cl=cl, cd=cd, masses_kg=[], base_mass_kg=mass, s_ref_m2=s_ref, rho=rho
+    )
+    w_min_discrete = sp.curves[0].w_min
+    w_min_closed = _min_sink_rate(mass, s_ref, cd0, ar, rho=rho, oswald_e=e)
+    assert w_min_closed is not None
+    assert w_min_discrete == pytest.approx(w_min_closed, rel=0.03)

--- a/app/tests/test_trim_enrichment.py
+++ b/app/tests/test_trim_enrichment.py
@@ -665,32 +665,54 @@ class TestControlEffectiveness:
 
 
 class TestDualRoleDecomposition:
-    def test_paired_elevons(self):
+    # gh-772: a mixed surface now exposes TWO axis control variables
+    # (pitch/lift + roll/yaw) from ONE physical surface, decomposed into
+    # symmetric + antisymmetric components and reconstructed into left/right
+    # physical angles. The old "two separately-named surfaces / half-difference"
+    # model — and its "single dual-role -> differential 0" bug — are gone.
+
+    def test_dual_axis_elevon_decomposes_to_left_right(self):
         controls = {
-            "[elevon]Left Elevon": 5.0,
-            "[elevon]Right Elevon": 3.0,
+            "[elevon]pitch_wing_0": 4.0,
+            "[elevon]roll_wing_0": 1.0,
         }
         mixer = decompose_dual_role(controls)
-        assert "elevon_mixer" in mixer
-        assert mixer["elevon_mixer"].symmetric_offset == pytest.approx(4.0)
-        assert mixer["elevon_mixer"].differential_throw == pytest.approx(1.0)
-        assert mixer["elevon_mixer"].role == "elevon"
+        assert "elevon_wing_0_mixer" in mixer
+        mv = mixer["elevon_wing_0_mixer"]
+        assert mv.symmetric_offset == pytest.approx(4.0)
+        assert mv.differential_throw == pytest.approx(1.0)
+        assert mv.deflection_left == pytest.approx(3.0)   # 4 - 1
+        assert mv.deflection_right == pytest.approx(5.0)  # 4 + 1
+        assert mv.role == "elevon"
 
-    def test_single_dual_role(self):
-        controls = {"[elevon]Single Elevon": 7.0}
+    def test_dual_role_with_both_axes_is_one_surface(self):
+        # The old code reported differential 0 for a single (mirrored) surface;
+        # now the antisymmetric axis variable carries the real roll/yaw throw.
+        controls = {
+            "[ruddervator]pitch_t_0": 7.0,
+            "[ruddervator]yaw_t_0": 2.0,
+        }
         mixer = decompose_dual_role(controls)
-        assert "[elevon]Single Elevon" in mixer
-        assert mixer["[elevon]Single Elevon"].symmetric_offset == pytest.approx(7.0)
-        assert mixer["[elevon]Single Elevon"].differential_throw == pytest.approx(0.0)
+        assert len(mixer) == 1
+        mv = next(iter(mixer.values()))
+        assert mv.differential_throw == pytest.approx(2.0)  # NOT 0
 
-    def test_no_dual_role_empty(self):
+    def test_truly_single_axis_roles_not_decomposed(self):
         controls = {
             "[elevator]Elev": -3.0,
-            "[aileron]Ail": 5.0,
             "[rudder]Rud": 2.0,
+            "[flap]Flap": 10.0,
         }
         mixer = decompose_dual_role(controls)
         assert len(mixer) == 0
+
+    def test_aileron_is_decomposed_for_differential(self):
+        # gh-772: aileron now yields left/right so differential can be shown.
+        mixer = decompose_dual_role({"[aileron]Ail": 5.0})
+        mv = next(iter(mixer.values()))
+        assert mv.role == "aileron"
+        assert mv.deflection_left == pytest.approx(-5.0)
+        assert mv.deflection_right == pytest.approx(5.0)
 
 
 # ---------------------------------------------------------------------------

--- a/docs/superpowers/specs/2026-05-30-geschwindigkeitspolare-design.md
+++ b/docs/superpowers/specs/2026-05-30-geschwindigkeitspolare-design.md
@@ -1,0 +1,192 @@
+# Geschwindigkeitspolare im „Analysis – Polar"-Tab
+
+**Datum:** 2026-05-30
+**Status:** Akzeptiert (Design), bereit für Implementierungsplanung
+**Sprache der UI:** Deutsch/Englisch gemischt wie im Bestand (Labels englisch, Tooltips teils deutsch)
+
+## Ziel
+
+Im Tab **„Analysis – Polar"** zusätzlich eine **Geschwindigkeitspolare**
+(Sinkrate `w` [m/s] über Fluggeschwindigkeit `V` [m/s]) anzeigen. Neben der
+gegebenen Masse (Design-Assumption `mass`, calculated **oder** estimate) sollen
+**weitere Massen** als Vergleichskurven angegeben werden können
+(Wasserballast-/Flächenbelastungs-Effekt beim Segler).
+
+## Entscheidungen (vom Nutzer bestätigt)
+
+1. **Datenbasis:** Echte AeroBuildup-α-Sweep-CL/CD (an die angezeigte
+   Widerstandspolare gekoppelt). Andere Massen skalieren die Kurve analytisch.
+2. **Massen-Eingabe:** Liste absoluter Massen in **kg**, vorbefüllt mit der
+   effektiven Assumption-Masse.
+3. **Darstellung:** Zusätzliches Chart in der bestehenden Polar-Grid.
+4. **Eingabeformat:** Deutsches Zahlenformat — **Dezimal-Komma**, **Semikolon
+   als Trenner**, z. B. `1,5; 2,0; 2,5`. Parser akzeptiert auch `.` als
+   Dezimaltrenner.
+
+## Physik (eine Aero-Rechnung, analytisch über Masse skaliert)
+
+Aerodynamische Beiwerte CL/CD (die Widerstandspolare) sind
+**massenunabhängig** — nur die bei gegebener Geschwindigkeit erreichte CL hängt
+von der Masse ab. Ein einziger AeroBuildup-α-Sweep liefert die CL/CD-Punkte;
+pro Masse `m` rein analytisch:
+
+```
+für jeden Sweep-Punkt mit CL > 0:
+    V(CL) = sqrt( 2 · m · g / (rho · S_ref · CL) )      # Gleitflug-Geschwindigkeit
+    w(CL) = V(CL) · (CD / CL)                            # Sinkrate (positiv = sinkend)
+```
+
+- Nur **CL > 0** wird berücksichtigt (stationärer Gleitflug; negative/Null-CL
+  liefern kein sinnvolles V).
+- Konsequenz: Massen skalieren die Kurve mit `V, w ∝ sqrt(m)` →
+  **kein zusätzlicher Aero-Lauf** nötig, nur Algebra über die bestehende Polare.
+- `g = 9.81`, `rho = asb.Atmosphere(altitude).density()`, `S_ref` aus dem
+  bereits gebauten ASB-Airplane (`asb_airplane.s_ref`).
+
+### Markante Punkte je Kurve
+
+- **V_stall** — bei `CL_max` (Maximum der Sweep-CL): `V = sqrt(2 m g / (rho S CL_max))`.
+- **V_min_sink / w_min** — Punkt mit minimalem `w`.
+- **V_best_glide / (L/D)_max** — Punkt mit minimalem `w/V` (= maximalem `V/w` =
+  maximalem `CL/CD`).
+
+Zur Konsistenz-Validierung: `w_min` aus dem diskreten Sweep muss näherungsweise
+mit dem geschlossenen `_min_sink_rate(...)` aus
+`assumption_compute_service.py` übereinstimmen (gleiche Physik, Anderson §6.7.2).
+
+## Darstellung
+
+- Neues Plotly-Chart **„Geschwindigkeitspolare (w über V)"** in der bestehenden
+  Polar-Grid (`AnalysisViewerPanel`, Bereich `activeTab === "Polar"`).
+- **Eine Kurve pro Masse** mit **Legende** (Masse in kg). Basis-Masse
+  hervorgehoben (kräftige Farbe/dicker), weitere Massen in abgesetzten Farben.
+- **Segler-Konvention:** `V` auf der x-Achse, **Sinkrate nach unten** aufgetragen
+  (y-Werte = `−w`), y-Achse beschriftet als `w [m/s]` (Sinken).
+- Marker + Annotation für **V_min_sink** und **V_best_glide** (auf der
+  Basis-Masse-Kurve; optional je Kurve).
+
+## Architektur & Komponenten
+
+### Backend
+
+**Schema** (`app/schemas/AeroplaneRequest.py`):
+- `AlphaSweepRequest` erhält optionales Feld
+  `masses_kg: Optional[list[float]] = None` (jeweils `> 0`).
+
+**Schema** (neu, `app/schemas/aeroanalysisschema.py` oder passendes Modul):
+```python
+class SpeedPolarCurve(BaseModel):
+    mass_kg: float
+    is_base: bool                 # entspricht der effektiven Assumption-Masse
+    V: list[float]                # m/s, aufsteigend nach V sortiert
+    w: list[float]                # m/s, Sinkrate positiv
+    cl: list[float]
+    cd: list[float]
+    v_stall: float | None
+    v_min_sink: float | None
+    w_min: float | None
+    v_best_glide: float | None
+    ld_max: float | None
+
+class SpeedPolar(BaseModel):
+    base_mass_kg: float
+    s_ref: float
+    rho: float
+    altitude: float
+    curves: list[SpeedPolarCurve]
+```
+
+**Service** (`app/services/analysis_service.py`):
+- Neuer reiner Helper
+  `_compute_speed_polar(cl, cd, masses_kg, base_mass_kg, s_ref, rho) -> SpeedPolar`.
+  Vollständig unit-testbar ohne DB/Aero.
+- `analyze_alpha_sweep(...)` ergänzt: effektive Masse aus Assumption (`mass`)
+  laden; `masses = (request.masses_kg or []) ∪ {base}`; `s_ref` aus
+  `asb_airplane`, `rho` aus `altitude`; `speed_polar` berechnen und in die
+  Antwort aufnehmen.
+- Antwort additiv:
+  ```python
+  return {
+      "analysis": result,
+      "characteristic_points": characteristic_points,
+      "speed_polar": speed_polar,          # NEU
+      "aircraft_name": ...,
+  }
+  ```
+- Massenliste: deduplizieren, aufsteigend sortieren; Basis-Masse markieren
+  (`is_base`). Liefert immer mindestens die Basis-Kurve.
+
+**Endpoint:** unverändert — `POST /aeroplanes/{id}/alpha_sweep` (additives
+Request-/Response-Feld). Keine neue Route.
+
+### Frontend
+
+**Hook** (`frontend/hooks/useAnalysis.ts`):
+- `AlphaSweepParams` erhält `masses_kg?: number[]`.
+- `AnalysisResult`/Rückgabe erhält `speedPolar` (aus `data.speed_polar`
+  extrahiert; null wenn nicht vorhanden).
+
+**ConfigPanel** (`frontend/components/workbench/AnalysisConfigPanel.tsx`):
+- Neuer Prop `effectiveMassKg?: number | null` (aus `currentMassKg` in
+  `app/workbench/analysis/page.tsx`, analog zu `designCgX`).
+- Neues Textfeld **„Massen [kg]"** im Polar-Bereich, vorbefüllt mit
+  `effectiveMassKg` (z. B. `"1,5"`). Placeholder `z. B. 1,5; 2,0; 2,5`.
+- Parser `parseMasses(input): number[]`:
+  ```
+  input.split(";") → je Token trim → "," durch "." ersetzen → parseFloat
+  → nur endliche Werte > 0 behalten
+  ```
+- `handleRunPolar` übergibt `masses_kg: parseMasses(massesInput)`.
+
+**Viewer** (`frontend/components/workbench/AnalysisViewerPanel.tsx`):
+- Neues Chart in der Polar-Grid, gespeist aus `result.speedPolar.curves`.
+- `PlotlyChart` minimal erweitern: Unterstützung mehrerer benannter Traces
+  (`traces: {name, x, y, color}[]`) + `showLegend?: boolean`. Bestehende
+  Single-Trace-Aufrufe bleiben unverändert (Abwärtskompatibilität).
+- y-Werte als `−w` auftragen (Sinken nach unten); Marker für V_min_sink /
+  V_best_glide.
+
+## Scope (YAGNI)
+
+**Enthalten:** echte Sweep-Daten, kg-Liste (deutsches Format), ein neues Chart
+mit Mehr-Massen-Kurven + markante Punkte; additive Backend-Erweiterung; Tests.
+
+**Nicht enthalten (separat):**
+- Parabolischer Umschalter (CD0 + k·CL²).
+- Tangenten-Overlay vom Ursprung (Sollfahrt).
+- Reynolds-Re-Run pro Masse.
+- Bereits gefundene Alt-Bugs (nur als separate Bug-Tickets notiert, **nicht** in
+  diesem Feature behoben):
+  - `sweep_var`-Dropdown und Analysis-Tool-/Flight-Profile-Selektoren sind
+    dekorativ (`handleRunPolar` ignoriert sie).
+  - `Number.parseFloat(alphaStart) || -5` verwirft eine eingegebene `0` als
+    Sweep-Start.
+
+## Tests (TDD, Ziel >80 %)
+
+**Backend** (`app/tests/`):
+- `_compute_speed_polar`: Formeln V/w korrekt; **√m-Skalierung** zwischen zwei
+  Massen; CL≤0-Punkte gefiltert; `w_min` konsistent mit `_min_sink_rate`
+  (Toleranz); leere/None-Massenliste → genau Basis-Kurve; `is_base` korrekt
+  gesetzt; Dedup/Sortierung.
+- Integration: `analyze_alpha_sweep` liefert `speed_polar` mit ≥1 Kurve für ein
+  Referenzflugzeug (z. B. Sailplane), Werte plausibel
+  (V_stall < V_min_sink < V_best_glide-Größenordnung; w_min > 0).
+
+**Frontend** (`frontend/__tests__/`):
+- `useAnalysis`: extrahiert `speedPolar` aus Mock-Response korrekt; null wenn
+  Feld fehlt.
+- `parseMasses`: `"1,5; 2,0; 2,5"` → `[1.5, 2.0, 2.5]`; gemischt `.`/`,`;
+  leere/ungültige Tokens verworfen; negative/0 verworfen.
+- Viewer rendert N Traces aus `speedPolar.curves` (N = Anzahl Massen) inkl.
+  Legende.
+
+## Risiken / Annahmen
+
+- CL/CD aus AeroBuildup sind für den relevanten Bereich (CL>0) monoton genug,
+  dass V/w sinnvolle Polaren ergeben; sehr kleine CL (hohes V) bleiben Teil der
+  Kurve (rechter Ast).
+- `S_ref` und `mass`-Assumption sind vorhanden (sonst klare Fehler-/Leerzustände
+  wie im Bestand).
+- Additive Erweiterung von `alpha_sweep` bricht bestehende Consumer nicht
+  (neues optionales Feld + neuer Response-Key).


### PR DESCRIPTION
Closes #783

## What

Adds a **Geschwindigkeitspolare** (glide/speed polar: sink rate `w` over forward
speed `V`) to the **Analysis → Polar** tab, with comparison curves for several
masses besides the effective design mass.

## How

- **One aero run, analytic mass scaling.** CL/CD (the drag polar) are
  mass-independent; per mass `m`, for each `CL > 0`:
  `V = √(2·m·g/(ρ·S_ref·CL))`, `w = V·CD/CL`. Curves scale as `V, w ∝ √m`, so no
  extra AeroBuildup runs are needed.
- **Backend (additive):** `AlphaSweepRequest.masses_kg?`; pure helper
  `_compute_speed_polar`; `analyze_alpha_sweep` now also returns `speed_polar`
  (`SpeedPolar`/`SpeedPolarCurve`). Effective mass from the `mass` assumption,
  `s_ref` from the ASB airplane, `ρ` from ISA at altitude. Existing route &
  response are unchanged otherwise.
- **Frontend:** `useAnalysis` (`masses_kg` + `speedPolar`); `lib/masses`
  (`parseMasses` — German comma decimals, semicolon separator; `formatMass`);
  `AnalysisConfigPanel` adds a **„Massen [kg]"** field prefilled with the
  effective mass; `AnalysisViewerPanel` renders `SpeedPolarChart` (one curve per
  mass, legend, base highlighted, sink plotted downward, V_min_sink &
  V_best_glide markers).

## Tests

- Backend: `app/tests/test_speed_polar.py` (7) — V/w formulas, √m scaling,
  CL≤0 filtering, dedup + base flag, characteristic points, and `w_min`
  consistency with the closed-form `_min_sink_rate`.
- Frontend: `parseMasses` (5) + `useAnalysis` speedPolar extraction (2).
- Full suites green: backend ruff clean; frontend `eslint` + `deps:check` clean,
  vitest **511/511**.

## Manual smoke test

Live in the Polar tab: entering `1,5; 2,5; 3,5` renders three curves
(`1,5 kg (Basis)`, `2,5 kg`, `3,5 kg`) with min-sink/best-glide markers.

## Out of scope (noted as separate bugs)

`sweep_var`/tool/flight-profile selectors in the polar config are decorative
(`handleRunPolar` ignores them); `parseFloat(alphaStart) || -5` discards a `0`
sweep start. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)