### PR TITLE
fix(gh-910): switch active aeroplane on branch ops; snapshot root_id; clearer is_main

### DIFF
--- a/app/services/aeroplane_version_service.py
+++ b/app/services/aeroplane_version_service.py
@@ -140,6 +140,11 @@ def snapshot(
     head = _get_node(db, node_id)
     _guard_immutable(head)
 
+    # Resolve the lineage root: if the head IS the root its root_id may be NULL
+    # or equal to its own id.  Either way the snapshot must carry the correct
+    # root_id so it remains findable by list_tree.
+    resolved_root_id = head.root_id if head.root_id is not None else head.id
+
     # Clone the current head into an immutable copy that becomes the predecessor.
     snapshot_node = clone_aeroplane_subgraph(
         db,
@@ -147,7 +152,7 @@ def snapshot(
         immutable=True,
         branch_id=head.branch_id,
         predecessor_id=head.predecessor_id,  # inherits head's old predecessor
-        root_id=head.root_id,
+        root_id=resolved_root_id,
     )
 
     # Set version metadata on the snapshot.

--- a/app/tests/test_aeroplane_version_service.py
+++ b/app/tests/test_aeroplane_version_service.py
@@ -162,6 +162,71 @@ def test_snapshot_not_found_raises(db: Session):
         snapshot(db, 99999, label="nope")
 
 
+def test_snapshot_root_id_is_set(db: Session):
+    """Snapshot node must carry the correct root_id (gh-910).
+
+    Before the fix, ``snapshot()`` passed ``head.root_id`` directly to the
+    clone — which is NULL on the lineage root itself — resulting in the snapshot
+    node having ``root_id=NULL``.  The fix resolves it to ``head.id`` when
+    ``head.root_id`` is NULL.
+    """
+    head, branch = _make_root(db, "root-id-test")
+
+    # Verify the fixture: root node has root_id == its own id (set by _make_root).
+    assert head.root_id == head.id
+
+    snap = snapshot(db, head.id, label="v1")
+    db.commit()
+
+    # The snapshot must inherit the root_id, not carry NULL.
+    assert snap.root_id is not None, (
+        "Snapshot node must NOT have root_id=NULL (gh-910)"
+    )
+    assert snap.root_id == head.root_id, (
+        f"Snapshot root_id={snap.root_id} must equal head.root_id={head.root_id}"
+    )
+
+
+def test_snapshot_root_id_is_set_when_head_root_id_is_none(db: Session):
+    """Snapshot root_id is correctly set even if head.root_id is NULL.
+
+    Simulates a legacy or improperly-backfilled node where root_id was not set.
+    The service must fall back to head.id.
+    """
+    # Manually create a node WITHOUT setting root_id (simulates pre-backfill state).
+    node = AeroplaneModel(
+        uuid=__import__("uuid").uuid4(),
+        name="no-root-id",
+        is_immutable=False,
+        root_id=None,  # intentionally NULL
+    )
+    db.add(node)
+    db.flush()
+
+    branch = BranchModel(
+        root_id=node.id,
+        head_id=node.id,
+        name="main",
+        is_main=True,
+        created_by="human",
+    )
+    db.add(branch)
+    db.flush()
+    node.branch_id = branch.id
+    db.commit()
+
+    snap = snapshot(db, node.id, label="fallback-root")
+    db.commit()
+
+    assert snap.root_id is not None, (
+        "Snapshot must NOT inherit NULL root_id — should fall back to head.id"
+    )
+    assert snap.root_id == node.id, (
+        f"Snapshot root_id={snap.root_id} must equal head.id={node.id} when "
+        "head.root_id is NULL"
+    )
+
+
 # ---------------------------------------------------------------------------
 # 2. create_branch
 # ---------------------------------------------------------------------------

--- a/frontend/__tests__/VersionHistoryPanel.test.tsx
+++ b/frontend/__tests__/VersionHistoryPanel.test.tsx
@@ -159,8 +159,10 @@ function renderPanel(overrides: {
   rootId?: number | null;
   currentHeadId?: number | null;
   aeroplaneId?: number | null;
-  treeOverride?: Partial<{ tree: TreeOut | undefined; isLoading: boolean; error: Error | undefined }>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  treeOverride?: Partial<{ tree: TreeOut | undefined; isLoading: boolean; error: Error | undefined; mutate: any }>;
   actionsOverride?: Partial<typeof DEFAULT_ACTIONS>;
+  onSwitchAeroplane?: (uuid: string) => void;
 } = {}) {
   const {
     rootId = 10,
@@ -168,13 +170,14 @@ function renderPanel(overrides: {
     aeroplaneId = 10,
     treeOverride = {},
     actionsOverride = {},
+    onSwitchAeroplane,
   } = overrides;
 
   mockUseLineageTree.mockReturnValue({
     tree: FAKE_TREE,
     isLoading: false,
     error: undefined,
-    mutate: vi.fn().mockResolvedValue(undefined),
+    mutate: vi.fn().mockResolvedValue(FAKE_TREE),
     ...treeOverride,
   });
 
@@ -186,6 +189,7 @@ function renderPanel(overrides: {
       currentHeadId={currentHeadId}
       aeroplaneId={aeroplaneId}
       onClose={vi.fn()}
+      onSwitchAeroplane={onSwitchAeroplane}
     />,
   );
 }
@@ -487,5 +491,134 @@ describe("VersionHistoryPanel (gh-907)", () => {
 
     await user.click(screen.getByRole("button", { name: /close history panel/i }));
     expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  // -------------------------------------------------------------------------
+  // gh-910: onSwitchAeroplane called after branch ops
+  // -------------------------------------------------------------------------
+  describe("gh-910: onSwitchAeroplane after branch operations", () => {
+    /**
+     * FAKE_TREE has:
+     *   nodes: [{id:10, uuid:"aaa"}, {id:11, uuid:"bbb"}, {id:20, uuid:"ccc"}]
+     *   branches: [{id:1, head_id:10}, {id:2, head_id:20}]
+     *
+     * createBranch/adopt/restore all return a BranchOut with head_id.
+     * The mutate() returns the fresh tree so the panel can look up the UUID.
+     */
+
+    it("createBranch: calls onSwitchAeroplane with the new head UUID", async () => {
+      const user = userEvent.setup();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const switchSpy = vi.fn() as any as (uuid: string) => void;
+
+      // createBranch returns a BranchOut whose head_id=10 → uuid="aaa"
+      const createBranch = vi.fn().mockResolvedValue({ id: 3, root_id: 10, head_id: 10, name: "exp", is_main: false, created_by: "human", created_at: "" });
+      renderPanel({ actionsOverride: { createBranch }, onSwitchAeroplane: switchSpy });
+
+      const branchBtns = screen.getAllByRole("button", { name: /fork a new branch/i });
+      await user.click(branchBtns[0]);
+      const input = screen.getByRole("textbox", { name: /branch name/i });
+      await user.type(input, "exp");
+      await user.click(screen.getByRole("button", { name: /confirm branch name/i }));
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await waitFor(() => expect(switchSpy as any).toHaveBeenCalledOnce());
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(switchSpy as any).toHaveBeenCalledWith("aaa");
+    });
+
+    it("adoptBranch: calls onSwitchAeroplane with the adopted head UUID", async () => {
+      const user = userEvent.setup();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const switchSpy = vi.fn() as any as (uuid: string) => void;
+
+      // adoptBranch returns a BranchOut whose head_id=20 → uuid="ccc"
+      const adoptBranch = vi.fn().mockResolvedValue({ id: 2, root_id: 10, head_id: 20, name: "ai/winglet-v1", is_main: true, created_by: "ai", created_at: "" });
+      renderPanel({ actionsOverride: { adoptBranch }, onSwitchAeroplane: switchSpy });
+
+      const adoptBtns = screen.getAllByRole("button", { name: /promote branch/i });
+      await user.click(adoptBtns[0]);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await waitFor(() => expect(switchSpy as any).toHaveBeenCalledOnce());
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(switchSpy as any).toHaveBeenCalledWith("ccc");
+    });
+
+    it("restore: calls onSwitchAeroplane with the restored head UUID", async () => {
+      const user = userEvent.setup();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const switchSpy = vi.fn() as any as (uuid: string) => void;
+
+      // restore returns a BranchOut whose head_id=10 → uuid="aaa"
+      const restore = vi.fn().mockResolvedValue({ id: 5, root_id: 10, head_id: 10, name: "restored", is_main: false, created_by: "human", created_at: "" });
+      renderPanel({ actionsOverride: { restore }, onSwitchAeroplane: switchSpy });
+
+      const restoreBtns = screen.getAllByRole("button", { name: /restore this snapshot/i });
+      await user.click(restoreBtns[0]);
+      const input = screen.getByRole("textbox", { name: /branch name/i });
+      await user.type(input, "restored-v1");
+      await user.click(screen.getByRole("button", { name: /confirm branch name/i }));
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await waitFor(() => expect(switchSpy as any).toHaveBeenCalledOnce());
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(switchSpy as any).toHaveBeenCalledWith("aaa");
+    });
+
+    it("does not call onSwitchAeroplane when prop is absent", async () => {
+      const user = userEvent.setup();
+      const createBranch = vi.fn().mockResolvedValue({ id: 3, root_id: 10, head_id: 10, name: "exp", is_main: false, created_by: "human", created_at: "" });
+      // No onSwitchAeroplane prop — must not throw
+      renderPanel({ actionsOverride: { createBranch } });
+
+      const branchBtns = screen.getAllByRole("button", { name: /fork a new branch/i });
+      await user.click(branchBtns[0]);
+      const input = screen.getByRole("textbox", { name: /branch name/i });
+      await user.type(input, "exp");
+      await user.click(screen.getByRole("button", { name: /confirm branch name/i }));
+
+      await waitFor(() => expect(createBranch).toHaveBeenCalledOnce());
+      // Just verify no error was thrown — test passes if no exception
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // gh-910 polish: is_main badge is visually distinct from the branch name
+  // -------------------------------------------------------------------------
+  describe("gh-910: is_main badge visual distinction", () => {
+    it("renders 'active main' badge (not just 'main') for the is_main branch", () => {
+      renderPanel();
+      // The is_main badge must contain "active main" so it is distinct from
+      // a branch merely NAMED "main"
+      expect(screen.getByLabelText("Active main branch")).toBeDefined();
+    });
+
+    it("a non-main branch with a name containing 'main' does not show the active-main badge", () => {
+      const treeWithMainNamedBranch = {
+        ...FAKE_TREE,
+        branches: [
+          { ...FAKE_TREE.branches[0], name: "not-main-branch", is_main: false },
+          { ...FAKE_TREE.branches[1], name: "main-variant", is_main: true },
+        ],
+      };
+      mockUseLineageTree.mockReturnValue({
+        tree: treeWithMainNamedBranch,
+        isLoading: false,
+        error: undefined,
+        mutate: vi.fn().mockResolvedValue(treeWithMainNamedBranch),
+      });
+      mockUseVersionActions.mockReturnValue(makeActions());
+      render(
+        <VersionHistoryPanel
+          rootId={10}
+          currentHeadId={10}
+          aeroplaneId={10}
+          onClose={vi.fn()}
+        />,
+      );
+      // Only one "Active main branch" aria-label should exist
+      expect(screen.getAllByLabelText("Active main branch").length).toBe(1);
+    });
   });
 });

--- a/frontend/app/workbench/layout.tsx
+++ b/frontend/app/workbench/layout.tsx
@@ -21,7 +21,7 @@ import { useAeroplanes } from "@/hooks/useAeroplanes";
 function WorkbenchInner({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
-  const { aeroplaneId } = useAeroplaneContext();
+  const { aeroplaneId, setAeroplaneId } = useAeroplaneContext();
   const { aeroplanes } = useAeroplanes();
   const [historyOpen, setHistoryOpen] = useState(false);
 
@@ -47,6 +47,7 @@ function WorkbenchInner({
               currentHeadId={intId}
               aeroplaneId={intId}
               onClose={handleCloseHistory}
+              onSwitchAeroplane={setAeroplaneId}
             />
           )}
         </main>

--- a/frontend/components/workbench/VersionHistoryPanel.tsx
+++ b/frontend/components/workbench/VersionHistoryPanel.tsx
@@ -348,8 +348,12 @@ function BranchSection({
           {branch.name}
         </span>
         {branch.is_main && (
-          <span className="rounded-full bg-primary/20 px-1.5 py-0.5 text-[9px] font-medium text-primary">
-            main
+          <span
+            className="inline-flex items-center gap-0.5 rounded-full bg-primary/20 px-1.5 py-0.5 text-[9px] font-semibold text-primary ring-1 ring-primary/50"
+            title="This branch is the active main — it appears in the aeroplane picker"
+            aria-label="Active main branch"
+          >
+            ★ active main
           </span>
         )}
         {isAiBranch && (
@@ -544,6 +548,8 @@ export interface VersionHistoryPanelProps {
   currentHeadId: number | null;
   aeroplaneId: number | null;
   onClose: () => void;
+  /** Called after a branch operation lands — argument is the new head's UUID. */
+  onSwitchAeroplane?: (uuid: string) => void;
 }
 
 export function VersionHistoryPanel({
@@ -551,6 +557,7 @@ export function VersionHistoryPanel({
   currentHeadId,
   aeroplaneId,
   onClose,
+  onSwitchAeroplane,
 }: VersionHistoryPanelProps) {
   const { tree, isLoading, error, mutate } = useLineageTree(rootId);
   const actions = useVersionActions(aeroplaneId, rootId);
@@ -573,6 +580,40 @@ export function VersionHistoryPanel({
   } = useCompareNodes(
     compareOpen ? compareIdA : null,
     compareOpen ? compareIdB : null,
+  );
+
+  /**
+   * Run a branch action, revalidate the tree, then switch the active aeroplane
+   * to the new branch head.
+   *
+   * `getHeadId` extracts the new head's integer PK from the action's return
+   * value.  We look the UUID up in the freshly-revalidated tree so the context
+   * always gets a UUID, never a stale or missing value.
+   */
+  const runBranchOp = useCallback(
+    async <T,>(
+      fn: () => Promise<T>,
+      getHeadId: (result: T) => number,
+    ) => {
+      setBusy(true);
+      setActionError(null);
+      try {
+        const result = await fn();
+        const freshTree = await mutate();
+        if (onSwitchAeroplane && freshTree) {
+          const headId = getHeadId(result);
+          const headNode = freshTree.nodes.find((n) => n.id === headId);
+          if (headNode) {
+            onSwitchAeroplane(headNode.uuid);
+          }
+        }
+      } catch (err) {
+        setActionError(err instanceof Error ? err.message : "Action failed.");
+      } finally {
+        setBusy(false);
+      }
+    },
+    [mutate, onSwitchAeroplane],
   );
 
   const run = useCallback(async (fn: () => Promise<unknown>) => {
@@ -602,23 +643,32 @@ export function VersionHistoryPanel({
 
   const handleBranchFrom = useCallback(
     async (nodeId: number, name: string) => {
-      await run(() => actions.createBranch(nodeId, { name }));
+      await runBranchOp(
+        () => actions.createBranch(nodeId, { name }),
+        (branch) => branch.head_id,
+      );
     },
-    [run, actions],
+    [runBranchOp, actions],
   );
 
   const handleRestore = useCallback(
     async (snapshotId: number, name: string) => {
-      await run(() => actions.restore(snapshotId, { name }));
+      await runBranchOp(
+        () => actions.restore(snapshotId, { name }),
+        (branch) => branch.head_id,
+      );
     },
-    [run, actions],
+    [runBranchOp, actions],
   );
 
   const handleAdopt = useCallback(
     async (branchId: number) => {
-      await run(() => actions.adoptBranch(branchId));
+      await runBranchOp(
+        () => actions.adoptBranch(branchId),
+        (branch) => branch.head_id,
+      );
     },
-    [run, actions],
+    [runBranchOp, actions],
   );
 
   const handleDiscard = useCallback(


### PR DESCRIPTION
Real-usage bug (#910): branching/adopting didn't switch the active aeroplane, so the maintainer's V-tail edits + snapshot landed on the wrong (`main`) branch instead of the adopted `v_tail` head.

- **Frontend (primary):** adopt / branch-from / restore now switch the active aeroplane (AeroplaneContext) to the resulting head node's **uuid** (resolved from the freshly-revalidated tree by matching `BranchOut.head_id → TreeNodeOut.uuid`). So you keep working on the line you just adopted/branched/restored.
- **Backend:** `snapshot()` now sets `root_id` on the new immutable node (was NULL; falls back to `head.id` when the head is itself a root).
- **Polish:** the is_main indicator is now `★ active main` (aria-labelled, ringed) — visually distinct from a branch literally *named* 'main', so you can tell which line is currently the main one.

Verified (both gates): backend ruff clean + version/base tests 58 passed; frontend (Node 22) tsc clean, ESLint clean, vitest 152 files / 1750 tests green.

Closes #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)