### PR TITLE
fix(gh-804): smooth fuselage nose-body fillet (cosine station spacing + baseline cap)

### DIFF
--- a/app/tests/test_slicer_arc_length_helpers.py
+++ b/app/tests/test_slicer_arc_length_helpers.py
@@ -252,17 +252,14 @@ class TestVspAnchoredStations:
         """
         from cad_designer.aerosandbox.slicing import vsp_anchored_x_stations
 
-        # One 10 m section between two equal body anchors → all budget
-        # lands here, so we can inspect the intra-section distribution.
         handler = self._make_handler([(0.0, 1.0, 1.0), (10.0, 1.0, 1.0)])
         st = sorted(vsp_anchored_x_stations(handler, total_stations=12, scale_to_mm=False))
         inter = [s for s in st if 0.0 < s < 10.0]
         assert len(inter) >= 4
         n = len(inter)
-        # Cosine places the first intermediate at frac 0.5(1-cos(pi/(n+1))),
-        # strictly inside the uniform 1/(n+1) → clustered toward the anchor.
+        # Cosine places the first intermediate inside the uniform 1/(n+1)
+        # spacing → clustered toward the anchor; symmetric at the far end.
         assert inter[0] < (1.0 / (n + 1)) * 10.0
-        # Symmetric: the last intermediate mirrors the first at the far end.
         assert (10.0 - inter[-1]) == pytest.approx(inter[0], rel=0.1)
 
     def test_long_featureless_section_does_not_starve_short_curved_one(self):
@@ -274,16 +271,15 @@ class TestVspAnchoredStations:
         handler = self._make_handler(
             [
                 (0.0, 0.0, 0.0),
-                (2.4, 1.18, 1.10),  # short fillet section (a/b change)
+                (2.4, 1.18, 1.10),
                 (3.4, 1.35, 1.25),
-                (12.5, 1.35, 1.25),  # long constant body (9 m)
+                (12.5, 1.35, 1.25),
                 (12.5, 0.0, 0.0),
             ]
         )
         st = vsp_anchored_x_stations(handler, total_stations=40, scale_to_mm=False)
-        fillet = sum(1 for s in st if 2.4 < s < 3.4)  # 1 m fillet section
-        body = sum(1 for s in st if 3.4 < s < 12.5)  # 9 m body section
-        # The 1 m fillet must be denser per metre than the 9 m body.
+        fillet = sum(1 for s in st if 2.4 < s < 3.4)
+        body = sum(1 for s in st if 3.4 < s < 12.5)
         assert fillet / 1.0 > body / 9.1
 
 

--- a/app/tests/test_slicer_arc_length_helpers.py
+++ b/app/tests/test_slicer_arc_length_helpers.py
@@ -158,28 +158,26 @@ class TestVspAnchoredStations:
     def _make_handler(self, positions_a_b):
         """Return list of handler-style xsec dicts. Each entry:
         (x_m, a_m, b_m). y/z fixed at 0."""
-        return [
-            {"xyz": [x, 0.0, 0.0], "a": a, "b": b, "n": 2.0}
-            for x, a, b in positions_a_b
-        ]
+        return [{"xyz": [x, 0.0, 0.0], "a": a, "b": b, "n": 2.0} for x, a, b in positions_a_b]
 
     def test_returns_empty_for_under_two_xsecs(self):
         from cad_designer.aerosandbox.slicing import vsp_anchored_x_stations
 
         assert vsp_anchored_x_stations([], total_stations=10) == []
-        assert vsp_anchored_x_stations(
-            [{"xyz": [0, 0, 0], "a": 0.1, "b": 0.1, "n": 2.0}],
-            total_stations=10,
-        ) == []
+        assert (
+            vsp_anchored_x_stations(
+                [{"xyz": [0, 0, 0], "a": 0.1, "b": 0.1, "n": 2.0}],
+                total_stations=10,
+            )
+            == []
+        )
 
     def test_includes_every_handler_anchor(self):
         """Every handler position must appear in the station list."""
         from cad_designer.aerosandbox.slicing import vsp_anchored_x_stations
 
-        handler = self._make_handler([(0.0, 0.1, 0.1), (1.0, 0.2, 0.2),
-                                       (2.0, 0.1, 0.1)])
-        stations = vsp_anchored_x_stations(handler, total_stations=20,
-                                            scale_to_mm=True)
+        handler = self._make_handler([(0.0, 0.1, 0.1), (1.0, 0.2, 0.2), (2.0, 0.1, 0.1)])
+        stations = vsp_anchored_x_stations(handler, total_stations=20, scale_to_mm=True)
         # 0, 1000, 2000 mm must all appear (within float tolerance).
         for required_mm in (0.0, 1000.0, 2000.0):
             assert any(abs(s - required_mm) < 1e-6 for s in stations), (
@@ -190,8 +188,7 @@ class TestVspAnchoredStations:
         from cad_designer.aerosandbox.slicing import vsp_anchored_x_stations
 
         handler = self._make_handler([(0.0, 0.1, 0.1), (1.0, 0.1, 0.1)])
-        stations = vsp_anchored_x_stations(handler, total_stations=5,
-                                            scale_to_mm=False)
+        stations = vsp_anchored_x_stations(handler, total_stations=5, scale_to_mm=False)
         assert stations[0] == 0.0
         assert stations[-1] == 1.0
 
@@ -203,13 +200,14 @@ class TestVspAnchoredStations:
 
         # Section 0: tip a=0 → body a=0.5 over 0.4 m (tip-cap)
         # Section 1: a=0.5 → a=0.5 over 1.0 m (uniform body)
-        handler = self._make_handler([
-            (0.0, 0.0, 0.0),     # tip
-            (0.4, 0.5, 0.5),     # body start
-            (1.4, 0.5, 0.5),     # body end
-        ])
-        stations = vsp_anchored_x_stations(handler, total_stations=20,
-                                            scale_to_mm=True)
+        handler = self._make_handler(
+            [
+                (0.0, 0.0, 0.0),  # tip
+                (0.4, 0.5, 0.5),  # body start
+                (1.4, 0.5, 0.5),  # body end
+            ]
+        )
+        stations = vsp_anchored_x_stations(handler, total_stations=20, scale_to_mm=True)
         # Count stations in section 0 vs section 1 (excluding anchors).
         sec0 = sum(1 for s in stations if 0.0 < s < 400.0)
         sec1 = sum(1 for s in stations if 400.0 < s < 1400.0)
@@ -222,11 +220,14 @@ class TestVspAnchoredStations:
         anchors)."""
         from cad_designer.aerosandbox.slicing import vsp_anchored_x_stations
 
-        handler = self._make_handler([
-            (0.0, 0.1, 0.1), (0.5, 0.1, 0.1), (1.0, 0.1, 0.1),
-        ])
-        stations = vsp_anchored_x_stations(handler, total_stations=10,
-                                            scale_to_mm=True)
+        handler = self._make_handler(
+            [
+                (0.0, 0.1, 0.1),
+                (0.5, 0.1, 0.1),
+                (1.0, 0.1, 0.1),
+            ]
+        )
+        stations = vsp_anchored_x_stations(handler, total_stations=10, scale_to_mm=True)
         # 3 anchors + up to 7 intermediates = ≤10 total.
         assert 3 <= len(stations) <= 12  # some slack for rounding
 
@@ -234,12 +235,56 @@ class TestVspAnchoredStations:
         """Output is sorted ascending."""
         from cad_designer.aerosandbox.slicing import vsp_anchored_x_stations
 
-        handler = self._make_handler([
-            (0.0, 0.1, 0.1), (1.0, 0.1, 0.1), (0.5, 0.1, 0.1),
-        ])
-        stations = vsp_anchored_x_stations(handler, total_stations=10,
-                                            scale_to_mm=False)
+        handler = self._make_handler(
+            [
+                (0.0, 0.1, 0.1),
+                (1.0, 0.1, 0.1),
+                (0.5, 0.1, 0.1),
+            ]
+        )
+        stations = vsp_anchored_x_stations(handler, total_stations=10, scale_to_mm=False)
         assert stations == sorted(stations)
+
+    def test_intermediates_cluster_near_anchors(self):
+        """gh-804: intermediate stations cluster toward the section ends
+        (cosine spacing), where VSP lofts round their corners — so the
+        nose-body fillet is sampled instead of straight-lined into a kink.
+        """
+        from cad_designer.aerosandbox.slicing import vsp_anchored_x_stations
+
+        # One 10 m section between two equal body anchors → all budget
+        # lands here, so we can inspect the intra-section distribution.
+        handler = self._make_handler([(0.0, 1.0, 1.0), (10.0, 1.0, 1.0)])
+        st = sorted(vsp_anchored_x_stations(handler, total_stations=12, scale_to_mm=False))
+        inter = [s for s in st if 0.0 < s < 10.0]
+        assert len(inter) >= 4
+        n = len(inter)
+        # Cosine places the first intermediate at frac 0.5(1-cos(pi/(n+1))),
+        # strictly inside the uniform 1/(n+1) → clustered toward the anchor.
+        assert inter[0] < (1.0 / (n + 1)) * 10.0
+        # Symmetric: the last intermediate mirrors the first at the far end.
+        assert (10.0 - inter[-1]) == pytest.approx(inter[0], rel=0.1)
+
+    def test_long_featureless_section_does_not_starve_short_curved_one(self):
+        """gh-804: the length-scaled baseline is capped so a long constant
+        mid-body can't steal the whole budget from a short, highly-curved
+        nose-body fillet section next to it."""
+        from cad_designer.aerosandbox.slicing import vsp_anchored_x_stations
+
+        handler = self._make_handler(
+            [
+                (0.0, 0.0, 0.0),
+                (2.4, 1.18, 1.10),  # short fillet section (a/b change)
+                (3.4, 1.35, 1.25),
+                (12.5, 1.35, 1.25),  # long constant body (9 m)
+                (12.5, 0.0, 0.0),
+            ]
+        )
+        st = vsp_anchored_x_stations(handler, total_stations=40, scale_to_mm=False)
+        fillet = sum(1 for s in st if 2.4 < s < 3.4)  # 1 m fillet section
+        body = sum(1 for s in st if 3.4 < s < 12.5)  # 9 m body section
+        # The 1 m fillet must be denser per metre than the 9 m body.
+        assert fillet / 1.0 > body / 9.1
 
 
 # ---------------------------------------------------------------------------

--- a/cad_designer/aerosandbox/slicing.py
+++ b/cad_designer/aerosandbox/slicing.py
@@ -25,7 +25,9 @@ from OCP.gp import gp_Dir, gp_Pln, gp_Pnt
 from cad_designer.cq_plugins.display import display
 
 import logging
+
 logger = logging.getLogger(__name__)
+
 
 def discretize_wire(wire: TopoDS_Wire, num_points: int) -> list[gp_Pnt]:
     comp_curve = BRepAdaptor_CompCurve(wire)
@@ -40,6 +42,7 @@ def discretize_wire(wire: TopoDS_Wire, num_points: int) -> list[gp_Pnt]:
         point = comp_curve.Value(param)
         points.append(point)
     return points
+
 
 def load_step_model(filepath: str) -> cq.Workplane:
     if not os.path.exists(filepath):
@@ -73,7 +76,9 @@ def _ensure_sliceable_shape(model: cq.Workplane) -> TopoDS_Shape:
     return sewing.SewedShape()
 
 
-def _section_outline_edges(shape: TopoDS_Shape, origin: tuple[float, float, float], normal: tuple[float, float, float]) -> list[cq.Edge]:
+def _section_outline_edges(
+    shape: TopoDS_Shape, origin: tuple[float, float, float], normal: tuple[float, float, float]
+) -> list[cq.Edge]:
     """Intersect ``shape`` with the plane ``(origin, normal)`` and
     return every resulting edge wrapped as a cadquery ``Edge``.
     """
@@ -149,9 +154,7 @@ def arc_length_weights(points_2d: np.ndarray) -> np.ndarray:
     return np.maximum(nn, floor)
 
 
-def thin_oversampled_points(
-    points_2d: np.ndarray, radius_ratio: float = 0.2
-) -> np.ndarray:
+def thin_oversampled_points(points_2d: np.ndarray, radius_ratio: float = 0.2) -> np.ndarray:
     """Drop points that are over-sampled relative to the cloud's
     natural inter-point spacing (gh-732).
 
@@ -365,9 +368,12 @@ def _curvature_density(
             continue
         # Non-uniform-spacing second derivative
         dz2[i - 1] = abs(
-            2 * (zs[i - 1] / (dx1 * (dx1 + dx2))
-                 - zs[i] / (dx1 * dx2)
-                 + zs[i + 1] / (dx2 * (dx1 + dx2)))
+            2
+            * (
+                zs[i - 1] / (dx1 * (dx1 + dx2))
+                - zs[i] / (dx1 * dx2)
+                + zs[i + 1] / (dx2 * (dx1 + dx2))
+            )
         )
     return xs[1:-1], dz2
 
@@ -453,9 +459,11 @@ def adaptive_x_stations(
     targets = np.linspace(0.0, 1.0, n_stations)
     return [float(np.interp(t, cdf, grid)) for t in targets]
 
+
 def get_x_bounds(shape: cq.Shape) -> tuple[float, float]:
     bb = shape.BoundingBox()
     return bb.xmin, bb.xmax
+
 
 def get_bounding_box_dims(shape: cq.Shape) -> dict[str, float]:
     """Return bounding box dimensions per axis."""
@@ -513,8 +521,9 @@ def slice_model_along_x(
             if polylines:
                 slices.append(polylines)
             x += spacing
-        logger.info(f"Section slicing complete: {len(slices)} slices "
-                    f"from x={xmin:.4f} to x={xmax:.4f}")
+        logger.info(
+            f"Section slicing complete: {len(slices)} slices from x={xmin:.4f} to x={xmax:.4f}"
+        )
         return slices
 
     # Solid path — preserve original behaviour byte-for-byte
@@ -558,11 +567,9 @@ def slice_model_along_x(
     logger.info(f"Slicing complete: {len(slices)} slices from x={xmin:.4f} to x={xmax:.4f}")
     return slices
 
+
 def to_superellipse(
-    vertices: Sequence[tuple[float, float]],
-    exponent: float = 2.5,
-    a: float = 1.0,
-    b: float = 1.0
+    vertices: Sequence[tuple[float, float]], exponent: float = 2.5, a: float = 1.0, b: float = 1.0
 ) -> NDArray[np.float64]:
     vertices = np.array(vertices)
     center = np.mean(vertices, axis=0)
@@ -571,8 +578,9 @@ def to_superellipse(
     normalized /= scale  # normalize to [-1, 1] box
 
     angles = np.arctan2(normalized[:, 1], normalized[:, 0])
-    super_radii = (np.abs(np.cos(angles) / a) ** exponent +
-                   np.abs(np.sin(angles) / b) ** exponent) ** (-1 / exponent)
+    super_radii = (
+        np.abs(np.cos(angles) / a) ** exponent + np.abs(np.sin(angles) / b) ** exponent
+    ) ** (-1 / exponent)
     x_new = super_radii * np.cos(angles)
     y_new = super_radii * np.sin(angles)
 
@@ -582,30 +590,39 @@ def to_superellipse(
     new_shape += center
     return new_shape
 
+
 def superellipse_radius(theta: np.ndarray, a: float, b: float, n: float) -> np.ndarray:
     return (np.abs(np.cos(theta) / a) ** n + np.abs(np.sin(theta) / b) ** n) ** (-1 / n)
+
 
 def approximate_perimeter(a: float, b: float, n: float) -> float:
     # Numerically integrate the perimeter of the superellipse
     def integrand(theta):
         r = (np.abs(np.cos(theta) / a) ** n + np.abs(np.sin(theta) / b) ** n) ** (-1 / n)
-        dr_dtheta = n * r * (
-                (np.abs(np.sin(theta) / b) ** (n - 1) * np.cos(theta) / b) -
-                (np.abs(np.cos(theta) / a) ** (n - 1) * np.sin(theta) / a)
+        dr_dtheta = (
+            n
+            * r
+            * (
+                (np.abs(np.sin(theta) / b) ** (n - 1) * np.cos(theta) / b)
+                - (np.abs(np.cos(theta) / a) ** (n - 1) * np.sin(theta) / a)
+            )
         )
-        return np.sqrt(r ** 2 + dr_dtheta ** 2)
+        return np.sqrt(r**2 + dr_dtheta**2)
 
     return quad(integrand, 0, 2 * np.pi, limit=200)[0]
 
+
 def approximate_area(a: float, b: float, n: float) -> float:
     # Approximation using Gamma function
-    return 4 * a * b * (gamma(1 + 1/n)**2) / gamma(1 + 2/n)
+    return 4 * a * b * (gamma(1 + 1 / n) ** 2) / gamma(1 + 2 / n)
+
 
 def polygon_area(points: np.ndarray) -> float:
     # Shoelace formula for polygon area
     x = points[:, 0]
     y = points[:, 1]
     return 0.5 * np.abs(np.dot(x, np.roll(y, 1)) - np.dot(y, np.roll(x, 1)))
+
 
 def fit_symmetric_superellipse(points: np.ndarray, initial_n: float = 2.0) -> dict:
     """
@@ -640,15 +657,15 @@ def fit_symmetric_superellipse(points: np.ndarray, initial_n: float = 2.0) -> di
         fit_r = superellipse_radius(angles, a, b, n)
         perimeter_fit = approximate_perimeter(a, b, n)
         perimeter_actual = np.sum(np.linalg.norm(np.roll(shifted, -1, axis=0) - shifted, axis=1))
-        radius_loss = np.mean((radii - fit_r)**2)
-        length_loss = (perimeter_fit - perimeter_actual)**2
+        radius_loss = np.mean((radii - fit_r) ** 2)
+        length_loss = (perimeter_fit - perimeter_actual) ** 2
         return radius_loss + 0.01 * length_loss
 
     result = minimize(
         objective,
         x0=[1.0, 1.0, initial_n],
         bounds=[(1e-3, None), (1e-3, None), (0.5, 8.0)],
-        method='L-BFGS-B'
+        method="L-BFGS-B",
     )
 
     return {
@@ -657,8 +674,9 @@ def fit_symmetric_superellipse(points: np.ndarray, initial_n: float = 2.0) -> di
         "b": result.x[1],
         "n": result.x[2],
         "success": result.success,
-        "fun": result.fun
+        "fun": result.fun,
     }
+
 
 def fit_superellipse(points: np.ndarray, initial_n: float = 2.0) -> dict:
     """
@@ -695,7 +713,7 @@ def fit_superellipse(points: np.ndarray, initial_n: float = 2.0) -> dict:
         objective,
         x0=[1.0, 1.0, initial_n],
         bounds=[(1e-3, None), (1e-3, None), (0.5, 8.0)],
-        method='L-BFGS-B'
+        method="L-BFGS-B",
     )
 
     return {
@@ -704,10 +722,16 @@ def fit_superellipse(points: np.ndarray, initial_n: float = 2.0) -> dict:
         "b": result.x[1],
         "n": result.x[2],
         "success": result.success,
-        "fun": result.fun
+        "fun": result.fun,
     }
 
-def fit_shape_area_superellipse(points: np.ndarray, initial_n: float = 2.0, prev_params: Optional[dict] = None, smoothness_weight: float = 0.1) -> dict:
+
+def fit_shape_area_superellipse(
+    points: np.ndarray,
+    initial_n: float = 2.0,
+    prev_params: Optional[dict] = None,
+    smoothness_weight: float = 0.1,
+) -> dict:
     """
     Fits a symmetric superellipse to a given set of 2D points, ensuring symmetry about the Z-axis.
 
@@ -772,16 +796,12 @@ def fit_shape_area_superellipse(points: np.ndarray, initial_n: float = 2.0, prev
     radii = np.concatenate([radii, radii])
     weights_full = np.concatenate([weights, weights])
     weight_sum = float(weights_full.sum()) or 1.0
-    radii_norm_sq = max(
-        float(np.sum(weights_full * radii ** 2) / weight_sum), 1e-9
-    )
+    radii_norm_sq = max(float(np.sum(weights_full * radii**2) / weight_sum), 1e-9)
 
     def objective(params: np.ndarray) -> float:
         n_val = float(params[0])
         fit_r = superellipse_radius(angles, a_fixed, b_fixed, n_val)
-        shape_loss = float(
-            np.sum(weights_full * (radii - fit_r) ** 2) / weight_sum
-        )
+        shape_loss = float(np.sum(weights_full * (radii - fit_r) ** 2) / weight_sum)
         loss = shape_loss / radii_norm_sq
 
         # Optional smoothness term — unused in the current ``slice_step_*``
@@ -799,7 +819,7 @@ def fit_shape_area_superellipse(points: np.ndarray, initial_n: float = 2.0, prev
         objective,
         x0=[float(initial_n)],
         bounds=[(0.5, 8.0)],
-        method='L-BFGS-B',
+        method="L-BFGS-B",
     )
 
     return {
@@ -811,6 +831,7 @@ def fit_shape_area_superellipse(points: np.ndarray, initial_n: float = 2.0, prev
         "fun": float(result.fun),
     }
 
+
 def plot_superellipse_fit(points_3d: np.ndarray, fit_result: dict, num_samples: int = 300) -> None:
     center = fit_result["center"]
     a, b, n = fit_result["a"], fit_result["b"], fit_result["n"]
@@ -820,15 +841,15 @@ def plot_superellipse_fit(points_3d: np.ndarray, fit_result: dict, num_samples: 
 
     # Generate superellipse points
     theta = np.linspace(0, 2 * np.pi, num_samples)
-    r = (np.abs(np.cos(theta)/a)**n + np.abs(np.sin(theta)/b)**n)**(-1/n)
+    r = (np.abs(np.cos(theta) / a) ** n + np.abs(np.sin(theta) / b) ** n) ** (-1 / n)
     x = r * np.cos(theta) + center[0]
     y = r * np.sin(theta) + center[1]
 
     # Plot
     plt.figure()
-    plt.plot(points_2d[:, 0], points_2d[:, 1], 'go', label="Original Points")
-    plt.plot(x, y, 'r-', label="Fitted Superellipse")
-    plt.axis('equal')
+    plt.plot(points_2d[:, 0], points_2d[:, 1], "go", label="Original Points")
+    plt.plot(x, y, "r-", label="Fitted Superellipse")
+    plt.axis("equal")
     plt.title("Superellipse Fit to Wire")
     plt.xlabel("Y")
     plt.ylabel("Z")
@@ -852,6 +873,7 @@ def compute_shape_properties(shape):
         "volume": volume,
         "surface_area": surface_area,
     }
+
 
 def slice_step_to_fuselage(
     step_path: str,
@@ -916,6 +938,7 @@ def slice_step_to_fuselage(
     else:
         from OCP.GProp import GProp_GProps as _GProp
         from OCP.BRepGProp import BRepGProp as _BRepGProp
+
         faces_shape = _ensure_sliceable_shape(model)
         sa_props = _GProp()
         _BRepGProp.SurfaceProperties_s(faces_shape, sa_props)
@@ -944,7 +967,9 @@ def slice_step_to_fuselage(
         if adaptive:
             top, bot = extract_xz_profile(sliceable)
             x_stations = adaptive_x_stations(
-                top, bot, n_stations=number_of_slices,
+                top,
+                bot,
+                n_stations=number_of_slices,
                 curvature_weight=curvature_weight,
             )
         else:
@@ -953,8 +978,7 @@ def slice_step_to_fuselage(
             # ``number_of_slices`` can't drive an unbounded loop.
             n_stations = max(2, min(int(number_of_slices), 4096))
             x_stations = [
-                bb.xmin + (bb.xmax - bb.xmin) * i / (n_stations - 1)
-                for i in range(n_stations)
+                bb.xmin + (bb.xmax - bb.xmin) * i / (n_stations - 1) for i in range(n_stations)
             ]
         wire_slices = []
         for x in x_stations:
@@ -998,24 +1022,28 @@ def slice_step_to_fuselage(
         points_2d = np.array([(y, z) for (_, y, z) in slice_points])
         fit = fit_shape_area_superellipse(points_2d, prev_params=None)
         xyz = [x, float(fit["center"][0]), float(fit["center"][1])]
-        xsec_dicts.append({
-            "xyz": xyz,
-            "a": float(fit["a"]),
-            "b": float(fit["b"]),
-            "n": float(np.clip(fit["n"], 0.5, 8.0)),
-        })
+        xsec_dicts.append(
+            {
+                "xyz": xyz,
+                "a": float(fit["a"]),
+                "b": float(fit["b"]),
+                "n": float(np.clip(fit["n"], 0.5, 8.0)),
+            }
+        )
 
     # Reconstruct as asb.Fuselage for fidelity comparison
     fuselage_xsecs = []
     for xsec in xsec_dicts:
-        fuselage_xsecs.append(asb.FuselageXSec(
-            xyz_c=xsec["xyz"],
-            xyz_normal=np.array([1.0, 0.0, 0.0]),
-            radius=None,
-            width=2.0 * xsec["a"],
-            height=2.0 * xsec["b"],
-            shape=xsec["n"],
-        ))
+        fuselage_xsecs.append(
+            asb.FuselageXSec(
+                xyz_c=xsec["xyz"],
+                xyz_normal=np.array([1.0, 0.0, 0.0]),
+                radius=None,
+                width=2.0 * xsec["a"],
+                height=2.0 * xsec["b"],
+                shape=xsec["n"],
+            )
+        )
 
     asb_fuselage = asb.Fuselage(name=fuselage_name, xsecs=fuselage_xsecs)
 
@@ -1027,8 +1055,12 @@ def slice_step_to_fuselage(
         "original_area": original_props["surface_area"],
         "reconstructed_volume": reconstructed_volume,
         "reconstructed_area": reconstructed_area,
-        "volume_ratio": reconstructed_volume / original_props["volume"] if original_props["volume"] > 0 else 0,
-        "area_ratio": reconstructed_area / original_props["surface_area"] if original_props["surface_area"] > 0 else 0,
+        "volume_ratio": reconstructed_volume / original_props["volume"]
+        if original_props["volume"] > 0
+        else 0,
+        "area_ratio": reconstructed_area / original_props["surface_area"]
+        if original_props["surface_area"] > 0
+        else 0,
     }
 
     logger.info(
@@ -1088,9 +1120,7 @@ def vsp_anchored_x_stations(
     # Find the body-typical scale so the tip-boost has a reference.
     # Use the median (a + b) over all non-degenerate anchors so a
     # single bogus anchor doesn't skew the calibration.
-    body_dim_median = float(np.median([
-        a + b for _, _, _, a, b in anchors if a + b > 1e-3
-    ])) or 1.0
+    body_dim_median = float(np.median([a + b for _, _, _, a, b in anchors if a + b > 1e-3])) or 1.0
     tip_threshold = 0.15 * body_dim_median  # below this, anchor is a tip
     for i in range(n_sections):
         x_a, y_a, z_a, a_a, b_a = anchors[i]
@@ -1099,9 +1129,14 @@ def vsp_anchored_x_stations(
         delta_position = abs(y_b - y_a) + abs(z_b - z_a)
         # Baseline so empty sections (rare but possible) still get a
         # couple of points. Scaled by section length so big featureless
-        # sections (tail boom) still get density-proportional coverage.
+        # sections (tail boom) still get density-proportional coverage —
+        # but the length contribution is **capped** at the body's typical
+        # cross-section size (gh-804): a long, featureless mid-body (e.g.
+        # Romo's 9 m constant section) otherwise dominates the budget and
+        # starves the short, highly-curved nose-body fillet next to it,
+        # which then renders as a kink.
         section_len = max(abs(x_b - x_a), 1e-6)
-        baseline = 0.3 * section_len
+        baseline = 0.3 * min(section_len, body_dim_median)
         weight = delta_shape + delta_position + baseline
         # Tip-cap boost (gh-732): sections that include the nose tip or
         # tail tip (a+b at one anchor below ~15% of the body's typical
@@ -1144,7 +1179,14 @@ def vsp_anchored_x_stations(
         stations.append(x_a)
         n_inter = intermediates_per_section[i]
         for k in range(1, n_inter + 1):
-            frac = k / (n_inter + 1)
+            # Cosine clustering toward BOTH anchors (gh-804): VSP lofts a
+            # spline through the control xsecs, so curvature is highest
+            # next to the anchors (the nose-body fillet, tail cone). A
+            # uniform split places the first intermediate too far from the
+            # anchor and the fillet renders as a kink; cosine spacing
+            # pulls samples toward the section ends where the surface
+            # actually curves.
+            frac = 0.5 * (1.0 - np.cos(np.pi * k / (n_inter + 1)))
             stations.append(x_a + frac * (x_b - x_a))
     stations.append(anchors[-1][0])
 
@@ -1246,6 +1288,7 @@ def slice_step_at_stations(
     else:
         from OCP.GProp import GProp_GProps as _GProp
         from OCP.BRepGProp import BRepGProp as _BRepGProp
+
         faces_shape = _ensure_sliceable_shape(model)
         sa_props = _GProp()
         _BRepGProp.SurfaceProperties_s(faces_shape, sa_props)
@@ -1297,32 +1340,40 @@ def slice_step_at_stations(
         "reconstructed_volume": rec_vol,
         "reconstructed_area": rec_area,
         "volume_ratio": (
-            rec_vol / original_props["volume"]
-            if original_props["volume"] > 0 else 0.0
+            rec_vol / original_props["volume"] if original_props["volume"] > 0 else 0.0
         ),
         "area_ratio": (
-            rec_area / original_props["surface_area"]
-            if original_props["surface_area"] > 0 else 0.0
+            rec_area / original_props["surface_area"] if original_props["surface_area"] > 0 else 0.0
         ),
     }
     logger.info(
         "Fuselage %r: %d xsecs from %d stations, volume_ratio=%.3f, area_ratio=%.3f",
-        fuselage_name, len(xsec_dicts), len(x_stations_mm),
-        metrics["volume_ratio"], metrics["area_ratio"],
+        fuselage_name,
+        len(xsec_dicts),
+        len(x_stations_mm),
+        metrics["volume_ratio"],
+        metrics["area_ratio"],
     )
     return xsec_dicts, metrics
 
 
 if __name__ == "__main__":
     import sys
-    logging.basicConfig(level=logging.DEBUG, format="%(asctime)s [%(levelname)s] %(message)s",
-                        handlers=[logging.StreamHandler(sys.stdout)])
+
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=[logging.StreamHandler(sys.stdout)],
+    )
 
     step_path = "../../components/aircraft/eHawk/e-Hawk Rumpf v29.step"
     xsecs, metrics = slice_step_to_fuselage(step_path, number_of_slices=50)
 
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print(f"Sections: {len(xsecs)}")
-    print(f"Volume:   original={metrics['original_volume']:.6f}  reconstructed={metrics['reconstructed_volume']:.6f}  ratio={metrics['volume_ratio']:.3f}")
-    print(f"Area:     original={metrics['original_area']:.6f}  reconstructed={metrics['reconstructed_area']:.6f}  ratio={metrics['area_ratio']:.3f}")
-
+    print(
+        f"Volume:   original={metrics['original_volume']:.6f}  reconstructed={metrics['reconstructed_volume']:.6f}  ratio={metrics['volume_ratio']:.3f}"
+    )
+    print(
+        f"Area:     original={metrics['original_area']:.6f}  reconstructed={metrics['reconstructed_area']:.6f}  ratio={metrics['area_ratio']:.3f}"
+    )

--- a/cad_designer/aerosandbox/slicing.py
+++ b/cad_designer/aerosandbox/slicing.py
@@ -25,9 +25,7 @@ from OCP.gp import gp_Dir, gp_Pln, gp_Pnt
 from cad_designer.cq_plugins.display import display
 
 import logging
-
 logger = logging.getLogger(__name__)
-
 
 def discretize_wire(wire: TopoDS_Wire, num_points: int) -> list[gp_Pnt]:
     comp_curve = BRepAdaptor_CompCurve(wire)
@@ -42,7 +40,6 @@ def discretize_wire(wire: TopoDS_Wire, num_points: int) -> list[gp_Pnt]:
         point = comp_curve.Value(param)
         points.append(point)
     return points
-
 
 def load_step_model(filepath: str) -> cq.Workplane:
     if not os.path.exists(filepath):
@@ -76,9 +73,7 @@ def _ensure_sliceable_shape(model: cq.Workplane) -> TopoDS_Shape:
     return sewing.SewedShape()
 
 
-def _section_outline_edges(
-    shape: TopoDS_Shape, origin: tuple[float, float, float], normal: tuple[float, float, float]
-) -> list[cq.Edge]:
+def _section_outline_edges(shape: TopoDS_Shape, origin: tuple[float, float, float], normal: tuple[float, float, float]) -> list[cq.Edge]:
     """Intersect ``shape`` with the plane ``(origin, normal)`` and
     return every resulting edge wrapped as a cadquery ``Edge``.
     """
@@ -154,7 +149,9 @@ def arc_length_weights(points_2d: np.ndarray) -> np.ndarray:
     return np.maximum(nn, floor)
 
 
-def thin_oversampled_points(points_2d: np.ndarray, radius_ratio: float = 0.2) -> np.ndarray:
+def thin_oversampled_points(
+    points_2d: np.ndarray, radius_ratio: float = 0.2
+) -> np.ndarray:
     """Drop points that are over-sampled relative to the cloud's
     natural inter-point spacing (gh-732).
 
@@ -368,12 +365,9 @@ def _curvature_density(
             continue
         # Non-uniform-spacing second derivative
         dz2[i - 1] = abs(
-            2
-            * (
-                zs[i - 1] / (dx1 * (dx1 + dx2))
-                - zs[i] / (dx1 * dx2)
-                + zs[i + 1] / (dx2 * (dx1 + dx2))
-            )
+            2 * (zs[i - 1] / (dx1 * (dx1 + dx2))
+                 - zs[i] / (dx1 * dx2)
+                 + zs[i + 1] / (dx2 * (dx1 + dx2)))
         )
     return xs[1:-1], dz2
 
@@ -459,11 +453,9 @@ def adaptive_x_stations(
     targets = np.linspace(0.0, 1.0, n_stations)
     return [float(np.interp(t, cdf, grid)) for t in targets]
 
-
 def get_x_bounds(shape: cq.Shape) -> tuple[float, float]:
     bb = shape.BoundingBox()
     return bb.xmin, bb.xmax
-
 
 def get_bounding_box_dims(shape: cq.Shape) -> dict[str, float]:
     """Return bounding box dimensions per axis."""
@@ -521,9 +513,8 @@ def slice_model_along_x(
             if polylines:
                 slices.append(polylines)
             x += spacing
-        logger.info(
-            f"Section slicing complete: {len(slices)} slices from x={xmin:.4f} to x={xmax:.4f}"
-        )
+        logger.info(f"Section slicing complete: {len(slices)} slices "
+                    f"from x={xmin:.4f} to x={xmax:.4f}")
         return slices
 
     # Solid path — preserve original behaviour byte-for-byte
@@ -567,9 +558,11 @@ def slice_model_along_x(
     logger.info(f"Slicing complete: {len(slices)} slices from x={xmin:.4f} to x={xmax:.4f}")
     return slices
 
-
 def to_superellipse(
-    vertices: Sequence[tuple[float, float]], exponent: float = 2.5, a: float = 1.0, b: float = 1.0
+    vertices: Sequence[tuple[float, float]],
+    exponent: float = 2.5,
+    a: float = 1.0,
+    b: float = 1.0
 ) -> NDArray[np.float64]:
     vertices = np.array(vertices)
     center = np.mean(vertices, axis=0)
@@ -578,9 +571,8 @@ def to_superellipse(
     normalized /= scale  # normalize to [-1, 1] box
 
     angles = np.arctan2(normalized[:, 1], normalized[:, 0])
-    super_radii = (
-        np.abs(np.cos(angles) / a) ** exponent + np.abs(np.sin(angles) / b) ** exponent
-    ) ** (-1 / exponent)
+    super_radii = (np.abs(np.cos(angles) / a) ** exponent +
+                   np.abs(np.sin(angles) / b) ** exponent) ** (-1 / exponent)
     x_new = super_radii * np.cos(angles)
     y_new = super_radii * np.sin(angles)
 
@@ -590,39 +582,30 @@ def to_superellipse(
     new_shape += center
     return new_shape
 
-
 def superellipse_radius(theta: np.ndarray, a: float, b: float, n: float) -> np.ndarray:
     return (np.abs(np.cos(theta) / a) ** n + np.abs(np.sin(theta) / b) ** n) ** (-1 / n)
-
 
 def approximate_perimeter(a: float, b: float, n: float) -> float:
     # Numerically integrate the perimeter of the superellipse
     def integrand(theta):
         r = (np.abs(np.cos(theta) / a) ** n + np.abs(np.sin(theta) / b) ** n) ** (-1 / n)
-        dr_dtheta = (
-            n
-            * r
-            * (
-                (np.abs(np.sin(theta) / b) ** (n - 1) * np.cos(theta) / b)
-                - (np.abs(np.cos(theta) / a) ** (n - 1) * np.sin(theta) / a)
-            )
+        dr_dtheta = n * r * (
+                (np.abs(np.sin(theta) / b) ** (n - 1) * np.cos(theta) / b) -
+                (np.abs(np.cos(theta) / a) ** (n - 1) * np.sin(theta) / a)
         )
-        return np.sqrt(r**2 + dr_dtheta**2)
+        return np.sqrt(r ** 2 + dr_dtheta ** 2)
 
     return quad(integrand, 0, 2 * np.pi, limit=200)[0]
 
-
 def approximate_area(a: float, b: float, n: float) -> float:
     # Approximation using Gamma function
-    return 4 * a * b * (gamma(1 + 1 / n) ** 2) / gamma(1 + 2 / n)
-
+    return 4 * a * b * (gamma(1 + 1/n)**2) / gamma(1 + 2/n)
 
 def polygon_area(points: np.ndarray) -> float:
     # Shoelace formula for polygon area
     x = points[:, 0]
     y = points[:, 1]
     return 0.5 * np.abs(np.dot(x, np.roll(y, 1)) - np.dot(y, np.roll(x, 1)))
-
 
 def fit_symmetric_superellipse(points: np.ndarray, initial_n: float = 2.0) -> dict:
     """
@@ -657,15 +640,15 @@ def fit_symmetric_superellipse(points: np.ndarray, initial_n: float = 2.0) -> di
         fit_r = superellipse_radius(angles, a, b, n)
         perimeter_fit = approximate_perimeter(a, b, n)
         perimeter_actual = np.sum(np.linalg.norm(np.roll(shifted, -1, axis=0) - shifted, axis=1))
-        radius_loss = np.mean((radii - fit_r) ** 2)
-        length_loss = (perimeter_fit - perimeter_actual) ** 2
+        radius_loss = np.mean((radii - fit_r)**2)
+        length_loss = (perimeter_fit - perimeter_actual)**2
         return radius_loss + 0.01 * length_loss
 
     result = minimize(
         objective,
         x0=[1.0, 1.0, initial_n],
         bounds=[(1e-3, None), (1e-3, None), (0.5, 8.0)],
-        method="L-BFGS-B",
+        method='L-BFGS-B'
     )
 
     return {
@@ -674,9 +657,8 @@ def fit_symmetric_superellipse(points: np.ndarray, initial_n: float = 2.0) -> di
         "b": result.x[1],
         "n": result.x[2],
         "success": result.success,
-        "fun": result.fun,
+        "fun": result.fun
     }
-
 
 def fit_superellipse(points: np.ndarray, initial_n: float = 2.0) -> dict:
     """
@@ -713,7 +695,7 @@ def fit_superellipse(points: np.ndarray, initial_n: float = 2.0) -> dict:
         objective,
         x0=[1.0, 1.0, initial_n],
         bounds=[(1e-3, None), (1e-3, None), (0.5, 8.0)],
-        method="L-BFGS-B",
+        method='L-BFGS-B'
     )
 
     return {
@@ -722,16 +704,10 @@ def fit_superellipse(points: np.ndarray, initial_n: float = 2.0) -> dict:
         "b": result.x[1],
         "n": result.x[2],
         "success": result.success,
-        "fun": result.fun,
+        "fun": result.fun
     }
 
-
-def fit_shape_area_superellipse(
-    points: np.ndarray,
-    initial_n: float = 2.0,
-    prev_params: Optional[dict] = None,
-    smoothness_weight: float = 0.1,
-) -> dict:
+def fit_shape_area_superellipse(points: np.ndarray, initial_n: float = 2.0, prev_params: Optional[dict] = None, smoothness_weight: float = 0.1) -> dict:
     """
     Fits a symmetric superellipse to a given set of 2D points, ensuring symmetry about the Z-axis.
 
@@ -796,12 +772,16 @@ def fit_shape_area_superellipse(
     radii = np.concatenate([radii, radii])
     weights_full = np.concatenate([weights, weights])
     weight_sum = float(weights_full.sum()) or 1.0
-    radii_norm_sq = max(float(np.sum(weights_full * radii**2) / weight_sum), 1e-9)
+    radii_norm_sq = max(
+        float(np.sum(weights_full * radii ** 2) / weight_sum), 1e-9
+    )
 
     def objective(params: np.ndarray) -> float:
         n_val = float(params[0])
         fit_r = superellipse_radius(angles, a_fixed, b_fixed, n_val)
-        shape_loss = float(np.sum(weights_full * (radii - fit_r) ** 2) / weight_sum)
+        shape_loss = float(
+            np.sum(weights_full * (radii - fit_r) ** 2) / weight_sum
+        )
         loss = shape_loss / radii_norm_sq
 
         # Optional smoothness term — unused in the current ``slice_step_*``
@@ -819,7 +799,7 @@ def fit_shape_area_superellipse(
         objective,
         x0=[float(initial_n)],
         bounds=[(0.5, 8.0)],
-        method="L-BFGS-B",
+        method='L-BFGS-B',
     )
 
     return {
@@ -831,7 +811,6 @@ def fit_shape_area_superellipse(
         "fun": float(result.fun),
     }
 
-
 def plot_superellipse_fit(points_3d: np.ndarray, fit_result: dict, num_samples: int = 300) -> None:
     center = fit_result["center"]
     a, b, n = fit_result["a"], fit_result["b"], fit_result["n"]
@@ -841,15 +820,15 @@ def plot_superellipse_fit(points_3d: np.ndarray, fit_result: dict, num_samples: 
 
     # Generate superellipse points
     theta = np.linspace(0, 2 * np.pi, num_samples)
-    r = (np.abs(np.cos(theta) / a) ** n + np.abs(np.sin(theta) / b) ** n) ** (-1 / n)
+    r = (np.abs(np.cos(theta)/a)**n + np.abs(np.sin(theta)/b)**n)**(-1/n)
     x = r * np.cos(theta) + center[0]
     y = r * np.sin(theta) + center[1]
 
     # Plot
     plt.figure()
-    plt.plot(points_2d[:, 0], points_2d[:, 1], "go", label="Original Points")
-    plt.plot(x, y, "r-", label="Fitted Superellipse")
-    plt.axis("equal")
+    plt.plot(points_2d[:, 0], points_2d[:, 1], 'go', label="Original Points")
+    plt.plot(x, y, 'r-', label="Fitted Superellipse")
+    plt.axis('equal')
     plt.title("Superellipse Fit to Wire")
     plt.xlabel("Y")
     plt.ylabel("Z")
@@ -873,7 +852,6 @@ def compute_shape_properties(shape):
         "volume": volume,
         "surface_area": surface_area,
     }
-
 
 def slice_step_to_fuselage(
     step_path: str,
@@ -938,7 +916,6 @@ def slice_step_to_fuselage(
     else:
         from OCP.GProp import GProp_GProps as _GProp
         from OCP.BRepGProp import BRepGProp as _BRepGProp
-
         faces_shape = _ensure_sliceable_shape(model)
         sa_props = _GProp()
         _BRepGProp.SurfaceProperties_s(faces_shape, sa_props)
@@ -967,9 +944,7 @@ def slice_step_to_fuselage(
         if adaptive:
             top, bot = extract_xz_profile(sliceable)
             x_stations = adaptive_x_stations(
-                top,
-                bot,
-                n_stations=number_of_slices,
+                top, bot, n_stations=number_of_slices,
                 curvature_weight=curvature_weight,
             )
         else:
@@ -978,7 +953,8 @@ def slice_step_to_fuselage(
             # ``number_of_slices`` can't drive an unbounded loop.
             n_stations = max(2, min(int(number_of_slices), 4096))
             x_stations = [
-                bb.xmin + (bb.xmax - bb.xmin) * i / (n_stations - 1) for i in range(n_stations)
+                bb.xmin + (bb.xmax - bb.xmin) * i / (n_stations - 1)
+                for i in range(n_stations)
             ]
         wire_slices = []
         for x in x_stations:
@@ -1022,28 +998,24 @@ def slice_step_to_fuselage(
         points_2d = np.array([(y, z) for (_, y, z) in slice_points])
         fit = fit_shape_area_superellipse(points_2d, prev_params=None)
         xyz = [x, float(fit["center"][0]), float(fit["center"][1])]
-        xsec_dicts.append(
-            {
-                "xyz": xyz,
-                "a": float(fit["a"]),
-                "b": float(fit["b"]),
-                "n": float(np.clip(fit["n"], 0.5, 8.0)),
-            }
-        )
+        xsec_dicts.append({
+            "xyz": xyz,
+            "a": float(fit["a"]),
+            "b": float(fit["b"]),
+            "n": float(np.clip(fit["n"], 0.5, 8.0)),
+        })
 
     # Reconstruct as asb.Fuselage for fidelity comparison
     fuselage_xsecs = []
     for xsec in xsec_dicts:
-        fuselage_xsecs.append(
-            asb.FuselageXSec(
-                xyz_c=xsec["xyz"],
-                xyz_normal=np.array([1.0, 0.0, 0.0]),
-                radius=None,
-                width=2.0 * xsec["a"],
-                height=2.0 * xsec["b"],
-                shape=xsec["n"],
-            )
-        )
+        fuselage_xsecs.append(asb.FuselageXSec(
+            xyz_c=xsec["xyz"],
+            xyz_normal=np.array([1.0, 0.0, 0.0]),
+            radius=None,
+            width=2.0 * xsec["a"],
+            height=2.0 * xsec["b"],
+            shape=xsec["n"],
+        ))
 
     asb_fuselage = asb.Fuselage(name=fuselage_name, xsecs=fuselage_xsecs)
 
@@ -1055,12 +1027,8 @@ def slice_step_to_fuselage(
         "original_area": original_props["surface_area"],
         "reconstructed_volume": reconstructed_volume,
         "reconstructed_area": reconstructed_area,
-        "volume_ratio": reconstructed_volume / original_props["volume"]
-        if original_props["volume"] > 0
-        else 0,
-        "area_ratio": reconstructed_area / original_props["surface_area"]
-        if original_props["surface_area"] > 0
-        else 0,
+        "volume_ratio": reconstructed_volume / original_props["volume"] if original_props["volume"] > 0 else 0,
+        "area_ratio": reconstructed_area / original_props["surface_area"] if original_props["surface_area"] > 0 else 0,
     }
 
     logger.info(
@@ -1120,7 +1088,9 @@ def vsp_anchored_x_stations(
     # Find the body-typical scale so the tip-boost has a reference.
     # Use the median (a + b) over all non-degenerate anchors so a
     # single bogus anchor doesn't skew the calibration.
-    body_dim_median = float(np.median([a + b for _, _, _, a, b in anchors if a + b > 1e-3])) or 1.0
+    body_dim_median = float(np.median([
+        a + b for _, _, _, a, b in anchors if a + b > 1e-3
+    ])) or 1.0
     tip_threshold = 0.15 * body_dim_median  # below this, anchor is a tip
     for i in range(n_sections):
         x_a, y_a, z_a, a_a, b_a = anchors[i]
@@ -1130,7 +1100,7 @@ def vsp_anchored_x_stations(
         # Baseline so empty sections (rare but possible) still get a
         # couple of points. Scaled by section length so big featureless
         # sections (tail boom) still get density-proportional coverage —
-        # but the length contribution is **capped** at the body's typical
+        # but the length contribution is capped at the body's typical
         # cross-section size (gh-804): a long, featureless mid-body (e.g.
         # Romo's 9 m constant section) otherwise dominates the budget and
         # starves the short, highly-curved nose-body fillet next to it,
@@ -1183,9 +1153,8 @@ def vsp_anchored_x_stations(
             # spline through the control xsecs, so curvature is highest
             # next to the anchors (the nose-body fillet, tail cone). A
             # uniform split places the first intermediate too far from the
-            # anchor and the fillet renders as a kink; cosine spacing
-            # pulls samples toward the section ends where the surface
-            # actually curves.
+            # anchor and the fillet renders as a kink; cosine spacing pulls
+            # samples toward the section ends where the surface curves.
             frac = 0.5 * (1.0 - np.cos(np.pi * k / (n_inter + 1)))
             stations.append(x_a + frac * (x_b - x_a))
     stations.append(anchors[-1][0])
@@ -1288,7 +1257,6 @@ def slice_step_at_stations(
     else:
         from OCP.GProp import GProp_GProps as _GProp
         from OCP.BRepGProp import BRepGProp as _BRepGProp
-
         faces_shape = _ensure_sliceable_shape(model)
         sa_props = _GProp()
         _BRepGProp.SurfaceProperties_s(faces_shape, sa_props)
@@ -1340,40 +1308,32 @@ def slice_step_at_stations(
         "reconstructed_volume": rec_vol,
         "reconstructed_area": rec_area,
         "volume_ratio": (
-            rec_vol / original_props["volume"] if original_props["volume"] > 0 else 0.0
+            rec_vol / original_props["volume"]
+            if original_props["volume"] > 0 else 0.0
         ),
         "area_ratio": (
-            rec_area / original_props["surface_area"] if original_props["surface_area"] > 0 else 0.0
+            rec_area / original_props["surface_area"]
+            if original_props["surface_area"] > 0 else 0.0
         ),
     }
     logger.info(
         "Fuselage %r: %d xsecs from %d stations, volume_ratio=%.3f, area_ratio=%.3f",
-        fuselage_name,
-        len(xsec_dicts),
-        len(x_stations_mm),
-        metrics["volume_ratio"],
-        metrics["area_ratio"],
+        fuselage_name, len(xsec_dicts), len(x_stations_mm),
+        metrics["volume_ratio"], metrics["area_ratio"],
     )
     return xsec_dicts, metrics
 
 
 if __name__ == "__main__":
     import sys
-
-    logging.basicConfig(
-        level=logging.DEBUG,
-        format="%(asctime)s [%(levelname)s] %(message)s",
-        handlers=[logging.StreamHandler(sys.stdout)],
-    )
+    logging.basicConfig(level=logging.DEBUG, format="%(asctime)s [%(levelname)s] %(message)s",
+                        handlers=[logging.StreamHandler(sys.stdout)])
 
     step_path = "../../components/aircraft/eHawk/e-Hawk Rumpf v29.step"
     xsecs, metrics = slice_step_to_fuselage(step_path, number_of_slices=50)
 
-    print(f"\n{'=' * 60}")
+    print(f"\n{'='*60}")
     print(f"Sections: {len(xsecs)}")
-    print(
-        f"Volume:   original={metrics['original_volume']:.6f}  reconstructed={metrics['reconstructed_volume']:.6f}  ratio={metrics['volume_ratio']:.3f}"
-    )
-    print(
-        f"Area:     original={metrics['original_area']:.6f}  reconstructed={metrics['reconstructed_area']:.6f}  ratio={metrics['area_ratio']:.3f}"
-    )
+    print(f"Volume:   original={metrics['original_volume']:.6f}  reconstructed={metrics['reconstructed_volume']:.6f}  ratio={metrics['volume_ratio']:.3f}")
+    print(f"Area:     original={metrics['original_area']:.6f}  reconstructed={metrics['reconstructed_area']:.6f}  ratio={metrics['area_ratio']:.3f}")
+


### PR DESCRIPTION
## Problem

Importing `romo.vsp3`, the main fuselage shows a kink just aft of the nose (in the analysis outline viewer), even with everything else hidden.

## Root cause (proven)

The VSP surface is actually **smooth** there — fine STEP slicing shows the centre-line slope decaying gradually (0.25 → 0 over x = 2.6–3.6 m). The kink is introduced by the slicer's station picker (`vsp_anchored_x_stations`):

1. **The length-scaled baseline** (`0.3·section_len`) lets the long 9 m constant mid-body dominate the budget and **starve** the short, highly-curved nose-body fillet next to it → the fillet got a single intermediate station.
2. **Uniform intra-section spacing** placed that station mid-section, far from the anchor where the loft actually curves → the fillet was straight-lined into a corner.

## Fix

In `vsp_anchored_x_stations`:
- **Cap the baseline's length term** at the body's typical cross-section size, so a long featureless section can't out-weight a short curved one.
- **Cosine intra-section spacing**, clustering stations toward both anchors where VSP lofts round their corners.

## Verification

- Romo `FuselageGeom` nose now transitions smoothly (verified by plotting the slicer output — dense samples capture the rounding).
- Regression: the cessna / dg101g / da42 fuselage-slice suites stay green (**38 passed**); new unit tests for cosine clustering + the baseline cap. `ruff check` clean.

## Note on scope

Touches `cad_designer/aerosandbox/slicing.py` — this is the gh-732 **importer slicing heuristic**, not a topology class or the `GeneralJSONEncoder/Decoder` (the read-only parts of `cad_designer`), so it's within scope. The diff is kept minimal (no unrelated reformatting of that file).

Closes #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)