### PR TITLE
fix(gh-924): velocity polar uses the chips' Reynolds model (velocities now match)

### DIFF
--- a/app/api/v2/endpoints/aeroplane/speed_polar.py
+++ b/app/api/v2/endpoints/aeroplane/speed_polar.py
@@ -79,8 +79,14 @@ def _get_aeroplane(db: Session, aeroplane_id: UUID4) -> AeroplaneModel:
     return plane
 
 
-def _extract_polar_inputs(plane: AeroplaneModel) -> dict[str, float | None]:
-    """Pull mass_kg, s_ref_m2, ar, e_oswald, cd0 from the computation context."""
+def _extract_polar_inputs(plane: AeroplaneModel) -> dict[str, Any]:
+    """Pull the parabolic-polar parameters from the computation context.
+
+    Beyond the legacy fixed cd0/e, also pulls the Reynolds cd0/e table, MAC,
+    and CL_max so the polar uses the SAME model as the characteristic-speed
+    chips (gh-924): the curve and the V_md / V_min_sink markers then match the
+    chips instead of diverging.
+    """
     ctx: dict[str, Any] = cast(dict[str, Any], plane.assumption_computation_context or {})
     return {
         "mass_kg": _safe_float(ctx.get("mass_kg")),
@@ -88,7 +94,26 @@ def _extract_polar_inputs(plane: AeroplaneModel) -> dict[str, float | None]:
         "ar": _safe_float(ctx.get("aspect_ratio")),
         "e_oswald": _safe_float(ctx.get("e_oswald")),
         "cd0": _safe_float(ctx.get("cd0")),
+        "polar_re_table": ctx.get("polar_re_table") or None,
+        "mac_m": _safe_float(ctx.get("mac_m")),
+        "cl_max": _extract_cl_max(ctx),
     }
+
+
+def _extract_cl_max(ctx: dict[str, Any]) -> float | None:
+    """Clean-config CL_max (stall) — clamps the sweep + markers at V_stall.
+
+    Prefers the clean polar config, falling back to the first Reynolds-table
+    row, then a top-level ``cl_max`` field.
+    """
+    clean = (ctx.get("polar_by_config") or {}).get("clean") or {}
+    candidate = clean.get("cl_max")
+    if candidate is None:
+        table = ctx.get("polar_re_table") or []
+        candidate = table[0].get("cl_max") if table else None
+    if candidate is None:
+        candidate = ctx.get("cl_max")
+    return _safe_float(candidate)
 
 
 def _safe_float(value: Any) -> float | None:

--- a/app/services/speed_polar_service.py
+++ b/app/services/speed_polar_service.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 # ISA sea-level constants
 _G = 9.80665  # m/s²
@@ -27,6 +27,11 @@ _RHO_ISA_SL = 1.225  # kg/m³
 # Speed-polar sweep: CL from CL_ms·1.4 down to CL_min_sweep
 _CL_SWEEP_POINTS = 200
 _CL_MIN_RATIO = 0.25  # fraction of CL_bg — stops before stall region
+
+# Reynolds mode (gh-924): one Picard pass re-looks-up cd0/e at the converged
+# speed, matching the characteristic-speed chips (assumption_compute_service,
+# gh-493) so the polar's V_md / V_min_sink markers equal the chip values.
+_PICARD_PASSES = 1
 
 
 # ---------------------------------------------------------------------------
@@ -82,6 +87,9 @@ def compute_speed_polar(
     cd0: float | None,
     *,
     rho: float = _RHO_ISA_SL,
+    polar_re_table: list[dict[str, Any]] | None = None,
+    mac_m: float | None = None,
+    cl_max: float | None = None,
 ) -> SpeedPolarResult | _MissingInputs:
     """Compute the aircraft speed polar from parabolic-polar parameters.
 
@@ -94,9 +102,20 @@ def compute_speed_polar(
     mass_kg : aircraft mass [kg]
     s_ref_m2 : reference wing area [m²]
     ar : aspect ratio (dimensionless)
-    e_oswald : Oswald efficiency factor (dimensionless, 0 < e ≤ 1)
-    cd0 : zero-lift drag coefficient (dimensionless, > 0)
+    e_oswald : Oswald efficiency factor (dimensionless, 0 < e ≤ 1) — used as the
+        fallback / legacy value when ``polar_re_table`` is not supplied
+    cd0 : zero-lift drag coefficient (dimensionless, > 0) — fallback / legacy
     rho : air density [kg/m³], default ISA sea-level 1.225
+    polar_re_table : optional Reynolds-binned cd0/e table. When supplied (with
+        ``mac_m``), the curve and the V_md / V_min_sink markers use the
+        Reynolds-dependent ``cd0(V)`` / ``e(V)`` model — the SAME model the
+        characteristic-speed chips use (gh-493) — so the polar markers match
+        the chips instead of diverging (gh-924).
+    mac_m : mean aerodynamic chord [m], required for the Reynolds lookups.
+    cl_max : maximum lift coefficient. When supplied, the CL sweep is truncated
+        at ``cl_max`` (the curve stops at V_stall instead of plotting a
+        physically-unreachable sub-stall region) and V_md / V_min_sink are
+        clamped to V_stall = V(cl_max) (gh-683), matching the chips.
     """
     missing = _check_inputs(mass_kg=mass_kg, s_ref_m2=s_ref_m2, ar=ar, e_oswald=e_oswald, cd0=cd0)
     if missing:
@@ -107,37 +126,77 @@ def compute_speed_polar(
     assert ar is not None and e_oswald is not None and cd0 is not None
 
     weight_n = mass_kg * _G
-    k = _induced_drag_factor(ar, e_oswald)
 
-    # Special CL values
-    cl_bg = _cl_best_glide(cd0, k)
-    cl_ms = _cl_min_sink(cd0, k)
+    reynolds_mode = bool(polar_re_table) and mac_m is not None and mac_m > 0
 
-    # Sweep CL from slightly above CL_ms down to a low-speed stop
+    def _cd0_e_at(v: float) -> tuple[float, float]:
+        """Reynolds cd0(V)/e(V) when a table is supplied, else the fixed pair."""
+        if reynolds_mode:
+            from app.services.polar_re_table_service import (
+                lookup_cd0_at_v,
+                lookup_e_oswald_at_v,
+            )
+
+            assert polar_re_table is not None and mac_m is not None
+            return (
+                lookup_cd0_at_v(v, polar_re_table, mac_m, rho),
+                lookup_e_oswald_at_v(v, polar_re_table),
+            )
+        return cd0, e_oswald
+
+    # V_stall and the CL ceiling for the sweep / marker clamp.
+    v_stall = _velocity(weight_n, rho, s_ref_m2, cl_max) if (cl_max and cl_max > 0) else None
+
+    # --- Special CL points (best-glide, min-sink) -------------------------
+    # One Picard pass: solve the closed-form optimum, re-look-up cd0/e at the
+    # converged speed, solve once more — identical to the chips' refinement.
+    cl_bg, v_bg, cd0_bg, k_bg = _converge_special_point(
+        _cl_best_glide, cd0, e_oswald, ar, weight_n, rho, s_ref_m2, _cd0_e_at
+    )
+    cl_ms, v_ms, cd0_ms, k_ms = _converge_special_point(
+        _cl_min_sink, cd0, e_oswald, ar, weight_n, rho, s_ref_m2, _cd0_e_at
+    )
+
+    # Clamp V_md / V_min_sink to V_stall — the closed-form optimum CL can
+    # exceed CL_max (high-AR / draggy polars), back-solving an unreachable
+    # sub-stall speed (gh-683). Clamping surfaces the real operating point.
+    if v_stall is not None and cl_max is not None:
+        if cl_bg >= cl_max:
+            cl_bg, v_bg = cl_max, v_stall
+            cd0_bg, e_bg = _cd0_e_at(v_bg)
+            k_bg = _induced_drag_factor(ar, e_bg)
+        if cl_ms >= cl_max:
+            cl_ms, v_ms = cl_max, v_stall
+            cd0_ms, e_ms = _cd0_e_at(v_ms)
+            k_ms = _induced_drag_factor(ar, e_ms)
+
+    bg = SpeedPolarPoint(
+        v_mps=round(v_bg, 4),
+        sink_mps=round(_sink_rate(v_bg, cd0_bg, k_bg, cl_bg), 5),
+        cl=round(cl_bg, 6),
+    )
+    ms = SpeedPolarPoint(
+        v_mps=round(v_ms, 4),
+        sink_mps=round(_sink_rate(v_ms, cd0_ms, k_ms, cl_ms), 5),
+        cl=round(cl_ms, 6),
+    )
+
+    # --- Curve sweep ------------------------------------------------------
+    # High-CL (low-speed) end: stop at CL_max so we never plot past stall.
     cl_high = cl_ms * 1.40
-    cl_low = cl_bg * _CL_MIN_RATIO  # well below best glide, not useful to plot further
-    # Build grid of CL values (descending → ascending V for the plot)
+    if cl_max and cl_max > 0:
+        cl_high = min(cl_high, cl_max)
+    cl_low = cl_bg * _CL_MIN_RATIO
     cl_arr = _linspace(cl_high, cl_low, _CL_SWEEP_POINTS)
 
     v_arr: list[float] = []
     sink_arr: list[float] = []
     for cl in cl_arr:
         v = _velocity(weight_n, rho, s_ref_m2, cl)
-        sink = _sink_rate(v, cd0, k, cl)
+        cd0_v, e_v = _cd0_e_at(v)
+        k_v = _induced_drag_factor(ar, e_v)
         v_arr.append(round(v, 4))
-        sink_arr.append(round(sink, 5))
-
-    # Best-glide and min-sink points
-    bg = SpeedPolarPoint(
-        v_mps=round(_velocity(weight_n, rho, s_ref_m2, cl_bg), 4),
-        sink_mps=round(_sink_rate(_velocity(weight_n, rho, s_ref_m2, cl_bg), cd0, k, cl_bg), 5),
-        cl=round(cl_bg, 6),
-    )
-    ms = SpeedPolarPoint(
-        v_mps=round(_velocity(weight_n, rho, s_ref_m2, cl_ms), 4),
-        sink_mps=round(_sink_rate(_velocity(weight_n, rho, s_ref_m2, cl_ms), cd0, k, cl_ms), 5),
-        cl=round(cl_ms, 6),
-    )
+        sink_arr.append(round(_sink_rate(v, cd0_v, k_v, cl), 5))
 
     return SpeedPolarResult(
         v_mps=v_arr,
@@ -152,8 +211,36 @@ def compute_speed_polar(
             "e_oswald": e_oswald,
             "cd0": cd0,
             "rho": rho,
+            "reynolds_mode": reynolds_mode,
+            "cl_max": cl_max,
         },
     )
+
+
+def _converge_special_point(
+    cl_fn,
+    cd0: float,
+    e_oswald: float,
+    ar: float,
+    weight_n: float,
+    rho: float,
+    s_ref_m2: float,
+    cd0_e_at,
+) -> tuple[float, float, float, float]:
+    """Solve a special-point CL (best-glide or min-sink) with one Picard pass.
+
+    Returns ``(cl, v, cd0_at_v, k_at_v)``. With a fixed cd0/e (legacy mode)
+    this reduces to the closed-form value in a single shot; with the Reynolds
+    table it refines cd0/e at the converged speed exactly like the chips.
+    """
+    cd0_i, e_i = cd0, e_oswald
+    cl = v = 0.0
+    for _ in range(_PICARD_PASSES + 1):
+        k = _induced_drag_factor(ar, e_i)
+        cl = cl_fn(cd0_i, k)
+        v = _velocity(weight_n, rho, s_ref_m2, cl)
+        cd0_i, e_i = cd0_e_at(v)
+    return cl, v, cd0_i, _induced_drag_factor(ar, e_i)
 
 
 def is_missing(result: SpeedPolarResult | _MissingInputs) -> bool:

--- a/app/tests/test_speed_polar_endpoint.py
+++ b/app/tests/test_speed_polar_endpoint.py
@@ -38,6 +38,45 @@ _FULL_CTX = {
 # ---------------------------------------------------------------------------
 
 
+_REYNOLDS_CTX = {
+    # eHawk-like high-AR glider with a Reynolds table + clean CL_max (gh-924)
+    "mass_kg": 1.5,
+    "s_ref_m2": 0.1999,
+    "aspect_ratio": 11.3,
+    "e_oswald": 0.7916,
+    "cd0": 0.02364,
+    "mac_m": 0.1398,
+    "v_md_mps": 11.4,
+    "v_min_sink_mps": 9.8,
+    "v_stall_mps": 9.8,
+    "polar_by_config": {"clean": {"cl_max": 1.256}},
+    "polar_re_table": [
+        {"re": 85000, "v_mps": 9.0, "cd0": None, "e_oswald": None,
+         "cl_max": 1.256, "fallback_used": True},
+        {"re": 170000, "v_mps": 18.0, "cd0": None, "e_oswald": None,
+         "cl_max": 1.256, "fallback_used": True},
+    ],
+}
+
+
+class TestSpeedPolarEndpointReynolds:
+    """gh-924: with a Reynolds table the polar markers must equal the chips."""
+
+    def test_markers_match_chip_speeds(self, client_and_db):
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_aeroplane_with_context(db, ctx=_REYNOLDS_CTX)
+            uid = str(plane.uuid)
+
+        data = client.get(f"/aeroplanes/{uid}/speed-polar").json()
+        # Polar special points must equal the characteristic-speed chips
+        assert data["best_glide"]["v_mps"] == pytest.approx(_REYNOLDS_CTX["v_md_mps"], abs=0.1)
+        assert data["min_sink"]["v_mps"] == pytest.approx(_REYNOLDS_CTX["v_min_sink_mps"], abs=0.1)
+        # Curve must not extend below V_stall (no past-stall plotting)
+        assert min(data["v_mps"]) >= _REYNOLDS_CTX["v_stall_mps"] - 0.1
+        assert data["inputs"]["reynolds_mode"] is True
+
+
 class TestSpeedPolarEndpointHappyPath:
     def test_returns_200(self, client_and_db):
         client, SessionLocal = client_and_db

--- a/app/tests/test_speed_polar_service.py
+++ b/app/tests/test_speed_polar_service.py
@@ -281,3 +281,89 @@ class TestComputeSpeedPolar:
         assert isinstance(result_alt, SpeedPolarResult)
         # Lower density → higher speed for same CL
         assert result_alt.best_glide.v_mps > result_sl.best_glide.v_mps
+
+
+# ---------------------------------------------------------------------------
+# Reynolds mode (gh-924) — polar markers must match the characteristic-speed
+# chips: cd0(V)/e(V) from the polar_re_table, CL_max clamp, sweep truncation.
+# ---------------------------------------------------------------------------
+
+
+def _fallback_table(cl_max: float = 1.256) -> list[dict]:
+    """All-fallback Re table → lookup_cd0_at_v returns 0.03, e returns 0.8."""
+    return [
+        {"re": 85000, "v_mps": 9.0, "cd0": None, "e_oswald": None,
+         "cl_max": cl_max, "fallback_used": True},
+        {"re": 170000, "v_mps": 18.0, "cd0": None, "e_oswald": None,
+         "cl_max": cl_max, "fallback_used": True},
+    ]
+
+
+class TestComputeSpeedPolarReynolds:
+    # eHawk-like high-AR glider: scalar cd0/e differ from the fallback table
+    EH = dict(mass_kg=1.5, s_ref_m2=0.1999, ar=11.3, e_oswald=0.7916, cd0=0.02364)
+    MAC = 0.1398
+    CL_MAX = 1.256
+
+    def test_uses_reynolds_cd0_not_passed_cd0(self):
+        """Best-glide uses cd0(V)=0.03 from the fallback table, NOT cd0=0.02364."""
+        res = compute_speed_polar(
+            **self.EH, polar_re_table=_fallback_table(self.CL_MAX),
+            mac_m=self.MAC, cl_max=self.CL_MAX,
+        )
+        assert isinstance(res, SpeedPolarResult)
+        # Closed-form best-glide with the FALLBACK cd0=0.03, e=0.8:
+        k = _induced_drag_factor(11.3, 0.8)
+        cl_bg = _cl_best_glide(0.03, k)
+        v_bg = _velocity(1.5 * G, RHO, 0.1999, cl_bg)
+        assert res.best_glide.v_mps == pytest.approx(v_bg, abs=0.05)
+        # And distinctly NOT the value the passed cd0=0.02364 would give
+        v_bg_passed = _velocity(
+            1.5 * G, RHO, 0.1999,
+            _cl_best_glide(0.02364, _induced_drag_factor(11.3, 0.7916)),
+        )
+        assert abs(res.best_glide.v_mps - v_bg_passed) > 0.3
+
+    def test_min_sink_clamped_to_v_stall(self):
+        """CL_min_sink > CL_max → min-sink marker sits at V_stall, not sub-stall."""
+        res = compute_speed_polar(
+            **self.EH, polar_re_table=_fallback_table(self.CL_MAX),
+            mac_m=self.MAC, cl_max=self.CL_MAX,
+        )
+        assert isinstance(res, SpeedPolarResult)
+        v_stall = _velocity(1.5 * G, RHO, 0.1999, self.CL_MAX)
+        assert res.min_sink.v_mps == pytest.approx(v_stall, abs=0.05)
+        assert res.min_sink.cl == pytest.approx(self.CL_MAX, abs=1e-3)
+
+    def test_sweep_does_not_go_below_v_stall(self):
+        """Curve is truncated at CL_max — nothing plotted past stall."""
+        res = compute_speed_polar(
+            **self.EH, polar_re_table=_fallback_table(self.CL_MAX),
+            mac_m=self.MAC, cl_max=self.CL_MAX,
+        )
+        assert isinstance(res, SpeedPolarResult)
+        v_stall = _velocity(1.5 * G, RHO, 0.1999, self.CL_MAX)
+        assert min(res.v_mps) >= v_stall - 0.05
+        assert max(res.cl) <= self.CL_MAX + 1e-6
+
+    def test_markers_match_chip_speeds_ehawk(self):
+        """Regression for the reported bug: polar V_md/V_min_sink == the chips."""
+        res = compute_speed_polar(
+            **self.EH, polar_re_table=_fallback_table(self.CL_MAX),
+            mac_m=self.MAC, cl_max=self.CL_MAX,
+        )
+        assert isinstance(res, SpeedPolarResult)
+        # The chips (assumption_compute_service) report 11.4 / 9.8 for eHawk
+        assert res.best_glide.v_mps == pytest.approx(11.4, abs=0.1)
+        assert res.min_sink.v_mps == pytest.approx(9.8, abs=0.1)
+
+    def test_legacy_mode_unchanged_without_table(self):
+        """No polar_re_table → identical to the legacy closed-form path."""
+        legacy = compute_speed_polar(**self.EH)
+        with_clmax_only = compute_speed_polar(**self.EH)  # still legacy
+        assert isinstance(legacy, SpeedPolarResult)
+        # Legacy best-glide uses the PASSED cd0/e (no Reynolds override, no clamp)
+        k = _induced_drag_factor(11.3, 0.7916)
+        v_bg = _velocity(1.5 * G, RHO, 0.1999, _cl_best_glide(0.02364, k))
+        assert legacy.best_glide.v_mps == pytest.approx(v_bg, abs=0.05)
+        assert legacy.best_glide.v_mps == with_clmax_only.best_glide.v_mps


### PR DESCRIPTION
## The bug
The velocity polar's **best-glide / min-sink markers don't match the characteristic-speed chips**. Verified on eHawk (no user override):

| Speed | Velocity polar | Chip | Issue |
|---|---|---|---|
| best-glide / V_md | 12.14 m/s | 11.4 m/s | polar used context `cd0`=0.02364; chip refines `cd0(V)`=0.03 from the all-fallback `polar_re_table` (Picard, gh-493) |
| min-sink / V_min_sink | 9.23 m/s (CL 1.41, **past stall**) | 9.8 m/s | polar ignored CL_max; chip clamps to V_stall (gh-683) |

The speed polar was a standalone closed-form path on a single fixed `cd0`/`e`; the chips use the Reynolds `lookup_cd0_at_v`/`lookup_e_oswald_at_v` model + Picard refine + CL_max clamp. Same quantity, different paths → divergence.

## Fix
`compute_speed_polar` now (when the endpoint passes `polar_re_table` + `mac` + `cl_max` from the context):
- builds the curve **and** the V_md/V_min_sink markers with `cd0(V)`/`e(V)` from the Reynolds table (one Picard pass) — the **same model as the chips**;
- truncates the CL sweep at CL_max (curve stops at V_stall — no past-stall plotting);
- clamps V_md/V_min_sink to V_stall when the optimum CL exceeds CL_max (gh-683).

The legacy closed-form path (no table) is unchanged, and the response shape is identical — **no frontend change** (the chart reads `best_glide.v_mps`/`min_sink.v_mps` directly).

## Verification
- **eHawk end-to-end:** polar best_glide **11.41** == chip V_md **11.4**; min_sink **9.78** == chip V_min_sink **9.8**; sweep now stops at V_stall.
- Tests: **+6 service** (Reynolds cd0 override, CL_max clamp, sweep truncation, eHawk regression, legacy-unchanged) **+1 endpoint** (Reynolds context). Full speed-polar suite green; ruff clean.

**Part of #924** — fixes the velocity-polar-vs-chips symptom. The deeper items in #924 (the `cd0`/`e` vs alpha-sweep **L/D ≈ 40%** disagreement — eHawk's `polar_re_table` is all-fallback so `cd0` falls to 0.03 while the AeroBuildup polar gives L/D 24 — and the **two neutral points**) remain open under #924.

🤖 Generated with [Claude Code](https://claude.com/claude-code)