### PR TITLE
feat(gh-783): Geschwindigkeitspolare (speed polar) in Analysis-Polar with multi-mass comparison

### DIFF
--- a/app/schemas/AeroplaneRequest.py
+++ b/app/schemas/AeroplaneRequest.py
@@ -77,6 +77,11 @@ class AlphaSweepRequest(BaseModel):
         [0.0, 0.0, 0.0], description="xyz reference points for moments and rotation rates"
     )
     altitude: Optional[float] = Field(0.0, description="altitude in m")
+    masses_kg: Optional[List[float]] = Field(
+        None,
+        description="Extra aircraft masses [kg] for speed-polar comparison curves. "
+        "The effective design mass is always included.",
+    )
 
 
 class SimpleSweepRequest(BaseModel):

--- a/app/schemas/aeroanalysisschema.py
+++ b/app/schemas/aeroanalysisschema.py
@@ -550,3 +550,37 @@ class AnalysisStatusResponse(BaseModel):
 AVLTrimResult.model_rebuild()
 AeroBuildupTrimResult.model_rebuild()
 StoredOperatingPointCreate.model_rebuild()
+
+
+class SpeedPolarCurve(BaseModel):
+    """One glide speed polar (sink rate w over forward speed V) for a mass."""
+
+    mass_kg: float = Field(..., description="Aircraft mass for this curve [kg]")
+    is_base: bool = Field(
+        ..., description="True if this is the effective design (assumption) mass"
+    )
+    V: List[float] = Field(..., description="Forward speed [m/s], ascending")
+    w: List[float] = Field(..., description="Sink rate [m/s], positive downward")
+    cl: List[float] = Field(..., description="Lift coefficient at each point")
+    cd: List[float] = Field(..., description="Drag coefficient at each point")
+    v_stall: Optional[float] = Field(None, description="Stall speed at CL_max [m/s]")
+    v_min_sink: Optional[float] = Field(
+        None, description="Speed for minimum sink rate [m/s]"
+    )
+    w_min: Optional[float] = Field(None, description="Minimum sink rate [m/s]")
+    v_best_glide: Optional[float] = Field(
+        None, description="Speed for best glide / max L/D [m/s]"
+    )
+    ld_max: Optional[float] = Field(None, description="Maximum lift-to-drag ratio")
+
+
+class SpeedPolar(BaseModel):
+    """Speed polar bundle: one curve per mass, derived from a drag polar."""
+
+    base_mass_kg: float = Field(..., description="Effective design mass [kg]")
+    s_ref: float = Field(..., description="Wing reference area [m^2]")
+    rho: float = Field(..., description="Air density used [kg/m^3]")
+    altitude: float = Field(..., description="Altitude used [m]")
+    curves: List[SpeedPolarCurve] = Field(
+        ..., description="Speed polar curves, ascending by mass"
+    )

--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -427,6 +427,146 @@ async def calculate_streamlines_json(
         raise InternalError(message=f"Analysis error: {e}") from e
 
 
+def _compute_speed_polar(
+    cl,
+    cd,
+    masses_kg,
+    base_mass_kg,
+    s_ref_m2,
+    rho,
+    altitude: float = 0.0,
+    g: float = 9.81,
+):
+    """Derive glide speed polars (sink rate ``w`` over forward speed ``V``) from
+    a drag polar (CL/CD), for one or more masses.
+
+    Aerodynamic coefficients are mass independent; only the speed required to
+    fly a given CL scales with mass. For each point with ``CL > 0``::
+
+        V = sqrt(2 * m * g / (rho * S_ref * CL))
+        w = V * (CD / CL)
+
+    Curves for different masses therefore scale as ``V, w ∝ sqrt(m)``. The
+    effective design mass (``base_mass_kg``) is always included and flagged
+    ``is_base``. Pure function — no DB or aero calls — so it is unit testable.
+    """
+    from app.schemas.aeroanalysisschema import SpeedPolar, SpeedPolarCurve
+
+    cl_arr = np.atleast_1d(np.asarray(cl, dtype=float))
+    cd_arr = np.atleast_1d(np.asarray(cd, dtype=float))
+    n = min(len(cl_arr), len(cd_arr))
+    cl_arr, cd_arr = cl_arr[:n], cd_arr[:n]
+
+    # Deduplicated, ascending mass set that always includes the base mass.
+    tol = 1e-9
+    masses: list[float] = [float(base_mass_kg)]
+    for m in masses_kg or []:
+        mf = float(m)
+        if mf > 0 and all(abs(mf - existing) > tol for existing in masses):
+            masses.append(mf)
+    masses.sort()
+
+    # Only positive-CL points describe a steady glide.
+    pos = cl_arr > 0
+    cl_pos = cl_arr[pos]
+    cd_pos = cd_arr[pos]
+    cl_max = float(np.max(cl_arr)) if cl_arr.size else 0.0
+    valid_geometry = s_ref_m2 > 0 and rho > 0
+
+    curves: list[SpeedPolarCurve] = []
+    for m in masses:
+        is_base = abs(m - float(base_mass_kg)) <= tol
+        if not valid_geometry or cl_pos.size == 0 or m <= 0:
+            curves.append(
+                SpeedPolarCurve(
+                    mass_kg=m,
+                    is_base=is_base,
+                    V=[],
+                    w=[],
+                    cl=[],
+                    cd=[],
+                    v_stall=None,
+                    v_min_sink=None,
+                    w_min=None,
+                    v_best_glide=None,
+                    ld_max=None,
+                )
+            )
+            continue
+        weight_n = m * g
+        v = np.sqrt(2.0 * weight_n / (rho * s_ref_m2 * cl_pos))
+        w = v * (cd_pos / cl_pos)
+        # Co-sort all parallel arrays ascending by V (higher CL -> lower V).
+        order = np.argsort(v)
+        v, w = v[order], w[order]
+        cl_s, cd_s = cl_pos[order], cd_pos[order]
+
+        i_min_sink = int(np.argmin(w))
+        ld = cl_s / cd_s  # equals V / w
+        i_best = int(np.argmax(ld))
+        v_stall = float(np.sqrt(2.0 * weight_n / (rho * s_ref_m2 * cl_max))) if cl_max > 0 else None
+        curves.append(
+            SpeedPolarCurve(
+                mass_kg=m,
+                is_base=is_base,
+                V=v.tolist(),
+                w=w.tolist(),
+                cl=cl_s.tolist(),
+                cd=cd_s.tolist(),
+                v_stall=v_stall,
+                v_min_sink=float(v[i_min_sink]),
+                w_min=float(w[i_min_sink]),
+                v_best_glide=float(v[i_best]),
+                ld_max=float(ld[i_best]),
+            )
+        )
+
+    return SpeedPolar(
+        base_mass_kg=float(base_mass_kg),
+        s_ref=float(s_ref_m2),
+        rho=float(rho),
+        altitude=float(altitude),
+        curves=curves,
+    )
+
+
+def _build_speed_polar(db, aeroplane_uuid, sweep_request, asb_airplane, cl_values, cd_values):
+    """Glue around :func:`_compute_speed_polar`: resolve effective mass, wing
+    reference area and air density, then build the speed polar. Returns ``None``
+    if no polar data is available or anything goes wrong (best-effort add-on)."""
+    if cl_values is None or cd_values is None:
+        return None
+    try:
+        import aerosandbox as asb
+
+        from app.core.exceptions import NotFoundError
+        from app.services.mass_cg_service import get_effective_assumption_value
+
+        try:
+            base_mass = float(get_effective_assumption_value(db, aeroplane_uuid, "mass"))
+        except NotFoundError:
+            base_mass = 1.0
+            logger.warning(
+                "No 'mass' assumption for %s; speed polar defaults to 1.0 kg",
+                aeroplane_uuid,
+            )
+        s_ref = float(getattr(asb_airplane, "s_ref", 0.0) or 0.0)
+        altitude = float(getattr(sweep_request, "altitude", 0.0) or 0.0)
+        rho = float(asb.Atmosphere(altitude=altitude).density())
+        return _compute_speed_polar(
+            cl=cl_values,
+            cd=cd_values,
+            masses_kg=getattr(sweep_request, "masses_kg", None) or [],
+            base_mass_kg=base_mass,
+            s_ref_m2=s_ref,
+            rho=rho,
+            altitude=altitude,
+        )
+    except Exception as e:  # pragma: no cover - defensive add-on
+        logger.error("Speed polar computation failed: %s", e)
+        return None
+
+
 async def analyze_alpha_sweep(db: Session, aeroplane_uuid, sweep_request: AlphaSweepRequest) -> Any:
     """
     Perform an angle of attack sweep.
@@ -464,9 +604,13 @@ async def analyze_alpha_sweep(db: Session, aeroplane_uuid, sweep_request: AlphaS
         characteristic_points = _compute_alpha_sweep_characteristic_points(
             alpha_array, cl_values, cd_values, cm_values
         )
+        speed_polar = _build_speed_polar(
+            db, aeroplane_uuid, sweep_request, asb_airplane, cl_values, cd_values
+        )
         return {
             "analysis": result,
             "characteristic_points": characteristic_points,
+            "speed_polar": speed_polar,
             "aircraft_name": getattr(plane_schema, "name", str(aeroplane_uuid)),
         }
     except Exception as e:

--- a/app/tests/test_speed_polar.py
+++ b/app/tests/test_speed_polar.py
@@ -1,0 +1,135 @@
+"""Unit tests for the speed polar (Geschwindigkeitspolare) derivation.
+
+The speed polar derives sink rate ``w`` over forward speed ``V`` from a drag
+polar (CL/CD) for one or more masses. Aerodynamic coefficients are mass
+independent; only the speed required to fly a given CL scales with mass, so
+curves for different masses scale as ``V, w ∝ sqrt(m)``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from app.services.analysis_service import _compute_speed_polar
+
+G = 9.81
+
+
+def _v_of(mass: float, rho: float, s: float, cl: float) -> float:
+    return math.sqrt(2.0 * mass * G / (rho * s * cl))
+
+
+def test_single_base_curve_formula() -> None:
+    cl = np.array([0.5, 1.0])
+    cd = np.array([0.02, 0.05])
+    sp = _compute_speed_polar(
+        cl=cl, cd=cd, masses_kg=[], base_mass_kg=1.5, s_ref_m2=0.225, rho=1.225
+    )
+    assert len(sp.curves) == 1
+    curve = sp.curves[0]
+    assert curve.is_base is True
+    assert curve.mass_kg == pytest.approx(1.5)
+    # Arrays sorted ascending by V (higher CL -> lower V).
+    assert curve.V == sorted(curve.V)
+    # Spot-check the V and w formulas at CL = 1.0 (the lowest-V point).
+    v_expected = _v_of(1.5, 1.225, 0.225, 1.0)
+    idx = next(i for i, c in enumerate(curve.cl) if abs(c - 1.0) < 1e-9)
+    assert curve.V[idx] == pytest.approx(v_expected, rel=1e-9)
+    assert curve.w[idx] == pytest.approx(v_expected * (0.05 / 1.0), rel=1e-9)
+
+
+def test_sqrt_m_scaling() -> None:
+    """Quadrupling the mass scales V and w by exactly 2 (sqrt(4))."""
+    cl = np.array([0.4, 0.8, 1.2])
+    cd = np.array([0.018, 0.03, 0.06])
+    sp = _compute_speed_polar(
+        cl=cl, cd=cd, masses_kg=[1.0, 4.0], base_mass_kg=1.0, s_ref_m2=0.3, rho=1.225
+    )
+    by_mass = {c.mass_kg: c for c in sp.curves}
+    light, heavy = by_mass[1.0], by_mass[4.0]
+    for vl, vh in zip(light.V, heavy.V, strict=True):
+        assert vh == pytest.approx(2.0 * vl, rel=1e-9)
+    for wl, wh in zip(light.w, heavy.w, strict=True):
+        assert wh == pytest.approx(2.0 * wl, rel=1e-9)
+
+
+def test_filters_nonpositive_cl() -> None:
+    cl = np.array([-0.3, 0.0, 0.5, 1.0])
+    cd = np.array([0.04, 0.02, 0.02, 0.05])
+    sp = _compute_speed_polar(
+        cl=cl, cd=cd, masses_kg=[], base_mass_kg=2.0, s_ref_m2=0.225, rho=1.225
+    )
+    curve = sp.curves[0]
+    # Only CL = 0.5 and CL = 1.0 survive.
+    assert len(curve.V) == 2
+    assert all(c > 0 for c in curve.cl)
+
+
+def test_empty_masses_returns_base_only() -> None:
+    cl = np.array([0.5, 1.0])
+    cd = np.array([0.02, 0.05])
+    sp = _compute_speed_polar(
+        cl=cl, cd=cd, masses_kg=[], base_mass_kg=1.5, s_ref_m2=0.225, rho=1.225
+    )
+    assert [c.mass_kg for c in sp.curves] == [pytest.approx(1.5)]
+    assert sp.base_mass_kg == pytest.approx(1.5)
+
+
+def test_dedup_sort_and_base_flag() -> None:
+    cl = np.array([0.5, 1.0])
+    cd = np.array([0.02, 0.05])
+    sp = _compute_speed_polar(
+        cl=cl,
+        cd=cd,
+        masses_kg=[2.5, 1.5, 2.5],  # duplicate 2.5, base 1.5 not in list explicitly
+        base_mass_kg=1.5,
+        s_ref_m2=0.225,
+        rho=1.225,
+    )
+    masses = [c.mass_kg for c in sp.curves]
+    # Deduplicated, base included, ascending.
+    assert masses == [pytest.approx(1.5), pytest.approx(2.5)]
+    base_curves = [c for c in sp.curves if c.is_base]
+    assert len(base_curves) == 1
+    assert base_curves[0].mass_kg == pytest.approx(1.5)
+
+
+def test_characteristic_points_present() -> None:
+    # Parabolic polar so min-sink and best-glide land on distinct CL points
+    # (min-sink CL = sqrt(3) * best-glide CL for an ideal parabolic polar).
+    cd0, e, ar = 0.012, 0.85, 14.4
+    cl = np.linspace(0.1, 1.4, 200)
+    cd = cd0 + cl**2 / (math.pi * e * ar)
+    sp = _compute_speed_polar(
+        cl=cl, cd=cd, masses_kg=[], base_mass_kg=1.5, s_ref_m2=0.225, rho=1.225
+    )
+    curve = sp.curves[0]
+    assert curve.w_min is not None and curve.w_min > 0
+    assert curve.v_min_sink is not None and curve.v_min_sink > 0
+    assert curve.v_best_glide is not None and curve.v_best_glide > 0
+    assert curve.ld_max is not None
+    # Best glide L/D equals max(CL/CD) of the polar.
+    assert curve.ld_max == pytest.approx(float(np.max(cl / cd)), rel=1e-9)
+    # Min-sink speed is strictly below best-glide speed (classic glider ordering).
+    assert curve.v_min_sink < curve.v_best_glide
+
+
+def test_w_min_matches_closed_form() -> None:
+    """w_min from the discrete polar matches the closed-form _min_sink_rate."""
+    from app.services.assumption_compute_service import _min_sink_rate
+
+    cd0, e, ar = 0.012, 0.85, 14.4
+    mass, s_ref, rho = 1.5, 0.225, 1.225
+    cl = np.linspace(0.05, 1.4, 600)
+    cd = cd0 + cl**2 / (math.pi * e * ar)
+
+    sp = _compute_speed_polar(
+        cl=cl, cd=cd, masses_kg=[], base_mass_kg=mass, s_ref_m2=s_ref, rho=rho
+    )
+    w_min_discrete = sp.curves[0].w_min
+    w_min_closed = _min_sink_rate(mass, s_ref, cd0, ar, rho=rho, oswald_e=e)
+    assert w_min_closed is not None
+    assert w_min_discrete == pytest.approx(w_min_closed, rel=0.03)

--- a/docs/superpowers/specs/2026-05-30-geschwindigkeitspolare-design.md
+++ b/docs/superpowers/specs/2026-05-30-geschwindigkeitspolare-design.md
@@ -1,0 +1,192 @@
+# Geschwindigkeitspolare im „Analysis – Polar"-Tab
+
+**Datum:** 2026-05-30
+**Status:** Akzeptiert (Design), bereit für Implementierungsplanung
+**Sprache der UI:** Deutsch/Englisch gemischt wie im Bestand (Labels englisch, Tooltips teils deutsch)
+
+## Ziel
+
+Im Tab **„Analysis – Polar"** zusätzlich eine **Geschwindigkeitspolare**
+(Sinkrate `w` [m/s] über Fluggeschwindigkeit `V` [m/s]) anzeigen. Neben der
+gegebenen Masse (Design-Assumption `mass`, calculated **oder** estimate) sollen
+**weitere Massen** als Vergleichskurven angegeben werden können
+(Wasserballast-/Flächenbelastungs-Effekt beim Segler).
+
+## Entscheidungen (vom Nutzer bestätigt)
+
+1. **Datenbasis:** Echte AeroBuildup-α-Sweep-CL/CD (an die angezeigte
+   Widerstandspolare gekoppelt). Andere Massen skalieren die Kurve analytisch.
+2. **Massen-Eingabe:** Liste absoluter Massen in **kg**, vorbefüllt mit der
+   effektiven Assumption-Masse.
+3. **Darstellung:** Zusätzliches Chart in der bestehenden Polar-Grid.
+4. **Eingabeformat:** Deutsches Zahlenformat — **Dezimal-Komma**, **Semikolon
+   als Trenner**, z. B. `1,5; 2,0; 2,5`. Parser akzeptiert auch `.` als
+   Dezimaltrenner.
+
+## Physik (eine Aero-Rechnung, analytisch über Masse skaliert)
+
+Aerodynamische Beiwerte CL/CD (die Widerstandspolare) sind
+**massenunabhängig** — nur die bei gegebener Geschwindigkeit erreichte CL hängt
+von der Masse ab. Ein einziger AeroBuildup-α-Sweep liefert die CL/CD-Punkte;
+pro Masse `m` rein analytisch:
+
+```
+für jeden Sweep-Punkt mit CL > 0:
+    V(CL) = sqrt( 2 · m · g / (rho · S_ref · CL) )      # Gleitflug-Geschwindigkeit
+    w(CL) = V(CL) · (CD / CL)                            # Sinkrate (positiv = sinkend)
+```
+
+- Nur **CL > 0** wird berücksichtigt (stationärer Gleitflug; negative/Null-CL
+  liefern kein sinnvolles V).
+- Konsequenz: Massen skalieren die Kurve mit `V, w ∝ sqrt(m)` →
+  **kein zusätzlicher Aero-Lauf** nötig, nur Algebra über die bestehende Polare.
+- `g = 9.81`, `rho = asb.Atmosphere(altitude).density()`, `S_ref` aus dem
+  bereits gebauten ASB-Airplane (`asb_airplane.s_ref`).
+
+### Markante Punkte je Kurve
+
+- **V_stall** — bei `CL_max` (Maximum der Sweep-CL): `V = sqrt(2 m g / (rho S CL_max))`.
+- **V_min_sink / w_min** — Punkt mit minimalem `w`.
+- **V_best_glide / (L/D)_max** — Punkt mit minimalem `w/V` (= maximalem `V/w` =
+  maximalem `CL/CD`).
+
+Zur Konsistenz-Validierung: `w_min` aus dem diskreten Sweep muss näherungsweise
+mit dem geschlossenen `_min_sink_rate(...)` aus
+`assumption_compute_service.py` übereinstimmen (gleiche Physik, Anderson §6.7.2).
+
+## Darstellung
+
+- Neues Plotly-Chart **„Geschwindigkeitspolare (w über V)"** in der bestehenden
+  Polar-Grid (`AnalysisViewerPanel`, Bereich `activeTab === "Polar"`).
+- **Eine Kurve pro Masse** mit **Legende** (Masse in kg). Basis-Masse
+  hervorgehoben (kräftige Farbe/dicker), weitere Massen in abgesetzten Farben.
+- **Segler-Konvention:** `V` auf der x-Achse, **Sinkrate nach unten** aufgetragen
+  (y-Werte = `−w`), y-Achse beschriftet als `w [m/s]` (Sinken).
+- Marker + Annotation für **V_min_sink** und **V_best_glide** (auf der
+  Basis-Masse-Kurve; optional je Kurve).
+
+## Architektur & Komponenten
+
+### Backend
+
+**Schema** (`app/schemas/AeroplaneRequest.py`):
+- `AlphaSweepRequest` erhält optionales Feld
+  `masses_kg: Optional[list[float]] = None` (jeweils `> 0`).
+
+**Schema** (neu, `app/schemas/aeroanalysisschema.py` oder passendes Modul):
+```python
+class SpeedPolarCurve(BaseModel):
+    mass_kg: float
+    is_base: bool                 # entspricht der effektiven Assumption-Masse
+    V: list[float]                # m/s, aufsteigend nach V sortiert
+    w: list[float]                # m/s, Sinkrate positiv
+    cl: list[float]
+    cd: list[float]
+    v_stall: float | None
+    v_min_sink: float | None
+    w_min: float | None
+    v_best_glide: float | None
+    ld_max: float | None
+
+class SpeedPolar(BaseModel):
+    base_mass_kg: float
+    s_ref: float
+    rho: float
+    altitude: float
+    curves: list[SpeedPolarCurve]
+```
+
+**Service** (`app/services/analysis_service.py`):
+- Neuer reiner Helper
+  `_compute_speed_polar(cl, cd, masses_kg, base_mass_kg, s_ref, rho) -> SpeedPolar`.
+  Vollständig unit-testbar ohne DB/Aero.
+- `analyze_alpha_sweep(...)` ergänzt: effektive Masse aus Assumption (`mass`)
+  laden; `masses = (request.masses_kg or []) ∪ {base}`; `s_ref` aus
+  `asb_airplane`, `rho` aus `altitude`; `speed_polar` berechnen und in die
+  Antwort aufnehmen.
+- Antwort additiv:
+  ```python
+  return {
+      "analysis": result,
+      "characteristic_points": characteristic_points,
+      "speed_polar": speed_polar,          # NEU
+      "aircraft_name": ...,
+  }
+  ```
+- Massenliste: deduplizieren, aufsteigend sortieren; Basis-Masse markieren
+  (`is_base`). Liefert immer mindestens die Basis-Kurve.
+
+**Endpoint:** unverändert — `POST /aeroplanes/{id}/alpha_sweep` (additives
+Request-/Response-Feld). Keine neue Route.
+
+### Frontend
+
+**Hook** (`frontend/hooks/useAnalysis.ts`):
+- `AlphaSweepParams` erhält `masses_kg?: number[]`.
+- `AnalysisResult`/Rückgabe erhält `speedPolar` (aus `data.speed_polar`
+  extrahiert; null wenn nicht vorhanden).
+
+**ConfigPanel** (`frontend/components/workbench/AnalysisConfigPanel.tsx`):
+- Neuer Prop `effectiveMassKg?: number | null` (aus `currentMassKg` in
+  `app/workbench/analysis/page.tsx`, analog zu `designCgX`).
+- Neues Textfeld **„Massen [kg]"** im Polar-Bereich, vorbefüllt mit
+  `effectiveMassKg` (z. B. `"1,5"`). Placeholder `z. B. 1,5; 2,0; 2,5`.
+- Parser `parseMasses(input): number[]`:
+  ```
+  input.split(";") → je Token trim → "," durch "." ersetzen → parseFloat
+  → nur endliche Werte > 0 behalten
+  ```
+- `handleRunPolar` übergibt `masses_kg: parseMasses(massesInput)`.
+
+**Viewer** (`frontend/components/workbench/AnalysisViewerPanel.tsx`):
+- Neues Chart in der Polar-Grid, gespeist aus `result.speedPolar.curves`.
+- `PlotlyChart` minimal erweitern: Unterstützung mehrerer benannter Traces
+  (`traces: {name, x, y, color}[]`) + `showLegend?: boolean`. Bestehende
+  Single-Trace-Aufrufe bleiben unverändert (Abwärtskompatibilität).
+- y-Werte als `−w` auftragen (Sinken nach unten); Marker für V_min_sink /
+  V_best_glide.
+
+## Scope (YAGNI)
+
+**Enthalten:** echte Sweep-Daten, kg-Liste (deutsches Format), ein neues Chart
+mit Mehr-Massen-Kurven + markante Punkte; additive Backend-Erweiterung; Tests.
+
+**Nicht enthalten (separat):**
+- Parabolischer Umschalter (CD0 + k·CL²).
+- Tangenten-Overlay vom Ursprung (Sollfahrt).
+- Reynolds-Re-Run pro Masse.
+- Bereits gefundene Alt-Bugs (nur als separate Bug-Tickets notiert, **nicht** in
+  diesem Feature behoben):
+  - `sweep_var`-Dropdown und Analysis-Tool-/Flight-Profile-Selektoren sind
+    dekorativ (`handleRunPolar` ignoriert sie).
+  - `Number.parseFloat(alphaStart) || -5` verwirft eine eingegebene `0` als
+    Sweep-Start.
+
+## Tests (TDD, Ziel >80 %)
+
+**Backend** (`app/tests/`):
+- `_compute_speed_polar`: Formeln V/w korrekt; **√m-Skalierung** zwischen zwei
+  Massen; CL≤0-Punkte gefiltert; `w_min` konsistent mit `_min_sink_rate`
+  (Toleranz); leere/None-Massenliste → genau Basis-Kurve; `is_base` korrekt
+  gesetzt; Dedup/Sortierung.
+- Integration: `analyze_alpha_sweep` liefert `speed_polar` mit ≥1 Kurve für ein
+  Referenzflugzeug (z. B. Sailplane), Werte plausibel
+  (V_stall < V_min_sink < V_best_glide-Größenordnung; w_min > 0).
+
+**Frontend** (`frontend/__tests__/`):
+- `useAnalysis`: extrahiert `speedPolar` aus Mock-Response korrekt; null wenn
+  Feld fehlt.
+- `parseMasses`: `"1,5; 2,0; 2,5"` → `[1.5, 2.0, 2.5]`; gemischt `.`/`,`;
+  leere/ungültige Tokens verworfen; negative/0 verworfen.
+- Viewer rendert N Traces aus `speedPolar.curves` (N = Anzahl Massen) inkl.
+  Legende.
+
+## Risiken / Annahmen
+
+- CL/CD aus AeroBuildup sind für den relevanten Bereich (CL>0) monoton genug,
+  dass V/w sinnvolle Polaren ergeben; sehr kleine CL (hohes V) bleiben Teil der
+  Kurve (rechter Ast).
+- `S_ref` und `mass`-Assumption sind vorhanden (sonst klare Fehler-/Leerzustände
+  wie im Bestand).
+- Additive Erweiterung von `alpha_sweep` bricht bestehende Consumer nicht
+  (neues optionales Feld + neuer Response-Key).

--- a/frontend/__tests__/parseMasses.test.ts
+++ b/frontend/__tests__/parseMasses.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { parseMasses } from "@/lib/masses";
+
+describe("parseMasses", () => {
+  it("parses German comma decimals with semicolon separators", () => {
+    expect(parseMasses("1,5; 2,0; 2,5")).toEqual([1.5, 2.0, 2.5]);
+  });
+
+  it("accepts dot decimals as well", () => {
+    expect(parseMasses("1.5; 2.5")).toEqual([1.5, 2.5]);
+  });
+
+  it("drops empty, non-numeric and non-positive tokens", () => {
+    expect(parseMasses("1,5; ; abc; -2; 0; 3")).toEqual([1.5, 3]);
+  });
+
+  it("returns an empty array for empty/whitespace input", () => {
+    expect(parseMasses("")).toEqual([]);
+    expect(parseMasses("   ")).toEqual([]);
+  });
+
+  it("handles a single value", () => {
+    expect(parseMasses("1,5")).toEqual([1.5]);
+  });
+});

--- a/frontend/__tests__/useAnalysis.test.ts
+++ b/frontend/__tests__/useAnalysis.test.ts
@@ -111,4 +111,79 @@ describe("useAnalysis", () => {
       alpha: [-5, 15],
     });
   });
+
+  it("extracts speed_polar curves from the response", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          analysis: {
+            coefficients: { CL: [0.5], CD: [0.02], Cm: [0.0] },
+            flight_condition: { alpha: [2] },
+          },
+          speed_polar: {
+            base_mass_kg: 1.5,
+            s_ref: 0.225,
+            rho: 1.225,
+            altitude: 0,
+            curves: [
+              {
+                mass_kg: 1.5,
+                is_base: true,
+                V: [12],
+                w: [0.5],
+                cl: [0.5],
+                cd: [0.02],
+                v_stall: 10,
+                v_min_sink: 12,
+                w_min: 0.5,
+                v_best_glide: 13,
+                ld_max: 25,
+              },
+            ],
+          },
+        }),
+    });
+
+    const { result } = renderHook(() => useAnalysis("aero-1"));
+    await act(async () => {
+      await result.current.runAlphaSweep({
+        alpha_start: 0,
+        alpha_end: 5,
+        alpha_num: 2,
+        velocity: 14,
+        beta: 0,
+        altitude: 0,
+        xyz_ref: [0, 0, 0],
+        masses_kg: [1.5],
+      });
+    });
+
+    expect(result.current.speedPolar?.base_mass_kg).toBe(1.5);
+    expect(result.current.speedPolar?.curves).toHaveLength(1);
+    expect(result.current.speedPolar?.curves[0].is_base).toBe(true);
+  });
+
+  it("leaves speedPolar null when response omits speed_polar", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(FAKE_RESPONSE),
+    });
+
+    const { result } = renderHook(() => useAnalysis("aero-1"));
+    await act(async () => {
+      await result.current.runAlphaSweep({
+        alpha_start: -5,
+        alpha_end: 15,
+        alpha_num: 21,
+        velocity: 14,
+        beta: 0,
+        altitude: 0,
+        xyz_ref: [0, 0, 0],
+      });
+    });
+
+    expect(result.current.result).not.toBeNull();
+    expect(result.current.speedPolar).toBeNull();
+  });
 });

--- a/frontend/app/workbench/analysis/page.tsx
+++ b/frontend/app/workbench/analysis/page.tsx
@@ -92,6 +92,7 @@ export default function AnalysisPage() {
         <div className="min-h-0 flex-1 overflow-hidden">
           <AnalysisViewerPanel
             result={analysis.result}
+            speedPolar={analysis.speedPolar}
             aeroplaneId={aeroplaneId}
             hasWings={hasWings}
             lastRunTime={analysis.lastRunTime}
@@ -183,6 +184,7 @@ export default function AnalysisPage() {
                   (a) => a.parameter_name === "cg_x",
                 )?.effective_value ?? null
               }
+              effectiveMassKg={currentMassKg}
               operatingPoints={ops.points}
               onClose={() => setConfigOpen(false)}
             />

--- a/frontend/components/workbench/AnalysisConfigPanel.tsx
+++ b/frontend/components/workbench/AnalysisConfigPanel.tsx
@@ -10,6 +10,11 @@ import type { Tab } from "@/components/workbench/AnalysisViewerPanel";
 import { parseMasses, formatMass } from "@/lib/masses";
 
 type Mode = "single" | "sweep";
+
+/** Default speed-polar masses field value: the effective mass, or empty. */
+function defaultMassesFor(effectiveMassKg?: number | null): string {
+  return effectiveMassKg != null ? formatMass(effectiveMassKg) : "";
+}
 /**
  * gh-577: Trefftz/Streamlines basis selection.
  * - "trimmed" (default): pick a stored, trimmed OperatingPoint from the
@@ -262,7 +267,7 @@ export function AnalysisConfigPanel({
   const [beta, setBeta] = useState("0");
   // Speed-polar masses [kg], German format (comma decimal, semicolon separator).
   // Prefilled with the effective design mass.
-  const defaultMassesInput = effectiveMassKg != null ? formatMass(effectiveMassKg) : "";
+  const defaultMassesInput = defaultMassesFor(effectiveMassKg);
   const [massesInput, setMassesInput] = useState(defaultMassesInput);
   const [analysisTool, setAnalysisTool] = useState("aero_buildup");
   // xyzRef defaults to the design CG (cg_x effective from assumptions)

--- a/frontend/components/workbench/AnalysisConfigPanel.tsx
+++ b/frontend/components/workbench/AnalysisConfigPanel.tsx
@@ -7,6 +7,7 @@ import type { StripForcesAllParams } from "@/hooks/useStripForces";
 import type { StreamlinesParams } from "@/hooks/useStreamlines";
 import type { StoredOperatingPoint } from "@/hooks/useOperatingPoints";
 import type { Tab } from "@/components/workbench/AnalysisViewerPanel";
+import { parseMasses, formatMass } from "@/lib/masses";
 
 type Mode = "single" | "sweep";
 /**
@@ -36,6 +37,9 @@ interface AnalysisConfigPanelProps {
   // (cg_x effective value from assumptions). Falls back to 0 when not
   // available.
   readonly designCgX?: number | null;
+  // Effective design mass [kg] (assumption: calculated or estimate). Prefills
+  // the speed-polar masses field. Falls back to empty when not available.
+  readonly effectiveMassKg?: number | null;
   // gh-577: stored operating points for the trimmed-OP dropdown on the
   // Trefftz Plane and Streamlines tabs. The panel filters to TRIMMED
   // entries before rendering.
@@ -228,6 +232,7 @@ export function AnalysisConfigPanel({
   streamlinesRunning,
   streamlinesError,
   designCgX,
+  effectiveMassKg,
   operatingPoints,
   onClose,
 }: Readonly<AnalysisConfigPanelProps>) {
@@ -255,6 +260,11 @@ export function AnalysisConfigPanel({
   const [velocity, setVelocity] = useState("14");
   const [altitude, setAltitude] = useState("100");
   const [beta, setBeta] = useState("0");
+  // Speed-polar masses [kg], German format (comma decimal, semicolon separator).
+  // Prefilled with the effective design mass.
+  const [massesInput, setMassesInput] = useState(
+    effectiveMassKg != null ? formatMass(effectiveMassKg) : "",
+  );
   const [analysisTool, setAnalysisTool] = useState("aero_buildup");
   // xyzRef defaults to the design CG (cg_x effective from assumptions)
   // — that is the moment-reference point the rest of the system uses.
@@ -286,6 +296,7 @@ export function AnalysisConfigPanel({
       beta: Number.parseFloat(beta) || 0,
       altitude: Number.parseFloat(altitude) || 0,
       xyz_ref: parseXyzRef(),
+      masses_kg: parseMasses(massesInput),
     });
     onClose?.();
   };
@@ -330,6 +341,7 @@ export function AnalysisConfigPanel({
     setVelocity("14");
     setAltitude("100");
     setBeta("0");
+    setMassesInput(effectiveMassKg != null ? formatMass(effectiveMassKg) : "");
     setAnalysisTool("aero_buildup");
     setXyzRef(designCgX != null ? `${designCgX.toFixed(4)}, 0, 0` : "0, 0, 0");
     setTrefftzAlpha("5");
@@ -648,6 +660,32 @@ export function AnalysisConfigPanel({
                 </div>
               </div>
             )}
+          </div>
+
+          {/* ── Speed Polar Masses Card ── */}
+          <div className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4">
+            <span className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-muted-foreground">
+              Geschwindigkeitspolare — Massen [kg]
+            </span>
+            <div className="flex flex-col gap-1">
+              <label
+                htmlFor="speed-polar-masses"
+                className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground"
+              >
+                Massen (Komma = Dezimal, Semikolon = Trenner)
+              </label>
+              <input
+                id="speed-polar-masses"
+                type="text"
+                value={massesInput}
+                onChange={(e) => setMassesInput(e.target.value)}
+                placeholder="z. B. 1,5; 2,0; 2,5"
+                className="w-full rounded-xl border border-border bg-input px-3 py-2 font-[family-name:var(--font-geist-sans)] text-[13px] text-foreground"
+              />
+              <p className="font-[family-name:var(--font-geist-sans)] text-[10px] italic text-subtle-foreground">
+                Die effektive Auslegungsmasse wird immer als Basiskurve ergänzt.
+              </p>
+            </div>
           </div>
 
           {/* ── Analysis Tool Card ── */}

--- a/frontend/components/workbench/AnalysisConfigPanel.tsx
+++ b/frontend/components/workbench/AnalysisConfigPanel.tsx
@@ -262,9 +262,8 @@ export function AnalysisConfigPanel({
   const [beta, setBeta] = useState("0");
   // Speed-polar masses [kg], German format (comma decimal, semicolon separator).
   // Prefilled with the effective design mass.
-  const [massesInput, setMassesInput] = useState(
-    effectiveMassKg != null ? formatMass(effectiveMassKg) : "",
-  );
+  const defaultMassesInput = effectiveMassKg != null ? formatMass(effectiveMassKg) : "";
+  const [massesInput, setMassesInput] = useState(defaultMassesInput);
   const [analysisTool, setAnalysisTool] = useState("aero_buildup");
   // xyzRef defaults to the design CG (cg_x effective from assumptions)
   // — that is the moment-reference point the rest of the system uses.
@@ -341,7 +340,7 @@ export function AnalysisConfigPanel({
     setVelocity("14");
     setAltitude("100");
     setBeta("0");
-    setMassesInput(effectiveMassKg != null ? formatMass(effectiveMassKg) : "");
+    setMassesInput(defaultMassesInput);
     setAnalysisTool("aero_buildup");
     setXyzRef(designCgX != null ? `${designCgX.toFixed(4)}, 0, 0` : "0, 0, 0");
     setTrefftzAlpha("5");

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -752,6 +752,7 @@ function StreamlinesTabContent({
 
 export function AnalysisViewerPanel({
   result,
+  speedPolar,
   aeroplaneId,
   lastRunTime,
   lastRunDurationMs,

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -5,6 +5,7 @@ import { Loader2, Maximize2, Minimize2, Settings } from "lucide-react";
 import { InfoChipRow } from "@/components/workbench/InfoChipRow";
 import type { AnalysisResult } from "@/hooks/useAnalysis";
 import type { StripForcesResult } from "@/hooks/useStripForces";
+import type { SpeedPolar } from "@/hooks/useAnalysis";
 import type { FlightEnvelopeData } from "@/hooks/useFlightEnvelope";
 import { EnvelopePanel } from "@/components/workbench/EnvelopePanel";
 import type { StoredOperatingPoint, AVLTrimResult, AeroBuildupTrimResult, TrimConstraint, ControlSurface } from "@/hooks/useOperatingPoints";
@@ -53,6 +54,7 @@ interface WingXSec {
 
 interface Props {
   readonly result: AnalysisResult | null;
+  readonly speedPolar?: SpeedPolar | null;
   readonly aeroplaneId?: string | null;
   readonly lastRunTime?: Date | null;
   readonly lastRunDurationMs?: number | null;
@@ -227,6 +229,129 @@ function PlotlyChart({
         className="rounded-xl border border-border bg-card"
         style={{ height: isMaximized ? "100%" : 220 }}
       >
+        <div ref={containerRef} className="h-full w-full" />
+      </div>
+    </div>
+  );
+}
+
+// -- Speed Polar (Geschwindigkeitspolare) ---------------------------------
+
+const SPEED_POLAR_COLORS = [
+  "#3B82F6", "#30A46C", "#E5484D", "#A78BFA", "#F59E0B", "#06B6D4",
+];
+
+/** Format a mass for German-style display ("1.5" -> "1,5"). */
+function fmtMassKg(m: number): string {
+  return String(m).replace(".", ",");
+}
+
+/**
+ * Glider speed polar: sink rate w over forward speed V, one curve per mass.
+ * Sink is plotted downward (y = -w). The base (effective design) mass is
+ * highlighted; min-sink and best-glide points are marked on it.
+ */
+function SpeedPolarChart({ speedPolar }: Readonly<{ speedPolar: SpeedPolar }>) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const node = containerRef.current;
+    const curves = speedPolar.curves.filter((c) => c.V.length > 0);
+    if (!node || curves.length === 0) return;
+    let disposed = false;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let PlotlyRef: any = null;
+
+    (async () => {
+      PlotlyRef = await import("plotly.js-gl3d-dist-min");
+      if (disposed || !node) return;
+
+      const traces: Record<string, unknown>[] = curves.map((c, i) => ({
+        x: c.V,
+        y: c.w.map((w) => -w),
+        customdata: c.w,
+        type: "scatter",
+        mode: "lines",
+        name: `${fmtMassKg(c.mass_kg)} kg${c.is_base ? " (Basis)" : ""}`,
+        line: {
+          color: c.is_base ? "#FF8400" : SPEED_POLAR_COLORS[i % SPEED_POLAR_COLORS.length],
+          width: c.is_base ? 2.5 : 1.5,
+        },
+        hovertemplate: `${fmtMassKg(c.mass_kg)} kg<br>V: %{x:.1f} m/s<br>w: %{customdata:.2f} m/s<extra></extra>`,
+      }));
+
+      // Mark min-sink and best-glide on the base curve.
+      const base = curves.find((c) => c.is_base) ?? curves[0];
+      const mX: number[] = [];
+      const mY: number[] = [];
+      const mT: string[] = [];
+      if (base.v_min_sink != null && base.w_min != null) {
+        mX.push(base.v_min_sink);
+        mY.push(-base.w_min);
+        mT.push("min sink");
+      }
+      if (base.v_best_glide != null && base.ld_max && base.ld_max > 0) {
+        mX.push(base.v_best_glide);
+        mY.push(-(base.v_best_glide / base.ld_max));
+        mT.push("best glide");
+      }
+      if (mX.length > 0) {
+        traces.push({
+          x: mX,
+          y: mY,
+          text: mT,
+          type: "scatter",
+          mode: "markers+text",
+          name: "Punkte",
+          textposition: "top center",
+          textfont: { size: 9, color: "#FAFAFA" },
+          marker: { color: "#FAFAFA", size: 7, symbol: "circle" },
+          hovertemplate: "%{text}<br>V: %{x:.1f} m/s<extra></extra>",
+        });
+      }
+
+      const layout: Record<string, unknown> = {
+        paper_bgcolor: "transparent",
+        plot_bgcolor: "transparent",
+        font: { color: "#A1A1AA", family: "JetBrains Mono, monospace", size: 10 },
+        margin: { l: 55, r: 15, t: 5, b: 40 },
+        xaxis: {
+          title: { text: "V [m/s]", font: { size: 11 } },
+          gridcolor: "#27272A",
+          zerolinecolor: "#3F3F46",
+        },
+        yaxis: {
+          title: { text: "w [m/s] (Sinken)", font: { size: 11 } },
+          gridcolor: "#27272A",
+          zerolinecolor: "#3F3F46",
+        },
+        showlegend: true,
+        legend: { font: { size: 9 }, bgcolor: "transparent", orientation: "h", y: 1.14 },
+        autosize: true,
+      };
+
+      await PlotlyRef.react(node, traces, layout, {
+        responsive: true,
+        displayModeBar: false,
+      });
+    })();
+
+    return () => {
+      disposed = true;
+      if (node && PlotlyRef) PlotlyRef.purge(node);
+    };
+  }, [speedPolar]);
+
+  if (speedPolar.curves.every((c) => c.V.length === 0)) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-foreground">
+        Geschwindigkeitspolare (w über V)
+      </span>
+      <div className="rounded-xl border border-border bg-card" style={{ height: 280 }}>
         <div ref={containerRef} className="h-full w-full" />
       </div>
     </div>
@@ -853,6 +978,9 @@ export function AnalysisViewerPanel({
                 Analysis{"\u201D"}
               </span>
             </div>
+          )}
+          {speedPolar && speedPolar.curves.some((c) => c.V.length > 0) && (
+            <SpeedPolarChart speedPolar={speedPolar} />
           )}
         </div>
       )}

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -5,7 +5,7 @@ import { Loader2, Maximize2, Minimize2, Settings } from "lucide-react";
 import { InfoChipRow } from "@/components/workbench/InfoChipRow";
 import type { AnalysisResult } from "@/hooks/useAnalysis";
 import type { StripForcesResult } from "@/hooks/useStripForces";
-import type { SpeedPolar } from "@/hooks/useAnalysis";
+import type { SpeedPolar, SpeedPolarCurve } from "@/hooks/useAnalysis";
 import type { FlightEnvelopeData } from "@/hooks/useFlightEnvelope";
 import { EnvelopePanel } from "@/components/workbench/EnvelopePanel";
 import type { StoredOperatingPoint, AVLTrimResult, AeroBuildupTrimResult, TrimConstraint, ControlSurface } from "@/hooks/useOperatingPoints";
@@ -246,6 +246,86 @@ function fmtMassKg(m: number): string {
   return String(m).replace(".", ",");
 }
 
+/** Negate one sink-rate value (plotted downward). Hoisted to avoid deep nesting. */
+function negate(w: number): number {
+  return -w;
+}
+
+/** Build the line trace for one mass curve. */
+function speedPolarLineTrace(c: SpeedPolarCurve, i: number): PlotlyTrace {
+  return {
+    x: c.V,
+    y: c.w.map(negate),
+    customdata: c.w,
+    type: "scatter",
+    mode: "lines",
+    name: `${fmtMassKg(c.mass_kg)} kg${c.is_base ? " (Basis)" : ""}`,
+    line: {
+      color: c.is_base ? "#FF8400" : SPEED_POLAR_COLORS[i % SPEED_POLAR_COLORS.length],
+      width: c.is_base ? 2.5 : 1.5,
+    },
+    hovertemplate: `${fmtMassKg(c.mass_kg)} kg<br>V: %{x:.1f} m/s<br>w: %{customdata:.2f} m/s<extra></extra>`,
+  };
+}
+
+/** Marker trace for min-sink / best-glide on the base curve, or null if absent. */
+function speedPolarMarkerTrace(base: SpeedPolarCurve): PlotlyTrace | null {
+  const mX: number[] = [];
+  const mY: number[] = [];
+  const mT: string[] = [];
+  if (base.v_min_sink != null && base.w_min != null) {
+    mX.push(base.v_min_sink);
+    mY.push(-base.w_min);
+    mT.push("min sink");
+  }
+  if (base.v_best_glide != null && base.ld_max && base.ld_max > 0) {
+    mX.push(base.v_best_glide);
+    mY.push(-(base.v_best_glide / base.ld_max));
+    mT.push("best glide");
+  }
+  if (mX.length === 0) return null;
+  return {
+    x: mX,
+    y: mY,
+    text: mT,
+    type: "scatter",
+    mode: "markers+text",
+    name: "Punkte",
+    textposition: "top center",
+    textfont: { size: 9, color: "#FAFAFA" },
+    marker: { color: "#FAFAFA", size: 7, symbol: "circle" },
+    hovertemplate: "%{text}<br>V: %{x:.1f} m/s<extra></extra>",
+  };
+}
+
+function speedPolarTraces(curves: SpeedPolarCurve[]): PlotlyTrace[] {
+  const traces = curves.map(speedPolarLineTrace);
+  const base = curves.find((c) => c.is_base) ?? curves[0];
+  const markers = speedPolarMarkerTrace(base);
+  if (markers) traces.push(markers);
+  return traces;
+}
+
+const SPEED_POLAR_LAYOUT: Record<string, unknown> = {
+  paper_bgcolor: "transparent",
+  plot_bgcolor: "transparent",
+  font: { color: "#A1A1AA", family: "JetBrains Mono, monospace", size: 10 },
+  margin: { l: 55, r: 15, t: 5, b: 40 },
+  xaxis: {
+    title: { text: "V [m/s]", font: { size: 11 } },
+    gridcolor: "#27272A",
+    zerolinecolor: "#3F3F46",
+  },
+  yaxis: {
+    title: { text: "w [m/s] (Sinken)", font: { size: 11 } },
+    gridcolor: "#27272A",
+    zerolinecolor: "#3F3F46",
+  },
+  showlegend: true,
+  legend: { font: { size: 9 }, bgcolor: "transparent", orientation: "h", y: 1.14 },
+  autosize: true,
+};
+
 /**
  * Glider speed polar: sink rate w over forward speed V, one curve per mass.
  * Sink is plotted downward (y = -w). The base (effective design) mass is
@@ -261,76 +341,12 @@ function SpeedPolarChart({ speedPolar }: Readonly<{ speedPolar: SpeedPolar }>) {
     let disposed = false;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let PlotlyRef: any = null;
+    const traces = speedPolarTraces(curves);
 
     (async () => {
       PlotlyRef = await import("plotly.js-gl3d-dist-min");
       if (disposed || !node) return;
-
-      const traces: Record<string, unknown>[] = curves.map((c, i) => ({
-        x: c.V,
-        y: c.w.map((w) => -w),
-        customdata: c.w,
-        type: "scatter",
-        mode: "lines",
-        name: `${fmtMassKg(c.mass_kg)} kg${c.is_base ? " (Basis)" : ""}`,
-        line: {
-          color: c.is_base ? "#FF8400" : SPEED_POLAR_COLORS[i % SPEED_POLAR_COLORS.length],
-          width: c.is_base ? 2.5 : 1.5,
-        },
-        hovertemplate: `${fmtMassKg(c.mass_kg)} kg<br>V: %{x:.1f} m/s<br>w: %{customdata:.2f} m/s<extra></extra>`,
-      }));
-
-      // Mark min-sink and best-glide on the base curve.
-      const base = curves.find((c) => c.is_base) ?? curves[0];
-      const mX: number[] = [];
-      const mY: number[] = [];
-      const mT: string[] = [];
-      if (base.v_min_sink != null && base.w_min != null) {
-        mX.push(base.v_min_sink);
-        mY.push(-base.w_min);
-        mT.push("min sink");
-      }
-      if (base.v_best_glide != null && base.ld_max && base.ld_max > 0) {
-        mX.push(base.v_best_glide);
-        mY.push(-(base.v_best_glide / base.ld_max));
-        mT.push("best glide");
-      }
-      if (mX.length > 0) {
-        traces.push({
-          x: mX,
-          y: mY,
-          text: mT,
-          type: "scatter",
-          mode: "markers+text",
-          name: "Punkte",
-          textposition: "top center",
-          textfont: { size: 9, color: "#FAFAFA" },
-          marker: { color: "#FAFAFA", size: 7, symbol: "circle" },
-          hovertemplate: "%{text}<br>V: %{x:.1f} m/s<extra></extra>",
-        });
-      }
-
-      const layout: Record<string, unknown> = {
-        paper_bgcolor: "transparent",
-        plot_bgcolor: "transparent",
-        font: { color: "#A1A1AA", family: "JetBrains Mono, monospace", size: 10 },
-        margin: { l: 55, r: 15, t: 5, b: 40 },
-        xaxis: {
-          title: { text: "V [m/s]", font: { size: 11 } },
-          gridcolor: "#27272A",
-          zerolinecolor: "#3F3F46",
-        },
-        yaxis: {
-          title: { text: "w [m/s] (Sinken)", font: { size: 11 } },
-          gridcolor: "#27272A",
-          zerolinecolor: "#3F3F46",
-        },
-        showlegend: true,
-        legend: { font: { size: 9 }, bgcolor: "transparent", orientation: "h", y: 1.14 },
-        autosize: true,
-      };
-
-      await PlotlyRef.react(node, traces, layout, {
+      await PlotlyRef.react(node, traces, SPEED_POLAR_LAYOUT, {
         responsive: true,
         displayModeBar: false,
       });

--- a/frontend/hooks/useAnalysis.ts
+++ b/frontend/hooks/useAnalysis.ts
@@ -11,6 +11,8 @@ export interface AlphaSweepParams {
   beta: number;
   altitude: number;
   xyz_ref: number[];
+  /** Extra masses [kg] for speed-polar comparison curves (base mass always included). */
+  masses_kg?: number[];
 }
 
 export interface AnalysisResult {
@@ -19,6 +21,28 @@ export interface AnalysisResult {
   Cm: number[];
   alpha: number[];
   [key: string]: unknown;
+}
+
+export interface SpeedPolarCurve {
+  mass_kg: number;
+  is_base: boolean;
+  V: number[];
+  w: number[];
+  cl: number[];
+  cd: number[];
+  v_stall: number | null;
+  v_min_sink: number | null;
+  w_min: number | null;
+  v_best_glide: number | null;
+  ld_max: number | null;
+}
+
+export interface SpeedPolar {
+  base_mass_kg: number;
+  s_ref: number;
+  rho: number;
+  altitude: number;
+  curves: SpeedPolarCurve[];
 }
 
 /**
@@ -40,6 +64,7 @@ function extractResult(data: Record<string, unknown>): AnalysisResult {
 
 export interface UseAnalysisReturn {
   result: AnalysisResult | null;
+  speedPolar: SpeedPolar | null;
   isRunning: boolean;
   error: string | null;
   lastRunTime: Date | null;
@@ -49,6 +74,7 @@ export interface UseAnalysisReturn {
 
 export function useAnalysis(aeroplaneId: string | null): UseAnalysisReturn {
   const [result, setResult] = useState<AnalysisResult | null>(null);
+  const [speedPolar, setSpeedPolar] = useState<SpeedPolar | null>(null);
   const [isRunning, setIsRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [lastRunTime, setLastRunTime] = useState<Date | null>(null);
@@ -76,6 +102,7 @@ export function useAnalysis(aeroplaneId: string | null): UseAnalysisReturn {
         }
         const data = await res.json();
         setResult(extractResult(data));
+        setSpeedPolar((data.speed_polar as SpeedPolar | undefined) ?? null);
         setLastRunTime(new Date());
         setLastRunDurationMs(Date.now() - t0);
       } catch (err) {
@@ -87,5 +114,5 @@ export function useAnalysis(aeroplaneId: string | null): UseAnalysisReturn {
     [aeroplaneId],
   );
 
-  return { result, isRunning, error, lastRunTime, lastRunDurationMs, runAlphaSweep };
+  return { result, speedPolar, isRunning, error, lastRunTime, lastRunDurationMs, runAlphaSweep };
 }

--- a/frontend/lib/masses.ts
+++ b/frontend/lib/masses.ts
@@ -1,0 +1,21 @@
+/**
+ * Helpers for the German-formatted mass list used by the speed polar
+ * (Geschwindigkeitspolare). Decimal separator is a comma, list separator a
+ * semicolon, e.g. "1,5; 2,0; 2,5". A "." decimal separator is also accepted.
+ *
+ * Kept dependency-free so it can be unit-tested without loading the analysis
+ * client-component graph.
+ */
+
+/** Parse a mass list. Empty, non-numeric and non-positive tokens are dropped. */
+export function parseMasses(input: string): number[] {
+  return input
+    .split(";")
+    .map((tok) => Number.parseFloat(tok.trim().replace(/,/g, ".")))
+    .filter((n) => Number.isFinite(n) && n > 0);
+}
+
+/** Format a mass for the German-style input ("1.5" -> "1,5"). */
+export function formatMass(m: number): string {
+  return String(m).replace(".", ",");
+}


### PR DESCRIPTION
Closes #783

## What
Adds a **Geschwindigkeitspolare** (glide speed polar: sink rate `w` over forward
speed `V`) to **Analysis → Polar**, with comparison curves for several masses
besides the effective design mass.

## How
- **One aero run, analytic mass scaling.** CL/CD are mass-independent; per mass
  `m`, for each `CL>0`: `V=√(2·m·g/(ρ·S_ref·CL))`, `w=V·CD/CL`. Curves scale as
  `V,w ∝ √m` — no extra AeroBuildup runs.
- **Backend (additive):** `AlphaSweepRequest.masses_kg?`; pure helper
  `_compute_speed_polar`; `analyze_alpha_sweep` also returns `speed_polar`
  (`SpeedPolar`/`SpeedPolarCurve`). Effective mass from the `mass` assumption,
  `s_ref` from the ASB airplane, `ρ` from ISA at altitude. Route unchanged.
- **Frontend:** `useAnalysis` (`masses_kg` + `speedPolar`); `lib/masses`
  (`parseMasses` — German comma/semicolon; `formatMass`); config field
  **„Massen [kg]"** prefilled with the effective mass; `SpeedPolarChart`
  (one curve per mass, legend, base highlighted, sink downward, V_min_sink &
  V_best_glide markers).

## Tests
- Backend `app/tests/test_speed_polar.py` (7): V/w formulas, √m scaling,
  CL≤0 filtering, dedup+base flag, characteristic points, `w_min` consistency
  with closed-form `_min_sink_rate`.
- Frontend: `parseMasses` (5) + `useAnalysis` speedPolar extraction (2).
- Local: backend ruff clean, speed-polar 7/7; frontend eslint clean, vitest green.

## Manual smoke test
In the Polar tab, `1,5; 2,5; 3,5` renders three curves (`1,5 kg (Basis)`,
`2,5 kg`, `3,5 kg`) with min-sink/best-glide markers.

## Out of scope (filed separately)
Decorative `sweep_var`/tool/flight-profile selectors; `0` sweep-start → `-5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)