### PR TITLE
docs: mark COPILOT_EMBEDDING_MODEL optional (superseded by #929)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,7 +74,11 @@ UVICORN_HOST=127.0.0.1
 # (strongest reasoning). The hub also passes through streaming + tool-calls.
 # COPILOT_MODEL=claude-sonnet-4-6
 #
-# Embedding model for RAG over the skill vaults (#902 lookup_method):
+# Embedding model — OPTIONAL / not on the critical path. The original
+# embedding-RAG idea was superseded by #929 (agentic expert panel): each
+# expert keeps its own vault and uses lexical retrieval (ripgrep + BM25 +
+# link-graph), no embeddings. Set this only if a later semantic re-rank is
+# added on top.
 # COPILOT_EMBEDDING_MODEL=text-embedding-3-large
 #
 # Available models on the adesso ai-hub (2026-06, names = hub routing ids):


### PR DESCRIPTION
One-line cleanup: the `.env.example` embedding-model note still pointed to the old embedding-RAG plan. Updated to reflect #929 (agentic expert panel — per-vault ripgrep + BM25 + link-graph, no embeddings). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)