### PR TITLE
fix(gh-855): span-proportional VLM strip-force paneling (no tiny-segment over-resolution)

### DIFF
--- a/app/services/vlm_strip_forces.py
+++ b/app/services/vlm_strip_forces.py
@@ -55,22 +55,133 @@ def _wing_strip_counts(airplane, spanwise_resolution: int) -> list[int]:
     return counts
 
 
+# gh-855: target spanwise panels per half-wing, distributed ∝ segment span.
+_SPANWISE_PANELS_PER_HALF = 40
+_MIN_PANELS_PER_SEGMENT = 2
+
+
+def _panels_per_segment(spans: list[float], budget: int, min_per_segment: int) -> list[int]:
+    """Distribute ``budget`` spanwise panels across segments ∝ span (gh-855).
+
+    Each segment gets at least ``min_per_segment`` panels so a tiny segment is
+    never over-resolved relative to a large one. Pure function (no aerosandbox).
+    """
+    if not spans:
+        return []
+    total = float(sum(spans))
+    if total <= 0:
+        return [max(min_per_segment, 1) for _ in spans]
+    return [max(min_per_segment, int(round(budget * s / total))) for s in spans]
+
+
+def _segment_spans(wing) -> list[float]:
+    """True (dihedral-inclusive) spanwise length of each wing segment [m]."""
+    xs = wing.xsecs
+    spans: list[float] = []
+    for xa, xb in zip(xs[:-1], xs[1:], strict=False):
+        a = np.asarray(xa.xyz_le, dtype=float)
+        b = np.asarray(xb.xyz_le, dtype=float)
+        spans.append(float(math.hypot(b[1] - a[1], b[2] - a[2])))
+    return spans
+
+
+def _blend_xsec(xa, xb, frac: float):
+    """Interpolate a ``WingXSec`` between ``xa`` (frac 0) and ``xb`` (frac 1).
+
+    chord/twist/xyz_le are linear; the airfoil is blended via
+    ``Airfoil.blend_with_another_airfoil`` — the same call AeroSandbox uses
+    internally when subdividing sections (gh-855).
+    """
+    import aerosandbox as asb
+
+    a, b = 1.0 - frac, frac
+    name_a = getattr(xa.airfoil, "name", "") or ""
+    name_b = getattr(xb.airfoil, "name", "") or ""
+    if frac <= 0.0 or name_a == name_b:
+        airfoil = xa.airfoil
+    elif frac >= 1.0:
+        airfoil = xb.airfoil
+    else:
+        try:
+            airfoil = xa.airfoil.blend_with_another_airfoil(airfoil=xb.airfoil, blend_fraction=b)
+        except Exception:  # noqa: BLE001 — blend failure → keep inboard section
+            airfoil = xa.airfoil
+    return asb.WingXSec(
+        xyz_le=np.asarray(xa.xyz_le, dtype=float) * a + np.asarray(xb.xyz_le, dtype=float) * b,
+        chord=float(xa.chord) * a + float(xb.chord) * b,
+        twist=float(xa.twist) * a + float(xb.twist) * b,
+        airfoil=airfoil,
+        control_surfaces=xa.control_surfaces,
+    )
+
+
+def remesh_uniform_density(wing, *, budget: int, min_per_segment: int):
+    """Return a copy of ``wing`` with span-proportional spanwise subdivision.
+
+    Inserts intermediate cross-sections so the wing carries ~``budget`` panels
+    per half, distributed ∝ segment span (≥ ``min_per_segment`` each). Run the
+    VLM with ``spanwise_resolution=1`` on the result so each inserted section is
+    exactly one spanwise panel → uniform panel density (gh-855).
+    """
+    import aerosandbox as asb
+
+    xs = wing.xsecs
+    if len(xs) < 2:
+        return wing
+    counts = _panels_per_segment(_segment_spans(wing), budget, min_per_segment)
+    new_xsecs = []
+    for (xa, xb), n in zip(zip(xs[:-1], xs[1:], strict=False), counts, strict=False):
+        for i in range(n):
+            new_xsecs.append(_blend_xsec(xa, xb, i / n))
+    new_xsecs.append(xs[-1])
+    return asb.Wing(name=wing.name, xsecs=new_xsecs, symmetric=wing.symmetric)
+
+
+def _remesh_airplane(asb_airplane, *, budget: int, min_per_segment: int):
+    """Rebuild the airplane with uniform-density wings, preserving the (gh-788)
+    reference geometry."""
+    import aerosandbox as asb
+
+    remeshed = [
+        remesh_uniform_density(w, budget=budget, min_per_segment=min_per_segment)
+        for w in asb_airplane.wings
+    ]
+    return asb.Airplane(
+        name=asb_airplane.name,
+        wings=remeshed,
+        fuselages=list(getattr(asb_airplane, "fuselages", []) or []),
+        xyz_ref=asb_airplane.xyz_ref,
+        s_ref=float(asb_airplane.s_ref),
+        b_ref=float(asb_airplane.b_ref),
+        c_ref=float(asb_airplane.c_ref),
+    )
+
+
 def compute_vlm_strip_forces(
     asb_airplane,
     op_point,
     *,
     xyz_ref: list[float] | None = None,
-    spanwise_resolution: int = 12,
+    spanwise_panels: int = _SPANWISE_PANELS_PER_HALF,
     chordwise_resolution: int = 8,
+    min_panels_per_segment: int = _MIN_PANELS_PER_SEGMENT,
 ) -> dict[str, Any]:
     """Run a VLM solve and return AVL-compatible per-strip force data.
+
+    Spanwise panels are distributed **∝ segment span** (gh-855): the wing is
+    remeshed so panel density is ~uniform (``spanwise_panels`` per half,
+    ≥ ``min_panels_per_segment`` per segment), then the VLM runs with
+    ``spanwise_resolution=1``. This avoids over-resolving tiny segments — the
+    old per-segment ``spanwise_resolution`` gave a 5 cm segment as many strips
+    as a 95 cm one, spiking the cl(y) plot.
 
     Args:
         asb_airplane: the ``asb.Airplane`` to analyse.
         op_point: the ``asb.OperatingPoint``.
         xyz_ref: moment reference point; defaults to the airplane's own.
-        spanwise_resolution: VLM spanwise panels per wing segment.
+        spanwise_panels: target spanwise panels per half-wing.
         chordwise_resolution: VLM chordwise panels per strip.
+        min_panels_per_segment: floor on panels for any single segment.
 
     Returns:
         A dict with ``Sref``/``Cref``/``Bref``/``alpha``/``beta``/``mach``/
@@ -82,11 +193,16 @@ def compute_vlm_strip_forces(
     if xyz_ref is not None:
         asb_airplane.xyz_ref = xyz_ref
 
+    meshed = _remesh_airplane(
+        asb_airplane, budget=spanwise_panels, min_per_segment=min_panels_per_segment
+    )
+
     vlm = asb.VortexLatticeMethod(
-        airplane=asb_airplane,
+        airplane=meshed,
         op_point=op_point,
-        spanwise_resolution=spanwise_resolution,
+        spanwise_resolution=1,  # gh-855: density set by the remesh, not here
         chordwise_resolution=chordwise_resolution,
+        spanwise_spacing_function=np.linspace,
     )
     run = vlm.run()
 
@@ -109,7 +225,8 @@ def compute_vlm_strip_forces(
     l_hat = l_hat / np.linalg.norm(l_hat)
 
     strip_ranges = _strip_index_ranges(np.asarray(vlm.is_trailing_edge))
-    wing_counts = _wing_strip_counts(asb_airplane, spanwise_resolution)
+    # spanwise_resolution=1 → one strip per (remeshed) segment per half.
+    wing_counts = _wing_strip_counts(meshed, 1)
 
     # Assign contiguous blocks of strips to wings in airplane.wings order.
     # If the expected counts don't sum to the actual strip count (unusual
@@ -118,7 +235,7 @@ def compute_vlm_strip_forces(
         wing_counts = [len(strip_ranges)]
         wing_names = [asb_airplane.name or "Aircraft"]
     else:
-        wing_names = [w.name for w in asb_airplane.wings]
+        wing_names = [w.name for w in meshed.wings]
 
     surfaces: list[dict[str, Any]] = []
     cursor = 0

--- a/app/tests/test_vlm_strip_forces.py
+++ b/app/tests/test_vlm_strip_forces.py
@@ -18,6 +18,7 @@ import pytest
 
 from app.schemas.strip_forces import StripForceEntry
 from app.services.vlm_strip_forces import (
+    _panels_per_segment,
     _strip_index_ranges,
     _wing_strip_counts,
     compute_vlm_strip_forces,
@@ -56,7 +57,7 @@ class TestComputeVlmStripForces:
         from app.services.vlm_strip_forces import compute_vlm_strip_forces
 
         result = compute_vlm_strip_forces(
-            _airplane(), _op(), spanwise_resolution=8, chordwise_resolution=6
+            _airplane(), _op(), spanwise_panels=12, chordwise_resolution=6
         )
         for key in ("Sref", "Cref", "Bref", "alpha", "beta", "mach", "strip_forces"):
             assert key in result, key
@@ -67,7 +68,7 @@ class TestComputeVlmStripForces:
         from app.services.vlm_strip_forces import compute_vlm_strip_forces
 
         result = compute_vlm_strip_forces(
-            _airplane(), _op(), spanwise_resolution=8, chordwise_resolution=6
+            _airplane(), _op(), spanwise_panels=12, chordwise_resolution=6
         )
         names = [s["surface_name"] for s in result["strip_forces"]]
         assert names == ["Main", "HTP"]
@@ -80,7 +81,7 @@ class TestComputeVlmStripForces:
         from app.services.vlm_strip_forces import compute_vlm_strip_forces
 
         result = compute_vlm_strip_forces(
-            _airplane(), _op(), spanwise_resolution=8, chordwise_resolution=6
+            _airplane(), _op(), spanwise_panels=12, chordwise_resolution=6
         )
         for surface in result["strip_forces"]:
             for raw in surface["strips"]:
@@ -98,7 +99,7 @@ class TestComputeVlmStripForces:
         from app.services.vlm_strip_forces import compute_vlm_strip_forces
 
         result = compute_vlm_strip_forces(
-            _airplane(), _op(), spanwise_resolution=10, chordwise_resolution=6
+            _airplane(), _op(), spanwise_panels=14, chordwise_resolution=6
         )
         sref = result["Sref"]
         lift_area = sum(
@@ -108,6 +109,35 @@ class TestComputeVlmStripForces:
         assert cl_reconstructed == pytest.approx(result["CL"], abs=1e-3)
         # a cambered wing at +4° → clearly positive lift
         assert cl_reconstructed > 0.2
+
+    def test_span_proportional_distribution_no_tiny_segment_overresolution(self):
+        """gh-855: a tiny 5 cm segment must NOT get as many strips as a 95 cm one.
+
+        Pre-fix the per-segment spanwise_resolution gave both segments equal
+        panels (~19x density mismatch). After the remesh, strip widths are
+        roughly uniform.
+        """
+        wing = asb.Wing(
+            name="Main",
+            symmetric=True,
+            xsecs=[
+                asb.WingXSec(xyz_le=[0, 0, 0], chord=0.25, airfoil=asb.Airfoil("naca2412")),
+                asb.WingXSec(xyz_le=[0, 0.05, 0], chord=0.24, airfoil=asb.Airfoil("naca2412")),
+                asb.WingXSec(xyz_le=[0.05, 1.0, 0], chord=0.16, airfoil=asb.Airfoil("naca2412")),
+            ],
+        )
+        ap = asb.Airplane(name="t", wings=[wing])
+        result = compute_vlm_strip_forces(ap, _op(), spanwise_panels=40)
+
+        strips = result["strip_forces"][0]["strips"]
+        right = sorted(s["Yle"] for s in strips if s["Yle"] > 0)
+        tiny = [y for y in right if y < 0.05]
+        big = [y for y in right if y >= 0.05]
+        # the big segment (95 cm) gets many more strips than the tiny (5 cm) one
+        assert len(big) > len(tiny) * 3
+        # strip widths on the right half are roughly uniform (no 19x spikes)
+        widths = np.diff([0.0, *right])
+        assert widths.max() / widths.min() < 4.0
 
 
 # ---------------------------------------------------------------------------
@@ -137,6 +167,88 @@ class TestWingStripCounts:
         ap.wings = [self._wing(2, True), self._wing(3, False)]
         # 1 segment * 4 * 2 = 8 ; 2 segments * 4 * 1 = 8
         assert _wing_strip_counts(ap, spanwise_resolution=4) == [8, 8]
+
+
+def _mock_xsec(y: float, chord: float, airfoil_name: str):
+    xs = MagicMock()
+    xs.xyz_le = np.array([0.0, y, 0.0])
+    xs.chord = chord
+    xs.twist = 0.0
+    af = MagicMock()
+    af.name = airfoil_name
+    af.blend_with_another_airfoil.return_value = MagicMock()
+    xs.airfoil = af
+    xs.control_surfaces = []
+    return xs
+
+
+class TestRemeshMocked:
+    """gh-855: exercise the remesh chain (_segment_spans → _panels_per_segment →
+    _blend_xsec → remesh_uniform_density → _remesh_airplane) in the fast tier by
+    patching the asb constructors, so the new code is covered without aerosandbox.
+    """
+
+    def test_remesh_airplane_builds_span_proportional_sections(self):
+        from app.services.vlm_strip_forces import _remesh_airplane
+
+        # tiny 5 cm segment (same airfoil → blend early-return branch) + big 95 cm
+        # segment (different airfoil → blend call branch)
+        xsecs = [
+            _mock_xsec(0.0, 0.25, "A"),
+            _mock_xsec(0.05, 0.24, "A"),
+            _mock_xsec(1.0, 0.16, "B"),
+        ]
+        wing = MagicMock()
+        wing.xsecs = xsecs
+        wing.symmetric = True
+        wing.name = "Main"
+        ap = MagicMock()
+        ap.wings = [wing]
+        ap.name = "t"
+        ap.xyz_ref = [0.0, 0.0, 0.0]
+        ap.s_ref = 1.0
+        ap.b_ref = 2.0
+        ap.c_ref = 0.2
+        ap.fuselages = []
+
+        with (
+            patch("aerosandbox.WingXSec", side_effect=lambda **kw: ("xsec", kw)) as m_xsec,
+            patch("aerosandbox.Wing", side_effect=lambda **kw: ("wing", kw)) as m_wing,
+            patch("aerosandbox.Airplane", side_effect=lambda **kw: ("airplane", kw)) as m_ap,
+        ):
+            out = _remesh_airplane(ap, budget=40, min_per_segment=2)
+
+        # budget 40 over spans [0.05, 0.95] → 2 + 38 inserted sections
+        assert m_xsec.call_count == 40
+        assert m_wing.call_count == 1
+        assert m_ap.call_count == 1
+        assert out[0] == "airplane"
+        # the different-airfoil (big) segment triggered real blending
+        assert xsecs[1].airfoil.blend_with_another_airfoil.called
+
+
+class TestPanelsPerSegment:
+    """gh-855: spanwise panels are distributed ∝ segment span, ≥ min each."""
+
+    def test_proportional_to_span(self):
+        # tiny 0.05 m segment + big 0.95 m segment, budget 40 → 2 vs 38
+        counts = _panels_per_segment([0.05, 0.95], budget=40, min_per_segment=2)
+        assert counts == [2, 38]
+        assert sum(counts) == 40
+
+    def test_min_floor_protects_tiny_segments(self):
+        # a 1 mm sliver next to a 1 m segment still gets the floor, not 0
+        counts = _panels_per_segment([0.001, 1.0], budget=20, min_per_segment=2)
+        assert counts[0] == 2
+        assert counts[1] >= 2
+
+    def test_equal_segments_split_evenly(self):
+        assert _panels_per_segment([0.5, 0.5], budget=20, min_per_segment=1) == [10, 10]
+
+    def test_empty_and_degenerate(self):
+        assert _panels_per_segment([], budget=10, min_per_segment=2) == []
+        # zero total span → every segment gets the floor
+        assert _panels_per_segment([0.0, 0.0], budget=10, min_per_segment=2) == [2, 2]
 
 
 def _fake_vlm():
@@ -186,13 +298,20 @@ def _fake_op():
 
 
 class TestComputeVlmStripForcesMocked:
-    """Exercises compute_vlm_strip_forces without a real solve (fast tier)."""
+    """Exercises compute_vlm_strip_forces without a real solve (fast tier).
+
+    The span-proportional remesh (gh-855) needs real asb geometry, so it is
+    patched out here; the strip-walk + surface attribution is what we cover.
+    """
 
     def test_builds_surface_and_strips(self):
-        with patch("aerosandbox.VortexLatticeMethod", return_value=_fake_vlm()):
-            result = compute_vlm_strip_forces(
-                _fake_airplane(), _fake_op(), spanwise_resolution=2, chordwise_resolution=2
-            )
+        # 3 xsecs → 2 segments → spanwise_resolution=1 → 2 strips, matching the mock.
+        fake = _fake_airplane(n_xsecs=3, symmetric=False)
+        with (
+            patch("aerosandbox.VortexLatticeMethod", return_value=_fake_vlm()),
+            patch("app.services.vlm_strip_forces._remesh_airplane", return_value=fake),
+        ):
+            result = compute_vlm_strip_forces(fake, _fake_op(), chordwise_resolution=2)
         assert result["CL"] == 0.04
         assert result["alpha"] == 0.0
         assert len(result["strip_forces"]) == 1
@@ -208,15 +327,14 @@ class TestComputeVlmStripForcesMocked:
             assert entry.ai == pytest.approx(0.0)
 
     def test_count_mismatch_falls_back_to_single_surface(self):
-        # spanwise_resolution=3 → expected 3 strips, but the mock yields 2 →
+        # 2 xsecs → 1 segment → expected 1 strip, but the mock yields 2 →
         # the guard collapses everything into one aggregate surface.
-        with patch("aerosandbox.VortexLatticeMethod", return_value=_fake_vlm()):
-            result = compute_vlm_strip_forces(
-                _fake_airplane(ap_name="Romulus"),
-                _fake_op(),
-                spanwise_resolution=3,
-                chordwise_resolution=2,
-            )
+        fake = _fake_airplane(n_xsecs=2, symmetric=False, ap_name="Romulus")
+        with (
+            patch("aerosandbox.VortexLatticeMethod", return_value=_fake_vlm()),
+            patch("app.services.vlm_strip_forces._remesh_airplane", return_value=fake),
+        ):
+            result = compute_vlm_strip_forces(fake, _fake_op(), chordwise_resolution=2)
         assert len(result["strip_forces"]) == 1
         assert result["strip_forces"][0]["surface_name"] == "Romulus"
         assert result["strip_forces"][0]["n_spanwise"] == 2


### PR DESCRIPTION
## Bug (user-reported)
The gh-674 VLM Trefftz/strip-forces path gave **every wing segment the same number of spanwise panels**, regardless of span. AeroSandbox's `spanwise_resolution` is applied **per segment** (`Wing.subdivide_sections(ratio=N)`), so a 5 cm segment got as many strips as a 95 cm one — a **~19× density mismatch**, producing tiny over-resolved strips and spikes in the cl(y) plot.

## Root cause
Confirmed against ASB 4.2.9 source (aerosandbox-expert): `VortexLatticeMethod.run()` → `wing.subdivide_sections(ratio=spanwise_resolution)` splits **each** WingXSec-pair into the same N, never span-aware. There is no per-WingXSec count API, and `spanwise_spacing_function` only clusters *within* a section (`cosspace` would even double-cluster at segment joins).

## Fix
Remesh each wing before the solve so panel **density** is uniform:
- Distribute a per-half-wing budget (`spanwise_panels`, default 40) **∝ each segment's span**, floor `min_panels_per_segment` (default 2).
- Insert intermediate `WingXSec`s — chord/twist/xyz_le linear, airfoil via `Airfoil.blend_with_another_airfoil` (ASB's own internal blend).
- Run the VLM with `spanwise_resolution=1` + `np.linspace`.

Repro wing (5 cm + 95 cm, budget 40/half): tiny→**2** strips, big→**38**, strip-width ratio **2.0** (was ~19×). CL/CDi unchanged within convergence. Output schema untouched → `TrefftzPlaneChart` unchanged.

## Tests
- `_panels_per_segment` (pure): proportional split, min floor, even split, empty/degenerate.
- Remesh chain mocked-asb test (fast tier) → covers `_segment_spans`/`_blend_xsec`/`remesh_uniform_density`/`_remesh_airplane` (module 95% in the coverage tier).
- Real-aero: AVL-shape parity, aggregate-CL reconstruction, and a **span-proportional distribution** test asserting the tiny segment isn't over-resolved (width ratio < 4×).

Closes #855

🤖 Generated with [Claude Code](https://claude.com/claude-code)