### PR TITLE
fix(gh-895): remove committed circular 'db' symlink (breaks local DB on pull)

### DIFF
--- a/db
+++ b/db
@@ -1,1 +1,0 @@
-/Users/szymanski/Projects/da3Dalus/cad-modelling-service/db


### PR DESCRIPTION
Removes the tracked self-referential `db` symlink committed in #877. On `git pull`/checkout it replaced the local `db/` directory, turning `./db/test.db` into an infinite symlink loop (`unable to open database file`) and destroying the local untracked DB. `db/` is already gitignored, so removing the tracked symlink restores the intended local-only `db/` directory. No code changes.

Closes #895

🤖 Generated with [Claude Code](https://claude.com/claude-code)