### PR TITLE
fix(gh-803): reject slicer refinement that diverges from the handler frame

### DIFF
--- a/app/services/openvsp_import_service.py
+++ b/app/services/openvsp_import_service.py
@@ -50,6 +50,7 @@ def _noop_progress(_step: str, _pct: int, _detail: str) -> None:  # pragma: no c
     """No-op default callback so the import flow doesn't need to
     check ``if progress_cb is not None`` at every checkpoint."""
 
+
 from sqlalchemy.orm import Session
 
 from app.converters import openvsp_adapter
@@ -206,8 +207,7 @@ def _resolve_scale_factor(
     """
     if target_span_m is not None and scale_factor is not None:
         raise ScaleValidationError(
-            "target_span_m and scale_factor are mutually exclusive; "
-            "specify at most one."
+            "target_span_m and scale_factor are mutually exclusive; specify at most one."
         )
 
     if scale_factor is not None:
@@ -302,9 +302,7 @@ def _resolve_aeroplane_name(
     return "OpenVSP Import"
 
 
-def _set_fuselage_step_path(
-    db: Session, aeroplane_uuid, fuse_name: str, rel_path: str
-) -> None:
+def _set_fuselage_step_path(db: Session, aeroplane_uuid, fuse_name: str, rel_path: str) -> None:
     """Write the per-geom Surface-STEP path onto an already-persisted
     ``FuselageModel`` row (gh-729)."""
     _update_fuselage_field(db, aeroplane_uuid, fuse_name, "step_path", rel_path)
@@ -319,9 +317,7 @@ def _set_fuselage_solid_step_path(
     _update_fuselage_field(db, aeroplane_uuid, fuse_name, "solid_step_path", rel_path)
 
 
-def _replace_fuselage_xsecs(
-    db: Session, aeroplane_uuid, fuse_name: str, new_xsecs
-) -> bool:
+def _replace_fuselage_xsecs(db: Session, aeroplane_uuid, fuse_name: str, new_xsecs) -> bool:
     """Replace the existing fuselage's ``x_secs`` rows with new ones
     (gh-732). Pure mutation of the persisted row — keeps the gh-729
     Surface STEP path and the gh-731 Solid STEP path intact.
@@ -341,9 +337,7 @@ def _replace_fuselage_xsecs(
         FuselageXSecSuperEllipseModel,
     )
 
-    aeroplane = (
-        db.query(AeroplaneModel).filter(AeroplaneModel.uuid == aeroplane_uuid).first()
-    )
+    aeroplane = db.query(AeroplaneModel).filter(AeroplaneModel.uuid == aeroplane_uuid).first()
     if aeroplane is None:
         return False
     fuse_row = (
@@ -364,9 +358,7 @@ def _replace_fuselage_xsecs(
         # set explicitly below to keep ordering stable.
         payload.pop("name", None)
         payload.pop("sort_index", None)
-        fuse_row.x_secs.append(
-            FuselageXSecSuperEllipseModel(sort_index=i, **payload)
-        )
+        fuse_row.x_secs.append(FuselageXSecSuperEllipseModel(sort_index=i, **payload))
     db.flush()
     return True
 
@@ -398,18 +390,52 @@ def _is_x_dominant_fuselage(handler_xsec_dicts: list[dict]) -> bool:
         return False
     import numpy as np
 
-    xs = np.array(
-        [[d["xyz"][0], d["xyz"][1], d["xyz"][2]] for d in handler_xsec_dicts]
-    )
+    xs = np.array([[d["xyz"][0], d["xyz"][1], d["xyz"][2]] for d in handler_xsec_dicts])
     extents = xs.max(axis=0) - xs.min(axis=0)
     if extents[0] <= 1e-6:
         return False
     # Cast to plain Python bool — numpy's bool_ doesn't satisfy ``is True``
     # / ``is False`` identity checks, which trips up test assertions.
-    return bool(
-        extents[0] >= 1.2 * extents[1]
-        and extents[0] >= 1.2 * extents[2]
-    )
+    return bool(extents[0] >= 1.2 * extents[1] and extents[0] >= 1.2 * extents[2])
+
+
+# Bounds for the slicer-vs-handler frame check (gh-803). The slicer
+# slices the STEP at the handler's anchor X-stations, so a faithful
+# refinement must reproduce the handler's overall X-extent. A gross
+# mismatch means the STEP and handler schema are in different
+# frames/units: gh-732 forces the exported STEP to metres, but the
+# importer keeps handler values in raw source units (OpenVSP 3.50 no
+# longer exposes the length unit, so a feet-unit model like cessna337
+# stays unconverted). The metric STEP then sits at ~0.305× the handler
+# extent, the slices truncate/shrink, and accepting them would desync
+# the fuselage from the (handler-frame) wings. Bounds are generous so
+# only gross unit/frame mismatches trip — a real refinement is ≈ 1.0.
+_SLICER_FRAME_RATIO_MIN = 0.5
+_SLICER_FRAME_RATIO_MAX = 2.0
+
+
+def _x_span(x_secs: list[FuselageXSecSuperEllipseSchema]) -> float:
+    xs = [s.xyz[0] for s in x_secs]
+    return (max(xs) - min(xs)) if xs else 0.0
+
+
+def _slicer_frame_matches_handler(
+    refined: list[FuselageXSecSuperEllipseSchema],
+    handler_x_secs: list[FuselageXSecSuperEllipseSchema],
+) -> bool:
+    """True when the slicer output shares the handler's X-frame (gh-803).
+
+    Compares the X-extent of the slicer result against the handler
+    anchors. A ratio far from 1.0 signals a unit/frame mismatch — the
+    refinement must then be rejected so the handler schema (which is
+    consistent with the wings) is kept.
+    """
+    h_span = _x_span(handler_x_secs)
+    r_span = _x_span(refined)
+    if h_span <= 1e-9 or r_span <= 1e-9:
+        return False
+    ratio = r_span / h_span
+    return _SLICER_FRAME_RATIO_MIN <= ratio <= _SLICER_FRAME_RATIO_MAX
 
 
 def _try_slicer_refinement(
@@ -459,8 +485,7 @@ def _try_slicer_refinement(
     # for the rare case where the handler list is empty / has < 2 xsecs.
     try:
         handler_xsec_dicts = [
-            {"xyz": list(xs.xyz), "a": xs.a, "b": xs.b, "n": xs.n}
-            for xs in handler_fuse.x_secs
+            {"xyz": list(xs.xyz), "a": xs.a, "b": xs.b, "n": xs.n} for xs in handler_fuse.x_secs
         ]
 
         # Frame-safety gate: only refine fuselages whose long axis is
@@ -500,9 +525,7 @@ def _try_slicer_refinement(
             # schema so each slice yields a single clean outline.
             keep_y_side: Optional[str] = None
             if getattr(handler_fuse, "symmetric", False):
-                mean_y_m = sum(
-                    d["xyz"][1] for d in handler_xsec_dicts
-                ) / len(handler_xsec_dicts)
+                mean_y_m = sum(d["xyz"][1] for d in handler_xsec_dicts) / len(handler_xsec_dicts)
                 if mean_y_m > 1e-3:
                     keep_y_side = "positive"
                 elif mean_y_m < -1e-3:
@@ -529,7 +552,8 @@ def _try_slicer_refinement(
     except Exception as exc:  # noqa: BLE001 — refinement is best-effort
         logger.info(
             "Slicer refinement skipped for %r (%s) — keeping handler-built schema.",
-            fuse_name, exc,
+            fuse_name,
+            exc,
         )
         return None
 
@@ -537,7 +561,8 @@ def _try_slicer_refinement(
     if len(slicer_xsecs) < 2:
         logger.info(
             "Slicer produced %d xsec(s) for %r — too few to refine; keeping handler schema.",
-            len(slicer_xsecs), fuse_name,
+            len(slicer_xsecs),
+            fuse_name,
         )
         return None
 
@@ -552,10 +577,26 @@ def _try_slicer_refinement(
             )
         )
 
+    # gh-803: reject a refinement that doesn't share the handler's frame
+    # (gross X-extent mismatch → unit/frame desync, e.g. cessna337's
+    # feet-unit handler vs the metre-forced STEP). Keep the handler schema
+    # so the fuselage stays consistent with the (handler-frame) wings.
+    if not _slicer_frame_matches_handler(refined, handler_fuse.x_secs):
+        logger.info(
+            "Slicer refinement for %r diverges from the handler frame "
+            "(refined X-span %.2f m vs handler %.2f m) — likely a unit/frame "
+            "mismatch (gh-803); keeping handler schema.",
+            fuse_name,
+            _x_span(refined),
+            _x_span(handler_fuse.x_secs),
+        )
+        return None
+
     logger.info(
-        "Slicer refinement for %r: %d→%d xsecs (area_ratio=%.3f, "
-        "vol_ratio=%.3f).",
-        fuse_name, len(handler_fuse.x_secs), len(refined),
+        "Slicer refinement for %r: %d→%d xsecs (area_ratio=%.3f, vol_ratio=%.3f).",
+        fuse_name,
+        len(handler_fuse.x_secs),
+        len(refined),
         metrics.get("area_ratio") or 0.0,
         metrics.get("volume_ratio") or 0.0,
     )
@@ -570,9 +611,7 @@ def _update_fuselage_field(
     """
     from app.models.aeroplanemodel import AeroplaneModel, FuselageModel
 
-    aeroplane = (
-        db.query(AeroplaneModel).filter(AeroplaneModel.uuid == aeroplane_uuid).first()
-    )
+    aeroplane = db.query(AeroplaneModel).filter(AeroplaneModel.uuid == aeroplane_uuid).first()
     if aeroplane is None:
         return
     fuse_row = (
@@ -770,9 +809,7 @@ def _persist_aeroplane(
                         geom_name=fuse_name,
                     )
                     if rel_solid:
-                        _set_fuselage_solid_step_path(
-                            db, aeroplane.uuid, fuse_name, rel_solid
-                        )
+                        _set_fuselage_solid_step_path(db, aeroplane.uuid, fuse_name, rel_solid)
 
                     # gh-732: refine the schema's xsecs from the just-exported
                     # (unscaled) STEP. Solid STEP gives the slicer a real
@@ -785,9 +822,7 @@ def _persist_aeroplane(
                         f"{fuse_name}: slicing for finer xsecs",
                     )
                     slicer_source = rel_solid or rel_step
-                    refined_xsecs = _try_slicer_refinement(
-                        slicer_source, fuse, fuse_name
-                    )
+                    refined_xsecs = _try_slicer_refinement(slicer_source, fuse, fuse_name)
 
             # gh-765: apply the import scale ONCE, after refinement (the
             # slicer ran in the unscaled STEP frame). When scaling, persist
@@ -831,7 +866,8 @@ def _persist_aeroplane(
     # CG-recompute hooks, and validation stay aligned.
     if result.weight_items:
         progress_cb(
-            "weight_items", 90,
+            "weight_items",
+            90,
             f"Persisting {len(result.weight_items)} weight items",
         )
     for item in result.weight_items:
@@ -894,7 +930,8 @@ def import_openvsp_file(
     progress_cb("parsing", 5, "Reading .vsp3 file")
     result = import_vsp3(path)
     progress_cb(
-        "parsing", 15,
+        "parsing",
+        15,
         f"Parsed {len(result.aeroplane.wings or {})} wing(s), "
         f"{len(result.aeroplane.fuselages or {})} fuselage(s)",
     )
@@ -905,18 +942,15 @@ def import_openvsp_file(
     # well below any user-typed scale value (UI step is 0.01).
     if factor is not None and abs(factor - 1.0) > 1e-9:
         progress_cb("scaling", 18, f"Scaling by {factor:g}")
-        _scale_aeroplane_lengths(
-            result.aeroplane, factor, weight_items=result.weight_items
-        )
+        _scale_aeroplane_lengths(result.aeroplane, factor, weight_items=result.weight_items)
         # Surface the scaling decision + the mass-not-scaled caveat to
         # the user. The frontend banner renders these alongside any
         # importer-level warnings.
-        result.warnings.append(
-            _make_scaling_warning(factor, target_span_m, scale_factor)
-        )
+        result.warnings.append(_make_scaling_warning(factor, target_span_m, scale_factor))
 
     uuid, name = _persist_aeroplane(
-        db, result,
+        db,
+        result,
         name=name,
         source_filename=source_filename,
         progress_cb=progress_cb,

--- a/app/tests/test_openvsp_import_slicer_scaling.py
+++ b/app/tests/test_openvsp_import_slicer_scaling.py
@@ -94,6 +94,39 @@ def test_slicer_refinement_takes_no_factor_argument():
     assert "scale_factor" not in params
 
 
+def test_slicer_refinement_rejected_on_frame_mismatch(monkeypatch, tmp_path):
+    """gh-803: a slicer result whose X-extent grossly mismatches the handler
+    anchors is rejected → the handler schema is kept.
+
+    This is the cessna337 feet-unit case: the handler keeps raw (feet)
+    values while gh-732 forces the exported STEP to metres, so the slicer
+    output sits at ~0.3× the handler extent. Accepting it would shrink the
+    fuselage out of sync with the (handler-frame) wings.
+    """
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "ARTIFACTS_BASE_DIR", str(tmp_path))
+    (tmp_path / "body.stp").write_text("dummy step")
+
+    # Handler _fuse() spans x 0..10 m; the slicer only covers 0..3 m
+    # (ratio 0.3) — a gross frame mismatch.
+    mm_xsecs = [
+        {"xyz": [0.0, 0.0, 0.0], "a": 60.0, "b": 30.0, "n": 2.0},
+        {"xyz": [1500.0, 0.0, 0.0], "a": 300.0, "b": 150.0, "n": 2.0},
+        {"xyz": [3000.0, 0.0, 0.0], "a": 60.0, "b": 30.0, "n": 2.0},
+    ]
+    fake = types.ModuleType("cad_designer.aerosandbox.slicing")
+    fake.slice_step_at_stations = MagicMock(return_value=(mm_xsecs, {"area_ratio": 1.0}))
+    fake.slice_step_to_fuselage = MagicMock(return_value=(mm_xsecs, {}))
+    fake.vsp_anchored_x_stations = MagicMock(return_value=[0.0, 5000.0, 10000.0])
+    monkeypatch.setitem(sys.modules, "cad_designer.aerosandbox.slicing", fake)
+
+    from app.services.openvsp_import_service import _try_slicer_refinement
+
+    refined = _try_slicer_refinement("body.stp", _fuse(), "Body")
+    assert refined is None  # handler schema kept (no desync with wings)
+
+
 # --------------------------------------------------------------------------- #
 # _scale_aeroplane_lengths — no longer touches fuselages (gh-765)
 # --------------------------------------------------------------------------- #
@@ -136,9 +169,7 @@ def test_scale_geom_step_scales_bounding_box(monkeypatch, tmp_path):
     rel = "openvsp_imports/uuid/body.stp"
     src = tmp_path / rel
     src.parent.mkdir(parents=True, exist_ok=True)
-    exporters.export(
-        cq.Workplane("XY").box(10, 4, 2), str(src), exporters.ExportTypes.STEP
-    )
+    exporters.export(cq.Workplane("XY").box(10, 4, 2), str(src), exporters.ExportTypes.STEP)
 
     new_rel = step_svc.scale_geom_step(rel, 0.1, "uuid")
     assert new_rel is not None
@@ -210,9 +241,7 @@ def test_persist_scales_fuselage_xsecs_when_vsp_unavailable(client_and_db, monke
     monkeypatch.setattr(openvsp_adapter, "is_available", lambda: False)
 
     db = SessionLocal()
-    uuid, _name = svc._persist_aeroplane(
-        db, _import_result_with_fuselage(), scale_factor=0.5
-    )
+    uuid, _name = svc._persist_aeroplane(db, _import_result_with_fuselage(), scale_factor=0.5)
     db.commit()
 
     f = _read_fuselage(db, uuid)
@@ -239,14 +268,12 @@ def test_persist_scales_refined_xsecs_and_step_with_vsp(client_and_db, monkeypat
     monkeypatch.setattr(openvsp_adapter, "is_available", lambda: True)
     monkeypatch.setattr(openvsp_adapter, "get_vsp", lambda: object())
     monkeypatch.setattr(step_svc, "export_geom_step", lambda **kw: "imp/u/body.stp")
-    monkeypatch.setattr(
-        sew_svc, "sew_imported_geom_to_solid", lambda **kw: "imp/u/body_solid.stp"
-    )
+    monkeypatch.setattr(sew_svc, "sew_imported_geom_to_solid", lambda **kw: "imp/u/body_solid.stp")
     scale_calls: list[tuple[str, float]] = []
     monkeypatch.setattr(
         step_svc,
         "scale_geom_step",
-        lambda rel, factor, uuid: (scale_calls.append((rel, factor)) or rel),
+        lambda rel, factor, uuid: scale_calls.append((rel, factor)) or rel,
     )
     # Slicer returns an UNSCALED refined list (mid a=2.0); persist scales it.
     refined = [


### PR DESCRIPTION
## Problem

Importing a **feet-unit** `.vsp3` (e.g. `cessna337.vsp3`), the fuselage renders tiny and detached from the wings.

## Root cause (full investigation in #803)

The diagnosis flipped three times before landing here — confirmed via OpenVSP's own `GetGeomBBoxMax`:

- The cessna337 model is in **feet**. OpenVSP's world bbox says the fuselage is 19.78 (feet) = 6.03 m — the real Skymaster size.
- OpenVSP 3.50 **no longer exposes the model length unit**, so the importer keeps handler values in **raw source units** (gh-640: treat-as-metres, user rescales to target span). The handler fuselage is therefore 19.78 (feet read as metres).
- The **STEP export forces metres** (gh-732, foot→metre 0.3048). For a feet model the metric STEP sits at **~0.305× (= 1/3.28)** the handler extent.
- The slicer faithfully slices that metric STEP and its output **replaces** the handler xsecs → the fuselage shrinks to 6 m while the wings stay at 19.78 m (handler frame) → the detached-fuselage render.

The slicer is documented as a best-effort refinement with the handler schema as fallback, but it only fell back on *too few points* — not on a frame/scale mismatch.

## Fix

Add a **frame-consistency gate** `_slicer_frame_matches_handler`: if the refinement's X-extent diverges grossly from the handler anchors (span ratio outside `[0.5, 2.0]`), keep the handler schema so the fuselage stays consistent with the wings.

## Verification

- Real `cessna337` import: refinement now **rejected**, fuselage kept at the handler's 19.78 m frame (matches wings).
- TDD: new `test_slicer_refinement_rejected_on_frame_mismatch` + existing slicer suite green (**49 passed**). `ruff check`/`format` clean.

## Scope note

This makes the import **robust** against the unit mismatch. The deeper issue — feet→metre handling (no unit conversion on import vs forced-metre STEP export) — and the metric STEP *download* for a feet model remain documented in #803 for a follow-up if desired.

Closes #803

🤖 Generated with [Claude Code](https://claude.com/claude-code)