### PR TITLE
feat(gh-825): scoring refinements (frontend)

### DIFF
--- a/frontend/__tests__/AirfoilSelector.a11y.test.tsx
+++ b/frontend/__tests__/AirfoilSelector.a11y.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * A11y tests for AirfoilSelector — ITEM 6.
+ * Asserts that root and tip AirfoilSelector instances get UNIQUE, non-empty
+ * ids so there are no duplicate-id violations.
+ *
+ * Background: AirfoilPreviewConfigPanel previously passed label='' to both
+ * selectors, causing BOTH to derive id='airfoil-' (duplicate empty id).
+ * Fix: additive optional `id` prop on AirfoilSelector; ConfigPanel passes
+ * id='airfoil-root' and id='airfoil-tip'.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import React from "react";
+
+// Mock SWR for the airfoil list used by AirfoilSelector
+vi.mock("swr", () => ({
+  default: vi.fn(() => ({
+    data: {
+      count: 2,
+      airfoils: [
+        { airfoil_name: "naca0015", file_name: "naca0015.dat" },
+        { airfoil_name: "e423", file_name: "e423.dat" },
+      ],
+    },
+    error: null,
+    isLoading: false,
+  })),
+}));
+
+vi.mock("lucide-react", () => ({
+  ChevronDown: (p: Record<string, unknown>) => <svg data-testid="chevron-down" {...p} />,
+  ChevronUp: (p: Record<string, unknown>) => <svg data-testid="chevron-up" {...p} />,
+  Search: (p: Record<string, unknown>) => <svg data-testid="search" {...p} />,
+  Check: (p: Record<string, unknown>) => <svg data-testid="check" {...p} />,
+  Info: (p: Record<string, unknown>) => <svg data-testid="info" {...p} />,
+  ArrowLeft: (p: Record<string, unknown>) => <svg data-testid="arrow-left" {...p} />,
+  Save: (p: Record<string, unknown>) => <svg data-testid="save" {...p} />,
+  Loader2: (p: Record<string, unknown>) => <svg data-testid="loader2" {...p} />,
+  ChevronLeft: (p: Record<string, unknown>) => <svg data-testid="chevron-left" {...p} />,
+  ChevronRight: (p: Record<string, unknown>) => <svg data-testid="chevron-right" {...p} />,
+  Undo2: (p: Record<string, unknown>) => <svg data-testid="undo2" {...p} />,
+  AlertTriangle: (p: Record<string, unknown>) => <svg data-testid="alert-triangle" {...p} />,
+}));
+
+import { AirfoilSelector } from "../components/workbench/AirfoilSelector";
+import { AirfoilPreviewConfigPanel } from "../components/workbench/AirfoilPreviewConfigPanel";
+
+// ── Standalone AirfoilSelector id prop ────────────────────────────
+
+describe("AirfoilSelector — additive id prop (ITEM 6)", () => {
+  it("uses the provided id on the trigger button when id prop is given", () => {
+    const { container } = render(
+      <AirfoilSelector label="" value="naca0015" id="airfoil-root" />,
+    );
+    const trigger = container.querySelector("#airfoil-root");
+    expect(trigger).not.toBeNull();
+    expect(trigger?.tagName.toLowerCase()).toBe("button");
+  });
+
+  it("uses the provided id on the label htmlFor when id prop is given", () => {
+    const { container } = render(
+      <AirfoilSelector label="" value="naca0015" id="airfoil-root" />,
+    );
+    const label = container.querySelector('label[for="airfoil-root"]');
+    expect(label).not.toBeNull();
+  });
+
+  it("falls back to label-derived id when id prop is absent", () => {
+    const { container } = render(
+      <AirfoilSelector label="Root" value="naca0015" />,
+    );
+    const trigger = container.querySelector("#airfoil-root");
+    expect(trigger).not.toBeNull();
+  });
+
+  it("two selectors with different id props have UNIQUE ids", () => {
+    const { container } = render(
+      <div>
+        <AirfoilSelector label="" value="naca0015" id="airfoil-root" />
+        <AirfoilSelector label="" value="e423" id="airfoil-tip" />
+      </div>,
+    );
+    const rootTrigger = container.querySelector("#airfoil-root");
+    const tipTrigger = container.querySelector("#airfoil-tip");
+    expect(rootTrigger).not.toBeNull();
+    expect(tipTrigger).not.toBeNull();
+    // They must not be the same element
+    expect(rootTrigger).not.toBe(tipTrigger);
+  });
+
+  it("id must not be empty ('airfoil-' with empty label causes duplicate-id violation)", () => {
+    // This test asserts that when id='airfoil-root' is passed, the button id
+    // is 'airfoil-root' and NOT the fallback 'airfoil-' (empty label fallback).
+    const { container } = render(
+      <AirfoilSelector label="" value="naca0015" id="airfoil-root" />,
+    );
+    const trigger = container.querySelector("button[id]");
+    expect(trigger?.id).toBe("airfoil-root");
+    expect(trigger?.id).not.toBe("airfoil-");
+  });
+});
+
+// ── AirfoilPreviewConfigPanel: no duplicate ids on root/tip selectors ─
+
+describe("AirfoilPreviewConfigPanel — no duplicate AirfoilSelector ids (ITEM 6)", () => {
+  const baseProps = {
+    rootAirfoil: "naca0015",
+    tipAirfoil: "e423",
+    onRootAirfoilChange: vi.fn(),
+    onTipAirfoilChange: vi.fn(),
+    isRunning: false,
+    segmentIndex: 0,
+    segmentCount: 1,
+    onSegmentChange: vi.fn(),
+    segmentProps: {},
+    velocity: 14,
+    onVelocityChange: vi.fn(),
+    rootRe: 200000,
+    tipRe: 150000,
+    onRootReChange: vi.fn(),
+    onTipReChange: vi.fn(),
+    rootChordMm: 200,
+    tipChordMm: 150,
+    isDirty: false,
+    isSaving: false,
+    onSave: vi.fn(),
+    onRevert: vi.fn(),
+    onBack: vi.fn(),
+  };
+
+  it("root AirfoilSelector trigger has id='airfoil-root'", () => {
+    const { container } = render(<AirfoilPreviewConfigPanel {...baseProps} />);
+    const rootTrigger = container.querySelector("#airfoil-root");
+    expect(rootTrigger).not.toBeNull();
+    expect(rootTrigger?.tagName.toLowerCase()).toBe("button");
+  });
+
+  it("tip AirfoilSelector trigger has id='airfoil-tip'", () => {
+    const { container } = render(<AirfoilPreviewConfigPanel {...baseProps} />);
+    const tipTrigger = container.querySelector("#airfoil-tip");
+    expect(tipTrigger).not.toBeNull();
+    expect(tipTrigger?.tagName.toLowerCase()).toBe("button");
+  });
+
+  it("root and tip selector ids are DISTINCT (no duplicate-id violation)", () => {
+    const { container } = render(<AirfoilPreviewConfigPanel {...baseProps} />);
+    const rootTrigger = container.querySelector("#airfoil-root");
+    const tipTrigger = container.querySelector("#airfoil-tip");
+    expect(rootTrigger).not.toBeNull();
+    expect(tipTrigger).not.toBeNull();
+    // Distinct elements
+    expect(rootTrigger).not.toBe(tipTrigger);
+  });
+
+  it("root selector label is associated with id='airfoil-root' via htmlFor", () => {
+    const { container } = render(<AirfoilPreviewConfigPanel {...baseProps} />);
+    const label = container.querySelector('label[for="airfoil-root"]');
+    expect(label).not.toBeNull();
+  });
+
+  it("tip selector label is associated with id='airfoil-tip' via htmlFor", () => {
+    const { container } = render(<AirfoilPreviewConfigPanel {...baseProps} />);
+    const label = container.querySelector('label[for="airfoil-tip"]');
+    expect(label).not.toBeNull();
+  });
+
+  it("there are no buttons with an empty id attribute", () => {
+    const { container } = render(<AirfoilPreviewConfigPanel {...baseProps} />);
+    // Collect all buttons that have an id attribute
+    const buttonsWithId = container.querySelectorAll("button[id]");
+    const emptyIds = Array.from(buttonsWithId).filter((btn) => !btn.id);
+    expect(emptyIds).toHaveLength(0);
+  });
+
+  it("no two elements share the same non-empty id", () => {
+    const { container } = render(<AirfoilPreviewConfigPanel {...baseProps} />);
+    const elements = container.querySelectorAll("[id]");
+    const ids = Array.from(elements).map((el) => el.id).filter(Boolean);
+    const uniqueIds = new Set(ids);
+    expect(ids.length).toBe(uniqueIds.size);
+  });
+});

--- a/frontend/__tests__/AirfoilSuitabilityCard.i18n.test.tsx
+++ b/frontend/__tests__/AirfoilSuitabilityCard.i18n.test.tsx
@@ -1,0 +1,307 @@
+/**
+ * i18n consistency tests for AirfoilSuitabilityCard — ITEM 4.
+ *
+ * Prevailing language decision: GERMAN.
+ * Rationale: The surrounding workbench panel uses English for pure structural
+ * navigation (segment, Save, Revert, Back to Construction) but all
+ * aerodynamic/physics content uses German (Reynolds-Zahl, Grenzschicht,
+ * Modellflugzeuge, Profiltiefe, etc.). The AirfoilSuitabilityCard is a physics
+ * content surface → German is the correct prevailing language.
+ *
+ * This test suite asserts that ALL visible human-readable card text uses German,
+ * with these exceptions that are standard notation (language-neutral):
+ *   - Score-axis labels C_L, C_D, alpha are scientific notation (in viewer panel,
+ *     not tested here — they live in AirfoilPreviewViewerPanel)
+ *   - Airfoil names (e.g. "e423") are identifiers, not language
+ *
+ * Items asserted:
+ *   4a. qualitativeLabel returns German strings
+ *   4b. ScoreBar labels are German
+ *   4c. Eignung header is German
+ *   4d. ConfidenceChip text is German ("Konfidenz")
+ *   4e. ProvenanceIndicator labels and tooltips are German
+ *   4f. StallClMaxRow labels are German ("Stall-Sanftheit", "CL-Margin")
+ *       and warning text "abrupt" and "Ziel > CL_max!" remain unchanged
+ *   4g. TipReClMaxWarning is German
+ *   4h. CaveatCallout is German
+ *   4i. AirfoilSuitabilityNoData is German
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+vi.mock("lucide-react", () => ({
+  ChevronDown: (p: Record<string, unknown>) => <svg data-testid="chevron-down" {...p} />,
+  ChevronRight: (p: Record<string, unknown>) => <svg data-testid="chevron-right" {...p} />,
+  AlertTriangle: (p: Record<string, unknown>) => <svg data-testid="alert-triangle" {...p} />,
+  Info: (p: Record<string, unknown>) => <svg data-testid="info" {...p} />,
+  Activity: (p: Record<string, unknown>) => <svg data-testid="activity" {...p} />,
+}));
+
+import {
+  AirfoilSuitabilityCard,
+  AirfoilSuitabilityNoData,
+  qualitativeLabel,
+} from "../components/workbench/AirfoilSuitabilityCard";
+import type { SuitabilityItem, SuitabilityCaveat } from "../hooks/useAirfoilSuitability";
+
+const baseItem: SuitabilityItem = {
+  airfoil_name: "e423",
+  family: "cambered",
+  re_agnostic: 0.82,
+  mission: 0.75,
+  target_cl_cruise: 0.68,
+  target_cl_best_glide: 0.80,
+  target_cl_min_sink: 0.55,
+  stall_gentleness: -0.02,
+  cl_max_margin: 0.15,
+  min_analysis_confidence: 0.92,
+  tip_re_flag: false,
+  caveat: "Nur relative Rangfolge.",
+};
+
+const abruptStallItem: SuitabilityItem = {
+  ...baseItem,
+  stall_gentleness: -0.18,
+};
+
+const negMarginItem: SuitabilityItem = {
+  ...baseItem,
+  cl_max_margin: -0.05,
+};
+
+const lowConfidenceItem: SuitabilityItem = {
+  ...baseItem,
+  min_analysis_confidence: 0.72,
+};
+
+const baseCaveat: SuitabilityCaveat = {
+  relative_ranking_only: true,
+  no_hysteresis_modelling: true,
+  ignores_tip_re_clmax_collapse: true,
+  recommend_xfoil_validation: false,
+  text: "Nur relative Rangfolge. Kein Hysterese-Modell.",
+};
+
+// ── 4a: qualitativeLabel returns German ─────────────────────────────
+
+describe("ITEM 4 — qualitativeLabel: German strings only", () => {
+  it("returns 'Gut' (German) for score >= 0.75 — not 'Good'", () => {
+    expect(qualitativeLabel(0.82)).toBe("Gut");
+    expect(qualitativeLabel(0.75)).toBe("Gut");
+    expect(qualitativeLabel(1.0)).toBe("Gut");
+  });
+
+  it("returns 'Mäßig' (German) for score 0.5–0.75 — not 'Average'", () => {
+    expect(qualitativeLabel(0.6)).toBe("Mäßig");
+    expect(qualitativeLabel(0.5)).toBe("Mäßig");
+    expect(qualitativeLabel(0.74)).toBe("Mäßig");
+  });
+
+  it("returns 'Schwach' (German) for score < 0.5 — not 'Weak'", () => {
+    expect(qualitativeLabel(0.3)).toBe("Schwach");
+    expect(qualitativeLabel(0.0)).toBe("Schwach");
+    expect(qualitativeLabel(0.49)).toBe("Schwach");
+  });
+});
+
+// ── 4b: ScoreBar labels are German ─────────────────────────────────
+
+describe("ITEM 4 — ScoreBar labels: German", () => {
+  it("renders 'Re-agnostisch' bar label (German)", () => {
+    render(<AirfoilSuitabilityCard item={baseItem} defaultOpen />);
+    expect(screen.getByText(/Re-agnostisch/)).toBeDefined();
+  });
+
+  it("renders 'Mission' bar label (language-neutral, acceptable)", () => {
+    render(<AirfoilSuitabilityCard item={baseItem} defaultOpen />);
+    expect(screen.getByText(/^Mission$/)).toBeDefined();
+  });
+
+  it("renders 'Ziel-CL · Cruise' label — German 'Ziel-CL' with 'Cruise' as accepted technical term", () => {
+    render(<AirfoilSuitabilityCard item={baseItem} defaultOpen />);
+    expect(screen.getByText(/Ziel-CL · Cruise/)).toBeDefined();
+  });
+
+  it("renders 'Ziel-CL · Best-Glide' label — German 'Ziel-CL' prefix", () => {
+    render(<AirfoilSuitabilityCard item={baseItem} defaultOpen />);
+    expect(screen.getByText(/Ziel-CL · Best-Glide/)).toBeDefined();
+  });
+
+  it("renders German sublabel 'Motorausfall / Segelflug' under Best-Glide bar", () => {
+    render(<AirfoilSuitabilityCard item={baseItem} defaultOpen />);
+    expect(screen.getByText(/Motorausfall \/ Segelflug/)).toBeDefined();
+  });
+
+  it("renders 'Ziel-CL · Min-Sink' label — German 'Ziel-CL' prefix", () => {
+    render(<AirfoilSuitabilityCard item={baseItem} defaultOpen />);
+    expect(screen.getByText(/Ziel-CL · Min-Sink/)).toBeDefined();
+  });
+});
+
+// ── 4c: Eignung header is German ────────────────────────────────────
+
+describe("ITEM 4 — 'Eignung' header: German (not 'Suitability')", () => {
+  it("card header shows 'Eignung' (German)", () => {
+    render(<AirfoilSuitabilityCard item={baseItem} defaultOpen />);
+    expect(screen.getByText(/Eignung/)).toBeDefined();
+  });
+
+  it("no-data placeholder also shows 'Eignung' (German)", () => {
+    render(<AirfoilSuitabilityNoData />);
+    const matches = screen.queryAllByText(/Eignung/);
+    expect(matches.length).toBeGreaterThan(0);
+  });
+});
+
+// ── 4d: ConfidenceChip text is German ──────────────────────────────
+
+describe("ITEM 4 — ConfidenceChip: German text ('Konfidenz' not 'Confidence')", () => {
+  it("chip shows 'Konfidenz' (German) not 'Confidence' (English)", () => {
+    render(<AirfoilSuitabilityCard item={baseItem} defaultOpen />);
+    // Should render 'Konfidenz' with the numeric value
+    const chip = screen.getByText(/Konfidenz/);
+    expect(chip).toBeDefined();
+    expect(chip.textContent).toMatch(/Konfidenz/);
+    // Should NOT contain the English word 'Confidence'
+    expect(chip.textContent).not.toMatch(/\bConfidence\b/);
+  });
+
+  it("confidence chip has a German tooltip (title attribute)", () => {
+    render(<AirfoilSuitabilityCard item={baseItem} defaultOpen />);
+    const chip = screen.getByText(/Konfidenz/);
+    const title = chip.getAttribute("title");
+    expect(title).toBeTruthy();
+    // Tooltip must contain German content
+    expect(title).toMatch(/Modell-Konfidenz|Stützstellen|Orientierung/);
+  });
+});
+
+// ── 4e: ProvenanceIndicator labels and tooltips are German ───────────
+
+describe("ITEM 4 — ProvenanceIndicator: German labels and tooltips", () => {
+  it("calculated provenance shows German label 'Ber. Referenz'", () => {
+    render(
+      <AirfoilSuitabilityCard item={baseItem} defaultOpen targetClProvenance="calculated" />,
+    );
+    const indicator = screen.getByTestId("provenance-indicator");
+    expect(indicator.textContent).toMatch(/Ber\. Referenz/);
+  });
+
+  it("estimated provenance shows German label 'Geschätzte Ref.'", () => {
+    render(
+      <AirfoilSuitabilityCard item={baseItem} defaultOpen targetClProvenance="estimated" />,
+    );
+    const indicator = screen.getByTestId("provenance-indicator");
+    expect(indicator.textContent).toMatch(/Gesch[äa]tzte Ref\./);
+  });
+
+  it("mixed provenance shows German label 'Gem. Referenz'", () => {
+    render(
+      <AirfoilSuitabilityCard item={baseItem} defaultOpen targetClProvenance="mixed" />,
+    );
+    const indicator = screen.getByTestId("provenance-indicator");
+    expect(indicator.textContent).toMatch(/Gem\. Referenz/);
+  });
+
+  it("calculated provenance tooltip is German (bewegliche Referenz)", () => {
+    render(
+      <AirfoilSuitabilityCard item={baseItem} defaultOpen targetClProvenance="calculated" />,
+    );
+    const indicator = screen.getByTestId("provenance-indicator");
+    const title = indicator.getAttribute("title");
+    expect(title).toMatch(/bewegliche Referenz/);
+  });
+
+  it("estimated provenance tooltip is German (feste Referenz)", () => {
+    render(
+      <AirfoilSuitabilityCard item={baseItem} defaultOpen targetClProvenance="estimated" />,
+    );
+    const indicator = screen.getByTestId("provenance-indicator");
+    const title = indicator.getAttribute("title");
+    expect(title).toMatch(/feste Referenz/);
+  });
+
+  it("mixed provenance tooltip is German (kombinierte Referenz)", () => {
+    render(
+      <AirfoilSuitabilityCard item={baseItem} defaultOpen targetClProvenance="mixed" />,
+    );
+    const indicator = screen.getByTestId("provenance-indicator");
+    const title = indicator.getAttribute("title");
+    expect(title).toMatch(/kombinierte Referenz/);
+  });
+});
+
+// ── 4f: StallClMaxRow labels are German ─────────────────────────────
+
+describe("ITEM 4 — StallClMaxRow: German row labels", () => {
+  it("stall row label shows 'Stall-Sanftheit' (German)", () => {
+    render(<AirfoilSuitabilityCard item={baseItem} defaultOpen />);
+    expect(screen.getByText(/Stall-Sanftheit/)).toBeDefined();
+  });
+
+  it("CL margin row label shows 'CL-Margin' (accepted technical term)", () => {
+    render(<AirfoilSuitabilityCard item={baseItem} defaultOpen />);
+    expect(screen.getByText(/CL-Margin/)).toBeDefined();
+  });
+
+  it("abrupt stall warning shows 'abrupt' (accepted technical term in German aviation context)", () => {
+    render(<AirfoilSuitabilityCard item={abruptStallItem} defaultOpen />);
+    const warning = screen.getByTestId("stall-abrupt-warning");
+    expect(warning.textContent).toMatch(/abrupt/);
+  });
+
+  it("negative CL-margin warning shows German 'Ziel > CL_max!'", () => {
+    render(<AirfoilSuitabilityCard item={negMarginItem} defaultOpen />);
+    const warning = screen.getByTestId("cl-max-margin-warning");
+    expect(warning.textContent).toMatch(/Ziel.*CL_max/);
+  });
+});
+
+// ── 4g: TipReClMaxWarning is German ─────────────────────────────────
+
+describe("ITEM 4 — TipReClMaxWarning: German text", () => {
+  it("tip-Re warning text is in German", () => {
+    render(
+      <AirfoilSuitabilityCard item={baseItem} defaultOpen caveatObject={baseCaveat} />,
+    );
+    const warning = screen.getByTestId("tip-re-clmax-warning");
+    // Text must contain German words (not English equivalent)
+    expect(warning.textContent).toMatch(
+      /Flügelspitze|Tip-Re|Einbruch|Stall-Zone|XFoil|Validierung/,
+    );
+  });
+});
+
+// ── 4h: CaveatCallout is German ─────────────────────────────────────
+
+describe("ITEM 4 — CaveatCallout: German text", () => {
+  it("regular caveat text comes from backend (German by convention)", () => {
+    render(<AirfoilSuitabilityCard item={baseItem} defaultOpen />);
+    expect(screen.getByRole("note").textContent).toMatch(/Rangfolge/);
+  });
+
+  it("low-confidence prefix is German ('Geringe Modell-Konfidenz')", () => {
+    render(<AirfoilSuitabilityCard item={lowConfidenceItem} defaultOpen />);
+    expect(screen.getByRole("note").textContent).toMatch(/Geringe Modell-Konfidenz/);
+  });
+
+  it("low-confidence caveat mentions German 'grobe Orientierung'", () => {
+    render(<AirfoilSuitabilityCard item={lowConfidenceItem} defaultOpen />);
+    expect(screen.getByRole("note").textContent).toMatch(/grobe Orientierung/);
+  });
+});
+
+// ── 4i: AirfoilSuitabilityNoData text is German ─────────────────────
+
+describe("ITEM 4 — AirfoilSuitabilityNoData: German text", () => {
+  it("no-data text is in German (not 'No data available')", () => {
+    render(<AirfoilSuitabilityNoData />);
+    expect(screen.getByText(/Keine Low-Re-Eignungsdaten/)).toBeDefined();
+  });
+
+  it("no-data text with airfoil name is in German", () => {
+    render(<AirfoilSuitabilityNoData airfoilName="rae2822" />);
+    expect(screen.getByText(/Keine Low-Re-Eignungsdaten für/)).toBeDefined();
+  });
+});

--- a/frontend/__tests__/airfoilPreviewPage.include.test.tsx
+++ b/frontend/__tests__/airfoilPreviewPage.include.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * Tests for ITEM 5-FE page wiring — include param on airfoil-preview page.
+ *
+ * Contract:
+ *   - Page passes `include: [rootAirfoil]` to the root useAirfoilSuitability call.
+ *   - Page passes `include: [tipAirfoil]` to the tip useAirfoilSuitability call.
+ *   - When the selected airfoil HAS rows in the response (backend returned it
+ *     because of include), rootSuitabilityItem is found → AirfoilSuitabilityCard renders.
+ *   - AirfoilSuitabilityNoData placeholder appears ONLY when the backend genuinely
+ *     omits the airfoil from results (no low-Re data for that name), not when it's
+ *     just outside the top-N.
+ *   - The guard against placeholder airfoil '—' (empty selection) prevents include=['—'].
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+// ── Mocks ─────────────────────────────────────────────────────────
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock("@/components/workbench/AeroplaneContext", () => ({
+  useAeroplaneContext: () => ({
+    aeroplaneId: "test-uuid-1234",
+    selectedWing: null,
+    selectedXsecIndex: 0,
+    selectXsec: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useWingConfig", () => ({
+  useWingConfig: () => ({
+    wingConfig: null,
+    saveWingConfig: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useAirfoilGeometry", () => ({
+  useAirfoilGeometry: () => ({ geometry: null, isLoading: false, error: null }),
+  interpolateY: () => null,
+}));
+
+vi.mock("@/hooks/useAirfoilAnalysis", () => ({
+  useAirfoilAnalysis: () => ({
+    result: null,
+    isRunning: false,
+    error: null,
+    run: vi.fn(),
+    clear: vi.fn(),
+  }),
+}));
+
+// Track which include values were passed to useAirfoilSuitability
+const capturedIncludes: Array<string[] | undefined> = [];
+let mockSuitabilityData: Record<string, unknown> | null = null;
+
+vi.mock("@/hooks/useAirfoilSuitability", () => ({
+  useAirfoilSuitability: (params: { include?: string[]; chord_m?: number }) => {
+    capturedIncludes.push(params.include);
+    return {
+      data: mockSuitabilityData,
+      isLoading: false,
+      error: null,
+    };
+  },
+}));
+
+// Render child panels minimally — expose props for assertions
+vi.mock("@/components/workbench/AirfoilPreviewViewerPanel", () => ({
+  AirfoilPreviewViewerPanel: () => <div data-testid="viewer-panel" />,
+}));
+
+vi.mock("@/components/workbench/AirfoilPreviewConfigPanel", () => ({
+  AirfoilPreviewConfigPanel: (props: Record<string, unknown>) => (
+    <div
+      data-testid="config-panel"
+      data-root-not-found={String(props.rootSuitabilityNotFound)}
+      data-tip-not-found={String(props.tipSuitabilityNotFound)}
+      data-has-root-item={String(props.rootSuitabilityItem != null)}
+      data-has-tip-item={String(props.tipSuitabilityItem != null)}
+    />
+  ),
+}));
+
+import AirfoilPreviewPage, { toInclude } from "@/app/workbench/airfoil-preview/page";
+
+// ── toInclude helper ──────────────────────────────────────────────
+
+describe("toInclude — pure helper (ITEM 5-FE)", () => {
+  it("returns [name] for a normal airfoil name", () => {
+    expect(toInclude("naca0015")).toEqual(["naca0015"]);
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(toInclude("")).toBeUndefined();
+  });
+
+  it("returns undefined for the placeholder '—'", () => {
+    expect(toInclude("—")).toBeUndefined();
+  });
+
+  it("returns [name] for a name with path prefix stripped already", () => {
+    expect(toInclude("e423")).toEqual(["e423"]);
+  });
+});
+
+// ── Page component tests ──────────────────────────────────────────
+
+describe("AirfoilPreviewPage — include param wiring (ITEM 5-FE)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedIncludes.length = 0;
+    mockSuitabilityData = null;
+  });
+
+  it("passes include=[rootAirfoil] to root suitability hook", () => {
+    render(<AirfoilPreviewPage />);
+    // Two calls: one for root, one for tip (naca0015/naca0015 both default)
+    // At least one call should have include=['naca0015']
+    const hasRootInclude = capturedIncludes.some(
+      (inc) => inc?.includes("naca0015"),
+    );
+    expect(hasRootInclude).toBe(true);
+  });
+
+  it("does NOT pass include=['—'] when airfoil is the placeholder '—'", () => {
+    render(<AirfoilPreviewPage />);
+    const hasDash = capturedIncludes.some((inc) => inc?.includes("—"));
+    expect(hasDash).toBe(false);
+  });
+
+  // ── No-data placeholder: only when backend genuinely omits the airfoil ──
+
+  it("rootSuitabilityNotFound=true ONLY when backend returns data but selected airfoil is absent from results", () => {
+    // Backend responded (non-null data) but didn't include 'naca0015' in results
+    mockSuitabilityData = {
+      query: { active_lens: "re_agnostic", target_cl_provenance: "estimated" },
+      results: [
+        {
+          airfoil_name: "e423",  // different airfoil — naca0015 not present
+          re_agnostic: 0.82,
+          mission: null,
+          target_cl_cruise: null,
+          target_cl_best_glide: null,
+          target_cl_min_sink: null,
+          stall_gentleness: null,
+          cl_max_margin: null,
+          min_analysis_confidence: 0.9,
+          tip_re_flag: false,
+          caveat: "",
+        },
+      ],
+      caveat: {
+        relative_ranking_only: true,
+        no_hysteresis_modelling: true,
+        ignores_tip_re_clmax_collapse: true,
+        recommend_xfoil_validation: false,
+        text: "",
+      },
+    };
+    render(<AirfoilPreviewPage />);
+    const config = screen.getByTestId("config-panel");
+    // rootSuitabilityNotFound should be true (data non-null, item absent)
+    expect(config.dataset.rootNotFound).toBe("true");
+    expect(config.dataset.hasRootItem).toBe("false");
+  });
+
+  it("rootSuitabilityNotFound=false when backend includes the selected airfoil in results", () => {
+    // Backend returned the selected airfoil (e.g. because include param worked)
+    mockSuitabilityData = {
+      query: { active_lens: "re_agnostic", target_cl_provenance: "estimated" },
+      results: [
+        {
+          airfoil_name: "naca0015",  // selected airfoil IS in results
+          re_agnostic: 0.75,
+          mission: null,
+          target_cl_cruise: null,
+          target_cl_best_glide: null,
+          target_cl_min_sink: null,
+          stall_gentleness: null,
+          cl_max_margin: null,
+          min_analysis_confidence: 0.9,
+          tip_re_flag: false,
+          caveat: "",
+        },
+      ],
+      caveat: {
+        relative_ranking_only: true,
+        no_hysteresis_modelling: true,
+        ignores_tip_re_clmax_collapse: true,
+        recommend_xfoil_validation: false,
+        text: "",
+      },
+    };
+    render(<AirfoilPreviewPage />);
+    const config = screen.getByTestId("config-panel");
+    expect(config.dataset.rootNotFound).toBe("false");
+    expect(config.dataset.hasRootItem).toBe("true");
+  });
+});

--- a/frontend/__tests__/useAirfoilSuitability.include.test.ts
+++ b/frontend/__tests__/useAirfoilSuitability.include.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for the additive `include` param on useAirfoilSuitability — ITEM 5-FE.
+ *
+ * Contract:
+ *   - When `include` (array of names) is supplied and non-empty, buildKey
+ *     appends `&include=<comma-joined>` to the SWR key.
+ *   - When `include` is undefined (old callers), the key is UNCHANGED
+ *     (byte-for-byte identical to today's behaviour → SWR cache not busted).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useAirfoilSuitability } from "@/hooks/useAirfoilSuitability";
+
+// ── Capture the SWR key ──────────────────────────────────────────
+
+let capturedKey: string | null = undefined as unknown as string | null;
+
+vi.mock("swr", () => ({
+  default: vi.fn((key: string | null) => {
+    capturedKey = key;
+    return { data: null, error: null, isLoading: false };
+  }),
+}));
+
+describe("useAirfoilSuitability — include param (ITEM 5-FE)", () => {
+  beforeEach(() => {
+    capturedKey = undefined as unknown as string | null;
+  });
+
+  // ── Backward-compatibility: old callers unaffected ──────────────
+
+  it("key is UNCHANGED (no include param) when include is undefined", () => {
+    renderHook(() =>
+      useAirfoilSuitability({ chord_m: 0.2, speed_ms: 14 }),
+    );
+    expect(capturedKey).not.toBeNull();
+    const url = new URL(capturedKey!, "http://localhost");
+    expect(url.searchParams.has("include")).toBe(false);
+  });
+
+  it("key is UNCHANGED when include is an empty array", () => {
+    renderHook(() =>
+      useAirfoilSuitability({ chord_m: 0.2, speed_ms: 14, include: [] }),
+    );
+    expect(capturedKey).not.toBeNull();
+    const url = new URL(capturedKey!, "http://localhost");
+    expect(url.searchParams.has("include")).toBe(false);
+  });
+
+  // ── New include param behaviour ─────────────────────────────────
+
+  it("appends include param when a single name is given", () => {
+    renderHook(() =>
+      useAirfoilSuitability({ chord_m: 0.2, speed_ms: 14, include: ["s1223"] }),
+    );
+    const url = new URL(capturedKey!, "http://localhost");
+    expect(url.searchParams.get("include")).toBe("s1223");
+  });
+
+  it("appends include param as comma-joined string for multiple names", () => {
+    renderHook(() =>
+      useAirfoilSuitability({
+        chord_m: 0.2,
+        speed_ms: 14,
+        include: ["s1223", "ag35"],
+      }),
+    );
+    const url = new URL(capturedKey!, "http://localhost");
+    expect(url.searchParams.get("include")).toBe("s1223,ag35");
+  });
+
+  it("include param is still null key when chord_m is missing", () => {
+    renderHook(() =>
+      useAirfoilSuitability({ chord_m: undefined, speed_ms: 14, include: ["e423"] }),
+    );
+    expect(capturedKey).toBeNull();
+  });
+
+  it("include param works together with aeroplane_id and other optional params", () => {
+    const uuid = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+    renderHook(() =>
+      useAirfoilSuitability({
+        chord_m: 0.3,
+        speed_ms: 18,
+        aeroplane_id: uuid,
+        mission_type: "trainer",
+        include: ["clark-y", "naca0012"],
+      }),
+    );
+    const url = new URL(capturedKey!, "http://localhost");
+    expect(url.searchParams.get("include")).toBe("clark-y,naca0012");
+    expect(url.searchParams.get("aeroplane_id")).toBe(uuid);
+    expect(url.searchParams.get("mission_type")).toBe("trainer");
+  });
+
+  it("include with a single name produces a different key than without include", () => {
+    renderHook(() =>
+      useAirfoilSuitability({ chord_m: 0.2, speed_ms: 14 }),
+    );
+    const keyWithout = capturedKey;
+
+    renderHook(() =>
+      useAirfoilSuitability({ chord_m: 0.2, speed_ms: 14, include: ["e423"] }),
+    );
+    const keyWith = capturedKey;
+
+    expect(keyWithout).not.toBe(keyWith);
+    expect(keyWith).toMatch(/include=e423/);
+  });
+});

--- a/frontend/app/workbench/airfoil-preview/page.tsx
+++ b/frontend/app/workbench/airfoil-preview/page.tsx
@@ -40,6 +40,16 @@ export function computeRe(velocityMs: number, chordMm: number): number {
   return Math.round((velocityMs * (chordMm / 1000)) / NU_AIR);
 }
 
+/**
+ * gh-825: Returns [name] as the include param for useAirfoilSuitability, or
+ * undefined when the name is empty / is the placeholder '\u2014'.
+ * Extracted as a module-level helper to keep AirfoilPreviewPage within
+ * sonarjs/cognitive-complexity budget.
+ */
+export function toInclude(name: string): string[] | undefined {
+  return name && name !== "\u2014" ? [name] : undefined;
+}
+
 export default function AirfoilPreviewPage() {
   const router = useRouter();
   const { aeroplaneId, selectedWing, selectedXsecIndex, selectXsec } =
@@ -88,11 +98,14 @@ export default function AirfoilPreviewPage() {
     chord_m: rootChordMm / 1000,
     speed_ms: velocity,
     aeroplane_id: aeroplaneId,
+    // gh-825 ADDITIVE: always score the selected airfoil even if outside top-N
+    include: toInclude(rootAirfoil),
   });
   const tipSuitability = useAirfoilSuitability({
     chord_m: tipChordMm / 1000,
     speed_ms: velocity,
     aeroplane_id: aeroplaneId,
+    include: toInclude(tipAirfoil),
   });
 
   // Build lookup maps: airfoil name -> score string + sorted names.

--- a/frontend/components/workbench/AirfoilPreviewConfigPanel.tsx
+++ b/frontend/components/workbench/AirfoilPreviewConfigPanel.tsx
@@ -295,6 +295,7 @@ export function AirfoilPreviewConfigPanel({
         </span>
         <AirfoilSelector
           label=""
+          id="airfoil-root"
           value={rootAirfoil}
           onChange={onRootAirfoilChange}
           stats={rootScoreMap}
@@ -332,6 +333,7 @@ export function AirfoilPreviewConfigPanel({
         </span>
         <AirfoilSelector
           label=""
+          id="airfoil-tip"
           value={tipAirfoil}
           onChange={onTipAirfoilChange}
           stats={tipScoreMap}

--- a/frontend/components/workbench/AirfoilSelector.tsx
+++ b/frontend/components/workbench/AirfoilSelector.tsx
@@ -24,6 +24,13 @@ interface AirfoilSelectorProps {
   /** Existing slot: right-aligned badge text per airfoil name */
   stats?: Record<string, string>;
   /**
+   * gh-825 ADDITIVE: explicit id for the <label htmlFor> and trigger <button id>.
+   * When provided, overrides the label-derived id fallback.
+   * Use this to avoid duplicate-id violations when label='' (e.g. in
+   * AirfoilPreviewConfigPanel where the visible heading is a sibling <span>).
+   */
+  id?: string;
+  /**
    * gh-822 ADDITIVE: pre-sorted list of airfoil names (desc by score).
    * When provided, the dropdown renders in this order instead of the
    * alphabetical default.
@@ -53,6 +60,7 @@ export function AirfoilSelector({
   onChange,
   onPreviewToggle,
   stats,
+  id: idProp,
   sortedNames,
   suitabilityToggle,
 }: Readonly<AirfoilSelectorProps>) {
@@ -102,6 +110,11 @@ export function AirfoilSelector({
     if (open) searchRef.current?.focus();
   }, [open]);
 
+  // Resolve the effective id: use idProp when provided, else derive from label.
+  // This avoids duplicate-id violations when label='' (both selectors would
+  // otherwise get id='airfoil-').
+  const effectiveId = idProp ?? `airfoil-${label.toLowerCase().replaceAll(/\s+/g, "-")}`;
+
   const toggle = () => {
     const next = !open;
     setOpen(next);
@@ -119,7 +132,7 @@ export function AirfoilSelector({
   return (
     <div ref={containerRef} className="relative flex flex-1 flex-col gap-1">
       <div className="flex items-center gap-1">
-        <label htmlFor={`airfoil-${label.toLowerCase().replaceAll(/\s+/g, "-")}`} className="flex-1 text-[11px] text-muted-foreground">{label}</label>
+        <label htmlFor={effectiveId} className="flex-1 text-[11px] text-muted-foreground">{label}</label>
         {/* gh-822 ADDITIVE: Passende finden toggle */}
         {suitabilityToggle && (
           <button
@@ -139,7 +152,7 @@ export function AirfoilSelector({
 
       {/* Trigger */}
       <button
-        id={`airfoil-${label.toLowerCase().replaceAll(/\s+/g, "-")}`}
+        id={effectiveId}
         onClick={toggle}
         className={`flex items-center gap-2 rounded-xl px-3 py-2 transition-colors ${
           open ? "border-2 border-primary bg-input" : "border border-border bg-input"

--- a/frontend/hooks/useAirfoilSuitability.ts
+++ b/frontend/hooks/useAirfoilSuitability.ts
@@ -121,6 +121,13 @@ export interface UseAirfoilSuitabilityParams {
   target_cl_best_glide?: number;
   limit?: number;
   tip_chord_m?: number;
+  /**
+   * gh-825 ADDITIVE: names of airfoils to always include in results even if
+   * they fall outside the top-`limit` ranked block (e.g. the currently-selected
+   * root/tip airfoil).  When undefined or empty, the SWR key is byte-for-byte
+   * identical to old callers → no cache bust for existing clients.
+   */
+  include?: string[];
 }
 
 // ── Hook ─────────────────────────────────────────────────────────
@@ -136,6 +143,7 @@ export function useAirfoilSuitability(params: UseAirfoilSuitabilityParams) {
     target_cl_best_glide,
     limit,
     tip_chord_m,
+    include,
   } = params;
 
   // Only build a key when required params are present
@@ -148,6 +156,7 @@ export function useAirfoilSuitability(params: UseAirfoilSuitabilityParams) {
           target_cl_best_glide,
           limit,
           tip_chord_m,
+          include,
         })
       : null;
 
@@ -178,6 +187,7 @@ function buildKey(
     target_cl_best_glide?: number;
     limit?: number;
     tip_chord_m?: number;
+    include?: string[];
   },
 ): string {
   const params = new URLSearchParams();
@@ -203,6 +213,11 @@ function buildKey(
   }
   if (optional.tip_chord_m != null) {
     params.set("tip_chord_m", String(optional.tip_chord_m));
+  }
+  // gh-825 ADDITIVE: include param — only appended when present and non-empty
+  // so old SWR cache keys are byte-for-byte unchanged for existing callers.
+  if (optional.include != null && optional.include.length > 0) {
+    params.set("include", optional.include.join(","));
   }
   return `/airfoils/db/suitability?${params.toString()}`;
 }

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -7,6 +7,9 @@ const nextConfig: NextConfig = {
   env: {
     NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8001",
   },
+  // gh-825 MINOR: allow both localhost and 127.0.0.1 as dev origins so the
+  // Next.js dev server does not reject requests from the backend HMR websocket.
+  allowedDevOrigins: ["127.0.0.1", "localhost"],
   turbopack: {
     resolveAlias: {
       three: threeAlias,


### PR DESCRIPTION
## Summary

Part of #825. Items 4, 5 (frontend), 6. Depends on backend PR (include param — `GET /airfoils/db/suitability?include=...`).

- **Item 6 (a11y):** Add additive `id?: string` prop to `AirfoilSelector`. `AirfoilPreviewConfigPanel` now passes `id='airfoil-root'` and `id='airfoil-tip'`, eliminating the duplicate empty-id a11y violation where both selectors derived `id='airfoil-'`. 12 new tests.
- **Item 5-FE (include param):** Add additive `include?: string[]` to `UseAirfoilSuitabilityParams` and thread through `buildKey` as `&include=<comma-joined>`. Old callers are byte-identical (no SWR cache bust). Airfoil-preview page passes `include: toInclude(rootAirfoil)` / `toInclude(tipAirfoil)` — selected profile always scored even outside top-N. `AirfoilSuitabilityNoData` fires only when backend genuinely omits the airfoil. 11 new tests + helper.
- **Item 4 (i18n):** `AirfoilSuitabilityCard` was already consistently German. 29 tests pin the prevailing German language for all card surfaces (Eignung, Re-agnostisch, Konfidenz, ProvenanceIndicator labels/tooltips, StallClMaxRow, TipReClMaxWarning, CaveatCallout, no-data placeholder).
- **Minor:** `next.config.ts` adds `allowedDevOrigins: ['127.0.0.1', 'localhost']`.

## Test plan

- [ ] `cd frontend && npm run test:unit` — 1399 passed (128 files)
- [ ] `npm run deps:check` — no NEW violations (13 pre-existing)
- [ ] `npm run lint` — 0 errors (10 pre-existing warnings)
- [ ] Lane purity: `git diff --name-only main...HEAD | grep -v "^frontend/"` — empty
- [ ] After backend PR merges (include param), manually verify selected airfoil card renders instead of no-data placeholder when airfoil is outside top-N

🤖 Generated with [Claude Code](https://claude.com/claude-code)