### PR TITLE
fix(gh-787): keep user-entered 0 in analysis numeric inputs

### DIFF
--- a/frontend/__tests__/AnalysisConfigPanel.test.tsx
+++ b/frontend/__tests__/AnalysisConfigPanel.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * gh-787: numeric inputs in the analysis config panel must keep a
+ * user-entered 0 (finiteOr) instead of the old `parseFloat || default`
+ * idiom that silently rewrote 0 → default.
+ *
+ * Also covers the three run handlers (Polar / Trefftz strip-forces /
+ * Streamlines) so the changed call-sites are exercised.
+ */
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) => React.createElement("span", props);
+  return {
+    Play: icon,
+    RefreshCw: icon,
+    ChevronDown: icon,
+    ChevronRight: icon,
+    Loader2: icon,
+  };
+});
+
+import { AnalysisConfigPanel } from "@/components/workbench/AnalysisConfigPanel";
+
+function makeAnalysis(overrides: Record<string, unknown> = {}) {
+  return {
+    isRunning: false,
+    error: null,
+    runAlphaSweep: vi.fn(),
+    ...overrides,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+const BASE = {
+  wingNames: ["Wing"] as string[],
+  selectedWing: "Wing" as string | null,
+  onClose: vi.fn(),
+};
+
+function runButton() {
+  return screen.getByRole("button", { name: /Run Analysis/i });
+}
+
+describe("AnalysisConfigPanel numeric inputs (gh-787)", () => {
+  it("keeps a sweep start of 0 instead of falling back to -5", () => {
+    const analysis = makeAnalysis();
+    render(<AnalysisConfigPanel activeTab="Polar" analysis={analysis} {...BASE} />);
+
+    fireEvent.change(screen.getByLabelText("start"), { target: { value: "0" } });
+    fireEvent.click(runButton());
+
+    expect(analysis.runAlphaSweep).toHaveBeenCalledTimes(1);
+    expect(analysis.runAlphaSweep.mock.calls[0][0]).toMatchObject({ alpha_start: 0 });
+  });
+
+  it("still falls back to -5 when the start field is cleared", () => {
+    const analysis = makeAnalysis();
+    render(<AnalysisConfigPanel activeTab="Polar" analysis={analysis} {...BASE} />);
+
+    fireEvent.change(screen.getByLabelText("start"), { target: { value: "" } });
+    fireEvent.click(runButton());
+
+    expect(analysis.runAlphaSweep.mock.calls[0][0]).toMatchObject({ alpha_start: -5 });
+  });
+
+  it("runs strip forces from the Trefftz Plane tab", () => {
+    const analysis = makeAnalysis();
+    const onRunStripForces = vi.fn();
+    render(
+      <AnalysisConfigPanel
+        activeTab="Trefftz Plane"
+        analysis={analysis}
+        onRunStripForces={onRunStripForces}
+        {...BASE}
+      />,
+    );
+
+    fireEvent.click(runButton());
+    expect(onRunStripForces).toHaveBeenCalledTimes(1);
+    // default velocity 14 is finite → kept
+    expect(onRunStripForces.mock.calls[0][0]).toMatchObject({ velocity: 14, beta: 0 });
+  });
+
+  it("runs streamlines from the Streamlines tab", () => {
+    const analysis = makeAnalysis();
+    const onRunStreamlines = vi.fn();
+    render(
+      <AnalysisConfigPanel
+        activeTab="Streamlines"
+        analysis={analysis}
+        onRunStreamlines={onRunStreamlines}
+        {...BASE}
+      />,
+    );
+
+    fireEvent.click(runButton());
+    expect(onRunStreamlines).toHaveBeenCalledTimes(1);
+    expect(onRunStreamlines.mock.calls[0][0]).toMatchObject({ beta: 0 });
+  });
+});

--- a/frontend/__tests__/numericInput.test.ts
+++ b/frontend/__tests__/numericInput.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { finiteOr } from "@/lib/numericInput";
+
+describe("finiteOr", () => {
+  it("keeps a user-entered 0 instead of falling back (the gh-787 bug)", () => {
+    expect(finiteOr("0", -5)).toBe(0);
+  });
+
+  it("parses normal positive and negative values", () => {
+    expect(finiteOr("3.5", -5)).toBe(3.5);
+    expect(finiteOr("-2", 1)).toBe(-2);
+    expect(finiteOr("1e3", 0)).toBe(1000);
+  });
+
+  it("falls back on empty / whitespace / non-numeric input", () => {
+    expect(finiteOr("", -5)).toBe(-5);
+    expect(finiteOr("   ", -5)).toBe(-5);
+    expect(finiteOr("abc", 7)).toBe(7);
+  });
+
+  it("falls back on non-finite parses (Infinity / NaN)", () => {
+    expect(finiteOr("Infinity", 1)).toBe(1);
+    expect(finiteOr("NaN", 2)).toBe(2);
+  });
+
+  it("ignores trailing garbage the same way parseFloat does, but stays finite", () => {
+    // parseFloat("12abc") === 12 — a finite value, so it is kept.
+    expect(finiteOr("12abc", 0)).toBe(12);
+  });
+});

--- a/frontend/components/workbench/AnalysisConfigPanel.tsx
+++ b/frontend/components/workbench/AnalysisConfigPanel.tsx
@@ -8,6 +8,7 @@ import type { StreamlinesParams } from "@/hooks/useStreamlines";
 import type { StoredOperatingPoint } from "@/hooks/useOperatingPoints";
 import type { Tab } from "@/components/workbench/AnalysisViewerPanel";
 import { parseMasses, formatMass } from "@/lib/masses";
+import { finiteOr } from "@/lib/numericInput";
 
 type Mode = "single" | "sweep";
 
@@ -289,16 +290,16 @@ export function AnalysisConfigPanel({
 
   // ── Polar handlers ──
   const handleRunPolar = () => {
-    const start = Number.parseFloat(alphaStart) || -5;
-    const end = Number.parseFloat(alphaEnd) || 15;
-    const step = Number.parseFloat(alphaStep) || 1;
+    const start = finiteOr(alphaStart, -5);
+    const end = finiteOr(alphaEnd, 15);
+    const step = finiteOr(alphaStep, 1);
     analysis.runAlphaSweep({
       alpha_start: start,
       alpha_end: end,
       alpha_num: Math.max(2, Math.round((end - start) / step) + 1),
-      velocity: Number.parseFloat(velocity) || 14,
-      beta: Number.parseFloat(beta) || 0,
-      altitude: Number.parseFloat(altitude) || 0,
+      velocity: finiteOr(velocity, 14),
+      beta: finiteOr(beta, 0),
+      altitude: finiteOr(altitude, 0),
       xyz_ref: parseXyzRef(),
       masses_kg: parseMasses(massesInput),
     });
@@ -315,10 +316,10 @@ export function AnalysisConfigPanel({
   // ── Trefftz Plane handlers ──
   const handleRunStripForces = () => {
     onRunStripForces?.({
-      velocity: Number.parseFloat(velocity) || 14,
-      alpha: Number.parseFloat(trefftzAlpha) || 5,
-      beta: Number.parseFloat(beta) || 0,
-      altitude: Number.parseFloat(altitude) || 100,
+      velocity: finiteOr(velocity, 14),
+      alpha: finiteOr(trefftzAlpha, 5),
+      beta: finiteOr(beta, 0),
+      altitude: finiteOr(altitude, 100),
       xyz_ref: parseXyzRef(),
       operating_point_id: useTrimmedOp ? effectiveOpId : null,
     });
@@ -328,10 +329,10 @@ export function AnalysisConfigPanel({
   // ── Streamlines handlers ──
   const handleRunStreamlines = () => {
     onRunStreamlines?.({
-      velocity: Number.parseFloat(velocity) || 14,
-      alpha: Number.parseFloat(trefftzAlpha) || 5,
-      beta: Number.parseFloat(beta) || 0,
-      altitude: Number.parseFloat(altitude) || 100,
+      velocity: finiteOr(velocity, 14),
+      alpha: finiteOr(trefftzAlpha, 5),
+      beta: finiteOr(beta, 0),
+      altitude: finiteOr(altitude, 100),
       xyz_ref: parseXyzRef(),
       operating_point_id: useTrimmedOp ? effectiveOpId : null,
     });

--- a/frontend/lib/numericInput.ts
+++ b/frontend/lib/numericInput.ts
@@ -1,0 +1,15 @@
+/**
+ * Parse a text-input value to a number, falling back only when the parse is
+ * not a finite number.
+ *
+ * This replaces the `Number.parseFloat(raw) || fallback` idiom, which wrongly
+ * discards a legitimate user-entered `0` (0 is falsy), e.g. an alpha-sweep
+ * starting at 0° silently became -5° (gh-787).
+ *
+ * @param raw      the raw input string (e.g. from a controlled <input>)
+ * @param fallback the value to use when `raw` does not parse to a finite number
+ */
+export function finiteOr(raw: string, fallback: number): number {
+  const parsed = Number.parseFloat(raw);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}


### PR DESCRIPTION
## Bug
`AnalysisConfigPanel.handleRunPolar` used `Number.parseFloat(raw) || fallback`. Since `0` is falsy, a user-entered alpha-sweep start of `0°` silently became `-5°`. The same idiom affected `velocity`/`beta`/`altitude`/`alpha` across the Polar, Trefftz strip-forces and streamlines handlers.

## Fix
New `finiteOr(raw, fallback)` helper (`frontend/lib/numericInput.ts`) gates on `Number.isFinite`, so a parsed `0` is kept and only genuinely non-numeric input falls back. Applied to every numeric field in `AnalysisConfigPanel`.

## Tests
`frontend/__tests__/numericInput.test.ts` — 5 cases incl. the gh-787 regression (`finiteOr("0", -5) === 0`), empty/whitespace/non-numeric fallback, and non-finite (Infinity/NaN) handling.

Closes #787

🤖 Generated with [Claude Code](https://claude.com/claude-code)