### PR TITLE
fix(gh-817): null-safe analysis Polar charts after gh-815 (clMax.toFixed crash)

### DIFF
--- a/frontend/__tests__/derivePolarCharts.test.tsx
+++ b/frontend/__tests__/derivePolarCharts.test.tsx
@@ -87,6 +87,17 @@ describe("derivePolarCharts", () => {
     expect(safeToFixed(charts!.clMax, 2)).toBe("n/a");
   });
 
+  it("treats zero drag as a non-computable L/D (null, not 0)", () => {
+    const charts = derivePolarCharts(
+      base({ CL: [0.5, 0.7], CD: [0, 0.05], Cm: [], alpha: [0, 5] }),
+    );
+    // cd === 0 -> null (gap), so it is never selected as the L/D max
+    expect(charts!.clOverCd[0]).toBeNull();
+    expect(charts!.clOverCd[1]).toBeCloseTo(0.7 / 0.05);
+    expect(charts!.ldMax).toBeCloseTo(0.7 / 0.05);
+    expect(charts!.alphaLdMax).toBe(5);
+  });
+
   it("still reports a finite max when only some entries are null", () => {
     const charts = derivePolarCharts(
       base({ CL: [null, 0.9, null], CD: [null, 0.05, null], Cm: [], alpha: [0, 6, 12] }),

--- a/frontend/__tests__/derivePolarCharts.test.tsx
+++ b/frontend/__tests__/derivePolarCharts.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * gh-817: the analysis Polar tab crashed with
+ *   "undefined is not an object (evaluating 'charts.clMax.toFixed')"
+ * once the backend (gh-815) started serializing non-finite aero coefficients
+ * as JSON null. `Math.max(...CL)` coerces null -> 0, so `CL.indexOf(max)`
+ * returns -1 (e.g. all-null, or all-negative CL plus a null), and `CL[-1]`
+ * is undefined -> `.toFixed` throws.
+ *
+ * These tests cover the null-safe extraction helpers.
+ */
+import { describe, it, expect } from "vitest";
+
+import {
+  finiteArgMax,
+  safeToFixed,
+  derivePolarCharts,
+} from "@/components/workbench/AnalysisViewerPanel";
+import type { AnalysisResult } from "@/hooks/useAnalysis";
+
+describe("finiteArgMax", () => {
+  it("returns the index of the largest finite value", () => {
+    expect(finiteArgMax([0.1, 0.5, 0.3])).toBe(1);
+  });
+
+  it("ignores null / undefined / NaN entries", () => {
+    expect(finiteArgMax([null, 0.5, undefined])).toBe(1);
+    expect(finiteArgMax([0.1, NaN, 0.3])).toBe(2);
+  });
+
+  it("handles all-negative arrays without being fooled by null->0 coercion", () => {
+    // the exact crash case: Math.max(...[-0.2, null, -0.1]) === 0, indexOf === -1
+    expect(finiteArgMax([-0.2, null, -0.1])).toBe(2);
+  });
+
+  it("returns -1 when there is no finite value", () => {
+    expect(finiteArgMax([null, null, null])).toBe(-1);
+    expect(finiteArgMax([])).toBe(-1);
+  });
+});
+
+describe("safeToFixed", () => {
+  it("formats finite numbers, including zero", () => {
+    expect(safeToFixed(1.234, 2)).toBe("1.23");
+    expect(safeToFixed(0, 2)).toBe("0.00");
+  });
+
+  it("returns the fallback for null / undefined / NaN", () => {
+    expect(safeToFixed(null, 2)).toBe("n/a");
+    expect(safeToFixed(undefined, 2)).toBe("n/a");
+    expect(safeToFixed(Number.NaN, 2)).toBe("n/a");
+  });
+});
+
+describe("derivePolarCharts", () => {
+  const base = (over: Partial<AnalysisResult>): AnalysisResult => ({
+    CL: [],
+    CD: [],
+    Cm: [],
+    alpha: [],
+    ...over,
+  });
+
+  it("returns null when there is no data", () => {
+    expect(derivePolarCharts(null)).toBeNull();
+    expect(derivePolarCharts(base({ CL: [] }))).toBeNull();
+  });
+
+  it("computes characteristic points for a normal sweep", () => {
+    const charts = derivePolarCharts(
+      base({ CL: [0.1, 0.8, 0.5], CD: [0.01, 0.04, 0.03], Cm: [0, -0.1, -0.2], alpha: [0, 5, 10] }),
+    );
+    expect(charts).not.toBeNull();
+    expect(charts!.clMax).toBe(0.8);
+    expect(charts!.alphaClMax).toBe(5);
+  });
+
+  it("does not crash on an all-null (degenerate) sweep — the gh-817 regression", () => {
+    const charts = derivePolarCharts(
+      base({ CL: [null, null], CD: [null, null], Cm: [], alpha: [0, 5] }),
+    );
+    expect(charts).not.toBeNull();
+    expect(charts!.clMax).toBeNull();
+    expect(charts!.alphaClMax).toBeNull();
+    expect(charts!.ldMax).toBeNull();
+    expect(charts!.alphaLdMax).toBeNull();
+    // and the annotation it feeds renders a fallback, not a thrown TypeError
+    expect(safeToFixed(charts!.clMax, 2)).toBe("n/a");
+  });
+
+  it("still reports a finite max when only some entries are null", () => {
+    const charts = derivePolarCharts(
+      base({ CL: [null, 0.9, null], CD: [null, 0.05, null], Cm: [], alpha: [0, 6, 12] }),
+    );
+    expect(charts!.clMax).toBe(0.9);
+    expect(charts!.alphaClMax).toBe(6);
+  });
+});

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -120,8 +120,10 @@ function PlotlyChart({
   extraTraces,
   shapes,
 }: Readonly<{
-  xData: number[];
-  yData: number[];
+  // null entries are rendered by Plotly as gaps (degenerate/sanitized
+  // coefficients from gh-815); see derivePolarCharts.
+  xData: (number | null)[];
+  yData: (number | null)[];
   xLabel: string;
   yLabel: string;
   title: string;
@@ -583,6 +585,75 @@ export function buildTrefftzAnnotationText(stripForces: StripForcesResult): stri
   return lines.join("<br>");
 }
 
+// -- Polar chart derivation (null-safe) -----------------------------------
+
+// gh-817: coefficient arrays may contain null where the backend sanitized a
+// non-finite solver value (gh-815). These helpers derive the polar
+// characteristic points without being fooled by null->0 coercion in
+// Math.max(...), and format them with a null-safe fallback. Exported for tests.
+
+export interface PolarCharts {
+  alpha: number[];
+  CL: (number | null)[];
+  CD: (number | null)[];
+  Cm: (number | null)[] | null;
+  clOverCd: (number | null)[];
+  clMax: number | null;
+  alphaClMax: number | null;
+  ldMax: number | null;
+  alphaLdMax: number | null;
+}
+
+/** Index of the largest finite value, or -1 if none is finite. */
+export function finiteArgMax(values: ReadonlyArray<number | null | undefined>): number {
+  let bestIdx = -1;
+  let bestVal = -Infinity;
+  for (let i = 0; i < values.length; i++) {
+    const v = values[i];
+    if (v != null && Number.isFinite(v) && v > bestVal) {
+      bestVal = v;
+      bestIdx = i;
+    }
+  }
+  return bestIdx;
+}
+
+/** toFixed that renders a fallback for null / undefined / non-finite values. */
+export function safeToFixed(
+  value: number | null | undefined,
+  digits: number,
+  fallback = "n/a",
+): string {
+  return value == null || !Number.isFinite(value) ? fallback : value.toFixed(digits);
+}
+
+/** Derive polar series + characteristic points, tolerating null coefficients. */
+export function derivePolarCharts(result: AnalysisResult | null): PolarCharts | null {
+  if (!result?.CL || result.CL.length === 0) return null;
+
+  const { CL, CD, Cm, alpha } = result;
+  const clOverCd = CL.map((cl, i) => {
+    const cd = CD[i];
+    if (cl == null || cd == null || !Number.isFinite(cl) || !Number.isFinite(cd)) return null;
+    return cd === 0 ? 0 : cl / cd;
+  });
+
+  const maxCLIdx = finiteArgMax(CL);
+  const maxLDIdx = finiteArgMax(clOverCd);
+
+  return {
+    alpha,
+    CL,
+    CD,
+    Cm: Cm.length > 0 ? Cm : null,
+    clOverCd,
+    clMax: maxCLIdx >= 0 ? (CL[maxCLIdx] as number) : null,
+    alphaClMax: maxCLIdx >= 0 ? alpha[maxCLIdx] : null,
+    ldMax: maxLDIdx >= 0 ? (clOverCd[maxLDIdx] as number) : null,
+    alphaLdMax: maxLDIdx >= 0 ? alpha[maxLDIdx] : null,
+  };
+}
+
 // -- Trefftz Plane Combined Chart -----------------------------------------
 
 function TrefftzPlaneChart({
@@ -814,27 +885,7 @@ export function AnalysisViewerPanel({
   ]);
   const showWingGate = !hasWings && COMPUTATION_TABS.has(activeTab);
 
-  const charts = useMemo(() => {
-    if (!result?.CL || result.CL.length === 0) return null;
-
-    const { CL, CD, Cm, alpha } = result;
-    const clOverCd = CL.map((cl, i) => (CD[i] === 0 ? 0 : cl / CD[i]));
-
-    const maxCLIdx = CL.indexOf(Math.max(...CL));
-    const maxLDIdx = clOverCd.indexOf(Math.max(...clOverCd));
-
-    return {
-      alpha,
-      CL,
-      CD,
-      Cm: Cm.length > 0 ? Cm : null,
-      clOverCd,
-      clMax: CL[maxCLIdx],
-      alphaClMax: alpha[maxCLIdx],
-      ldMax: clOverCd[maxLDIdx],
-      alphaLdMax: alpha[maxLDIdx],
-    };
-  }, [result]);
+  const charts = useMemo(() => derivePolarCharts(result), [result]);
 
   return (
     <div className="flex h-full flex-col overflow-hidden rounded-xl border border-border">
@@ -907,7 +958,7 @@ export function AnalysisViewerPanel({
                   xLabel: "\u03B1 [\u00B0]",
                   yLabel: "C_L",
                   title: "C_L vs \u03B1",
-                  annotation: `C_L,max \u2248 ${charts.clMax.toFixed(2)} @ ${charts.alphaClMax.toFixed(0)}\u00B0`,
+                  annotation: `C_L,max \u2248 ${safeToFixed(charts.clMax, 2)} @ ${safeToFixed(charts.alphaClMax, 0)}\u00B0`,
                   color: "#FF8400",
                 },
                 {
@@ -926,7 +977,7 @@ export function AnalysisViewerPanel({
                   xLabel: "\u03B1 [\u00B0]",
                   yLabel: "C_L / C_D",
                   title: "C_L / C_D vs \u03B1",
-                  annotation: `L/D,max \u2248 ${charts.ldMax.toFixed(1)} @ ${charts.alphaLdMax.toFixed(0)}\u00B0`,
+                  annotation: `L/D,max \u2248 ${safeToFixed(charts.ldMax, 1)} @ ${safeToFixed(charts.alphaLdMax, 0)}\u00B0`,
                   color: "#30A46C",
                 },
                 {

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -634,8 +634,11 @@ export function derivePolarCharts(result: AnalysisResult | null): PolarCharts | 
   const { CL, CD, Cm, alpha } = result;
   const clOverCd = CL.map((cl, i) => {
     const cd = CD[i];
-    if (cl == null || cd == null || !Number.isFinite(cl) || !Number.isFinite(cd)) return null;
-    return cd === 0 ? 0 : cl / cd;
+    // null for any non-computable L/D — including cd === 0 (degenerate), so it
+    // renders as a gap and is never picked as the L/D max.
+    if (cl == null || cd == null || !Number.isFinite(cl) || !Number.isFinite(cd) || cd === 0)
+      return null;
+    return cl / cd;
   });
 
   const maxCLIdx = finiteArgMax(CL);

--- a/frontend/hooks/useAnalysis.ts
+++ b/frontend/hooks/useAnalysis.ts
@@ -58,7 +58,8 @@ export interface SpeedPolar {
  */
 function extractResult(data: Record<string, unknown>): AnalysisResult {
   const analysis = data.analysis as Record<string, unknown> | undefined;
-  const coefficients = analysis?.coefficients as Record<string, number[]> | undefined;
+  // Coefficients may contain null where the backend sanitized non-finite values (gh-815).
+  const coefficients = analysis?.coefficients as Record<string, (number | null)[]> | undefined;
   const flightCondition = analysis?.flight_condition as Record<string, number[]> | undefined;
 
   return {

--- a/frontend/hooks/useAnalysis.ts
+++ b/frontend/hooks/useAnalysis.ts
@@ -16,9 +16,12 @@ export interface AlphaSweepParams {
 }
 
 export interface AnalysisResult {
-  CL: number[];
-  CD: number[];
-  Cm: number[];
+  // Coefficients may contain null where the backend sanitized a non-finite
+  // (NaN/Inf) solver value for a degenerate sweep (gh-815). alpha is the swept
+  // input, always finite.
+  CL: (number | null)[];
+  CD: (number | null)[];
+  Cm: (number | null)[];
   alpha: number[];
   [key: string]: unknown;
 }


### PR DESCRIPTION
## Summary

Follow-up to #815. Once the backend started serializing non-finite aero coefficients as JSON `null`, the Analysis **Polar** tab crashed:

```
TypeError: undefined is not an object (evaluating 'charts.clMax.toFixed')
  at components/workbench/AnalysisViewerPanel.tsx
```

**Root cause:** the `charts` memo derived `clMax` via `CL.indexOf(Math.max(...CL))`. `Math.max(...CL)` coerces `null → 0`, so for an all-null sweep (or all-negative CL plus any null) `indexOf` returns `-1` → `CL[-1]` is `undefined` → `charts.clMax.toFixed(2)` throws. The annotations called `.toFixed` directly, bypassing the null-safe formatter the file already had.

## Fix

- Extract three pure, exported helpers from `AnalysisViewerPanel`:
  - `finiteArgMax(values)` — index of the largest **finite** value (ignores `null`/`NaN`), `-1` if none.
  - `safeToFixed(value, digits, fallback="n/a")` — `toFixed` that renders a fallback for `null`/`undefined`/non-finite (zero still formats).
  - `derivePolarCharts(result)` — the `charts` derivation, null-tolerant; characteristic points become `null` when no finite value exists.
- `C_L,max` / `L/D,max` annotations now render `n/a` instead of crashing.
- Tighten `AnalysisResult.CL/CD/Cm` to `(number | null)[]` (reflects gh-815) and widen `PlotlyChart` x/y data to match — Plotly renders `null` as gaps.

## Tests

`frontend/__tests__/derivePolarCharts.test.tsx` — 10 tests, TDD red→green, including the exact all-null and all-negative-plus-null regressions.

Verification (Node 22): full unit suite **1143 passing** (114 files), **eslint 0 errors**. No new `tsc` errors (5 unrelated pre-existing errors in this file are unchanged from `main`).

Closes #817

🤖 Generated with [Claude Code](https://claude.com/claude-code)
