### PR TITLE
fix(gh-897): EnvelopeAxis duplicate React keys on coincident speed markers

### DIFF
--- a/frontend/__tests__/EnvelopeAxis.test.tsx
+++ b/frontend/__tests__/EnvelopeAxis.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * gh-897: EnvelopeAxis must not emit duplicate React keys when two speed
+ * markers coincide (same value + kind, e.g. V_md == V_cruise). The colour
+ * zones are derived from sorted markers; a coincident marker produces a
+ * zero-width zone that previously collided on the `${kind}-${to}` key.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render } from "@testing-library/react";
+import { EnvelopeAxis } from "@/components/workbench/metrics-dashboard/primitives";
+import type { SpeedMarker } from "@/components/workbench/metrics-dashboard/metricsTypes";
+
+function marker(
+  symbol: string,
+  value: number,
+  kind: SpeedMarker["kind"] = "normal",
+): SpeedMarker {
+  return { symbol, label: symbol, value, kind };
+}
+
+// Two markers at the same value AND kind — the reported `normal-16.6` collision.
+const COINCIDENT: SpeedMarker[] = [
+  marker("V_stall", 11.0, "stall"),
+  marker("V_md", 16.6, "normal"),
+  marker("V_cruise", 16.6, "normal"),
+  marker("V_ne", 30.0, "ne"),
+];
+
+describe("EnvelopeAxis — coincident markers (gh-897)", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("emits no React duplicate-key error when two markers share value+kind", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(<EnvelopeAxis markers={COINCIDENT} />);
+    const dupKeyErrors = errSpy.mock.calls.filter((args) =>
+      args.some((a) => typeof a === "string" && a.includes("same key")),
+    );
+    expect(dupKeyErrors).toEqual([]);
+  });
+
+  it("renders no zero-width colour zones", () => {
+    const { container } = render(<EnvelopeAxis markers={COINCIDENT} />);
+    // colour-zone divs carry opacity-25; markers do not
+    const zones = Array.from(container.querySelectorAll<HTMLElement>(".opacity-25"));
+    expect(zones.length).toBeGreaterThan(0);
+    for (const z of zones) {
+      expect(z.style.width).not.toBe("0%");
+    }
+  });
+});

--- a/frontend/components/workbench/metrics-dashboard/primitives.tsx
+++ b/frontend/components/workbench/metrics-dashboard/primitives.tsx
@@ -55,16 +55,21 @@ export function EnvelopeAxis({
   const zones: { from: number; to: number; kind: SpeedMarker["kind"] }[] = [];
   let prev = 0;
   for (const m of sorted) {
-    zones.push({ from: prev, to: m.value, kind: m.kind });
+    // gh-897: coincident markers (e.g. V_md == V_cruise) would push a
+    // zero-width zone that renders nothing and collided on the zone key —
+    // skip them.
+    if (m.value > prev) {
+      zones.push({ from: prev, to: m.value, kind: m.kind });
+    }
     prev = m.value;
   }
 
   return (
     <div className={large ? "pt-10 pb-1" : "py-4"}>
       <div className="relative h-2 w-full rounded-pill bg-card-muted">
-        {zones.map((z) => (
+        {zones.map((z, i) => (
           <div
-            key={`${z.kind}-${z.to}`}
+            key={`zone-${i}-${z.kind}`}
             className={`absolute top-0 h-2 ${ZONE_COLOR[z.kind]} opacity-25`}
             style={{ left: pos(z.from), width: `${((z.to - z.from) / max) * 100}%` }}
           />


### PR DESCRIPTION
## Problem
Console error in the metrics dashboard:
> Encountered two children with the same key, `normal-16.6`.
(`EnvelopeAxis` → `SpeedTile`)

## Root cause
`EnvelopeAxis` derives contiguous colour zones from markers sorted by value (`zones.push({from: prev, to: m.value, kind})`), keyed by `${kind}-${to}`. Two markers at the **same value + kind** (e.g. V_md == V_cruise ≈ 16.6, both `normal`) push a **zero-width** zone (`from == to`) with the same `kind`+`to` as the previous zone → duplicate key. Coincident speeds are legitimate, so this is a key bug, not a data bug.

## Fix
- Skip zero-width zones (`m.value > prev`) — they render nothing and are the sole collision source.
- Key zones by index too, so siblings stay unique regardless of coincident values.

## Tests (`EnvelopeAxis.test.tsx`)
- Two markers at the same value+kind → **no** React duplicate-key console error (failed before, passes after).
- No zero-width zone divs are rendered.
- 35 existing MetricsDashboard tests still green; eslint clean.

Closes #897

🤖 Generated with [Claude Code](https://claude.com/claude-code)