### PR TITLE
fix(gh-829): graceful degrade on malformed aeroplane_id

### DIFF
--- a/app/services/suitability_service.py
+++ b/app/services/suitability_service.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import logging
 import math
+import uuid as _uuid_module
 from typing import Optional
 
 from sqlalchemy.orm import Session
@@ -233,62 +234,78 @@ def search_suitability(
     provenance: TargetClProvenance = "estimated"
 
     if aeroplane_id is not None:
-        aeroplane = (
-            db.query(AeroplaneModel).filter(AeroplaneModel.uuid == str(aeroplane_id)).first()
-        )
-        if aeroplane is None:
+        # Guard: validate that aeroplane_id is a well-formed UUID before querying.
+        # A malformed value (e.g. '9', 'not-a-uuid') would cause SQLAlchemy to
+        # raise StatementError(ValueError('badly formed hexadecimal UUID string'))
+        # leaking raw SQL into the response.  Treat any malformed id exactly like
+        # an unknown-but-valid UUID — degrade to re_agnostic-only (gh-829).
+        _is_valid_uuid = False
+        try:
+            _uuid_module.UUID(str(aeroplane_id))
+            _is_valid_uuid = True
+        except (ValueError, AttributeError):
             logger.warning(
-                "Unknown aeroplane_id '%s' — degrading to re_agnostic-only", aeroplane_id
+                "Malformed aeroplane_id '%s' — degrading to re_agnostic-only (gh-829)",
+                aeroplane_id,
             )
-        else:
-            # Resolve mission type (explicit param overrides model value)
-            if effective_mission_type is None:
-                mission_obj = (
-                    db.query(MissionObjectiveModel)
-                    .filter(MissionObjectiveModel.aeroplane_id == aeroplane.id)
-                    .first()
+
+        if _is_valid_uuid:
+            aeroplane = (
+                db.query(AeroplaneModel).filter(AeroplaneModel.uuid == str(aeroplane_id)).first()
+            )
+            if aeroplane is None:
+                logger.warning(
+                    "Unknown aeroplane_id '%s' — degrading to re_agnostic-only", aeroplane_id
                 )
-                if mission_obj is not None:
-                    mapped = _MISSION_TYPE_MAP.get((mission_obj.mission_type or "").lower())
-                    effective_mission_type = mapped  # may still be None if unmapped
+            else:
+                # Resolve mission type (explicit param overrides model value)
+                if effective_mission_type is None:
+                    mission_obj = (
+                        db.query(MissionObjectiveModel)
+                        .filter(MissionObjectiveModel.aeroplane_id == aeroplane.id)
+                        .first()
+                    )
+                    if mission_obj is not None:
+                        mapped = _MISSION_TYPE_MAP.get((mission_obj.mission_type or "").lower())
+                        effective_mission_type = mapped  # may still be None if unmapped
 
-            # Resolve operating CLs from assumption_computation_context
-            ctx = getattr(aeroplane, "assumption_computation_context", None) or {}
-            mass_kg: Optional[float] = ctx.get("mass_kg")
-            v_cruise_mps: Optional[float] = ctx.get("v_cruise_mps")
-            v_md_mps: Optional[float] = ctx.get("v_md_mps")  # best-glide speed (NEW)
-            v_min_sink_mps: Optional[float] = ctx.get("v_min_sink_mps")
-            s_ref_m2: Optional[float] = ctx.get("s_ref_m2")
+                # Resolve operating CLs from assumption_computation_context
+                ctx = getattr(aeroplane, "assumption_computation_context", None) or {}
+                mass_kg: Optional[float] = ctx.get("mass_kg")
+                v_cruise_mps: Optional[float] = ctx.get("v_cruise_mps")
+                v_md_mps: Optional[float] = ctx.get("v_md_mps")  # best-glide speed (NEW)
+                v_min_sink_mps: Optional[float] = ctx.get("v_min_sink_mps")
+                s_ref_m2: Optional[float] = ctx.get("s_ref_m2")
 
-            # Compute cruise CL (explicit param overrides derived)
-            if effective_target_cl_cruise is None:
-                if all(v is not None for v in (mass_kg, v_cruise_mps, s_ref_m2)):
-                    try:
-                        effective_target_cl_cruise = _level_flight_cl(
-                            mass_kg, v_cruise_mps, s_ref_m2
-                        )
-                    except (ValueError, ZeroDivisionError):
-                        effective_target_cl_cruise = None
+                # Compute cruise CL (explicit param overrides derived)
+                if effective_target_cl_cruise is None:
+                    if all(v is not None for v in (mass_kg, v_cruise_mps, s_ref_m2)):
+                        try:
+                            effective_target_cl_cruise = _level_flight_cl(
+                                mass_kg, v_cruise_mps, s_ref_m2
+                            )
+                        except (ValueError, ZeroDivisionError):
+                            effective_target_cl_cruise = None
 
-            # Compute best-glide CL from v_md_mps (explicit param overrides derived)
-            if effective_target_cl_best_glide is None:
-                if all(v is not None for v in (mass_kg, v_md_mps, s_ref_m2)):
-                    try:
-                        effective_target_cl_best_glide = _level_flight_cl(
-                            mass_kg, v_md_mps, s_ref_m2
-                        )
-                    except (ValueError, ZeroDivisionError):
-                        effective_target_cl_best_glide = None
+                # Compute best-glide CL from v_md_mps (explicit param overrides derived)
+                if effective_target_cl_best_glide is None:
+                    if all(v is not None for v in (mass_kg, v_md_mps, s_ref_m2)):
+                        try:
+                            effective_target_cl_best_glide = _level_flight_cl(
+                                mass_kg, v_md_mps, s_ref_m2
+                            )
+                        except (ValueError, ZeroDivisionError):
+                            effective_target_cl_best_glide = None
 
-            # Compute min-sink CL (renamed from loiter; explicit param overrides derived)
-            if effective_target_cl_min_sink is None:
-                if all(v is not None for v in (mass_kg, v_min_sink_mps, s_ref_m2)):
-                    try:
-                        effective_target_cl_min_sink = _level_flight_cl(
-                            mass_kg, v_min_sink_mps, s_ref_m2
-                        )
-                    except (ValueError, ZeroDivisionError):
-                        effective_target_cl_min_sink = None
+                # Compute min-sink CL (renamed from loiter; explicit param overrides derived)
+                if effective_target_cl_min_sink is None:
+                    if all(v is not None for v in (mass_kg, v_min_sink_mps, s_ref_m2)):
+                        try:
+                            effective_target_cl_min_sink = _level_flight_cl(
+                                mass_kg, v_min_sink_mps, s_ref_m2
+                            )
+                        except (ValueError, ZeroDivisionError):
+                            effective_target_cl_min_sink = None
 
     # --- Provenance ---
     provenance = _resolve_provenance(aeroplane, db, ctx)

--- a/app/tests/test_airfoil_suitability_scoring.py
+++ b/app/tests/test_airfoil_suitability_scoring.py
@@ -278,9 +278,7 @@ class TestTargetClScoreGlidePoints:
         import math
         from app.services.airfoil_low_re_service import score_target_cl, best_ld_cl
 
-        cl_star = best_ld_cl(
-            _GLIDER_POLAR["cd0"], _GLIDER_POLAR["k"], _GLIDER_POLAR["cl0"]
-        )
+        cl_star = best_ld_cl(_GLIDER_POLAR["cd0"], _GLIDER_POLAR["k"], _GLIDER_POLAR["cl0"])
         cl_min_sink = math.sqrt(3) * cl_star
 
         # Sanity: min-sink CL must be above cl_star for this to test the right path
@@ -306,9 +304,7 @@ class TestTargetClScoreGlidePoints:
         import math
         from app.services.airfoil_low_re_service import score_target_cl, best_ld_cl
 
-        cl_star = best_ld_cl(
-            _GLIDER_POLAR["cd0"], _GLIDER_POLAR["k"], _GLIDER_POLAR["cl0"]
-        )
+        cl_star = best_ld_cl(_GLIDER_POLAR["cd0"], _GLIDER_POLAR["k"], _GLIDER_POLAR["cl0"])
         cl_min_sink = math.sqrt(3) * cl_star
 
         settings = self._settings()
@@ -326,9 +322,15 @@ class TestTargetClScoreGlidePoints:
         polar_stall = dict(_GLIDER_POLAR)
         polar_stall["cl_max"] = cl_min_sink - 0.05  # stall risk
 
-        score_good = score_target_cl(polar_good, cl_target=cl_min_sink, re_cd0_reference=re_ref, settings=settings)
-        score_poor = score_target_cl(polar_poor, cl_target=cl_min_sink, re_cd0_reference=re_ref, settings=settings)
-        score_stall = score_target_cl(polar_stall, cl_target=cl_min_sink, re_cd0_reference=re_ref, settings=settings)
+        score_good = score_target_cl(
+            polar_good, cl_target=cl_min_sink, re_cd0_reference=re_ref, settings=settings
+        )
+        score_poor = score_target_cl(
+            polar_poor, cl_target=cl_min_sink, re_cd0_reference=re_ref, settings=settings
+        )
+        score_stall = score_target_cl(
+            polar_stall, cl_target=cl_min_sink, re_cd0_reference=re_ref, settings=settings
+        )
 
         assert score_good is not None and score_poor is not None and score_stall is not None
         assert score_good > score_poor, (
@@ -345,9 +347,7 @@ class TestTargetClScoreGlidePoints:
 
         settings = self._settings()
         re_ref = 0.009
-        cl_star = best_ld_cl(
-            _GLIDER_POLAR["cd0"], _GLIDER_POLAR["k"], _GLIDER_POLAR["cl0"]
-        )
+        cl_star = best_ld_cl(_GLIDER_POLAR["cd0"], _GLIDER_POLAR["k"], _GLIDER_POLAR["cl0"])
         delta = 0.01  # 0.01 CL units either side of the boundary
 
         score_just_below = score_target_cl(

--- a/app/tests/test_airfoil_suitability_service.py
+++ b/app/tests/test_airfoil_suitability_service.py
@@ -585,3 +585,45 @@ def test_confidence_aware_ranking_high_score_low_conf_ranks_below_reliable(seede
             f"Last high-conf idx={last_high_conf_idx}, first low-conf idx={first_low_conf_idx}. "
             f"Order: {result_names}"
         )
+
+
+# ---------------------------------------------------------------------------
+# gh-829: malformed aeroplane_id must degrade gracefully, never 500
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        "9",  # bare integer string
+        "not-a-uuid",  # arbitrary text
+        "00000000",  # too short hex
+        "",  # empty string (edge)
+        "abc!@#$",  # special chars
+    ],
+)
+def test_malformed_aeroplane_id_degrades_gracefully(seeded_db, bad_id):
+    """gh-829: a non-UUID aeroplane_id must NOT raise an exception.
+
+    The service must degrade to the re_agnostic-only response (active_lens=
+    're_agnostic', mission_type=null, target_cl_cruise=null) — exactly as an
+    unknown-but-valid UUID does.  It must NEVER propagate a ValueError /
+    database-level exception or return HTTP 500.
+    """
+    from app.services.suitability_service import search_suitability
+
+    SessionLocal, _ = seeded_db
+    with SessionLocal() as session:
+        resp = search_suitability(
+            db=session,
+            chord_m=0.15,
+            speed_ms=15.0,
+            aeroplane_id=bad_id,
+        )
+
+    # Must return a valid response (not raise)
+    assert resp is not None
+    # No mission/CL context resolved — re_agnostic-only
+    assert resp.query.active_lens == "re_agnostic"
+    assert resp.query.mission_type is None
+    assert resp.query.target_cl_cruise is None


### PR DESCRIPTION
Closes #829.

## Summary

- `GET /airfoils/db/suitability?aeroplane_id=9` (or any non-UUID string) previously raised `StatementError(ValueError('badly formed hexadecimal UUID string'))` → HTTP 500, leaking raw SQL.
- Fix: validate `aeroplane_id` with `uuid.UUID()` before the DB query. A malformed value is treated as 'no aeroplane' — the same degrade path as an unknown-but-valid UUID — returning `active_lens='re_agnostic'`, `mission_type=null`, and target CLs null (HTTP 200).
- Added a parametrized regression test covering `'9'`, `'not-a-uuid'`, `'00000000'`, `''`, and `'abc!@#$'`.

## Test plan

- [x] `poetry run pytest app/tests/test_airfoil_suitability_service.py::test_malformed_aeroplane_id_degrades_gracefully` — 5/5 passed (was 5/5 failing before fix)
- [x] Full suitability test suite (63 tests) — 0 failures
- [x] Full fast suite (`-m "not slow"`) — 4593 passed, 0 failures
- [x] `ruff check . && ruff format --check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)