### PR TITLE
feat(gh-925): copilot answer-quality hardening — deterministic drag split + accessibility

### DIFF
--- a/app/services/copilot_service.py
+++ b/app/services/copilot_service.py
@@ -139,6 +139,14 @@ to adjust."
    imply different values, do NOT present a table whose numbers fail to
    reconcile — state the figure you trust, give its source, and note the
    discrepancy. Do not re-derive an x_NP that contradicts the reported SM.
+6. **Always DERIVE a recommended CG, never pass through a raw band.** To
+   recommend a CG for a target static margin, compute it explicitly:
+   x_CG = x_NP − (SM_target × MAC). State which x_NP and SM_target you used
+   and show the result (e.g. "for 10% SM with NP=0.109 m, MAC=0.140 m →
+   x_CG ≈ 0.095 m"). If a tool returns raw CG limits, do NOT present them as
+   an SM recommendation without first computing the SM each limit implies,
+   SM = (x_NP − x_CG)/MAC; if a limit implies an implausible SM (>35% or
+   <0%), flag it as suspect rather than recommending it.
 
 ## L/D and performance numbers (HARD)
 - The snapshot's `ld_max` (and any L/D in `get_design_snapshot`) is a

--- a/app/services/copilot_service.py
+++ b/app/services/copilot_service.py
@@ -134,6 +134,29 @@ to adjust."
    reduces it. Moving the CG forward increases margin; aft reduces it.
    Double-check the direction of any "to change it, do X" advice against
    this before stating it.
+5. **Static margin from ONE source.** Report static margin from a single
+   tool field. If the static_margin field and the (x_NP − x_CG)/MAC fields
+   imply different values, do NOT present a table whose numbers fail to
+   reconcile — state the figure you trust, give its source, and note the
+   discrepancy. Do not re-derive an x_NP that contradicts the reported SM.
+
+## L/D and performance numbers (HARD)
+- The snapshot's `ld_max` (and any L/D in `get_design_snapshot`) is a
+  COARSE parametric ESTIMATE and can differ substantially (20%+) from the
+  refined `run_analysis: polar` value. NEVER present the snapshot L/D as the
+  definitive performance number. When you mention it, label it explicitly
+  as a rough estimate and either run the polar or offer to, citing the
+  polar value as authoritative once available.
+
+## Design-warning heuristics (raise these proactively)
+- **Minimum sink at stall:** if `v_min_sink` ≈ `v_stall` (within ~5%), warn
+  that the aircraft can only reach its best (minimum-sink) soaring
+  performance at the very edge of stall, leaving no margin — a real design
+  issue for a soarer. Recommend reducing mass or increasing wing area. Do
+  NOT say stall is "no concern" when this holds.
+- **Tight cruise/stall margin:** if cruise speed is < ~1.2 × stall speed,
+  note the limited speed buffer.
+Surface these as honest design feedback, not hidden behind reassurance.
 
 ## Audience & clarity (you serve hobbyist beginners AND professionals)
 1. **Answer the question that was asked.** Do not pre-empt with a full

--- a/app/services/copilot_service.py
+++ b/app/services/copilot_service.py
@@ -105,6 +105,66 @@ to adjust."
    timeout, say so explicitly.
 3. When you cite a number, state which tool produced it.
 4. If you are unsure, say so; do not guess.
+5. NEVER report a CG, neutral-point, or static-margin number that is not
+   directly present in a tool's output. Do not compute a "blended" or
+   "representative" value and present it as if it came from a tool.
+
+## Physical-consistency rules (HARD)
+1. **Do not mix data sources in one calculation.** The snapshot's `cd0`
+   and `e_oswald` belong to a coarse estimate; the polar tool's `CD`/`L/D`
+   come from a separate, refined model. NEVER subtract, add, or compare a
+   snapshot parameter and a polar total in the same expression — they
+   parametrise different drag models.
+2. **Decompose drag from the tool, not by hand.** When the polar result
+   includes a `drag_breakdown` object, report THOSE numbers (cd_induced,
+   cd_parasite, induced_fraction) directly — do NOT recompute CD_i yourself
+   (hand arithmetic here has been unreliable). If `drag_breakdown` carries a
+   `note` (inconsistent split), relay that caveat instead of inventing a
+   split. Only if no `drag_breakdown` is present, fall back to
+   CD_i = CL² / (π · AR · e) and CD_parasite = CD_total − CD_i from ONE
+   source, and sanity-check each component is ≥ 0 and < CD_total.
+3. **Surface disagreements; never paper over them.** If two tool values
+   disagree (e.g. two neutral points, or snapshot cd0 implying a different
+   L/D_max than the polar), say so plainly, state both numbers and their
+   sources, and explain which is more reliable and why — do not silently
+   pick one or invent a reconciliation.
+4. **CG / neutral-point / static-margin direction.** Static margin =
+   (x_NP − x_CG) / MAC. Moving the wing AFT moves the neutral point aft →
+   larger margin (more stable) for a fixed CG; moving the wing FORWARD
+   reduces it. Moving the CG forward increases margin; aft reduces it.
+   Double-check the direction of any "to change it, do X" advice against
+   this before stating it.
+
+## Audience & clarity (you serve hobbyist beginners AND professionals)
+1. **Answer the question that was asked.** Do not pre-empt with a full
+   multi-topic design review when the user asked one thing. Answer it, then
+   offer to go deeper on specific related areas.
+2. **Lead with a plain-language takeaway** (1–2 sentences a beginner
+   understands), THEN the supporting detail/numbers. Put the bottom line
+   first, not last.
+3. **Gloss jargon on first use** with a short parenthetical, every reply:
+   MAC ("mean aerodynamic chord — roughly the average wing width"), AR
+   ("aspect ratio — slender wings have high AR"), Re ("Reynolds number — a
+   size×speed number; small models run at 'sticky-air' low Re"), Oswald e
+   ("how efficiently the wing uses its span, 1.0 = ideal"), SM/static
+   margin ("how far the balance point sits ahead of the neutral point;
+   higher = more stable, more sluggish"), NP/neutral point ("the balance
+   point the aircraft naturally pitches around"), parasitic vs induced drag
+   ("drag from pushing the shape through air" vs "the drag cost of making
+   lift").
+4. **Always translate L/D to glide ratio** the first time it appears:
+   "L/D 24 means it glides ~24 m forward for every 1 m of descent."
+5. **Paraphrase raw tool flags** into plain language — e.g.
+   `fallback_used: true` → "the stall number is an estimate because the
+   exact airfoil isn't defined yet"; `non_monotonic_polar` → "the drag
+   curve looks slightly irregular (possible low-Re bubble), so treat the
+   drag figures as good estimates."
+6. **Keep tables lean** — prefer one short summary table over several raw
+   intermediate tables. When you suggest a change, name the workbench area
+   to do it in (e.g. "Components panel", "Wing Editor → cross-section")
+   rather than just "in the workbench".
+Keep the physics rigorous for pros; never dumb the numbers down — just make
+the first read reachable for a beginner.
 
 ## Provisional knowledge (until RAG is available)
 Use the following as approximate guidance only — the user's actual design

--- a/app/services/copilot_tools.py
+++ b/app/services/copilot_tools.py
@@ -174,6 +174,48 @@ def _drag_breakdown(
     }
 
 
+def _polar_drag_breakdown(
+    db: Session, aeroplane_uuid: str, cl_values, cd_values
+) -> dict | None:
+    """Best-glide drag split for a polar sweep, using AR/e from the snapshot.
+
+    Pulls AR and Oswald e from the design snapshot's computation context (the
+    same source as the polar's `e`), picks the max-L/D point from the sweep,
+    and delegates the arithmetic to :func:`_drag_breakdown`. Best-effort: any
+    failure (missing context, empty arrays) returns ``None`` and the polar
+    summary simply omits the breakdown.
+    """
+    import numpy as np
+
+    if cl_values is None or cd_values is None:
+        return None
+    try:
+        ratio = cl_values / np.where(cd_values > 0, cd_values, np.nan)
+        idx = int(np.nanargmax(ratio))
+        from app.models.aeroplanemodel import AeroplaneModel
+        from app.services.aeroplane_version_service import _metrics_payload
+
+        node = (
+            db.query(AeroplaneModel)
+            .filter(AeroplaneModel.uuid == aeroplane_uuid)
+            .first()
+        )
+        ctx = (
+            (_metrics_payload(node) or {}).get("assumption_computation_context", {})
+            if node is not None
+            else {}
+        )
+        return _drag_breakdown(
+            cl=float(cl_values[idx]),
+            cd_total=float(cd_values[idx]),
+            ar=ctx.get("aspect_ratio"),
+            e=ctx.get("e_oswald"),
+        )
+    except Exception:  # noqa: BLE001 — breakdown is best-effort
+        logger.debug("drag_breakdown computation skipped", exc_info=True)
+        return None
+
+
 async def _run_polar_async(db: Session, aeroplane_uuid: str) -> dict:
     """Run an AeroBuildup alpha sweep and return key polar numbers."""
     import numpy as np
@@ -233,29 +275,9 @@ async def _run_polar_async(db: Session, aeroplane_uuid: str) -> dict:
 
         # Deterministic drag breakdown at the best-glide (max L/D) point, so
         # the model reports it instead of doing the error-prone arithmetic.
-        try:
-            idx = int(np.nanargmax(ratio))
-            from app.models.aeroplanemodel import AeroplaneModel
-            from app.services.aeroplane_version_service import _metrics_payload
-
-            node = (
-                db.query(AeroplaneModel)
-                .filter(AeroplaneModel.uuid == aeroplane_uuid)
-                .first()
-            )
-            ctx = (_metrics_payload(node) or {}).get(
-                "assumption_computation_context", {}
-            ) if node is not None else {}
-            breakdown = _drag_breakdown(
-                cl=float(cl_values[idx]),
-                cd_total=float(cd_values[idx]),
-                ar=ctx.get("aspect_ratio"),
-                e=ctx.get("e_oswald"),
-            )
-            if breakdown:
-                summary["drag_breakdown"] = breakdown
-        except Exception:  # noqa: BLE001 — breakdown is best-effort
-            logger.debug("drag_breakdown computation skipped", exc_info=True)
+        breakdown = _polar_drag_breakdown(db, aeroplane_uuid, cl_values, cd_values)
+        if breakdown:
+            summary["drag_breakdown"] = breakdown
 
     # Include key characteristic points (rename keys for LLM clarity)
     _char_map = {

--- a/app/services/copilot_tools.py
+++ b/app/services/copilot_tools.py
@@ -128,6 +128,52 @@ def _run_analysis(db: Session, aeroplane_id: int, kind: str = "polar") -> dict:
         return {"error": str(exc)}
 
 
+def _drag_breakdown(
+    cl: float | None, cd_total: float | None, ar: float | None, e: float | None
+) -> dict | None:
+    """Deterministic induced/parasitic drag split at one operating point.
+
+    The LLM is unreliable at this arithmetic (it has produced both
+    physically-impossible splits and 10x errors), so we compute it here and
+    let the model simply report it. Induced drag uses the lifting-line form
+    CD_i = CL^2 / (pi * AR * e); parasitic is the remainder of the polar's
+    own total CD — one consistent source, never mixing snapshot cd0 with a
+    polar total.
+    """
+    import math
+
+    if cl is None or cd_total is None or ar is None or e is None:
+        return None
+    if ar <= 0 or e <= 0 or cd_total <= 0:
+        return None
+    cd_i = cl**2 / (math.pi * ar * e)
+    cd_par = cd_total - cd_i
+    if cd_i < 0 or cd_par < 0 or cd_i > cd_total:
+        # Inconsistent — surface the raw inputs rather than a wrong split.
+        return {
+            "note": (
+                "induced-drag estimate is inconsistent with the polar total "
+                "(possible non-parabolic polar or e/AR mismatch); not decomposed"
+            ),
+            "cl": round(float(cl), 4),
+            "cd_total": round(float(cd_total), 5),
+            "aspect_ratio": round(float(ar), 3),
+            "e_oswald": round(float(e), 4),
+        }
+    return {
+        "cl": round(float(cl), 4),
+        "cd_total": round(float(cd_total), 5),
+        "cd_induced": round(float(cd_i), 5),
+        "cd_parasite": round(float(cd_par), 5),
+        "induced_fraction": round(float(cd_i / cd_total), 3),
+        "parasite_fraction": round(float(cd_par / cd_total), 3),
+        "aspect_ratio": round(float(ar), 3),
+        "e_oswald": round(float(e), 4),
+        "operating_point": "best_glide (max L/D)",
+        "method": "CD_i = CL^2/(pi*AR*e); CD_parasite = CD_total - CD_i",
+    }
+
+
 async def _run_polar_async(db: Session, aeroplane_uuid: str) -> dict:
     """Run an AeroBuildup alpha sweep and return key polar numbers."""
     import numpy as np
@@ -184,6 +230,32 @@ async def _run_polar_async(db: Session, aeroplane_uuid: str) -> dict:
     if cl_values is not None and cd_values is not None:
         ratio = cl_values / np.where(cd_values > 0, cd_values, np.nan)
         summary["cl_cd_max"] = float(np.nanmax(ratio))
+
+        # Deterministic drag breakdown at the best-glide (max L/D) point, so
+        # the model reports it instead of doing the error-prone arithmetic.
+        try:
+            idx = int(np.nanargmax(ratio))
+            from app.models.aeroplanemodel import AeroplaneModel
+            from app.services.aeroplane_version_service import _metrics_payload
+
+            node = (
+                db.query(AeroplaneModel)
+                .filter(AeroplaneModel.uuid == aeroplane_uuid)
+                .first()
+            )
+            ctx = (_metrics_payload(node) or {}).get(
+                "assumption_computation_context", {}
+            ) if node is not None else {}
+            breakdown = _drag_breakdown(
+                cl=float(cl_values[idx]),
+                cd_total=float(cd_values[idx]),
+                ar=ctx.get("aspect_ratio"),
+                e=ctx.get("e_oswald"),
+            )
+            if breakdown:
+                summary["drag_breakdown"] = breakdown
+        except Exception:  # noqa: BLE001 — breakdown is best-effort
+            logger.debug("drag_breakdown computation skipped", exc_info=True)
 
     # Include key characteristic points (rename keys for LLM clarity)
     _char_map = {

--- a/app/tests/test_copilot_service.py
+++ b/app/tests/test_copilot_service.py
@@ -829,6 +829,53 @@ class TestHistoryToOpenaiToolResultReconstruction:
 
 
 # ---------------------------------------------------------------------------
+# System-prompt hardening guards (gh-925, from the 3-persona UAT)
+# ---------------------------------------------------------------------------
+
+
+class TestSystemPromptHardening:
+    """Guard the answer-quality directives added after the UAT — regression
+    guard only; real verification is the re-run UAT against the hub.
+    """
+
+    def test_prompt_forbids_mixing_snapshot_and_polar(self):
+        from app.services.copilot_service import SYSTEM_PROMPT
+
+        low = SYSTEM_PROMPT.lower()
+        assert "do not mix data sources" in low
+        # the specific failure mode: cd0 (snapshot) vs polar total
+        assert "cd_parasite" in low or "cd_parasite = cd_total" in low
+
+    def test_prompt_requires_drag_sanity_check(self):
+        from app.services.copilot_service import SYSTEM_PROMPT
+
+        low = SYSTEM_PROMPT.lower()
+        assert "< cd_total" in low or "parasitic ever comes out" in low
+
+    def test_prompt_has_static_margin_direction_rule(self):
+        from app.services.copilot_service import SYSTEM_PROMPT
+
+        low = SYSTEM_PROMPT.lower()
+        assert "moving the wing aft" in low
+        assert "(x_np" in low or "x_np − x_cg" in low
+
+    def test_prompt_requires_glide_ratio_translation(self):
+        from app.services.copilot_service import SYSTEM_PROMPT
+
+        assert "glide ratio" in SYSTEM_PROMPT.lower()
+
+    def test_prompt_answers_question_asked(self):
+        from app.services.copilot_service import SYSTEM_PROMPT
+
+        assert "Answer the question that was asked" in SYSTEM_PROMPT
+
+    def test_prompt_glosses_jargon(self):
+        from app.services.copilot_service import SYSTEM_PROMPT
+
+        assert "Gloss jargon on first use" in SYSTEM_PROMPT
+
+
+# ---------------------------------------------------------------------------
 # _sanitize_error unit tests
 # ---------------------------------------------------------------------------
 

--- a/app/tests/test_copilot_service.py
+++ b/app/tests/test_copilot_service.py
@@ -874,6 +874,20 @@ class TestSystemPromptHardening:
 
         assert "Gloss jargon on first use" in SYSTEM_PROMPT
 
+    def test_prompt_flags_snapshot_ld_as_estimate(self):
+        from app.services.copilot_service import SYSTEM_PROMPT
+
+        low = SYSTEM_PROMPT.lower()
+        assert "ld_max" in low and "estimate" in low
+        assert "polar value as authoritative" in low
+
+    def test_prompt_has_min_sink_at_stall_warning(self):
+        from app.services.copilot_service import SYSTEM_PROMPT
+
+        low = SYSTEM_PROMPT.lower()
+        assert "v_min_sink" in low and "v_stall" in low
+        assert "no margin" in low or "edge of stall" in low
+
 
 # ---------------------------------------------------------------------------
 # _sanitize_error unit tests

--- a/app/tests/test_copilot_tools.py
+++ b/app/tests/test_copilot_tools.py
@@ -357,6 +357,50 @@ class TestGetVersionTree:
 # ---------------------------------------------------------------------------
 
 
+class TestDragBreakdown:
+    """Deterministic induced/parasitic split (gh-925) — the LLM is unreliable
+    at this arithmetic, so the tool computes it.
+    """
+
+    def test_split_is_correct_for_ehawk_best_glide(self):
+        from app.services.copilot_tools import _drag_breakdown
+
+        # eHawk best-glide point from the real polar (the case the LLM got
+        # wrong by 10x): CL 0.552, CD 0.02302, AR 11.3, e 0.7916.
+        bd = _drag_breakdown(cl=0.552, cd_total=0.02302, ar=11.3, e=0.7916)
+        assert bd is not None and "note" not in bd
+        # CD_i = 0.552^2 / (pi * 11.3 * 0.7916) ≈ 0.01084 (NOT 0.00108)
+        assert bd["cd_induced"] == pytest.approx(0.01084, abs=2e-4)
+        assert bd["cd_parasite"] == pytest.approx(0.02302 - 0.01084, abs=2e-4)
+        # induced is ~47% of total — well above the ~5% the model hallucinated
+        assert bd["induced_fraction"] == pytest.approx(0.47, abs=0.03)
+        # components are physical
+        assert 0 < bd["cd_induced"] < bd["cd_total"]
+        assert 0 < bd["cd_parasite"] < bd["cd_total"]
+
+    def test_components_sum_to_total(self):
+        from app.services.copilot_tools import _drag_breakdown
+
+        bd = _drag_breakdown(cl=0.5, cd_total=0.03, ar=10.0, e=0.8)
+        assert bd["cd_induced"] + bd["cd_parasite"] == pytest.approx(0.03, abs=1e-9)
+
+    def test_inconsistent_split_returns_note_not_wrong_numbers(self):
+        from app.services.copilot_tools import _drag_breakdown
+
+        # CD_i would exceed total → must NOT fabricate a negative parasitic
+        bd = _drag_breakdown(cl=1.5, cd_total=0.01, ar=5.0, e=0.7)
+        assert bd is not None
+        assert "note" in bd
+        assert "cd_parasite" not in bd
+
+    def test_missing_inputs_return_none(self):
+        from app.services.copilot_tools import _drag_breakdown
+
+        assert _drag_breakdown(cl=0.5, cd_total=0.03, ar=None, e=0.8) is None
+        assert _drag_breakdown(cl=None, cd_total=0.03, ar=10, e=0.8) is None
+        assert _drag_breakdown(cl=0.5, cd_total=0.03, ar=0, e=0.8) is None
+
+
 class TestToolRegistry:
     def test_registry_has_three_tools(self):
         assert len(tools_module.TOOL_REGISTRY) == 3

--- a/app/tests/test_copilot_tools.py
+++ b/app/tests/test_copilot_tools.py
@@ -455,6 +455,22 @@ class TestPolarDragBreakdownWiring:
                 is None
             )
 
+    def test_breakdown_swallows_errors_and_returns_none(self, client_and_db):
+        import numpy as np
+
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = make_aeroplane(db)
+            # _metrics_payload blowing up must not break the polar — best-effort
+            with patch(
+                "app.services.aeroplane_version_service._metrics_payload",
+                side_effect=RuntimeError("boom"),
+            ):
+                bd = tools_module._polar_drag_breakdown(
+                    db, str(plane.uuid), np.array([0.5, 0.55]), np.array([0.03, 0.023])
+                )
+        assert bd is None
+
 
 class TestToolRegistry:
     def test_registry_has_three_tools(self):

--- a/app/tests/test_copilot_tools.py
+++ b/app/tests/test_copilot_tools.py
@@ -401,6 +401,61 @@ class TestDragBreakdown:
         assert _drag_breakdown(cl=0.5, cd_total=0.03, ar=0, e=0.8) is None
 
 
+class TestPolarDragBreakdownWiring:
+    """The polar wiring that picks best-glide and pulls AR/e from the snapshot
+    context (gh-925). Mocks only _metrics_payload — no aero deps needed.
+    """
+
+    def test_breakdown_uses_context_ar_and_e(self, client_and_db):
+        import numpy as np
+
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = make_aeroplane(db)
+            # best L/D is at index 1 (CL 0.552 / CD 0.02302) — the eHawk point
+            cl = np.array([0.1, 0.552, 1.2])
+            cd = np.array([0.013, 0.02302, 0.10])
+            with patch(
+                "app.services.aeroplane_version_service._metrics_payload",
+                return_value={
+                    "assumption_computation_context": {
+                        "aspect_ratio": 11.3,
+                        "e_oswald": 0.7916,
+                    }
+                },
+            ):
+                bd = tools_module._polar_drag_breakdown(db, str(plane.uuid), cl, cd)
+
+        assert bd is not None and "note" not in bd
+        assert bd["cd_induced"] == pytest.approx(0.01084, abs=2e-4)
+        assert bd["induced_fraction"] == pytest.approx(0.47, abs=0.03)
+        assert bd["cd_total"] == pytest.approx(0.02302, abs=1e-5)
+
+    def test_breakdown_none_when_context_missing_ar_e(self, client_and_db):
+        import numpy as np
+
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = make_aeroplane(db)
+            with patch(
+                "app.services.aeroplane_version_service._metrics_payload",
+                return_value={"assumption_computation_context": {}},
+            ):
+                bd = tools_module._polar_drag_breakdown(
+                    db, str(plane.uuid), np.array([0.5]), np.array([0.03])
+                )
+        assert bd is None
+
+    def test_breakdown_none_on_empty_arrays(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = make_aeroplane(db)
+            assert (
+                tools_module._polar_drag_breakdown(db, str(plane.uuid), None, None)
+                is None
+            )
+
+
 class TestToolRegistry:
     def test_registry_has_three_tools(self):
         assert len(tools_module.TOOL_REGISTRY) == 3

--- a/scripts/uat_copilot_driver.py
+++ b/scripts/uat_copilot_driver.py
@@ -1,0 +1,135 @@
+"""UAT driver for the AI copilot (#902 Slice 1) — drives the REAL hub.
+
+Runs a set of realistic design questions through the live
+``/aeroplanes/{uuid}/copilot/stream`` endpoint against a COPY of the
+local DB (so UAT copilot messages never touch the real db), and writes a
+JSON transcript per question (assistant text, tools called, tool
+summaries). The transcript is then handed to the 3 persona judges
+(RC expert / Scholz / hobbyist).
+
+Usage:
+    poetry run python scripts/uat_copilot_driver.py <aeroplane_uuid> [--out FILE]
+
+The real hub key/base-url are read from .env via app.core.config (this
+script never reads .env directly). Requires COPILOT_API_KEY + COPILOT_BASE_URL
+to be set in .env.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+import tempfile
+
+# --- point the app at a throwaway COPY of the local db BEFORE importing it ---
+_SRC_DB = os.path.join(os.getcwd(), "db", "test.db")
+_TMP_DB = os.path.join(tempfile.gettempdir(), "uat_copilot_copy.db")
+# Start from a TRULY clean copy: delete the temp db AND its SQLite sidecars
+# (-wal/-shm). Leaving a stale -wal resurrects prior-run history on open, which
+# silently bleeds copilot conversation across runs.
+for _suffix in ("", "-wal", "-shm", "-journal"):
+    try:
+        os.remove(_TMP_DB + _suffix)
+    except FileNotFoundError:
+        pass
+shutil.copy2(_SRC_DB, _TMP_DB)
+os.environ["SQLALCHEMY_DATABASE_URL"] = f"sqlite:///{_TMP_DB}"
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from app.core.config import settings  # noqa: E402
+from app.main import app  # noqa: E402
+
+
+QUESTIONS: list[str] = [
+    # 1. Snapshot / explain (beginner-accessible)
+    "Give me a quick overview of this aircraft — what kind of plane is it, "
+    "and what are its main wing dimensions and weight?",
+    # 2. Stability / static margin (Scholz + RC bands)
+    "Is the static margin of this design healthy? What value would you "
+    "recommend for its mission, and how would I change it if needed?",
+    # 3. Performance — needs a real number from a tool (anti-hallucination probe)
+    "What is the stall speed, and how does the wing loading compare to what "
+    "you'd expect for an aircraft like this?",
+    # 4. Triggers run_analysis (polar) + interpretation
+    "Run an aerodynamic analysis and tell me the best lift-to-drag ratio and "
+    "the angle of attack where it occurs.",
+    # 5. Design advice (rule-of-thumb correctness)
+    "I want to add a winglet to reduce induced drag. Is that worthwhile for "
+    "this aircraft, and what's the trade-off?",
+]
+
+
+def _parse_sse(raw: str) -> list[tuple[str, dict]]:
+    events: list[tuple[str, dict]] = []
+    ev = None
+    for line in raw.splitlines():
+        line = line.strip()
+        if line.startswith("event:"):
+            ev = line[len("event:"):].strip()
+        elif line.startswith("data:") and ev is not None:
+            try:
+                data = json.loads(line[len("data:"):].strip())
+            except json.JSONDecodeError:
+                data = {"raw": line[len("data:"):].strip()}
+            events.append((ev, data))
+            ev = None
+    return events
+
+
+def run_question(client: TestClient, uuid: str, question: str) -> dict:
+    resp = client.post(
+        f"/aeroplanes/{uuid}/copilot/stream",
+        json={"message": question},
+    )
+    events = _parse_sse(resp.text)
+    text = "".join(d.get("text", "") for t, d in events if t == "token")
+    tool_calls = [d for t, d in events if t == "tool_call"]
+    tool_results = [d for t, d in events if t == "tool_result"]
+    errors = [d for t, d in events if t == "error"]
+    done = next((d for t, d in events if t == "done"), {})
+    return {
+        "question": question,
+        "status_code": resp.status_code,
+        "answer": text,
+        "tools_called": [c.get("name") for c in tool_calls],
+        "tool_summaries": [r.get("summary") for r in tool_results],
+        "errors": errors,
+        "truncated": bool(done.get("truncated")),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("uuid")
+    ap.add_argument("--out", default=os.path.join(tempfile.gettempdir(), "uat_copilot_transcript.json"))
+    args = ap.parse_args()
+
+    if not settings.COPILOT_API_KEY or not settings.COPILOT_BASE_URL:
+        print("ERROR: COPILOT_API_KEY / COPILOT_BASE_URL not set in .env", file=sys.stderr)
+        return 2
+
+    print(f"Hub: {settings.COPILOT_BASE_URL}  model={settings.COPILOT_MODEL}")
+    print(f"DB copy: {_TMP_DB}")
+    print(f"Aeroplane: {args.uuid}\n")
+
+    client = TestClient(app)
+    transcript = []
+    for i, q in enumerate(QUESTIONS, 1):
+        print(f"=== Q{i}: {q[:70]}...")
+        rec = run_question(client, args.uuid, q)
+        print(f"    tools={rec['tools_called']} truncated={rec['truncated']} "
+              f"errors={len(rec['errors'])} answer_chars={len(rec['answer'])}")
+        transcript.append(rec)
+
+    with open(args.out, "w") as f:
+        json.dump(transcript, f, indent=2)
+    print(f"\nTranscript written to {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Context
After the multi-turn fix (#922), the **3-persona UAT** (Scholz, RC-expert, hobbyist) drove the real hub against eHawk and found answer-quality defects. This PR fixes the correctness + accessibility findings the user prioritised. The app-level aero inconsistency they exposed is tracked separately in **#924**.

## Correctness — the headline fix
The copilot kept getting the induced/parasitic drag split wrong: first a **physically-impossible** result (parasitic CD0 0.02364 > total CD 0.02302, from mixing snapshot cd0 with the polar total), then — after a prompt-only fix — a **10× arithmetic error** (induced ~5% vs the correct ~47%). Prompt rules can't make an LLM a reliable calculator, so:

- **`run_analysis(polar)` now returns a deterministic `drag_breakdown`** at the best-glide point: `CD_i = CL²/(π·AR·e)`, `CD_parasite = CD_total − CD_i`, from one consistent source, with a sanity guard that emits a `note` instead of fabricating a negative/over-total component. The model just reports it.
- **System prompt** hardened: report the tool's `drag_breakdown` (don't recompute); never mix snapshot `cd0`/`e` with polar totals; surface tool disagreements (two NPs; snapshot-vs-polar L/D) rather than hiding them; correct CG/NP/static-margin direction; never report CG/NP/SM numbers not present in tool output.

**Verified against the real hub:** Q5 now reports induced **0.01085 (47%)** / parasite **0.01218 (53%)** — matching the hand calculation exactly.

## Accessibility (serves hobbyists AND pros)
Prompt now: answer the question asked (no pre-answering everything); lead with a plain-language takeaway; gloss jargon on first use (MAC, AR, Re, Oswald e, SM, NP, parasitic/induced); always translate L/D → glide ratio; paraphrase raw tool flags; lean tables; name the workbench panel for each action. **Verified:** Q1 went from 6568 → ~1500 chars with jargon glossed and only the asked question answered.

## Tests
- Deterministic `_drag_breakdown` unit tests — the exact 10× case (asserts induced ≈ 0.01084 / ~47%), components-sum-to-total, inconsistent→note (no wrong numbers), missing→None.
- System-prompt guard tests for the new directives.
- Full copilot suite: **90 passed**. ruff clean.
- Adds `scripts/uat_copilot_driver.py` — the reproducible real-hub UAT harness (drives a DB copy, never the user's data).

Closes #925 · relates to #902 (Slice 1 sign-off) · app inconsistency → #924

🤖 Generated with [Claude Code](https://claude.com/claude-code)