### PR TITLE
feat(gh-795,gh-796): morphed intermediate wing airfoils + content-hash airfoil storage

### DIFF
--- a/app/converters/openvsp_airfoil.py
+++ b/app/converters/openvsp_airfoil.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 
 import hashlib
 import math
+import os
+import tempfile
 from pathlib import Path
 from types import ModuleType
 from typing import Optional
@@ -686,7 +688,9 @@ def _coords_hash(coordinates: CoordList) -> str:
     re-import (no ``vsp_imported_<random-geom-id>`` clutter).
     """
     canon = ";".join(f"{float(x):.6f},{float(y):.6f}" for x, y in coordinates)
-    return hashlib.sha1(canon.encode("utf-8")).hexdigest()[:10]
+    # Not a security primitive — a short content-dedup key. usedforsecurity
+    # silences SAST/Sonar weak-hash hotspots.
+    return hashlib.sha1(canon.encode("utf-8"), usedforsecurity=False).hexdigest()[:10]
 
 
 def _read_dat_coords(path: Path) -> CoordList:
@@ -742,23 +746,59 @@ def _resolve_coords(ref: str) -> Optional[CoordList]:
         af = asb.Airfoil(name=ref)
         if af.coordinates is not None:
             return [(float(x), float(y)) for x, y in af.coordinates]
-    except Exception:  # noqa: BLE001 — asb optional / unknown name
+    except (ImportError, ModuleNotFoundError, ValueError, KeyError, TypeError):
+        # asb absent or the name isn't in its library — expected misses.
         pass
     return None
 
 
+# Content-keyed cache of Kulfan fits: the SLSQP fit is the expensive part
+# of morphing, and the augmenter morphs every insert of a pair from the
+# same two anchors. Keyed by coordinate-content hash (not file path), so
+# it's correct regardless of AIRFOILS_DIR and safe across imports/tests.
+_KULFAN_FIT_CACHE: dict[str, Optional[tuple]] = {}
+
+
+def _fit_kulfan(coords: CoordList) -> Optional[tuple]:
+    """Fit ``coords`` to a KulfanAirfoil; return (upper, lower, le, te)
+    weight tuple, or ``None`` on failure. Cached by content hash."""
+    key = _coords_hash(coords)
+    if key in _KULFAN_FIT_CACHE:
+        return _KULFAN_FIT_CACHE[key]
+    try:
+        import aerosandbox as asb
+        import numpy as np
+
+        k = asb.Airfoil(coordinates=np.array(coords, dtype=float)).to_kulfan_airfoil()
+        res: Optional[tuple] = (
+            tuple(float(w) for w in k.upper_weights),
+            tuple(float(w) for w in k.lower_weights),
+            float(k.leading_edge_weight),
+            float(k.TE_thickness),
+        )
+    except Exception:  # noqa: BLE001 — asb optional / fit failure → caller falls back
+        res = None
+    _KULFAN_FIT_CACHE[key] = res
+    return res
+
+
 def _kulfan_morph(ca: CoordList, cb: CoordList, t: float) -> Optional[CoordList]:
     """Morph two airfoils in Kulfan/CST weight space at fraction ``t``
-    (gh-796). Both are fit to ``asb.KulfanAirfoil`` (same mode count), the
-    weights interpolated, and coordinates regenerated. Returns ``None`` on
-    any failure / mode-count mismatch / non-finite result so the caller
-    can fall back to a raw coordinate blend."""
+    (gh-796). Both are fit to ``asb.KulfanAirfoil``, the weights
+    interpolated, and coordinates regenerated. Returns ``None`` on any
+    failure / mode-count mismatch / non-finite result so the caller can
+    fall back to a raw coordinate blend."""
     import aerosandbox as asb
     import numpy as np
 
-    ka = asb.Airfoil(coordinates=np.array(ca, dtype=float)).to_kulfan_airfoil()
-    kb = asb.Airfoil(coordinates=np.array(cb, dtype=float)).to_kulfan_airfoil()
-    if len(ka.upper_weights) != len(kb.upper_weights):
+    fa, fb = _fit_kulfan(ca), _fit_kulfan(cb)
+    if fa is None or fb is None:
+        return None
+    ua, la, lea, tea = fa
+    ub, lb, leb, teb = fb
+    # Guard for callers that fit with different n_weights_per_side — the
+    # default fit always matches, but stay defensive.
+    if len(ua) != len(ub) or len(la) != len(lb):
         return None
 
     def _blend(a, b):
@@ -766,12 +806,10 @@ def _kulfan_morph(ca: CoordList, cb: CoordList, t: float) -> Optional[CoordList]
 
     m = asb.KulfanAirfoil(
         name="morph",
-        upper_weights=_blend(ka.upper_weights, kb.upper_weights),
-        lower_weights=_blend(ka.lower_weights, kb.lower_weights),
-        leading_edge_weight=float(
-            (1.0 - t) * ka.leading_edge_weight + t * kb.leading_edge_weight
-        ),
-        TE_thickness=float((1.0 - t) * ka.TE_thickness + t * kb.TE_thickness),
+        upper_weights=_blend(ua, ub),
+        lower_weights=_blend(la, lb),
+        leading_edge_weight=float((1.0 - t) * lea + t * leb),
+        TE_thickness=float((1.0 - t) * tea + t * teb),
     )
     coords = np.array(m.coordinates, dtype=float)
     if coords.size == 0 or not np.isfinite(coords).all():
@@ -789,15 +827,24 @@ def _raw_blend(ca: CoordList, cb: CoordList, t: float) -> Optional[CoordList]:
         arr = np.array(c, dtype=float)
         i = int(np.argmin(arr[:, 0]))
         top, bot = arr[: i + 1], arr[i:]
+        if top.shape[0] < 2 or bot.shape[0] < 2:
+            return None, None
         if top[0, 0] > top[-1, 0]:
             top = top[::-1]
         if bot[0, 0] > bot[-1, 0]:
             bot = bot[::-1]
+        # The argmin-split assumes Selig order (upper then lower). If the
+        # points came the other way round, the halves are inverted — detect
+        # via mean-y and swap so ``top`` is always the upper surface.
+        if float(top[:, 1].mean()) < float(bot[:, 1].mean()):
+            top, bot = bot, top
         return top, bot
 
     xs = 0.5 * (1.0 - np.cos(np.linspace(0.0, np.pi, 80)))
     ta, ba = _split(ca)
     tb, bb = _split(cb)
+    if ta is None or tb is None:
+        return None
     yu = (1.0 - t) * np.interp(xs, ta[:, 0], ta[:, 1]) + t * np.interp(xs, tb[:, 0], tb[:, 1])
     yl = (1.0 - t) * np.interp(xs, ba[:, 0], ba[:, 1]) + t * np.interp(xs, bb[:, 0], bb[:, 1])
     if not (np.isfinite(yu).all() and np.isfinite(yl).all()):
@@ -854,20 +901,32 @@ def _export_selig(
     if u is None:
         # End-cap — call with 0.0 to keep behaviour deterministic.
         u = 0.0
-    tmp = AIRFOILS_DIR / f"._tmp_{geom_id}_xsec{xs_index}.dat"
+    # Collision-safe OS temp name (geom_id may contain unsafe chars).
+    fd, tmp_name = tempfile.mkstemp(prefix="_tmp_export_", suffix=".dat", dir=AIRFOILS_DIR)
+    os.close(fd)
+    tmp = Path(tmp_name)
     vsp.WriteSeligAirfoil(str(tmp), geom_id, float(u))
     coords = _read_dat_coords(tmp) if tmp.exists() else []
     try:
         tmp.unlink()
     except OSError:
         pass
-    if not coords:
-        # Defensive: keep the legacy stable-ish name if the export produced
-        # nothing parseable (should not happen for valid geometry).
-        fallback = AIRFOILS_DIR / f"{tag}_{geom_id}_xsec{xs_index}.dat"
-        vsp.WriteSeligAirfoil(str(fallback), geom_id, float(u))
-        return f"./components/airfoils/{fallback.name}"
-    return write_imported_airfoil_dat(coords, tag=tag)
+    if coords:
+        return write_imported_airfoil_dat(coords, tag=tag)
+    # Defensive fallback (should not happen for valid geometry): re-export
+    # to a sanitized name and still route through the content-hash sink so
+    # the result dedups like every other imported airfoil.
+    safe_id = "".join(c if c.isalnum() else "_" for c in str(geom_id))
+    fallback = AIRFOILS_DIR / f"{tag}_{safe_id}_xsec{xs_index}.dat"
+    vsp.WriteSeligAirfoil(str(fallback), geom_id, float(u))
+    fb_coords = _read_dat_coords(fallback) if fallback.exists() else []
+    if fb_coords:
+        try:
+            fallback.unlink()
+        except OSError:
+            pass
+        return write_imported_airfoil_dat(fb_coords, tag=tag)
+    return f"./components/airfoils/{fallback.name}"
 
 
 # ---------------------------------------------------------------------------

--- a/app/converters/openvsp_airfoil.py
+++ b/app/converters/openvsp_airfoil.py
@@ -18,6 +18,7 @@ Scope (per ``feedback_openvsp_import_rc_scope``)
 
 from __future__ import annotations
 
+import hashlib
 import math
 from pathlib import Path
 from types import ModuleType
@@ -673,6 +674,58 @@ def foilsurf_u_for_xs(vsp: ModuleType, xsurf: object, xsec_index: int) -> Option
 # ---------------------------------------------------------------------------
 
 
+CoordList = list[tuple[float, float]]
+
+
+def _coords_hash(coordinates: CoordList) -> str:
+    """Stable 10-hex content hash of an airfoil's coordinates (gh-795).
+
+    Coordinates are rounded to 6 decimals before hashing so trivial
+    float-formatting differences don't change the name. Identical
+    geometry → identical hash → identical filename → reused on
+    re-import (no ``vsp_imported_<random-geom-id>`` clutter).
+    """
+    canon = ";".join(f"{float(x):.6f},{float(y):.6f}" for x, y in coordinates)
+    return hashlib.sha1(canon.encode("utf-8")).hexdigest()[:10]
+
+
+def _read_dat_coords(path: Path) -> CoordList:
+    """Parse ``x y`` coordinate pairs from a Selig ``.dat`` (header lines
+    and blanks ignored)."""
+    coords: CoordList = []
+    for line in path.read_text().splitlines():
+        parts = line.split()
+        if len(parts) != 2:
+            continue
+        try:
+            coords.append((float(parts[0]), float(parts[1])))
+        except ValueError:
+            continue
+    return coords
+
+
+def _write_selig_dat(target: Path, coordinates: CoordList, *, name: str) -> None:
+    lines = [name]
+    lines += [f"{float(x):.6f} {float(y):.6f}" for x, y in coordinates]
+    target.write_text("\n".join(lines) + "\n")
+
+
+def write_imported_airfoil_dat(coordinates: CoordList, *, tag: str = "vsp_imported") -> str:
+    """Store an imported/derived airfoil under a **content-hash** filename
+    and return its relative path (gh-795).
+
+    Re-import of the same geometry maps to the same ``{tag}_{hash}.dat``
+    and the write is skipped (dedup). Used both for VSP-exported anchor
+    profiles and for morphed intermediate profiles (gh-796).
+    """
+    AIRFOILS_DIR.mkdir(parents=True, exist_ok=True)
+    fname = f"{tag}_{_coords_hash(coordinates)}.dat"
+    target = AIRFOILS_DIR / fname
+    if not target.exists():
+        _write_selig_dat(target, coordinates, name=fname[:-4])
+    return f"./components/airfoils/{fname}"
+
+
 def _export_selig(
     vsp: ModuleType,
     geom_id: str,
@@ -680,21 +733,33 @@ def _export_selig(
     xs_index: int,
     tag: str = "vsp_imported",
 ) -> str:
-    """Write a Selig ``.dat`` file via ``vsp.WriteSeligAirfoil``.
+    """Export an XSec's airfoil via ``vsp.WriteSeligAirfoil`` and store it
+    under a content-hash filename (gh-795).
 
-    Returns a relative path string the WingXSecSchema can store.
-    Filenames are unique per (geom, xs_index, tag) to support multiple
-    file-airfoils on a single import.
+    VSP writes by path, so we export to a throwaway temp file, read the
+    coordinates back, and re-store them under ``{tag}_{hash}.dat`` so
+    identical geometry dedups across re-imports. Returns a relative path
+    the WingXSecSchema can store.
     """
     AIRFOILS_DIR.mkdir(parents=True, exist_ok=True)
-    fname = f"{tag}_{geom_id}_xsec{xs_index}.dat"
-    target = AIRFOILS_DIR / fname
     u = foilsurf_u_for_xs(vsp, xsurf, xs_index)
     if u is None:
         # End-cap — call with 0.0 to keep behaviour deterministic.
         u = 0.0
-    vsp.WriteSeligAirfoil(str(target), geom_id, float(u))
-    return f"./components/airfoils/{fname}"
+    tmp = AIRFOILS_DIR / f"._tmp_{geom_id}_xsec{xs_index}.dat"
+    vsp.WriteSeligAirfoil(str(tmp), geom_id, float(u))
+    coords = _read_dat_coords(tmp) if tmp.exists() else []
+    try:
+        tmp.unlink()
+    except OSError:
+        pass
+    if not coords:
+        # Defensive: keep the legacy stable-ish name if the export produced
+        # nothing parseable (should not happen for valid geometry).
+        fallback = AIRFOILS_DIR / f"{tag}_{geom_id}_xsec{xs_index}.dat"
+        vsp.WriteSeligAirfoil(str(fallback), geom_id, float(u))
+        return f"./components/airfoils/{fallback.name}"
+    return write_imported_airfoil_dat(coords, tag=tag)
 
 
 # ---------------------------------------------------------------------------

--- a/app/converters/openvsp_airfoil.py
+++ b/app/converters/openvsp_airfoil.py
@@ -726,6 +726,114 @@ def write_imported_airfoil_dat(coordinates: CoordList, *, tag: str = "vsp_import
     return f"./components/airfoils/{fname}"
 
 
+def _resolve_coords(ref: str) -> Optional[CoordList]:
+    """Resolve an airfoil reference (NACA name or ``.dat`` path) to
+    coordinates (gh-796). Tries the path as-is, under ``AIRFOILS_DIR``,
+    and as ``<name>.dat``; falls back to AeroSandbox's named library for
+    bare NACA names. Returns ``None`` if nothing resolves."""
+    for cand in (Path(ref), AIRFOILS_DIR / Path(ref).name, AIRFOILS_DIR / f"{ref}.dat"):
+        if cand.exists():
+            coords = _read_dat_coords(cand)
+            if coords:
+                return coords
+    try:
+        import aerosandbox as asb
+
+        af = asb.Airfoil(name=ref)
+        if af.coordinates is not None:
+            return [(float(x), float(y)) for x, y in af.coordinates]
+    except Exception:  # noqa: BLE001 — asb optional / unknown name
+        pass
+    return None
+
+
+def _kulfan_morph(ca: CoordList, cb: CoordList, t: float) -> Optional[CoordList]:
+    """Morph two airfoils in Kulfan/CST weight space at fraction ``t``
+    (gh-796). Both are fit to ``asb.KulfanAirfoil`` (same mode count), the
+    weights interpolated, and coordinates regenerated. Returns ``None`` on
+    any failure / mode-count mismatch / non-finite result so the caller
+    can fall back to a raw coordinate blend."""
+    import aerosandbox as asb
+    import numpy as np
+
+    ka = asb.Airfoil(coordinates=np.array(ca, dtype=float)).to_kulfan_airfoil()
+    kb = asb.Airfoil(coordinates=np.array(cb, dtype=float)).to_kulfan_airfoil()
+    if len(ka.upper_weights) != len(kb.upper_weights):
+        return None
+
+    def _blend(a, b):
+        return (1.0 - t) * np.asarray(a, dtype=float) + t * np.asarray(b, dtype=float)
+
+    m = asb.KulfanAirfoil(
+        name="morph",
+        upper_weights=_blend(ka.upper_weights, kb.upper_weights),
+        lower_weights=_blend(ka.lower_weights, kb.lower_weights),
+        leading_edge_weight=float(
+            (1.0 - t) * ka.leading_edge_weight + t * kb.leading_edge_weight
+        ),
+        TE_thickness=float((1.0 - t) * ka.TE_thickness + t * kb.TE_thickness),
+    )
+    coords = np.array(m.coordinates, dtype=float)
+    if coords.size == 0 or not np.isfinite(coords).all():
+        return None
+    return [(float(x), float(y)) for x, y in coords]
+
+
+def _raw_blend(ca: CoordList, cb: CoordList, t: float) -> Optional[CoordList]:
+    """Fallback morph: blend upper/lower surfaces on a common cosine
+    x-grid (gh-796). Pure NumPy — works when AeroSandbox/Kulfan is
+    unavailable or its fit fails (e.g. reflex/cusp profiles)."""
+    import numpy as np
+
+    def _split(c):
+        arr = np.array(c, dtype=float)
+        i = int(np.argmin(arr[:, 0]))
+        top, bot = arr[: i + 1], arr[i:]
+        if top[0, 0] > top[-1, 0]:
+            top = top[::-1]
+        if bot[0, 0] > bot[-1, 0]:
+            bot = bot[::-1]
+        return top, bot
+
+    xs = 0.5 * (1.0 - np.cos(np.linspace(0.0, np.pi, 80)))
+    ta, ba = _split(ca)
+    tb, bb = _split(cb)
+    yu = (1.0 - t) * np.interp(xs, ta[:, 0], ta[:, 1]) + t * np.interp(xs, tb[:, 0], tb[:, 1])
+    yl = (1.0 - t) * np.interp(xs, ba[:, 0], ba[:, 1]) + t * np.interp(xs, bb[:, 0], bb[:, 1])
+    if not (np.isfinite(yu).all() and np.isfinite(yl).all()):
+        return None
+    upper = list(zip(xs[::-1], yu[::-1], strict=True))
+    lower = list(zip(xs, yl, strict=True))
+    return [(float(x), float(y)) for x, y in upper + lower[1:]]
+
+
+def morph_airfoils(ref_a: str, ref_b: str, t: float) -> Optional[str]:
+    """Morph between two airfoil references at fraction ``t`` and store the
+    result under a content-hash ``vsp_morph_*.dat`` (gh-796).
+
+    Kulfan/CST interpolation first (smooth, always-valid); raw coordinate
+    blend as fallback. Returns the relative ``.dat`` path, or ``None`` if
+    neither anchor resolves / both methods fail — the caller then assigns
+    the nearer anchor's airfoil so the geometric form is still captured.
+    """
+    ca, cb = _resolve_coords(ref_a), _resolve_coords(ref_b)
+    if ca is None or cb is None:
+        return None
+    coords: Optional[CoordList] = None
+    try:
+        coords = _kulfan_morph(ca, cb, t)
+    except Exception:  # noqa: BLE001 — fall back on any asb/fit failure
+        coords = None
+    if coords is None:
+        try:
+            coords = _raw_blend(ca, cb, t)
+        except Exception:  # noqa: BLE001
+            return None
+    if not coords:
+        return None
+    return write_imported_airfoil_dat(coords, tag="vsp_morph")
+
+
 def _export_selig(
     vsp: ModuleType,
     geom_id: str,

--- a/app/converters/openvsp_wing_handler.py
+++ b/app/converters/openvsp_wing_handler.py
@@ -361,7 +361,7 @@ def _chord_from_le_te(le: tuple[float, float, float], te: tuple[float, float, fl
     review flagged that as wrong for any non-zero-dihedral wing
     (VTPs would get a 90° "twist" from the upright rotation). Twist
     is instead linearly interpolated between the anchor xsecs' own
-    ``twist`` parm values — see :func:`_augment_same_airfoil_pairs`.
+    ``twist`` parm values — see :func:`_augment_xsec_pairs`.
 
     Returns ``0.0`` when LE and TE coincide (degenerate xsec).
     """
@@ -464,7 +464,7 @@ def _try_emit_one_insert(
     ``u``. Returns one of the ``_OUTCOME_*`` strings so the caller can
     bookkeep cap-clamps, dedupes, and CompPnt01 failures separately.
 
-    Extracted from :func:`_augment_same_airfoil_pairs` to keep the
+    Extracted from :func:`_augment_xsec_pairs` to keep the
     outer loop's cognitive complexity below SonarQube's ``python:S3776``
     threshold (= 15). Each early-return represents one decision branch
     that would otherwise have lived in the loop body.
@@ -512,21 +512,25 @@ def _try_emit_one_insert(
     return _OUTCOME_INSERTED
 
 
-def _augment_same_airfoil_pairs(
+def _augment_xsec_pairs(
     x_secs: list[WingXSecSchema],
     vsp: ModuleType,
     gid: str,
     ctx: ImportContext,
     geom_name: str,
 ) -> list[WingXSecSchema]:
-    """Insert ``_N_INTERP_PER_PAIR`` interpolated xsecs between every
-    consecutive pair of anchors that shares the same ``airfoil``
-    reference. Pairs with different airfoils are left untouched.
+    """Insert ``_N_INTERP_PER_PAIR`` interpolated xsecs between **every**
+    consecutive anchor pair (gh-796 — previously only same-airfoil pairs,
+    which left e.g. the Corsair gull wing unaugmented).
 
     The interpolated xsecs:
     - sit at evenly spaced ``u`` values between the two anchors
-    - inherit the anchor's airfoil name (NACA preserved — no
-      ``vsp_imported_*.dat`` generated for same-airfoil paths)
+    - get their airfoil from the anchors:
+      - same airfoil on both → inherit it (NACA name preserved, no file)
+      - different → a **Kulfan-morphed** profile blended at the insert's
+        spanwise fraction ``t`` (``openvsp_airfoil.morph_airfoils``),
+        stored under a content-hash ``vsp_morph_*.dat``. If morphing
+        fails, the nearer anchor's airfoil is used (form still captured).
     - carry ``x_sec_type="segment"`` (intermediate, not root/tip)
     - take their ``xyz_le`` and ``chord`` from VSP's parametric
       surface via ``CompPnt01`` — the "real" Spitfire ellipse, not
@@ -598,8 +602,7 @@ def _augment_same_airfoil_pairs(
         if i == n_anchors - 1:
             break  # last anchor, no next pair
         nxt = x_secs[i + 1]
-        if anchor.airfoil != nxt.airfoil:
-            continue  # different profiles → skip (user-edit-ability)
+        same_airfoil = anchor.airfoil == nxt.airfoil
 
         # gh-760: query VSP for each anchor's real u-position instead
         # of the naive ``i / (n_anchors - 1)`` mapping. The cap-aware
@@ -627,13 +630,21 @@ def _augment_same_airfoil_pairs(
             # anchors at fractional position t = k / (N_INTERP + 1).
             t = k / float(_N_INTERP_PER_PAIR + 1)
             twist_deg = twist_lo + (twist_hi - twist_lo) * t
+            # gh-796: same airfoil → inherit; different → morph at t (with
+            # nearest-anchor fallback so the form is captured regardless).
+            if same_airfoil:
+                insert_airfoil = anchor.airfoil
+            else:
+                insert_airfoil = openvsp_airfoil.morph_airfoils(
+                    str(anchor.airfoil), str(nxt.airfoil), t
+                ) or (anchor.airfoil if t < 0.5 else nxt.airfoil)
             outcome = _try_emit_one_insert(
                 vsp=vsp,
                 gid=gid,
                 u=u,
                 u_max=u_max,
                 twist_deg=twist_deg,
-                airfoil=anchor.airfoil,
+                airfoil=insert_airfoil,
                 out=out,
             )
             counts[outcome] += 1
@@ -917,7 +928,7 @@ def _handle_wing(
     # render as smooth splines. Runs in WORLD frame post-XForm — CompPnt01
     # returns world-frame coordinates so the inserts compose directly with
     # the post-XForm anchors. No further transform is applied to the inserts.
-    x_secs = _augment_same_airfoil_pairs(x_secs, vsp, gid, ctx, name)
+    x_secs = _augment_xsec_pairs(x_secs, vsp, gid, ctx, name)
 
     wing = AsbWingSchema(
         name=name,

--- a/app/converters/openvsp_wing_handler.py
+++ b/app/converters/openvsp_wing_handler.py
@@ -226,17 +226,19 @@ def _apply_xform(
 
 
 # ---------------------------------------------------------------------------
-# Spanwise xsec augmentation between same-airfoil anchors (gh-753)
+# Spanwise xsec augmentation between anchor pairs (gh-753, gh-796)
 # ---------------------------------------------------------------------------
 #
 # OpenVSP wings with few defined XSecs render polygonal in the
 # workbench — the Spitfire's elliptical wing has only 4 anchors in
 # the .vsp3, so the planform looks like a pentagon. We augment via
-# VSP's ``CompPnt01`` parametric-surface sampling, *but only between
-# XSec pairs that share the same airfoil reference*. The user must
-# remain able to swap profiles at the anchors for Re-number scaling
-# workflows — interpolated cross-airfoil xsecs would be opaque
-# morphed-profile blobs the user can't edit cleanly.
+# VSP's ``CompPnt01`` parametric-surface sampling between **every**
+# consecutive anchor pair (gh-796 — previously only same-airfoil pairs,
+# which left the Corsair gull wing unaugmented). Same-airfoil pairs
+# inherit the airfoil name; differing-airfoil pairs get a Kulfan-morphed
+# intermediate profile per insert (nearest-anchor fallback if morphing
+# is unavailable). The anchors keep their raw airfoils, so the user can
+# still swap profiles there for Re-number scaling workflows.
 
 
 # VSP wing surface parametrisation:
@@ -590,6 +592,7 @@ def _augment_xsec_pairs(
     u_max = u_max_formula if use_formula_u else _find_cap_safe_u_max(vsp, gid)
     out: list[WingXSecSchema] = []
     expected_inserts = 0
+    morph_fallbacks = 0  # gh-796: inserts that fell back to a nearest-anchor airfoil
     counts: dict[str, int] = {
         _OUTCOME_INSERTED: 0,
         _OUTCOME_CAP_CLAMPED: 0,
@@ -635,9 +638,14 @@ def _augment_xsec_pairs(
             if same_airfoil:
                 insert_airfoil = anchor.airfoil
             else:
-                insert_airfoil = openvsp_airfoil.morph_airfoils(
+                morphed = openvsp_airfoil.morph_airfoils(
                     str(anchor.airfoil), str(nxt.airfoil), t
-                ) or (anchor.airfoil if t < 0.5 else nxt.airfoil)
+                )
+                if morphed is None:
+                    morph_fallbacks += 1
+                    insert_airfoil = anchor.airfoil if t < 0.5 else nxt.airfoil
+                else:
+                    insert_airfoil = morphed
             outcome = _try_emit_one_insert(
                 vsp=vsp,
                 gid=gid,
@@ -656,6 +664,19 @@ def _augment_xsec_pairs(
         expected_inserts=expected_inserts,
         counts=counts,
     )
+    if morph_fallbacks:
+        # gh-796: surface silent airfoil approximations (e.g. AeroSandbox not
+        # installed) so the user knows the morphed sections are placeholders.
+        ctx.add_warning(
+            component_type="WING",
+            component_name=geom_name,
+            reason=(
+                f"{morph_fallbacks} augmented xsec(s) used the nearest anchor's "
+                f"airfoil because Kulfan morphing was unavailable or failed; the "
+                f"planform is correct but those sections' profiles are approximate."
+            ),
+            severity="info",
+        )
 
     return out
 

--- a/app/tests/test_openvsp_airfoil.py
+++ b/app/tests/test_openvsp_airfoil.py
@@ -221,13 +221,11 @@ class TestImportAirfoilFromXsec:
         assert result == "naca2412"
         assert ctx.warnings == []
 
-    def test_file_airfoil_writes_dat_file(self, airfoils_dir, monkeypatch):
-        capture: list[str] = []
+    def test_file_airfoil_writes_dat_file(self, airfoils_dir):
         fake = _make_airfoil_vsp(
             xs_shape=12,  # XS_FILE_AIRFOIL
             xs_parms={},
             xs_shapes_in_surface=[12, 12, 12],
-            write_path_capture=capture,
         )
         ctx = ImportContext()
         result = import_airfoil_from_xsec(
@@ -240,39 +238,30 @@ class TestImportAirfoilFromXsec:
         )
         assert result is not None
         assert result.endswith(".dat")
-        assert len(capture) == 1
-        # The file actually exists on disk now.
-        written = Path(capture[0])
-        assert written.exists()
-        assert "vsp_imported" in written.name
+        # gh-795: stored under a content-hash name (not the ephemeral
+        # geom-id). The file exists at the returned path's basename.
+        assert "vsp_imported" in Path(result).name
+        assert (airfoils_dir / Path(result).name).exists()
 
-    def test_unique_filenames_for_two_file_airfoils(self, airfoils_dir):
-        capture: list[str] = []
+    def test_identical_airfoils_dedup_to_one_file(self, airfoils_dir):
+        # gh-795: two xsecs with identical geometry (the fake VSP writes the
+        # same coordinates) now map to the SAME content-hash file instead of
+        # two geom-id-named duplicates. (Distinct-geometry → distinct-file is
+        # covered in test_openvsp_airfoil_hash_morph.py.)
         fake = _make_airfoil_vsp(
             xs_shape=12,
             xs_parms={},
             xs_shapes_in_surface=[12, 12, 12],
-            write_path_capture=capture,
         )
         ctx = ImportContext()
         r1 = import_airfoil_from_xsec(
-            xs_id="XS_0",
-            geom_id="WING1",
-            xsurf="XSURF",
-            xs_index=0,
-            ctx=ctx,
-            vsp=fake,
+            xs_id="XS_0", geom_id="WING1", xsurf="XSURF", xs_index=0, ctx=ctx, vsp=fake
         )
         r2 = import_airfoil_from_xsec(
-            xs_id="XS_1",
-            geom_id="WING1",
-            xsurf="XSURF",
-            xs_index=1,
-            ctx=ctx,
-            vsp=fake,
+            xs_id="XS_1", geom_id="WING1", xsurf="XSURF", xs_index=1, ctx=ctx, vsp=fake
         )
-        assert r1 != r2
-        assert len(set(capture)) == 2
+        assert r1 == r2
+        assert len(list(airfoils_dir.glob("vsp_imported_*.dat"))) == 1
 
     def test_cst_falls_back_to_file_export_with_warning(self, airfoils_dir):
         fake = _make_airfoil_vsp(

--- a/app/tests/test_openvsp_airfoil_hash_morph.py
+++ b/app/tests/test_openvsp_airfoil_hash_morph.py
@@ -66,3 +66,54 @@ def test_custom_tag_prefix(tmp_path, monkeypatch):
     monkeypatch.setattr(oa, "AIRFOILS_DIR", tmp_path)
     rel = oa.write_imported_airfoil_dat(_sym(0.05), tag="vsp_morph")
     assert Path(rel).name.startswith("vsp_morph_")
+
+
+# --------------------------------------------------------------------------- #
+# gh-796 — morphing
+# --------------------------------------------------------------------------- #
+
+
+def _max_upper_y(coords):
+    return max(y for _x, y in coords)
+
+
+def test_raw_blend_thickness_is_between_anchors():
+    # Pure NumPy fallback: blend a 6% and a 10% symmetric section at 0.5
+    # → ~8% half-thickness, valid finite coords.
+    out = oa._raw_blend(_sym(0.06), _sym(0.10), 0.5)
+    assert out is not None
+    assert _max_upper_y(out) == pytest.approx(0.08, abs=0.01)
+
+
+def test_morph_falls_back_to_raw_blend_when_kulfan_fails(tmp_path, monkeypatch):
+    # No AeroSandbox needed: resolve two .dat from disk, force the Kulfan
+    # path to raise → raw-blend fallback still yields a content-hash file.
+    monkeypatch.setattr(oa, "AIRFOILS_DIR", tmp_path)
+    a = oa.write_imported_airfoil_dat(_sym(0.06), tag="anchor_a")
+    b = oa.write_imported_airfoil_dat(_sym(0.10), tag="anchor_b")
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("kulfan unavailable")
+
+    monkeypatch.setattr(oa, "_kulfan_morph", _boom)
+    rel = oa.morph_airfoils(Path(a).name, Path(b).name, 0.5)
+    assert rel is not None
+    assert Path(rel).name.startswith("vsp_morph_")
+    assert (tmp_path / Path(rel).name).exists()
+
+
+def test_morph_returns_none_when_anchor_unresolvable(tmp_path, monkeypatch):
+    monkeypatch.setattr(oa, "AIRFOILS_DIR", tmp_path)
+    assert oa.morph_airfoils("does_not_exist_a", "does_not_exist_b", 0.5) is None
+
+
+def test_kulfan_morph_thickness_between_anchors(tmp_path, monkeypatch):
+    """Real Kulfan interpolation between two symmetric NACA sections."""
+    pytest.importorskip("aerosandbox")
+    monkeypatch.setattr(oa, "AIRFOILS_DIR", tmp_path)
+    # asb resolves bare NACA names; 18% and 8% symmetric → ~13% at t=0.5.
+    rel = oa.morph_airfoils("naca0018", "naca0008", 0.5)
+    assert rel is not None
+    assert Path(rel).name.startswith("vsp_morph_")
+    coords = oa._read_dat_coords(tmp_path / Path(rel).name)
+    assert _max_upper_y(coords) == pytest.approx(0.065, abs=0.02)  # ~half of 13%

--- a/app/tests/test_openvsp_airfoil_hash_morph.py
+++ b/app/tests/test_openvsp_airfoil_hash_morph.py
@@ -107,6 +107,49 @@ def test_morph_returns_none_when_anchor_unresolvable(tmp_path, monkeypatch):
     assert oa.morph_airfoils("does_not_exist_a", "does_not_exist_b", 0.5) is None
 
 
+def test_raw_blend_degenerate_split_returns_none():
+    # Fewer than 2 points per surface → _split bails → None (caller then
+    # uses nearest-anchor airfoil).
+    assert oa._raw_blend([(0.0, 0.0)], [(0.0, 0.0)], 0.5) is None
+
+
+class _FakeSeligVsp:
+    """Minimal VSP stub for _export_selig: writes a chosen sequence of
+    file contents on successive WriteSeligAirfoil calls."""
+
+    def __init__(self, contents):
+        self._contents = list(contents)
+        self.calls = 0
+
+    def WriteSeligAirfoil(self, path, geom_id, u):  # noqa: N802 — VSP API name
+        body = self._contents[min(self.calls, len(self._contents) - 1)]
+        Path(path).write_text(body)
+        self.calls += 1
+
+
+def test_export_selig_routes_fallback_through_content_hash(tmp_path, monkeypatch):
+    # Temp export empty (unparseable) → fallback re-export yields coords →
+    # still stored under a content-hash name (no legacy-named dedup bypass).
+    monkeypatch.setattr(oa, "AIRFOILS_DIR", tmp_path)
+    monkeypatch.setattr(oa, "foilsurf_u_for_xs", lambda *a, **k: 0.0)
+    vsp = _FakeSeligVsp(["", "fb\n1.0 0.0\n0.0 0.0\n1.0 -0.0\n"])
+    rel = oa._export_selig(vsp, "GEOM/UNSAFE\\ID", object(), 2)
+    assert vsp.calls == 2  # temp empty → fallback re-export
+    assert Path(rel).name.startswith("vsp_imported_")
+    assert (tmp_path / Path(rel).name).exists()
+
+
+def test_export_selig_last_resort_legacy_name_when_unparseable(tmp_path, monkeypatch):
+    # Both temp and fallback unparseable → last-resort sanitized legacy name.
+    monkeypatch.setattr(oa, "AIRFOILS_DIR", tmp_path)
+    monkeypatch.setattr(oa, "foilsurf_u_for_xs", lambda *a, **k: 0.0)
+    vsp = _FakeSeligVsp([""])  # always empty
+    rel = oa._export_selig(vsp, "GEOM/UNSAFE\\ID", object(), 0)
+    name = Path(rel).name
+    assert name.startswith("vsp_imported_")
+    assert "/" not in name and "\\" not in name  # geom_id sanitized
+
+
 def test_kulfan_morph_thickness_between_anchors(tmp_path, monkeypatch):
     """Real Kulfan interpolation between two symmetric NACA sections."""
     pytest.importorskip("aerosandbox")

--- a/app/tests/test_openvsp_airfoil_hash_morph.py
+++ b/app/tests/test_openvsp_airfoil_hash_morph.py
@@ -1,0 +1,68 @@
+"""Content-hash airfoil naming (gh-795) + Kulfan morph (gh-796).
+
+The naming/IO helpers are pure-Python (no OpenVSP/AeroSandbox) so they run
+in the fast CI tier and contribute coverage. The morph tests gate on
+``aerosandbox`` via ``importorskip`` (installed in the fast tier).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.converters import openvsp_airfoil as oa
+
+
+# --------------------------------------------------------------------------- #
+# gh-795 — content-hash naming + dedup
+# --------------------------------------------------------------------------- #
+
+
+def _sym(thick: float) -> list[tuple[float, float]]:
+    """A tiny symmetric 'airfoil' of given half-thickness, valid coords."""
+    return [(1.0, 0.0), (0.5, thick), (0.0, 0.0), (0.5, -thick), (1.0, 0.0)]
+
+
+def test_coords_hash_deterministic_and_distinct():
+    assert oa._coords_hash(_sym(0.06)) == oa._coords_hash(_sym(0.06))
+    assert oa._coords_hash(_sym(0.06)) != oa._coords_hash(_sym(0.09))
+
+
+def test_coords_hash_rounds_to_six_decimals():
+    a = [(0.5, 0.0600001), (0.0, 0.0)]
+    b = [(0.5, 0.0600002), (0.0, 0.0)]  # same to 6 dp
+    assert oa._coords_hash(a) == oa._coords_hash(b)
+
+
+def test_write_imported_airfoil_dedup_and_distinct(tmp_path, monkeypatch):
+    monkeypatch.setattr(oa, "AIRFOILS_DIR", tmp_path)
+
+    p1 = oa.write_imported_airfoil_dat(_sym(0.06))
+    assert Path(p1).name.startswith("vsp_imported_")
+    assert p1.startswith("./components/airfoils/")
+    assert (tmp_path / Path(p1).name).exists()
+
+    # Same geometry → same name, no second file written.
+    p2 = oa.write_imported_airfoil_dat(_sym(0.06))
+    assert p2 == p1
+    assert len(list(tmp_path.glob("*.dat"))) == 1
+
+    # Different geometry → different file.
+    p3 = oa.write_imported_airfoil_dat(_sym(0.09))
+    assert p3 != p1
+    assert len(list(tmp_path.glob("*.dat"))) == 2
+
+
+def test_write_then_read_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setattr(oa, "AIRFOILS_DIR", tmp_path)
+    coords = _sym(0.08)
+    rel = oa.write_imported_airfoil_dat(coords)
+    read_back = oa._read_dat_coords(tmp_path / Path(rel).name)
+    assert read_back == [(round(x, 6), round(y, 6)) for x, y in coords]
+
+
+def test_custom_tag_prefix(tmp_path, monkeypatch):
+    monkeypatch.setattr(oa, "AIRFOILS_DIR", tmp_path)
+    rel = oa.write_imported_airfoil_dat(_sym(0.05), tag="vsp_morph")
+    assert Path(rel).name.startswith("vsp_morph_")

--- a/app/tests/test_openvsp_wing_xsec_augmentation.py
+++ b/app/tests/test_openvsp_wing_xsec_augmentation.py
@@ -28,7 +28,7 @@ from app.converters.openvsp_wing_handler import (
     _W_LE,
     _W_TE,
     _anchor_u_position,
-    _augment_same_airfoil_pairs,
+    _augment_xsec_pairs,
     _chord_from_le_te,
     _find_cap_safe_u_max,
     _sample_le_te_at,
@@ -162,7 +162,7 @@ class TestSameAirfoilPairAugmentation:
             _xsec(airfoil="naca2412", xyz_le=(-1.0, 0.0, 0.0), chord=2.0, t="root"),
             _xsec(airfoil="naca2412", xyz_le=(0.0, 6.0, 0.0), chord=0.0, t=None),
         ]
-        out = _augment_same_airfoil_pairs(anchors, _ellipse_vsp(), "wing-gid", _ctx(), "wing")
+        out = _augment_xsec_pairs(anchors, _ellipse_vsp(), "wing-gid", _ctx(), "wing")
         # 2 anchors + N inserts = 2 + 4 = 6
         assert len(out) == 2 + _N_INTERP_PER_PAIR
 
@@ -171,7 +171,7 @@ class TestSameAirfoilPairAugmentation:
             _xsec(airfoil="naca2412", t="root"),
             _xsec(airfoil="naca2412", t=None),
         ]
-        out = _augment_same_airfoil_pairs(anchors, _ellipse_vsp(), "wing-gid", _ctx(), "wing")
+        out = _augment_xsec_pairs(anchors, _ellipse_vsp(), "wing-gid", _ctx(), "wing")
         # All inserts inherit the anchor's airfoil — never a generated
         # ``vsp_imported_*.dat`` for same-airfoil paths.
         for xs in out[1:-1]:
@@ -182,7 +182,7 @@ class TestSameAirfoilPairAugmentation:
             _xsec(airfoil="naca2412", t="root"),
             _xsec(airfoil="naca2412", t=None),
         ]
-        out = _augment_same_airfoil_pairs(anchors, _ellipse_vsp(), "wing-gid", _ctx(), "wing")
+        out = _augment_xsec_pairs(anchors, _ellipse_vsp(), "wing-gid", _ctx(), "wing")
         # The inserts sit between root and the terminal xsec, so they
         # all carry x_sec_type="segment" (intermediate).
         for xs in out[1:-1]:
@@ -199,7 +199,7 @@ class TestSameAirfoilPairAugmentation:
             _xsec(airfoil="naca2412", xyz_le=(-1.0, 0.0, 0.0), chord=2.0, t="root"),
             _xsec(airfoil="naca2412", xyz_le=(0.0, 6.0, 0.0), chord=0.0, t=None),
         ]
-        out = _augment_same_airfoil_pairs(anchors, _ellipse_vsp(), "wing-gid", _ctx(), "wing")
+        out = _augment_xsec_pairs(anchors, _ellipse_vsp(), "wing-gid", _ctx(), "wing")
         # The middle insert (k=2) sits at u = 0 + 2 · (1/(4+1)) = 0.4.
         # On the elliptical surface, chord(0.4) = 2 · sqrt(1 - 0.16) ≈ 1.833.
         # Linear interpolation between anchors would give 2.0·(1-0.4)=1.2.
@@ -213,35 +213,74 @@ class TestSameAirfoilPairAugmentation:
         assert u04.chord == pytest.approx(expected_chord, rel=1e-6)
 
 
-class TestDifferentAirfoilPairSkipped:
-    """gh-753 user constraint: pairs with different airfoils are
-    skipped so the user can swap profiles for Re-number scaling
-    at the anchors without dealing with morphed-profile blobs in
-    between."""
+class TestDifferentAirfoilPairMorphed:
+    """gh-796: pairs with DIFFERENT airfoils are now augmented too — each
+    insert carries a morphed profile (a content-hash ``vsp_morph_*.dat``).
+    Morphing is mocked here to keep the test CAD-free and deterministic;
+    the real Kulfan morph is exercised in test_openvsp_airfoil_hash_morph.py.
+    """
 
-    def test_zero_inserts_between_different_airfoils(self):
+    def test_inserts_between_different_airfoils_carry_morphed_profile(self, monkeypatch):
+        from app.converters import openvsp_airfoil
+
+        calls: list[tuple[str, str]] = []
+
+        def _fake_morph(a, b, t):
+            calls.append((a, b))
+            return "./components/airfoils/vsp_morph_DEADBEEF.dat"
+
+        monkeypatch.setattr(openvsp_airfoil, "morph_airfoils", _fake_morph)
         anchors = [
             _xsec(airfoil="naca2412", t="root"),
             _xsec(airfoil="naca6409", t=None),
         ]
-        out = _augment_same_airfoil_pairs(anchors, _ellipse_vsp(), "wing-gid", _ctx(), "wing")
-        # 2 anchors, no inserts.
-        assert len(out) == 2
-        assert out[0].airfoil == "naca2412"
-        assert out[1].airfoil == "naca6409"
+        out = _augment_xsec_pairs(anchors, _ellipse_vsp(), "wing-gid", _ctx(), "wing")
 
-    def test_mixed_wing_augments_only_same_airfoil_segments(self):
-        """A three-anchor wing where root→mid share airfoil and mid→tip
-        differ should get ``N_INTERP`` inserts in the first segment
-        and zero in the second."""
+        assert len(out) == 2 + _N_INTERP_PER_PAIR
+        inserts = out[1:-1]
+        assert all(
+            ins.airfoil == "./components/airfoils/vsp_morph_DEADBEEF.dat"
+            for ins in inserts
+        )
+        assert calls == [("naca2412", "naca6409")] * _N_INTERP_PER_PAIR
+        # Anchors keep their raw airfoils (faithful original).
+        assert out[0].airfoil == "naca2412"
+        assert out[-1].airfoil == "naca6409"
+
+    def test_morph_failure_falls_back_to_nearest_anchor(self, monkeypatch):
+        from app.converters import openvsp_airfoil
+
+        monkeypatch.setattr(openvsp_airfoil, "morph_airfoils", lambda a, b, t: None)
+        anchors = [
+            _xsec(airfoil="naca2412", t="root"),
+            _xsec(airfoil="naca6409", t=None),
+        ]
+        out = _augment_xsec_pairs(anchors, _ellipse_vsp(), "wing-gid", _ctx(), "wing")
+        # t = 0.2/0.4/0.6/0.8 → nearest anchor: 2412 (t<0.5) else 6409.
+        assert [ins.airfoil for ins in out[1:-1]] == [
+            "naca2412",
+            "naca2412",
+            "naca6409",
+            "naca6409",
+        ]
+
+    def test_mixed_wing_augments_all_segments(self, monkeypatch):
+        """Root→mid same airfoil, mid→tip different: BOTH segments now get
+        ``N_INTERP`` inserts (was: only the same-airfoil segment)."""
+        from app.converters import openvsp_airfoil
+
+        monkeypatch.setattr(
+            openvsp_airfoil,
+            "morph_airfoils",
+            lambda a, b, t: "./components/airfoils/vsp_morph_X.dat",
+        )
         anchors = [
             _xsec(airfoil="naca2412", t="root"),
             _xsec(airfoil="naca2412", t="segment"),
             _xsec(airfoil="naca6409", t=None),
         ]
-        out = _augment_same_airfoil_pairs(anchors, _ellipse_vsp(), "wing-gid", _ctx(), "wing")
-        # 3 anchors + N inserts (first segment only)
-        assert len(out) == 3 + _N_INTERP_PER_PAIR
+        out = _augment_xsec_pairs(anchors, _ellipse_vsp(), "wing-gid", _ctx(), "wing")
+        assert len(out) == 3 + 2 * _N_INTERP_PER_PAIR
 
 
 class TestSpitfireAnchorCount:
@@ -256,7 +295,7 @@ class TestSpitfireAnchorCount:
             _xsec(airfoil="naca2213", t="segment"),
             _xsec(airfoil="naca2213", t=None),
         ]
-        out = _augment_same_airfoil_pairs(anchors, _ellipse_vsp(), "wing-gid", _ctx(), "wing")
+        out = _augment_xsec_pairs(anchors, _ellipse_vsp(), "wing-gid", _ctx(), "wing")
         # 4 anchors + 3 pairs · N inserts each = 4 + 12 = 16
         assert len(out) == 4 + 3 * _N_INTERP_PER_PAIR
 
@@ -275,7 +314,7 @@ class TestTwistInterpolation:
             _xsec(airfoil="naca2412", twist=0.0, t="root"),
             _xsec(airfoil="naca2412", twist=-4.0, t=None),
         ]
-        out = _augment_same_airfoil_pairs(anchors, _ellipse_vsp(), "wing-gid", _ctx(), "wing")
+        out = _augment_xsec_pairs(anchors, _ellipse_vsp(), "wing-gid", _ctx(), "wing")
         inserts = out[1:-1]
         expected = [-0.8, -1.6, -2.4, -3.2]
         for ins, exp in zip(inserts, expected, strict=True):
@@ -291,7 +330,7 @@ class TestTwistInterpolation:
             _xsec(airfoil="naca2412", twist=0.0, t="root"),
             _xsec(airfoil="naca2412", twist=0.0, t=None),
         ]
-        out = _augment_same_airfoil_pairs(anchors, _ellipse_vsp(), "wing-gid", _ctx(), "wing")
+        out = _augment_xsec_pairs(anchors, _ellipse_vsp(), "wing-gid", _ctx(), "wing")
         for ins in out[1:-1]:
             assert ins.twist == 0.0
 
@@ -320,7 +359,7 @@ class TestTwistInterpolation:
             _xsec(airfoil="naca2412", twist=0.0, t="root"),
             _xsec(airfoil="naca2412", twist=0.0, t=None),
         ]
-        out = _augment_same_airfoil_pairs(anchors, _DihedralStub(), "wing-gid", _ctx(), "wing")
+        out = _augment_xsec_pairs(anchors, _DihedralStub(), "wing-gid", _ctx(), "wing")
         # Anchor twists are 0 → every insert twist must be 0 even
         # though the body-frame LE/TE has a 0.5 m vertical offset.
         for ins in out[1:-1]:
@@ -352,7 +391,7 @@ class TestLossyWarning:
             _xsec(airfoil="naca2412", t="root"),
             _xsec(airfoil="naca2412", t=None),
         ]
-        out = _augment_same_airfoil_pairs(anchors, _AlwaysRaises(), "wing-gid", ctx, "main_wing")
+        out = _augment_xsec_pairs(anchors, _AlwaysRaises(), "wing-gid", ctx, "main_wing")
         # No inserts succeeded → 2 anchors only.
         assert len(out) == 2
         # Exactly one info-warning emitted with the count diff.
@@ -381,7 +420,7 @@ class TestLossyWarning:
             _xsec(airfoil="naca2412", t="root"),
             _xsec(airfoil="naca2412", t=None),
         ]
-        out = _augment_same_airfoil_pairs(anchors, _FlakyAtMidU(), "wing-gid", ctx, "main_wing")
+        out = _augment_xsec_pairs(anchors, _FlakyAtMidU(), "wing-gid", ctx, "main_wing")
         # 3 successful inserts + 2 anchors = 5
         assert len(out) == 5
         info_warnings = [w for w in ctx.warnings if "gh-753" in w.reason]
@@ -396,7 +435,7 @@ class TestLossyWarning:
             _xsec(airfoil="naca2412", t="root"),
             _xsec(airfoil="naca2412", t=None),
         ]
-        _augment_same_airfoil_pairs(anchors, _ellipse_vsp(), "wing-gid", ctx, "main_wing")
+        _augment_xsec_pairs(anchors, _ellipse_vsp(), "wing-gid", ctx, "main_wing")
         info_warnings = [w for w in ctx.warnings if "gh-753" in w.reason]
         assert info_warnings == []
 
@@ -404,7 +443,7 @@ class TestLossyWarning:
 class TestDegenerateInputs:
     def test_single_xsec_passthrough(self):
         anchors = [_xsec(airfoil="naca2412", t="root")]
-        out = _augment_same_airfoil_pairs(anchors, _ellipse_vsp(), "wing-gid", _ctx(), "wing")
+        out = _augment_xsec_pairs(anchors, _ellipse_vsp(), "wing-gid", _ctx(), "wing")
         assert out == anchors
 
     def test_no_comppnt01_passes_through_unchanged(self):
@@ -419,7 +458,7 @@ class TestDegenerateInputs:
             _xsec(airfoil="naca2412", t="root"),
             _xsec(airfoil="naca2412", t=None),
         ]
-        out = _augment_same_airfoil_pairs(
+        out = _augment_xsec_pairs(
             anchors, _StubWithoutCompPnt(), "wing-gid", _ctx(), "wing"
         )
         assert out == anchors
@@ -448,7 +487,7 @@ class TestDegenerateInputs:
             _xsec(airfoil="naca2412", t="root"),
             _xsec(airfoil="naca2412", t=None),
         ]
-        out = _augment_same_airfoil_pairs(anchors, _FlakyVsp(), "wing-gid", _ctx(), "wing")
+        out = _augment_xsec_pairs(anchors, _FlakyVsp(), "wing-gid", _ctx(), "wing")
         # The u≈0.4 insert is skipped; the other 3 succeed.
         # Total: 2 anchors + 3 successful inserts = 5
         assert len(out) == 5
@@ -588,7 +627,7 @@ class TestCapAwareAugmentation:
             _xsec(airfoil="naca2213", xyz_le=(0.0, 4.0, 0.0), chord=1.2, t="segment"),
             _xsec(airfoil="naca2213", xyz_le=(0.0, 5.4, 0.0), chord=0.4, t=None),
         ]
-        out = _augment_same_airfoil_pairs(
+        out = _augment_xsec_pairs(
             anchors, _capped_vsp(u_cap_start=0.85), "wing-gid", _ctx(), "wing"
         )
         # Walk the output and assert no two consecutive xsecs share
@@ -613,7 +652,7 @@ class TestCapAwareAugmentation:
             _xsec(airfoil="naca2213", xyz_le=(0.0, 4.0, 0.0), chord=1.2, t="segment"),
             _xsec(airfoil="naca2213", xyz_le=(0.0, 5.1, 0.0), chord=0.4, t=None),
         ]
-        out = _augment_same_airfoil_pairs(
+        out = _augment_xsec_pairs(
             anchors, _capped_vsp(u_cap_start=0.85, cap_z=0.5), "wing-gid", _ctx(), "wing"
         )
         # All inserts (everything except first/last anchors) must have
@@ -643,7 +682,7 @@ class TestCapAwareAugmentation:
             _xsec(airfoil="naca2213", xyz_le=(0.0, 4.0, 0.0), chord=1.2, t="segment"),
             _xsec(airfoil="naca2213", xyz_le=(0.0, 5.4, 0.0), chord=0.4, t=None),
         ]
-        _augment_same_airfoil_pairs(
+        _augment_xsec_pairs(
             anchors, _capped_vsp(u_cap_start=0.85), "wing-gid", ctx, "main_wing"
         )
         # Look for a gh-758 cap-truncation warning specifically.
@@ -660,7 +699,7 @@ class TestCapAwareAugmentation:
             _xsec(airfoil="naca2213", xyz_le=(0.0, 0.0, 0.0), chord=2.0, t="root"),
             _xsec(airfoil="naca2213", xyz_le=(0.0, 6.0, 0.0), chord=0.0, t=None),
         ]
-        _augment_same_airfoil_pairs(anchors, _ellipse_vsp(), "wing-gid", ctx, "main_wing")
+        _augment_xsec_pairs(anchors, _ellipse_vsp(), "wing-gid", ctx, "main_wing")
         cap_warnings = [w for w in ctx.warnings if "gh-758" in w.reason]
         assert cap_warnings == []
 
@@ -673,7 +712,7 @@ class TestCapAwareAugmentation:
             _xsec(airfoil="naca2213", xyz_le=(0.0, 2.0, 0.0), chord=1.8, t="segment"),
             _xsec(airfoil="naca2213", xyz_le=(0.0, 5.4, 0.0), chord=0.4, t=None),
         ]
-        out = _augment_same_airfoil_pairs(
+        out = _augment_xsec_pairs(
             anchors, _capped_vsp(u_cap_start=0.85), "wing-gid", _ctx(), "wing"
         )
         # First segment (root → mid): 4 inserts expected (u ∈ [0, 0.5]
@@ -718,7 +757,7 @@ class TestCapAwareAugmentation:
             _xsec(airfoil="naca2213", xyz_le=(0.0, 0.0, 0.0), chord=2.0, t="root"),
             _xsec(airfoil="naca2213", xyz_le=(0.0, 6.0, 0.0), chord=0.0, t=None),
         ]
-        out = _augment_same_airfoil_pairs(anchors, _clustered_mid_vsp(), "wing-gid", ctx, "wing")
+        out = _augment_xsec_pairs(anchors, _clustered_mid_vsp(), "wing-gid", ctx, "wing")
         # No duplicate consecutive xyz_le in the output.
         for prev, curr in zip(out, out[1:], strict=False):
             d = math.sqrt(sum((a - b) ** 2 for a, b in zip(prev.xyz_le, curr.xyz_le, strict=True)))
@@ -741,7 +780,7 @@ class TestCapAwareAugmentation:
             _xsec(airfoil="naca2213", xyz_le=(0.0, 0.0, 0.0), chord=2.0, t="root"),
             _xsec(airfoil="naca2213", xyz_le=(0.0, 5.88, 0.0), chord=0.0, t=None),
         ]
-        out = _augment_same_airfoil_pairs(
+        out = _augment_xsec_pairs(
             anchors, _capped_vsp(u_cap_start=0.98), "wing-gid", _ctx(), "wing"
         )
         # 2 anchors + N inserts. With u_cap_start=0.98 and inserts at
@@ -784,7 +823,7 @@ class TestCapAwareAugmentation:
             _xsec(airfoil="naca2213", xyz_le=(0.0, 0.0, 0.0), chord=2.0, twist=0.0, t="root"),
             _xsec(airfoil="naca2213", xyz_le=(0.0, 6.0, 0.6), chord=0.0, twist=0.0, t=None),
         ]
-        out = _augment_same_airfoil_pairs(
+        out = _augment_xsec_pairs(
             anchors, _dihedral_capped_vsp(), "wing-gid", _ctx(), "wing"
         )
         # No insert may carry the cap z-offset (0.5).
@@ -972,7 +1011,7 @@ class TestAugmenterUsesCorrectUMapping:
             _xsec(airfoil="naca2213", xyz_le=(-0.07, 5.5, 0.0), chord=0.14, t=None),
         ]
         vsp = _CappedWingStub(n_xsec=4, cap_min_option=1, cap_max_option=1)
-        out = _augment_same_airfoil_pairs(anchors, vsp, "wing-gid", _ctx(), "Wing")
+        out = _augment_xsec_pairs(anchors, vsp, "wing-gid", _ctx(), "Wing")
         # No consecutive xsecs share an xyz_le within 1 mm (= the
         # gh-760 DB-evidence threshold; pre-fix the gap was ~1 mm).
         for prev, curr in zip(out, out[1:], strict=False):
@@ -994,7 +1033,7 @@ class TestAugmenterUsesCorrectUMapping:
             _xsec(airfoil="naca2213", xyz_le=(-0.07, 5.5, 0.0), chord=0.14, t=None),
         ]
         vsp = _CappedWingStub(n_xsec=4, cap_min_option=1, cap_max_option=1)
-        out = _augment_same_airfoil_pairs(anchors, vsp, "wing-gid", _ctx(), "Wing")
+        out = _augment_xsec_pairs(anchors, vsp, "wing-gid", _ctx(), "Wing")
         # 4 anchors + 4 inserts × 3 pairs = 16 expected when augmenter
         # correctly maps anchor-u and the cap-clamp is reachable only
         # for inserts truly in the cap region.
@@ -1022,7 +1061,7 @@ class TestAugmenterUsesCorrectUMapping:
         ]
         ctx = _ctx()
         vsp = _CappedWingStub(n_xsec=2, cap_min_option=1, cap_max_option=1)
-        out = _augment_same_airfoil_pairs(anchors, vsp, "wing-gid", ctx, "Wing")
+        out = _augment_xsec_pairs(anchors, vsp, "wing-gid", ctx, "Wing")
         # 2 anchors + 4 inserts (none should dedup with cap-aware mapping).
         assert len(out) == 2 + _N_INTERP_PER_PAIR
         # The dedup safety-net warning must NOT fire — cap-aware

--- a/app/tests/test_openvsp_wing_xsec_augmentation.py
+++ b/app/tests/test_openvsp_wing_xsec_augmentation.py
@@ -264,6 +264,18 @@ class TestDifferentAirfoilPairMorphed:
             "naca6409",
         ]
 
+    def test_morph_fallback_emits_info_warning(self, monkeypatch):
+        from app.converters import openvsp_airfoil
+
+        monkeypatch.setattr(openvsp_airfoil, "morph_airfoils", lambda a, b, t: None)
+        ctx = _ctx()
+        anchors = [
+            _xsec(airfoil="naca2412", t="root"),
+            _xsec(airfoil="naca6409", t=None),
+        ]
+        _augment_xsec_pairs(anchors, _ellipse_vsp(), "wing-gid", ctx, "main_wing")
+        assert any("nearest anchor" in w.reason for w in ctx.warnings)
+
     def test_mixed_wing_augments_all_segments(self, monkeypatch):
         """Root→mid same airfoil, mid→tip different: BOTH segments now get
         ``N_INTERP`` inserts (was: only the same-airfoil segment)."""


### PR DESCRIPTION
Epic #794. Closes #795, #796.

## Problem
The wing xsec augmenter (gh-753) only inserted between **same-airfoil** anchors. The Corsair inverted-gull main wing (5 sections, each a different NACA thickness `naca13018/16/15/12/09`) got **zero** inserts — the gull bend and taper were lost to linear interpolation between 5 sparse anchors. Separately, imported airfoils were named `vsp_imported_<geom_id>_xsec<i>.dat` with the **ephemeral** VSP geom-id, so every re-import cluttered `components/airfoils/` with orphaned duplicates.

## #795 — content-hash airfoil naming
Imported/derived airfoils are now named by a stable hash of their (6-dp-rounded) coordinates: `vsp_imported_<hash>.dat` / `vsp_morph_<hash>.dat`. Identical geometry → identical file → reused (write skipped). Shared sink `write_imported_airfoil_dat`. `_export_selig` exports to a temp, parses, and re-stores under the hash.

## #796 — Kulfan-morphed inserts on any-anchor augmentation
`_augment_same_airfoil_pairs` → `_augment_xsec_pairs`: augment **every** consecutive anchor pair. For differing anchors, each insert's airfoil is **morphed in Kulfan/CST weight space** (`asb.KulfanAirfoil`, weights interpolated at the insert's spanwise fraction `t`), stored under a content-hash `vsp_morph_*.dat`. Fallbacks: raw NumPy coordinate blend if the CST fit fails (reflex/cusp profiles); nearest-anchor airfoil if morphing returns nothing. **Anchors keep their raw airfoils** (faithful original for ASB/AVL cross-validation against VSPAERO).

Why Kulfan: interpolating in CST weight space yields smooth, always-valid intermediate airfoils; raw-coordinate blending can misbehave at the LE. Empirically asb fits ~all wing airfoils to <0.25% chord (outliers like reflexed `ag35` fall back to raw blend).

## Verification
- Unit (fast tier, CAD-free + asb via `importorskip`): content-hash dedup/distinct, round-trip, Kulfan morph thickness-between, raw-blend fallback, unresolvable→None; augmenter inserts morphed profiles between differing anchors, nearest-anchor fallback, both segments of a mixed wing augmented; same-airfoil (Spitfire) path unchanged.
- **E2E `corsair.vsp3`**: main wing **5 → 21 xsecs**; 5 raw NACA anchors + 16 morphed inserts; gull curvature captured (an insert dips to z=−0.821, below both bounding anchors at −0.764). **Re-import dedup-stable** (20 → 20 generated airfoils).
- 767 fast openvsp/wing/airfoil tests pass; ruff clean; new-code coverage ~86% (wing_handler 100%).

#C (admin cleanup endpoint for orphaned airfoils) tracked separately in #797.

🤖 Generated with [Claude Code](https://claude.com/claude-code)