### PR TITLE
fix(gh-922): replay tool_result messages so multi-turn copilot works

### DIFF
--- a/app/services/copilot_service.py
+++ b/app/services/copilot_service.py
@@ -193,6 +193,28 @@ def _history_to_openai(messages) -> list[dict[str, Any]]:
             if m.tool_calls:
                 msg["tool_calls"] = m.tool_calls
             result.append(msg)
+            # Anthropic's strict tool protocol (and OpenAI's) requires every
+            # assistant ``tool_use``/``tool_call`` to be immediately followed by
+            # a matching ``tool`` result message. We persist the turn as a single
+            # assistant row carrying both tool_calls and tool_results (no separate
+            # ``tool`` rows), so reconstruct the result messages here — otherwise
+            # the replayed history has an orphaned tool_use and the hub 400s on
+            # every turn after the first tool use (gh-922).
+            if m.tool_calls:
+                results_by_id = {
+                    tr.get("tool_call_id", ""): tr for tr in (m.tool_results or [])
+                }
+                for tc in m.tool_calls:
+                    tc_id = tc.get("id", "")
+                    tr = results_by_id.get(tc_id)
+                    content = (
+                        json.dumps(tr.get("result", tr))
+                        if tr is not None
+                        else json.dumps({"error": "tool result unavailable"})
+                    )
+                    result.append(
+                        {"role": "tool", "tool_call_id": tc_id, "content": content}
+                    )
         elif m.role == "tool":
             # Tool result messages: one message per tool result
             if m.tool_results:

--- a/app/tests/test_copilot_service.py
+++ b/app/tests/test_copilot_service.py
@@ -743,6 +743,92 @@ class TestTruncatedFlag:
 
 
 # ---------------------------------------------------------------------------
+# _history_to_openai — multi-turn tool-result reconstruction (gh-922)
+# ---------------------------------------------------------------------------
+
+
+class TestHistoryToOpenaiToolResultReconstruction:
+    """Replaying a tool-bearing history must keep tool_use/tool_result
+    adjacency. The real hub (Anthropic via Vertex/litellm) rejects an
+    assistant ``tool_use`` that has no following ``tool_result`` with a 400 —
+    this broke every copilot turn after the first tool use (gh-922).
+    """
+
+    @staticmethod
+    def _msg(role, content, *, tool_calls=None, tool_results=None, i=1):
+        from datetime import datetime, timezone
+
+        return CopilotMessageRead(
+            id=i,
+            role=role,
+            content=content,
+            tool_calls=tool_calls,
+            tool_results=tool_results,
+            parent_id=None,
+            created_at=datetime.now(timezone.utc),
+        )
+
+    def _tool_bearing_history(self):
+        tool_calls = [
+            {
+                "id": "call_abc",
+                "type": "function",
+                "function": {"name": "get_design_snapshot", "arguments": "{}"},
+            }
+        ]
+        tool_results = [
+            {"tool_call_id": "call_abc", "name": "get_design_snapshot", "result": {"span": 1.5}}
+        ]
+        return [
+            self._msg("user", "Give me an overview", i=1),
+            self._msg(
+                "assistant",
+                "Here is your overview.",
+                tool_calls=tool_calls,
+                tool_results=tool_results,
+                i=2,
+            ),
+            self._msg("user", "Is the static margin healthy?", i=3),
+        ]
+
+    def test_no_orphaned_tool_use_in_replayed_history(self):
+        """Every assistant tool_call id must be answered by a tool message."""
+        from app.services.copilot_service import _history_to_openai
+
+        out = _history_to_openai(self._tool_bearing_history())
+
+        called = [
+            tc["id"]
+            for m in out
+            if m["role"] == "assistant"
+            for tc in (m.get("tool_calls") or [])
+        ]
+        answered = [m["tool_call_id"] for m in out if m["role"] == "tool"]
+        assert called, "expected the assistant message to carry tool_calls"
+        assert set(called) <= set(answered), (
+            f"orphaned tool_use (would 400 on the real hub): "
+            f"called={called} answered={answered} messages={out}"
+        )
+
+    def test_assistant_tool_calls_immediately_followed_by_tool_messages(self):
+        """The tool messages must come right after the assistant message, in id order."""
+        from app.services.copilot_service import _history_to_openai
+
+        out = _history_to_openai(self._tool_bearing_history())
+
+        for idx, m in enumerate(out):
+            if m["role"] == "assistant" and m.get("tool_calls"):
+                ids = [tc["id"] for tc in m["tool_calls"]]
+                following = out[idx + 1 : idx + 1 + len(ids)]
+                assert all(f["role"] == "tool" for f in following), (
+                    f"assistant tool_calls not immediately followed by tool messages: {out}"
+                )
+                assert [f["tool_call_id"] for f in following] == ids, (
+                    f"tool_call ids {ids} not matched in order by {following}"
+                )
+
+
+# ---------------------------------------------------------------------------
 # _sanitize_error unit tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## The bug
The advisory copilot worked on the **first** message but **400'd on every message after the first tool use**. Caught by the 3-persona UAT driving the **real** LiteLLM hub against eHawk: Q1 (snapshot) succeeded; Q2–Q5 all failed with:

> `tool_use` ids were found without `tool_result` blocks immediately after… Each `tool_use` block must have a corresponding `tool_result` block in the next message.

## Root cause
A turn is persisted as a **single `assistant` row** carrying both `tool_calls` and `tool_results` (no separate `tool` rows). On replay, `_history_to_openai` emitted the assistant message *with* `tool_calls` but reconstructed tool messages only from `role=="tool"` rows — which never exist. The assistant's `tool_use` was left orphaned, and Anthropic's strict tool protocol (via Vertex/litellm) rejects it.

The existing tests mocked the hub and only exercised single turns, so the orphaned-tool_use replay was never produced — the real multi-turn UAT was needed to surface it.

## Fix
In `_history_to_openai`, after an `assistant` message with `tool_calls`, append one `tool` message per `tool_call` id (content = the matching persisted result, or an explicit error stub). Guarantees every `tool_use` is immediately followed by its `tool_result`.

## Verification
- **Real-hub UAT, after fix: all 5 turns succeed, 0 errors** (was 1/5). Tools fire correctly across turns (`get_design_snapshot`, multiple `run_analysis`).
- +2 unit tests on `_history_to_openai` (no orphaned tool_use; correct ordering) — the invariant the mocked single-turn tests missed. Copilot service + endpoint suites: **33 passed**. ruff clean.

Closes #922

🤖 Generated with [Claude Code](https://claude.com/claude-code)