### PR TITLE
feat(gh-838,gh-839): operating-point Re fix + speed buttons + diagram markers

### DIFF
--- a/app/schemas/airfoil.py
+++ b/app/schemas/airfoil.py
@@ -133,6 +133,14 @@ class SuitabilityQuery(BaseModel):
       - 'calculated' : mass and cruise speed were both auto-computed
       - 'estimated'  : at least one input was a manual estimate
       - 'mixed'      : some inputs calculated, some estimated
+
+    Speed fields (gh-839 additive):
+      v_cruise_mps   — cruise speed from aeroplane context (null when absent)
+      v_md_mps       — best-glide speed from aeroplane context (null when absent)
+      v_min_sink_mps — min-sink speed from aeroplane context (null when absent)
+
+    These are the per-lens speeds used for #838 Re computation.
+    They are null when no aeroplane context is available.
     """
 
     chord_m: float
@@ -145,6 +153,10 @@ class SuitabilityQuery(BaseModel):
     target_cl_min_sink: Optional[float] = None
     target_cl_provenance: TargetClProvenance = "estimated"
     active_lens: ActiveLens
+    # gh-839: design-speed values from aeroplane context (additive; null when absent)
+    v_cruise_mps: Optional[float] = None
+    v_md_mps: Optional[float] = None
+    v_min_sink_mps: Optional[float] = None
 
 
 class SuitabilityCaveat(BaseModel):

--- a/app/services/suitability_service.py
+++ b/app/services/suitability_service.py
@@ -231,7 +231,7 @@ def search_suitability(
     mission_weights = settings.low_re_mission_weights
     low_conf_flag = settings.low_re_low_confidence_flag
 
-    # --- Reynolds number at root chord ---
+    # --- Reynolds number at root chord (query / slider Re) ---
     re_root = _compute_re(chord_m, speed_ms)
     re_clamped_root, re_clamped = _clamp_re_to_grid(re_root, re_grid)
 
@@ -338,6 +338,38 @@ def search_suitability(
     # --- Provenance ---
     provenance = _resolve_provenance(aeroplane, db, ctx)
 
+    # ── gh-838: per-lens Re ───────────────────────────────────────────────────
+    # Each target-CL lens is scored at its OWN Reynolds number, derived from
+    # its own design speed and the same root chord.  This makes the score
+    # independent of the slider Re (speed_ms).
+    #
+    # Rule:
+    #   - When a design speed is available from the aeroplane context (v_*_mps),
+    #     Re_lens = v_*_mps * chord_m / nu   (nu = 1.46e-5 m²/s)
+    #     clamped to the grid just like re_root.
+    #   - When no aeroplane context is available (or explicit target_cl_* params
+    #     with no design speed), fall back to the slider Re (re_clamped_root).
+    #     This preserves existing behaviour for explicit-param callers.
+    _NU = 1.46e-5  # kinematic viscosity m²/s at 15°C
+
+    def _per_lens_re(v_mps: Optional[float]) -> float:
+        """Return clamped Re for this lens speed, or the slider Re as fallback."""
+        if v_mps is None:
+            return re_clamped_root
+        raw = v_mps * chord_m / _NU
+        clamped, _ = _clamp_re_to_grid(raw, re_grid)
+        return clamped
+
+    # Resolved design speeds (from context — used for both Re computation and query echo)
+    _v_cruise: Optional[float] = ctx.get("v_cruise_mps")
+    _v_md: Optional[float] = ctx.get("v_md_mps")
+    _v_min_sink: Optional[float] = ctx.get("v_min_sink_mps")
+
+    # Per-lens clamped Re values (gh-838)
+    re_cruise = _per_lens_re(_v_cruise if aeroplane is not None else None)
+    re_best_glide = _per_lens_re(_v_md if aeroplane is not None else None)
+    re_min_sink = _per_lens_re(_v_min_sink if aeroplane is not None else None)
+
     # --- Query DB: all airfoil geometries + polars ---
     geo_rows = db.query(AirfoilGeometryModel).all()
     # Index geometry by airfoil_name
@@ -349,8 +381,27 @@ def search_suitability(
     for p in polar_rows:
         polars_by_name.setdefault(p.airfoil_name, []).append(p)
 
-    # --- Per-Re cd0 reference (computed once for the request) ---
+    # --- Per-Re cd0 references (gh-838) ---
+    # re_agnostic and mission lenses use the slider Re (re_clamped_root).
+    # Each target-CL lens uses its own per-lens Re.
+    # We need a cd0 fleet reference at each distinct Re to normalise efficiency.
     re_cd0_ref = compute_re_cd0_reference(polars_by_name, re_clamped_root)
+    # Only compute per-lens references when they differ from the slider Re
+    re_cd0_ref_cruise = (
+        compute_re_cd0_reference(polars_by_name, re_cruise)
+        if re_cruise != re_clamped_root
+        else re_cd0_ref
+    )
+    re_cd0_ref_best_glide = (
+        compute_re_cd0_reference(polars_by_name, re_best_glide)
+        if re_best_glide != re_clamped_root
+        else re_cd0_ref
+    )
+    re_cd0_ref_min_sink = (
+        compute_re_cd0_reference(polars_by_name, re_min_sink)
+        if re_min_sink != re_clamped_root
+        else re_cd0_ref
+    )
 
     # --- Score each airfoil ---
     items: list[SuitabilityItem] = []
@@ -358,13 +409,32 @@ def search_suitability(
 
     for name, geo in geo_by_name.items():
         rows = polars_by_name.get(name, [])
+        # Slider-Re polar (for re_agnostic, mission, stall_gentleness, cl_max_margin)
         polar = interpolate_polar_at_re(rows, re_clamped_root, re_grid)
+
+        # gh-838: per-lens polars for target-CL scoring
+        # When the per-lens Re equals the slider Re, reuse the already-interpolated polar.
+        polar_cruise = (
+            interpolate_polar_at_re(rows, re_cruise, re_grid)
+            if re_cruise != re_clamped_root
+            else polar
+        )
+        polar_best_glide = (
+            interpolate_polar_at_re(rows, re_best_glide, re_grid)
+            if re_best_glide != re_clamped_root
+            else polar
+        )
+        polar_min_sink = (
+            interpolate_polar_at_re(rows, re_min_sink, re_grid)
+            if re_min_sink != re_clamped_root
+            else polar
+        )
 
         re_agn = score_re_agnostic(polar)
         if re_agn is None:
             re_agn = 0.0
 
-        # Mission lens
+        # Mission lens (uses slider-Re polar)
         mission_score: Optional[float] = None
         if effective_mission_type is not None:
             mission_score = score_mission(
@@ -377,30 +447,31 @@ def search_suitability(
             )
 
         # Target CL lenses — cruise can auto-rank; glide points are display-only
+        # gh-838: each lens uses its own per-lens polar + cd0 reference
         cl_cruise_score: Optional[float] = None
-        if effective_target_cl_cruise is not None and polar is not None:
+        if effective_target_cl_cruise is not None and polar_cruise is not None:
             cl_cruise_score = score_target_cl(
-                polar,
+                polar_cruise,
                 effective_target_cl_cruise,
-                re_cd0_reference=re_cd0_ref,
+                re_cd0_reference=re_cd0_ref_cruise,
                 settings=settings,
             )
 
         cl_best_glide_score: Optional[float] = None
-        if effective_target_cl_best_glide is not None and polar is not None:
+        if effective_target_cl_best_glide is not None and polar_best_glide is not None:
             cl_best_glide_score = score_target_cl(
-                polar,
+                polar_best_glide,
                 effective_target_cl_best_glide,
-                re_cd0_reference=re_cd0_ref,
+                re_cd0_reference=re_cd0_ref_best_glide,
                 settings=settings,
             )
 
         cl_min_sink_score: Optional[float] = None
-        if effective_target_cl_min_sink is not None and polar is not None:
+        if effective_target_cl_min_sink is not None and polar_min_sink is not None:
             cl_min_sink_score = score_target_cl(
-                polar,
+                polar_min_sink,
                 effective_target_cl_min_sink,
-                re_cd0_reference=re_cd0_ref,
+                re_cd0_reference=re_cd0_ref_min_sink,
                 settings=settings,
             )
 
@@ -543,6 +614,10 @@ def search_suitability(
         target_cl_min_sink=effective_target_cl_min_sink,
         target_cl_provenance=provenance,
         active_lens=active_lens,
+        # gh-839: expose design speeds from context (null when no aeroplane)
+        v_cruise_mps=_v_cruise if aeroplane is not None else None,
+        v_md_mps=_v_md if aeroplane is not None else None,
+        v_min_sink_mps=_v_min_sink if aeroplane is not None else None,
     )
     caveat = SuitabilityCaveat(
         relative_ranking_only=True,

--- a/app/tests/test_gh838_839_service.py
+++ b/app/tests/test_gh838_839_service.py
@@ -1,0 +1,362 @@
+"""TDD tests for gh-838 (target-CL scored at own Re) and gh-839-BE (speed fields in query).
+
+RED first, then GREEN.
+
+#838: The three target-CL lenses (cruise/best_glide/min_sink) must each be
+      scored at their OWN Reynolds number (derived from their own speed + chord),
+      not the shared query Re from the slider.
+
+      Key test: when speed_ms changes but the aeroplane context stays the same,
+      the re_agnostic score DOES change (it uses query Re), while the three
+      target_cl scores stay IDENTICAL (they use the per-lens Re derived from
+      v_cruise_mps / v_md_mps / v_min_sink_mps in the context, which are fixed).
+
+#839-BE: query{} block must expose v_cruise_mps, v_md_mps, v_min_sink_mps
+         from the aeroplane context (additive; null when absent).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+
+# ---------------------------------------------------------------------------
+# Shared in-memory DB fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def in_memory_db():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    from app.db.base import Base
+    import app.models  # noqa: F401
+
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, class_=Session)
+    yield SessionLocal
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture()
+def seeded_db_838(in_memory_db):
+    """DB with one airfoil (two Re polars) + aeroplane with v_cruise/v_md/v_min_sink context."""
+    from app.models.airfoil import AirfoilModel
+    from app.models.airfoil_low_re import AirfoilGeometryModel, AirfoilLowRePolarModel
+    from app.models.aeroplanemodel import AeroplaneModel
+
+    ap_uuid = uuid.uuid4()
+
+    with in_memory_db() as session:
+        session.add(AirfoilModel(name="e423", coordinates=[[0, 0], [0.5, 0.08], [1, 0]]))
+        session.flush()
+        session.add(
+            AirfoilGeometryModel(
+                airfoil_name="e423",
+                max_thickness_pct=12.0,
+                max_camber_pct=5.0,
+                camber_at_te=0.001,
+                family="cambered",
+                computed_at=datetime.now(timezone.utc),
+            )
+        )
+        # Two Re grid points so interpolation works
+        for re_val, ld, cl_max_v, cd0, k, cl0, bucket, stall_g in [
+            (100_000, 45.0, 1.3, 0.012, 0.040, 0.25, 0.60, -0.03),
+            (250_000, 60.0, 1.4, 0.009, 0.033, 0.28, 0.72, -0.02),
+        ]:
+            session.add(
+                AirfoilLowRePolarModel(
+                    airfoil_name="e423",
+                    reynolds=float(re_val),
+                    ld_max=ld,
+                    cl_max=cl_max_v,
+                    alpha_attached_lo=-4.0,
+                    alpha_attached_hi=14.0,
+                    drag_bucket_width=bucket,
+                    cd_min=cd0,
+                    stall_gentleness=stall_g,
+                    cd0=cd0,
+                    k=k,
+                    cl0=cl0,
+                    cl_valid_lo=0.0,
+                    cl_valid_hi=cl_max_v,
+                    min_analysis_confidence=0.95,
+                    neuralfoil_model_size="xxxlarge",
+                    n_crit=9.0,
+                    computed_at=datetime.now(timezone.utc),
+                )
+            )
+
+        # Aeroplane: v_cruise=18, v_md=13, v_min_sink=10 m/s
+        ap = AeroplaneModel(
+            name="glider838",
+            uuid=ap_uuid,
+            total_mass_kg=3.0,
+            assumption_computation_context={
+                "mass_kg": 3.0,
+                "s_ref_m2": 0.50,
+                "v_cruise_mps": 18.0,
+                "v_md_mps": 13.0,
+                "v_min_sink_mps": 10.0,
+                "v_cruise_auto": True,
+            },
+        )
+        session.add(ap)
+        session.commit()
+
+    return in_memory_db, ap_uuid
+
+
+# ---------------------------------------------------------------------------
+# gh-838: target-CL scores are slider-independent (use own Re)
+# ---------------------------------------------------------------------------
+
+
+class TestTargetClOwnRe:
+    """gh-838 — each target-CL lens uses its own speed-derived Re."""
+
+    def test_target_cl_scores_same_at_different_slider_speeds(self, seeded_db_838):
+        """target_cl_* scores must be IDENTICAL for two different speed_ms values
+        (same aeroplane + chord), because they use the fixed context speeds.
+        re_agnostic must DIFFER (it uses the slider Re).
+        """
+        from app.services.suitability_service import search_suitability
+
+        SessionLocal, ap_uuid = seeded_db_838
+        chord = 0.18  # metres
+
+        with SessionLocal() as s1:
+            r1 = search_suitability(db=s1, chord_m=chord, speed_ms=12.0, aeroplane_id=str(ap_uuid))
+        with SessionLocal() as s2:
+            r2 = search_suitability(db=s2, chord_m=chord, speed_ms=20.0, aeroplane_id=str(ap_uuid))
+
+        # Must have results
+        assert len(r1.results) > 0
+        assert len(r2.results) > 0
+
+        item1 = r1.results[0]
+        item2 = r2.results[0]
+
+        # re_agnostic MUST differ (uses query Re = slider × chord)
+        assert item1.re_agnostic != pytest.approx(item2.re_agnostic, abs=0.001), (
+            "re_agnostic should differ across different slider speeds"
+        )
+
+        # target_cl_cruise scores must be the SAME (own Re = v_cruise * chord / nu)
+        if item1.target_cl_cruise is not None and item2.target_cl_cruise is not None:
+            assert item1.target_cl_cruise == pytest.approx(item2.target_cl_cruise, abs=1e-6), (
+                f"target_cl_cruise scores should be identical: "
+                f"{item1.target_cl_cruise} vs {item2.target_cl_cruise}"
+            )
+
+        # target_cl_best_glide scores must be the SAME
+        if item1.target_cl_best_glide is not None and item2.target_cl_best_glide is not None:
+            assert item1.target_cl_best_glide == pytest.approx(
+                item2.target_cl_best_glide, abs=1e-6
+            ), (
+                f"target_cl_best_glide scores should be identical: "
+                f"{item1.target_cl_best_glide} vs {item2.target_cl_best_glide}"
+            )
+
+        # target_cl_min_sink scores must be the SAME
+        if item1.target_cl_min_sink is not None and item2.target_cl_min_sink is not None:
+            assert item1.target_cl_min_sink == pytest.approx(item2.target_cl_min_sink, abs=1e-6), (
+                f"target_cl_min_sink scores should be identical: "
+                f"{item1.target_cl_min_sink} vs {item2.target_cl_min_sink}"
+            )
+
+    def test_target_cl_scores_present(self, seeded_db_838):
+        """All three target-CL scores must be computed (not None) when context is complete."""
+        from app.services.suitability_service import search_suitability
+
+        SessionLocal, ap_uuid = seeded_db_838
+        with SessionLocal() as session:
+            resp = search_suitability(
+                db=session, chord_m=0.18, speed_ms=15.0, aeroplane_id=str(ap_uuid)
+            )
+        item = resp.results[0]
+        assert item.target_cl_cruise is not None
+        assert item.target_cl_best_glide is not None
+        assert item.target_cl_min_sink is not None
+
+    def test_re_agnostic_lens_uses_query_re(self, seeded_db_838):
+        """Without aeroplane context, target_cl scores are None; re_agnostic differs
+        between slider speeds."""
+        from app.services.suitability_service import search_suitability
+
+        SessionLocal, _ = seeded_db_838
+        with SessionLocal() as s1:
+            r1 = search_suitability(db=s1, chord_m=0.18, speed_ms=10.0)
+        with SessionLocal() as s2:
+            r2 = search_suitability(db=s2, chord_m=0.18, speed_ms=20.0)
+
+        item1 = r1.results[0]
+        item2 = r2.results[0]
+
+        # No context → all target_cl_* are None
+        assert item1.target_cl_cruise is None
+        assert item1.target_cl_best_glide is None
+        assert item1.target_cl_min_sink is None
+
+        # re_agnostic differs across speeds (different Re → different polar interpolation)
+        assert item1.re_agnostic != pytest.approx(item2.re_agnostic, abs=0.001)
+
+    def test_fallback_to_query_re_when_no_aeroplane(self, seeded_db_838):
+        """Explicit target_cl_* params (no aeroplane) still score at query Re (slider).
+        Two calls with different speed_ms and the SAME explicit target_cl_cruise
+        must produce different cruise scores — they use the slider Re for the polar.
+        """
+        from app.services.suitability_service import search_suitability
+
+        SessionLocal, _ = seeded_db_838
+        with SessionLocal() as s1:
+            r1 = search_suitability(db=s1, chord_m=0.18, speed_ms=10.0, target_cl_cruise=0.5)
+        with SessionLocal() as s2:
+            r2 = search_suitability(db=s2, chord_m=0.18, speed_ms=20.0, target_cl_cruise=0.5)
+
+        # Both have target_cl_cruise scored
+        assert r1.results[0].target_cl_cruise is not None
+        assert r2.results[0].target_cl_cruise is not None
+
+        # Scores differ because they use the slider Re (polar differs at Re=10*0.18/nu vs 20*0.18/nu)
+        assert r1.results[0].target_cl_cruise != pytest.approx(
+            r2.results[0].target_cl_cruise, abs=0.001
+        ), "Explicit target_cl with no aeroplane should use slider Re → scores differ"
+
+
+# ---------------------------------------------------------------------------
+# gh-839-BE: speed fields in query{}
+# ---------------------------------------------------------------------------
+
+
+class TestSpeedFieldsInQuery:
+    """gh-839-BE: v_cruise_mps, v_md_mps, v_min_sink_mps exposed in query{}."""
+
+    def test_schema_has_speed_fields(self):
+        """SuitabilityQuery schema must accept the three speed fields."""
+        from app.schemas.airfoil import SuitabilityQuery
+
+        q = SuitabilityQuery(
+            chord_m=0.15,
+            speed_ms=15.0,
+            reynolds=150_000.0,
+            re_clamped=False,
+            active_lens="re_agnostic",
+            target_cl_provenance="estimated",
+            v_cruise_mps=18.0,
+            v_md_mps=13.0,
+            v_min_sink_mps=10.0,
+        )
+        assert q.v_cruise_mps == pytest.approx(18.0)
+        assert q.v_md_mps == pytest.approx(13.0)
+        assert q.v_min_sink_mps == pytest.approx(10.0)
+
+    def test_schema_speed_fields_default_to_none(self):
+        """Speed fields must be Optional (null when absent)."""
+        from app.schemas.airfoil import SuitabilityQuery
+
+        q = SuitabilityQuery(
+            chord_m=0.15,
+            speed_ms=15.0,
+            reynolds=150_000.0,
+            re_clamped=False,
+            active_lens="re_agnostic",
+            target_cl_provenance="estimated",
+        )
+        assert q.v_cruise_mps is None
+        assert q.v_md_mps is None
+        assert q.v_min_sink_mps is None
+
+    def test_service_populates_speed_fields_from_context(self, seeded_db_838):
+        """search_suitability must populate v_cruise_mps/v_md_mps/v_min_sink_mps
+        from the aeroplane context."""
+        from app.services.suitability_service import search_suitability
+
+        SessionLocal, ap_uuid = seeded_db_838
+        with SessionLocal() as session:
+            resp = search_suitability(
+                db=session, chord_m=0.18, speed_ms=15.0, aeroplane_id=str(ap_uuid)
+            )
+        assert resp.query.v_cruise_mps == pytest.approx(18.0)
+        assert resp.query.v_md_mps == pytest.approx(13.0)
+        assert resp.query.v_min_sink_mps == pytest.approx(10.0)
+
+    def test_service_speed_fields_null_without_aeroplane(self, seeded_db_838):
+        """Without aeroplane context, speed fields must be null."""
+        from app.services.suitability_service import search_suitability
+
+        SessionLocal, _ = seeded_db_838
+        with SessionLocal() as session:
+            resp = search_suitability(db=session, chord_m=0.18, speed_ms=15.0)
+        assert resp.query.v_cruise_mps is None
+        assert resp.query.v_md_mps is None
+        assert resp.query.v_min_sink_mps is None
+
+    def test_service_speed_fields_partial_when_missing_context_key(self, in_memory_db):
+        """If v_md_mps is absent from context, v_md_mps in query must be None."""
+        from app.models.airfoil import AirfoilModel
+        from app.models.airfoil_low_re import AirfoilGeometryModel
+        from app.models.aeroplanemodel import AeroplaneModel
+        from app.services.suitability_service import search_suitability
+
+        ap_uuid = uuid.uuid4()
+        with in_memory_db() as session:
+            session.add(AirfoilModel(name="af_partial", coordinates=[[0, 0], [1, 0]]))
+            session.flush()
+            session.add(
+                AirfoilGeometryModel(
+                    airfoil_name="af_partial",
+                    max_thickness_pct=10.0,
+                    max_camber_pct=2.0,
+                    camber_at_te=0.0,
+                    family="cambered",
+                    computed_at=datetime.now(timezone.utc),
+                )
+            )
+            ap = AeroplaneModel(
+                name="partial_ctx",
+                uuid=ap_uuid,
+                total_mass_kg=2.0,
+                assumption_computation_context={
+                    "mass_kg": 2.0,
+                    "s_ref_m2": 0.35,
+                    "v_cruise_mps": 16.0,
+                    # v_md_mps and v_min_sink_mps absent
+                },
+            )
+            session.add(ap)
+            session.commit()
+
+        with in_memory_db() as session:
+            resp = search_suitability(
+                db=session, chord_m=0.15, speed_ms=15.0, aeroplane_id=str(ap_uuid)
+            )
+        assert resp.query.v_cruise_mps == pytest.approx(16.0)
+        assert resp.query.v_md_mps is None
+        assert resp.query.v_min_sink_mps is None
+
+    def test_speed_fields_in_json_serialization(self, seeded_db_838):
+        """Speed fields must be present in JSON output of SuitabilityResponse."""
+        from app.services.suitability_service import search_suitability
+
+        SessionLocal, ap_uuid = seeded_db_838
+        with SessionLocal() as session:
+            resp = search_suitability(
+                db=session, chord_m=0.18, speed_ms=15.0, aeroplane_id=str(ap_uuid)
+            )
+        data = resp.model_dump()
+        q = data["query"]
+        assert "v_cruise_mps" in q
+        assert "v_md_mps" in q
+        assert "v_min_sink_mps" in q
+        assert q["v_cruise_mps"] == pytest.approx(18.0)

--- a/frontend/__tests__/gh839_speed_buttons.test.tsx
+++ b/frontend/__tests__/gh839_speed_buttons.test.tsx
@@ -1,0 +1,308 @@
+/**
+ * TDD tests for gh-839-FE:
+ * 1. Speed quick-set buttons (Cruise / Best-Glide / Min-Sink) in AirfoilPreviewConfigPanel
+ * 2. Operating-point markers on alpha-diagrams in AirfoilPreviewViewerPanel
+ *
+ * Tests are written RED first; implementation follows.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+// ── Mocks ─────────────────────────────────────────────────────────
+
+vi.mock("lucide-react", () => ({
+  Info: (p: Record<string, unknown>) => <svg data-testid="info" {...p} />,
+  ArrowLeft: (p: Record<string, unknown>) => <svg data-testid="arrow-left" {...p} />,
+  Save: (p: Record<string, unknown>) => <svg data-testid="save" {...p} />,
+  Loader2: (p: Record<string, unknown>) => <svg data-testid="loader2" {...p} />,
+  ChevronLeft: (p: Record<string, unknown>) => <svg data-testid="chevron-left" {...p} />,
+  ChevronRight: (p: Record<string, unknown>) => <svg data-testid="chevron-right" {...p} />,
+  ChevronDown: (p: Record<string, unknown>) => <svg data-testid="chevron-down" {...p} />,
+  ChevronUp: (p: Record<string, unknown>) => <svg data-testid="chevron-up" {...p} />,
+  Search: (p: Record<string, unknown>) => <svg data-testid="search" {...p} />,
+  Check: (p: Record<string, unknown>) => <svg data-testid="check" {...p} />,
+  Undo2: (p: Record<string, unknown>) => <svg data-testid="undo2" {...p} />,
+  AlertTriangle: (p: Record<string, unknown>) => <svg data-testid="alert-triangle" {...p} />,
+  Maximize2: (p: Record<string, unknown>) => <svg data-testid="maximize" {...p} />,
+  Minimize2: (p: Record<string, unknown>) => <svg data-testid="minimize" {...p} />,
+}));
+
+vi.mock("swr", () => ({
+  default: vi.fn(() => ({
+    data: {
+      count: 1,
+      airfoils: [{ airfoil_name: "e423", file_name: "e423.dat" }],
+    },
+    error: null,
+    isLoading: false,
+  })),
+}));
+
+import { AirfoilPreviewConfigPanel } from "../components/workbench/AirfoilPreviewConfigPanel";
+import { AirfoilPreviewViewerPanel } from "../components/workbench/AirfoilPreviewViewerPanel";
+import type { AirfoilAnalysisResult } from "../hooks/useAirfoilAnalysis";
+import type { AirfoilGeometry } from "../hooks/useAirfoilGeometry";
+
+// ── Shared fixtures ────────────────────────────────────────────────
+
+const BASE_CONFIG_PROPS = {
+  rootAirfoil: "e423",
+  tipAirfoil: "e423",
+  onRootAirfoilChange: vi.fn(),
+  onTipAirfoilChange: vi.fn(),
+  isRunning: false,
+  segmentIndex: 0,
+  segmentCount: 1,
+  onSegmentChange: vi.fn(),
+  segmentProps: {},
+  velocity: 14,
+  onVelocityChange: vi.fn(),
+  rootRe: 200000,
+  tipRe: 200000,
+  onRootReChange: vi.fn(),
+  onTipReChange: vi.fn(),
+  rootChordMm: 200,
+  tipChordMm: 200,
+  isDirty: false,
+  isSaving: false,
+  onSave: vi.fn(),
+  onRevert: vi.fn(),
+  onBack: vi.fn(),
+};
+
+const mockAnalysis: AirfoilAnalysisResult = {
+  airfoilName: "e423",
+  alphaDeg: [-5, 0, 5, 10, 15],
+  cl: [-0.2, 0.1, 0.5, 0.9, 1.2],
+  cd: [0.015, 0.01, 0.012, 0.02, 0.04],
+  cm: [-0.02, -0.01, -0.01, -0.02, -0.03],
+  clOverCd: [-13.3, 10, 41.7, 45, 30],
+  clMax: 1.2,
+  alphaAtClMax: 15,
+  ldMax: 45,
+  alphaAtLdMax: 10,
+};
+
+const mockGeometry: AirfoilGeometry = {
+  upper: [[0, 0], [0.5, 0.08], [1, 0]],
+  lower: [[0, 0], [0.5, -0.04], [1, 0]],
+  maxThicknessPct: 12,
+  maxCamberPct: 4,
+  maxThicknessX: 0.3,
+};
+
+const BASE_VIEWER_PROPS = {
+  rootAirfoilName: "e423",
+  tipAirfoilName: null,
+  rootGeometry: mockGeometry,
+  tipGeometry: null,
+  geometryLoading: false,
+  rootAnalysisResult: mockAnalysis,
+  tipAnalysisResult: null,
+  rootRe: 200000,
+  tipRe: null,
+  ma: 0,
+  onMaChange: vi.fn(),
+};
+
+// ── Tests: Speed Quick-Set Buttons ────────────────────────────────
+
+describe("gh-839-FE: Speed quick-set buttons in AirfoilPreviewConfigPanel", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("renders Cruise button when v_cruise_mps is provided", () => {
+    render(
+      <AirfoilPreviewConfigPanel
+        {...BASE_CONFIG_PROPS}
+        suitabilitySpeedContext={{ v_cruise_mps: 18, v_md_mps: null, v_min_sink_mps: null }}
+      />,
+    );
+    expect(screen.getByTestId("speed-btn-cruise")).toBeDefined();
+  });
+
+  it("renders Best-Glide button when v_md_mps is provided", () => {
+    render(
+      <AirfoilPreviewConfigPanel
+        {...BASE_CONFIG_PROPS}
+        suitabilitySpeedContext={{ v_cruise_mps: null, v_md_mps: 13, v_min_sink_mps: null }}
+      />,
+    );
+    expect(screen.getByTestId("speed-btn-best-glide")).toBeDefined();
+  });
+
+  it("renders Min-Sink button when v_min_sink_mps is provided", () => {
+    render(
+      <AirfoilPreviewConfigPanel
+        {...BASE_CONFIG_PROPS}
+        suitabilitySpeedContext={{ v_cruise_mps: null, v_md_mps: null, v_min_sink_mps: 10 }}
+      />,
+    );
+    expect(screen.getByTestId("speed-btn-min-sink")).toBeDefined();
+  });
+
+  it("does NOT render speed buttons when suitabilitySpeedContext is not provided", () => {
+    render(<AirfoilPreviewConfigPanel {...BASE_CONFIG_PROPS} />);
+    expect(screen.queryByTestId("speed-btn-cruise")).toBeNull();
+    expect(screen.queryByTestId("speed-btn-best-glide")).toBeNull();
+    expect(screen.queryByTestId("speed-btn-min-sink")).toBeNull();
+  });
+
+  it("does NOT render Cruise button when v_cruise_mps is null", () => {
+    render(
+      <AirfoilPreviewConfigPanel
+        {...BASE_CONFIG_PROPS}
+        suitabilitySpeedContext={{ v_cruise_mps: null, v_md_mps: 13, v_min_sink_mps: 10 }}
+      />,
+    );
+    expect(screen.queryByTestId("speed-btn-cruise")).toBeNull();
+    expect(screen.getByTestId("speed-btn-best-glide")).toBeDefined();
+    expect(screen.getByTestId("speed-btn-min-sink")).toBeDefined();
+  });
+
+  it("clicking Cruise button calls onVelocityChange with v_cruise_mps", async () => {
+    const onVelocityChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AirfoilPreviewConfigPanel
+        {...BASE_CONFIG_PROPS}
+        onVelocityChange={onVelocityChange}
+        suitabilitySpeedContext={{ v_cruise_mps: 18, v_md_mps: 13, v_min_sink_mps: 10 }}
+      />,
+    );
+    await user.click(screen.getByTestId("speed-btn-cruise"));
+    expect(onVelocityChange).toHaveBeenCalledWith(18);
+  });
+
+  it("clicking Best-Glide button calls onVelocityChange with v_md_mps", async () => {
+    const onVelocityChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AirfoilPreviewConfigPanel
+        {...BASE_CONFIG_PROPS}
+        onVelocityChange={onVelocityChange}
+        suitabilitySpeedContext={{ v_cruise_mps: 18, v_md_mps: 13, v_min_sink_mps: 10 }}
+      />,
+    );
+    await user.click(screen.getByTestId("speed-btn-best-glide"));
+    expect(onVelocityChange).toHaveBeenCalledWith(13);
+  });
+
+  it("clicking Min-Sink button calls onVelocityChange with v_min_sink_mps", async () => {
+    const onVelocityChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AirfoilPreviewConfigPanel
+        {...BASE_CONFIG_PROPS}
+        onVelocityChange={onVelocityChange}
+        suitabilitySpeedContext={{ v_cruise_mps: 18, v_md_mps: 13, v_min_sink_mps: 10 }}
+      />,
+    );
+    await user.click(screen.getByTestId("speed-btn-min-sink"));
+    expect(onVelocityChange).toHaveBeenCalledWith(10);
+  });
+
+  it("renders all three buttons when all speeds are provided", () => {
+    render(
+      <AirfoilPreviewConfigPanel
+        {...BASE_CONFIG_PROPS}
+        suitabilitySpeedContext={{ v_cruise_mps: 18, v_md_mps: 13, v_min_sink_mps: 10 }}
+      />,
+    );
+    expect(screen.getByTestId("speed-btn-cruise")).toBeDefined();
+    expect(screen.getByTestId("speed-btn-best-glide")).toBeDefined();
+    expect(screen.getByTestId("speed-btn-min-sink")).toBeDefined();
+  });
+});
+
+// ── Tests: Diagram markers ─────────────────────────────────────────
+
+describe("gh-839-FE: Key-point markers in AirfoilPreviewViewerPanel", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows CL_max marker when analysis has clMax and alphaAtClMax", () => {
+    render(
+      <AirfoilPreviewViewerPanel
+        {...BASE_VIEWER_PROPS}
+        rootAnalysisResult={mockAnalysis}
+      />,
+    );
+    // CL_max and L/D_max markers should be rendered in the SVG diagrams
+    const clMaxMarkers = screen.getAllByTestId("clmax-marker");
+    expect(clMaxMarkers.length).toBeGreaterThan(0);
+  });
+
+  it("shows L/D_max marker when analysis has ldMax and alphaAtLdMax", () => {
+    render(
+      <AirfoilPreviewViewerPanel
+        {...BASE_VIEWER_PROPS}
+        rootAnalysisResult={mockAnalysis}
+      />,
+    );
+    const ldMaxMarkers = screen.getAllByTestId("ldmax-marker");
+    expect(ldMaxMarkers.length).toBeGreaterThan(0);
+  });
+
+  it("shows operating-point markers for cruise/best-glide/min-sink when provided", () => {
+    render(
+      <AirfoilPreviewViewerPanel
+        {...BASE_VIEWER_PROPS}
+        rootAnalysisResult={mockAnalysis}
+        operatingAlphaDeg={5}
+        operatingPoints={{
+          cruise: { alpha: 5, label: "Cruise" },
+          bestGlide: { alpha: 10, label: "Best-Glide" },
+          minSink: { alpha: 12, label: "Min-Sink" },
+        }}
+      />,
+    );
+    // All three operating point markers should be present
+    expect(screen.getAllByTestId("op-marker-cruise").length).toBeGreaterThan(0);
+    expect(screen.getAllByTestId("op-marker-best-glide").length).toBeGreaterThan(0);
+    expect(screen.getAllByTestId("op-marker-min-sink").length).toBeGreaterThan(0);
+  });
+
+  it("does NOT render operating-point markers when operatingPoints is not provided", () => {
+    render(
+      <AirfoilPreviewViewerPanel
+        {...BASE_VIEWER_PROPS}
+        rootAnalysisResult={mockAnalysis}
+      />,
+    );
+    expect(screen.queryAllByTestId("op-marker-cruise")).toHaveLength(0);
+    expect(screen.queryAllByTestId("op-marker-best-glide")).toHaveLength(0);
+    expect(screen.queryAllByTestId("op-marker-min-sink")).toHaveLength(0);
+  });
+
+  it("does NOT render clmax-marker when analysis clMax is null", () => {
+    const noClMaxAnalysis: AirfoilAnalysisResult = {
+      ...mockAnalysis,
+      clMax: null,
+      alphaAtClMax: null,
+    };
+    render(
+      <AirfoilPreviewViewerPanel
+        {...BASE_VIEWER_PROPS}
+        rootAnalysisResult={noClMaxAnalysis}
+      />,
+    );
+    expect(screen.queryAllByTestId("clmax-marker")).toHaveLength(0);
+  });
+
+  it("shows a legend with labels when multiple markers are rendered", () => {
+    render(
+      <AirfoilPreviewViewerPanel
+        {...BASE_VIEWER_PROPS}
+        rootAnalysisResult={mockAnalysis}
+        operatingPoints={{
+          cruise: { alpha: 5, label: "Cruise" },
+          bestGlide: { alpha: 10, label: "Best-Glide" },
+          minSink: { alpha: 12, label: "Min-Sink" },
+        }}
+      />,
+    );
+    // Legend labels should be rendered somewhere in the charts
+    expect(screen.getByTestId("chart-markers-legend")).toBeDefined();
+  });
+});

--- a/frontend/app/workbench/airfoil-preview/page.tsx
+++ b/frontend/app/workbench/airfoil-preview/page.tsx
@@ -8,6 +8,7 @@ import { useAirfoilGeometry } from "@/hooks/useAirfoilGeometry";
 import { useAirfoilAnalysis } from "@/hooks/useAirfoilAnalysis";
 import { useAirfoilSuitability } from "@/hooks/useAirfoilSuitability";
 import { AirfoilPreviewViewerPanel } from "@/components/workbench/AirfoilPreviewViewerPanel";
+import type { OperatingPoints } from "@/components/workbench/AirfoilPreviewViewerPanel";
 import { AirfoilPreviewConfigPanel } from "@/components/workbench/AirfoilPreviewConfigPanel";
 
 export function airfoilShortName(raw: string): string {
@@ -174,6 +175,49 @@ export default function AirfoilPreviewPage() {
     return rootAnalysis.result.alphaDeg[closestIdx];
   }, [rootAnalysis.result, rootSuitabilityItem]);
 
+  // gh-839: Compute operating points (alpha positions) for the three design-speed lenses.
+  // Each target CL is mapped to an alpha via the analysis CL-alpha curve.
+  function clToAlpha(targetCl: number | null | undefined): number | undefined {
+    if (targetCl == null || !rootAnalysis.result) return undefined;
+    const cls = rootAnalysis.result.cl;
+    const alphas = rootAnalysis.result.alphaDeg;
+    if (cls.length === 0) return undefined;
+    let closestIdx = 0;
+    let closestDist = Math.abs((cls[0] ?? 0) - targetCl);
+    for (let i = 1; i < cls.length; i++) {
+      const v = cls[i];
+      if (v == null) continue;
+      const d = Math.abs(v - targetCl);
+      if (d < closestDist) {
+        closestDist = d;
+        closestIdx = i;
+      }
+    }
+    return alphas[closestIdx];
+  }
+
+  const rootOperatingPoints = useMemo((): OperatingPoints | undefined => {
+    if (!rootAnalysis.result || !rootSuitabilityItem) return undefined;
+    const q = rootSuitability.data?.query;
+    const alphaCruise = clToAlpha(rootSuitabilityItem.target_cl_cruise);
+    const alphaBestGlide = clToAlpha(rootSuitabilityItem.target_cl_best_glide);
+    const alphaMinSink = clToAlpha(rootSuitabilityItem.target_cl_min_sink);
+
+    const pts: OperatingPoints = {};
+    if (alphaCruise != null && q?.v_cruise_mps != null) {
+      pts.cruise = { alpha: alphaCruise, label: `Cruise ${q.v_cruise_mps.toFixed(1)} m/s` };
+    }
+    if (alphaBestGlide != null && q?.v_md_mps != null) {
+      pts.bestGlide = { alpha: alphaBestGlide, label: `Best-Glide ${q.v_md_mps.toFixed(1)} m/s` };
+    }
+    if (alphaMinSink != null && q?.v_min_sink_mps != null) {
+      pts.minSink = { alpha: alphaMinSink, label: `Min-Sink ${q.v_min_sink_mps.toFixed(1)} m/s` };
+    }
+    if (!pts.cruise && !pts.bestGlide && !pts.minSink) return undefined;
+    return pts;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rootAnalysis.result, rootSuitabilityItem, rootSuitability.data?.query]);
+
   // Sync airfoils from segment when index or wingConfig changes
   useEffect(() => {
     const seg = wingConfig?.segments?.[selectedXsecIndex ?? 0];
@@ -261,6 +305,7 @@ export default function AirfoilPreviewPage() {
           onMaChange={setMa}
           operatingAlphaDeg={rootOperatingAlpha}
           tipSuitabilityItem={hasTip ? (tipSuitabilityItem ?? undefined) : undefined}
+          operatingPoints={rootOperatingPoints}
         />
       </div>
       <div className="shrink-0 overflow-hidden" style={{ width: 480 }}>
@@ -315,6 +360,15 @@ export default function AirfoilPreviewPage() {
           onTipRankedModeToggle={() => setTipRankedMode((v) => !v)}
           targetClProvenance={rootSuitability.data?.query.target_cl_provenance}
           suitabilityCaveat={rootSuitability.data?.caveat}
+          suitabilitySpeedContext={
+            rootSuitability.data?.query
+              ? {
+                  v_cruise_mps: rootSuitability.data.query.v_cruise_mps,
+                  v_md_mps: rootSuitability.data.query.v_md_mps,
+                  v_min_sink_mps: rootSuitability.data.query.v_min_sink_mps,
+                }
+              : undefined
+          }
         />
       </div>
     </div>

--- a/frontend/components/workbench/AirfoilPreviewConfigPanel.tsx
+++ b/frontend/components/workbench/AirfoilPreviewConfigPanel.tsx
@@ -6,6 +6,13 @@ import { AirfoilSelector } from "./AirfoilSelector";
 import { AirfoilSuitabilityCard, AirfoilSuitabilityNoData } from "./AirfoilSuitabilityCard";
 import type { SuitabilityItem, SuitabilityCaveat, TargetClProvenance } from "@/hooks/useAirfoilSuitability";
 
+/** gh-839 ADDITIVE: design speeds from aeroplane context for speed quick-set buttons */
+export interface SuitabilitySpeedContext {
+  v_cruise_mps: number | null;
+  v_md_mps: number | null;
+  v_min_sink_mps: number | null;
+}
+
 interface AirfoilPreviewConfigPanelProps {
   rootAirfoil: string;
   tipAirfoil: string;
@@ -66,6 +73,12 @@ interface AirfoilPreviewConfigPanelProps {
   targetClProvenance?: TargetClProvenance;
   /** gh-825 ADDITIVE: full caveat object from suitability response, for tip-Re CL_max warning */
   suitabilityCaveat?: SuitabilityCaveat;
+  /**
+   * gh-839 ADDITIVE: design speeds from aeroplane context.
+   * When provided, speed quick-set buttons (Cruise / Best-Glide / Min-Sink) appear
+   * next to the velocity input. A button is hidden when its speed is null.
+   */
+  suitabilitySpeedContext?: SuitabilitySpeedContext;
 }
 
 function ReadOnlyField({
@@ -179,6 +192,7 @@ export function AirfoilPreviewConfigPanel({
   onTipRankedModeToggle,
   targetClProvenance,
   suitabilityCaveat,
+  suitabilitySpeedContext,
 }: Readonly<AirfoilPreviewConfigPanelProps>) {
   const [showReInfo, setShowReInfo] = useState(false);
   const [velocityDraft, setVelocityDraft] = useState(String(velocity));
@@ -267,6 +281,37 @@ export function AirfoilPreviewConfigPanel({
           <span className="font-[family-name:var(--font-jetbrains-mono)] text-[10px] text-muted-foreground">
             m/s ({(velocity * 3.6).toFixed(1)} km/h)
           </span>
+          {/* gh-839: speed quick-set buttons */}
+          {suitabilitySpeedContext?.v_cruise_mps != null && (
+            <button
+              data-testid="speed-btn-cruise"
+              onClick={() => onVelocityChange(suitabilitySpeedContext.v_cruise_mps!)}
+              className="rounded-full border border-border px-2 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[9px] text-muted-foreground hover:border-primary hover:text-primary"
+              title={`Set to cruise speed: ${suitabilitySpeedContext.v_cruise_mps} m/s`}
+            >
+              Cruise
+            </button>
+          )}
+          {suitabilitySpeedContext?.v_md_mps != null && (
+            <button
+              data-testid="speed-btn-best-glide"
+              onClick={() => onVelocityChange(suitabilitySpeedContext.v_md_mps!)}
+              className="rounded-full border border-border px-2 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[9px] text-muted-foreground hover:border-primary hover:text-primary"
+              title={`Set to best-glide speed: ${suitabilitySpeedContext.v_md_mps} m/s`}
+            >
+              Best-Glide
+            </button>
+          )}
+          {suitabilitySpeedContext?.v_min_sink_mps != null && (
+            <button
+              data-testid="speed-btn-min-sink"
+              onClick={() => onVelocityChange(suitabilitySpeedContext.v_min_sink_mps!)}
+              className="rounded-full border border-border px-2 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[9px] text-muted-foreground hover:border-primary hover:text-primary"
+              title={`Set to min-sink speed: ${suitabilitySpeedContext.v_min_sink_mps} m/s`}
+            >
+              Min-Sink
+            </button>
+          )}
           <span className="flex-1" />
           <button
             onClick={() => setShowReInfo((s) => !s)}

--- a/frontend/components/workbench/AirfoilPreviewViewerPanel.tsx
+++ b/frontend/components/workbench/AirfoilPreviewViewerPanel.tsx
@@ -7,6 +7,21 @@ import type { AirfoilAnalysisResult } from "@/hooks/useAirfoilAnalysis";
 import type { SuitabilityItem } from "@/hooks/useAirfoilSuitability";
 import { interpolateY } from "@/hooks/useAirfoilGeometry";
 
+/** gh-839 ADDITIVE: a single operating point for alpha-diagram markers. */
+export interface OperatingPoint {
+  /** alpha in degrees — used as the x-coordinate on alpha-based charts */
+  alpha: number;
+  /** human-readable label for the legend */
+  label: string;
+}
+
+/** gh-839 ADDITIVE: operating points for the three design-speed lenses. */
+export interface OperatingPoints {
+  cruise?: OperatingPoint;
+  bestGlide?: OperatingPoint;
+  minSink?: OperatingPoint;
+}
+
 interface AirfoilPreviewViewerPanelProps {
   rootAirfoilName: string;
   tipAirfoilName: string | null;
@@ -27,12 +42,27 @@ interface AirfoilPreviewViewerPanelProps {
    * The arithmetic fallback (tipRe < rootRe) is only used when no suitability item is available.
    */
   tipSuitabilityItem?: SuitabilityItem;
+  /**
+   * gh-839 ADDITIVE: operating points for cruise/best-glide/min-sink.
+   * Each point maps a target CL to an alpha via the analysis CL-alpha curve.
+   * When provided, markers and a legend are added to the L/D and CL/CD charts.
+   */
+  operatingPoints?: OperatingPoints;
 }
 
 const COLOR_ROOT = "#FF8400";
 const COLOR_TIP = "#22D3EE";
 
 // ── SVG Line Chart (follows AnalysisViewerPanel pattern) ────────
+
+/** gh-839: a named marker on the chart (x, y in data coords) */
+interface ChartMarker {
+  x: number;
+  y: number;
+  color: string;
+  testId: string;
+  label?: string;
+}
 
 function LineChart({
   xData,
@@ -52,6 +82,8 @@ function LineChart({
   isMaximized,
   operatingX,
   operatingY,
+  markers,
+  showMarkersLegend,
 }: Readonly<{
   xData: (number | null)[];
   yData: (number | null)[];
@@ -72,6 +104,10 @@ function LineChart({
   operatingX?: number;
   /** gh-822: operating point marker y value (L/D at operating α) */
   operatingY?: number;
+  /** gh-839: additional named markers (CL_max, L/D_max, operating points) */
+  markers?: ChartMarker[];
+  /** gh-839: when true, render a compact legend for markers */
+  showMarkersLegend?: boolean;
 }>) {
   const W = 400;
   const H = 200;
@@ -305,7 +341,7 @@ function LineChart({
             />
           )}
 
-          {/* gh-822: Operating point marker */}
+          {/* gh-822: Operating point marker (legacy single-marker) */}
           {operatingX != null && operatingY != null && (
             <circle
               data-testid="operating-point-marker"
@@ -318,8 +354,50 @@ function LineChart({
               opacity="0.9"
             />
           )}
+
+          {/* gh-839: named markers (CL_max, L/D_max, operating points) */}
+          {markers?.map((m) => {
+            // Guard: only render when within the chart range
+            if (!Number.isFinite(m.x) || !Number.isFinite(m.y)) return null;
+            return (
+              <circle
+                key={m.testId}
+                data-testid={m.testId}
+                cx={sx(m.x)}
+                cy={sy(m.y)}
+                r="4"
+                fill={m.color}
+                stroke="white"
+                strokeWidth="1.5"
+                opacity="0.92"
+              />
+            );
+          })}
         </svg>
       </div>
+
+      {/* gh-839: markers legend */}
+      {showMarkersLegend && markers && markers.length > 0 && (
+        <div
+          data-testid="chart-markers-legend"
+          className="flex flex-wrap items-center gap-x-3 gap-y-0.5 pt-1"
+        >
+          {markers.map((m) =>
+            m.label ? (
+              <span
+                key={m.testId}
+                className="flex items-center gap-1 font-[family-name:var(--font-jetbrains-mono)] text-[8px] text-muted-foreground"
+              >
+                <span
+                  className="inline-block size-[5px] rounded-full"
+                  style={{ backgroundColor: m.color }}
+                />
+                {m.label}
+              </span>
+            ) : null,
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -496,6 +574,96 @@ function AirfoilSvg({
 
 // ── Main Panel ──────────────────────────────────────────────────
 
+// ── Helpers ─────────────────────────────────────────────────────
+
+/** Marker colors (gh-839) */
+const COLOR_CLMAX = "#ef4444";
+const COLOR_LDMAX = "#22c55e";
+const COLOR_CRUISE = "#FF8400";
+const COLOR_BEST_GLIDE = "#38bdf8";
+const COLOR_MIN_SINK = "#a78bfa";
+
+/** Look up y-value at alpha x from two parallel arrays */
+function lookupYAtX(
+  xs: (number | null)[],
+  ys: (number | null)[],
+  targetX: number,
+): number | null {
+  if (xs.length === 0) return null;
+  let closestIdx = 0;
+  let closestDist = Math.abs((xs[0] ?? 0) - targetX);
+  for (let i = 1; i < xs.length; i++) {
+    const x = xs[i];
+    if (x == null) continue;
+    const d = Math.abs(x - targetX);
+    if (d < closestDist) {
+      closestDist = d;
+      closestIdx = i;
+    }
+  }
+  return ys[closestIdx] ?? null;
+}
+
+/** gh-839: build CL-alpha chart markers from analysis + optional operating points */
+function buildClChartMarkers(
+  result: AirfoilAnalysisResult,
+  pts?: OperatingPoints,
+): ChartMarker[] {
+  const markers: ChartMarker[] = [];
+  if (result.clMax != null && result.alphaAtClMax != null) {
+    markers.push({
+      x: result.alphaAtClMax,
+      y: result.clMax,
+      color: COLOR_CLMAX,
+      testId: "clmax-marker",
+      label: `C_L,max≈${result.clMax.toFixed(2)}`,
+    });
+  }
+  if (pts?.cruise != null) {
+    const y = lookupYAtX(result.alphaDeg, result.cl, pts.cruise.alpha);
+    if (y != null) markers.push({ x: pts.cruise.alpha, y, color: COLOR_CRUISE, testId: "op-marker-cruise", label: pts.cruise.label });
+  }
+  if (pts?.bestGlide != null) {
+    const y = lookupYAtX(result.alphaDeg, result.cl, pts.bestGlide.alpha);
+    if (y != null) markers.push({ x: pts.bestGlide.alpha, y, color: COLOR_BEST_GLIDE, testId: "op-marker-best-glide", label: pts.bestGlide.label });
+  }
+  if (pts?.minSink != null) {
+    const y = lookupYAtX(result.alphaDeg, result.cl, pts.minSink.alpha);
+    if (y != null) markers.push({ x: pts.minSink.alpha, y, color: COLOR_MIN_SINK, testId: "op-marker-min-sink", label: pts.minSink.label });
+  }
+  return markers;
+}
+
+/** gh-839: build L/D-alpha chart markers from analysis + optional operating points */
+function buildLdChartMarkers(
+  result: AirfoilAnalysisResult,
+  pts?: OperatingPoints,
+): ChartMarker[] {
+  const markers: ChartMarker[] = [];
+  if (result.ldMax != null && result.alphaAtLdMax != null) {
+    markers.push({
+      x: result.alphaAtLdMax,
+      y: result.ldMax,
+      color: COLOR_LDMAX,
+      testId: "ldmax-marker",
+      label: `L/D,max≈${result.ldMax.toFixed(1)}`,
+    });
+  }
+  if (pts?.cruise != null) {
+    const y = lookupYAtX(result.alphaDeg, result.clOverCd, pts.cruise.alpha);
+    if (y != null) markers.push({ x: pts.cruise.alpha, y, color: COLOR_CRUISE, testId: "op-marker-cruise", label: pts.cruise.label });
+  }
+  if (pts?.bestGlide != null) {
+    const y = lookupYAtX(result.alphaDeg, result.clOverCd, pts.bestGlide.alpha);
+    if (y != null) markers.push({ x: pts.bestGlide.alpha, y, color: COLOR_BEST_GLIDE, testId: "op-marker-best-glide", label: pts.bestGlide.label });
+  }
+  if (pts?.minSink != null) {
+    const y = lookupYAtX(result.alphaDeg, result.clOverCd, pts.minSink.alpha);
+    if (y != null) markers.push({ x: pts.minSink.alpha, y, color: COLOR_MIN_SINK, testId: "op-marker-min-sink", label: pts.minSink.label });
+  }
+  return markers;
+}
+
 export function AirfoilPreviewViewerPanel({
   rootAirfoilName,
   tipAirfoilName,
@@ -510,6 +678,7 @@ export function AirfoilPreviewViewerPanel({
   onMaChange,
   operatingAlphaDeg,
   tipSuitabilityItem,
+  operatingPoints,
 }: Readonly<AirfoilPreviewViewerPanelProps>) {
   const [maximizedChart, setMaximizedChart] = useState<string | null>(null);
 
@@ -675,6 +844,14 @@ export function AirfoilPreviewViewerPanel({
             return ld != null ? ld : undefined;
           })();
 
+          // gh-839: build named markers using extracted helpers \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+          const clChartMarkers = buildClChartMarkers(rootAnalysisResult, operatingPoints);
+          const ldChartMarkers = buildLdChartMarkers(rootAnalysisResult, operatingPoints);
+          const hasAnyOperatingPoints =
+            operatingPoints?.cruise != null ||
+            operatingPoints?.bestGlide != null ||
+            operatingPoints?.minSink != null;
+
           const allCharts = [
             {
               id: "cl",
@@ -693,6 +870,7 @@ export function AirfoilPreviewViewerPanel({
               color2: COLOR_TIP,
               label: seriesLabel,
               label2: seriesLabel2,
+              markers: clChartMarkers.length > 0 ? clChartMarkers : undefined,
             },
             {
               id: "cd",
@@ -725,9 +903,12 @@ export function AirfoilPreviewViewerPanel({
               color2: COLOR_TIP,
               label: seriesLabel,
               label2: seriesLabel2,
-              // gh-822: operating point marker on L/D chart
+              // gh-822: operating point marker on L/D chart (legacy single marker)
               operatingX: operatingAlphaDeg,
               operatingY: operatingLdAtAlpha,
+              // gh-839: named markers + legend
+              markers: ldChartMarkers.length > 0 ? ldChartMarkers : undefined,
+              showMarkersLegend: hasAnyOperatingPoints && ldChartMarkers.length > 0,
             },
             {
               id: "polar",

--- a/frontend/hooks/useAirfoilSuitability.ts
+++ b/frontend/hooks/useAirfoilSuitability.ts
@@ -87,6 +87,12 @@ export interface SuitabilityQuery {
   /** NEW gh-825 — provenance of the target CL values */
   target_cl_provenance: TargetClProvenance;
   active_lens: ActiveLens;
+  /** NEW gh-839 — design speeds from aeroplane context (null when absent) */
+  v_cruise_mps: number | null;
+  /** NEW gh-839 — best-glide speed from aeroplane context (null when absent) */
+  v_md_mps: number | null;
+  /** NEW gh-839 — min-sink speed from aeroplane context (null when absent) */
+  v_min_sink_mps: number | null;
 }
 
 export interface SuitabilityCaveat {


### PR DESCRIPTION
## Summary

- **Closes #838.** Closes **#839.**
- Target-CL scores (cruise / best-glide / min-sink) are now each evaluated at their own Reynolds number derived from the respective design speed in `assumption_computation_context` (v_cruise_mps / v_md_mps / v_min_sink_mps). Previously all three lenses shared the slider Re, making scores slider-dependent. Re-agnostic and mission lenses still use the query (slider) Re. Callers that pass explicit `target_cl_*` params without an aeroplane context fall back to the slider Re (backwards-compatible).
- `SuitabilityQuery` now includes `v_cruise_mps`, `v_md_mps`, `v_min_sink_mps` (additive; null when absent) so the frontend can read design speeds directly from the response.
- Speed quick-set buttons **Cruise / Best-Glide / Min-Sink** appear in the airfoil-preview config panel next to the velocity input when speeds are available from the suitability response. Each button sets the velocity input to the respective design speed; buttons are hidden when their speed is null.
- Key-point markers added to the L/D-vs-α and C_L-vs-α diagrams: C_L,max (red), L/D,max (green), and the three operating-point markers (orange/sky/violet) with a compact legend on the L/D chart.

## Test plan

- [ ] Backend: `poetry run pytest app/tests/test_gh838_839_service.py` — 10 new TDD tests all green
- [ ] Backend: `poetry run pytest -m "not slow" -q` — 4655 tests all green
- [ ] Frontend: `npm run test:unit` — 1414 tests all green (1399 existing + 15 new)
- [ ] Frontend: `npm run deps:check` — no new violations
- [ ] Ruff: clean; ESLint: pre-commit hook passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)