### PR TITLE
fix(gh-815): serialize non-finite aero coefficients as JSON null

### DIFF
--- a/app/api/v2/endpoints/aeroanalysis.py
+++ b/app/api/v2/endpoints/aeroanalysis.py
@@ -17,6 +17,7 @@ from app.core.exceptions import (
     ConflictError,
     InternalError,
 )
+from app.core.json_safe import NonFiniteSafeJSONResponse
 from app.db.session import get_db
 from app.schemas.AeroplaneRequest import AnalysisToolUrlType, AlphaSweepRequest, SimpleSweepRequest
 from app.schemas.api_responses import StaticUrlResponse
@@ -28,7 +29,10 @@ from app.services import stability_service
 from app.services.wing_service import get_aeroplane_or_raise
 from app.settings import Settings, get_settings
 
-router = APIRouter()
+# Aero solvers (AeroBuildup) can emit non-finite coefficients (NaN / +/-Inf) for
+# degenerate inputs; serialize via a response class that renders those as JSON
+# null so the API never 500s on "Out of range float values" (gh#815).
+router = APIRouter(default_response_class=NonFiniteSafeJSONResponse)
 AeroPlaneID = UUID4
 
 _DESC_AEROPLANE_ID = "The ID of the aeroplane"

--- a/app/core/json_safe.py
+++ b/app/core/json_safe.py
@@ -1,0 +1,57 @@
+"""JSON-safety helpers for non-finite floats.
+
+Starlette's :class:`~starlette.responses.JSONResponse` renders with
+``json.dumps(..., allow_nan=False)``, so any NaN / +/-Inf in a response payload
+raises ``ValueError: Out of range float values are not JSON compliant`` and
+surfaces as an unhandled HTTP 500.
+
+Numeric solvers (AeroSandbox AeroBuildup in particular) can legitimately emit
+non-finite values for degenerate inputs — a zero-volume fuselage gives
+``length**3 / volume`` -> NaN, a zero Reynolds number gives ``log10(0)`` ->
+-inf. The JSON API must stay robust to those: we represent a non-finite float as
+JSON ``null`` — an honest "no value", never a fabricated fallback number that
+would hide the underlying design problem.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import numpy as np
+from starlette.responses import JSONResponse
+
+__all__ = ["replace_nonfinite", "NonFiniteSafeJSONResponse"]
+
+
+def replace_nonfinite(obj: Any) -> Any:
+    """Recursively replace non-finite floats (NaN, +/-Inf) with ``None``.
+
+    Walks dicts, lists and tuples. Python and ``numpy`` float scalars are both
+    handled — note ``np.float32`` is *not* a :class:`float` subclass, so numpy
+    floats are matched explicitly and finite ones are returned as native floats
+    (which the JSON encoder can serialize). Booleans, ints and every other value
+    pass through unchanged.
+    """
+    if isinstance(obj, bool):
+        return obj
+    if isinstance(obj, float):
+        return obj if math.isfinite(obj) else None
+    if isinstance(obj, np.floating):
+        return float(obj) if math.isfinite(obj) else None
+    if isinstance(obj, dict):
+        return {key: replace_nonfinite(value) for key, value in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [replace_nonfinite(item) for item in obj]
+    return obj
+
+
+class NonFiniteSafeJSONResponse(JSONResponse):
+    """JSONResponse that emits non-finite floats as ``null`` instead of crashing.
+
+    Set as the ``default_response_class`` of routers whose responses carry solver
+    output that may contain NaN / +/-Inf.
+    """
+
+    def render(self, content: Any) -> bytes:
+        return super().render(replace_nonfinite(content))

--- a/app/core/json_safe.py
+++ b/app/core/json_safe.py
@@ -10,11 +10,13 @@ non-finite values for degenerate inputs — a zero-volume fuselage gives
 ``length**3 / volume`` -> NaN, a zero Reynolds number gives ``log10(0)`` ->
 -inf. The JSON API must stay robust to those: we represent a non-finite float as
 JSON ``null`` — an honest "no value", never a fabricated fallback number that
-would hide the underlying design problem.
+would hide the underlying design problem. The substitution is *logged* so the
+degenerate result still leaves a server-side trace rather than vanishing.
 """
 
 from __future__ import annotations
 
+import logging
 import math
 from typing import Any
 
@@ -23,35 +25,68 @@ from starlette.responses import JSONResponse
 
 __all__ = ["replace_nonfinite", "NonFiniteSafeJSONResponse"]
 
+logger = logging.getLogger(__name__)
+
+
+def _sanitize(obj: Any) -> tuple[Any, int]:
+    """Recurse over *obj*, returning ``(clean, num_replaced)``.
+
+    Non-finite floats (NaN, +/-Inf) — Python or ``numpy`` scalars — become
+    ``None``; ``num_replaced`` counts how many were substituted. Tuples are
+    normalized to lists (JSON has no tuple type). Booleans, ints and every other
+    value pass through unchanged.
+    """
+    if isinstance(obj, bool):
+        return obj, 0
+    if isinstance(obj, float):
+        return (obj, 0) if math.isfinite(obj) else (None, 1)
+    # np.float32 (and friends) are NOT float subclasses, so match numpy floats
+    # explicitly; finite ones become native floats the JSON encoder can handle.
+    if isinstance(obj, np.floating):
+        return (float(obj), 0) if math.isfinite(obj) else (None, 1)
+    if isinstance(obj, dict):
+        clean: dict[Any, Any] = {}
+        replaced = 0
+        for key, value in obj.items():
+            clean[key], count = _sanitize(value)
+            replaced += count
+        return clean, replaced
+    if isinstance(obj, (list, tuple)):
+        items: list[Any] = []
+        replaced = 0
+        for item in obj:
+            clean_item, count = _sanitize(item)
+            items.append(clean_item)
+            replaced += count
+        return items, replaced
+    return obj, 0
+
 
 def replace_nonfinite(obj: Any) -> Any:
     """Recursively replace non-finite floats (NaN, +/-Inf) with ``None``.
 
-    Walks dicts, lists and tuples. Python and ``numpy`` float scalars are both
-    handled — note ``np.float32`` is *not* a :class:`float` subclass, so numpy
-    floats are matched explicitly and finite ones are returned as native floats
-    (which the JSON encoder can serialize). Booleans, ints and every other value
-    pass through unchanged.
+    Walks dicts, lists and tuples (tuples are normalized to lists). Python and
+    ``numpy`` float scalars are both handled. Booleans, ints and every other
+    value pass through unchanged.
     """
-    if isinstance(obj, bool):
-        return obj
-    if isinstance(obj, float):
-        return obj if math.isfinite(obj) else None
-    if isinstance(obj, np.floating):
-        return float(obj) if math.isfinite(obj) else None
-    if isinstance(obj, dict):
-        return {key: replace_nonfinite(value) for key, value in obj.items()}
-    if isinstance(obj, (list, tuple)):
-        return [replace_nonfinite(item) for item in obj]
-    return obj
+    return _sanitize(obj)[0]
 
 
 class NonFiniteSafeJSONResponse(JSONResponse):
     """JSONResponse that emits non-finite floats as ``null`` instead of crashing.
 
     Set as the ``default_response_class`` of routers whose responses carry solver
-    output that may contain NaN / +/-Inf.
+    output that may contain NaN / +/-Inf. When a substitution occurs it is logged
+    at WARNING level so the degenerate result is traceable server-side.
     """
 
     def render(self, content: Any) -> bytes:
-        return super().render(replace_nonfinite(content))
+        sanitized, replaced = _sanitize(content)
+        if replaced:
+            logger.warning(
+                "Replaced %d non-finite float value(s) (NaN/Inf) with null in a "
+                "JSON response — likely degenerate geometry or a zero Reynolds "
+                "number upstream.",
+                replaced,
+            )
+        return super().render(sanitized)

--- a/app/tests/test_alpha_sweep_nonfinite_json.py
+++ b/app/tests/test_alpha_sweep_nonfinite_json.py
@@ -22,12 +22,15 @@ Two layers of tests:
 
 from __future__ import annotations
 
+import json
 import uuid
 from unittest.mock import AsyncMock, patch
 
 import numpy as np
+import pytest
 
-from app.core.json_safe import replace_nonfinite
+from app.core.json_safe import NonFiniteSafeJSONResponse, replace_nonfinite
+from app.core.platform import aerosandbox_available
 
 
 class TestReplaceNonFinite:
@@ -74,6 +77,33 @@ class TestReplaceNonFinite:
         assert result["CL"][2] is None
 
 
+class TestNonFiniteSafeJSONResponse:
+    """Cover the response class directly — no app / aero deps required."""
+
+    def test_render_emits_null_for_nonfinite(self):
+        response = NonFiniteSafeJSONResponse(content=None)
+        rendered = response.render({"CL": [0.1, float("nan"), float("inf")], "name": "x"})
+        assert json.loads(rendered) == {"CL": [0.1, None, None], "name": "x"}
+
+    def test_render_preserves_finite_payload(self):
+        response = NonFiniteSafeJSONResponse(content=None)
+        rendered = response.render({"CL": [0.1, 0.2], "n": 3})
+        assert json.loads(rendered) == {"CL": [0.1, 0.2], "n": 3}
+
+    def test_render_logs_warning_only_when_substituting(self, caplog):
+        response = NonFiniteSafeJSONResponse(content=None)
+        with caplog.at_level("WARNING", logger="app.core.json_safe"):
+            response.render({"CL": [0.1, 0.2]})
+        assert not caplog.records
+        with caplog.at_level("WARNING", logger="app.core.json_safe"):
+            response.render({"CL": [float("nan")]})
+        assert any("non-finite" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.skipif(
+    not aerosandbox_available(),
+    reason="alpha_sweep route is only mounted when AeroSandbox is available",
+)
 class TestAlphaSweepEndpointDoesNotCrashOnNonFinite:
     def test_alpha_sweep_returns_200_with_nulls_not_500(self, client_and_db):
         client, _ = client_and_db

--- a/app/tests/test_alpha_sweep_nonfinite_json.py
+++ b/app/tests/test_alpha_sweep_nonfinite_json.py
@@ -65,6 +65,14 @@ class TestReplaceNonFinite:
         assert result["points"][0]["CL"] == 1.2
         assert result["name"] == "wing"
 
+    def test_nested_numpy_floats_are_converted(self):
+        payload = {"CL": [np.float64(0.3), np.float32("nan"), np.float64("inf")]}
+        result = replace_nonfinite(payload)
+        assert result["CL"][0] == 0.3
+        assert isinstance(result["CL"][0], float)
+        assert result["CL"][1] is None
+        assert result["CL"][2] is None
+
 
 class TestAlphaSweepEndpointDoesNotCrashOnNonFinite:
     def test_alpha_sweep_returns_200_with_nulls_not_500(self, client_and_db):
@@ -103,3 +111,34 @@ class TestAlphaSweepEndpointDoesNotCrashOnNonFinite:
         assert body["characteristic_points"]["stall_point"]["alpha_deg"] is None
         assert body["characteristic_points"]["stall_point"]["CL"] == 1.2
         assert body["aircraft_name"] == "test-plane"
+
+    def test_nonfinite_substitution_is_logged(self, client_and_db, caplog):
+        """The substitution must leave a server-side trace, not vanish silently."""
+        client, _ = client_and_db
+        plane_id = uuid.uuid4()
+        nan_payload = {"analysis": {"coefficients": {"CL": [float("nan")]}}}
+
+        with patch(
+            "app.services.analysis_service.analyze_alpha_sweep",
+            new=AsyncMock(return_value=nan_payload),
+        ):
+            with caplog.at_level("WARNING", logger="app.core.json_safe"):
+                res = client.post(f"/aeroplanes/{plane_id}/alpha_sweep", json={})
+
+        assert res.status_code == 200
+        assert any("non-finite" in rec.message for rec in caplog.records)
+
+    def test_raised_solver_error_still_surfaces_as_500_not_swallowed(self, client_and_db):
+        """The sanitizer must not turn a genuine failure into a fake 200."""
+        from app.core.exceptions import InternalError
+
+        client, _ = client_and_db
+        plane_id = uuid.uuid4()
+
+        with patch(
+            "app.services.analysis_service.analyze_alpha_sweep",
+            new=AsyncMock(side_effect=InternalError("solver blew up")),
+        ):
+            res = client.post(f"/aeroplanes/{plane_id}/alpha_sweep", json={})
+
+        assert res.status_code == 500

--- a/app/tests/test_alpha_sweep_nonfinite_json.py
+++ b/app/tests/test_alpha_sweep_nonfinite_json.py
@@ -1,0 +1,105 @@
+"""Regression test for gh#815: alpha_sweep returns 500 on non-finite floats.
+
+Cause: AeroBuildup can emit non-finite coefficients (NaN / +/-Inf) — e.g. a
+degenerate fuselage with zero volume yields ``length**3 / volume`` -> NaN and a
+zero Reynolds number yields ``log10(0)`` -> -inf. The aero analysis endpoints
+return these raw computed dicts, and FastAPI serializes them through Starlette's
+``JSONResponse.render``, which calls ``json.dumps(content, allow_nan=False)``.
+stdlib json then raises ``ValueError: Out of range float values are not JSON
+compliant`` -> unhandled HTTP 500 (the crash escapes the endpoint's try/except
+because serialization happens after the handler returns).
+
+Fix: the aero router serializes via a response class that represents non-finite
+floats as JSON ``null`` — an honest "no value", not a fabricated fallback.
+
+Two layers of tests:
+
+1. Unit: the ``replace_nonfinite`` helper maps NaN/Inf (incl. numpy floats) to
+   None recursively while preserving every finite/other value.
+2. Integration: a real request through the aero router whose service returns a
+   NaN/Inf-laden payload must respond 200 with nulls, not 500.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import numpy as np
+
+from app.core.json_safe import replace_nonfinite
+
+
+class TestReplaceNonFinite:
+    def test_nan_and_infinities_become_none(self):
+        assert replace_nonfinite(float("nan")) is None
+        assert replace_nonfinite(float("inf")) is None
+        assert replace_nonfinite(float("-inf")) is None
+
+    def test_numpy_nonfinite_become_none(self):
+        assert replace_nonfinite(np.float64("nan")) is None
+        assert replace_nonfinite(np.float64("inf")) is None
+        assert replace_nonfinite(np.float32("-inf")) is None
+
+    def test_finite_and_other_values_preserved(self):
+        assert replace_nonfinite(0.0) == 0.0
+        assert replace_nonfinite(-3.5) == -3.5
+        assert replace_nonfinite(7) == 7
+        assert replace_nonfinite("ok") == "ok"
+        assert replace_nonfinite(True) is True
+        assert replace_nonfinite(None) is None
+
+    def test_nested_structures_are_sanitized(self):
+        payload = {
+            "coefficients": {
+                "CL": [0.1, float("nan"), 0.5],
+                "CD": (0.01, float("inf"), 0.02),
+            },
+            "points": [{"alpha": float("-inf"), "CL": 1.2}],
+            "name": "wing",
+        }
+        result = replace_nonfinite(payload)
+        assert result["coefficients"]["CL"] == [0.1, None, 0.5]
+        assert result["coefficients"]["CD"] == [0.01, None, 0.02]
+        assert result["points"][0]["alpha"] is None
+        assert result["points"][0]["CL"] == 1.2
+        assert result["name"] == "wing"
+
+
+class TestAlphaSweepEndpointDoesNotCrashOnNonFinite:
+    def test_alpha_sweep_returns_200_with_nulls_not_500(self, client_and_db):
+        client, _ = client_and_db
+        plane_id = uuid.uuid4()
+
+        # Payload shaped like a real alpha_sweep result, but with the non-finite
+        # values AeroBuildup emits for degenerate geometry / zero Reynolds number.
+        nan_payload = {
+            "analysis": {
+                "coefficients": {
+                    "CL": [0.1, float("nan"), 0.5],
+                    "CD": [0.01, float("inf"), 0.02],
+                    "Cm": [-0.05, 0.0, float("-inf")],
+                }
+            },
+            "characteristic_points": {
+                "stall_point": {"alpha_deg": float("nan"), "CL": 1.2},
+            },
+            "speed_polar": None,
+            "aircraft_name": "test-plane",
+        }
+
+        with patch(
+            "app.services.analysis_service.analyze_alpha_sweep",
+            new=AsyncMock(return_value=nan_payload),
+        ):
+            res = client.post(f"/aeroplanes/{plane_id}/alpha_sweep", json={})
+
+        assert res.status_code == 200, f"expected 200, got {res.status_code}: {res.text[:300]}"
+        body = res.json()
+        coeffs = body["analysis"]["coefficients"]
+        assert coeffs["CL"] == [0.1, None, 0.5]
+        assert coeffs["CD"] == [0.01, None, 0.02]
+        assert coeffs["Cm"] == [-0.05, 0.0, None]
+        assert body["characteristic_points"]["stall_point"]["alpha_deg"] is None
+        assert body["characteristic_points"]["stall_point"]["CL"] == 1.2
+        assert body["aircraft_name"] == "test-plane"


### PR DESCRIPTION
## Summary

`POST /aeroplanes/{id}/alpha_sweep` (and its sibling aero endpoints) returned an unhandled **HTTP 500** whenever AeroBuildup emitted a non-finite coefficient.

**Root cause:** the aero-analysis endpoints return raw computed dicts. FastAPI serializes them via Starlette's `JSONResponse.render`, which calls `json.dumps(content, allow_nan=False)`. A NaN / ±Inf therefore raises `ValueError: Out of range float values are not JSON compliant`. The crash escapes the handler's `try/except` because serialization runs **after** the handler returns (`fastapi/routing.py`), so it surfaces as a bare 500.

Non-finite values appear for degenerate solver inputs — a zero-volume fuselage gives `length³ / volume → NaN`; a zero Reynolds number gives `log10(0) → -inf`.

## Fix

- New `app/core/json_safe.py`:
  - `replace_nonfinite(obj)` — recursively maps NaN / ±Inf (incl. numpy float scalars, which `np.float32` does *not* expose as a `float` subclass) to `None`, preserving every finite/other value.
  - `NonFiniteSafeJSONResponse(JSONResponse)` — sanitizes at render time.
- Set as the **aeroanalysis router's** `default_response_class`. Non-finite floats now serialize as JSON `null` — an honest "no value", **not** a fabricated fallback that would hide the underlying design problem.

Scoped to the aero router (not app-wide) so large CAD/mesh responses don't pay a render-time deep-walk.

## Tests (TDD, red-green verified)

`app/tests/test_alpha_sweep_nonfinite_json.py`:
1. Unit tests for `replace_nonfinite` — Python + numpy non-finite scalars, nested dict/list/tuple, finite/other values preserved.
2. Integration test through the real endpoint + serialization path: a NaN/Inf-laden service result now returns **200 with nulls** instead of 500.

Reverting the router wiring makes the integration test fail with the exact production `ValueError`; restoring it passes. `132` related aero tests pass; ruff check + format clean.

## Follow-up (separate concern)

*Why* AeroBuildup emits NaN here is a degenerate fuselage (zero length/volume) reaching the solver — a data/converter question tracked separately. This crash fix is correct and solver-agnostic regardless.

Closes #815

🤖 Generated with [Claude Code](https://claude.com/claude-code)
