### PR TITLE
feat(gh-825): scoring refinements (backend)

### DIFF
--- a/app/api/v2/endpoints/airfoils.py
+++ b/app/api/v2/endpoints/airfoils.py
@@ -545,6 +545,17 @@ async def get_airfoil_suitability(
         float | None,
         Query(description="Tip chord in metres — only used to compute tip Re and set tip_re_flag."),
     ] = None,
+    include: Annotated[
+        str | None,
+        Query(
+            description=(
+                "Comma-separated airfoil names to always score+return even if outside top-N. "
+                "Additive; old clients (no include) get identical behaviour to before. "
+                "Names with no low-Re polar rows are NOT fabricated. "
+                "Example: ?include=s1223,ag35"
+            )
+        ),
+    ] = None,
     limit: Annotated[
         int, Query(description="Maximum number of results to return.", ge=1, le=200)
     ] = 50,
@@ -569,6 +580,13 @@ async def get_airfoil_suitability(
     - Tip-Re CL_max collapse is not modelled; surfaced via tip_re_flag + cl_max_margin +
       caveat.ignores_tip_re_clmax_collapse.
     """
+    # Parse include: comma-separated string → list[str] (strip whitespace, drop empties)
+    include_list: list[str] | None = None
+    if include is not None:
+        parsed = [name.strip() for name in include.split(",")]
+        parsed = [name for name in parsed if name]
+        include_list = parsed if parsed else None
+
     try:
         return search_suitability(
             db=db,
@@ -580,6 +598,7 @@ async def get_airfoil_suitability(
             target_cl_best_glide=target_cl_best_glide,
             target_cl_min_sink=target_cl_min_sink,
             tip_chord_m=tip_chord_m,
+            include=include_list,
             limit=limit,
             settings=settings,
         )

--- a/app/services/airfoil_low_re_service.py
+++ b/app/services/airfoil_low_re_service.py
@@ -42,8 +42,20 @@ RHO = 1.225  # kg/m³  (ISA sea-level)
 # Thresholds for family classifier
 _SYMMETRIC_MAX_CAMBER_PCT = 0.5  # max_camber_pct below which → symmetric
 _SEMI_SYMMETRIC_MAX_CAMBER_PCT = 2.0  # between SYMMETRIC and this → semi_symmetric
-_FLAT_BOTTOM_Y_THRESHOLD = 0.002  # lower surface mean abs(y) below this → flat
+_FLAT_BOTTOM_Y_THRESHOLD = 0.002  # lower surface mean abs(y) below this → flat (strict legacy)
 _REFLEX_CAMBER_AT_TE_THRESHOLD = -0.003  # camber_at_te below this → reflexed
+# --- gh-825 item 3: improved flat-bottom detection ---
+# Evaluate flatness of the lower surface over the aft chord region [AFT_X_LO, 1.0].
+# Many real flat-bottom airfoils (Clark Y, Gottingen 417a) have a small forward camber
+# bulge but are essentially flat aft of ~25% chord. We detect flatness by measuring
+# the MAXIMUM absolute y_lower value over the aft window [AFT_X_LO, 1.0].
+# A near-flat lower surface (flat-bottom) has max |y_lower| well below the threshold,
+# while semi-symmetric airfoils have their lower surface tracking the camber line
+# (larger positive y_lower values even in the aft region).
+# Note: stored AirfoilGeometryModel.family values may change after this improvement;
+# a PO-run re-backfill is required post-merge (gh-825 item 3).
+_FLAT_BOTTOM_AFT_X_LO = 0.25  # start of the aft evaluation window (25% chord)
+_FLAT_BOTTOM_FLATNESS_THRESHOLD = 0.005  # max |y_lower| over aft region → flat_bottom
 
 
 # ---------------------------------------------------------------------------
@@ -143,12 +155,27 @@ def classify_family(coords: np.ndarray) -> AirfoilFamily:
 
     # --- Classification rules (ordered by priority) ---
     # 1. Reflexed: camber line is clearly negative (below chord) at TE
+    #    (must stay first so reflexed airfoils aren't misclassified as flat_bottom)
     if camber_at_te < _REFLEX_CAMBER_AT_TE_THRESHOLD:
         return "reflexed"
 
-    # 2. Flat-bottom: lower surface is essentially flat (y ≈ 0)
+    # 2. Flat-bottom: lower surface is near-flat over the aft chord region.
+    #    Two-tier heuristic (gh-825 item 3):
+    #    (a) Strict legacy: mean |y_lower| < strict threshold — catches pure y=0 lower surfaces.
+    #    (b) Aft-flatness: max |y_lower| over [AFT_X_LO, 1.0] is below the flatness threshold —
+    #        catches real flat-bottom airfoils (Clark Y, Gottingen 417a) that have a small forward
+    #        camber bulge but an aft lower surface that stays very close to y=0. This reliably
+    #        distinguishes flat-bottom from semi-symmetric, where the lower surface tracks the
+    #        camber line and has larger positive y values in the aft region (~0.005–0.007).
     if mean_lower_abs_y < _FLAT_BOTTOM_Y_THRESHOLD:
         return "flat_bottom"
+    # Aft-flatness test: max |y_lower| over x ∈ [_FLAT_BOTTOM_AFT_X_LO, 1.0]
+    aft_mask = x_eval >= _FLAT_BOTTOM_AFT_X_LO
+    if aft_mask.sum() >= 4:
+        y_aft = y_lower[aft_mask]
+        max_aft_abs_y = float(np.max(np.abs(y_aft)))
+        if max_aft_abs_y < _FLAT_BOTTOM_FLATNESS_THRESHOLD:
+            return "flat_bottom"
 
     # 3. Symmetric: almost no camber
     if max_camber_pct < _SYMMETRIC_MAX_CAMBER_PCT:
@@ -307,6 +334,19 @@ def compute_airfoil_low_re(
     list[dict]
         One dict per Re-grid point with scalar metrics + fit coefficients.
         May be empty if AeroSandbox is not available on this platform.
+
+    NOTE (gh-825 item 1): ``min_analysis_confidence`` stored in the returned
+    rows is the MIN of ``analysis_confidence`` over the ATTACHED/OPERATING alpha
+    window [alpha_attached_lo, alpha_attached_hi], NOT the full sweep minimum.
+    This reflects the confidence of the aerodynamic model in the region that
+    actually matters for performance scoring (cruise / operating point).
+    Deep-stall alpha points often have low confidence that is irrelevant to
+    operational performance and should not penalise the stored confidence metric.
+
+    IMPORTANT: This semantic change from the original implementation (which used
+    the global sweep minimum) means that stored AirfoilLowRePolarModel rows
+    computed before this change must be RE-BACKFILLED by the PO after merge.
+    Do NOT run any backfill in the workflow.
     """
     try:
         import aerosandbox as asb
@@ -335,26 +375,88 @@ def compute_airfoil_low_re(
         if conf_arr.size == 1:
             conf_arr = np.full_like(cl_arr, float(conf_arr[0]))
 
-        min_confidence = float(np.nanmin(conf_arr)) if np.any(np.isfinite(conf_arr)) else 0.0
-
         # Gate: only use alpha points with confidence >= gate
         trusted = conf_arr >= confidence_gate
         cl_trusted = cl_arr[trusted] if trusted.any() else np.array([])
         cd_trusted = cd_arr[trusted] if trusted.any() else np.array([])
         alpha_trusted = alpha_deg[trusted] if trusted.any() else np.array([])
 
+        # Compute metrics from trusted arrays (provides alpha_attached_lo/hi)
+        # Use a placeholder for min_confidence initially; we'll overwrite below.
         row = _extract_metrics(
             cl_trusted,
             cd_trusted,
             alpha_trusted,
-            min_confidence,
+            0.0,  # placeholder — overwritten with windowed min below
             re,
             model_size=model_size,
             n_crit=n_crit,
         )
+
+        # --- Windowed min_analysis_confidence (gh-825 item 1) ---
+        # Use the attached/operating alpha window returned by _extract_metrics.
+        # Only alphas within [alpha_attached_lo, alpha_attached_hi] are relevant
+        # for operational performance; deep-stall confidence is irrelevant.
+        # Fallback to whole-sweep min_confidence if the window is undefined,
+        # has fewer than 4 points, or has no finite conf values in window.
+        alpha_attached_lo = row.get("alpha_attached_lo")
+        alpha_attached_hi = row.get("alpha_attached_hi")
+        min_confidence = _windowed_min_confidence(
+            alpha_deg=alpha_deg,
+            conf_arr=conf_arr,
+            alpha_attached_lo=alpha_attached_lo,
+            alpha_attached_hi=alpha_attached_hi,
+        )
+        row["min_analysis_confidence"] = min_confidence
+
         results.append(row)
 
     return results
+
+
+def _windowed_min_confidence(
+    alpha_deg: np.ndarray,
+    conf_arr: np.ndarray,
+    alpha_attached_lo: float | None,
+    alpha_attached_hi: float | None,
+) -> float:
+    """Compute min analysis_confidence over the attached alpha window.
+
+    If the window is undefined (None bounds, < 4 points, or no finite values),
+    falls back to the whole-sweep min confidence (does NOT regress to 0.0).
+
+    Parameters
+    ----------
+    alpha_deg : np.ndarray
+        Full alpha sweep array (same length as conf_arr).
+    conf_arr : np.ndarray
+        Full confidence array from NeuralFoil (same length as alpha_deg).
+    alpha_attached_lo : float | None
+        Lower bound of the attached alpha window (from _extract_metrics).
+    alpha_attached_hi : float | None
+        Upper bound of the attached alpha window (from _extract_metrics).
+
+    Returns
+    -------
+    float
+        Min confidence over the windowed region, or whole-sweep min as fallback.
+    """
+    # Compute fallback: whole-sweep min (finite values only)
+    finite_conf = conf_arr[np.isfinite(conf_arr)]
+    fallback = float(np.min(finite_conf)) if len(finite_conf) > 0 else 0.0
+
+    if alpha_attached_lo is None or alpha_attached_hi is None:
+        return fallback
+
+    # Mask to the attached window
+    window_mask = (alpha_deg >= alpha_attached_lo) & (alpha_deg <= alpha_attached_hi)
+    window_conf = conf_arr[window_mask]
+    window_finite = window_conf[np.isfinite(window_conf)]
+
+    if len(window_finite) < 4:
+        return fallback
+
+    return float(np.min(window_finite))
 
 
 def _extract_metrics(

--- a/app/services/suitability_service.py
+++ b/app/services/suitability_service.py
@@ -13,6 +13,16 @@ Three lenses (ranked desc by active_lens):
 active_lens priority: mission (if resolved) > target_cl_cruise (if resolved) > re_agnostic.
 active_lens is NEVER a glide point (target_cl_best_glide / target_cl_min_sink).
 
+## Additive `include` parameter (gh-825 item 5)
+search_suitability accepts an optional ``include: Optional[list[str]]`` kwarg.
+Any airfoil name in ``include`` that genuinely has low-Re polar rows is ALWAYS
+scored and returned, even if it falls outside the top-``limit`` ranked block.
+Airfoils with NO polar rows are NOT fabricated — they are simply absent.
+Names already in the top-N are NOT duplicated.
+Ordering: top-N ranked block first (confidence-aware sort), then any included
+extras that were dropped by the limit (appended in order of `include`).
+Old clients omitting `include` get identical behaviour to before (include=None).
+
 ## Documented assumptions (gh-825)
 - Re stays LOCAL (per xsec chord).
 - Section CL ≈ whole-wing CL under the elliptical, untwisted ideal (top-down design target).
@@ -87,7 +97,7 @@ _MISSION_TYPE_MAP = {
     "sailplane": "glider",
     "motor_glider": "glider",
     "motorglider": "glider",  # legacy spelling without underscore
-    "slope_soarer": "glider",  # slope soarer is aerobatic-capable but glider in airfoil needs
+    "slope_soarer": "slope_soarer",  # gh-825 item 12: own weighting (thinner t/c, semi_sym/cambered)
     "thermal": "glider",  # forward-compat if "thermal" ever becomes a preset id
     "soarer": "glider",  # forward-compat
     # Wing-racer / FPV → sport (speed + moderate maneuver)
@@ -176,6 +186,7 @@ def search_suitability(
     target_cl_min_sink: Optional[float] = None,
     tip_chord_m: Optional[float] = None,
     limit: int = 50,
+    include: Optional[list[str]] = None,
     settings: Optional[Settings] = None,
 ) -> SuitabilityResponse:
     """Search and rank airfoils by suitability at the given chord/speed.
@@ -195,6 +206,13 @@ def search_suitability(
                            (renamed from target_cl_loiter).
     tip_chord_m : float    Optional tip chord for tip Re flag only.
     limit : int            Maximum results to return.
+    include : list[str]    Optional list of airfoil names to ALWAYS score and return,
+                           even if they fall outside the top-``limit`` ranked block.
+                           - Only names with genuine low-Re polar rows are returned;
+                             names with no data are NOT fabricated.
+                           - Names already in the top-N are NOT duplicated.
+                           - Included extras are appended AFTER the top-N block.
+                           - None (default) → identical behaviour to before (no-op).
     settings : Settings    Application settings.  When omitted the module-level
                            lru-cached ``get_settings()`` is used — avoids
                            constructing a fresh ``Settings()`` per request.
@@ -218,10 +236,20 @@ def search_suitability(
     re_clamped_root, re_clamped = _clamp_re_to_grid(re_root, re_grid)
 
     # --- Tip Re flag ---
+    # (gh-825 item 2) Flag is True if:
+    #   - tip_Re < settings.low_re_tip_re_abs_floor  (absolute low-Re regime)
+    #   OR
+    #   - (re_root - re_tip) > settings.low_re_tip_re_rel_drop
+    #     (tip Re is in a meaningfully different aerodynamic regime than root)
+    # Both comparisons use the RAW (un-clamped) Re values from _compute_re.
+    # Boundary: strictly less-than / strictly greater-than (edges are NOT flagged).
     tip_re_flag_all = False
     if tip_chord_m is not None:
         re_tip = _compute_re(tip_chord_m, speed_ms)
-        tip_re_flag_all = re_tip < re_root
+        tip_re_flag_all = (
+            re_tip < settings.low_re_tip_re_abs_floor
+            or (re_root - re_tip) > settings.low_re_tip_re_rel_drop
+        )
 
     # --- Resolve aeroplane context ---
     effective_mission_type: Optional[str] = mission_type
@@ -456,8 +484,40 @@ def search_suitability(
         active_lens = "re_agnostic"
         items.sort(key=lambda i: (_conf_tier(i), -i.re_agnostic))
 
+    # Save full scored+sorted list before applying limit (needed for include extras)
+    all_items = list(items)
+
     # Apply limit
     items = items[:limit]
+
+    # --- Additive `include` extras (gh-825 item 5) ---
+    # Append items whose airfoil_name is in `include` but were dropped by the limit.
+    # Only genuine entries (with scored polar rows, re_agnostic > 0 or has been scored)
+    # are appended; names with no geometry/polar data are not fabricated.
+    # De-duplication: skip names already present in the top-N block.
+    if include:
+        # Build a lookup from the full (pre-limit) scored set, keyed by lowercase name
+        all_items_by_name: dict[str, SuitabilityItem] = {
+            item.airfoil_name.lower(): item for item in all_items
+        }
+        present_names = {item.airfoil_name.lower() for item in items}
+        for name_raw in include:
+            name_lower = name_raw.strip().lower()
+            if not name_lower:
+                continue
+            if name_lower in present_names:
+                continue  # already in top-N — no duplicate
+            candidate = all_items_by_name.get(name_lower)
+            if candidate is None:
+                continue  # no geometry row at all — not fabricated
+            # Only include if the airfoil genuinely has polar rows
+            # (polars_by_name is populated only for airfoils with rows)
+            # Match against geo_by_name keys (case-insensitive)
+            has_polars = any(n.lower() == name_lower for n in polars_by_name)
+            if not has_polars:
+                continue  # no polar data — not fabricated
+            items.append(candidate)
+            present_names.add(name_lower)
 
     # --- Build response ---
     caveat_text = (

--- a/app/settings.py
+++ b/app/settings.py
@@ -47,6 +47,12 @@ _DEFAULT_MISSION_WEIGHTS: dict[str, dict[str, Any]] = {
         "cl_max_weight": 0.5,
         "preferred_families": ["reflexed", "symmetric"],
     },
+    "slope_soarer": {
+        "thickness_min_pct": 8.0,
+        "thickness_max_pct": 12.0,
+        "cl_max_weight": 0.45,
+        "preferred_families": ["semi_symmetric", "cambered"],
+    },
 }
 
 # Absolute Re grid for the low-Re backfill (13 log-spaced points).
@@ -99,6 +105,13 @@ class Settings(BaseSettings):
     # CL_max margin (cl_max − cl_target) at which the high-CL Match component
     # reaches 1.0.  Below 0 → score 0 (stall risk).  (gh-825 glide-point fix)
     low_re_score_cl_max_safety_band: float = 0.30
+    # Tip-Re significance: absolute floor below which tip Re is flagged regardless
+    # of root Re.  Re_tip < this value → tip_re_flag = True.  (gh-825 item 2)
+    low_re_tip_re_abs_floor: float = 80_000.0
+    # Tip-Re significance: relative drop threshold.  If (Re_root − Re_tip) exceeds
+    # this value the tip is in a meaningfully different aerodynamic regime and
+    # tip_re_flag = True.  (gh-825 item 2)
+    low_re_tip_re_rel_drop: float = 50_000.0
     # Mission-weight coefficient table keyed by mission preset name.
     low_re_mission_weights: dict[str, dict[str, Any]] = Field(
         default_factory=lambda: dict(_DEFAULT_MISSION_WEIGHTS)

--- a/app/tests/test_airfoil_family_classifier.py
+++ b/app/tests/test_airfoil_family_classifier.py
@@ -1,6 +1,16 @@
-"""Tests for the airfoil family classifier (Task 4, gh-821).
+"""Tests for the airfoil family classifier (Task 4, gh-821; Item 3, gh-825).
 
 Uses hand-built minimal coordinate arrays to test each family type.
+
+gh-825 item 3: Improved flat-bottom detection.
+  The original strict threshold (mean |y_lower| < 0.002) was too narrow —
+  it only detects true y=0 lower surfaces. Real flat-bottom airfoils
+  (Clark Y, Gottingen 417a) have a slightly curved forward section with
+  a near-flat aft region. The improved heuristic keys on low curvature
+  of the lower surface aft of 20% chord, not on absolute y magnitude.
+
+NOTE: Stored AirfoilGeometryModel.family values may change after this
+improvement. A PO-run re-backfill is required post-merge.
 """
 
 from __future__ import annotations
@@ -24,10 +34,48 @@ def _make_symmetric_naca0012():
 
 
 def _make_flat_bottom():
-    """Flat-bottom airfoil: lower surface is flat (y_lower ≈ 0 everywhere)."""
+    """Strict flat-bottom: lower surface is exactly y=0 everywhere."""
     x = np.linspace(0, 1, 30)
     upper = np.column_stack([x, 0.1 * np.sin(np.pi * x)])
     lower = np.column_stack([x, np.zeros_like(x)])
+    return np.vstack([upper[::-1], lower[1:]])
+
+
+def _make_clark_y_like():
+    """Clark-Y-like flat-bottom: lower surface has a small forward bulge
+    (~1.2% chord peak at x≈0.1) then is nearly flat from ~25% chord to TE.
+
+    This mimics real flat-bottom airfoils (Clark Y, Gottingen 417a) where the
+    lower surface is NOT a perfect y=0 line — it has a slight convex forward
+    section but the aft lower surface (x > 0.25) has max |y_lower| ≤ ~0.004,
+    well within the flat-bottom detection band.
+
+    The aft lower surface (x ≥ 0.25) has values ≤ 0.004 with very low curvature,
+    which clearly distinguishes it from semi-symmetric airfoils where the lower
+    surface tracks the camber line (y_lower ≈ 0.005–0.007 in the aft region).
+    """
+    x = np.linspace(0, 1, 50)
+    # Upper surface: cambered and thick, Clark-Y-like (~11.5% max thickness)
+    t = 0.115 * (0.2969 * np.sqrt(x) - 0.126 * x - 0.3516 * x**2 + 0.2843 * x**3 - 0.1015 * x**4)
+    m, p = 0.035, 0.35
+    camber_upper = np.where(
+        x <= p,
+        (m / p**2) * (2 * p * x - x**2),
+        (m / (1 - p) ** 2) * ((1 - 2 * p) + 2 * p * x - x**2),
+    )
+    y_upper = camber_upper + t
+
+    # Lower surface: small forward bulge (~1.2% at x=0.12), then near-flat aft
+    # Forward (x ≤ 0.25): sinusoidal bulge, peaks at x~0.12
+    # Aft (x > 0.25): very small nearly-flat values (max ~0.003–0.004)
+    y_lower = np.where(
+        x <= 0.25,
+        0.012 * np.sin(np.pi * x / 0.25),  # forward bulge, peak ~1.2% at x≈0.125
+        0.003 * (1.0 - (x - 0.25) / 0.75),  # linear taper from 0.003 to 0 at TE
+    )
+
+    upper = np.column_stack([x, y_upper])
+    lower = np.column_stack([x, y_lower])
     return np.vstack([upper[::-1], lower[1:]])
 
 
@@ -77,6 +125,10 @@ def _make_semi_symmetric():
     [
         (_make_symmetric_naca0012, "symmetric"),
         (_make_flat_bottom, "flat_bottom"),
+        (
+            _make_clark_y_like,
+            "flat_bottom",
+        ),  # gh-825 item 3: Clark-Y-like must detect as flat_bottom
         (_make_cambered, "cambered"),
         (_make_reflexed, "reflexed"),
         (_make_semi_symmetric, "semi_symmetric"),
@@ -93,12 +145,13 @@ def test_classify_family(coords_fn, expected):
 
 
 def test_classify_family_output_always_valid_literal():
-    """Verify every output is in the frozen literal set."""
+    """Verify every output is in the frozen literal set (gh-825 item 3)."""
     from app.services.airfoil_low_re_service import classify_family
 
     for coords_fn in [
         _make_symmetric_naca0012,
         _make_flat_bottom,
+        _make_clark_y_like,
         _make_cambered,
         _make_reflexed,
         _make_semi_symmetric,

--- a/app/tests/test_airfoil_low_re_compute.py
+++ b/app/tests/test_airfoil_low_re_compute.py
@@ -213,3 +213,171 @@ def test_compute_graceful_when_aerosandbox_unavailable(monkeypatch):
         if saved is not None:
             sys.modules["aerosandbox"] = saved
         monkeypatch.undo()
+
+
+# ---------------------------------------------------------------------------
+# ITEM 1 (gh-825): windowed min_analysis_confidence
+# ---------------------------------------------------------------------------
+#
+# The attached/operating alpha window is [alpha_attached_lo, alpha_attached_hi]
+# which is the ascending CL portion up to CL_max.  The min_analysis_confidence
+# stored in the row must be the MIN of analysis_confidence over ONLY that window,
+# NOT the global sweep minimum.
+#
+# This test constructs a crafted NeuralFoil result where:
+#   - confidence is HIGH (0.97) in the attached/ascending CL region
+#   - confidence is LOW  (0.40) in the deep-stall post-peak region
+# The test asserts that min_analysis_confidence == 0.97 (windowed min),
+# NOT 0.40 (global sweep min).
+
+
+def _make_windowed_confidence_result(alpha_deg: np.ndarray) -> dict:
+    """NeuralFoil result with high confidence in attached region, low in deep stall.
+
+    CL peaks at ~12 deg (CL ≈ 1.3).  Attached window: alpha ≤ 12 deg.
+    Confidence is 0.97 for alpha ≤ 12 deg (attached), 0.40 for alpha > 12 deg.
+    Global sweep min confidence = 0.40; windowed (attached) min = 0.97.
+    """
+    # CL rises linearly, peaks at 12 deg, then drops
+    cl = np.where(
+        alpha_deg <= 12.0,
+        0.1 + 0.1 * alpha_deg,  # attached: 0.1 at α=-5, 1.3 at α=12
+        1.3 - 0.05 * (alpha_deg - 12.0),  # post-stall: drops
+    )
+    # CD parabolic in CL (cd0=0.012, k=0.04, cl0=0.3)
+    cd0_true, k_true, cl0_true = 0.012, 0.04, 0.3
+    cd = cd0_true + k_true * (cl - cl0_true) ** 2
+
+    # HIGH confidence in attached region (alpha ≤ 12), LOW beyond
+    conf = np.where(alpha_deg <= 12.0, 0.97, 0.40)
+    return {"CL": cl, "CD": cd, "analysis_confidence": conf}
+
+
+def test_min_analysis_confidence_is_windowed_not_global(monkeypatch):
+    """ITEM 1: min_analysis_confidence must be the MIN over the attached alpha window.
+
+    The global sweep min is 0.40 (deep-stall region).
+    The windowed (attached, alpha ≤ CL_max) min is 0.97.
+    We assert min_analysis_confidence == 0.97 (windowed).
+
+    NOTE: This test documents the gh-825 item 1 semantic change.
+    Stored AirfoilLowRePolarModel.min_analysis_confidence rows require
+    PO-run re-backfill after merge — NOT done in the workflow.
+    """
+    import sys
+    import types
+
+    # Ensure aerosandbox is available as a mock
+    if "aerosandbox" not in sys.modules:
+        asb_module = types.ModuleType("aerosandbox")
+
+        class FakeAirfoilWindowed:
+            def __init__(self, name=None, coordinates=None):
+                self.name = name
+
+            def get_aero_from_neuralfoil(
+                self, alpha, Re, mach=0, n_crit=9.0, model_size="large", **kwargs
+            ):
+                return _make_windowed_confidence_result(np.atleast_1d(alpha))
+
+        asb_module.Airfoil = FakeAirfoilWindowed
+        sys.modules["aerosandbox"] = asb_module
+
+    import aerosandbox as asb
+
+    def fake_windowed(self, alpha, Re, mach=0, n_crit=9.0, model_size="large", **kwargs):
+        return _make_windowed_confidence_result(np.atleast_1d(alpha))
+
+    monkeypatch.setattr(asb.Airfoil, "get_aero_from_neuralfoil", fake_windowed)
+
+    from app.services.airfoil_low_re_service import compute_airfoil_low_re
+
+    coords = np.array([[0.0, 0.0], [0.5, 0.07], [1.0, 0.0]])
+    # Use confidence_gate=0.90 so the attached region (conf=0.97) is trusted,
+    # but deep-stall (conf=0.40) points are NOT included in the trusted cl/cd arrays.
+    # This means _extract_metrics receives only the trusted (attached) points,
+    # so the windowed confidence must be computed over the FULL conf_arr restricted
+    # to the alpha_attached_lo .. alpha_attached_hi range.
+    results = compute_airfoil_low_re(
+        "test_windowed_af",
+        coords,
+        [100_000],
+        confidence_gate=0.90,
+        alpha_start=-5.0,
+        alpha_end=18.0,
+        alpha_step=0.5,
+    )
+    assert len(results) == 1
+    row = results[0]
+
+    # The attached window is alpha ≤ ~12 deg → all trusted (conf=0.97)
+    # Deep stall alpha > 12 deg has conf=0.40, but falls below gate (0.90)
+    # so they are excluded from the trusted set anyway.
+    # min_analysis_confidence should be the windowed min over attached region = 0.97
+    assert row["min_analysis_confidence"] is not None
+    assert row["min_analysis_confidence"] == pytest.approx(0.97, abs=0.02), (
+        f"Expected windowed min_analysis_confidence ≈ 0.97 (attached region), "
+        f"got {row['min_analysis_confidence']:.4f}. "
+        f"This test verifies gh-825 item 1: min_analysis_confidence is the windowed "
+        f"(attached-alpha) min, NOT the global sweep min (0.40 in deep stall)."
+    )
+
+
+def test_min_analysis_confidence_windowed_gate_below_attached(monkeypatch):
+    """Item 1 variant: gate below attached-region confidence.
+
+    When some attached-region alpha points have confidence < full window min
+    but still ABOVE the gate, the windowed min is correctly the min of the
+    full conf_arr restricted to alpha_attached_lo..alpha_attached_hi.
+    This uses a lower gate (0.50) to include all alpha in the trusted set,
+    so the service must explicitly window by alpha_attached bounds.
+    """
+    import sys
+    import types
+
+    if "aerosandbox" not in sys.modules:
+        asb_module = types.ModuleType("aerosandbox")
+
+        class FakeAirfoilLowGate:
+            def __init__(self, name=None, coordinates=None):
+                pass
+
+            def get_aero_from_neuralfoil(self, alpha, Re, **kwargs):
+                return _make_windowed_confidence_result(np.atleast_1d(alpha))
+
+        asb_module.Airfoil = FakeAirfoilLowGate
+        sys.modules["aerosandbox"] = asb_module
+
+    import aerosandbox as asb
+
+    def fake_low_gate(self, alpha, Re, **kwargs):
+        return _make_windowed_confidence_result(np.atleast_1d(alpha))
+
+    monkeypatch.setattr(asb.Airfoil, "get_aero_from_neuralfoil", fake_low_gate)
+
+    from app.services.airfoil_low_re_service import compute_airfoil_low_re
+
+    coords = np.array([[0.0, 0.0], [0.5, 0.07], [1.0, 0.0]])
+    # Use gate=0.35 so deep-stall (conf=0.40) points ARE included in trusted set.
+    # Global sweep min = 0.40 (deep stall).  Windowed (attached) min = 0.97.
+    # We assert windowed min = 0.97, not global min = 0.40.
+    results = compute_airfoil_low_re(
+        "test_lowgate_af",
+        coords,
+        [100_000],
+        confidence_gate=0.35,  # both 0.97 and 0.40 pass gate
+        alpha_start=-5.0,
+        alpha_end=18.0,
+        alpha_step=0.5,
+    )
+    assert len(results) == 1
+    row = results[0]
+
+    assert row["min_analysis_confidence"] is not None
+    # The service must use the windowed min (over attached alpha range), not global min.
+    # Windowed min = 0.97 (attached), global min = 0.40 (deep-stall included via low gate).
+    assert row["min_analysis_confidence"] == pytest.approx(0.97, abs=0.02), (
+        f"Expected windowed min_analysis_confidence ≈ 0.97; "
+        f"got {row['min_analysis_confidence']:.4f}. "
+        f"gh-825 item 1: must be windowed min over attached alpha range, NOT global sweep min."
+    )

--- a/app/tests/test_airfoil_low_re_config.py
+++ b/app/tests/test_airfoil_low_re_config.py
@@ -64,12 +64,21 @@ def test_low_confidence_flag_default():
 
 
 def test_mission_weights_keys():
-    """Mission weight table must have all required mission types."""
+    """Mission weight table must have all required mission types.
+
+    gh-825 item 12: slope_soarer added as an additional key (additive — no renames).
+    """
     from app.settings import Settings
 
     s = Settings()
     required_keys = {"trainer", "sport", "aerobatic", "glider", "flying_wing"}
-    assert required_keys == set(s.low_re_mission_weights.keys())
+    # All original keys must be present (additive — no renames)
+    assert required_keys.issubset(set(s.low_re_mission_weights.keys())), (
+        f"All original mission weight keys must be present; "
+        f"missing: {required_keys - set(s.low_re_mission_weights.keys())}"
+    )
+    # slope_soarer is the new additive key (gh-825 item 12)
+    assert "slope_soarer" in s.low_re_mission_weights
 
 
 def test_mission_weights_structure():

--- a/app/tests/test_airfoil_suitability_service.py
+++ b/app/tests/test_airfoil_suitability_service.py
@@ -443,7 +443,7 @@ def test_sailplane_mission_type_activates_mission_lens(seeded_db):
         ("sailplane", "glider"),
         ("motor_glider", "glider"),
         ("motorglider", "glider"),
-        ("slope_soarer", "glider"),
+        ("slope_soarer", "slope_soarer"),  # gh-825 item 12: own weight key
         ("wing_racer", "sport"),
         ("acro_3d", "aerobatic"),
         ("stol_bush", "trainer"),

--- a/app/tests/test_airfoils_suitability_endpoint.py
+++ b/app/tests/test_airfoils_suitability_endpoint.py
@@ -216,3 +216,78 @@ def test_endpoint_aeroplane_id_forwarded(client_no_svc):
     assert resp.status_code == 200
     call_kwargs = mock_svc.call_args[1]
     assert call_kwargs.get("aeroplane_id") == ap_uuid
+
+
+# ---------------------------------------------------------------------------
+# ITEM 5-BE (gh-825): `include` query param — endpoint-level tests
+# ---------------------------------------------------------------------------
+
+
+def test_endpoint_include_param_parsed_and_forwarded(client_no_svc):
+    """include=s1223,ag35 is parsed and forwarded as list[str] to the service."""
+    fake_resp = _make_fake_response()
+    with patch(
+        "app.api.v2.endpoints.airfoils.search_suitability", return_value=fake_resp
+    ) as mock_svc:
+        resp = client_no_svc.get(
+            "/airfoils/db/suitability",
+            params={
+                "chord_m": 0.15,
+                "speed_ms": 15.0,
+                "include": "s1223,ag35",
+            },
+        )
+    assert resp.status_code == 200
+    call_kwargs = mock_svc.call_args[1]
+    include_param = call_kwargs.get("include")
+    assert include_param is not None, "include must be forwarded to service"
+    assert isinstance(include_param, list), (
+        f"include must be parsed to list, got {type(include_param)}"
+    )
+    assert sorted(include_param) == sorted(["s1223", "ag35"]), (
+        f"include must contain ['s1223', 'ag35'], got {include_param}"
+    )
+
+
+def test_endpoint_include_param_absent_gives_none(client_no_svc):
+    """Old clients (no include param) must get include=None → identical behaviour."""
+    fake_resp = _make_fake_response()
+    with patch(
+        "app.api.v2.endpoints.airfoils.search_suitability", return_value=fake_resp
+    ) as mock_svc:
+        resp = client_no_svc.get(
+            "/airfoils/db/suitability",
+            params={"chord_m": 0.15, "speed_ms": 15.0},
+        )
+    assert resp.status_code == 200
+    call_kwargs = mock_svc.call_args[1]
+    # include should either be absent or None — either way, no include list
+    include_param = call_kwargs.get("include")
+    assert include_param is None, (
+        f"Old clients (no include) must get include=None; got {include_param}"
+    )
+
+
+def test_endpoint_include_whitespace_stripped(client_no_svc):
+    """include values are stripped of whitespace (e.g. 's1223 , ag35')."""
+    fake_resp = _make_fake_response()
+    with patch(
+        "app.api.v2.endpoints.airfoils.search_suitability", return_value=fake_resp
+    ) as mock_svc:
+        resp = client_no_svc.get(
+            "/airfoils/db/suitability",
+            params={
+                "chord_m": 0.15,
+                "speed_ms": 15.0,
+                "include": " s1223 , ag35 , ",
+            },
+        )
+    assert resp.status_code == 200
+    call_kwargs = mock_svc.call_args[1]
+    include_param = call_kwargs.get("include")
+    # Empty strings after split+strip must be dropped
+    assert "" not in (include_param or []), (
+        f"Empty strings must be dropped from include: {include_param}"
+    )
+    assert "s1223" in (include_param or []), "s1223 must be present after strip"
+    assert "ag35" in (include_param or []), "ag35 must be present after strip"

--- a/app/tests/test_suitability_service.py
+++ b/app/tests/test_suitability_service.py
@@ -896,3 +896,592 @@ class TestEndpointParams825:
             assert "stall_gentleness" in item
             assert "cl_max_margin" in item
             assert "target_cl_loiter" not in item
+
+
+# ---------------------------------------------------------------------------
+# ITEM 2 (gh-825): Tip-Re significance threshold tests
+# ---------------------------------------------------------------------------
+#
+# The threshold logic (gh-825 item 2):
+#   tip_re_flag = True  iff
+#       (re_tip < settings.low_re_tip_re_abs_floor)
+#     OR
+#       ((re_root - re_tip) > settings.low_re_tip_re_rel_drop)
+#   otherwise False.
+#
+# Re computation: re = RHO * speed * chord / MU  (1.225*v*c/1.81e-5)
+# For speed_ms=15.0:
+#   chord 0.15 → Re ~152_072   (root)
+#   tip_chord 0.10 → Re ~101_381
+#   tip_chord 0.08 → Re ~81_105
+#   tip_chord 0.07 → Re ~70_967  (below 80k floor)
+#
+# _RHO=1.225, _MU=1.81e-5 → Re = 1.225*15/1.81e-5 * chord
+#                                = 1_015_470 * chord  (approx)
+# More precisely: 1.225*15.0/1.81e-5 = 1_015_470.0 (per metre of chord)
+
+
+def _make_minimal_db_with_airfoil(in_memory_db):
+    """Seed one airfoil + geometry + polar so search_suitability returns items."""
+    from app.models.airfoil import AirfoilModel
+    from app.models.airfoil_low_re import AirfoilGeometryModel, AirfoilLowRePolarModel
+    from datetime import datetime, timezone
+
+    with in_memory_db() as session:
+        session.add(AirfoilModel(name="tip_re_af", coordinates=[[0, 0], [0.5, 0.07], [1, 0]]))
+        session.flush()
+        session.add(
+            AirfoilGeometryModel(
+                airfoil_name="tip_re_af",
+                max_thickness_pct=10.0,
+                max_camber_pct=2.0,
+                camber_at_te=0.001,
+                family="cambered",
+                computed_at=datetime.now(timezone.utc),
+            )
+        )
+        session.add(
+            AirfoilLowRePolarModel(
+                airfoil_name="tip_re_af",
+                reynolds=100_000.0,
+                ld_max=45.0,
+                cl_max=1.2,
+                alpha_attached_lo=-3.0,
+                alpha_attached_hi=12.0,
+                drag_bucket_width=0.50,
+                cd_min=0.012,
+                stall_gentleness=-0.05,
+                cd0=0.012,
+                k=0.04,
+                cl0=0.25,
+                cl_valid_lo=0.0,
+                cl_valid_hi=1.2,
+                min_analysis_confidence=0.93,
+                neuralfoil_model_size="xxxlarge",
+                n_crit=9.0,
+                computed_at=datetime.now(timezone.utc),
+            )
+        )
+        session.commit()
+    return in_memory_db
+
+
+class TestTipReSignificanceThreshold:
+    """Item 2 (gh-825): boundary tests for the tip-Re significance threshold.
+
+    Uses explicit Settings overrides to isolate threshold logic from defaults.
+    abs_floor=80_000, rel_drop=50_000 (matching new default values).
+    """
+
+    # Re = 1.225 * speed * chord / 1.81e-5
+    # speed_ms = 15.0
+    # Factor = 1.225 * 15.0 / 1.81e-5 ≈ 1_015_469.6  per metre chord
+    _FACTOR = 1.225 * 15.0 / 1.81e-5
+
+    def _re(self, chord_m):
+        return self._FACTOR * chord_m
+
+    def test_tip_re_flag_false_gentle_taper(self, in_memory_db):
+        """Gentle taper: tip_Re above floor AND (root_Re - tip_Re) <= rel_drop → flag False."""
+        from app.services.suitability_service import search_suitability
+        from app.settings import Settings
+
+        db_factory = _make_minimal_db_with_airfoil(in_memory_db)
+
+        # root_chord → Re ≈ 152_220  (0.15 m)
+        # tip_chord  → Re ≈ 101_480  (0.1 m)
+        # re_tip > 80_000 (floor)  ✓  abs_floor passes
+        # re_root - re_tip ≈ 50_740  > 50_000  → would trip rel_drop
+        # Need gentler taper: tip = 0.105 m → re_tip ≈ 106_524
+        # re_root - re_tip ≈ 152_220 - 106_524 = 45_696 < 50_000  ✓
+
+        root_chord = 0.15
+        tip_chord = 0.105
+        re_root = self._re(root_chord)
+        re_tip = self._re(tip_chord)
+
+        settings = Settings(
+            low_re_tip_re_abs_floor=80_000.0,
+            low_re_tip_re_rel_drop=50_000.0,
+        )
+        # Verify our test invariants hold
+        assert re_tip >= settings.low_re_tip_re_abs_floor, (
+            f"re_tip={re_tip:.0f} must be >= floor={settings.low_re_tip_re_abs_floor}"
+        )
+        assert (re_root - re_tip) <= settings.low_re_tip_re_rel_drop, (
+            f"drop={re_root - re_tip:.0f} must be <= rel_drop={settings.low_re_tip_re_rel_drop}"
+        )
+
+        with db_factory() as session:
+            resp = search_suitability(
+                db=session,
+                chord_m=root_chord,
+                speed_ms=15.0,
+                tip_chord_m=tip_chord,
+                settings=settings,
+            )
+
+        for item in resp.results:
+            assert item.tip_re_flag is False, (
+                f"Expected tip_re_flag=False for gentle taper, got True on {item.airfoil_name}"
+            )
+
+    def test_tip_re_flag_true_below_abs_floor(self, in_memory_db):
+        """tip_Re < abs_floor (80k) → flag must be True."""
+        from app.services.suitability_service import search_suitability
+        from app.settings import Settings
+
+        db_factory = _make_minimal_db_with_airfoil(in_memory_db)
+
+        # tip_chord = 0.07 → re_tip ≈ 70_983 < 80_000  → flag True
+        tip_chord = 0.07
+        re_tip = self._re(tip_chord)
+        settings = Settings(
+            low_re_tip_re_abs_floor=80_000.0,
+            low_re_tip_re_rel_drop=50_000.0,
+        )
+        assert re_tip < settings.low_re_tip_re_abs_floor, (
+            f"re_tip={re_tip:.0f} must be < floor={settings.low_re_tip_re_abs_floor}"
+        )
+
+        with db_factory() as session:
+            resp = search_suitability(
+                db=session,
+                chord_m=0.15,
+                speed_ms=15.0,
+                tip_chord_m=tip_chord,
+                settings=settings,
+            )
+
+        for item in resp.results:
+            assert item.tip_re_flag is True, (
+                f"Expected tip_re_flag=True for re_tip < floor, got False on {item.airfoil_name}"
+            )
+
+    def test_tip_re_flag_true_large_rel_drop(self, in_memory_db):
+        """(re_root - re_tip) > rel_drop (50k) → flag must be True even if re_tip > floor."""
+        from app.services.suitability_service import search_suitability
+        from app.settings import Settings
+
+        db_factory = _make_minimal_db_with_airfoil(in_memory_db)
+
+        # root_chord = 0.15 → re_root ≈ 152_220
+        # tip_chord = 0.095 → re_tip ≈ 96_470
+        # drop ≈ 55_750 > 50_000  → flag True
+        # re_tip > 80_000  → abs_floor alone wouldn't flag it
+        root_chord = 0.15
+        tip_chord = 0.095
+        re_root = self._re(root_chord)
+        re_tip = self._re(tip_chord)
+        settings = Settings(
+            low_re_tip_re_abs_floor=80_000.0,
+            low_re_tip_re_rel_drop=50_000.0,
+        )
+        assert re_tip >= settings.low_re_tip_re_abs_floor, (
+            f"re_tip={re_tip:.0f} must be >= floor (testing rel_drop path only)"
+        )
+        assert (re_root - re_tip) > settings.low_re_tip_re_rel_drop, (
+            f"drop={re_root - re_tip:.0f} must be > rel_drop={settings.low_re_tip_re_rel_drop}"
+        )
+
+        with db_factory() as session:
+            resp = search_suitability(
+                db=session,
+                chord_m=root_chord,
+                speed_ms=15.0,
+                tip_chord_m=tip_chord,
+                settings=settings,
+            )
+
+        for item in resp.results:
+            assert item.tip_re_flag is True, (
+                f"Expected tip_re_flag=True for large rel_drop, got False on {item.airfoil_name}"
+            )
+
+    def test_tip_re_flag_edge_exactly_at_floor(self, in_memory_db):
+        """Exactly at abs_floor: re_tip == floor → flag must be False (not strictly less than)."""
+        from app.services.suitability_service import search_suitability
+        from app.settings import Settings
+
+        db_factory = _make_minimal_db_with_airfoil(in_memory_db)
+
+        # We need re_tip == exactly 80_000.  Compute chord:
+        # chord = 80_000 / FACTOR
+        abs_floor = 80_000.0
+        tip_chord_exact = abs_floor / self._FACTOR
+        # Also ensure rel_drop doesn't fire: root=0.15 → re_root≈152_220
+        # drop = 152_220 - 80_000 = 72_220 > 50_000 → rel_drop fires
+        # So use a small root where re_root - 80_000 <= 50_000
+        # re_root <= 130_000 → chord_root <= 0.128 m
+        root_chord = 0.125  # re_root ≈ 126_934
+        re_root = self._re(root_chord)
+        re_tip = self._re(tip_chord_exact)
+        drop = re_root - re_tip
+
+        settings = Settings(
+            low_re_tip_re_abs_floor=abs_floor,
+            low_re_tip_re_rel_drop=50_000.0,
+        )
+        # Validate our invariants
+        assert abs(re_tip - abs_floor) < 1.0, f"re_tip={re_tip:.2f} must equal floor={abs_floor}"
+        assert drop <= settings.low_re_tip_re_rel_drop, (
+            f"drop={drop:.0f} must be <= rel_drop so only floor edge matters"
+        )
+
+        with db_factory() as session:
+            resp = search_suitability(
+                db=session,
+                chord_m=root_chord,
+                speed_ms=15.0,
+                tip_chord_m=tip_chord_exact,
+                settings=settings,
+            )
+
+        # re_tip == floor exactly: not strictly less than → flag False
+        for item in resp.results:
+            assert item.tip_re_flag is False, (
+                f"At exactly floor boundary, tip_re_flag should be False; "
+                f"got True on {item.airfoil_name}"
+            )
+
+    def test_tip_re_flag_edge_just_below_rel_drop(self, in_memory_db):
+        """Just below rel_drop: (re_root - re_tip) slightly < rel_drop → flag must be False."""
+        from app.services.suitability_service import search_suitability
+        from app.settings import Settings
+
+        db_factory = _make_minimal_db_with_airfoil(in_memory_db)
+
+        # Use a rel_drop threshold of 50_000 and ensure (re_root - re_tip) < 50_000
+        # by giving a relatively long tip chord.
+        # root_chord = 0.15 → re_root ≈ 152_279
+        # We want re_tip = re_root - 49_000 ≈ 103_279  (drop of 49k < 50k)
+        # tip_chord = (re_root - 49_000) / FACTOR  ≈ 0.10166 m
+        # re_tip ≈ 103_279 > 80_000 floor  → abs_floor doesn't fire either
+        rel_drop = 50_000.0
+        abs_floor = 80_000.0
+        root_chord = 0.15
+        re_root = self._re(root_chord)
+        re_tip_target = re_root - 49_000.0  # 1000 Re units below the threshold
+        tip_chord = re_tip_target / self._FACTOR
+
+        settings = Settings(
+            low_re_tip_re_abs_floor=abs_floor,
+            low_re_tip_re_rel_drop=rel_drop,
+        )
+
+        # Confirm our invariants hold for this test case
+        re_tip_actual = self._re(tip_chord)
+        assert re_tip_actual > abs_floor
+        assert (re_root - re_tip_actual) < rel_drop
+
+        with db_factory() as session:
+            resp = search_suitability(
+                db=session,
+                chord_m=root_chord,
+                speed_ms=15.0,
+                tip_chord_m=tip_chord,
+                settings=settings,
+            )
+
+        # Drop is clearly below rel_drop → flag False
+        for item in resp.results:
+            assert item.tip_re_flag is False, (
+                f"Drop just below rel_drop: tip_re_flag should be False; "
+                f"got True on {item.airfoil_name}"
+            )
+
+    def test_tip_re_flag_none_when_no_tip_chord(self, in_memory_db):
+        """When tip_chord_m is None, tip_re_flag must always be False."""
+        from app.services.suitability_service import search_suitability
+        from app.settings import Settings
+
+        db_factory = _make_minimal_db_with_airfoil(in_memory_db)
+        settings = Settings(
+            low_re_tip_re_abs_floor=80_000.0,
+            low_re_tip_re_rel_drop=50_000.0,
+        )
+
+        with db_factory() as session:
+            resp = search_suitability(
+                db=session,
+                chord_m=0.15,
+                speed_ms=15.0,
+                tip_chord_m=None,
+                settings=settings,
+            )
+
+        for item in resp.results:
+            assert item.tip_re_flag is False, (
+                f"tip_re_flag should be False when no tip_chord_m; got True on {item.airfoil_name}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# ITEM 5-BE (gh-825): `include` additive query param — service-level tests
+# ---------------------------------------------------------------------------
+
+
+class TestIncludeParam:
+    """Service-level tests for the additive `include` parameter in search_suitability.
+
+    Contract (gh-825 item 5):
+    - Named airfoils in `include` that have low-Re polar rows are ALWAYS returned,
+      even if `limit` would drop them from the top-N ranked block.
+    - Named airfoils with NO polar rows are NOT fabricated (not returned).
+    - De-duplication: included names already in the top-N are NOT duplicated.
+    - Default None → identical behaviour to before (no include).
+    """
+
+    @pytest.fixture()
+    def db_many_airfoils(self, in_memory_db):
+        """DB with 5 airfoils with varying quality + 1 airfoil with NO polar rows."""
+        from app.models.airfoil import AirfoilModel
+        from app.models.airfoil_low_re import AirfoilGeometryModel, AirfoilLowRePolarModel
+        from datetime import datetime, timezone
+
+        with in_memory_db() as session:
+            for i, (ld, cl_max_val, cd0_val) in enumerate(
+                [
+                    (55, 1.4, 0.010),  # af_0 — best
+                    (45, 1.2, 0.013),  # af_1
+                    (35, 1.1, 0.016),  # af_2
+                    (25, 0.9, 0.020),  # af_3
+                    (15, 0.7, 0.025),  # af_4 — worst
+                ]
+            ):
+                name = f"af_{i}"
+                session.add(AirfoilModel(name=name, coordinates=[[0, 0], [0.5, 0.07], [1, 0]]))
+                session.flush()
+                session.add(
+                    AirfoilGeometryModel(
+                        airfoil_name=name,
+                        max_thickness_pct=10.0,
+                        max_camber_pct=2.0,
+                        camber_at_te=0.0,
+                        family="cambered",
+                        computed_at=datetime.now(timezone.utc),
+                    )
+                )
+                session.add(
+                    AirfoilLowRePolarModel(
+                        airfoil_name=name,
+                        reynolds=100_000.0,
+                        ld_max=float(ld),
+                        cl_max=float(cl_max_val),
+                        alpha_attached_lo=-3.0,
+                        alpha_attached_hi=12.0,
+                        drag_bucket_width=0.50,
+                        cd_min=float(cd0_val),
+                        stall_gentleness=-0.05,
+                        cd0=float(cd0_val),
+                        k=0.04,
+                        cl0=0.25,
+                        cl_valid_lo=0.0,
+                        cl_valid_hi=float(cl_max_val),
+                        min_analysis_confidence=0.93,
+                        neuralfoil_model_size="xxxlarge",
+                        n_crit=9.0,
+                        computed_at=datetime.now(timezone.utc),
+                    )
+                )
+
+            # Add one airfoil with geometry but NO polar rows
+            session.add(AirfoilModel(name="no_polar_af", coordinates=[[0, 0], [0.5, 0.06], [1, 0]]))
+            session.flush()
+            session.add(
+                AirfoilGeometryModel(
+                    airfoil_name="no_polar_af",
+                    max_thickness_pct=11.0,
+                    max_camber_pct=1.5,
+                    camber_at_te=0.0,
+                    family="semi_symmetric",
+                    computed_at=datetime.now(timezone.utc),
+                )
+            )
+            # No AirfoilLowRePolarModel for no_polar_af
+            session.commit()
+
+        return in_memory_db
+
+    def test_include_forces_airfoil_beyond_limit(self, db_many_airfoils):
+        """Airfoils named in `include` appear even when limit drops them."""
+        from app.services.suitability_service import search_suitability
+
+        # limit=1 → only top 1 (af_0). But include=['af_4'] should force af_4 to appear.
+        with db_many_airfoils() as session:
+            resp = search_suitability(
+                db=session,
+                chord_m=0.15,
+                speed_ms=15.0,
+                limit=1,
+                include=["af_4"],
+            )
+
+        result_names = [item.airfoil_name for item in resp.results]
+        assert "af_4" in result_names, (
+            f"af_4 should be in results due to include=[]; got {result_names}"
+        )
+        # Top-N (limit=1) still has af_0
+        assert "af_0" in result_names, f"af_0 (top-1) should still be present; got {result_names}"
+        # Total should be 2 (top-1 + include)
+        assert len(resp.results) == 2, (
+            f"Expected 2 results, got {len(resp.results)}: {result_names}"
+        )
+
+    def test_include_no_fabrication_for_no_polar(self, db_many_airfoils):
+        """Airfoils in `include` with NO polar rows must NOT be fabricated."""
+        from app.services.suitability_service import search_suitability
+
+        with db_many_airfoils() as session:
+            resp = search_suitability(
+                db=session,
+                chord_m=0.15,
+                speed_ms=15.0,
+                limit=1,
+                include=["no_polar_af"],
+            )
+
+        result_names = [item.airfoil_name for item in resp.results]
+        assert "no_polar_af" not in result_names, (
+            f"no_polar_af has no polar rows and must NOT be fabricated; got {result_names}"
+        )
+
+    def test_include_no_duplication_when_in_topn(self, db_many_airfoils):
+        """An included name already in top-N must NOT appear twice."""
+        from app.services.suitability_service import search_suitability
+
+        # limit=5 → all 5 af_* are in top-N. include=['af_0'] → should not duplicate.
+        with db_many_airfoils() as session:
+            resp = search_suitability(
+                db=session,
+                chord_m=0.15,
+                speed_ms=15.0,
+                limit=5,
+                include=["af_0"],
+            )
+
+        result_names = [item.airfoil_name for item in resp.results]
+        count_af0 = result_names.count("af_0")
+        assert count_af0 == 1, (
+            f"af_0 should appear exactly once; found {count_af0} times in {result_names}"
+        )
+
+    def test_include_none_identical_to_before(self, db_many_airfoils):
+        """include=None (default) must give identical results to omitting the param."""
+        from app.services.suitability_service import search_suitability
+
+        with db_many_airfoils() as session:
+            resp_default = search_suitability(
+                db=session,
+                chord_m=0.15,
+                speed_ms=15.0,
+                limit=3,
+            )
+        with db_many_airfoils() as session:
+            resp_none = search_suitability(
+                db=session,
+                chord_m=0.15,
+                speed_ms=15.0,
+                limit=3,
+                include=None,
+            )
+
+        names_default = [item.airfoil_name for item in resp_default.results]
+        names_none = [item.airfoil_name for item in resp_none.results]
+        assert names_default == names_none, (
+            f"include=None must give identical behaviour to omitting param; "
+            f"default={names_default}, none={names_none}"
+        )
+
+    def test_include_case_insensitive(self, db_many_airfoils):
+        """include names should match case-insensitively against geo_by_name keys."""
+        from app.services.suitability_service import search_suitability
+
+        with db_many_airfoils() as session:
+            resp = search_suitability(
+                db=session,
+                chord_m=0.15,
+                speed_ms=15.0,
+                limit=1,
+                include=["AF_4"],  # uppercase variant
+            )
+
+        result_names = [item.airfoil_name for item in resp.results]
+        assert "af_4" in result_names, (
+            f"include=['AF_4'] should match 'af_4' case-insensitively; got {result_names}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# ITEM 12 (gh-825): slope_soarer gets its own mission-weighting key
+# ---------------------------------------------------------------------------
+
+
+class TestSlopeSoarerMissionWeight:
+    """gh-825 item 12: 'slope_soarer' maps to its own weight key (not 'glider')."""
+
+    def test_slope_soarer_resolves_to_slope_soarer_weights(self, seeded_db_825):
+        """search_suitability with mission_type='slope_soarer' must use 'slope_soarer' weights
+        (semi_symmetric/cambered preferred), NOT 'glider' weights."""
+        from app.services.suitability_service import search_suitability
+        from app.settings import Settings
+
+        # Verify the mission weight key exists in settings
+        settings = Settings()
+        assert "slope_soarer" in settings.low_re_mission_weights, (
+            "slope_soarer weight key must exist in Settings.low_re_mission_weights"
+        )
+        weights = settings.low_re_mission_weights["slope_soarer"]
+        assert "preferred_families" in weights
+        assert (
+            "semi_symmetric" in weights["preferred_families"]
+            or "cambered" in weights["preferred_families"]
+        ), "slope_soarer preferred_families should include semi_symmetric or cambered"
+
+        # Check 'glider' is still present for unmapped aliases
+        assert "glider" in settings.low_re_mission_weights, (
+            "glider key must still exist as fallback"
+        )
+
+        # The mapping: 'slope_soarer' → 'slope_soarer' (not 'glider')
+        from app.services.suitability_service import _MISSION_TYPE_MAP
+
+        assert _MISSION_TYPE_MAP.get("slope_soarer") == "slope_soarer", (
+            f"_MISSION_TYPE_MAP['slope_soarer'] must be 'slope_soarer', "
+            f"got {_MISSION_TYPE_MAP.get('slope_soarer')!r}"
+        )
+
+        # Service: with explicit mission_type='slope_soarer', items should get mission score
+        # (non-None) rather than None (which would happen if the key were missing)
+        SessionLocal, _ = seeded_db_825
+        with SessionLocal() as session:
+            resp = search_suitability(
+                db=session,
+                chord_m=0.15,
+                speed_ms=15.0,
+                mission_type="slope_soarer",
+                settings=settings,
+            )
+
+        # With slope_soarer weights, mission scores should be non-None (key exists in weights)
+        items_with_polar = [r for r in resp.results if r.re_agnostic > 0]
+        assert any(r.mission is not None for r in items_with_polar), (
+            "slope_soarer mission type should produce non-None mission scores; "
+            "check that 'slope_soarer' key is in Settings.low_re_mission_weights"
+        )
+        # active_lens should be 'mission' when mission scores are available
+        assert resp.query.active_lens == "mission", (
+            f"active_lens should be 'mission' for slope_soarer; got {resp.query.active_lens!r}"
+        )
+
+    def test_slope_soarer_different_from_glider_weights(self):
+        """slope_soarer and glider must have different preferred_families."""
+        from app.settings import Settings
+
+        settings = Settings()
+        ss_weights = settings.low_re_mission_weights.get("slope_soarer", {})
+        glider_weights = settings.low_re_mission_weights.get("glider", {})
+        # They should not be identical (slope_soarer has own niche)
+        assert ss_weights != glider_weights, (
+            "slope_soarer weights should differ from glider weights (own aerobatic niche)"
+        )


### PR DESCRIPTION
Part of #825. Items 1-3,5(BE) + item 12 minor.

## Summary

- **Item 1**: `min_analysis_confidence` is now windowed (attached-alpha range only, not global sweep min). Deep-stall confidence no longer penalises the stored metric. PO re-backfill required after merge.
- **Item 2**: Tip-Re flag uses two-threshold logic instead of simple `re_tip < re_root`. New tunables: `low_re_tip_re_abs_floor=80_000`, `low_re_tip_re_rel_drop=50_000`. Strict greater/less-than semantics at boundaries.
- **Item 3**: Improved flat-bottom family classifier — aft-flatness heuristic (`max |y_lower|` over x≥0.25 < 0.005) detects Clark-Y-like profiles that escaped the old strict mean-threshold. PO re-backfill required after merge.
- **Item 5 (BE)**: Additive `include` query param on `GET /airfoils/db/suitability`. Named airfoils with polar rows always appear even outside top-N limit. No fabrication for no-data names. Old clients (no include) get identical behaviour.
- **Item 12 (minor)**: `slope_soarer` mission gets its own weighting key (`semi_symmetric/cambered` preferred, t/c 8-12%) instead of mapping to `glider`.

## Contract

Only contract change: additive `include` query param (old clients unaffected). No field renames. Items 1+3 change stored-value semantics — PO re-backfill (scripts/backfill) needed post-merge, NOT run in workflow.

## Re-backfill needed (PO action after merge)

- Item 1: `AirfoilLowRePolarModel.min_analysis_confidence` — windowed min
- Item 3: `AirfoilGeometryModel.family` — improved flat-bottom detection

## Test plan

- [x] 80 tests all green in gate suite (`-m 'not slow'`)
- [x] `airfoil_low_re_service` 91% coverage, `suitability_service` 95% coverage
- [x] `ruff check` + `ruff format --check` clean
- [x] Lane purity: all changes in `app/` only (no frontend/)
- [x] Full app fast suite: 4079/4079 passed (1 pre-existing xfail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)