### PR TITLE
fix(gh-868): scroll the Airfoil-Preview page wrapper (real fix)

### DIFF
--- a/frontend/__tests__/AirfoilPreviewViewerPanel.scroll.test.tsx
+++ b/frontend/__tests__/AirfoilPreviewViewerPanel.scroll.test.tsx
@@ -1,9 +1,19 @@
 /**
- * Regression test for gh-868: Airfoil-Preview chart column must be
- * vertically scrollable (overflow-y-auto), not clipped (overflow-hidden).
+ * Regression test for gh-868: Airfoil-Preview charts must be vertically
+ * scrollable.
  *
- * The right-hand config panel already uses overflow-y-auto; the chart column
- * must follow the same pattern so lower charts are reachable by scrolling.
+ * IMPORTANT (the real bug): the panel root expands to full content height, so
+ * it never overflows *itself* — putting `overflow-y-auto` on the panel root
+ * (the first, ineffective fix) produced no scrollbar. The actual scroll
+ * container is the bounded-height page wrapper in
+ * `app/workbench/airfoil-preview/page.tsx` (`flex-1 overflow-y-auto`,
+ * data-testid="airfoil-preview-scroll").
+ *
+ * jsdom has no layout engine, so real scrollability is verified in a browser
+ * (Playwright) — see the PR. This unit test only guards against re-introducing
+ * the wrong fix: the panel root must NOT try to own vertical overflow (neither
+ * clip with overflow-hidden nor scroll with overflow-y-auto); it must grow and
+ * let the page wrapper scroll.
  */
 import { describe, it, expect, vi } from "vitest";
 import { render } from "@testing-library/react";
@@ -57,11 +67,16 @@ const baseProps = {
 };
 
 describe("AirfoilPreviewViewerPanel — scroll (gh-868)", () => {
-  it("chart column container has overflow-y-auto and does NOT have overflow-hidden", () => {
+  it("panel root grows and does NOT own vertical overflow (page wrapper scrolls)", () => {
     const { getByTestId } = render(<AirfoilPreviewViewerPanel {...baseProps} />);
     const container = getByTestId("airfoil-preview-charts");
     const classes = container.className;
-    expect(classes).toContain("overflow-y-auto");
+    // Must be a growing flex column...
+    expect(classes).toContain("flex-col");
+    expect(classes).toContain("flex-1");
+    // ...but must NOT clip (the original bug) NOR try to scroll itself (the
+    // ineffective first fix). Real scrolling lives on the page wrapper.
     expect(classes).not.toContain("overflow-hidden");
+    expect(classes).not.toContain("overflow-y-auto");
   });
 });

--- a/frontend/app/workbench/airfoil-preview/page.tsx
+++ b/frontend/app/workbench/airfoil-preview/page.tsx
@@ -391,7 +391,10 @@ export default function AirfoilPreviewPage() {
 
   return (
     <div className="flex flex-1 gap-4 overflow-hidden">
-      <div className="flex-1 overflow-hidden">
+      {/* gh-868: this wrapper is the actual scroll container — the panel root
+          inside expands to full content height, so the bounded-height wrapper
+          must scroll (not the panel). */}
+      <div data-testid="airfoil-preview-scroll" className="flex-1 overflow-y-auto">
         <AirfoilPreviewViewerPanel
           rootAirfoilName={rootAirfoil}
           tipAirfoilName={hasTip ? tipAirfoil : null}

--- a/frontend/components/workbench/AirfoilPreviewViewerPanel.tsx
+++ b/frontend/components/workbench/AirfoilPreviewViewerPanel.tsx
@@ -765,7 +765,7 @@ export function AirfoilPreviewViewerPanel({
   );
 
   return (
-    <div data-testid="airfoil-preview-charts" className="flex flex-1 flex-col gap-4 overflow-y-auto p-4">
+    <div data-testid="airfoil-preview-charts" className="flex flex-1 flex-col gap-4 p-4">
       {/* gh-822: Tip-Re < Root-Re warning banner */}
       {showTipReBanner && (
         <div


### PR DESCRIPTION
## Problem
The Airfoil-Preview diagrams still couldn't be scrolled after PR #872. That PR put `overflow-y-auto` on the **panel root** (`AirfoilPreviewViewerPanel.tsx`), but that element expands to full content height, so it never overflows itself — no scrollbar.

## Root cause (live-DOM measurement on the running app)
| element | display | overflow-y | clientH | scrollH | clipped |
|---|---|---|---|---|---|
| panel root (`airfoil-preview-charts`) | flex | auto | 1051 | 1051 | 0 — never scrolls |
| **page wrapper** (`page.tsx`, `flex-1 overflow-hidden`) | block | hidden | **584** | **1051** | **467** ← the real overflow |

The bounded-height **page wrapper** is what overflows; the scroll belongs there.

## Fix
- `app/workbench/airfoil-preview/page.tsx`: wrapper `overflow-hidden` → `overflow-y-auto` (+ `data-testid="airfoil-preview-scroll"`).
- `AirfoilPreviewViewerPanel.tsx`: drop the ineffective `overflow-y-auto` from the panel root so there's one clear scroll container.

## Verification
- **Browser (authoritative)**: on the running app, applying `overflow-y-auto` to that exact wrapper element scrolls to **466 of 467px** max (`fixWorks: true`). The code change applies that exact CSS to that exact element.
- **Unit test rewritten**: the previous className-only test passed but didn't verify real scroll (jsdom has no layout). It now guards against the *wrong* fix — the panel root must NOT own vertical overflow (no `overflow-hidden`, no `overflow-y-auto`).
- eslint clean.

Closes #868

🤖 Generated with [Claude Code](https://claude.com/claude-code)