### PR TITLE
feat(gh-672): auto-refine α-resolution on resolution-related polar-fit rejection

### DIFF
--- a/app/schemas/polar_by_config.py
+++ b/app/schemas/polar_by_config.py
@@ -144,6 +144,12 @@ class ParabolicPolar(BaseModel):
         "primary path (gh-636); `fit` is the gh-486 OLS-on-polar fallback; "
         "`fallback` is the 0.8 regime-naive default when both above failed.",
     )
+    auto_refined: bool = Field(
+        False,
+        description="True when the α-sweep resolution was automatically refined to "
+        "recover a polar fit that was first rejected for being too coarse "
+        "(gh-672). Lets the UI show a 'resolution auto-refined' hint.",
+    )
 
 
 PolarByConfig = dict[ConfigName, ParabolicPolar]

--- a/app/services/assumption_compute_service.py
+++ b/app/services/assumption_compute_service.py
@@ -141,12 +141,19 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
     # of the fallback constant 0.8.
     aspect_ratio = _main_wing_aspect_ratio(asb_airplane)
     cl_max_effective_for_fit = _load_effective_assumption(db, aircraft.id, "cl_max")
-    _cd0_fit, e_oswald_fit, e_r2, polar_rejection = _fit_parabolic_polar(
-        np.asarray(sweep_cl_arr, dtype=float),
-        np.asarray(sweep_cd_arr, dtype=float),
-        ar=aspect_ratio if aspect_ratio is not None else 0.0,
-        cl_max=cl_max_effective_for_fit,
-        cd0_stability=cd0,
+    _cd0_fit, e_oswald_fit, e_r2, polar_rejection, polar_auto_refined = (
+        _fit_parabolic_polar_with_refinement(
+            asb_airplane=asb_airplane,
+            stall_alpha_deg=stall_alpha,
+            v_cruise=v_cruise,
+            v_max=v_max,
+            config=config,
+            aspect_ratio=aspect_ratio if aspect_ratio is not None else 0.0,
+            cl_max_for_fit=cl_max_effective_for_fit,
+            cd0_stability=cd0,
+            cl=np.asarray(sweep_cl_arr, dtype=float),
+            cd=np.asarray(sweep_cd_arr, dtype=float),
+        )
     )
     # gh-636: derive (L/D)max + e_oswald directly from the AeroBuildup sweep
     # — no parabolic-fit dependency for e. The fit still gives us cd0; e is
@@ -209,6 +216,7 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
         ld_max=round(ld_max_clean, 2) if ld_max_clean is not None else None,
         cl_at_ld_max=round(cl_at_ld_max_clean, 3) if cl_at_ld_max_clean is not None else None,
         e_oswald_provenance=e_oswald_provenance_clean,
+        auto_refined=polar_auto_refined,
     )
 
     ted_max = _extract_flap_ted_max(aircraft)
@@ -688,12 +696,19 @@ def _run_polar_for_deflection(
     cl_max, cl_arr, cd_arr, _v_arr, cdi_arr = _fine_sweep_cl_max(
         deflected, stall_alpha, v_cruise, v_max, config
     )
-    _cd0_fit, e_oswald_fit, e_r2, polar_rejection = _fit_parabolic_polar(
-        np.asarray(cl_arr, dtype=float),
-        np.asarray(cd_arr, dtype=float),
-        ar=aspect_ratio if aspect_ratio is not None else 0.0,
-        cl_max=cl_max_effective_for_fit if cl_max_effective_for_fit else cl_max,
-        cd0_stability=cd0_stability,
+    _cd0_fit, e_oswald_fit, e_r2, polar_rejection, polar_auto_refined = (
+        _fit_parabolic_polar_with_refinement(
+            asb_airplane=deflected,
+            stall_alpha_deg=stall_alpha,
+            v_cruise=v_cruise,
+            v_max=v_max,
+            config=config,
+            aspect_ratio=aspect_ratio if aspect_ratio is not None else 0.0,
+            cl_max_for_fit=cl_max_effective_for_fit if cl_max_effective_for_fit else cl_max,
+            cd0_stability=cd0_stability,
+            cl=np.asarray(cl_arr, dtype=float),
+            cd=np.asarray(cd_arr, dtype=float),
+        )
     )
     # gh-636: empirical (L/D)max + AB-Trefftz e for this configuration.
     ld_max_cfg, cl_at_ld_max_cfg, ld_max_idx_cfg = _ld_max_from_sweep(
@@ -727,6 +742,7 @@ def _run_polar_for_deflection(
         ld_max=round(ld_max_cfg, 2) if ld_max_cfg is not None else None,
         cl_at_ld_max=round(cl_at_ld_max_cfg, 3) if cl_at_ld_max_cfg is not None else None,
         e_oswald_provenance=provenance_e,
+        auto_refined=polar_auto_refined,
     )
 
 
@@ -939,6 +955,9 @@ def _fine_sweep_cl_max(
     v_cruise: float,
     v_max: float,
     config: AircraftComputationConfigModel,
+    *,
+    alpha_step_override: float | None = None,
+    alpha_margin_override: float | None = None,
 ) -> tuple[float, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Returns (CL_max, cl_array, cd_array, v_array, cdi_array) from a fine α × V sweep.
 
@@ -950,12 +969,22 @@ def _fine_sweep_cl_max(
       at each sample. It lets `recompute_assumptions` extract Oswald e directly
       via ``e = CL² / (π·AR·CDi)`` at the (L/D)max point, without re-fitting a
       parabola. Costs zero extra AeroBuildup calls.
+
+    ``alpha_step_override`` / ``alpha_margin_override`` (gh-672) let the
+    polar-fit auto-recovery re-run a *finer* sweep without mutating the stored
+    config. They default to the config's values.
     """
     import aerosandbox as asb
 
-    alpha_min = stall_alpha_deg - config.fine_alpha_margin_deg
-    alpha_max = stall_alpha_deg + config.fine_alpha_margin_deg
-    alphas = np.arange(alpha_min, alpha_max + 0.01, config.fine_alpha_step_deg)
+    alpha_step = (
+        alpha_step_override if alpha_step_override is not None else config.fine_alpha_step_deg
+    )
+    alpha_margin = (
+        alpha_margin_override if alpha_margin_override is not None else config.fine_alpha_margin_deg
+    )
+    alpha_min = stall_alpha_deg - alpha_margin
+    alpha_max = stall_alpha_deg + alpha_margin
+    alphas = np.arange(alpha_min, alpha_max + 0.01, alpha_step)
 
     v_stall_approx = max(v_cruise * 0.5, 3.0)
     velocities = np.linspace(v_stall_approx, v_max, config.fine_velocity_count)
@@ -1382,6 +1411,90 @@ def _fit_parabolic_polar(
         n_pts,
     )
     return float(cd0_fit), float(e_oswald), float(r2), None
+
+
+# gh-672: rejection gates that are caused by too-coarse α-resolution (vs a
+# genuinely unphysical polar). Only these trigger an auto-refinement retry.
+_REFINABLE_REJECTION_GATES = frozenset({"insufficient_points", "non_monotonic_polar"})
+
+
+def _fit_parabolic_polar_with_refinement(
+    *,
+    asb_airplane,
+    stall_alpha_deg: float,
+    v_cruise: float,
+    v_max: float,
+    config: "AircraftComputationConfigModel",
+    aspect_ratio: float,
+    cl_max_for_fit: float | None,
+    cd0_stability: float,
+    cl: np.ndarray,
+    cd: np.ndarray,
+    max_retries: int = 2,
+) -> tuple[float | None, float | None, float | None, "PolarRejection | None", bool]:
+    """Fit the parabolic polar, auto-refining the α-resolution on resolution-
+    related rejections (gh-672).
+
+    If the fit is rejected with ``insufficient_points`` or
+    ``non_monotonic_polar`` — both caused by a too-coarse sweep — re-run a
+    *finer* ``_fine_sweep_cl_max`` (halved α-step, ×1.5 α-margin) and refit,
+    up to ``max_retries`` times. Per memory ``feedback_aerobuildup_resolution``
+    this only ever **increases resolution** — it never loosens a threshold.
+    Other gates (negative slope, unphysical e, …) are genuine design/physics
+    rejections and do not retry.
+
+    Returns ``(cd0_fit, e_oswald, r2, rejection, auto_refined)`` where
+    ``auto_refined`` is True only when a refinement produced a *successful* fit
+    (so the UI banner is shown only when it actually helped).
+    """
+    fit = _fit_parabolic_polar(
+        np.asarray(cl, dtype=float),
+        np.asarray(cd, dtype=float),
+        ar=aspect_ratio,
+        cl_max=cl_max_for_fit,
+        cd0_stability=cd0_stability,
+    )
+    did_refine = False
+    for attempt in range(1, max_retries + 1):
+        rejection = fit[3]
+        if rejection is None or rejection.gate not in _REFINABLE_REJECTION_GATES:
+            break
+        step = config.fine_alpha_step_deg / (2**attempt)
+        margin = config.fine_alpha_margin_deg * (1.5**attempt)
+        logger.info(
+            "gh-672: polar fit gate '%s' — auto-refining α-resolution "
+            "(attempt %d/%d): step→%.3f°, margin→%.2f°",
+            rejection.gate,
+            attempt,
+            max_retries,
+            step,
+            margin,
+        )
+        try:
+            refined = _fine_sweep_cl_max(
+                asb_airplane,
+                stall_alpha_deg,
+                v_cruise,
+                v_max,
+                config,
+                alpha_step_override=step,
+                alpha_margin_override=margin,
+            )
+        except Exception:
+            logger.exception("gh-672: refined fine sweep failed; keeping original rejection")
+            break
+        did_refine = True
+        fit = _fit_parabolic_polar(
+            np.asarray(refined[1], dtype=float),
+            np.asarray(refined[2], dtype=float),
+            ar=aspect_ratio,
+            cl_max=cl_max_for_fit,
+            cd0_stability=cd0_stability,
+        )
+
+    cd0_fit, e_oswald, r2, rejection = fit
+    auto_refined = did_refine and rejection is None
+    return cd0_fit, e_oswald, r2, rejection, auto_refined
 
 
 def _classify_polar_quality(r2: float) -> str:

--- a/app/tests/test_assumption_compute_service.py
+++ b/app/tests/test_assumption_compute_service.py
@@ -418,13 +418,22 @@ def test_no_flap_aircraft_runs_one_pass_with_fallback_flag(client_and_db):
             recompute_assumptions(db, aeroplane_uuid)
             db.commit()
 
-    assert fine_sweep_mock.call_count == 1, (
-        f"Expected 1 AeroBuildup pass (no flap geometry), got {fine_sweep_mock.call_count}"
+    # No flap geometry → only the CLEAN config is computed (takeoff/landing are
+    # cloned, not separately swept). gh-672: this fixture's sweep yields only 5
+    # in-window points (cl_max=1.35 → window [0.135, 1.1475]), so the clean fit
+    # is rejected for `insufficient_points` and the α-resolution auto-recovery
+    # re-runs the (still-degenerate) clean sweep twice → 1 initial + 2 retries.
+    # That no takeoff/landing AeroBuildup passes run is carried by the
+    # provenance assertions below.
+    assert fine_sweep_mock.call_count == 3, (
+        f"Expected 1 clean pass + 2 gh-672 refinement retries, got {fine_sweep_mock.call_count}"
     )
 
     ctx = _load_ctx(SessionLocal, aeroplane_id)
     pbc = ctx["polar_by_config"]
     assert pbc["clean"]["provenance"] == "aerobuildup"
+    # refinement was attempted but the degenerate sweep still didn't fit → no banner
+    assert pbc["clean"]["auto_refined"] is False
     assert pbc["takeoff"]["provenance"] == "no_flap_geometry"
     assert pbc["landing"]["provenance"] == "no_flap_geometry"
     # C_L_max identical when fallback cloned from clean

--- a/app/tests/test_polar_fit_autorecovery.py
+++ b/app/tests/test_polar_fit_autorecovery.py
@@ -1,0 +1,148 @@
+"""gh-672: α-resolution auto-recovery for the parabolic polar fit.
+
+When the fit is rejected because the α-sweep was too coarse
+(``insufficient_points`` / ``non_monotonic_polar``), the service re-runs a
+*finer* sweep and refits — up to 2 times — instead of dropping straight to the
+0.8 Oswald fallback. Only resolution is increased; no threshold is loosened
+(memory ``feedback_aerobuildup_resolution``).
+
+Pure logic with mocked solver/fit, so these run in the fast tier.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+
+from app.schemas.polar_by_config import ParabolicPolar, PolarRejection
+from app.services import assumption_compute_service as svc
+
+
+def _config(step: float = 0.5, margin: float = 5.0):
+    return SimpleNamespace(fine_alpha_step_deg=step, fine_alpha_margin_deg=margin)
+
+
+def _reject(gate: str, category: str) -> PolarRejection:
+    return PolarRejection(gate=gate, category=category, fitted_value=1.0, threshold="x", hint="h")
+
+
+def _dummy_sweep():
+    # (cl_max, cl_arr, cd_arr, v_arr, cdi_arr)
+    cl = np.array([0.1, 0.5, 0.9])
+    cd = np.array([0.01, 0.02, 0.05])
+    return (1.2, cl, cd, np.array([14.0, 14.0, 14.0]), np.array([0.005, 0.01, 0.03]))
+
+
+def _call(**overrides):
+    kwargs = dict(
+        asb_airplane=object(),
+        stall_alpha_deg=8.0,
+        v_cruise=14.0,
+        v_max=20.0,
+        config=_config(),
+        aspect_ratio=8.0,
+        cl_max_for_fit=1.2,
+        cd0_stability=0.02,
+        cl=np.array([0.1, 0.5, 0.9]),
+        cd=np.array([0.01, 0.02, 0.05]),
+    )
+    kwargs.update(overrides)
+    return svc._fit_parabolic_polar_with_refinement(**kwargs)
+
+
+class TestAutoRecovery:
+    def test_insufficient_points_retries_once_then_succeeds(self):
+        rej = _reject("insufficient_points", "sweep")
+        good = (0.02, 0.85, 0.98, None)
+        with (
+            patch.object(
+                svc, "_fit_parabolic_polar", side_effect=[(None, None, None, rej), good]
+            ) as m_fit,
+            patch.object(svc, "_fine_sweep_cl_max", return_value=_dummy_sweep()) as m_sweep,
+        ):
+            cd0, e, r2, rejection, auto_refined = _call()
+
+        assert (cd0, e, r2) == (0.02, 0.85, 0.98)
+        assert rejection is None
+        assert auto_refined is True
+        assert m_sweep.call_count == 1  # exactly one refinement
+        assert m_fit.call_count == 2
+        # the retry halved the step and widened the margin (×1.5)
+        kw = m_sweep.call_args.kwargs
+        assert kw["alpha_step_override"] == 0.25  # 0.5 / 2
+        assert kw["alpha_margin_override"] == 7.5  # 5.0 * 1.5
+
+    def test_non_monotonic_retries_twice_then_passes_rejection_through(self):
+        rej = _reject("non_monotonic_polar", "data")
+        with (
+            patch.object(
+                svc,
+                "_fit_parabolic_polar",
+                side_effect=[(None, None, None, rej)] * 3,  # initial + 2 retries all reject
+            ) as m_fit,
+            patch.object(svc, "_fine_sweep_cl_max", return_value=_dummy_sweep()) as m_sweep,
+        ):
+            cd0, e, r2, rejection, auto_refined = _call()
+
+        assert rejection is not None and rejection.gate == "non_monotonic_polar"
+        assert auto_refined is False  # refinement didn't help → no banner
+        assert m_sweep.call_count == 2  # capped at max_retries
+        assert m_fit.call_count == 3
+
+    def test_non_refinable_gate_does_not_retry(self):
+        rej = _reject("negative_slope_k", "design")
+        with (
+            patch.object(
+                svc, "_fit_parabolic_polar", return_value=(None, None, None, rej)
+            ) as m_fit,
+            patch.object(svc, "_fine_sweep_cl_max") as m_sweep,
+        ):
+            cd0, e, r2, rejection, auto_refined = _call()
+
+        assert rejection is not None and rejection.gate == "negative_slope_k"
+        assert auto_refined is False
+        m_sweep.assert_not_called()  # design rejections are not a resolution problem
+        assert m_fit.call_count == 1
+
+    def test_clean_fit_on_first_try_does_not_refine(self):
+        with (
+            patch.object(svc, "_fit_parabolic_polar", return_value=(0.02, 0.85, 0.99, None)),
+            patch.object(svc, "_fine_sweep_cl_max") as m_sweep,
+        ):
+            cd0, e, r2, rejection, auto_refined = _call()
+
+        assert rejection is None
+        assert auto_refined is False
+        m_sweep.assert_not_called()
+
+    def test_second_retry_step_quartered(self):
+        """A gate that resolves only on the 2nd retry uses step/4, margin×2.25."""
+        rej = _reject("insufficient_points", "sweep")
+        good = (0.02, 0.8, 0.97, None)
+        with (
+            patch.object(
+                svc,
+                "_fit_parabolic_polar",
+                side_effect=[(None, None, None, rej), (None, None, None, rej), good],
+            ),
+            patch.object(svc, "_fine_sweep_cl_max", return_value=_dummy_sweep()) as m_sweep,
+        ):
+            _cd0, _e, _r2, rejection, auto_refined = _call()
+
+        assert rejection is None and auto_refined is True
+        assert m_sweep.call_count == 2
+        last = m_sweep.call_args_list[-1].kwargs
+        assert last["alpha_step_override"] == 0.125  # 0.5 / 2**2
+        assert last["alpha_margin_override"] == 11.25  # 5.0 * 1.5**2
+
+
+class TestParabolicPolarSchema:
+    def test_auto_refined_defaults_false(self):
+        p = ParabolicPolar(cl_max=1.2)
+        assert p.auto_refined is False
+
+    def test_auto_refined_roundtrips(self):
+        p = ParabolicPolar(cl_max=1.2, auto_refined=True)
+        assert ParabolicPolar.model_validate(p.model_dump()).auto_refined is True


### PR DESCRIPTION
## Why
When the parabolic polar fit (`_fit_parabolic_polar`) is rejected for **`insufficient_points`** or **`non_monotonic_polar`**, the Oswald-provenance chain falls through to the **0.8 fallback** — even though both gates are usually just a **too-coarse α-sweep**, not a real design problem. Memory `feedback_aerobuildup_resolution`: *"increase α-resolution, never loosen thresholds."*

## What
- **`_fit_parabolic_polar_with_refinement`** — on a resolution-related rejection, re-runs a **finer** `_fine_sweep_cl_max` (`α-step/2`, `α-margin×1.5`) and refits, **up to 2 times**, before accepting the rejection. Both polar call sites use it: the **clean** config in `recompute_assumptions` and the **deflected** configs in `_run_polar_for_deflection`.
- **`_fine_sweep_cl_max`** gains `alpha_step_override` / `alpha_margin_override` so the retry **never mutates the stored config**.
- **`ParabolicPolar.auto_refined: bool`** — set only when a refinement produced a *successful* fit, so the UI can show a "resolution auto-refined" hint (front-end banner is a small follow-up; the flag enables it).
- **No threshold is ever loosened** — only resolution increases. The other four gates (`negative_slope_k`, `unphysical_e_oswald`, `non_positive_cd0`, `cd0_stability_mismatch`) are genuine design/physics rejections and do **not** retry.

Cheap now that AeroBuildup sweeps are vectorized (gh-670, already merged).

## Mehrwert
More aircraft get a **real, fit-derived** `cd0`/Oswald-`e` (feeding range/endurance, glide ratio, min-sink speed) instead of the regime-naive 0.8 fallback — automatically, and visibly (no silent magic).

## Acceptance criteria
- [x] `insufficient_points` → exactly one retry with halved step, then green fit
- [x] `non_monotonic_polar` → up to 2 retries, then the rejection passes through
- [x] The other 4 gates trigger **no** retry
- [x] `auto_refined` flag on `ParabolicPolar`
- [x] No thresholds loosened (only resolution)

## Tests
`test_polar_fit_autorecovery.py` (fast tier, mocked solver/fit): one-retry-success, two-retries-then-passthrough, non-refinable-no-retry, clean-first-try, step-quartering on 2nd retry, schema default/roundtrip. Updated the no-flap assumption test to reflect that a degenerate clean sweep now refines (1 + 2 retries) — its no-takeoff/landing-pass intent is preserved by the provenance assertions.

Closes #672

🤖 Generated with [Claude Code](https://claude.com/claude-code)