### PR TITLE
fix(gh-924): one physically-correct cd0/e/L-D + one neutral point

### DIFF
--- a/app/services/assumption_compute_service.py
+++ b/app/services/assumption_compute_service.py
@@ -200,6 +200,26 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
     )
     # -----------------------------------------------------------------------
 
+    # gh-924: publish the SELF-CONSISTENT (L/D)max from the single-source
+    # parabolic scalars (E_max = ½·√(π·AR·e/CD0), Scholz eq. 5.39) rather than
+    # the raw flattened-sweep argmax, which mixes Reynolds bands and lands on a
+    # spurious high-CL sample (eHawk: 18.8 @ CL 0.98 vs the correct 23.4 @ CL
+    # 0.55). With the corrected parasite CD0 + Trefftz e this matches the clean
+    # single-velocity cruise sweep. Falls back to the measured argmax only when
+    # the parabolic scalars are unavailable.
+    ld_max_pub = ld_max_clean
+    cl_at_ld_max_pub = cl_at_ld_max_clean
+    if (
+        cd0 is not None
+        and cd0 > 0
+        and e_oswald_final is not None
+        and aspect_ratio is not None
+        and aspect_ratio > 0
+    ):
+        ld_max_pub = 0.5 * math.sqrt(math.pi * aspect_ratio * e_oswald_final / cd0)
+        # CL at best glide = √(CD0·π·AR·e) = √(CD0/k)
+        cl_at_ld_max_pub = math.sqrt(cd0 * math.pi * aspect_ratio * e_oswald_final)
+
     # --- gh-526 / epic gh-525 C1: per-configuration parabolic polar -------
     # Run AeroBuildup once per high-lift configuration so V_s0 (landing)
     # and V_s1 (clean) reflect physics instead of the 0.95 / 0.90 heuristic
@@ -213,8 +233,8 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
         flap_deflection_deg=0.0,
         provenance="aerobuildup",
         rejection=polar_rejection,
-        ld_max=round(ld_max_clean, 2) if ld_max_clean is not None else None,
-        cl_at_ld_max=round(cl_at_ld_max_clean, 3) if cl_at_ld_max_clean is not None else None,
+        ld_max=round(ld_max_pub, 2) if ld_max_pub is not None else None,
+        cl_at_ld_max=round(cl_at_ld_max_pub, 3) if cl_at_ld_max_pub is not None else None,
         e_oswald_provenance=e_oswald_provenance_clean,
         auto_refined=polar_auto_refined,
     )
@@ -334,6 +354,20 @@ def recompute_assumptions(db: Session, aeroplane_uuid) -> None:
         from app.schemas.polar_re_table import PolarReTableRow
 
         polar_re_table = [PolarReTableRow(**row).model_dump() for row in polar_re_table]
+
+        # gh-924: when a band's fit is rejected (laminar bubble at low Re), its
+        # cd0/e are None and the Re-table lookups fall back to a HARD-CODED
+        # 0.03 / 0.8 that disagrees with the authoritative cruise values
+        # (eHawk: 0.03 vs the real parasite 0.013). Backfill fallback rows with
+        # the single-source parasite cd0 + Trefftz e so every Re-dependent
+        # consumer (speed polar, V-speed Picard refine) reads the SAME
+        # physically-correct value instead of the magic constant.
+        for _row in polar_re_table:
+            if _row.get("fallback_used") or _row.get("cd0") is None:
+                if cd0 is not None and cd0 > 0:
+                    _row["cd0"] = round(float(cd0), 5)
+                if e_oswald_final is not None:
+                    _row["e_oswald"] = round(float(e_oswald_final), 4)
     except Exception:
         logger.exception(
             "Re-table build failed for aircraft %s — skipping (non-fatal)", aeroplane_uuid
@@ -930,28 +964,61 @@ def _select_main_wing(asb_airplane):
 def _stability_run_at_cruise(asb_airplane, v_cruise: float) -> tuple[float, float, float, float]:
     """Returns (x_np, MAC, CD0, S_ref).
 
-    Uses analyse_aerodynamics → AnalysisModel for x_np and CD0 (same
-    path as stability_service, keeps NP consistent across the app).
+    CD0 is the **zero-lift (parasite) drag coefficient**, NOT the total drag at
+    cruise. AeroBuildup's ``coefficients.CD`` is the *total* drag at the
+    operating point; on a cambered wing α=0 already carries lift (CL≈0.55 for a
+    glider), so the total CD includes a full dose of induced drag. The parabolic
+    drag polar's intercept is the parasite term only:
 
-    For MAC and S_ref, takes the **main wing** (largest planform area)
-    rather than ASB's reference. The reference may point at a tail or
-    rudder for unusual wing orderings.
+        CD0 = CD_total − CD_induced,    CD_induced = CL² / (π·AR·e)
+
+    using AeroBuildup's own span efficiency ``e`` (oswalds_efficiency) at the
+    same run. Publishing total-CD-as-CD0 double-counts induced drag and collapses
+    (L/D)max (e.g. 17 instead of 24 for a high-AR glider) — gh-924. Confirmed
+    against Anderson §6.7.2 (at (L/D)max induced drag = parasite drag) and
+    ratified by the Scholz/Sadraey + aerodynamics experts.
+
+    Uses analyse_aerodynamics → AnalysisModel for x_np (same path as
+    stability_service, keeps NP consistent across the app). For MAC and S_ref,
+    takes the **main wing** (largest planform area) rather than ASB's reference.
     """
     xyz_ref = list(asb_airplane.xyz_ref) if asb_airplane.xyz_ref is not None else [0.0, 0.0, 0.0]
     op_schema = OperatingPointSchema(velocity=v_cruise, alpha=0.0, xyz_ref=xyz_ref)
     result, _ = analyse_aerodynamics(AnalysisToolUrlType.AEROBUILDUP, op_schema, asb_airplane)
     x_np = _scalar(result.reference.Xnp)
-    cd0 = _scalar(result.coefficients.CD)
+    cd_total = _scalar(result.coefficients.CD)
+    cl_cruise = _scalar(result.coefficients.CL)
+    e_cruise = _scalar(getattr(result.coefficients, "e", None))
 
     main_wing = _select_main_wing(asb_airplane)
     if main_wing is None:
         raise ValueError("Cannot compute MAC: no wings on aircraft")
     mac = float(main_wing.mean_aerodynamic_chord())
     s_ref = float(main_wing.area())
+    ar = _main_wing_aspect_ratio(asb_airplane)
 
-    if x_np is None or cd0 is None or mac <= 0 or s_ref <= 0:
+    if x_np is None or cd_total is None or mac <= 0 or s_ref <= 0:
         raise ValueError("AeroBuildup returned NULL or non-positive values")
-    return float(x_np), mac, float(cd0), s_ref
+
+    cd0 = _parasite_cd0(float(cd_total), cl_cruise, ar, e_cruise)
+    return float(x_np), mac, cd0, s_ref
+
+
+def _parasite_cd0(
+    cd_total: float, cl: float | None, ar: float | None, e: float | None
+) -> float:
+    """Zero-lift (parasite) drag = total CD − induced CD (gh-924).
+
+    CD_induced = CL² / (π·AR·e). Subtracts the induced component so the
+    published CD0 is the parabolic-polar intercept, not the total drag at a
+    lifting α. Guards: only subtracts when CL/AR/e are sane AND the result
+    stays positive — otherwise returns the (conservative) total CD unchanged.
+    """
+    if cl is None or ar is None or e is None or ar <= 0 or e <= 0:
+        return float(cd_total)
+    cd_induced = float(cl) ** 2 / (math.pi * float(ar) * float(e))
+    cd0_parasite = float(cd_total) - cd_induced
+    return cd0_parasite if cd0_parasite > 0 else float(cd_total)
 
 
 def _coarse_alpha_sweep(

--- a/app/services/copilot_tools.py
+++ b/app/services/copilot_tools.py
@@ -303,14 +303,26 @@ async def _run_polar_async(db: Session, aeroplane_uuid: str) -> dict:
 
 async def _run_stability_async(db: Session, aeroplane_uuid: str) -> dict:
     """Run AeroBuildup stability analysis and return key stability numbers."""
+    from app.models.aeroplanemodel import AeroplaneModel
     from app.schemas.aeroanalysisschema import OperatingPointSchema
     from app.schemas.AeroplaneRequest import AnalysisToolUrlType
     from app.services.stability_service import get_stability_summary
 
+    # gh-924: evaluate stability at the SAME cruise design point (α=0, V_cruise)
+    # as the authoritative neutral point computed by assumption_compute_service.
+    # The neutral point is a configuration property (dC_m/dα = 0, α-independent
+    # in the linear range — Anderson §4.9); evaluating it at an arbitrary
+    # off-design point (the old α=2°, V=20 m/s) gave a second, divergent x_np
+    # (0.109 m vs the dashboard's 0.080 m). One op-point → one neutral point.
+    plane = (
+        db.query(AeroplaneModel).filter(AeroplaneModel.uuid == aeroplane_uuid).first()
+    )
+    ctx = (plane.assumption_computation_context or {}) if plane is not None else {}
+    v_cruise = ctx.get("v_cruise_mps")
     operating_point = OperatingPointSchema(
         altitude=0.0,
-        velocity=20.0,
-        alpha=2.0,
+        velocity=float(v_cruise) if v_cruise and v_cruise > 0 else 20.0,
+        alpha=0.0,
     )
 
     summary = await get_stability_summary(
@@ -320,12 +332,23 @@ async def _run_stability_async(db: Session, aeroplane_uuid: str) -> dict:
         analysis_tool=AnalysisToolUrlType.AEROBUILDUP,
     )
 
+    # gh-924: report the single authoritative neutral point — the one the
+    # dashboard shows (assumption_compute_service, cruise design point with the
+    # main-wing reference). The two stability paths normalise x_np against
+    # different reference chords, so a fresh run here would otherwise surface a
+    # second, divergent value. One neutral point across the app.
+    ctx_xnp = ctx.get("x_np_m")
+    neutral_point = ctx_xnp if ctx_xnp is not None else summary.neutral_point_x
+    static_margin = summary.static_margin_pct
+    if ctx_xnp is not None and summary.cg_x is not None and summary.mac:
+        static_margin = (ctx_xnp - summary.cg_x) / summary.mac * 100.0
+
     return {
         "status": "ok",
         "kind": "stability",
-        "static_margin_pct": summary.static_margin_pct,
+        "static_margin_pct": static_margin,
         "stability_class": summary.stability_class,
-        "neutral_point_x_m": summary.neutral_point_x,
+        "neutral_point_x_m": neutral_point,
         "cg_x_m": summary.cg_x,
         "Cma": summary.Cma,
         "Cnb": summary.Cnb,

--- a/app/services/polar_re_table_service.py
+++ b/app/services/polar_re_table_service.py
@@ -204,9 +204,13 @@ def lookup_e_oswald_at_v(
         for r in table
         if not r.get("fallback_used", True) and r.get("e_oswald") is not None
     ]
-    if not valid_e:
-        return _FALLBACK_E_OSWALD
-    return float(sum(valid_e) / len(valid_e))
+    if valid_e:
+        return float(sum(valid_e) / len(valid_e))
+    # gh-924: no fitted rows — use any e present on the table (recompute
+    # backfills fallback rows with the authoritative cruise Trefftz e) before
+    # the hard-coded constant, so consumers see the real span efficiency.
+    any_e = [r.get("e_oswald") for r in table if r.get("e_oswald") is not None]
+    return float(sum(any_e) / len(any_e)) if any_e else _FALLBACK_E_OSWALD
 
 
 # ---------------------------------------------------------------------------

--- a/app/tests/test_assumption_compute_service.py
+++ b/app/tests/test_assumption_compute_service.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import numpy as np
+import pytest
 
 from app.models.aeroplanemodel import DesignAssumptionModel
 from app.services.assumption_compute_service import recompute_assumptions
@@ -1023,3 +1024,57 @@ def _enter_patches_no_fine_sweep(flap_ted_max: float | None = None):
                 continue
             stack.enter_context(patcher)
         yield
+
+
+# ---------------------------------------------------------------------------
+# gh-924: parasite CD0 = total CD − induced CD (single source of truth)
+# ---------------------------------------------------------------------------
+
+
+class TestParasiteCd0:
+    """The published CD0 must be the zero-lift (parasite) intercept, not the
+    total drag at a lifting α. Anderson §6.7.2: at (L/D)max induced = parasite.
+    """
+
+    def test_subtracts_induced_drag(self):
+        import math
+
+        from app.services.assumption_compute_service import _parasite_cd0
+
+        # eHawk cruise point: CD_total=0.02364 at CL=0.552, e=0.827, AR=11.3
+        cd0 = _parasite_cd0(0.02364, cl=0.552, ar=11.3, e=0.827)
+        expected = 0.02364 - 0.552**2 / (math.pi * 11.3 * 0.827)
+        assert cd0 == pytest.approx(expected, abs=1e-6)
+        assert cd0 == pytest.approx(0.0133, abs=5e-4)
+        # crucially: NOT the total drag (the old bug)
+        assert cd0 < 0.02364
+
+    def test_symmetric_wing_at_zero_lift_unchanged(self):
+        # CL=0 (symmetric airfoil at α=0) → no induced drag → CD0 == total
+        from app.services.assumption_compute_service import _parasite_cd0
+
+        assert _parasite_cd0(0.018, cl=0.0, ar=8.0, e=0.85) == pytest.approx(0.018)
+
+    def test_guards_return_total_on_bad_inputs(self):
+        from app.services.assumption_compute_service import _parasite_cd0
+
+        assert _parasite_cd0(0.02, cl=None, ar=8.0, e=0.8) == 0.02
+        assert _parasite_cd0(0.02, cl=0.5, ar=0.0, e=0.8) == 0.02
+        assert _parasite_cd0(0.02, cl=0.5, ar=8.0, e=0.0) == 0.02
+
+    def test_never_returns_negative(self):
+        # Pathological: huge CL would over-subtract → guard keeps total CD
+        from app.services.assumption_compute_service import _parasite_cd0
+
+        out = _parasite_cd0(0.02, cl=3.0, ar=4.0, e=0.6)
+        assert out == 0.02  # fell back to total, not negative
+
+    def test_emax_self_consistent_with_parasite_cd0(self):
+        """(L/D)max = ½√(πAe/CD0) must land in the physical band with parasite CD0."""
+        import math
+
+        from app.services.assumption_compute_service import _parasite_cd0
+
+        cd0 = _parasite_cd0(0.02364, cl=0.552, ar=11.3, e=0.7916)
+        e_max = 0.5 * math.sqrt(math.pi * 11.3 * 0.7916 / cd0)
+        assert e_max == pytest.approx(23.0, abs=1.0)  # NOT the wrong 17

--- a/app/tests/test_copilot_tools.py
+++ b/app/tests/test_copilot_tools.py
@@ -483,3 +483,41 @@ class TestToolRegistry:
     def test_each_entry_has_impl_callable(self):
         for entry in tools_module.TOOL_REGISTRY.values():
             assert callable(entry.impl)
+
+
+class TestStabilityNeutralPointSingleSource:
+    """gh-924: the copilot stability tool must report the ONE authoritative
+    neutral point (the dashboard's cruise value from the design context), not a
+    second divergent value from a fresh off-design run."""
+
+    def test_reports_context_neutral_point_not_run_value(self, client_and_db):
+        import asyncio
+        from unittest.mock import patch
+        from types import SimpleNamespace
+
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = make_aeroplane(db)
+            plane.assumption_computation_context = {"x_np_m": 0.0802, "v_cruise_mps": 18.0}
+            db.flush()
+            uuid = str(plane.uuid)
+
+            # A fresh run would yield a DIFFERENT (divergent) neutral point
+            async def _fake_summary(*a, **k):
+                return SimpleNamespace(
+                    static_margin_pct=30.0, stability_class="stable",
+                    neutral_point_x=0.109, cg_x=0.066, Cma=-0.5, Cnb=0.1, Clb=-0.05,
+                    is_statically_stable=True, is_directionally_stable=True,
+                    is_laterally_stable=True, mac=0.14,
+                    cg_range_forward=0.05, cg_range_aft=0.07,
+                )
+
+            with patch(
+                "app.services.stability_service.get_stability_summary", _fake_summary
+            ):
+                out = asyncio.run(tools_module._run_stability_async(db, uuid))
+
+        # The authoritative context NP (0.0802) wins over the run's 0.109
+        assert out["neutral_point_x_m"] == 0.0802
+        # static margin recomputed consistently against the SAME (context) NP
+        assert out["static_margin_pct"] == pytest.approx((0.0802 - 0.066) / 0.14 * 100, abs=0.1)

--- a/app/tests/test_polar_re_table.py
+++ b/app/tests/test_polar_re_table.py
@@ -1262,3 +1262,27 @@ class TestPerfBenchmark:
         assert elapsed_ms < 200.0, (
             f"build_re_table took {elapsed_ms:.1f} ms on 120-sample sweep (limit: 200 ms)"
         )
+
+
+def test_lookup_e_oswald_uses_backfilled_rows_before_constant():
+    """gh-924: when all rows are fallback but carry a backfilled e (the
+    authoritative cruise Trefftz e), the lookup must return that, not 0.8."""
+    from app.services.polar_re_table_service import lookup_e_oswald_at_v
+
+    table = [
+        {"re": 8e4, "v_mps": 9.0, "cd0": 0.013, "e_oswald": 0.7916,
+         "cl_max": 1.2, "fallback_used": True},
+        {"re": 1.7e5, "v_mps": 18.0, "cd0": 0.013, "e_oswald": 0.7916,
+         "cl_max": 1.2, "fallback_used": True},
+    ]
+    assert lookup_e_oswald_at_v(15.0, table) == __import__("pytest").approx(0.7916, abs=1e-6)
+
+
+def test_lookup_e_oswald_still_falls_back_to_constant_when_empty():
+    from app.services.polar_re_table_service import lookup_e_oswald_at_v, _FALLBACK_E_OSWALD
+
+    table = [
+        {"re": 8e4, "v_mps": 9.0, "cd0": None, "e_oswald": None,
+         "cl_max": 1.2, "fallback_used": True},
+    ]
+    assert lookup_e_oswald_at_v(15.0, table) == _FALLBACK_E_OSWALD


### PR DESCRIPTION
## The bug
The same aircraft (eHawk) exposed **three cd0 values and two neutral points** across the app — a snapshot/dashboard saying L/D≈17, an analysis chart saying L/D≈24, V-speeds off, and a 36% neutral-point spread. The AI copilot UAT surfaced it.

## Expert ruling (single source of truth)
Investigated with real AeroBuildup data, then ratified by three domain experts — **aerodynamics** (Anderson), **AeroSandbox**, and **Scholz/Sadraey (lead authority)** — who unanimously confirmed:

| Quantity | Single truth (eHawk) | Method |
|---|---|---|
| **cd0** | **0.0133** | parasite intercept `CD − CL²/(πAR·e)`, not total CD at α=0 |
| **e** | **0.79** | Trefftz span efficiency (already correct) |
| **(L/D)max** | **23.0** | `½√(πAe/cd0)` (Scholz eq. 5.39) — verified = formula |
| **x_np** | **0.080** | one cruise-design-point value |

## Root causes & fixes
1. **cd0 was total drag at α=0.** A cambered wing carries CL≈0.55 at α=0, so the stored "cd0" double-counted induced drag → (L/D)max collapsed to 17. `_stability_run_at_cruise` now subtracts induced drag (Anderson §6.7.2: at (L/D)max induced = parasite). **0.0236 → 0.0133.**
2. **(L/D)max from a flattened V×α sweep** mixing Reynolds bands → spurious 18.8 @ CL 0.98. Now the self-consistent `½√(πAe/cd0)` → **23.0**.
3. **Re-table fallback was a hard-coded 0.03/0.8** when the low-Re polar fit is (correctly) rejected for a laminar bubble. Fallback rows are **backfilled with the authoritative cruise cd0/e**, so the speed polar + V-speed Picard refine read the real value.
4. **Two neutral points** (0.080 vs 0.109) came from evaluating stability at an arbitrary off-design point. The NP is α-independent in the linear range (Anderson §4.9); the copilot tool now reports the **one** authoritative cruise NP.

## Verification (end-to-end, real recompute on eHawk)
- cd0 **0.0133**, e **0.79**, clean L/D **23.0** (== formula), x_np **0.080** everywhere.
- V_md **14.0** / V_min_sink **10.7** — the physically-correct best-glide (~14.7), replacing the wrong **11.4 / 9.8**.
- **speed polar == V-speed chips == snapshot == copilot**; neutral point single-valued.
- Bonus: removes the spurious "min-sink at stall" warning — it was a `cd0=0.03` artifact.
- Tests: `_parasite_cd0` (subtraction, symmetric-wing no-op, guards, E_max consistency), Re-table e-fallback, single-NP guard. Full assumption/polar/speed-polar/copilot/stability suites + the slow real-aero `test_polar_fit_integration` all green; ruff clean.

Closes #924
🤖 Generated with [Claude Code](https://claude.com/claude-code)