### PR TITLE
fix(gh-857): span-proportional paneling for VLM streamlines

### DIFF
--- a/app/api/utils.py
+++ b/app/api/utils.py
@@ -12,6 +12,7 @@ from pyvista import Plotter
 
 from app.schemas.AeroplaneRequest import AnalysisToolUrlType
 from app.schemas.aeroanalysisschema import OperatingPointSchema
+from app.services.vlm_strip_forces import _remesh_airplane
 from cad_designer.airplane.aircraft_topology.models.analysis_model import AnalysisModel
 
 
@@ -68,9 +69,19 @@ def _run_aerobuildup(asb_airplane, op_point, operating_point):
 
 
 def _run_vlm(asb_airplane, op_point, operating_point, draw_streamlines, backend):
-    """Run Vortex Lattice Method analysis."""
+    """Run Vortex Lattice Method analysis.
+
+    gh-857: spanwise panels are distributed ∝ segment span (the same remesh as
+    the strip-force path, gh-855) so tiny segments aren't over-resolved — this
+    keeps the streamline panel density uniform and the VLM solve consistent.
+    """
+    meshed = _remesh_airplane(asb_airplane)
     vlm = asb.VortexLatticeMethod(
-        airplane=asb_airplane, op_point=op_point, xyz_ref=operating_point.xyz_ref
+        airplane=meshed,
+        op_point=op_point,
+        xyz_ref=operating_point.xyz_ref,
+        spanwise_resolution=1,  # gh-857: density set by the remesh, not here
+        spanwise_spacing_function=np.linspace,
     )
     vlm.verbose = True
     vlm_results = vlm.run_with_stability_derivatives()

--- a/app/services/vlm_strip_forces.py
+++ b/app/services/vlm_strip_forces.py
@@ -137,7 +137,12 @@ def remesh_uniform_density(wing, *, budget: int, min_per_segment: int):
     return asb.Wing(name=wing.name, xsecs=new_xsecs, symmetric=wing.symmetric)
 
 
-def _remesh_airplane(asb_airplane, *, budget: int, min_per_segment: int):
+def _remesh_airplane(
+    asb_airplane,
+    *,
+    budget: int = _SPANWISE_PANELS_PER_HALF,
+    min_per_segment: int = _MIN_PANELS_PER_SEGMENT,
+):
     """Rebuild the airplane with uniform-density wings, preserving the (gh-788)
     reference geometry."""
     import aerosandbox as asb

--- a/app/tests/test_api_utils.py
+++ b/app/tests/test_api_utils.py
@@ -242,9 +242,12 @@ class TestRunAerobuildup:
 class TestRunVlm:
     """_run_vlm creates a VortexLatticeMethod, runs, and optionally draws."""
 
+    @patch("app.api.utils._remesh_airplane", side_effect=lambda ap: ap)
     @patch("app.api.utils.AnalysisModel")
     @patch("app.api.utils.asb")
-    def test_without_streamlines(self, mock_asb, mock_analysis_model):
+    def test_without_streamlines(self, mock_asb, mock_analysis_model, _mock_remesh):
+        import numpy as np
+
         from app.api.utils import _run_vlm
 
         mock_vlm_instance = MagicMock()
@@ -264,19 +267,23 @@ class TestRunVlm:
             backend="plotly",
         )
 
+        # gh-857: span-proportional remesh + spanwise_resolution=1
         mock_asb.VortexLatticeMethod.assert_called_once_with(
             airplane=airplane,
             op_point=op_point,
             xyz_ref=operating_point.xyz_ref,
+            spanwise_resolution=1,
+            spanwise_spacing_function=np.linspace,
         )
         assert mock_vlm_instance.verbose is True
         mock_vlm_instance.run_with_stability_derivatives.assert_called_once()
         mock_vlm_instance.draw.assert_not_called()
         assert figure is None
 
+    @patch("app.api.utils._remesh_airplane", side_effect=lambda ap: ap)
     @patch("app.api.utils.AnalysisModel")
     @patch("app.api.utils.asb")
-    def test_with_streamlines(self, mock_asb, mock_analysis_model):
+    def test_with_streamlines(self, mock_asb, mock_analysis_model, _mock_remesh):
         from app.api.utils import _run_vlm
 
         mock_vlm_instance = MagicMock()
@@ -300,9 +307,12 @@ class TestRunVlm:
         mock_vlm_instance.draw.assert_called_once_with(show=False, backend="pyvista")
         assert figure is not None
 
+    @patch("app.api.utils._remesh_airplane", side_effect=lambda ap: ap)
     @patch("app.api.utils.AnalysisModel")
     @patch("app.api.utils.asb")
-    def test_from_abu_dict_called_with_vortex_lattice_method(self, mock_asb, mock_analysis_model):
+    def test_from_abu_dict_called_with_vortex_lattice_method(
+        self, mock_asb, mock_analysis_model, _mock_remesh
+    ):
         from app.api.utils import _run_vlm
 
         mock_vlm_instance = MagicMock()


### PR DESCRIPTION
## Bug (user-reported)
Same root cause as #855, different path: `app/api/utils.py:_run_vlm` (streamlines + opt-in `vortex_lattice` analysis) built the VLM with ASB's **default per-segment** `spanwise_resolution`, so tiny wing segments (root fairings, winglet transitions) were over-resolved → uneven streamline/vortex density near small segments.

## Fix
Reuse the #855 remesh: distribute spanwise panels **∝ segment span** before the solve (`_remesh_airplane`, now defaulting budget=40/half, min 2/segment), then run with `spanwise_resolution=1` + `np.linspace`. Streamline panel density is now uniform; `xyz_ref` and reference geometry preserved.

AeroBuildup remains the default analysis tool, so only the opt-in VLM/streamlines path changes. Verified end-to-end: real `_run_vlm` on a 3-segment wing produces the streamlines figure in ~5 s.

## Tests
Updated the 3 `_run_vlm` tests (`test_api_utils.py`) to mock the remesh and assert the VLM is built with `spanwise_resolution=1` + `spanwise_spacing_function=np.linspace`. The remesh chain itself is covered by #855's tests.

Closes #857
Depends on #855 (shared remesh helpers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)