### PR TITLE
feat(gh-837): 'In Verwendung' airfoils in the picker

### DIFF
--- a/frontend/__tests__/AirfoilSelector.usedNames.test.tsx
+++ b/frontend/__tests__/AirfoilSelector.usedNames.test.tsx
@@ -1,0 +1,235 @@
+/**
+ * Tests for the gh-837 'In Verwendung' section in AirfoilSelector.
+ *
+ * Covers:
+ * - 'In Verwendung' header and items render at the top when usedNames provided
+ * - Selection from the 'In Verwendung' section calls onChange
+ * - Search filters both the 'In Verwendung' section and the full list
+ * - Empty / absent usedNames → no 'In Verwendung' section
+ * - De-duplication of usedNames
+ * - Currently selected airfoil is marked in the 'In Verwendung' section
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+vi.mock("lucide-react", () => ({
+  ChevronDown: (p: Record<string, unknown>) => (
+    <svg data-testid="chevron-down" {...p} />
+  ),
+  ChevronUp: (p: Record<string, unknown>) => (
+    <svg data-testid="chevron-up" {...p} />
+  ),
+  Search: (p: Record<string, unknown>) => <svg data-testid="search" {...p} />,
+  Check: (p: Record<string, unknown>) => <svg data-testid="check" {...p} />,
+}));
+
+// SWR mock returning a larger list so the full-list section also renders
+vi.mock("swr", () => ({
+  default: vi.fn(() => ({
+    data: {
+      count: 4,
+      airfoils: [
+        { airfoil_name: "clark-y", file_name: "clark-y.dat" },
+        { airfoil_name: "e423", file_name: "e423.dat" },
+        { airfoil_name: "naca0015", file_name: "naca0015.dat" },
+        { airfoil_name: "naca2412", file_name: "naca2412.dat" },
+      ],
+    },
+    error: null,
+    isLoading: false,
+  })),
+}));
+
+import { AirfoilSelector } from "../components/workbench/AirfoilSelector";
+
+describe("AirfoilSelector — 'In Verwendung' section (gh-837)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders 'In Verwendung' header at the top of the dropdown when usedNames is provided", async () => {
+    const user = userEvent.setup();
+    render(
+      <AirfoilSelector
+        label="Root"
+        value="naca0015"
+        usedNames={["e423", "clark-y"]}
+      />,
+    );
+    await user.click(screen.getByRole("button"));
+    expect(screen.getByTestId("in-verwendung-header")).toBeDefined();
+    expect(screen.getByTestId("in-verwendung-header").textContent).toMatch(
+      /In Verwendung/i,
+    );
+  });
+
+  it("renders all usedNames as items in the 'In Verwendung' section", async () => {
+    const user = userEvent.setup();
+    render(
+      <AirfoilSelector
+        label="Root"
+        value="naca0015"
+        usedNames={["e423", "clark-y"]}
+      />,
+    );
+    await user.click(screen.getByRole("button"));
+    const items = screen.getAllByTestId("in-verwendung-item");
+    const texts = items.map((el) => el.textContent);
+    expect(texts.some((t) => t?.includes("e423"))).toBe(true);
+    expect(texts.some((t) => t?.includes("clark-y"))).toBe(true);
+  });
+
+  it("places the 'In Verwendung' section ABOVE the full list", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <AirfoilSelector
+        label="Root"
+        value="naca0015"
+        usedNames={["e423"]}
+      />,
+    );
+    await user.click(screen.getByRole("button"));
+
+    const listContainer = container.querySelector('[class*="max-h"]');
+    expect(listContainer).not.toBeNull();
+
+    // All children (header, items, divider, then full-list items)
+    const allButtons = listContainer!.querySelectorAll("button");
+    const buttonTexts = Array.from(allButtons).map((b) => b.textContent ?? "");
+
+    // The first airfoil-named button should be the used one (e423)
+    const firstAirfoilBtn = buttonTexts.find((t) =>
+      ["e423", "clark-y", "naca0015", "naca2412"].some((n) => t.includes(n)),
+    );
+    expect(firstAirfoilBtn).toContain("e423");
+  });
+
+  it("calling select() on a 'In Verwendung' item calls onChange with correct name", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AirfoilSelector
+        label="Root"
+        value="naca0015"
+        onChange={onChange}
+        usedNames={["e423", "clark-y"]}
+      />,
+    );
+    await user.click(screen.getByRole("button"));
+    const items = screen.getAllByTestId("in-verwendung-item");
+    const e423Item = items.find((el) => el.textContent?.includes("e423"));
+    expect(e423Item).toBeDefined();
+    await user.click(e423Item!);
+    expect(onChange).toHaveBeenCalledWith("e423");
+  });
+
+  it("does NOT show the 'In Verwendung' section when usedNames is empty", async () => {
+    const user = userEvent.setup();
+    render(<AirfoilSelector label="Root" value="naca0015" usedNames={[]} />);
+    await user.click(screen.getByRole("button"));
+    expect(screen.queryByTestId("in-verwendung-header")).toBeNull();
+    expect(screen.queryByTestId("in-verwendung-item")).toBeNull();
+  });
+
+  it("does NOT show the 'In Verwendung' section when usedNames prop is absent", async () => {
+    const user = userEvent.setup();
+    render(<AirfoilSelector label="Root" value="naca0015" />);
+    await user.click(screen.getByRole("button"));
+    expect(screen.queryByTestId("in-verwendung-header")).toBeNull();
+  });
+
+  it("search filters the 'In Verwendung' section (matching items remain, non-matching items are hidden)", async () => {
+    const user = userEvent.setup();
+    render(
+      <AirfoilSelector
+        label="Root"
+        value="naca0015"
+        usedNames={["e423", "clark-y"]}
+      />,
+    );
+    await user.click(screen.getByRole("button"));
+    const searchInput = screen.getByPlaceholderText("Search airfoils…");
+    await user.type(searchInput, "e42");
+
+    // e423 should still appear in 'In Verwendung'
+    const items = screen.getAllByTestId("in-verwendung-item");
+    expect(items.some((el) => el.textContent?.includes("e423"))).toBe(true);
+    // clark-y should be filtered out of 'In Verwendung'
+    expect(items.every((el) => !el.textContent?.includes("clark-y"))).toBe(true);
+  });
+
+  it("search also filters the regular (full) list in addition to the 'In Verwendung' section", async () => {
+    const user = userEvent.setup();
+    render(
+      <AirfoilSelector
+        label="Root"
+        value="naca0015"
+        usedNames={["e423"]}
+      />,
+    );
+    await user.click(screen.getByRole("button"));
+    const searchInput = screen.getByPlaceholderText("Search airfoils…");
+    await user.type(searchInput, "naca");
+
+    // The full list should show naca entries
+    expect(screen.queryByText("clark-y")).toBeNull();
+    // naca names should still appear somewhere on screen
+    const nacaTexts = screen
+      .getAllByRole("button")
+      .flatMap((b) => [b.textContent ?? ""])
+      .filter((t) => t.includes("naca"));
+    expect(nacaTexts.length).toBeGreaterThan(0);
+  });
+
+  it("shows 'No airfoils found' only when BOTH sections produce no results", async () => {
+    const user = userEvent.setup();
+    render(
+      <AirfoilSelector
+        label="Root"
+        value="naca0015"
+        usedNames={["e423"]}
+      />,
+    );
+    await user.click(screen.getByRole("button"));
+    const searchInput = screen.getByPlaceholderText("Search airfoils…");
+    await user.type(searchInput, "zzz_no_match");
+    expect(screen.getByText("No airfoils found")).toBeDefined();
+  });
+
+  it("de-duplicates usedNames (duplicate entries appear only once in the section)", async () => {
+    const user = userEvent.setup();
+    render(
+      <AirfoilSelector
+        label="Root"
+        value="naca0015"
+        usedNames={["e423", "e423", "clark-y"]}
+      />,
+    );
+    await user.click(screen.getByRole("button"));
+    const items = screen.getAllByTestId("in-verwendung-item");
+    const e423Items = items.filter((el) => el.textContent?.includes("e423"));
+    // e423 should appear exactly once despite being passed twice
+    expect(e423Items).toHaveLength(1);
+  });
+
+  it("marks the currently selected airfoil with a Check icon when it appears in the 'In Verwendung' section", async () => {
+    const user = userEvent.setup();
+    // value='e423' is also in usedNames
+    render(
+      <AirfoilSelector
+        label="Root"
+        value="e423"
+        usedNames={["e423", "clark-y"]}
+      />,
+    );
+    await user.click(screen.getByRole("button"));
+    const items = screen.getAllByTestId("in-verwendung-item");
+    const e423Item = items.find((el) => el.textContent?.includes("e423"));
+    expect(e423Item).toBeDefined();
+    // The Check icon is rendered as an svg with data-testid="check" (from lucide mock)
+    const checkIcon = e423Item!.querySelector('[data-testid="check"]');
+    expect(checkIcon).not.toBeNull();
+  });
+});

--- a/frontend/app/workbench/airfoil-preview/page.tsx
+++ b/frontend/app/workbench/airfoil-preview/page.tsx
@@ -143,6 +143,18 @@ export default function AirfoilPreviewPage() {
     [tipSuitability.data],
   );
 
+  // gh-837: collect all airfoil names used across the current aeroplane model
+  // (all segments' root + tip airfoils). Derived client-side from wingConfig.
+  const usedAirfoilNames = useMemo(() => {
+    if (!wingConfig?.segments) return [];
+    const names: string[] = [];
+    for (const seg of wingConfig.segments) {
+      if (seg.root_airfoil?.airfoil) names.push(airfoilShortName(seg.root_airfoil.airfoil));
+      if (seg.tip_airfoil?.airfoil) names.push(airfoilShortName(seg.tip_airfoil.airfoil));
+    }
+    return Array.from(new Set(names));
+  }, [wingConfig]);
+
   // Find the selected airfoil's suitability item
   const rootSuitabilityItem = useMemo(
     () => rootSuitability.data?.results.find((item) => item.airfoil_name === rootAirfoil) ?? null,
@@ -369,6 +381,7 @@ export default function AirfoilPreviewPage() {
                 }
               : undefined
           }
+          usedAirfoilNames={usedAirfoilNames}
         />
       </div>
     </div>

--- a/frontend/components/workbench/AirfoilPreviewConfigPanel.tsx
+++ b/frontend/components/workbench/AirfoilPreviewConfigPanel.tsx
@@ -79,6 +79,13 @@ interface AirfoilPreviewConfigPanelProps {
    * next to the velocity input. A button is hidden when its speed is null.
    */
   suitabilitySpeedContext?: SuitabilitySpeedContext;
+  /**
+   * gh-837 ADDITIVE: airfoil names already used in the current aeroplane model
+   * (derived client-side from all segments' root/tip airfoils). Passed through
+   * to both root and tip AirfoilSelector instances so the user can re-select
+   * without searching again.
+   */
+  usedAirfoilNames?: string[];
 }
 
 function ReadOnlyField({
@@ -193,6 +200,7 @@ export function AirfoilPreviewConfigPanel({
   targetClProvenance,
   suitabilityCaveat,
   suitabilitySpeedContext,
+  usedAirfoilNames,
 }: Readonly<AirfoilPreviewConfigPanelProps>) {
   const [showReInfo, setShowReInfo] = useState(false);
   const [velocityDraft, setVelocityDraft] = useState(String(velocity));
@@ -350,6 +358,7 @@ export function AirfoilPreviewConfigPanel({
               ? { active: rootRankedMode ?? false, onToggle: onRootRankedModeToggle }
               : undefined
           }
+          usedNames={usedAirfoilNames}
         />
         <ReynoldsField
           label="Re"
@@ -388,6 +397,7 @@ export function AirfoilPreviewConfigPanel({
               ? { active: tipRankedMode ?? false, onToggle: onTipRankedModeToggle }
               : undefined
           }
+          usedNames={usedAirfoilNames}
         />
         {hasTip && (
           <ReynoldsField

--- a/frontend/components/workbench/AirfoilSelector.tsx
+++ b/frontend/components/workbench/AirfoilSelector.tsx
@@ -61,6 +61,57 @@ function scoreBadgeColor(scoreStr: string): string {
   return "#F87171";
 }
 
+/** Shared row renderer used by both the 'In Verwendung' section and the main list. */
+function AirfoilRow({
+  name,
+  value,
+  stats,
+  onSelect,
+  testId,
+  itemKey,
+}: {
+  name: string;
+  value: string;
+  stats?: Record<string, string>;
+  onSelect: (name: string) => void;
+  testId?: string;
+  itemKey: string;
+}) {
+  return (
+    <button
+      key={itemKey}
+      data-testid={testId}
+      onClick={() => onSelect(name)}
+      className="flex w-full items-center gap-2 px-3 py-1.5 hover:bg-sidebar-accent"
+    >
+      {name === value ? (
+        <Check size={12} className="text-primary" />
+      ) : (
+        <div className="w-3" />
+      )}
+      <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-foreground">
+        {name}
+      </span>
+      {stats?.[name] && (
+        <>
+          <span className="flex-1" />
+          <span
+            data-testid="score-badge"
+            className="rounded-full border border-current px-1.5 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[10px]"
+            style={{
+              color: scoreBadgeColor(stats[name]),
+              backgroundColor: `${scoreBadgeColor(stats[name])}1a`,
+              borderColor: `${scoreBadgeColor(stats[name])}40`,
+            }}
+          >
+            {stats[name]}
+          </span>
+        </>
+      )}
+    </button>
+  );
+}
+
 export function AirfoilSelector({
   label,
   value,
@@ -216,37 +267,15 @@ export function AirfoilSelector({
                   In Verwendung
                 </div>
                 {filteredUsed.map((name) => (
-                  <button
+                  <AirfoilRow
                     key={`used-${name}`}
-                    data-testid="in-verwendung-item"
-                    onClick={() => select(name)}
-                    className="flex w-full items-center gap-2 px-3 py-1.5 hover:bg-sidebar-accent"
-                  >
-                    {name === value ? (
-                      <Check size={12} className="text-primary" />
-                    ) : (
-                      <div className="w-3" />
-                    )}
-                    <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-foreground">
-                      {name}
-                    </span>
-                    {stats?.[name] && (
-                      <>
-                        <span className="flex-1" />
-                        <span
-                          data-testid="score-badge"
-                          className="rounded-full border border-current px-1.5 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[10px]"
-                          style={{
-                            color: scoreBadgeColor(stats[name]),
-                            backgroundColor: `${scoreBadgeColor(stats[name])}1a`,
-                            borderColor: `${scoreBadgeColor(stats[name])}40`,
-                          }}
-                        >
-                          {stats[name]}
-                        </span>
-                      </>
-                    )}
-                  </button>
+                    itemKey={`used-${name}`}
+                    name={name}
+                    value={value}
+                    stats={stats}
+                    onSelect={select}
+                    testId="in-verwendung-item"
+                  />
                 ))}
                 <div className="mx-3 my-1 border-t border-border" />
               </>
@@ -257,36 +286,14 @@ export function AirfoilSelector({
               </div>
             ) : (
               filtered.map((name) => (
-                <button
+                <AirfoilRow
                   key={name}
-                  onClick={() => select(name)}
-                  className="flex w-full items-center gap-2 px-3 py-1.5 hover:bg-sidebar-accent"
-                >
-                  {name === value ? (
-                    <Check size={12} className="text-primary" />
-                  ) : (
-                    <div className="w-3" />
-                  )}
-                  <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-foreground">
-                    {name}
-                  </span>
-                  {stats?.[name] && (
-                    <>
-                      <span className="flex-1" />
-                      <span
-                        data-testid="score-badge"
-                        className="rounded-full border border-current px-1.5 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[10px]"
-                        style={{
-                          color: scoreBadgeColor(stats[name]),
-                          backgroundColor: `${scoreBadgeColor(stats[name])}1a`,
-                          borderColor: `${scoreBadgeColor(stats[name])}40`,
-                        }}
-                      >
-                        {stats[name]}
-                      </span>
-                    </>
-                  )}
-                </button>
+                  itemKey={name}
+                  name={name}
+                  value={value}
+                  stats={stats}
+                  onSelect={select}
+                />
               ))
             )}
           </div>

--- a/frontend/components/workbench/AirfoilSelector.tsx
+++ b/frontend/components/workbench/AirfoilSelector.tsx
@@ -41,6 +41,13 @@ interface AirfoilSelectorProps {
    * button next to the dropdown trigger.
    */
   suitabilityToggle?: SuitabilityToggle;
+  /**
+   * gh-837 ADDITIVE: airfoil names already used in the current model.
+   * When provided and non-empty, renders an 'In Verwendung' section at the
+   * top of the dropdown (above the full list) so the user can re-select
+   * without searching again. Deduped internally; filtered by search query.
+   */
+  usedNames?: string[];
 }
 
 const MAX_VISIBLE = 50;
@@ -63,6 +70,7 @@ export function AirfoilSelector({
   id: idProp,
   sortedNames,
   suitabilityToggle,
+  usedNames,
 }: Readonly<AirfoilSelectorProps>) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
@@ -80,6 +88,19 @@ export function AirfoilSelector({
     if (sortedNames && sortedNames.length > 0) return sortedNames;
     return data?.airfoils?.map((a) => a.airfoil_name) ?? [];
   }, [data, sortedNames]);
+
+  // gh-837: deduped list of in-use names; empty array when prop is absent/empty
+  const dedupeUsedNames = useMemo(() => {
+    if (!usedNames || usedNames.length === 0) return [];
+    return Array.from(new Set(usedNames));
+  }, [usedNames]);
+
+  const filteredUsed = useMemo(() => {
+    if (dedupeUsedNames.length === 0) return [];
+    const q = search.toLowerCase();
+    if (!q) return dedupeUsedNames;
+    return dedupeUsedNames.filter((n) => n.toLowerCase().includes(q));
+  }, [dedupeUsedNames, search]);
 
   const filtered = useMemo(() => {
     const q = search.toLowerCase();
@@ -185,7 +206,52 @@ export function AirfoilSelector({
 
           {/* List */}
           <div className="max-h-[240px] overflow-y-auto py-1">
-            {filtered.length === 0 ? (
+            {/* gh-837: 'In Verwendung' section — shown when usedNames is non-empty */}
+            {filteredUsed.length > 0 && (
+              <>
+                <div
+                  data-testid="in-verwendung-header"
+                  className="px-3 py-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground"
+                >
+                  In Verwendung
+                </div>
+                {filteredUsed.map((name) => (
+                  <button
+                    key={`used-${name}`}
+                    data-testid="in-verwendung-item"
+                    onClick={() => select(name)}
+                    className="flex w-full items-center gap-2 px-3 py-1.5 hover:bg-sidebar-accent"
+                  >
+                    {name === value ? (
+                      <Check size={12} className="text-primary" />
+                    ) : (
+                      <div className="w-3" />
+                    )}
+                    <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-foreground">
+                      {name}
+                    </span>
+                    {stats?.[name] && (
+                      <>
+                        <span className="flex-1" />
+                        <span
+                          data-testid="score-badge"
+                          className="rounded-full border border-current px-1.5 py-0.5 font-[family-name:var(--font-jetbrains-mono)] text-[10px]"
+                          style={{
+                            color: scoreBadgeColor(stats[name]),
+                            backgroundColor: `${scoreBadgeColor(stats[name])}1a`,
+                            borderColor: `${scoreBadgeColor(stats[name])}40`,
+                          }}
+                        >
+                          {stats[name]}
+                        </span>
+                      </>
+                    )}
+                  </button>
+                ))}
+                <div className="mx-3 my-1 border-t border-border" />
+              </>
+            )}
+            {filtered.length === 0 && filteredUsed.length === 0 ? (
               <div className="px-3 py-3 text-center text-[12px] text-muted-foreground">
                 No airfoils found
               </div>


### PR DESCRIPTION
Closes #837.

## Summary

- Adds a separated **'In Verwendung'** section at the TOP of the `AirfoilSelector` dropdown listing airfoils already in use across the current aeroplane model (all wing segments' root + tip airfoil names), so the user can re-select without searching the full list again.
- Scope: airfoils used in the **current aeroplane** (all wing cross-sections), derived client-side from the `wingConfig` the airfoil-preview page already holds.
- **Additive-only** — new optional `usedNames?: string[]` prop on `AirfoilSelector`; caller (`AirfoilPreviewConfigPanel` / `page.tsx`) computes the names and passes them. No existing props or signatures changed.

## Behaviour

- **'In Verwendung' header** + entries shown at top; separated by a thin divider from the normal list below.
- **Search filters both sections** simultaneously.
- **Currently selected airfoil** is marked with a Check icon in the used section too.
- **De-duplication** handled internally.
- **Empty / absent `usedNames`** → section not rendered at all.

## Tests (vitest, Node 22)

11 new tests in `__tests__/AirfoilSelector.usedNames.test.tsx` covering all specified behaviours.

Total suite: **1425 tests, all passing**. No new `deps:check` violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)