### PR TITLE
feat(gh-880): metrics dashboard follow-ups — component-CG, S_HT, CopilotStrip collapse

### DIFF
--- a/frontend/__tests__/CopilotStrip.test.tsx
+++ b/frontend/__tests__/CopilotStrip.test.tsx
@@ -19,6 +19,16 @@ describe("CopilotStrip", () => {
     ).toBeInTheDocument();
   });
 
+  it("toggle button has aria-controls matching the panel id (disclosure pattern)", () => {
+    render(<CopilotStrip />);
+    const toggleBtn = screen.getByRole("button", { name: "Expand copilot panel" });
+    const panel = screen.getByTestId("copilot-panel");
+    // The panel must have an id attribute.
+    expect(panel).toHaveAttribute("id");
+    // aria-controls on the toggle must reference the same id.
+    expect(toggleBtn).toHaveAttribute("aria-controls", panel.getAttribute("id"));
+  });
+
   it("starts collapsed: panel is present in DOM but visually hidden (grid-rows-[0fr])", () => {
     render(<CopilotStrip />);
     // The toggle button has aria-expanded=false initially.

--- a/frontend/__tests__/CopilotStrip.test.tsx
+++ b/frontend/__tests__/CopilotStrip.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect } from "vitest";
+import { CopilotStrip } from "@/components/workbench/CopilotStrip";
+
+describe("CopilotStrip", () => {
+  it("renders the slim bar with 'Ask the copilot…' label", () => {
+    render(<CopilotStrip />);
+    expect(screen.getByText("Ask the copilot…")).toBeInTheDocument();
+  });
+
+  it("renders a Send button in the slim bar and a toggle button", () => {
+    render(<CopilotStrip />);
+    // The slim-bar Send button has aria-label="Send"
+    const sendBtns = screen.getAllByRole("button", { name: "Send" });
+    expect(sendBtns.length).toBeGreaterThanOrEqual(1);
+    expect(
+      screen.getByRole("button", { name: "Expand copilot panel" })
+    ).toBeInTheDocument();
+  });
+
+  it("starts collapsed: panel is present in DOM but visually hidden (grid-rows-[0fr])", () => {
+    render(<CopilotStrip />);
+    // The toggle button has aria-expanded=false initially.
+    const toggleBtn = screen.getByRole("button", { name: "Expand copilot panel" });
+    expect(toggleBtn).toHaveAttribute("aria-expanded", "false");
+
+    // The panel container has the collapsed CSS class.
+    const panel = screen.getByTestId("copilot-panel");
+    const slideWrapper = panel.parentElement?.parentElement;
+    expect(slideWrapper?.className).toContain("grid-rows-[0fr]");
+  });
+
+  it("expands on first click: aria-expanded becomes true and panel is shown", async () => {
+    const user = userEvent.setup();
+    render(<CopilotStrip />);
+
+    const toggleBtn = screen.getByRole("button", { name: "Expand copilot panel" });
+    await user.click(toggleBtn);
+
+    // Button now reports aria-expanded=true and its label switches.
+    expect(
+      screen.getByRole("button", { name: "Collapse copilot panel" })
+    ).toHaveAttribute("aria-expanded", "true");
+
+    // Slide wrapper now has the open CSS class.
+    const panel = screen.getByTestId("copilot-panel");
+    const slideWrapper = panel.parentElement?.parentElement;
+    expect(slideWrapper?.className).toContain("grid-rows-[1fr]");
+  });
+
+  it("collapses again on second click", async () => {
+    const user = userEvent.setup();
+    render(<CopilotStrip />);
+
+    const expandBtn = screen.getByRole("button", { name: "Expand copilot panel" });
+    await user.click(expandBtn);
+
+    const collapseBtn = screen.getByRole("button", { name: "Collapse copilot panel" });
+    await user.click(collapseBtn);
+
+    const toggleBtn = screen.getByRole("button", { name: "Expand copilot panel" });
+    expect(toggleBtn).toHaveAttribute("aria-expanded", "false");
+
+    const panel = screen.getByTestId("copilot-panel");
+    const slideWrapper = panel.parentElement?.parentElement;
+    expect(slideWrapper?.className).toContain("grid-rows-[0fr]");
+  });
+
+  it("shows textarea placeholder and Send button inside expanded panel", async () => {
+    const user = userEvent.setup();
+    render(<CopilotStrip />);
+
+    await user.click(screen.getByRole("button", { name: "Expand copilot panel" }));
+
+    expect(
+      screen.getByPlaceholderText("Ask a design question…")
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/MetricsDashboard.test.tsx
+++ b/frontend/__tests__/MetricsDashboard.test.tsx
@@ -20,7 +20,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import React from "react";
 
 // ---------------------------------------------------------------------------
@@ -767,8 +767,6 @@ describe("MetricsDashboard — gh-889: component-CG fallback in Balance panel", 
     // The geometry tile only renders the SM mini-cell when balance != null.
     // With no CG source, balance=null → the SM cell (which renders an "SM" label
     // and a percentage value) is absent.
-    // Just assert the column renders without crashing.
-    expect(geomCol).not.toBeNull();
     // In tile mode, the SM% cell is absent. The AR value (11.3) still renders.
     expect(geomCol!.textContent).toContain("11.3");
     // smCell-based assertion: query the mini-cell div that only renders when balance != null.
@@ -782,18 +780,40 @@ describe("MetricsDashboard — gh-889: component-CG fallback in Balance panel", 
   });
 
   it("renders the 'calc' badge when balance panel is in component-CG mode", async () => {
+    // Setup: cg_agg_m=null (no aero CG yet) but cg_x assumption is present → cgIsComponent=true.
     setupHooks({
       ctx: { ...NOMINAL_CTX, cg_agg_m: null },
-      assumptions: NOMINAL_ASSUMPTIONS,
+      assumptions: NOMINAL_ASSUMPTIONS, // effective_value=0.122 → cgIsComponent=true
     });
     const { container } = await renderDashboard();
-    // The 'calc' badge is only in the BalancePanel (GeometryLarge → not rendered in
-    // tile mode). Verify at the adapter level that the balance has cgIsComponent=true,
-    // and verify the container renders the geometry column without crashing.
+
+    // The calc badge lives in BalancePanel which is rendered inside GeometryLarge.
+    // GeometryLarge is only mounted when the Geometry column is in "large" mode
+    // (active === "geometry"). Expand the column by clicking it.
     const geomCol = container.querySelector('[data-testid="metric-col-geometry"]');
     expect(geomCol).not.toBeNull();
-    // At minimum: column renders; adapter correctness is verified in metricsAdapters.test.ts.
-    expect(container.querySelector("[data-testid='metrics-band']")).not.toBeNull();
+    fireEvent.click(geomCol!);
+
+    // After clicking, the geometry column is in large mode → GeometryLarge renders
+    // → BalancePanel renders with cgIsComponent=true → calc badge is present.
+    const calcBadge = container.querySelector('[data-testid="balance-cg-calc-badge"]');
+    expect(calcBadge).not.toBeNull();
+    expect(calcBadge!.textContent?.toLowerCase()).toContain("calc");
+  });
+
+  it("does NOT render the 'calc' badge in nominal aero-CG mode", async () => {
+    // Inverse: cg_agg_m is present → cgIsComponent=false → no calc badge.
+    setupHooks({}); // NOMINAL_CTX has cg_agg_m=0.132
+    const { container } = await renderDashboard();
+
+    // Expand the Geometry column to large mode so BalancePanel is rendered.
+    const geomCol = container.querySelector('[data-testid="metric-col-geometry"]');
+    expect(geomCol).not.toBeNull();
+    fireEvent.click(geomCol!);
+
+    // With a real aero CG, BalancePanel renders WITHOUT the calc badge.
+    const calcBadge = container.querySelector('[data-testid="balance-cg-calc-badge"]');
+    expect(calcBadge).toBeNull();
   });
 
   it("nominal path (cg_agg_m present): Balance still rendered, cgIsComponent absent", async () => {

--- a/frontend/__tests__/MetricsDashboard.test.tsx
+++ b/frontend/__tests__/MetricsDashboard.test.tsx
@@ -61,6 +61,11 @@ vi.mock("@/hooks/useEndurance", () => ({
   useEndurance: vi.fn(),
 }));
 
+// gh-889: design assumptions hook (for component CG fallback)
+vi.mock("@/hooks/useDesignAssumptions", () => ({
+  useDesignAssumptions: vi.fn(),
+}));
+
 // ---------------------------------------------------------------------------
 // Lazy imports (after mock hoisting)
 // ---------------------------------------------------------------------------
@@ -71,6 +76,7 @@ import type { ComputationContext } from "@/hooks/useComputationContext";
 import { useTailSizing } from "@/hooks/useTailSizing";
 import type { TailSizingResult } from "@/hooks/useTailSizing";
 import { useEndurance } from "@/hooks/useEndurance";
+import { useDesignAssumptions } from "@/hooks/useDesignAssumptions";
 
 // ---------------------------------------------------------------------------
 // Shared fixtures
@@ -181,7 +187,28 @@ const NOMINAL_ENDURANCE = {
   warnings: [],
 };
 
-/** Set up all three hooks to return the given ctx, tail, and endurance data. */
+// Default assumptions payload with a cg_x assumption.
+const NOMINAL_ASSUMPTIONS = {
+  assumptions: [
+    {
+      id: 1,
+      parameter_name: "cg_x" as const,
+      estimate_value: 0.120,
+      calculated_value: 0.122,
+      calculated_source: "component_tree",
+      active_source: "CALCULATED" as const,
+      effective_value: 0.122,
+      divergence_pct: null,
+      divergence_level: "none" as const,
+      unit: "m",
+      is_design_choice: false,
+      updated_at: "2026-01-01T00:00:00Z",
+    },
+  ],
+  warnings_count: 0,
+};
+
+/** Set up all four hooks to return the given ctx, tail, endurance, and assumptions data. */
 function setupHooks(opts: {
   aeroplaneId?: string | null;
   ctx?: typeof NOMINAL_CTX | null;
@@ -190,6 +217,8 @@ function setupHooks(opts: {
   tailLoading?: boolean;
   endurance?: typeof NOMINAL_ENDURANCE | null;
   enduranceLoading?: boolean;
+  assumptions?: typeof NOMINAL_ASSUMPTIONS | null;
+  assumptionsLoading?: boolean;
 }) {
   const {
     aeroplaneId = "42",
@@ -199,6 +228,8 @@ function setupHooks(opts: {
     tailLoading = false,
     endurance = NOMINAL_ENDURANCE,
     enduranceLoading = false,
+    assumptions = NOMINAL_ASSUMPTIONS,
+    assumptionsLoading = false,
   } = opts;
 
   (useAeroplaneContext as ReturnType<typeof vi.fn>).mockReturnValue({
@@ -218,6 +249,16 @@ function setupHooks(opts: {
     data: endurance,
     isLoading: enduranceLoading,
     error: null,
+  });
+  (useDesignAssumptions as ReturnType<typeof vi.fn>).mockReturnValue({
+    data: assumptions,
+    isLoading: assumptionsLoading,
+    error: null,
+    seedDefaults: vi.fn(),
+    updateEstimate: vi.fn(),
+    switchSource: vi.fn(),
+    mutate: vi.fn(),
+    isRecomputing: false,
   });
 }
 
@@ -691,5 +732,78 @@ describe("MetricsDashboard — loading state", () => {
     const { container } = await renderDashboard();
     // SpeedTile and other tiles fall back to "Loading…" via <Placeholder loading>.
     expect(container.textContent).toMatch(/Loading/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 12. gh-889: component-CG fallback in Balance panel
+// ---------------------------------------------------------------------------
+
+describe("MetricsDashboard — gh-889: component-CG fallback in Balance panel", () => {
+  it("renders Balance panel (SM value) when cg_agg_m is null but cg_x assumption is available", async () => {
+    // cg_agg_m null → no aerodynamic CG yet; but cg_x=0.122 m is the design CG.
+    setupHooks({
+      ctx: { ...NOMINAL_CTX, cg_agg_m: null },
+      assumptions: NOMINAL_ASSUMPTIONS, // effective_value = 0.122
+    });
+    const { container } = await renderDashboard();
+    const geomCol = container.querySelector('[data-testid="metric-col-geometry"]');
+    expect(geomCol).not.toBeNull();
+    // The geometry tile shows SM% computed from component CG.
+    // (x_np_m=0.143, cg=0.122, mac=0.135) → SM = (0.143-0.122)/0.135*100 ≈ 15.6%
+    // The SM mini-cell renders the SM value with a % sign.
+    // Use includes() to avoid a regex that sonarjs flags as potentially slow.
+    expect(geomCol!.textContent).toContain("%");
+  });
+
+  it("shows 'No balance data' when cg_agg_m is null AND no cg_x assumption is available", async () => {
+    setupHooks({
+      ctx: { ...NOMINAL_CTX, cg_agg_m: null },
+      assumptions: { assumptions: [], warnings_count: 0 }, // no cg_x assumption
+    });
+    const { container } = await renderDashboard();
+    const geomCol = container.querySelector('[data-testid="metric-col-geometry"]');
+    expect(geomCol).not.toBeNull();
+    // The geometry tile only renders the SM mini-cell when balance != null.
+    // With no CG source, balance=null → the SM cell (which renders an "SM" label
+    // and a percentage value) is absent.
+    // Just assert the column renders without crashing.
+    expect(geomCol).not.toBeNull();
+    // In tile mode, the SM% cell is absent. The AR value (11.3) still renders.
+    expect(geomCol!.textContent).toContain("11.3");
+    // smCell-based assertion: query the mini-cell div that only renders when balance != null.
+    // That div has a "SM" uppercase label and a % value. When balance=null it's gone.
+    const smDivs = Array.from(geomCol!.querySelectorAll("div")).filter(
+      (el) => el.textContent?.trim() === "SM",
+    );
+    // The uppercase "SM" label in the geometry tile is only present when balance != null.
+    // (The geometry tile uses renderSymbol("SM") → "SM" with no subscript.)
+    expect(smDivs.length).toBe(0);
+  });
+
+  it("renders the 'calc' badge when balance panel is in component-CG mode", async () => {
+    setupHooks({
+      ctx: { ...NOMINAL_CTX, cg_agg_m: null },
+      assumptions: NOMINAL_ASSUMPTIONS,
+    });
+    const { container } = await renderDashboard();
+    // The 'calc' badge is only in the BalancePanel (GeometryLarge → not rendered in
+    // tile mode). Verify at the adapter level that the balance has cgIsComponent=true,
+    // and verify the container renders the geometry column without crashing.
+    const geomCol = container.querySelector('[data-testid="metric-col-geometry"]');
+    expect(geomCol).not.toBeNull();
+    // At minimum: column renders; adapter correctness is verified in metricsAdapters.test.ts.
+    expect(container.querySelector("[data-testid='metrics-band']")).not.toBeNull();
+  });
+
+  it("nominal path (cg_agg_m present): Balance still rendered, cgIsComponent absent", async () => {
+    // Regression guard: existing nominal behaviour must not break.
+    setupHooks({});  // NOMINAL_CTX has cg_agg_m=0.132
+    const { container } = await renderDashboard();
+    const geomCol = container.querySelector('[data-testid="metric-col-geometry"]');
+    expect(geomCol).not.toBeNull();
+    // With a valid aero CG (cg_agg_m=0.132), balance != null → SM mini-cell renders.
+    // The SM% value must appear in the geometry column. Use toContain("%").
+    expect(geomCol!.textContent).toContain("%");
   });
 });

--- a/frontend/__tests__/metricsAdapters.test.ts
+++ b/frontend/__tests__/metricsAdapters.test.ts
@@ -144,6 +144,13 @@ const NOMINAL_TAIL: TailSizingResult = {
   warnings: [],
 };
 
+// NOMINAL_TAIL has s_h_recommended_mm2: null (tests that item is conditional).
+// TAIL_WITH_S_HT provides a realistic 80 000 mm² recommended area (= 8.0 dm²).
+const TAIL_WITH_S_HT: TailSizingResult = {
+  ...NOMINAL_TAIL,
+  s_h_recommended_mm2: 80_000,
+};
+
 const NOT_APPLICABLE_TAIL: TailSizingResult = {
   ...NOMINAL_TAIL,
   v_h_current: null,
@@ -620,6 +627,45 @@ describe("toTail", () => {
     const result = toTail(NOMINAL_TAIL, NOMINAL_CTX)!;
     expect(typeof result.bandsNote).toBe("string");
     expect(result.bandsNote.length).toBeGreaterThan(10);
+  });
+
+  // gh-890: S_HT recommended area
+  it("S_HT item is present when s_h_recommended_mm2 is provided", () => {
+    const result = toTail(TAIL_WITH_S_HT, NOMINAL_CTX)!;
+    const shtItem = result.items.find((i) => i.symbol === "S_HT");
+    expect(shtItem).toBeDefined();
+  });
+
+  it("S_HT value is s_h_recommended_mm2 converted to dm² (÷ 10 000), 1 dp", () => {
+    const result = toTail(TAIL_WITH_S_HT, NOMINAL_CTX)!;
+    const shtItem = result.items.find((i) => i.symbol === "S_HT")!;
+    // 80 000 mm² ÷ 10 000 = 8.0 dm²
+    expect(shtItem.value).toBe("8.0");
+    expect(shtItem.unit).toBe("dm²");
+  });
+
+  it("S_HT label contains 'rec.' to distinguish recommended from current", () => {
+    const result = toTail(TAIL_WITH_S_HT, NOMINAL_CTX)!;
+    const shtItem = result.items.find((i) => i.symbol === "S_HT")!;
+    expect(shtItem.label).toMatch(/rec\./i);
+  });
+
+  it("S_HT description contains formula reference", () => {
+    const result = toTail(TAIL_WITH_S_HT, NOMINAL_CTX)!;
+    const shtItem = result.items.find((i) => i.symbol === "S_HT")!;
+    expect(shtItem.description).toMatch(/V_H/);
+  });
+
+  it("S_HT item is absent when s_h_recommended_mm2 is null", () => {
+    // NOMINAL_TAIL has s_h_recommended_mm2: null
+    const result = toTail(NOMINAL_TAIL, NOMINAL_CTX)!;
+    const shtItem = result.items.find((i) => i.symbol === "S_HT");
+    expect(shtItem).toBeUndefined();
+  });
+
+  it("S_HT item is absent when classification is not_applicable", () => {
+    // classification=not_applicable causes toTail to return null entirely
+    expect(toTail(NOT_APPLICABLE_TAIL, NOMINAL_CTX)).toBeNull();
   });
 });
 

--- a/frontend/__tests__/metricsAdapters.test.ts
+++ b/frontend/__tests__/metricsAdapters.test.ts
@@ -349,6 +349,61 @@ describe("toBalanceData", () => {
     const result = toBalanceData(NOMINAL_CTX)!;
     expect(result.cgComponent).toBeUndefined();
   });
+
+  // gh-889: component-CG fallback scenarios
+  it("returns null when NEITHER cg_agg_m nor cgComponent is available", () => {
+    const ctx: ComputationContext = { ...NOMINAL_CTX, cg_agg_m: null };
+    expect(toBalanceData(ctx, undefined)).toBeNull();
+    expect(toBalanceData(ctx)).toBeNull();
+  });
+
+  it("returns BalanceData flagged cgIsComponent=true when cg_agg_m is null but cgComponent is provided", () => {
+    const ctx: ComputationContext = { ...NOMINAL_CTX, cg_agg_m: null };
+    const result = toBalanceData(ctx, 0.120);
+    expect(result).not.toBeNull();
+    expect(result!.cgIsComponent).toBe(true);
+    // The primary CG should be the component value
+    expect(result!.cg).toBeCloseTo(0.120);
+    // No cross-check when component CG is primary
+    expect(result!.cgComponent).toBeUndefined();
+    // SM is computed from the component CG
+    const expectedSm = ((NOMINAL_CTX.x_np_m - 0.120) / NOMINAL_CTX.mac_m) * 100;
+    expect(result!.smPercent).toBeCloseTo(expectedSm, 2);
+  });
+
+  it("cgIsComponent is omitted (undefined) when aero CG is used", () => {
+    const result = toBalanceData(NOMINAL_CTX, 0.129)!;
+    // cgIsComponent should be falsy when using the real aero CG
+    expect(result.cgIsComponent).toBeFalsy();
+  });
+
+  it("cgDivergencePct is computed when BOTH cg_agg_m and cgComponent are present", () => {
+    // cg_agg_m=0.132, cgComponent=0.129, mac=0.135
+    const result = toBalanceData(NOMINAL_CTX, 0.129)!;
+    const expectedDivPct = (Math.abs(0.132 - 0.129) / 0.135) * 100;
+    expect(result.cgDivergencePct).toBeCloseTo(expectedDivPct, 2);
+  });
+
+  it("cgDivergencePct is undefined when only aero CG is present (no cross-check)", () => {
+    const result = toBalanceData(NOMINAL_CTX)!;
+    expect(result.cgDivergencePct).toBeUndefined();
+  });
+
+  it("cgDivergencePct is undefined when only component CG is used (no aero CG to diverge from)", () => {
+    const ctx: ComputationContext = { ...NOMINAL_CTX, cg_agg_m: null };
+    const result = toBalanceData(ctx, 0.120)!;
+    expect(result.cgDivergencePct).toBeUndefined();
+  });
+
+  it("component-CG fallback: NP, mac, target SM are still taken from ctx", () => {
+    const ctx: ComputationContext = { ...NOMINAL_CTX, cg_agg_m: null };
+    const result = toBalanceData(ctx, 0.120)!;
+    expect(result.np).toBeCloseTo(NOMINAL_CTX.x_np_m);
+    expect(result.macLength).toBeCloseTo(NOMINAL_CTX.mac_m);
+    const targetPct = NOMINAL_CTX.target_static_margin * 100;
+    expect(result.targetSmMin).toBeLessThan(targetPct);
+    expect(result.targetSmMax).toBeGreaterThan(targetPct);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/components/workbench/CopilotStrip.tsx
+++ b/frontend/components/workbench/CopilotStrip.tsx
@@ -23,6 +23,7 @@ export function CopilotStrip() {
           type="button"
           onClick={() => setOpen((v) => !v)}
           aria-expanded={open}
+          aria-controls="copilot-panel"
           aria-label={open ? "Collapse copilot panel" : "Expand copilot panel"}
           className="flex h-7 w-7 items-center justify-center rounded-xl border border-border bg-card-muted hover:bg-sidebar-accent"
         >
@@ -42,6 +43,7 @@ export function CopilotStrip() {
       >
         <div className="min-h-0 overflow-hidden">
           <div
+            id="copilot-panel"
             data-testid="copilot-panel"
             className="flex flex-col gap-3 px-6 pb-4 pt-2"
           >

--- a/frontend/components/workbench/CopilotStrip.tsx
+++ b/frontend/components/workbench/CopilotStrip.tsx
@@ -1,20 +1,70 @@
 "use client";
 
-import { Send, ChevronUp } from "lucide-react";
+import { useState } from "react";
+import { Send, ChevronUp, ChevronDown } from "lucide-react";
 
 export function CopilotStrip() {
+  const [open, setOpen] = useState(false);
+
   return (
-    <footer className="flex h-10 shrink-0 items-center gap-3 border-t border-border bg-sidebar px-6">
-      <span className="text-[13px] text-subtle-foreground">
-        Ask the copilot…
-      </span>
-      <div className="flex-1" />
-      <button className="flex h-7 w-7 items-center justify-center rounded-xl border border-border bg-card-muted hover:bg-sidebar-accent">
-        <Send size={14} className="text-muted-foreground" />
-      </button>
-      <button className="flex h-7 w-7 items-center justify-center rounded-xl border border-border bg-card-muted hover:bg-sidebar-accent">
-        <ChevronUp size={14} className="text-muted-foreground" />
-      </button>
+    <footer className="shrink-0 border-t border-border bg-sidebar">
+      {/* Slim handle bar — always visible */}
+      <div className="flex h-10 items-center gap-3 px-6">
+        <span className="text-[13px] text-subtle-foreground">Ask the copilot…</span>
+        <div className="flex-1" />
+        <button
+          type="button"
+          className="flex h-7 w-7 items-center justify-center rounded-xl border border-border bg-card-muted hover:bg-sidebar-accent"
+          aria-label="Send"
+        >
+          <Send size={14} className="text-muted-foreground" />
+        </button>
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+          aria-label={open ? "Collapse copilot panel" : "Expand copilot panel"}
+          className="flex h-7 w-7 items-center justify-center rounded-xl border border-border bg-card-muted hover:bg-sidebar-accent"
+        >
+          {open ? (
+            <ChevronDown size={14} className="text-muted-foreground" />
+          ) : (
+            <ChevronUp size={14} className="text-muted-foreground" />
+          )}
+        </button>
+      </div>
+
+      {/* Collapsible panel — slides open/closed via the grid-rows trick */}
+      <div
+        className={`grid transition-[grid-template-rows] duration-300 ease-out ${
+          open ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+        }`}
+      >
+        <div className="min-h-0 overflow-hidden">
+          <div
+            data-testid="copilot-panel"
+            className="flex flex-col gap-3 px-6 pb-4 pt-2"
+          >
+            <textarea
+              className="w-full resize-none rounded-lg border border-border bg-card px-3 py-2 text-[13px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+              rows={4}
+              placeholder="Ask a design question…"
+            />
+            <div className="flex items-center justify-between">
+              <span className="text-[11px] text-muted-foreground">
+                Copilot is in preview — responses are not yet connected to the backend.
+              </span>
+              <button
+                type="button"
+                className="flex items-center gap-1.5 rounded-lg border border-border bg-card-muted px-3 py-1.5 text-[12px] text-foreground hover:bg-sidebar-accent"
+              >
+                <Send size={12} />
+                Send
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
     </footer>
   );
 }

--- a/frontend/components/workbench/metrics-dashboard/MetricsDashboard.tsx
+++ b/frontend/components/workbench/metrics-dashboard/MetricsDashboard.tsx
@@ -172,16 +172,68 @@ function BalancePanel({ balance, loading }: { readonly balance: BalanceData | nu
   const smInTarget = balance.smPercent >= balance.targetSmMin && balance.smPercent <= balance.targetSmMax;
   const smStr = `${balance.smPercent.toFixed(1)}%`;
   const targetRange = `${balance.targetSmMin.toFixed(0)}–${balance.targetSmMax.toFixed(0)}`;
+
+  // gh-889: when the CG is component-derived (not yet aerodynamically balanced),
+  // show a muted "calc" badge and a tooltip explaining the source.
+  const isComponentCg = !!balance.cgIsComponent;
+
+  // Divergence warning between aero CG and component CG.
+  const divPct = balance.cgDivergencePct;
+  let divColor: string | null = null;
+  if (divPct != null) {
+    if (divPct < 5) {
+      divColor = "text-emerald-400";
+    } else if (divPct <= 15) {
+      divColor = "text-amber-400";
+    } else {
+      divColor = "text-destructive";
+    }
+  }
+
   return (
     <>
-      <div className="group/m relative" tabIndex={0}>
+      <div className="group/m relative" tabIndex={0} data-testid="balance-panel-row">
         SM{" "}
         <span className={smInTargetClass(smInTarget)}>{smStr}</span>
-        {" · "}CG {balance.cg.toFixed(3)} m{" · "}NP {balance.np.toFixed(3)} m
-        <Tip>Static margin = (NP − CG) / MAC. CG must sit ahead of the neutral point. Target {targetRange}% MAC.</Tip>
+        {" · "}
+        {isComponentCg ? (
+          <>
+            CG{" "}
+            <span className="text-muted-foreground" data-testid="balance-cg-component">
+              {balance.cg.toFixed(3)} m
+            </span>
+            {" "}
+            <span
+              className="rounded bg-muted px-0.5 py-px text-[9px] uppercase tracking-wide text-muted-foreground"
+              data-testid="balance-cg-calc-badge"
+            >
+              calc
+            </span>
+          </>
+        ) : (
+          <>CG {balance.cg.toFixed(3)} m</>
+        )}
+        {" · "}NP {balance.np.toFixed(3)} m
+        <Tip>
+          {isComponentCg
+            ? "CG shown is the component/calculated design CG (cg_x assumption). Run an aerodynamic analysis to get the VLM-balanced CG."
+            : "Static margin = (NP − CG) / MAC. CG must sit ahead of the neutral point."}
+          {" "}Target {targetRange}% MAC.
+        </Tip>
       </div>
       <p className="text-[10px] text-subtle-foreground">
-        {balance.cgComponent != null && `Component CG ${balance.cgComponent.toFixed(3)} m · `}
+        {!isComponentCg && balance.cgComponent != null && (
+          <>
+            Component CG{" "}
+            {divColor != null ? (
+              <span className={divColor}>{balance.cgComponent.toFixed(3)} m</span>
+            ) : (
+              `${balance.cgComponent.toFixed(3)} m`
+            )}
+            {divPct != null && ` (Δ ${divPct.toFixed(1)}% MAC)`}
+            {" · "}
+          </>
+        )}
         target SM {targetRange}% MAC
       </p>
     </>

--- a/frontend/components/workbench/metrics-dashboard/MetricsDashboardContainer.tsx
+++ b/frontend/components/workbench/metrics-dashboard/MetricsDashboardContainer.tsx
@@ -10,6 +10,7 @@ import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
 import { useComputationContext } from "@/hooks/useComputationContext";
 import { useTailSizing } from "@/hooks/useTailSizing";
 import { useEndurance } from "@/hooks/useEndurance";
+import { useDesignAssumptions } from "@/hooks/useDesignAssumptions";
 import {
   toSpeedData,
   toGeometryItems,
@@ -28,6 +29,9 @@ export function MetricsDashboardContainer() {
   const { data: ctx, isLoading: ctxLoading } = useComputationContext(aeroplaneId);
   const { data: tailSizing, isLoading: tailLoading } = useTailSizing(aeroplaneId);
   const { data: endurance, isLoading: enduranceLoading } = useEndurance(aeroplaneId);
+  // gh-889: fetch design assumptions to get the component/calculated CG (cg_x)
+  // as a fallback when cg_agg_m is null (i.e., not yet aerodynamically balanced).
+  const { data: assumptionsData, isLoading: assumptionsLoading } = useDesignAssumptions(aeroplaneId);
 
   // No aeroplane selected → render empty state
   if (!aeroplaneId) {
@@ -43,12 +47,21 @@ export function MetricsDashboardContainer() {
     />;
   }
 
-  const loading = ctxLoading || tailLoading || enduranceLoading;
+  const loading = ctxLoading || tailLoading || enduranceLoading || assumptionsLoading;
+
+  // gh-889: derive component/calculated CG from design assumptions (same pattern
+  // as analysis/page.tsx derives designCgX).  This is the cg_x assumption's
+  // effective_value (metres), which may be either a user estimate or a value
+  // calculated from the component tree.
+  const cgComponentM =
+    assumptionsData?.assumptions.find((a) => a.parameter_name === "cg_x")
+      ?.effective_value ?? undefined;
 
   // Adapter calls — pure transforms, safe to call with null inputs
   const speed = toSpeedData(ctx);
   const geometryItems = toGeometryItems(ctx);
-  const balance = toBalanceData(ctx);
+  // Pass cgComponentM as the fallback CG for when cg_agg_m is null.
+  const balance = toBalanceData(ctx, cgComponentM);
 
   // Quality gauges: base from ctx, then append P_margin from endurance
   const baseGauges = toQualityGauges(ctx);

--- a/frontend/components/workbench/metrics-dashboard/metricsTypes.ts
+++ b/frontend/components/workbench/metrics-dashboard/metricsTypes.ts
@@ -29,6 +29,18 @@ export interface BalanceData {
   readonly targetSmMin: number;
   readonly targetSmMax: number;
   readonly cgComponent?: number; // component-derived CG, m
+  /**
+   * True when `cg` is the component/calculated CG (cg_x design assumption)
+   * rather than the aerodynamic aggregated CG from the VLM run.
+   * When false (default), `cg` is the aero CG and `cgComponent` (if set)
+   * is the cross-check value.
+   */
+  readonly cgIsComponent?: boolean;
+  /**
+   * CG divergence level between component CG and aero CG, as % of MAC.
+   * Only set when BOTH cg_agg_m and cgComponent are available.
+   */
+  readonly cgDivergencePct?: number;
 }
 
 export interface GaugeZone {

--- a/frontend/lib/metricsAdapters.ts
+++ b/frontend/lib/metricsAdapters.ts
@@ -627,7 +627,9 @@ export function toTail(
       unit: "dm²",
       description:
         "Recommended horizontal-tail area derived from V_H target (mid-band) × S_W × MAC / l_HT. " +
-        "Source: tail-sizing service using the RC rule-of-thumb V_H band for the detected aircraft class.",
+        "Source: tail-sizing service using the RC rule-of-thumb V_H band for the detected aircraft class. " +
+        "This is the TARGET area at the V_H midpoint — the current S_HT is not shown separately here. " +
+        "Whether your actual H-tail area meets this target is indicated by the V_H coefficient gauge above.",
     });
   }
 

--- a/frontend/lib/metricsAdapters.ts
+++ b/frontend/lib/metricsAdapters.ts
@@ -176,20 +176,40 @@ export function toGeometryItems(
 
 /**
  * Map ctx stability fields to the BalanceData shape consumed by MacCgDiagram /
- * PlanformDiagram. Returns null when cg_agg_m is absent (design not balanced).
+ * PlanformDiagram.
  *
- * @param cgComponent optional component-derived CG from the tree (metres)
+ * Fallback behaviour (gh-889):
+ *   - When `ctx.cg_agg_m` is present → use it as the primary CG (aero CG).
+ *     `cgComponent` (if provided) is stored as the cross-check value and
+ *     `cgDivergencePct` is computed from the difference.
+ *   - When `ctx.cg_agg_m` is null but `cgComponent` is available → use the
+ *     component/calculated CG as the primary CG and set `cgIsComponent=true`.
+ *     The dashboard MUST render but with a "calculated CG" marker so the user
+ *     knows it is not aerodynamically balanced yet.
+ *   - When NEITHER is available → return null (no balance data at all).
+ *
+ * @param cgComponent optional component/calculated CG from the design assumptions
+ *                    (the `cg_x` assumption's effective_value, in metres)
  */
 export function toBalanceData(
   ctx: ComputationContext | null | undefined,
   cgComponent?: number,
 ): BalanceData | null {
   if (ctx == null) return null;
-  if (ctx.cg_agg_m == null) return null;
 
-  const cg = ctx.cg_agg_m;
+  const hasAeroCg = ctx.cg_agg_m != null;
+  const hasComponentCg = cgComponent != null && Number.isFinite(cgComponent);
+
+  // Guard: need at least one CG source.
+  if (!hasAeroCg && !hasComponentCg) return null;
+
   const np = ctx.x_np_m;
   const mac = ctx.mac_m;
+
+  // Primary CG selection.
+  const cg = hasAeroCg ? (ctx.cg_agg_m as number) : (cgComponent as number);
+  const cgIsComponent = !hasAeroCg;
+
   const smPercent = ((np - cg) / mac) * 100;
 
   // Build a target SM range centred on target_static_margin.
@@ -201,13 +221,18 @@ export function toBalanceData(
   const targetSmMin = Math.max(0, targetPct - halfBand);
   const targetSmMax = targetPct + halfBand;
 
-  // macStart: place MAC so that cg_agg_m is at smPercent along it.
-  // We know: (np - cg) / mac = smPercent/100 → already consistent.
-  // The MAC leading-edge position: macStart = cg - (smPercent/100 - SM_LE_fraction)*mac.
-  // We don't have the LE fraction from the API, so use a reasonable approximation:
+  // macStart: place MAC so that the CG is at smPercent along it.
+  // We don't have the LE fraction from the API, so approximate:
   // place the CG at 30% of MAC from the LE, consistent with typical aircraft.
   const cgFracInMac = 0.30;
   const macStart = cg - cgFracInMac * mac;
+
+  // Divergence between aero CG and component CG (% MAC) — only meaningful
+  // when both are present.
+  const cgDivergencePct =
+    hasAeroCg && hasComponentCg
+      ? (Math.abs((ctx.cg_agg_m as number) - (cgComponent as number)) / mac) * 100
+      : undefined;
 
   return {
     cg,
@@ -217,7 +242,11 @@ export function toBalanceData(
     smPercent,
     targetSmMin,
     targetSmMax,
-    cgComponent,
+    // Cross-check value: when aero CG is primary, pass cgComponent as cross-check;
+    // when component CG is primary (cgIsComponent), there is no separate cross-check.
+    cgComponent: hasAeroCg ? cgComponent : undefined,
+    cgIsComponent: cgIsComponent || undefined, // omit false to keep the type tidy
+    cgDivergencePct,
   };
 }
 

--- a/frontend/lib/metricsAdapters.ts
+++ b/frontend/lib/metricsAdapters.ts
@@ -615,6 +615,22 @@ export function toTail(
     });
   }
 
+  // S_HT recommended — convert mm² → dm² (÷ 10 000) for a human-readable scale.
+  // At typical RC sizes (S_W ~0.1–1 m²), the recommended HT area is 10 000–150 000 mm²
+  // which reads as 1–15 dm². cm² would give 100–1 500, which is noisier to scan.
+  if (tailSizing.s_h_recommended_mm2 != null) {
+    const s_ht_dm2 = tailSizing.s_h_recommended_mm2 / 10_000;
+    items.push({
+      symbol: "S_HT",
+      label: "H-tail area (rec.)",
+      value: s_ht_dm2.toFixed(1),
+      unit: "dm²",
+      description:
+        "Recommended horizontal-tail area derived from V_H target (mid-band) × S_W × MAC / l_HT. " +
+        "Source: tail-sizing service using the RC rule-of-thumb V_H band for the detected aircraft class.",
+    });
+  }
+
   const bandsNote =
     "V_H target band depends on aircraft type: trainer 0.60–0.70, sport 0.50–0.60, aerobatic 0.45–0.55, glider ~0.45–0.60. RC rule of thumb (rcplanedesigner / Lennon) — defer to Scholz for UAV / full-scale.";
 


### PR DESCRIPTION
Closes the remaining #880 sub-tickets (epic can close after this).

- **#889** — wire the component/calculated CG (cg_x assumption) into the Geometry→Balance panel so SM/CG render even when the aerodynamic `cg_agg_m` is null (the smoke-test 'No balance data' gap). Component-derived CG is flagged with a 'calc' badge + tooltip (divergence-aware); no fabrication when neither CG exists.
- **#890** — add S_HT (recommended H-tail area at the V_H target midpoint) to the tail-sizing block, clearly labelled '(rec.)' with a tooltip clarifying current-vs-recommended (V_H gauge shows current sizing status); hidden when tail is not_applicable.
- **#891** — give the real `CopilotStrip` the same collapse-drawer pattern as the metrics band (chevron toggle, grid-rows slide, aria-expanded/aria-controls disclosure).

Verified (Node 22): tsc clean, ESLint --max-warnings=0 clean, vitest 146 files / 1670 tests green. Review-found assertion-free calc-badge test was strengthened to actually assert the badge (+ inverse).

Closes #889
Closes #890
Closes #891

🤖 Generated with [Claude Code](https://claude.com/claude-code)