### PR TITLE
feat(gh-869): airfoil eye-button in X-Sec wing editor

### DIFF
--- a/frontend/__tests__/PropertyFormAsbEyeButton.test.tsx
+++ b/frontend/__tests__/PropertyFormAsbEyeButton.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * GH-869: Eye-button (airfoil preview) in the X-Sec (ASB) wing editor.
+ *
+ * Verifies:
+ *  1. The eye-button renders next to the airfoil field in ASB/x-sec mode.
+ *  2. Clicking it calls `selectXsec` with the current index (so the preview
+ *     page opens on the right airfoil) and then navigates to
+ *     /workbench/airfoil-preview.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+// ── Icon stubs ─────────────────────────────────────────────────
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) =>
+    React.createElement("span", { ...props, "data-testid": `icon-${String(props.className ?? "icon")}` });
+  return {
+    ChevronDown: icon,
+    ChevronRight: icon,
+    Eye: (props: Record<string, unknown>) =>
+      React.createElement("span", { ...props, "data-testid": "eye-icon" }),
+    Box: icon,
+  };
+});
+
+// ── next/navigation ────────────────────────────────────────────
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, prefetch: vi.fn() }),
+}));
+
+// ── misc stubs ─────────────────────────────────────────────────
+vi.mock("@/lib/fetcher", () => ({
+  API_BASE: "http://localhost:8000",
+  fetcher: vi.fn(),
+}));
+
+vi.mock("@/components/workbench/AirfoilSelector", () => ({
+  AirfoilSelector: ({ label }: { label: string }) =>
+    React.createElement("div", { "data-testid": `airfoil-selector-${label}` }, label),
+}));
+
+vi.mock("@/components/workbench/ImportFuselageDialog", () => ({
+  ImportFuselageDialog: () => null,
+}));
+
+vi.mock("@/components/workbench/UnsavedChangesContext", () => ({
+  useUnsavedChanges: () => ({
+    isDirty: false,
+    setDirty: vi.fn(),
+    registerSave: vi.fn(),
+    pendingHref: null,
+    isSaving: false,
+    confirmDiscard: vi.fn(),
+    confirmSave: vi.fn(),
+    cancelNavigation: vi.fn(),
+  }),
+}));
+
+// ── Controllable context ───────────────────────────────────────
+const mockSelectXsec = vi.fn();
+let ctxOverrides: Record<string, unknown> = {};
+
+vi.mock("@/components/workbench/AeroplaneContext", () => ({
+  useAeroplaneContext: () => ({
+    aeroplaneId: "aero-1",
+    selectedWing: "wing-1",
+    selectedXsecIndex: 2,          // non-zero index to test selectXsec call
+    selectedFuselage: null,
+    selectedFuselageXsecIndex: null,
+    treeMode: "asb",
+    setAeroplaneId: vi.fn(),
+    selectWing: vi.fn(),
+    selectXsec: mockSelectXsec,
+    selectFuselage: vi.fn(),
+    selectFuselageXsec: vi.fn(),
+    setTreeMode: vi.fn(),
+    ...ctxOverrides,
+  }),
+}));
+
+// ── Wing data ─────────────────────────────────────────────────
+const mockXsec = {
+  airfoil: "mh32",
+  chord: 0.3,
+  twist: 2,
+  xyz_le: [0, 0, 0] as [number, number, number],
+  x_sec_type: "uniform",
+};
+
+vi.mock("@/hooks/useWings", () => ({
+  useWing: () => ({
+    wing: { x_secs: [mockXsec, mockXsec, mockXsec], design_model: "asb" },
+    updateXSec: vi.fn().mockResolvedValue(undefined),
+    mutate: vi.fn().mockResolvedValue(undefined),
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@/hooks/useWingConfig", () => ({
+  useWingConfig: () => ({
+    wingConfig: null,
+    saveWingConfig: vi.fn(),
+    mutate: vi.fn(),
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@/hooks/useFuselage", () => ({
+  useFuselage: () => ({
+    fuselage: null,
+    updateXSec: vi.fn(),
+    mutate: vi.fn(),
+    isLoading: false,
+  }),
+}));
+
+import { PropertyForm } from "@/components/workbench/PropertyForm";
+
+// ── Tests ──────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ctxOverrides = {};
+});
+
+describe("GH-869: eye-button in ASB/x-sec mode", () => {
+  it("renders an eye-button next to the airfoil selector in ASB mode", () => {
+    render(<PropertyForm />);
+    // The airfoil selector must be present
+    expect(screen.getByTestId("airfoil-selector-airfoil")).toBeTruthy();
+    // The eye-button must be present (identified by title attribute)
+    const eyeBtn = screen.getByTitle("Preview airfoil");
+    expect(eyeBtn).toBeTruthy();
+    // Eye icon inside
+    expect(screen.getByTestId("eye-icon")).toBeTruthy();
+  });
+
+  it("clicking the eye-button calls selectXsec with the current index and navigates to /workbench/airfoil-preview", () => {
+    render(<PropertyForm />);
+    const eyeBtn = screen.getByTitle("Preview airfoil");
+    fireEvent.click(eyeBtn);
+    // selectXsec must be called with the current xsec index (2)
+    expect(mockSelectXsec).toHaveBeenCalledWith(2);
+    // router.push must navigate to the preview page
+    expect(mockPush).toHaveBeenCalledWith("/workbench/airfoil-preview");
+  });
+});

--- a/frontend/components/workbench/PropertyForm.tsx
+++ b/frontend/components/workbench/PropertyForm.tsx
@@ -313,21 +313,38 @@ function AsbFields({
   setAsb,
   xsec,
   setDirty,
+  router,
+  selectXsec,
+  selectedXsecIndex,
 }: Readonly<{
   asb: AsbState;
   setAsb: (v: AsbState) => void;
   xsec: XSec;
   setDirty: (v: boolean) => void;
+  router: ReturnType<typeof useRouter>;
+  selectXsec: (index: number | null) => void;
+  selectedXsecIndex: number;
 }>) {
   return (
     <>
       {/* ASB mode: airfoil | chord */}
       <div className="flex gap-3">
-        <AirfoilSelector
-          label="airfoil"
-          value={asb.airfoil}
-          onChange={(v) => { setDirty(true); setAsb({ ...asb, airfoil: v }); }}
-        />
+        <div className="flex flex-1 items-end gap-1.5">
+          <div className="flex-1">
+            <AirfoilSelector
+              label="airfoil"
+              value={asb.airfoil}
+              onChange={(v) => { setDirty(true); setAsb({ ...asb, airfoil: v }); }}
+            />
+          </div>
+          <button
+            onClick={() => { selectXsec(selectedXsecIndex); router.push("/workbench/airfoil-preview"); }}
+            className="mb-0.5 flex size-8 shrink-0 items-center justify-center rounded-full border border-border bg-card-muted text-muted-foreground hover:bg-sidebar-accent"
+            title="Preview airfoil"
+          >
+            <Eye size={14} />
+          </button>
+        </div>
         <Field
           label="chord"
           value={asb.chord}
@@ -388,6 +405,7 @@ interface FieldGridContentProps {
   selectedXsecIndex: number;
   setDirty: (v: boolean) => void;
   router: ReturnType<typeof useRouter>;
+  selectXsec: (index: number | null) => void;
 }
 
 function FieldGridContent({
@@ -406,6 +424,7 @@ function FieldGridContent({
   selectedXsecIndex,
   setDirty,
   router,
+  selectXsec,
 }: Readonly<FieldGridContentProps>) {
   if (mode === "wingconfig" && wc) {
     return (
@@ -425,7 +444,15 @@ function FieldGridContent({
 
   if (asb && !isReadOnly) {
     return (
-      <AsbFields asb={asb} setAsb={setAsb} xsec={xsec} setDirty={setDirty} />
+      <AsbFields
+        asb={asb}
+        setAsb={setAsb}
+        xsec={xsec}
+        setDirty={setDirty}
+        router={router}
+        selectXsec={selectXsec}
+        selectedXsecIndex={selectedXsecIndex}
+      />
     );
   }
 
@@ -526,7 +553,7 @@ export function PropertyForm({ onGeometryChanged, ref }: Readonly<{
   onGeometryChanged?: (wingName: string) => void;
   ref?: React.Ref<PropertyFormHandle>;
 }>) {
-  const { aeroplaneId, selectedWing, selectedXsecIndex, selectedFuselage, selectedFuselageXsecIndex, treeMode } =
+  const { aeroplaneId, selectedWing, selectedXsecIndex, selectXsec, selectedFuselage, selectedFuselageXsecIndex, treeMode } =
     useAeroplaneContext();
   const { wing, updateXSec, mutate } = useWing(aeroplaneId, selectedWing);
 
@@ -711,6 +738,7 @@ export function PropertyForm({ onGeometryChanged, ref }: Readonly<{
           selectedXsecIndex={selectedXsecIndex}
           setDirty={setDirty}
           router={router}
+          selectXsec={selectXsec}
         />
       </div>
 


### PR DESCRIPTION
## Summary

- **Selector already present:** `AsbFields` already renders an `AirfoilSelector` for the airfoil field — only the eye-button was missing.
- Added the eye-button (matching the exact WingConfig pattern) next to the `AirfoilSelector` in `AsbFields`, wrapped in the same `flex flex-1 items-end gap-1.5` container used by the root/tip selectors in segment mode.
- Threaded `router`, `selectXsec`, and `selectedXsecIndex` down the prop chain: `PropertyForm` → `FieldGridContent` → `AsbFields`.
- Clicking the button calls `selectXsec(currentIndex)` (so the preview page opens on the correct airfoil) then `router.push("/workbench/airfoil-preview")`.

## Test plan

- [ ] `npx vitest run __tests__/PropertyFormAsbEyeButton.test.tsx` → 2 tests pass (red before change, green after)
- [ ] `npx vitest run __tests__/PropertyFormSave.test.tsx __tests__/PropertyFormHandle.test.tsx` → 7 tests still pass (no regressions)
- [ ] `npx eslint components/workbench/PropertyForm.tsx __tests__/PropertyFormAsbEyeButton.test.tsx` → 0 errors (4 pre-existing warnings in unrelated `useEffect` dep arrays)
- [ ] Manually open an ASB-mode wing in the workbench, verify the eye-button appears next to the airfoil selector and opens the airfoil preview for the correct x-sec

Closes #869

🤖 Generated with [Claude Code](https://claude.com/claude-code)