### PR TITLE
fix(gh-786): honest Polar config selectors (remove decorative, fix Single Point)

### DIFF
--- a/frontend/__tests__/AnalysisConfigPanel.test.tsx
+++ b/frontend/__tests__/AnalysisConfigPanel.test.tsx
@@ -100,3 +100,44 @@ describe("AnalysisConfigPanel numeric inputs (gh-787)", () => {
     expect(onRunStreamlines.mock.calls[0][0]).toMatchObject({ beta: 0 });
   });
 });
+
+describe("AnalysisConfigPanel honest Polar selectors (gh-786)", () => {
+  it("no longer renders the decorative sweep_var / solver / flight-profile selectors", () => {
+    render(<AnalysisConfigPanel activeTab="Polar" analysis={makeAnalysis()} {...BASE} />);
+
+    // sweep_var (alpha/beta/velocity) select removed — alpha is the only sweep
+    expect(screen.queryByLabelText("sweep_var")).toBeNull();
+    // solver picker + flight-profile select + the whole card removed
+    expect(screen.queryByText("Analysis Tool")).toBeNull();
+    expect(screen.queryByLabelText("Flight profile")).toBeNull();
+    // the misleading footer claim is gone too
+    expect(screen.queryByText(/AVL: single point only/i)).toBeNull();
+  });
+
+  it("Single Point mode runs a genuine 1-point evaluation (alpha_num=1)", () => {
+    const analysis = makeAnalysis();
+    render(<AnalysisConfigPanel activeTab="Polar" analysis={analysis} {...BASE} />);
+
+    // switch to Single Point (first radio) and set the single α
+    fireEvent.click(screen.getAllByRole("radio")[0]);
+    fireEvent.change(screen.getByLabelText("alpha"), { target: { value: "6" } });
+    fireEvent.click(runButton());
+
+    expect(analysis.runAlphaSweep).toHaveBeenCalledTimes(1);
+    expect(analysis.runAlphaSweep.mock.calls[0][0]).toMatchObject({
+      alpha_start: 6,
+      alpha_end: 6,
+      alpha_num: 1,
+    });
+  });
+
+  it("Parameter Sweep mode still produces a multi-point sweep", () => {
+    const analysis = makeAnalysis();
+    render(<AnalysisConfigPanel activeTab="Polar" analysis={analysis} {...BASE} />);
+
+    // default mode is sweep; defaults -5..15 step 1 → 21 points
+    fireEvent.click(runButton());
+    const call = analysis.runAlphaSweep.mock.calls[0][0];
+    expect(call.alpha_num).toBeGreaterThan(1);
+  });
+});

--- a/frontend/__tests__/AnalysisConfigPanel.test.tsx
+++ b/frontend/__tests__/AnalysisConfigPanel.test.tsx
@@ -140,4 +140,26 @@ describe("AnalysisConfigPanel honest Polar selectors (gh-786)", () => {
     const call = analysis.runAlphaSweep.mock.calls[0][0];
     expect(call.alpha_num).toBeGreaterThan(1);
   });
+
+  it("activates Single Point via keyboard (ModeRadio onKeyDown)", () => {
+    render(<AnalysisConfigPanel activeTab="Polar" analysis={makeAnalysis()} {...BASE} />);
+
+    // default sweep → range "start" shown, no single "alpha"
+    expect(screen.queryByLabelText("alpha")).toBeNull();
+    fireEvent.keyDown(screen.getAllByRole("radio")[0], { key: "Enter" });
+    // single mode now → single-alpha input present, range gone
+    expect(screen.getByLabelText("alpha")).toBeTruthy();
+    expect(screen.queryByLabelText("start")).toBeNull();
+  });
+
+  it("Reset to defaults restores the sweep start (and resets single α) without crashing", () => {
+    const analysis = makeAnalysis();
+    render(<AnalysisConfigPanel activeTab="Polar" analysis={analysis} {...BASE} />);
+
+    fireEvent.change(screen.getByLabelText("start"), { target: { value: "3" } });
+    fireEvent.click(screen.getByRole("button", { name: /Reset to defaults/i }));
+    fireEvent.click(runButton());
+
+    expect(analysis.runAlphaSweep.mock.calls[0][0]).toMatchObject({ alpha_start: -5 });
+  });
 });

--- a/frontend/components/workbench/AnalysisConfigPanel.tsx
+++ b/frontend/components/workbench/AnalysisConfigPanel.tsx
@@ -16,6 +16,60 @@ type Mode = "single" | "sweep";
 function defaultMassesFor(effectiveMassKg?: number | null): string {
   return effectiveMassKg != null ? formatMass(effectiveMassKg) : "";
 }
+
+/**
+ * Resolve the α-axis for a polar run (gh-786). "single" → one evaluation
+ * point (alpha_num=1); "sweep" → the start/end/step range (≥2 points).
+ */
+function polarAlphaRange(
+  mode: Mode,
+  v: { singlePointAlpha: string; alphaStart: string; alphaEnd: string; alphaStep: string },
+): { alpha_start: number; alpha_end: number; alpha_num: number } {
+  if (mode === "single") {
+    const a = finiteOr(v.singlePointAlpha, 5);
+    return { alpha_start: a, alpha_end: a, alpha_num: 1 };
+  }
+  const start = finiteOr(v.alphaStart, -5);
+  const end = finiteOr(v.alphaEnd, 15);
+  const step = finiteOr(v.alphaStep, 1);
+  return {
+    alpha_start: start,
+    alpha_end: end,
+    alpha_num: Math.max(2, Math.round((end - start) / step) + 1),
+  };
+}
+
+/** Accessible radio for the Single Point / Parameter Sweep choice. */
+function ModeRadio({
+  checked,
+  label,
+  onSelect,
+}: Readonly<{ checked: boolean; label: string; onSelect: () => void }>) {
+  return (
+    <label className="flex cursor-pointer items-center gap-2">
+      <span
+        onClick={onSelect}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onSelect();
+          }
+        }}
+        role="radio"
+        aria-checked={checked}
+        tabIndex={0}
+        className={`flex h-4 w-4 items-center justify-center rounded-full border-2 bg-background ${
+          checked ? "border-primary" : "border-border-strong"
+        }`}
+      >
+        {checked && <span className="h-2 w-2 rounded-full bg-primary" />}
+      </span>
+      <span className="font-[family-name:var(--font-geist-sans)] text-[13px] text-foreground">
+        {label}
+      </span>
+    </label>
+  );
+}
 /**
  * gh-577: Trefftz/Streamlines basis selection.
  * - "trimmed" (default): pick a stored, trimmed OperatingPoint from the
@@ -270,7 +324,8 @@ export function AnalysisConfigPanel({
   // Prefilled with the effective design mass.
   const defaultMassesInput = defaultMassesFor(effectiveMassKg);
   const [massesInput, setMassesInput] = useState(defaultMassesInput);
-  const [analysisTool, setAnalysisTool] = useState("aero_buildup");
+  // Single-point α (gh-786): used when mode === "single".
+  const [singlePointAlpha, setSinglePointAlpha] = useState("5");
   // xyzRef defaults to the design CG (cg_x effective from assumptions)
   // — that is the moment-reference point the rest of the system uses.
   // Falling back to "0, 0, 0" is just a placeholder until the prop arrives.
@@ -290,13 +345,10 @@ export function AnalysisConfigPanel({
 
   // ── Polar handlers ──
   const handleRunPolar = () => {
-    const start = finiteOr(alphaStart, -5);
-    const end = finiteOr(alphaEnd, 15);
-    const step = finiteOr(alphaStep, 1);
+    // gh-786: "Single Point" runs a genuine 1-point evaluation (alpha_num=1)
+    // instead of silently falling back to the default α-sweep.
     analysis.runAlphaSweep({
-      alpha_start: start,
-      alpha_end: end,
-      alpha_num: Math.max(2, Math.round((end - start) / step) + 1),
+      ...polarAlphaRange(mode, { singlePointAlpha, alphaStart, alphaEnd, alphaStep }),
       velocity: finiteOr(velocity, 14),
       beta: finiteOr(beta, 0),
       altitude: finiteOr(altitude, 0),
@@ -347,7 +399,7 @@ export function AnalysisConfigPanel({
     setAltitude("100");
     setBeta("0");
     setMassesInput(defaultMassesInput);
-    setAnalysisTool("aero_buildup");
+    setSinglePointAlpha("5");
     setXyzRef(designCgX != null ? `${designCgX.toFixed(4)}, 0, 0` : "0, 0, 0");
     setTrefftzAlpha("5");
   };
@@ -439,68 +491,25 @@ export function AnalysisConfigPanel({
 
             {/* Radio row */}
             <div className="flex items-center gap-4">
-              <label className="flex cursor-pointer items-center gap-2">
-                <span
-                  onClick={() => setMode("single")}
-                  onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setMode("single"); } }}
-                  role="radio"
-                  aria-checked={mode === "single"}
-                  tabIndex={0}
-                  className={`flex h-4 w-4 items-center justify-center rounded-full border-2 bg-background ${
-                    mode === "single" ? "border-primary" : "border-border-strong"
-                  }`}
-                >
-                  {mode === "single" && (
-                    <span className="h-2 w-2 rounded-full bg-primary" />
-                  )}
-                </span>
-                <span className="font-[family-name:var(--font-geist-sans)] text-[13px] text-foreground">
-                  Single Point
-                </span>
-              </label>
-              <label className="flex cursor-pointer items-center gap-2">
-                <span
-                  onClick={() => setMode("sweep")}
-                  onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setMode("sweep"); } }}
-                  role="radio"
-                  aria-checked={mode === "sweep"}
-                  tabIndex={0}
-                  className={`flex h-4 w-4 items-center justify-center rounded-full border-2 bg-background ${
-                    mode === "sweep" ? "border-primary" : "border-border-strong"
-                  }`}
-                >
-                  {mode === "sweep" && (
-                    <span className="h-2 w-2 rounded-full bg-primary" />
-                  )}
-                </span>
-                <span className="font-[family-name:var(--font-geist-sans)] text-[13px] text-foreground">
-                  Parameter Sweep
-                </span>
-              </label>
+              <ModeRadio
+                checked={mode === "single"}
+                label="Single Point"
+                onSelect={() => setMode("single")}
+              />
+              <ModeRadio
+                checked={mode === "sweep"}
+                label="Parameter Sweep"
+                onSelect={() => setMode("sweep")}
+              />
             </div>
 
-            {/* Sweep fields (shown when Parameter Sweep is selected) */}
-            {mode === "sweep" && (
-              <div className="flex flex-col gap-3">
-                {/* sweep_var */}
-                <div className="flex flex-col gap-1">
-                  <label htmlFor="sweep-var-select" className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
-                    sweep_var
-                  </label>
-                  <div className="relative">
-                    <select id="sweep-var-select" className="w-full appearance-none rounded-xl border border-border bg-input px-3 py-2 pr-8 font-[family-name:var(--font-geist-sans)] text-[13px] text-foreground">
-                      <option>alpha</option>
-                      <option>beta</option>
-                      <option>velocity</option>
-                    </select>
-                    <ChevronDown
-                      size={14}
-                      className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground"
-                    />
-                  </div>
-                </div>
-
-                {/* Range row */}
+            {/* Operating-point inputs. alpha is the only sweep variable —
+                gh-786 removed the decorative beta/velocity sweep_var select.
+                Single Point shows one α; Parameter Sweep shows the α range.
+                The fixed values below render in BOTH modes. */}
+            <div className="flex flex-col gap-3">
+              {mode === "sweep" ? (
+                /* Range row */
                 <div className="grid grid-cols-3 gap-3">
                   <div className="flex flex-col gap-1">
                     <label htmlFor="sweep-start" className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
@@ -539,6 +548,26 @@ export function AnalysisConfigPanel({
                     />
                   </div>
                 </div>
+              ) : (
+                /* Single α (gh-786): one evaluation point */
+                <div className="flex flex-col gap-1">
+                  <label htmlFor="single-alpha" className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+                    alpha
+                  </label>
+                  <div className="relative">
+                    <input
+                      id="single-alpha"
+                      type="text"
+                      value={singlePointAlpha}
+                      onChange={(e) => setSinglePointAlpha(e.target.value)}
+                      className="w-full rounded-xl border border-border bg-input px-3 py-2 pr-8 font-[family-name:var(--font-geist-sans)] text-[13px] text-foreground"
+                    />
+                    <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+                      &deg;
+                    </span>
+                  </div>
+                </div>
+              )}
 
                 {/* Divider with "Fixed values" */}
                 <div className="flex items-center gap-3">
@@ -664,7 +693,6 @@ export function AnalysisConfigPanel({
                   )}
                 </div>
               </div>
-            )}
           </div>
 
           {/* ── Speed Polar Masses Card ── */}
@@ -693,62 +721,6 @@ export function AnalysisConfigPanel({
             </div>
           </div>
 
-          {/* ── Analysis Tool Card ── */}
-          <div className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4">
-            <span className="font-[family-name:var(--font-jetbrains-mono)] text-[12px] text-muted-foreground">
-              Analysis Tool
-            </span>
-
-            {/* Tool select */}
-            <div className="relative">
-              <select
-                value={analysisTool}
-                onChange={(e) => setAnalysisTool(e.target.value)}
-                className="w-full appearance-none rounded-xl border border-border bg-input px-3 py-2 pr-8 font-[family-name:var(--font-geist-sans)] text-[13px] text-foreground"
-              >
-                <option value="aero_buildup">aerobuildup</option>
-                <option value="avl">avl</option>
-                <option value="vortex_lattice">vortex_lattice</option>
-              </select>
-              <ChevronDown
-                size={14}
-                className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground"
-              />
-            </div>
-
-            {/* Tool chips */}
-            <div className="flex items-center gap-2">
-              <span className="rounded-full border border-border bg-card-muted px-2.5 py-1 font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-muted-foreground">
-                avl
-              </span>
-              <span className="rounded-full border border-border bg-card-muted px-2.5 py-1 font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-muted-foreground">
-                vortex_lattice
-              </span>
-            </div>
-
-            {/* Flight profile */}
-            <div className="flex flex-col gap-1">
-              <label htmlFor="flight-profile-select" className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
-                Flight profile
-              </label>
-              <div className="relative">
-                <select id="flight-profile-select" className="w-full appearance-none rounded-xl border border-border bg-input px-3 py-2 pr-8 font-[family-name:var(--font-geist-sans)] text-[13px] text-foreground">
-                  <option>cruise</option>
-                  <option>takeoff</option>
-                  <option>landing</option>
-                </select>
-                <ChevronDown
-                  size={14}
-                  className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground"
-                />
-              </div>
-            </div>
-
-            {/* Footer text */}
-            <p className="font-[family-name:var(--font-geist-sans)] text-[10px] italic text-subtle-foreground">
-              AVL: single point only &middot; AeroBuildup / VLM: sweeps supported
-            </p>
-          </div>
         </>
       )}
 


### PR DESCRIPTION
## Bug
The Analysis → Polar dialog had three controls with **no effect**: `sweep_var` (alpha/beta/velocity), Analysis Tool (AVL/VLM — state set but never sent), and Flight profile (cruise/takeoff/landing). Selecting AVL or a velocity sweep silently ran a **cruise AeroBuildup alpha sweep**. "Single Point" mode rendered no inputs and also ran the default sweep.

## Decision basis — RC-design expert consult
Asked the `/rc-aircraft-designer` expert what polar DOFs RC/model designers actually need:
- **Alpha sweep is the core** — keep it.
- **Beta sweep** is niche/pro (RC tunes directional stability via dihedral/VT-volume rules, never a β-polar) → drop.
- **Velocity** is covered by the **speed-polar (sink vs V, gh-841)** + **Re annotation/overlay**, not a raw velocity axis → drop the selector.
- **Solver choice** is irrelevant to RC users — they care about trust + Re-validity, not AVL vs VLM → hide (VLM is the fast in-process default since gh-674).
- **Flight profile** is really a flap/camber-phase input → defer to a focused follow-up.

## Changes (frontend-only)
- Remove the `sweep_var` select (alpha is the only sweep variable).
- Remove the entire **Analysis Tool card** (solver select + decorative chips + flight-profile select + misleading "AVL: single point only" footer).
- **Fix Single Point**: renders a single α input and runs a genuine 1-point evaluation (`alpha_num=1`); fixed values (velocity/altitude/beta) now show in **both** modes (previously only in sweep, which is why Single Point looked empty).
- Extract `ModeRadio` + `polarAlphaRange` helpers (DRY; keeps cognitive complexity under the eslint gate).

## Tests
`AnalysisConfigPanel.test.tsx`: decorative selectors gone (sweep_var / Analysis Tool / Flight profile / misleading footer), Single Point → `alpha_num=1` at the chosen α, Parameter Sweep still multi-point. All gh-787 tests still green.

Follow-up: flap-state (Speed/Thermal/Launch/Landing) as a real flap-deflection input — filed separately.

Closes #786

🤖 Generated with [Claude Code](https://claude.com/claude-code)