### PR TITLE
chore(gh-894): remove orphaned Mass Sweep backend

### DIFF
--- a/app/api/v2/endpoints/aeroplane/mass_cg.py
+++ b/app/api/v2/endpoints/aeroplane/mass_cg.py
@@ -11,7 +11,6 @@ from sqlalchemy.orm import Session
 
 from app.core.exceptions import (
     ConflictError,
-    InternalError,
     NotFoundError,
     ServiceException,
     ValidationDomainError,
@@ -22,8 +21,6 @@ from app.schemas.mass_cg import (
     CGComparisonResponse,
     DesignMetricsRequest,
     DesignMetricsResponse,
-    MassSweepRequest,
-    MassSweepResponse,
 )
 from app.services import mass_cg_service as svc
 
@@ -77,33 +74,6 @@ async def design_metrics_endpoint(
         svc.get_design_metrics_for_aeroplane,
         db,
         aeroplane_id,
-        body.velocity,
-        body.altitude,
-    )
-
-
-@router.post(
-    "/aeroplanes/{aeroplane_id}/mass_sweep",
-    status_code=status.HTTP_200_OK,
-    tags=["mass-cg"],
-    operation_id="compute_mass_sweep",
-    responses={
-        404: {"description": "Resource not found"},
-        422: {"description": "Validation error"},
-        500: {"description": "Internal server error"},
-    },
-)
-async def mass_sweep_endpoint(
-    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
-    body: Annotated[MassSweepRequest, Body(..., description="Sweep parameters")],
-    db: Annotated[Session, Depends(get_db)],
-) -> MassSweepResponse:
-    """Sweep mass values and compute derived metrics at each point (no aero re-run)."""
-    return _call(
-        svc.get_mass_sweep_for_aeroplane,
-        db,
-        aeroplane_id,
-        body.masses_kg,
         body.velocity,
         body.altitude,
     )

--- a/app/schemas/mass_cg.py
+++ b/app/schemas/mass_cg.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Annotated
-
 from pydantic import BaseModel, Field
 
 
@@ -41,36 +39,6 @@ class DesignMetricsResponse(BaseModel):
     stall_speed_ms: float = Field(..., description="Stall speed at given altitude [m/s]")
     required_cl: float = Field(..., description="CL required for level flight at given velocity")
     cl_margin: float = Field(..., description="CL_max - required_CL (positive = above stall)")
-
-
-class MassSweepRequest(BaseModel):
-    """Input for a mass sweep (post-processing, no re-run of aero)."""
-
-    masses_kg: list[Annotated[float, Field(gt=0)]] = Field(
-        ..., min_length=1, max_length=100, description="List of mass values to evaluate [kg]"
-    )
-    velocity: float = Field(15.0, gt=0, description="Cruise velocity in m/s")
-    altitude: float = Field(0.0, ge=0, description="Altitude in meters")
-
-
-class MassSweepPoint(BaseModel):
-    """One data point in a mass sweep."""
-
-    mass_kg: float = Field(..., description="Mass at this sweep point [kg]")
-    wing_loading_pa: float = Field(..., description="Wing loading W/S [N/m^2]")
-    stall_speed_ms: float = Field(..., description="Stall speed at given altitude [m/s]")
-    required_cl: float = Field(..., description="CL required for level flight")
-    cl_margin: float = Field(..., description="CL_max - required_CL")
-
-
-class MassSweepResponse(BaseModel):
-    """Result of a mass sweep."""
-
-    s_ref: float = Field(..., description="Wing reference area [m^2]")
-    cl_max: float = Field(..., description="Maximum lift coefficient")
-    velocity: float = Field(..., description="Cruise velocity used [m/s]")
-    altitude: float = Field(..., description="Altitude used [m]")
-    points: list[MassSweepPoint] = Field(..., description="Sweep data points")
 
 
 class CGComparisonResponse(BaseModel):

--- a/app/services/mass_cg_service.py
+++ b/app/services/mass_cg_service.py
@@ -1,4 +1,4 @@
-"""Mass / CG design parameter service — derived metrics, sweep, and CG comparison."""
+"""Mass / CG design parameter service — derived metrics and CG comparison."""
 
 from __future__ import annotations
 

--- a/app/services/mass_cg_service.py
+++ b/app/services/mass_cg_service.py
@@ -13,8 +13,6 @@ from app.models.aeroplanemodel import AeroplaneModel, DesignAssumptionModel, Wei
 from app.schemas.mass_cg import (
     CGComparisonResponse,
     DesignMetricsResponse,
-    MassSweepPoint,
-    MassSweepResponse,
 )
 
 logger = logging.getLogger(__name__)
@@ -75,29 +73,6 @@ def compute_design_metrics(
         required_cl=required_cl,
         cl_margin=cl_margin,
     )
-
-
-def compute_mass_sweep(
-    masses_kg: list[float],
-    s_ref: float,
-    cl_max: float,
-    rho: float,
-    velocity: float,
-) -> list[MassSweepPoint]:
-    """Compute derived metrics at each mass point (no aero re-run needed)."""
-    points: list[MassSweepPoint] = []
-    for m in masses_kg:
-        dm = compute_design_metrics(m, s_ref, cl_max, rho, velocity)
-        points.append(
-            MassSweepPoint(
-                mass_kg=m,
-                wing_loading_pa=dm.wing_loading_pa,
-                stall_speed_ms=dm.stall_speed_ms,
-                required_cl=dm.required_cl,
-                cl_margin=dm.cl_margin,
-            )
-        )
-    return points
 
 
 def aggregate_weight_items(
@@ -307,25 +282,3 @@ def get_design_metrics_for_aeroplane(
     return compute_design_metrics(mass_kg, s_ref, cl_max, rho, velocity)
 
 
-def get_mass_sweep_for_aeroplane(
-    db: Session,
-    aeroplane_uuid,
-    masses_kg: list[float],
-    velocity: float,
-    altitude: float,
-) -> MassSweepResponse:
-    """Compute a mass sweep for an aeroplane."""
-    import aerosandbox as asb
-
-    cl_max = get_effective_assumption_value(db, aeroplane_uuid, "cl_max")
-    s_ref = get_s_ref_for_aeroplane(db, aeroplane_uuid)
-    rho = asb.Atmosphere(altitude=altitude).density()
-
-    points = compute_mass_sweep(masses_kg, s_ref, cl_max, rho, velocity)
-    return MassSweepResponse(
-        s_ref=s_ref,
-        cl_max=cl_max,
-        velocity=velocity,
-        altitude=altitude,
-        points=points,
-    )

--- a/app/tests/test_analysis_smoke.py
+++ b/app/tests/test_analysis_smoke.py
@@ -202,23 +202,6 @@ def test_aerobuildup_trim(smoke_plane):
 
 
 @pytest.mark.integration
-@pytest.mark.requires_aerosandbox
-def test_mass_sweep(smoke_plane):
-    client, aeroplane, config = smoke_plane
-    response = client.post(
-        f"/aeroplanes/{aeroplane.uuid}/mass_sweep",
-        json={
-            "masses_kg": [1.0, 1.5, 2.0],
-            "velocity": 15.0,
-            "altitude": 0,
-        },
-    )
-    assert response.status_code == 200, f"{config.name}: {response.text}"
-    data = response.json()
-    assert "points" in data, f"{config.name}: missing 'points'"
-
-
-@pytest.mark.integration
 def test_cg_comparison(smoke_plane):
     client, aeroplane, config = smoke_plane
     response = client.get(f"/aeroplanes/{aeroplane.uuid}/cg_comparison")

--- a/app/tests/test_epic417_integration.py
+++ b/app/tests/test_epic417_integration.py
@@ -186,49 +186,6 @@ def test_stability_analysis_pipeline(client_and_db):
 
 
 # ---------------------------------------------------------------------------
-# Test 5 — Mass Sweep
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.integration
-@pytest.mark.requires_aerosandbox
-def test_mass_sweep(client_and_db):
-    client, SessionLocal = client_and_db
-    session = SessionLocal()
-    try:
-        aeroplane = seed_integration_aeroplane(session)
-        seed_design_assumptions(session, aeroplane.id)
-
-        masses = [0.5, 1.0, 1.5, 2.0, 2.5, 3.0]
-        response = client.post(
-            f"/aeroplanes/{aeroplane.uuid}/mass_sweep",
-            json={
-                "masses_kg": masses,
-                "velocity": 15.0,
-                "altitude": 0.0,
-            },
-        )
-        assert response.status_code == 200, response.text
-        data = response.json()
-
-        points = data["points"]
-        assert len(points) == 6
-
-        stall_speeds = [p["stall_speed_ms"] for p in points]
-        for i in range(1, len(stall_speeds)):
-            assert stall_speeds[i] >= stall_speeds[i - 1]
-
-        cl_margins = [p["cl_margin"] for p in points]
-        for i in range(1, len(cl_margins)):
-            assert cl_margins[i] <= cl_margins[i - 1]
-
-        assert points[0]["cl_margin"] > 0
-        assert points[0]["cl_margin"] > points[-1]["cl_margin"]
-    finally:
-        session.close()
-
-
-# ---------------------------------------------------------------------------
 # Test 6 — CG Comparison
 # ---------------------------------------------------------------------------
 

--- a/app/tests/test_mass_cg_endpoints.py
+++ b/app/tests/test_mass_cg_endpoints.py
@@ -64,63 +64,6 @@ class TestDesignMetricsEndpoint:
 
 
 # ---------------------------------------------------------------------------
-# POST /aeroplanes/{id}/mass_sweep
-# ---------------------------------------------------------------------------
-
-
-class TestMassSweepEndpoint:
-    def test_returns_200(self, client_and_db):
-        client, SessionLocal = client_and_db
-        with SessionLocal() as db:
-            aeroplane = make_aeroplane(db)
-
-        client.post(f"/aeroplanes/{aeroplane.uuid}/assumptions")
-        with patch(
-            "app.services.mass_cg_service.get_s_ref_for_aeroplane",
-            return_value=MOCK_S_REF,
-        ):
-            resp = client.post(
-                f"/aeroplanes/{aeroplane.uuid}/mass_sweep",
-                json={"masses_kg": [1.0, 1.5, 2.0], "velocity": 15.0, "altitude": 0.0},
-            )
-        assert resp.status_code == 200
-        body = resp.json()
-        assert len(body["points"]) == 3
-        assert body["velocity"] == 15.0
-        assert body["s_ref"] == MOCK_S_REF
-
-    def test_404_for_missing_aeroplane(self, client_and_db):
-        client, _ = client_and_db
-        resp = client.post(
-            f"/aeroplanes/{uuid.uuid4()}/mass_sweep",
-            json={"masses_kg": [1.0], "velocity": 15.0, "altitude": 0.0},
-        )
-        assert resp.status_code == 404
-
-    def test_422_for_empty_masses(self, client_and_db):
-        client, SessionLocal = client_and_db
-        with SessionLocal() as db:
-            aeroplane = make_aeroplane(db)
-
-        resp = client.post(
-            f"/aeroplanes/{aeroplane.uuid}/mass_sweep",
-            json={"masses_kg": [], "velocity": 15.0, "altitude": 0.0},
-        )
-        assert resp.status_code == 422
-
-    def test_422_for_negative_mass(self, client_and_db):
-        client, SessionLocal = client_and_db
-        with SessionLocal() as db:
-            aeroplane = make_aeroplane(db)
-
-        resp = client.post(
-            f"/aeroplanes/{aeroplane.uuid}/mass_sweep",
-            json={"masses_kg": [1.0, -0.5], "velocity": 15.0, "altitude": 0.0},
-        )
-        assert resp.status_code == 422
-
-
-# ---------------------------------------------------------------------------
 # GET /aeroplanes/{id}/cg_comparison
 # ---------------------------------------------------------------------------
 

--- a/app/tests/test_mass_cg_service.py
+++ b/app/tests/test_mass_cg_service.py
@@ -154,52 +154,6 @@ class TestComputeDesignMetrics:
 
 
 # ---------------------------------------------------------------------------
-# compute_mass_sweep
-# ---------------------------------------------------------------------------
-
-
-class TestComputeMassSweep:
-    def test_returns_correct_number_of_points(self):
-        masses = [1.0, 1.5, 2.0, 2.5]
-        result = svc.compute_mass_sweep(masses, 0.3, 1.4, SEA_LEVEL_RHO, 15.0)
-        assert len(result) == 4
-
-    def test_wing_loading_increases_with_mass(self):
-        masses = [1.0, 2.0, 3.0]
-        points = svc.compute_mass_sweep(masses, 0.3, 1.4, SEA_LEVEL_RHO, 15.0)
-        loadings = [p.wing_loading_pa for p in points]
-        assert loadings == sorted(loadings)
-
-    def test_stall_speed_increases_with_mass(self):
-        masses = [1.0, 2.0, 3.0]
-        points = svc.compute_mass_sweep(masses, 0.3, 1.4, SEA_LEVEL_RHO, 15.0)
-        speeds = [p.stall_speed_ms for p in points]
-        assert speeds == sorted(speeds)
-
-    def test_cl_margin_decreases_with_mass(self):
-        masses = [1.0, 2.0, 3.0]
-        points = svc.compute_mass_sweep(masses, 0.3, 1.4, SEA_LEVEL_RHO, 15.0)
-        margins = [p.cl_margin for p in points]
-        assert margins == sorted(margins, reverse=True)
-
-    def test_single_mass_point(self):
-        points = svc.compute_mass_sweep([1.5], 0.3, 1.4, SEA_LEVEL_RHO, 15.0)
-        assert len(points) == 1
-        assert points[0].mass_kg == 1.5
-
-    def test_each_point_matches_single_computation(self):
-        """Each sweep point must match a standalone compute_design_metrics call."""
-        masses = [1.0, 1.5, 2.0]
-        points = svc.compute_mass_sweep(masses, 0.3, 1.4, SEA_LEVEL_RHO, 15.0)
-        for pt in points:
-            single = svc.compute_design_metrics(pt.mass_kg, 0.3, 1.4, SEA_LEVEL_RHO, 15.0)
-            assert pt.wing_loading_pa == pytest.approx(single.wing_loading_pa)
-            assert pt.stall_speed_ms == pytest.approx(single.stall_speed_ms)
-            assert pt.required_cl == pytest.approx(single.required_cl)
-            assert pt.cl_margin == pytest.approx(single.cl_margin)
-
-
-# ---------------------------------------------------------------------------
 # aggregate_weight_items
 # ---------------------------------------------------------------------------
 

--- a/docs/md/value-trace.md
+++ b/docs/md/value-trace.md
@@ -21,7 +21,7 @@
 > sowie persistierte Aero/Trim-Resultate (Operating Points, Strip-Forces,
 > Flight-Envelope) ab.
 
-**Inventar:** ~80 distinkte Werte, 26 API-Endpoints, 6 unterschiedliche
+**Inventar:** ~80 distinkte Werte, 25 API-Endpoints, 6 unterschiedliche
 Parametersätze, 2 alternative Solver-Backends (AeroSandbox / AVL).
 
 ---
@@ -79,7 +79,6 @@ flowchart TB
         H_end[useEndurance]
         H_tail[useTailSizing]
         H_mis[useMissionKpis]
-        H_mass[useMassSweep]
     end
 
     subgraph API["FastAPI v2"]
@@ -94,7 +93,6 @@ flowchart TB
         E_mis["GET /mission-kpis"]
         E_op["GET/POST /operating_points"]
         E_trim["POST /operating-points/avl-trim<br/>POST /operating-points/aerobuildup-trim"]
-        E_mass["POST /mass_sweep"]
     end
 
     subgraph SVC["Service-Layer"]
@@ -131,7 +129,6 @@ flowchart TB
     UI_OP    --> H_op   --> E_op   --> C_op
     UI_OP    -.trim trigger.-> E_trim --> S_trim_abu & S_trim_avl
     UI_Polar --> H_ana  --> E_alpha & E_strip & E_stream
-    UI_Mass  --> H_mass --> E_mass
 
     C_ctx --populated by--> S_recompute --> S_polar
     S_recompute --> SLV_ABU
@@ -528,28 +525,7 @@ beim Trainer), Wing-Loading 10–50 N/m², Cruise 10–25 m/s.
 
 ---
 
-## 10. Pfad: Mass Sweep (Matching-Chart)
-
-```mermaid
-flowchart LR
-    classDef geom  fill:#cfe8ff,stroke:#1f6feb,stroke-width:2px
-    classDef polar fill:#ffe0b2,stroke:#ef6c00,stroke-width:2px
-    classDef user  fill:#fff59d,stroke:#f9a825,stroke-width:2px
-
-    UI[MassSweepChart.tsx] --> H[useMassSweep]
-    H --> EP["POST /aeroplanes/{id}/mass_sweep"]
-
-    G[🟦 S_ref]:::geom --> SVC
-    P["🟧 CL_max"]:::polar --> SVC
-    U["🟨 mass range (default 0.5..10 kg),<br/>velocity, altitude"]:::user --> SVC
-
-    EP --> SVC["mass_sweep_service<br/>(parameter sweep over mass)"]
-    SVC --> PTS["points[]:<br/>mass_kg, wing_loading_pa,<br/>stall_speed_ms, cl_margin"]
-```
-
----
-
-## 11. Pfad: Operating-Point-Persistierung & Resolver
+## 10. Pfad: Operating-Point-Persistierung & Resolver
 
 Operating Points sind die einzigen **persistierten** Berechnungsergebnisse
 neben dem ComputationContext. Sie ermöglichen reproducible Visualisierungen
@@ -611,7 +587,7 @@ LIMIT_REACHED | DIRTY`
 
 ---
 
-## 14. Vollständige Endpoint-Übersicht (26 Endpoints)
+## 14. Vollständige Endpoint-Übersicht (25 Endpoints)
 
 ### Computation Context & Assumptions
 1. `GET /aeroplanes/{id}/assumptions/computation-context` — ⭐ Hauptcache
@@ -648,14 +624,11 @@ LIMIT_REACHED | DIRTY`
 22. `POST /aeroplanes/{id}/operating-points/aerobuildup-trim` — ASB-Trim
 23. `POST /aeroplanes/{id}/operating-pointsets/generate-default` — Default OPs
 
-### Mass Sweep & Sizing
-24. `POST /aeroplanes/{id}/mass_sweep` — Matching-Chart
-
 ### Mission Compliance
-25. `GET /aeroplanes/{id}/mission-kpis?missions=...` — 7-Achs-Radar
+24. `GET /aeroplanes/{id}/mission-kpis?missions=...` — 7-Achs-Radar
 
 ### Wings & Geometry
-26. `GET /aeroplanes/{id}/wings/{name}` — Wing-Geometrie inkl. x_secs
+25. `GET /aeroplanes/{id}/wings/{name}` — Wing-Geometrie inkl. x_secs
 
 ---
 
@@ -706,7 +679,6 @@ LIMIT_REACHED | DIRTY`
 - `frontend/components/.../EnduranceCard.tsx`
 - `frontend/components/.../TailVolumeCard.tsx`
 - `frontend/components/.../MissionRadarChart.tsx`
-- `frontend/components/.../MassSweepChart.tsx`
 - `frontend/components/.../OperatingPointsPanel.tsx`
 - `frontend/lib/polar.ts` — derived metrics (k, C_L_md, L/D_max, ρ)
 - `frontend/lib/missionScale.ts` — Spider-Chart-Normalisierung


### PR DESCRIPTION
Follow-up to #893 (frontend Mass Sweep removed). Removes the now-dead backend:
- `mass_sweep_endpoint` (POST /aeroplanes/{id}/mass_sweep) in mass_cg.py
- `MassSweepRequest/Point/Response` schemas
- `compute_mass_sweep` + `get_mass_sweep_for_aeroplane` service fns
- their pytest tests (TestMassSweepEndpoint, TestComputeMassSweep, test_analysis_smoke::test_mass_sweep, test_epic417_integration::test_mass_sweep)
- stale doc/docstring references (value-trace.md, mass_cg_service docstring)

Siblings kept intact (design_metrics, cg_comparison, weight-item sync). Verified: no dangling `mass_sweep`/`MassSweep` refs, `import app.main` OK, `pytest test_mass_cg_endpoints.py test_mass_cg_service.py` → 45 passed.

Closes #894

🤖 Generated with [Claude Code](https://claude.com/claude-code)