### PR TITLE
feat(gh-871): angle of attack at characteristic-speed chips

### DIFF
--- a/app/schemas/aeroanalysisschema.py
+++ b/app/schemas/aeroanalysisschema.py
@@ -590,6 +590,21 @@ class SpeedPolarCurve(BaseModel):
     w_min: Optional[float] = Field(None, description="Minimum sink rate [m/s]")
     v_best_glide: Optional[float] = Field(None, description="Speed for best glide / max L/D [m/s]")
     ld_max: Optional[float] = Field(None, description="Maximum lift-to-drag ratio")
+    # gh-871: angle of attack at each characteristic speed, derived from the
+    # linear lift curve (CL = cl_0 + cl_alpha*alpha). None when the lift-curve
+    # regression data is absent from the computation context.
+    alpha_stall_deg: Optional[float] = Field(
+        None,
+        description="Angle of attack at stall (CL_max) [deg]; None when lift-curve data absent",
+    )
+    alpha_min_sink_deg: Optional[float] = Field(
+        None,
+        description="Angle of attack at minimum-sink speed [deg]; None when lift-curve data absent",
+    )
+    alpha_best_glide_deg: Optional[float] = Field(
+        None,
+        description="Angle of attack at best-glide speed [deg]; None when lift-curve data absent",
+    )
 
 
 class SpeedPolar(BaseModel):

--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -437,6 +437,8 @@ def _compute_speed_polar(
     altitude: float = 0.0,
     g: float = 9.81,
     v_dive: float | None = None,
+    cl_alpha_per_rad: float | None = None,
+    alpha_0_deg: float | None = None,
 ):
     """Derive glide speed polars (sink rate ``w`` over forward speed ``V``) from
     a drag polar (CL/CD), for one or more masses.
@@ -450,8 +452,14 @@ def _compute_speed_polar(
     Curves for different masses therefore scale as ``V, w ∝ sqrt(m)``. The
     effective design mass (``base_mass_kg``) is always included and flagged
     ``is_base``. Pure function — no DB or aero calls — so it is unit testable.
+
+    gh-871: ``cl_alpha_per_rad`` and ``alpha_0_deg`` (from the linear lift-curve
+    regression stored in the computation context) are used to convert the CL at
+    each characteristic speed to an angle of attack in degrees. Both must be
+    present for the alpha fields to be populated; otherwise they are None.
     """
     from app.schemas.aeroanalysisschema import SpeedPolar, SpeedPolarCurve
+    from app.services.assumption_compute_service import _cl_to_alpha_deg
 
     cl_arr = np.atleast_1d(np.asarray(cl, dtype=float))
     cd_arr = np.atleast_1d(np.asarray(cd, dtype=float))
@@ -474,6 +482,11 @@ def _compute_speed_polar(
     cl_max = float(np.max(cl_arr)) if cl_arr.size else 0.0
     valid_geometry = s_ref_m2 > 0 and rho > 0
 
+    # gh-871: CL indices for characteristic points are mass-independent (only
+    # V scales with mass, not CL). Pre-compute alpha_stall here; alpha at
+    # min-sink and best-glide CL come from the per-curve i_min_sink / i_best.
+    alpha_stall_deg_val = _cl_to_alpha_deg(cl_max, cl_alpha_per_rad, alpha_0_deg)
+
     curves: list[SpeedPolarCurve] = []
     for m in masses:
         is_base = abs(m - float(base_mass_kg)) <= tol
@@ -491,6 +504,9 @@ def _compute_speed_polar(
                     w_min=None,
                     v_best_glide=None,
                     ld_max=None,
+                    alpha_stall_deg=None,
+                    alpha_min_sink_deg=None,
+                    alpha_best_glide_deg=None,
                 )
             )
             continue
@@ -506,6 +522,15 @@ def _compute_speed_polar(
         ld = cl_s / cd_s  # equals V / w
         i_best = int(np.argmax(ld))
         v_stall = float(np.sqrt(2.0 * weight_n / (rho * s_ref_m2 * cl_max))) if cl_max > 0 else None
+
+        # gh-871: alpha at characteristic CL values (mass-independent).
+        alpha_min_sink_deg_val = _cl_to_alpha_deg(
+            float(cl_s[i_min_sink]), cl_alpha_per_rad, alpha_0_deg
+        )
+        alpha_best_glide_deg_val = _cl_to_alpha_deg(
+            float(cl_s[i_best]), cl_alpha_per_rad, alpha_0_deg
+        )
+
         curves.append(
             SpeedPolarCurve(
                 mass_kg=m,
@@ -519,6 +544,9 @@ def _compute_speed_polar(
                 w_min=float(w[i_min_sink]),
                 v_best_glide=float(v[i_best]),
                 ld_max=float(ld[i_best]),
+                alpha_stall_deg=alpha_stall_deg_val,
+                alpha_min_sink_deg=alpha_min_sink_deg_val,
+                alpha_best_glide_deg=alpha_best_glide_deg_val,
             )
         )
 
@@ -596,18 +624,32 @@ def _build_speed_polar(db, aeroplane_uuid, sweep_request, asb_airplane, cl_value
         s_ref = float(getattr(asb_airplane, "s_ref", 0.0) or 0.0)
         altitude = float(getattr(sweep_request, "altitude", 0.0) or 0.0)
         rho = float(asb.Atmosphere(altitude=altitude).density())
-        # Resolve V_dive from the cached assumption computation context (gh-799).
-        # Best-effort: a missing or None context must not break the polar.
+        # Resolve V_dive, cl_alpha_per_rad and alpha_0_deg from the cached
+        # assumption computation context (gh-799 / gh-871). Best-effort: a
+        # missing or None context must not break the polar.
         v_dive: float | None = None
+        cl_alpha_from_ctx: float | None = None
+        alpha_0_from_ctx: float | None = None
         try:
             from app.models.aeroplanemodel import AeroplaneModel
 
             aeroplane_row = (
                 db.query(AeroplaneModel).filter(AeroplaneModel.uuid == aeroplane_uuid).first()
             )
-            v_dive = _resolve_v_dive_from_context(
-                getattr(aeroplane_row, "assumption_computation_context", None)
-            )
+            ctx = getattr(aeroplane_row, "assumption_computation_context", None) or {}
+            v_dive = _resolve_v_dive_from_context(ctx)
+            # gh-871: lift-curve regression data stored by recompute_assumptions
+            if isinstance(ctx, dict):
+                raw_cl_alpha = ctx.get("cl_alpha_per_rad")
+                raw_alpha_0 = ctx.get("alpha_0_deg")
+                try:
+                    cl_alpha_from_ctx = float(raw_cl_alpha) if raw_cl_alpha is not None else None
+                except (TypeError, ValueError):
+                    cl_alpha_from_ctx = None
+                try:
+                    alpha_0_from_ctx = float(raw_alpha_0) if raw_alpha_0 is not None else None
+                except (TypeError, ValueError):
+                    alpha_0_from_ctx = None
         except Exception:  # pragma: no cover - defensive
             pass
         return _compute_speed_polar(
@@ -619,6 +661,8 @@ def _build_speed_polar(db, aeroplane_uuid, sweep_request, asb_airplane, cl_value
             rho=rho,
             altitude=altitude,
             v_dive=v_dive,
+            cl_alpha_per_rad=cl_alpha_from_ctx,
+            alpha_0_deg=alpha_0_from_ctx,
         )
     except Exception as e:  # pragma: no cover - defensive add-on
         logger.error("Speed polar computation failed: %s", e)

--- a/app/services/assumption_compute_service.py
+++ b/app/services/assumption_compute_service.py
@@ -526,7 +526,28 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
     # Regression over α ∈ [-2°, +6°] with R² > 0.995 quality gate.
     # Cached as cl_alpha_per_rad; downstream compute_vn_curve uses it
     # for the Pratt-Walker gust alleviation computation.
-    cl_alpha_per_rad = _extract_cl_alpha_from_linear_sweep(asb_airplane, v_cruise)
+    cl_alpha_per_rad, alpha_0_deg = _extract_cl_alpha_from_linear_sweep(asb_airplane, v_cruise)
+
+    # gh-871: α at characteristic speeds from the linear lift curve.
+    # CL at stall = cl_max_effective; CL at best-glide and min-sink come from
+    # the closed-form parabolic-polar optima (same scalars used by _min_drag_speed
+    # / _min_sink_speed). All three are mass-independent.
+    alpha_stall_ctx: float | None = None
+    alpha_md_ctx: float | None = None
+    alpha_min_sink_ctx: float | None = None
+    if cl_alpha_per_rad is not None and alpha_0_deg is not None:
+        alpha_stall_ctx = _cl_to_alpha_deg(cl_max_effective or 0.0, cl_alpha_per_rad, alpha_0_deg)
+        if (
+            cd0_effective is not None
+            and cd0_effective > 0
+            and aspect_ratio is not None
+            and aspect_ratio > 0
+        ):
+            k = 1.0 / (math.pi * aspect_ratio * e_oswald_effective)
+            cl_bg = math.sqrt(cd0_effective / k)
+            cl_ms = math.sqrt(3.0 * cd0_effective / k)
+            alpha_md_ctx = _cl_to_alpha_deg(cl_bg, cl_alpha_per_rad, alpha_0_deg)
+            alpha_min_sink_ctx = _cl_to_alpha_deg(cl_ms, cl_alpha_per_rad, alpha_0_deg)
 
     # Build base context; enrich_context_with_cg_envelope appends gh-488 keys
     # additively (cg_forward_m, cg_aft_m, sm_at_fwd, sm_at_aft) without
@@ -593,6 +614,16 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
         "e_oswald_fallback_used": e_oswald_fallback,
         # Linear-range CL_α from α-sweep (gh-487) — consumed by compute_vn_curve for gust loads
         "cl_alpha_per_rad": round(cl_alpha_per_rad, 4) if cl_alpha_per_rad is not None else None,
+        # gh-871: zero-lift angle α₀ [degrees] — paired with cl_alpha_per_rad to invert CL→α
+        # at characteristic speeds (V_stall, V_min_sink, V_md) for the speed-chip display.
+        "alpha_0_deg": round(alpha_0_deg, 4) if alpha_0_deg is not None else None,
+        # gh-871: α at characteristic speeds [degrees], surfaced on the speed-chip row.
+        # Derived from the linear lift curve; None when lift-curve data is absent.
+        "alpha_stall_deg": round(alpha_stall_ctx, 2) if alpha_stall_ctx is not None else None,
+        "alpha_best_glide_deg": round(alpha_md_ctx, 2) if alpha_md_ctx is not None else None,
+        "alpha_min_sink_deg": round(alpha_min_sink_ctx, 2)
+        if alpha_min_sink_ctx is not None
+        else None,
         # Reynolds-dependent polar table (gh-493) — 3 V-bands from existing fine-sweep rebinning.
         # No extra AeroBuildup runs. Schema per row: {re, v_mps, cd0, e_oswald, cl_max, r2, fallback_used}
         # ctx["cd0"] and ctx["e_oswald"] scalar keys REMAIN for backward compat (gh-486 consumers).
@@ -1028,20 +1059,22 @@ def _extract_cl_alpha_from_linear_sweep(
     alpha_max_deg: float = 6.0,
     alpha_step_deg: float = 1.0,
     r2_threshold: float = 0.995,
-) -> float | None:
-    """CL_α from a linear-range alpha-sweep at cruise speed (gh-487).
+) -> tuple[float | None, float | None]:
+    """CL_α and zero-lift angle from a linear-range alpha-sweep at cruise speed (gh-487).
 
     Runs AeroBuildup at α ∈ [alpha_min_deg, alpha_max_deg] (default [-2°, +6°])
     and fits CL = CL_α·α + CL_0 with ordinary least squares.
 
     Quality gate: if R² < r2_threshold (default 0.995), the lift curve is
     nonlinear in this range (early stall, control surface interaction, etc.)
-    and cl_alpha_per_rad is returned as None.  The downstream gust computation
-    will then fall back to Helmbold-Diederich.
+    and (None, None) is returned.  The downstream gust computation will then
+    fall back to Helmbold-Diederich.
 
-    Returns CL_α in rad⁻¹ (radians, not degrees).
+    Returns:
+        (cl_alpha_per_rad, alpha_0_deg) — CL_α in rad⁻¹ and zero-lift angle α₀ in degrees.
+        (None, None) on failure / quality-gate rejection.
 
-    Sources: gh-487 spec; Anderson 6e §5.3; FAR-25.341(a)(2).
+    Sources: gh-487 spec; Anderson 6e §5.3; FAR-25.341(a)(2); gh-871.
     """
     import aerosandbox as asb
 
@@ -1067,7 +1100,7 @@ def _extract_cl_alpha_from_linear_sweep(
             alpha_min_deg,
             alpha_max_deg,
         )
-        return None
+        return None, None
 
     a_fit = alphas_arr[mask]
     cl_fit = cls_arr[mask]
@@ -1095,7 +1128,7 @@ def _extract_cl_alpha_from_linear_sweep(
             alpha_min_deg,
             alpha_max_deg,
         )
-        return None
+        return None, None
 
     if cl_alpha_fit <= 0:
         logger.warning(
@@ -1103,17 +1136,23 @@ def _extract_cl_alpha_from_linear_sweep(
             "Setting cl_alpha_per_rad=None.",
             cl_alpha_fit,
         )
-        return None
+        return None, None
+
+    # gh-871: zero-lift angle α₀ = -cl_0 / cl_alpha [radians] → degrees
+    # The linear lift curve is CL = cl_alpha * (alpha - alpha_0), so
+    # alpha_0 = -cl_0 / cl_alpha (in radians). Convert to degrees for storage.
+    alpha_0_deg = math.degrees(-cl_0 / cl_alpha_fit)
 
     logger.debug(
-        "CL_α extraction: CL_α=%.4f rad⁻¹, CL_0=%.4f, R²=%.4f (α ∈ [%.0f°, %.0f°]).",
+        "CL_α extraction: CL_α=%.4f rad⁻¹, CL_0=%.4f, α₀=%.2f°, R²=%.4f (α ∈ [%.0f°, %.0f°]).",
         cl_alpha_fit,
         cl_0,
+        alpha_0_deg,
         r2,
         alpha_min_deg,
         alpha_max_deg,
     )
-    return cl_alpha_fit
+    return cl_alpha_fit, alpha_0_deg
 
 
 def _extract_scalar(result: Any, key: str, *, default: float) -> float:
@@ -1801,6 +1840,29 @@ def _min_sink_rate(
     # aspect_ratio is guaranteed > 0 here (None / ≤ 0 already returned None above).
     cd_over_cl = 4.0 * float(np.sqrt(cd0 / (3.0 * np.pi * oswald_e * aspect_ratio)))
     return float(v_ms * cd_over_cl)
+
+
+def _cl_to_alpha_deg(
+    cl: float,
+    cl_alpha_per_rad: float | None,
+    alpha_0_deg: float | None,
+) -> float | None:
+    """Convert a lift coefficient to angle of attack [degrees] via the linear lift curve.
+
+    The linear lift curve is: CL = cl_alpha * (alpha - alpha_0)
+    Inverted: alpha = alpha_0 + CL / cl_alpha [radians] → converted to degrees.
+
+    gh-871: used to annotate characteristic speeds with their operating α.
+
+    Returns None when cl_alpha_per_rad or alpha_0_deg are absent/invalid.
+    """
+    if cl_alpha_per_rad is None or alpha_0_deg is None:
+        return None
+    if cl_alpha_per_rad <= 0:
+        return None
+    alpha_0_rad = math.radians(alpha_0_deg)
+    alpha_rad = alpha_0_rad + cl / cl_alpha_per_rad
+    return math.degrees(alpha_rad)
 
 
 def _picard_iterate_speed(

--- a/app/tests/test_aerobuildup_sweep_vectorization.py
+++ b/app/tests/test_aerobuildup_sweep_vectorization.py
@@ -269,13 +269,15 @@ class TestEquivalenceAgainstSerialBaseline:
         coeffs, *_ = np.linalg.lstsq(a_mat, cls[mask], rcond=None)
         serial_cl_alpha = float(coeffs[0])
 
-        # Both either produce a number or both reject via the R² gate.
-        if vectorised is None:
+        # gh-871: now returns (cl_alpha_per_rad, alpha_0_deg). Both either
+        # produce numbers or both reject via the R² gate.
+        cl_alpha_v, alpha_0_v = vectorised
+        if cl_alpha_v is None:
             # If the vectorised path rejected, the serial fit on the same
             # data should also produce a low R². We don't recompute R² here
             # — leave the rejection to the production-side gate.
             pytest.skip("vectorised CL_α extraction rejected via R² gate")
-        assert abs(vectorised - serial_cl_alpha) < 1e-9
+        assert abs(cl_alpha_v - serial_cl_alpha) < 1e-9
 
 
 # ---------------------------------------------------------------------------

--- a/app/tests/test_assumption_compute_integration.py
+++ b/app/tests/test_assumption_compute_integration.py
@@ -91,7 +91,7 @@ def test_recompute_publishes_assumption_changed_on_cg_change(client_and_db):
         ),
         patch(
             "app.services.assumption_compute_service._extract_cl_alpha_from_linear_sweep",
-            return_value=5.7,
+            return_value=(5.7, -2.3),  # gh-871: (cl_alpha_per_rad, alpha_0_deg)
         ),
         patch(
             "app.services.assumption_compute_service._load_flight_profile_speeds",
@@ -166,7 +166,7 @@ def test_recompute_does_not_publish_when_cg_unchanged(client_and_db):
         ),
         patch(
             "app.services.assumption_compute_service._extract_cl_alpha_from_linear_sweep",
-            return_value=5.7,
+            return_value=(5.7, -2.3),  # gh-871: (cl_alpha_per_rad, alpha_0_deg)
         ),
         patch(
             "app.services.assumption_compute_service._load_flight_profile_speeds",

--- a/app/tests/test_assumption_compute_service.py
+++ b/app/tests/test_assumption_compute_service.py
@@ -116,7 +116,7 @@ def _patches(flap_ted_max: float | None = None, fine_sweep_cl_max: float = 1.35)
         ),
         patch(
             "app.services.assumption_compute_service._extract_cl_alpha_from_linear_sweep",
-            return_value=5.7,
+            return_value=(5.7, -2.3),  # gh-871: now returns (cl_alpha_per_rad, alpha_0_deg)
         ),
         patch(
             "app.services.assumption_compute_service._load_flight_profile_speeds",
@@ -605,7 +605,7 @@ def test_flap_geometry_mismatch_falls_back_with_warning(client_and_db, caplog):
         ),
         patch(
             "app.services.assumption_compute_service._extract_cl_alpha_from_linear_sweep",
-            return_value=5.7,
+            return_value=(5.7, -2.3),  # gh-871: now returns (cl_alpha_per_rad, alpha_0_deg)
         ),
         patch(
             "app.services.assumption_compute_service._load_flight_profile_speeds",

--- a/app/tests/test_epic_485_acceptance.py
+++ b/app/tests/test_epic_485_acceptance.py
@@ -615,7 +615,7 @@ def _patches_for_ac(ac: dict, fake_airplane, sweep_data):
         ),
         patch(
             "app.services.assumption_compute_service._extract_cl_alpha_from_linear_sweep",
-            return_value=5.7,
+            return_value=(5.7, -2.3),  # gh-871: (cl_alpha_per_rad, alpha_0_deg)
         ),
         patch(
             "app.services.assumption_compute_service._load_flight_profile_speeds",

--- a/app/tests/test_gh871_alpha_at_speeds.py
+++ b/app/tests/test_gh871_alpha_at_speeds.py
@@ -1,0 +1,326 @@
+"""TDD tests for gh-871: angle of attack at characteristic speeds.
+
+Backend tests only — no AeroSandbox, no DB required.
+Strategy:
+  - Pure-function tests for the new _cl_to_alpha_deg helper
+  - _compute_speed_polar tests verifying alpha fields on SpeedPolarCurve
+  - Tests that alpha_0_deg propagates correctly from computation context stub
+  - Null-safety: missing lift-curve data → None for all alpha fields
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from app.services.analysis_service import _compute_speed_polar
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+G = 9.81
+
+
+def _parabolic_polar(cd0: float, e: float, ar: float, cl_range=(0.1, 1.4), n: int = 200):
+    """Return (cl_arr, cd_arr) for a parabolic polar."""
+    cl = np.linspace(*cl_range, n)
+    cd = cd0 + cl**2 / (math.pi * e * ar)
+    return cl, cd
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _cl_to_alpha_deg (pure math helper)
+# ---------------------------------------------------------------------------
+
+
+class TestClToAlphaDeg:
+    """_cl_to_alpha_deg must invert the linear lift curve CL = cl_0 + cl_alpha*alpha."""
+
+    def test_zero_cl_gives_zero_lift_alpha(self):
+        """At CL=0, α = α_0 = alpha_0_deg."""
+        from app.services.assumption_compute_service import _cl_to_alpha_deg
+
+        # α_0 = -2°, so at CL=0 the result should be -2°
+        result = _cl_to_alpha_deg(cl=0.0, cl_alpha_per_rad=5.7, alpha_0_deg=-2.0)
+        assert result == pytest.approx(-2.0, abs=1e-6)
+
+    def test_positive_cl_above_zero_lift(self):
+        """At CL > 0 with α_0 = 0°, α = CL / cl_alpha_per_rad (in degrees)."""
+        from app.services.assumption_compute_service import _cl_to_alpha_deg
+
+        cl_alpha = 5.7  # rad⁻¹
+        cl = 1.0
+        alpha_0 = 0.0
+        expected_deg = math.degrees(cl / cl_alpha)  # = cl / cl_alpha * 180/π
+        result = _cl_to_alpha_deg(cl=cl, cl_alpha_per_rad=cl_alpha, alpha_0_deg=alpha_0)
+        assert result == pytest.approx(expected_deg, rel=1e-6)
+
+    def test_roundtrip_with_nonzero_alpha_0(self):
+        """α_0 = -2°: cl_to_alpha should invert cl_alpha*(alpha - alpha_0)."""
+        from app.services.assumption_compute_service import _cl_to_alpha_deg
+
+        cl_alpha = 5.5  # rad⁻¹
+        alpha_0_deg = -2.0
+        # Forward: CL = cl_alpha * deg2rad(alpha - alpha_0)
+        alpha_target_deg = 5.0
+        alpha_0_rad = math.radians(alpha_0_deg)
+        cl = cl_alpha * (math.radians(alpha_target_deg) - alpha_0_rad)
+        # Invert:
+        result = _cl_to_alpha_deg(cl=cl, cl_alpha_per_rad=cl_alpha, alpha_0_deg=alpha_0_deg)
+        assert result == pytest.approx(alpha_target_deg, abs=1e-9)
+
+    def test_returns_none_when_cl_alpha_is_none(self):
+        from app.services.assumption_compute_service import _cl_to_alpha_deg
+
+        assert _cl_to_alpha_deg(cl=1.0, cl_alpha_per_rad=None, alpha_0_deg=-2.0) is None
+
+    def test_returns_none_when_alpha_0_is_none(self):
+        from app.services.assumption_compute_service import _cl_to_alpha_deg
+
+        assert _cl_to_alpha_deg(cl=1.0, cl_alpha_per_rad=5.7, alpha_0_deg=None) is None
+
+    def test_returns_none_when_cl_alpha_is_zero(self):
+        """Guard: cl_alpha=0 would cause division by zero — return None."""
+        from app.services.assumption_compute_service import _cl_to_alpha_deg
+
+        assert _cl_to_alpha_deg(cl=1.0, cl_alpha_per_rad=0.0, alpha_0_deg=-2.0) is None
+
+    def test_returns_none_when_cl_alpha_negative(self):
+        """Non-positive cl_alpha is degenerate."""
+        from app.services.assumption_compute_service import _cl_to_alpha_deg
+
+        assert _cl_to_alpha_deg(cl=1.0, cl_alpha_per_rad=-5.7, alpha_0_deg=-2.0) is None
+
+
+# ---------------------------------------------------------------------------
+# _compute_speed_polar: alpha fields on SpeedPolarCurve
+# ---------------------------------------------------------------------------
+
+
+class TestAlphaFieldsOnSpeedPolarCurve:
+    """_compute_speed_polar must populate alpha_*_deg fields on SpeedPolarCurve
+    when cl_alpha_per_rad and alpha_0_deg are supplied.
+    """
+
+    @pytest.fixture()
+    def parabolic_cl_cd(self):
+        return _parabolic_polar(cd0=0.012, e=0.85, ar=14.4)
+
+    def test_alpha_fields_present_in_schema(self, parabolic_cl_cd):
+        """SpeedPolarCurve must now have the three alpha fields."""
+        from app.schemas.aeroanalysisschema import SpeedPolarCurve
+
+        curve = SpeedPolarCurve(
+            mass_kg=1.5,
+            is_base=True,
+            V=[10.0, 12.0],
+            w=[0.5, 0.4],
+            cl=[1.0, 0.8],
+            cd=[0.05, 0.04],
+            v_stall=9.0,
+            v_min_sink=10.0,
+            w_min=0.4,
+            v_best_glide=12.0,
+            ld_max=20.0,
+        )
+        # Fields must exist (Optional → default None)
+        assert hasattr(curve, "alpha_stall_deg")
+        assert hasattr(curve, "alpha_min_sink_deg")
+        assert hasattr(curve, "alpha_best_glide_deg")
+
+    def test_alpha_populated_when_lift_curve_provided(self, parabolic_cl_cd):
+        """When cl_alpha_per_rad and alpha_0_deg are provided, all three alpha
+        fields should be finite floats for a normal parabolic polar."""
+        cl, cd = parabolic_cl_cd
+        sp = _compute_speed_polar(
+            cl=cl,
+            cd=cd,
+            masses_kg=[],
+            base_mass_kg=1.5,
+            s_ref_m2=0.225,
+            rho=1.225,
+            cl_alpha_per_rad=5.7,
+            alpha_0_deg=-2.0,
+        )
+        curve = sp.curves[0]
+        assert curve.alpha_stall_deg is not None
+        assert curve.alpha_min_sink_deg is not None
+        assert curve.alpha_best_glide_deg is not None
+        assert math.isfinite(curve.alpha_stall_deg)
+        assert math.isfinite(curve.alpha_min_sink_deg)
+        assert math.isfinite(curve.alpha_best_glide_deg)
+
+    def test_alpha_none_when_lift_curve_missing(self, parabolic_cl_cd):
+        """Without lift-curve data, alpha fields must be None — no KeyError/exception."""
+        cl, cd = parabolic_cl_cd
+        sp = _compute_speed_polar(
+            cl=cl,
+            cd=cd,
+            masses_kg=[],
+            base_mass_kg=1.5,
+            s_ref_m2=0.225,
+            rho=1.225,
+            cl_alpha_per_rad=None,
+            alpha_0_deg=None,
+        )
+        curve = sp.curves[0]
+        assert curve.alpha_stall_deg is None
+        assert curve.alpha_min_sink_deg is None
+        assert curve.alpha_best_glide_deg is None
+
+    def test_alpha_none_when_only_cl_alpha_missing(self, parabolic_cl_cd):
+        cl, cd = parabolic_cl_cd
+        sp = _compute_speed_polar(
+            cl=cl,
+            cd=cd,
+            masses_kg=[],
+            base_mass_kg=1.5,
+            s_ref_m2=0.225,
+            rho=1.225,
+            cl_alpha_per_rad=None,
+            alpha_0_deg=-2.0,
+        )
+        assert sp.curves[0].alpha_stall_deg is None
+
+    def test_alpha_stall_corresponds_to_cl_max(self, parabolic_cl_cd):
+        """alpha_stall is computed from cl_max (not cl at best-glide or min-sink)."""
+        from app.services.assumption_compute_service import _cl_to_alpha_deg
+
+        cl, cd = parabolic_cl_cd
+        cl_alpha = 5.7
+        alpha_0 = -2.0
+        sp = _compute_speed_polar(
+            cl=cl,
+            cd=cd,
+            masses_kg=[],
+            base_mass_kg=1.5,
+            s_ref_m2=0.225,
+            rho=1.225,
+            cl_alpha_per_rad=cl_alpha,
+            alpha_0_deg=alpha_0,
+        )
+        curve = sp.curves[0]
+        cl_max = float(np.max(cl))  # CL_max of the polar
+        expected = _cl_to_alpha_deg(cl_max, cl_alpha, alpha_0)
+        assert curve.alpha_stall_deg == pytest.approx(expected, rel=1e-6)
+
+    def test_alpha_best_glide_corresponds_to_cl_at_ld_max(self, parabolic_cl_cd):
+        """alpha_best_glide is computed from the CL at maximum L/D."""
+        from app.services.assumption_compute_service import _cl_to_alpha_deg
+
+        cl, cd = parabolic_cl_cd
+        cl_alpha = 5.7
+        alpha_0 = -2.0
+        sp = _compute_speed_polar(
+            cl=cl,
+            cd=cd,
+            masses_kg=[],
+            base_mass_kg=1.5,
+            s_ref_m2=0.225,
+            rho=1.225,
+            cl_alpha_per_rad=cl_alpha,
+            alpha_0_deg=alpha_0,
+        )
+        curve = sp.curves[0]
+        # Find CL at i_best (argmax of L/D = CL/CD)
+        cl_arr = np.asarray(cl)
+        cd_arr = np.asarray(cd)
+        pos = cl_arr > 0
+        cl_pos, cd_pos = cl_arr[pos], cd_arr[pos]
+        order = np.argsort(np.sqrt(2 * 1.5 * G / (1.225 * 0.225 * cl_pos)))
+        cl_s = cl_pos[order]
+        cd_s = cd_pos[order]
+        i_best = int(np.argmax(cl_s / cd_s))
+        expected = _cl_to_alpha_deg(float(cl_s[i_best]), cl_alpha, alpha_0)
+        assert curve.alpha_best_glide_deg == pytest.approx(expected, rel=1e-6)
+
+    def test_alpha_ordering_makes_physical_sense(self, parabolic_cl_cd):
+        """For a clean parabolic polar: alpha_stall > alpha_min_sink > alpha_best_glide.
+        (Higher α → higher CL; CL_stall > CL_min_sink > CL_best_glide.)
+        """
+        cl, cd = parabolic_cl_cd
+        sp = _compute_speed_polar(
+            cl=cl,
+            cd=cd,
+            masses_kg=[],
+            base_mass_kg=1.5,
+            s_ref_m2=0.225,
+            rho=1.225,
+            cl_alpha_per_rad=5.7,
+            alpha_0_deg=-2.0,
+        )
+        curve = sp.curves[0]
+        assert curve.alpha_stall_deg > curve.alpha_min_sink_deg
+        assert curve.alpha_min_sink_deg > curve.alpha_best_glide_deg
+
+    def test_alpha_same_for_all_masses(self, parabolic_cl_cd):
+        """Alpha values depend only on CL (lift curve), not on mass.
+        So alpha_best_glide, alpha_min_sink, alpha_stall should be identical
+        for all mass variants.
+        """
+        cl, cd = parabolic_cl_cd
+        sp = _compute_speed_polar(
+            cl=cl,
+            cd=cd,
+            masses_kg=[3.0],
+            base_mass_kg=1.5,
+            s_ref_m2=0.225,
+            rho=1.225,
+            cl_alpha_per_rad=5.7,
+            alpha_0_deg=-2.0,
+        )
+        c1, c2 = sp.curves[0], sp.curves[1]
+        # Alpha fields should be identical (mass-independent CL→α mapping)
+        assert c1.alpha_best_glide_deg == pytest.approx(c2.alpha_best_glide_deg, abs=1e-9)
+        assert c1.alpha_min_sink_deg == pytest.approx(c2.alpha_min_sink_deg, abs=1e-9)
+        assert c1.alpha_stall_deg == pytest.approx(c2.alpha_stall_deg, abs=1e-9)
+
+    def test_degenerate_empty_curve_alpha_none(self):
+        """Degenerate curve (no positive CL) → alpha fields None."""
+        cl = np.array([-0.5, 0.0])
+        cd = np.array([0.04, 0.02])
+        sp = _compute_speed_polar(
+            cl=cl,
+            cd=cd,
+            masses_kg=[],
+            base_mass_kg=1.5,
+            s_ref_m2=0.225,
+            rho=1.225,
+            cl_alpha_per_rad=5.7,
+            alpha_0_deg=-2.0,
+        )
+        curve = sp.curves[0]
+        assert curve.alpha_stall_deg is None
+        assert curve.alpha_min_sink_deg is None
+        assert curve.alpha_best_glide_deg is None
+
+
+# ---------------------------------------------------------------------------
+# alpha_0_deg propagation from computation context
+# ---------------------------------------------------------------------------
+
+
+class TestAlpha0DegStoredInContext:
+    """alpha_0_deg must be stored in the assumption_computation_context."""
+
+    def test_cl_to_alpha_matches_context_values(self):
+        """Given context values (cl_alpha_per_rad, alpha_0_deg), the CL→α
+        formula should be invertible and stable."""
+        from app.services.assumption_compute_service import _cl_to_alpha_deg
+
+        # Simulate what the context stores
+        cl_alpha = 5.7
+        alpha_0 = -2.3
+
+        # Forward: CL at α=8°
+        alpha_test_rad = math.radians(8.0)
+        alpha_0_rad = math.radians(alpha_0)
+        cl_at_8 = cl_alpha * (alpha_test_rad - alpha_0_rad)
+
+        # Invert: back to α=8°
+        recovered = _cl_to_alpha_deg(cl_at_8, cl_alpha, alpha_0)
+        assert recovered == pytest.approx(8.0, abs=1e-9)

--- a/app/tests/test_gust_envelope.py
+++ b/app/tests/test_gust_envelope.py
@@ -934,8 +934,11 @@ class TestExtractClAlphaFromLinearSweep:
         with patch("aerosandbox.AeroBuildup.run", lambda self_: vec_result):
             result = _extract_cl_alpha_from_linear_sweep(asb_airplane, v_cruise=18.0)
 
-        assert result is not None
-        assert result == pytest.approx(5.7, rel=0.02)
+        # gh-871: now returns (cl_alpha_per_rad, alpha_0_deg)
+        cl_alpha, alpha_0 = result
+        assert cl_alpha is not None
+        assert cl_alpha == pytest.approx(5.7, rel=0.02)
+        assert alpha_0 is not None  # zero-lift angle should be ~0° for this input
 
     def test_nan_handling_returns_none_when_fewer_than_3_valid(self):
         """When < 3 valid (non-NaN) CL points, returns None."""
@@ -951,7 +954,8 @@ class TestExtractClAlphaFromLinearSweep:
         with patch("aerosandbox.AeroBuildup.run", lambda self_: nan_result):
             result = _extract_cl_alpha_from_linear_sweep(asb_airplane, v_cruise=18.0)
 
-        assert result is None
+        # gh-871: returns (None, None) on failure
+        assert result == (None, None)
 
     def test_low_r2_returns_none(self):
         """When R² < threshold (nonlinear lift curve), returns None."""
@@ -972,7 +976,8 @@ class TestExtractClAlphaFromLinearSweep:
         with patch("aerosandbox.AeroBuildup.run", lambda self_: vec_result):
             result = _extract_cl_alpha_from_linear_sweep(asb_airplane, v_cruise=18.0)
 
-        assert result is None
+        # gh-871: returns (None, None) on failure
+        assert result == (None, None)
 
     def test_negative_slope_returns_none(self):
         """When fitted CL_α ≤ 0 (inverted lift curve), returns None."""
@@ -994,7 +999,8 @@ class TestExtractClAlphaFromLinearSweep:
         with patch("aerosandbox.AeroBuildup.run", lambda self_: vec_result):
             result = _extract_cl_alpha_from_linear_sweep(asb_airplane, v_cruise=18.0)
 
-        assert result is None
+        # gh-871: returns (None, None) on failure
+        assert result == (None, None)
 
     def test_exception_during_asb_propagates_up(self):
         """Exception from AeroBuildup.run propagates out of the function."""
@@ -1033,10 +1039,13 @@ class TestExtractClAlphaFromLinearSweep:
             # With only 3 points R² might be perfect (3 points → perfect line)
             # but the result will be some float (not None from the <3 check).
             result = _extract_cl_alpha_from_linear_sweep(asb_airplane, v_cruise=18.0)
-        # Result may be None (low R² or negative slope) or a float — either is acceptable.
+        # gh-871: now returns (cl_alpha_per_rad, alpha_0_deg).
+        # Result may be (None, None) (low R² or negative slope) or (float, float).
         # Key thing: the < 3 guard did NOT fire for exactly 3 valid points.
         # We just verify no exception was raised.
-        assert result is None or isinstance(result, float)
+        cl_alpha, alpha_0 = result
+        assert cl_alpha is None or isinstance(cl_alpha, float)
+        assert alpha_0 is None or isinstance(alpha_0, float)
 
 
 # ────────────────────────────────────────────────────────────────────────────

--- a/app/tests/test_polar_fit.py
+++ b/app/tests/test_polar_fit.py
@@ -368,7 +368,7 @@ class TestCachedContextIntegration:
             ),
             patch(
                 "app.services.assumption_compute_service._extract_cl_alpha_from_linear_sweep",
-                return_value=5.7,
+                return_value=(5.7, -2.3),  # gh-871: (cl_alpha_per_rad, alpha_0_deg)
             ),
             patch(
                 "app.services.assumption_compute_service._load_flight_profile_speeds",
@@ -572,7 +572,7 @@ class TestCachedContextIntegration:
             ),
             patch(
                 "app.services.assumption_compute_service._extract_cl_alpha_from_linear_sweep",
-                return_value=5.7,
+                return_value=(5.7, -2.3),  # gh-871: (cl_alpha_per_rad, alpha_0_deg)
             ),
             patch(
                 "app.services.assumption_compute_service._load_flight_profile_speeds",

--- a/app/tests/test_polar_rejection_propagation.py
+++ b/app/tests/test_polar_rejection_propagation.py
@@ -108,7 +108,7 @@ def _enter_patches_with_rejection():
         stack.enter_context(
             patch(
                 "app.services.assumption_compute_service._extract_cl_alpha_from_linear_sweep",
-                return_value=5.7,
+                return_value=(5.7, -2.3),  # gh-871: (cl_alpha_per_rad, alpha_0_deg)
             )
         )
         stack.enter_context(

--- a/frontend/__tests__/SpeedChipRow.test.tsx
+++ b/frontend/__tests__/SpeedChipRow.test.tsx
@@ -72,4 +72,73 @@ describe("SpeedChipRow", () => {
     );
     expect(screen.getByTestId("my-slot")).toBeInTheDocument();
   });
+
+  // gh-871: angle of attack display
+  describe("gh-871 α at characteristic speeds", () => {
+    it("shows α alongside V_stall when alpha_stall_deg is available", () => {
+      render(
+        <SpeedChipRow
+          ctx={{ ...baseCtx, alpha_stall_deg: 14.5 } as unknown as ComputationContext}
+          isRecomputing={false}
+        />,
+      );
+      // V_stall chip must show "13.2 m/s @ 14.5°"
+      expect(screen.getByText("13.2 m/s @ 14.5°")).toBeInTheDocument();
+    });
+
+    it("shows α alongside V_min_sink when alpha_min_sink_deg is available", () => {
+      render(
+        <SpeedChipRow
+          ctx={{ ...baseCtx, alpha_min_sink_deg: 8.3 } as unknown as ComputationContext}
+          isRecomputing={false}
+        />,
+      );
+      expect(screen.getByText("14.5 m/s @ 8.3°")).toBeInTheDocument();
+    });
+
+    it("shows α alongside V_md when alpha_best_glide_deg is available", () => {
+      render(
+        <SpeedChipRow
+          ctx={{ ...baseCtx, alpha_best_glide_deg: 6.2 } as unknown as ComputationContext}
+          isRecomputing={false}
+        />,
+      );
+      expect(screen.getByText("17.0 m/s @ 6.2°")).toBeInTheDocument();
+    });
+
+    it("shows speed without α suffix when alpha_stall_deg is null", () => {
+      render(
+        <SpeedChipRow
+          ctx={{ ...baseCtx, alpha_stall_deg: null } as unknown as ComputationContext}
+          isRecomputing={false}
+        />,
+      );
+      expect(screen.getByText("13.2 m/s")).toBeInTheDocument();
+    });
+
+    it("shows speed without α suffix when alpha field is absent from context", () => {
+      // baseCtx has no alpha fields at all
+      render(<SpeedChipRow ctx={baseCtx as unknown as ComputationContext} isRecomputing={false} />);
+      // No "@ " pattern should appear in the V_stall chip when alpha is absent
+      const stall = screen.getByText(/13\.2 m\/s/);
+      expect(stall.textContent).not.toContain("@");
+    });
+
+    it("all three alpha chips together", () => {
+      render(
+        <SpeedChipRow
+          ctx={{
+            ...baseCtx,
+            alpha_stall_deg: 14.5,
+            alpha_min_sink_deg: 8.3,
+            alpha_best_glide_deg: 6.2,
+          } as unknown as ComputationContext}
+          isRecomputing={false}
+        />,
+      );
+      expect(screen.getByText("13.2 m/s @ 14.5°")).toBeInTheDocument();
+      expect(screen.getByText("14.5 m/s @ 8.3°")).toBeInTheDocument();
+      expect(screen.getByText("17.0 m/s @ 6.2°")).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/components/workbench/SpeedChipRow.tsx
+++ b/frontend/components/workbench/SpeedChipRow.tsx
@@ -16,6 +16,16 @@ function fmt(v: number | null | undefined, decimals: number, suffix = "") {
   return v != null ? `${v.toFixed(decimals)}${suffix}` : "–";
 }
 
+/** Format a speed+alpha pair: "X.X m/s @ Y.Y°" or just "X.X m/s" when α is absent. */
+function fmtSpeedAlpha(
+  speed: number | null | undefined,
+  alpha: number | null | undefined,
+): string {
+  if (speed == null) return "–";
+  const alphaPart = alpha != null ? ` @ ${alpha.toFixed(1)}°` : "";
+  return `${speed.toFixed(1)} m/s${alphaPart}`;
+}
+
 export function SpeedChipRow({ ctx, isRecomputing, rightSlot }: Props) {
   const stale = isRecomputing;
   return (
@@ -27,14 +37,14 @@ export function SpeedChipRow({ ctx, isRecomputing, rightSlot }: Props) {
         icon={AlertTriangle}
         symbol="V_stall"
         description="Stall speed in clean configuration at 1 g"
-        value={fmt(ctx?.v_stall_mps, 1, " m/s")}
+        value={fmtSpeedAlpha(ctx?.v_stall_mps, ctx?.alpha_stall_deg)}
         stale={stale}
       />
       <Chip
         icon={Wind}
         symbol="V_min_sink"
         description="Speed for minimum sink rate — best endurance / longest glide time"
-        value={fmt(ctx?.v_min_sink_mps, 1, " m/s")}
+        value={fmtSpeedAlpha(ctx?.v_min_sink_mps, ctx?.alpha_min_sink_deg)}
         stale={stale}
       />
       <Chip
@@ -48,7 +58,7 @@ export function SpeedChipRow({ ctx, isRecomputing, rightSlot }: Props) {
         icon={Wind}
         symbol="V_md"
         description="Minimum-drag speed — best L/D, longest glide distance"
-        value={fmt(ctx?.v_md_mps, 1, " m/s")}
+        value={fmtSpeedAlpha(ctx?.v_md_mps, ctx?.alpha_best_glide_deg)}
         stale={stale}
       />
       <Chip

--- a/frontend/hooks/useComputationContext.ts
+++ b/frontend/hooks/useComputationContext.ts
@@ -58,6 +58,13 @@ export interface ComputationContext {
   // gh-692: vertical speed at V_min_sink — minimum sink rate the polar can deliver.
   // Glider/Motorsegler chip; powered aircraft also receive it for completeness.
   min_sink_rate_mps?: number | null;
+  // gh-871: angle of attack at characteristic speeds [degrees], derived from the
+  // linear lift-curve regression (CL_α, α₀) stored in the computation context.
+  // Null when the lift-curve data is absent (e.g. before first recompute or
+  // degenerate geometry that fails the R² quality gate).
+  alpha_stall_deg?: number | null;
+  alpha_min_sink_deg?: number | null;
+  alpha_best_glide_deg?: number | null;
   v_a_mps?: number | null;
   v_dive_mps?: number | null;
   v_x_mps?: number | null;


### PR DESCRIPTION
## Summary

- **Backend**: `_extract_cl_alpha_from_linear_sweep` now returns `(cl_alpha_per_rad, alpha_0_deg)` — the zero-lift angle α₀ is derived from the regression intercept (`α₀ = −CL₀ / CL_α`), no extra AeroBuildup calls.
- **New pure helper** `_cl_to_alpha_deg(cl, cl_alpha_per_rad, alpha_0_deg)` inverts the linear lift curve `CL = CL_α · (α − α₀)` to degrees; null-safe (returns None when either lift-curve parameter is absent).
- **Computation context** gains `alpha_0_deg`, `alpha_stall_deg`, `alpha_best_glide_deg`, `alpha_min_sink_deg` — computed from CL_max and the closed-form parabolic-polar optima (CL_bg = √(CD₀/k), CL_ms = √(3·CD₀/k)).
- **`SpeedPolarCurve` schema** gains the same three alpha fields (Optional[float], null when lift-curve data absent); `_compute_speed_polar` populates them from the CL→α mapping at each characteristic CL.
- **Frontend**: `ComputationContext` type gets `alpha_stall_deg`, `alpha_min_sink_deg`, `alpha_best_glide_deg`. `SpeedChipRow` uses a new `fmtSpeedAlpha()` helper that renders `"X.X m/s @ Y.Y°"` when α is known and `"X.X m/s"` when absent. V_stall, V_min_sink, V_md chips updated.

### How α is derived

The computation context already stores `cl_alpha_per_rad` (rad⁻¹) from a linear AeroBuildup alpha-sweep (gh-487). The same regression also yields `CL₀`, the zero-lift intercept. From these two scalars: `α(CL) = α₀ + CL / CL_α` where `α₀ = −CL₀ / CL_α` (degrees). No extra solver calls.

## Test plan

- [ ] 17 new backend unit tests (`test_gh871_alpha_at_speeds.py`): `_cl_to_alpha_deg` roundtrip, null-safety, `_compute_speed_polar` alpha fields, ordering (α_stall > α_min_sink > α_best_glide), mass-independence, degenerate case
- [ ] 6 new frontend tests (`SpeedChipRow.test.tsx`): α displayed alongside speed, fallback to plain speed when α null/absent, all three chips together
- [ ] All existing mocks of `_extract_cl_alpha_from_linear_sweep` updated to return tuple `(5.7, -2.3)`
- [ ] Full fast test suite: 4855 passed, 0 failures
- [ ] `ruff check` + `ruff format --check` clean; `eslint` clean

Closes #871

🤖 Generated with [Claude Code](https://claude.com/claude-code)