### PR TITLE
feat(gh-822): surface low-Re airfoil suitability on /workbench/airfoil-preview

### DIFF
--- a/frontend/__tests__/AirfoilPreviewConfigPanel.coverage.test.tsx
+++ b/frontend/__tests__/AirfoilPreviewConfigPanel.coverage.test.tsx
@@ -1,0 +1,336 @@
+/**
+ * Coverage tests for AirfoilPreviewConfigPanel (gh-822).
+ *
+ * Covers: commitVelocity (valid/invalid), Re info toggle, segment nav,
+ * isDirty path (Revert + Save buttons), hasTip=true (tipRe field),
+ * isSaving=true (Loader2), ranked mode toggles, and ReadOnlyField.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+vi.mock("lucide-react", () => ({
+  Info: (p: Record<string, unknown>) => <svg data-testid="info" {...p} />,
+  ArrowLeft: (p: Record<string, unknown>) => <svg data-testid="arrow-left" {...p} />,
+  Save: (p: Record<string, unknown>) => <svg data-testid="save" {...p} />,
+  Loader2: (p: Record<string, unknown>) => <svg data-testid="loader2" {...p} />,
+  ChevronLeft: (p: Record<string, unknown>) => <svg data-testid="chevron-left" {...p} />,
+  ChevronRight: (p: Record<string, unknown>) => <svg data-testid="chevron-right" {...p} />,
+  ChevronDown: (p: Record<string, unknown>) => <svg data-testid="chevron-down" {...p} />,
+  ChevronUp: (p: Record<string, unknown>) => <svg data-testid="chevron-up" {...p} />,
+  Search: (p: Record<string, unknown>) => <svg data-testid="search" {...p} />,
+  Check: (p: Record<string, unknown>) => <svg data-testid="check" {...p} />,
+  Undo2: (p: Record<string, unknown>) => <svg data-testid="undo2" {...p} />,
+  AlertTriangle: (p: Record<string, unknown>) => <svg data-testid="alert-triangle" {...p} />,
+}));
+
+vi.mock("swr", () => ({
+  default: vi.fn(() => ({
+    data: {
+      count: 2,
+      airfoils: [
+        { airfoil_name: "e423", file_name: "e423.dat" },
+        { airfoil_name: "naca0015", file_name: "naca0015.dat" },
+      ],
+    },
+    error: null,
+    isLoading: false,
+  })),
+}));
+
+import { AirfoilPreviewConfigPanel } from "../components/workbench/AirfoilPreviewConfigPanel";
+
+const BASE_PROPS = {
+  rootAirfoil: "e423",
+  tipAirfoil: "naca0015",
+  onRootAirfoilChange: vi.fn(),
+  onTipAirfoilChange: vi.fn(),
+  isRunning: false,
+  segmentIndex: 1,
+  segmentCount: 3,
+  onSegmentChange: vi.fn(),
+  segmentProps: {
+    length: 500,
+    sweep: 2,
+    dihedral: 3,
+    incidence: 1,
+  },
+  velocity: 14,
+  onVelocityChange: vi.fn(),
+  rootRe: 190000,
+  tipRe: 140000,
+  onRootReChange: vi.fn(),
+  onTipReChange: vi.fn(),
+  rootChordMm: 200,
+  tipChordMm: 150,
+  isDirty: false,
+  isSaving: false,
+  onSave: vi.fn(),
+  onRevert: vi.fn(),
+  onBack: vi.fn(),
+};
+
+describe("AirfoilPreviewConfigPanel — coverage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders segment navigation correctly", () => {
+    render(<AirfoilPreviewConfigPanel {...BASE_PROPS} />);
+    expect(screen.getByText("segment 1")).toBeDefined();
+    expect(screen.getByText("2/3")).toBeDefined();
+  });
+
+  it("previous segment button calls onSegmentChange with segmentIndex - 1", async () => {
+    const user = userEvent.setup();
+    render(<AirfoilPreviewConfigPanel {...BASE_PROPS} segmentIndex={1} />);
+    const prevBtn = screen.getByTitle("Previous segment");
+    await user.click(prevBtn);
+    expect(BASE_PROPS.onSegmentChange).toHaveBeenCalledWith(0);
+  });
+
+  it("next segment button calls onSegmentChange with segmentIndex + 1", async () => {
+    const user = userEvent.setup();
+    render(<AirfoilPreviewConfigPanel {...BASE_PROPS} segmentIndex={1} segmentCount={3} />);
+    const nextBtn = screen.getByTitle("Next segment");
+    await user.click(nextBtn);
+    expect(BASE_PROPS.onSegmentChange).toHaveBeenCalledWith(2);
+  });
+
+  it("previous segment button is disabled when segmentIndex is 0", () => {
+    render(<AirfoilPreviewConfigPanel {...BASE_PROPS} segmentIndex={0} />);
+    const prevBtn = screen.getByTitle("Previous segment");
+    expect((prevBtn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("next segment button is disabled when at last segment", () => {
+    render(<AirfoilPreviewConfigPanel {...BASE_PROPS} segmentIndex={2} segmentCount={3} />);
+    const nextBtn = screen.getByTitle("Next segment");
+    expect((nextBtn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("back button calls onBack", async () => {
+    const user = userEvent.setup();
+    render(<AirfoilPreviewConfigPanel {...BASE_PROPS} />);
+    await user.click(screen.getByTitle("Back to Construction"));
+    expect(BASE_PROPS.onBack).toHaveBeenCalledOnce();
+  });
+
+  it("Re info toggle shows/hides Re explanation on click", async () => {
+    const user = userEvent.setup();
+    render(<AirfoilPreviewConfigPanel {...BASE_PROPS} />);
+    // No Re info initially
+    expect(screen.queryByText(/Reynolds-Zahl/i)).toBeNull();
+    await user.click(screen.getByTitle("Reynolds-Zahl Berechnung"));
+    // Now shown
+    expect(screen.getByText(/Reynolds-Zahl/i)).toBeDefined();
+    // Toggle off
+    await user.click(screen.getByTitle("Reynolds-Zahl Berechnung"));
+    expect(screen.queryByText(/Reynolds-Zahl/i)).toBeNull();
+  });
+
+  it("isDirty=true shows Revert and Save buttons", () => {
+    render(<AirfoilPreviewConfigPanel {...BASE_PROPS} isDirty />);
+    expect(screen.getByTitle("Revert to saved airfoils")).toBeDefined();
+    expect(screen.getByText("Save")).toBeDefined();
+  });
+
+  it("isDirty=false hides Revert and Save buttons", () => {
+    render(<AirfoilPreviewConfigPanel {...BASE_PROPS} isDirty={false} />);
+    expect(screen.queryByTitle("Revert to saved airfoils")).toBeNull();
+  });
+
+  it("Revert button calls onRevert", async () => {
+    const user = userEvent.setup();
+    render(<AirfoilPreviewConfigPanel {...BASE_PROPS} isDirty />);
+    await user.click(screen.getByTitle("Revert to saved airfoils"));
+    expect(BASE_PROPS.onRevert).toHaveBeenCalledOnce();
+  });
+
+  it("Save button calls onSave", async () => {
+    const user = userEvent.setup();
+    render(<AirfoilPreviewConfigPanel {...BASE_PROPS} isDirty />);
+    await user.click(screen.getByText("Save"));
+    expect(BASE_PROPS.onSave).toHaveBeenCalledOnce();
+  });
+
+  it("isSaving=true shows Loader2 and 'Saving…' text", () => {
+    render(<AirfoilPreviewConfigPanel {...BASE_PROPS} isDirty isSaving />);
+    expect(screen.getByTestId("loader2")).toBeDefined();
+    // The Unicode ellipsis is U+2026, or the "…" character
+    const savingText = screen.queryByText(/Saving/);
+    expect(savingText).toBeDefined();
+  });
+
+  it("velocity input changes commit on blur with valid value", async () => {
+    const onVelocityChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AirfoilPreviewConfigPanel
+        {...BASE_PROPS}
+        velocity={14}
+        onVelocityChange={onVelocityChange}
+      />,
+    );
+    const velocityInput = screen.getByDisplayValue("14") as HTMLInputElement;
+    await user.clear(velocityInput);
+    await user.type(velocityInput, "20");
+    fireEvent.blur(velocityInput);
+    expect(onVelocityChange).toHaveBeenCalledWith(20);
+  });
+
+  it("velocity input resets to previous value on blur with invalid (NaN) input", async () => {
+    const onVelocityChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AirfoilPreviewConfigPanel
+        {...BASE_PROPS}
+        velocity={14}
+        onVelocityChange={onVelocityChange}
+      />,
+    );
+    const velocityInput = screen.getByDisplayValue("14") as HTMLInputElement;
+    await user.clear(velocityInput);
+    await user.type(velocityInput, "abc");
+    fireEvent.blur(velocityInput);
+    // Should not call onVelocityChange with NaN
+    expect(onVelocityChange).not.toHaveBeenCalled();
+    // Should reset to "14"
+    expect(velocityInput.value).toBe("14");
+  });
+
+  it("velocity input commits on Enter key", async () => {
+    const onVelocityChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AirfoilPreviewConfigPanel
+        {...BASE_PROPS}
+        velocity={14}
+        onVelocityChange={onVelocityChange}
+      />,
+    );
+    const velocityInput = screen.getByDisplayValue("14") as HTMLInputElement;
+    await user.clear(velocityInput);
+    await user.type(velocityInput, "18");
+    await user.keyboard("{Enter}");
+    expect(onVelocityChange).toHaveBeenCalledWith(18);
+  });
+
+  it("velocity input rejects zero value (v <= 0) and resets", async () => {
+    const onVelocityChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AirfoilPreviewConfigPanel
+        {...BASE_PROPS}
+        velocity={14}
+        onVelocityChange={onVelocityChange}
+      />,
+    );
+    const velocityInput = screen.getByDisplayValue("14") as HTMLInputElement;
+    await user.clear(velocityInput);
+    await user.type(velocityInput, "0");
+    fireEvent.blur(velocityInput);
+    // v=0 → should reset, not call onChange
+    expect(onVelocityChange).not.toHaveBeenCalled();
+    expect(velocityInput.value).toBe("14");
+  });
+
+  it("tipRe Reynolds field is shown when tipAirfoil differs from rootAirfoil", () => {
+    // root=e423, tip=naca0015 → hasTip=true → tipRe field shown
+    render(<AirfoilPreviewConfigPanel {...BASE_PROPS} />);
+    // The Re fields have the Re value displayed; "c=150mm" appears in the tip Re row
+    expect(screen.getByText(/c=150mm/)).toBeDefined();
+  });
+
+  it("tipRe Reynolds field is hidden when tipAirfoil equals rootAirfoil", () => {
+    render(
+      <AirfoilPreviewConfigPanel
+        {...BASE_PROPS}
+        rootAirfoil="e423"
+        tipAirfoil="e423"
+      />,
+    );
+    // hasTip=false → no c=150mm in tip position
+    expect(screen.queryByText(/c=150mm/)).toBeNull();
+  });
+
+  it("ReadOnlyField shows '—' for undefined values", () => {
+    render(
+      <AirfoilPreviewConfigPanel
+        {...BASE_PROPS}
+        segmentProps={{}}
+      />,
+    );
+    // length, sweep, dihedral, incidence are all undefined → show '—'
+    const dashes = screen.getAllByText("—");
+    expect(dashes.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("ReadOnlyField shows values when segmentProps are provided", () => {
+    render(<AirfoilPreviewConfigPanel {...BASE_PROPS} />);
+    expect(screen.getByDisplayValue("14")).toBeDefined(); // velocity input
+    // segment props are shown in read-only fields
+    expect(screen.getByText("500")).toBeDefined(); // length
+    expect(screen.getByText("2")).toBeDefined(); // sweep
+  });
+
+  it("ranked mode toggle buttons fire callbacks when provided", async () => {
+    const onRootRankedModeToggle = vi.fn();
+    const onTipRankedModeToggle = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AirfoilPreviewConfigPanel
+        {...BASE_PROPS}
+        rootRankedMode={false}
+        onRootRankedModeToggle={onRootRankedModeToggle}
+        tipRankedMode={false}
+        onTipRankedModeToggle={onTipRankedModeToggle}
+      />,
+    );
+    // There should be two "🔍" toggle buttons
+    const toggleBtns = screen.getAllByTitle(/Passende finden/i);
+    expect(toggleBtns.length).toBeGreaterThanOrEqual(1);
+    await user.click(toggleBtns[0]);
+    expect(onRootRankedModeToggle).toHaveBeenCalledOnce();
+  });
+
+  it("shows root_airfoil label in primary color", () => {
+    const { container } = render(<AirfoilPreviewConfigPanel {...BASE_PROPS} />);
+    expect(container.textContent).toContain("root_airfoil");
+  });
+
+  it("shows tip_airfoil label", () => {
+    const { container } = render(<AirfoilPreviewConfigPanel {...BASE_PROPS} />);
+    expect(container.textContent).toContain("tip_airfoil");
+  });
+
+  it("Re input calls onRootReChange with parsed int when valid positive value entered", async () => {
+    const onRootReChange = vi.fn();
+    render(
+      <AirfoilPreviewConfigPanel
+        {...BASE_PROPS}
+        rootRe={190000}
+        onRootReChange={onRootReChange}
+      />,
+    );
+    // Find the Re input for root (shows "Re" label with "c=200mm")
+    const reInput = screen.getByDisplayValue("190000") as HTMLInputElement;
+    fireEvent.change(reInput, { target: { value: "250000" } });
+    expect(onRootReChange).toHaveBeenCalledWith(250000);
+  });
+
+  it("Re input does NOT call onRootReChange when value is NaN", async () => {
+    const onRootReChange = vi.fn();
+    render(
+      <AirfoilPreviewConfigPanel
+        {...BASE_PROPS}
+        rootRe={190000}
+        onRootReChange={onRootReChange}
+      />,
+    );
+    const reInput = screen.getByDisplayValue("190000") as HTMLInputElement;
+    fireEvent.change(reInput, { target: { value: "xyz" } });
+    expect(onRootReChange).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/__tests__/AirfoilPreviewConfigPanel.suitability.test.tsx
+++ b/frontend/__tests__/AirfoilPreviewConfigPanel.suitability.test.tsx
@@ -123,6 +123,38 @@ describe("AirfoilPreviewConfigPanel — suitability card wiring", () => {
     expect(screen.queryByText(/Re-agnostisch/i)).toBeNull();
   });
 
+  // ── Issue #3: No-data placeholder ─────────────────────────────
+  it("renders no-data placeholder for root when rootSuitabilityNotFound is true", () => {
+    render(
+      <AirfoilPreviewConfigPanel
+        {...baseProps}
+        rootSuitabilityNotFound
+      />,
+    );
+    expect(screen.getByTestId("suitability-no-data")).toBeDefined();
+    expect(screen.getByText(/Keine Low-Re-Eignungsdaten/i)).toBeDefined();
+  });
+
+  it("does NOT render no-data placeholder when rootSuitabilityNotFound is false", () => {
+    render(
+      <AirfoilPreviewConfigPanel
+        {...baseProps}
+        rootSuitabilityNotFound={false}
+      />,
+    );
+    expect(screen.queryByTestId("suitability-no-data")).toBeNull();
+  });
+
+  it("renders no-data placeholder for tip when tipSuitabilityNotFound is true", () => {
+    render(
+      <AirfoilPreviewConfigPanel
+        {...baseProps}
+        tipSuitabilityNotFound
+      />,
+    );
+    expect(screen.getByTestId("suitability-no-data")).toBeDefined();
+  });
+
   it("passes stats to root AirfoilSelector and score badge appears in dropdown", async () => {
     // Strengthened from a no-crash check: opens the dropdown and asserts the
     // score badge text is visible for the airfoil in the rootScoreMap.

--- a/frontend/__tests__/AirfoilPreviewConfigPanel.suitability.test.tsx
+++ b/frontend/__tests__/AirfoilPreviewConfigPanel.suitability.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * Unit tests for AirfoilPreviewConfigPanel suitability wiring (gh-822).
+ * Verifies: AirfoilSuitabilityCard rendered under each AirfoilSelector +
+ * ReynoldsField (root open, tip collapsed).
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+// Mock lucide-react
+vi.mock("lucide-react", () => ({
+  Info: (p: Record<string, unknown>) => <svg data-testid="info" {...p} />,
+  ArrowLeft: (p: Record<string, unknown>) => <svg data-testid="arrow-left" {...p} />,
+  Save: (p: Record<string, unknown>) => <svg data-testid="save" {...p} />,
+  Loader2: (p: Record<string, unknown>) => <svg data-testid="loader2" {...p} />,
+  ChevronLeft: (p: Record<string, unknown>) => <svg data-testid="chevron-left" {...p} />,
+  ChevronRight: (p: Record<string, unknown>) => <svg data-testid="chevron-right" {...p} />,
+  ChevronDown: (p: Record<string, unknown>) => <svg data-testid="chevron-down" {...p} />,
+  ChevronUp: (p: Record<string, unknown>) => <svg data-testid="chevron-up" {...p} />,
+  Search: (p: Record<string, unknown>) => <svg data-testid="search" {...p} />,
+  Check: (p: Record<string, unknown>) => <svg data-testid="check" {...p} />,
+  Undo2: (p: Record<string, unknown>) => <svg data-testid="undo2" {...p} />,
+  AlertTriangle: (p: Record<string, unknown>) => <svg data-testid="alert-triangle" {...p} />,
+}));
+
+// Mock SWR for AirfoilSelector airfoil list
+vi.mock("swr", () => ({
+  default: vi.fn(() => ({
+    data: {
+      count: 1,
+      airfoils: [{ airfoil_name: "e423", file_name: "e423.dat" }],
+    },
+    error: null,
+    isLoading: false,
+  })),
+}));
+
+import { AirfoilPreviewConfigPanel } from "../components/workbench/AirfoilPreviewConfigPanel";
+import type { SuitabilityItem } from "../hooks/useAirfoilSuitability";
+
+const rootSuitabilityItem: SuitabilityItem = {
+  airfoil_name: "e423",
+  family: "cambered",
+  re_agnostic: 0.82,
+  mission: 0.75,
+  target_cl_cruise: 0.68,
+  target_cl_loiter: 0.55,
+  min_analysis_confidence: 0.92,
+  tip_re_flag: false,
+  caveat: "Nur relative Rangfolge.",
+};
+
+const tipSuitabilityItem: SuitabilityItem = {
+  airfoil_name: "naca0015",
+  family: "symmetric",
+  re_agnostic: 0.65,
+  mission: null,
+  target_cl_cruise: null,
+  target_cl_loiter: null,
+  min_analysis_confidence: 0.88,
+  tip_re_flag: false,
+  caveat: "Keine Missionsdaten.",
+};
+
+const baseProps = {
+  rootAirfoil: "e423",
+  tipAirfoil: "naca0015",
+  onRootAirfoilChange: vi.fn(),
+  onTipAirfoilChange: vi.fn(),
+  isRunning: false,
+  segmentIndex: 0,
+  segmentCount: 1,
+  onSegmentChange: vi.fn(),
+  segmentProps: {},
+  velocity: 14,
+  onVelocityChange: vi.fn(),
+  rootRe: 200000,
+  tipRe: 150000,
+  onRootReChange: vi.fn(),
+  onTipReChange: vi.fn(),
+  rootChordMm: 200,
+  tipChordMm: 150,
+  isDirty: false,
+  isSaving: false,
+  onSave: vi.fn(),
+  onRevert: vi.fn(),
+  onBack: vi.fn(),
+};
+
+describe("AirfoilPreviewConfigPanel — suitability card wiring", () => {
+  it("renders AirfoilSuitabilityCard for root airfoil (open by default) when rootSuitabilityItem provided", () => {
+    render(
+      <AirfoilPreviewConfigPanel
+        {...baseProps}
+        rootSuitabilityItem={rootSuitabilityItem}
+      />,
+    );
+    // Root card should be open — Re-agnostisch bar visible
+    expect(screen.getByText(/Re-agnostisch/i)).toBeDefined();
+  });
+
+  it("renders AirfoilSuitabilityCard for tip airfoil (collapsed by default) when tipSuitabilityItem provided", () => {
+    render(
+      <AirfoilPreviewConfigPanel
+        {...baseProps}
+        rootSuitabilityItem={rootSuitabilityItem}
+        tipSuitabilityItem={tipSuitabilityItem}
+      />,
+    );
+    // Root card is open - Re-agnostisch visible
+    expect(screen.getByText(/Re-agnostisch/i)).toBeDefined();
+    // Tip card is collapsed by default — its Re-agnostisch bar is hidden
+    // (both cards show "Re-agnostisch" only when open; with tip collapsed
+    // there should be exactly one "Re-agnostisch" label)
+    const reAgnosticLabels = screen.getAllByText(/Re-agnostisch/i);
+    expect(reAgnosticLabels).toHaveLength(1); // only root card open
+  });
+
+  it("does NOT render AirfoilSuitabilityCard when no suitability item provided", () => {
+    render(<AirfoilPreviewConfigPanel {...baseProps} />);
+    // No suitability card content
+    expect(screen.queryByText(/Re-agnostisch/i)).toBeNull();
+  });
+
+  it("passes stats to root AirfoilSelector when rootScoreMap provided", () => {
+    const rootScoreMap: Record<string, string> = { "e423": "0.82" };
+    render(
+      <AirfoilPreviewConfigPanel
+        {...baseProps}
+        rootScoreMap={rootScoreMap}
+      />,
+    );
+    // The AirfoilSelector accepts stats; the score should show up
+    // when the dropdown is opened, but we only check the prop is passed
+    // (the actual rendering of stats is tested in AirfoilSelector tests)
+    // We verify no crash — component renders
+    expect(screen.getByText("root_airfoil")).toBeDefined();
+  });
+});

--- a/frontend/__tests__/AirfoilPreviewConfigPanel.suitability.test.tsx
+++ b/frontend/__tests__/AirfoilPreviewConfigPanel.suitability.test.tsx
@@ -5,6 +5,7 @@
  */
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 // Mock lucide-react
@@ -122,7 +123,10 @@ describe("AirfoilPreviewConfigPanel — suitability card wiring", () => {
     expect(screen.queryByText(/Re-agnostisch/i)).toBeNull();
   });
 
-  it("passes stats to root AirfoilSelector when rootScoreMap provided", () => {
+  it("passes stats to root AirfoilSelector and score badge appears in dropdown", async () => {
+    // Strengthened from a no-crash check: opens the dropdown and asserts the
+    // score badge text is visible for the airfoil in the rootScoreMap.
+    const user = userEvent.setup();
     const rootScoreMap: Record<string, string> = { "e423": "0.82" };
     render(
       <AirfoilPreviewConfigPanel
@@ -130,10 +134,18 @@ describe("AirfoilPreviewConfigPanel — suitability card wiring", () => {
         rootScoreMap={rootScoreMap}
       />,
     );
-    // The AirfoilSelector accepts stats; the score should show up
-    // when the dropdown is opened, but we only check the prop is passed
-    // (the actual rendering of stats is tested in AirfoilSelector tests)
-    // We verify no crash — component renders
+    // The root_airfoil label is visible before opening
     expect(screen.getByText("root_airfoil")).toBeDefined();
+
+    // Open the root AirfoilSelector dropdown (first trigger button in the form)
+    // The root selector trigger shows the current value "e423"
+    const triggers = screen.getAllByRole("button");
+    // Find the button that shows the current root airfoil value "e423" as its text
+    const rootTrigger = triggers.find((btn) => btn.textContent?.includes("e423"));
+    expect(rootTrigger).toBeDefined();
+    await user.click(rootTrigger!);
+
+    // The score badge "0.82" should now be visible in the dropdown row for e423
+    expect(screen.getByText("0.82")).toBeDefined();
   });
 });

--- a/frontend/__tests__/AirfoilPreviewViewerPanel.coverage.test.tsx
+++ b/frontend/__tests__/AirfoilPreviewViewerPanel.coverage.test.tsx
@@ -1,0 +1,233 @@
+/**
+ * Coverage tests for AirfoilPreviewViewerPanel additional branches (gh-822).
+ *
+ * Covers:
+ * - Ma input onChange (lines 601-602)
+ * - maximizedChart toggle (lines 762-769)
+ * - geometry loading state
+ * - no rootGeometry state ("No airfoil selected")
+ * - hasTip geometry stats
+ * - no rootAnalysisResult ("Run Analysis" placeholder)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+vi.mock("lucide-react", () => ({
+  Maximize2: (p: Record<string, unknown>) => <svg data-testid="maximize" {...p} />,
+  Minimize2: (p: Record<string, unknown>) => <svg data-testid="minimize" {...p} />,
+  AlertTriangle: (p: Record<string, unknown>) => (
+    <svg data-testid="alert-triangle" {...p} />
+  ),
+}));
+
+import { AirfoilPreviewViewerPanel } from "../components/workbench/AirfoilPreviewViewerPanel";
+import type { AirfoilAnalysisResult } from "../hooks/useAirfoilAnalysis";
+import type { AirfoilGeometry } from "../hooks/useAirfoilGeometry";
+
+const mockGeometry: AirfoilGeometry = {
+  upper: [[0, 0], [0.5, 0.08], [1, 0]],
+  lower: [[0, 0], [0.5, -0.04], [1, 0]],
+  maxThicknessPct: 12,
+  maxCamberPct: 4,
+  maxThicknessX: 0.3,
+};
+
+const tipGeometry: AirfoilGeometry = {
+  upper: [[0, 0], [0.5, 0.06], [1, 0]],
+  lower: [[0, 0], [0.5, -0.03], [1, 0]],
+  maxThicknessPct: 9,
+  maxCamberPct: 3,
+  maxThicknessX: 0.3,
+};
+
+const mockAnalysis: AirfoilAnalysisResult = {
+  airfoilName: "e423",
+  alphaDeg: [-5, 0, 5, 10, 15],
+  cl: [-0.2, 0.1, 0.5, 0.9, 1.2],
+  cd: [0.015, 0.01, 0.012, 0.02, 0.04],
+  cm: [-0.02, -0.01, -0.01, -0.02, -0.03],
+  clOverCd: [-13.3, 10, 41.7, 45, 30],
+  clMax: 1.2,
+  alphaAtClMax: 15,
+  ldMax: 45,
+  alphaAtLdMax: 10,
+};
+
+const baseProps = {
+  rootAirfoilName: "e423",
+  tipAirfoilName: null as string | null,
+  rootGeometry: mockGeometry,
+  tipGeometry: null as AirfoilGeometry | null,
+  geometryLoading: false,
+  rootAnalysisResult: mockAnalysis,
+  tipAnalysisResult: null as AirfoilAnalysisResult | null,
+  rootRe: 200000,
+  tipRe: null as number | null,
+  ma: 0,
+  onMaChange: vi.fn(),
+};
+
+describe("AirfoilPreviewViewerPanel — coverage (gh-822)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("Ma input fires onMaChange with parsed float", async () => {
+    const onMaChange = vi.fn();
+    render(<AirfoilPreviewViewerPanel {...baseProps} onMaChange={onMaChange} />);
+    const maInput = screen.getByDisplayValue("0") as HTMLInputElement;
+    fireEvent.change(maInput, { target: { value: "0.3" } });
+    expect(onMaChange).toHaveBeenCalledWith(0.3);
+  });
+
+  it("Ma input does NOT fire onMaChange for NaN input", async () => {
+    const onMaChange = vi.fn();
+    render(<AirfoilPreviewViewerPanel {...baseProps} onMaChange={onMaChange} />);
+    const maInput = screen.getByDisplayValue("0") as HTMLInputElement;
+    fireEvent.change(maInput, { target: { value: "abc" } });
+    expect(onMaChange).not.toHaveBeenCalled();
+  });
+
+  it("shows 'Loading…' text when geometryLoading is true", () => {
+    render(
+      <AirfoilPreviewViewerPanel
+        {...baseProps}
+        rootGeometry={null}
+        geometryLoading
+      />,
+    );
+    expect(screen.getByText(/Loading/)).toBeDefined();
+  });
+
+  it("shows 'No airfoil selected' when geometry not loaded and not loading", () => {
+    render(
+      <AirfoilPreviewViewerPanel
+        {...baseProps}
+        rootGeometry={null}
+        geometryLoading={false}
+      />,
+    );
+    expect(screen.getByText(/No airfoil selected/)).toBeDefined();
+  });
+
+  it("shows 'Run Analysis to see polars' placeholder when no analysis result", () => {
+    render(
+      <AirfoilPreviewViewerPanel {...baseProps} rootAnalysisResult={null} />,
+    );
+    expect(screen.getByText(/Run Analysis to see polars/i)).toBeDefined();
+  });
+
+  it("renders chart titles when analysis result is provided", () => {
+    render(<AirfoilPreviewViewerPanel {...baseProps} />);
+    // The SVG charts have text elements with titles (multiple charts, so getAllBy)
+    expect(screen.getAllByText(/C_L vs/i).length).toBeGreaterThan(0);
+  });
+
+  it("maximize button toggles chart to maximized mode", async () => {
+    const user = userEvent.setup();
+    render(<AirfoilPreviewViewerPanel {...baseProps} />);
+    // Hover to reveal maximize button (group-hover:opacity-100 — jsdom ignores hover)
+    // Force click the first maximize button by querying all
+    const maxBtns = screen.getAllByTitle("Maximize");
+    expect(maxBtns.length).toBeGreaterThan(0);
+    await user.click(maxBtns[0]);
+    // After maximizing, we should see "Restore" button
+    expect(screen.getByTitle("Restore")).toBeDefined();
+    // And the Minimize icon
+    expect(screen.getByTestId("minimize")).toBeDefined();
+  });
+
+  it("clicking Restore collapses back from maximized view", async () => {
+    const user = userEvent.setup();
+    render(<AirfoilPreviewViewerPanel {...baseProps} />);
+    const maxBtns = screen.getAllByTitle("Maximize");
+    // Maximize first chart
+    await user.click(maxBtns[0]);
+    // Now restore
+    const restoreBtn = screen.getByTitle("Restore");
+    await user.click(restoreBtn);
+    // Should be back to normal multi-chart view
+    expect(screen.getAllByTitle("Maximize").length).toBeGreaterThan(0);
+  });
+
+  it("hasTip=true: shows tip airfoil name and tip Re", () => {
+    render(
+      <AirfoilPreviewViewerPanel
+        {...baseProps}
+        tipAirfoilName="naca0015"
+        tipRe={150000}
+      />,
+    );
+    // Tip name shown
+    expect(screen.getAllByText("naca0015").length).toBeGreaterThan(0);
+    // Tip Re shown ("150k") — may appear in multiple text nodes
+    expect(screen.getAllByText(/150k/).length).toBeGreaterThan(0);
+  });
+
+  it("hasTip=true with tipGeometry: geo stats include tip info", () => {
+    render(
+      <AirfoilPreviewViewerPanel
+        {...baseProps}
+        tipAirfoilName="naca0015"
+        tipRe={150000}
+        tipGeometry={tipGeometry}
+      />,
+    );
+    // The stats string includes "tip: t/c = ..."
+    expect(screen.getByText(/tip:/)).toBeDefined();
+  });
+
+  it("hasTip=true with null tipGeometry: geo stats only show root", () => {
+    render(
+      <AirfoilPreviewViewerPanel
+        {...baseProps}
+        tipAirfoilName="naca0015"
+        tipRe={150000}
+        tipGeometry={null}
+      />,
+    );
+    // Only root geo stats visible (no "tip:" prefix)
+    expect(screen.queryByText(/tip: t\/c/)).toBeNull();
+  });
+
+  it("hasTip=true: shows secondary data trace (dashed line) for tip analysis", () => {
+    render(
+      <AirfoilPreviewViewerPanel
+        {...baseProps}
+        tipAirfoilName="naca0015"
+        tipRe={150000}
+        tipAnalysisResult={mockAnalysis}
+      />,
+    );
+    // With tip data, legend should appear (label + label2)
+    // The SVG text for "root" label appears in the legend
+    const rootLabels = screen.getAllByText("root");
+    expect(rootLabels.length).toBeGreaterThan(0);
+  });
+
+  it("operating point marker absent when alphaDeg has valid entries but operatingAlphaDeg not provided", () => {
+    render(<AirfoilPreviewViewerPanel {...baseProps} />);
+    expect(screen.queryByTestId("operating-point-marker")).toBeNull();
+  });
+
+  it("displays clMax annotation when clMax and alphaAtClMax are non-null", () => {
+    render(<AirfoilPreviewViewerPanel {...baseProps} />);
+    // annotation text: "C_L,max ≈ 1.20 @ 15°"
+    expect(screen.getByText(/C_L,max/)).toBeDefined();
+  });
+
+  it("does NOT show clMax annotation when analysis has null clMax", () => {
+    const analysisNoClmax = { ...mockAnalysis, clMax: null, alphaAtClMax: null };
+    render(
+      <AirfoilPreviewViewerPanel {...baseProps} rootAnalysisResult={analysisNoClmax} />,
+    );
+    expect(screen.queryByText(/C_L,max/)).toBeNull();
+  });
+
+  it("shows L/D max annotation when ldMax and alphaAtLdMax are non-null", () => {
+    render(<AirfoilPreviewViewerPanel {...baseProps} />);
+    expect(screen.getByText(/L\/D,max/)).toBeDefined();
+  });
+});

--- a/frontend/__tests__/AirfoilPreviewViewerPanel.suitability.test.tsx
+++ b/frontend/__tests__/AirfoilPreviewViewerPanel.suitability.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for AirfoilPreviewViewerPanel suitability enhancements (gh-822).
+ * Verifies:
+ * - Operating-point marker trace on the L/D polar at operating CL/α
+ * - Tip-Re < root-Re warning banner (red, AlertTriangle, role='alert')
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+// Mock lucide-react
+vi.mock("lucide-react", () => ({
+  Maximize2: (p: Record<string, unknown>) => <svg data-testid="maximize" {...p} />,
+  Minimize2: (p: Record<string, unknown>) => <svg data-testid="minimize" {...p} />,
+  AlertTriangle: (p: Record<string, unknown>) => (
+    <svg data-testid="alert-triangle" {...p} />
+  ),
+}));
+
+import { AirfoilPreviewViewerPanel } from "../components/workbench/AirfoilPreviewViewerPanel";
+import type { AirfoilAnalysisResult } from "../hooks/useAirfoilAnalysis";
+import type { AirfoilGeometry } from "../hooks/useAirfoilGeometry";
+
+const mockGeometry: AirfoilGeometry = {
+  upper: [[0, 0], [0.5, 0.08], [1, 0]],
+  lower: [[0, 0], [0.5, -0.04], [1, 0]],
+  maxThicknessPct: 12,
+  maxCamberPct: 4,
+  maxThicknessX: 0.3,
+};
+
+const mockAnalysis: AirfoilAnalysisResult = {
+  airfoilName: "e423",
+  alphaDeg: [-5, 0, 5, 10, 15],
+  cl: [-0.2, 0.1, 0.5, 0.9, 1.2],
+  cd: [0.015, 0.01, 0.012, 0.02, 0.04],
+  cm: [-0.02, -0.01, -0.01, -0.02, -0.03],
+  clOverCd: [-13.3, 10, 41.7, 45, 30],
+  clMax: 1.2,
+  alphaAtClMax: 15,
+  ldMax: 45,
+  alphaAtLdMax: 10,
+};
+
+const baseProps = {
+  rootAirfoilName: "e423",
+  tipAirfoilName: null,
+  rootGeometry: mockGeometry,
+  tipGeometry: null,
+  geometryLoading: false,
+  rootAnalysisResult: mockAnalysis,
+  tipAnalysisResult: null,
+  rootRe: 200000,
+  tipRe: null,
+  ma: 0,
+  onMaChange: vi.fn(),
+};
+
+describe("AirfoilPreviewViewerPanel — suitability enhancements", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does NOT show tip-Re banner when tipRe is null (no tip)", () => {
+    render(<AirfoilPreviewViewerPanel {...baseProps} />);
+    // No alert banner should appear
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("does NOT show tip-Re banner when tipRe equals rootRe", () => {
+    render(
+      <AirfoilPreviewViewerPanel
+        {...baseProps}
+        tipAirfoilName="naca0012"
+        tipRe={200000}
+        rootRe={200000}
+      />,
+    );
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("does NOT show tip-Re banner when tipRe > rootRe", () => {
+    render(
+      <AirfoilPreviewViewerPanel
+        {...baseProps}
+        tipAirfoilName="naca0012"
+        tipRe={300000}
+        rootRe={200000}
+      />,
+    );
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("shows tip-Re warning banner (role=alert) when tipRe < rootRe", () => {
+    render(
+      <AirfoilPreviewViewerPanel
+        {...baseProps}
+        tipAirfoilName="naca0012"
+        tipRe={100000}
+        rootRe={200000}
+      />,
+    );
+    const alert = screen.getByRole("alert");
+    expect(alert).toBeDefined();
+  });
+
+  it("tip-Re banner shows AlertTriangle icon", () => {
+    render(
+      <AirfoilPreviewViewerPanel
+        {...baseProps}
+        tipAirfoilName="naca0012"
+        tipRe={100000}
+        rootRe={200000}
+      />,
+    );
+    expect(screen.getByTestId("alert-triangle")).toBeDefined();
+  });
+
+  it("renders operating point marker when operatingAlphaDeg is provided", () => {
+    render(
+      <AirfoilPreviewViewerPanel
+        {...baseProps}
+        operatingAlphaDeg={5}
+      />,
+    );
+    // The marker should appear as a circle element in the SVG polar chart
+    // We look for an SVG circle with the operating point data-testid
+    const marker = screen.queryByTestId("operating-point-marker");
+    expect(marker).not.toBeNull();
+  });
+
+  it("does NOT render operating point marker when operatingAlphaDeg is not provided", () => {
+    render(<AirfoilPreviewViewerPanel {...baseProps} />);
+    expect(screen.queryByTestId("operating-point-marker")).toBeNull();
+  });
+
+  it("banner text mentions tip Re reduction", () => {
+    render(
+      <AirfoilPreviewViewerPanel
+        {...baseProps}
+        tipAirfoilName="naca0012"
+        tipRe={100000}
+        rootRe={200000}
+      />,
+    );
+    const alert = screen.getByRole("alert");
+    // Should mention tip or Re in some form
+    expect(alert.textContent).toMatch(/tip|Re|Tip/i);
+  });
+});

--- a/frontend/__tests__/AirfoilPreviewViewerPanel.suitability.test.tsx
+++ b/frontend/__tests__/AirfoilPreviewViewerPanel.suitability.test.tsx
@@ -20,6 +20,19 @@ vi.mock("lucide-react", () => ({
 import { AirfoilPreviewViewerPanel } from "../components/workbench/AirfoilPreviewViewerPanel";
 import type { AirfoilAnalysisResult } from "../hooks/useAirfoilAnalysis";
 import type { AirfoilGeometry } from "../hooks/useAirfoilGeometry";
+import type { SuitabilityItem } from "../hooks/useAirfoilSuitability";
+
+const baseSuitabilityItem: SuitabilityItem = {
+  airfoil_name: "naca0012",
+  family: "symmetric",
+  re_agnostic: 0.65,
+  mission: null,
+  target_cl_cruise: null,
+  target_cl_loiter: null,
+  min_analysis_confidence: 0.88,
+  tip_re_flag: false,
+  caveat: "Nur relative Rangfolge.",
+};
 
 const mockGeometry: AirfoilGeometry = {
   upper: [[0, 0], [0.5, 0.08], [1, 0]],
@@ -134,6 +147,28 @@ describe("AirfoilPreviewViewerPanel — suitability enhancements", () => {
     expect(screen.queryByTestId("operating-point-marker")).toBeNull();
   });
 
+  it("does NOT render operating point marker when alphaDeg array is empty (empty-array guard)", () => {
+    // Regression guard for the unguarded alphas[0] access: an empty alphaDeg array
+    // must not produce a NaN coordinate that renders an invisible/misplaced marker.
+    const emptyAlphaAnalysis: AirfoilAnalysisResult = {
+      ...mockAnalysis,
+      alphaDeg: [],
+      cl: [],
+      cd: [],
+      cm: [],
+      clOverCd: [],
+    };
+    render(
+      <AirfoilPreviewViewerPanel
+        {...baseProps}
+        rootAnalysisResult={emptyAlphaAnalysis}
+        operatingAlphaDeg={5}
+      />,
+    );
+    // The component must not crash, and the marker must be absent (no valid coords)
+    expect(screen.queryByTestId("operating-point-marker")).toBeNull();
+  });
+
   it("banner text mentions tip Re reduction", () => {
     render(
       <AirfoilPreviewViewerPanel
@@ -146,5 +181,50 @@ describe("AirfoilPreviewViewerPanel — suitability enhancements", () => {
     const alert = screen.getByRole("alert");
     // Should mention tip or Re in some form
     expect(alert.textContent).toMatch(/tip|Re|Tip/i);
+  });
+
+  // tip_re_flag is the AUTHORITATIVE trigger when a suitability item is available.
+  // The arithmetic fallback (tipRe < rootRe) is only used when no item is present.
+
+  it("shows tip-Re banner when tipSuitabilityItem.tip_re_flag is true, even if tipRe > rootRe", () => {
+    // Authoritative path: backend flag set → show banner regardless of arithmetic
+    render(
+      <AirfoilPreviewViewerPanel
+        {...baseProps}
+        tipAirfoilName="naca0012"
+        tipRe={300000}
+        rootRe={200000}
+        tipSuitabilityItem={{ ...baseSuitabilityItem, tip_re_flag: true }}
+      />,
+    );
+    expect(screen.getByRole("alert")).toBeDefined();
+  });
+
+  it("does NOT show tip-Re banner when tipSuitabilityItem.tip_re_flag is false, even if tipRe < rootRe", () => {
+    // Authoritative path: backend flag clear → no banner even when arithmetic says tipRe < rootRe
+    render(
+      <AirfoilPreviewViewerPanel
+        {...baseProps}
+        tipAirfoilName="naca0012"
+        tipRe={100000}
+        rootRe={200000}
+        tipSuitabilityItem={{ ...baseSuitabilityItem, tip_re_flag: false }}
+      />,
+    );
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("falls back to arithmetic (tipRe < rootRe) when no tipSuitabilityItem is provided", () => {
+    // Fallback path: no suitability data, use arithmetic check
+    render(
+      <AirfoilPreviewViewerPanel
+        {...baseProps}
+        tipAirfoilName="naca0012"
+        tipRe={100000}
+        rootRe={200000}
+        // tipSuitabilityItem intentionally omitted
+      />,
+    );
+    expect(screen.getByRole("alert")).toBeDefined();
   });
 });

--- a/frontend/__tests__/AirfoilSelector.coverage.test.tsx
+++ b/frontend/__tests__/AirfoilSelector.coverage.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * Coverage tests for AirfoilSelector additional branches (gh-822).
+ *
+ * Covers:
+ * - select() function with onChange and onPreviewToggle callbacks (lines 104-107)
+ * - search input onChange (line 158)
+ * - "No airfoils found" path (filtered.length === 0)
+ * - totalMatches > MAX_VISIBLE footer
+ * - clicking outside closes dropdown
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+vi.mock("lucide-react", () => ({
+  ChevronDown: (p: Record<string, unknown>) => (
+    <svg data-testid="chevron-down" {...p} />
+  ),
+  ChevronUp: (p: Record<string, unknown>) => (
+    <svg data-testid="chevron-up" {...p} />
+  ),
+  Search: (p: Record<string, unknown>) => <svg data-testid="search" {...p} />,
+  Check: (p: Record<string, unknown>) => <svg data-testid="check" {...p} />,
+}));
+
+// SWR mock returning a list of airfoils
+vi.mock("swr", () => ({
+  default: vi.fn(() => ({
+    data: {
+      count: 3,
+      airfoils: [
+        { airfoil_name: "e423", file_name: "e423.dat" },
+        { airfoil_name: "naca0015", file_name: "naca0015.dat" },
+        { airfoil_name: "clark-y", file_name: "clark-y.dat" },
+      ],
+    },
+    error: null,
+    isLoading: false,
+  })),
+}));
+
+import { AirfoilSelector } from "../components/workbench/AirfoilSelector";
+
+describe("AirfoilSelector — coverage (gh-822)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls onChange when an airfoil is selected from the dropdown", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AirfoilSelector label="Root" value="naca0015" onChange={onChange} />,
+    );
+    // Open dropdown
+    await user.click(screen.getByRole("button"));
+    // Click on e423
+    await user.click(screen.getByText("e423"));
+    expect(onChange).toHaveBeenCalledWith("e423");
+  });
+
+  it("calls onPreviewToggle(false) when airfoil is selected", async () => {
+    const onPreviewToggle = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AirfoilSelector
+        label="Root"
+        value="naca0015"
+        onPreviewToggle={onPreviewToggle}
+      />,
+    );
+    await user.click(screen.getByRole("button"));
+    // onPreviewToggle called with true on open
+    expect(onPreviewToggle).toHaveBeenCalledWith(true);
+    await user.click(screen.getByText("e423"));
+    // onPreviewToggle called with false on select
+    expect(onPreviewToggle).toHaveBeenCalledWith(false);
+  });
+
+  it("closes dropdown and clears search after selection", async () => {
+    const user = userEvent.setup();
+    render(<AirfoilSelector label="Root" value="naca0015" />);
+    // Open dropdown
+    const trigger = screen.getByRole("button");
+    await user.click(trigger);
+    // Type in search
+    const searchInput = screen.getByPlaceholderText("Search airfoils…");
+    await user.type(searchInput, "e423");
+    // Select the airfoil
+    await user.click(screen.getByText("e423"));
+    // Dropdown should be closed (search input gone)
+    expect(screen.queryByPlaceholderText("Search airfoils…")).toBeNull();
+  });
+
+  it("search input filters the list", async () => {
+    const user = userEvent.setup();
+    render(<AirfoilSelector label="Root" value="naca0015" />);
+    await user.click(screen.getByRole("button"));
+    const searchInput = screen.getByPlaceholderText("Search airfoils…");
+    await user.type(searchInput, "clark");
+    // Only clark-y should be visible
+    expect(screen.getByText("clark-y")).toBeDefined();
+    expect(screen.queryByText("e423")).toBeNull();
+  });
+
+  it("shows 'No airfoils found' when search has no results", async () => {
+    const user = userEvent.setup();
+    render(<AirfoilSelector label="Root" value="naca0015" />);
+    await user.click(screen.getByRole("button"));
+    const searchInput = screen.getByPlaceholderText("Search airfoils…");
+    await user.type(searchInput, "zzz_no_match");
+    expect(screen.getByText("No airfoils found")).toBeDefined();
+  });
+
+  it("toggle button closes dropdown and calls onPreviewToggle(false) on second click", async () => {
+    const onPreviewToggle = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AirfoilSelector
+        label="Root"
+        value="naca0015"
+        onPreviewToggle={onPreviewToggle}
+      />,
+    );
+    const trigger = screen.getByRole("button");
+    // Open
+    await user.click(trigger);
+    expect(onPreviewToggle).toHaveBeenLastCalledWith(true);
+    // Close
+    await user.click(trigger);
+    expect(onPreviewToggle).toHaveBeenLastCalledWith(false);
+  });
+
+  it("uses sortedNames ordering when provided and search is empty", async () => {
+    const user = userEvent.setup();
+    const sortedNames = ["clark-y", "naca0015", "e423"];
+    const { container } = render(
+      <AirfoilSelector
+        label="Root"
+        value="naca0015"
+        sortedNames={sortedNames}
+      />,
+    );
+    const trigger = screen.getByRole("button");
+    await user.click(trigger);
+    // Sorted order buttons
+    const dropdown = container.querySelector('[class*="max-h"]');
+    expect(dropdown).not.toBeNull();
+    if (dropdown) {
+      const btns = Array.from(dropdown.querySelectorAll("button"));
+      const names = btns
+        .map((b) => b.querySelector("span")?.textContent ?? "")
+        .filter((t) => ["clark-y", "naca0015", "e423"].includes(t));
+      expect(names[0]).toBe("clark-y");
+    }
+  });
+
+  it("shows Check icon for currently selected airfoil", async () => {
+    const user = userEvent.setup();
+    render(<AirfoilSelector label="Root" value="e423" />);
+    await user.click(screen.getByRole("button"));
+    // Check icon appears for the selected item
+    expect(screen.getByTestId("check")).toBeDefined();
+  });
+
+  it("ChevronUp shows when dropdown is open", async () => {
+    const user = userEvent.setup();
+    render(<AirfoilSelector label="Root" value="naca0015" />);
+    // Initially ChevronDown
+    expect(screen.getByTestId("chevron-down")).toBeDefined();
+    await user.click(screen.getByRole("button"));
+    // After open: ChevronUp
+    expect(screen.getByTestId("chevron-up")).toBeDefined();
+  });
+});

--- a/frontend/__tests__/AirfoilSelector.suitability.test.tsx
+++ b/frontend/__tests__/AirfoilSelector.suitability.test.tsx
@@ -162,4 +162,46 @@ describe("AirfoilSelector — suitability enhancements", () => {
     // Active state — should have primary/accent styling
     expect(findBtn.className).toMatch(/primary|text-primary|text-\[#FF8400\]/);
   });
+
+  // ── Issue #2: Score badge visually rendered in ranked mode ────
+  it("score badge has data-testid='score-badge' and is not just muted text", async () => {
+    const user = userEvent.setup();
+    render(
+      <AirfoilSelector
+        label="Root"
+        value="naca0015"
+        stats={STATS}
+      />,
+    );
+    const trigger = screen.getByRole("button");
+    await user.click(trigger);
+
+    // Should find at least one score badge with data-testid
+    const badges = screen.getAllByTestId("score-badge");
+    expect(badges.length).toBeGreaterThan(0);
+    // Badge for e423 (0.85) should be present
+    const e423Badge = badges.find((el) => el.textContent === "0.85");
+    expect(e423Badge).toBeDefined();
+  });
+
+  it("score badge has inline color styling (not plain text-muted-foreground)", async () => {
+    const user = userEvent.setup();
+    render(
+      <AirfoilSelector
+        label="Root"
+        value="naca0015"
+        stats={STATS}
+      />,
+    );
+    const trigger = screen.getByRole("button");
+    await user.click(trigger);
+
+    const badges = screen.getAllByTestId("score-badge");
+    // At least one badge should have a color style (green/amber/red)
+    const hasColorStyle = badges.some((el) => {
+      const style = el.getAttribute("style") ?? "";
+      return style.includes("color");
+    });
+    expect(hasColorStyle).toBe(true);
+  });
 });

--- a/frontend/__tests__/AirfoilSelector.suitability.test.tsx
+++ b/frontend/__tests__/AirfoilSelector.suitability.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * Unit tests for AirfoilSelector suitability enhancements (gh-822).
+ * Verifies: per-row badge via stats slot; sorted rows by score;
+ * '🔍 Passende finden' toggle switches to ranked mode.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+// Mock SWR to return a fixed airfoil list
+vi.mock("swr", () => ({
+  default: vi.fn(() => ({
+    data: {
+      count: 3,
+      airfoils: [
+        { airfoil_name: "naca0015", file_name: "naca0015.dat" },
+        { airfoil_name: "e423", file_name: "e423.dat" },
+        { airfoil_name: "clark-y", file_name: "clark-y.dat" },
+      ],
+    },
+    error: null,
+    isLoading: false,
+  })),
+}));
+
+vi.mock("lucide-react", () => ({
+  ChevronDown: (p: Record<string, unknown>) => (
+    <svg data-testid="chevron-down" {...p} />
+  ),
+  ChevronUp: (p: Record<string, unknown>) => (
+    <svg data-testid="chevron-up" {...p} />
+  ),
+  Search: (p: Record<string, unknown>) => <svg data-testid="search" {...p} />,
+  Check: (p: Record<string, unknown>) => <svg data-testid="check" {...p} />,
+}));
+
+import { AirfoilSelector } from "../components/workbench/AirfoilSelector";
+
+// stats slot uses string values per the existing interface
+const STATS: Record<string, string> = {
+  "naca0015": "0.45",
+  "e423": "0.85",
+  "clark-y": "0.65",
+};
+
+describe("AirfoilSelector — suitability enhancements", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows stats badge text in dropdown rows when stats prop is given", async () => {
+    const user = userEvent.setup();
+    render(
+      <AirfoilSelector
+        label="Root"
+        value="naca0015"
+        stats={STATS}
+      />,
+    );
+    // Open the dropdown
+    const trigger = screen.getByRole("button");
+    await user.click(trigger);
+
+    // Each airfoil row should show its stats value
+    expect(screen.getByText("0.85")).toBeDefined(); // e423
+    expect(screen.getByText("0.65")).toBeDefined(); // clark-y
+    expect(screen.getByText("0.45")).toBeDefined(); // naca0015
+  });
+
+  it("does NOT show stats when stats prop is not provided", async () => {
+    const user = userEvent.setup();
+    render(<AirfoilSelector label="Root" value="naca0015" />);
+
+    const trigger = screen.getByRole("button");
+    await user.click(trigger);
+
+    // No numeric score text
+    expect(screen.queryByText("0.85")).toBeNull();
+  });
+
+  it("sorts rows by score desc when sortedNames prop provided", async () => {
+    const user = userEvent.setup();
+    // sortedNames: e423 (0.85) first, then clark-y (0.65), then naca0015 (0.45)
+    const sortedNames = ["e423", "clark-y", "naca0015"];
+    const { container } = render(
+      <AirfoilSelector
+        label="Root"
+        value="naca0015"
+        stats={STATS}
+        sortedNames={sortedNames}
+      />,
+    );
+
+    // The trigger button is the first button in the component (before dropdown opens)
+    const buttons = screen.getAllByRole("button");
+    // The first button (without the suitabilityToggle) is the dropdown trigger
+    const triggerBtn = buttons[0];
+    await user.click(triggerBtn);
+
+    // After opening, look for the dropdown list
+    const dropdownContainer = container.querySelector('[class*="max-h"]');
+    expect(dropdownContainer).not.toBeNull();
+
+    if (dropdownContainer) {
+      // Get all the airfoil name spans in the dropdown (inside list item buttons)
+      const listButtons = dropdownContainer.querySelectorAll('button');
+      const texts = Array.from(listButtons)
+        .map((btn) => {
+          const nameSpan = btn.querySelector('span[class*="jetbrains"]');
+          return nameSpan?.textContent ?? "";
+        })
+        .filter((t) => ["e423", "clark-y", "naca0015"].includes(t));
+      // First item should be e423 (highest score)
+      expect(texts[0]).toBe("e423");
+    }
+  });
+
+  it("renders 'Passende finden' toggle button when suitabilityToggle is provided", async () => {
+    const onToggle = vi.fn();
+    render(
+      <AirfoilSelector
+        label="Root"
+        value="naca0015"
+        stats={STATS}
+        suitabilityToggle={{ active: false, onToggle }}
+      />,
+    );
+
+    // The button should be visible even before opening dropdown
+    expect(screen.getByTitle(/Passende finden/i)).toBeDefined();
+  });
+
+  it("calls onToggle when 'Passende finden' button is clicked", async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+    render(
+      <AirfoilSelector
+        label="Root"
+        value="naca0015"
+        stats={STATS}
+        suitabilityToggle={{ active: false, onToggle }}
+      />,
+    );
+
+    const findBtn = screen.getByTitle(/Passende finden/i);
+    await user.click(findBtn);
+    expect(onToggle).toHaveBeenCalledOnce();
+  });
+
+  it("shows ranked mode active styling when suitabilityToggle.active is true", () => {
+    render(
+      <AirfoilSelector
+        label="Root"
+        value="naca0015"
+        stats={STATS}
+        suitabilityToggle={{ active: true, onToggle: vi.fn() }}
+      />,
+    );
+
+    const findBtn = screen.getByTitle(/Passende finden/i);
+    // Active state — should have primary/accent styling
+    expect(findBtn.className).toMatch(/primary|text-primary|text-\[#FF8400\]/);
+  });
+});

--- a/frontend/__tests__/AirfoilSuitabilityCard.test.tsx
+++ b/frontend/__tests__/AirfoilSuitabilityCard.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for AirfoilSuitabilityCard (gh-822).
+ * Verifies: three lens bars, null handling, confidence chip, caveat callout,
+ * collapsible behaviour.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+// Mock lucide-react icons
+vi.mock("lucide-react", () => ({
+  ChevronDown: (p: Record<string, unknown>) => (
+    <svg data-testid="chevron-down" {...p} />
+  ),
+  ChevronRight: (p: Record<string, unknown>) => (
+    <svg data-testid="chevron-right" {...p} />
+  ),
+  AlertTriangle: (p: Record<string, unknown>) => (
+    <svg data-testid="alert-triangle" {...p} />
+  ),
+  Info: (p: Record<string, unknown>) => <svg data-testid="info" {...p} />,
+  Activity: (p: Record<string, unknown>) => (
+    <svg data-testid="activity" {...p} />
+  ),
+}));
+
+import { AirfoilSuitabilityCard } from "../components/workbench/AirfoilSuitabilityCard";
+import type { SuitabilityItem } from "../hooks/useAirfoilSuitability";
+
+const baseItem: SuitabilityItem = {
+  airfoil_name: "e423",
+  family: "cambered",
+  re_agnostic: 0.82,
+  mission: 0.75,
+  target_cl_cruise: 0.68,
+  target_cl_loiter: 0.55,
+  min_analysis_confidence: 0.92,
+  tip_re_flag: false,
+  caveat: "Nur relative Rangfolge.",
+};
+
+const lowConfidenceItem: SuitabilityItem = {
+  ...baseItem,
+  min_analysis_confidence: 0.72,
+};
+
+const nullMissionItem: SuitabilityItem = {
+  ...baseItem,
+  mission: null,
+  target_cl_loiter: null,
+};
+
+describe("AirfoilSuitabilityCard", () => {
+  it("renders Re-agnostisch bar", () => {
+    render(<AirfoilSuitabilityCard item={baseItem} defaultOpen />);
+    expect(
+      screen.getByText(/Re-agnostisch/i),
+    ).toBeDefined();
+  });
+
+  it("renders Mission bar with score", () => {
+    render(<AirfoilSuitabilityCard item={baseItem} defaultOpen />);
+    expect(screen.getByText(/Mission/i)).toBeDefined();
+  });
+
+  it("renders Ziel-CL Cruise bar", () => {
+    render(<AirfoilSuitabilityCard item={baseItem} defaultOpen />);
+    expect(screen.getByText(/Cruise/i)).toBeDefined();
+  });
+
+  it("renders Ziel-CL Loiter bar", () => {
+    render(<AirfoilSuitabilityCard item={baseItem} defaultOpen />);
+    expect(screen.getByText(/Loiter/i)).toBeDefined();
+  });
+
+  it("hides Mission bar or shows n/a when mission score is null", () => {
+    render(<AirfoilSuitabilityCard item={nullMissionItem} defaultOpen />);
+    // When mission is null, it should either not render the bar or show 'n/a'
+    const missionBars = screen.queryAllByText(/Mission/i);
+    if (missionBars.length > 0) {
+      // If the bar label is still there, the value should be n/a (may be multiple)
+      const naElements = screen.queryAllByText(/n\/a/i);
+      expect(naElements.length).toBeGreaterThan(0);
+    }
+    // Otherwise it's hidden — both are valid per spec
+  });
+
+  it("hides Loiter bar or shows n/a when target_cl_loiter score is null", () => {
+    render(<AirfoilSuitabilityCard item={nullMissionItem} defaultOpen />);
+    const loiterBars = screen.queryAllByText(/Loiter/i);
+    if (loiterBars.length > 0) {
+      const naElements = screen.queryAllByText(/n\/a/i);
+      expect(naElements.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("shows green color class for score >= 0.7", () => {
+    const { container } = render(
+      <AirfoilSuitabilityCard item={baseItem} defaultOpen />,
+    );
+    // re_agnostic = 0.82 (green), mission = 0.75 (green)
+    // jsdom renders inline styles as rgb(), check for the rgb equivalent of #34D399
+    // or the hex value in background-color style
+    const html = container.innerHTML;
+    // Either hex or rgb(52, 211, 153) for #34D399
+    expect(
+      html.includes("34D399") || html.includes("rgb(52, 211, 153)")
+    ).toBe(true);
+  });
+
+  it("shows amber color class for score 0.4-0.7", () => {
+    const amberItem: SuitabilityItem = {
+      ...baseItem,
+      re_agnostic: 0.55,
+      mission: 0.45,
+    };
+    const { container } = render(
+      <AirfoilSuitabilityCard item={amberItem} defaultOpen />,
+    );
+    // #FBBF24 = rgb(251, 191, 36)
+    const html = container.innerHTML;
+    expect(
+      html.includes("FBBF24") || html.includes("rgb(251, 191, 36)")
+    ).toBe(true);
+  });
+
+  it("shows red color class for score < 0.4", () => {
+    const redItem: SuitabilityItem = {
+      ...baseItem,
+      re_agnostic: 0.25,
+    };
+    const { container } = render(
+      <AirfoilSuitabilityCard item={redItem} defaultOpen />,
+    );
+    // #F87171 = rgb(248, 113, 113)
+    const html = container.innerHTML;
+    expect(
+      html.includes("F87171") || html.includes("rgb(248, 113, 113)")
+    ).toBe(true);
+  });
+
+  it("shows confidence chip in normal state when confidence >= 0.85", () => {
+    render(<AirfoilSuitabilityCard item={baseItem} defaultOpen />);
+    // Should show confidence value (0.92)
+    expect(screen.getByText(/0\.9\d/)).toBeDefined();
+  });
+
+  it("shows confidence chip amber styling when min_analysis_confidence < 0.85", () => {
+    const { container } = render(
+      <AirfoilSuitabilityCard item={lowConfidenceItem} defaultOpen />,
+    );
+    // Amber color should be present in the confidence chip
+    // #FBBF24 = rgb(251, 191, 36)
+    const html = container.innerHTML;
+    expect(
+      html.includes("FBBF24") || html.includes("rgb(251, 191, 36)")
+    ).toBe(true);
+  });
+
+  it("shows caveat callout text", () => {
+    render(<AirfoilSuitabilityCard item={baseItem} defaultOpen />);
+    expect(screen.getByText(/Nur relative Rangfolge/)).toBeDefined();
+  });
+
+  it("is collapsed by default when defaultOpen is false", () => {
+    render(<AirfoilSuitabilityCard item={baseItem} defaultOpen={false} />);
+    // When collapsed, the Re-agnostisch bar should NOT be visible
+    expect(screen.queryByText(/Re-agnostisch/i)).toBeNull();
+  });
+
+  it("shows ChevronRight when collapsed", () => {
+    render(<AirfoilSuitabilityCard item={baseItem} defaultOpen={false} />);
+    expect(screen.getByTestId("chevron-right")).toBeDefined();
+  });
+
+  it("shows ChevronDown when open", () => {
+    render(<AirfoilSuitabilityCard item={baseItem} defaultOpen />);
+    expect(screen.getByTestId("chevron-down")).toBeDefined();
+  });
+
+  it("expands when toggle is clicked while collapsed", async () => {
+    const user = userEvent.setup();
+    render(<AirfoilSuitabilityCard item={baseItem} defaultOpen={false} />);
+    expect(screen.queryByText(/Re-agnostisch/i)).toBeNull();
+
+    const toggle = screen.getByRole("button");
+    await user.click(toggle);
+
+    expect(screen.getByText(/Re-agnostisch/i)).toBeDefined();
+  });
+
+  it("collapses when toggle is clicked while open", async () => {
+    const user = userEvent.setup();
+    render(<AirfoilSuitabilityCard item={baseItem} defaultOpen />);
+    expect(screen.getByText(/Re-agnostisch/i)).toBeDefined();
+
+    const toggle = screen.getByRole("button");
+    await user.click(toggle);
+
+    expect(screen.queryByText(/Re-agnostisch/i)).toBeNull();
+  });
+});

--- a/frontend/__tests__/AirfoilSuitabilityCard.test.tsx
+++ b/frontend/__tests__/AirfoilSuitabilityCard.test.tsx
@@ -25,7 +25,7 @@ vi.mock("lucide-react", () => ({
   ),
 }));
 
-import { AirfoilSuitabilityCard } from "../components/workbench/AirfoilSuitabilityCard";
+import { AirfoilSuitabilityCard, AirfoilSuitabilityNoData, qualitativeLabel } from "../components/workbench/AirfoilSuitabilityCard";
 import type { SuitabilityItem } from "../hooks/useAirfoilSuitability";
 
 const baseItem: SuitabilityItem = {
@@ -199,5 +199,113 @@ describe("AirfoilSuitabilityCard", () => {
     await user.click(toggle);
 
     expect(screen.queryByText(/Re-agnostisch/i)).toBeNull();
+  });
+
+  // ── Issue #1: Confidence chip overflow fix ─────────────────────
+  it("confidence chip is rendered inside the button (not overflowing header row)", () => {
+    render(<AirfoilSuitabilityCard item={baseItem} defaultOpen />);
+    // The chip now lives in its own sub-row (pl-4 wrapper) inside the toggle button.
+    // It must still be present and not overflow the 480px panel.
+    // We verify the chip text is present at all.
+    expect(screen.getByText(/Konfidenz 0\.92/i)).toBeDefined();
+  });
+
+  it("confidence chip text contains the confidence value", () => {
+    render(<AirfoilSuitabilityCard item={lowConfidenceItem} defaultOpen />);
+    expect(screen.getByText(/Konfidenz 0\.72/i)).toBeDefined();
+  });
+
+  it("confidence chip has a tooltip (title) explaining the value", () => {
+    render(<AirfoilSuitabilityCard item={baseItem} defaultOpen />);
+    const chip = screen.getByText(/Konfidenz 0\.92/i);
+    const title = chip.getAttribute("title");
+    expect(title).toBeTruthy();
+    expect(title).toMatch(/Konfidenz|Modell|Re/i);
+  });
+
+  // ── Issue #3: No-data placeholder ─────────────────────────────
+  it("AirfoilSuitabilityNoData renders placeholder text without airfoilName", () => {
+    render(<AirfoilSuitabilityNoData />);
+    expect(screen.getByTestId("suitability-no-data")).toBeDefined();
+    expect(screen.getByText(/Keine Low-Re-Eignungsdaten/i)).toBeDefined();
+  });
+
+  it("AirfoilSuitabilityNoData renders airfoil name when provided", () => {
+    render(<AirfoilSuitabilityNoData airfoilName="rae2822" />);
+    expect(screen.getByText(/rae2822/i)).toBeDefined();
+  });
+
+  // ── Issue #4a: Qualitative labels ─────────────────────────────
+  describe("qualitativeLabel (exported)", () => {
+    it("returns 'Gut' for score >= 0.75", () => {
+      expect(qualitativeLabel(0.75)).toBe("Gut");
+      expect(qualitativeLabel(1.0)).toBe("Gut");
+      expect(qualitativeLabel(0.85)).toBe("Gut");
+    });
+
+    it("returns 'Mäßig' for score >= 0.5 and < 0.75", () => {
+      expect(qualitativeLabel(0.5)).toBe("Mäßig");
+      expect(qualitativeLabel(0.6)).toBe("Mäßig");
+      expect(qualitativeLabel(0.74)).toBe("Mäßig");
+    });
+
+    it("returns 'Schwach' for score < 0.5", () => {
+      expect(qualitativeLabel(0.49)).toBe("Schwach");
+      expect(qualitativeLabel(0.0)).toBe("Schwach");
+      expect(qualitativeLabel(0.3)).toBe("Schwach");
+    });
+  });
+
+  it("renders qualitative label next to each score bar", () => {
+    render(<AirfoilSuitabilityCard item={baseItem} defaultOpen />);
+    // re_agnostic = 0.82 → "Gut"
+    // mission = 0.75 → "Gut"
+    const labels = screen.getAllByTestId("qualitative-label");
+    expect(labels.length).toBeGreaterThan(0);
+    // At least one "Gut" label visible (re_agnostic=0.82)
+    const gutLabels = labels.filter((el) => el.textContent === "Gut");
+    expect(gutLabels.length).toBeGreaterThan(0);
+  });
+
+  it("renders 'Mäßig' qualitative label for mid-range scores", () => {
+    const midItem: SuitabilityItem = {
+      ...baseItem,
+      re_agnostic: 0.6,
+      mission: 0.55,
+      target_cl_cruise: 0.52,
+      target_cl_loiter: 0.51,
+    };
+    render(<AirfoilSuitabilityCard item={midItem} defaultOpen />);
+    const labels = screen.getAllByTestId("qualitative-label");
+    const masigLabels = labels.filter((el) => el.textContent === "Mäßig");
+    expect(masigLabels.length).toBeGreaterThan(0);
+  });
+
+  it("renders 'Schwach' qualitative label for low scores", () => {
+    const weakItem: SuitabilityItem = {
+      ...baseItem,
+      re_agnostic: 0.25,
+      mission: 0.3,
+      target_cl_cruise: 0.2,
+      target_cl_loiter: 0.1,
+    };
+    render(<AirfoilSuitabilityCard item={weakItem} defaultOpen />);
+    const labels = screen.getAllByTestId("qualitative-label");
+    const schwachLabels = labels.filter((el) => el.textContent === "Schwach");
+    expect(schwachLabels.length).toBeGreaterThan(0);
+  });
+
+  // ── Issue #4b: Softer low-confidence caveat ──────────────────
+  it("shows softened caveat when confidence is low (<0.85)", () => {
+    render(<AirfoilSuitabilityCard item={lowConfidenceItem} defaultOpen />);
+    // The CaveatCallout should include the hobbyist-friendly low-confidence prefix
+    expect(screen.getByRole("note").textContent).toMatch(/Geringe Modell-Konfidenz|grobe Orientierung/i);
+  });
+
+  it("does NOT show low-confidence prefix in caveat when confidence is high (>=0.85)", () => {
+    render(<AirfoilSuitabilityCard item={baseItem} defaultOpen />);
+    // baseItem confidence = 0.92 (high)
+    const note = screen.getByRole("note");
+    expect(note.textContent).not.toMatch(/Geringe Modell-Konfidenz/i);
   });
 });

--- a/frontend/__tests__/airfoilPreviewPage.coverage.test.tsx
+++ b/frontend/__tests__/airfoilPreviewPage.coverage.test.tsx
@@ -1,0 +1,592 @@
+/**
+ * Coverage tests for airfoil-preview page.tsx and pure helpers (gh-822).
+ *
+ * Scope: airfoilShortName, page component rendering, ranked mode toggles,
+ * save/revert callbacks, segment navigation, velocity input interactions.
+ *
+ * Strategy: mock every Next.js / hook dependency; render the page in
+ * various states to exercise uncovered branches.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+// ── Pure helper tests (no mocks needed) ─────────────────────────
+
+import {
+  airfoilShortName,
+  activeLensScore,
+  computeRe,
+} from "@/app/workbench/airfoil-preview/page";
+
+describe("airfoilShortName — pure helper", () => {
+  it("strips .dat extension (case-insensitive)", () => {
+    expect(airfoilShortName("e423.dat")).toBe("e423");
+    expect(airfoilShortName("naca0015.DAT")).toBe("naca0015");
+  });
+
+  it("strips path prefix before .dat", () => {
+    expect(airfoilShortName("UIUC/e423.dat")).toBe("e423");
+  });
+
+  it("handles deep path prefix", () => {
+    expect(airfoilShortName("data/airfoils/clark-y.dat")).toBe("clark-y");
+  });
+
+  it("leaves plain name without extension unchanged", () => {
+    expect(airfoilShortName("naca0012")).toBe("naca0012");
+  });
+
+  it("handles empty string gracefully", () => {
+    expect(airfoilShortName("")).toBe("");
+  });
+});
+
+describe("activeLensScore — edge cases", () => {
+  const item = {
+    re_agnostic: 0.8,
+    mission: null as number | null,
+    target_cl_cruise: null as number | null,
+    target_cl_loiter: null as number | null,
+  };
+
+  it("falls back to re_agnostic when mission is null", () => {
+    expect(activeLensScore({ ...item, mission: null }, "mission")).toBe(0.8);
+  });
+
+  it("falls back to re_agnostic when target_cl_cruise is null", () => {
+    expect(activeLensScore({ ...item, target_cl_cruise: null }, "target_cl_cruise")).toBe(0.8);
+  });
+
+  it("uses re_agnostic for unknown lens string", () => {
+    expect(activeLensScore(item, "unknown_lens")).toBe(0.8);
+  });
+});
+
+describe("computeRe — edge cases", () => {
+  it("returns 0 when velocity is 0", () => {
+    expect(computeRe(0, 200)).toBe(0);
+  });
+
+  it("returns 0 when chord is 0", () => {
+    expect(computeRe(14, 0)).toBe(0);
+  });
+
+  it("scales linearly with velocity", () => {
+    const re1 = computeRe(14, 200);
+    const re2 = computeRe(28, 200);
+    expect(re2 / re1).toBeCloseTo(2, 0);
+  });
+});
+
+// ── Page component tests ──────────────────────────────────────────
+
+// Mocks must be defined before imports
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const mockSelectXsec = vi.fn();
+let mockAeroplaneId: string | null = null;
+let mockSelectedWing: string | null = null;
+let mockSelectedXsecIndex: number | null = 0;
+
+vi.mock("@/components/workbench/AeroplaneContext", () => ({
+  useAeroplaneContext: () => ({
+    aeroplaneId: mockAeroplaneId,
+    selectedWing: mockSelectedWing,
+    selectedXsecIndex: mockSelectedXsecIndex,
+    selectXsec: mockSelectXsec,
+  }),
+}));
+
+const mockSaveWingConfig = vi.fn();
+let mockWingConfig: Record<string, unknown> | null = null;
+
+vi.mock("@/hooks/useWingConfig", () => ({
+  useWingConfig: () => ({
+    wingConfig: mockWingConfig,
+    saveWingConfig: mockSaveWingConfig,
+  }),
+}));
+
+vi.mock("@/hooks/useAirfoilGeometry", () => ({
+  useAirfoilGeometry: () => ({
+    geometry: null,
+    isLoading: false,
+    error: null,
+  }),
+  interpolateY: () => null,
+}));
+
+const mockRun = vi.fn();
+const mockClear = vi.fn();
+let mockAnalysisResult: Record<string, unknown> | null = null;
+
+vi.mock("@/hooks/useAirfoilAnalysis", () => ({
+  useAirfoilAnalysis: () => ({
+    result: mockAnalysisResult,
+    isRunning: false,
+    error: null,
+    run: mockRun,
+    clear: mockClear,
+  }),
+}));
+
+let mockSuitabilityData: Record<string, unknown> | null = null;
+
+vi.mock("@/hooks/useAirfoilSuitability", () => ({
+  useAirfoilSuitability: () => ({
+    data: mockSuitabilityData,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+// Stub child panels to pure pass-through to avoid deep rendering
+vi.mock("@/components/workbench/AirfoilPreviewViewerPanel", () => ({
+  AirfoilPreviewViewerPanel: (props: Record<string, unknown>) => (
+    <div
+      data-testid="viewer-panel"
+      data-root-airfoil={props.rootAirfoilName as string}
+      data-tip-airfoil={props.tipAirfoilName as string ?? ""}
+      data-operating-alpha={props.operatingAlphaDeg as number ?? ""}
+    />
+  ),
+}));
+
+vi.mock("@/components/workbench/AirfoilPreviewConfigPanel", () => ({
+  AirfoilPreviewConfigPanel: (props: Record<string, unknown>) => (
+    <div
+      data-testid="config-panel"
+      data-root-airfoil={props.rootAirfoil as string}
+      data-tip-airfoil={props.tipAirfoil as string}
+      data-root-ranked-mode={String(props.rootRankedMode)}
+      data-tip-ranked-mode={String(props.tipRankedMode)}
+    >
+      <button
+        data-testid="trigger-back"
+        onClick={() => (props.onBack as () => void)?.()}
+      >
+        back
+      </button>
+      <button
+        data-testid="trigger-save"
+        onClick={() => (props.onSave as () => void)?.()}
+      >
+        save
+      </button>
+      <button
+        data-testid="trigger-revert"
+        onClick={() => (props.onRevert as () => void)?.()}
+      >
+        revert
+      </button>
+      <button
+        data-testid="trigger-root-ranked"
+        onClick={() => (props.onRootRankedModeToggle as () => void)?.()}
+      >
+        root-ranked
+      </button>
+      <button
+        data-testid="trigger-tip-ranked"
+        onClick={() => (props.onTipRankedModeToggle as () => void)?.()}
+      >
+        tip-ranked
+      </button>
+      <button
+        data-testid="trigger-segment-change"
+        onClick={() => (props.onSegmentChange as (i: number) => void)?.(1)}
+      >
+        seg-change
+      </button>
+      <button
+        data-testid="trigger-root-airfoil-change"
+        onClick={() => (props.onRootAirfoilChange as (n: string) => void)?.("clark-y")}
+      >
+        root-airfoil-change
+      </button>
+      <button
+        data-testid="trigger-tip-airfoil-change"
+        onClick={() => (props.onTipAirfoilChange as (n: string) => void)?.("naca0012")}
+      >
+        tip-airfoil-change
+      </button>
+    </div>
+  ),
+}));
+
+import AirfoilPreviewPage from "@/app/workbench/airfoil-preview/page";
+
+describe("AirfoilPreviewPage — rendering and wiring (gh-822)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAeroplaneId = null;
+    mockSelectedWing = null;
+    mockSelectedXsecIndex = 0;
+    mockWingConfig = null;
+    mockSuitabilityData = null;
+    mockAnalysisResult = null;
+  });
+
+  it("renders both panels (viewer + config)", () => {
+    render(<AirfoilPreviewPage />);
+    expect(screen.getByTestId("viewer-panel")).toBeDefined();
+    expect(screen.getByTestId("config-panel")).toBeDefined();
+  });
+
+  it("defaults rootAirfoil to 'naca0015' when no wingConfig", () => {
+    render(<AirfoilPreviewPage />);
+    const config = screen.getByTestId("config-panel");
+    expect(config.dataset.rootAirfoil).toBe("naca0015");
+  });
+
+  it("reads rootAirfoil from wingConfig segment", () => {
+    mockWingConfig = {
+      segments: [
+        {
+          root_airfoil: { airfoil: "e423.dat", chord: 200 },
+          tip_airfoil: { airfoil: "clark-y.dat", chord: 150 },
+          length: 500,
+          sweep: 0,
+        },
+      ],
+    };
+    render(<AirfoilPreviewPage />);
+    const config = screen.getByTestId("config-panel");
+    // airfoilShortName strips ".dat"
+    expect(config.dataset.rootAirfoil).toBe("e423");
+    expect(config.dataset.tipAirfoil).toBe("clark-y");
+  });
+
+  it("back button calls router.push('/workbench')", async () => {
+    const user = userEvent.setup();
+    render(<AirfoilPreviewPage />);
+    await user.click(screen.getByTestId("trigger-back"));
+    expect(mockPush).toHaveBeenCalledWith("/workbench");
+  });
+
+  it("rootRankedMode toggles on rootRankedModeToggle click", async () => {
+    const user = userEvent.setup();
+    render(<AirfoilPreviewPage />);
+    const config = screen.getByTestId("config-panel");
+    expect(config.dataset.rootRankedMode).toBe("false");
+
+    await user.click(screen.getByTestId("trigger-root-ranked"));
+    expect(screen.getByTestId("config-panel").dataset.rootRankedMode).toBe("true");
+
+    await user.click(screen.getByTestId("trigger-root-ranked"));
+    expect(screen.getByTestId("config-panel").dataset.rootRankedMode).toBe("false");
+  });
+
+  it("tipRankedMode toggles on tipRankedModeToggle click", async () => {
+    const user = userEvent.setup();
+    render(<AirfoilPreviewPage />);
+    await user.click(screen.getByTestId("trigger-tip-ranked"));
+    expect(screen.getByTestId("config-panel").dataset.tipRankedMode).toBe("true");
+  });
+
+  it("root airfoil change updates the displayed root airfoil", async () => {
+    const user = userEvent.setup();
+    render(<AirfoilPreviewPage />);
+    await user.click(screen.getByTestId("trigger-root-airfoil-change"));
+    expect(screen.getByTestId("config-panel").dataset.rootAirfoil).toBe("clark-y");
+  });
+
+  it("tip airfoil change updates the displayed tip airfoil", async () => {
+    const user = userEvent.setup();
+    render(<AirfoilPreviewPage />);
+    await user.click(screen.getByTestId("trigger-tip-airfoil-change"));
+    expect(screen.getByTestId("config-panel").dataset.tipAirfoil).toBe("naca0012");
+  });
+
+  it("segment change calls selectXsec", async () => {
+    const user = userEvent.setup();
+    render(<AirfoilPreviewPage />);
+    await user.click(screen.getByTestId("trigger-segment-change"));
+    expect(mockSelectXsec).toHaveBeenCalledWith(1);
+  });
+
+  it("save calls saveWingConfig when wingConfig and segment are present", async () => {
+    mockWingConfig = {
+      segments: [
+        {
+          root_airfoil: { airfoil: "e423.dat", chord: 200 },
+          tip_airfoil: { airfoil: "clark-y.dat", chord: 150 },
+          length: 500,
+          sweep: 0,
+        },
+      ],
+    };
+    mockSaveWingConfig.mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    render(<AirfoilPreviewPage />);
+    await user.click(screen.getByTestId("trigger-save"));
+    expect(mockSaveWingConfig).toHaveBeenCalled();
+  });
+
+  it("save is a no-op when wingConfig is null", async () => {
+    mockWingConfig = null;
+    const user = userEvent.setup();
+    render(<AirfoilPreviewPage />);
+    await user.click(screen.getByTestId("trigger-save"));
+    expect(mockSaveWingConfig).not.toHaveBeenCalled();
+  });
+
+  it("revert restores naca0015 defaults when wingConfig is null", async () => {
+    const user = userEvent.setup();
+    render(<AirfoilPreviewPage />);
+    // Change to clark-y
+    await user.click(screen.getByTestId("trigger-root-airfoil-change"));
+    expect(screen.getByTestId("config-panel").dataset.rootAirfoil).toBe("clark-y");
+    // Revert
+    await user.click(screen.getByTestId("trigger-revert"));
+    expect(screen.getByTestId("config-panel").dataset.rootAirfoil).toBe("naca0015");
+  });
+
+  it("suitabilityData present: rootScoreMap passed as defined", () => {
+    mockSuitabilityData = {
+      query: { active_lens: "re_agnostic" },
+      results: [
+        {
+          airfoil_name: "e423",
+          re_agnostic: 0.82,
+          mission: null,
+          target_cl_cruise: null,
+          target_cl_loiter: null,
+          min_analysis_confidence: 0.9,
+          tip_re_flag: false,
+          caveat: "",
+        },
+      ],
+    };
+    // Render and assert rootRankedMode is false (scores but not ranked)
+    render(<AirfoilPreviewPage />);
+    const config = screen.getByTestId("config-panel");
+    expect(config.dataset.rootRankedMode).toBe("false");
+  });
+
+  it("renders with aeroplane_id from context", () => {
+    mockAeroplaneId = "test-uuid-1234";
+    render(<AirfoilPreviewPage />);
+    // Should render without crash
+    expect(screen.getByTestId("viewer-panel")).toBeDefined();
+  });
+
+  it("airfoilShortName strips path prefix from UIUC path in segment", () => {
+    mockWingConfig = {
+      segments: [
+        {
+          root_airfoil: { airfoil: "UIUC/e423.dat", chord: 200 },
+          tip_airfoil: { airfoil: "UIUC/clark-y.dat", chord: 150 },
+          length: 500,
+          sweep: 0,
+        },
+      ],
+    };
+    render(<AirfoilPreviewPage />);
+    const config = screen.getByTestId("config-panel");
+    expect(config.dataset.rootAirfoil).toBe("e423");
+    expect(config.dataset.tipAirfoil).toBe("clark-y");
+  });
+
+  it("uses root airfoil as tip when tip_airfoil is missing from segment", () => {
+    mockWingConfig = {
+      segments: [
+        {
+          root_airfoil: { airfoil: "naca2412.dat", chord: 200 },
+          // tip_airfoil intentionally missing — triggers the fallback
+          length: 500,
+          sweep: 0,
+        },
+      ],
+    };
+    render(<AirfoilPreviewPage />);
+    const config = screen.getByTestId("config-panel");
+    expect(config.dataset.rootAirfoil).toBe("naca2412");
+    // tip falls back to root
+    expect(config.dataset.tipAirfoil).toBe("naca2412");
+  });
+
+  it("viewer panel receives null tipAirfoilName when root and tip are the same", () => {
+    render(<AirfoilPreviewPage />);
+    // Default: root=naca0015, tip=naca0015 (same → hasTip=false → tipAirfoilName=null)
+    const viewer = screen.getByTestId("viewer-panel");
+    expect(viewer.dataset.tipAirfoil).toBe("");
+  });
+
+  it("viewer panel receives tipAirfoilName when root and tip differ", async () => {
+    const user = userEvent.setup();
+    render(<AirfoilPreviewPage />);
+    // Change tip to a different airfoil
+    await user.click(screen.getByTestId("trigger-tip-airfoil-change"));
+    const viewer = screen.getByTestId("viewer-panel");
+    expect(viewer.dataset.tipAirfoil).toBe("naca0012");
+  });
+
+  it("activeLensScore: mission lens with non-null value uses mission score", () => {
+    // Test through activeLensScore export (already covered in helpers, extra coverage)
+    const item = {
+      re_agnostic: 0.5,
+      mission: 0.9,
+      target_cl_cruise: 0.6,
+      target_cl_loiter: 0.4,
+    };
+    expect(activeLensScore(item, "mission")).toBe(0.9);
+    expect(activeLensScore(item, "target_cl_cruise")).toBe(0.6);
+    expect(activeLensScore(item, "re_agnostic")).toBe(0.5);
+  });
+
+  it("rootOperatingAlpha is computed when analysis result + target_cl_cruise are both non-null", () => {
+    // Cover lines 144-160: rootOperatingAlpha useMemo with valid analysis + suitability
+    mockAnalysisResult = {
+      airfoilName: "e423",
+      alphaDeg: [-5, 0, 5, 10, 15],
+      cl: [-0.2, 0.1, 0.5, 0.9, 1.2],
+      cd: [0.015, 0.01, 0.012, 0.02, 0.04],
+      cm: [-0.02, -0.01, -0.01, -0.02, -0.03],
+      clOverCd: [-13.3, 10, 41.7, 45, 30],
+      clMax: 1.2,
+      alphaAtClMax: 15,
+      ldMax: 45,
+      alphaAtLdMax: 10,
+    };
+    mockSuitabilityData = {
+      query: { active_lens: "target_cl_cruise" },
+      results: [
+        {
+          airfoil_name: "naca0015",
+          re_agnostic: 0.75,
+          mission: null,
+          target_cl_cruise: 0.5,  // matches cl[2]=0.5 → α=5°
+          target_cl_loiter: null,
+          min_analysis_confidence: 0.9,
+          tip_re_flag: false,
+          caveat: "",
+        },
+      ],
+    };
+    render(<AirfoilPreviewPage />);
+    // The page should render without crash; the viewer panel receives operatingAlphaDeg
+    const viewer = screen.getByTestId("viewer-panel");
+    // operatingAlphaDeg should be 5 (index 2 matches cl=0.5)
+    expect(viewer.dataset.operatingAlpha).toBe("5");
+  });
+
+  it("rootOperatingAlpha is undefined when rootSuitabilityItem has null target_cl_cruise", () => {
+    mockAnalysisResult = {
+      airfoilName: "naca0015",
+      alphaDeg: [0, 5, 10],
+      cl: [0.1, 0.5, 0.9],
+      cd: [0.01, 0.012, 0.02],
+      cm: [-0.01, -0.01, -0.02],
+      clOverCd: [10, 41.7, 45],
+      clMax: null,
+      alphaAtClMax: null,
+      ldMax: null,
+      alphaAtLdMax: null,
+    };
+    mockSuitabilityData = {
+      query: { active_lens: "re_agnostic" },
+      results: [
+        {
+          airfoil_name: "naca0015",
+          re_agnostic: 0.75,
+          mission: null,
+          target_cl_cruise: null,  // null → no operating alpha
+          target_cl_loiter: null,
+          min_analysis_confidence: 0.9,
+          tip_re_flag: false,
+          caveat: "",
+        },
+      ],
+    };
+    render(<AirfoilPreviewPage />);
+    // operatingAlphaDeg should be empty string (undefined passed to dataset)
+    const viewer = screen.getByTestId("viewer-panel");
+    expect(viewer.dataset.operatingAlpha).toBe("");
+  });
+
+  it("rootOperatingAlpha: covers the loop iteration (lines 151-158) to find closest CL index", () => {
+    // Tests the inner loop by using a target CL that matches a non-zero index
+    mockAnalysisResult = {
+      airfoilName: "naca0015",
+      alphaDeg: [0, 5, 10, 15, 20],
+      cl: [0.1, 0.3, 0.7, 1.0, 1.2],
+      cd: [0.01, 0.012, 0.018, 0.025, 0.04],
+      cm: [-0.01, -0.01, -0.015, -0.02, -0.025],
+      clOverCd: [10, 25, 38, 40, 30],
+      clMax: 1.2,
+      alphaAtClMax: 20,
+      ldMax: 40,
+      alphaAtLdMax: 15,
+    };
+    mockSuitabilityData = {
+      query: { active_lens: "target_cl_cruise" },
+      results: [
+        {
+          airfoil_name: "naca0015",
+          re_agnostic: 0.78,
+          mission: null,
+          target_cl_cruise: 0.68,  // closest to cl[2]=0.7 → α=10°
+          target_cl_loiter: null,
+          min_analysis_confidence: 0.9,
+          tip_re_flag: false,
+          caveat: "",
+        },
+      ],
+    };
+    render(<AirfoilPreviewPage />);
+    const viewer = screen.getByTestId("viewer-panel");
+    // Should find α=10 as closest to CL=0.68
+    expect(viewer.dataset.operatingAlpha).toBe("10");
+  });
+
+  it("rootScoreMap built from suitabilityData with mission lens", () => {
+    mockSuitabilityData = {
+      query: { active_lens: "mission" },
+      results: [
+        {
+          airfoil_name: "e423",
+          re_agnostic: 0.82,
+          mission: 0.90,
+          target_cl_cruise: 0.70,
+          target_cl_loiter: 0.55,
+          min_analysis_confidence: 0.92,
+          tip_re_flag: false,
+          caveat: "",
+        },
+      ],
+    };
+    // When rootRankedMode=false, rootScoreMap is undefined (scores not passed)
+    render(<AirfoilPreviewPage />);
+    // Just verify no crash
+    expect(screen.getByTestId("config-panel")).toBeDefined();
+  });
+
+  it("revert restores segment airfoils from wingConfig", async () => {
+    mockWingConfig = {
+      segments: [
+        {
+          root_airfoil: { airfoil: "e423.dat", chord: 200 },
+          tip_airfoil: { airfoil: "clark-y.dat", chord: 150 },
+          length: 500,
+          sweep: 0,
+        },
+      ],
+    };
+    const user = userEvent.setup();
+    render(<AirfoilPreviewPage />);
+    // Initially shows e423
+    expect(screen.getByTestId("config-panel").dataset.rootAirfoil).toBe("e423");
+    // Change root airfoil to something else
+    await user.click(screen.getByTestId("trigger-root-airfoil-change"));
+    expect(screen.getByTestId("config-panel").dataset.rootAirfoil).toBe("clark-y");
+    // Revert should restore e423
+    await user.click(screen.getByTestId("trigger-revert"));
+    expect(screen.getByTestId("config-panel").dataset.rootAirfoil).toBe("e423");
+  });
+});

--- a/frontend/__tests__/airfoilPreviewPage.helpers.test.ts
+++ b/frontend/__tests__/airfoilPreviewPage.helpers.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Unit tests for airfoil-preview page helper functions (gh-822).
+ * Tests activeLensScore and computeRe pure helpers in isolation.
+ */
+import { describe, it, expect } from "vitest";
+import { activeLensScore, computeRe } from "../app/workbench/airfoil-preview/page";
+
+const ITEM = {
+  re_agnostic: 0.80,
+  mission: 0.70,
+  target_cl_cruise: 0.60,
+  target_cl_loiter: 0.50,
+};
+
+describe("activeLensScore — active-lens badge helper (gh-822)", () => {
+  it("returns re_agnostic for lens 're_agnostic'", () => {
+    expect(activeLensScore(ITEM, "re_agnostic")).toBe(0.80);
+  });
+
+  it("returns re_agnostic for undefined lens (default)", () => {
+    expect(activeLensScore(ITEM, undefined)).toBe(0.80);
+  });
+
+  it("returns mission score for lens 'mission'", () => {
+    expect(activeLensScore(ITEM, "mission")).toBe(0.70);
+  });
+
+  it("falls back to re_agnostic when lens is 'mission' but mission is null", () => {
+    const item = { ...ITEM, mission: null };
+    expect(activeLensScore(item, "mission")).toBe(0.80);
+  });
+
+  it("returns target_cl_cruise score for lens 'target_cl_cruise'", () => {
+    expect(activeLensScore(ITEM, "target_cl_cruise")).toBe(0.60);
+  });
+
+  it("falls back to re_agnostic when lens is 'target_cl_cruise' but score is null", () => {
+    const item = { ...ITEM, target_cl_cruise: null };
+    expect(activeLensScore(item, "target_cl_cruise")).toBe(0.80);
+  });
+
+  it("returns re_agnostic for lens 'target_cl_loiter' (display-only, never ranking lens)", () => {
+    // target_cl_loiter is display-only; activeLensScore deliberately falls through to re_agnostic
+    expect(activeLensScore(ITEM, "target_cl_loiter")).toBe(0.80);
+  });
+
+  it("score badge matches the ranking order: mission badge uses mission score, not re_agnostic", () => {
+    // Regression guard: previous code hardcoded item.re_agnostic regardless of lens,
+    // causing the badge to mismatch the ranked order when mission/cruise lens is active.
+    const highMissionItem = { re_agnostic: 0.50, mission: 0.95, target_cl_cruise: null, target_cl_loiter: null };
+    expect(activeLensScore(highMissionItem, "mission")).toBe(0.95);
+    // must NOT return the lower re_agnostic value
+    expect(activeLensScore(highMissionItem, "mission")).not.toBe(0.50);
+  });
+});
+
+describe("computeRe — Reynolds number helper", () => {
+  it("computes correct Re for a given velocity and chord", () => {
+    // Re = V * c / nu = 14 * (200/1000) / 1.46e-5 ≈ 191781
+    const re = computeRe(14, 200);
+    expect(re).toBeGreaterThan(190000);
+    expect(re).toBeLessThan(195000);
+  });
+});

--- a/frontend/__tests__/useAirfoilSuitability.test.ts
+++ b/frontend/__tests__/useAirfoilSuitability.test.ts
@@ -136,6 +136,38 @@ describe("useAirfoilSuitability — query string construction", () => {
     const url = new URL(capturedKey!, "http://localhost");
     expect(url.searchParams.has("aeroplane_id")).toBe(false);
   });
+
+  it("appends limit when provided", () => {
+    renderHook(() =>
+      useAirfoilSuitability({ chord_m: 0.2, speed_ms: 14, limit: 20 }),
+    );
+    const url = new URL(capturedKey!, "http://localhost");
+    expect(url.searchParams.get("limit")).toBe("20");
+  });
+
+  it("does NOT append limit when not provided", () => {
+    renderHook(() =>
+      useAirfoilSuitability({ chord_m: 0.2, speed_ms: 14 }),
+    );
+    const url = new URL(capturedKey!, "http://localhost");
+    expect(url.searchParams.has("limit")).toBe(false);
+  });
+
+  it("appends tip_chord_m when provided", () => {
+    renderHook(() =>
+      useAirfoilSuitability({ chord_m: 0.2, speed_ms: 14, tip_chord_m: 0.15 }),
+    );
+    const url = new URL(capturedKey!, "http://localhost");
+    expect(url.searchParams.get("tip_chord_m")).toBe("0.15");
+  });
+
+  it("does NOT append tip_chord_m when not provided", () => {
+    renderHook(() =>
+      useAirfoilSuitability({ chord_m: 0.2, speed_ms: 14 }),
+    );
+    const url = new URL(capturedKey!, "http://localhost");
+    expect(url.searchParams.has("tip_chord_m")).toBe(false);
+  });
 });
 
 // ── Type-level tests for ActiveLens and RankingLens (gh-822) ────

--- a/frontend/__tests__/useAirfoilSuitability.test.ts
+++ b/frontend/__tests__/useAirfoilSuitability.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { useAirfoilSuitability } from "@/hooks/useAirfoilSuitability";
+import type { ActiveLens, RankingLens } from "@/hooks/useAirfoilSuitability";
 
 // ── Capture the SWR key ──────────────────────────────────────────
 let capturedKey: string | null = undefined as unknown as string | null;
@@ -134,5 +135,22 @@ describe("useAirfoilSuitability — query string construction", () => {
     );
     const url = new URL(capturedKey!, "http://localhost");
     expect(url.searchParams.has("aeroplane_id")).toBe(false);
+  });
+});
+
+// ── Type-level tests for ActiveLens and RankingLens (gh-822) ────
+describe("useAirfoilSuitability — ActiveLens and RankingLens types (gh-822)", () => {
+  it("ActiveLens includes 'target_cl_loiter' to match the backend verbatim", () => {
+    // This compiles only if 'target_cl_loiter' is a valid ActiveLens member
+    const lens: ActiveLens = "target_cl_loiter";
+    expect(lens).toBe("target_cl_loiter");
+  });
+
+  it("RankingLens excludes 'target_cl_loiter' (display-only, never ranking lens)", () => {
+    // All valid RankingLens values must compile; 'target_cl_loiter' must NOT be assignable
+    const lenses: RankingLens[] = ["re_agnostic", "mission", "target_cl_cruise"];
+    expect(lenses).toHaveLength(3);
+    // TypeScript would catch this at compile time; at runtime we verify the array excludes it
+    expect(lenses.includes("target_cl_loiter" as RankingLens)).toBe(false);
   });
 });

--- a/frontend/__tests__/useAirfoilSuitability.test.ts
+++ b/frontend/__tests__/useAirfoilSuitability.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for useAirfoilSuitability hook (gh-822).
+ * Verifies that the SWR query string is built correctly per the frozen contract.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useAirfoilSuitability } from "@/hooks/useAirfoilSuitability";
+
+// ── Capture the SWR key ──────────────────────────────────────────
+let capturedKey: string | null = undefined as unknown as string | null;
+
+vi.mock("swr", () => ({
+  default: vi.fn((key: string | null) => {
+    capturedKey = key;
+    return {
+      data: null,
+      error: null,
+      isLoading: false,
+    };
+  }),
+}));
+
+describe("useAirfoilSuitability — query string construction", () => {
+  beforeEach(() => {
+    capturedKey = undefined as unknown as string | null;
+  });
+
+  it("returns null key (no fetch) when chord_m is missing", () => {
+    renderHook(() =>
+      useAirfoilSuitability({ chord_m: undefined, speed_ms: 14 }),
+    );
+    expect(capturedKey).toBeNull();
+  });
+
+  it("returns null key (no fetch) when speed_ms is missing", () => {
+    renderHook(() =>
+      useAirfoilSuitability({ chord_m: 0.2, speed_ms: undefined }),
+    );
+    expect(capturedKey).toBeNull();
+  });
+
+  it("returns null key when both missing", () => {
+    renderHook(() =>
+      useAirfoilSuitability({ chord_m: undefined, speed_ms: undefined }),
+    );
+    expect(capturedKey).toBeNull();
+  });
+
+  it("builds key with chord_m and speed_ms only when no aeroplane_id", () => {
+    renderHook(() =>
+      useAirfoilSuitability({ chord_m: 0.2, speed_ms: 14 }),
+    );
+    expect(capturedKey).not.toBeNull();
+    const url = new URL(capturedKey!, "http://localhost");
+    expect(url.pathname).toBe("/airfoils/db/suitability");
+    expect(url.searchParams.get("chord_m")).toBe("0.2");
+    expect(url.searchParams.get("speed_ms")).toBe("14");
+    expect(url.searchParams.has("aeroplane_id")).toBe(false);
+  });
+
+  it("appends aeroplane_id as UUID string verbatim when aeroplane_id is present", () => {
+    const uuid = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+    renderHook(() =>
+      useAirfoilSuitability({ chord_m: 0.2, speed_ms: 14, aeroplane_id: uuid }),
+    );
+    const url = new URL(capturedKey!, "http://localhost");
+    expect(url.searchParams.get("aeroplane_id")).toBe(uuid);
+  });
+
+  it("appends mission_type when provided", () => {
+    renderHook(() =>
+      useAirfoilSuitability({
+        chord_m: 0.2,
+        speed_ms: 14,
+        mission_type: "trainer",
+      }),
+    );
+    const url = new URL(capturedKey!, "http://localhost");
+    expect(url.searchParams.get("mission_type")).toBe("trainer");
+  });
+
+  it("appends target_cl_cruise when provided", () => {
+    renderHook(() =>
+      useAirfoilSuitability({
+        chord_m: 0.2,
+        speed_ms: 14,
+        target_cl_cruise: 0.6,
+      }),
+    );
+    const url = new URL(capturedKey!, "http://localhost");
+    expect(url.searchParams.get("target_cl_cruise")).toBe("0.6");
+  });
+
+  it("appends target_cl_loiter when provided", () => {
+    renderHook(() =>
+      useAirfoilSuitability({
+        chord_m: 0.2,
+        speed_ms: 14,
+        target_cl_loiter: 0.9,
+      }),
+    );
+    const url = new URL(capturedKey!, "http://localhost");
+    expect(url.searchParams.get("target_cl_loiter")).toBe("0.9");
+  });
+
+  it("builds complete query string with all optional params", () => {
+    const uuid = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+    renderHook(() =>
+      useAirfoilSuitability({
+        chord_m: 0.3,
+        speed_ms: 18,
+        aeroplane_id: uuid,
+        mission_type: "sport",
+        target_cl_cruise: 0.7,
+        target_cl_loiter: 1.0,
+      }),
+    );
+    const url = new URL(capturedKey!, "http://localhost");
+    expect(url.searchParams.get("chord_m")).toBe("0.3");
+    expect(url.searchParams.get("speed_ms")).toBe("18");
+    expect(url.searchParams.get("aeroplane_id")).toBe(uuid);
+    expect(url.searchParams.get("mission_type")).toBe("sport");
+    expect(url.searchParams.get("target_cl_cruise")).toBe("0.7");
+    expect(url.searchParams.get("target_cl_loiter")).toBe("1");
+  });
+
+  // The spec says: appends aeroplane_id as the UUID string from
+  // useAeroplaneContext().aeroplaneId VERBATIM when present.
+  // Since the hook accepts aeroplane_id as a param (injected by the caller
+  // which uses useAeroplaneContext), the hook test verifies the verbatim pass-through.
+  it("does NOT add aeroplane_id when aeroplane_id is null", () => {
+    renderHook(() =>
+      useAirfoilSuitability({ chord_m: 0.2, speed_ms: 14, aeroplane_id: null }),
+    );
+    const url = new URL(capturedKey!, "http://localhost");
+    expect(url.searchParams.has("aeroplane_id")).toBe(false);
+  });
+});

--- a/frontend/app/workbench/airfoil-preview/page.tsx
+++ b/frontend/app/workbench/airfoil-preview/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
 import { useWingConfig } from "@/hooks/useWingConfig";
 import { useAirfoilGeometry } from "@/hooks/useAirfoilGeometry";
 import { useAirfoilAnalysis } from "@/hooks/useAirfoilAnalysis";
+import { useAirfoilSuitability } from "@/hooks/useAirfoilSuitability";
 import { AirfoilPreviewViewerPanel } from "@/components/workbench/AirfoilPreviewViewerPanel";
 import { AirfoilPreviewConfigPanel } from "@/components/workbench/AirfoilPreviewConfigPanel";
 
@@ -58,6 +59,84 @@ export default function AirfoilPreviewPage() {
   const tipGeo = useAirfoilGeometry(tipAirfoil === rootAirfoil ? null : tipAirfoil);
   const rootAnalysis = useAirfoilAnalysis();
   const tipAnalysis = useAirfoilAnalysis();
+
+  // gh-822: Suitability hooks (chord in metres = chordMm / 1000)
+  const [rootRankedMode, setRootRankedMode] = useState(false);
+  const [tipRankedMode, setTipRankedMode] = useState(false);
+
+  const rootSuitability = useAirfoilSuitability({
+    chord_m: rootChordMm / 1000,
+    speed_ms: velocity,
+    aeroplane_id: aeroplaneId,
+  });
+  const tipSuitability = useAirfoilSuitability({
+    chord_m: tipChordMm / 1000,
+    speed_ms: velocity,
+    aeroplane_id: aeroplaneId,
+  });
+
+  // Build lookup maps: airfoil name -> score string + sorted names
+  const rootScoreMap = useMemo((): Record<string, string> => {
+    if (!rootSuitability.data) return {};
+    return Object.fromEntries(
+      rootSuitability.data.results.map((item) => [
+        item.airfoil_name,
+        item.re_agnostic.toFixed(2),
+      ]),
+    );
+  }, [rootSuitability.data]);
+
+  const tipScoreMap = useMemo((): Record<string, string> => {
+    if (!tipSuitability.data) return {};
+    return Object.fromEntries(
+      tipSuitability.data.results.map((item) => [
+        item.airfoil_name,
+        item.re_agnostic.toFixed(2),
+      ]),
+    );
+  }, [tipSuitability.data]);
+
+  const rootSortedNames = useMemo(
+    () => rootSuitability.data?.results.map((item) => item.airfoil_name),
+    [rootSuitability.data],
+  );
+
+  const tipSortedNames = useMemo(
+    () => tipSuitability.data?.results.map((item) => item.airfoil_name),
+    [tipSuitability.data],
+  );
+
+  // Find the selected airfoil's suitability item
+  const rootSuitabilityItem = useMemo(
+    () => rootSuitability.data?.results.find((item) => item.airfoil_name === rootAirfoil) ?? null,
+    [rootSuitability.data, rootAirfoil],
+  );
+
+  const tipSuitabilityItem = useMemo(
+    () => tipSuitability.data?.results.find((item) => item.airfoil_name === tipAirfoil) ?? null,
+    [tipSuitability.data, tipAirfoil],
+  );
+
+  // gh-822: Compute operating alpha from operating CL via the L/D polar
+  // (find closest CL index in the analysis result)
+  const rootOperatingAlpha = useMemo((): number | undefined => {
+    if (!rootAnalysis.result) return undefined;
+    const targetCl = rootSuitabilityItem?.target_cl_cruise;
+    if (targetCl == null) return undefined;
+    const cls = rootAnalysis.result.cl;
+    let closestIdx = 0;
+    let closestDist = Math.abs((cls[0] ?? 0) - targetCl);
+    for (let i = 1; i < cls.length; i++) {
+      const v = cls[i];
+      if (v == null) continue;
+      const d = Math.abs(v - targetCl);
+      if (d < closestDist) {
+        closestDist = d;
+        closestIdx = i;
+      }
+    }
+    return rootAnalysis.result.alphaDeg[closestIdx];
+  }, [rootAnalysis.result, rootSuitabilityItem]);
 
   // Sync airfoils from segment when index or wingConfig changes
   useEffect(() => {
@@ -144,6 +223,7 @@ export default function AirfoilPreviewPage() {
           tipRe={hasTip ? tipRe : null}
           ma={ma}
           onMaChange={setMa}
+          operatingAlphaDeg={rootOperatingAlpha}
         />
       </div>
       <div className="shrink-0 overflow-hidden" style={{ width: 480 }}>
@@ -175,6 +255,16 @@ export default function AirfoilPreviewPage() {
           onSave={handleSave}
           onRevert={handleRevert}
           onBack={handleBack}
+          rootSuitabilityItem={rootSuitabilityItem ?? undefined}
+          tipSuitabilityItem={hasTip ? (tipSuitabilityItem ?? undefined) : undefined}
+          rootScoreMap={rootRankedMode ? rootScoreMap : undefined}
+          tipScoreMap={tipRankedMode ? tipScoreMap : undefined}
+          rootSortedNames={rootRankedMode ? rootSortedNames : undefined}
+          tipSortedNames={tipRankedMode ? tipSortedNames : undefined}
+          rootRankedMode={rootRankedMode}
+          onRootRankedModeToggle={() => setRootRankedMode((v) => !v)}
+          tipRankedMode={tipRankedMode}
+          onTipRankedModeToggle={() => setTipRankedMode((v) => !v)}
         />
       </div>
     </div>

--- a/frontend/app/workbench/airfoil-preview/page.tsx
+++ b/frontend/app/workbench/airfoil-preview/page.tsx
@@ -14,6 +14,25 @@ function airfoilShortName(raw: string): string {
   return (raw.split("/").pop() ?? raw).replace(/\.dat$/i, "");
 }
 
+/**
+ * Returns the score to display in the dropdown badge for a suitability item,
+ * based on the active lens from the backend query.
+ *
+ * Relationship:
+ *  - 'mission'          → item.mission ?? item.re_agnostic (fallback when no mission score)
+ *  - 'target_cl_cruise' → item.target_cl_cruise ?? item.re_agnostic
+ *  - 'target_cl_loiter' → display-only lens, never used as ranking lens; fall through to re_agnostic
+ *  - 're_agnostic' / default → item.re_agnostic
+ */
+export function activeLensScore(
+  item: { re_agnostic: number; mission: number | null; target_cl_cruise: number | null; target_cl_loiter: number | null },
+  lens: string | undefined,
+): number {
+  if (lens === "mission") return item.mission ?? item.re_agnostic;
+  if (lens === "target_cl_cruise") return item.target_cl_cruise ?? item.re_agnostic;
+  return item.re_agnostic;
+}
+
 const NU_AIR = 1.46e-5; // kinematic viscosity [m\u00B2/s] at 15\u00B0C
 
 export function computeRe(velocityMs: number, chordMm: number): number {
@@ -75,23 +94,26 @@ export default function AirfoilPreviewPage() {
     aeroplane_id: aeroplaneId,
   });
 
-  // Build lookup maps: airfoil name -> score string + sorted names
+  // Build lookup maps: airfoil name -> score string + sorted names.
+  // The displayed score uses the active lens so the badge matches the ranking order.
   const rootScoreMap = useMemo((): Record<string, string> => {
     if (!rootSuitability.data) return {};
+    const lens = rootSuitability.data.query.active_lens;
     return Object.fromEntries(
       rootSuitability.data.results.map((item) => [
         item.airfoil_name,
-        item.re_agnostic.toFixed(2),
+        activeLensScore(item, lens).toFixed(2),
       ]),
     );
   }, [rootSuitability.data]);
 
   const tipScoreMap = useMemo((): Record<string, string> => {
     if (!tipSuitability.data) return {};
+    const lens = tipSuitability.data.query.active_lens;
     return Object.fromEntries(
       tipSuitability.data.results.map((item) => [
         item.airfoil_name,
-        item.re_agnostic.toFixed(2),
+        activeLensScore(item, lens).toFixed(2),
       ]),
     );
   }, [tipSuitability.data]);
@@ -224,6 +246,7 @@ export default function AirfoilPreviewPage() {
           ma={ma}
           onMaChange={setMa}
           operatingAlphaDeg={rootOperatingAlpha}
+          tipSuitabilityItem={hasTip ? (tipSuitabilityItem ?? undefined) : undefined}
         />
       </div>
       <div className="shrink-0 overflow-hidden" style={{ width: 480 }}>

--- a/frontend/app/workbench/airfoil-preview/page.tsx
+++ b/frontend/app/workbench/airfoil-preview/page.tsx
@@ -10,7 +10,7 @@ import { useAirfoilSuitability } from "@/hooks/useAirfoilSuitability";
 import { AirfoilPreviewViewerPanel } from "@/components/workbench/AirfoilPreviewViewerPanel";
 import { AirfoilPreviewConfigPanel } from "@/components/workbench/AirfoilPreviewConfigPanel";
 
-function airfoilShortName(raw: string): string {
+export function airfoilShortName(raw: string): string {
   return (raw.split("/").pop() ?? raw).replace(/\.dat$/i, "");
 }
 

--- a/frontend/app/workbench/airfoil-preview/page.tsx
+++ b/frontend/app/workbench/airfoil-preview/page.tsx
@@ -279,7 +279,18 @@ export default function AirfoilPreviewPage() {
           onRevert={handleRevert}
           onBack={handleBack}
           rootSuitabilityItem={rootSuitabilityItem ?? undefined}
+          rootSuitabilityNotFound={
+            !rootSuitability.isLoading &&
+            rootSuitability.data != null &&
+            rootSuitabilityItem == null
+          }
           tipSuitabilityItem={hasTip ? (tipSuitabilityItem ?? undefined) : undefined}
+          tipSuitabilityNotFound={
+            hasTip &&
+            !tipSuitability.isLoading &&
+            tipSuitability.data != null &&
+            tipSuitabilityItem == null
+          }
           rootScoreMap={rootRankedMode ? rootScoreMap : undefined}
           tipScoreMap={tipRankedMode ? tipScoreMap : undefined}
           rootSortedNames={rootRankedMode ? rootSortedNames : undefined}

--- a/frontend/components/workbench/AirfoilPreviewConfigPanel.tsx
+++ b/frontend/components/workbench/AirfoilPreviewConfigPanel.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { Info, ArrowLeft, Save, Loader2, ChevronLeft, ChevronRight, Undo2 } from "lucide-react";
 import { AirfoilSelector } from "./AirfoilSelector";
-import { AirfoilSuitabilityCard } from "./AirfoilSuitabilityCard";
+import { AirfoilSuitabilityCard, AirfoilSuitabilityNoData } from "./AirfoilSuitabilityCard";
 import type { SuitabilityItem } from "@/hooks/useAirfoilSuitability";
 
 interface AirfoilPreviewConfigPanelProps {
@@ -38,6 +38,16 @@ interface AirfoilPreviewConfigPanelProps {
   rootSuitabilityItem?: SuitabilityItem;
   /** gh-822 ADDITIVE: suitability item for tip airfoil */
   tipSuitabilityItem?: SuitabilityItem;
+  /**
+   * gh-822 ADDITIVE: true when the suitability API responded but did not
+   * include the selected root airfoil (non-seeded profile). Used to show
+   * the "no data" placeholder instead of silently hiding the card.
+   */
+  rootSuitabilityNotFound?: boolean;
+  /**
+   * gh-822 ADDITIVE: same as rootSuitabilityNotFound but for the tip.
+   */
+  tipSuitabilityNotFound?: boolean;
   /** gh-822 ADDITIVE: score map (airfoil name -> score string) for root AirfoilSelector stats slot */
   rootScoreMap?: Record<string, string>;
   /** gh-822 ADDITIVE: score map for tip AirfoilSelector stats slot */
@@ -153,6 +163,8 @@ export function AirfoilPreviewConfigPanel({
   onBack,
   rootSuitabilityItem,
   tipSuitabilityItem,
+  rootSuitabilityNotFound,
+  tipSuitabilityNotFound,
   rootScoreMap,
   tipScoreMap,
   rootSortedNames,
@@ -295,9 +307,8 @@ export function AirfoilPreviewConfigPanel({
           color="#FF8400"
         />
         {/* gh-822: Root suitability card (open by default) */}
-        {rootSuitabilityItem && (
-          <AirfoilSuitabilityCard item={rootSuitabilityItem} defaultOpen />
-        )}
+        {rootSuitabilityItem && <AirfoilSuitabilityCard item={rootSuitabilityItem} defaultOpen />}
+        {!rootSuitabilityItem && rootSuitabilityNotFound && <AirfoilSuitabilityNoData airfoilName={rootAirfoil} />}
 
         {/* Divider */}
         <div className="border-t border-border" />
@@ -328,9 +339,8 @@ export function AirfoilPreviewConfigPanel({
           />
         )}
         {/* gh-822: Tip suitability card (collapsed by default) */}
-        {tipSuitabilityItem && (
-          <AirfoilSuitabilityCard item={tipSuitabilityItem} defaultOpen={false} />
-        )}
+        {tipSuitabilityItem && <AirfoilSuitabilityCard item={tipSuitabilityItem} defaultOpen={false} />}
+        {!tipSuitabilityItem && tipSuitabilityNotFound && <AirfoilSuitabilityNoData airfoilName={tipAirfoil} />}
 
         {/* Divider */}
         <div className="border-t border-border" />

--- a/frontend/components/workbench/AirfoilPreviewConfigPanel.tsx
+++ b/frontend/components/workbench/AirfoilPreviewConfigPanel.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect } from "react";
 import { Info, ArrowLeft, Save, Loader2, ChevronLeft, ChevronRight, Undo2 } from "lucide-react";
 import { AirfoilSelector } from "./AirfoilSelector";
+import { AirfoilSuitabilityCard } from "./AirfoilSuitabilityCard";
+import type { SuitabilityItem } from "@/hooks/useAirfoilSuitability";
 
 interface AirfoilPreviewConfigPanelProps {
   rootAirfoil: string;
@@ -32,6 +34,24 @@ interface AirfoilPreviewConfigPanelProps {
   onSave: () => void;
   onRevert: () => void;
   onBack: () => void;
+  /** gh-822 ADDITIVE: suitability item for root airfoil */
+  rootSuitabilityItem?: SuitabilityItem;
+  /** gh-822 ADDITIVE: suitability item for tip airfoil */
+  tipSuitabilityItem?: SuitabilityItem;
+  /** gh-822 ADDITIVE: score map (airfoil name -> score string) for root AirfoilSelector stats slot */
+  rootScoreMap?: Record<string, string>;
+  /** gh-822 ADDITIVE: score map for tip AirfoilSelector stats slot */
+  tipScoreMap?: Record<string, string>;
+  /** gh-822 ADDITIVE: sorted names for root AirfoilSelector ranked mode */
+  rootSortedNames?: string[];
+  /** gh-822 ADDITIVE: sorted names for tip AirfoilSelector ranked mode */
+  tipSortedNames?: string[];
+  /** gh-822 ADDITIVE: toggle state for root ranked mode */
+  rootRankedMode?: boolean;
+  onRootRankedModeToggle?: () => void;
+  /** gh-822 ADDITIVE: toggle state for tip ranked mode */
+  tipRankedMode?: boolean;
+  onTipRankedModeToggle?: () => void;
 }
 
 function ReadOnlyField({
@@ -131,6 +151,16 @@ export function AirfoilPreviewConfigPanel({
   onSave,
   onRevert,
   onBack,
+  rootSuitabilityItem,
+  tipSuitabilityItem,
+  rootScoreMap,
+  tipScoreMap,
+  rootSortedNames,
+  tipSortedNames,
+  rootRankedMode,
+  onRootRankedModeToggle,
+  tipRankedMode,
+  onTipRankedModeToggle,
 }: Readonly<AirfoilPreviewConfigPanelProps>) {
   const [showReInfo, setShowReInfo] = useState(false);
   const [velocityDraft, setVelocityDraft] = useState(String(velocity));
@@ -249,6 +279,13 @@ export function AirfoilPreviewConfigPanel({
           label=""
           value={rootAirfoil}
           onChange={onRootAirfoilChange}
+          stats={rootScoreMap}
+          sortedNames={rootSortedNames}
+          suitabilityToggle={
+            onRootRankedModeToggle
+              ? { active: rootRankedMode ?? false, onToggle: onRootRankedModeToggle }
+              : undefined
+          }
         />
         <ReynoldsField
           label="Re"
@@ -257,6 +294,10 @@ export function AirfoilPreviewConfigPanel({
           chordMm={rootChordMm}
           color="#FF8400"
         />
+        {/* gh-822: Root suitability card (open by default) */}
+        {rootSuitabilityItem && (
+          <AirfoilSuitabilityCard item={rootSuitabilityItem} defaultOpen />
+        )}
 
         {/* Divider */}
         <div className="border-t border-border" />
@@ -269,6 +310,13 @@ export function AirfoilPreviewConfigPanel({
           label=""
           value={tipAirfoil}
           onChange={onTipAirfoilChange}
+          stats={tipScoreMap}
+          sortedNames={tipSortedNames}
+          suitabilityToggle={
+            onTipRankedModeToggle
+              ? { active: tipRankedMode ?? false, onToggle: onTipRankedModeToggle }
+              : undefined
+          }
         />
         {hasTip && (
           <ReynoldsField
@@ -278,6 +326,10 @@ export function AirfoilPreviewConfigPanel({
             chordMm={tipChordMm}
             color="#22D3EE"
           />
+        )}
+        {/* gh-822: Tip suitability card (collapsed by default) */}
+        {tipSuitabilityItem && (
+          <AirfoilSuitabilityCard item={tipSuitabilityItem} defaultOpen={false} />
         )}
 
         {/* Divider */}

--- a/frontend/components/workbench/AirfoilPreviewViewerPanel.tsx
+++ b/frontend/components/workbench/AirfoilPreviewViewerPanel.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from "react";
 import { Maximize2, Minimize2, AlertTriangle } from "lucide-react";
 import type { AirfoilGeometry } from "@/hooks/useAirfoilGeometry";
 import type { AirfoilAnalysisResult } from "@/hooks/useAirfoilAnalysis";
+import type { SuitabilityItem } from "@/hooks/useAirfoilSuitability";
 import { interpolateY } from "@/hooks/useAirfoilGeometry";
 
 interface AirfoilPreviewViewerPanelProps {
@@ -20,6 +21,12 @@ interface AirfoilPreviewViewerPanelProps {
   onMaChange: (ma: number) => void;
   /** gh-822 ADDITIVE: operating α for the polar marker (degrees) */
   operatingAlphaDeg?: number;
+  /**
+   * gh-822 ADDITIVE: suitability item for the tip airfoil.
+   * When present, tip_re_flag is the AUTHORITATIVE trigger for the tip-Re warning banner.
+   * The arithmetic fallback (tipRe < rootRe) is only used when no suitability item is available.
+   */
+  tipSuitabilityItem?: SuitabilityItem;
 }
 
 const COLOR_ROOT = "#FF8400";
@@ -502,6 +509,7 @@ export function AirfoilPreviewViewerPanel({
   ma,
   onMaChange,
   operatingAlphaDeg,
+  tipSuitabilityItem,
 }: Readonly<AirfoilPreviewViewerPanelProps>) {
   const [maximizedChart, setMaximizedChart] = useState<string | null>(null);
 
@@ -528,8 +536,14 @@ export function AirfoilPreviewViewerPanel({
     return parts.join("  |  ");
   }, [rootGeometry, tipGeometry, hasTip]);
 
-  // gh-822: show tip-Re warning when tip is present and tipRe < rootRe
-  const showTipReBanner = hasTip && tipRe != null && tipRe < rootRe;
+  // gh-822: tip-Re warning banner.
+  // AUTHORITATIVE trigger: tipSuitabilityItem.tip_re_flag (set by the backend suitability scorer).
+  // FALLBACK (no suitability data): arithmetic tipRe < rootRe check.
+  const showTipReBanner = hasTip && (
+    tipSuitabilityItem != null
+      ? tipSuitabilityItem.tip_re_flag
+      : (tipRe != null && tipRe < rootRe)
+  );
 
   return (
     <div className="flex flex-1 flex-col gap-4 overflow-hidden p-4">
@@ -645,10 +659,11 @@ export function AirfoilPreviewViewerPanel({
           // gh-822: Find L/D value at operating alpha for the marker
           const operatingLdAtAlpha: number | undefined = (() => {
             if (operatingAlphaDeg == null) return undefined;
-            // Find the closest alpha index
+            // Guard: empty alphaDeg array yields no marker
             const alphas = rootAnalysisResult.alphaDeg;
+            if (alphas.length === 0) return undefined;
             let closestIdx = 0;
-            let closestDist = Math.abs(alphas[0] - operatingAlphaDeg);
+            let closestDist = Math.abs((alphas[0] ?? 0) - operatingAlphaDeg);
             for (let i = 1; i < alphas.length; i++) {
               const d = Math.abs(alphas[i] - operatingAlphaDeg);
               if (d < closestDist) {

--- a/frontend/components/workbench/AirfoilPreviewViewerPanel.tsx
+++ b/frontend/components/workbench/AirfoilPreviewViewerPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { Maximize2, Minimize2 } from "lucide-react";
+import { Maximize2, Minimize2, AlertTriangle } from "lucide-react";
 import type { AirfoilGeometry } from "@/hooks/useAirfoilGeometry";
 import type { AirfoilAnalysisResult } from "@/hooks/useAirfoilAnalysis";
 import { interpolateY } from "@/hooks/useAirfoilGeometry";
@@ -18,6 +18,8 @@ interface AirfoilPreviewViewerPanelProps {
   tipRe: number | null;
   ma: number;
   onMaChange: (ma: number) => void;
+  /** gh-822 ADDITIVE: operating α for the polar marker (degrees) */
+  operatingAlphaDeg?: number;
 }
 
 const COLOR_ROOT = "#FF8400";
@@ -41,6 +43,8 @@ function LineChart({
   color = "var(--color-primary)",
   onToggleMaximize,
   isMaximized,
+  operatingX,
+  operatingY,
 }: Readonly<{
   xData: (number | null)[];
   yData: (number | null)[];
@@ -57,6 +61,10 @@ function LineChart({
   xFormat?: (v: number) => string;
   onToggleMaximize?: () => void;
   isMaximized?: boolean;
+  /** gh-822: operating point marker x value (α in degrees for L/D chart) */
+  operatingX?: number;
+  /** gh-822: operating point marker y value (L/D at operating α) */
+  operatingY?: number;
 }>) {
   const W = 400;
   const H = 200;
@@ -289,6 +297,20 @@ function LineChart({
               strokeLinejoin="round"
             />
           )}
+
+          {/* gh-822: Operating point marker */}
+          {operatingX != null && operatingY != null && (
+            <circle
+              data-testid="operating-point-marker"
+              cx={sx(operatingX)}
+              cy={sy(operatingY)}
+              r="4"
+              fill={COLOR_ROOT}
+              stroke="white"
+              strokeWidth="1.5"
+              opacity="0.9"
+            />
+          )}
         </svg>
       </div>
     </div>
@@ -479,6 +501,7 @@ export function AirfoilPreviewViewerPanel({
   tipRe,
   ma,
   onMaChange,
+  operatingAlphaDeg,
 }: Readonly<AirfoilPreviewViewerPanelProps>) {
   const [maximizedChart, setMaximizedChart] = useState<string | null>(null);
 
@@ -505,8 +528,24 @@ export function AirfoilPreviewViewerPanel({
     return parts.join("  |  ");
   }, [rootGeometry, tipGeometry, hasTip]);
 
+  // gh-822: show tip-Re warning when tip is present and tipRe < rootRe
+  const showTipReBanner = hasTip && tipRe != null && tipRe < rootRe;
+
   return (
     <div className="flex flex-1 flex-col gap-4 overflow-hidden p-4">
+      {/* gh-822: Tip-Re < Root-Re warning banner */}
+      {showTipReBanner && (
+        <div
+          role="alert"
+          className="flex items-center gap-2 rounded-xl border border-red-500/40 bg-red-500/10 px-3 py-2 text-[12px] text-red-300"
+        >
+          <AlertTriangle size={13} className="shrink-0" aria-hidden="true" />
+          <span>
+            Tip Re ({tipRe != null ? `${Math.round(tipRe / 1000)}k` : "—"}) &lt; Root Re ({Math.round(rootRe / 1000)}k) — tapered chord reduces effective Re at the tip.
+          </span>
+        </div>
+      )}
+
       {/* Header Row */}
       <div className="flex items-center gap-2">
         <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-foreground">
@@ -603,6 +642,24 @@ export function AirfoilPreviewViewerPanel({
           const seriesLabel = hasTip ? "root" : undefined;
           const seriesLabel2 = hasTip ? "tip" : undefined;
 
+          // gh-822: Find L/D value at operating alpha for the marker
+          const operatingLdAtAlpha: number | undefined = (() => {
+            if (operatingAlphaDeg == null) return undefined;
+            // Find the closest alpha index
+            const alphas = rootAnalysisResult.alphaDeg;
+            let closestIdx = 0;
+            let closestDist = Math.abs(alphas[0] - operatingAlphaDeg);
+            for (let i = 1; i < alphas.length; i++) {
+              const d = Math.abs(alphas[i] - operatingAlphaDeg);
+              if (d < closestDist) {
+                closestDist = d;
+                closestIdx = i;
+              }
+            }
+            const ld = rootAnalysisResult.clOverCd[closestIdx];
+            return ld != null ? ld : undefined;
+          })();
+
           const allCharts = [
             {
               id: "cl",
@@ -653,6 +710,9 @@ export function AirfoilPreviewViewerPanel({
               color2: COLOR_TIP,
               label: seriesLabel,
               label2: seriesLabel2,
+              // gh-822: operating point marker on L/D chart
+              operatingX: operatingAlphaDeg,
+              operatingY: operatingLdAtAlpha,
             },
             {
               id: "polar",

--- a/frontend/components/workbench/AirfoilSelector.tsx
+++ b/frontend/components/workbench/AirfoilSelector.tsx
@@ -10,12 +10,30 @@ interface AirfoilListResponse {
   airfoils: { airfoil_name: string; file_name: string }[];
 }
 
+interface SuitabilityToggle {
+  /** Whether ranked / "Passende finden" mode is currently active */
+  active: boolean;
+  onToggle: () => void;
+}
+
 interface AirfoilSelectorProps {
   label: string;
   value: string;
   onChange?: (value: string) => void;
   onPreviewToggle?: (active: boolean) => void;
+  /** Existing slot: right-aligned badge text per airfoil name */
   stats?: Record<string, string>;
+  /**
+   * gh-822 ADDITIVE: pre-sorted list of airfoil names (desc by score).
+   * When provided, the dropdown renders in this order instead of the
+   * alphabetical default.
+   */
+  sortedNames?: string[];
+  /**
+   * gh-822 ADDITIVE: when provided, renders a "🔍 Passende finden" toggle
+   * button next to the dropdown trigger.
+   */
+  suitabilityToggle?: SuitabilityToggle;
 }
 
 const MAX_VISIBLE = 50;
@@ -26,6 +44,8 @@ export function AirfoilSelector({
   onChange,
   onPreviewToggle,
   stats,
+  sortedNames,
+  suitabilityToggle,
 }: Readonly<AirfoilSelectorProps>) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
@@ -38,10 +58,11 @@ export function AirfoilSelector({
     dedupingInterval: 60_000,
   });
 
-  const allNames = useMemo(
-    () => data?.airfoils?.map((a) => a.airfoil_name) ?? [],
-    [data],
-  );
+  const allNames = useMemo(() => {
+    // gh-822: when sortedNames is provided, use that order (ranked by suitability)
+    if (sortedNames && sortedNames.length > 0) return sortedNames;
+    return data?.airfoils?.map((a) => a.airfoil_name) ?? [];
+  }, [data, sortedNames]);
 
   const filtered = useMemo(() => {
     const q = search.toLowerCase();
@@ -88,7 +109,24 @@ export function AirfoilSelector({
 
   return (
     <div ref={containerRef} className="relative flex flex-1 flex-col gap-1">
-      <label htmlFor={`airfoil-${label.toLowerCase().replaceAll(/\s+/g, "-")}`} className="text-[11px] text-muted-foreground">{label}</label>
+      <div className="flex items-center gap-1">
+        <label htmlFor={`airfoil-${label.toLowerCase().replaceAll(/\s+/g, "-")}`} className="flex-1 text-[11px] text-muted-foreground">{label}</label>
+        {/* gh-822 ADDITIVE: Passende finden toggle */}
+        {suitabilityToggle && (
+          <button
+            type="button"
+            title="🔍 Passende finden"
+            onClick={suitabilityToggle.onToggle}
+            className={`text-[10px] transition-colors ${
+              suitabilityToggle.active
+                ? "text-primary font-medium"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            🔍
+          </button>
+        )}
+      </div>
 
       {/* Trigger */}
       <button

--- a/frontend/components/workbench/AirfoilSelector.tsx
+++ b/frontend/components/workbench/AirfoilSelector.tsx
@@ -38,6 +38,15 @@ interface AirfoilSelectorProps {
 
 const MAX_VISIBLE = 50;
 
+// Score badge colour: green ≥ 0.7, amber 0.4–0.7, red < 0.4
+function scoreBadgeColor(scoreStr: string): string {
+  const v = Number.parseFloat(scoreStr);
+  if (Number.isNaN(v)) return "#9CA3AF"; // neutral gray
+  if (v >= 0.7) return "#34D399";
+  if (v >= 0.4) return "#FBBF24";
+  return "#F87171";
+}
+
 export function AirfoilSelector({
   label,
   value,
@@ -185,7 +194,15 @@ export function AirfoilSelector({
                   {stats?.[name] && (
                     <>
                       <span className="flex-1" />
-                      <span className="font-[family-name:var(--font-jetbrains-mono)] text-[10px] text-muted-foreground">
+                      <span
+                        data-testid="score-badge"
+                        className="rounded-full border border-current px-1.5 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[10px]"
+                        style={{
+                          color: scoreBadgeColor(stats[name]),
+                          backgroundColor: `${scoreBadgeColor(stats[name])}1a`,
+                          borderColor: `${scoreBadgeColor(stats[name])}40`,
+                        }}
+                      >
                         {stats[name]}
                       </span>
                     </>

--- a/frontend/components/workbench/AirfoilSuitabilityCard.tsx
+++ b/frontend/components/workbench/AirfoilSuitabilityCard.tsx
@@ -15,6 +15,14 @@ function scoreColor(score: number): string {
   return COLOR_RED;
 }
 
+// ── Qualitative label (issue #4a) ─────────────────────────────────
+// >= 0.75 → "Gut", 0.5–0.75 → "Mäßig", < 0.5 → "Schwach"
+export function qualitativeLabel(score: number): string {
+  if (score >= 0.75) return "Gut";
+  if (score >= 0.5) return "Mäßig";
+  return "Schwach";
+}
+
 // ── Score bar ─────────────────────────────────────────────────────
 
 function ScoreBar({
@@ -39,6 +47,7 @@ function ScoreBar({
 
   const color = scoreColor(score);
   const pct = Math.round(score * 100);
+  const qlabel = qualitativeLabel(score);
 
   return (
     <div className="flex items-center gap-2">
@@ -60,11 +69,21 @@ function ScoreBar({
       >
         {(score).toFixed(2)}
       </span>
+      <span
+        data-testid="qualitative-label"
+        className="w-12 text-right font-[family-name:var(--font-jetbrains-mono)] text-[9px]"
+        style={{ color }}
+      >
+        {qlabel}
+      </span>
     </div>
   );
 }
 
 // ── Confidence chip ───────────────────────────────────────────────
+// Issue #1 fix: chip moved to its own row below the toggle label so it never
+// overflows the 480 px panel at any text size.
+// Issue #4c fix: title tooltip explains what the number means.
 
 function ConfidenceChip({
   confidence,
@@ -73,30 +92,58 @@ function ConfidenceChip({
 }) {
   const isLow = confidence < 0.85;
   const color = isLow ? COLOR_AMBER : COLOR_GREEN;
+  const tooltipText =
+    "Modell-Konfidenz: Anteil der Re-Stützstellen mit konvergenter XFoil-Analyse. " +
+    "1.0 = alle Stützstellen zuverlässig; < 0.85 = Werte als grobe Orientierung verstehen.";
   return (
     <span
-      className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[10px]"
+      title={tooltipText}
+      className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[10px] cursor-help"
       style={{
         color,
         backgroundColor: isLow ? "rgba(251, 191, 36, 0.12)" : "rgba(52, 211, 153, 0.12)",
         border: `1px solid ${color}40`,
       }}
     >
-      ● Confidence {confidence.toFixed(2)}
+      ● Konfidenz {confidence.toFixed(2)}
     </span>
   );
 }
 
 // ── Caveat callout (mirrors PolarRejectionBadge amber pattern) ─────
+// Issue #4b: softer, actionable wording for hobbyists.
 
-function CaveatCallout({ text }: { readonly text: string }) {
+function CaveatCallout({ text, hasLowConfidence }: { readonly text: string; readonly hasLowConfidence?: boolean }) {
+  const displayText = hasLowConfidence
+    ? `Geringe Modell-Konfidenz bei diesem Re — Werte als grobe Orientierung verstehen. ${text}`
+    : text;
   return (
     <div
       role="note"
       className="inline-flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-2.5 py-1 text-xs leading-tight text-amber-200"
     >
       <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" aria-hidden="true" />
-      <span>{text}</span>
+      <span>{displayText}</span>
+    </div>
+  );
+}
+
+// ── No-data placeholder (issue #3) ───────────────────────────────
+
+export function AirfoilSuitabilityNoData({ airfoilName }: { readonly airfoilName?: string }) {
+  return (
+    <div
+      data-testid="suitability-no-data"
+      className="flex flex-col gap-1 rounded-xl border border-border bg-card-muted px-3 py-2"
+    >
+      <span className="font-[family-name:var(--font-jetbrains-mono)] text-[10px] text-muted-foreground">
+        Eignung
+      </span>
+      <span className="font-[family-name:var(--font-jetbrains-mono)] text-[10px] text-subtle-foreground">
+        {airfoilName
+          ? `Keine Low-Re-Eignungsdaten für „${airfoilName}"`
+          : "Keine Low-Re-Eignungsdaten für dieses Profil"}
+      </span>
     </div>
   );
 }
@@ -113,25 +160,29 @@ export function AirfoilSuitabilityCard({
   defaultOpen = true,
 }: Readonly<AirfoilSuitabilityCardProps>) {
   const [open, setOpen] = useState(defaultOpen);
+  const isLowConfidence = item.min_analysis_confidence < 0.85;
 
   return (
     <div className="flex flex-col gap-1 rounded-xl border border-border bg-card-muted px-3 py-2">
-      {/* Header / toggle */}
+      {/* Header / toggle — issue #1 fix: chip on its own row to prevent overflow */}
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
-        className="flex w-full items-center gap-1.5 text-left"
+        className="flex w-full flex-col gap-0.5 text-left"
       >
-        {open ? (
-          <ChevronDown size={11} className="text-muted-foreground" />
-        ) : (
-          <ChevronRight size={11} className="text-muted-foreground" />
-        )}
-        <span className="font-[family-name:var(--font-jetbrains-mono)] text-[10px] text-muted-foreground">
-          Eignung
-        </span>
-        <span className="flex-1" />
-        <ConfidenceChip confidence={item.min_analysis_confidence} />
+        <div className="flex items-center gap-1.5">
+          {open ? (
+            <ChevronDown size={11} className="text-muted-foreground" />
+          ) : (
+            <ChevronRight size={11} className="text-muted-foreground" />
+          )}
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[10px] text-muted-foreground">
+            Eignung
+          </span>
+        </div>
+        <div className="pl-4">
+          <ConfidenceChip confidence={item.min_analysis_confidence} />
+        </div>
       </button>
 
       {/* Body (collapsible) */}
@@ -139,14 +190,14 @@ export function AirfoilSuitabilityCard({
         <div className="flex flex-col gap-1.5 pt-1">
           <ScoreBar label="Re-agnostisch" score={item.re_agnostic} />
           <ScoreBar
-            label={`Mission`}
+            label="Mission"
             score={item.mission}
           />
           <ScoreBar label="Ziel-CL · Cruise" score={item.target_cl_cruise} />
           <ScoreBar label="Ziel-CL · Loiter" score={item.target_cl_loiter} />
           {item.caveat && (
             <div className="mt-1">
-              <CaveatCallout text={item.caveat} />
+              <CaveatCallout text={item.caveat} hasLowConfidence={isLowConfidence} />
             </div>
           )}
         </div>

--- a/frontend/components/workbench/AirfoilSuitabilityCard.tsx
+++ b/frontend/components/workbench/AirfoilSuitabilityCard.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, ChevronRight, AlertTriangle } from "lucide-react";
+import type { SuitabilityItem } from "@/hooks/useAirfoilSuitability";
+
+// ── Colour thresholds ─────────────────────────────────────────────
+const COLOR_GREEN = "#34D399";
+const COLOR_AMBER = "#FBBF24";
+const COLOR_RED = "#F87171";
+
+function scoreColor(score: number): string {
+  if (score >= 0.7) return COLOR_GREEN;
+  if (score >= 0.4) return COLOR_AMBER;
+  return COLOR_RED;
+}
+
+// ── Score bar ─────────────────────────────────────────────────────
+
+function ScoreBar({
+  label,
+  score,
+}: {
+  readonly label: string;
+  readonly score: number | null;
+}) {
+  if (score === null) {
+    return (
+      <div className="flex items-center gap-2">
+        <span className="w-32 font-[family-name:var(--font-jetbrains-mono)] text-[10px] text-muted-foreground">
+          {label}
+        </span>
+        <span className="font-[family-name:var(--font-jetbrains-mono)] text-[10px] text-muted-foreground">
+          n/a
+        </span>
+      </div>
+    );
+  }
+
+  const color = scoreColor(score);
+  const pct = Math.round(score * 100);
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="w-32 font-[family-name:var(--font-jetbrains-mono)] text-[10px] text-muted-foreground">
+        {label}
+      </span>
+      <div className="flex-1 overflow-hidden rounded-full bg-card-muted" style={{ height: 6 }}>
+        <div
+          className="h-full rounded-full transition-all"
+          style={{
+            width: `${pct}%`,
+            backgroundColor: color,
+          }}
+        />
+      </div>
+      <span
+        className="w-8 text-right font-[family-name:var(--font-jetbrains-mono)] text-[10px]"
+        style={{ color }}
+      >
+        {(score).toFixed(2)}
+      </span>
+    </div>
+  );
+}
+
+// ── Confidence chip ───────────────────────────────────────────────
+
+function ConfidenceChip({
+  confidence,
+}: {
+  readonly confidence: number;
+}) {
+  const isLow = confidence < 0.85;
+  const color = isLow ? COLOR_AMBER : COLOR_GREEN;
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[10px]"
+      style={{
+        color,
+        backgroundColor: isLow ? "rgba(251, 191, 36, 0.12)" : "rgba(52, 211, 153, 0.12)",
+        border: `1px solid ${color}40`,
+      }}
+    >
+      ● Confidence {confidence.toFixed(2)}
+    </span>
+  );
+}
+
+// ── Caveat callout (mirrors PolarRejectionBadge amber pattern) ─────
+
+function CaveatCallout({ text }: { readonly text: string }) {
+  return (
+    <div
+      role="note"
+      className="inline-flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-2.5 py-1 text-xs leading-tight text-amber-200"
+    >
+      <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" aria-hidden="true" />
+      <span>{text}</span>
+    </div>
+  );
+}
+
+// ── Main card ─────────────────────────────────────────────────────
+
+export interface AirfoilSuitabilityCardProps {
+  item: SuitabilityItem;
+  defaultOpen?: boolean;
+}
+
+export function AirfoilSuitabilityCard({
+  item,
+  defaultOpen = true,
+}: Readonly<AirfoilSuitabilityCardProps>) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <div className="flex flex-col gap-1 rounded-xl border border-border bg-card-muted px-3 py-2">
+      {/* Header / toggle */}
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center gap-1.5 text-left"
+      >
+        {open ? (
+          <ChevronDown size={11} className="text-muted-foreground" />
+        ) : (
+          <ChevronRight size={11} className="text-muted-foreground" />
+        )}
+        <span className="font-[family-name:var(--font-jetbrains-mono)] text-[10px] text-muted-foreground">
+          Eignung
+        </span>
+        <span className="flex-1" />
+        <ConfidenceChip confidence={item.min_analysis_confidence} />
+      </button>
+
+      {/* Body (collapsible) */}
+      {open && (
+        <div className="flex flex-col gap-1.5 pt-1">
+          <ScoreBar label="Re-agnostisch" score={item.re_agnostic} />
+          <ScoreBar
+            label={`Mission`}
+            score={item.mission}
+          />
+          <ScoreBar label="Ziel-CL · Cruise" score={item.target_cl_cruise} />
+          <ScoreBar label="Ziel-CL · Loiter" score={item.target_cl_loiter} />
+          {item.caveat && (
+            <div className="mt-1">
+              <CaveatCallout text={item.caveat} />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/e2e/features/airfoil-suitability.feature
+++ b/frontend/e2e/features/airfoil-suitability.feature
@@ -1,0 +1,22 @@
+Feature: Airfoil suitability surfacing on airfoil-preview page (gh-822)
+
+  Scenario: Suitability card shows three lenses for the selected root airfoil
+    Given I am on the airfoil-preview page with a stubbed suitability response
+    Then the root suitability card shows the Re-agnostisch lens
+    And the root suitability card shows the Mission lens
+    And the root suitability card shows the Ziel-CL Cruise lens
+    And the root suitability card shows the Ziel-CL Loiter lens
+
+  Scenario: Low-confidence airfoil shows amber chip and caveat
+    Given I am on the airfoil-preview page with a low-confidence suitability response
+    Then the root suitability card shows an amber confidence chip
+    And the root suitability card shows a caveat callout
+
+  Scenario: Tapered segment shows tip-Re warning banner
+    Given I am on the airfoil-preview page with tip Re lower than root Re
+    Then a tip-Re warning banner is visible with role "alert"
+
+  Scenario: Passende finden re-orders the dropdown
+    Given I am on the airfoil-preview page with a stubbed suitability response
+    When I click the Passende finden toggle for the root selector
+    Then the root airfoil dropdown shows airfoils sorted by suitability score

--- a/frontend/e2e/steps/airfoil-suitability.steps.ts
+++ b/frontend/e2e/steps/airfoil-suitability.steps.ts
@@ -1,0 +1,277 @@
+/**
+ * gh-822: Playwright-BDD step definitions for airfoil suitability feature.
+ *
+ * Strategy: use page.route() to stub GET /airfoils/db/suitability with
+ * frozen-contract fixtures. A minimal stub for GET /airfoils is also provided
+ * so the AirfoilSelector populates. The page is loaded directly via URL.
+ */
+
+import { createBdd } from "playwright-bdd";
+import { expect } from "@playwright/test";
+
+const { Given, When, Then } = createBdd();
+
+// ── Frozen-contract fixtures ─────────────────────────────────────
+
+function suitabilityItem(
+  airfoil_name: string,
+  overrides: Partial<{
+    re_agnostic: number;
+    mission: number | null;
+    target_cl_cruise: number | null;
+    target_cl_loiter: number | null;
+    min_analysis_confidence: number;
+    tip_re_flag: boolean;
+    caveat: string;
+  }> = {},
+) {
+  return {
+    airfoil_name,
+    family: "cambered",
+    re_agnostic: 0.82,
+    mission: 0.75,
+    target_cl_cruise: 0.68,
+    target_cl_loiter: 0.55,
+    min_analysis_confidence: 0.92,
+    tip_re_flag: false,
+    caveat: "Nur relative Rangfolge.",
+    ...overrides,
+  };
+}
+
+function suitabilityResponse(items: ReturnType<typeof suitabilityItem>[]) {
+  return {
+    query: {
+      chord_m: 0.2,
+      speed_ms: 14,
+      reynolds: 191781,
+      re_clamped: false,
+      mission_type: "trainer",
+      target_cl_cruise: 0.68,
+      target_cl_loiter: 0.55,
+      active_lens: "re_agnostic",
+    },
+    caveat: {
+      relative_ranking_only: true,
+      no_hysteresis_modelling: true,
+      recommend_xfoil_validation: false,
+      text: "Nur relative Rangfolge. Kein Hysterese-Modell.",
+    },
+    results: items,
+  };
+}
+
+// Stub for the airfoil list (minimal)
+const AIRFOILS_STUB = {
+  count: 3,
+  airfoils: [
+    { airfoil_name: "e423", file_name: "e423.dat" },
+    { airfoil_name: "naca0015", file_name: "naca0015.dat" },
+    { airfoil_name: "clark-y", file_name: "clark-y.dat" },
+  ],
+};
+
+// ── Shared setup helpers ─────────────────────────────────────────
+
+async function setupPage(
+  page: import("@playwright/test").Page,
+  suitabilityBody: object,
+) {
+  // Stub the suitability endpoint
+  await page.route("**/airfoils/db/suitability**", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(suitabilityBody),
+    });
+  });
+
+  // Stub the airfoil list
+  await page.route("**/airfoils", (route) => {
+    if (!route.request().url().includes("suitability")) {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(AIRFOILS_STUB),
+      });
+    } else {
+      route.continue();
+    }
+  });
+
+  // Navigate to the airfoil-preview page without a real aeroplane id
+  // (suitability hook still fires with just chord_m + speed_ms)
+  await page.goto("/workbench/airfoil-preview");
+  // Wait for the page to be stable
+  await page.waitForLoadState("networkidle");
+}
+
+// ── Given steps ──────────────────────────────────────────────────
+
+Given(
+  "I am on the airfoil-preview page with a stubbed suitability response",
+  async ({ page }) => {
+    const items = [
+      suitabilityItem("e423", { re_agnostic: 0.82, mission: 0.75 }),
+      suitabilityItem("naca0015", { re_agnostic: 0.55, mission: 0.45 }),
+      suitabilityItem("clark-y", { re_agnostic: 0.65, mission: 0.60 }),
+    ];
+    await setupPage(page, suitabilityResponse(items));
+  },
+);
+
+Given(
+  "I am on the airfoil-preview page with a low-confidence suitability response",
+  async ({ page }) => {
+    const items = [
+      suitabilityItem("e423", {
+        re_agnostic: 0.72,
+        min_analysis_confidence: 0.72, // < 0.85 => amber chip
+        caveat: "Niedrige Konfidenz — XFoil-Validierung empfohlen.",
+      }),
+    ];
+    await setupPage(page, suitabilityResponse(items));
+  },
+);
+
+Given(
+  "I am on the airfoil-preview page with tip Re lower than root Re",
+  async ({ page }) => {
+    const items = [suitabilityItem("e423")];
+    // Stub suitability (doesn't affect Re display)
+    await page.route("**/airfoils/db/suitability**", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(suitabilityResponse(items)),
+      });
+    });
+    await page.route("**/airfoils", (route) => {
+      if (!route.request().url().includes("suitability")) {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(AIRFOILS_STUB),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    // Navigate and then manipulate the Re fields so tipRe < rootRe
+    // The page derives Re from velocity + chord; with tipChord < rootChord,
+    // tipRe < rootRe. We navigate with default state and rely on the
+    // fixture values which set tip chord < root chord.
+    await page.goto("/workbench/airfoil-preview");
+    await page.waitForLoadState("networkidle");
+
+    // Manually set the tip Re field to a value lower than root Re
+    // The root Re field is labelled "Re" with color #FF8400, tip is #22D3EE
+    // We set tip airfoil to something different first to ensure hasTip=true
+    // For E2E: we just check that if tipRe < rootRe the banner appears.
+    // Since AirfoilPreviewViewerPanel receives tipRe as a prop from page.tsx,
+    // and the test page uses default chords (root=200mm, tip=200mm), we need
+    // to explicitly set a different tip chord via the Re inputs.
+    // We'll manually type into the tip Re input to set a lower value.
+    const tipReInput = page.locator('input[type="number"]').nth(2);
+    await tipReInput.fill("50000");
+    await tipReInput.press("Enter");
+  },
+);
+
+// ── When steps ───────────────────────────────────────────────────
+
+When(
+  "I click the Passende finden toggle for the root selector",
+  async ({ page }) => {
+    // The toggle button has title containing "Passende finden"
+    const toggleBtn = page.getByTitle(/Passende finden/i).first();
+    await expect(toggleBtn).toBeVisible({ timeout: 10000 });
+    await toggleBtn.click();
+  },
+);
+
+// ── Then steps ───────────────────────────────────────────────────
+
+Then(
+  "the root suitability card shows the Re-agnostisch lens",
+  async ({ page }) => {
+    await expect(
+      page.getByText(/Re-agnostisch/i).first(),
+    ).toBeVisible({ timeout: 10000 });
+  },
+);
+
+Then(
+  "the root suitability card shows the Mission lens",
+  async ({ page }) => {
+    await expect(
+      page.getByText(/Mission/i).first(),
+    ).toBeVisible({ timeout: 10000 });
+  },
+);
+
+Then(
+  "the root suitability card shows the Ziel-CL Cruise lens",
+  async ({ page }) => {
+    await expect(
+      page.getByText(/Cruise/i).first(),
+    ).toBeVisible({ timeout: 10000 });
+  },
+);
+
+Then(
+  "the root suitability card shows the Ziel-CL Loiter lens",
+  async ({ page }) => {
+    await expect(
+      page.getByText(/Loiter/i).first(),
+    ).toBeVisible({ timeout: 10000 });
+  },
+);
+
+Then(
+  "the root suitability card shows an amber confidence chip",
+  async ({ page }) => {
+    // The chip shows "● Confidence 0.72" and should have amber colour
+    // We look for a confidence value < 0.85 (will be styled amber)
+    const chip = page.getByText(/Confidence\s+0\.[0-7]\d/i).first();
+    await expect(chip).toBeVisible({ timeout: 10000 });
+  },
+);
+
+Then("the root suitability card shows a caveat callout", async ({ page }) => {
+  await expect(
+    page.getByText(/Niedrige Konfidenz/i).first(),
+  ).toBeVisible({ timeout: 10000 });
+});
+
+Then(
+  "a tip-Re warning banner is visible with role {string}",
+  async ({ page }, _role: string) => {
+    const banner = page.getByRole("alert").first();
+    await expect(banner).toBeVisible({ timeout: 10000 });
+    await expect(banner).toHaveAttribute("role", "alert");
+  },
+);
+
+Then(
+  "the root airfoil dropdown shows airfoils sorted by suitability score",
+  async ({ page }) => {
+    // Open the root dropdown trigger button
+    // The trigger button for root_airfoil is labeled "root_airfoil" section
+    const rootSection = page.locator("text=root_airfoil").first();
+    await expect(rootSection).toBeVisible({ timeout: 10000 });
+
+    // Click the dropdown trigger for root airfoil
+    const dropdownTrigger = rootSection
+      .locator("..") // parent
+      .locator("button")
+      .first();
+    await dropdownTrigger.click();
+
+    // The dropdown should be open with items
+    // e423 (0.82) should appear before naca0015 (0.55)
+    const e423 = page.getByText("e423").first();
+    await expect(e423).toBeVisible({ timeout: 5000 });
+  },
+);

--- a/frontend/hooks/useAirfoilSuitability.ts
+++ b/frontend/hooks/useAirfoilSuitability.ts
@@ -22,7 +22,15 @@ export type MissionType =
 export type ActiveLens =
   | "re_agnostic"
   | "mission"
-  | "target_cl_cruise";
+  | "target_cl_cruise"
+  | "target_cl_loiter";
+
+/**
+ * Lenses that drive the ranked sort order in the UI.
+ * 'target_cl_loiter' is display-only — it adds a score column but never
+ * re-ranks the list, so it is excluded here.
+ */
+export type RankingLens = Exclude<ActiveLens, "target_cl_loiter">;
 
 export interface SuitabilityItem {
   airfoil_name: string;
@@ -33,6 +41,12 @@ export interface SuitabilityItem {
   target_cl_loiter: number | null;
   min_analysis_confidence: number;
   tip_re_flag: boolean;
+  /**
+   * Pre-formatted human-readable caveat text.
+   * This is the `.text` field of the backend `SuitabilityCaveat` object —
+   * not the caveat object itself. The backend serialises it as a plain string
+   * per item so the UI can render it without further processing.
+   */
   caveat: string;
 }
 

--- a/frontend/hooks/useAirfoilSuitability.ts
+++ b/frontend/hooks/useAirfoilSuitability.ts
@@ -1,0 +1,155 @@
+"use client";
+
+import useSWR from "swr";
+import { fetcher } from "@/lib/fetcher";
+
+// ── Types (snake_case verbatim per frozen contract) ──────────────
+
+export type AirfoilFamily =
+  | "flat_bottom"
+  | "semi_symmetric"
+  | "symmetric"
+  | "cambered"
+  | "reflexed";
+
+export type MissionType =
+  | "trainer"
+  | "sport"
+  | "aerobatic"
+  | "glider"
+  | "flying_wing";
+
+export type ActiveLens =
+  | "re_agnostic"
+  | "mission"
+  | "target_cl_cruise";
+
+export interface SuitabilityItem {
+  airfoil_name: string;
+  family: AirfoilFamily;
+  re_agnostic: number;
+  mission: number | null;
+  target_cl_cruise: number | null;
+  target_cl_loiter: number | null;
+  min_analysis_confidence: number;
+  tip_re_flag: boolean;
+  caveat: string;
+}
+
+export interface SuitabilityQuery {
+  chord_m: number;
+  speed_ms: number;
+  reynolds: number;
+  re_clamped: boolean;
+  mission_type: string | null;
+  target_cl_cruise: number | null;
+  target_cl_loiter: number | null;
+  active_lens: ActiveLens;
+}
+
+export interface SuitabilityCaveat {
+  relative_ranking_only: boolean;
+  no_hysteresis_modelling: boolean;
+  recommend_xfoil_validation: boolean;
+  text: string;
+}
+
+export interface AirfoilSuitabilityResponse {
+  query: SuitabilityQuery;
+  caveat: SuitabilityCaveat;
+  results: SuitabilityItem[];
+}
+
+export interface UseAirfoilSuitabilityParams {
+  chord_m: number | undefined;
+  speed_ms: number | undefined;
+  /**
+   * The aeroplane UUID string (from useAeroplaneContext().aeroplaneId).
+   * Passed by the caller rather than read from context, to keep the hook
+   * free of component-layer imports (dependency-cruiser: no-hooks-import-components).
+   */
+  aeroplane_id?: string | null;
+  mission_type?: MissionType;
+  target_cl_cruise?: number;
+  target_cl_loiter?: number;
+  limit?: number;
+  tip_chord_m?: number;
+}
+
+// ── Hook ─────────────────────────────────────────────────────────
+
+export function useAirfoilSuitability(params: UseAirfoilSuitabilityParams) {
+  const {
+    chord_m,
+    speed_ms,
+    aeroplane_id,
+    mission_type,
+    target_cl_cruise,
+    target_cl_loiter,
+    limit,
+    tip_chord_m,
+  } = params;
+
+  // Only build a key when required params are present
+  const key =
+    chord_m != null && speed_ms != null
+      ? buildKey(chord_m, speed_ms, aeroplane_id ?? null, {
+          mission_type,
+          target_cl_cruise,
+          target_cl_loiter,
+          limit,
+          tip_chord_m,
+        })
+      : null;
+
+  const { data, error, isLoading } = useSWR<AirfoilSuitabilityResponse>(
+    key,
+    fetcher,
+    {
+      revalidateOnFocus: false,
+      dedupingInterval: 30_000,
+    },
+  );
+
+  return {
+    data: data ?? null,
+    isLoading,
+    error: error ?? null,
+  };
+}
+
+function buildKey(
+  chord_m: number,
+  speed_ms: number,
+  aeroplaneId: string | null,
+  optional: {
+    mission_type?: MissionType;
+    target_cl_cruise?: number;
+    target_cl_loiter?: number;
+    limit?: number;
+    tip_chord_m?: number;
+  },
+): string {
+  const params = new URLSearchParams();
+  params.set("chord_m", String(chord_m));
+  params.set("speed_ms", String(speed_ms));
+  if (aeroplaneId != null) {
+    params.set("aeroplane_id", aeroplaneId);
+  }
+  if (optional.mission_type != null) {
+    params.set("mission_type", optional.mission_type);
+  }
+  if (optional.target_cl_cruise != null) {
+    params.set("target_cl_cruise", String(optional.target_cl_cruise));
+  }
+  if (optional.target_cl_loiter != null) {
+    params.set("target_cl_loiter", String(optional.target_cl_loiter));
+  }
+  if (optional.limit != null) {
+    params.set("limit", String(optional.limit));
+  }
+  if (optional.tip_chord_m != null) {
+    params.set("tip_chord_m", String(optional.tip_chord_m));
+  }
+  return `/airfoils/db/suitability?${params.toString()}`;
+}


### PR DESCRIPTION
Implements #822 (frontend). Adds `useAirfoilSuitability` hook, `AirfoilSuitabilityCard` (three lenses + confidence + caveat, collapsible), AirfoilSelector per-row badges + ranked 'Passende finden' mode (additive props only), operating-point polar marker, tip-Re warning banner. Stubbed-contract vitest + playwright-bdd.

Depends on #821 (backend endpoint + contract). Live smoke after #821 merges.

Closes #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)