### PR TITLE
feat(gh-825): RC-aware target-CL suitability scoring (backend)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,8 +41,18 @@ UVICORN_HOST=127.0.0.1
 # and the conditional_execute decorator). Leave unset in production.
 # DISPLAY_CONSTRUCTION_STEP=
 
-  # --- SonarQube / SonarCloud -------------------------------------------------                                                                                                                                                                                         
+  # --- SonarQube / SonarCloud -------------------------------------------------
   # Authentication token for the SonarCloud API. Used by supercycle skills
-  # to fetch quality-gate results. Generate at https://sonarcloud.io/account/security                                                                                                                                                                                    
+  # to fetch quality-gate results. Generate at https://sonarcloud.io/account/security
   # SONAR_TOKEN=
+
+# --- Low-Re airfoil scoring tuning (gh-825) --------------------------------
+# Relative drag-rise r = CD(CL_target)/cd0 at which Match score → 0.
+# Default 2.5 means: CD at target = 2.5 × cd0 earns zero credit.
+# LOW_RE_SCORE_R_POOR=2.5
+#
+# Drag-bucket width (ΔCL at CD ≤ 1.15·cd_min) that earns full tolerance credit.
+# A wider bucket yields a wider sweet-spot acceptance band in the Match formula.
+# Default 0.6 corresponds to an excellent low-Re airfoil bucket.
+# LOW_RE_BUCKET_TOLERANCE_REF=0.6
                       

--- a/app/api/v2/endpoints/airfoils.py
+++ b/app/api/v2/endpoints/airfoils.py
@@ -521,10 +521,24 @@ async def get_airfoil_suitability(
         float | None,
         Query(description="Explicit target CL at cruise (overrides aeroplane-derived value)."),
     ] = None,
-    target_cl_loiter: Annotated[
+    target_cl_best_glide: Annotated[
         float | None,
         Query(
-            description="Explicit target CL at loiter/landing (display-only, not used for ranking)."
+            description=(
+                "Explicit target CL at best-glide speed (V_md). "
+                "Display-only — does not drive active_lens. "
+                "Overrides aeroplane-derived value from v_md_mps context."
+            )
+        ),
+    ] = None,
+    target_cl_min_sink: Annotated[
+        float | None,
+        Query(
+            description=(
+                "Explicit target CL at min-sink speed (V_min_sink). "
+                "Display-only — does not drive active_lens. "
+                "Renamed from target_cl_loiter (gh-825)."
+            )
         ),
     ] = None,
     tip_chord_m: Annotated[
@@ -535,15 +549,25 @@ async def get_airfoil_suitability(
         int, Query(description="Maximum number of results to return.", ge=1, le=200)
     ] = 50,
 ) -> SuitabilityResponse:
-    """Return airfoils ranked by low-Re suitability.
+    """Return airfoils ranked by low-Re suitability (gh-821, gh-825).
 
     Three scoring lenses are computed at query time (no precomputed scores stored):
     1. **re_agnostic** — normalised quality from scalar metrics at the query Re.
     2. **mission** — re_agnostic × mission weighting (family/thickness/CL_max).
-    3. **target_cl_cruise** — drag from parabolic fit at the operating cruise CL.
+    3. **target_cl_cruise** — Match×Efficiency score at the cruise CL.
+
+    Two additional display-only CL scores are computed but never drive ranking:
+    - **target_cl_best_glide** — Match×Efficiency at V_md (best-glide / max-range speed).
+    - **target_cl_min_sink**   — Match×Efficiency at V_min_sink (slowest / highest CL).
 
     active_lens priority: mission > target_cl_cruise > re_agnostic.
-    active_lens is NEVER 'target_cl_loiter' (loiter is display-only).
+    Glide points (best_glide, min_sink) NEVER appear in active_lens.
+
+    Documented assumptions:
+    - Re is LOCAL (per xsec chord).
+    - Section CL ≈ wing CL (ideal elliptic, untwisted assumption).
+    - Tip-Re CL_max collapse is not modelled; surfaced via tip_re_flag + cl_max_margin +
+      caveat.ignores_tip_re_clmax_collapse.
     """
     try:
         return search_suitability(
@@ -553,7 +577,8 @@ async def get_airfoil_suitability(
             aeroplane_id=aeroplane_id,
             mission_type=mission_type,
             target_cl_cruise=target_cl_cruise,
-            target_cl_loiter=target_cl_loiter,
+            target_cl_best_glide=target_cl_best_glide,
+            target_cl_min_sink=target_cl_min_sink,
             tip_chord_m=tip_chord_m,
             limit=limit,
             settings=settings,

--- a/app/schemas/airfoil.py
+++ b/app/schemas/airfoil.py
@@ -1,7 +1,20 @@
 """Pydantic schemas for airfoil profiles.
 
-Includes the frozen API contract for the low-Re suitability endpoint (gh-821).
+Includes the frozen API contract for the low-Re suitability endpoint (gh-821, gh-825).
 See docs/superpowers/specs/2026-06-04-low-re-airfoil-scoring-design.md.
+
+## Unit and CL assumptions (documented per contract)
+
+Reynolds number stays LOCAL (per xsec chord).  Section CL is treated as
+equal to the whole-wing CL under the elliptical, untwisted ideal — this is
+the standard top-down design target assumption.  The approximation breaks
+down where tip-stall lives (low-Re tip chord, CL_max collapse), which is
+explicitly surfaced via:
+  - ``SuitabilityItem.tip_re_flag`` — True when tip Re < root Re.
+  - ``SuitabilityCaveat.ignores_tip_re_clmax_collapse`` — always True.
+  - ``SuitabilityItem.cl_max_margin`` — margin from target CL to section CL_max;
+    negative values flag designs where the section may stall before the
+    tip CL_max collapse is modelled.
 """
 
 from __future__ import annotations
@@ -49,49 +62,103 @@ class AirfoilImportResult(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# Low-Re suitability scoring — frozen API contract (gh-821)
+# Low-Re suitability scoring — frozen API contract (gh-821, updated gh-825)
 # ---------------------------------------------------------------------------
 
 # Frozen family literals — must match the classifier labels exactly.
 AirfoilFamily = Literal["flat_bottom", "semi_symmetric", "symmetric", "cambered", "reflexed"]
 
-# Frozen active-lens literals — 'target_cl_loiter' is explicitly excluded (loiter
-# is display-only; see spec §FROZEN API CONTRACT).
+# Frozen active-lens literals (gh-825):
+#   Only THREE values are valid for active_lens:
+#     - re_agnostic  : general Re-normalised quality score
+#     - mission      : mission-weighted re_agnostic
+#     - target_cl_cruise : efficiency at the cruise operating CL
+#
+#   GLIDE POINTS NEVER AUTO-RANK:
+#     target_cl_best_glide and target_cl_min_sink are display-only.
+#     The backend never sets active_lens to a glide point, so the default
+#     sort is always driven by a design-primary operating point (cruise)
+#     or mission weighting — not an engine-out / min-sink contingency point.
+#     A user may re-sort the UI list by any target-CL column (client-side),
+#     but that is an explicit user action and does NOT change active_lens.
 ActiveLens = Literal["re_agnostic", "mission", "target_cl_cruise"]
+
+# Provenance of the target CL values (gh-825).
+# Derived from the 'mass' DesignAssumptionModel.active_source combined with
+# ctx['v_cruise_auto']:
+#   - all inputs CALCULATED/auto  → "calculated"
+#   - all inputs ESTIMATE/manual  → "estimated"
+#   - otherwise                   → "mixed"
+#   - null/no mass row            → "estimated" (default)
+TargetClProvenance = Literal["estimated", "calculated", "mixed"]
 
 
 class SuitabilityItem(BaseModel):
-    """One airfoil in the ranked suitability response."""
+    """One airfoil in the ranked suitability response.
+
+    Field notes (gh-825 contract):
+      - target_cl_cruise : score at the cruise operating CL (drives active_lens).
+      - target_cl_best_glide : score at V_md (best L/D speed, display-only).
+      - target_cl_min_sink : score at V_min_sink (min-sink speed, display-only).
+      - stall_gentleness : raw dCL/dα slope past CL_max peak (≈0 gentle, negative abrupt).
+          NOT normalised to [0, 1] — raw slope value in units of CL per degree.
+      - cl_max_margin : cl_max − max(target CLs present). Negative means target CL
+          exceeds section CL_max — a stall-risk flag.
+    """
 
     airfoil_name: str
     family: AirfoilFamily
     re_agnostic: float = Field(..., ge=0.0, le=1.0)
     mission: Optional[float] = Field(None, ge=0.0, le=1.0)
     target_cl_cruise: Optional[float] = Field(None, ge=0.0, le=1.0)
-    target_cl_loiter: Optional[float] = Field(None, ge=0.0, le=1.0)
+    target_cl_best_glide: Optional[float] = Field(None, ge=0.0, le=1.0)
+    target_cl_min_sink: Optional[float] = Field(None, ge=0.0, le=1.0)
+    stall_gentleness: Optional[float] = Field(
+        None,
+        description="dCL/dα past CL_max peak (raw, ≈0 gentle / negative abrupt). NOT 0..1.",
+    )
+    cl_max_margin: Optional[float] = Field(
+        None,
+        description="cl_max − max(target CLs present). Negative → target above section CL_max.",
+    )
     min_analysis_confidence: float = Field(..., ge=0.0, le=1.0)
     tip_re_flag: bool
     caveat: str
 
 
 class SuitabilityQuery(BaseModel):
-    """Echo of the query parameters used to compute this response."""
+    """Echo of the query parameters used to compute this response.
+
+    target_cl_provenance documents how reliably the three target CLs were derived:
+      - 'calculated' : mass and cruise speed were both auto-computed
+      - 'estimated'  : at least one input was a manual estimate
+      - 'mixed'      : some inputs calculated, some estimated
+    """
 
     chord_m: float
     speed_ms: float
     reynolds: float
     re_clamped: bool
-    mission_type: Optional[str]
-    target_cl_cruise: Optional[float]
-    target_cl_loiter: Optional[float]
+    mission_type: Optional[str] = None
+    target_cl_cruise: Optional[float] = None
+    target_cl_best_glide: Optional[float] = None
+    target_cl_min_sink: Optional[float] = None
+    target_cl_provenance: TargetClProvenance = "estimated"
     active_lens: ActiveLens
 
 
 class SuitabilityCaveat(BaseModel):
-    """Caveats block. Always present in every suitability response."""
+    """Caveats block. Always present in every suitability response.
+
+    ignores_tip_re_clmax_collapse is always True: the score uses section CL as
+    a proxy for whole-wing CL (ideal elliptic, untwisted assumption).  This
+    ignores the tip-Re CL_max collapse that governs tip-stall onset on tapered
+    wings.  Use tip_re_flag + cl_max_margin to surface this risk in the UI.
+    """
 
     relative_ranking_only: bool = True
     no_hysteresis_modelling: bool = True
+    ignores_tip_re_clmax_collapse: bool = True
     recommend_xfoil_validation: bool
     text: str
 

--- a/app/services/airfoil_low_re_service.py
+++ b/app/services/airfoil_low_re_service.py
@@ -22,11 +22,14 @@ from __future__ import annotations
 
 import logging
 import math
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
 from app.schemas.airfoil import AirfoilFamily
+
+if TYPE_CHECKING:
+    from app.settings import Settings
 
 logger = logging.getLogger(__name__)
 
@@ -496,6 +499,122 @@ def _level_flight_cl(mass_kg: float, v_ms: float, s_ref_m2: float) -> float:
 
 
 # ---------------------------------------------------------------------------
+# best_ld_cl — closed-form CL at maximum L/D (gh-825)
+# ---------------------------------------------------------------------------
+
+
+def best_ld_cl(cd0: float, k: float, cl0: float) -> float | None:
+    """Compute the CL that maximises L/D for a parabolic drag polar.
+
+    Polar model: CD = cd0 + k·(CL − cl0)²
+
+    From d/dCL [ CL / CD ] = 0 we get:
+
+        CD·1 − CL·d(CD)/dCL = 0
+        (cd0 + k·(CL−cl0)²) − CL·2k·(CL−cl0) = 0
+
+    Let u = CL − cl0:
+        cd0 + k·u² = (u + cl0)·2k·u
+        cd0 = 2k·u² + 2k·cl0·u − k·u²
+        cd0 = k·u² + 2k·cl0·u   ← rearranged
+                                    (using symmetry around cl0: the cl0 cross
+                                     term cancels and we get u = sqrt(cd0/k))
+
+    The exact closed-form solution is:
+        CL* = cl0 + sqrt(cd0 / k)
+
+    Full derivation:  L/D = CL/CD.  d(L/D)/dCL = 0 gives
+        CD − CL·dCD/dCL = 0
+        cd0 + k(CL−cl0)² = CL·2k(CL−cl0)
+    Let u = CL−cl0, so CL = u + cl0:
+        cd0 + k·u² = 2k(u+cl0)·u = 2k·u² + 2k·cl0·u
+        0 = k·u² + 2k·cl0·u − cd0
+    Solve quadratic: u = [−2k·cl0 ± sqrt(4k²·cl0² + 4k·cd0)] / (2k)
+                       = −cl0 ± sqrt(cl0² + cd0/k)
+    CL* = u + cl0 = ±sqrt(cl0² + cd0/k); take positive root.
+
+    Special case cl0=0: CL* = sqrt(cd0/k). ✓
+
+    Parameters
+    ----------
+    cd0 : float  Parasite drag coefficient (must be > 0).
+    k   : float  Induced drag factor (must be > 0).
+    cl0 : float  CL at minimum CD (offset of the parabola vertex).
+
+    Returns
+    -------
+    float | None
+        CL at maximum L/D (positive root), or None if the inputs are unphysical.
+    """
+    if cd0 <= 0.0 or k <= 0.0:
+        return None
+    return math.sqrt(cl0**2 + cd0 / k)
+
+
+# ---------------------------------------------------------------------------
+# compute_re_cd0_reference — fleet-level cd0 percentile for Re-fair efficiency
+# ---------------------------------------------------------------------------
+
+# Fallback cd0 reference when no finite values can be extracted.
+_CD0_REFERENCE_FALLBACK = 0.020
+
+
+def compute_re_cd0_reference(
+    polars_by_name: dict[str, list],
+    re_query: float,
+    percentile: float = 20.0,
+) -> float:
+    """Compute a robust low-percentile cd0 across the fleet at the given Re.
+
+    This provides a per-Re reference for the Efficiency component of
+    score_target_cl: how does this airfoil's cd0 compare to the *best*
+    airfoils achievable at this Re?
+
+    Algorithm:
+      1. For each airfoil in `polars_by_name`, interpolate to re_query (log-linear).
+      2. Collect all finite cd0 values from the interpolated polars.
+      3. Return the `percentile`-th percentile (default 20th) — a robust minimum
+         that is not dominated by outliers but still reflects the best performers.
+
+    Returns the documented fallback value (_CD0_REFERENCE_FALLBACK = 0.020) when
+    no finite cd0 values are present (empty fleet or all-None rows).
+
+    Parameters
+    ----------
+    polars_by_name : dict[str, list[AirfoilLowRePolarModel]]
+        Keyed by airfoil_name.  One entry per unique airfoil.
+    re_query : float
+        Query Re (may be between grid points — will be interpolated).
+    percentile : float
+        Which percentile of the fleet cd0 distribution to use as reference.
+        Default 20.0 (robust low end; not the absolute minimum).
+
+    Returns
+    -------
+    float  Per-Re cd0 reference (> 0).
+    """
+    # We need the grid for interpolation.  Use a wide grid to avoid clamping.
+    from app.settings import get_settings
+
+    re_grid = get_settings().low_re_grid
+
+    cd0_values: list[float] = []
+    for rows in polars_by_name.values():
+        polar = interpolate_polar_at_re(rows, re_query, re_grid)
+        if polar is None:
+            continue
+        cd0 = polar.get("cd0")
+        if cd0 is not None and math.isfinite(cd0) and cd0 > 0.0:
+            cd0_values.append(cd0)
+
+    if not cd0_values:
+        return _CD0_REFERENCE_FALLBACK
+
+    cd0_arr = np.array(cd0_values, dtype=float)
+    return float(np.percentile(cd0_arr, percentile))
+
+
+# ---------------------------------------------------------------------------
 # Three scoring lenses
 # ---------------------------------------------------------------------------
 
@@ -613,15 +732,54 @@ def score_mission(
 
 
 def score_target_cl(
-    polar: dict,
+    polar: dict | None,
     cl_target: float,
+    *,
+    re_cd0_reference: float,
+    settings: "Settings",
 ) -> float | None:
-    """Score how well an airfoil performs at the target CL (0..1).
+    """Score how well an airfoil performs at the target CL (0..1) — gh-825.
 
-    Uses the parabolic drag fit CD = cd0 + k*(CL-cl0)^2.
-    Returns None if fit coefficients are absent or cl_target is out of valid range.
+    Formula: Match × Efficiency, clamped to [0, 1].
 
-    Higher score = lower drag at cl_target (better suitability).
+    **Match** — how well cl_target sits in this airfoil's drag sweet-spot:
+
+        cl_star = best_ld_cl(cd0, k, cl0)   # CL at max L/D
+        r = CD(cl_target) / cd0             # relative drag rise at target
+        r_poor = settings.low_re_score_r_poor   # r at which Match → 0
+
+        A wider drag bucket gives a wider tolerance band.  The tolerance
+        half-width is scaled by the airfoil's drag_bucket_width relative to
+        settings.low_re_bucket_tolerance_ref (a wide-bucket reference).
+
+        Specifically:
+          tolerance = (drag_bucket_width / low_re_bucket_tolerance_ref) × 0.5
+          (half-width of a linearly forgiving zone around cl_star)
+
+        Within tolerance: Match = 1 − (r−1) / (r_poor − 1)   [linear in r]
+        r ≤ 1 (at/below cl_star): Match = 1.0 (can only be better)
+        r ≥ r_poor: Match = 0.0
+
+        A wider bucket: tolerance zone is wider → Match degrades more slowly
+        with distance from cl_star.
+
+    **Efficiency** — Re-fair: how clean is this airfoil at this Re vs fleet?
+
+        efficiency = min(re_cd0_reference / cd0, 1.0)
+
+        If this airfoil has cd0 < re_cd0_reference it earns extra efficiency
+        (capped at 1.0). An airfoil with cd0 = fleet median gets partial credit.
+
+    Final = Match × Efficiency, clamped to [0, 1].
+
+    Returns None when cd0/k/cl0 are absent in the polar dict.
+
+    Parameters
+    ----------
+    polar : dict | None        Interpolated polar dict (from interpolate_polar_at_re).
+    cl_target : float          Operating CL to evaluate (level-flight cruise, etc.).
+    re_cd0_reference : float   Per-Re fleet cd0 reference (from compute_re_cd0_reference).
+    settings : Settings        Application settings (for r_poor and bucket_tolerance_ref).
     """
     if polar is None:
         return None
@@ -629,34 +787,60 @@ def score_target_cl(
     cd0 = polar.get("cd0")
     k = polar.get("k")
     cl0 = polar.get("cl0")
-    cl_lo = polar.get("cl_valid_lo")
-    cl_hi = polar.get("cl_valid_hi")
 
     if any(v is None for v in (cd0, k, cl0)):
         return None
 
-    # Check if cl_target is within the valid fit range
-    in_range = True
-    if cl_lo is not None and cl_hi is not None:
-        if cl_target < cl_lo or cl_target > cl_hi:
-            in_range = False
+    # Guard against unphysical fit values (e.g. near-zero k from bad fit)
+    if cd0 <= 0.0 or k <= 0.0:
+        return None
+
+    bucket_width = polar.get("drag_bucket_width") or 0.0
+    r_poor = settings.low_re_score_r_poor
+    bucket_ref = settings.low_re_bucket_tolerance_ref
+
+    # --- Match component ---
+    cl_star = best_ld_cl(cd0, k, cl0)
+    if cl_star is None:
+        return None
 
     cd_at_target = cd0 + k * (cl_target - cl0) ** 2
+    r = cd_at_target / cd0  # relative drag rise; r=1 at CL_min, r>1 away from it
 
-    # Score: normalise against a reference CD (good RC airfoil at op. CL)
-    # CD of 0.012 at operating CL → score 1.0; CD of 0.05 → score ~0
-    CD_REF_EXCELLENT = 0.010
-    CD_REF_POOR = 0.050
+    # Tolerance: wider bucket → wider acceptance zone
+    tolerance_half = (bucket_width / max(bucket_ref, 1e-9)) * 0.5
+    distance_from_sweet_spot = abs(cl_target - cl_star)
 
-    if cd_at_target <= 0:
-        return 0.0
+    # Inside tolerance zone: Match decays only due to r
+    # Outside: Match decays due to r (which grows with distance)
+    # Use r to compute Match directly: it captures both bucket penalty and drag rise
+    if r <= 1.0:
+        # At or below minimum drag: match = 1.0 (but softened by tolerance if
+        # we're in the bucket centre)
+        match = 1.0
+    elif r >= r_poor:
+        match = 0.0
+    else:
+        # Linear decay from 1 (r=1) to 0 (r=r_poor)
+        match_raw = 1.0 - (r - 1.0) / (r_poor - 1.0)
+        # Bonus for wide bucket: widen the effective r=1 zone by scaling down
+        # the distance from optimal — a wider bucket means we reach a given r
+        # more slowly as target moves away from cl_star.
+        # Implement: if distance_from_sweet_spot < tolerance_half, boost match
+        if tolerance_half > 0 and distance_from_sweet_spot < tolerance_half:
+            # Partial credit for being inside the bucket tolerance zone:
+            # interpolate between match_raw and 1.0 based on proximity
+            frac = 1.0 - distance_from_sweet_spot / tolerance_half
+            match = match_raw + (1.0 - match_raw) * frac * 0.5
+            match = min(match, 1.0)
+        else:
+            match = match_raw
 
-    # Linear scale: 1.0 at excellent, 0.0 at poor
-    cd_score = max(0.0, (CD_REF_POOR - cd_at_target) / (CD_REF_POOR - CD_REF_EXCELLENT))
-    cd_score = min(cd_score, 1.0)
+    # --- Efficiency component ---
+    if re_cd0_reference > 0.0 and cd0 > 0.0:
+        efficiency = min(re_cd0_reference / cd0, 1.0)
+    else:
+        efficiency = 1.0
 
-    # Penalise if outside valid range
-    if not in_range:
-        cd_score *= 0.5
-
-    return float(cd_score)
+    score = match * efficiency
+    return float(min(max(score, 0.0), 1.0))

--- a/app/services/airfoil_low_re_service.py
+++ b/app/services/airfoil_low_re_service.py
@@ -742,7 +742,9 @@ def score_target_cl(
 
     Formula: Match × Efficiency, clamped to [0, 1].
 
-    **Match** — how well cl_target sits in this airfoil's drag sweet-spot:
+    Formula: Match × Efficiency, clamped to [0, 1].
+
+    **Match** — primary: drag-rise ratio r-formula (cruise / best-glide region)
 
         cl_star = best_ld_cl(cd0, k, cl0)   # CL at max L/D
         r = CD(cl_target) / cd0             # relative drag rise at target
@@ -763,6 +765,28 @@ def score_target_cl(
         A wider bucket: tolerance zone is wider → Match degrades more slowly
         with distance from cl_star.
 
+    **CL_max safety fallback** (high-CL glide-point correction — gh-825)
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    When r ≥ r_poor (drag-rise formula gives 0), an airfoil with ample
+    CL_max margin above cl_target is unfairly penalised. This occurs for
+    glider min-sink CLs (CL ≈ sqrt(3)·CL_md >> cl_star), where r >> r_poor
+    even for excellent glider airfoils.
+
+    When r ≥ r_poor AND cl_max is present in the polar, we replace the
+    drag-rise Match=0 with a CL_max-margin score:
+
+        margin = cl_max − cl_target
+        safety_band = settings.low_re_score_cl_max_safety_band  (default 0.30)
+
+        Match_fallback = clamp(margin / safety_band, 0, 1)
+
+        margin ≤ 0    : Match = 0.0 (target CL at or above CL_max — stall risk)
+        margin ≥ band : Match = 1.0 (ample safety margin)
+        in between    : linear interpolation
+
+    This ensures the glide-point lens differentiates airfoils by their
+    usable CL range rather than collapsing to zero universally.
+
     **Efficiency** — Re-fair: how clean is this airfoil at this Re vs fleet?
 
         efficiency = min(re_cd0_reference / cd0, 1.0)
@@ -779,7 +803,8 @@ def score_target_cl(
     polar : dict | None        Interpolated polar dict (from interpolate_polar_at_re).
     cl_target : float          Operating CL to evaluate (level-flight cruise, etc.).
     re_cd0_reference : float   Per-Re fleet cd0 reference (from compute_re_cd0_reference).
-    settings : Settings        Application settings (for r_poor and bucket_tolerance_ref).
+    settings : Settings        Application settings (for r_poor, bucket_tolerance_ref,
+                               and cl_max_safety_band).
     """
     if polar is None:
         return None
@@ -798,11 +823,15 @@ def score_target_cl(
     bucket_width = polar.get("drag_bucket_width") or 0.0
     r_poor = settings.low_re_score_r_poor
     bucket_ref = settings.low_re_bucket_tolerance_ref
+    cl_max_safety_band = settings.low_re_score_cl_max_safety_band
 
-    # --- Match component ---
+    # --- cl_star: CL at maximum L/D ---
     cl_star = best_ld_cl(cd0, k, cl0)
     if cl_star is None:
         return None
+
+    # --- Match component: drag-rise r-formula with CL_max safety fallback ---
+    cl_max = polar.get("cl_max")
 
     cd_at_target = cd0 + k * (cl_target - cl0) ** 2
     r = cd_at_target / cd0  # relative drag rise; r=1 at CL_min, r>1 away from it
@@ -811,32 +840,34 @@ def score_target_cl(
     tolerance_half = (bucket_width / max(bucket_ref, 1e-9)) * 0.5
     distance_from_sweet_spot = abs(cl_target - cl_star)
 
-    # Inside tolerance zone: Match decays only due to r
-    # Outside: Match decays due to r (which grows with distance)
-    # Use r to compute Match directly: it captures both bucket penalty and drag rise
     if r <= 1.0:
-        # At or below minimum drag: match = 1.0 (but softened by tolerance if
-        # we're in the bucket centre)
+        # At or below minimum drag: match = 1.0
         match = 1.0
     elif r >= r_poor:
-        match = 0.0
+        # Drag-rise formula would give 0. For high-CL glide points (e.g.
+        # V_min_sink where CL ≈ sqrt(3)·CL_md), r is structurally large even
+        # for excellent airfoils. Use CL_max safety margin as a fallback when
+        # cl_max is available: differentiates by stall margin rather than
+        # collapsing universally to 0.
+        if cl_max is not None:
+            margin = cl_max - cl_target
+            if margin <= 0.0:
+                match = 0.0  # stall risk: target at or above CL_max
+            else:
+                match = min(margin / max(cl_max_safety_band, 1e-9), 1.0)
+        else:
+            match = 0.0
     else:
-        # Linear decay from 1 (r=1) to 0 (r=r_poor)
+        # r in (1, r_poor): linear decay + bucket tolerance bonus
         match_raw = 1.0 - (r - 1.0) / (r_poor - 1.0)
-        # Bonus for wide bucket: widen the effective r=1 zone by scaling down
-        # the distance from optimal — a wider bucket means we reach a given r
-        # more slowly as target moves away from cl_star.
-        # Implement: if distance_from_sweet_spot < tolerance_half, boost match
         if tolerance_half > 0 and distance_from_sweet_spot < tolerance_half:
-            # Partial credit for being inside the bucket tolerance zone:
-            # interpolate between match_raw and 1.0 based on proximity
             frac = 1.0 - distance_from_sweet_spot / tolerance_half
             match = match_raw + (1.0 - match_raw) * frac * 0.5
             match = min(match, 1.0)
         else:
             match = match_raw
 
-    # --- Efficiency component ---
+    # --- Efficiency component (both paths) ---
     if re_cd0_reference > 0.0 and cd0 > 0.0:
         efficiency = min(re_cd0_reference / cd0, 1.0)
     else:

--- a/app/services/suitability_service.py
+++ b/app/services/suitability_service.py
@@ -1,4 +1,4 @@
-"""Airfoil suitability search service (gh-821).
+"""Airfoil suitability search service (gh-821, gh-825).
 
 Implements GET /airfoils/db/suitability — resolves Re from chord/speed,
 optionally resolves aeroplane context (UUID → mission + operating CLs),
@@ -8,10 +8,23 @@ ranked results with a caveat block.
 Three lenses (ranked desc by active_lens):
   1. re_agnostic — normalised quality from scalar metrics at query Re.
   2. mission     — re_agnostic × mission-weighting table (family/thickness/cl_max).
-  3. target_cl_cruise — CD(CL_target) from parabolic fit; null when CL unavailable.
+  3. target_cl_cruise — Match×Efficiency at the cruise CL; null when CL unavailable.
 
 active_lens priority: mission (if resolved) > target_cl_cruise (if resolved) > re_agnostic.
-active_lens is NEVER 'target_cl_loiter' (loiter is display-only).
+active_lens is NEVER a glide point (target_cl_best_glide / target_cl_min_sink).
+
+## Documented assumptions (gh-825)
+- Re stays LOCAL (per xsec chord).
+- Section CL ≈ whole-wing CL under the elliptical, untwisted ideal (top-down design target).
+- Tip-Re CL_max collapse is NOT modelled — surfaced via tip_re_flag + cl_max_margin +
+  caveat.ignores_tip_re_clmax_collapse.
+
+## Target CL provenance
+target_cl_provenance documents the reliability of the three resolved target CLs:
+  - 'calculated' : mass row CALCULATED/auto AND v_cruise_auto=True in ctx
+  - 'estimated'  : mass row ESTIMATE/manual OR v_cruise_auto absent/False
+  - 'mixed'      : mass calculated but speed estimated (or vice versa)
+  - Default 'estimated' when no aeroplane or no mass row.
 """
 
 from __future__ import annotations
@@ -22,7 +35,7 @@ from typing import Optional
 
 from sqlalchemy.orm import Session
 
-from app.models.aeroplanemodel import AeroplaneModel
+from app.models.aeroplanemodel import AeroplaneModel, DesignAssumptionModel
 from app.models.airfoil import AirfoilModel
 from app.models.airfoil_low_re import AirfoilGeometryModel, AirfoilLowRePolarModel
 from app.models.mission_objective import MissionObjectiveModel
@@ -31,9 +44,11 @@ from app.schemas.airfoil import (
     SuitabilityItem,
     SuitabilityQuery,
     SuitabilityResponse,
+    TargetClProvenance,
 )
 from app.services.airfoil_low_re_service import (
     _level_flight_cl,
+    compute_re_cd0_reference,
     interpolate_polar_at_re,
     score_mission,
     score_re_agnostic,
@@ -106,6 +121,48 @@ def _clamp_re_to_grid(re: float, grid: list[int]) -> tuple[float, bool]:
     return re, False
 
 
+def _resolve_provenance(
+    aeroplane: Optional[AeroplaneModel],
+    db: Session,
+    ctx: dict,
+) -> TargetClProvenance:
+    """Derive target_cl_provenance from the mass DesignAssumptionModel + v_cruise_auto.
+
+    Rules:
+      - No aeroplane / no mass row → 'estimated'
+      - mass.active_source in ('CALCULATED', 'COMPUTED') AND ctx['v_cruise_auto'] is truthy
+        → 'calculated'
+      - mass.active_source in ('ESTIMATE', 'MANUAL') AND NOT v_cruise_auto
+        → 'estimated'
+      - Otherwise (one calculated, one estimated) → 'mixed'
+    """
+    if aeroplane is None:
+        return "estimated"
+
+    mass_row = (
+        db.query(DesignAssumptionModel)
+        .filter(
+            DesignAssumptionModel.aeroplane_id == aeroplane.id,
+            DesignAssumptionModel.parameter_name == "mass",
+        )
+        .first()
+    )
+
+    mass_is_calculated = False
+    if mass_row is not None:
+        src = (mass_row.active_source or "").upper()
+        mass_is_calculated = src in ("CALCULATED", "COMPUTED", "AUTO")
+
+    v_cruise_auto = bool(ctx.get("v_cruise_auto", False))
+
+    if mass_is_calculated and v_cruise_auto:
+        return "calculated"
+    if not mass_is_calculated and not v_cruise_auto:
+        return "estimated"
+    # Mixed: one is calculated, the other is not
+    return "mixed"
+
+
 def search_suitability(
     db: Session,
     chord_m: float,
@@ -114,7 +171,8 @@ def search_suitability(
     aeroplane_id: Optional[str] = None,
     mission_type: Optional[str] = None,
     target_cl_cruise: Optional[float] = None,
-    target_cl_loiter: Optional[float] = None,
+    target_cl_best_glide: Optional[float] = None,
+    target_cl_min_sink: Optional[float] = None,
     tip_chord_m: Optional[float] = None,
     limit: int = 50,
     settings: Optional[Settings] = None,
@@ -131,13 +189,22 @@ def search_suitability(
                            Unknown UUID → degrade to re_agnostic-only (no 500).
     mission_type : str     Optional explicit mission type (overrides model-derived).
     target_cl_cruise : float  Optional explicit override for cruise target CL.
-    target_cl_loiter : float  Optional explicit override for loiter target CL.
+    target_cl_best_glide : float  Optional explicit override for best-glide CL.
+    target_cl_min_sink : float    Optional explicit override for min-sink CL
+                           (renamed from target_cl_loiter).
     tip_chord_m : float    Optional tip chord for tip Re flag only.
     limit : int            Maximum results to return.
     settings : Settings    Application settings.  When omitted the module-level
                            lru-cached ``get_settings()`` is used — avoids
                            constructing a fresh ``Settings()`` per request.
                            Pass an explicit instance from the CLI or tests.
+
+    ## Three target CLs
+    target_cl_cruise    ← v_cruise_mps   (drives active_lens; can auto-rank)
+    target_cl_best_glide ← v_md_mps     (display-only; never auto-ranks)
+    target_cl_min_sink  ← v_min_sink_mps (display-only; never auto-ranks)
+
+    Explicit params always override context-derived values.
     """
     if settings is None:
         settings = get_settings()
@@ -158,7 +225,12 @@ def search_suitability(
     # --- Resolve aeroplane context ---
     effective_mission_type: Optional[str] = mission_type
     effective_target_cl_cruise: Optional[float] = target_cl_cruise
-    effective_target_cl_loiter: Optional[float] = target_cl_loiter
+    effective_target_cl_best_glide: Optional[float] = target_cl_best_glide
+    effective_target_cl_min_sink: Optional[float] = target_cl_min_sink
+
+    aeroplane: Optional[AeroplaneModel] = None
+    ctx: dict = {}
+    provenance: TargetClProvenance = "estimated"
 
     if aeroplane_id is not None:
         aeroplane = (
@@ -184,6 +256,7 @@ def search_suitability(
             ctx = getattr(aeroplane, "assumption_computation_context", None) or {}
             mass_kg: Optional[float] = ctx.get("mass_kg")
             v_cruise_mps: Optional[float] = ctx.get("v_cruise_mps")
+            v_md_mps: Optional[float] = ctx.get("v_md_mps")  # best-glide speed (NEW)
             v_min_sink_mps: Optional[float] = ctx.get("v_min_sink_mps")
             s_ref_m2: Optional[float] = ctx.get("s_ref_m2")
 
@@ -197,15 +270,28 @@ def search_suitability(
                     except (ValueError, ZeroDivisionError):
                         effective_target_cl_cruise = None
 
-            # Compute loiter CL (explicit param overrides derived)
-            if effective_target_cl_loiter is None:
+            # Compute best-glide CL from v_md_mps (explicit param overrides derived)
+            if effective_target_cl_best_glide is None:
+                if all(v is not None for v in (mass_kg, v_md_mps, s_ref_m2)):
+                    try:
+                        effective_target_cl_best_glide = _level_flight_cl(
+                            mass_kg, v_md_mps, s_ref_m2
+                        )
+                    except (ValueError, ZeroDivisionError):
+                        effective_target_cl_best_glide = None
+
+            # Compute min-sink CL (renamed from loiter; explicit param overrides derived)
+            if effective_target_cl_min_sink is None:
                 if all(v is not None for v in (mass_kg, v_min_sink_mps, s_ref_m2)):
                     try:
-                        effective_target_cl_loiter = _level_flight_cl(
+                        effective_target_cl_min_sink = _level_flight_cl(
                             mass_kg, v_min_sink_mps, s_ref_m2
                         )
                     except (ValueError, ZeroDivisionError):
-                        effective_target_cl_loiter = None
+                        effective_target_cl_min_sink = None
+
+    # --- Provenance ---
+    provenance = _resolve_provenance(aeroplane, db, ctx)
 
     # --- Query DB: all airfoil geometries + polars ---
     geo_rows = db.query(AirfoilGeometryModel).all()
@@ -217,6 +303,9 @@ def search_suitability(
     polars_by_name: dict[str, list] = {}
     for p in polar_rows:
         polars_by_name.setdefault(p.airfoil_name, []).append(p)
+
+    # --- Per-Re cd0 reference (computed once for the request) ---
+    re_cd0_ref = compute_re_cd0_reference(polars_by_name, re_clamped_root)
 
     # --- Score each airfoil ---
     items: list[SuitabilityItem] = []
@@ -242,14 +331,54 @@ def search_suitability(
                 mission_weights=mission_weights,
             )
 
-        # Target CL lenses
+        # Target CL lenses — cruise can auto-rank; glide points are display-only
         cl_cruise_score: Optional[float] = None
         if effective_target_cl_cruise is not None and polar is not None:
-            cl_cruise_score = score_target_cl(polar, effective_target_cl_cruise)
+            cl_cruise_score = score_target_cl(
+                polar,
+                effective_target_cl_cruise,
+                re_cd0_reference=re_cd0_ref,
+                settings=settings,
+            )
 
-        cl_loiter_score: Optional[float] = None
-        if effective_target_cl_loiter is not None and polar is not None:
-            cl_loiter_score = score_target_cl(polar, effective_target_cl_loiter)
+        cl_best_glide_score: Optional[float] = None
+        if effective_target_cl_best_glide is not None and polar is not None:
+            cl_best_glide_score = score_target_cl(
+                polar,
+                effective_target_cl_best_glide,
+                re_cd0_reference=re_cd0_ref,
+                settings=settings,
+            )
+
+        cl_min_sink_score: Optional[float] = None
+        if effective_target_cl_min_sink is not None and polar is not None:
+            cl_min_sink_score = score_target_cl(
+                polar,
+                effective_target_cl_min_sink,
+                re_cd0_reference=re_cd0_ref,
+                settings=settings,
+            )
+
+        # stall_gentleness — raw from polar
+        stall_gentleness: Optional[float] = polar.get("stall_gentleness") if polar else None
+
+        # cl_max_margin = cl_max − max(resolved target CLs present)
+        cl_max_margin: Optional[float] = None
+        if polar is not None:
+            cl_max_val = polar.get("cl_max")
+            if cl_max_val is not None:
+                # Collect all resolved target CLs
+                target_cls = [
+                    v
+                    for v in (
+                        effective_target_cl_cruise,
+                        effective_target_cl_best_glide,
+                        effective_target_cl_min_sink,
+                    )
+                    if v is not None
+                ]
+                if target_cls:
+                    cl_max_margin = cl_max_val - max(target_cls)
 
         # min_analysis_confidence
         min_conf = polar.get("min_analysis_confidence") if polar else None
@@ -270,7 +399,10 @@ def search_suitability(
                 re_agnostic=re_agn,
                 mission=mission_score,
                 target_cl_cruise=cl_cruise_score,
-                target_cl_loiter=cl_loiter_score,
+                target_cl_best_glide=cl_best_glide_score,
+                target_cl_min_sink=cl_min_sink_score,
+                stall_gentleness=stall_gentleness,
+                cl_max_margin=cl_max_margin,
                 min_analysis_confidence=min_conf,
                 tip_re_flag=tip_re_flag_all,
                 caveat=item_caveat,
@@ -283,6 +415,13 @@ def search_suitability(
     #   Secondary: active-lens score descending within each confidence tier
     # The *displayed* scores (re_agnostic / mission / target_cl_cruise) are
     # intentionally unchanged — only the sort position is confidence-aware.
+    #
+    # RANKING RULE (gh-825):
+    #   active_lens chosen by priority:
+    #     1. 'mission'           — if any item.mission is not None
+    #     2. 'target_cl_cruise'  — else if any item.target_cl_cruise is not None
+    #     3. 're_agnostic'       — otherwise
+    #   Glide points NEVER auto-rank (never assigned to active_lens).
     has_mission = any(item.mission is not None for item in items)
     has_cruise = any(item.target_cl_cruise is not None for item in items)
 
@@ -304,10 +443,15 @@ def search_suitability(
     items = items[:limit]
 
     # --- Build response ---
-    caveat_text = "Relative ranking only. No hysteresis or laminar-bubble modelling. "
+    caveat_text = (
+        "Relative ranking only. "
+        "No hysteresis or laminar-bubble modelling. "
+        "Section CL ≈ wing CL (ideal elliptic, untwisted). "
+        "Tip-Re CL_max collapse not modelled — check tip_re_flag and cl_max_margin."
+    )
     if recommend_xfoil:
         caveat_text += (
-            "Some airfoils have low analysis confidence — "
+            " Some airfoils have low analysis confidence — "
             "validation with XFoil or wind tunnel recommended."
         )
 
@@ -318,12 +462,15 @@ def search_suitability(
         re_clamped=re_clamped,
         mission_type=effective_mission_type,
         target_cl_cruise=effective_target_cl_cruise,
-        target_cl_loiter=effective_target_cl_loiter,
+        target_cl_best_glide=effective_target_cl_best_glide,
+        target_cl_min_sink=effective_target_cl_min_sink,
+        target_cl_provenance=provenance,
         active_lens=active_lens,
     )
     caveat = SuitabilityCaveat(
         relative_ranking_only=True,
         no_hysteresis_modelling=True,
+        ignores_tip_re_clmax_collapse=True,
         recommend_xfoil_validation=recommend_xfoil,
         text=caveat_text,
     )

--- a/app/settings.py
+++ b/app/settings.py
@@ -96,6 +96,9 @@ class Settings(BaseSettings):
     low_re_score_r_poor: float = 2.5
     # Drag-bucket width that earns full tolerance credit in Match formula (gh-825).
     low_re_bucket_tolerance_ref: float = 0.6
+    # CL_max margin (cl_max − cl_target) at which the high-CL Match component
+    # reaches 1.0.  Below 0 → score 0 (stall risk).  (gh-825 glide-point fix)
+    low_re_score_cl_max_safety_band: float = 0.30
     # Mission-weight coefficient table keyed by mission preset name.
     low_re_mission_weights: dict[str, dict[str, Any]] = Field(
         default_factory=lambda: dict(_DEFAULT_MISSION_WEIGHTS)

--- a/app/settings.py
+++ b/app/settings.py
@@ -92,6 +92,10 @@ class Settings(BaseSettings):
     low_re_confidence_gate: float = 0.90
     # Flag threshold: any item with min_analysis_confidence < flag → caveat.
     low_re_low_confidence_flag: float = 0.85
+    # Relative drag-rise CD(CL_target)/cd0 at which Match→0  (gh-825 scoring).
+    low_re_score_r_poor: float = 2.5
+    # Drag-bucket width that earns full tolerance credit in Match formula (gh-825).
+    low_re_bucket_tolerance_ref: float = 0.6
     # Mission-weight coefficient table keyed by mission preset name.
     low_re_mission_weights: dict[str, dict[str, Any]] = Field(
         default_factory=lambda: dict(_DEFAULT_MISSION_WEIGHTS)

--- a/app/tests/test_airfoil_low_re_config.py
+++ b/app/tests/test_airfoil_low_re_config.py
@@ -90,3 +90,35 @@ def test_mission_weights_values_positive():
     s = Settings()
     for mission, weights in s.low_re_mission_weights.items():
         assert weights["cl_max_weight"] > 0, f"cl_max_weight must be positive for {mission}"
+
+
+# ---------------------------------------------------------------------------
+# gh-825 new scoring constants
+# ---------------------------------------------------------------------------
+
+
+def test_low_re_score_r_poor_default():
+    """low_re_score_r_poor must default to ~2.5 (relative drag-rise at Match→0)."""
+    from app.settings import Settings
+
+    s = Settings()
+    assert s.low_re_score_r_poor == pytest.approx(2.5)
+
+
+def test_low_re_bucket_tolerance_ref_default():
+    """low_re_bucket_tolerance_ref must default to ~0.6 (full-credit bucket width)."""
+    from app.settings import Settings
+
+    s = Settings()
+    assert s.low_re_bucket_tolerance_ref == pytest.approx(0.6)
+
+
+def test_settings_gh825_fields_present():
+    """Both gh-825 fields must be accessible on the Settings object."""
+    from app.settings import Settings
+
+    s = Settings()
+    assert hasattr(s, "low_re_score_r_poor")
+    assert hasattr(s, "low_re_bucket_tolerance_ref")
+    assert s.low_re_score_r_poor > 1.0
+    assert 0.0 < s.low_re_bucket_tolerance_ref <= 2.0

--- a/app/tests/test_airfoil_low_re_service.py
+++ b/app/tests/test_airfoil_low_re_service.py
@@ -1,0 +1,746 @@
+"""Tests for airfoil_low_re_service math helpers (gh-825).
+
+TDD: RED first, then implementation makes them GREEN.
+No AeroSandbox / NeuralFoil needed — pure math over polar dicts.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+# ---------------------------------------------------------------------------
+# Shared polar fixtures
+# ---------------------------------------------------------------------------
+
+_GOOD_POLAR = {
+    "ld_max": 55.0,
+    "cl_max": 1.3,
+    "alpha_attached_lo": -3.0,
+    "alpha_attached_hi": 12.0,
+    "drag_bucket_width": 0.6,
+    "cd_min": 0.009,
+    "stall_gentleness": -0.05,
+    "cd0": 0.010,
+    "k": 0.040,
+    "cl0": 0.3,
+    "cl_valid_lo": -0.2,
+    "cl_valid_hi": 1.3,
+    "min_analysis_confidence": 0.95,
+}
+
+_NARROW_BUCKET_POLAR = {
+    **_GOOD_POLAR,
+    "drag_bucket_width": 0.1,  # narrow bucket — same centre cd0/k/cl0
+}
+
+_HIGH_DRAG_POLAR = {
+    **_GOOD_POLAR,
+    "cd0": 0.030,  # 3× higher cd0, same k
+}
+
+
+# ---------------------------------------------------------------------------
+# TASK B1: best_ld_cl — closed-form CL at max L/D
+# ---------------------------------------------------------------------------
+
+
+class TestBestLdCl:
+    """Unit tests for best_ld_cl(cd0, k, cl0) -> float | None."""
+
+    def test_symmetric_airfoil_cl0_zero(self):
+        """For cl0=0: CL* = sqrt(cd0/k) — verified analytically."""
+        from app.services.airfoil_low_re_service import best_ld_cl
+
+        cd0, k, cl0 = 0.010, 0.040, 0.0
+        cl_star = best_ld_cl(cd0, k, cl0)
+        expected = math.sqrt(cd0 / k)  # = sqrt(0.25) = 0.5
+        assert cl_star is not None
+        assert cl_star == pytest.approx(expected, rel=1e-9)
+
+    def test_cambered_airfoil_cl0_nonzero(self):
+        """For cl0 != 0: CL* = sqrt(cl0^2 + cd0/k) — full quadratic result."""
+        from app.services.airfoil_low_re_service import best_ld_cl
+
+        cd0, k, cl0 = 0.010, 0.040, 0.3
+        cl_star = best_ld_cl(cd0, k, cl0)
+        # Full quadratic: CL* = sqrt(cl0^2 + cd0/k) = sqrt(0.09 + 0.25) = sqrt(0.34)
+        expected = math.sqrt(cl0**2 + cd0 / k)
+        assert cl_star is not None
+        assert cl_star == pytest.approx(expected, rel=1e-9)
+
+    def test_none_when_cd0_zero(self):
+        """cd0 = 0 → no valid minimum; return None."""
+        from app.services.airfoil_low_re_service import best_ld_cl
+
+        assert best_ld_cl(0.0, 0.04, 0.3) is None
+
+    def test_none_when_cd0_negative(self):
+        """cd0 < 0 is unphysical; return None."""
+        from app.services.airfoil_low_re_service import best_ld_cl
+
+        assert best_ld_cl(-0.001, 0.04, 0.3) is None
+
+    def test_none_when_k_zero(self):
+        """k = 0 → division by zero; return None."""
+        from app.services.airfoil_low_re_service import best_ld_cl
+
+        assert best_ld_cl(0.010, 0.0, 0.3) is None
+
+    def test_none_when_k_negative(self):
+        """k < 0 is unphysical; return None."""
+        from app.services.airfoil_low_re_service import best_ld_cl
+
+        assert best_ld_cl(0.010, -0.01, 0.3) is None
+
+    def test_larger_cd0_shifts_cl_star_up(self):
+        """Higher parasitic drag → higher CL needed for max L/D."""
+        from app.services.airfoil_low_re_service import best_ld_cl
+
+        cl_low = best_ld_cl(0.008, 0.040, 0.3)
+        cl_high = best_ld_cl(0.020, 0.040, 0.3)
+        assert cl_high > cl_low
+
+    def test_larger_k_shifts_cl_star_down(self):
+        """Stiffer curvature (bigger k) → lower CL* for same cd0."""
+        from app.services.airfoil_low_re_service import best_ld_cl
+
+        cl_flat = best_ld_cl(0.010, 0.020, 0.3)
+        cl_steep = best_ld_cl(0.010, 0.080, 0.3)
+        assert cl_steep < cl_flat
+
+    def test_derivative_is_zero_at_cl_star(self):
+        """Numerical check: d/dCL[CL/CD] == 0 at CL*."""
+        from app.services.airfoil_low_re_service import best_ld_cl
+
+        cd0, k, cl0 = 0.012, 0.035, 0.25
+        cl_star = best_ld_cl(cd0, k, cl0)
+        assert cl_star is not None
+
+        eps = 1e-6
+
+        def ld(cl):
+            cd = cd0 + k * (cl - cl0) ** 2
+            return cl / cd if cd > 0 else 0.0
+
+        grad = (ld(cl_star + eps) - ld(cl_star - eps)) / (2 * eps)
+        assert abs(grad) < 1e-4, f"Gradient at CL*={cl_star:.4f} is {grad:.2e}, expected ~0"
+
+
+# ---------------------------------------------------------------------------
+# TASK B2: score_target_cl — Match × Efficiency
+# ---------------------------------------------------------------------------
+
+
+class TestScoreTargetCl825:
+    """Tests for the new score_target_cl signature with Match × Efficiency."""
+
+    def test_wide_bucket_beats_narrow_bucket_same_centre(self):
+        """Wide drag bucket > narrow bucket at same cd0/k/cl0 and same target CL."""
+        from app.services.airfoil_low_re_service import score_target_cl
+        from app.settings import Settings
+
+        settings = Settings()
+        re_cd0_ref = 0.010  # same Re reference for both
+
+        # Target CL is right at the best-LD point for both
+        cl_target = 0.8  # near cl0 + sqrt(cd0/k) = 0.3 + 0.5 = 0.8
+
+        wide_score = score_target_cl(
+            _GOOD_POLAR, cl_target, re_cd0_reference=re_cd0_ref, settings=settings
+        )
+        narrow_score = score_target_cl(
+            _NARROW_BUCKET_POLAR, cl_target, re_cd0_reference=re_cd0_ref, settings=settings
+        )
+
+        assert wide_score is not None
+        assert narrow_score is not None
+        assert wide_score > narrow_score, (
+            f"Wide bucket (width=0.6) should score higher than narrow (width=0.1) "
+            f"at same centre; got {wide_score:.4f} vs {narrow_score:.4f}"
+        )
+
+    def test_lower_cd0_same_re_scores_higher(self):
+        """Lower cd0 at same Re reference → higher efficiency → higher score.
+
+        To isolate the efficiency component, we place cl_target at each airfoil's
+        cl_star (r=1, match=1.0 for both).  The only difference is efficiency =
+        min(re_cd0_ref / cd0, 1.0), which is lower for the high-cd0 airfoil.
+        """
+        import math
+        from app.services.airfoil_low_re_service import score_target_cl, best_ld_cl
+        from app.settings import Settings
+
+        settings = Settings()
+        # Use a fleet reference above both cd0 values so efficiency < 1 for both
+        re_cd0_ref = 0.008  # better than _GOOD_POLAR (0.010) → efficiency capped at 1.0
+
+        # Use cl_star of _GOOD_POLAR → r=1 → match is maximised for _GOOD_POLAR
+        cl_star_good = best_ld_cl(_GOOD_POLAR["cd0"], _GOOD_POLAR["k"], _GOOD_POLAR["cl0"])
+        assert cl_star_good is not None
+
+        # _GOOD_POLAR: efficiency = min(0.008/0.010, 1.0) = 0.8
+        # _HIGH_DRAG_POLAR: cd0=0.030 → efficiency = min(0.008/0.030, 1.0) = 0.267
+        # At cl_star_good: _GOOD_POLAR has r=1 → match=1; _HIGH_DRAG_POLAR has different r
+        # Even if match differs, the much lower efficiency should give a lower score for HIGH_DRAG.
+
+        # Choose a re_cd0_ref BETWEEN the two cd0 values so efficiency ordering is clear:
+        re_cd0_ref = (
+            0.015  # _GOOD_POLAR (cd0=0.010) gets eff=1.0; _HIGH_DRAG (cd0=0.030) gets eff=0.5
+        )
+
+        low_drag_score = score_target_cl(
+            _GOOD_POLAR, cl_star_good, re_cd0_reference=re_cd0_ref, settings=settings
+        )
+        # _HIGH_DRAG at cl_star_good: r = CD_high(cl_star_good)/cd0_high
+        high_drag_score = score_target_cl(
+            _HIGH_DRAG_POLAR, cl_star_good, re_cd0_reference=re_cd0_ref, settings=settings
+        )
+
+        assert low_drag_score is not None
+        assert high_drag_score is not None
+        assert low_drag_score > high_drag_score, (
+            f"Lower cd0 airfoil (cd0=0.010) should score higher than high-drag (cd0=0.030) "
+            f"when re_cd0_ref={re_cd0_ref}; got {low_drag_score:.4f} vs {high_drag_score:.4f}"
+        )
+
+    def test_target_far_outside_bucket_low_score(self):
+        """Target CL far from cl_star yields low Match score."""
+        from app.services.airfoil_low_re_service import score_target_cl
+        from app.settings import Settings
+
+        settings = Settings()
+        re_cd0_ref = 0.010
+
+        # cl_star ≈ 0.8 for _GOOD_POLAR; target at 1.6 is well outside bucket
+        near_score = score_target_cl(
+            _GOOD_POLAR, 0.8, re_cd0_reference=re_cd0_ref, settings=settings
+        )
+        far_score = score_target_cl(
+            _GOOD_POLAR, 1.6, re_cd0_reference=re_cd0_ref, settings=settings
+        )
+
+        assert near_score is not None
+        assert far_score is not None
+        assert near_score > far_score * 1.5, (
+            f"Near-centre score ({near_score:.3f}) should be substantially above "
+            f"far-outside score ({far_score:.3f})"
+        )
+
+    def test_closeness_alone_does_not_dominate(self):
+        """A narrow but deep bucket close to target should NOT beat a wide but
+        shallower bucket at the same centre — bucket WIDTH must be rewarded."""
+        from app.services.airfoil_low_re_service import score_target_cl
+        from app.settings import Settings
+
+        settings = Settings()
+        re_cd0_ref = 0.010
+        cl_target = 0.8
+
+        # Both at same cl0/k/cd0 — ONLY bucket width differs
+        wide_score = score_target_cl(
+            _GOOD_POLAR, cl_target, re_cd0_reference=re_cd0_ref, settings=settings
+        )
+        narrow_score = score_target_cl(
+            _NARROW_BUCKET_POLAR, cl_target, re_cd0_reference=re_cd0_ref, settings=settings
+        )
+        assert wide_score > narrow_score
+
+    def test_none_when_cd0_missing(self):
+        """Return None when cd0 is absent from the polar."""
+        from app.services.airfoil_low_re_service import score_target_cl
+        from app.settings import Settings
+
+        polar = {**_GOOD_POLAR, "cd0": None}
+        result = score_target_cl(polar, 0.8, re_cd0_reference=0.010, settings=Settings())
+        assert result is None
+
+    def test_none_when_k_missing(self):
+        from app.services.airfoil_low_re_service import score_target_cl
+        from app.settings import Settings
+
+        polar = {**_GOOD_POLAR, "k": None}
+        result = score_target_cl(polar, 0.8, re_cd0_reference=0.010, settings=Settings())
+        assert result is None
+
+    def test_none_when_cl0_missing(self):
+        from app.services.airfoil_low_re_service import score_target_cl
+        from app.settings import Settings
+
+        polar = {**_GOOD_POLAR, "cl0": None}
+        result = score_target_cl(polar, 0.8, re_cd0_reference=0.010, settings=Settings())
+        assert result is None
+
+    def test_none_polar(self):
+        from app.services.airfoil_low_re_service import score_target_cl
+        from app.settings import Settings
+
+        result = score_target_cl(None, 0.8, re_cd0_reference=0.010, settings=Settings())
+        assert result is None
+
+    def test_score_clamped_0_to_1(self):
+        from app.services.airfoil_low_re_service import score_target_cl
+        from app.settings import Settings
+
+        settings = Settings()
+        score = score_target_cl(_GOOD_POLAR, 0.8, re_cd0_reference=0.010, settings=settings)
+        assert score is not None
+        assert 0.0 <= score <= 1.0
+
+    def test_r_poor_controls_match_decay(self):
+        """At r = r_poor, Match should be at/near 0; at r=1 (cd0=cd0) it should be high."""
+        from app.services.airfoil_low_re_service import score_target_cl
+        from app.settings import Settings
+
+        settings = Settings()
+        cd0 = _GOOD_POLAR["cd0"]
+        r_poor = settings.low_re_score_r_poor
+        re_cd0_ref = cd0  # same as airfoil cd0 → efficiency=1.0
+
+        # At CL* (best LD): CL* = sqrt(cl0^2 + cd0/k)
+        cl_star = math.sqrt(_GOOD_POLAR["cl0"] ** 2 + cd0 / _GOOD_POLAR["k"])
+        near_score = score_target_cl(
+            _GOOD_POLAR, cl_star, re_cd0_reference=re_cd0_ref, settings=settings
+        )
+
+        # At very far CL, r >> r_poor
+        far_score = score_target_cl(
+            _GOOD_POLAR, 2.5, re_cd0_reference=re_cd0_ref, settings=settings
+        )
+
+        assert near_score is not None
+        assert near_score > 0.3, f"Score near cl_star should be decent, got {near_score:.3f}"
+        if far_score is not None:
+            assert near_score > far_score
+
+
+# ---------------------------------------------------------------------------
+# TASK B3: compute_re_cd0_reference
+# ---------------------------------------------------------------------------
+
+
+class TestComputeReCd0Reference:
+    """Tests for compute_re_cd0_reference(polars_by_name, re) -> float."""
+
+    def _make_polar_rows(self, entries: list[tuple[float, float]]) -> dict:
+        """Build a polars_by_name dict from (reynolds, cd0) tuples."""
+
+        class FakeRow:
+            def __init__(self, re, cd0_val, **kw):
+                self.reynolds = float(re)
+                self.ld_max = kw.get("ld_max", 40.0)
+                self.cl_max = kw.get("cl_max", 1.0)
+                self.alpha_attached_lo = -3.0
+                self.alpha_attached_hi = 10.0
+                self.drag_bucket_width = kw.get("drag_bucket_width", 0.4)
+                self.cd_min = kw.get("cd_min", cd0_val)
+                self.stall_gentleness = -0.05
+                self.cd0 = cd0_val
+                self.k = 0.04
+                self.cl0 = 0.3
+                self.cl_valid_lo = 0.0
+                self.cl_valid_hi = 1.2
+                self.min_analysis_confidence = 0.92
+
+        result = {}
+        for i, (re, cd0_val) in enumerate(entries):
+            name = f"airfoil_{i}"
+            result[name] = [FakeRow(re, cd0_val)]
+        return result
+
+    def test_returns_float_for_single_airfoil(self):
+        from app.services.airfoil_low_re_service import compute_re_cd0_reference
+
+        polars = self._make_polar_rows([(100_000, 0.012)])
+        ref = compute_re_cd0_reference(polars, 100_000)
+        assert isinstance(ref, float)
+        assert ref == pytest.approx(0.012)
+
+    def test_returns_low_percentile_across_fleet(self):
+        """Reference should be a robust low percentile — below the median."""
+        from app.services.airfoil_low_re_service import compute_re_cd0_reference
+
+        # Fleet: cd0 values 0.010, 0.015, 0.020, 0.030, 0.040
+        polars = self._make_polar_rows(
+            [
+                (100_000, 0.010),
+                (100_000, 0.015),
+                (100_000, 0.020),
+                (100_000, 0.030),
+                (100_000, 0.040),
+            ]
+        )
+        ref = compute_re_cd0_reference(polars, 100_000)
+        median = 0.020
+        assert ref < median, f"Reference {ref:.4f} should be below median {median}"
+        assert ref >= 0.010, f"Reference {ref:.4f} should not be below the minimum"
+
+    def test_interpolates_between_re_points(self):
+        """When no row exactly matches Re, reference uses interpolated cd0."""
+        from app.services.airfoil_low_re_service import compute_re_cd0_reference
+
+        polars = self._make_polar_rows(
+            [
+                (100_000, 0.012),
+                (200_000, 0.010),
+            ]
+        )
+        # Query at 150k — between the two points
+        ref = compute_re_cd0_reference(polars, 150_000)
+        assert 0.010 <= ref <= 0.012
+
+    def test_none_safe_no_cd0_rows(self):
+        """When all cd0 values are None, must return a fallback (not crash)."""
+        from app.services.airfoil_low_re_service import compute_re_cd0_reference
+
+        class NullRow:
+            def __init__(self):
+                self.reynolds = 100_000.0
+                self.ld_max = None
+                self.cl_max = None
+                self.alpha_attached_lo = None
+                self.alpha_attached_hi = None
+                self.drag_bucket_width = None
+                self.cd_min = None
+                self.stall_gentleness = None
+                self.cd0 = None
+                self.k = None
+                self.cl0 = None
+                self.cl_valid_lo = None
+                self.cl_valid_hi = None
+                self.min_analysis_confidence = 0.80
+
+        polars = {"airfoil_null": [NullRow()]}
+        ref = compute_re_cd0_reference(polars, 100_000)
+        # Must return a sensible fallback — we document the expected default below
+        assert ref > 0.0, "Reference must be positive even when cd0 rows are all None"
+
+    def test_empty_fleet_returns_fallback(self):
+        """Empty fleet must not crash — returns a documented fallback."""
+        from app.services.airfoil_low_re_service import compute_re_cd0_reference
+
+        ref = compute_re_cd0_reference({}, 100_000)
+        assert ref > 0.0
+
+
+# ---------------------------------------------------------------------------
+# TASK B4: three target CLs from context
+# ---------------------------------------------------------------------------
+
+
+class TestResolveThreeTargetCls:
+    """Verify that suitability_service resolves cruise / best-glide / min-sink CLs
+    from assumption_computation_context correctly.  All tests mock the DB lookup.
+    """
+
+    def _make_aeroplane(self, ctx: dict) -> object:
+        class FakeAeroplane:
+            assumption_computation_context = ctx
+            id = 1
+
+        return FakeAeroplane()
+
+    def test_cruise_cl_from_v_cruise(self):
+        from app.services.airfoil_low_re_service import _level_flight_cl, G, RHO
+
+        m, v, s = 2.0, 18.0, 0.35
+        expected = (m * G) / (0.5 * RHO * v**2 * s)
+        assert _level_flight_cl(m, v, s) == pytest.approx(expected)
+
+    def test_best_glide_cl_from_v_md(self):
+        """v_md (min-drag speed, max range) resolves to a target CL for best glide."""
+        from app.services.airfoil_low_re_service import _level_flight_cl
+
+        m, v_md, s = 2.0, 14.0, 0.35
+        cl_bg = _level_flight_cl(m, v_md, s)
+        cl_cruise = _level_flight_cl(m, 18.0, s)
+        # Best-glide CL is higher than cruise CL (slower speed)
+        assert cl_bg > cl_cruise
+
+    def test_min_sink_cl_from_v_min_sink(self):
+        """v_min_sink resolves to highest CL (slowest speed)."""
+        from app.services.airfoil_low_re_service import _level_flight_cl
+
+        m, s = 2.0, 0.35
+        cl_ms = _level_flight_cl(m, 10.0, s)
+        cl_bg = _level_flight_cl(m, 14.0, s)
+        assert cl_ms > cl_bg
+
+    def test_missing_speed_gives_null_cl(self):
+        """When a speed value is absent, the corresponding CL must be None."""
+        ctx = {"mass_kg": 2.0, "s_ref_m2": 0.35}
+        assert ctx.get("v_cruise_mps") is None
+        assert ctx.get("v_md_mps") is None
+        assert ctx.get("v_min_sink_mps") is None
+
+    def test_all_three_present(self):
+        from app.services.airfoil_low_re_service import _level_flight_cl
+
+        ctx = {
+            "mass_kg": 2.0,
+            "s_ref_m2": 0.35,
+            "v_cruise_mps": 18.0,
+            "v_md_mps": 14.0,
+            "v_min_sink_mps": 10.0,
+        }
+        cl_c = _level_flight_cl(ctx["mass_kg"], ctx["v_cruise_mps"], ctx["s_ref_m2"])
+        cl_bg = _level_flight_cl(ctx["mass_kg"], ctx["v_md_mps"], ctx["s_ref_m2"])
+        cl_ms = _level_flight_cl(ctx["mass_kg"], ctx["v_min_sink_mps"], ctx["s_ref_m2"])
+        assert cl_c < cl_bg < cl_ms
+
+
+# ---------------------------------------------------------------------------
+# Coverage gap fill: score_target_cl edge branches
+# ---------------------------------------------------------------------------
+
+
+class TestScoreTargetClEdgeCases:
+    """Coverage for branches not reached by main tests."""
+
+    def _settings(self):
+        from app.settings import Settings
+
+        return Settings()
+
+    def test_r_leq_1_gives_match_1(self):
+        """When cl_target = cl0 (minimum drag point), r=1 → match=1.0."""
+        from app.services.airfoil_low_re_service import score_target_cl
+
+        settings = self._settings()
+        # At cl_target = cl0, CD = cd0 + k*(cl0-cl0)^2 = cd0 → r=1
+        polar = {**_GOOD_POLAR, "drag_bucket_width": 0.0}  # no bucket
+        score = score_target_cl(
+            polar, _GOOD_POLAR["cl0"], re_cd0_reference=0.010, settings=settings
+        )
+        assert score is not None
+        # r=1 → match=1.0, efficiency = min(re_ref/cd0, 1.0)
+        assert score > 0.0
+
+    def test_r_geq_r_poor_gives_match_0(self):
+        """When r >= r_poor, Match → 0 → score = 0."""
+        from app.services.airfoil_low_re_service import score_target_cl
+
+        settings = self._settings()
+        r_poor = settings.low_re_score_r_poor
+        cd0 = _GOOD_POLAR["cd0"]
+        k = _GOOD_POLAR["k"]
+        cl0 = _GOOD_POLAR["cl0"]
+        # Find cl_target such that r >= r_poor:
+        # CD(cl) = cd0 + k*(cl-cl0)^2 >= r_poor * cd0
+        # k*(cl-cl0)^2 >= (r_poor-1)*cd0
+        # |cl-cl0| >= sqrt((r_poor-1)*cd0/k)
+        delta = math.sqrt((r_poor - 1.0) * cd0 / k) + 0.5  # well beyond r_poor
+        cl_far = cl0 + delta
+        score = score_target_cl(_GOOD_POLAR, cl_far, re_cd0_reference=0.010, settings=settings)
+        assert score is not None
+        assert score == pytest.approx(0.0), f"Expected 0, got {score:.4f} for r>>r_poor"
+
+    def test_unphysical_cd0_returns_none(self):
+        """cd0 <= 0 in polar → return None."""
+        from app.services.airfoil_low_re_service import score_target_cl
+
+        settings = self._settings()
+        polar = {**_GOOD_POLAR, "cd0": -0.001}
+        assert score_target_cl(polar, 0.5, re_cd0_reference=0.010, settings=settings) is None
+
+    def test_zero_re_cd0_reference_still_returns_score(self):
+        """When re_cd0_reference = 0, efficiency = 1.0 (fallback branch)."""
+        from app.services.airfoil_low_re_service import score_target_cl
+
+        settings = self._settings()
+        score = score_target_cl(_GOOD_POLAR, 0.5, re_cd0_reference=0.0, settings=settings)
+        # Should not crash; efficiency defaults to 1.0
+        assert score is not None
+        assert 0.0 <= score <= 1.0
+
+    def test_none_bucket_width_does_not_crash(self):
+        """When drag_bucket_width is None, treat as 0 — no crash."""
+        from app.services.airfoil_low_re_service import score_target_cl
+
+        settings = self._settings()
+        polar = {**_GOOD_POLAR, "drag_bucket_width": None}
+        score = score_target_cl(polar, 0.5, re_cd0_reference=0.010, settings=settings)
+        assert score is not None
+
+
+# ---------------------------------------------------------------------------
+# Coverage gap fill: score_mission thickness branch (above t_max)
+# ---------------------------------------------------------------------------
+
+
+class TestScoreMissionThicknessBranches:
+    def test_thickness_above_t_max_reduces_score(self):
+        """Thickness above t_max band → thickness_match < 1."""
+        from app.services.airfoil_low_re_service import score_mission
+        from app.settings import Settings
+
+        weights = Settings().low_re_mission_weights
+        re_agn = 0.8
+        # trainer: t_max=14%; test with 20% (well above band)
+        in_band = score_mission(re_agn, "flat_bottom", 12.0, 1.3, "trainer", weights)
+        above_band = score_mission(re_agn, "flat_bottom", 20.0, 1.3, "trainer", weights)
+        assert in_band is not None
+        assert above_band is not None
+        assert in_band > above_band
+
+
+# ---------------------------------------------------------------------------
+# Coverage gap fill: compute_re_cd0_reference with None-returning polar
+# ---------------------------------------------------------------------------
+
+
+class TestComputeReCd0ReferenceEdges:
+    def test_polar_returns_none_skipped(self):
+        """Airfoil with empty rows → None from interpolate → skipped."""
+        from app.services.airfoil_low_re_service import compute_re_cd0_reference
+
+        # A name with no rows at all → interpolate returns None
+        polars = {"empty_af": []}
+        ref = compute_re_cd0_reference(polars, 100_000)
+        assert ref > 0.0  # falls back to _CD0_REFERENCE_FALLBACK
+
+
+# ---------------------------------------------------------------------------
+# Coverage gap: compute_airfoil_low_re with mocked AeroSandbox
+# ---------------------------------------------------------------------------
+
+
+class TestComputeAirfoilLowReMocked:
+    """Cover the NeuralFoil-dependent code path using a mocked AeroSandbox.
+
+    Per the plan: mock NeuralFoil only where a compute path test is touched.
+    The import-guard path (aerosandbox not available) is always testable.
+    """
+
+    def test_compute_returns_empty_when_no_aerosandbox(self):
+        """When aerosandbox is not importable, returns empty list (no crash)."""
+        coords = np.array([[0, 0], [0.5, 0.06], [1, 0]])
+        re_grid = [100_000]
+
+        # Temporarily make aerosandbox unimportable
+        with patch.dict(sys.modules, {"aerosandbox": None}):
+            from app.services.airfoil_low_re_service import compute_airfoil_low_re
+
+            result = compute_airfoil_low_re("test", coords, re_grid)
+            assert result == []
+
+    def test_compute_with_mocked_aerosandbox(self):
+        """compute_airfoil_low_re with a fully mocked AeroSandbox returns one dict per Re."""
+        coords = np.array([[0, 0], [0.25, 0.06], [0.5, 0.08], [0.75, 0.06], [1, 0]])
+        re_grid = [100_000, 200_000]
+
+        # Match the actual alpha grid used by compute_airfoil_low_re:
+        # alpha_start=-5, alpha_end=18, alpha_step=0.2
+        alpha = np.arange(-5.0, 18.0 + 0.2 * 0.5, 0.2)
+        n_alpha = len(alpha)
+        # Generate a realistic synthetic polar
+        cl = 2 * np.pi * np.radians(alpha) + 0.3  # thin-airfoil CL approx
+        cd = 0.012 + 0.04 * (cl - 0.3) ** 2
+        conf = np.full(n_alpha, 0.95)
+        fake_aero_result = {"CL": cl, "CD": cd, "analysis_confidence": conf}
+
+        mock_asb = MagicMock()
+        mock_airfoil_instance = MagicMock()
+        mock_airfoil_instance.get_aero_from_neuralfoil.return_value = fake_aero_result
+        mock_asb.Airfoil.return_value = mock_airfoil_instance
+
+        # Patch the import inside the function
+        with patch.dict(sys.modules, {"aerosandbox": mock_asb}):
+            import importlib
+            import app.services.airfoil_low_re_service as _svc_module
+
+            # Reload with the mock in place
+            importlib.reload(_svc_module)
+            try:
+                result = _svc_module.compute_airfoil_low_re("test_af", coords, re_grid)
+                # Should return one dict per Re grid point
+                assert len(result) == len(re_grid)
+                for row in result:
+                    assert "reynolds" in row
+                    assert "min_analysis_confidence" in row
+            finally:
+                # Reload without mock to restore normal state
+                if "aerosandbox" in sys.modules:
+                    del sys.modules["aerosandbox"]
+                importlib.reload(_svc_module)
+
+
+# ---------------------------------------------------------------------------
+# Coverage gap fill: interpolate_polar_at_re clamping (re_query below grid)
+# ---------------------------------------------------------------------------
+
+
+class TestInterpolatePolarClamp:
+    class _Row:
+        def __init__(self, re):
+            self.reynolds = float(re)
+            self.ld_max = 40.0
+            self.cl_max = 1.0
+            self.alpha_attached_lo = -3.0
+            self.alpha_attached_hi = 10.0
+            self.drag_bucket_width = 0.4
+            self.cd_min = 0.012
+            self.stall_gentleness = -0.05
+            self.cd0 = 0.012
+            self.k = 0.04
+            self.cl0 = 0.3
+            self.cl_valid_lo = 0.0
+            self.cl_valid_hi = 1.2
+            self.min_analysis_confidence = 0.92
+
+    def test_re_below_grid_clamps_to_lowest(self):
+        """When re_query < lowest grid point, return the lowest row."""
+        from app.services.airfoil_low_re_service import interpolate_polar_at_re
+
+        rows = [self._Row(100_000), self._Row(200_000)]
+        # Query below the lowest available re
+        polar = interpolate_polar_at_re(rows, 50_000, [100_000, 200_000])
+        assert polar is not None
+        assert polar["cd0"] == pytest.approx(0.012)
+
+    def test_re_above_grid_clamps_to_highest(self):
+        """When re_query > highest grid point, return the highest row."""
+        from app.services.airfoil_low_re_service import interpolate_polar_at_re
+
+        rows = [self._Row(100_000), self._Row(200_000)]
+        polar = interpolate_polar_at_re(rows, 500_000, [100_000, 200_000])
+        assert polar is not None
+        assert polar["cd0"] == pytest.approx(0.012)
+
+    def test_single_row_exact_match_returns_dict(self):
+        """Exact Re match returns row dict directly (no interpolation)."""
+        from app.services.airfoil_low_re_service import interpolate_polar_at_re
+
+        rows = [self._Row(150_000)]
+        polar = interpolate_polar_at_re(rows, 150_000, [100_000, 200_000])
+        assert polar is not None
+        assert polar["cd0"] == pytest.approx(0.012)
+
+    def test_empty_rows_after_dict_build_returns_none(self):
+        """Edge: polar_rows has items but rows_by_re maps to nothing — line 200 branch."""
+        from app.services.airfoil_low_re_service import interpolate_polar_at_re
+
+        class RowNoneRe:
+            reynolds = None
+            ld_max = 40.0
+            cl_max = 1.0
+            alpha_attached_lo = -3.0
+            alpha_attached_hi = 10.0
+            drag_bucket_width = 0.4
+            cd_min = 0.012
+            stall_gentleness = -0.05
+            cd0 = 0.012
+            k = 0.04
+            cl0 = 0.3
+            cl_valid_lo = 0.0
+            cl_valid_hi = 1.2
+            min_analysis_confidence = 0.92
+
+        # float(None) would raise, so test with an empty list which triggers path through
+        # available_re being empty
+        result = interpolate_polar_at_re([], 100_000, [100_000])
+        assert result is None

--- a/app/tests/test_airfoil_suitability_schema.py
+++ b/app/tests/test_airfoil_suitability_schema.py
@@ -15,7 +15,10 @@ def test_suitability_item_required_fields():
         re_agnostic=0.85,
         mission=None,
         target_cl_cruise=None,
-        target_cl_loiter=None,
+        target_cl_best_glide=None,
+        target_cl_min_sink=None,
+        stall_gentleness=-0.04,
+        cl_max_margin=0.3,
         min_analysis_confidence=0.92,
         tip_re_flag=False,
         caveat="",
@@ -25,7 +28,10 @@ def test_suitability_item_required_fields():
     assert item.re_agnostic == pytest.approx(0.85)
     assert item.mission is None
     assert item.target_cl_cruise is None
-    assert item.target_cl_loiter is None
+    assert item.target_cl_best_glide is None
+    assert item.target_cl_min_sink is None
+    assert item.stall_gentleness == pytest.approx(-0.04)
+    assert item.cl_max_margin == pytest.approx(0.3)
     assert item.min_analysis_confidence == pytest.approx(0.92)
     assert item.tip_re_flag is False
     assert item.caveat == ""
@@ -42,7 +48,8 @@ def test_suitability_item_family_literals():
             re_agnostic=0.5,
             mission=None,
             target_cl_cruise=None,
-            target_cl_loiter=None,
+            target_cl_best_glide=None,
+            target_cl_min_sink=None,
             min_analysis_confidence=0.9,
             tip_re_flag=False,
             caveat="",
@@ -60,7 +67,8 @@ def test_suitability_item_invalid_family():
             re_agnostic=0.5,
             mission=None,
             target_cl_cruise=None,
-            target_cl_loiter=None,
+            target_cl_best_glide=None,
+            target_cl_min_sink=None,
             min_analysis_confidence=0.9,
             tip_re_flag=False,
             caveat="",
@@ -77,7 +85,9 @@ def test_suitability_query_required_fields():
         re_clamped=False,
         mission_type=None,
         target_cl_cruise=None,
-        target_cl_loiter=None,
+        target_cl_best_glide=None,
+        target_cl_min_sink=None,
+        target_cl_provenance="estimated",
         active_lens="re_agnostic",
     )
     assert q.chord_m == pytest.approx(0.15)
@@ -86,7 +96,9 @@ def test_suitability_query_required_fields():
     assert q.re_clamped is False
     assert q.mission_type is None
     assert q.target_cl_cruise is None
-    assert q.target_cl_loiter is None
+    assert q.target_cl_best_glide is None
+    assert q.target_cl_min_sink is None
+    assert q.target_cl_provenance == "estimated"
     assert q.active_lens == "re_agnostic"
 
 
@@ -102,27 +114,32 @@ def test_suitability_query_active_lens_literals():
             re_clamped=False,
             mission_type=None,
             target_cl_cruise=None,
-            target_cl_loiter=None,
+            target_cl_best_glide=None,
+            target_cl_min_sink=None,
+            target_cl_provenance="estimated",
             active_lens=lens,
         )
         assert q.active_lens == lens
 
 
-def test_suitability_query_active_lens_never_loiter():
-    """active_lens MUST NOT be 'target_cl_loiter' per the frozen contract."""
+def test_suitability_query_active_lens_never_glide_point():
+    """active_lens MUST NOT be any glide point per the gh-825 contract."""
     from app.schemas.airfoil import SuitabilityQuery
 
-    with pytest.raises(ValidationError):
-        SuitabilityQuery(
-            chord_m=0.15,
-            speed_ms=15.0,
-            reynolds=150_000.0,
-            re_clamped=False,
-            mission_type=None,
-            target_cl_cruise=None,
-            target_cl_loiter=None,
-            active_lens="target_cl_loiter",  # NOT valid
-        )
+    for bad_lens in ("target_cl_loiter", "target_cl_best_glide", "target_cl_min_sink"):
+        with pytest.raises(ValidationError):
+            SuitabilityQuery(
+                chord_m=0.15,
+                speed_ms=15.0,
+                reynolds=150_000.0,
+                re_clamped=False,
+                mission_type=None,
+                target_cl_cruise=None,
+                target_cl_best_glide=None,
+                target_cl_min_sink=None,
+                target_cl_provenance="estimated",
+                active_lens=bad_lens,  # NOT valid
+            )
 
 
 def test_suitability_caveat_required_fields():
@@ -156,12 +173,15 @@ def test_suitability_response_shape():
             re_clamped=False,
             mission_type=None,
             target_cl_cruise=None,
-            target_cl_loiter=None,
+            target_cl_best_glide=None,
+            target_cl_min_sink=None,
+            target_cl_provenance="estimated",
             active_lens="re_agnostic",
         ),
         caveat=SuitabilityCaveat(
             relative_ranking_only=True,
             no_hysteresis_modelling=True,
+            ignores_tip_re_clmax_collapse=True,
             recommend_xfoil_validation=False,
             text="Nur relative Reihenfolge.",
         ),
@@ -172,7 +192,10 @@ def test_suitability_response_shape():
                 re_agnostic=0.85,
                 mission=None,
                 target_cl_cruise=None,
-                target_cl_loiter=None,
+                target_cl_best_glide=None,
+                target_cl_min_sink=None,
+                stall_gentleness=-0.04,
+                cl_max_margin=0.4,
                 min_analysis_confidence=0.92,
                 tip_re_flag=False,
                 caveat="",
@@ -191,12 +214,16 @@ def test_suitability_response_shape():
     assert "re_clamped" in q
     assert "mission_type" in q
     assert "target_cl_cruise" in q
-    assert "target_cl_loiter" in q
+    assert "target_cl_best_glide" in q
+    assert "target_cl_min_sink" in q
+    assert "target_cl_provenance" in q
     assert "active_lens" in q
+    assert "target_cl_loiter" not in q
 
     c = data["caveat"]
     assert "relative_ranking_only" in c
     assert "no_hysteresis_modelling" in c
+    assert "ignores_tip_re_clmax_collapse" in c
     assert "recommend_xfoil_validation" in c
     assert "text" in c
 
@@ -206,7 +233,11 @@ def test_suitability_response_shape():
     assert "re_agnostic" in r
     assert "mission" in r
     assert "target_cl_cruise" in r
-    assert "target_cl_loiter" in r
+    assert "target_cl_best_glide" in r
+    assert "target_cl_min_sink" in r
+    assert "stall_gentleness" in r
+    assert "cl_max_margin" in r
     assert "min_analysis_confidence" in r
     assert "tip_re_flag" in r
     assert "caveat" in r
+    assert "target_cl_loiter" not in r

--- a/app/tests/test_airfoil_suitability_scoring.py
+++ b/app/tests/test_airfoil_suitability_scoring.py
@@ -229,6 +229,143 @@ class TestTargetClScore:
 
 
 # ---------------------------------------------------------------------------
+# Task 6c-glide: score_target_cl for high-CL operating points (gh-825 bug fix)
+#
+# Root cause: the drag-rise ratio r = CD(cl_target)/cd0 measures distance from
+# the parabola vertex (cl0, minimum drag), NOT from cl_star (best L/D).
+# For a glider operating at V_min_sink, CL ≈ sqrt(3)×CL_md >> cl0, giving
+# r >> r_poor and score=0.0 for nearly every airfoil.
+#
+# Fix: when cl_target > cl_star (high-CL regime), switch to a CL_max-margin
+# score: how safely can the airfoil fly at this CL without stalling?
+# ---------------------------------------------------------------------------
+
+# A glider-representative airfoil polar (high CL_max, low drag)
+_GLIDER_POLAR = {
+    "ld_max": 60.0,
+    "cl_max": 1.45,
+    "alpha_attached_lo": -3.0,
+    "alpha_attached_hi": 13.0,
+    "drag_bucket_width": 0.7,
+    "cd_min": 0.008,
+    "stall_gentleness": -0.03,
+    "cd0": 0.009,
+    "k": 0.025,
+    "cl0": 0.3,
+    "cl_valid_lo": 0.0,
+    "cl_valid_hi": 1.4,
+    "min_analysis_confidence": 0.97,
+}
+
+# cl_star for _GLIDER_POLAR: sqrt(0.3^2 + 0.009/0.025) ≈ sqrt(0.09 + 0.36) = sqrt(0.45) ≈ 0.671
+# cl_min_sink ≈ sqrt(3) * 0.671 ≈ 1.162
+
+
+class TestTargetClScoreGlidePoints:
+    """score_target_cl must return non-trivial scores for high-CL glide points.
+
+    Bug: with the drag-rise r-formula, nearly all glider airfoils score 0.0 at
+    the min-sink CL because r = CD(cl_min_sink)/cd0 >> r_poor=2.5.
+    """
+
+    def _settings(self):
+        from app.settings import Settings
+
+        return Settings()
+
+    def test_min_sink_cl_scores_above_zero_for_good_glider(self):
+        """A glider airfoil with CL_max well above the min-sink CL must score > 0."""
+        import math
+        from app.services.airfoil_low_re_service import score_target_cl, best_ld_cl
+
+        cl_star = best_ld_cl(
+            _GLIDER_POLAR["cd0"], _GLIDER_POLAR["k"], _GLIDER_POLAR["cl0"]
+        )
+        cl_min_sink = math.sqrt(3) * cl_star
+
+        # Sanity: min-sink CL must be above cl_star for this to test the right path
+        assert cl_min_sink > cl_star, (
+            f"cl_min_sink={cl_min_sink:.3f} should be above cl_star={cl_star:.3f}"
+        )
+
+        score = score_target_cl(
+            _GLIDER_POLAR,
+            cl_target=cl_min_sink,
+            re_cd0_reference=0.009,
+            settings=self._settings(),
+        )
+        assert score is not None
+        assert score > 0.0, (
+            f"Good glider airfoil (cl_max={_GLIDER_POLAR['cl_max']}) scoring 0 "
+            f"at min-sink CL={cl_min_sink:.3f} — glide-point scoring is broken. "
+            f"Got score={score}"
+        )
+
+    def test_min_sink_cl_monotone_in_cl_max_margin(self):
+        """Airfoil with larger CL_max margin at min-sink CL must score higher."""
+        import math
+        from app.services.airfoil_low_re_service import score_target_cl, best_ld_cl
+
+        cl_star = best_ld_cl(
+            _GLIDER_POLAR["cd0"], _GLIDER_POLAR["k"], _GLIDER_POLAR["cl0"]
+        )
+        cl_min_sink = math.sqrt(3) * cl_star
+
+        settings = self._settings()
+        re_ref = 0.009
+
+        # Good: cl_max well above cl_min_sink (large margin)
+        polar_good = dict(_GLIDER_POLAR)
+        polar_good["cl_max"] = cl_min_sink + 0.40  # big margin
+
+        # Poor: cl_max barely above cl_min_sink (tiny margin)
+        polar_poor = dict(_GLIDER_POLAR)
+        polar_poor["cl_max"] = cl_min_sink + 0.05  # tiny margin
+
+        # Stall risk: cl_max BELOW cl_min_sink
+        polar_stall = dict(_GLIDER_POLAR)
+        polar_stall["cl_max"] = cl_min_sink - 0.05  # stall risk
+
+        score_good = score_target_cl(polar_good, cl_target=cl_min_sink, re_cd0_reference=re_ref, settings=settings)
+        score_poor = score_target_cl(polar_poor, cl_target=cl_min_sink, re_cd0_reference=re_ref, settings=settings)
+        score_stall = score_target_cl(polar_stall, cl_target=cl_min_sink, re_cd0_reference=re_ref, settings=settings)
+
+        assert score_good is not None and score_poor is not None and score_stall is not None
+        assert score_good > score_poor, (
+            f"Larger CL_max margin should score higher: good={score_good:.3f}, poor={score_poor:.3f}"
+        )
+        assert score_stall == 0.0, (
+            f"Stall-risk airfoil (cl_max < cl_target) must score 0.0, got {score_stall:.3f}"
+        )
+
+    def test_score_continuous_across_cl_star_boundary(self):
+        """score_target_cl must not produce a large discontinuity at cl_target == cl_star."""
+        import math
+        from app.services.airfoil_low_re_service import score_target_cl, best_ld_cl
+
+        settings = self._settings()
+        re_ref = 0.009
+        cl_star = best_ld_cl(
+            _GLIDER_POLAR["cd0"], _GLIDER_POLAR["k"], _GLIDER_POLAR["cl0"]
+        )
+        delta = 0.01  # 0.01 CL units either side of the boundary
+
+        score_just_below = score_target_cl(
+            _GLIDER_POLAR, cl_target=cl_star - delta, re_cd0_reference=re_ref, settings=settings
+        )
+        score_just_above = score_target_cl(
+            _GLIDER_POLAR, cl_target=cl_star + delta, re_cd0_reference=re_ref, settings=settings
+        )
+        assert score_just_below is not None and score_just_above is not None
+        # Allow at most 40% relative jump at the boundary
+        gap = abs(score_just_above - score_just_below)
+        assert gap < 0.40, (
+            f"Discontinuity at cl_star boundary: below={score_just_below:.3f}, "
+            f"above={score_just_above:.3f}, gap={gap:.3f}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Task 6d: Numeric test of _level_flight_cl
 # ---------------------------------------------------------------------------
 

--- a/app/tests/test_airfoil_suitability_scoring.py
+++ b/app/tests/test_airfoil_suitability_scoring.py
@@ -147,28 +147,46 @@ class TestMissionScore:
 
 
 # ---------------------------------------------------------------------------
-# Task 6c: target_cl_cruise/loiter from parabolic fit
+# Task 6c: target_cl — gh-825 Match×Efficiency scoring (updated contract)
 # ---------------------------------------------------------------------------
 
 
 class TestTargetClScore:
+    """Updated for gh-825: score_target_cl now requires re_cd0_reference + settings."""
+
+    def _settings(self):
+        from app.settings import Settings
+
+        return Settings()
+
     def test_target_cl_within_range_returns_score(self):
         from app.services.airfoil_low_re_service import score_target_cl
 
-        result = score_target_cl(_GOOD_POLAR, cl_target=0.5)
+        result = score_target_cl(
+            _GOOD_POLAR, cl_target=0.5, re_cd0_reference=0.012, settings=self._settings()
+        )
         assert result is not None
         assert 0.0 <= result <= 1.0
 
-    def test_target_cl_outside_valid_range_penalized(self):
-        """CL outside [cl_valid_lo, cl_valid_hi] should score lower."""
-        from app.services.airfoil_low_re_service import score_target_cl
+    def test_target_cl_outside_sweet_spot_scores_lower(self):
+        """CL far from cl_star should score lower than CL near cl_star."""
+        from app.services.airfoil_low_re_service import score_target_cl, best_ld_cl
+        import math
 
-        in_range = score_target_cl(_GOOD_POLAR, cl_target=0.5)
-        out_of_range = score_target_cl(_GOOD_POLAR, cl_target=2.0)  # above cl_valid_hi=1.2
-        # Out-of-range should be penalized (lower score or None)
-        assert in_range is not None
-        if out_of_range is not None:
-            assert in_range >= out_of_range
+        settings = self._settings()
+        re_ref = 0.012
+        # cl_star ≈ sqrt(cl0^2 + cd0/k) for _GOOD_POLAR
+        cl_star = best_ld_cl(_GOOD_POLAR["cd0"], _GOOD_POLAR["k"], _GOOD_POLAR["cl0"])
+        near_score = score_target_cl(
+            _GOOD_POLAR, cl_target=cl_star, re_cd0_reference=re_ref, settings=settings
+        )
+        far_score = score_target_cl(
+            _GOOD_POLAR, cl_target=2.0, re_cd0_reference=re_ref, settings=settings
+        )
+        # near cl_star should score higher than far away
+        assert near_score is not None
+        if far_score is not None:
+            assert near_score >= far_score
 
     def test_target_cl_none_when_no_fit(self):
         from app.services.airfoil_low_re_service import score_target_cl
@@ -177,21 +195,37 @@ class TestTargetClScore:
         polar_no_fit["cd0"] = None
         polar_no_fit["k"] = None
         polar_no_fit["cl0"] = None
-        result = score_target_cl(polar_no_fit, cl_target=0.5)
+        result = score_target_cl(
+            polar_no_fit, cl_target=0.5, re_cd0_reference=0.012, settings=self._settings()
+        )
         assert result is None
 
     def test_lower_drag_at_target_cl_yields_higher_score(self):
-        from app.services.airfoil_low_re_service import score_target_cl
+        """At the same fleet reference cd0, lower airfoil cd0 → higher efficiency → higher score."""
+        from app.services.airfoil_low_re_service import score_target_cl, best_ld_cl
 
-        # Airfoil with very low cd0 should score higher
+        settings = self._settings()
+        # Use a fleet reference between the two cd0 values
+        re_ref = 0.020  # > 0.012 (good) and < 0.040 (high drag)
+
+        # Use cl_star for _GOOD_POLAR so match is maximised
+        cl_star = best_ld_cl(_GOOD_POLAR["cd0"], _GOOD_POLAR["k"], _GOOD_POLAR["cl0"])
+
+        # High drag polar: same structure but higher cd0
         high_drag_polar = dict(_GOOD_POLAR)
-        high_drag_polar["cd0"] = 0.040  # much higher drag
-        high_drag_polar["k"] = 0.04
-        high_drag_polar["cl0"] = 0.3
+        high_drag_polar["cd0"] = 0.040
 
-        low_score = score_target_cl(high_drag_polar, cl_target=0.5)
-        high_score = score_target_cl(_GOOD_POLAR, cl_target=0.5)
-        assert high_score > low_score
+        high_score = score_target_cl(
+            _GOOD_POLAR, cl_target=cl_star, re_cd0_reference=re_ref, settings=settings
+        )
+        low_score = score_target_cl(
+            high_drag_polar, cl_target=cl_star, re_cd0_reference=re_ref, settings=settings
+        )
+        assert high_score is not None
+        assert low_score is not None
+        # Good polar (cd0=0.012 < re_ref=0.020) gets efficiency=1.0
+        # High-drag polar (cd0=0.040 > re_ref=0.020) gets efficiency<1.0
+        assert high_score >= low_score
 
 
 # ---------------------------------------------------------------------------

--- a/app/tests/test_airfoil_suitability_service.py
+++ b/app/tests/test_airfoil_suitability_service.py
@@ -264,8 +264,10 @@ def test_search_suitability_explicit_target_cl_overrides(seeded_db):
     assert resp.query.target_cl_cruise == pytest.approx(0.5)
 
 
-def test_search_suitability_active_lens_is_never_loiter(seeded_db):
-    """active_lens must never be 'target_cl_loiter'."""
+def test_search_suitability_active_lens_is_never_glide_point(seeded_db):
+    """active_lens must never be a glide point (target_cl_best_glide / target_cl_min_sink).
+    Updated for gh-825: target_cl_loiter renamed to target_cl_min_sink.
+    """
     from app.services.suitability_service import search_suitability
 
     SessionLocal, ap_uuid = seeded_db
@@ -273,13 +275,16 @@ def test_search_suitability_active_lens_is_never_loiter(seeded_db):
         for params in [
             {},
             {"aeroplane_id": str(ap_uuid)},
-            {"target_cl_loiter": 0.8},
+            {"target_cl_min_sink": 0.8},
+            {"target_cl_best_glide": 0.75},
             {"mission_type": "glider"},
         ]:
             resp = search_suitability(db=session, chord_m=0.15, speed_ms=15.0, **params)
-            assert resp.query.active_lens != "target_cl_loiter", (
-                f"active_lens must never be 'target_cl_loiter', got '{resp.query.active_lens}'"
-            )
+            assert resp.query.active_lens not in (
+                "target_cl_loiter",
+                "target_cl_best_glide",
+                "target_cl_min_sink",
+            ), f"active_lens must never be a glide point, got '{resp.query.active_lens}'"
 
 
 def test_search_suitability_tip_re_flag(seeded_db):

--- a/app/tests/test_airfoils_suitability_endpoint.py
+++ b/app/tests/test_airfoils_suitability_endpoint.py
@@ -63,7 +63,7 @@ def client_no_svc():
 
 
 def _make_fake_response():
-    """Build a minimal SuitabilityResponse for mocking."""
+    """Build a minimal SuitabilityResponse for mocking (gh-825 contract)."""
     from app.schemas.airfoil import (
         SuitabilityResponse,
         SuitabilityQuery,
@@ -79,12 +79,15 @@ def _make_fake_response():
             re_clamped=False,
             mission_type=None,
             target_cl_cruise=None,
-            target_cl_loiter=None,
+            target_cl_best_glide=None,
+            target_cl_min_sink=None,
+            target_cl_provenance="estimated",
             active_lens="re_agnostic",
         ),
         caveat=SuitabilityCaveat(
             relative_ranking_only=True,
             no_hysteresis_modelling=True,
+            ignores_tip_re_clmax_collapse=True,
             recommend_xfoil_validation=False,
             text="Nur relative Reihenfolge.",
         ),
@@ -95,7 +98,10 @@ def _make_fake_response():
                 re_agnostic=0.85,
                 mission=None,
                 target_cl_cruise=None,
-                target_cl_loiter=None,
+                target_cl_best_glide=None,
+                target_cl_min_sink=None,
+                stall_gentleness=-0.04,
+                cl_max_margin=0.4,
                 min_analysis_confidence=0.95,
                 tip_re_flag=False,
                 caveat="",
@@ -125,6 +131,7 @@ def test_endpoint_returns_200_with_required_params(client_no_svc):
 
 
 def test_endpoint_response_has_frozen_shape(client_no_svc):
+    """Verify response shape matches gh-825 contract."""
     fake_resp = _make_fake_response()
     with patch("app.api.v2.endpoints.airfoils.search_suitability", return_value=fake_resp):
         resp = client_no_svc.get(
@@ -141,9 +148,14 @@ def test_endpoint_response_has_frozen_shape(client_no_svc):
     assert "reynolds" in q
     assert "re_clamped" in q
     assert "active_lens" in q
+    assert "target_cl_best_glide" in q
+    assert "target_cl_min_sink" in q
+    assert "target_cl_provenance" in q
+    assert "target_cl_loiter" not in q
     c = data["caveat"]
     assert "relative_ranking_only" in c
     assert "no_hysteresis_modelling" in c
+    assert "ignores_tip_re_clmax_collapse" in c
     assert "recommend_xfoil_validation" in c
     r = data["results"][0]
     assert "airfoil_name" in r
@@ -151,10 +163,14 @@ def test_endpoint_response_has_frozen_shape(client_no_svc):
     assert "re_agnostic" in r
     assert "mission" in r
     assert "target_cl_cruise" in r
-    assert "target_cl_loiter" in r
+    assert "target_cl_best_glide" in r
+    assert "target_cl_min_sink" in r
+    assert "stall_gentleness" in r
+    assert "cl_max_margin" in r
     assert "min_analysis_confidence" in r
     assert "tip_re_flag" in r
     assert "caveat" in r
+    assert "target_cl_loiter" not in r
 
 
 def test_endpoint_passes_optional_params_to_service(client_no_svc):

--- a/app/tests/test_suitability_service.py
+++ b/app/tests/test_suitability_service.py
@@ -1,0 +1,898 @@
+"""Tests for suitability_service gh-825 additions.
+
+TDD: RED first for new features, then GREEN.  All pure math / mocked DB.
+Covers:
+  - B4: three target CLs from ctx (v_cruise, v_md, v_min_sink)
+  - B5: three target scores + stall_gentleness + cl_max_margin per item
+  - B6: target_cl_provenance from DesignAssumptionModel
+  - B7: schema contract (new fields)
+  - B8/B9: endpoint param rename + full flow
+"""
+
+from __future__ import annotations
+
+import math
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+
+# ---------------------------------------------------------------------------
+# In-memory DB fixture (shared)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def in_memory_db():
+    """In-memory SQLite with all tables."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    from app.db.base import Base
+    import app.models  # noqa: F401
+
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, class_=Session)
+    yield SessionLocal
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture()
+def seeded_db_825(in_memory_db):
+    """DB with 2 airfoils + polars + aeroplane with all 3 speed context values."""
+    from app.models.airfoil import AirfoilModel
+    from app.models.airfoil_low_re import AirfoilGeometryModel, AirfoilLowRePolarModel
+    from app.models.aeroplanemodel import AeroplaneModel, DesignAssumptionModel
+    from app.models.mission_objective import MissionObjectiveModel
+
+    ap_uuid = uuid.uuid4()
+
+    with in_memory_db() as session:
+        # Airfoil 1: good performer
+        session.add(AirfoilModel(name="good_af", coordinates=[[0, 0], [0.5, 0.07], [1, 0]]))
+        session.flush()
+        session.add(
+            AirfoilGeometryModel(
+                airfoil_name="good_af",
+                max_thickness_pct=9.5,
+                max_camber_pct=3.0,
+                camber_at_te=0.001,
+                family="cambered",
+                computed_at=datetime.now(timezone.utc),
+            )
+        )
+        # Polar at two Re points with wide bucket
+        for re_val, ld, cl_max_val, cd0, k, cl0, bucket, stall_g in [
+            (100_000, 48.0, 1.2, 0.011, 0.038, 0.30, 0.65, -0.04),
+            (200_000, 58.0, 1.3, 0.010, 0.035, 0.30, 0.70, -0.03),
+        ]:
+            session.add(
+                AirfoilLowRePolarModel(
+                    airfoil_name="good_af",
+                    reynolds=float(re_val),
+                    ld_max=ld,
+                    cl_max=cl_max_val,
+                    alpha_attached_lo=-3.0,
+                    alpha_attached_hi=12.0,
+                    drag_bucket_width=bucket,
+                    cd_min=cd0,
+                    stall_gentleness=stall_g,
+                    cd0=cd0,
+                    k=k,
+                    cl0=cl0,
+                    cl_valid_lo=0.0,
+                    cl_valid_hi=1.3,
+                    min_analysis_confidence=0.95,
+                    neuralfoil_model_size="xxxlarge",
+                    n_crit=9.0,
+                    computed_at=datetime.now(timezone.utc),
+                )
+            )
+
+        # Airfoil 2: poor performer
+        session.add(AirfoilModel(name="poor_af", coordinates=[[0, 0], [0.5, 0.06], [1, 0]]))
+        session.flush()
+        session.add(
+            AirfoilGeometryModel(
+                airfoil_name="poor_af",
+                max_thickness_pct=12.0,
+                max_camber_pct=0.0,
+                camber_at_te=0.0,
+                family="symmetric",
+                computed_at=datetime.now(timezone.utc),
+            )
+        )
+        session.add(
+            AirfoilLowRePolarModel(
+                airfoil_name="poor_af",
+                reynolds=100_000.0,
+                ld_max=20.0,
+                cl_max=0.9,
+                alpha_attached_lo=-5.0,
+                alpha_attached_hi=10.0,
+                drag_bucket_width=0.15,
+                cd_min=0.022,
+                stall_gentleness=-0.35,
+                cd0=0.024,
+                k=0.065,
+                cl0=0.0,
+                cl_valid_lo=-0.2,
+                cl_valid_hi=0.8,
+                min_analysis_confidence=0.90,
+                neuralfoil_model_size="xxxlarge",
+                n_crit=9.0,
+                computed_at=datetime.now(timezone.utc),
+            )
+        )
+
+        # Aeroplane with all three speed context values
+        ap = AeroplaneModel(
+            name="test825",
+            uuid=ap_uuid,
+            total_mass_kg=2.0,
+            assumption_computation_context={
+                "mass_kg": 2.0,
+                "s_ref_m2": 0.35,
+                "v_cruise_mps": 18.0,
+                "v_md_mps": 13.0,  # best-glide speed
+                "v_min_sink_mps": 10.0,
+                "v_cruise_auto": True,
+            },
+        )
+        session.add(ap)
+        session.flush()
+        session.add(MissionObjectiveModel(aeroplane_id=ap.id, mission_type="glider"))
+
+        # DesignAssumptionModel for 'mass' parameter with CALCULATED source
+        session.add(
+            DesignAssumptionModel(
+                aeroplane_id=ap.id,
+                parameter_name="mass",
+                estimate_value=2.0,
+                calculated_value=1.95,
+                active_source="CALCULATED",
+            )
+        )
+        session.commit()
+        session.refresh(ap)
+
+    return in_memory_db, ap_uuid
+
+
+# ---------------------------------------------------------------------------
+# TASK B4: Three target CLs from context
+# ---------------------------------------------------------------------------
+
+
+class TestThreeTargetCls:
+    def test_cruise_cl_resolved_from_v_cruise(self, seeded_db_825):
+        from app.services.suitability_service import search_suitability
+
+        SessionLocal, ap_uuid = seeded_db_825
+        with SessionLocal() as session:
+            resp = search_suitability(
+                db=session,
+                chord_m=0.15,
+                speed_ms=15.0,
+                aeroplane_id=str(ap_uuid),
+            )
+        # cruise CL should be resolved (not None)
+        assert resp.query.target_cl_cruise is not None
+        assert resp.query.target_cl_cruise > 0.0
+
+    def test_best_glide_cl_resolved_from_v_md(self, seeded_db_825):
+        from app.services.suitability_service import search_suitability
+
+        SessionLocal, ap_uuid = seeded_db_825
+        with SessionLocal() as session:
+            resp = search_suitability(
+                db=session,
+                chord_m=0.15,
+                speed_ms=15.0,
+                aeroplane_id=str(ap_uuid),
+            )
+        # best_glide CL from v_md_mps
+        assert resp.query.target_cl_best_glide is not None
+        assert resp.query.target_cl_best_glide > 0.0
+        # Best-glide CL > cruise CL (slower speed = higher CL)
+        assert resp.query.target_cl_best_glide > resp.query.target_cl_cruise
+
+    def test_min_sink_cl_resolved_from_v_min_sink(self, seeded_db_825):
+        from app.services.suitability_service import search_suitability
+
+        SessionLocal, ap_uuid = seeded_db_825
+        with SessionLocal() as session:
+            resp = search_suitability(
+                db=session,
+                chord_m=0.15,
+                speed_ms=15.0,
+                aeroplane_id=str(ap_uuid),
+            )
+        # min-sink CL from v_min_sink_mps
+        assert resp.query.target_cl_min_sink is not None
+        assert resp.query.target_cl_min_sink > resp.query.target_cl_best_glide
+
+    def test_missing_v_md_gives_null_best_glide(self, in_memory_db):
+        """When v_md_mps is absent, target_cl_best_glide must be None."""
+        from app.models.airfoil import AirfoilModel
+        from app.models.airfoil_low_re import AirfoilGeometryModel
+        from app.models.aeroplanemodel import AeroplaneModel
+        from app.services.suitability_service import search_suitability
+
+        ap_uuid2 = uuid.uuid4()
+        with in_memory_db() as session:
+            session.add(AirfoilModel(name="af_x", coordinates=[[0, 0], [1, 0]]))
+            session.flush()
+            session.add(
+                AirfoilGeometryModel(
+                    airfoil_name="af_x",
+                    max_thickness_pct=10.0,
+                    max_camber_pct=2.0,
+                    camber_at_te=0.0,
+                    family="cambered",
+                    computed_at=datetime.now(timezone.utc),
+                )
+            )
+            ap = AeroplaneModel(
+                name="no_vmd",
+                uuid=ap_uuid2,
+                total_mass_kg=2.0,
+                assumption_computation_context={
+                    "mass_kg": 2.0,
+                    "s_ref_m2": 0.35,
+                    "v_cruise_mps": 18.0,
+                    # v_md_mps ABSENT
+                    "v_min_sink_mps": 10.0,
+                },
+            )
+            session.add(ap)
+            session.commit()
+
+        with in_memory_db() as session:
+            resp = search_suitability(
+                db=session,
+                chord_m=0.15,
+                speed_ms=15.0,
+                aeroplane_id=str(ap_uuid2),
+            )
+        assert resp.query.target_cl_best_glide is None
+
+    def test_explicit_best_glide_override_echoes_back(self, seeded_db_825):
+        from app.services.suitability_service import search_suitability
+
+        SessionLocal, _ = seeded_db_825
+        with SessionLocal() as session:
+            resp = search_suitability(
+                db=session,
+                chord_m=0.15,
+                speed_ms=15.0,
+                target_cl_best_glide=0.9,
+            )
+        assert resp.query.target_cl_best_glide == pytest.approx(0.9)
+
+    def test_explicit_min_sink_override_echoes_back(self, seeded_db_825):
+        from app.services.suitability_service import search_suitability
+
+        SessionLocal, _ = seeded_db_825
+        with SessionLocal() as session:
+            resp = search_suitability(
+                db=session,
+                chord_m=0.15,
+                speed_ms=15.0,
+                target_cl_min_sink=1.1,
+            )
+        assert resp.query.target_cl_min_sink == pytest.approx(1.1)
+
+
+# ---------------------------------------------------------------------------
+# TASK B5: stall_gentleness + cl_max_margin + three target scores per item
+# ---------------------------------------------------------------------------
+
+
+class TestItemNewFields:
+    def test_stall_gentleness_present_in_items(self, seeded_db_825):
+        from app.services.suitability_service import search_suitability
+
+        SessionLocal, _ = seeded_db_825
+        with SessionLocal() as session:
+            resp = search_suitability(db=session, chord_m=0.15, speed_ms=15.0)
+        # Items with polar data should have stall_gentleness != None
+        items_with_polar = [r for r in resp.results if r.re_agnostic > 0]
+        assert any(r.stall_gentleness is not None for r in items_with_polar)
+
+    def test_cl_max_margin_present_and_numeric(self, seeded_db_825):
+        from app.services.suitability_service import search_suitability
+
+        SessionLocal, ap_uuid = seeded_db_825
+        with SessionLocal() as session:
+            resp = search_suitability(
+                db=session,
+                chord_m=0.15,
+                speed_ms=15.0,
+                aeroplane_id=str(ap_uuid),
+            )
+        # At least one item should have cl_max_margin computed
+        items_with_margin = [r for r in resp.results if r.cl_max_margin is not None]
+        assert len(items_with_margin) > 0
+
+    def test_cl_max_margin_positive_when_target_below_cl_max(self, seeded_db_825):
+        """cl_max_margin = cl_max - max(target CLs) > 0 when target < cl_max."""
+        from app.services.suitability_service import search_suitability
+
+        SessionLocal, ap_uuid = seeded_db_825
+        with SessionLocal() as session:
+            # low target CL — well below any airfoil's cl_max
+            resp = search_suitability(
+                db=session,
+                chord_m=0.15,
+                speed_ms=15.0,
+                target_cl_cruise=0.3,
+            )
+        for item in resp.results:
+            if item.cl_max_margin is not None:
+                assert item.cl_max_margin >= -0.1, (
+                    f"cl_max_margin should be positive for CL target=0.3 << cl_max; "
+                    f"got {item.cl_max_margin:.3f} for {item.airfoil_name}"
+                )
+
+    def test_three_target_scores_present_in_items(self, seeded_db_825):
+        """When aeroplane context resolves all three speeds, items should carry
+        all three target CL scores (not all None)."""
+        from app.services.suitability_service import search_suitability
+
+        SessionLocal, ap_uuid = seeded_db_825
+        with SessionLocal() as session:
+            resp = search_suitability(
+                db=session,
+                chord_m=0.15,
+                speed_ms=15.0,
+                aeroplane_id=str(ap_uuid),
+            )
+        items_with_polar = [r for r in resp.results if r.re_agnostic > 0]
+        assert any(r.target_cl_cruise is not None for r in items_with_polar)
+        assert any(r.target_cl_best_glide is not None for r in items_with_polar)
+        assert any(r.target_cl_min_sink is not None for r in items_with_polar)
+
+    def test_none_propagation_when_no_context(self, seeded_db_825):
+        """Without aeroplane context, all three target CL scores should be None."""
+        from app.services.suitability_service import search_suitability
+
+        SessionLocal, _ = seeded_db_825
+        with SessionLocal() as session:
+            resp = search_suitability(db=session, chord_m=0.15, speed_ms=15.0)
+        for item in resp.results:
+            assert item.target_cl_cruise is None
+            assert item.target_cl_best_glide is None
+            assert item.target_cl_min_sink is None
+
+
+# ---------------------------------------------------------------------------
+# TASK B6: target_cl_provenance from DesignAssumptionModel
+# ---------------------------------------------------------------------------
+
+
+class TestTargetClProvenance:
+    def test_provenance_calculated_when_mass_calculated(self, seeded_db_825):
+        """When mass has CALCULATED source + v_cruise_auto=True → 'calculated'."""
+        from app.services.suitability_service import search_suitability
+
+        SessionLocal, ap_uuid = seeded_db_825
+        with SessionLocal() as session:
+            resp = search_suitability(
+                db=session,
+                chord_m=0.15,
+                speed_ms=15.0,
+                aeroplane_id=str(ap_uuid),
+            )
+        assert resp.query.target_cl_provenance == "calculated"
+
+    def test_provenance_estimated_when_no_aeroplane(self, seeded_db_825):
+        """No aeroplane context → provenance defaults to 'estimated'."""
+        from app.services.suitability_service import search_suitability
+
+        SessionLocal, _ = seeded_db_825
+        with SessionLocal() as session:
+            resp = search_suitability(db=session, chord_m=0.15, speed_ms=15.0)
+        assert resp.query.target_cl_provenance == "estimated"
+
+    def test_provenance_estimated_when_mass_is_estimate(self, in_memory_db):
+        """Mass with ESTIMATE source → provenance = 'estimated'."""
+        from app.models.airfoil import AirfoilModel
+        from app.models.airfoil_low_re import AirfoilGeometryModel
+        from app.models.aeroplanemodel import AeroplaneModel, DesignAssumptionModel
+        from app.services.suitability_service import search_suitability
+
+        ap_uuid2 = uuid.uuid4()
+        with in_memory_db() as session:
+            session.add(AirfoilModel(name="af_prov", coordinates=[[0, 0], [1, 0]]))
+            session.flush()
+            session.add(
+                AirfoilGeometryModel(
+                    airfoil_name="af_prov",
+                    max_thickness_pct=10.0,
+                    max_camber_pct=2.0,
+                    camber_at_te=0.0,
+                    family="cambered",
+                    computed_at=datetime.now(timezone.utc),
+                )
+            )
+            ap = AeroplaneModel(
+                name="estimate_plane",
+                uuid=ap_uuid2,
+                total_mass_kg=2.0,
+                assumption_computation_context={
+                    "mass_kg": 2.0,
+                    "s_ref_m2": 0.35,
+                    "v_cruise_mps": 18.0,
+                    # v_cruise_auto NOT set → estimated
+                },
+            )
+            session.add(ap)
+            session.flush()
+            session.add(
+                DesignAssumptionModel(
+                    aeroplane_id=ap.id,
+                    parameter_name="mass",
+                    estimate_value=2.0,
+                    active_source="ESTIMATE",
+                )
+            )
+            session.commit()
+
+        with in_memory_db() as session:
+            resp = search_suitability(
+                db=session,
+                chord_m=0.15,
+                speed_ms=15.0,
+                aeroplane_id=str(ap_uuid2),
+            )
+        assert resp.query.target_cl_provenance == "estimated"
+
+    def test_provenance_mixed_when_mass_calculated_but_no_v_cruise_auto(self, in_memory_db):
+        """Mass CALCULATED but v_cruise_auto missing/False → 'mixed'."""
+        from app.models.airfoil import AirfoilModel
+        from app.models.airfoil_low_re import AirfoilGeometryModel
+        from app.models.aeroplanemodel import AeroplaneModel, DesignAssumptionModel
+        from app.services.suitability_service import search_suitability
+
+        ap_uuid3 = uuid.uuid4()
+        with in_memory_db() as session:
+            session.add(AirfoilModel(name="af_mixed", coordinates=[[0, 0], [1, 0]]))
+            session.flush()
+            session.add(
+                AirfoilGeometryModel(
+                    airfoil_name="af_mixed",
+                    max_thickness_pct=10.0,
+                    max_camber_pct=2.0,
+                    camber_at_te=0.0,
+                    family="cambered",
+                    computed_at=datetime.now(timezone.utc),
+                )
+            )
+            ap = AeroplaneModel(
+                name="mixed_plane",
+                uuid=ap_uuid3,
+                total_mass_kg=2.0,
+                assumption_computation_context={
+                    "mass_kg": 2.0,
+                    "s_ref_m2": 0.35,
+                    "v_cruise_mps": 18.0,
+                    # v_cruise_auto ABSENT → speed is estimated
+                },
+            )
+            session.add(ap)
+            session.flush()
+            session.add(
+                DesignAssumptionModel(
+                    aeroplane_id=ap.id,
+                    parameter_name="mass",
+                    estimate_value=2.0,
+                    calculated_value=1.95,
+                    active_source="CALCULATED",  # mass is calculated
+                )
+            )
+            session.commit()
+
+        with in_memory_db() as session:
+            resp = search_suitability(
+                db=session,
+                chord_m=0.15,
+                speed_ms=15.0,
+                aeroplane_id=str(ap_uuid3),
+            )
+        assert resp.query.target_cl_provenance == "mixed"
+
+
+# ---------------------------------------------------------------------------
+# TASK B7: Schema contract — new fields
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaContract825:
+    def test_suitability_item_new_fields_present(self):
+        from app.schemas.airfoil import SuitabilityItem
+
+        item = SuitabilityItem(
+            airfoil_name="sd7037",
+            family="cambered",
+            re_agnostic=0.85,
+            mission=None,
+            target_cl_cruise=None,
+            target_cl_best_glide=None,
+            target_cl_min_sink=None,
+            stall_gentleness=-0.04,
+            cl_max_margin=0.3,
+            min_analysis_confidence=0.92,
+            tip_re_flag=False,
+            caveat="",
+        )
+        assert item.target_cl_best_glide is None
+        assert item.target_cl_min_sink is None
+        assert item.stall_gentleness == pytest.approx(-0.04)
+        assert item.cl_max_margin == pytest.approx(0.3)
+
+    def test_suitability_item_no_target_cl_loiter_field(self):
+        """target_cl_loiter must NOT be in the schema (renamed to target_cl_min_sink)."""
+        from app.schemas.airfoil import SuitabilityItem
+
+        item = SuitabilityItem(
+            airfoil_name="test",
+            family="symmetric",
+            re_agnostic=0.5,
+            min_analysis_confidence=0.9,
+            tip_re_flag=False,
+            caveat="",
+        )
+        data = item.model_dump()
+        assert "target_cl_loiter" not in data, "target_cl_loiter must be removed in gh-825"
+        assert "target_cl_min_sink" in data
+        assert "target_cl_best_glide" in data
+        assert "stall_gentleness" in data
+        assert "cl_max_margin" in data
+
+    def test_suitability_query_new_fields(self):
+        from app.schemas.airfoil import SuitabilityQuery
+
+        q = SuitabilityQuery(
+            chord_m=0.15,
+            speed_ms=15.0,
+            reynolds=150_000.0,
+            re_clamped=False,
+            mission_type=None,
+            target_cl_cruise=None,
+            target_cl_best_glide=None,
+            target_cl_min_sink=None,
+            target_cl_provenance="estimated",
+            active_lens="re_agnostic",
+        )
+        assert q.target_cl_best_glide is None
+        assert q.target_cl_min_sink is None
+        assert q.target_cl_provenance == "estimated"
+
+    def test_suitability_query_no_target_cl_loiter(self):
+        from app.schemas.airfoil import SuitabilityQuery
+
+        q = SuitabilityQuery(
+            chord_m=0.15,
+            speed_ms=15.0,
+            reynolds=150_000.0,
+            re_clamped=False,
+            active_lens="re_agnostic",
+            target_cl_provenance="estimated",
+        )
+        data = q.model_dump()
+        assert "target_cl_loiter" not in data
+        assert "target_cl_min_sink" in data
+        assert "target_cl_best_glide" in data
+        assert "target_cl_provenance" in data
+
+    def test_active_lens_never_glide_point(self):
+        """active_lens must NOT accept best_glide or min_sink — glide points are display-only."""
+        from app.schemas.airfoil import SuitabilityQuery
+        from pydantic import ValidationError
+
+        for bad_lens in ("target_cl_best_glide", "target_cl_min_sink", "target_cl_loiter"):
+            with pytest.raises(ValidationError):
+                SuitabilityQuery(
+                    chord_m=0.15,
+                    speed_ms=15.0,
+                    reynolds=150_000.0,
+                    re_clamped=False,
+                    active_lens=bad_lens,
+                    target_cl_provenance="estimated",
+                )
+
+    def test_target_cl_provenance_literal(self):
+        from app.schemas.airfoil import SuitabilityQuery
+        from pydantic import ValidationError
+
+        for valid in ("estimated", "calculated", "mixed"):
+            q = SuitabilityQuery(
+                chord_m=0.15,
+                speed_ms=15.0,
+                reynolds=150_000.0,
+                re_clamped=False,
+                active_lens="re_agnostic",
+                target_cl_provenance=valid,
+            )
+            assert q.target_cl_provenance == valid
+
+        with pytest.raises(ValidationError):
+            SuitabilityQuery(
+                chord_m=0.15,
+                speed_ms=15.0,
+                reynolds=150_000.0,
+                re_clamped=False,
+                active_lens="re_agnostic",
+                target_cl_provenance="unknown",
+            )
+
+    def test_caveat_has_ignores_tip_re_clmax_collapse(self):
+        from app.schemas.airfoil import SuitabilityCaveat
+
+        cav = SuitabilityCaveat(
+            relative_ranking_only=True,
+            no_hysteresis_modelling=True,
+            ignores_tip_re_clmax_collapse=True,
+            recommend_xfoil_validation=False,
+            text="Test caveat.",
+        )
+        assert cav.ignores_tip_re_clmax_collapse is True
+
+    def test_active_lens_excludes_glide_points(self):
+        """ActiveLens literal must only be re_agnostic / mission / target_cl_cruise."""
+        from app.schemas.airfoil import ActiveLens
+
+        # These are the only valid values:
+        valid = {"re_agnostic", "mission", "target_cl_cruise"}
+        # We access the __args__ via typing.get_args
+        import typing
+
+        args = set(typing.get_args(ActiveLens))
+        assert args == valid, f"ActiveLens args {args} != {valid}"
+
+    def test_target_cl_provenance_type_exists(self):
+        from app.schemas.airfoil import TargetClProvenance
+        import typing
+
+        args = set(typing.get_args(TargetClProvenance))
+        assert args == {"estimated", "calculated", "mixed"}
+
+
+# ---------------------------------------------------------------------------
+# TASK B8/B9: Endpoint param rename + full flow
+# ---------------------------------------------------------------------------
+
+
+class TestEndpointParams825:
+    @pytest.fixture()
+    def client_825(self, in_memory_db):
+        """TestClient backed by in-memory DB."""
+        from app.db.base import Base
+        import app.models  # noqa: F401
+        from app.db.session import get_db
+        from app.main import create_app
+        from app.services.component_type_service import seed_default_types
+        from app.services.mission_objective_service import seed_mission_presets
+
+        app = create_app()
+        engine = create_engine(
+            "sqlite://",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(bind=engine)
+        TestingSessionLocal = sessionmaker(
+            bind=engine, autocommit=False, autoflush=False, class_=Session
+        )
+
+        _s = TestingSessionLocal()
+        try:
+            seed_default_types(_s)
+            seed_mission_presets(_s)
+            _s.commit()
+        finally:
+            _s.close()
+
+        def override_get_db():
+            db = TestingSessionLocal()
+            try:
+                yield db
+                db.commit()
+            except Exception:
+                db.rollback()
+                raise
+            finally:
+                db.close()
+
+        app.dependency_overrides[get_db] = override_get_db
+        from fastapi.testclient import TestClient
+
+        with TestClient(app) as client:
+            yield client
+        app.dependency_overrides.clear()
+
+    def _make_fake_response_825(self):
+        """Build a minimal SuitabilityResponse with new gh-825 fields."""
+        from app.schemas.airfoil import (
+            SuitabilityResponse,
+            SuitabilityQuery,
+            SuitabilityCaveat,
+            SuitabilityItem,
+        )
+
+        return SuitabilityResponse(
+            query=SuitabilityQuery(
+                chord_m=0.15,
+                speed_ms=15.0,
+                reynolds=150_000.0,
+                re_clamped=False,
+                mission_type=None,
+                target_cl_cruise=None,
+                target_cl_best_glide=None,
+                target_cl_min_sink=None,
+                target_cl_provenance="estimated",
+                active_lens="re_agnostic",
+            ),
+            caveat=SuitabilityCaveat(
+                relative_ranking_only=True,
+                no_hysteresis_modelling=True,
+                ignores_tip_re_clmax_collapse=True,
+                recommend_xfoil_validation=False,
+                text="Relative ranking only. Section CL ≈ wing CL (ideal elliptic). "
+                "Tip-Re CL_max collapse not modelled.",
+            ),
+            results=[
+                SuitabilityItem(
+                    airfoil_name="sd7037",
+                    family="cambered",
+                    re_agnostic=0.85,
+                    mission=None,
+                    target_cl_cruise=None,
+                    target_cl_best_glide=None,
+                    target_cl_min_sink=None,
+                    stall_gentleness=-0.04,
+                    cl_max_margin=0.4,
+                    min_analysis_confidence=0.95,
+                    tip_re_flag=False,
+                    caveat="",
+                )
+            ],
+        )
+
+    def test_target_cl_min_sink_param_accepted(self, client_825):
+        """target_cl_min_sink param (renamed from loiter) must be accepted by endpoint."""
+        fake_resp = self._make_fake_response_825()
+        with patch(
+            "app.api.v2.endpoints.airfoils.search_suitability", return_value=fake_resp
+        ) as mock_svc:
+            resp = client_825.get(
+                "/airfoils/db/suitability",
+                params={
+                    "chord_m": 0.15,
+                    "speed_ms": 15.0,
+                    "target_cl_min_sink": 0.9,
+                },
+            )
+        assert resp.status_code == 200
+        call_kwargs = mock_svc.call_args[1]
+        assert call_kwargs.get("target_cl_min_sink") == pytest.approx(0.9)
+
+    def test_target_cl_best_glide_param_accepted(self, client_825):
+        """target_cl_best_glide NEW param must be accepted and forwarded."""
+        fake_resp = self._make_fake_response_825()
+        with patch(
+            "app.api.v2.endpoints.airfoils.search_suitability", return_value=fake_resp
+        ) as mock_svc:
+            resp = client_825.get(
+                "/airfoils/db/suitability",
+                params={
+                    "chord_m": 0.15,
+                    "speed_ms": 15.0,
+                    "target_cl_best_glide": 0.75,
+                },
+            )
+        assert resp.status_code == 200
+        call_kwargs = mock_svc.call_args[1]
+        assert call_kwargs.get("target_cl_best_glide") == pytest.approx(0.75)
+
+    def test_endpoint_response_has_new_fields(self, client_825):
+        """Endpoint response must include the new gh-825 fields."""
+        fake_resp = self._make_fake_response_825()
+        with patch("app.api.v2.endpoints.airfoils.search_suitability", return_value=fake_resp):
+            resp = client_825.get(
+                "/airfoils/db/suitability",
+                params={"chord_m": 0.15, "speed_ms": 15.0},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        q = data["query"]
+        assert "target_cl_best_glide" in q
+        assert "target_cl_min_sink" in q
+        assert "target_cl_provenance" in q
+        assert "target_cl_loiter" not in q
+
+        cav = data["caveat"]
+        assert "ignores_tip_re_clmax_collapse" in cav
+
+        r = data["results"][0]
+        assert "target_cl_best_glide" in r
+        assert "target_cl_min_sink" in r
+        assert "stall_gentleness" in r
+        assert "cl_max_margin" in r
+        assert "target_cl_loiter" not in r
+
+    def test_active_lens_never_glide_point_in_response(self, seeded_db_825):
+        """active_lens in actual service response must never be a glide point."""
+        from app.services.suitability_service import search_suitability
+
+        SessionLocal, ap_uuid = seeded_db_825
+        with SessionLocal() as session:
+            for kwargs in [
+                {},
+                {"aeroplane_id": str(ap_uuid)},
+                {"target_cl_min_sink": 0.9},
+                {"target_cl_best_glide": 0.75},
+            ]:
+                resp = search_suitability(db=session, chord_m=0.15, speed_ms=15.0, **kwargs)
+                assert resp.query.active_lens not in (
+                    "target_cl_best_glide",
+                    "target_cl_min_sink",
+                    "target_cl_loiter",
+                ), f"active_lens must never be a glide point, got '{resp.query.active_lens}'"
+
+    def test_provenance_present_in_query_response(self, seeded_db_825):
+        """target_cl_provenance must always be present in the response."""
+        from app.services.suitability_service import search_suitability
+
+        SessionLocal, ap_uuid = seeded_db_825
+        with SessionLocal() as session:
+            resp = search_suitability(
+                db=session,
+                chord_m=0.15,
+                speed_ms=15.0,
+                aeroplane_id=str(ap_uuid),
+            )
+        assert resp.query.target_cl_provenance in ("estimated", "calculated", "mixed")
+
+    def test_full_flow_response_shape(self, seeded_db_825):
+        """End-to-end: full response shape with all new fields."""
+        from app.services.suitability_service import search_suitability
+
+        SessionLocal, ap_uuid = seeded_db_825
+        with SessionLocal() as session:
+            resp = search_suitability(
+                db=session,
+                chord_m=0.15,
+                speed_ms=15.0,
+                aeroplane_id=str(ap_uuid),
+            )
+        # Schema-validated response
+        data = resp.model_dump()
+
+        # Query block
+        q = data["query"]
+        assert "target_cl_best_glide" in q
+        assert "target_cl_min_sink" in q
+        assert "target_cl_provenance" in q
+        assert "target_cl_loiter" not in q
+        assert q["active_lens"] in ("re_agnostic", "mission", "target_cl_cruise")
+
+        # Caveat block
+        cav = data["caveat"]
+        assert cav["ignores_tip_re_clmax_collapse"] is True
+
+        # Results block
+        for item in data["results"]:
+            assert "target_cl_best_glide" in item
+            assert "target_cl_min_sink" in item
+            assert "stall_gentleness" in item
+            assert "cl_max_margin" in item
+            assert "target_cl_loiter" not in item


### PR DESCRIPTION
Part of #825 (target-CL scoring v2). No migration/backfill — query-time scoring over existing low_re polar tables.