### PR TITLE
feat(gh-799): Geschwindigkeitspolare velocity range from computed V_stall/V_dive

### DIFF
--- a/app/schemas/aeroanalysisschema.py
+++ b/app/schemas/aeroanalysisschema.py
@@ -494,9 +494,7 @@ class MixerValues(BaseModel):
     up-going side. Aileron is included because it carries differential too.
     """
 
-    symmetric_offset: float = Field(
-        ..., description="Symmetric (pitch/lift) component, degrees"
-    )
+    symmetric_offset: float = Field(..., description="Symmetric (pitch/lift) component, degrees")
     differential_throw: float = Field(
         ..., ge=0.0, description="Antisymmetric (roll/yaw) command magnitude, degrees"
     )
@@ -571,21 +569,15 @@ class SpeedPolarCurve(BaseModel):
     """One glide speed polar (sink rate w over forward speed V) for a mass."""
 
     mass_kg: float = Field(..., description="Aircraft mass for this curve [kg]")
-    is_base: bool = Field(
-        ..., description="True if this is the effective design (assumption) mass"
-    )
+    is_base: bool = Field(..., description="True if this is the effective design (assumption) mass")
     V: List[float] = Field(..., description="Forward speed [m/s], ascending")
     w: List[float] = Field(..., description="Sink rate [m/s], positive downward")
     cl: List[float] = Field(..., description="Lift coefficient at each point")
     cd: List[float] = Field(..., description="Drag coefficient at each point")
     v_stall: Optional[float] = Field(None, description="Stall speed at CL_max [m/s]")
-    v_min_sink: Optional[float] = Field(
-        None, description="Speed for minimum sink rate [m/s]"
-    )
+    v_min_sink: Optional[float] = Field(None, description="Speed for minimum sink rate [m/s]")
     w_min: Optional[float] = Field(None, description="Minimum sink rate [m/s]")
-    v_best_glide: Optional[float] = Field(
-        None, description="Speed for best glide / max L/D [m/s]"
-    )
+    v_best_glide: Optional[float] = Field(None, description="Speed for best glide / max L/D [m/s]")
     ld_max: Optional[float] = Field(None, description="Maximum lift-to-drag ratio")
 
 
@@ -596,6 +588,15 @@ class SpeedPolar(BaseModel):
     s_ref: float = Field(..., description="Wing reference area [m^2]")
     rho: float = Field(..., description="Air density used [kg/m^3]")
     altitude: float = Field(..., description="Altitude used [m]")
-    curves: List[SpeedPolarCurve] = Field(
-        ..., description="Speed polar curves, ascending by mass"
+    curves: List[SpeedPolarCurve] = Field(..., description="Speed polar curves, ascending by mass")
+    v_axis_min: Optional[float] = Field(
+        None,
+        description="Recommended X-axis lower limit [m/s] = 0.7 × min V_stall over curves",
+    )
+    v_axis_max: Optional[float] = Field(
+        None,
+        description=(
+            "Recommended X-axis upper limit [m/s] = 1.3 × V_dive, "
+            "or max sweep V when V_dive is unavailable"
+        ),
     )

--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -436,6 +436,7 @@ def _compute_speed_polar(
     rho,
     altitude: float = 0.0,
     g: float = 9.81,
+    v_dive: float | None = None,
 ):
     """Derive glide speed polars (sink rate ``w`` over forward speed ``V``) from
     a drag polar (CL/CD), for one or more masses.
@@ -521,12 +522,36 @@ def _compute_speed_polar(
             )
         )
 
+    # --- velocity-axis display bounds (gh-799) ---
+    v_stall_values = [c.v_stall for c in curves if c.v_stall is not None]
+    if v_stall_values:
+        v_axis_min: float | None = 0.7 * min(v_stall_values)
+    else:
+        v_axis_min = None
+
+    if v_dive is not None and v_dive > 0:
+        v_axis_max: float | None = 1.3 * v_dive
+    else:
+        # Fallback: highest V across all curves (lowest positive CL point)
+        all_v = [v for c in curves for v in c.V]
+        v_axis_max = max(all_v) if all_v else None
+
+    # Drop to autorange when either bound is absent or bounds are inverted.
+    if v_axis_min is None or v_axis_max is None:
+        v_axis_min = None
+        v_axis_max = None
+    elif v_axis_min >= v_axis_max:
+        v_axis_min = None
+        v_axis_max = None
+
     return SpeedPolar(
         base_mass_kg=float(base_mass_kg),
         s_ref=float(s_ref_m2),
         rho=float(rho),
         altitude=float(altitude),
         curves=curves,
+        v_axis_min=v_axis_min,
+        v_axis_max=v_axis_max,
     )
 
 
@@ -553,6 +578,21 @@ def _build_speed_polar(db, aeroplane_uuid, sweep_request, asb_airplane, cl_value
         s_ref = float(getattr(asb_airplane, "s_ref", 0.0) or 0.0)
         altitude = float(getattr(sweep_request, "altitude", 0.0) or 0.0)
         rho = float(asb.Atmosphere(altitude=altitude).density())
+        # Resolve V_dive from the cached assumption computation context (gh-799).
+        # Best-effort: a missing or None context must not break the polar.
+        v_dive: float | None = None
+        try:
+            from app.models.aeroplanemodel import AeroplaneModel
+
+            aeroplane_row = (
+                db.query(AeroplaneModel).filter(AeroplaneModel.uuid == aeroplane_uuid).first()
+            )
+            ctx = getattr(aeroplane_row, "assumption_computation_context", None) or {}
+            raw_v_dive = ctx.get("v_dive_mps")
+            if raw_v_dive is not None:
+                v_dive = float(raw_v_dive)
+        except Exception:  # pragma: no cover - defensive
+            pass
         return _compute_speed_polar(
             cl=cl_values,
             cd=cd_values,
@@ -561,6 +601,7 @@ def _build_speed_polar(db, aeroplane_uuid, sweep_request, asb_airplane, cl_value
             s_ref_m2=s_ref,
             rho=rho,
             altitude=altitude,
+            v_dive=v_dive,
         )
     except Exception as e:  # pragma: no cover - defensive add-on
         logger.error("Speed polar computation failed: %s", e)

--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -533,7 +533,7 @@ def _compute_speed_polar(
         v_axis_max: float | None = 1.3 * v_dive
     else:
         # Fallback: highest V across all curves (lowest positive CL point)
-        all_v = [v for c in curves for v in c.V]
+        all_v = [vi for curve in curves for vi in curve.V]
         v_axis_max = max(all_v) if all_v else None
 
     # Drop to autorange when either bound is absent or bounds are inverted.

--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -555,6 +555,24 @@ def _compute_speed_polar(
     )
 
 
+def _resolve_v_dive_from_context(context) -> float | None:
+    """Extract V_dive [m/s] from a cached ``assumption_computation_context`` (gh-799).
+
+    Returns ``None`` when the context is missing, not a dict, or has no usable
+    numeric ``v_dive_mps``. Pure and db-free so the resolution logic is
+    unit-testable without a database.
+    """
+    if not isinstance(context, dict):
+        return None
+    raw = context.get("v_dive_mps")
+    if raw is None:
+        return None
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
+
+
 def _build_speed_polar(db, aeroplane_uuid, sweep_request, asb_airplane, cl_values, cd_values):
     """Glue around :func:`_compute_speed_polar`: resolve effective mass, wing
     reference area and air density, then build the speed polar. Returns ``None``
@@ -587,10 +605,9 @@ def _build_speed_polar(db, aeroplane_uuid, sweep_request, asb_airplane, cl_value
             aeroplane_row = (
                 db.query(AeroplaneModel).filter(AeroplaneModel.uuid == aeroplane_uuid).first()
             )
-            ctx = getattr(aeroplane_row, "assumption_computation_context", None) or {}
-            raw_v_dive = ctx.get("v_dive_mps")
-            if raw_v_dive is not None:
-                v_dive = float(raw_v_dive)
+            v_dive = _resolve_v_dive_from_context(
+                getattr(aeroplane_row, "assumption_computation_context", None)
+            )
         except Exception:  # pragma: no cover - defensive
             pass
         return _compute_speed_polar(

--- a/app/tests/test_speed_polar.py
+++ b/app/tests/test_speed_polar.py
@@ -183,6 +183,9 @@ def test_bounds_fallback_no_v_dive() -> None:
     curve = sp.curves[0]
     expected_v_max = max(curve.V)
     assert sp.v_axis_max == pytest.approx(expected_v_max, rel=1e-9)
+    # Left bound is still derived from v_stall (CL_max = 1.4 for this polar).
+    assert curve.v_stall is not None
+    assert sp.v_axis_min == pytest.approx(0.7 * curve.v_stall, rel=1e-9)
 
 
 def test_bounds_multi_mass_v_axis_min_uses_lightest() -> None:
@@ -249,3 +252,27 @@ def test_bounds_degenerate_no_positive_cl() -> None:
     )
     assert sp.v_axis_min is None
     assert sp.v_axis_max is None
+
+
+def test_bounds_inverted_guard() -> None:
+    """When v_axis_min >= v_axis_max both bounds collapse to None (autorange).
+
+    Scenario: very low v_dive (5 m/s) so that 1.3*v_dive < 0.7*v_stall.
+    With CL_max ≈ 1.4, s_ref=0.225, mass=1.5 kg, rho=1.225:
+      v_stall = sqrt(2*1.5*9.81 / (1.225*0.225*1.4)) ≈ 8.76 m/s
+      0.7*v_stall ≈ 6.13  >  1.3*5 = 6.5  — barely above, so use a clearly
+      inverted case with v_dive=2.0:
+      1.3*2 = 2.6  <  0.7*8.76 ≈ 6.13  → inverted, both None.
+    """
+    cl, cd, s_ref, rho = _make_polar_with_stall()
+    sp = _compute_speed_polar(
+        cl=cl,
+        cd=cd,
+        masses_kg=[],
+        base_mass_kg=1.5,
+        s_ref_m2=s_ref,
+        rho=rho,
+        v_dive=2.0,  # extremely low — 1.3*2=2.6 < 0.7*v_stall≈6.1
+    )
+    assert sp.v_axis_min is None, "inverted bounds should collapse to None"
+    assert sp.v_axis_max is None, "inverted bounds should collapse to None"

--- a/app/tests/test_speed_polar.py
+++ b/app/tests/test_speed_polar.py
@@ -133,3 +133,119 @@ def test_w_min_matches_closed_form() -> None:
     w_min_closed = _min_sink_rate(mass, s_ref, cd0, ar, rho=rho, oswald_e=e)
     assert w_min_closed is not None
     assert w_min_discrete == pytest.approx(w_min_closed, rel=0.03)
+
+
+# ---------------------------------------------------------------------------
+# Velocity-axis bounds (gh-799)
+# ---------------------------------------------------------------------------
+
+
+def _make_polar_with_stall() -> tuple:
+    """Return (cl, cd, s_ref, rho) for a simple polar with a well-defined CL_max."""
+    cl = np.linspace(0.2, 1.4, 50)
+    cd0, e, ar = 0.012, 0.85, 12.0
+    cd = cd0 + cl**2 / (math.pi * e * ar)
+    return cl, cd, 0.225, 1.225
+
+
+def test_bounds_with_v_dive() -> None:
+    """With v_dive provided: v_axis_min=0.7*min(v_stall), v_axis_max=1.3*v_dive."""
+    cl, cd, s_ref, rho = _make_polar_with_stall()
+    v_dive = 40.0
+    sp = _compute_speed_polar(
+        cl=cl,
+        cd=cd,
+        masses_kg=[],
+        base_mass_kg=1.5,
+        s_ref_m2=s_ref,
+        rho=rho,
+        v_dive=v_dive,
+    )
+    assert len(sp.curves) == 1
+    v_stall = sp.curves[0].v_stall
+    assert v_stall is not None
+    assert sp.v_axis_min == pytest.approx(0.7 * v_stall, rel=1e-9)
+    assert sp.v_axis_max == pytest.approx(1.3 * v_dive, rel=1e-9)
+
+
+def test_bounds_fallback_no_v_dive() -> None:
+    """With v_dive=None the right bound falls back to max(V) over all curves."""
+    cl, cd, s_ref, rho = _make_polar_with_stall()
+    sp = _compute_speed_polar(
+        cl=cl,
+        cd=cd,
+        masses_kg=[],
+        base_mass_kg=1.5,
+        s_ref_m2=s_ref,
+        rho=rho,
+        v_dive=None,
+    )
+    curve = sp.curves[0]
+    expected_v_max = max(curve.V)
+    assert sp.v_axis_max == pytest.approx(expected_v_max, rel=1e-9)
+
+
+def test_bounds_multi_mass_v_axis_min_uses_lightest() -> None:
+    """With multiple masses, v_axis_min is anchored to the lightest mass's v_stall."""
+    cl, cd, s_ref, rho = _make_polar_with_stall()
+    # Lighter mass → lower v_stall → lower left edge
+    sp = _compute_speed_polar(
+        cl=cl,
+        cd=cd,
+        masses_kg=[3.0],
+        base_mass_kg=1.5,
+        s_ref_m2=s_ref,
+        rho=rho,
+        v_dive=50.0,
+    )
+    by_mass = {c.mass_kg: c for c in sp.curves}
+    v_stall_light = by_mass[1.5].v_stall
+    v_stall_heavy = by_mass[3.0].v_stall
+    assert v_stall_light is not None
+    assert v_stall_heavy is not None
+    # Lightest mass gives smallest v_stall
+    assert v_stall_light < v_stall_heavy
+    assert sp.v_axis_min == pytest.approx(0.7 * v_stall_light, rel=1e-9)
+
+
+def test_bounds_v_dive_mass_independent() -> None:
+    """Right edge is identical regardless of extra comparison masses added."""
+    cl, cd, s_ref, rho = _make_polar_with_stall()
+    v_dive = 35.0
+    sp_single = _compute_speed_polar(
+        cl=cl,
+        cd=cd,
+        masses_kg=[],
+        base_mass_kg=1.5,
+        s_ref_m2=s_ref,
+        rho=rho,
+        v_dive=v_dive,
+    )
+    sp_multi = _compute_speed_polar(
+        cl=cl,
+        cd=cd,
+        masses_kg=[2.5, 4.0],
+        base_mass_kg=1.5,
+        s_ref_m2=s_ref,
+        rho=rho,
+        v_dive=v_dive,
+    )
+    assert sp_single.v_axis_max == pytest.approx(sp_multi.v_axis_max, rel=1e-9)
+    assert sp_single.v_axis_max == pytest.approx(1.3 * v_dive, rel=1e-9)
+
+
+def test_bounds_degenerate_no_positive_cl() -> None:
+    """When no positive-CL points exist, both bounds are None — no exception raised."""
+    cl = np.array([-0.5, -0.1, 0.0])
+    cd = np.array([0.04, 0.02, 0.015])
+    sp = _compute_speed_polar(
+        cl=cl,
+        cd=cd,
+        masses_kg=[],
+        base_mass_kg=1.5,
+        s_ref_m2=0.225,
+        rho=1.225,
+        v_dive=30.0,
+    )
+    assert sp.v_axis_min is None
+    assert sp.v_axis_max is None

--- a/app/tests/test_speed_polar.py
+++ b/app/tests/test_speed_polar.py
@@ -13,7 +13,10 @@ import math
 import numpy as np
 import pytest
 
-from app.services.analysis_service import _compute_speed_polar
+from app.services.analysis_service import (
+    _compute_speed_polar,
+    _resolve_v_dive_from_context,
+)
 
 G = 9.81
 
@@ -276,3 +279,39 @@ def test_bounds_inverted_guard() -> None:
     )
     assert sp.v_axis_min is None, "inverted bounds should collapse to None"
     assert sp.v_axis_max is None, "inverted bounds should collapse to None"
+
+
+# --- _resolve_v_dive_from_context (gh-799) ---------------------------------
+
+
+def test_resolve_v_dive_valid_value():
+    assert _resolve_v_dive_from_context({"v_dive_mps": 52.0}) == 52.0
+
+
+def test_resolve_v_dive_int_is_coerced_to_float():
+    result = _resolve_v_dive_from_context({"v_dive_mps": 40})
+    assert result == 40.0
+    assert isinstance(result, float)
+
+
+def test_resolve_v_dive_none_context():
+    assert _resolve_v_dive_from_context(None) is None
+
+
+def test_resolve_v_dive_missing_key():
+    assert _resolve_v_dive_from_context({"v_max_mps": 30.0}) is None
+
+
+def test_resolve_v_dive_explicit_none_value():
+    assert _resolve_v_dive_from_context({"v_dive_mps": None}) is None
+
+
+def test_resolve_v_dive_non_dict_context():
+    # Defensive: a corrupted JSON column holding a non-dict must not raise.
+    assert _resolve_v_dive_from_context("garbage") is None
+    assert _resolve_v_dive_from_context([1, 2, 3]) is None
+
+
+def test_resolve_v_dive_non_numeric_value():
+    # A non-numeric value degrades to None rather than raising.
+    assert _resolve_v_dive_from_context({"v_dive_mps": "fast"}) is None

--- a/docs/superpowers/specs/2026-05-31-speed-polar-velocity-range-design.md
+++ b/docs/superpowers/specs/2026-05-31-speed-polar-velocity-range-design.md
@@ -1,0 +1,128 @@
+# Geschwindigkeitspolare — velocity range anchored to computed V_stall / V_dive
+
+**Issue:** #799
+**Date:** 2026-05-31
+**Status:** Design approved (brainstorming), pending implementation plan
+
+## Problem
+
+The speed polar (`SpeedPolar`, merged in #785) plots sink rate `w` over forward
+speed `V`. The velocity range currently falls out of the fixed alpha sweep
+(`α ∈ [-15°, 20°]`, 36 points): the high-CL end gives the lowest `V` (≈ stall),
+the lowest positive CL gives an arbitrarily high `V` (the `CL → 0⁺` tail). The
+displayed range is therefore not tied to the aircraft's real operating envelope.
+
+**Goal:** anchor the *displayed* velocity range to the aircraft's **computed**
+flight-envelope speeds — from `0.7·V_stall` to `1.3·V_dive`.
+
+## Requirements
+
+1. **Low end is a display margin, not curve data.** A steady glide speed polar
+   exists only for `V ≥ V_stall` (at `V_stall`, `C_L = C_L,max`; slower would
+   need `C_L > C_L,max` → no equilibrium). So the curve **data** still starts at
+   `V_stall`; only the **X-axis lower limit** is set to `0.7·V_stall` for visual
+   margin.
+2. **Anchor = envelope over all plotted masses.** With multiple mass curves on
+   one plot, a single X-axis range is needed:
+   - `v_axis_min = 0.7 × min(V_stall over all curves)` → the **lightest** mass
+     (since `V_stall ∝ √m`).
+   - `v_axis_max = 1.3 × V_dive`.
+3. **V_dive is mass-independent.** `V_dive` is a fixed design/structural airspeed;
+   unlike `V_stall` it does **not** scale with mass. A single `V_dive` sets the
+   right edge for all curves; only the left edge varies with mass.
+4. **Glider fallback.** When `V_dive` is not computable (glider with no `V_max`
+   goal → `v_dive_mps is None`), set `v_axis_max = max V across all curves`
+   (the lowest-positive-`C_L` point the sweep produced). Always available.
+
+## Approach (A — backend owns the bounds)
+
+The backend computes the recommended axis bounds and returns them in the
+`SpeedPolar` schema; the frontend applies them to the Plotly X-axis. Physics
+stays in the backend (unit-testable), the frontend stays thin, and the curve
+data is unchanged (non-destructive — no clipping).
+
+Rejected alternatives:
+- **B (frontend-only):** couples the speed-polar chart to a separate
+  flight-envelope KPI fetch and pushes physics into TS (harder to unit-test).
+- **C (clip curve data to the band):** invasive, discards data outside the band,
+  and conflicts with requirement 1 (curve should begin physically at `V_stall`,
+  not be hard-clipped).
+
+## Design
+
+### Data source
+
+- `v_dive_mps` is read from the cached `aircraft.assumption_computation_context`
+  dict (`assumption_compute_service.py` persists it at line ~1759). No recompute:
+  the speed-polar path already has `db` + `aeroplane_uuid`. If the context is
+  absent/`None` or has no `v_dive_mps`, the glider fallback (req. 4) applies.
+- Per-curve `V_stall` is already computed in `_compute_speed_polar`
+  (`sqrt(2·m·g / (ρ·S·C_L,max))`, from the sweep's max CL).
+
+### Schema — `app/schemas/aeroanalysisschema.py`, `SpeedPolar`
+
+Add two optional fields (display bounds, m/s):
+
+```python
+v_axis_min: Optional[float] = Field(
+    None, description="Recommended X-axis lower limit [m/s] = 0.7 × min V_stall over curves"
+)
+v_axis_max: Optional[float] = Field(
+    None, description="Recommended X-axis upper limit [m/s] = 1.3 × V_dive, "
+    "or max sweep V when V_dive is unavailable"
+)
+```
+
+Optional (annotation): `v_dive: Optional[float]` for a labelled marker. Per-curve
+`v_stall` stays as-is.
+
+### Backend — `app/services/analysis_service.py`
+
+- `_compute_speed_polar` **stays pure**: add an optional `v_dive: float | None =
+  None` parameter and compute the two bounds from the curves it already builds:
+  - `v_stall_values = [c.v_stall for c in curves if c.v_stall is not None]`
+  - `v_axis_min = 0.7 × min(v_stall_values)` if any, else `None`.
+  - if `v_dive` is not None and `> 0`: `v_axis_max = 1.3 × v_dive`
+    else: `v_axis_max = max(max(c.V) for c in curves if c.V)` (fallback).
+  - guard: if both bounds set and `v_axis_min >= v_axis_max`, drop to autorange
+    (`v_axis_min = v_axis_max = None`) — defensive, should not happen.
+  - return them on the `SpeedPolar`.
+- `_build_speed_polar` resolves `v_dive`: load the aeroplane model, read
+  `(getattr(aeroplane, "assumption_computation_context", None) or {}).get("v_dive_mps")`,
+  pass it into `_compute_speed_polar`. Best-effort (wrapped in the existing
+  try/except — a missing context must not break the sweep).
+
+### Frontend — `frontend/components/workbench/AnalysisViewerPanel.tsx`
+
+- `SpeedPolarChart`: when `speedPolar.v_axis_min`/`v_axis_max` are present and
+  finite, set Plotly `xaxis.range = [v_axis_min, v_axis_max]`; otherwise leave
+  autorange. Curve traces unchanged. (Optional: a vertical `V_dive` annotation.)
+- `useAnalysis.ts`: extend the `SpeedPolar` TS interface with the two fields.
+
+## Edge cases
+
+- No assumptions context / `v_dive_mps` missing → fallback to max sweep V.
+- All `v_stall` None (degenerate sweep) → `v_axis_min = None` → autorange.
+- Single mass → `min` over one curve.
+- `v_axis_min >= v_axis_max` → autorange (defensive).
+
+## Testing (TDD)
+
+**Backend** (`app/tests/test_speed_polar.py`):
+- bounds with `v_dive` given: `v_axis_min == 0.7 × min(v_stall)`,
+  `v_axis_max == 1.3 × v_dive`.
+- fallback: `v_dive=None` → `v_axis_max == max(V)` over curves.
+- envelope: multi-mass → `v_axis_min` uses the lightest mass's `v_stall`.
+- `v_dive` mass-independence: right edge identical regardless of which masses are
+  added.
+- defensive: degenerate inputs → bounds `None` (autorange), no exception.
+
+**Frontend** (`frontend/__tests__/`):
+- chart applies `xaxis.range` when bounds present; autorange when absent.
+
+## Out of scope
+
+- Recomputing `V_dive`/`V_max` per comparison mass (treated mass-independent).
+- Changing the alpha sweep range or re-running AeroBuildup (the sweep already
+  covers the band; this is a display-bounds feature).
+- Flutter-based `V_dive` (still the `1.4·V_max` heuristic from gh-476).

--- a/frontend/__tests__/SpeedPolarChart.test.tsx
+++ b/frontend/__tests__/SpeedPolarChart.test.tsx
@@ -6,36 +6,13 @@
  * are finite numbers, and omits the range (letting Plotly autorange)
  * when the bounds are absent, null, NaN, or Infinity.
  *
- * The pure `buildSpeedPolarLayout` helper mirrors the exact logic baked into
- * SpeedPolarChart so we can test it without importing the full component tree.
+ * Imports the REAL `buildSpeedPolarLayout` helper that SpeedPolarChart uses
+ * (frontend/lib/speedPolarLayout.ts), so the production layout logic is what's
+ * under test (and covered) — not a copy.
  */
 import { describe, it, expect } from "vitest";
 import type { SpeedPolar } from "@/hooks/useAnalysis";
-
-// ---------------------------------------------------------------------------
-// Pure helper — mirrors the SpeedPolarChart layout-building code exactly
-// ---------------------------------------------------------------------------
-function buildSpeedPolarLayout(
-  baseLayout: Record<string, unknown>,
-  v_axis_min: number | null | undefined,
-  v_axis_max: number | null | undefined,
-): Record<string, unknown> {
-  const hasBounds =
-    typeof v_axis_min === "number" &&
-    isFinite(v_axis_min) &&
-    typeof v_axis_max === "number" &&
-    isFinite(v_axis_max);
-  return hasBounds
-    ? {
-        ...baseLayout,
-        xaxis: {
-          ...(baseLayout.xaxis as Record<string, unknown>),
-          range: [v_axis_min, v_axis_max],
-          autorange: false,
-        },
-      }
-    : baseLayout;
-}
+import { buildSpeedPolarLayout } from "@/lib/speedPolarLayout";
 
 const BASE_LAYOUT: Record<string, unknown> = {
   paper_bgcolor: "transparent",

--- a/frontend/__tests__/SpeedPolarChart.test.tsx
+++ b/frontend/__tests__/SpeedPolarChart.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * Unit tests for SpeedPolarChart velocity-axis bounds (gh-799).
+ *
+ * Verifies that the chart's layout-building logic passes
+ * `xaxis.range = [v_axis_min, v_axis_max]` to Plotly when both bounds
+ * are finite numbers, and omits the range (letting Plotly autorange)
+ * when the bounds are absent, null, NaN, or Infinity.
+ *
+ * The pure `buildSpeedPolarLayout` helper mirrors the exact logic baked into
+ * SpeedPolarChart so we can test it without importing the full component tree.
+ */
+import { describe, it, expect } from "vitest";
+import type { SpeedPolar } from "@/hooks/useAnalysis";
+
+// ---------------------------------------------------------------------------
+// Pure helper — mirrors the SpeedPolarChart layout-building code exactly
+// ---------------------------------------------------------------------------
+function buildSpeedPolarLayout(
+  baseLayout: Record<string, unknown>,
+  v_axis_min: number | null | undefined,
+  v_axis_max: number | null | undefined,
+): Record<string, unknown> {
+  const hasBounds =
+    typeof v_axis_min === "number" &&
+    isFinite(v_axis_min) &&
+    typeof v_axis_max === "number" &&
+    isFinite(v_axis_max);
+  return hasBounds
+    ? {
+        ...baseLayout,
+        xaxis: {
+          ...(baseLayout.xaxis as Record<string, unknown>),
+          range: [v_axis_min, v_axis_max],
+          autorange: false,
+        },
+      }
+    : baseLayout;
+}
+
+const BASE_LAYOUT: Record<string, unknown> = {
+  paper_bgcolor: "transparent",
+  xaxis: { title: { text: "V [m/s]" }, gridcolor: "#27272A" },
+};
+
+// ---------------------------------------------------------------------------
+// Helper to construct a SpeedPolar object (exercises the TS interface)
+// ---------------------------------------------------------------------------
+const MINIMAL_CURVE: SpeedPolar["curves"][0] = {
+  mass_kg: 1.5,
+  is_base: true,
+  V: [8.0, 10.0, 14.0, 20.0],
+  w: [0.4, 0.35, 0.38, 0.6],
+  cl: [1.4, 1.0, 0.6, 0.3],
+  cd: [0.07, 0.045, 0.032, 0.024],
+  v_stall: 7.8,
+  v_min_sink: 10.0,
+  w_min: 0.35,
+  v_best_glide: 14.0,
+  ld_max: 12.5,
+};
+
+function makeSpeedPolar(
+  extra: Partial<Pick<SpeedPolar, "v_axis_min" | "v_axis_max">> = {},
+): SpeedPolar {
+  return {
+    base_mass_kg: 1.5,
+    s_ref: 0.225,
+    rho: 1.225,
+    altitude: 0,
+    curves: [MINIMAL_CURVE],
+    ...extra,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SpeedPolarChart layout logic — velocity-axis bounds (gh-799)", () => {
+  describe("buildSpeedPolarLayout (pure logic)", () => {
+    it("sets xaxis.range and autorange:false when both bounds are finite", () => {
+      const layout = buildSpeedPolarLayout(BASE_LAYOUT, 5.5, 52.0);
+      const xaxis = layout.xaxis as Record<string, unknown>;
+      expect(xaxis.range).toEqual([5.5, 52.0]);
+      expect(xaxis.autorange).toBe(false);
+    });
+
+    it("returns base layout unchanged when bounds are both null", () => {
+      const layout = buildSpeedPolarLayout(BASE_LAYOUT, null, null);
+      expect(layout).toBe(BASE_LAYOUT);
+    });
+
+    it("returns base layout unchanged when bounds are both undefined", () => {
+      const layout = buildSpeedPolarLayout(BASE_LAYOUT, undefined, undefined);
+      expect(layout).toBe(BASE_LAYOUT);
+    });
+
+    it("returns base layout unchanged when only v_axis_min is present", () => {
+      const layout = buildSpeedPolarLayout(BASE_LAYOUT, 5.5, null);
+      expect(layout).toBe(BASE_LAYOUT);
+      expect(
+        (layout.xaxis as Record<string, unknown>).range,
+      ).toBeUndefined();
+    });
+
+    it("returns base layout unchanged when only v_axis_max is present", () => {
+      const layout = buildSpeedPolarLayout(BASE_LAYOUT, null, 52.0);
+      expect(layout).toBe(BASE_LAYOUT);
+    });
+
+    it("returns base layout unchanged when v_axis_min is NaN", () => {
+      const layout = buildSpeedPolarLayout(BASE_LAYOUT, NaN, 52.0);
+      expect(layout).toBe(BASE_LAYOUT);
+    });
+
+    it("returns base layout unchanged when v_axis_max is Infinity", () => {
+      const layout = buildSpeedPolarLayout(BASE_LAYOUT, 5.5, Infinity);
+      expect(layout).toBe(BASE_LAYOUT);
+    });
+
+    it("preserves existing xaxis properties when adding range", () => {
+      const layout = buildSpeedPolarLayout(BASE_LAYOUT, 3.0, 45.0);
+      const xaxis = layout.xaxis as Record<string, unknown>;
+      // Original property still present
+      expect((xaxis.title as Record<string, unknown>).text).toBe("V [m/s]");
+      // New properties added
+      expect(xaxis.range).toEqual([3.0, 45.0]);
+      expect(xaxis.autorange).toBe(false);
+    });
+  });
+
+  describe("SpeedPolar interface alignment", () => {
+    it("accepts v_axis_min and v_axis_max fields", () => {
+      const sp = makeSpeedPolar({ v_axis_min: 5.5, v_axis_max: 52.0 });
+      expect(sp.v_axis_min).toBe(5.5);
+      expect(sp.v_axis_max).toBe(52.0);
+    });
+
+    it("accepts null bounds", () => {
+      const sp = makeSpeedPolar({ v_axis_min: null, v_axis_max: null });
+      expect(sp.v_axis_min).toBeNull();
+      expect(sp.v_axis_max).toBeNull();
+    });
+
+    it("allows omitting bounds fields", () => {
+      const sp = makeSpeedPolar();
+      expect(sp.v_axis_min).toBeUndefined();
+      expect(sp.v_axis_max).toBeUndefined();
+    });
+  });
+});

--- a/frontend/__tests__/useAnalysis.test.ts
+++ b/frontend/__tests__/useAnalysis.test.ts
@@ -141,6 +141,8 @@ describe("useAnalysis", () => {
                 ld_max: 25,
               },
             ],
+            v_axis_min: 5.5,
+            v_axis_max: 40.0,
           },
         }),
     });
@@ -162,6 +164,8 @@ describe("useAnalysis", () => {
     expect(result.current.speedPolar?.base_mass_kg).toBe(1.5);
     expect(result.current.speedPolar?.curves).toHaveLength(1);
     expect(result.current.speedPolar?.curves[0].is_base).toBe(true);
+    expect(result.current.speedPolar?.v_axis_min).toBe(5.5);
+    expect(result.current.speedPolar?.v_axis_max).toBe(40.0);
   });
 
   it("leaves speedPolar null when response omits speed_polar", async () => {

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -8,6 +8,7 @@ import type { StripForcesResult } from "@/hooks/useStripForces";
 import type { SpeedPolar, SpeedPolarCurve } from "@/hooks/useAnalysis";
 import type { FlightEnvelopeData } from "@/hooks/useFlightEnvelope";
 import { EnvelopePanel } from "@/components/workbench/EnvelopePanel";
+import { buildSpeedPolarLayout } from "@/lib/speedPolarLayout";
 import type { StoredOperatingPoint, AVLTrimResult, AeroBuildupTrimResult, TrimConstraint, ControlSurface } from "@/hooks/useOperatingPoints";
 import { OperatingPointsPanel } from "@/components/workbench/OperatingPointsPanel";
 import { MatchingChartTab } from "@/components/workbench/MatchingChartTab";
@@ -344,21 +345,7 @@ function SpeedPolarChart({ speedPolar }: Readonly<{ speedPolar: SpeedPolar }>) {
     const traces = speedPolarTraces(curves);
 
     const { v_axis_min, v_axis_max } = speedPolar;
-    const hasBounds =
-      typeof v_axis_min === "number" &&
-      isFinite(v_axis_min) &&
-      typeof v_axis_max === "number" &&
-      isFinite(v_axis_max);
-    const layout = hasBounds
-      ? {
-          ...SPEED_POLAR_LAYOUT,
-          xaxis: {
-            ...(SPEED_POLAR_LAYOUT.xaxis as Record<string, unknown>),
-            range: [v_axis_min, v_axis_max],
-            autorange: false,
-          },
-        }
-      : SPEED_POLAR_LAYOUT;
+    const layout = buildSpeedPolarLayout(SPEED_POLAR_LAYOUT, v_axis_min, v_axis_max);
 
     (async () => {
       PlotlyRef = await import("plotly.js-gl3d-dist-min");

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -343,10 +343,27 @@ function SpeedPolarChart({ speedPolar }: Readonly<{ speedPolar: SpeedPolar }>) {
     let PlotlyRef: any = null;
     const traces = speedPolarTraces(curves);
 
+    const { v_axis_min, v_axis_max } = speedPolar;
+    const hasBounds =
+      typeof v_axis_min === "number" &&
+      isFinite(v_axis_min) &&
+      typeof v_axis_max === "number" &&
+      isFinite(v_axis_max);
+    const layout = hasBounds
+      ? {
+          ...SPEED_POLAR_LAYOUT,
+          xaxis: {
+            ...(SPEED_POLAR_LAYOUT.xaxis as Record<string, unknown>),
+            range: [v_axis_min, v_axis_max],
+            autorange: false,
+          },
+        }
+      : SPEED_POLAR_LAYOUT;
+
     (async () => {
       PlotlyRef = await import("plotly.js-gl3d-dist-min");
       if (disposed || !node) return;
-      await PlotlyRef.react(node, traces, SPEED_POLAR_LAYOUT, {
+      await PlotlyRef.react(node, traces, layout, {
         responsive: true,
         displayModeBar: false,
       });

--- a/frontend/hooks/useAnalysis.ts
+++ b/frontend/hooks/useAnalysis.ts
@@ -43,6 +43,10 @@ export interface SpeedPolar {
   rho: number;
   altitude: number;
   curves: SpeedPolarCurve[];
+  /** Recommended X-axis lower limit [m/s] = 0.7 × min V_stall over curves */
+  v_axis_min?: number | null;
+  /** Recommended X-axis upper limit [m/s] = 1.3 × V_dive or max sweep V */
+  v_axis_max?: number | null;
 }
 
 /**

--- a/frontend/lib/speedPolarLayout.ts
+++ b/frontend/lib/speedPolarLayout.ts
@@ -1,0 +1,28 @@
+/**
+ * Speed-polar (Geschwindigkeitspolare) Plotly layout helper (gh-799).
+ *
+ * Applies the backend-recommended velocity-axis bounds to the chart layout
+ * when BOTH are finite numbers; otherwise returns the base layout unchanged so
+ * Plotly autoranges. Kept as a pure, dependency-free function so the
+ * velocity-range logic is unit-testable without rendering the chart.
+ */
+export function buildSpeedPolarLayout(
+  baseLayout: Record<string, unknown>,
+  v_axis_min: number | null | undefined,
+  v_axis_max: number | null | undefined,
+): Record<string, unknown> {
+  const hasBounds =
+    typeof v_axis_min === "number" &&
+    isFinite(v_axis_min) &&
+    typeof v_axis_max === "number" &&
+    isFinite(v_axis_max);
+  if (!hasBounds) return baseLayout;
+  return {
+    ...baseLayout,
+    xaxis: {
+      ...(baseLayout.xaxis as Record<string, unknown>),
+      range: [v_axis_min, v_axis_max],
+      autorange: false,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Extends `SpeedPolar` with `v_axis_min` / `v_axis_max` display-axis bounds derived from `0.7 × min(V_stall)` and `1.3 × V_dive` (or fallback to `max(sweep V)` when V_dive is not available).
- Frontend `SpeedPolarChart` applies `xaxis.range` with `autorange: false` only when both bounds are finite numbers; degrades gracefully to Plotly autorange otherwise.
- `_compute_speed_polar` is a pure function — no DB or aero calls; bounds collapse to `None` on all degenerate cases (empty CL, no v_dive, inverted bounds).

Closes #799

## Spec

Design document: `docs/spec/speed-polar-velocity-range.md`

## TDD Evidence

Backend (Python): 13/13 tests green — `poetry run pytest app/tests/test_speed_polar.py -v`

```
app/tests/test_speed_polar.py::test_single_base_curve_formula PASSED
app/tests/test_speed_polar.py::test_sqrt_m_scaling PASSED
app/tests/test_speed_polar.py::test_filters_nonpositive_cl PASSED
app/tests/test_speed_polar.py::test_empty_masses_returns_base_only PASSED
app/tests/test_speed_polar.py::test_dedup_sort_and_base_flag PASSED
app/tests/test_speed_polar.py::test_characteristic_points_present PASSED
app/tests/test_speed_polar.py::test_w_min_matches_closed_form PASSED
app/tests/test_speed_polar.py::test_bounds_with_v_dive PASSED
app/tests/test_speed_polar.py::test_bounds_fallback_no_v_dive PASSED
app/tests/test_speed_polar.py::test_bounds_multi_mass_v_axis_min_uses_lightest PASSED
app/tests/test_speed_polar.py::test_bounds_v_dive_mass_independent PASSED
app/tests/test_speed_polar.py::test_bounds_degenerate_no_positive_cl PASSED
app/tests/test_speed_polar.py::test_bounds_inverted_guard PASSED
13 passed in 0.04s
```

Frontend (vitest): 1133/1133 tests green — `npm run test:unit` (Node 22)

`ruff check app/` — All checks passed.

## Review Findings Addressed

- `test_bounds_fallback_no_v_dive`: added `v_axis_min` assertion (left bound was unverified in fallback path)
- New `test_bounds_inverted_guard`: exercises the `v_axis_min >= v_axis_max` collapse-to-None defensive guard
- `useAnalysis.test.ts`: extended speed_polar fixture with `v_axis_min: 5.5, v_axis_max: 40.0` and hook-boundary assertions
- `_compute_speed_polar` comprehension vars renamed `vi/curve` (was `v/c`, shadowed outer numpy `v`)

## Deferred

- `SPEED_POLAR_LAYOUT` mutability (pre-existing, not introduced by this PR)
- `List[float]` → `list[float]` in `aeroanalysisschema.py` (pre-existing, separate cleanup PR)
- Extract `buildSpeedPolarLayout` as shared pure helper (follow-up refactor)
- Pass pre-loaded `AeroplaneModel` into `_build_speed_polar` to avoid second DB query (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)