### PR TITLE
feat(gh-819): 'no valid results' notice in Polar tab for degenerate sweeps

### DIFF
--- a/frontend/__tests__/derivePolarCharts.test.tsx
+++ b/frontend/__tests__/derivePolarCharts.test.tsx
@@ -8,14 +8,48 @@
  *
  * These tests cover the null-safe extraction helpers.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
 
 import {
   finiteArgMax,
   safeToFixed,
   derivePolarCharts,
+  polarHasFiniteData,
 } from "@/components/workbench/AnalysisViewerPanel";
 import type { AnalysisResult } from "@/hooks/useAnalysis";
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) => React.createElement("span", props);
+  return {
+    Maximize2: icon,
+    Minimize2: icon,
+    Settings: icon,
+    Wind: icon,
+    Ruler: icon,
+    Target: icon,
+    Navigation: icon,
+    Gauge: icon,
+    AlertTriangle: icon,
+    SlidersHorizontal: icon,
+    Activity: icon,
+    Loader2: icon,
+    Plane: icon,
+    TrendingUp: icon,
+    Zap: icon,
+    RefreshCw: icon,
+    Square: icon,
+    ArrowLeftRight: icon,
+    MapPin: icon,
+  };
+});
+vi.mock("@/hooks/useComputationContext", () => ({
+  useComputationContext: () => ({ data: null, isLoading: false }),
+}));
+vi.mock("@/hooks/useDesignAssumptions", () => ({
+  useDesignAssumptions: () => ({ data: null, isLoading: false }),
+}));
 
 describe("finiteArgMax", () => {
   it("returns the index of the largest finite value", () => {
@@ -51,15 +85,15 @@ describe("safeToFixed", () => {
   });
 });
 
-describe("derivePolarCharts", () => {
-  const base = (over: Partial<AnalysisResult>): AnalysisResult => ({
-    CL: [],
-    CD: [],
-    Cm: [],
-    alpha: [],
-    ...over,
-  });
+const base = (over: Partial<AnalysisResult>): AnalysisResult => ({
+  CL: [],
+  CD: [],
+  Cm: [],
+  alpha: [],
+  ...over,
+});
 
+describe("derivePolarCharts", () => {
   it("returns null when there is no data", () => {
     expect(derivePolarCharts(null)).toBeNull();
     expect(derivePolarCharts(base({ CL: [] }))).toBeNull();
@@ -104,5 +138,55 @@ describe("derivePolarCharts", () => {
     );
     expect(charts!.clMax).toBe(0.9);
     expect(charts!.alphaClMax).toBe(6);
+  });
+});
+
+describe("polarHasFiniteData", () => {
+  it("is false when every coefficient is null", () => {
+    const charts = derivePolarCharts(
+      base({ CL: [null, null], CD: [null, null], Cm: [], alpha: [0, 5] }),
+    );
+    expect(polarHasFiniteData(charts!)).toBe(false);
+  });
+
+  it("is true for a normal sweep", () => {
+    const charts = derivePolarCharts(
+      base({ CL: [0.1, 0.8], CD: [0.01, 0.04], Cm: [0, -0.1], alpha: [0, 5] }),
+    );
+    expect(polarHasFiniteData(charts!)).toBe(true);
+  });
+
+  it("is true when only some series have finite values", () => {
+    const charts = derivePolarCharts(
+      base({ CL: [null, null], CD: [0.02, 0.03], Cm: [], alpha: [0, 5] }),
+    );
+    expect(polarHasFiniteData(charts!)).toBe(true);
+  });
+});
+
+describe("Polar tab empty states", () => {
+  const renderPolar = async (result: AnalysisResult | null) => {
+    const { AnalysisViewerPanel } = await import("@/components/workbench/AnalysisViewerPanel");
+    render(
+      <AnalysisViewerPanel
+        result={result}
+        activeTab="Polar"
+        onTabChange={() => {}}
+        hasWings
+        wingXSecs={null}
+      />,
+    );
+  };
+
+  it("shows a 'no valid results' notice for an all-null sweep instead of blank charts", async () => {
+    await renderPolar({ CL: [null, null], CD: [null, null], Cm: [], alpha: [0, 5] });
+    expect(screen.getByText(/no valid results/i)).toBeInTheDocument();
+    expect(screen.queryByText(/run an analysis/i)).not.toBeInTheDocument();
+  });
+
+  it("shows the run-analysis prompt when there is no result yet", async () => {
+    await renderPolar(null);
+    expect(screen.getByText(/run an analysis/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no valid results/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo, useRef, useEffect } from "react";
-import { Loader2, Maximize2, Minimize2, Settings } from "lucide-react";
+import { AlertTriangle, Loader2, Maximize2, Minimize2, Settings } from "lucide-react";
 import { InfoChipRow } from "@/components/workbench/InfoChipRow";
 import type { AnalysisResult } from "@/hooks/useAnalysis";
 import type { StripForcesResult } from "@/hooks/useStripForces";
@@ -627,6 +627,12 @@ export function safeToFixed(
   return value == null || !Number.isFinite(value) ? fallback : value.toFixed(digits);
 }
 
+/** True if any coefficient series holds at least one finite value to plot. */
+export function polarHasFiniteData(charts: PolarCharts): boolean {
+  const series = [charts.CL, charts.CD, charts.clOverCd, charts.Cm ?? []];
+  return series.some((arr) => arr.some((v) => v != null && Number.isFinite(v)));
+}
+
 /** Derive polar series + characteristic points, tolerating null coefficients. */
 export function derivePolarCharts(result: AnalysisResult | null): PolarCharts | null {
   if (!result?.CL || result.CL.length === 0) return null;
@@ -953,6 +959,24 @@ export function AnalysisViewerPanel({
         <div className="flex flex-1 flex-col gap-4 overflow-auto bg-card-muted p-6">
           {charts ? (
             (() => {
+              // Degenerate sweep: coefficients all non-finite -> null (gh-815).
+              // Surface it instead of rendering blank charts (gh-819).
+              if (!polarHasFiniteData(charts)) {
+                return (
+                  <div className="flex flex-1 flex-col items-center justify-center gap-3 text-center">
+                    <AlertTriangle size={28} className="text-primary" />
+                    <span className="font-[family-name:var(--font-jetbrains-mono)] text-[14px] text-foreground">
+                      Analysis produced no valid results
+                    </span>
+                    <span className="max-w-md text-[12px] text-subtle-foreground">
+                      All coefficients are non-finite (NaN/Inf) for this sweep —
+                      usually a sign of degenerate geometry, e.g. a zero-volume
+                      fuselage from an incomplete import. Check the imported model
+                      and re-run.
+                    </span>
+                  </div>
+                );
+              }
               const allCharts = [
                 {
                   id: "cl",


### PR DESCRIPTION
## Summary

Follow-up to #817 / #815. The Analysis **Polar** tab stopped crashing on degenerate sweeps, but then rendered **blank charts with no explanation** when the backend returned all-null coefficients (e.g. a zero-volume fuselage from an incomplete import poisons the total forces → NaN/Inf → null).

This surfaces the condition as a visible notice instead of empty axes — matching the project's design-error-feedback principle (don't hide a degenerate result behind blank charts).

## Change

- New exported `polarHasFiniteData(charts)` — true iff any of CL/CD/Cm/CL·CD⁻¹ holds a finite value.
- Polar tab: when a result is present but has no finite data, render a clear notice ("Analysis produced no valid results … degenerate geometry, e.g. a zero-volume fuselage from an incomplete import. Check the imported model and re-run.") instead of the Plotly grid. Implemented as an early return inside the existing IIFE (no nested ternary).

## Tests

`frontend/__tests__/derivePolarCharts.test.tsx` (16 total):
- `polarHasFiniteData`: all-null → false, normal → true, partially-finite → true.
- Render: all-null sweep shows the notice (not blank, not the run-analysis prompt); no result still shows the run-analysis prompt.

Verification (Node 22): full unit suite **1149 passing** (114 files), **eslint 0 errors**.

Closes #819

🤖 Generated with [Claude Code](https://claude.com/claude-code)
