### PR TITLE
fix(gh-912): adopt_branch demote-first + one-main index on model + E2E migrated-schema test

### DIFF
--- a/app/models/aeroplanemodel.py
+++ b/app/models/aeroplanemodel.py
@@ -1,4 +1,5 @@
-from sqlalchemy import Column, Integer, String, Float, Boolean, ForeignKey, JSON, Text, UniqueConstraint
+from sqlalchemy import Column, Integer, String, Float, Boolean, ForeignKey, JSON, Text, UniqueConstraint, Index
+from sqlalchemy import text
 from sqlalchemy.orm import relationship
 import uuid
 from sqlalchemy.dialects.postgresql import UUID
@@ -537,6 +538,19 @@ class BranchModel(Base):
     """
 
     __tablename__ = "branches"
+
+    # Partial unique index: exactly one is_main=True per lineage root (gh-903).
+    # Mirrored here from the Alembic migration so create_all (used in tests)
+    # produces a schema identical to a migrated production database.
+    __table_args__ = (
+        Index(
+            "uq_branches_one_main_per_root",
+            "root_id",
+            unique=True,
+            sqlite_where=text("is_main = 1"),
+            postgresql_where=text("is_main = true"),
+        ),
+    )
 
     # FK declared with use_alter to break the circular dependency between
     # aeroplanes ↔ branches (aeroplanes.branch_id → branches.id and

--- a/app/services/aeroplane_version_service.py
+++ b/app/services/aeroplane_version_service.py
@@ -264,6 +264,7 @@ def adopt_branch(db: Session, branch_id: int) -> BranchModel:
     )
     if current_main is not None:
         current_main.is_main = False
+        db.flush()  # demote FIRST so the partial unique index never sees two is_main=True
 
     branch.is_main = True
     db.flush()

--- a/app/tests/test_aeroplane_version_service.py
+++ b/app/tests/test_aeroplane_version_service.py
@@ -294,6 +294,105 @@ def test_adopt_branch_not_found_raises(db: Session):
         adopt_branch(db, 99999)
 
 
+def test_adopt_branch_no_integrity_error_with_unique_index(db: Session):
+    """adopt_branch must not raise IntegrityError from the partial unique index.
+
+    Regression test for gh-912: before the demote-first fix, SQLite fired
+    ``UNIQUE constraint failed: branches.root_id`` (from the partial index
+    ``uq_branches_one_main_per_root``) because the target branch was promoted
+    BEFORE the old main was demoted within the same flush, creating a transient
+    window with two is_main=True rows for the same root_id.
+
+    This test ONLY passes when:
+      1. The partial unique index is present on BranchModel (so create_all
+         builds a schema that enforces the constraint), AND
+      2. The service demotes the old main FIRST (with a flush) before setting
+         the new is_main=True.
+    """
+    from sqlalchemy.exc import IntegrityError
+
+    root, main_branch = _make_root(db, "integrity-test")
+    side_branch = create_branch(db, root.id, name="side", created_by="human")
+    db.commit()
+
+    # This must not raise IntegrityError.
+    try:
+        promoted = adopt_branch(db, side_branch.id)
+        db.commit()
+    except IntegrityError as exc:
+        pytest.fail(
+            f"adopt_branch raised IntegrityError (gh-912 regression): {exc}"
+        )
+
+    # Exactly one is_main=True for this root.
+    main_count = (
+        db.query(BranchModel)
+        .filter(
+            BranchModel.root_id == root.id,
+            BranchModel.is_main == True,  # noqa: E712
+        )
+        .count()
+    )
+    assert main_count == 1, f"Expected 1 main branch, got {main_count}"
+
+    # It is the adopted branch.
+    db.refresh(promoted)
+    assert promoted.is_main is True
+    assert promoted.id == side_branch.id
+
+    # The old main is demoted.
+    db.refresh(main_branch)
+    assert main_branch.is_main is False
+
+
+def test_adopt_branch_round_trip(db: Session):
+    """Adopting back the original branch after promoting a side branch works.
+
+    Verifies that the demote-first flush is idempotent across two adoption
+    cycles (A→B, then B→A).
+    """
+    from sqlalchemy.exc import IntegrityError
+
+    root, main_branch = _make_root(db, "round-trip-test")
+    side_branch = create_branch(db, root.id, name="alt", created_by="human")
+    db.commit()
+
+    # First adoption: promote side_branch.
+    try:
+        adopt_branch(db, side_branch.id)
+        db.commit()
+    except IntegrityError as exc:
+        pytest.fail(f"First adopt_branch raised IntegrityError: {exc}")
+
+    db.refresh(main_branch)
+    db.refresh(side_branch)
+    assert side_branch.is_main is True
+    assert main_branch.is_main is False
+
+    # Second adoption: promote main_branch again (reverse).
+    try:
+        adopt_branch(db, main_branch.id)
+        db.commit()
+    except IntegrityError as exc:
+        pytest.fail(f"Second adopt_branch raised IntegrityError: {exc}")
+
+    db.refresh(main_branch)
+    db.refresh(side_branch)
+    assert main_branch.is_main is True
+    assert side_branch.is_main is False
+
+    # Still exactly one main branch.
+    main_count = (
+        db.query(BranchModel)
+        .filter(
+            BranchModel.root_id == root.id,
+            BranchModel.is_main == True,  # noqa: E712
+        )
+        .count()
+    )
+    assert main_count == 1
+
+
 # ---------------------------------------------------------------------------
 # 4. discard_branch
 # ---------------------------------------------------------------------------

--- a/app/tests/test_versioning_e2e_migrated.py
+++ b/app/tests/test_versioning_e2e_migrated.py
@@ -1,0 +1,62 @@
+"""End-to-end versioning lifecycle against a REAL alembic-migrated schema.
+
+The create_all-based unit tests build the schema from the models, which has
+historically missed migration-only constraints (e.g. the
+``uq_branches_one_main_per_root`` partial unique index — gh-912). This test
+upgrades a throwaway DB with ``alembic upgrade head`` and then exercises the
+full versioning lifecycle (create → snapshot → branch → adopt → re-adopt →
+restore → compare → tree → discard + guards) via the service layer, so any
+real-schema bug is caught.
+
+Runs in an isolated subprocess via ``sys.executable`` (never a hardcoded venv
+path) so it works on CI runners too.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+E2E_SCRIPT = REPO_ROOT / "scripts" / "e2e_versioning.py"
+
+
+def _env(db_url: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env["SQLALCHEMY_DATABASE_URL"] = db_url
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    return env
+
+
+def test_versioning_lifecycle_on_migrated_schema() -> None:
+    assert E2E_SCRIPT.exists(), f"missing e2e script: {E2E_SCRIPT}"
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "e2e.db"
+        db_url = f"sqlite:///{db_path}"
+        env = _env(db_url)
+
+        upgrade = subprocess.run(
+            [sys.executable, "-m", "alembic", "-c", str(REPO_ROOT / "alembic.ini"), "upgrade", "head"],
+            cwd=str(REPO_ROOT),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert upgrade.returncode == 0, (
+            f"alembic upgrade head failed:\nSTDOUT:\n{upgrade.stdout}\nSTDERR:\n{upgrade.stderr}"
+        )
+
+        run = subprocess.run(
+            [sys.executable, str(E2E_SCRIPT)],
+            cwd=str(REPO_ROOT),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        # The script prints PASS/FAIL per check and exits non-zero on any failure.
+        assert run.returncode == 0, (
+            f"versioning E2E failed against the migrated schema:\n{run.stdout}\n{run.stderr}"
+        )
+        assert "0 failed" in run.stdout, run.stdout

--- a/scripts/e2e_versioning.py
+++ b/scripts/e2e_versioning.py
@@ -1,0 +1,160 @@
+"""End-to-end exercise of the versioning backend against a MIGRATED schema.
+
+Runs against whatever SQLALCHEMY_DATABASE_URL points to (a throwaway DB that has
+been `alembic upgrade head`-ed, so the partial unique index + all real
+constraints are present — the layer where create_all unit tests miss bugs).
+Exits non-zero on the first failure.
+"""
+from __future__ import annotations
+
+import sys
+
+from app.db.session import SessionLocal
+from app.services import aeroplane_service
+from app.services import aeroplane_version_service as vs
+from app.models.aeroplanemodel import AeroplaneModel, BranchModel
+
+ok = 0
+fail = 0
+
+
+def check(label: str, cond: bool, extra: str = "") -> None:
+    global ok, fail
+    if cond:
+        ok += 1
+        print(f"  PASS  {label}")
+    else:
+        fail += 1
+        print(f"  FAIL  {label}  {extra}")
+
+
+def main_branch_of(db, root_id: int) -> BranchModel:
+    return (
+        db.query(BranchModel)
+        .filter(BranchModel.root_id == root_id, BranchModel.is_main.is_(True))
+        .one()
+    )
+
+
+def count_main(db, root_id: int) -> int:
+    return (
+        db.query(BranchModel)
+        .filter(BranchModel.root_id == root_id, BranchModel.is_main.is_(True))
+        .count()
+    )
+
+
+db = SessionLocal()
+try:
+    # 1) create_aeroplane → must bootstrap a main branch + versioning columns
+    ap = aeroplane_service.create_aeroplane(db, "E2E-Plane")
+    db.commit()
+    db.refresh(ap)
+    root_id = ap.root_id
+    check("create_aeroplane sets root_id=self", ap.root_id == ap.id, f"root_id={ap.root_id} id={ap.id}")
+    check("create_aeroplane sets branch_id", ap.branch_id is not None)
+    check("create_aeroplane node is mutable", not ap.is_immutable)
+    mb = main_branch_of(db, root_id)
+    check("create_aeroplane creates a main branch", mb.head_id == ap.id and mb.name == "main")
+    check("exactly one main for root", count_main(db, root_id) == 1)
+    heads = vs.list_aeroplanes_heads_only(db)
+    check("new aeroplane is a head", any(h.id == ap.id for h in heads))
+
+    # 2) snapshot → immutable predecessor, root_id set (gh-910), head unchanged
+    snap = vs.snapshot(db, ap.id, "snap-1", "first snapshot")
+    db.commit()
+    db.refresh(snap)
+    db.refresh(mb)
+    check("snapshot is immutable", bool(snap.is_immutable))
+    check("snapshot has root_id (gh-910)", snap.root_id == root_id, f"snap.root_id={snap.root_id}")
+    check("snapshot NOT a head (heads_only excludes it)",
+          all(h.id != snap.id for h in vs.list_aeroplanes_heads_only(db)))
+    db.refresh(ap)
+    check("branch head unchanged after snapshot", mb.head_id == ap.id)
+
+    # 3) create_branch (variant) from the head
+    br_variant = vs.create_branch(db, ap.id, "variant")
+    db.commit()
+    db.refresh(br_variant)
+    variant_head_id = br_variant.head_id
+    check("create_branch new mutable head (clone)", variant_head_id != ap.id)
+    check("variant branch not main", not br_variant.is_main)
+    check("variant head in heads", any(h.id == variant_head_id for h in vs.list_aeroplanes_heads_only(db)))
+
+    # 4) adopt variant  ← gh-912 (must not violate the one-main partial index)
+    try:
+        vs.adopt_branch(db, br_variant.id)
+        db.commit()
+        adopt_ok = True
+        err = ""
+    except Exception as exc:  # noqa: BLE001
+        adopt_ok = False
+        err = repr(exc)
+        db.rollback()
+    check("adopt variant succeeds (no IntegrityError)", adopt_ok, err)
+    check("exactly one main after adopt", count_main(db, root_id) == 1)
+    if adopt_ok:
+        db.refresh(br_variant)
+        check("variant is now main", bool(br_variant.is_main))
+
+    # 5) re-adopt original main (round trip)
+    try:
+        vs.adopt_branch(db, mb.id)
+        db.commit()
+        readopt_ok = True
+        err = ""
+    except Exception as exc:  # noqa: BLE001
+        readopt_ok = False
+        err = repr(exc)
+        db.rollback()
+    check("re-adopt original main succeeds (round trip)", readopt_ok, err)
+    check("still exactly one main after round trip", count_main(db, root_id) == 1)
+
+    # 6) restore from the snapshot
+    br_restore = vs.restore(db, snap.id, "restored")
+    db.commit()
+    db.refresh(br_restore)
+    check("restore creates a new branch from snapshot", br_restore.id not in (mb.id, br_variant.id))
+    check("restore head is mutable clone", br_restore.head_id != snap.id)
+
+    # 7) compare two nodes
+    na, nb, ma, mbx = vs.compare(db, ap.id, variant_head_id)
+    check("compare returns both nodes + metric dicts", na.id == ap.id and nb.id == variant_head_id
+          and isinstance(ma, dict) and isinstance(mbx, dict))
+
+    # 8) list_tree
+    nodes, branches = vs.list_tree(db, root_id)
+    check("list_tree returns the lineage nodes", len(nodes) >= 4, f"nodes={len(nodes)}")
+    check("list_tree returns the branches", len(branches) >= 3, f"branches={len(branches)}")
+
+    # 9) discard a non-main branch
+    vs.discard_branch(db, br_variant.id)
+    db.commit()
+    check("discard non-main branch removed it",
+          db.query(BranchModel).filter(BranchModel.id == br_variant.id).first() is None)
+
+    # 10) discard guards: cannot discard main
+    try:
+        vs.discard_branch(db, mb.id)
+        db.commit()
+        guarded = False
+    except Exception:  # noqa: BLE001
+        db.rollback()
+        guarded = True
+    check("discard main is guarded (raises)", guarded)
+
+    # 11) mutation guard: snapshot on an immutable node is rejected
+    try:
+        vs.snapshot(db, snap.id, "bad")
+        db.commit()
+        immut_guarded = False
+    except Exception:  # noqa: BLE001
+        db.rollback()
+        immut_guarded = True
+    check("snapshot on immutable node is guarded", immut_guarded)
+
+finally:
+    db.close()
+
+print(f"\n=== E2E: {ok} passed, {fail} failed ===")
+sys.exit(1 if fail else 0)


### PR DESCRIPTION
Real-usage bug (#912): `POST /branches/{id}/adopt` → 500 `UNIQUE constraint failed: branches.root_id`. Adopt was broken on any migrated DB.

## Root cause
1. `adopt_branch` promoted the target (`is_main=True`) **before** demoting the current main → a transient two-`is_main` state for one `root_id` → the partial unique index `uq_branches_one_main_per_root` (added in the gh-903 migration) fired immediately.
2. That index lived **only in the migration, not on the model**, so create_all-based unit tests never had it → the bug passed CI.

## Fix
- **`adopt_branch`: demote-first** — set the current main `is_main=False` and `db.flush()` BEFORE promoting the target. Never two mains transiently.
- **Index on the model** (`BranchModel.__table_args__`, same name/predicate as the migration) so `create_all` matches the migrated schema and tests reflect reality.
- Unit tests for adopt-over-existing-main + round-trip.

## Make the backend really work + keep it working
Added an **end-to-end integration test against a real `alembic upgrade head` schema** (`scripts/e2e_versioning.py` + `app/tests/test_versioning_e2e_migrated.py`): exercises create→snapshot→branch→adopt→re-adopt→restore→compare→tree→discard + all guards via the service layer. **26/26 checks pass.** This catches exactly the migration-vs-model class of bug that unit tests miss.

Verified locally: ruff clean, e2e test passes, version/base/clone/migration suite 67 passed.

Closes #912

🤖 Generated with [Claude Code](https://claude.com/claude-code)