### PR TITLE
feat(gh-902): copilot advisory backend — config, tool facade, /copilot/stream SSE

### DIFF
--- a/app/api/v2/endpoints/aeroplane/__init__.py
+++ b/app/api/v2/endpoints/aeroplane/__init__.py
@@ -11,6 +11,7 @@ from .fuselages import router as fuselages_router
 from .mission_objectives import router as mission_objectives_router
 from .weight_items import router as weight_items_router
 from .copilot_history import router as copilot_history_router
+from .copilot_stream import router as copilot_stream_router
 from .design_versions import router as design_versions_router
 from .powertrain_sizing import router as powertrain_sizing_router
 from .avl_geometry import router as avl_geometry_router
@@ -32,6 +33,7 @@ router.include_router(fuselages_router)
 router.include_router(mission_objectives_router)
 router.include_router(weight_items_router)
 router.include_router(copilot_history_router)
+router.include_router(copilot_stream_router)
 router.include_router(design_versions_router)
 router.include_router(powertrain_sizing_router)
 router.include_router(avl_geometry_router)

--- a/app/api/v2/endpoints/aeroplane/copilot_stream.py
+++ b/app/api/v2/endpoints/aeroplane/copilot_stream.py
@@ -1,0 +1,184 @@
+"""SSE endpoint — POST /aeroplanes/{aeroplane_id}/copilot/stream (gh-918).
+
+Flow
+----
+1. Persist the user message via copilot_history_service.append_message.
+2. Load the full history.
+3. Run copilot_service.run_turn as an async generator.
+4. Format each yielded event via _sse_format and stream as text/event-stream.
+5. On receiving the ``done`` event, persist the final assistant message
+   (with accumulated tool_calls and tool_results).
+6. Any exception → ``event: error {message}``; never leak the API key.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Annotated, AsyncGenerator
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, status
+from fastapi.responses import StreamingResponse
+from pydantic import UUID4, BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.schemas.copilot_history import CopilotMessageWrite
+from app.services import copilot_history_service as hist_svc
+from app.services import copilot_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Request body
+# ---------------------------------------------------------------------------
+
+
+class CopilotStreamRequest(BaseModel):
+    message: str = Field(..., description="User message to send to the copilot")
+    context_hint: str = Field(
+        default="",
+        description="Short context string injected into the system prompt (e.g. active tab + aircraft name)",
+    )
+
+
+# ---------------------------------------------------------------------------
+# SSE helper (mirrors openvsp_import._sse_format)
+# ---------------------------------------------------------------------------
+
+
+def _sse_format(event_type: str, data: dict) -> str:
+    """Encode one SSE event as a UTF-8 string."""
+    return f"event: {event_type}\ndata: {json.dumps(data, separators=(',', ':'))}\n\n"
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/aeroplanes/{aeroplane_id}/copilot/stream",
+    tags=["copilot"],
+    operation_id="copilot_stream",
+    responses={
+        200: {
+            "content": {"text/event-stream": {}},
+            "description": (
+                "SSE stream. Events: "
+                "``token`` {text} — assistant text delta; "
+                "``tool_call`` {name, args} — tool invocation; "
+                "``tool_result`` {name, summary} — tool result; "
+                "``done`` — turn complete; "
+                "``error`` {message} — error (key never leaked)."
+            ),
+        },
+        404: {"description": "Aeroplane not found"},
+        422: {"description": "Validation error"},
+    },
+)
+async def copilot_stream(
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    body: Annotated[CopilotStreamRequest, Body(...)],
+    db: Annotated[Session, Depends(get_db)],
+) -> StreamingResponse:
+    """Stream a copilot response as text/event-stream.
+
+    Persists the user message first, runs the tool-calling loop against the
+    LiteLLM hub (OpenAI SDK, hub mocked in CI), and persists the final
+    assistant message on completion.
+    """
+    # Validate aeroplane exists and persist the user message
+    try:
+        hist_svc.append_message(
+            db,
+            aeroplane_id,
+            CopilotMessageWrite(role="user", content=body.message),
+        )
+    except Exception as exc:
+        # Convert service / not-found errors to HTTP before opening the stream
+        from app.core.exceptions import NotFoundError, ServiceException
+
+        if isinstance(exc, NotFoundError):
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        if isinstance(exc, ServiceException):
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+        raise HTTPException(status_code=500, detail=f"Unexpected error: {exc}") from exc
+
+    # Load history (includes the user message we just appended)
+    history = hist_svc.get_history(db, aeroplane_id)
+
+    # Look up the integer PK (tools need it)
+    from app.models.aeroplanemodel import AeroplaneModel
+
+    plane = db.query(AeroplaneModel).filter(AeroplaneModel.uuid == aeroplane_id).first()
+    if plane is None:
+        raise HTTPException(status_code=404, detail="Aeroplane not found")
+
+    async def _generate() -> AsyncGenerator[str, None]:
+        accumulated_tool_calls = []
+        accumulated_tool_results = []
+        final_text = ""
+
+        try:
+            async for event in copilot_service.run_turn(
+                db=db,
+                aeroplane_id=plane.id,
+                history=history,
+                context_hint=body.context_hint,
+            ):
+                event_type = event.get("type", "unknown")
+
+                if event_type == "done":
+                    accumulated_tool_calls = event.get("tool_calls", [])
+                    accumulated_tool_results = event.get("tool_results", [])
+                    final_text = event.get("final_text", "")
+                    # Persist the final assistant message
+                    try:
+                        hist_svc.append_message(
+                            db,
+                            aeroplane_id,
+                            CopilotMessageWrite(
+                                role="assistant",
+                                content=final_text,
+                                tool_calls=accumulated_tool_calls or None,
+                                tool_results=accumulated_tool_results or None,
+                            ),
+                        )
+                    except Exception as persist_exc:
+                        logger.error("Failed to persist assistant message: %s", persist_exc)
+                    yield _sse_format("done", {"status": "ok"})
+
+                elif event_type == "error":
+                    yield _sse_format("error", {"message": event.get("message", "Unknown error")})
+
+                elif event_type == "token":
+                    yield _sse_format("token", {"text": event.get("text", "")})
+
+                elif event_type == "tool_call":
+                    yield _sse_format(
+                        "tool_call",
+                        {"name": event.get("name", ""), "args": event.get("args", {})},
+                    )
+
+                elif event_type == "tool_result":
+                    yield _sse_format(
+                        "tool_result",
+                        {"name": event.get("name", ""), "summary": event.get("summary", {})},
+                    )
+
+        except Exception as exc:
+            logger.exception("Unhandled error in copilot stream generator")
+            yield _sse_format("error", {"message": "Internal server error"})
+
+    return StreamingResponse(
+        _generate(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from pydantic import SecretStr
+from pydantic import SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Canonical, absolute project paths — the single source of truth.
@@ -21,8 +21,15 @@ class Settings(BaseSettings):
     VERSION: str = "1.0.0"
     UVICORN_HOST: str = "127.0.0.1"
 
-    # Construction plan artifacts directory
+    # Construction plan artifacts directory.  Always resolved to an absolute
+    # path so that a relative env-var override becomes absolute regardless of
+    # the working directory at startup.
     ARTIFACTS_BASE_DIR: Path = Path("/tmp/da3dalus_artifacts")
+
+    @field_validator("ARTIFACTS_BASE_DIR", mode="after")
+    @classmethod
+    def _resolve_artifacts_dir(cls, v: Path) -> Path:
+        return v.resolve()
 
     # ------------------------------------------------------------------
     # AI Copilot (gh-902 / gh-916)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,5 +1,7 @@
-import os
 from pathlib import Path
+
+from pydantic import SecretStr
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Canonical, absolute project paths — the single source of truth.
 #
@@ -12,15 +14,28 @@ REPO_ROOT: Path = Path(__file__).resolve().parents[2]
 AIRFOILS_DIR: Path = REPO_ROOT / "components" / "airfoils"
 
 
-class Settings:
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
     PROJECT_NAME: str = "My FastAPI Project"
     VERSION: str = "1.0.0"
     UVICORN_HOST: str = "127.0.0.1"
 
     # Construction plan artifacts directory
-    ARTIFACTS_BASE_DIR: Path = Path(
-        os.environ.get("ARTIFACTS_BASE_DIR", "/tmp/da3dalus_artifacts")
-    ).resolve()
+    ARTIFACTS_BASE_DIR: Path = Path("/tmp/da3dalus_artifacts")
+
+    # ------------------------------------------------------------------
+    # AI Copilot (gh-902 / gh-916)
+    # ------------------------------------------------------------------
+    # API key for the LiteLLM hub (OpenAI-compatible).  SecretStr so it
+    # is masked in repr/logs; access the raw value with .get_secret_value().
+    COPILOT_API_KEY: SecretStr | None = None
+    # Base URL of the LiteLLM hub.  None → use the OpenAI default endpoint.
+    COPILOT_BASE_URL: str | None = None
+    # Chat model routed through the hub.
+    COPILOT_MODEL: str = "claude-sonnet-4-6"
+    # Embedding model (used from Slice 4 / RAG onward).
+    COPILOT_EMBEDDING_MODEL: str = "text-embedding-3-large"
 
 
 settings = Settings()

--- a/app/services/copilot_service.py
+++ b/app/services/copilot_service.py
@@ -26,6 +26,7 @@ inject a fake client — **no real API call is ever made in CI**.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from typing import Any, AsyncGenerator
@@ -33,6 +34,47 @@ from typing import Any, AsyncGenerator
 from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# SSE error sanitization
+# ---------------------------------------------------------------------------
+
+
+def _sanitize_error(exc: BaseException) -> str:
+    """Return a safe error message that never exposes the configured API key.
+
+    Any occurrence of the raw COPILOT_API_KEY value in ``str(exc)`` is
+    replaced with the placeholder ``"[REDACTED]"``.  Additionally the raw
+    exception text is replaced with a category message so that transient
+    auth / network details are not forwarded to the browser.
+    """
+    try:
+        from app.core.config import settings
+
+        secret = settings.COPILOT_API_KEY
+        key_value = secret.get_secret_value() if secret else None
+    except Exception:  # noqa: BLE001
+        key_value = None
+
+    # Build a human-friendly category string from the exception type.
+    exc_type = type(exc).__name__
+    raw = str(exc)
+
+    # Redact the key before doing anything else.
+    if key_value and key_value in raw:
+        raw = raw.replace(key_value, "[REDACTED]")
+
+    # For authentication/connection errors substitute a generic message so
+    # internal details (URLs, tokens) are not forwarded to the browser.
+    lower = raw.lower()
+    if any(kw in lower for kw in ("auth", "key", "token", "api_key", "secret", "credential")):
+        return f"{exc_type}: authentication or configuration error"
+    if any(kw in lower for kw in ("connect", "timeout", "network", "refused", "unreachable")):
+        return f"{exc_type}: hub connection error"
+
+    # Generic fallback — include redacted message.
+    return f"{exc_type}: {raw}"
 
 # ---------------------------------------------------------------------------
 # Guard
@@ -225,6 +267,11 @@ async def run_turn(
     # The final text the assistant produced (used for persistence)
     final_text = ""
 
+    # Set to True when the loop exits via a clean finish_reason="stop"; stays
+    # False if we ran out of MAX_LOOP_ITERATIONS while the model was still
+    # requesting tool calls (truncated turn).
+    turn_complete = False
+
     client = _make_openai_client()
 
     for iteration in range(MAX_LOOP_ITERATIONS):
@@ -239,7 +286,7 @@ async def run_turn(
             )
         except Exception as exc:  # noqa: BLE001
             logger.exception("Hub call failed on iteration %d", iteration)
-            yield {"type": "error", "message": f"Hub error: {exc}"}
+            yield {"type": "error", "message": f"Hub error: {_sanitize_error(exc)}"}
             return
 
         # Collect the streamed response
@@ -284,7 +331,7 @@ async def run_turn(
                                 )
         except Exception as exc:  # noqa: BLE001
             logger.exception("Stream read failed on iteration %d", iteration)
-            yield {"type": "error", "message": f"Stream error: {exc}"}
+            yield {"type": "error", "message": f"Stream error: {_sanitize_error(exc)}"}
             return
 
         if text_delta:
@@ -294,10 +341,12 @@ async def run_turn(
 
         if finish_reason == "stop" or (not tool_call_chunks and finish_reason != "tool_calls"):
             # Normal text completion — we're done
+            turn_complete = True
             break
 
         if not tool_call_chunks:
             # Unexpected finish without tool_calls and not stop
+            turn_complete = True
             break
 
         # ---- execute tool calls ------------------------------------------
@@ -330,9 +379,14 @@ async def run_turn(
 
             yield {"type": "tool_call", "name": tool_name, "args": args}
 
-            # Execute server-side
+            # Execute server-side in a worker thread so the event loop stays
+            # free (tool execution is CPU-bound / blocking I/O).  Inside the
+            # worker thread there is no running event loop, so _run_analysis
+            # can safely call asyncio.run().
             try:
-                result = copilot_tools.execute(tool_name, db, aeroplane_id, **args)
+                result = await asyncio.to_thread(
+                    copilot_tools.execute, tool_name, db, aeroplane_id, **args
+                )
             except Exception as exc:  # noqa: BLE001
                 logger.exception("Tool %s execution failed", tool_name)
                 result = {"error": str(exc)}
@@ -357,7 +411,15 @@ async def run_turn(
         # Append all tool results to the message thread
         openai_messages.extend(tool_result_messages)
 
-    # Guard: if we hit MAX_LOOP_ITERATIONS without a stop, emit a note
-    # (the final text is whatever was accumulated so far)
+    # If we exhausted MAX_LOOP_ITERATIONS without a clean stop the client
+    # should know the turn was cut off so it can tell the user.
+    done_event: dict[str, Any] = {
+        "type": "done",
+        "tool_calls": accumulated_tool_calls,
+        "tool_results": accumulated_tool_results,
+        "final_text": final_text,
+    }
+    if not turn_complete:
+        done_event["truncated"] = True
 
-    yield {"type": "done", "tool_calls": accumulated_tool_calls, "tool_results": accumulated_tool_results, "final_text": final_text}
+    yield done_event

--- a/app/services/copilot_service.py
+++ b/app/services/copilot_service.py
@@ -1,0 +1,363 @@
+"""Copilot service — tool-calling loop that drives the AI agent (gh-918).
+
+The public surface is a single async generator ``run_turn`` that:
+
+1. Builds the messages list (system prompt + history).
+2. Calls the OpenAI-compatible LiteLLM hub using the ``openai`` SDK with
+   streaming enabled.
+3. Yields ``dict`` events that the SSE endpoint formats and sends to the
+   browser:
+
+   * ``{"type": "token", "text": "…"}``      — assistant text delta
+   * ``{"type": "tool_call", "name": "…", "args": {…}}``  — model wants to call a tool
+   * ``{"type": "tool_result", "name": "…", "summary": {…}}``  — server-side result
+
+4. Executes tool calls server-side via ``copilot_tools.execute``, appends
+   the results to the conversation, and continues the loop.
+5. Stops after at most ``MAX_LOOP_ITERATIONS`` exchanges (guard against
+   runaway tool loops).
+
+Hub client injection
+--------------------
+The OpenAI client is built by the module-level factory ``_make_openai_client``.
+Tests monkeypatch ``app.services.copilot_service._make_openai_client`` to
+inject a fake client — **no real API call is ever made in CI**.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, AsyncGenerator
+
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Guard
+# ---------------------------------------------------------------------------
+
+MAX_LOOP_ITERATIONS: int = 6
+
+# ---------------------------------------------------------------------------
+# System prompt
+# ---------------------------------------------------------------------------
+
+SYSTEM_PROMPT = """\
+You are da3Dalus, an AI aircraft-design copilot integrated into the
+da3Dalus workbench. You serve both hobbyists (RC / model aircraft, FPV)
+and professional engineers (UAV, light aircraft).
+
+## Role
+Advisory-only (Slice 1). You help users understand and improve their design
+by answering questions, running analyses, and interpreting results. You do
+NOT change the design directly; if asked, say "Design changes are coming
+in a future update — for now I can show you the numbers and explain what
+to adjust."
+
+## Anti-hallucination rules (HARD)
+1. NEVER invent numbers. Always retrieve real values via the tools.
+2. Before quoting any figure (mass, span, CL, static margin, …) call
+   get_design_snapshot or run_analysis. If a tool returns an error or
+   timeout, say so explicitly.
+3. When you cite a number, state which tool produced it.
+4. If you are unsure, say so; do not guess.
+
+## Provisional knowledge (until RAG is available)
+Use the following as approximate guidance only — the user's actual design
+numbers from the tools take precedence.
+
+### Static margin targets (% MAC)
+- RC trainer / beginner: 15–25 %
+- RC sport / intermediate: 8–15 %
+- RC aerobatic / advanced: 0–8 % (neutrally stable)
+- UAV / autonomous: 5–15 % (depends on autopilot authority)
+- Light GA (Scholz/Sadraey): 5–15 %
+
+### Horizontal tail volume coefficient V_H
+- Light GA / trainer: 0.30–0.50
+- RC trainer: 0.35–0.55
+- RC sport: 0.25–0.40
+- Flying wing: not applicable (elevon authority)
+
+### Lift-to-drag benchmarks
+- RC trainer: L/D 8–12
+- RC glider / thermal soarer: L/D 20–35
+- RC sport: L/D 10–15
+- Small UAV (fixed-wing): L/D 12–20
+
+### Sizing methodology (Scholz / Sadraey)
+For preliminary sizing use: T/W vs W/S matching chart, Breguet endurance
+equation, and constraint analysis. These are analytical starting points;
+refine with the polar tool.
+
+### First-flight CG (RC models only)
+Set CG to the aft edge of the safe forward CG range (typically 25–30 % MAC
+for trainers). Verify with a slow glide test at safe altitude.
+
+## Language
+Reply in the same language the user writes in (German if they write in
+German, English otherwise). UI chrome and code comments are always English.
+
+## Context hint (injected per turn)
+{context_hint}
+"""
+
+
+# ---------------------------------------------------------------------------
+# OpenAI client factory — monkeypatched in tests
+# ---------------------------------------------------------------------------
+
+
+def _make_openai_client():  # pragma: no cover — tested via monkeypatch
+    """Build an OpenAI-compatible client from config.
+
+    Returns an ``openai.AsyncOpenAI`` (or compatible) instance configured
+    to talk to the LiteLLM hub.  Tests replace this function to inject a
+    fake client.
+    """
+    from openai import AsyncOpenAI
+
+    from app.core.config import settings
+
+    kwargs: dict[str, Any] = {}
+    if settings.COPILOT_BASE_URL:
+        kwargs["base_url"] = settings.COPILOT_BASE_URL
+    if settings.COPILOT_API_KEY:
+        kwargs["api_key"] = settings.COPILOT_API_KEY.get_secret_value()
+    else:
+        # AsyncOpenAI requires an api_key; use a placeholder so the import
+        # succeeds even without a real key.  Actual calls will fail gracefully
+        # and the error is surfaced as an SSE error event.
+        kwargs["api_key"] = "no-key"
+
+    return AsyncOpenAI(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Helper — convert CopilotMessageRead → OpenAI message dict
+# ---------------------------------------------------------------------------
+
+
+def _history_to_openai(messages) -> list[dict[str, Any]]:
+    """Convert a list of CopilotMessageRead to OpenAI chat message dicts."""
+    result: list[dict[str, Any]] = []
+    for m in messages:
+        if m.role == "user":
+            result.append({"role": "user", "content": m.content or ""})
+        elif m.role == "assistant":
+            msg: dict[str, Any] = {"role": "assistant", "content": m.content or ""}
+            if m.tool_calls:
+                msg["tool_calls"] = m.tool_calls
+            result.append(msg)
+        elif m.role == "tool":
+            # Tool result messages: one message per tool result
+            if m.tool_results:
+                for tr in m.tool_results:
+                    result.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": tr.get("tool_call_id", ""),
+                            "content": json.dumps(tr.get("result", tr)),
+                        }
+                    )
+            else:
+                result.append({"role": "tool", "content": m.content or "", "tool_call_id": ""})
+    return result
+
+
+# ---------------------------------------------------------------------------
+# run_turn — async generator
+# ---------------------------------------------------------------------------
+
+
+async def run_turn(
+    *,
+    db: Session,
+    aeroplane_id: int,
+    history,
+    context_hint: str = "",
+) -> AsyncGenerator[dict[str, Any], None]:
+    """Run one copilot turn as an async generator of SSE-ready events.
+
+    Parameters
+    ----------
+    db:
+        SQLAlchemy session (caller-owned, no commit inside this function).
+    aeroplane_id:
+        Integer PK of the aeroplane (used for tool execution).
+    history:
+        CopilotHistory from ``copilot_history_service.get_history``.
+        The latest message is the user turn just appended.
+    context_hint:
+        Short string injected into the system prompt (e.g. "Active tab:
+        Wing Editor · Aircraft: MyGlider").
+
+    Yields
+    ------
+    dict
+        SSE-ready event dicts:
+        ``{"type": "token", "text": "…"}``
+        ``{"type": "tool_call", "name": "…", "args": {…}}``
+        ``{"type": "tool_result", "name": "…", "summary": {…}}``
+        ``{"type": "done"}``
+        ``{"type": "error", "message": "…"}``
+    """
+    from app.services import copilot_tools
+
+    from app.core.config import settings
+
+    system_content = SYSTEM_PROMPT.format(context_hint=context_hint or "(no context)")
+
+    # Build initial messages list
+    openai_messages: list[dict[str, Any]] = [
+        {"role": "system", "content": system_content},
+        *_history_to_openai(history.messages),
+    ]
+
+    tool_schemas = copilot_tools.list_schemas()
+
+    # Accumulate tool calls and results for final persistence
+    accumulated_tool_calls: list[dict[str, Any]] = []
+    accumulated_tool_results: list[dict[str, Any]] = []
+
+    # The final text the assistant produced (used for persistence)
+    final_text = ""
+
+    client = _make_openai_client()
+
+    for iteration in range(MAX_LOOP_ITERATIONS):
+        # ---- stream one completion ----------------------------------------
+        try:
+            stream = await client.chat.completions.create(
+                model=settings.COPILOT_MODEL,
+                messages=openai_messages,
+                tools=tool_schemas,
+                tool_choice="auto",
+                stream=True,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Hub call failed on iteration %d", iteration)
+            yield {"type": "error", "message": f"Hub error: {exc}"}
+            return
+
+        # Collect the streamed response
+        text_delta = ""
+        tool_call_chunks: dict[int, dict[str, Any]] = {}  # index → accumulated chunk
+        finish_reason: str | None = None
+
+        try:
+            async for chunk in stream:
+                choice = chunk.choices[0] if chunk.choices else None
+                if choice is None:
+                    continue
+
+                finish_reason = choice.finish_reason or finish_reason
+                delta = choice.delta
+
+                # Text token
+                if delta.content:
+                    text_delta += delta.content
+                    yield {"type": "token", "text": delta.content}
+
+                # Tool call chunk accumulation
+                if delta.tool_calls:
+                    for tc_chunk in delta.tool_calls:
+                        idx = tc_chunk.index
+                        if idx not in tool_call_chunks:
+                            tool_call_chunks[idx] = {
+                                "id": tc_chunk.id or "",
+                                "type": "function",
+                                "function": {"name": "", "arguments": ""},
+                            }
+                        if tc_chunk.id:
+                            tool_call_chunks[idx]["id"] = tc_chunk.id
+                        if tc_chunk.function:
+                            if tc_chunk.function.name:
+                                tool_call_chunks[idx]["function"]["name"] += (
+                                    tc_chunk.function.name
+                                )
+                            if tc_chunk.function.arguments:
+                                tool_call_chunks[idx]["function"]["arguments"] += (
+                                    tc_chunk.function.arguments
+                                )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Stream read failed on iteration %d", iteration)
+            yield {"type": "error", "message": f"Stream error: {exc}"}
+            return
+
+        if text_delta:
+            final_text += text_delta
+
+        # ---- handle finish_reason ----------------------------------------
+
+        if finish_reason == "stop" or (not tool_call_chunks and finish_reason != "tool_calls"):
+            # Normal text completion — we're done
+            break
+
+        if not tool_call_chunks:
+            # Unexpected finish without tool_calls and not stop
+            break
+
+        # ---- execute tool calls ------------------------------------------
+        # Build the assistant message with tool_calls
+        tool_calls_list = [tool_call_chunks[i] for i in sorted(tool_call_chunks)]
+
+        # Append assistant tool-call message to the conversation
+        openai_messages.append(
+            {
+                "role": "assistant",
+                "content": text_delta or None,
+                "tool_calls": tool_calls_list,
+            }
+        )
+
+        accumulated_tool_calls.extend(tool_calls_list)
+
+        tool_result_messages: list[dict[str, Any]] = []
+
+        for tc in tool_calls_list:
+            tool_name = tc["function"]["name"]
+            args_str = tc["function"]["arguments"]
+            tool_call_id = tc["id"]
+
+            # Parse args
+            try:
+                args = json.loads(args_str) if args_str else {}
+            except json.JSONDecodeError:
+                args = {}
+
+            yield {"type": "tool_call", "name": tool_name, "args": args}
+
+            # Execute server-side
+            try:
+                result = copilot_tools.execute(tool_name, db, aeroplane_id, **args)
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("Tool %s execution failed", tool_name)
+                result = {"error": str(exc)}
+
+            yield {"type": "tool_result", "name": tool_name, "summary": result}
+
+            tool_result_entry = {
+                "tool_call_id": tool_call_id,
+                "name": tool_name,
+                "result": result,
+            }
+            accumulated_tool_results.append(tool_result_entry)
+
+            tool_result_messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tool_call_id,
+                    "content": json.dumps(result),
+                }
+            )
+
+        # Append all tool results to the message thread
+        openai_messages.extend(tool_result_messages)
+
+    # Guard: if we hit MAX_LOOP_ITERATIONS without a stop, emit a note
+    # (the final text is whatever was accumulated so far)
+
+    yield {"type": "done", "tool_calls": accumulated_tool_calls, "tool_results": accumulated_tool_results, "final_text": final_text}

--- a/app/services/copilot_tools.py
+++ b/app/services/copilot_tools.py
@@ -1,0 +1,422 @@
+"""Copilot tool facade — curated registry for the AI copilot (gh-917).
+
+This module exposes a SMALL, carefully chosen set of tools that the copilot
+agent may call.  It is intentionally NOT the full 51-tool MCP surface — only
+the tools that are safe, fast, and meaningful for an advisory interaction.
+
+Tool contract
+-------------
+- Each tool impl has the signature ``fn(db, aeroplane_id, **kwargs) -> dict``.
+- Return value must be JSON-serializable (all SI/m units — no mm).
+- Errors are returned as ``{"error": "<message>"}`` — never raised raw.
+- ``run_analysis`` has a configurable timeout; on expiry it returns a status
+  dict so the copilot can tell the user to check the Analysis tab.
+
+Registry shape
+--------------
+``TOOL_REGISTRY``  dict[str, ToolEntry]
+
+``list_schemas()``   -> list[dict]   (OpenAI function-calling schemas)
+``execute(name, db, aeroplane_id, **kwargs) -> dict``
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Default timeout for run_analysis (seconds).
+# Override via dependency injection or monkeypatching in tests.
+# ---------------------------------------------------------------------------
+DEFAULT_ANALYSIS_TIMEOUT_S: float = 60.0
+
+# ---------------------------------------------------------------------------
+# Tool entry
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ToolEntry:
+    """Registry entry: OpenAI function schema + synchronous implementation."""
+
+    schema: dict  # the full OpenAI function-calling object (type="function")
+    impl: Callable[..., dict]
+
+
+# ---------------------------------------------------------------------------
+# Tool implementations
+# ---------------------------------------------------------------------------
+
+
+def _get_design_snapshot(db: Session, aeroplane_id: int) -> dict:
+    """Return full metrics payload for the current design state."""
+    try:
+        from app.services.aeroplane_version_service import _metrics_payload
+        from app.models.aeroplanemodel import AeroplaneModel
+
+        node = db.query(AeroplaneModel).filter(AeroplaneModel.id == aeroplane_id).first()
+        if node is None:
+            return {"error": f"Aeroplane {aeroplane_id} not found"}
+        return _metrics_payload(node)
+    except Exception as exc:
+        logger.exception("get_design_snapshot failed for aeroplane_id=%s", aeroplane_id)
+        return {"error": str(exc)}
+
+
+def _run_analysis(db: Session, aeroplane_id: int, kind: str = "polar") -> dict:
+    """Trigger a fast analysis and return a concise summary dict.
+
+    Parameters
+    ----------
+    kind:
+        ``"polar"``     — AeroBuildup alpha sweep (α: −10 … +15 deg) returning
+                          CL/CD/efficiency characteristics.
+        ``"stability"`` — AeroBuildup-based static-margin & stability
+                          derivatives.
+    """
+    kind = kind.lower()
+    if kind not in ("polar", "stability"):
+        return {
+            "error": f"Unsupported kind {kind!r}. Supported: 'polar', 'stability'."
+        }
+
+    from app.models.aeroplanemodel import AeroplaneModel
+
+    node = db.query(AeroplaneModel).filter(AeroplaneModel.id == aeroplane_id).first()
+    if node is None:
+        return {"error": f"Aeroplane {aeroplane_id} not found"}
+
+    aeroplane_uuid = str(node.uuid)
+
+    try:
+        loop = asyncio.new_event_loop()
+        try:
+            if kind == "polar":
+                result = loop.run_until_complete(
+                    asyncio.wait_for(
+                        _run_polar_async(db, aeroplane_uuid),
+                        timeout=DEFAULT_ANALYSIS_TIMEOUT_S,
+                    )
+                )
+            else:
+                result = loop.run_until_complete(
+                    asyncio.wait_for(
+                        _run_stability_async(db, aeroplane_uuid),
+                        timeout=DEFAULT_ANALYSIS_TIMEOUT_S,
+                    )
+                )
+        finally:
+            loop.close()
+        return result
+    except asyncio.TimeoutError:
+        return {
+            "status": "timeout",
+            "note": (
+                f"The {kind} analysis did not complete within "
+                f"{DEFAULT_ANALYSIS_TIMEOUT_S:.0f} s. "
+                "Check the Analysis tab for results once it finishes."
+            ),
+        }
+    except Exception as exc:
+        logger.exception(
+            "_run_analysis(%s) failed for aeroplane_id=%s", kind, aeroplane_id
+        )
+        return {"error": str(exc)}
+
+
+async def _run_polar_async(db: Session, aeroplane_uuid: str) -> dict:
+    """Run an AeroBuildup alpha sweep and return key polar numbers."""
+    import numpy as np
+    from app.schemas.AeroplaneRequest import AlphaSweepRequest, AnalysisToolUrlType
+    from app.schemas.aeroanalysisschema import OperatingPointSchema
+    from app.services.analysis_service import (
+        get_aeroplane_schema_or_raise,
+        _extract_alpha_sweep_arrays,
+        _compute_alpha_sweep_characteristic_points,
+    )
+    from app.converters.model_schema_converters import aeroplane_schema_to_asb_airplane_async
+    from app.api.utils import analyse_aerodynamics
+
+    sweep_request = AlphaSweepRequest(
+        altitude=0.0,
+        velocity=20.0,
+        alpha_start=-10.0,
+        alpha_end=15.0,
+        alpha_num=26,
+    )
+
+    plane_schema = get_aeroplane_schema_or_raise(db, aeroplane_uuid)
+    asb_airplane = aeroplane_schema_to_asb_airplane_async(plane_schema=plane_schema)
+
+    operating_point = OperatingPointSchema(
+        altitude=sweep_request.altitude,
+        velocity=sweep_request.velocity,
+        alpha=np.linspace(sweep_request.alpha_start, sweep_request.alpha_end, sweep_request.alpha_num),
+        beta=sweep_request.beta,
+        p=sweep_request.p,
+        q=sweep_request.q,
+        r=sweep_request.r,
+        xyz_ref=sweep_request.xyz_ref,
+    )
+
+    result, _ = analyse_aerodynamics(
+        AnalysisToolUrlType.AEROBUILDUP, operating_point, asb_airplane
+    )
+
+    alpha_array, cl_values, cd_values, cm_values = _extract_alpha_sweep_arrays(
+        result, sweep_request
+    )
+    char_points = _compute_alpha_sweep_characteristic_points(
+        alpha_array, cl_values, cd_values, cm_values
+    )
+
+    # Build a concise summary (SI/dimensionless)
+    summary: dict[str, Any] = {"status": "ok", "kind": "polar"}
+    if cl_values is not None:
+        summary["cl_max"] = float(np.nanmax(cl_values))
+        summary["cl_min"] = float(np.nanmin(cl_values))
+    if cd_values is not None:
+        summary["cd_min"] = float(np.nanmin(cd_values))
+    if cl_values is not None and cd_values is not None:
+        ratio = cl_values / np.where(cd_values > 0, cd_values, np.nan)
+        summary["cl_cd_max"] = float(np.nanmax(ratio))
+
+    # Include key characteristic points (rename keys for LLM clarity)
+    _char_map = {
+        "maximum_lift_to_drag_ratio_point": "best_glide",
+        "minimum_drag_coefficient_point": "min_drag",
+        "maximum_lift_coefficient_point": "cl_max_point",
+        "stall_point": "stall",
+    }
+    char_summary: dict[str, Any] = {}
+    for raw_key, friendly_key in _char_map.items():
+        pt = char_points.get(raw_key)
+        if pt:
+            char_summary[friendly_key] = {
+                k: (float(v) if isinstance(v, (int, float)) else v)
+                for k, v in pt.items()
+                if isinstance(v, (int, float, str))
+            }
+    if char_summary:
+        summary["characteristic_points"] = char_summary
+
+    return summary
+
+
+async def _run_stability_async(db: Session, aeroplane_uuid: str) -> dict:
+    """Run AeroBuildup stability analysis and return key stability numbers."""
+    from app.schemas.aeroanalysisschema import OperatingPointSchema
+    from app.schemas.AeroplaneRequest import AnalysisToolUrlType
+    from app.services.stability_service import get_stability_summary
+
+    operating_point = OperatingPointSchema(
+        altitude=0.0,
+        velocity=20.0,
+        alpha=2.0,
+    )
+
+    summary = await get_stability_summary(
+        db,
+        aeroplane_uuid,
+        operating_point=operating_point,
+        analysis_tool=AnalysisToolUrlType.AEROBUILDUP,
+    )
+
+    return {
+        "status": "ok",
+        "kind": "stability",
+        "static_margin_pct": summary.static_margin_pct,
+        "stability_class": summary.stability_class,
+        "neutral_point_x_m": summary.neutral_point_x,
+        "cg_x_m": summary.cg_x,
+        "Cma": summary.Cma,
+        "Cnb": summary.Cnb,
+        "Clb": summary.Clb,
+        "is_statically_stable": summary.is_statically_stable,
+        "is_directionally_stable": summary.is_directionally_stable,
+        "is_laterally_stable": summary.is_laterally_stable,
+        "mac_m": summary.mac,
+        "cg_range_forward_m": summary.cg_range_forward,
+        "cg_range_aft_m": summary.cg_range_aft,
+    }
+
+
+def _get_version_tree(db: Session, aeroplane_id: int) -> dict:
+    """Return the version lineage (branches + snapshots) for the aeroplane."""
+    try:
+        from app.services.aeroplane_version_service import list_tree
+        from app.models.aeroplanemodel import AeroplaneModel
+
+        node = db.query(AeroplaneModel).filter(AeroplaneModel.id == aeroplane_id).first()
+        if node is None:
+            return {"error": f"Aeroplane {aeroplane_id} not found"}
+
+        # Determine lineage root
+        root_id = node.root_id if node.root_id is not None else node.id
+
+        nodes, branches = list_tree(db, root_id)
+
+        serialized_nodes = [
+            {
+                "id": n.id,
+                "uuid": str(n.uuid),
+                "name": n.name,
+                "version_label": n.version_label,
+                "is_immutable": n.is_immutable,
+                "predecessor_id": n.predecessor_id,
+                "branch_id": n.branch_id,
+                "created_at": n.created_at.isoformat() if n.created_at else None,
+            }
+            for n in nodes
+        ]
+        serialized_branches = [
+            {
+                "id": b.id,
+                "name": b.name,
+                "is_main": b.is_main,
+                "head_id": b.head_id,
+                "root_id": b.root_id,
+            }
+            for b in branches
+        ]
+        return {
+            "root_id": root_id,
+            "nodes": serialized_nodes,
+            "branches": serialized_branches,
+        }
+    except Exception as exc:
+        logger.exception("get_version_tree failed for aeroplane_id=%s", aeroplane_id)
+        return {"error": str(exc)}
+
+
+# ---------------------------------------------------------------------------
+# OpenAI function-calling schemas
+# ---------------------------------------------------------------------------
+
+_SCHEMA_GET_DESIGN_SNAPSHOT = {
+    "type": "function",
+    "function": {
+        "name": "get_design_snapshot",
+        "description": (
+            "Retrieve the full current design metrics for the active aeroplane: "
+            "geometry (span, area, AR), mass, balance/CG, speeds, stability summary, "
+            "tail sizing, and powertrain.  Call this first to ground any analysis in "
+            "real numbers.  All values are in SI units (m, kg, m/s)."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    },
+}
+
+_SCHEMA_RUN_ANALYSIS = {
+    "type": "function",
+    "function": {
+        "name": "run_analysis",
+        "description": (
+            "Trigger a fast aerodynamic analysis and return key results. "
+            "Use kind='polar' for the lift/drag polar (CL, CD, best-glide, stall). "
+            "Use kind='stability' for static margin, neutral point, CG range, "
+            "and longitudinal/directional/lateral derivatives. "
+            "Analysis runs with AeroBuildup (fast, no AVL). "
+            "If it times out you will get a status='timeout' response — tell the "
+            "user to check the Analysis tab."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "kind": {
+                    "type": "string",
+                    "enum": ["polar", "stability"],
+                    "description": (
+                        "'polar' — alpha sweep returning CL/CD characteristics; "
+                        "'stability' — static margin, neutral point, derivatives."
+                    ),
+                }
+            },
+            "required": ["kind"],
+        },
+    },
+}
+
+_SCHEMA_GET_VERSION_TREE = {
+    "type": "function",
+    "function": {
+        "name": "get_version_tree",
+        "description": (
+            "Return the version lineage for the active aeroplane: all design "
+            "snapshots and branches with their labels, immutability status, "
+            "and predecessor links.  Use this to answer questions like 'what "
+            "versions do I have?' or to identify which snapshot to compare."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+TOOL_REGISTRY: dict[str, ToolEntry] = {
+    "get_design_snapshot": ToolEntry(
+        schema=_SCHEMA_GET_DESIGN_SNAPSHOT,
+        impl=_get_design_snapshot,
+    ),
+    "run_analysis": ToolEntry(
+        schema=_SCHEMA_RUN_ANALYSIS,
+        impl=_run_analysis,
+    ),
+    "get_version_tree": ToolEntry(
+        schema=_SCHEMA_GET_VERSION_TREE,
+        impl=_get_version_tree,
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def list_schemas() -> list[dict]:
+    """Return OpenAI function-calling schemas for all registered tools."""
+    return [entry.schema for entry in TOOL_REGISTRY.values()]
+
+
+def execute(name: str, db: Session, aeroplane_id: int, **kwargs: Any) -> dict:
+    """Execute a registered tool by name.
+
+    Parameters
+    ----------
+    name:
+        Tool name (must be in ``TOOL_REGISTRY``).
+    db:
+        SQLAlchemy session (caller-owned; this function does NOT commit).
+    aeroplane_id:
+        Integer PK of the target aeroplane.
+    **kwargs:
+        Tool-specific arguments (validated by the tool impl).
+
+    Returns
+    -------
+    dict
+        JSON-serializable result.  On unknown tool: ``{"error": "..."}``.
+    """
+    entry = TOOL_REGISTRY.get(name)
+    if entry is None:
+        known = ", ".join(sorted(TOOL_REGISTRY))
+        return {"error": f"Unknown tool {name!r}. Known tools: {known}"}
+    return entry.impl(db, aeroplane_id, **kwargs)

--- a/app/services/copilot_tools.py
+++ b/app/services/copilot_tools.py
@@ -96,24 +96,21 @@ def _run_analysis(db: Session, aeroplane_id: int, kind: str = "polar") -> dict:
     aeroplane_uuid = str(node.uuid)
 
     try:
-        loop = asyncio.new_event_loop()
-        try:
-            if kind == "polar":
-                result = loop.run_until_complete(
-                    asyncio.wait_for(
-                        _run_polar_async(db, aeroplane_uuid),
-                        timeout=DEFAULT_ANALYSIS_TIMEOUT_S,
-                    )
-                )
-            else:
-                result = loop.run_until_complete(
-                    asyncio.wait_for(
-                        _run_stability_async(db, aeroplane_uuid),
-                        timeout=DEFAULT_ANALYSIS_TIMEOUT_S,
-                    )
-                )
-        finally:
-            loop.close()
+        # ``_run_analysis`` is always called from a worker thread (via
+        # ``asyncio.to_thread`` in ``run_turn``), so there is NO running event
+        # loop here.  Use ``asyncio.run`` — it creates a fresh loop, runs the
+        # coroutine, and closes the loop when done.  This is safe and correct;
+        # do NOT use ``asyncio.new_event_loop().run_until_complete`` because
+        # that leaks the loop and fails if accidentally called on the main
+        # thread while a loop is already running.
+        if kind == "polar":
+            coro = _run_polar_async(db, aeroplane_uuid)
+        else:
+            coro = _run_stability_async(db, aeroplane_uuid)
+
+        result = asyncio.run(
+            asyncio.wait_for(coro, timeout=DEFAULT_ANALYSIS_TIMEOUT_S)
+        )
         return result
     except asyncio.TimeoutError:
         return {

--- a/app/tests/test_copilot_config.py
+++ b/app/tests/test_copilot_config.py
@@ -163,3 +163,41 @@ class TestExistingFields:
         assert isinstance(REPO_ROOT, Path)
         assert isinstance(AIRFOILS_DIR, Path)
         assert AIRFOILS_DIR == REPO_ROOT / "components" / "airfoils"
+
+
+# ---------------------------------------------------------------------------
+# ARTIFACTS_BASE_DIR always resolved to absolute path (gh-902 minor fix)
+# ---------------------------------------------------------------------------
+
+
+class TestArtifactsDirResolution:
+    """ARTIFACTS_BASE_DIR must always be an absolute Path, even when set via env."""
+
+    def test_default_is_absolute(self):
+        from app.core.config import Settings
+
+        s = Settings()
+        assert s.ARTIFACTS_BASE_DIR.is_absolute(), (
+            f"Default ARTIFACTS_BASE_DIR must be absolute, got: {s.ARTIFACTS_BASE_DIR}"
+        )
+
+    def test_relative_env_override_is_resolved_to_absolute(self, monkeypatch):
+        """A relative path in the env var must be made absolute by the validator."""
+        monkeypatch.setenv("ARTIFACTS_BASE_DIR", "relative/path/to/artifacts")
+        from app.core.config import Settings
+
+        s = Settings()
+        assert s.ARTIFACTS_BASE_DIR.is_absolute(), (
+            f"Relative ARTIFACTS_BASE_DIR env override was not resolved: "
+            f"{s.ARTIFACTS_BASE_DIR}"
+        )
+
+    def test_absolute_env_override_stays_absolute(self, monkeypatch):
+        monkeypatch.setenv("ARTIFACTS_BASE_DIR", "/tmp/custom_artifacts")
+        from app.core.config import Settings
+
+        s = Settings()
+        assert s.ARTIFACTS_BASE_DIR.is_absolute()
+        # resolve() may expand symlinks (e.g. /tmp → /private/tmp on macOS),
+        # so just check the meaningful path suffix is preserved.
+        assert "custom_artifacts" in str(s.ARTIFACTS_BASE_DIR)

--- a/app/tests/test_copilot_config.py
+++ b/app/tests/test_copilot_config.py
@@ -1,0 +1,165 @@
+"""Tests for COPILOT_* settings in app.core.config (gh-916)."""
+
+import importlib
+import sys
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fresh_settings(**env_overrides):
+    """
+    Import (or re-import) app.core.config with the given env vars injected,
+    returning a *new* Settings() instance (not the module-level singleton).
+
+    We reload the module so pydantic-settings picks up the patched env.
+    """
+    import app.core.config as mod
+
+    # Reload so any previous module-level singleton does not pollute state.
+    importlib.reload(mod)
+    return mod.Settings(**env_overrides)
+
+
+# ---------------------------------------------------------------------------
+# Default values
+# ---------------------------------------------------------------------------
+
+class TestCopilotDefaults:
+    def test_api_key_default_is_none(self):
+        from app.core.config import Settings
+
+        s = Settings()
+        assert s.COPILOT_API_KEY is None
+
+    def test_base_url_default_is_none(self):
+        from app.core.config import Settings
+
+        s = Settings()
+        assert s.COPILOT_BASE_URL is None
+
+    def test_model_default(self):
+        from app.core.config import Settings
+
+        s = Settings()
+        assert s.COPILOT_MODEL == "claude-sonnet-4-6"
+
+    def test_embedding_model_default(self):
+        from app.core.config import Settings
+
+        s = Settings()
+        assert s.COPILOT_EMBEDDING_MODEL == "text-embedding-3-large"
+
+
+# ---------------------------------------------------------------------------
+# Values loaded from environment variables
+# ---------------------------------------------------------------------------
+
+class TestCopilotFromEnv:
+    def test_api_key_from_env(self, monkeypatch):
+        monkeypatch.setenv("COPILOT_API_KEY", "sk-test-1234")
+        from app.core.config import Settings
+
+        s = Settings()
+        assert s.COPILOT_API_KEY is not None
+        assert s.COPILOT_API_KEY.get_secret_value() == "sk-test-1234"
+
+    def test_base_url_from_env(self, monkeypatch):
+        monkeypatch.setenv("COPILOT_BASE_URL", "https://hub.example.com/v1")
+        from app.core.config import Settings
+
+        s = Settings()
+        assert s.COPILOT_BASE_URL == "https://hub.example.com/v1"
+
+    def test_model_override_from_env(self, monkeypatch):
+        monkeypatch.setenv("COPILOT_MODEL", "claude-opus-4-5")
+        from app.core.config import Settings
+
+        s = Settings()
+        assert s.COPILOT_MODEL == "claude-opus-4-5"
+
+    def test_embedding_model_override_from_env(self, monkeypatch):
+        monkeypatch.setenv("COPILOT_EMBEDDING_MODEL", "text-embedding-ada-002")
+        from app.core.config import Settings
+
+        s = Settings()
+        assert s.COPILOT_EMBEDDING_MODEL == "text-embedding-ada-002"
+
+
+# ---------------------------------------------------------------------------
+# SecretStr masking
+# ---------------------------------------------------------------------------
+
+class TestSecretStrMasking:
+    def test_api_key_masked_in_str(self, monkeypatch):
+        monkeypatch.setenv("COPILOT_API_KEY", "sk-supersecret")
+        from app.core.config import Settings
+
+        s = Settings()
+        # The raw key must NOT appear in the default string representation.
+        assert "sk-supersecret" not in str(s)
+        assert "sk-supersecret" not in repr(s)
+
+    def test_api_key_masked_in_repr(self, monkeypatch):
+        monkeypatch.setenv("COPILOT_API_KEY", "sk-supersecret")
+        from app.core.config import Settings
+
+        s = Settings()
+        # pydantic-settings renders SecretStr as '**********' in repr.
+        assert "**" in repr(s)
+
+    def test_api_key_accessible_via_get_secret_value(self, monkeypatch):
+        monkeypatch.setenv("COPILOT_API_KEY", "sk-supersecret")
+        from app.core.config import Settings
+
+        s = Settings()
+        assert s.COPILOT_API_KEY.get_secret_value() == "sk-supersecret"  # type: ignore[union-attr]
+
+
+# ---------------------------------------------------------------------------
+# Existing fields still work (non-regression)
+# ---------------------------------------------------------------------------
+
+class TestExistingFields:
+    def test_project_name(self):
+        from app.core.config import Settings
+
+        s = Settings()
+        assert s.PROJECT_NAME == "My FastAPI Project"
+
+    def test_version(self):
+        from app.core.config import Settings
+
+        s = Settings()
+        assert s.VERSION == "1.0.0"
+
+    def test_uvicorn_host(self):
+        from app.core.config import Settings
+
+        s = Settings()
+        assert s.UVICORN_HOST == "127.0.0.1"
+
+    def test_artifacts_base_dir_is_path(self):
+        from pathlib import Path
+
+        from app.core.config import Settings
+
+        s = Settings()
+        assert isinstance(s.ARTIFACTS_BASE_DIR, Path)
+
+    def test_module_level_singleton(self):
+        from app.core.config import Settings, settings
+
+        assert isinstance(settings, Settings)
+
+    def test_module_constants(self):
+        from pathlib import Path
+
+        from app.core.config import AIRFOILS_DIR, REPO_ROOT
+
+        assert isinstance(REPO_ROOT, Path)
+        assert isinstance(AIRFOILS_DIR, Path)
+        assert AIRFOILS_DIR == REPO_ROOT / "components" / "airfoils"

--- a/app/tests/test_copilot_service.py
+++ b/app/tests/test_copilot_service.py
@@ -173,7 +173,7 @@ class TestRunTurnTextOnly:
             with patch.object(svc_module, "_make_openai_client", return_value=fake_client):
                 import asyncio
 
-                events = asyncio.get_event_loop().run_until_complete(
+                events = asyncio.run(
                     _collect_events(
                         run_turn(
                             db=db,
@@ -204,7 +204,7 @@ class TestRunTurnTextOnly:
             with patch.object(svc_module, "_make_openai_client", return_value=fake_client):
                 import asyncio
 
-                events = asyncio.get_event_loop().run_until_complete(
+                events = asyncio.run(
                     _collect_events(
                         run_turn(
                             db=db,
@@ -243,7 +243,7 @@ class TestRunTurnWithToolCall:
                 ) as mock_execute:
                     import asyncio
 
-                    events = asyncio.get_event_loop().run_until_complete(
+                    events = asyncio.run(
                         _collect_events(
                             run_turn(
                                 db=db,
@@ -282,7 +282,7 @@ class TestRunTurnWithToolCall:
                 with patch("app.services.copilot_tools.execute", return_value={"status": "ok"}):
                     import asyncio
 
-                    events = asyncio.get_event_loop().run_until_complete(
+                    events = asyncio.run(
                         _collect_events(
                             run_turn(db=db, aeroplane_id=aeroplane.id, history=history)
                         )
@@ -311,7 +311,7 @@ class TestRunTurnWithToolCall:
                 with patch("app.services.copilot_tools.execute", return_value=stub_result):
                     import asyncio
 
-                    events = asyncio.get_event_loop().run_until_complete(
+                    events = asyncio.run(
                         _collect_events(
                             run_turn(db=db, aeroplane_id=aeroplane.id, history=history)
                         )
@@ -341,7 +341,7 @@ class TestRunTurnWithToolCall:
                 ):
                     import asyncio
 
-                    events = asyncio.get_event_loop().run_until_complete(
+                    events = asyncio.run(
                         _collect_events(
                             run_turn(db=db, aeroplane_id=aeroplane.id, history=history)
                         )
@@ -384,7 +384,7 @@ class TestMaxIterationsGuard:
                 ):
                     import asyncio
 
-                    events = asyncio.get_event_loop().run_until_complete(
+                    events = asyncio.run(
                         _collect_events(
                             run_turn(db=db, aeroplane_id=aeroplane.id, history=history)
                         )
@@ -416,7 +416,7 @@ class TestHubError:
             with patch.object(svc_module, "_make_openai_client", return_value=client):
                 import asyncio
 
-                events = asyncio.get_event_loop().run_until_complete(
+                events = asyncio.run(
                     _collect_events(
                         run_turn(db=db, aeroplane_id=aeroplane.id, history=history)
                     )
@@ -450,7 +450,7 @@ class TestHubError:
                 original_key = cfg_mod.settings.COPILOT_API_KEY
                 cfg_mod.settings.COPILOT_API_KEY = SecretStr("sk-secret-key-value")
                 try:
-                    events = asyncio.get_event_loop().run_until_complete(
+                    events = asyncio.run(
                         _collect_events(
                             run_turn(db=db, aeroplane_id=aeroplane.id, history=history)
                         )
@@ -517,7 +517,7 @@ class TestRunAnalysisViaToThread:
                 with patch.object(tools_module, "_run_polar_async", _instant_polar):
                     # Run on a live event loop — this is what raises if the
                     # asyncio.new_event_loop().run_until_complete() bug exists.
-                    events = asyncio.get_event_loop().run_until_complete(
+                    events = asyncio.run(
                         _collect_events(
                             run_turn(
                                 db=db,
@@ -572,7 +572,7 @@ class TestRunAnalysisViaToThread:
                     )
             return result
 
-        result = asyncio.get_event_loop().run_until_complete(_run())
+        result = asyncio.run(_run())
         # Must not raise; must return the mocked polar result
         assert result.get("status") == "ok"
         assert result.get("kind") == "polar"
@@ -614,7 +614,7 @@ class TestApiKeyNotLeakedInSseEvents:
             cfg_mod.settings.COPILOT_API_KEY = SecretStr(fake_key)
             try:
                 with patch.object(svc_module, "_make_openai_client", return_value=client):
-                    events = asyncio.get_event_loop().run_until_complete(
+                    events = asyncio.run(
                         _collect_events(
                             run_turn(db=db, aeroplane_id=aeroplane.id, history=history)
                         )
@@ -659,7 +659,7 @@ class TestApiKeyNotLeakedInSseEvents:
             cfg_mod.settings.COPILOT_API_KEY = SecretStr(fake_key)
             try:
                 with patch.object(svc_module, "_make_openai_client", return_value=client):
-                    events = asyncio.get_event_loop().run_until_complete(
+                    events = asyncio.run(
                         _collect_events(
                             run_turn(db=db, aeroplane_id=aeroplane.id, history=history)
                         )
@@ -708,7 +708,7 @@ class TestTruncatedFlag:
                 with patch(
                     "app.services.copilot_tools.execute", return_value={"data": "ok"}
                 ):
-                    events = asyncio.get_event_loop().run_until_complete(
+                    events = asyncio.run(
                         _collect_events(
                             run_turn(db=db, aeroplane_id=aeroplane.id, history=history)
                         )
@@ -730,7 +730,7 @@ class TestTruncatedFlag:
             fake_client = _fake_client_for_text("All done cleanly.")
 
             with patch.object(svc_module, "_make_openai_client", return_value=fake_client):
-                events = asyncio.get_event_loop().run_until_complete(
+                events = asyncio.run(
                     _collect_events(
                         run_turn(db=db, aeroplane_id=aeroplane.id, history=history)
                     )

--- a/app/tests/test_copilot_service.py
+++ b/app/tests/test_copilot_service.py
@@ -1,0 +1,452 @@
+"""Tests for app.services.copilot_service — tool-calling loop (gh-918).
+
+The LiteLLM hub is NEVER called in these tests.  ``_make_openai_client``
+is monkeypatched to return a scripted fake client whose
+``chat.completions.create`` returns pre-built async streams.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import AsyncGenerator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import app.services.copilot_service as svc_module
+from app.schemas.copilot_history import CopilotHistory, CopilotMessageRead
+from app.services.copilot_service import MAX_LOOP_ITERATIONS, run_turn
+from app.tests.conftest import make_aeroplane
+
+
+# ---------------------------------------------------------------------------
+# Fake stream helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_chunk(content: str | None = None, tool_calls=None, finish_reason: str | None = None):
+    """Build a minimal streaming chunk object."""
+    delta = MagicMock()
+    delta.content = content
+    delta.tool_calls = tool_calls or []
+
+    choice = MagicMock()
+    choice.delta = delta
+    choice.finish_reason = finish_reason
+
+    chunk = MagicMock()
+    chunk.choices = [choice]
+    return chunk
+
+
+def _make_tool_call_chunk(index: int, call_id: str, name: str, args: str):
+    """Build a tool-call delta chunk."""
+    func = MagicMock()
+    func.name = name
+    func.arguments = args
+
+    tc = MagicMock()
+    tc.index = index
+    tc.id = call_id
+    tc.function = func
+
+    return _make_chunk(tool_calls=[tc], finish_reason="tool_calls")
+
+
+async def _async_iter(items):
+    """Yield items from a list as an async iterator."""
+    for item in items:
+        yield item
+
+
+class FakeStream:
+    """An async context manager that yields chunks."""
+
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def __aiter__(self):
+        return _async_iter(self._chunks).__aiter__()
+
+
+def _fake_client_for_text(text: str):
+    """A fake client whose single stream yields a text response then stops."""
+    chunks = [
+        _make_chunk(content=text[:5]),
+        _make_chunk(content=text[5:]),
+        _make_chunk(finish_reason="stop"),
+    ]
+
+    client = MagicMock()
+    client.chat = MagicMock()
+    client.chat.completions = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=FakeStream(chunks))
+    return client
+
+
+def _fake_client_with_one_tool_call(
+    tool_name: str,
+    tool_args: dict,
+    call_id: str,
+    final_text: str,
+):
+    """A fake client that: first yields a tool_call, then yields text + stop."""
+    args_str = json.dumps(tool_args)
+
+    # First stream: one tool-call chunk + finish_reason=tool_calls
+    tc_chunk = _make_tool_call_chunk(0, call_id, tool_name, args_str)
+    first_stream = FakeStream([tc_chunk])
+
+    # Second stream: text reply + stop
+    second_chunks = [
+        _make_chunk(content=final_text),
+        _make_chunk(finish_reason="stop"),
+    ]
+    second_stream = FakeStream(second_chunks)
+
+    call_count = [0]
+
+    async def _create(**_kwargs):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return first_stream
+        return second_stream
+
+    client = MagicMock()
+    client.chat = MagicMock()
+    client.chat.completions = MagicMock()
+    client.chat.completions.create = _create
+    return client
+
+
+def _build_history(messages=None) -> CopilotHistory:
+    """Build a minimal CopilotHistory for testing."""
+    from datetime import datetime, timezone
+
+    msgs = []
+    for i, (role, content) in enumerate(messages or [("user", "hello")]):
+        msgs.append(
+            CopilotMessageRead(
+                id=i + 1,
+                role=role,
+                content=content,
+                tool_calls=None,
+                tool_results=None,
+                parent_id=None,
+                created_at=datetime.now(timezone.utc),
+            )
+        )
+    return CopilotHistory(messages=msgs)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _collect_events(gen: AsyncGenerator) -> list[dict]:
+    events = []
+    async for ev in gen:
+        events.append(ev)
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunTurnTextOnly:
+    """A plain text response with no tool calls."""
+
+    def test_yields_tokens_and_done(self, client_and_db):
+        _, SessionLocal = client_and_db
+
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            history = _build_history([("user", "What is the static margin?")])
+
+            fake_client = _fake_client_for_text("Hello world")
+
+            with patch.object(svc_module, "_make_openai_client", return_value=fake_client):
+                import asyncio
+
+                events = asyncio.get_event_loop().run_until_complete(
+                    _collect_events(
+                        run_turn(
+                            db=db,
+                            aeroplane_id=aeroplane.id,
+                            history=history,
+                            context_hint="Wing Editor",
+                        )
+                    )
+                )
+
+            types = [e["type"] for e in events]
+            assert "token" in types
+            assert types[-1] == "done"
+
+            # Verify text is assembled correctly
+            token_text = "".join(e["text"] for e in events if e["type"] == "token")
+            assert "Hello world" == token_text
+
+    def test_done_event_has_final_text(self, client_and_db):
+        _, SessionLocal = client_and_db
+
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            history = _build_history()
+
+            fake_client = _fake_client_for_text("test response")
+
+            with patch.object(svc_module, "_make_openai_client", return_value=fake_client):
+                import asyncio
+
+                events = asyncio.get_event_loop().run_until_complete(
+                    _collect_events(
+                        run_turn(
+                            db=db,
+                            aeroplane_id=aeroplane.id,
+                            history=history,
+                        )
+                    )
+                )
+
+            done_event = next(e for e in events if e["type"] == "done")
+            assert done_event["final_text"] == "test response"
+
+
+class TestRunTurnWithToolCall:
+    """One tool call followed by a text response."""
+
+    def test_yields_tool_call_tool_result_token_done(self, client_and_db):
+        _, SessionLocal = client_and_db
+
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            history = _build_history([("user", "What is my design like?")])
+
+            fake_client = _fake_client_with_one_tool_call(
+                tool_name="get_design_snapshot",
+                tool_args={},
+                call_id="call_abc123",
+                final_text="Here is your design summary.",
+            )
+
+            # Stub out the actual tool execution (no real DB queries needed)
+            stub_result = {"span_m": 1.5, "mass_kg": 1.2}
+            with patch.object(svc_module, "_make_openai_client", return_value=fake_client):
+                with patch(
+                    "app.services.copilot_tools.execute", return_value=stub_result
+                ) as mock_execute:
+                    import asyncio
+
+                    events = asyncio.get_event_loop().run_until_complete(
+                        _collect_events(
+                            run_turn(
+                                db=db,
+                                aeroplane_id=aeroplane.id,
+                                history=history,
+                            )
+                        )
+                    )
+
+            types = [e["type"] for e in events]
+            assert "tool_call" in types
+            assert "tool_result" in types
+            assert "token" in types
+            assert types[-1] == "done"
+
+            # Verify tool was called with correct name and args
+            mock_execute.assert_called_once_with(
+                "get_design_snapshot", db, aeroplane.id
+            )
+
+    def test_tool_call_event_has_name_and_args(self, client_and_db):
+        _, SessionLocal = client_and_db
+
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            history = _build_history()
+
+            fake_client = _fake_client_with_one_tool_call(
+                tool_name="run_analysis",
+                tool_args={"kind": "polar"},
+                call_id="call_xyz",
+                final_text="Analysis complete.",
+            )
+
+            with patch.object(svc_module, "_make_openai_client", return_value=fake_client):
+                with patch("app.services.copilot_tools.execute", return_value={"status": "ok"}):
+                    import asyncio
+
+                    events = asyncio.get_event_loop().run_until_complete(
+                        _collect_events(
+                            run_turn(db=db, aeroplane_id=aeroplane.id, history=history)
+                        )
+                    )
+
+            tc_event = next(e for e in events if e["type"] == "tool_call")
+            assert tc_event["name"] == "run_analysis"
+            assert tc_event["args"] == {"kind": "polar"}
+
+    def test_tool_result_event_has_summary(self, client_and_db):
+        _, SessionLocal = client_and_db
+
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            history = _build_history()
+
+            fake_client = _fake_client_with_one_tool_call(
+                tool_name="get_design_snapshot",
+                tool_args={},
+                call_id="call_r1",
+                final_text="Done.",
+            )
+            stub_result = {"mass_kg": 1.5}
+
+            with patch.object(svc_module, "_make_openai_client", return_value=fake_client):
+                with patch("app.services.copilot_tools.execute", return_value=stub_result):
+                    import asyncio
+
+                    events = asyncio.get_event_loop().run_until_complete(
+                        _collect_events(
+                            run_turn(db=db, aeroplane_id=aeroplane.id, history=history)
+                        )
+                    )
+
+            tr_event = next(e for e in events if e["type"] == "tool_result")
+            assert tr_event["name"] == "get_design_snapshot"
+            assert tr_event["summary"] == stub_result
+
+    def test_done_accumulates_tool_calls_and_results(self, client_and_db):
+        _, SessionLocal = client_and_db
+
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            history = _build_history()
+
+            fake_client = _fake_client_with_one_tool_call(
+                tool_name="get_version_tree",
+                tool_args={},
+                call_id="call_v1",
+                final_text="Version info provided.",
+            )
+
+            with patch.object(svc_module, "_make_openai_client", return_value=fake_client):
+                with patch(
+                    "app.services.copilot_tools.execute", return_value={"nodes": []}
+                ):
+                    import asyncio
+
+                    events = asyncio.get_event_loop().run_until_complete(
+                        _collect_events(
+                            run_turn(db=db, aeroplane_id=aeroplane.id, history=history)
+                        )
+                    )
+
+            done_event = next(e for e in events if e["type"] == "done")
+            assert len(done_event["tool_calls"]) == 1
+            assert len(done_event["tool_results"]) == 1
+            assert done_event["tool_calls"][0]["function"]["name"] == "get_version_tree"
+
+
+class TestMaxIterationsGuard:
+    """The loop must stop after MAX_LOOP_ITERATIONS even if the model keeps requesting tools."""
+
+    def test_guard_prevents_infinite_loop(self, client_and_db):
+        _, SessionLocal = client_and_db
+
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            history = _build_history()
+
+            # Every call returns another tool_call (never stops)
+            call_count = [0]
+
+            async def _always_tool_call(**_kwargs):
+                call_count[0] += 1
+                tc_chunk = _make_tool_call_chunk(
+                    0, f"call_{call_count[0]}", "get_design_snapshot", "{}"
+                )
+                return FakeStream([tc_chunk])
+
+            client = MagicMock()
+            client.chat = MagicMock()
+            client.chat.completions = MagicMock()
+            client.chat.completions.create = _always_tool_call
+
+            with patch.object(svc_module, "_make_openai_client", return_value=client):
+                with patch(
+                    "app.services.copilot_tools.execute", return_value={"data": "ok"}
+                ):
+                    import asyncio
+
+                    events = asyncio.get_event_loop().run_until_complete(
+                        _collect_events(
+                            run_turn(db=db, aeroplane_id=aeroplane.id, history=history)
+                        )
+                    )
+
+            # Should have stopped after MAX_LOOP_ITERATIONS completions
+            assert call_count[0] <= MAX_LOOP_ITERATIONS
+            # Last event should be done (not an error)
+            assert events[-1]["type"] == "done"
+
+
+class TestHubError:
+    """If the hub raises, an error event is emitted."""
+
+    def test_hub_error_yields_error_event(self, client_and_db):
+        _, SessionLocal = client_and_db
+
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            history = _build_history()
+
+            client = MagicMock()
+            client.chat = MagicMock()
+            client.chat.completions = MagicMock()
+            client.chat.completions.create = AsyncMock(
+                side_effect=RuntimeError("connection refused")
+            )
+
+            with patch.object(svc_module, "_make_openai_client", return_value=client):
+                import asyncio
+
+                events = asyncio.get_event_loop().run_until_complete(
+                    _collect_events(
+                        run_turn(db=db, aeroplane_id=aeroplane.id, history=history)
+                    )
+                )
+
+            assert events[0]["type"] == "error"
+            assert "connection refused" in events[0]["message"]
+
+    def test_hub_error_does_not_leak_api_key(self, client_and_db):
+        _, SessionLocal = client_and_db
+
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            history = _build_history()
+
+            client = MagicMock()
+            client.chat = MagicMock()
+            client.chat.completions = MagicMock()
+            client.chat.completions.create = AsyncMock(
+                side_effect=RuntimeError("auth failed: key=sk-secret-key-value")
+            )
+
+            # The error message is emitted as-is from the exception, but
+            # the endpoint layer never leaks it as an HTTP body.
+            # This test just confirms the event type is correct.
+            with patch.object(svc_module, "_make_openai_client", return_value=client):
+                import asyncio
+
+                events = asyncio.get_event_loop().run_until_complete(
+                    _collect_events(
+                        run_turn(db=db, aeroplane_id=aeroplane.id, history=history)
+                    )
+                )
+
+            assert events[0]["type"] == "error"

--- a/app/tests/test_copilot_service.py
+++ b/app/tests/test_copilot_service.py
@@ -7,6 +7,7 @@ is monkeypatched to return a scripted fake client whose
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import AsyncGenerator
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -14,8 +15,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 import app.services.copilot_service as svc_module
+import app.services.copilot_tools as tools_module
 from app.schemas.copilot_history import CopilotHistory, CopilotMessageRead
-from app.services.copilot_service import MAX_LOOP_ITERATIONS, run_turn
+from app.services.copilot_service import MAX_LOOP_ITERATIONS, _sanitize_error, run_turn
 from app.tests.conftest import make_aeroplane
 
 
@@ -421,7 +423,8 @@ class TestHubError:
                 )
 
             assert events[0]["type"] == "error"
-            assert "connection refused" in events[0]["message"]
+            # The sanitizer replaces raw connection details with a category message.
+            assert "error" in events[0]["message"].lower()
 
     def test_hub_error_does_not_leak_api_key(self, client_and_db):
         _, SessionLocal = client_and_db
@@ -439,14 +442,342 @@ class TestHubError:
 
             # The error message is emitted as-is from the exception, but
             # the endpoint layer never leaks it as an HTTP body.
-            # This test just confirms the event type is correct.
+            # The sanitizer must redact the key — this test now asserts absence.
             with patch.object(svc_module, "_make_openai_client", return_value=client):
-                import asyncio
+                import app.core.config as cfg_mod
+                from pydantic import SecretStr
 
+                original_key = cfg_mod.settings.COPILOT_API_KEY
+                cfg_mod.settings.COPILOT_API_KEY = SecretStr("sk-secret-key-value")
+                try:
+                    events = asyncio.get_event_loop().run_until_complete(
+                        _collect_events(
+                            run_turn(db=db, aeroplane_id=aeroplane.id, history=history)
+                        )
+                    )
+                finally:
+                    cfg_mod.settings.COPILOT_API_KEY = original_key
+
+            assert events[0]["type"] == "error"
+            # The raw key must NOT appear in any event
+            all_event_text = json.dumps(events)
+            assert "sk-secret-key-value" not in all_event_text, (
+                f"API key leaked in events: {all_event_text}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Blocker 1 — event-loop safety: run_analysis via asyncio.to_thread
+# ---------------------------------------------------------------------------
+
+
+class TestRunAnalysisViaToThread:
+    """The critical regression guard for gh-902 Blocker 1.
+
+    ``run_turn`` is an async generator that runs on the uvicorn event loop.
+    It must dispatch ``copilot_tools.execute`` (and therefore ``_run_analysis``)
+    to a worker thread via ``asyncio.to_thread`` so that the worker can call
+    ``asyncio.run()`` without raising
+    "RuntimeError: This event loop is already running".
+
+    This test exercises the REAL ``copilot_tools.execute`` → ``_run_analysis``
+    code path (NOT mocked) on a live event loop.  Only ``_run_polar_async`` is
+    stubbed to avoid real aero computation in CI.
+    """
+
+    def test_run_analysis_does_not_raise_on_live_event_loop(self, client_and_db):
+        """Drives run_turn end-to-end on a live loop with a real execute call."""
+        _, SessionLocal = client_and_db
+
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            history = _build_history([("user", "What is the polar?")])
+
+            # Hub client: first call returns run_analysis tool call, second
+            # returns a text stop — the hub never makes a real network call.
+            fake_client = _fake_client_with_one_tool_call(
+                tool_name="run_analysis",
+                tool_args={"kind": "polar"},
+                call_id="call_event_loop_test",
+                final_text="Polar analysed.",
+            )
+
+            # Stub the expensive async polar computation to return immediately.
+            # We do NOT stub copilot_tools.execute — the real dispatch path must run.
+            async def _instant_polar(db, aeroplane_uuid):
+                return {
+                    "status": "ok",
+                    "kind": "polar",
+                    "cl_max": 1.2,
+                    "cd_min": 0.03,
+                    "cl_cd_max": 15.0,
+                }
+
+            with patch.object(svc_module, "_make_openai_client", return_value=fake_client):
+                with patch.object(tools_module, "_run_polar_async", _instant_polar):
+                    # Run on a live event loop — this is what raises if the
+                    # asyncio.new_event_loop().run_until_complete() bug exists.
+                    events = asyncio.get_event_loop().run_until_complete(
+                        _collect_events(
+                            run_turn(
+                                db=db,
+                                aeroplane_id=aeroplane.id,
+                                history=history,
+                            )
+                        )
+                    )
+
+            # Must NOT have raised RuntimeError — if it did, the run_until_complete
+            # above would have propagated it.
+            types = [e["type"] for e in events]
+            # The tool call was dispatched and a result was produced.
+            assert "tool_call" in types, "Expected tool_call event"
+            assert "tool_result" in types, "Expected tool_result event — real execute() must run"
+            assert types[-1] == "done"
+
+            # The tool result must contain real polar data (not a stub from
+            # patch("copilot_tools.execute")), proving the real path ran.
+            tr = next(e for e in events if e["type"] == "tool_result")
+            assert tr["name"] == "run_analysis"
+            assert tr["summary"].get("status") == "ok", (
+                f"Expected ok polar result, got: {tr['summary']}"
+            )
+
+    def test_run_analysis_tool_execute_does_not_raise_when_called_from_running_loop(
+        self, client_and_db
+    ):
+        """Direct sanity check: execute() in a worker thread from a running loop.
+
+        Previously _run_analysis called asyncio.new_event_loop().run_until_complete()
+        which raises RuntimeError if a loop is already running.  The fix runs
+        execute() in a worker thread (no running loop there) and _run_analysis
+        calls asyncio.run() which is always safe in that context.
+
+        This test simulates the same isolation by calling execute() via
+        asyncio.to_thread from within a coroutine running on a live loop.
+        """
+        _, SessionLocal = client_and_db
+
+        async def _run():
+            with SessionLocal() as db:
+                plane = make_aeroplane(db)
+
+                async def _instant_polar(db, aeroplane_uuid):
+                    return {"status": "ok", "kind": "polar", "cl_max": 1.1}
+
+                with patch.object(tools_module, "_run_polar_async", _instant_polar):
+                    # This is the exact pattern run_turn now uses.
+                    result = await asyncio.to_thread(
+                        tools_module.execute, "run_analysis", db, plane.id, kind="polar"
+                    )
+            return result
+
+        result = asyncio.get_event_loop().run_until_complete(_run())
+        # Must not raise; must return the mocked polar result
+        assert result.get("status") == "ok"
+        assert result.get("kind") == "polar"
+
+
+# ---------------------------------------------------------------------------
+# API key must never appear in SSE events
+# ---------------------------------------------------------------------------
+
+
+class TestApiKeyNotLeakedInSseEvents:
+    """The configured COPILOT_API_KEY must never appear in any SSE event."""
+
+    def test_hub_error_with_key_in_exc_does_not_leak_key(self, client_and_db):
+        """An auth exception whose text contains the API key must be redacted."""
+        _, SessionLocal = client_and_db
+
+        fake_key = "sk-super-secret-test-key-12345"
+
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            history = _build_history()
+
+            client = MagicMock()
+            client.chat = MagicMock()
+            client.chat.completions = MagicMock()
+            # Exception message literally embeds the key — simulates what OpenAI
+            # SDK does when reporting auth failures.
+            client.chat.completions.create = AsyncMock(
+                side_effect=RuntimeError(
+                    f"Authentication failed: api_key={fake_key} is invalid"
+                )
+            )
+
+            import app.core.config as cfg_mod
+            from pydantic import SecretStr
+
+            original_key = cfg_mod.settings.COPILOT_API_KEY
+            cfg_mod.settings.COPILOT_API_KEY = SecretStr(fake_key)
+            try:
+                with patch.object(svc_module, "_make_openai_client", return_value=client):
+                    events = asyncio.get_event_loop().run_until_complete(
+                        _collect_events(
+                            run_turn(db=db, aeroplane_id=aeroplane.id, history=history)
+                        )
+                    )
+            finally:
+                cfg_mod.settings.COPILOT_API_KEY = original_key
+
+        # The raw key must NOT appear anywhere in any event.
+        all_event_text = json.dumps(events)
+        assert fake_key not in all_event_text, (
+            f"API key leaked in SSE events: {all_event_text}"
+        )
+        assert events[0]["type"] == "error"
+
+    def test_stream_error_with_key_in_exc_does_not_leak_key(self, client_and_db):
+        """A streaming exception whose text contains the API key must be redacted."""
+        _, SessionLocal = client_and_db
+
+        fake_key = "sk-another-secret-key-99999"
+
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            history = _build_history()
+
+            async def _bad_stream():
+                raise RuntimeError(f"Stream broken: bearer={fake_key}")
+                yield  # makes this an async generator (unreachable but required)
+
+            class _ErrStream:
+                def __aiter__(self):
+                    return _bad_stream().__aiter__()
+
+            client = MagicMock()
+            client.chat = MagicMock()
+            client.chat.completions = MagicMock()
+            client.chat.completions.create = AsyncMock(return_value=_ErrStream())
+
+            import app.core.config as cfg_mod
+            from pydantic import SecretStr
+
+            original_key = cfg_mod.settings.COPILOT_API_KEY
+            cfg_mod.settings.COPILOT_API_KEY = SecretStr(fake_key)
+            try:
+                with patch.object(svc_module, "_make_openai_client", return_value=client):
+                    events = asyncio.get_event_loop().run_until_complete(
+                        _collect_events(
+                            run_turn(db=db, aeroplane_id=aeroplane.id, history=history)
+                        )
+                    )
+            finally:
+                cfg_mod.settings.COPILOT_API_KEY = original_key
+
+        all_event_text = json.dumps(events)
+        assert fake_key not in all_event_text, (
+            f"API key leaked in SSE stream-error events: {all_event_text}"
+        )
+        assert events[0]["type"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# Truncated flag on MAX_LOOP_ITERATIONS
+# ---------------------------------------------------------------------------
+
+
+class TestTruncatedFlag:
+    """done event must carry truncated=True when the loop hit MAX_LOOP_ITERATIONS."""
+
+    def test_done_has_truncated_true_on_loop_exhaustion(self, client_and_db):
+        _, SessionLocal = client_and_db
+
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            history = _build_history()
+
+            # Every hub response is another tool_call — never stops naturally.
+            call_count = [0]
+
+            async def _always_tool_call(**_kwargs):
+                call_count[0] += 1
+                tc_chunk = _make_tool_call_chunk(
+                    0, f"call_{call_count[0]}", "get_design_snapshot", "{}"
+                )
+                return FakeStream([tc_chunk])
+
+            client = MagicMock()
+            client.chat = MagicMock()
+            client.chat.completions = MagicMock()
+            client.chat.completions.create = _always_tool_call
+
+            with patch.object(svc_module, "_make_openai_client", return_value=client):
+                with patch(
+                    "app.services.copilot_tools.execute", return_value={"data": "ok"}
+                ):
+                    events = asyncio.get_event_loop().run_until_complete(
+                        _collect_events(
+                            run_turn(db=db, aeroplane_id=aeroplane.id, history=history)
+                        )
+                    )
+
+        done_event = next(e for e in events if e["type"] == "done")
+        assert done_event.get("truncated") is True, (
+            f"Expected truncated=True in done event, got: {done_event}"
+        )
+
+    def test_done_has_no_truncated_key_on_clean_stop(self, client_and_db):
+        """When the model stops naturally, truncated must NOT be in the done event."""
+        _, SessionLocal = client_and_db
+
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            history = _build_history()
+
+            fake_client = _fake_client_for_text("All done cleanly.")
+
+            with patch.object(svc_module, "_make_openai_client", return_value=fake_client):
                 events = asyncio.get_event_loop().run_until_complete(
                     _collect_events(
                         run_turn(db=db, aeroplane_id=aeroplane.id, history=history)
                     )
                 )
 
-            assert events[0]["type"] == "error"
+        done_event = next(e for e in events if e["type"] == "done")
+        assert "truncated" not in done_event, (
+            f"truncated key should not be present on clean stop, got: {done_event}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_error unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeError:
+    """Unit tests for the _sanitize_error helper."""
+
+    def test_redacts_key_in_raw_message(self):
+        import app.core.config as cfg_mod
+        from pydantic import SecretStr
+
+        fake_key = "sk-unit-test-key-xyz"
+        original = cfg_mod.settings.COPILOT_API_KEY
+        cfg_mod.settings.COPILOT_API_KEY = SecretStr(fake_key)
+        try:
+            exc = RuntimeError(f"request failed api_key={fake_key}")
+            result = _sanitize_error(exc)
+        finally:
+            cfg_mod.settings.COPILOT_API_KEY = original
+
+        assert fake_key not in result
+
+    def test_connection_errors_become_generic(self):
+        exc = RuntimeError("Connection refused to 10.0.0.1:8080")
+        result = _sanitize_error(exc)
+        assert "10.0.0.1" not in result
+        assert "connection" in result.lower() or "error" in result.lower()
+
+    def test_auth_errors_become_generic(self):
+        exc = ValueError("Invalid api_key provided: sk-abc123")
+        result = _sanitize_error(exc)
+        assert "sk-abc123" not in result
+
+    def test_benign_error_preserved(self):
+        exc = RuntimeError("division by zero")
+        result = _sanitize_error(exc)
+        # Not a key/connection error — message should pass through (redacted form)
+        assert "division by zero" in result

--- a/app/tests/test_copilot_stream_endpoint.py
+++ b/app/tests/test_copilot_stream_endpoint.py
@@ -1,0 +1,258 @@
+"""Tests for POST /aeroplanes/{id}/copilot/stream SSE endpoint (gh-918).
+
+The LiteLLM hub is NEVER called.  ``copilot_service.run_turn`` is replaced
+with a scripted async generator that emits a predefined event sequence.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import AsyncGenerator
+from unittest.mock import patch, AsyncMock
+
+import pytest
+
+from app.services import copilot_history_service as hist_svc
+from app.schemas.copilot_history import CopilotMessageWrite
+from app.tests.conftest import make_aeroplane
+
+
+# ---------------------------------------------------------------------------
+# SSE parsing helper
+# ---------------------------------------------------------------------------
+
+
+def _parse_sse(raw: str) -> list[tuple[str, dict]]:
+    """Parse a raw SSE response body into a list of (event_type, data) tuples."""
+    result = []
+    current_event = None
+    current_data = None
+
+    for line in raw.splitlines():
+        line = line.strip()
+        if line.startswith("event:"):
+            current_event = line[len("event:"):].strip()
+        elif line.startswith("data:"):
+            raw_data = line[len("data:"):].strip()
+            try:
+                current_data = json.loads(raw_data)
+            except json.JSONDecodeError:
+                current_data = {"raw": raw_data}
+        elif line == "" and current_event is not None:
+            result.append((current_event, current_data or {}))
+            current_event = None
+            current_data = None
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Fake run_turn generators
+# ---------------------------------------------------------------------------
+
+
+async def _gen_token_tool_done(*_, **__) -> AsyncGenerator[dict, None]:
+    """Scripted sequence: one token → one tool_call → one tool_result → done."""
+    yield {"type": "token", "text": "Here is your design."}
+    yield {"type": "tool_call", "name": "get_design_snapshot", "args": {}}
+    yield {"type": "tool_result", "name": "get_design_snapshot", "summary": {"span": 1.5}}
+    yield {
+        "type": "done",
+        "final_text": "Here is your design.",
+        "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "get_design_snapshot", "arguments": "{}"}}],
+        "tool_results": [{"tool_call_id": "c1", "name": "get_design_snapshot", "result": {"span": 1.5}}],
+    }
+
+
+async def _gen_error(*_, **__) -> AsyncGenerator[dict, None]:
+    """Scripted sequence: error event."""
+    yield {"type": "error", "message": "Hub unreachable"}
+
+
+async def _gen_text_only(*_, **__) -> AsyncGenerator[dict, None]:
+    """Simple text-only response."""
+    yield {"type": "token", "text": "Hello!"}
+    yield {"type": "done", "final_text": "Hello!", "tool_calls": [], "tool_results": []}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCopilotStreamEndpoint:
+    """Integration tests for POST /aeroplanes/{id}/copilot/stream."""
+
+    def test_returns_200_with_event_stream_content_type(self, client_and_db):
+        client, SessionLocal = client_and_db
+
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+
+        with patch("app.services.copilot_service.run_turn", new=_gen_text_only):
+            resp = client.post(
+                f"/aeroplanes/{aeroplane.uuid}/copilot/stream",
+                json={"message": "What is my CL max?"},
+            )
+
+        assert resp.status_code == 200
+        assert "text/event-stream" in resp.headers["content-type"]
+
+    def test_sse_events_include_token_and_done(self, client_and_db):
+        client, SessionLocal = client_and_db
+
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+
+        with patch("app.services.copilot_service.run_turn", new=_gen_text_only):
+            resp = client.post(
+                f"/aeroplanes/{aeroplane.uuid}/copilot/stream",
+                json={"message": "hello"},
+            )
+
+        events = _parse_sse(resp.text)
+        event_types = [e[0] for e in events]
+
+        assert "token" in event_types
+        assert "done" in event_types
+
+    def test_sse_events_include_tool_call_and_tool_result(self, client_and_db):
+        client, SessionLocal = client_and_db
+
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+
+        with patch("app.services.copilot_service.run_turn", new=_gen_token_tool_done):
+            resp = client.post(
+                f"/aeroplanes/{aeroplane.uuid}/copilot/stream",
+                json={"message": "Analyse my design"},
+            )
+
+        events = _parse_sse(resp.text)
+        event_types = [e[0] for e in events]
+
+        assert "tool_call" in event_types
+        assert "tool_result" in event_types
+        assert "done" in event_types
+
+    def test_history_has_user_and_assistant_messages_after_stream(self, client_and_db):
+        client, SessionLocal = client_and_db
+
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            aeroplane_uuid = aeroplane.uuid
+
+        with patch("app.services.copilot_service.run_turn", new=_gen_text_only):
+            client.post(
+                f"/aeroplanes/{aeroplane_uuid}/copilot/stream",
+                json={"message": "What is my wing area?"},
+            )
+
+        # Verify history was persisted
+        with SessionLocal() as db:
+            history = hist_svc.get_history(db, aeroplane_uuid)
+
+        assert len(history.messages) == 2
+        assert history.messages[0].role == "user"
+        assert history.messages[0].content == "What is my wing area?"
+        assert history.messages[1].role == "assistant"
+        assert history.messages[1].content == "Hello!"
+
+    def test_assistant_message_persists_tool_calls_and_results(self, client_and_db):
+        client, SessionLocal = client_and_db
+
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+            aeroplane_uuid = aeroplane.uuid
+
+        with patch("app.services.copilot_service.run_turn", new=_gen_token_tool_done):
+            client.post(
+                f"/aeroplanes/{aeroplane_uuid}/copilot/stream",
+                json={"message": "Show me the snapshot"},
+            )
+
+        with SessionLocal() as db:
+            history = hist_svc.get_history(db, aeroplane_uuid)
+
+        assistant_msg = next(m for m in history.messages if m.role == "assistant")
+        assert assistant_msg.tool_calls is not None
+        assert len(assistant_msg.tool_calls) == 1
+        assert assistant_msg.tool_results is not None
+        assert len(assistant_msg.tool_results) == 1
+
+    def test_error_event_in_sse_stream(self, client_and_db):
+        client, SessionLocal = client_and_db
+
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+
+        with patch("app.services.copilot_service.run_turn", new=_gen_error):
+            resp = client.post(
+                f"/aeroplanes/{aeroplane.uuid}/copilot/stream",
+                json={"message": "test"},
+            )
+
+        events = _parse_sse(resp.text)
+        event_types = [e[0] for e in events]
+        assert "error" in event_types
+
+        error_data = next(d for t, d in events if t == "error")
+        assert "message" in error_data
+
+    def test_returns_404_for_unknown_aeroplane(self, client_and_db):
+        client, _ = client_and_db
+
+        import uuid
+
+        with patch("app.services.copilot_service.run_turn", new=_gen_text_only):
+            resp = client.post(
+                f"/aeroplanes/{uuid.uuid4()}/copilot/stream",
+                json={"message": "test"},
+            )
+
+        assert resp.status_code == 404
+
+    def test_returns_422_for_missing_message_body(self, client_and_db):
+        client, SessionLocal = client_and_db
+
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+
+        resp = client.post(
+            f"/aeroplanes/{aeroplane.uuid}/copilot/stream",
+            json={},  # missing required "message"
+        )
+
+        assert resp.status_code == 422
+
+    def test_token_text_matches_generated_content(self, client_and_db):
+        client, SessionLocal = client_and_db
+
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+
+        with patch("app.services.copilot_service.run_turn", new=_gen_text_only):
+            resp = client.post(
+                f"/aeroplanes/{aeroplane.uuid}/copilot/stream",
+                json={"message": "hello"},
+            )
+
+        events = _parse_sse(resp.text)
+        token_events = [(t, d) for t, d in events if t == "token"]
+        assert len(token_events) == 1
+        assert token_events[0][1]["text"] == "Hello!"
+
+    def test_context_hint_accepted(self, client_and_db):
+        """context_hint field is accepted without error."""
+        client, SessionLocal = client_and_db
+
+        with SessionLocal() as db:
+            aeroplane = make_aeroplane(db)
+
+        with patch("app.services.copilot_service.run_turn", new=_gen_text_only):
+            resp = client.post(
+                f"/aeroplanes/{aeroplane.uuid}/copilot/stream",
+                json={"message": "hello", "context_hint": "Wing Editor · MyGlider"},
+            )
+
+        assert resp.status_code == 200

--- a/app/tests/test_copilot_tools.py
+++ b/app/tests/test_copilot_tools.py
@@ -1,0 +1,370 @@
+"""Tests for app.services.copilot_tools — curated copilot tool facade (gh-917).
+
+All heavy analysis services are mocked so these run fast with no real
+aerosandbox/network call.  The hub is never reached.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import app.services.copilot_tools as tools_module
+from app.services.copilot_tools import execute, list_schemas
+from app.tests.conftest import make_aeroplane
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_db(client_and_db):
+    _, SessionLocal = client_and_db
+    return SessionLocal()
+
+
+# ---------------------------------------------------------------------------
+# list_schemas
+# ---------------------------------------------------------------------------
+
+
+class TestListSchemas:
+    def test_returns_three_schemas(self):
+        schemas = list_schemas()
+        assert len(schemas) == 3
+
+    def test_schema_names(self):
+        names = {s["function"]["name"] for s in list_schemas()}
+        assert names == {"get_design_snapshot", "run_analysis", "get_version_tree"}
+
+    def test_each_schema_has_required_keys(self):
+        for s in list_schemas():
+            assert s["type"] == "function"
+            fn = s["function"]
+            assert "name" in fn
+            assert "description" in fn
+            assert "parameters" in fn
+
+    def test_run_analysis_schema_has_kind_param(self):
+        schema = next(
+            s for s in list_schemas() if s["function"]["name"] == "run_analysis"
+        )
+        props = schema["function"]["parameters"]["properties"]
+        assert "kind" in props
+        assert props["kind"]["enum"] == ["polar", "stability"]
+
+
+# ---------------------------------------------------------------------------
+# execute — unknown tool
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteUnknownTool:
+    def test_returns_error_dict_for_unknown_tool(self, client_and_db):
+        db = _make_db(client_and_db)
+        try:
+            result = execute("nonexistent_tool", db, aeroplane_id=1)
+            assert "error" in result
+            assert "nonexistent_tool" in result["error"]
+        finally:
+            db.close()
+
+    def test_error_message_lists_known_tools(self, client_and_db):
+        db = _make_db(client_and_db)
+        try:
+            result = execute("bad_tool", db, aeroplane_id=1)
+            error_msg = result["error"]
+            assert "get_design_snapshot" in error_msg
+            assert "run_analysis" in error_msg
+            assert "get_version_tree" in error_msg
+        finally:
+            db.close()
+
+
+# ---------------------------------------------------------------------------
+# get_design_snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestGetDesignSnapshot:
+    def test_returns_dict_for_known_aeroplane(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = make_aeroplane(db)
+            result = execute("get_design_snapshot", db, aeroplane_id=plane.id)
+        assert isinstance(result, dict)
+        assert "error" not in result
+
+    def test_contains_basic_fields(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = make_aeroplane(db, name="snapshot-plane")
+            result = execute("get_design_snapshot", db, aeroplane_id=plane.id)
+        assert result["id"] == plane.id
+        assert result["name"] == "snapshot-plane"
+
+    def test_returns_error_for_missing_aeroplane(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            result = execute("get_design_snapshot", db, aeroplane_id=999999)
+        assert "error" in result
+
+    def test_returns_uuid_as_string(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = make_aeroplane(db)
+            result = execute("get_design_snapshot", db, aeroplane_id=plane.id)
+        assert isinstance(result.get("uuid"), str)
+
+    def test_wing_count_field_present(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = make_aeroplane(db)
+            result = execute("get_design_snapshot", db, aeroplane_id=plane.id)
+        assert "wing_count" in result
+
+
+# ---------------------------------------------------------------------------
+# run_analysis — unknown kind
+# ---------------------------------------------------------------------------
+
+
+class TestRunAnalysisUnknownKind:
+    def test_returns_error_for_bad_kind(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = make_aeroplane(db)
+            result = execute("run_analysis", db, aeroplane_id=plane.id, kind="avl_full")
+        assert "error" in result
+        assert "avl_full" in result["error"]
+
+    def test_returns_error_for_missing_aeroplane(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            result = execute("run_analysis", db, aeroplane_id=999999, kind="polar")
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# run_analysis — timeout path
+# ---------------------------------------------------------------------------
+
+
+class TestRunAnalysisTimeout:
+    def test_polar_timeout_returns_status_dict(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = make_aeroplane(db)
+
+            original_timeout = tools_module.DEFAULT_ANALYSIS_TIMEOUT_S
+            tools_module.DEFAULT_ANALYSIS_TIMEOUT_S = 0.001  # near-zero → always times out
+
+            async def _slow_polar(*args, **kwargs):
+                await asyncio.sleep(10)
+                return {}
+
+            try:
+                with patch.object(tools_module, "_run_polar_async", _slow_polar):
+                    result = execute("run_analysis", db, aeroplane_id=plane.id, kind="polar")
+            finally:
+                tools_module.DEFAULT_ANALYSIS_TIMEOUT_S = original_timeout
+
+        assert result.get("status") == "timeout"
+        assert "note" in result
+
+    def test_stability_timeout_returns_status_dict(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = make_aeroplane(db)
+
+            original_timeout = tools_module.DEFAULT_ANALYSIS_TIMEOUT_S
+            tools_module.DEFAULT_ANALYSIS_TIMEOUT_S = 0.001
+
+            async def _slow_stability(*args, **kwargs):
+                await asyncio.sleep(10)
+                return {}
+
+            try:
+                with patch.object(tools_module, "_run_stability_async", _slow_stability):
+                    result = execute("run_analysis", db, aeroplane_id=plane.id, kind="stability")
+            finally:
+                tools_module.DEFAULT_ANALYSIS_TIMEOUT_S = original_timeout
+
+        assert result.get("status") == "timeout"
+        assert "note" in result
+
+
+# ---------------------------------------------------------------------------
+# run_analysis — mocked happy-path (polar)
+# ---------------------------------------------------------------------------
+
+
+class TestRunAnalysisPolarMocked:
+    def test_polar_returns_ok_shape(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = make_aeroplane(db)
+
+            expected = {
+                "status": "ok",
+                "kind": "polar",
+                "cl_max": 1.4,
+                "cl_min": -0.3,
+                "cd_min": 0.02,
+                "cl_cd_max": 18.5,
+            }
+
+            async def _mock_polar(*args, **kwargs):
+                return expected
+
+            with patch.object(tools_module, "_run_polar_async", _mock_polar):
+                result = execute("run_analysis", db, aeroplane_id=plane.id, kind="polar")
+
+        assert result["status"] == "ok"
+        assert result["kind"] == "polar"
+        assert "cl_max" in result
+        assert "cl_cd_max" in result
+
+    def test_polar_values_are_finite_floats(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = make_aeroplane(db)
+
+            async def _mock_polar(*args, **kwargs):
+                return {
+                    "status": "ok",
+                    "kind": "polar",
+                    "cl_max": 1.4,
+                    "cd_min": 0.025,
+                    "cl_cd_max": 16.0,
+                }
+
+            with patch.object(tools_module, "_run_polar_async", _mock_polar):
+                result = execute("run_analysis", db, aeroplane_id=plane.id, kind="polar")
+
+        for key in ("cl_max", "cd_min", "cl_cd_max"):
+            assert isinstance(result[key], float)
+            assert result[key] == result[key]  # not NaN
+
+
+# ---------------------------------------------------------------------------
+# run_analysis — mocked happy-path (stability)
+# ---------------------------------------------------------------------------
+
+
+class TestRunAnalysisStabilityMocked:
+    def test_stability_returns_ok_shape(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = make_aeroplane(db)
+
+            expected = {
+                "status": "ok",
+                "kind": "stability",
+                "static_margin_pct": 12.3,
+                "stability_class": "stable",
+                "is_statically_stable": True,
+                "neutral_point_x_m": 0.45,
+                "mac_m": 0.25,
+                "Cma": -0.8,
+                "Cnb": 0.12,
+                "Clb": -0.09,
+                "is_directionally_stable": True,
+                "is_laterally_stable": True,
+                "cg_x_m": 0.40,
+                "cg_range_forward_m": 0.35,
+                "cg_range_aft_m": 0.48,
+            }
+
+            async def _mock_stability(*args, **kwargs):
+                return expected
+
+            with patch.object(tools_module, "_run_stability_async", _mock_stability):
+                result = execute("run_analysis", db, aeroplane_id=plane.id, kind="stability")
+
+        assert result["status"] == "ok"
+        assert result["kind"] == "stability"
+        assert "static_margin_pct" in result
+        assert "stability_class" in result
+        assert "is_statically_stable" in result
+
+
+# ---------------------------------------------------------------------------
+# get_version_tree
+# ---------------------------------------------------------------------------
+
+
+class TestGetVersionTree:
+    def test_returns_dict_with_required_keys(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = make_aeroplane(db)
+            result = execute("get_version_tree", db, aeroplane_id=plane.id)
+        assert isinstance(result, dict)
+        assert "error" not in result
+        assert "root_id" in result
+        assert "nodes" in result
+        assert "branches" in result
+
+    def test_nodes_is_list(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = make_aeroplane(db)
+            result = execute("get_version_tree", db, aeroplane_id=plane.id)
+        assert isinstance(result["nodes"], list)
+
+    def test_branches_is_list(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = make_aeroplane(db)
+            result = execute("get_version_tree", db, aeroplane_id=plane.id)
+        assert isinstance(result["branches"], list)
+
+    def test_node_has_expected_fields(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = make_aeroplane(db)
+            result = execute("get_version_tree", db, aeroplane_id=plane.id)
+        # For a plain (non-versioned) aeroplane the node list contains just itself
+        if result["nodes"]:
+            node = result["nodes"][0]
+            for field_name in ("id", "uuid", "name", "is_immutable"):
+                assert field_name in node, f"Missing field: {field_name}"
+
+    def test_returns_error_for_missing_aeroplane(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            result = execute("get_version_tree", db, aeroplane_id=999999)
+        assert "error" in result
+
+    def test_result_is_json_serializable(self, client_and_db):
+        import json
+
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = make_aeroplane(db)
+            result = execute("get_version_tree", db, aeroplane_id=plane.id)
+        # This must not raise
+        serialized = json.dumps(result)
+        assert serialized
+
+
+# ---------------------------------------------------------------------------
+# Tool registry structure
+# ---------------------------------------------------------------------------
+
+
+class TestToolRegistry:
+    def test_registry_has_three_tools(self):
+        assert len(tools_module.TOOL_REGISTRY) == 3
+
+    def test_registry_keys_match_schema_names(self):
+        for key, entry in tools_module.TOOL_REGISTRY.items():
+            assert entry.schema["function"]["name"] == key
+
+    def test_each_entry_has_impl_callable(self):
+        for entry in tools_module.TOOL_REGISTRY.values():
+            assert callable(entry.impl)

--- a/poetry.lock
+++ b/poetry.lock
@@ -6409,4 +6409,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "a7573cd058eabb20eb90f5a077cfca4d636c71e0de6dfa334d1e0c01e3d9bd52"
+content-hash = "1ee6913a14eb0645cdaf17affee72b84c1f17118a615b71a23e478629f58b1aa"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ package-mode = false
 
 [tool.poetry.dependencies]
 python = ">=3.11,<3.13" # because of vtk9.3.1 not in py3.13 yet
+openai = "^2.41"
 
 [tool.poetry.group.binary.dependencies]
 nlopt = ">=2.9,<3.0"


### PR DESCRIPTION
Slice 1 (Foundation/advisory) backend of the AI Copilot epic #902. Spec: `docs/superpowers/specs/2026-06-08-ai-copilot-foundation-design.md`.

- **#916 config:** `app/core/config.py` → pydantic-settings; `COPILOT_API_KEY` (SecretStr) / `COPILOT_BASE_URL` / `COPILOT_MODEL` (claude-sonnet-4-6) / `COPILOT_EMBEDDING_MODEL`; `openai` dep (+ poetry.lock).
- **#917 tool facade** (`copilot_tools.py`, NOT the 51-tool MCP surface): `get_design_snapshot`, `run_analysis` (fast polar/stability, timeout), `get_version_tree`. One SI unit convention; numbers only from services.
- **#918 service loop + SSE:** `copilot_service.run_turn` (OpenAI-SDK, hand-rolled tool loop, max-iter guard) + `POST /aeroplanes/{id}/copilot/stream` (SSE token/tool_call/tool_result/done/error); reuses the existing `copilot_messages` persistence; system prompt = advisory-only, hard anti-hallucination, reply in the user's language.

**Adversarial review caught 2 real runtime blockers the mocked unit tests missed, both fixed + guarded by REAL tests:**
- `run_analysis` did `asyncio.new_event_loop().run_until_complete()` from the live uvicorn loop → `RuntimeError` + 60s block. Now tools run via `await asyncio.to_thread(...)`; a test drives the real async path (run_analysis NOT mocked) on a live loop.
- API key could leak in SSE error text → sanitized + redacted; tested that the key never appears in error events.
Plus: `truncated` flag on max-iter; `ARTIFACTS_BASE_DIR` `.resolve()` restored; a test-isolation fix (`asyncio.run()` per test).

**Hub is MOCKED in all tests — no real API call in CI.** Verified: ruff clean, `import app.main` ok, full fast backend suite **4413 passed** (incl. the real async-path + key-leak tests). Frontend (#919) + the real-hub 3-persona UAT follow.

Closes #916
Closes #917
Closes #918

🤖 Generated with [Claude Code](https://claude.com/claude-code)