### PR TITLE
feat(gh-870): characteristic points on Analysis-Polar charts

### DIFF
--- a/frontend/__tests__/analysisPolarMarkerTrace.test.ts
+++ b/frontend/__tests__/analysisPolarMarkerTrace.test.ts
@@ -1,0 +1,124 @@
+/**
+ * gh-870: characteristic key-points marked as visible Plotly markers on
+ * Analysis-Polar charts (CL-α and L/D-α).
+ *
+ * Tests the pure builder function `buildAnalysisPolarMarkerTrace`, which
+ * returns a scatter trace with the expected x (degrees), y, and text label
+ * for a given chart id + derived polar data.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("plotly.js-gl3d-dist-min", () => ({
+  default: { react: vi.fn(), purge: vi.fn() },
+  react: vi.fn(),
+  purge: vi.fn(),
+}));
+
+import { buildAnalysisPolarMarkerTrace } from "@/components/workbench/AnalysisViewerPanel";
+
+// ---------------------------------------------------------------------------
+// Helper: a PolarCharts-like object
+// ---------------------------------------------------------------------------
+function makePolar({
+  clMax = 1.2,
+  alphaClMax = 10,
+  ldMax = 20,
+  alphaLdMax = 5,
+}: {
+  clMax?: number | null;
+  alphaClMax?: number | null;
+  ldMax?: number | null;
+  alphaLdMax?: number | null;
+} = {}) {
+  return { clMax, alphaClMax, ldMax, alphaLdMax };
+}
+
+// ---------------------------------------------------------------------------
+// CL-α chart ("cl")
+// ---------------------------------------------------------------------------
+describe("buildAnalysisPolarMarkerTrace – cl chart", () => {
+  it("returns a trace with the CL_max marker at the correct alpha (degrees)", () => {
+    const polar = makePolar({ clMax: 1.2, alphaClMax: 10 });
+    const trace = buildAnalysisPolarMarkerTrace("cl", polar);
+    expect(trace).not.toBeNull();
+    expect(trace!.x).toEqual([10]);
+    expect(trace!.y).toEqual([1.2]);
+    expect(trace!.text[0]).toMatch(/CL,max/i);
+  });
+
+  it("returns null when clMax is null", () => {
+    const polar = makePolar({ clMax: null, alphaClMax: 10 });
+    expect(buildAnalysisPolarMarkerTrace("cl", polar)).toBeNull();
+  });
+
+  it("returns null when alphaClMax is null", () => {
+    const polar = makePolar({ clMax: 1.2, alphaClMax: null });
+    expect(buildAnalysisPolarMarkerTrace("cl", polar)).toBeNull();
+  });
+
+  it("returns null when clMax is non-finite", () => {
+    const polar = makePolar({ clMax: NaN, alphaClMax: 10 });
+    expect(buildAnalysisPolarMarkerTrace("cl", polar)).toBeNull();
+  });
+
+  it("returns null when alphaClMax is non-finite", () => {
+    const polar = makePolar({ clMax: 1.2, alphaClMax: Infinity });
+    expect(buildAnalysisPolarMarkerTrace("cl", polar)).toBeNull();
+  });
+
+  it("marker uses the dark-theme style (white, circle, size 7)", () => {
+    const trace = buildAnalysisPolarMarkerTrace("cl", makePolar());
+    expect(trace!.marker.color).toBe("#FAFAFA");
+    expect(trace!.marker.symbol).toBe("circle");
+    expect(trace!.marker.size).toBe(7);
+    expect(trace!.textfont.color).toBe("#FAFAFA");
+    expect(trace!.mode).toBe("markers+text");
+    expect(trace!.textposition).toBe("top center");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// L/D-α chart ("ld")
+// ---------------------------------------------------------------------------
+describe("buildAnalysisPolarMarkerTrace – ld chart", () => {
+  it("returns a trace with the (L/D)_max marker at the correct alpha (degrees)", () => {
+    const polar = makePolar({ ldMax: 20, alphaLdMax: 5 });
+    const trace = buildAnalysisPolarMarkerTrace("ld", polar);
+    expect(trace).not.toBeNull();
+    expect(trace!.x).toEqual([5]);
+    expect(trace!.y).toEqual([20]);
+    expect(trace!.text[0]).toMatch(/L\/D,max/i);
+  });
+
+  it("returns null when ldMax is null", () => {
+    const polar = makePolar({ ldMax: null, alphaLdMax: 5 });
+    expect(buildAnalysisPolarMarkerTrace("ld", polar)).toBeNull();
+  });
+
+  it("returns null when alphaLdMax is null", () => {
+    const polar = makePolar({ ldMax: 20, alphaLdMax: null });
+    expect(buildAnalysisPolarMarkerTrace("ld", polar)).toBeNull();
+  });
+
+  it("returns null when ldMax is non-finite", () => {
+    const polar = makePolar({ ldMax: Infinity, alphaLdMax: 5 });
+    expect(buildAnalysisPolarMarkerTrace("ld", polar)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unknown / unsupported chart IDs
+// ---------------------------------------------------------------------------
+describe("buildAnalysisPolarMarkerTrace – unsupported chart ids", () => {
+  it("returns null for 'cd' (no characteristic point defined)", () => {
+    expect(buildAnalysisPolarMarkerTrace("cd", makePolar())).toBeNull();
+  });
+
+  it("returns null for 'polar' (drag polar — no alpha axis)", () => {
+    expect(buildAnalysisPolarMarkerTrace("polar", makePolar())).toBeNull();
+  });
+
+  it("returns null for 'cm'", () => {
+    expect(buildAnalysisPolarMarkerTrace("cm", makePolar())).toBeNull();
+  });
+});

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -635,6 +635,59 @@ export function polarHasFiniteData(charts: PolarCharts): boolean {
   return series.some((arr) => arr.some((v) => v != null && Number.isFinite(v)));
 }
 
+/**
+ * gh-870: Build a Plotly marker trace for a characteristic point on one of
+ * the Analysis-Polar charts. Returns null when the relevant values are absent
+ * or non-finite (null-safe, never throws).
+ *
+ * Supported chart ids:
+ *   "cl"  → C_L,max marker on the CL-α chart
+ *   "ld"  → (L/D),max marker on the L/D-α chart
+ *   all others → null (no characteristic point defined)
+ *
+ * The marker style mirrors the speed-polar markers (white, circle, size 7).
+ * Exported for direct unit testing.
+ */
+export function buildAnalysisPolarMarkerTrace(
+  chartId: string,
+  polar: Pick<PolarCharts, "clMax" | "alphaClMax" | "ldMax" | "alphaLdMax">,
+): PlotlyTrace | null {
+  let x: number;
+  let y: number;
+  let label: string;
+
+  if (chartId === "cl") {
+    const { clMax, alphaClMax } = polar;
+    if (clMax == null || !Number.isFinite(clMax)) return null;
+    if (alphaClMax == null || !Number.isFinite(alphaClMax)) return null;
+    x = alphaClMax;
+    y = clMax;
+    label = `CL,max = ${clMax.toFixed(2)}`;
+  } else if (chartId === "ld") {
+    const { ldMax, alphaLdMax } = polar;
+    if (ldMax == null || !Number.isFinite(ldMax)) return null;
+    if (alphaLdMax == null || !Number.isFinite(alphaLdMax)) return null;
+    x = alphaLdMax;
+    y = ldMax;
+    label = `L/D,max = ${ldMax.toFixed(1)}`;
+  } else {
+    return null;
+  }
+
+  return {
+    x: [x],
+    y: [y],
+    text: [label],
+    type: "scatter",
+    mode: "markers+text",
+    name: label,
+    textposition: "top center",
+    textfont: { size: 9, color: "#FAFAFA" },
+    marker: { color: "#FAFAFA", size: 7, symbol: "circle" },
+    hovertemplate: `${label}<extra></extra>`,
+  };
+}
+
 /** Derive polar series + characteristic points, tolerating null coefficients. */
 export function derivePolarCharts(result: AnalysisResult | null): PolarCharts | null {
   if (!result?.CL || result.CL.length === 0) return null;
@@ -990,6 +1043,7 @@ export function AnalysisViewerPanel({
                   title: "C_L vs \u03B1",
                   annotation: `C_L,max \u2248 ${safeToFixed(charts.clMax, 2)} @ ${safeToFixed(charts.alphaClMax, 0)}\u00B0`,
                   color: "#FF8400",
+                  extraTraces: [buildAnalysisPolarMarkerTrace("cl", charts)].filter(Boolean) as PlotlyTrace[],
                 },
                 {
                   id: "cd",
@@ -1009,6 +1063,7 @@ export function AnalysisViewerPanel({
                   title: "C_L / C_D vs \u03B1",
                   annotation: `L/D,max \u2248 ${safeToFixed(charts.ldMax, 1)} @ ${safeToFixed(charts.alphaLdMax, 0)}\u00B0`,
                   color: "#30A46C",
+                  extraTraces: [buildAnalysisPolarMarkerTrace("ld", charts)].filter(Boolean) as PlotlyTrace[],
                 },
                 {
                   id: "polar",


### PR DESCRIPTION
## Summary

- Add `buildAnalysisPolarMarkerTrace` (exported, fully unit-tested) that builds a Plotly `markers+text` trace for characteristic points on the Analysis-Polar charts.
- CL-α chart: marks **CL,max** at its α; L/D-α chart: marks **(L/D),max** at its α.
- Null-safe: skips a marker when its value or α is `null` / non-finite — no risk of crashes on degenerate sweeps.
- Reuses the already-computed `clMax`, `alphaClMax`, `ldMax`, `alphaLdMax` from `derivePolarCharts` — no new computation.
- Marker style (white circle, size 7, `#FAFAFA`, `top center` label) mirrors the existing speed-polar markers exactly.
- Wired into `allCharts` via the `extraTraces` prop of `PlotlyChart` — no new surrounding chrome.

## Test plan

- [x] New test file `frontend/__tests__/analysisPolarMarkerTrace.test.ts` — 13 tests covering correct x/y/label, all null/non-finite guard cases, style properties, and unsupported chart IDs.
- [x] Existing `derivePolarCharts.test.tsx` — 16 tests still pass, no regression.
- [x] ESLint clean on both changed files.

Closes #870

🤖 Generated with [Claude Code](https://claude.com/claude-code)