### PR TITLE
fix(gh-789): de-duplicate adjacent points in imported airfoil .dat

### DIFF
--- a/app/converters/openvsp_airfoil.py
+++ b/app/converters/openvsp_airfoil.py
@@ -705,6 +705,25 @@ def _write_selig_dat(target: Path, coordinates: CoordList, *, name: str) -> None
     target.write_text("\n".join(lines) + "\n")
 
 
+def _dedup_consecutive_points(coordinates: CoordList, *, tol: float = 1e-9) -> CoordList:
+    """Drop consecutive duplicate (within ``tol``) coordinate pairs (gh-789).
+
+    OpenVSP exports can carry adjacent identical points, which makes
+    AeroSandbox's ``Airfoil.repanel()`` (used during VLM section
+    subdivision) raise "duplicate point" and crash the solve. Only
+    *adjacent* duplicates are removed, so a legitimately repeated
+    closing point (first == last of a closed contour) is preserved.
+    """
+    out: CoordList = []
+    for pt in coordinates:
+        if out:
+            px, py = out[-1]
+            if abs(pt[0] - px) <= tol and abs(pt[1] - py) <= tol:
+                continue
+        out.append(pt)
+    return out
+
+
 def write_imported_airfoil_dat(coordinates: CoordList, *, tag: str = "vsp_imported") -> str:
     """Store an imported/derived airfoil under a **content-hash** filename
     and return its relative path (gh-795).
@@ -712,7 +731,12 @@ def write_imported_airfoil_dat(coordinates: CoordList, *, tag: str = "vsp_import
     Re-import of the same geometry maps to the same ``{tag}_{hash}.dat``
     and the write is skipped (dedup). Used both for VSP-exported anchor
     profiles and for morphed intermediate profiles (gh-796).
+
+    Consecutive duplicate points are removed before hashing/writing so the
+    stored ``.dat`` never trips AeroSandbox's repanel duplicate-point guard
+    (gh-789).
     """
+    coordinates = _dedup_consecutive_points(coordinates)
     AIRFOILS_DIR.mkdir(parents=True, exist_ok=True)
     fname = f"{tag}_{_coords_hash(coordinates)}.dat"
     target = AIRFOILS_DIR / fname

--- a/app/tests/test_openvsp_airfoil_dedup.py
+++ b/app/tests/test_openvsp_airfoil_dedup.py
@@ -1,0 +1,88 @@
+"""gh-789: imported airfoil .dat files must not contain duplicate adjacent
+points.
+
+OpenVSP exports can emit consecutive identical coordinates. AeroSandbox's
+``Airfoil.repanel()`` (called during VLM section subdivision) raises
+"It looks like your Airfoil has a duplicate point" and crashes the solve.
+The importer must de-duplicate consecutive points when writing
+``vsp_imported_*.dat``.
+
+These tests are pure-Python (no aerosandbox / cadquery) so they run in the
+PR-fast / coverage tier.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.converters import openvsp_airfoil
+from app.converters.openvsp_airfoil import (
+    _dedup_consecutive_points,
+    _read_dat_coords,
+    write_imported_airfoil_dat,
+)
+
+
+@pytest.fixture
+def airfoils_dir(tmp_path, monkeypatch):
+    d = tmp_path / "airfoils"
+    d.mkdir(parents=True)
+    monkeypatch.setattr(openvsp_airfoil, "AIRFOILS_DIR", d)
+    return d
+
+
+def _has_consecutive_duplicates(coords, tol: float = 1e-9) -> bool:
+    for a, b in zip(coords, coords[1:], strict=False):
+        if abs(a[0] - b[0]) <= tol and abs(a[1] - b[1]) <= tol:
+            return True
+    return False
+
+
+class TestDedupConsecutivePoints:
+    def test_removes_adjacent_duplicate(self):
+        coords = [(1.0, 0.0), (0.5, 0.05), (0.5, 0.05), (0.0, 0.0), (1.0, 0.0)]
+        out = _dedup_consecutive_points(coords)
+        assert out == [(1.0, 0.0), (0.5, 0.05), (0.0, 0.0), (1.0, 0.0)]
+
+    def test_collapses_runs_of_more_than_two(self):
+        coords = [(0.0, 0.0), (0.0, 0.0), (0.0, 0.0), (1.0, 0.0)]
+        assert _dedup_consecutive_points(coords) == [(0.0, 0.0), (1.0, 0.0)]
+
+    def test_keeps_non_consecutive_repeat(self):
+        # First and last point legitimately coincide (closed contour) — only
+        # *adjacent* duplicates are removed, so the endpoints survive.
+        coords = [(1.0, 0.0), (0.0, 0.0), (1.0, 0.0)]
+        assert _dedup_consecutive_points(coords) == coords
+
+    def test_near_duplicate_within_tolerance_removed(self):
+        coords = [(0.5, 0.05), (0.5 + 1e-12, 0.05 - 1e-12), (0.4, 0.04)]
+        assert _dedup_consecutive_points(coords) == [(0.5, 0.05), (0.4, 0.04)]
+
+    def test_clean_input_unchanged(self):
+        coords = [(1.0, 0.0), (0.5, 0.05), (0.0, 0.0)]
+        assert _dedup_consecutive_points(coords) == coords
+
+    def test_empty_and_single(self):
+        assert _dedup_consecutive_points([]) == []
+        assert _dedup_consecutive_points([(0.0, 0.0)]) == [(0.0, 0.0)]
+
+
+class TestWriteImportedAirfoilDatDedups:
+    def test_written_file_has_no_adjacent_duplicates(self, airfoils_dir):
+        dirty = [(1.0, 0.0), (0.5, 0.05), (0.5, 0.05), (0.0, 0.0), (0.5, -0.05), (1.0, 0.0)]
+        rel = write_imported_airfoil_dat(dirty)
+        written = _read_dat_coords(airfoils_dir / Path(rel).name)
+        assert not _has_consecutive_duplicates(written), written
+        # the one duplicated point was dropped
+        assert len(written) == len(dirty) - 1
+
+    def test_dirty_and_clean_map_to_same_hash_file(self, airfoils_dir):
+        clean = [(1.0, 0.0), (0.5, 0.05), (0.0, 0.0), (0.5, -0.05), (1.0, 0.0)]
+        dirty = [(1.0, 0.0), (0.5, 0.05), (0.5, 0.05), (0.0, 0.0), (0.5, -0.05), (1.0, 0.0)]
+        r_clean = write_imported_airfoil_dat(clean)
+        r_dirty = write_imported_airfoil_dat(dirty)
+        # de-dup happens before hashing → both resolve to one file
+        assert r_clean == r_dirty
+        assert len(list(airfoils_dir.glob("vsp_imported_*.dat"))) == 1


### PR DESCRIPTION
## Bug
Imported `vsp_imported_*.dat` airfoils carry duplicate adjacent coordinates. `aerosandbox.Airfoil.repanel()` (called during VLM section subdivision) raises *"It looks like your Airfoil has a duplicate point"* → `VortexLatticeMethod.run()` crashes. (Benchmark FINDINGS F2; DG-101G import had 3 such points.)

## Fix
`write_imported_airfoil_dat` now strips **consecutive** duplicate points (`_dedup_consecutive_points`, tol 1e-9) before hashing/writing. Only adjacent duplicates are removed, so a legitimately repeated closing point (first==last) is preserved. De-dup runs before the content hash, so a dirty variant and its already-clean twin resolve to a single file.

## Tests (pure-Python, run in PR-fast/coverage tier)
`app/tests/test_openvsp_airfoil_dedup.py` — helper unit cases (adjacent dup, runs >2, near-dup within tol, non-consecutive repeat preserved, clean/empty/single) + end-to-end write asserting the on-disk `.dat` has no adjacent duplicates and dirty/clean map to one hash file.

Closes #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)