### PR TITLE
fix(gh-863): show all control surfaces in OP Comparison (not just elevator)

### DIFF
--- a/app/services/trim_enrichment_service.py
+++ b/app/services/trim_enrichment_service.py
@@ -407,7 +407,7 @@ def compute_enrichment(
     # and Control Authority views show all surfaces the aircraft has. Untrimmed
     # surfaces sit at 0° (full reserve); trimmed deflections win where present.
     deflection_reserves: dict[str, DeflectionReserve] = {}
-    surface_deflections: dict[str, float] = {name: 0.0 for name in limits}
+    surface_deflections: dict[str, float] = dict.fromkeys(limits, 0.0)
     surface_deflections.update(controls)
     for surface_name, deflection_deg in surface_deflections.items():
         max_pos, max_neg = limits.get(surface_name, (25.0, 25.0))

--- a/app/services/trim_enrichment_service.py
+++ b/app/services/trim_enrichment_service.py
@@ -402,8 +402,14 @@ def compute_enrichment(
     analysis_goal = ANALYSIS_GOALS.get(op_name, _DEFAULT_ANALYSIS_GOAL)
 
     # --- Deflection reserves ---
+    # gh-863: report EVERY geometry control surface (the union of `limits` and
+    # the trimmed `controls`), not just the trimmed one — so the OP Comparison
+    # and Control Authority views show all surfaces the aircraft has. Untrimmed
+    # surfaces sit at 0° (full reserve); trimmed deflections win where present.
     deflection_reserves: dict[str, DeflectionReserve] = {}
-    for surface_name, deflection_deg in controls.items():
+    surface_deflections: dict[str, float] = {name: 0.0 for name in limits}
+    surface_deflections.update(controls)
+    for surface_name, deflection_deg in surface_deflections.items():
         max_pos, max_neg = limits.get(surface_name, (25.0, 25.0))
         limit = max_pos if deflection_deg >= 0 else max_neg
         usage = abs(deflection_deg) / limit if limit > 0 else 0.0

--- a/frontend/__tests__/trim-interpretation/OpComparisonTable.test.tsx
+++ b/frontend/__tests__/trim-interpretation/OpComparisonTable.test.tsx
@@ -93,7 +93,7 @@ describe("OpComparisonTable", () => {
     render(<OpComparisonTable points={POINTS} />);
     expect(screen.getByText("OP")).toBeTruthy();
     expect(screen.getByText("α (°)")).toBeTruthy();
-    expect(screen.getByText("Elev (°)")).toBeTruthy();
+    expect(screen.getByText("Elevator (°)")).toBeTruthy();
     expect(screen.getByText("Reserve")).toBeTruthy();
     expect(screen.getByText("CL")).toBeTruthy();
     expect(screen.getByText("CD")).toBeTruthy();
@@ -132,5 +132,57 @@ describe("OpComparisonTable", () => {
     const untrimmed = [makeOp({ name: "x", status: "NOT_TRIMMED" })];
     const { container } = render(<OpComparisonTable points={untrimmed} />);
     expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a column for EVERY control surface, not just elevator (gh-863)", () => {
+    const op = makeOp({
+      id: 9,
+      name: "turn",
+      alpha: 6 * RAD,
+      trim_enrichment: {
+        analysis_goal: "Turn",
+        result_summary: "",
+        trim_method: "opti",
+        trim_score: 0.02,
+        trim_residuals: {},
+        deflection_reserves: {
+          "[elevator]Elevator": {
+            deflection_deg: -3.0,
+            max_pos_deg: 25,
+            max_neg_deg: 25,
+            usage_fraction: 0.12,
+          },
+          "[aileron]Aileron": {
+            deflection_deg: 8.0,
+            max_pos_deg: 20,
+            max_neg_deg: 20,
+            usage_fraction: 0.4,
+          },
+          "[rudder]Rudder": {
+            deflection_deg: 4.0,
+            max_pos_deg: 30,
+            max_neg_deg: 30,
+            usage_fraction: 0.133,
+          },
+        },
+        design_warnings: [],
+        effectiveness: {},
+        stability_classification: null,
+        mixer_values: {},
+        aero_coefficients: { CL: 0.6, CD: 0.04 },
+      },
+    });
+    render(<OpComparisonTable points={[op]} />);
+
+    // a header per surface (display names, role-ordered elevator→aileron→rudder)
+    expect(screen.getByText("Elevator (°)")).toBeTruthy();
+    expect(screen.getByText("Aileron (°)")).toBeTruthy();
+    expect(screen.getByText("Rudder (°)")).toBeTruthy();
+    // and their deflection values are shown
+    expect(screen.getByText("-3.0")).toBeTruthy();
+    expect(screen.getByText("8.0")).toBeTruthy();
+    expect(screen.getByText("4.0")).toBeTruthy();
+    // Reserve is the binding (max) authority used across surfaces → aileron 40%
+    expect(screen.getByText("40%")).toBeTruthy();
   });
 });

--- a/frontend/__tests__/trim-interpretation/OpComparisonTable.test.tsx
+++ b/frontend/__tests__/trim-interpretation/OpComparisonTable.test.tsx
@@ -134,11 +134,64 @@ describe("OpComparisonTable", () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it("sorting by every column re-sorts without crashing", async () => {
+  it("sorting every column (mixed surfaces, unknown roles, null aero, both directions)", async () => {
     const user = userEvent.setup();
-    render(<OpComparisonTable points={POINTS} />);
-    for (const label of ["OP", "Elevator (°)", "CL", "CD", "L/D", "Reserve", "α (°)"]) {
-      await user.click(screen.getByText(label));
+    // A second OP with a known + two unknown-role surfaces and NO aero — exercises
+    // the role-rank fallback, the absent-surface / null-coefficient (?? 0) branches,
+    // and the asc↔desc toggle for every column.
+    const mixed = makeOp({
+      id: 8,
+      name: "mixed",
+      alpha: 7 * RAD,
+      trim_enrichment: {
+        analysis_goal: "Mixed",
+        result_summary: "",
+        trim_method: "opti",
+        trim_score: 0.04,
+        trim_residuals: {},
+        deflection_reserves: {
+          "[aileron]Aileron": {
+            deflection_deg: 6.0,
+            max_pos_deg: 20,
+            max_neg_deg: 20,
+            usage_fraction: 0.3,
+          },
+          "[winglet]Winglet": {
+            deflection_deg: 1.0,
+            max_pos_deg: 10,
+            max_neg_deg: 10,
+            usage_fraction: 0.1,
+          },
+          "[spoiler]Spoiler": {
+            deflection_deg: 2.0,
+            max_pos_deg: 15,
+            max_neg_deg: 15,
+            usage_fraction: 0.13,
+          },
+        },
+        design_warnings: [],
+        effectiveness: {},
+        stability_classification: null,
+        mixer_values: {},
+        aero_coefficients: {}, // null CL/CD/LD → "—" + ?? 0 sort branches
+      },
+    });
+    render(<OpComparisonTable points={[POINTS[0], mixed]} />);
+    // role-ordered: known roles first (Elevator, Aileron), unknown last alpha-sorted (Spoiler, Winglet)
+    for (const label of [
+      "OP",
+      "Elevator (°)",
+      "Aileron (°)",
+      "Spoiler (°)",
+      "Winglet (°)",
+      "CL",
+      "CD",
+      "L/D",
+      "Reserve",
+      "α (°)",
+    ]) {
+      await user.click(screen.getByText(label)); // desc
+      await user.click(screen.getByText(label)); // asc (toggle)
       expect(screen.getAllByTestId(/^op-row-/)).toHaveLength(2);
     }
   });

--- a/frontend/__tests__/trim-interpretation/OpComparisonTable.test.tsx
+++ b/frontend/__tests__/trim-interpretation/OpComparisonTable.test.tsx
@@ -134,6 +134,48 @@ describe("OpComparisonTable", () => {
     expect(container.firstChild).toBeNull();
   });
 
+  it("sorting by every column re-sorts without crashing", async () => {
+    const user = userEvent.setup();
+    render(<OpComparisonTable points={POINTS} />);
+    for (const label of ["OP", "Elevator (°)", "CL", "CD", "L/D", "Reserve", "α (°)"]) {
+      await user.click(screen.getByText(label));
+      expect(screen.getAllByTestId(/^op-row-/)).toHaveLength(2);
+    }
+  });
+
+  it("shows — for missing coefficients and absent surfaces", () => {
+    const partial = makeOp({
+      id: 7,
+      name: "partial",
+      alpha: 4 * RAD,
+      trim_enrichment: {
+        analysis_goal: "Partial",
+        result_summary: "",
+        trim_method: "opti",
+        trim_score: 0.03,
+        trim_residuals: {},
+        // only a rudder reserve; no elevator, and no aero_coefficients
+        deflection_reserves: {
+          "[rudder]Rudder": {
+            deflection_deg: 5.0,
+            max_pos_deg: 30,
+            max_neg_deg: 30,
+            usage_fraction: 0.17,
+          },
+        },
+        design_warnings: [],
+        effectiveness: {},
+        stability_classification: null,
+        mixer_values: {},
+        aero_coefficients: {},
+      },
+    });
+    // POINTS[0] has elevator → union columns are Elevator + Rudder.
+    render(<OpComparisonTable points={[POINTS[0], partial]} />);
+    // partial row: Elevator absent → "—"; CL/CD/LD absent → "—" (multiple dashes)
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(3);
+  });
+
   it("renders a column for EVERY control surface, not just elevator (gh-863)", () => {
     const op = makeOp({
       id: 9,

--- a/frontend/components/workbench/trim-interpretation/OpComparisonTable.tsx
+++ b/frontend/components/workbench/trim-interpretation/OpComparisonTable.tsx
@@ -3,36 +3,35 @@
 import { useState, useMemo } from "react";
 import { ChevronUp, ChevronDown } from "lucide-react";
 import type { StoredOperatingPoint } from "@/hooks/useOperatingPoints";
+import { displaySurfaceName } from "./utils";
 
 const RAD_TO_DEG = 180 / Math.PI;
 
-type SortKey = "name" | "alpha" | "elevator" | "reserve" | "cl" | "cd" | "ld";
+// Role priority for ordering the dynamic control-surface columns (gh-863).
+const ROLE_ORDER = [
+  "elevator",
+  "stabilator",
+  "elevon",
+  "ruddervator",
+  "aileron",
+  "flaperon",
+  "flap",
+  "rudder",
+];
+
+type FixedKey = "name" | "alpha" | "reserve" | "cl" | "cd" | "ld";
+type SortKey = FixedKey | `surf:${string}`;
 type SortDir = "asc" | "desc";
 
 interface RowData {
   id: number;
   name: string;
   alpha_deg: number;
-  elevator_deg: number | null;
-  reserve_pct: number;
+  reserve_pct: number; // binding (max) authority used across the OP's surfaces
   cl: number | null;
   cd: number | null;
   ld: number | null;
-}
-
-function extractElevator(enrichment: NonNullable<StoredOperatingPoint["trim_enrichment"]>): {
-  deg: number | null;
-  reserve: number;
-} {
-  const elevatorEntry = Object.entries(enrichment.deflection_reserves).find(([key]) =>
-    key.toLowerCase().includes("elevator"),
-  );
-  if (!elevatorEntry) {
-    const firstEntry = Object.entries(enrichment.deflection_reserves)[0];
-    if (!firstEntry) return { deg: null, reserve: 0 };
-    return { deg: firstEntry[1].deflection_deg, reserve: firstEntry[1].usage_fraction };
-  }
-  return { deg: elevatorEntry[1].deflection_deg, reserve: elevatorEntry[1].usage_fraction };
+  deflections: Record<string, number>; // display surface name → deflection [deg]
 }
 
 interface Props {
@@ -43,12 +42,22 @@ export function OpComparisonTable({ points }: Props) {
   const [sortKey, setSortKey] = useState<SortKey>("reserve");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
 
-  const rows: RowData[] = useMemo(() => {
-    return points
+  const { surfaces, rows } = useMemo(() => {
+    const roleByDisplay = new Map<string, string>();
+    const rowData: RowData[] = points
       .filter((p) => p.status === "TRIMMED" && p.trim_enrichment)
       .map((p) => {
         const enrichment = p.trim_enrichment!;
-        const { deg, reserve } = extractElevator(enrichment);
+        const deflections: Record<string, number> = {};
+        let maxUsage = 0;
+        for (const [key, reserve] of Object.entries(enrichment.deflection_reserves)) {
+          const dn = displaySurfaceName(key);
+          deflections[dn] = reserve.deflection_deg;
+          if (!roleByDisplay.has(dn)) {
+            roleByDisplay.set(dn, (/^\[(\w+)\]/.exec(key)?.[1] ?? "").toLowerCase());
+          }
+          maxUsage = Math.max(maxUsage, reserve.usage_fraction);
+        }
         const cl = enrichment.aero_coefficients?.CL ?? null;
         const cd = enrichment.aero_coefficients?.CD ?? null;
         const ld = cl !== null && cd !== null && cd > 0 ? cl / cd : null;
@@ -56,43 +65,50 @@ export function OpComparisonTable({ points }: Props) {
           id: p.id,
           name: p.name,
           alpha_deg: p.alpha * RAD_TO_DEG,
-          elevator_deg: deg,
-          reserve_pct: Math.round(reserve * 100),
+          reserve_pct: Math.round(maxUsage * 100),
           cl,
           cd,
           ld,
+          deflections,
         };
       });
+
+    const roleRank = (dn: string): number => {
+      const idx = ROLE_ORDER.indexOf(roleByDisplay.get(dn) ?? "");
+      return idx < 0 ? ROLE_ORDER.length : idx;
+    };
+    const surfaceNames = [...roleByDisplay.keys()].sort((a, b) => {
+      const ra = roleRank(a);
+      const rb = roleRank(b);
+      return ra !== rb ? ra - rb : a.localeCompare(b);
+    });
+    return { surfaces: surfaceNames, rows: rowData };
   }, [points]);
 
   const sorted = useMemo(() => {
-    return [...rows].sort((a, b) => {
-      let cmp = 0;
+    const cmpFor = (a: RowData, b: RowData): number => {
+      if (sortKey.startsWith("surf:")) {
+        const s = sortKey.slice(5);
+        return (a.deflections[s] ?? 0) - (b.deflections[s] ?? 0);
+      }
       switch (sortKey) {
         case "name":
-          cmp = a.name.localeCompare(b.name);
-          break;
+          return a.name.localeCompare(b.name);
         case "alpha":
-          cmp = a.alpha_deg - b.alpha_deg;
-          break;
-        case "elevator":
-          cmp = (a.elevator_deg ?? 0) - (b.elevator_deg ?? 0);
-          break;
+          return a.alpha_deg - b.alpha_deg;
         case "reserve":
-          cmp = a.reserve_pct - b.reserve_pct;
-          break;
+          return a.reserve_pct - b.reserve_pct;
         case "cl":
-          cmp = (a.cl ?? 0) - (b.cl ?? 0);
-          break;
+          return (a.cl ?? 0) - (b.cl ?? 0);
         case "cd":
-          cmp = (a.cd ?? 0) - (b.cd ?? 0);
-          break;
+          return (a.cd ?? 0) - (b.cd ?? 0);
         case "ld":
-          cmp = (a.ld ?? 0) - (b.ld ?? 0);
-          break;
+          return (a.ld ?? 0) - (b.ld ?? 0);
+        default:
+          return 0;
       }
-      return sortDir === "asc" ? cmp : -cmp;
-    });
+    };
+    return [...rows].sort((a, b) => (sortDir === "asc" ? cmpFor(a, b) : -cmpFor(a, b)));
   }, [rows, sortKey, sortDir]);
 
   const worstId = useMemo(() => {
@@ -114,7 +130,7 @@ export function OpComparisonTable({ points }: Props) {
   const columns: { key: SortKey; label: string }[] = [
     { key: "name", label: "OP" },
     { key: "alpha", label: "α (°)" },
-    { key: "elevator", label: "Elev (°)" },
+    ...surfaces.map((s) => ({ key: `surf:${s}` as SortKey, label: `${s} (°)` })),
     { key: "reserve", label: "Reserve" },
     { key: "cl", label: "CL" },
     { key: "cd", label: "CD" },
@@ -160,9 +176,11 @@ export function OpComparisonTable({ points }: Props) {
               >
                 <td className="px-2 py-1.5 font-medium">{row.name}</td>
                 <td className="px-2 py-1.5">{row.alpha_deg.toFixed(1)}</td>
-                <td className="px-2 py-1.5">
-                  {row.elevator_deg !== null ? row.elevator_deg.toFixed(1) : "—"}
-                </td>
+                {surfaces.map((s) => (
+                  <td key={s} className="px-2 py-1.5">
+                    {row.deflections[s] !== undefined ? row.deflections[s].toFixed(1) : "—"}
+                  </td>
+                ))}
                 <td className="px-2 py-1.5">{row.reserve_pct}%</td>
                 <td className="px-2 py-1.5">{row.cl !== null ? row.cl.toFixed(3) : "—"}</td>
                 <td className="px-2 py-1.5">{row.cd !== null ? row.cd.toFixed(4) : "—"}</td>

--- a/frontend/components/workbench/trim-interpretation/OpComparisonTable.tsx
+++ b/frontend/components/workbench/trim-interpretation/OpComparisonTable.tsx
@@ -80,7 +80,7 @@ export function OpComparisonTable({ points }: Props) {
     const surfaceNames = [...roleByDisplay.keys()].sort((a, b) => {
       const ra = roleRank(a);
       const rb = roleRank(b);
-      return ra !== rb ? ra - rb : a.localeCompare(b);
+      return ra === rb ? a.localeCompare(b) : ra - rb;
     });
     return { surfaces: surfaceNames, rows: rowData };
   }, [points]);
@@ -178,7 +178,7 @@ export function OpComparisonTable({ points }: Props) {
                 <td className="px-2 py-1.5">{row.alpha_deg.toFixed(1)}</td>
                 {surfaces.map((s) => (
                   <td key={s} className="px-2 py-1.5">
-                    {row.deflections[s] !== undefined ? row.deflections[s].toFixed(1) : "—"}
+                    {row.deflections[s] === undefined ? "—" : row.deflections[s].toFixed(1)}
                   </td>
                 ))}
                 <td className="px-2 py-1.5">{row.reserve_pct}%</td>


### PR DESCRIPTION
## Bug (user-reported)
The OP Comparison table showed only **Elevator** as a control surface, even when the aircraft has ailerons / rudder / flaps / elevons. It should show **all** of them.

## Root cause (two parts)
1. **Backend** — `compute_enrichment` built `deflection_reserves` only from the trimmed `controls`. Level-flight OPs trim only the pitch surface, so the persisted enrichment held just `[elevator]elevator` (confirmed in the local DB). Untrimmed surfaces (at 0°) were never reported.
2. **Frontend** — `OpComparisonTable` was hardcoded to a single "Elev (°)" column.

## Fix
- **Backend:** build `deflection_reserves` from the **union of `limits` (all geometry surfaces) and `controls`** — untrimmed surfaces report 0° / full reserve. Also makes the Control Authority chart show every surface.
- **Frontend:** one **dynamic deflection column per control surface** (role-ordered: elevator→…→rudder; display names via `displaySurfaceName`), sortable. The "Reserve" column is now the **binding** (max) authority used across the OP's surfaces (drives the worst-row highlight).

## Tests
- Backend: existing 88 trim-enrichment tests stay green with the union construction.
- Frontend: `OpComparisonTable.test.tsx` updated (header now "Elevator (°)") + new test asserting a per-surface column for elevator/aileron/rudder with their deflections and binding reserve.

Coupled BE+FE in one PR/worktree. Closes #863. Relates to #861 (same table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)