### PR TITLE
fix(gh-834): correct reflexed-family detection (camber-line shape)

### DIFF
--- a/app/services/airfoil_low_re_service.py
+++ b/app/services/airfoil_low_re_service.py
@@ -43,7 +43,49 @@ RHO = 1.225  # kg/m³  (ISA sea-level)
 _SYMMETRIC_MAX_CAMBER_PCT = 0.5  # max_camber_pct below which → symmetric
 _SEMI_SYMMETRIC_MAX_CAMBER_PCT = 2.0  # between SYMMETRIC and this → semi_symmetric
 _FLAT_BOTTOM_Y_THRESHOLD = 0.002  # lower surface mean abs(y) below this → flat (strict legacy)
-_REFLEX_CAMBER_AT_TE_THRESHOLD = -0.003  # camber_at_te below this → reflexed
+# --- gh-834: reflex detection from camber-line SHAPE (replaces TE-endpoint check) ---
+#
+# Background: The old code used camber_at_te = camber[-1] (the mean-camber-line endpoint
+# value).  For any sharp-TE airfoil upper[-1] == lower[-1], so camber[-1] ≈ 0 for EVERY
+# sharp-TE airfoil regardless of whether it is reflexed.  Only blunt/open-TE airfoils like
+# supercritical sc20xxx shapes ever produced a non-zero (negative) TE-endpoint value, so
+# those were wrongly labelled 'reflexed' while true flying-wing sections (MH60, E184, EH
+# series) were missed entirely.
+#
+# The fix uses the camber-line SHAPE over the aft chord, not just the endpoint:
+#
+# Signal A — sharp-TE reflex (MH / E / EH / S-series flying-wing sections):
+#   These airfoils have a steeply falling camber line that reaches close to 0 — or dips
+#   below it — by x = 0.9 while the max_camber sits further forward.  Metric:
+#
+#       aft_camber_ratio = camber_at_x90 / max_camber
+#
+#   where camber_at_x90 is the mean-camber-line value at x = 0.9.  For reflexed sharp-TE
+#   airfoils this ratio is always < 0.06 (camber almost vanishes at 90% chord).  For
+#   non-reflexed cambered (NACA 4412: 0.31) or flat-bottom (Clark Y: 0.28) it is >> 0.06.
+#
+# Signal B — open / upturned-TE reflex (Clark YH and similar plank + reflexed-TE shapes):
+#   The camber line does not dip to near-zero — it decreases gently but curves gently
+#   upward in the aft section, producing a POSITIVE quadratic coefficient when a 2nd-order
+#   polynomial is fitted to the camber line over x ∈ [0.5, 1.0].  For Clark YH this
+#   coefficient ≈ +0.039; for NACA 4412 (not reflexed) it is −0.11.  Threshold 0.015 with
+#   a minimum max_camber guard (> 2%) prevents symmetric airfoils (which have zero camber)
+#   from triggering this path.
+#
+# Together the two signals correctly classify the full MH / E / EH / clarkyh / s5010 suite
+# as reflexed without introducing false positives on NACA 4412, Clark Y, NACA 0006, or
+# supercritical sc20xxx shapes.
+#
+# camber_at_te is now stored as the camber-line value at x = 0.9 (not the TE endpoint).
+# This value is non-trivially informative for all airfoils including sharp-TE sections and
+# directly encodes Signal A above.
+_REFLEX_AFT_CAMBER_RATIO_MAX = (
+    0.06  # aft_camber_ratio = c_at_x90 / max_camber; below → reflexed (A)
+)
+_REFLEX_AFT_CONCAVITY_MIN = (
+    0.015  # min positive quadratic coeff of camber line over [0.5,1] → reflexed (B)
+)
+_REFLEX_B_MIN_CAMBER_PCT = 2.0  # Signal B only fires if max_camber_pct > this (% chord)
 # --- gh-825 item 1 (re-tuned): lower-surface linearity for flat-bottom detection ---
 # Real flat-bottom airfoils (Clark Y, Gottingen 417a, Clark X/V/K/Z, Dormoy, PT40) have a
 # lower surface that is nearly LINEAR from ~30% chord to the TE — it runs at a slight
@@ -95,7 +137,15 @@ def classify_family(coords: np.ndarray) -> AirfoilFamily:
     1. Split into upper / lower surfaces by finding the leading edge (min x).
     2. Compute camber line by interpolating both surfaces to common x stations.
     3. Evaluate in priority order:
-       a. reflexed:      camber_at_te (camber line at x≈1) strongly negative.
+       a. reflexed:      camber-line SHAPE signals A or B (gh-834):
+            A. Aft camber ratio: camber_at_x90 / max_camber < 0.06.
+               Catches sharp-TE flying-wing sections (MH, E, EH, S series)
+               where the camber line nearly vanishes at 90% chord.
+            B. Positive aft concavity: quadratic coefficient of camber-line
+               polynomial fit over [0.5, 1.0] > 0.015 AND max_camber > 2%.
+               Catches upturned-TE sections (Clark YH and similar).
+          Must stay first so reflexed airfoils aren't mis-classified as
+          flat_bottom or semi_symmetric.
        b. symmetric:     max_camber_pct < 0.5% (checked BEFORE flat_bottom to
                          prevent purely symmetric airfoils being mis-labelled).
        c. flat_bottom:   lower surface is near-linear over aft chord (gh-825
@@ -105,10 +155,10 @@ def classify_family(coords: np.ndarray) -> AirfoilFamily:
        d. semi_symmetric: max_camber_pct < 2%.
        e. cambered:      everything else.
 
-    NOTE: The existing ``_compute_geometry_stats`` in endpoints/airfoils.py
-    returns max thickness/camber + their x-positions but does NOT extract
-    ``camber_at_te`` or detect reflex. This function implements those separately
-    from the mean camber line.
+    NOTE: ``camber_at_te`` as returned by this module is now the mean-camber-line
+    value at x = 0.9 (aft-reflex signal A), not the TE endpoint.  This is more
+    informative for all airfoils including sharp-TE sections.  The stored column
+    name is unchanged (gh-834).
     """
     coords = np.asarray(coords, dtype=float)
     # Find LE (min x) to split surfaces
@@ -163,8 +213,26 @@ def classify_family(coords: np.ndarray) -> AirfoilFamily:
     max_camber = float(np.max(camber))
     max_camber_pct = max_camber * 100.0  # as % of chord (coords normalized 0..1)
 
-    # camber_at_te: evaluate camber line at x=max(x_eval) which is near TE
-    camber_at_te = float(camber[-1])
+    # --- gh-834: reflex signals derived from camber-line SHAPE ---
+    # camber_at_te is now the camber value at x = 0.9, not the TE endpoint.
+    # For sharp-TE airfoils the TE endpoint camber ≈ 0 for ALL airfoils (both
+    # surfaces meet), so that value carries no reflex information. At x = 0.9
+    # the mean camber line still separates reflexed from non-reflexed.
+    camber_at_te = float(np.interp(0.9, x_eval, camber))  # camber at x = 0.9
+
+    # Signal A: aft camber ratio — near-zero camber at 90% chord → reflexed
+    # For reflexed sharp-TE sections (MH / E / EH / S series): ratio < 0.06
+    # For non-reflexed cambered / flat-bottom: ratio >> 0.06
+    aft_camber_ratio = camber_at_te / max(max_camber, 1e-9)
+
+    # Signal B: positive aft camber concavity → upturned-TE reflex (Clark YH type)
+    # Fit 2nd-order polynomial to camber over [0.5, 1.0]; positive leading
+    # coefficient means the camber line curves upward (S-shape) in the aft region.
+    aft_concavity_mask = (x_eval >= 0.50) & (x_eval <= 1.0)
+    aft_concavity = 0.0
+    if aft_concavity_mask.sum() >= 4:
+        p_aft_c = np.polyfit(x_eval[aft_concavity_mask], camber[aft_concavity_mask], 2)
+        aft_concavity = float(p_aft_c[0])
 
     # Lower surface mean abs y (strict legacy flat-bottom gate for pure y=0 lower surfaces)
     mean_lower_abs_y = float(np.mean(np.abs(y_lower)))
@@ -178,9 +246,25 @@ def classify_family(coords: np.ndarray) -> AirfoilFamily:
         aft_quad_coeff = float(abs(p_aft[0]))
 
     # --- Classification rules (ordered by priority) ---
-    # 1. Reflexed: camber line is clearly negative (below chord) at TE
-    #    (must stay first so reflexed airfoils aren't mis-classified as flat_bottom)
-    if camber_at_te < _REFLEX_CAMBER_AT_TE_THRESHOLD:
+    # 1. Reflexed: camber-line SHAPE signals (gh-834).
+    #    Two complementary signals cover both reflexed families:
+    #    A. Sharp-TE reflex (MH/E/EH/S flying-wing sections):
+    #       aft_camber_ratio = camber_at_x90 / max_camber < 0.06
+    #       Guard: only fires when max_camber_pct > symmetric threshold
+    #       (symmetric airfoils have max_camber = 0, yielding ratio = 0,
+    #       which would falsely trigger Signal A without this guard).
+    #    B. Upturned-TE reflex (Clark YH, plank + reflexed-TE airfoils):
+    #       aft camber concavity > 0.015 AND max_camber_pct > 2%
+    #    Must fire BEFORE flat_bottom/semi_symmetric so reflexed airfoils
+    #    are not mis-classified by the lower-surface linearity test.
+    reflex_signal_a = (
+        max_camber_pct >= _SYMMETRIC_MAX_CAMBER_PCT  # guard: not symmetric
+        and aft_camber_ratio < _REFLEX_AFT_CAMBER_RATIO_MAX
+    )
+    reflex_signal_b = (
+        aft_concavity > _REFLEX_AFT_CONCAVITY_MIN and max_camber_pct > _REFLEX_B_MIN_CAMBER_PCT
+    )
+    if reflex_signal_a or reflex_signal_b:
         return "reflexed"
 
     # 2. Symmetric: almost no camber.

--- a/app/tests/test_airfoil_family_classifier.py
+++ b/app/tests/test_airfoil_family_classifier.py
@@ -1,4 +1,4 @@
-"""Tests for the airfoil family classifier (Task 4, gh-821; Item 1, gh-825).
+"""Tests for the airfoil family classifier (Task 4, gh-821; Item 1, gh-825; gh-834).
 
 Uses hand-built minimal coordinate arrays to test each family type AND loads
 real Clark Y coordinates from components/airfoils/clarky.dat to verify the
@@ -16,8 +16,33 @@ gh-825 item 1 (re-tuned): Improved flat-bottom detection.
   Additionally, the symmetric check now fires BEFORE flat_bottom to prevent
   purely symmetric airfoils (NACA 0000) from being mis-labelled as flat_bottom.
 
+gh-834: Corrected reflexed-family detection (camber-line shape).
+  The previous code keyed reflex on camber_at_te = the mean-camber-line
+  ENDPOINT value (camber[-1]).  For sharp-TE airfoils (upper == lower at TE)
+  that value is ~0 for EVERY airfoil → true reflexed airfoils (mh60, e184;
+  sharp TE) scored 0 and were missed; only blunt/open-TE airfoils (sc20612)
+  got a non-zero (negative) value and were wrongly labelled reflexed.
+
+  The fix uses two complementary signals derived from the camber-LINE SHAPE:
+
+    A. Sharp-TE reflex (MH / E / EH / S-series flying-wing sections):
+       The camber at x=0.9 is nearly zero or negative relative to max_camber.
+       Criterion: camber_at_x90 / max_camber < 0.06.
+       These airfoils' camber line falls steeply from its peak and almost
+       reaches the chord line (or dips below it) by 90% chord.
+
+    B. Open / upturned-TE reflex (Clark YH and similar):
+       The aft camber line has positive second-order concavity — the camber
+       curves gently upward toward the TE (S-shape visible in the curvature).
+       Criterion: quadratic coefficient of camber-line polynomial fit over
+       [0.5..1.0] > 0.015 AND max_camber_pct > 2.0%.
+
+  camber_at_te is now repurposed to store the camber-line value at x=0.9
+  (instead of the TE endpoint), which is the primary reflex signal and
+  is meaningful even for sharp-TE airfoils.
+
 NOTE: Stored AirfoilGeometryModel.family values change after this re-tune.
-A PO-run re-backfill (--force) is required post-merge (gh-825 item 1).
+A PO-run re-backfill (--force) is required post-merge (gh-834).
 """
 
 from __future__ import annotations
@@ -244,5 +269,96 @@ def test_classify_real_airfoil_family_regression(filename: str, expected: str, d
     result = classify_family(coords)
     assert result == expected, (
         f"{description}: expected {expected!r}, got {result!r} for {filename}"
+    )
+    assert result in VALID_FAMILIES
+
+
+# ---------------------------------------------------------------------------
+# gh-834: Reflexed family — real coordinate tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "filename,description",
+    [
+        # Martin Hepperle flying-wing sections (sharp TE, camber dips to ~0 at 90% chord)
+        ("mh60.dat", "MH 60 (Maughmer flying-wing, sharp TE reflex)"),
+        ("mh61.dat", "MH 61 (Maughmer flying-wing, sharp TE reflex)"),
+        ("mh62.dat", "MH 62 (Maughmer flying-wing, sharp TE reflex)"),
+        ("mh64.dat", "MH 64 (Maughmer flying-wing, sharp TE reflex)"),
+        ("mh78.dat", "MH 78 (Maughmer flying-wing, steep reflex)"),
+        # Eppler flying-wing sections (sharp TE, camber goes below chord in aft)
+        ("e184.dat", "E 184 (Eppler flying-wing reflex)"),
+        ("e186.dat", "E 186 (Eppler flying-wing reflex)"),
+        # Althaus / EH tailless sections (sharp TE, near-zero aft camber)
+        ("eh1070.dat", "EH 1070 (Althaus tailless reflex)"),
+        ("eh2010.dat", "EH 2010 (Althaus tailless reflex)"),
+        # Upturned-TE reflex via positive aft camber concavity (S-shape)
+        ("clarkyh.dat", "Clark YH (flat-bottom + upturned TE for flying wings)"),
+        # Selig flying-wing section
+        ("s5010.dat", "S 5010 (Selig flying-wing reflex)"),
+    ],
+)
+def test_classify_real_reflexed_airfoil(filename: str, description: str) -> None:
+    """gh-834: Real flying-wing / reflexed-TE airfoils must classify as 'reflexed'.
+
+    Previous code (gh-825) used camber_at_te = camber[-1] (the TE endpoint).
+    For sharp-TE airfoils upper == lower at TE → camber[-1] ≈ 0 for every
+    airfoil, so the old threshold (-0.003) was never triggered and all these
+    airfoils were mis-classified as semi_symmetric / flat_bottom / cambered.
+
+    The fix (gh-834): detect reflex from the camber-LINE SHAPE, not the
+    endpoint.  Two signals:
+      A. Aft camber ratio: camber_at_x90 / max_camber < 0.06  (sharp-TE types)
+      B. Positive aft concavity: quadratic coeff of camber over [0.5..1.0] > 0.015
+         AND max_camber_pct > 2%  (upturned-TE types like Clark YH)
+    """
+    from app.services.airfoil_low_re_service import classify_family
+
+    coords = _load_dat(filename)
+    result = classify_family(coords)
+    assert result == "reflexed", (
+        f"{description} ({filename}) must be 'reflexed', got {result!r}. "
+        "gh-834: reflex detection must use camber-line shape, not TE endpoint."
+    )
+    assert result in VALID_FAMILIES
+
+
+@pytest.mark.parametrize(
+    "filename,expected_not_reflexed,description",
+    [
+        # Supercritical — previously WRONGLY labelled reflexed due to blunt TE
+        # giving negative camber_at_te = TE-endpoint value.  With max_camber ≈ 1.1%
+        # the correct family after the reflex fix is semi_symmetric.
+        ("sc20612.dat", "semi_symmetric", "SC 20612 (supercritical — blunt TE, NOT reflexed)"),
+        # Genuine cambered — must not be reflexed
+        ("naca4412.dat", "cambered", "NACA 4412 (cambered — must NOT be reflexed)"),
+        # Symmetric — symmetric check fires first
+        ("naca0006.dat", "symmetric", "NACA 0006 (symmetric — must NOT be reflexed)"),
+        # Flat-bottom — flat-bottom, not reflexed
+        ("clarky.dat", "flat_bottom", "Clark Y (flat-bottom — NOT reflexed)"),
+    ],
+)
+def test_classify_real_not_reflexed(
+    filename: str, expected_not_reflexed: str, description: str
+) -> None:
+    """gh-834: Airfoils that are NOT reflexed must NOT be classified as 'reflexed'.
+
+    sc20612 (supercritical with blunt TE) was previously mis-labelled 'reflexed'
+    because its TE endpoint camber value is -0.0096 (below the old -0.003 threshold).
+    That is purely a TE-thickness asymmetry artifact, not a reflexed camber line.
+
+    After the fix these must remain in their correct non-reflexed families.
+    """
+    from app.services.airfoil_low_re_service import classify_family
+
+    coords = _load_dat(filename)
+    result = classify_family(coords)
+    assert result != "reflexed", (
+        f"{description} ({filename}) must NOT be 'reflexed', got {result!r}. "
+        "gh-834: blunt-TE / supercritical mis-labelling regression."
+    )
+    assert result == expected_not_reflexed, (
+        f"{description}: expected {expected_not_reflexed!r}, got {result!r}"
     )
     assert result in VALID_FAMILIES

--- a/scripts/backfill_airfoil_low_re.py
+++ b/scripts/backfill_airfoil_low_re.py
@@ -239,7 +239,12 @@ def _compute_geometry_stats(coords: np.ndarray) -> tuple[float, float, float]:
 
     max_thickness_pct = float(np.max(thickness)) * 100.0
     max_camber_pct = float(np.max(np.abs(camber))) * 100.0
-    camber_at_te = float(camber[-1])
+    # gh-834: store camber at x=0.9 (not the TE endpoint) as camber_at_te.
+    # For sharp-TE airfoils the TE endpoint has camber ≈ 0 for all airfoils
+    # (both surfaces meet), so that value carries no reflex information.
+    # The camber at x=0.9 is the primary reflex signal (Signal A) used by
+    # classify_family() and remains meaningful even for sharp-TE sections.
+    camber_at_te = float(np.interp(0.9, x_eval, camber))
 
     return max_thickness_pct, max_camber_pct, camber_at_te
 


### PR DESCRIPTION
## Summary

Closes #834. Reflex now detected from camber-line shape, not the TE endpoint. MH60/61/62/64/78, E184/186, EH-series, clarkyh, s5010 → reflexed; supercritical (sc20612) and cambered (naca4412) no longer mislabelled. Changes stored geometry.family → PO re-backfills after merge.

- **Root cause**: `classify_family` used `camber[-1]` (TE endpoint). For any sharp-TE airfoil both surfaces meet at TE so `camber[-1] ≈ 0` for all profiles — the old `-0.003` threshold was never triggered for MH/E/EH series. Only blunt-TE supercritical airfoils (sc20612) produced a negative endpoint value and were wrongly labelled reflexed.
- **Fix**: Two shape-based signals from the mean camber line:
  - **Signal A** (sharp-TE reflex): `camber_at_x90 / max_camber < 0.06` — catches MH60/61/62/64/78, E184/186, EH1070/2010, S5010
  - **Signal B** (upturned-TE reflex): quadratic coefficient of camber-line poly fit over [0.5, 1.0] > 0.015 AND max_camber > 2% — catches Clark YH
- `camber_at_te` column repurposed to store camber at x=0.9 (not TE endpoint); column name unchanged, semantics upgraded to a meaningful aft-reflex measure

## Test plan

- [x] 11 new `test_classify_real_reflexed_airfoil` parametrized cases (mh60, mh61, mh62, mh64, mh78, e184, e186, eh1070, eh2010, clarkyh, s5010) assert `'reflexed'`
- [x] 4 new `test_classify_real_not_reflexed` cases (sc20612, naca4412, naca0006, clarky) assert not reflexed + correct family
- [x] All 14 pre-existing `test_airfoil_family_classifier` cases still pass (Clark Y/X/V/K flat-bottom, NACA 4412 cambered, NACA 0006 symmetric, synthetic shape suite)
- [x] 4635 fast tests pass (`poetry run pytest -m "not slow" -q`)
- [x] `ruff check && ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)