### PR TITLE
fix(gh-914): unshadow GET /aeroplanes/compare (422 uuid_parsing) + HTTP-level versioning tests

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -205,6 +205,9 @@ def create_app() -> FastAPI:
     )
     app.include_router(health.router, prefix="", tags=["health"])
     app.include_router(endurance.router, prefix="", tags=["endurance"])
+    # Versioning router BEFORE the aeroplane base router so the static route
+    # /aeroplanes/compare is matched ahead of /aeroplanes/{aeroplane_id} (gh-914).
+    app.include_router(versioning_v2.router, prefix="", tags=["versioning"])
     app.include_router(aeroplane_v2.router, prefix="", tags=[])
     app.include_router(openvsp_import.router, prefix="/api/v2", tags=["import"])
     app.include_router(components.router, prefix="", tags=["components"])
@@ -216,7 +219,6 @@ def create_app() -> FastAPI:
     app.include_router(construction_templates.router, prefix="", tags=["construction-templates"])
     app.include_router(flight_profiles.router, prefix="", tags=["flight-profiles"])
     app.include_router(fuselage_slice.router, prefix="", tags=["fuselages"])
-    app.include_router(versioning_v2.router, prefix="", tags=["versioning"])
     if _cad_router is not None:
         app.include_router(_cad_router, prefix="", tags=["cad"])
     if _aeroanalysis_router is not None:

--- a/app/tests/test_versioning_api_http.py
+++ b/app/tests/test_versioning_api_http.py
@@ -1,0 +1,65 @@
+"""HTTP-level integration tests for the versioning API.
+
+The service-layer E2E (test_versioning_e2e_migrated) does not exercise FastAPI
+routing or response serialization. This caught a real bug (gh-914): the static
+GET /aeroplanes/compare was shadowed by the dynamic GET /aeroplanes/{aeroplane_id}
+(UUID), so 'compare' was parsed as a UUID → 422. These tests hit the real app
+via TestClient so routing/serialization collisions are caught.
+"""
+from __future__ import annotations
+
+from app.services import aeroplane_service
+from app.services import aeroplane_version_service as vs
+
+
+def _seed_two_nodes(SessionLocal):
+    """Create an aeroplane + a branch head → two distinct integer node ids."""
+    db = SessionLocal()
+    try:
+        ap = aeroplane_service.create_aeroplane(db, "HTTP-Cmp")
+        db.commit()
+        db.refresh(ap)
+        br = vs.create_branch(db, ap.id, "variant")
+        db.commit()
+        db.refresh(br)
+        return ap.id, ap.root_id, br.head_id
+    finally:
+        db.close()
+
+
+def test_compare_route_not_shadowed_by_aeroplane_id(client_and_db):
+    """GET /aeroplanes/compare must reach the compare handler, not be parsed as a UUID."""
+    client, SessionLocal = client_and_db
+    a_id, _root_id, b_id = _seed_two_nodes(SessionLocal)
+
+    resp = client.get("/aeroplanes/compare", params={"a": a_id, "b": b_id})
+
+    assert resp.status_code == 200, resp.text
+    assert "uuid_parsing" not in resp.text  # regression guard for gh-914
+    body = resp.json()
+    assert "metrics_a" in body and "metrics_b" in body
+
+
+def test_lineage_tree_over_http(client_and_db):
+    client, SessionLocal = client_and_db
+    _a, root_id, _b = _seed_two_nodes(SessionLocal)
+
+    resp = client.get(f"/lineages/{root_id}/tree")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "nodes" in body and "branches" in body
+    assert len(body["nodes"]) >= 2
+
+
+def test_snapshot_and_branch_over_http(client_and_db):
+    """POST snapshot + branch exercise routing + VersionNode/BranchOut serialization."""
+    client, SessionLocal = client_and_db
+    a_id, _root_id, _b = _seed_two_nodes(SessionLocal)
+
+    snap = client.post(f"/aeroplanes/{a_id}/snapshot", json={"label": "http-snap", "note": "via http"})
+    assert snap.status_code in (200, 201), snap.text
+
+    branch = client.post(f"/aeroplanes/{a_id}/branch", json={"name": "http-branch"})
+    assert branch.status_code in (200, 201), branch.text
+    assert branch.json().get("name") == "http-branch"


### PR DESCRIPTION
Real-usage bug (#914): clicking **Compare** → 422 `uuid_parsing` — `/aeroplanes/compare` was being matched by `/aeroplanes/{aeroplane_id}` (UUID), so 'compare' was parsed as a UUID.

## Fix
- Include the **versioning router before the aeroplane base router** in main.py, so the static `/aeroplanes/compare` route is matched ahead of the dynamic `/aeroplanes/{aeroplane_id}`. (Only that one pair overlaps; other versioning routes are suffix-distinct.)
- **HTTP-level integration tests** (FastAPI TestClient): compare, lineage tree, snapshot, branch — exercising routing + response serialization, the layer the service-level E2E (#912) misses. Confirmed the compare test **fails without the fix** and passes with it.

Verified locally: ruff clean; routing-sensitive suite 109 passed (versioning HTTP + migrated-schema E2E + aeroplane base + version service + endurance + field-length).

Closes #914

🤖 Generated with [Claude Code](https://claude.com/claude-code)