### PR TITLE
fix(gh-790): drop degenerate fuselages from the ASB aero model

### DIFF
--- a/app/converters/model_schema_converters.py
+++ b/app/converters/model_schema_converters.py
@@ -1,3 +1,4 @@
+import logging
 import math
 import os
 from typing import Any, List, Optional
@@ -22,6 +23,8 @@ from cad_designer.airplane.aircraft_topology.wing import (
     TrailingEdgeDevice,
     WingConfiguration,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def aeroplane_model_to_aeroplane_schema_async(plane: AeroplaneModel) -> AeroplaneSchema:
@@ -419,11 +422,35 @@ def _asb_fuselage_xsecs_from_schema(
     ]
 
 
+def _asb_fuselage_is_degenerate(fuselage, *, eps: float = 1e-9) -> bool:
+    """True when an ASB fuselage has zero/non-finite length or volume (gh-790).
+
+    AeroBuildup derives the fineness ratio as ``sqrt(length**3 / volume * …)``
+    and a skin-friction term as ``log10(Re)`` (Re ∝ length). A degenerate
+    imported fuselage (all xsecs at one station → length 0, or all-zero radii
+    → volume 0) drives those to inf/NaN and poisons the *entire* aero solve
+    with NaN. Such a body has no meaningful aerodynamic contribution, so the
+    caller drops it from the ASB model.
+    """
+    try:
+        length = float(fuselage.length())
+        volume = float(fuselage.volume())
+    except (ValueError, ZeroDivisionError, FloatingPointError):
+        return True
+    if not (math.isfinite(length) and math.isfinite(volume)):
+        return True
+    return length <= eps or volume <= eps
+
+
 def _build_asb_fuselages(
     fuselages: dict[str, schemas.FuselageSchema],
 ):
     """Build the ``asb.Airplane.fuselages`` list, expanding each
     ``symmetric=True`` fuselage into its mirrored pair (gh-715).
+
+    Degenerate fuselages (zero length/volume) are dropped with a warning so
+    they cannot make AeroBuildup return all-NaN (gh-790). The CAD pipeline
+    builds fuselages on a separate path and is unaffected.
     """
     from aerosandbox import Fuselage
 
@@ -431,7 +458,15 @@ def _build_asb_fuselages(
     for name, fuselage in fuselages.items():
         if not fuselage.x_secs:
             continue
-        result.append(Fuselage(name=name, xsecs=_asb_fuselage_xsecs_from_schema(fuselage)))
+        primary = Fuselage(name=name, xsecs=_asb_fuselage_xsecs_from_schema(fuselage))
+        if _asb_fuselage_is_degenerate(primary):
+            logger.warning(
+                "Skipping degenerate fuselage %r from the ASB aero model "
+                "(zero length/volume would make AeroBuildup return NaN); gh-790.",
+                name,
+            )
+            continue
+        result.append(primary)
         if fuselage.symmetric:
             result.append(
                 Fuselage(

--- a/app/tests/test_asb_fuselage_degenerate_guard.py
+++ b/app/tests/test_asb_fuselage_degenerate_guard.py
@@ -1,0 +1,114 @@
+"""gh-790: a degenerate imported fuselage (zero length / zero volume) makes
+AeroBuildup return all-NaN (divide-by-zero in fineness_ratio / log10(Re)).
+
+AeroSandbox is third-party and can't be patched, so the converter must drop
+a degenerate fuselage from the ASB aero model (with a warning) instead of
+feeding NaN-poison into the solve. The separate CAD pipeline is unaffected.
+
+These tests need aerosandbox importable (it is in the PR-fast/coverage tier)
+but do not run a solver.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from app import schemas
+from app.converters.model_schema_converters import (
+    _asb_fuselage_is_degenerate,
+    _build_asb_fuselages,
+)
+
+
+def _xsec(x: float, a: float, b: float, n: float = 2.0):
+    return schemas.FuselageXSecSuperEllipseSchema(xyz=[x, 0.0, 0.0], a=a, b=b, n=n)
+
+
+def _fuselage(name: str, xsecs, symmetric: bool = False):
+    return schemas.FuselageSchema(name=name, x_secs=xsecs, symmetric=symmetric)
+
+
+def _normal_xsecs():
+    # length 1.0 m, non-zero radii → finite volume
+    return [_xsec(0.0, 0.05, 0.05), _xsec(0.5, 0.2, 0.2), _xsec(1.0, 0.05, 0.05)]
+
+
+def _degenerate_zero_length():
+    # all sections at the same x → length 0
+    return [_xsec(0.0, 0.2, 0.2), _xsec(0.0, 0.2, 0.2)]
+
+
+def _degenerate_zero_volume():
+    # finite length but zero radii → zero volume
+    return [_xsec(0.0, 0.0, 0.0), _xsec(1.0, 0.0, 0.0)]
+
+
+class TestIsDegenerate:
+    def test_zero_length_is_degenerate(self):
+        from aerosandbox import Fuselage
+
+        from app.converters.model_schema_converters import _asb_fuselage_xsecs_from_schema
+
+        fus = Fuselage(
+            name="z",
+            xsecs=_asb_fuselage_xsecs_from_schema(_fuselage("z", _degenerate_zero_length())),
+        )
+        assert _asb_fuselage_is_degenerate(fus) is True
+
+    def test_zero_volume_is_degenerate(self):
+        from aerosandbox import Fuselage
+
+        from app.converters.model_schema_converters import _asb_fuselage_xsecs_from_schema
+
+        fus = Fuselage(
+            name="v",
+            xsecs=_asb_fuselage_xsecs_from_schema(_fuselage("v", _degenerate_zero_volume())),
+        )
+        assert _asb_fuselage_is_degenerate(fus) is True
+
+    def test_normal_fuselage_is_not_degenerate(self):
+        from aerosandbox import Fuselage
+
+        from app.converters.model_schema_converters import _asb_fuselage_xsecs_from_schema
+
+        fus = Fuselage(
+            name="ok", xsecs=_asb_fuselage_xsecs_from_schema(_fuselage("ok", _normal_xsecs()))
+        )
+        assert _asb_fuselage_is_degenerate(fus) is False
+        # sanity: a normal fuselage yields a finite fineness ratio
+        import math
+
+        assert math.isfinite(fus.fineness_ratio())
+
+
+class TestBuildAsbFuselagesGuard:
+    def test_degenerate_fuselage_is_skipped_with_warning(self, caplog):
+        fuses = {"deg": _fuselage("deg", _degenerate_zero_length())}
+        with caplog.at_level(logging.WARNING):
+            result = _build_asb_fuselages(fuses)
+        assert result == []
+        assert any("deg" in r.message for r in caplog.records)
+
+    def test_normal_fuselage_is_kept(self):
+        fuses = {"body": _fuselage("body", _normal_xsecs())}
+        result = _build_asb_fuselages(fuses)
+        assert len(result) == 1
+        import math
+
+        assert math.isfinite(result[0].fineness_ratio())
+
+    def test_symmetric_normal_fuselage_expands_to_pair(self):
+        fuses = {"body": _fuselage("body", _normal_xsecs(), symmetric=True)}
+        result = _build_asb_fuselages(fuses)
+        assert len(result) == 2
+
+    def test_mixed_keeps_only_finite_fuselages(self):
+        fuses = {
+            "deg": _fuselage("deg", _degenerate_zero_volume()),
+            "body": _fuselage("body", _normal_xsecs()),
+        }
+        result = _build_asb_fuselages(fuses)
+        assert len(result) == 1
+        assert result[0].name == "body"

--- a/app/tests/test_fuselage_symmetric_expansion.py
+++ b/app/tests/test_fuselage_symmetric_expansion.py
@@ -16,13 +16,32 @@ from app.schemas import aeroplaneschema as schemas
 
 
 def _make_strut(symmetric: bool = True) -> schemas.FuselageSchema:
-    """Build a minimal off-spine sub-fuselage suitable for mirror checks."""
+    """Build a minimal off-spine sub-fuselage suitable for mirror checks.
+
+    Note: both xsecs sit at x=0 (a purely vertical leg), so the body has zero
+    x-spine length/volume — i.e. it is *degenerate* for AeroBuildup (gh-790).
+    Used for the CAD-config / pure-Python mirror tests, where that is fine.
+    """
     return schemas.FuselageSchema(
         name="Strut",
         symmetric=symmetric,
         x_secs=[
             schemas.FuselageXSecSuperEllipseSchema(xyz=[0.0, 0.6, -0.3], a=0.02, b=0.02, n=2.0),
             schemas.FuselageXSecSuperEllipseSchema(xyz=[0.0, 0.6, -1.0], a=0.02, b=0.02, n=2.0),
+        ],
+    )
+
+
+def _make_pod(symmetric: bool = True) -> schemas.FuselageSchema:
+    """Build an off-spine sub-fuselage with a real x-extent (non-degenerate),
+    so it survives the gh-790 aero-model guard while still exercising the
+    mirror-expansion (Y-flip) logic."""
+    return schemas.FuselageSchema(
+        name="Pod",
+        symmetric=symmetric,
+        x_secs=[
+            schemas.FuselageXSecSuperEllipseSchema(xyz=[0.0, 0.6, 0.0], a=0.05, b=0.05, n=2.0),
+            schemas.FuselageXSecSuperEllipseSchema(xyz=[0.5, 0.6, 0.0], a=0.05, b=0.05, n=2.0),
         ],
     )
 
@@ -70,10 +89,10 @@ class TestBuildAsbFuselages:
 
         from app.converters.model_schema_converters import _build_asb_fuselages
 
-        result = _build_asb_fuselages(OrderedDict([("Strut", _make_strut(symmetric=True))]))
+        result = _build_asb_fuselages(OrderedDict([("Pod", _make_pod(symmetric=True))]))
         assert len(result) == 2
-        assert result[0].name == "Strut"
-        assert result[1].name == "Strut (mirror)"
+        assert result[0].name == "Pod"
+        assert result[1].name == "Pod (mirror)"
         # Y centres flipped on the mirror, X/Z preserved.
         assert result[0].xsecs[0].xyz_c[1] == pytest.approx(0.6)
         assert result[1].xsecs[0].xyz_c[1] == pytest.approx(-0.6)
@@ -85,9 +104,19 @@ class TestBuildAsbFuselages:
 
         from app.converters.model_schema_converters import _build_asb_fuselages
 
-        result = _build_asb_fuselages(OrderedDict([("Main", _make_strut(symmetric=False))]))
+        result = _build_asb_fuselages(OrderedDict([("Main", _make_pod(symmetric=False))]))
         assert len(result) == 1
         assert result[0].name == "Main"
+
+    def test_degenerate_strut_skipped_from_aero_model(self):
+        # gh-790: a zero-x-length strut would make AeroBuildup return all-NaN,
+        # so it is dropped from the ASB aero model (the CAD mirror path keeps it).
+        from collections import OrderedDict
+
+        from app.converters.model_schema_converters import _build_asb_fuselages
+
+        result = _build_asb_fuselages(OrderedDict([("Strut", _make_strut(symmetric=True))]))
+        assert result == []
 
     def test_skips_empty_xsecs(self):
         from collections import OrderedDict


### PR DESCRIPTION
## Bug
For the Ligeti Stratos (boxwing) import, AeroBuildup returns all-NaN — a divide-by-zero in `fineness_ratio()` (`sqrt(length³/volume·…)`) and `log10(Re)`, triggered by a degenerate imported fuselage (zero x-spine length / zero volume). VLM on the same airplane succeeds, localising it to the fuselage feeding AeroBuildup. (Benchmark FINDINGS F3.)

## Fix
AeroSandbox is third-party, so guard at the boundary: `_build_asb_fuselages` now skips any fuselage flagged by `_asb_fuselage_is_degenerate` (non-finite or ≤eps length/volume) and logs a warning. Such bodies carry no meaningful aerodynamic contribution; including them poisons the entire solve with NaN.

A purely vertical landing-gear strut (both xsecs at the same x) is degenerate by the same definition and **was already** silently NaN-ing AeroBuildup — it is now dropped from the aero model too. The CAD pipeline (`_fuselage_configs_with_mirrors`) is on a separate path and still mirrors struts, so visible geometry is unchanged.

## Tests (fast tier; aerosandbox importable, no solver)
- `app/tests/test_asb_fuselage_degenerate_guard.py` — helper (zero-length, zero-volume, normal) + `_build_asb_fuselages` (degenerate skipped with warning, normal kept, symmetric→pair, mixed keeps only finite).
- Updated `test_fuselage_symmetric_expansion.py`: the gh-715 mirror-expansion aero tests now use a non-degenerate pod (mirror Y-flip math still asserted) + an explicit "degenerate strut skipped from aero model" test.

Closes #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)