### PR TITLE
feat(gh-841): speed polar (sink vs V) + 2D airfoil proxy

### DIFF
--- a/app/api/v2/endpoints/aeroplane/__init__.py
+++ b/app/api/v2/endpoints/aeroplane/__init__.py
@@ -23,6 +23,7 @@ from .tail_sizing import router as tail_sizing_router
 from .matching_chart import router as matching_chart_router
 from .sm_suggestions import router as sm_suggestions_router
 from .forward_cg import router as forward_cg_router
+from .speed_polar import router as speed_polar_router
 
 # Include the routers
 router.include_router(base_router)
@@ -43,3 +44,4 @@ router.include_router(tail_sizing_router)
 router.include_router(matching_chart_router)
 router.include_router(sm_suggestions_router)
 router.include_router(forward_cg_router)
+router.include_router(speed_polar_router)

--- a/app/api/v2/endpoints/aeroplane/speed_polar.py
+++ b/app/api/v2/endpoints/aeroplane/speed_polar.py
@@ -1,0 +1,179 @@
+"""Speed polar endpoint — GET /aeroplanes/{id}/speed-polar (gh-841).
+
+Returns the closed-form aircraft speed polar (sink vs V) from the aeroplane's
+assumption_computation_context.  All math lives in speed_polar_service; this
+module only handles HTTP plumbing and context extraction.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated, Any, NoReturn, cast
+
+from fastapi import APIRouter, Depends, HTTPException, Path, status
+from pydantic import UUID4, BaseModel
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import NotFoundError, ServiceException
+from app.db.session import get_db
+from app.models.aeroplanemodel import AeroplaneModel
+from app.services.speed_polar_service import (
+    SpeedPolarResult,
+    _MissingInputs,
+    compute_speed_polar,
+    is_missing,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Response schema
+# ---------------------------------------------------------------------------
+
+
+class SpeedPolarPoint(BaseModel):
+    v_mps: float
+    sink_mps: float
+    cl: float
+
+
+class SpeedPolarResponse(BaseModel):
+    """Aircraft speed polar — sink rate [m/s] vs airspeed [m/s].
+
+    All values use SI units. ``sink_mps`` is positive downward.
+    """
+
+    v_mps: list[float]
+    sink_mps: list[float]
+    cl: list[float]
+    best_glide: SpeedPolarPoint
+    min_sink: SpeedPolarPoint
+    inputs: dict[str, Any]
+
+
+class SpeedPolarMissingResponse(BaseModel):
+    """Returned with HTTP 422 when required inputs are absent from the aeroplane context."""
+
+    error: str
+    missing_inputs: list[str]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _raise_http_from_domain(exc: ServiceException) -> NoReturn:
+    if isinstance(exc, NotFoundError):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=exc.message) from exc
+    raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)) from exc
+
+
+def _get_aeroplane(db: Session, aeroplane_id: UUID4) -> AeroplaneModel:
+    plane = db.query(AeroplaneModel).filter(AeroplaneModel.uuid == str(aeroplane_id)).first()
+    if plane is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Aeroplane not found")
+    return plane
+
+
+def _extract_polar_inputs(plane: AeroplaneModel) -> dict[str, float | None]:
+    """Pull mass_kg, s_ref_m2, ar, e_oswald, cd0 from the computation context."""
+    ctx: dict[str, Any] = cast(dict[str, Any], plane.assumption_computation_context or {})
+    return {
+        "mass_kg": _safe_float(ctx.get("mass_kg")),
+        "s_ref_m2": _safe_float(ctx.get("s_ref_m2")),
+        "ar": _safe_float(ctx.get("aspect_ratio")),
+        "e_oswald": _safe_float(ctx.get("e_oswald")),
+        "cd0": _safe_float(ctx.get("cd0")),
+    }
+
+
+def _safe_float(value: Any) -> float | None:
+    """Return a float from *value*, or None if absent/non-numeric/non-positive."""
+    if value is None:
+        return None
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    return f if f > 0 else None
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/aeroplanes/{aeroplane_id}/speed-polar",
+    operation_id="get_speed_polar",
+    tags=["speed-polar"],
+    summary="Aircraft speed polar (sink vs V, closed-form parabolic polar)",
+    response_model=SpeedPolarResponse,
+    responses={
+        404: {"description": "Aeroplane not found"},
+        422: {
+            "description": "Missing inputs in assumption_computation_context",
+            "model": SpeedPolarMissingResponse,
+        },
+    },
+)
+async def get_speed_polar(
+    aeroplane_id: Annotated[UUID4, Path(..., description="Aeroplane UUID")],
+    db: Annotated[Session, Depends(get_db)],
+) -> SpeedPolarResponse:
+    """Return the closed-form aircraft speed polar from polar parameters.
+
+    Reads **mass_kg**, **s_ref_m2**, **aspect_ratio**, **e_oswald**, and **cd0**
+    from the aeroplane's ``assumption_computation_context`` (written by the
+    assumption-compute job). Returns HTTP 422 with a ``missing_inputs`` list
+    when any of these fields is absent or non-positive.
+
+    Formula references (ISA sea-level, parabolic drag polar):
+    - V(CL) = sqrt(2W / (ρ·S·CL))
+    - CD = CD0 + CL² / (π·AR·e)
+    - sink = V · CD / CL
+    - Best-glide: CL_bg = sqrt(CD0 / k)
+    - Min-sink:   CL_ms = sqrt(3·CD0 / k) = √3 · CL_bg
+    """
+    plane = _get_aeroplane(db, aeroplane_id)
+    polar_inputs = _extract_polar_inputs(plane)
+
+    result: SpeedPolarResult | _MissingInputs = compute_speed_polar(**polar_inputs)
+
+    if is_missing(result):
+        missing_result = cast(_MissingInputs, result)
+        logger.info(
+            "Speed polar: missing inputs %s for aeroplane %s",
+            missing_result.missing,
+            aeroplane_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={
+                "error": "Insufficient aircraft parameters for speed polar. "
+                "Run assumption recompute first.",
+                "missing_inputs": missing_result.missing,
+            },
+        )
+
+    polar = cast(SpeedPolarResult, result)
+    return SpeedPolarResponse(
+        v_mps=polar.v_mps,
+        sink_mps=polar.sink_mps,
+        cl=polar.cl,
+        best_glide=SpeedPolarPoint(
+            v_mps=polar.best_glide.v_mps,
+            sink_mps=polar.best_glide.sink_mps,
+            cl=polar.best_glide.cl,
+        ),
+        min_sink=SpeedPolarPoint(
+            v_mps=polar.min_sink.v_mps,
+            sink_mps=polar.min_sink.sink_mps,
+            cl=polar.min_sink.cl,
+        ),
+        inputs=polar.inputs,
+    )

--- a/app/services/speed_polar_service.py
+++ b/app/services/speed_polar_service.py
@@ -1,0 +1,222 @@
+"""Aircraft speed polar (Geschwindigkeitspolare) — closed-form, pure math (gh-841).
+
+Reference formulas (ISA sea level, parabolic drag polar):
+    W = m · g                          [N]       g = 9.80665 m/s²
+    V(CL) = sqrt(2W / (ρ · S · CL))  [m/s]     ρ = 1.225 kg/m³
+    CD = CD0 + k · CL²                           k = 1 / (π · AR · e)
+    sink(CL) = V · CD / CL            [m/s]
+
+Special CL values:
+    CL_bg   = sqrt(CD0 / k)           best-glide  ((L/D)_max tangent from origin)
+    CL_ms   = sqrt(3 · CD0 / k)       min-sink    (= √3 · CL_bg)
+    V_ms    ≈ 0.76 · V_bg             (closed-form ratio for parabolic polar)
+
+All inputs/outputs use SI units.  No AeroSandbox, no solver dependencies.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import NamedTuple
+
+# ISA sea-level constants
+_G = 9.80665  # m/s²
+_RHO_ISA_SL = 1.225  # kg/m³
+
+# Speed-polar sweep: CL from CL_ms·1.4 down to CL_min_sweep
+_CL_SWEEP_POINTS = 200
+_CL_MIN_RATIO = 0.25  # fraction of CL_bg — stops before stall region
+
+
+# ---------------------------------------------------------------------------
+# Public data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SpeedPolarPoint:
+    """A single (V, sink, CL) triplet on the polar curve."""
+
+    v_mps: float
+    sink_mps: float
+    cl: float
+
+
+@dataclass(frozen=True)
+class SpeedPolarResult:
+    """Full speed polar for a single aircraft configuration.
+
+    Attributes
+    ----------
+    v_mps : list of V values [m/s] (ascending)
+    sink_mps : list of corresponding sink rates [m/s] (positive = down)
+    cl : list of CL values (descending, paired with v/sink)
+    best_glide : SpeedPolarPoint at (L/D)_max — tangent from origin
+    min_sink : SpeedPolarPoint at minimum sink rate
+    inputs : dict with the inputs that produced this result (for provenance)
+    """
+
+    v_mps: list[float]
+    sink_mps: list[float]
+    cl: list[float]
+    best_glide: SpeedPolarPoint
+    min_sink: SpeedPolarPoint
+    inputs: dict
+
+
+class _MissingInputs(NamedTuple):
+    missing: list[str]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def compute_speed_polar(
+    mass_kg: float | None,
+    s_ref_m2: float | None,
+    ar: float | None,
+    e_oswald: float | None,
+    cd0: float | None,
+    *,
+    rho: float = _RHO_ISA_SL,
+) -> SpeedPolarResult | _MissingInputs:
+    """Compute the aircraft speed polar from parabolic-polar parameters.
+
+    Returns a ``SpeedPolarResult`` on success, or a ``_MissingInputs``
+    tuple listing the absent / non-positive parameters when the caller
+    should produce an empty-state response.
+
+    Parameters
+    ----------
+    mass_kg : aircraft mass [kg]
+    s_ref_m2 : reference wing area [m²]
+    ar : aspect ratio (dimensionless)
+    e_oswald : Oswald efficiency factor (dimensionless, 0 < e ≤ 1)
+    cd0 : zero-lift drag coefficient (dimensionless, > 0)
+    rho : air density [kg/m³], default ISA sea-level 1.225
+    """
+    missing = _check_inputs(mass_kg=mass_kg, s_ref_m2=s_ref_m2, ar=ar, e_oswald=e_oswald, cd0=cd0)
+    if missing:
+        return _MissingInputs(missing=missing)
+
+    # All inputs validated — narrow types
+    assert mass_kg is not None and s_ref_m2 is not None
+    assert ar is not None and e_oswald is not None and cd0 is not None
+
+    weight_n = mass_kg * _G
+    k = _induced_drag_factor(ar, e_oswald)
+
+    # Special CL values
+    cl_bg = _cl_best_glide(cd0, k)
+    cl_ms = _cl_min_sink(cd0, k)
+
+    # Sweep CL from slightly above CL_ms down to a low-speed stop
+    cl_high = cl_ms * 1.40
+    cl_low = cl_bg * _CL_MIN_RATIO  # well below best glide, not useful to plot further
+    # Build grid of CL values (descending → ascending V for the plot)
+    cl_arr = _linspace(cl_high, cl_low, _CL_SWEEP_POINTS)
+
+    v_arr: list[float] = []
+    sink_arr: list[float] = []
+    for cl in cl_arr:
+        v = _velocity(weight_n, rho, s_ref_m2, cl)
+        sink = _sink_rate(v, cd0, k, cl)
+        v_arr.append(round(v, 4))
+        sink_arr.append(round(sink, 5))
+
+    # Best-glide and min-sink points
+    bg = SpeedPolarPoint(
+        v_mps=round(_velocity(weight_n, rho, s_ref_m2, cl_bg), 4),
+        sink_mps=round(_sink_rate(_velocity(weight_n, rho, s_ref_m2, cl_bg), cd0, k, cl_bg), 5),
+        cl=round(cl_bg, 6),
+    )
+    ms = SpeedPolarPoint(
+        v_mps=round(_velocity(weight_n, rho, s_ref_m2, cl_ms), 4),
+        sink_mps=round(_sink_rate(_velocity(weight_n, rho, s_ref_m2, cl_ms), cd0, k, cl_ms), 5),
+        cl=round(cl_ms, 6),
+    )
+
+    return SpeedPolarResult(
+        v_mps=v_arr,
+        sink_mps=sink_arr,
+        cl=[round(c, 6) for c in cl_arr],
+        best_glide=bg,
+        min_sink=ms,
+        inputs={
+            "mass_kg": mass_kg,
+            "s_ref_m2": s_ref_m2,
+            "ar": ar,
+            "e_oswald": e_oswald,
+            "cd0": cd0,
+            "rho": rho,
+        },
+    )
+
+
+def is_missing(result: SpeedPolarResult | _MissingInputs) -> bool:
+    """Return True when ``compute_speed_polar`` returned a _MissingInputs."""
+    return isinstance(result, _MissingInputs)
+
+
+# ---------------------------------------------------------------------------
+# Pure math helpers (unit-testable in isolation)
+# ---------------------------------------------------------------------------
+
+
+def _check_inputs(
+    *,
+    mass_kg: float | None,
+    s_ref_m2: float | None,
+    ar: float | None,
+    e_oswald: float | None,
+    cd0: float | None,
+) -> list[str]:
+    """Return a list of missing/invalid input names (empty = all OK)."""
+    missing: list[str] = []
+    for name, val in [
+        ("mass_kg", mass_kg),
+        ("s_ref_m2", s_ref_m2),
+        ("ar", ar),
+        ("e_oswald", e_oswald),
+        ("cd0", cd0),
+    ]:
+        if val is None or not math.isfinite(val) or val <= 0:
+            missing.append(name)
+    return missing
+
+
+def _induced_drag_factor(ar: float, e_oswald: float) -> float:
+    """k = 1 / (π · AR · e)."""
+    return 1.0 / (math.pi * ar * e_oswald)
+
+
+def _cl_best_glide(cd0: float, k: float) -> float:
+    """CL at (L/D)_max = sqrt(CD0 / k)."""
+    return math.sqrt(cd0 / k)
+
+
+def _cl_min_sink(cd0: float, k: float) -> float:
+    """CL at minimum sink = sqrt(3 · CD0 / k) = √3 · CL_bg."""
+    return math.sqrt(3.0 * cd0 / k)
+
+
+def _velocity(weight_n: float, rho: float, s_ref_m2: float, cl: float) -> float:
+    """V = sqrt(2W / (ρ · S · CL)) [m/s]."""
+    return math.sqrt(2.0 * weight_n / (rho * s_ref_m2 * cl))
+
+
+def _sink_rate(v_mps: float, cd0: float, k: float, cl: float) -> float:
+    """sink = V · CD / CL  (positive = downward) [m/s]."""
+    cd = cd0 + k * cl**2
+    return v_mps * cd / cl
+
+
+def _linspace(start: float, stop: float, n: int) -> list[float]:
+    """Uniform grid from start to stop with n points."""
+    if n <= 1:
+        return [start]
+    step = (stop - start) / (n - 1)
+    return [start + i * step for i in range(n)]

--- a/app/tests/test_speed_polar_endpoint.py
+++ b/app/tests/test_speed_polar_endpoint.py
@@ -1,0 +1,165 @@
+"""Endpoint tests for GET /aeroplanes/{id}/speed-polar (gh-841)."""
+
+from __future__ import annotations
+
+import math
+import uuid
+
+import pytest
+
+from app.models.aeroplanemodel import AeroplaneModel
+from app.tests.conftest import make_aeroplane
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_aeroplane_with_context(session, *, ctx: dict) -> AeroplaneModel:
+    plane = make_aeroplane(session, name=f"speed-polar-test-{uuid.uuid4().hex[:8]}")
+    plane.assumption_computation_context = ctx
+    session.flush()
+    session.commit()
+    return plane
+
+
+_FULL_CTX = {
+    "mass_kg": 2.0,
+    "s_ref_m2": 0.40,
+    "aspect_ratio": 8.0,
+    "e_oswald": 0.80,
+    "cd0": 0.025,
+}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSpeedPolarEndpointHappyPath:
+    def test_returns_200(self, client_and_db):
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_aeroplane_with_context(db, ctx=_FULL_CTX)
+            uid = str(plane.uuid)
+
+        resp = client.get(f"/aeroplanes/{uid}/speed-polar")
+        assert resp.status_code == 200, resp.text
+
+    def test_response_has_required_fields(self, client_and_db):
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_aeroplane_with_context(db, ctx=_FULL_CTX)
+            uid = str(plane.uuid)
+
+        data = client.get(f"/aeroplanes/{uid}/speed-polar").json()
+        for field in ("v_mps", "sink_mps", "cl", "best_glide", "min_sink", "inputs"):
+            assert field in data, f"Missing field: {field}"
+
+    def test_best_glide_and_min_sink_have_point_fields(self, client_and_db):
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_aeroplane_with_context(db, ctx=_FULL_CTX)
+            uid = str(plane.uuid)
+
+        data = client.get(f"/aeroplanes/{uid}/speed-polar").json()
+        for key in ("best_glide", "min_sink"):
+            pt = data[key]
+            for f in ("v_mps", "sink_mps", "cl"):
+                assert f in pt, f"{key} missing {f}"
+
+    def test_min_sink_cl_is_sqrt3_times_best_glide_cl(self, client_and_db):
+        """CL_ms = √3 · CL_bg (closed-form invariant)."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_aeroplane_with_context(db, ctx=_FULL_CTX)
+            uid = str(plane.uuid)
+
+        data = client.get(f"/aeroplanes/{uid}/speed-polar").json()
+        cl_bg = data["best_glide"]["cl"]
+        cl_ms = data["min_sink"]["cl"]
+        assert abs(cl_ms / cl_bg - math.sqrt(3)) < 1e-3
+
+    def test_v_ms_approx_076_v_bg(self, client_and_db):
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_aeroplane_with_context(db, ctx=_FULL_CTX)
+            uid = str(plane.uuid)
+
+        data = client.get(f"/aeroplanes/{uid}/speed-polar").json()
+        v_bg = data["best_glide"]["v_mps"]
+        v_ms = data["min_sink"]["v_mps"]
+        ratio = v_ms / v_bg
+        assert abs(ratio - 0.76) < 0.01
+
+    def test_min_sink_lower_than_best_glide_sink(self, client_and_db):
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_aeroplane_with_context(db, ctx=_FULL_CTX)
+            uid = str(plane.uuid)
+
+        data = client.get(f"/aeroplanes/{uid}/speed-polar").json()
+        assert data["min_sink"]["sink_mps"] < data["best_glide"]["sink_mps"]
+
+    def test_curve_has_multiple_points(self, client_and_db):
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_aeroplane_with_context(db, ctx=_FULL_CTX)
+            uid = str(plane.uuid)
+
+        data = client.get(f"/aeroplanes/{uid}/speed-polar").json()
+        assert len(data["v_mps"]) > 10
+
+    def test_inputs_echoed_in_response(self, client_and_db):
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_aeroplane_with_context(db, ctx=_FULL_CTX)
+            uid = str(plane.uuid)
+
+        data = client.get(f"/aeroplanes/{uid}/speed-polar").json()
+        assert data["inputs"]["mass_kg"] == _FULL_CTX["mass_kg"]
+        assert data["inputs"]["cd0"] == _FULL_CTX["cd0"]
+
+
+class TestSpeedPolarEndpointErrors:
+    def test_404_for_unknown_aeroplane(self, client_and_db):
+        client, _ = client_and_db
+        uid = str(uuid.uuid4())
+        resp = client.get(f"/aeroplanes/{uid}/speed-polar")
+        assert resp.status_code == 404
+
+    def test_422_when_context_missing(self, client_and_db):
+        """When aeroplane has no computation context, return 422."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_aeroplane_with_context(db, ctx={})
+            uid = str(plane.uuid)
+
+        resp = client.get(f"/aeroplanes/{uid}/speed-polar")
+        assert resp.status_code == 422
+
+    def test_422_includes_missing_inputs_list(self, client_and_db):
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            # Only mass_kg is present — all others missing
+            plane = _make_aeroplane_with_context(db, ctx={"mass_kg": 2.0})
+            uid = str(plane.uuid)
+
+        resp = client.get(f"/aeroplanes/{uid}/speed-polar")
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert "missing_inputs" in detail
+        assert len(detail["missing_inputs"]) > 0
+
+    def test_422_when_cd0_zero(self, client_and_db):
+        """cd0 = 0 is invalid (non-positive) → 422."""
+        client, SessionLocal = client_and_db
+        ctx = {**_FULL_CTX, "cd0": 0.0}
+        with SessionLocal() as db:
+            plane = _make_aeroplane_with_context(db, ctx=ctx)
+            uid = str(plane.uuid)
+
+        resp = client.get(f"/aeroplanes/{uid}/speed-polar")
+        assert resp.status_code == 422

--- a/app/tests/test_speed_polar_service.py
+++ b/app/tests/test_speed_polar_service.py
@@ -1,0 +1,283 @@
+"""Unit tests for the aircraft speed polar service (gh-841).
+
+Tests are pure math — no DB, no AeroSandbox, no HTTP.
+
+Hand-chosen reference aircraft (based on a typical RC trainer):
+    mass_kg   = 2.0
+    s_ref_m2  = 0.4
+    AR        = 8.0
+    e_oswald  = 0.80
+    CD0       = 0.025
+
+Derived reference values (closed-form):
+    g         = 9.80665 m/s²
+    W         = 2.0 × 9.80665 = 19.6133 N
+    k         = 1 / (π × 8 × 0.8) ≈ 0.04974
+
+    CL_bg     = sqrt(0.025 / 0.04974)     ≈ 0.70914
+    CL_ms     = sqrt(3 × 0.025 / 0.04974) ≈ 1.22867  (= √3 × CL_bg)
+    V_bg      = sqrt(2×W / (ρ×S×CL_bg))  ≈ 10.63 m/s
+    V_ms      ≈ 0.759 × V_bg              ≈  8.08 m/s  (≈ 0.76 per spec)
+
+    Sink_min  = V_ms × CD_ms / CL_ms
+    CD_ms     = CD0 + k × CL_ms²  ≈ 0.025 + 0.04974 × 1.22867² ≈ 0.1000
+    Sink_min  ≈ 8.08 × 0.1000 / 1.22867 ≈ 0.658 m/s
+
+The tests verify all closed-form invariants within engineering tolerances.
+"""
+
+from __future__ import annotations
+
+import math
+import pytest
+
+from app.services.speed_polar_service import (
+    SpeedPolarResult,
+    compute_speed_polar,
+    is_missing,
+    _check_inputs,
+    _induced_drag_factor,
+    _cl_best_glide,
+    _cl_min_sink,
+    _velocity,
+    _sink_rate,
+    _linspace,
+)
+
+# ---------------------------------------------------------------------------
+# Reference aircraft (hand-chosen for easy mental cross-check)
+# ---------------------------------------------------------------------------
+
+REF = dict(
+    mass_kg=2.0,
+    s_ref_m2=0.40,
+    ar=8.0,
+    e_oswald=0.80,
+    cd0=0.025,
+)
+
+G = 9.80665
+RHO = 1.225
+
+
+# ---------------------------------------------------------------------------
+# Pure math helpers
+# ---------------------------------------------------------------------------
+
+
+class TestInducedDragFactor:
+    def test_known_value(self):
+        k = _induced_drag_factor(ar=8.0, e_oswald=0.80)
+        expected = 1.0 / (math.pi * 8.0 * 0.80)
+        assert abs(k - expected) < 1e-10
+
+    def test_higher_ar_gives_lower_k(self):
+        k_low = _induced_drag_factor(ar=4.0, e_oswald=0.8)
+        k_high = _induced_drag_factor(ar=10.0, e_oswald=0.8)
+        assert k_high < k_low
+
+    def test_higher_e_gives_lower_k(self):
+        k_low_e = _induced_drag_factor(ar=8.0, e_oswald=0.6)
+        k_high_e = _induced_drag_factor(ar=8.0, e_oswald=1.0)
+        assert k_high_e < k_low_e
+
+
+class TestClBestGlide:
+    def test_formula(self):
+        k = _induced_drag_factor(8.0, 0.80)
+        cl_bg = _cl_best_glide(cd0=0.025, k=k)
+        assert abs(cl_bg - math.sqrt(0.025 / k)) < 1e-12
+
+    def test_reference_value(self):
+        k = _induced_drag_factor(8.0, 0.80)
+        cl_bg = _cl_best_glide(0.025, k)
+        assert abs(cl_bg - 0.7091) < 5e-4
+
+
+class TestClMinSink:
+    def test_is_sqrt3_times_cl_bg(self):
+        k = _induced_drag_factor(8.0, 0.80)
+        cl_bg = _cl_best_glide(0.025, k)
+        cl_ms = _cl_min_sink(0.025, k)
+        assert abs(cl_ms - math.sqrt(3) * cl_bg) < 1e-10
+
+    def test_greater_than_cl_bg(self):
+        k = _induced_drag_factor(8.0, 0.80)
+        cl_bg = _cl_best_glide(0.025, k)
+        cl_ms = _cl_min_sink(0.025, k)
+        assert cl_ms > cl_bg
+
+
+class TestVelocity:
+    def test_higher_cl_gives_lower_v(self):
+        w = 2.0 * G
+        v_low_cl = _velocity(w, RHO, 0.40, cl=0.5)
+        v_high_cl = _velocity(w, RHO, 0.40, cl=1.5)
+        assert v_high_cl < v_low_cl
+
+    def test_reference_v_bg(self):
+        """V_bg ≈ 10.63 m/s for the reference aircraft."""
+        k = _induced_drag_factor(8.0, 0.80)
+        cl_bg = _cl_best_glide(0.025, k)
+        w = 2.0 * G
+        v_bg = _velocity(w, RHO, 0.40, cl_bg)
+        assert abs(v_bg - 10.63) < 0.10
+
+    def test_v_ms_approx_0_76_v_bg(self):
+        """V_ms / V_bg ≈ 0.76 as given in the spec."""
+        k = _induced_drag_factor(8.0, 0.80)
+        cl_bg = _cl_best_glide(0.025, k)
+        cl_ms = _cl_min_sink(0.025, k)
+        w = 2.0 * G
+        v_bg = _velocity(w, RHO, 0.40, cl_bg)
+        v_ms = _velocity(w, RHO, 0.40, cl_ms)
+        ratio = v_ms / v_bg
+        # Exact closed-form ratio is (3)^(-1/4) ≈ 0.7598 ≈ 0.76
+        assert abs(ratio - 0.76) < 0.005
+
+
+class TestSinkRate:
+    def test_sink_positive(self):
+        sink = _sink_rate(v_mps=10.0, cd0=0.025, k=0.05, cl=0.8)
+        assert sink > 0
+
+    def test_sink_at_cl_ms_is_minimum(self):
+        """The sink rate is minimum at CL_ms — by definition."""
+        k = _induced_drag_factor(8.0, 0.80)
+        cl_ms = _cl_min_sink(0.025, k)
+        w = 2.0 * G
+        v_ms = _velocity(w, RHO, 0.40, cl_ms)
+        sink_at_ms = _sink_rate(v_ms, 0.025, k, cl_ms)
+
+        # Check several CL values on both sides
+        for cl_other in [cl_ms * 0.7, cl_ms * 0.85, cl_ms * 1.15, cl_ms * 1.3]:
+            v_other = _velocity(w, RHO, 0.40, cl_other)
+            sink_other = _sink_rate(v_other, 0.025, k, cl_other)
+            assert sink_at_ms < sink_other + 1e-6  # CL_ms is minimum
+
+
+class TestLinspace:
+    def test_endpoints(self):
+        xs = _linspace(0.0, 1.0, 5)
+        assert abs(xs[0] - 0.0) < 1e-12
+        assert abs(xs[-1] - 1.0) < 1e-12
+
+    def test_length(self):
+        assert len(_linspace(0.0, 1.0, 10)) == 10
+
+    def test_single_point(self):
+        xs = _linspace(3.0, 9.0, 1)
+        assert xs == [3.0]
+
+
+class TestCheckInputs:
+    def test_all_valid_returns_empty(self):
+        missing = _check_inputs(mass_kg=2.0, s_ref_m2=0.4, ar=8.0, e_oswald=0.8, cd0=0.025)
+        assert missing == []
+
+    def test_none_mass_reported(self):
+        missing = _check_inputs(mass_kg=None, s_ref_m2=0.4, ar=8.0, e_oswald=0.8, cd0=0.025)
+        assert "mass_kg" in missing
+
+    def test_zero_ar_reported(self):
+        missing = _check_inputs(mass_kg=2.0, s_ref_m2=0.4, ar=0.0, e_oswald=0.8, cd0=0.025)
+        assert "ar" in missing
+
+    def test_negative_cd0_reported(self):
+        missing = _check_inputs(mass_kg=2.0, s_ref_m2=0.4, ar=8.0, e_oswald=0.8, cd0=-0.01)
+        assert "cd0" in missing
+
+    def test_nan_reported(self):
+        import math
+
+        missing = _check_inputs(mass_kg=2.0, s_ref_m2=0.4, ar=math.nan, e_oswald=0.8, cd0=0.025)
+        assert "ar" in missing
+
+    def test_multiple_missing(self):
+        missing = _check_inputs(mass_kg=None, s_ref_m2=None, ar=8.0, e_oswald=0.8, cd0=0.025)
+        assert set(missing) == {"mass_kg", "s_ref_m2"}
+
+
+# ---------------------------------------------------------------------------
+# Full compute_speed_polar integration
+# ---------------------------------------------------------------------------
+
+
+class TestComputeSpeedPolar:
+    def test_returns_speed_polar_result(self):
+        result = compute_speed_polar(**REF)
+        assert isinstance(result, SpeedPolarResult)
+        assert not is_missing(result)
+
+    def test_curve_lengths_consistent(self):
+        result = compute_speed_polar(**REF)
+        assert isinstance(result, SpeedPolarResult)
+        assert len(result.v_mps) == len(result.sink_mps) == len(result.cl)
+        assert len(result.v_mps) > 1
+
+    def test_v_ascending(self):
+        """Speed is monotonically increasing as CL decreases."""
+        result = compute_speed_polar(**REF)
+        assert isinstance(result, SpeedPolarResult)
+        for i in range(1, len(result.v_mps)):
+            assert result.v_mps[i] >= result.v_mps[i - 1]
+
+    def test_best_glide_cl_correct(self):
+        result = compute_speed_polar(**REF)
+        assert isinstance(result, SpeedPolarResult)
+        k = _induced_drag_factor(REF["ar"], REF["e_oswald"])
+        expected_cl_bg = _cl_best_glide(REF["cd0"], k)
+        assert abs(result.best_glide.cl - expected_cl_bg) < 1e-4
+
+    def test_min_sink_cl_is_sqrt3_times_cl_bg(self):
+        result = compute_speed_polar(**REF)
+        assert isinstance(result, SpeedPolarResult)
+        ratio = result.min_sink.cl / result.best_glide.cl
+        assert abs(ratio - math.sqrt(3)) < 1e-4
+
+    def test_v_ms_approx_076_v_bg(self):
+        result = compute_speed_polar(**REF)
+        assert isinstance(result, SpeedPolarResult)
+        ratio = result.min_sink.v_mps / result.best_glide.v_mps
+        assert abs(ratio - 0.76) < 0.005
+
+    def test_min_sink_has_lower_sink_than_best_glide(self):
+        result = compute_speed_polar(**REF)
+        assert isinstance(result, SpeedPolarResult)
+        assert result.min_sink.sink_mps < result.best_glide.sink_mps
+
+    def test_inputs_preserved_in_result(self):
+        result = compute_speed_polar(**REF)
+        assert isinstance(result, SpeedPolarResult)
+        assert result.inputs["mass_kg"] == REF["mass_kg"]
+        assert result.inputs["cd0"] == REF["cd0"]
+
+    def test_missing_mass_returns_missing_inputs(self):
+        result = compute_speed_polar(mass_kg=None, s_ref_m2=0.4, ar=8.0, e_oswald=0.8, cd0=0.025)
+        assert is_missing(result)
+
+    def test_missing_cd0_returns_missing_inputs(self):
+        result = compute_speed_polar(mass_kg=2.0, s_ref_m2=0.4, ar=8.0, e_oswald=0.8, cd0=None)
+        assert is_missing(result)
+
+    def test_all_missing_returns_missing_inputs(self):
+        result = compute_speed_polar(mass_kg=None, s_ref_m2=None, ar=None, e_oswald=None, cd0=None)
+        assert is_missing(result)
+        assert len(result.missing) == 5  # type: ignore[union-attr]
+
+    def test_sink_curve_shape_has_minimum(self):
+        """Sink curve has a U-shape — minimum is in the middle, not at endpoints."""
+        result = compute_speed_polar(**REF)
+        assert isinstance(result, SpeedPolarResult)
+        sinks = result.sink_mps
+        min_idx = sinks.index(min(sinks))
+        # Minimum should NOT be at the very first or very last point
+        assert 0 < min_idx < len(sinks) - 1
+
+    def test_custom_rho_changes_velocities(self):
+        result_sl = compute_speed_polar(**REF, rho=1.225)
+        result_alt = compute_speed_polar(**REF, rho=1.0)
+        assert isinstance(result_sl, SpeedPolarResult)
+        assert isinstance(result_alt, SpeedPolarResult)
+        # Lower density → higher speed for same CL
+        assert result_alt.best_glide.v_mps > result_sl.best_glide.v_mps

--- a/frontend/__tests__/AirfoilProxyChart.test.tsx
+++ b/frontend/__tests__/AirfoilProxyChart.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for AirfoilProxyChart component (gh-841).
+ *
+ * Tests verify:
+ * - Empty state when no analysis result
+ * - Chart renders with cl/cd and cl^1.5/cd curves
+ * - Disclaimer badge present (clearly labelled as 2D proxy)
+ * - Peak markers rendered
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { AirfoilProxyChart } from "@/components/workbench/AirfoilProxyChart";
+import type { AirfoilAnalysisResult } from "@/hooks/useAirfoilAnalysis";
+
+// ---------------------------------------------------------------------------
+// Test fixture — representative NACA 2412 polar values
+// ---------------------------------------------------------------------------
+
+const MOCK_ANALYSIS: AirfoilAnalysisResult = {
+  airfoilName: "naca2412",
+  alphaDeg: [-4, -2, 0, 2, 4, 6, 8, 10, 12],
+  cl: [-0.2, 0.1, 0.35, 0.55, 0.75, 0.95, 1.1, 1.2, 1.3],
+  cd: [0.012, 0.010, 0.009, 0.009, 0.010, 0.012, 0.015, 0.020, 0.027],
+  cm: [-0.05, -0.04, -0.04, -0.04, -0.04, -0.04, -0.04, -0.04, -0.04],
+  clOverCd: [-16.7, 10.0, 38.9, 61.1, 75.0, 79.2, 73.3, 60.0, 48.1],
+  clMax: 1.3,
+  alphaAtClMax: 12,
+  ldMax: 79.2,
+  alphaAtLdMax: 6,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AirfoilProxyChart", () => {
+  it("renders empty state when no analysis result", () => {
+    render(<AirfoilProxyChart analysisResult={null} />);
+    expect(screen.getByTestId("airfoil-proxy-chart-empty")).toBeDefined();
+  });
+
+  it("renders chart when analysis result is provided", () => {
+    render(<AirfoilProxyChart analysisResult={MOCK_ANALYSIS} />);
+    expect(screen.getByTestId("airfoil-proxy-chart")).toBeDefined();
+  });
+
+  it("renders cl/cd line", () => {
+    render(<AirfoilProxyChart analysisResult={MOCK_ANALYSIS} />);
+    expect(screen.getByTestId("airfoil-proxy-clovercd-line")).toBeDefined();
+  });
+
+  it("renders cl^1.5/cd line", () => {
+    render(<AirfoilProxyChart analysisResult={MOCK_ANALYSIS} />);
+    expect(screen.getByTestId("airfoil-proxy-cl15-line")).toBeDefined();
+  });
+
+  it("renders peak cl/cd marker", () => {
+    render(<AirfoilProxyChart analysisResult={MOCK_ANALYSIS} />);
+    expect(screen.getByTestId("airfoil-proxy-peak-clovercd")).toBeDefined();
+  });
+
+  it("renders peak cl^1.5/cd marker", () => {
+    render(<AirfoilProxyChart analysisResult={MOCK_ANALYSIS} />);
+    expect(screen.getByTestId("airfoil-proxy-peak-cl15overcd")).toBeDefined();
+  });
+
+  it("shows disclaimer badge labelling chart as 2D proxy", () => {
+    render(<AirfoilProxyChart analysisResult={MOCK_ANALYSIS} />);
+    expect(screen.getByTestId("airfoil-proxy-disclaimer")).toBeDefined();
+  });
+
+  it("shows title Profil-Indikator (2D)", () => {
+    render(<AirfoilProxyChart analysisResult={MOCK_ANALYSIS} />);
+    // The title span contains "Profil-Indikator (2D)" — at least one element matches
+    const matches = screen.getAllByText(/Profil-Indikator/);
+    expect(matches.length).toBeGreaterThan(0);
+  });
+
+  it("empty state when all cl values are non-positive", () => {
+    const noPositiveCl: AirfoilAnalysisResult = {
+      ...MOCK_ANALYSIS,
+      cl: [-0.5, -0.2, 0.0],
+      cd: [0.01, 0.01, 0.01],
+    };
+    render(<AirfoilProxyChart analysisResult={noPositiveCl} />);
+    expect(screen.getByTestId("airfoil-proxy-chart-empty")).toBeDefined();
+  });
+});

--- a/frontend/__tests__/GeschwindigkeitspolareChart.test.tsx
+++ b/frontend/__tests__/GeschwindigkeitspolareChart.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for GeschwindigkeitspolareChart component (gh-841).
+ *
+ * Tests verify:
+ * - Empty state when polar is null
+ * - Loading state rendering
+ * - Chart renders when data is provided
+ * - Best-glide and min-sink markers present
+ * - Tangent line present
+ * - Disclaimer/title visible
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { GeschwindigkeitspolareChart } from "@/components/workbench/GeschwindigkeitspolareChart";
+import type { AircraftSpeedPolar } from "@/hooks/useSpeedPolar";
+
+// ---------------------------------------------------------------------------
+// Test fixture
+// ---------------------------------------------------------------------------
+
+const MOCK_POLAR: AircraftSpeedPolar = {
+  v_mps: [7.5, 8.0, 9.0, 10.0, 12.0, 14.0, 16.0, 20.0],
+  sink_mps: [0.62, 0.58, 0.52, 0.50, 0.54, 0.62, 0.74, 1.1],
+  cl: [1.4, 1.2, 0.95, 0.78, 0.54, 0.40, 0.31, 0.20],
+  best_glide: { v_mps: 10.0, sink_mps: 0.50, cl: 0.78 },
+  min_sink: { v_mps: 8.0, sink_mps: 0.58, cl: 1.2 },
+  inputs: {
+    mass_kg: 2.0,
+    s_ref_m2: 0.40,
+    ar: 8.0,
+    e_oswald: 0.80,
+    cd0: 0.025,
+    rho: 1.225,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GeschwindigkeitspolareChart", () => {
+  it("renders empty state when polar is null", () => {
+    render(<GeschwindigkeitspolareChart polar={null} />);
+    expect(screen.getByTestId("speed-polar-empty")).toBeDefined();
+  });
+
+  it("renders loading state", () => {
+    render(<GeschwindigkeitspolareChart polar={null} isLoading />);
+    expect(screen.getByTestId("speed-polar-loading")).toBeDefined();
+  });
+
+  it("renders chart when polar data is provided", () => {
+    render(<GeschwindigkeitspolareChart polar={MOCK_POLAR} />);
+    expect(screen.getByTestId("geschwindigkeitspolare-chart")).toBeDefined();
+  });
+
+  it("renders the polar curve path", () => {
+    render(<GeschwindigkeitspolareChart polar={MOCK_POLAR} />);
+    expect(screen.getByTestId("speed-polar-curve")).toBeDefined();
+  });
+
+  it("renders best-glide marker", () => {
+    render(<GeschwindigkeitspolareChart polar={MOCK_POLAR} />);
+    expect(screen.getByTestId("speed-polar-best-glide-marker")).toBeDefined();
+  });
+
+  it("renders min-sink marker", () => {
+    render(<GeschwindigkeitspolareChart polar={MOCK_POLAR} />);
+    expect(screen.getByTestId("speed-polar-min-sink-marker")).toBeDefined();
+  });
+
+  it("renders best-glide tangent line", () => {
+    render(<GeschwindigkeitspolareChart polar={MOCK_POLAR} />);
+    expect(screen.getByTestId("speed-polar-best-glide-tangent")).toBeDefined();
+  });
+
+  it("shows chart title Geschwindigkeitspolare", () => {
+    render(<GeschwindigkeitspolareChart polar={MOCK_POLAR} />);
+    expect(screen.getByText(/Geschwindigkeitspolare/)).toBeDefined();
+  });
+});

--- a/frontend/__tests__/airfoilProxyChartData.test.ts
+++ b/frontend/__tests__/airfoilProxyChartData.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for the 2D airfoil proxy chart data helpers (gh-841).
+ *
+ * Tests cover:
+ * - buildAirfoilProxyChartData: filtering, formula correctness, sort order
+ * - findPeakClOverCd / findPeakCl15OverCd: peak detection
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildAirfoilProxyChartData,
+  findPeakClOverCd,
+  findPeakCl15OverCd,
+} from "@/lib/airfoilProxyChartData";
+
+// ---------------------------------------------------------------------------
+// buildAirfoilProxyChartData
+// ---------------------------------------------------------------------------
+
+describe("buildAirfoilProxyChartData", () => {
+  it("computes cl/cd correctly", () => {
+    const data = buildAirfoilProxyChartData([0.8], [0.02]);
+    expect(data).toHaveLength(1);
+    expect(data[0].clOverCd).toBeCloseTo(0.8 / 0.02, 6);
+  });
+
+  it("computes cl^1.5/cd correctly", () => {
+    const data = buildAirfoilProxyChartData([0.8], [0.02]);
+    expect(data[0].cl15OverCd).toBeCloseTo(Math.pow(0.8, 1.5) / 0.02, 6);
+  });
+
+  it("filters out null values", () => {
+    const data = buildAirfoilProxyChartData([null, 0.8, null], [0.02, 0.02, 0.02]);
+    expect(data).toHaveLength(1);
+    expect(data[0].cl).toBe(0.8);
+  });
+
+  it("filters out non-positive cd", () => {
+    const data = buildAirfoilProxyChartData([0.8, 0.9], [0.0, 0.02]);
+    expect(data).toHaveLength(1);
+    expect(data[0].cl).toBe(0.9);
+  });
+
+  it("filters out non-positive cl (no endurance metric for cl <= 0)", () => {
+    const data = buildAirfoilProxyChartData([-0.1, 0.0, 0.5], [0.02, 0.02, 0.02]);
+    expect(data).toHaveLength(1);
+    expect(data[0].cl).toBe(0.5);
+  });
+
+  it("filters out non-finite values", () => {
+    const data = buildAirfoilProxyChartData(
+      [Infinity, NaN, 0.7],
+      [0.02, 0.02, 0.02],
+    );
+    expect(data).toHaveLength(1);
+  });
+
+  it("returns empty array for all-null inputs", () => {
+    const data = buildAirfoilProxyChartData([null, null], [null, null]);
+    expect(data).toHaveLength(0);
+  });
+
+  it("returns empty array for empty inputs", () => {
+    expect(buildAirfoilProxyChartData([], [])).toHaveLength(0);
+  });
+
+  it("sorts output by cl ascending", () => {
+    const data = buildAirfoilProxyChartData(
+      [1.5, 0.5, 1.0],
+      [0.03, 0.02, 0.025],
+    );
+    const cls = data.map((p) => p.cl);
+    for (let i = 1; i < cls.length; i++) {
+      expect(cls[i]).toBeGreaterThanOrEqual(cls[i - 1]);
+    }
+  });
+
+  it("handles mismatched array lengths gracefully (uses shorter)", () => {
+    const data = buildAirfoilProxyChartData([0.5, 0.8, 1.0], [0.02, 0.025]);
+    expect(data.length).toBeLessThanOrEqual(2);
+  });
+
+  it("cl value is preserved in output", () => {
+    const data = buildAirfoilProxyChartData([0.9], [0.03]);
+    expect(data[0].cl).toBe(0.9);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findPeakClOverCd
+// ---------------------------------------------------------------------------
+
+describe("findPeakClOverCd", () => {
+  it("returns null for empty data", () => {
+    expect(findPeakClOverCd([])).toBeNull();
+  });
+
+  it("finds the correct peak", () => {
+    const data = buildAirfoilProxyChartData(
+      [0.5, 1.0, 0.8],
+      [0.02, 0.025, 0.015], // cl/cd: 25, 40, 53.3
+    );
+    const peak = findPeakClOverCd(data);
+    expect(peak).not.toBeNull();
+    expect(peak!.cl).toBe(0.8); // highest cl/cd = 0.8/0.015
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findPeakCl15OverCd
+// ---------------------------------------------------------------------------
+
+describe("findPeakCl15OverCd", () => {
+  it("returns null for empty data", () => {
+    expect(findPeakCl15OverCd([])).toBeNull();
+  });
+
+  it("finds the correct peak", () => {
+    const data = buildAirfoilProxyChartData(
+      [0.5, 1.0, 0.8],
+      [0.02, 0.025, 0.03],
+    );
+    // cl^1.5/cd: 0.5^1.5/0.02=17.7, 1.0^1.5/0.025=40, 0.8^1.5/0.03=23.9
+    const peak = findPeakCl15OverCd(data);
+    expect(peak).not.toBeNull();
+    expect(peak!.cl).toBe(1.0);
+  });
+});

--- a/frontend/__tests__/useSpeedPolar.test.ts
+++ b/frontend/__tests__/useSpeedPolar.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Unit tests for the useSpeedPolar hook type definitions (gh-841).
+ *
+ * The hook itself is a thin SWR wrapper — we verify the TypeScript interface
+ * shapes are correct rather than mocking fetch (integration covered by E2E).
+ */
+
+import { describe, it, expect } from "vitest";
+import type { AircraftSpeedPolar, SpeedPolarPoint } from "@/hooks/useSpeedPolar";
+
+// ---------------------------------------------------------------------------
+// Type-level smoke tests — verify the interface is correct
+// ---------------------------------------------------------------------------
+
+describe("AircraftSpeedPolar interface (gh-841)", () => {
+  it("accepts a fully-populated speed polar", () => {
+    const pt: SpeedPolarPoint = { v_mps: 10.0, sink_mps: 0.5, cl: 0.8 };
+    const polar: AircraftSpeedPolar = {
+      v_mps: [8.0, 10.0, 14.0, 20.0],
+      sink_mps: [0.65, 0.50, 0.55, 0.85],
+      cl: [1.2, 0.8, 0.5, 0.25],
+      best_glide: pt,
+      min_sink: { v_mps: 8.0, sink_mps: 0.65, cl: 1.2 },
+      inputs: {
+        mass_kg: 2.0,
+        s_ref_m2: 0.4,
+        ar: 8.0,
+        e_oswald: 0.8,
+        cd0: 0.025,
+        rho: 1.225,
+      },
+    };
+    expect(polar.v_mps.length).toBe(4);
+    expect(polar.best_glide.v_mps).toBe(10.0);
+    expect(polar.inputs.cd0).toBe(0.025);
+  });
+
+  it("SpeedPolarPoint has required numeric fields", () => {
+    const pt: SpeedPolarPoint = { v_mps: 12.3, sink_mps: 0.48, cl: 0.71 };
+    expect(pt.v_mps).toBeGreaterThan(0);
+    expect(pt.sink_mps).toBeGreaterThan(0);
+    expect(pt.cl).toBeGreaterThan(0);
+  });
+});

--- a/frontend/app/workbench/airfoil-preview/page.tsx
+++ b/frontend/app/workbench/airfoil-preview/page.tsx
@@ -7,6 +7,7 @@ import { useWingConfig } from "@/hooks/useWingConfig";
 import { useAirfoilGeometry } from "@/hooks/useAirfoilGeometry";
 import { useAirfoilAnalysis } from "@/hooks/useAirfoilAnalysis";
 import { useAirfoilSuitability } from "@/hooks/useAirfoilSuitability";
+import { useSpeedPolar } from "@/hooks/useSpeedPolar";
 import { AirfoilPreviewViewerPanel } from "@/components/workbench/AirfoilPreviewViewerPanel";
 import type { OperatingPoints } from "@/components/workbench/AirfoilPreviewViewerPanel";
 import { AirfoilPreviewConfigPanel } from "@/components/workbench/AirfoilPreviewConfigPanel";
@@ -194,6 +195,9 @@ export default function AirfoilPreviewPage() {
   const tipGeo = useAirfoilGeometry(tipAirfoil === rootAirfoil ? null : tipAirfoil);
   const rootAnalysis = useAirfoilAnalysis();
   const tipAnalysis = useAirfoilAnalysis();
+
+  // gh-841: aircraft speed polar from the backend (closed-form from assumptions)
+  const speedPolar = useSpeedPolar(aeroplaneId);
 
   // gh-822: Suitability hooks (chord in metres = chordMm / 1000)
   const [rootRankedMode, setRootRankedMode] = useState(false);
@@ -386,6 +390,9 @@ export default function AirfoilPreviewPage() {
           operatingAlphaDeg={rootOperatingAlpha}
           tipSuitabilityItem={hasTip ? (tipSuitabilityItem ?? undefined) : undefined}
           operatingPoints={rootOperatingPoints}
+          // gh-841: speed polar + 2D proxy charts
+          speedPolar={speedPolar.data ?? null}
+          speedPolarLoading={speedPolar.isLoading}
         />
       </div>
       <div className="shrink-0 overflow-hidden" style={{ width: 480 }}>

--- a/frontend/components/workbench/AirfoilPreviewViewerPanel.tsx
+++ b/frontend/components/workbench/AirfoilPreviewViewerPanel.tsx
@@ -6,6 +6,9 @@ import type { AirfoilGeometry } from "@/hooks/useAirfoilGeometry";
 import type { AirfoilAnalysisResult } from "@/hooks/useAirfoilAnalysis";
 import type { SuitabilityItem } from "@/hooks/useAirfoilSuitability";
 import { interpolateY } from "@/hooks/useAirfoilGeometry";
+import type { AircraftSpeedPolar } from "@/hooks/useSpeedPolar";
+import { GeschwindigkeitspolareChart } from "@/components/workbench/GeschwindigkeitspolareChart";
+import { AirfoilProxyChart } from "@/components/workbench/AirfoilProxyChart";
 
 /** gh-839 ADDITIVE: a single operating point for alpha-diagram markers. */
 export interface OperatingPoint {
@@ -48,6 +51,14 @@ interface AirfoilPreviewViewerPanelProps {
    * When provided, markers and a legend are added to the L/D and CL/CD charts.
    */
   operatingPoints?: OperatingPoints;
+  /**
+   * gh-841 ADDITIVE: aircraft speed polar from the backend (closed-form).
+   * When provided, renders the Geschwindigkeitspolare chart with best-glide
+   * and min-sink markers.
+   */
+  speedPolar?: AircraftSpeedPolar | null;
+  /** gh-841 ADDITIVE: true while speed polar is loading from the backend. */
+  speedPolarLoading?: boolean;
 }
 
 const COLOR_ROOT = "#FF8400";
@@ -679,6 +690,8 @@ export function AirfoilPreviewViewerPanel({
   operatingAlphaDeg,
   tipSuitabilityItem,
   operatingPoints,
+  speedPolar,
+  speedPolarLoading,
 }: Readonly<AirfoilPreviewViewerPanelProps>) {
   const [maximizedChart, setMaximizedChart] = useState<string | null>(null);
 
@@ -971,6 +984,19 @@ export function AirfoilPreviewViewerPanel({
           </span>
         </div>
       )}
+
+      {/* gh-841: Geschwindigkeitspolare + 2D airfoil proxy charts */}
+      <div className="grid grid-cols-2 gap-4 rounded-xl border border-border bg-card p-4">
+        <div className="flex flex-col">
+          <GeschwindigkeitspolareChart
+            polar={speedPolar ?? null}
+            isLoading={speedPolarLoading}
+          />
+        </div>
+        <div className="flex flex-col">
+          <AirfoilProxyChart analysisResult={rootAnalysisResult} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/components/workbench/AirfoilProxyChart.tsx
+++ b/frontend/components/workbench/AirfoilProxyChart.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useMemo } from "react";
+import type { AirfoilAnalysisResult } from "@/hooks/useAirfoilAnalysis";
+import {
+  buildAirfoilProxyChartData,
+  findPeakClOverCd,
+  findPeakCl15OverCd,
+} from "@/lib/airfoilProxyChartData";
+
+// ── Colors ───────────────────────────────────────────────────────
+const COLOR_CL_OVER_CD = "#22c55e";    // cl/cd — green (range/glide)
+const COLOR_CL15_OVER_CD = "#a78bfa"; // cl^1.5/cd — violet (endurance)
+
+// ── Chart geometry ───────────────────────────────────────────────
+const W = 400;
+const H = 200;
+const PAD = { top: 14, right: 20, bottom: 36, left: 52 };
+const PW = W - PAD.left - PAD.right;
+const PH = H - PAD.top - PAD.bottom;
+
+interface AirfoilProxyChartProps {
+  /** Root airfoil analysis result.  null = empty state. */
+  analysisResult: AirfoilAnalysisResult | null;
+}
+
+/**
+ * 2D airfoil proxy chart — cl/cd and cl^1.5/cd vs cl.
+ *
+ * IMPORTANT: These are SECTION-level (2D) metrics from the NeuralFoil polar,
+ * NOT the aircraft polar.  The chart is labelled clearly to avoid confusion
+ * with the aircraft Geschwindigkeitspolare.
+ *
+ * - cl/cd: range / glide indicator (section best-glide proxy)
+ * - cl^1.5/cd: endurance indicator (section best-endurance proxy)
+ */
+export function AirfoilProxyChart({
+  analysisResult,
+}: Readonly<AirfoilProxyChartProps>) {
+  const plotData = useMemo(() => {
+    if (!analysisResult) return null;
+
+    const proxyData = buildAirfoilProxyChartData(
+      analysisResult.cl,
+      analysisResult.cd,
+    );
+    if (proxyData.length < 2) return null;
+
+    const cls = proxyData.map((p) => p.cl);
+    const clovercds = proxyData.map((p) => p.clOverCd);
+    const cl15overcds = proxyData.map((p) => p.cl15OverCd);
+
+    const xMin = Math.max(0, Math.min(...cls) * 0.95);
+    const xMax = Math.max(...cls) * 1.05;
+    const xRange = xMax - xMin || 1;
+
+    const allY = [...clovercds, ...cl15overcds];
+    const yMin = 0;
+    const yMax = Math.max(...allY) * 1.15;
+    const yRange = yMax - yMin || 1;
+
+    function sx(cl: number) { return PAD.left + ((cl - xMin) / xRange) * PW; }
+    function sy(y: number) { return PAD.top + PH - ((y - yMin) / yRange) * PH; }
+
+    function buildPath(xs: number[], ys: number[]) {
+      return xs
+        .map((x, i) => `${i === 0 ? "M" : "L"}${sx(x).toFixed(1)},${sy(ys[i]).toFixed(1)}`)
+        .join(" ");
+    }
+
+    const pathClOverCd = buildPath(cls, clovercds);
+    const pathCl15OverCd = buildPath(cls, cl15overcds);
+
+    const peakClOverCd = findPeakClOverCd(proxyData);
+    const peakCl15OverCd = findPeakCl15OverCd(proxyData);
+
+    const xTicks = Array.from({ length: 5 }, (_, i) => xMin + (xRange * i) / 4);
+    const yTicks = Array.from({ length: 5 }, (_, i) => yMin + (yRange * i) / 4);
+
+    return {
+      pathClOverCd, pathCl15OverCd,
+      peakClOverCd, peakCl15OverCd,
+      sx, sy, xTicks, yTicks,
+    };
+  }, [analysisResult]);
+
+  if (!analysisResult || !plotData) {
+    return (
+      <div
+        className="flex h-full items-center justify-center font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-muted-foreground"
+        data-testid="airfoil-proxy-chart-empty"
+      >
+        Analyse ausf{"ü"}hren um Profil-Indikator zu sehen
+      </div>
+    );
+  }
+
+  const {
+    pathClOverCd, pathCl15OverCd,
+    peakClOverCd, peakCl15OverCd,
+    sx, sy, xTicks, yTicks,
+  } = plotData;
+
+  return (
+    <div className="flex flex-col gap-2" data-testid="airfoil-proxy-chart">
+      {/* Chart title + disclaimer */}
+      <div className="flex items-baseline gap-2">
+        <span className="font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-foreground">
+          Profil-Indikator (2D)
+        </span>
+        <span
+          className="rounded border border-amber-500/40 bg-amber-500/10 px-1 font-[family-name:var(--font-jetbrains-mono)] text-[8px] text-amber-400"
+          data-testid="airfoil-proxy-disclaimer"
+        >
+          kein Flugzeug — Profil-Indikator
+        </span>
+      </div>
+
+      {/* SVG chart */}
+      <div className="rounded-xl border border-border bg-card p-2">
+        <svg viewBox={`0 0 ${W} ${H}`} className="h-full w-full" preserveAspectRatio="xMidYMid meet">
+          {/* Grid */}
+          {yTicks.map((y) => (
+            <line key={`yg${y}`} x1={PAD.left} x2={W - PAD.right}
+              y1={sy(y)} y2={sy(y)} stroke="var(--color-border)" strokeWidth="0.5" />
+          ))}
+          {xTicks.map((x) => (
+            <line key={`xg${x}`} x1={sx(x)} x2={sx(x)}
+              y1={PAD.top} y2={PAD.top + PH} stroke="var(--color-border)" strokeWidth="0.5" />
+          ))}
+
+          {/* Axes */}
+          <line x1={PAD.left} x2={PAD.left} y1={PAD.top} y2={PAD.top + PH}
+            stroke="var(--color-muted-foreground)" strokeWidth="1" />
+          <line x1={PAD.left} x2={W - PAD.right} y1={PAD.top + PH} y2={PAD.top + PH}
+            stroke="var(--color-muted-foreground)" strokeWidth="1" />
+
+          {/* Y-axis labels */}
+          {yTicks.map((y) => (
+            <text key={`yl${y}`} x={PAD.left - 5} y={sy(y) + 3}
+              textAnchor="end" fontSize="8" fill="var(--color-muted-foreground)"
+              fontFamily="var(--font-jetbrains-mono)">
+              {y.toFixed(0)}
+            </text>
+          ))}
+
+          {/* X-axis labels */}
+          {xTicks.map((x) => (
+            <text key={`xl${x}`} x={sx(x)} y={PAD.top + PH + 12}
+              textAnchor="middle" fontSize="8" fill="var(--color-muted-foreground)"
+              fontFamily="var(--font-jetbrains-mono)">
+              {x.toFixed(2)}
+            </text>
+          ))}
+
+          {/* Axis labels */}
+          <text x={W / 2} y={H - 3} textAnchor="middle" fontSize="9"
+            fill="var(--color-muted-foreground)" fontFamily="var(--font-jetbrains-mono)">
+            C_L
+          </text>
+          <text x={12} y={H / 2} textAnchor="middle" fontSize="9"
+            fill="var(--color-muted-foreground)" fontFamily="var(--font-jetbrains-mono)"
+            transform={`rotate(-90, 12, ${H / 2})`}>
+            [–]
+          </text>
+
+          {/* cl^1.5/cd curve (endurance) — dashed */}
+          <path d={pathCl15OverCd} fill="none" stroke={COLOR_CL15_OVER_CD}
+            strokeWidth="1.5" strokeLinejoin="round" strokeDasharray="6 3"
+            data-testid="airfoil-proxy-cl15-line" />
+
+          {/* cl/cd curve (range/glide) — solid */}
+          <path d={pathClOverCd} fill="none" stroke={COLOR_CL_OVER_CD}
+            strokeWidth="2" strokeLinejoin="round"
+            data-testid="airfoil-proxy-clovercd-line" />
+
+          {/* Peak markers */}
+          {peakClOverCd && isFinite(peakClOverCd.cl) && isFinite(peakClOverCd.clOverCd) && (
+            <circle
+              data-testid="airfoil-proxy-peak-clovercd"
+              cx={sx(peakClOverCd.cl)}
+              cy={sy(peakClOverCd.clOverCd)}
+              r="4" fill={COLOR_CL_OVER_CD} stroke="white" strokeWidth="1.5" opacity="0.92"
+            />
+          )}
+          {peakCl15OverCd && isFinite(peakCl15OverCd.cl) && isFinite(peakCl15OverCd.cl15OverCd) && (
+            <circle
+              data-testid="airfoil-proxy-peak-cl15overcd"
+              cx={sx(peakCl15OverCd.cl)}
+              cy={sy(peakCl15OverCd.cl15OverCd)}
+              r="4" fill={COLOR_CL15_OVER_CD} stroke="white" strokeWidth="1.5" opacity="0.92"
+            />
+          )}
+        </svg>
+      </div>
+
+      {/* Legend */}
+      <div className="flex flex-wrap gap-x-4 gap-y-0.5">
+        <span className="flex items-center gap-1 font-[family-name:var(--font-jetbrains-mono)] text-[8px] text-muted-foreground">
+          <span className="inline-block size-[5px] rounded-full" style={{ backgroundColor: COLOR_CL_OVER_CD }} />
+          c_l / c_d (Gleitzahl)
+          {peakClOverCd && (
+            <span className="ml-0.5 text-muted-foreground/60">
+              max≈{peakClOverCd.clOverCd.toFixed(1)} @ c_l={peakClOverCd.cl.toFixed(2)}
+            </span>
+          )}
+        </span>
+        <span className="flex items-center gap-1 font-[family-name:var(--font-jetbrains-mono)] text-[8px] text-muted-foreground">
+          <span className="inline-block h-[5px] w-3 rounded" style={{
+            background: `repeating-linear-gradient(90deg, ${COLOR_CL15_OVER_CD} 0 6px, transparent 6px 9px)`,
+          }} />
+          c_l^1.5 / c_d (Ausdauer)
+          {peakCl15OverCd && (
+            <span className="ml-0.5 text-muted-foreground/60">
+              max≈{peakCl15OverCd.cl15OverCd.toFixed(1)} @ c_l={peakCl15OverCd.cl.toFixed(2)}
+            </span>
+          )}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/workbench/GeschwindigkeitspolareChart.tsx
+++ b/frontend/components/workbench/GeschwindigkeitspolareChart.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { useMemo } from "react";
+import type { AircraftSpeedPolar } from "@/hooks/useSpeedPolar";
+
+// ── Colors (consistent with existing airfoil viewer palette) ────
+const COLOR_POLAR = "#FF8400";       // main curve — orange accent
+const COLOR_BEST_GLIDE = "#38bdf8";  // best-glide marker — sky blue
+const COLOR_MIN_SINK = "#a78bfa";    // min-sink marker — violet
+
+// ── Chart geometry ───────────────────────────────────────────────
+const W = 400;
+const H = 200;
+const PAD = { top: 14, right: 20, bottom: 36, left: 52 };
+const PW = W - PAD.left - PAD.right;
+const PH = H - PAD.top - PAD.bottom;
+
+interface GeschwindigkeitspolareChartProps {
+  /** Speed polar from the backend. null = empty state. */
+  polar: AircraftSpeedPolar | null;
+  /** Whether the speed polar data is being loaded. */
+  isLoading?: boolean;
+}
+
+/** Marker on the speed polar: a named point with a dot + label. */
+interface PolarMarker {
+  v: number;
+  sink: number;
+  color: string;
+  label: string;
+  testId: string;
+}
+
+/** Format a float to N decimal places, removing trailing zeros. */
+function fmt(x: number, decimals: number): string {
+  // Parse back to number then to string to strip trailing zeros (no regex needed)
+  return String(parseFloat(x.toFixed(decimals)));
+}
+
+/**
+ * Aircraft speed polar chart (Geschwindigkeitspolare) — sink rate vs airspeed.
+ *
+ * Sink is plotted positive downward (y-axis inverted): fastest sink is at the
+ * top, slowest (best soaring performance) at the bottom. This is the standard
+ * aviation convention for speed polars.
+ *
+ * Best-glide and min-sink are shown as named markers.
+ */
+export function GeschwindigkeitspolareChart({
+  polar,
+  isLoading,
+}: Readonly<GeschwindigkeitspolareChartProps>) {
+  const plotData = useMemo(() => {
+    if (!polar) return null;
+
+    // Build valid (v, sink) pairs from the curve arrays
+    const pairs: { v: number; sink: number }[] = [];
+    for (let i = 0; i < polar.v_mps.length; i++) {
+      const v = polar.v_mps[i];
+      const s = polar.sink_mps[i];
+      if (isFinite(v) && isFinite(s) && v > 0 && s >= 0) {
+        pairs.push({ v, sink: s });
+      }
+    }
+    if (pairs.length < 2) return null;
+
+    // Axis ranges — sink is inverted (y=0 at bottom, y=PH at top)
+    const vMin = Math.min(...pairs.map((p) => p.v));
+    const vMax = Math.max(...pairs.map((p) => p.v));
+    // Include marker V values in x-range to ensure they fit
+    const allV = [
+      ...pairs.map((p) => p.v),
+      polar.best_glide.v_mps,
+      polar.min_sink.v_mps,
+    ];
+    const xMin = Math.max(0, Math.min(...allV) * 0.95);
+    const xMax = Math.max(...allV) * 1.05;
+    const xRange = xMax - xMin || 1;
+
+    const allSink = [
+      ...pairs.map((p) => p.sink),
+      polar.best_glide.sink_mps,
+      polar.min_sink.sink_mps,
+    ];
+    // Ensure y axis starts near zero (minimum sink), ends a bit above max sink
+    const yMin = 0;
+    const yMax = Math.max(...allSink) * 1.15;
+    const yRange = yMax - yMin || 1;
+
+    // SVG coordinate transformations
+    // x: V increases left→right
+    function sx(v: number) { return PAD.left + ((v - xMin) / xRange) * PW; }
+    // y: sink increases bottom→top (small sink = more lift = bottom)
+    // Axis is inverted so high sink is "up" (top of plot)
+    function sy(s: number) { return PAD.top + ((s - yMin) / yRange) * PH; }
+
+    const pathD = pairs
+      .map((p, i) => `${i === 0 ? "M" : "L"}${sx(p.v).toFixed(1)},${sy(p.sink).toFixed(1)}`)
+      .join(" ");
+
+    // Best-glide tangent line from origin to best-glide point
+    // Tangent from (0,0) — in SVG coords: origin is the bottom-left corner
+    const bgV = polar.best_glide.v_mps;
+    const bgSink = polar.best_glide.sink_mps;
+    // Extend the tangent line past the chart edge for visual clarity
+    const tanX2 = xMax * 1.05;
+    const tanY2 = (bgSink / bgV) * tanX2;
+
+    const markers: PolarMarker[] = [
+      {
+        v: polar.best_glide.v_mps,
+        sink: polar.best_glide.sink_mps,
+        color: COLOR_BEST_GLIDE,
+        label: `Best-Glide V=${fmt(polar.best_glide.v_mps, 1)} m/s`,
+        testId: "speed-polar-best-glide-marker",
+      },
+      {
+        v: polar.min_sink.v_mps,
+        sink: polar.min_sink.sink_mps,
+        color: COLOR_MIN_SINK,
+        label: `Min-Sink V=${fmt(polar.min_sink.v_mps, 1)} m/s`,
+        testId: "speed-polar-min-sink-marker",
+      },
+    ];
+
+    // Axis tick generators
+    const xTicks = Array.from({ length: 5 }, (_, i) => xMin + (xRange * i) / 4);
+    const yTicks = Array.from({ length: 5 }, (_, i) => yMin + (yRange * i) / 4);
+
+    return {
+      pathD, sx, sy, xTicks, yTicks, markers,
+      tanX1: 0, tanY1: 0, tanX2, tanY2,
+      xMin, xMax, yMin, yMax, vMin, vMax,
+    };
+  }, [polar]);
+
+  if (isLoading) {
+    return (
+      <div
+        className="flex h-full items-center justify-center font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-muted-foreground"
+        data-testid="speed-polar-loading"
+      >
+        Loading{"…"}
+      </div>
+    );
+  }
+
+  if (!polar || !plotData) {
+    return (
+      <div
+        className="flex h-full items-center justify-center font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-muted-foreground"
+        data-testid="speed-polar-empty"
+      >
+        Keine Daten — Annahmen berechnen um die Polare zu sehen
+      </div>
+    );
+  }
+
+  const { pathD, sx, sy, xTicks, yTicks, markers, tanX2, tanY2 } = plotData;
+
+  return (
+    <div className="flex flex-col gap-2" data-testid="geschwindigkeitspolare-chart">
+      {/* Chart title */}
+      <div className="flex items-baseline gap-2">
+        <span className="font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-foreground">
+          Geschwindigkeitspolare
+        </span>
+        <span className="font-[family-name:var(--font-jetbrains-mono)] text-[9px] text-muted-foreground">
+          m={fmt(polar.inputs.mass_kg, 1)} kg · S={fmt(polar.inputs.s_ref_m2, 3)} m² ·
+          AR={fmt(polar.inputs.ar, 1)} · e={fmt(polar.inputs.e_oswald, 2)} ·
+          CD₀={fmt(polar.inputs.cd0, 4)}
+        </span>
+      </div>
+
+      {/* SVG chart */}
+      <div className="rounded-xl border border-border bg-card p-2">
+        <svg viewBox={`0 0 ${W} ${H}`} className="h-full w-full" preserveAspectRatio="xMidYMid meet">
+          {/* Grid lines */}
+          {yTicks.map((s) => (
+            <line
+              key={`yg${s}`}
+              x1={PAD.left} x2={W - PAD.right}
+              y1={sy(s)} y2={sy(s)}
+              stroke="var(--color-border)" strokeWidth="0.5"
+            />
+          ))}
+          {xTicks.map((v) => (
+            <line
+              key={`xg${v}`}
+              x1={sx(v)} x2={sx(v)}
+              y1={PAD.top} y2={PAD.top + PH}
+              stroke="var(--color-border)" strokeWidth="0.5"
+            />
+          ))}
+
+          {/* Axes */}
+          <line x1={PAD.left} x2={PAD.left} y1={PAD.top} y2={PAD.top + PH}
+            stroke="var(--color-muted-foreground)" strokeWidth="1" />
+          <line x1={PAD.left} x2={W - PAD.right} y1={PAD.top + PH} y2={PAD.top + PH}
+            stroke="var(--color-muted-foreground)" strokeWidth="1" />
+
+          {/* Y-axis labels (sink rate) */}
+          {yTicks.map((s) => (
+            <text key={`yl${s}`} x={PAD.left - 5} y={sy(s) + 3}
+              textAnchor="end" fontSize="8" fill="var(--color-muted-foreground)"
+              fontFamily="var(--font-jetbrains-mono)">
+              {s.toFixed(2)}
+            </text>
+          ))}
+
+          {/* X-axis labels (speed) */}
+          {xTicks.map((v) => (
+            <text key={`xl${v}`} x={sx(v)} y={PAD.top + PH + 12}
+              textAnchor="middle" fontSize="8" fill="var(--color-muted-foreground)"
+              fontFamily="var(--font-jetbrains-mono)">
+              {v.toFixed(0)}
+            </text>
+          ))}
+
+          {/* Axis labels */}
+          <text x={W / 2} y={H - 3} textAnchor="middle" fontSize="9"
+            fill="var(--color-muted-foreground)" fontFamily="var(--font-jetbrains-mono)">
+            V [m/s]
+          </text>
+          <text x={12} y={H / 2} textAnchor="middle" fontSize="9"
+            fill="var(--color-muted-foreground)" fontFamily="var(--font-jetbrains-mono)"
+            transform={`rotate(-90, 12, ${H / 2})`}>
+            Sinken [m/s]
+          </text>
+
+          {/* Best-glide tangent line (from origin of the plot axes, clipped) */}
+          <line
+            x1={sx(0)} y1={sy(0)}
+            x2={sx(tanX2)} y2={sy(tanY2)}
+            stroke={COLOR_BEST_GLIDE}
+            strokeWidth="1"
+            strokeDasharray="6 3"
+            opacity="0.5"
+            data-testid="speed-polar-best-glide-tangent"
+          />
+
+          {/* Speed polar curve */}
+          <path
+            d={pathD}
+            fill="none"
+            stroke={COLOR_POLAR}
+            strokeWidth="2"
+            strokeLinejoin="round"
+            data-testid="speed-polar-curve"
+          />
+
+          {/* Markers */}
+          {markers.map((m) => {
+            if (!isFinite(m.v) || !isFinite(m.sink)) return null;
+            return (
+              <circle
+                key={m.testId}
+                data-testid={m.testId}
+                cx={sx(m.v)}
+                cy={sy(m.sink)}
+                r="4"
+                fill={m.color}
+                stroke="white"
+                strokeWidth="1.5"
+                opacity="0.92"
+              />
+            );
+          })}
+        </svg>
+      </div>
+
+      {/* Marker legend */}
+      <div className="flex flex-wrap gap-x-4 gap-y-0.5">
+        {markers.map((m) => (
+          <span
+            key={m.testId}
+            className="flex items-center gap-1 font-[family-name:var(--font-jetbrains-mono)] text-[8px] text-muted-foreground"
+          >
+            <span className="inline-block size-[5px] rounded-full" style={{ backgroundColor: m.color }} />
+            {m.label}
+          </span>
+        ))}
+        <span className="flex items-center gap-1 font-[family-name:var(--font-jetbrains-mono)] text-[8px] text-muted-foreground">
+          <span className="inline-block h-[5px] w-3 rounded" style={{ backgroundColor: COLOR_BEST_GLIDE, opacity: 0.5 }} />
+          Best-Glide Tangente
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/hooks/useSpeedPolar.ts
+++ b/frontend/hooks/useSpeedPolar.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import useSWR from "swr";
+
+// ---------------------------------------------------------------------------
+// Types — mirror backend SpeedPolarResponse / SpeedPolarPoint schemas (gh-841)
+// ---------------------------------------------------------------------------
+
+export interface SpeedPolarPoint {
+  /** Airspeed [m/s] */
+  v_mps: number;
+  /** Sink rate [m/s] (positive = downward) */
+  sink_mps: number;
+  /** Lift coefficient at this point */
+  cl: number;
+}
+
+export interface AircraftSpeedPolar {
+  /** Airspeed sweep [m/s] — ascending */
+  v_mps: number[];
+  /** Sink rate [m/s] — positive downward */
+  sink_mps: number[];
+  /** CL sweep — decreasing (paired with v_mps/sink_mps) */
+  cl: number[];
+  /** (L/D)_max operating point — origin-tangent to the curve */
+  best_glide: SpeedPolarPoint;
+  /** Minimum sink rate operating point */
+  min_sink: SpeedPolarPoint;
+  /** Inputs used to produce this polar (for provenance display) */
+  inputs: {
+    mass_kg: number;
+    s_ref_m2: number;
+    ar: number;
+    e_oswald: number;
+    cd0: number;
+    rho: number;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * SWR hook for the aircraft speed polar endpoint (gh-841).
+ *
+ * Fetches GET /aeroplanes/{aeroplaneId}/speed-polar.
+ * Returns null data when the aeroplane has insufficient context (HTTP 422).
+ * Callers should render an empty-state when data is null.
+ */
+export function useSpeedPolar(aeroplaneId: string | null) {
+  const url = aeroplaneId
+    ? `/aeroplanes/${encodeURIComponent(aeroplaneId)}/speed-polar`
+    : null;
+
+  const { data, error, isLoading, mutate } = useSWR<AircraftSpeedPolar | null>(
+    url,
+    async (path: string) => {
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8001"}${path}`,
+      );
+      if (res.status === 422) {
+        // Insufficient context — not an error, just missing inputs
+        return null;
+      }
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        throw new Error(`${res.status}: ${body}`);
+      }
+      return res.json() as Promise<AircraftSpeedPolar>;
+    },
+    { revalidateOnFocus: false },
+  );
+
+  return { data: data ?? null, error, isLoading, mutate };
+}

--- a/frontend/lib/airfoilProxyChartData.ts
+++ b/frontend/lib/airfoilProxyChartData.ts
@@ -1,0 +1,85 @@
+/**
+ * 2D airfoil proxy chart helpers (gh-841).
+ *
+ * Computes cl^1.5/cd (endurance indicator) and cl/cd (range/glide indicator)
+ * vs cl from a 2D airfoil polar.  These are SECTION-level metrics, NOT the
+ * aircraft polar — callers must label charts clearly to avoid confusion.
+ *
+ * All functions are pure with no side effects, enabling isolated unit tests.
+ */
+
+export interface AirfoilProxyPoint {
+  cl: number;
+  /** cl^1.5 / cd — section endurance indicator */
+  cl15OverCd: number;
+  /** cl / cd — section range / glide indicator */
+  clOverCd: number;
+}
+
+/**
+ * Build proxy chart data from parallel cl/cd arrays.
+ *
+ * Filters out:
+ * - null / non-finite values (from NeuralFoil degenerate outputs)
+ * - non-positive cd (unphysical, would invert metrics)
+ * - non-positive cl (negative CL range not meaningful for endurance/glide)
+ */
+export function buildAirfoilProxyChartData(
+  cl: (number | null)[],
+  cd: (number | null)[],
+): AirfoilProxyPoint[] {
+  const result: AirfoilProxyPoint[] = [];
+  const n = Math.min(cl.length, cd.length);
+  for (let i = 0; i < n; i++) {
+    const c = cl[i];
+    const d = cd[i];
+    if (
+      c == null ||
+      d == null ||
+      !isFinite(c) ||
+      !isFinite(d) ||
+      c <= 0 ||
+      d <= 0
+    ) {
+      continue;
+    }
+    result.push({
+      cl: c,
+      cl15OverCd: Math.pow(c, 1.5) / d,
+      clOverCd: c / d,
+    });
+  }
+  // Sort by cl ascending so lines are drawn left-to-right
+  result.sort((a, b) => a.cl - b.cl);
+  return result;
+}
+
+/**
+ * Extract the peak cl/cd value and its cl from proxy data.
+ * Returns null when data is empty.
+ */
+export function findPeakClOverCd(
+  data: AirfoilProxyPoint[],
+): { cl: number; clOverCd: number } | null {
+  if (data.length === 0) return null;
+  let peak = data[0];
+  for (const pt of data) {
+    if (pt.clOverCd > peak.clOverCd) peak = pt;
+  }
+  return { cl: peak.cl, clOverCd: peak.clOverCd };
+}
+
+/**
+ * Extract the peak cl^1.5/cd value and its cl from proxy data.
+ * Returns null when data is empty.
+ */
+export function findPeakCl15OverCd(
+  data: AirfoilProxyPoint[],
+): { cl: number; cl15OverCd: number } | null {
+  if (data.length === 0) return null;
+  let peak = data[0];
+  for (const pt of data) {
+    if (pt.cl15OverCd > peak.cl15OverCd) peak = pt;
+  }
+  return { cl: peak.cl, cl15OverCd: peak.cl15OverCd };
+}


### PR DESCRIPTION
## Summary

- **Backend:** Pure closed-form aircraft speed polar service (`app/services/speed_polar_service.py`) + REST endpoint `GET /aeroplanes/{id}/speed-polar`. Reads `mass_kg`, `s_ref_m2`, `aspect_ratio`, `e_oswald`, `cd0` from the aeroplane's `assumption_computation_context`. Returns sink vs V curve with best-glide (origin tangent) and min-sink special points. Returns 422 with `missing_inputs` list when context is incomplete.
- **Frontend:** `GeschwindigkeitspolareChart` (sink vs V, Plotly-free SVG, dark theme, best-glide tangent + min-sink markers) + `AirfoilProxyChart` (cl^1.5/cd endurance and cl/cd range vs cl, clearly labelled "Profil-Indikator (2D, kein Flugzeug)"). `useSpeedPolar` SWR hook mirrors existing patterns. `airfoilProxyChartData.ts` is a pure testable helper.
- Both charts integrated into `AirfoilPreviewViewerPanel` and wired in the airfoil-preview page.

## Formulas implemented

- V(CL) = sqrt(2W / (ρ·S·CL)), W = m·g, ρ = 1.225 kg/m³
- CD = CD0 + CL² / (π·AR·e)
- sink = V · CD / CL
- CL_bg = sqrt(CD0 / k), CL_ms = sqrt(3·CD0 / k) = √3·CL_bg, V_ms/V_bg ≈ 0.76

## Test plan

- [ ] Backend: `poetry run pytest app/tests/test_speed_polar_service.py app/tests/test_speed_polar_endpoint.py -q` → 46 passed
- [ ] Backend full non-slow suite: 4749 passed
- [ ] Frontend: `npm run test:unit` → 1501 passed
- [ ] Frontend deps: `npm run deps:check` → no new violations
- [ ] Manual: navigate to airfoil-preview for an aeroplane with computed assumptions → both charts appear
- [ ] Manual: aeroplane without assumptions → empty state "Keine Daten — Annahmen berechnen"

Closes #841

🤖 Generated with [Claude Code](https://claude.com/claude-code)