### PR TITLE
feat(gh-934): turbulator domain model — topology, schema, DB, converter, backward-compat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,6 +285,11 @@ Details in `.claude/rules/python-conventions.md`.
   **New Creators** (subclasses of `AbstractShapeCreator`) may be
   added. Use `cad_designer/airplane/creator/_creator_template.py`
   as the starting point.
+  **Approved exception (gh-934):** `Turbulator` is a new per-segment
+  optional element (analogous to `TrailingEdgeDevice`/`Spare`). Its
+  introduction required extending `WingSegment` and `WingConfiguration`
+  to accept a `turbulator` parameter — this is the one permitted
+  addition to existing topology classes for this domain object.
 - **Units: mm in WingConfig, meters in DB/ASB.** The WingConfig
   schemas and topology classes use **millimetres**. The database and
   Aerosandbox integration use **metres**. Conversion happens in the

--- a/alembic/versions/6eca6229ba65_gh_934_add_wing_xsec_turbulators_table.py
+++ b/alembic/versions/6eca6229ba65_gh_934_add_wing_xsec_turbulators_table.py
@@ -1,0 +1,46 @@
+"""gh-934 add wing_xsec_turbulators table
+
+Revision ID: 6eca6229ba65
+Revises: 15f45e64a7c0
+Create Date: 2026-06-09 22:54:45.817319
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '6eca6229ba65'
+down_revision: Union[str, None] = '15f45e64a7c0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add wing_xsec_turbulators table (gh-934 Slice 1)."""
+    op.create_table(
+        'wing_xsec_turbulators',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('wing_xsec_detail_id', sa.Integer(), nullable=False),
+        sa.Column('form', sa.String(), nullable=True),
+        sa.Column('height_mm', sa.Float(), nullable=True),
+        sa.Column('position_root', sa.Float(), nullable=True),
+        sa.Column('position_tip', sa.Float(), nullable=True),
+        sa.Column('enabled', sa.Boolean(), server_default='1', nullable=False),
+        sa.ForeignKeyConstraint(
+            ['wing_xsec_detail_id'], ['wing_xsec_details.id'], ondelete='CASCADE'
+        ),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('wing_xsec_detail_id'),
+    )
+    op.create_index(
+        op.f('ix_wing_xsec_turbulators_id'), 'wing_xsec_turbulators', ['id'], unique=False
+    )
+
+
+def downgrade() -> None:
+    """Drop wing_xsec_turbulators table."""
+    op.drop_index(op.f('ix_wing_xsec_turbulators_id'), table_name='wing_xsec_turbulators')
+    op.drop_table('wing_xsec_turbulators')

--- a/app/converters/model_schema_converters.py
+++ b/app/converters/model_schema_converters.py
@@ -24,6 +24,7 @@ from cad_designer.airplane.aircraft_topology.wing import (
     TrailingEdgeDevice,
     WingConfiguration,
 )
+from cad_designer.airplane.aircraft_topology.wing.Turbulator import Turbulator
 
 logger = logging.getLogger(__name__)
 
@@ -300,6 +301,36 @@ def _trailing_edge_device_schema_to_wing_ted(
         0.0 if ted_schema.deflection_deg is None else float(ted_schema.deflection_deg)
     )
     return ted
+
+
+def _turbulator_to_schema(
+    turbulator: Turbulator,
+) -> schemas.TurbulatorDetailSchema:
+    """Convert a topology Turbulator to its ``TurbulatorDetailSchema`` representation.
+
+    Positions (position_root/tip) are dimensionless x/c ratios — no unit conversion.
+    height_mm stays in mm.
+    """
+    return schemas.TurbulatorDetailSchema(
+        form=turbulator.form,
+        height_mm=turbulator.height_mm,
+        position_root=turbulator.position_root,
+        position_tip=turbulator.position_tip,
+        enabled=turbulator.enabled,
+    )
+
+
+def _turbulator_schema_to_wing_turbulator(
+    turbulator_schema: schemas.TurbulatorDetailSchema,
+) -> Turbulator:
+    """Convert a ``TurbulatorDetailSchema`` to a topology ``Turbulator`` instance."""
+    return Turbulator(
+        form=turbulator_schema.form,
+        height_mm=turbulator_schema.height_mm,
+        position_root=turbulator_schema.position_root,
+        position_tip=turbulator_schema.position_tip,  # None → defaults to position_root in __init__
+        enabled=turbulator_schema.enabled,
+    )
 
 
 def _control_surface_from_ted(
@@ -614,6 +645,12 @@ def _hydrate_segment_from_xsec(
         _trailing_edge_device_schema_to_wing_ted(ted_schema) if ted_schema is not None else None
     )
 
+    turb_raw = _to_payload(root_x_sec.turbulator)
+    turb_schema = schemas.TurbulatorDetailSchema.model_validate(turb_raw) if turb_raw else None
+    segment.turbulator = (
+        _turbulator_schema_to_wing_turbulator(turb_schema) if turb_schema is not None else None
+    )
+
     if root_x_sec.spare_list is not None:
         segment.spare_list = [_spare_schema_to_spare(s) for s in root_x_sec.spare_list]
 
@@ -815,6 +852,7 @@ def wing_model_to_asb_wing_schema(wing: WingModel) -> schemas.AsbWingSchema:
         last["x_sec_type"] = None
         last["tip_type"] = None
         last["number_interpolation_points"] = None
+        last["turbulator"] = None
 
     return schemas.AsbWingSchema.model_validate(
         {
@@ -878,7 +916,7 @@ def _resolve_airfoil_ref_for_index(index, section_data, x_sec):
 
 
 def _build_segment_details(segment):
-    """Extract TED, spare list, and segment metadata from a WingConfiguration segment.
+    """Extract TED, spare list, turbulator, and segment metadata from a WingConfiguration segment.
 
     Both TED and control_surface are derived solely from the segment's
     own trailing_edge_device. The caller overwrites the x_sec-derived
@@ -892,6 +930,7 @@ def _build_segment_details(segment):
     trailing_edge_device = None
     control_surface = None
     spare_list = None
+    turbulator = None
 
     if segment.trailing_edge_device is not None:
         trailing_edge_device = _trailing_edge_device_to_schema(segment.trailing_edge_device)
@@ -900,6 +939,9 @@ def _build_segment_details(segment):
     if segment.spare_list is not None:
         spare_list = [_spare_to_schema(spare) for spare in segment.spare_list]
 
+    if getattr(segment, "turbulator", None) is not None:
+        turbulator = _turbulator_to_schema(segment.turbulator)
+
     return (
         trailing_edge_device,
         spare_list,
@@ -907,6 +949,7 @@ def _build_segment_details(segment):
         segment.wing_segment_type,
         segment.tip_type,
         segment.number_interpolation_points,
+        turbulator,
     )
 
 
@@ -934,6 +977,7 @@ def wing_config_to_asb_wing_schema(
         x_sec_type = None
         tip_type = None
         number_interpolation_points = None
+        turbulator = None
 
         segment = wing_config.segments[index] if index < len(wing_config.segments) else None
         if segment is not None:
@@ -944,6 +988,7 @@ def wing_config_to_asb_wing_schema(
                 x_sec_type,
                 tip_type,
                 number_interpolation_points,
+                turbulator,
             ) = _build_segment_details(segment)
 
         x_secs.append(
@@ -958,6 +1003,7 @@ def wing_config_to_asb_wing_schema(
                 number_interpolation_points=number_interpolation_points,
                 spare_list=spare_list,
                 trailing_edge_device=trailing_edge_device,
+                turbulator=turbulator,
             )
         )
 

--- a/app/models/aeroplanemodel.py
+++ b/app/models/aeroplanemodel.py
@@ -1,4 +1,15 @@
-from sqlalchemy import Column, Integer, String, Float, Boolean, ForeignKey, JSON, Text, UniqueConstraint, Index
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    Float,
+    Boolean,
+    ForeignKey,
+    JSON,
+    Text,
+    UniqueConstraint,
+    Index,
+)
 from sqlalchemy import text
 from sqlalchemy.orm import relationship
 import uuid
@@ -69,6 +80,22 @@ class ProjectedControlSurface:
         self.deflection = deflection
 
 
+class WingXSecTurbulatorModel(Base):
+    """One-to-one optional turbulator per wing cross-section detail (gh-934)."""
+
+    __tablename__ = "wing_xsec_turbulators"
+    wing_xsec_detail_id = Column(
+        Integer, ForeignKey("wing_xsec_details.id", ondelete="CASCADE"), nullable=False, unique=True
+    )
+    form = Column(String, nullable=True)
+    height_mm = Column(Float, nullable=True)
+    position_root = Column(Float, nullable=True)
+    position_tip = Column(Float, nullable=True)
+    enabled = Column(Boolean, nullable=False, default=True, server_default="1")
+
+    detail = relationship("WingXSecDetailModel", back_populates="turbulator")
+
+
 class WingXSecDetailModel(Base):
     __tablename__ = "wing_xsec_details"
     wing_xsec_id = Column(
@@ -87,6 +114,12 @@ class WingXSecDetailModel(Base):
     )
     trailing_edge_device = relationship(
         "WingXSecTrailingEdgeDeviceModel",
+        back_populates="detail",
+        uselist=False,
+        cascade=_CASCADE_ALL_DELETE_ORPHAN,
+    )
+    turbulator = relationship(
+        "WingXSecTurbulatorModel",
         back_populates="detail",
         uselist=False,
         cascade=_CASCADE_ALL_DELETE_ORPHAN,
@@ -217,6 +250,10 @@ class WingXSecModel(Base):
     @property
     def trailing_edge_device(self):
         return self.detail.trailing_edge_device if self.detail else None
+
+    @property
+    def turbulator(self):
+        return self.detail.turbulator if self.detail else None
 
     @property
     def control_surface(self):
@@ -353,6 +390,19 @@ class WingModel(Base):
         return ted
 
     @classmethod
+    def _build_turbulator_model(cls, turbulator: Any):
+        """Build a WingXSecTurbulatorModel from a turbulator payload dict or None."""
+        turb_payload = cls._as_payload(turbulator)
+        if not turb_payload:
+            return None
+
+        turb_payload = turb_payload.copy()
+        turb_payload.pop("id", None)
+        turb_payload.pop("wing_xsec_detail_id", None)
+        turb_payload.pop("detail", None)
+        return WingXSecTurbulatorModel(**turb_payload)
+
+    @classmethod
     def _extract_xsec_segment_fields(cls, xsec_payload: dict):
         """Pop segment-specific fields from xsec_payload; return them as a tuple."""
         control_surface = cls._as_payload(xsec_payload.pop("control_surface", None))
@@ -366,11 +416,18 @@ class WingModel(Base):
             xsec_payload.pop("x_sec_type", None),
             xsec_payload.pop("tip_type", None),
             xsec_payload.pop("number_interpolation_points", None),
+            xsec_payload.pop("turbulator", None),
         )
 
     @classmethod
     def _build_xsec_detail(
-        cls, x_sec_type, tip_type, number_interpolation_points, trailing_edge_device, spare_list
+        cls,
+        x_sec_type,
+        tip_type,
+        number_interpolation_points,
+        trailing_edge_device,
+        spare_list,
+        turbulator=None,
     ):
         """Build a WingXSecDetailModel if any segment field is non-None, else return None."""
         has_detail = any(
@@ -381,6 +438,7 @@ class WingModel(Base):
                 number_interpolation_points,
                 trailing_edge_device,
                 spare_list,
+                turbulator,
             ]
         )
         if not has_detail:
@@ -400,6 +458,10 @@ class WingModel(Base):
         if ted_model is not None:
             detail.trailing_edge_device = ted_model
 
+        turbulator_model = cls._build_turbulator_model(turbulator)
+        if turbulator_model is not None:
+            detail.turbulator = turbulator_model
+
         return detail
 
     @classmethod
@@ -414,11 +476,11 @@ class WingModel(Base):
             xsec_payload = (cls._as_payload(raw_xsec) or {}).copy()
             is_terminal = index == len(xsec_dicts) - 1
 
-            ted, spare_list, x_sec_type, tip_type, n_interp = cls._extract_xsec_segment_fields(
-                xsec_payload
+            ted, spare_list, x_sec_type, tip_type, n_interp, turbulator = (
+                cls._extract_xsec_segment_fields(xsec_payload)
             )
             if is_terminal:
-                ted = spare_list = x_sec_type = tip_type = n_interp = None
+                ted = spare_list = x_sec_type = tip_type = n_interp = turbulator = None
 
             if "airfoil" in xsec_payload:
                 from app.converters.model_schema_converters import (
@@ -432,7 +494,9 @@ class WingModel(Base):
             if "sort_index" not in xsec_payload:
                 xsec_payload["sort_index"] = index
             xsec = WingXSecModel(**xsec_payload)
-            xsec.detail = cls._build_xsec_detail(x_sec_type, tip_type, n_interp, ted, spare_list)
+            xsec.detail = cls._build_xsec_detail(
+                x_sec_type, tip_type, n_interp, ted, spare_list, turbulator
+            )
 
             wing.x_secs.append(xsec)
         return wing
@@ -771,7 +835,6 @@ class CopilotMessageModel(Base):
         back_populates="copilot_messages",
         foreign_keys=[aeroplane_id],
     )
-
 
 
 class DesignAssumptionModel(Base):

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -12,6 +12,7 @@ from app.schemas.aeroplaneschema import WingXSecReadSchema
 from app.schemas.aeroplaneschema import WingXSecGeometryWriteSchema
 from app.schemas.aeroplaneschema import WingUnitsSchema
 from app.schemas.aeroplaneschema import SpareDetailSchema
+from app.schemas.aeroplaneschema import TurbulatorDetailSchema
 from app.schemas.aeroplaneschema import TrailingEdgeDeviceDetailSchema
 from app.schemas.aeroplaneschema import TrailingEdgeDevicePatchSchema
 from app.schemas.aeroplaneschema import TrailingEdgeServoSchema

--- a/app/schemas/aeroplaneschema.py
+++ b/app/schemas/aeroplaneschema.py
@@ -230,6 +230,41 @@ class ControlSurfaceCadDetailsPatchSchema(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class TurbulatorDetailSchema(BaseModel):
+    """Turbulator strip detail for a wing cross-section (gh-934).
+
+    Stored one-to-one with ``WingXSecDetailModel``, upper surface only.
+    Positions are dimensionless x/c ratios (0–1) — no unit conversion needed.
+    """
+
+    form: Literal["zigzag", "dots", "thread"] = Field(
+        default="zigzag",
+        description="Build form of the turbulator strip.",
+    )
+    height_mm: float = Field(
+        default=0.3,
+        ge=0.0,
+        description="Strip/thread height in millimetres (non-negative).",
+    )
+    position_root: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Chordwise x/c position (0–1) at the segment root.",
+    )
+    position_tip: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Chordwise x/c position (0–1) at the segment tip; defaults to position_root.",
+    )
+    enabled: bool = Field(
+        default=True, description="Whether the turbulator is rendered in CAD output."
+    )
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class SpareDetailSchema(BaseModel):
     spare_support_dimension_width: float = Field(..., description="Spar support width in meters")
     spare_support_dimension_height: float = Field(..., description="Spar support height in meters")
@@ -531,6 +566,10 @@ class WingXSecSchema(BaseModel):
     trailing_edge_device: Optional[TrailingEdgeDeviceDetailSchema] = Field(
         None,
         description="Detailed trailing-edge device definition for the outgoing segment at this x-section",
+    )
+    turbulator: Optional["TurbulatorDetailSchema"] = Field(
+        None,
+        description="Optional upper-surface turbulator strip for the outgoing segment at this x-section (gh-934).",
     )
 
     model_config = ConfigDict(from_attributes=True)

--- a/app/schemas/wing.py
+++ b/app/schemas/wing.py
@@ -1,10 +1,47 @@
 from typing import List, Optional, Literal
-from pydantic import AliasChoices, BaseModel, PositiveFloat, Field
+from pydantic import AliasChoices, BaseModel, NonNegativeFloat, PositiveFloat, Field
 
 from app.schemas.Servo import Servo
 
 # --- Shared literal constant (S1192) ---
 _DEFAULT_AIRFOIL_RG15 = "./components/airfoils/rg15.dat"
+
+
+class Turbulator(BaseModel):
+    """Optional upper-surface turbulator strip for a wing segment (gh-934).
+
+    A turbulator trips the boundary layer to delay flow separation and
+    reduce profile drag at low Reynolds numbers. One turbulator per
+    segment, upper surface only.
+    """
+
+    form: Literal["zigzag", "dots", "thread"] = Field(
+        default="zigzag",
+        description="Build form of the turbulator strip: 'zigzag' tape, 'dots', or adhesive 'thread'.",
+    )
+    height_mm: NonNegativeFloat = Field(
+        default=0.3,
+        description="Strip/thread height in millimetres (non-negative).",
+    )
+    position_root: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Chordwise x/c position (0–1) of the turbulator at the segment root.",
+    )
+    position_tip: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Chordwise x/c position (0–1) at the segment tip. "
+            "Defaults to position_root when None (flat strip, no taper)."
+        ),
+    )
+    enabled: bool = Field(
+        default=True,
+        description="Whether the turbulator is rendered in CAD output.",
+    )
 
 
 class TrailingEdgeDevice(BaseModel):
@@ -172,6 +209,10 @@ class Segment(BaseModel):
     )
     trailing_edge_device: Optional[TrailingEdgeDevice] = Field(
         default=None, description="Control surface attached to the trailing edge of the segment"
+    )
+    turbulator: Optional[Turbulator] = Field(
+        default=None,
+        description="Optional upper-surface turbulator strip for this segment (gh-934).",
     )
     number_interpolation_points: Optional[int] = Field(
         default=None,

--- a/app/services/aeroplane_clone_service.py
+++ b/app/services/aeroplane_clone_service.py
@@ -74,6 +74,7 @@ CLONED_TABLES: frozenset[str] = frozenset(
         "wing_xsec_details",  # owned by wing_xsec_id FK
         "wing_xsec_spares",  # owned by wing_xsec_detail_id FK
         "wing_xsec_trailing_edge_devices",  # owned by wing_xsec_detail_id FK
+        "wing_xsec_turbulators",  # owned by wing_xsec_detail_id FK (gh-934)
         "wing_xsec_ted_servos",  # owned by ted_id FK; component_id is a shared ref
         "fuselages",  # owned by aeroplane_id FK; step_path/solid_step_path nulled
         "fuselage_xsecs",  # owned by fuselage_id FK

--- a/app/services/create_wing_configuration.py
+++ b/app/services/create_wing_configuration.py
@@ -5,10 +5,12 @@ from cad_designer.airplane.aircraft_topology.wing import (
     Spare,
 )
 from cad_designer.airplane.aircraft_topology.wing import Airfoil
+from cad_designer.airplane.aircraft_topology.wing.Turbulator import Turbulator
 from app.schemas.wing import Wing as WingModel
 from app.schemas.wing import Airfoil as AirfoilModel
 from app.schemas.wing import Segment as SegmentModel
 from app.schemas.wing import TrailingEdgeDevice as TrailingEdgeDeviceModel
+from app.schemas.wing import Turbulator as TurbulatorModel
 from app.schemas.wing import Servo as ServoModel
 from app.schemas.wing import Spare as SpareModel
 from pathlib import Path
@@ -114,6 +116,19 @@ def create_trailing_edge_device(ted_model: TrailingEdgeDeviceModel) -> TrailingE
     return TrailingEdgeDevice(**initialization_dict)
 
 
+def create_turbulator(turbulator_model: TurbulatorModel | None) -> Turbulator | None:
+    """Convert a schema Turbulator (app.schemas.wing.Turbulator) to a topology Turbulator."""
+    if turbulator_model is None:
+        return None
+    return Turbulator(
+        form=turbulator_model.form,
+        height_mm=turbulator_model.height_mm,
+        position_root=turbulator_model.position_root,
+        position_tip=turbulator_model.position_tip,
+        enabled=turbulator_model.enabled,
+    )
+
+
 def create_spare(spare_model: SpareModel) -> Spare | None:
     return Spare(**spare_model.__dict__.copy()) if spare_model is not None else None
 
@@ -134,6 +149,9 @@ def create_segment(segment_model: SegmentModel) -> dict | None:
         create_trailing_edge_device(segment_model.trailing_edge_device)
         if segment_model.trailing_edge_device is not None
         else None
+    )
+    initialization_dict["turbulator"] = create_turbulator(
+        getattr(segment_model, "turbulator", None)
     )
 
     del initialization_dict["root_airfoil"]
@@ -161,6 +179,7 @@ def create_tip_segment(segment_model: SegmentModel) -> dict | None:
     del initialization_dict["root_airfoil"]
     del initialization_dict["spare_list"]
     del initialization_dict["trailing_edge_device"]
+    initialization_dict.pop("turbulator", None)
     initialization_dict.pop("wing_segment_type", None)
 
     return initialization_dict
@@ -242,6 +261,7 @@ def create_root_segment(wing_model: WingModel) -> dict:
         if root_segment.trailing_edge_device is not None
         else None
     )
+    initialization_dict["turbulator"] = create_turbulator(getattr(root_segment, "turbulator", None))
 
     del initialization_dict["tip_type"]
     initialization_dict.pop("wing_segment_type", None)

--- a/app/tests/test_gh903_migration.py
+++ b/app/tests/test_gh903_migration.py
@@ -239,7 +239,10 @@ class TestGh903Migration:
         _seed_db_to_prev_head(tmp_db)
         _insert_aeroplanes(tmp_db, count=2)
         _run_alembic(f"sqlite:///{tmp_db}", "upgrade head")
-        _run_alembic(f"sqlite:///{tmp_db}", "downgrade -1")
+        # Downgrade to the revision *before* gh-903 rather than a relative
+        # "-1": the gh-903 migration is no longer guaranteed to be head once
+        # later migrations are added, so target the stable named revision.
+        _run_alembic(f"sqlite:///{tmp_db}", f"downgrade {PREV_REVISION}")
 
         conn = sqlite3.connect(tmp_db)
         try:
@@ -272,7 +275,9 @@ class TestGh903Migration:
         _seed_db_to_prev_head(tmp_db)
         # No aeroplanes inserted
         _run_alembic(f"sqlite:///{tmp_db}", "upgrade head")
-        _run_alembic(f"sqlite:///{tmp_db}", "downgrade -1")
+        # Downgrade to the revision *before* gh-903 (stable named revision)
+        # instead of a relative "-1", which assumed gh-903 was head.
+        _run_alembic(f"sqlite:///{tmp_db}", f"downgrade {PREV_REVISION}")
 
         conn = sqlite3.connect(tmp_db)
         try:

--- a/app/tests/test_turbulator_persistence.py
+++ b/app/tests/test_turbulator_persistence.py
@@ -1,0 +1,360 @@
+"""TDD tests for Turbulator persistence — gh-934 Slice 1.
+
+Covers:
+- WingXSecTurbulatorModel DB persistence (one-to-one with WingXSecDetailModel)
+- Converter round-trip: schema → topology → DB → topology → schema
+- WingModel.from_dict builds turbulator detail when segment carries one
+- Backward compat: segments without turbulator still load fine
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.db.base import Base
+from app.models.aeroplanemodel import (
+    AeroplaneModel,
+    WingModel,
+    WingXSecDetailModel,
+    WingXSecModel,
+    WingXSecTurbulatorModel,
+)
+
+
+# ---------------------------------------------------------------------------
+# In-memory SQLite fixture (no FastAPI overhead)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_session():
+    """Fresh in-memory SQLite + all tables for each test."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, class_=Session)
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+    Base.metadata.drop_all(bind=engine)
+
+
+# ---------------------------------------------------------------------------
+# Helper: minimal aeroplane + wing payload
+# ---------------------------------------------------------------------------
+
+AIRFOIL = "./components/airfoils/rg15.dat"
+
+
+def _wing_dict_with_turbulator(
+    form="zigzag",
+    height_mm=0.3,
+    position_root=0.1,
+    position_tip=0.15,
+    enabled=True,
+) -> dict:
+    """Return a WingModel.from_dict-compatible dict with one segment carrying a turbulator."""
+    return {
+        "symmetric": True,
+        "x_secs": [
+            {
+                "xyz_le": [0.0, 0.0, 0.0],
+                "chord": 0.2,
+                "twist": 0.0,
+                "airfoil": AIRFOIL,
+                "x_sec_type": "root",
+                "turbulator": {
+                    "form": form,
+                    "height_mm": height_mm,
+                    "position_root": position_root,
+                    "position_tip": position_tip,
+                    "enabled": enabled,
+                },
+            },
+            {
+                "xyz_le": [0.0, 0.5, 0.0],
+                "chord": 0.16,
+                "twist": 0.0,
+                "airfoil": AIRFOIL,
+                # terminal x-sec — no turbulator
+            },
+        ],
+    }
+
+
+def _wing_dict_without_turbulator() -> dict:
+    """Return a WingModel.from_dict-compatible dict with NO turbulator (backward compat)."""
+    return {
+        "symmetric": True,
+        "x_secs": [
+            {
+                "xyz_le": [0.0, 0.0, 0.0],
+                "chord": 0.2,
+                "twist": 0.0,
+                "airfoil": AIRFOIL,
+                "x_sec_type": "root",
+                # No "turbulator" key — old format
+            },
+            {
+                "xyz_le": [0.0, 0.5, 0.0],
+                "chord": 0.16,
+                "twist": 0.0,
+                "airfoil": AIRFOIL,
+            },
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# WingXSecTurbulatorModel basic persistence
+# ---------------------------------------------------------------------------
+
+
+class TestWingXSecTurbulatorModel:
+    def test_turbulator_model_exists(self):
+        """WingXSecTurbulatorModel is importable and has expected columns."""
+        t = WingXSecTurbulatorModel()
+        assert hasattr(t, "form")
+        assert hasattr(t, "height_mm")
+        assert hasattr(t, "position_root")
+        assert hasattr(t, "position_tip")
+        assert hasattr(t, "enabled")
+
+    def test_persist_and_reload(self, db_session):
+        """Turbulator row survives a flush + reload from DB."""
+        aeroplane = AeroplaneModel(name="test_plane", uuid="a" * 32)
+        db_session.add(aeroplane)
+        db_session.flush()
+
+        wing = WingModel(name="main", symmetric=True, aeroplane_id=aeroplane.id)
+        db_session.add(wing)
+        db_session.flush()
+
+        xsec = WingXSecModel(
+            xyz_le=[0.0, 0.0, 0.0],
+            chord=0.2,
+            twist=0.0,
+            airfoil=AIRFOIL,
+            sort_index=0,
+            wing_id=wing.id,
+        )
+        db_session.add(xsec)
+        db_session.flush()
+
+        detail = WingXSecDetailModel(
+            wing_xsec_id=xsec.id,
+            x_sec_type="root",
+        )
+        db_session.add(detail)
+        db_session.flush()
+
+        turb = WingXSecTurbulatorModel(
+            wing_xsec_detail_id=detail.id,
+            form="dots",
+            height_mm=0.4,
+            position_root=0.08,
+            position_tip=0.12,
+            enabled=True,
+        )
+        db_session.add(turb)
+        db_session.commit()
+
+        # Reload
+        db_session.expire_all()
+        reloaded_detail = db_session.get(WingXSecDetailModel, detail.id)
+        assert reloaded_detail.turbulator is not None
+        t = reloaded_detail.turbulator
+        assert t.form == "dots"
+        assert t.height_mm == pytest.approx(0.4)
+        assert t.position_root == pytest.approx(0.08)
+        assert t.position_tip == pytest.approx(0.12)
+        assert t.enabled is True
+
+    def test_cascade_delete(self, db_session):
+        """Deleting detail cascades to turbulator row."""
+        aeroplane = AeroplaneModel(name="cascade_plane", uuid="b" * 32)
+        db_session.add(aeroplane)
+        db_session.flush()
+
+        wing = WingModel(name="cascade_wing", symmetric=True, aeroplane_id=aeroplane.id)
+        db_session.add(wing)
+        db_session.flush()
+
+        xsec = WingXSecModel(
+            xyz_le=[0.0, 0.0, 0.0],
+            chord=0.2,
+            twist=0.0,
+            airfoil=AIRFOIL,
+            sort_index=0,
+            wing_id=wing.id,
+        )
+        db_session.add(xsec)
+        db_session.flush()
+
+        detail = WingXSecDetailModel(wing_xsec_id=xsec.id, x_sec_type="root")
+        db_session.add(detail)
+        db_session.flush()
+
+        turb = WingXSecTurbulatorModel(
+            wing_xsec_detail_id=detail.id,
+            form="zigzag",
+            height_mm=0.3,
+            position_root=0.1,
+            position_tip=0.1,
+            enabled=True,
+        )
+        db_session.add(turb)
+        db_session.commit()
+        turb_id = turb.id
+
+        db_session.delete(detail)
+        db_session.commit()
+
+        assert db_session.get(WingXSecTurbulatorModel, turb_id) is None
+
+
+# ---------------------------------------------------------------------------
+# WingModel.from_dict builds turbulator
+# ---------------------------------------------------------------------------
+
+
+class TestWingModelFromDictWithTurbulator:
+    def test_from_dict_builds_turbulator(self, db_session):
+        data = _wing_dict_with_turbulator(
+            form="thread", height_mm=0.5, position_root=0.07, position_tip=0.09
+        )
+        wing = WingModel.from_dict(name="w", data=data)
+        db_session.add(wing)
+        db_session.commit()
+
+        db_session.expire_all()
+        reloaded = db_session.get(WingModel, wing.id)
+        # First xsec has a detail with turbulator
+        xsec0 = reloaded.x_secs[0]
+        assert xsec0.turbulator is not None
+        t = xsec0.turbulator
+        assert t.form == "thread"
+        assert t.height_mm == pytest.approx(0.5)
+        assert t.position_root == pytest.approx(0.07)
+        assert t.position_tip == pytest.approx(0.09)
+        assert t.enabled is True
+
+    def test_from_dict_no_turbulator_backward_compat(self, db_session):
+        """Old wing dicts without turbulator field should load without error."""
+        data = _wing_dict_without_turbulator()
+        wing = WingModel.from_dict(name="w_old", data=data)
+        db_session.add(wing)
+        db_session.commit()
+
+        db_session.expire_all()
+        reloaded = db_session.get(WingModel, wing.id)
+        xsec0 = reloaded.x_secs[0]
+        # Should have no turbulator (may have no detail at all, or detail.turbulator is None)
+        assert xsec0.turbulator is None
+
+    def test_terminal_xsec_has_no_turbulator(self, db_session):
+        """The last x-sec should never carry a turbulator (it's just a boundary)."""
+        data = _wing_dict_with_turbulator()
+        wing = WingModel.from_dict(name="w_term", data=data)
+        db_session.add(wing)
+        db_session.commit()
+
+        db_session.expire_all()
+        reloaded = db_session.get(WingModel, wing.id)
+        last_xsec = reloaded.x_secs[-1]
+        assert last_xsec.turbulator is None
+
+
+# ---------------------------------------------------------------------------
+# Converter round-trip: topology → DB → topology
+# ---------------------------------------------------------------------------
+
+
+class TestConverterRoundTrip:
+    def test_turbulator_survives_schema_db_roundtrip(self, db_session):
+        """schema turbulator → WingModel → reload → WingXSecSchema turbulator matches."""
+        from app.converters.model_schema_converters import wing_model_to_asb_wing_schema
+        import app.schemas as schemas
+
+        data = _wing_dict_with_turbulator(
+            form="zigzag",
+            height_mm=0.3,
+            position_root=0.1,
+            position_tip=0.15,
+            enabled=True,
+        )
+        wing = WingModel.from_dict(name="rt_wing", data=data)
+        db_session.add(wing)
+        db_session.commit()
+
+        db_session.expire_all()
+        reloaded = db_session.get(WingModel, wing.id)
+
+        # Convert model → schema
+        asb_schema = wing_model_to_asb_wing_schema(reloaded)
+        # First xsec carries the turbulator
+        xsec0_schema = asb_schema.x_secs[0]
+        assert xsec0_schema.turbulator is not None
+        t_schema = xsec0_schema.turbulator
+        assert t_schema.form == "zigzag"
+        assert t_schema.height_mm == pytest.approx(0.3)
+        assert t_schema.position_root == pytest.approx(0.1)
+        assert t_schema.position_tip == pytest.approx(0.15)
+        assert t_schema.enabled is True
+
+    def test_turbulator_survives_topology_to_db(self, db_session):
+        """Pydantic Turbulator schema → WingSegment topology → WingModel DB → WingXSecSchema."""
+        from app.converters.model_schema_converters import wing_model_to_asb_wing_schema
+        from app.schemas.wing import Turbulator as TurbulatorSchema, Segment, Wing, Airfoil
+        from app.services.create_wing_configuration import create_wing_configuration
+        from app.converters.model_schema_converters import wing_config_to_wing_model
+
+        turb = TurbulatorSchema(
+            form="dots",
+            height_mm=0.25,
+            position_root=0.09,
+            position_tip=0.11,
+            enabled=False,
+        )
+        segment = Segment(
+            root_airfoil=Airfoil(airfoil=AIRFOIL, chord=200.0),
+            tip_airfoil=Airfoil(airfoil=AIRFOIL, chord=160.0),
+            length=500.0,
+            sweep=0.0,
+            turbulator=turb,
+        )
+        wing_schema = Wing(nose_pnt=[0.0, 0.0, 0.0], symmetric=True, segments=[segment])
+
+        # topology
+        wc = create_wing_configuration(wing_schema)
+        assert wc.segments[0].turbulator is not None
+        assert wc.segments[0].turbulator.form == "dots"
+
+        # to DB model
+        wing_model = wing_config_to_wing_model(wc, "dots_wing", scale=0.001)
+        db_session.add(wing_model)
+        db_session.commit()
+
+        db_session.expire_all()
+        reloaded = db_session.get(WingModel, wing_model.id)
+
+        asb_schema = wing_model_to_asb_wing_schema(reloaded)
+        xsec0 = asb_schema.x_secs[0]
+        assert xsec0.turbulator is not None
+        assert xsec0.turbulator.form == "dots"
+        assert xsec0.turbulator.height_mm == pytest.approx(0.25)
+        assert xsec0.turbulator.position_root == pytest.approx(0.09)
+        assert xsec0.turbulator.position_tip == pytest.approx(0.11)
+        assert xsec0.turbulator.enabled is False

--- a/cad_designer/airplane/aircraft_topology/wing/Turbulator.py
+++ b/cad_designer/airplane/aircraft_topology/wing/Turbulator.py
@@ -1,0 +1,79 @@
+from typing import Literal, Optional
+
+from cad_designer.airplane.types import Factor
+
+TurbulatorForm = Literal["zigzag", "dots", "thread"]
+
+
+class Turbulator:
+    """Represents an optional upper-surface turbulator strip on a wing segment.
+
+    Turbulators trip the boundary layer to delay separation and reduce drag at
+    low Reynolds numbers. One turbulator per segment, upper surface only.
+
+    Attributes:
+        form: Build form — "zigzag" tape, "dots", or adhesive "thread".
+        height_mm: Strip/thread height in mm.
+        position_root: Chordwise x/c position (0–1) at segment root.
+        position_tip: Chordwise x/c position (0–1) at segment tip; mirrors
+            position_root when not specified explicitly.
+        enabled: Whether the turbulator is active (for CAD output).
+    """
+
+    def __init__(
+        self,
+        position_root: Factor,
+        form: TurbulatorForm = "zigzag",
+        height_mm: float = 0.3,
+        position_tip: Optional[Factor] = None,
+        enabled: bool = True,
+    ) -> None:
+        """Initialise a Turbulator instance.
+
+        Args:
+            position_root: Chordwise x/c position (0–1) at segment root.
+            form: Build form — ``"zigzag"``, ``"dots"``, or ``"thread"``.
+            height_mm: Strip/thread height in mm (non-negative).
+            position_tip: Chordwise x/c position at segment tip; defaults to
+                ``position_root`` when ``None`` (flat strip, no taper).
+            enabled: Whether the turbulator is rendered in CAD output.
+        """
+        self.form: TurbulatorForm = form
+        self.height_mm: float = height_mm
+        self.position_root: Factor = position_root
+        self.position_tip: Factor = position_tip if position_tip is not None else position_root
+        self.enabled: bool = enabled
+
+    def __repr__(self) -> str:
+        from pprint import pformat
+
+        return pformat(vars(self), indent=4, width=1)
+
+    def __getstate__(self) -> dict:
+        """Return a dictionary of serialisable attributes for JSON serialisation."""
+        return {
+            "form": self.form,
+            "height_mm": self.height_mm,
+            "position_root": self.position_root,
+            "position_tip": self.position_tip,
+            "enabled": self.enabled,
+        }
+
+    @staticmethod
+    def from_json_dict(data: dict) -> "Turbulator":
+        """Create a Turbulator from a JSON dictionary.
+
+        Args:
+            data: Dictionary containing Turbulator field values.
+
+        Returns:
+            A new Turbulator instance.
+        """
+        position_root = data.get("position_root", 0.1)
+        return Turbulator(
+            form=data.get("form", "zigzag"),
+            height_mm=data.get("height_mm", 0.3),
+            position_root=position_root,
+            position_tip=data.get("position_tip"),  # None → defaults to position_root in __init__
+            enabled=data.get("enabled", True),
+        )

--- a/cad_designer/airplane/aircraft_topology/wing/WingConfiguration.py
+++ b/cad_designer/airplane/aircraft_topology/wing/WingConfiguration.py
@@ -23,6 +23,7 @@ from scipy.interpolate import interp1d
 
 from cad_designer.airplane.aircraft_topology.wing.Spare import Spare
 from cad_designer.airplane.aircraft_topology.wing.TrailingEdgeDevice import TrailingEdgeDevice
+from cad_designer.airplane.aircraft_topology.wing.Turbulator import Turbulator
 from cad_designer.airplane.aircraft_topology.wing.WingSegment import WingSegment
 from cad_designer.airplane.aircraft_topology.wing.Airfoil import Airfoil
 from cad_designer.airplane.types import Factor, TipType, CoordinateSystemBase
@@ -76,6 +77,7 @@ class WingConfiguration:
                  number_interpolation_points: PositiveInt | None = None,
                  spare_list: list[Spare] | None = None,
                  trailing_edge_device: TrailingEdgeDevice | None = None,
+                 turbulator: Turbulator | None = None,
                  symmetric: bool = True,
                  parameters: Literal["relative", "aerosandbox"] = "relative") -> T:
         self.segments: list[WingSegment] | None = None
@@ -92,6 +94,7 @@ class WingConfiguration:
         root_segment = WingSegment(root_airfoil=root_airfoil, length=length, sweep=sweep, sweep_is_angle=sweep_is_angle,
                                    tip_airfoil=tip_airfoil,
                                    spare_list=spare_list, trailing_edge_device=trailing_edge_device,
+                                   turbulator=turbulator,
                                    number_interpolation_points=number_interpolation_points, wing_segment_type='root')
 
         self.segments: list[WingSegment] = [root_segment]
@@ -238,7 +241,8 @@ class WingConfiguration:
                     tip_airfoil: Airfoil | None = None,
                     number_interpolation_points: PositiveInt | None = None,
                     spare_list: list[Spare] | None = None,
-                    trailing_edge_device: TrailingEdgeDevice | None = None
+                    trailing_edge_device: TrailingEdgeDevice | None = None,
+                    turbulator: Turbulator | None = None
                     ) -> T:
         """
         Adds a new segment to the wing configuration.
@@ -279,6 +283,7 @@ class WingConfiguration:
         segment = WingSegment(root_airfoil=root_airfoil, length=length, sweep=sweep, sweep_is_angle=sweep_is_angle,
                               tip_airfoil=tip_airfoil,
                               spare_list=spare_list, trailing_edge_device=trailing_edge_device,
+                              turbulator=turbulator,
                               number_interpolation_points=nip, tip_type=None, wing_segment_type='segment')
         self.segments.append(segment)
 
@@ -833,6 +838,7 @@ class WingConfiguration:
         from cad_designer.airplane.aircraft_topology.wing.Airfoil import Airfoil
         from cad_designer.airplane.aircraft_topology.wing.Spare import Spare
         from cad_designer.airplane.aircraft_topology.wing.TrailingEdgeDevice import TrailingEdgeDevice
+        from cad_designer.airplane.aircraft_topology.wing.Turbulator import Turbulator
 
         # Get airfoil data from the first segment if available
         first_segment = data.get('segments', [])[0] if data.get('segments') else {}
@@ -843,6 +849,7 @@ class WingConfiguration:
         spare_list_data = first_segment.get('spare_list', []) if first_segment else data.get('spare_list', [])
         trailing_edge_device_data = first_segment.get('trailing_edge_device', {}) if first_segment else data.get(
             'trailing_edge_device', {})
+        turbulator_data = first_segment.get('turbulator') if first_segment else data.get('turbulator')
 
         # Get length and sweep from first segment if available
         length = first_segment.get('length', data.get('length', 0)) if first_segment else data.get('length', 0)
@@ -858,6 +865,8 @@ class WingConfiguration:
                                              spare_list_data] if spare_list_data else None,
                                  trailing_edge_device=TrailingEdgeDevice.from_json_dict(
                                      trailing_edge_device_data) if trailing_edge_device_data else None,
+                                 turbulator=Turbulator.from_json_dict(
+                                     turbulator_data) if turbulator_data else None,
                                  symmetric=data.get('symmetric', True))
 
         # Restore segments if they exist

--- a/cad_designer/airplane/aircraft_topology/wing/WingSegment.py
+++ b/cad_designer/airplane/aircraft_topology/wing/WingSegment.py
@@ -6,6 +6,7 @@ from pydantic import PositiveFloat, PositiveInt, NonNegativeFloat
 from cad_designer.airplane.aircraft_topology.wing.Airfoil import Airfoil
 from cad_designer.airplane.aircraft_topology.wing.Spare import Spare
 from cad_designer.airplane.aircraft_topology.wing.TrailingEdgeDevice import TrailingEdgeDevice
+from cad_designer.airplane.aircraft_topology.wing.Turbulator import Turbulator
 from cad_designer.airplane.types import WingSegmentType, TipType
 
 
@@ -41,7 +42,8 @@ class WingSegment:
                  trailing_edge_device: Optional[TrailingEdgeDevice] = None,
                  number_interpolation_points: Optional[PositiveInt] = None,
                  tip_type: Optional[TipType] = None,
-                 wing_segment_type: WingSegmentType = 'segment'):
+                 wing_segment_type: WingSegmentType = 'segment',
+                 turbulator: Optional[Turbulator] = None):
         """
         Initializes a WingSegment instance.
 
@@ -80,6 +82,7 @@ class WingSegment:
 
         self.spare_list = spare_list
         self.trailing_edge_device = trailing_edge_device
+        self.turbulator = turbulator
         self.number_interpolation_points = number_interpolation_points
         self.tip_type = tip_type
         self.wing_segment_type = wing_segment_type
@@ -97,6 +100,8 @@ class WingSegment:
             elif key == 'spare_list':
                 data[key] = [spare.__getstate__() for spare in value] if value is not None else None
             elif key == 'trailing_edge_device':
+                data[key] = value.__getstate__() if value else None
+            elif key == 'turbulator':
                 data[key] = value.__getstate__() if value else None
             else:
                 data[key] = value
@@ -116,6 +121,7 @@ class WingSegment:
         from cad_designer.airplane.aircraft_topology.wing.Airfoil import Airfoil
         from cad_designer.airplane.aircraft_topology.wing.Spare import Spare
         from cad_designer.airplane.aircraft_topology.wing.TrailingEdgeDevice import TrailingEdgeDevice
+        from cad_designer.airplane.aircraft_topology.wing.Turbulator import Turbulator
 
         # Create root_airfoil and tip_airfoil objects
         root_airfoil = Airfoil.from_json_dict(data.get('root_airfoil')) if data.get('root_airfoil') else None
@@ -131,6 +137,11 @@ class WingSegment:
         if data.get('trailing_edge_device'):
             trailing_edge_device = TrailingEdgeDevice.from_json_dict(data.get('trailing_edge_device'))
 
+        # Create turbulator
+        turbulator = None
+        if data.get('turbulator'):
+            turbulator = Turbulator.from_json_dict(data.get('turbulator'))
+
         # Create and return the WingSegment
         return WingSegment(
             root_airfoil=root_airfoil,
@@ -142,5 +153,6 @@ class WingSegment:
             trailing_edge_device=trailing_edge_device,
             number_interpolation_points=data.get('number_interpolation_points'),
             tip_type=data.get('tip_type'),
-            wing_segment_type=data.get('wing_segment_type', 'segment')
+            wing_segment_type=data.get('wing_segment_type', 'segment'),
+            turbulator=turbulator
         )

--- a/cad_designer/airplane/aircraft_topology/wing/__init__.py
+++ b/cad_designer/airplane/aircraft_topology/wing/__init__.py
@@ -1,5 +1,6 @@
 from .Spare import Spare
 from .TrailingEdgeDevice import TrailingEdgeDevice
+from .Turbulator import Turbulator
 from .WingConfiguration import WingConfiguration
 from .WingConfiguration import WingSegment
 from .Airfoil import Airfoil

--- a/cad_designer/tests/test_turbulator.py
+++ b/cad_designer/tests/test_turbulator.py
@@ -1,0 +1,203 @@
+"""TDD tests for the Turbulator domain object — gh-934 Slice 1.
+
+All tests here must be RED before production code is written.
+"""
+
+import pytest
+
+from cad_designer.airplane.aircraft_topology.wing.Turbulator import Turbulator
+from cad_designer.airplane.aircraft_topology.wing.WingSegment import WingSegment
+from cad_designer.airplane.aircraft_topology.wing.Airfoil import Airfoil
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_turbulator(**kwargs) -> Turbulator:
+    defaults = dict(
+        form="zigzag",
+        height_mm=0.3,
+        position_root=0.1,
+        position_tip=None,
+        enabled=True,
+    )
+    defaults.update(kwargs)
+    return Turbulator(**defaults)
+
+
+def _make_segment(turbulator=None) -> WingSegment:
+    root_airfoil = Airfoil(airfoil="./components/airfoils/rg15.dat", chord=200.0)
+    return WingSegment(
+        root_airfoil=root_airfoil,
+        length=100.0,
+        turbulator=turbulator,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Turbulator construction
+# ---------------------------------------------------------------------------
+
+
+class TestTurbulatorConstruction:
+    def test_defaults(self):
+        t = Turbulator(position_root=0.1)
+        assert t.form == "zigzag"
+        assert t.height_mm == pytest.approx(0.3)
+        assert t.position_root == pytest.approx(0.1)
+        assert t.position_tip == pytest.approx(0.1)  # defaults to position_root
+        assert t.enabled is True
+
+    def test_explicit_values(self):
+        t = Turbulator(
+            form="dots",
+            height_mm=0.5,
+            position_root=0.15,
+            position_tip=0.2,
+            enabled=False,
+        )
+        assert t.form == "dots"
+        assert t.height_mm == pytest.approx(0.5)
+        assert t.position_root == pytest.approx(0.15)
+        assert t.position_tip == pytest.approx(0.2)
+        assert t.enabled is False
+
+    def test_thread_form(self):
+        t = Turbulator(form="thread", position_root=0.12)
+        assert t.form == "thread"
+
+    def test_repr_contains_form(self):
+        t = _make_turbulator()
+        assert "zigzag" in repr(t)
+
+
+# ---------------------------------------------------------------------------
+# Turbulator __getstate__ / from_json_dict round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestTurbulatorRoundTrip:
+    def test_getstate_keys(self):
+        t = _make_turbulator(form="dots", height_mm=0.4, position_root=0.08, position_tip=0.12)
+        state = t.__getstate__()
+        assert "form" in state
+        assert "height_mm" in state
+        assert "position_root" in state
+        assert "position_tip" in state
+        assert "enabled" in state
+
+    def test_getstate_values(self):
+        t = _make_turbulator(
+            form="thread", height_mm=0.6, position_root=0.05, position_tip=0.07, enabled=False
+        )
+        state = t.__getstate__()
+        assert state["form"] == "thread"
+        assert state["height_mm"] == pytest.approx(0.6)
+        assert state["position_root"] == pytest.approx(0.05)
+        assert state["position_tip"] == pytest.approx(0.07)
+        assert state["enabled"] is False
+
+    def test_from_json_dict_roundtrip(self):
+        t = _make_turbulator(
+            form="dots", height_mm=0.25, position_root=0.09, position_tip=0.11, enabled=False
+        )
+        state = t.__getstate__()
+        t2 = Turbulator.from_json_dict(state)
+        assert t2.form == t.form
+        assert t2.height_mm == pytest.approx(t.height_mm)
+        assert t2.position_root == pytest.approx(t.position_root)
+        assert t2.position_tip == pytest.approx(t.position_tip)
+        assert t2.enabled == t.enabled
+
+    def test_from_json_dict_defaults_position_tip(self):
+        """from_json_dict without position_tip should default to position_root."""
+        data = {"form": "zigzag", "height_mm": 0.3, "position_root": 0.1, "enabled": True}
+        t = Turbulator.from_json_dict(data)
+        assert t.position_tip == pytest.approx(0.1)
+
+
+# ---------------------------------------------------------------------------
+# WingSegment carries turbulator
+# ---------------------------------------------------------------------------
+
+
+class TestWingSegmentTurbulator:
+    def test_default_turbulator_is_none(self):
+        seg = _make_segment(turbulator=None)
+        assert seg.turbulator is None
+
+    def test_segment_stores_turbulator(self):
+        t = _make_turbulator()
+        seg = _make_segment(turbulator=t)
+        assert seg.turbulator is t
+
+    def test_segment_getstate_includes_turbulator(self):
+        t = _make_turbulator(form="dots", height_mm=0.4, position_root=0.1, position_tip=0.15)
+        seg = _make_segment(turbulator=t)
+        state = seg.__getstate__()
+        assert "turbulator" in state
+        assert state["turbulator"]["form"] == "dots"
+        assert state["turbulator"]["height_mm"] == pytest.approx(0.4)
+
+    def test_segment_getstate_none_turbulator(self):
+        seg = _make_segment(turbulator=None)
+        state = seg.__getstate__()
+        assert "turbulator" in state
+        assert state["turbulator"] is None
+
+    def test_segment_from_json_dict_roundtrip_with_turbulator(self):
+        t = _make_turbulator(
+            form="thread", height_mm=0.3, position_root=0.08, position_tip=0.1, enabled=True
+        )
+        seg = _make_segment(turbulator=t)
+        state = seg.__getstate__()
+        seg2 = WingSegment.from_json_dict(state)
+        assert seg2.turbulator is not None
+        assert seg2.turbulator.form == "thread"
+        assert seg2.turbulator.height_mm == pytest.approx(0.3)
+        assert seg2.turbulator.position_root == pytest.approx(0.08)
+        assert seg2.turbulator.position_tip == pytest.approx(0.1)
+        assert seg2.turbulator.enabled is True
+
+    def test_segment_from_json_dict_roundtrip_without_turbulator(self):
+        seg = _make_segment(turbulator=None)
+        state = seg.__getstate__()
+        seg2 = WingSegment.from_json_dict(state)
+        assert seg2.turbulator is None
+
+
+# ---------------------------------------------------------------------------
+# Backward-compatibility: old dicts without 'turbulator' key
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompatibility:
+    def test_wing_segment_from_old_dict_no_turbulator_key(self):
+        """WingSegment.from_json_dict on a pre-gh-934 dict (no 'turbulator' key) must yield turbulator=None."""
+        old_dict = {
+            "root_airfoil": {
+                "airfoil": "./components/airfoils/rg15.dat",
+                "chord": 200.0,
+                "dihedral_as_rotation_in_degrees": 0.0,
+                "incidence": 0.0,
+            },
+            "tip_airfoil": {
+                "airfoil": "./components/airfoils/rg15.dat",
+                "chord": 180.0,
+                "dihedral_as_rotation_in_degrees": 0.0,
+                "incidence": 0.0,
+            },
+            "length": 100.0,
+            "sweep": 0.0,
+            "sweep_angle": 0.0,
+            "spare_list": None,
+            "trailing_edge_device": None,
+            "number_interpolation_points": None,
+            "tip_type": None,
+            "wing_segment_type": "segment",
+            # NOTE: NO 'turbulator' key — simulates a pre-gh-934 serialised dict
+        }
+        seg = WingSegment.from_json_dict(old_dict)
+        assert seg.turbulator is None


### PR DESCRIPTION
## Summary

Slice 1 of the Turbulator epic (#933): models a **Turbulator** as a new optional per-segment wing element, mirroring the `TrailingEdgeDevice` pattern across all layers. **Domain model & persistence only** — no aero logic, no API endpoints, no UI (those are Slices #935 / #936).

Closes #934.

## What's included

- **Topology** (`cad_designer`): new `Turbulator` class (`__getstate__`/`from_json_dict`); `WingSegment` + `WingConfiguration` extended with a `turbulator` param. This is the maintainer-approved, documented exception to the cad_designer read-only rule (see `CLAUDE.md` change).
- **Schema**: `Turbulator` in `app/schemas/wing.py` (+ `Segment.turbulator`), `TurbulatorDetailSchema` in `aeroplaneschema.py`. Fields: `form` (`zigzag`/`dots`/`thread`), `height_mm` (mm), `position_root`/`position_tip` (x/c, dimensionless 0..1), `enabled`.
- **DB**: `WingXSecTurbulatorModel` (table `wing_xsec_turbulators`, one-to-one FK → `wing_xsec_details`) + relationship + `WingXSecModel.turbulator` property + `WingModel` factory wiring. Alembic migration `6eca6229ba65` (additive; downgrade verified). Registered in `aeroplane_clone_service.CLONED_TABLES`.
- **Converter**: `_turbulator_to_schema` / `_turbulator_schema_to_wing_turbulator` wired into segment round-trip. No unit scaling on x/c positions.
- **Backward-compat**: new fields are `Optional=None`; old WingConfig JSON / DB rows without a turbulator load unchanged.

## Quality gates

- `cad_designer/tests/test_turbulator.py` (15) + `app/tests/test_turbulator_persistence.py` (8): round-trip (topology↔schema↔DB), backward-compat, cascade delete, persistence — **23 passed**.
- Affected-area regression (fast tier): **1019 passed, 0 failed**.
- `ruff check` clean on all changed files.
- `alembic upgrade head` / `downgrade -1` round-trip clean; single head.

## Review

Independent code review run; 1 blocker + 1 minor + 2 nits, **all fixed** (blocker: `wing_xsec_turbulators` was missing from `CLONED_TABLES` → would lose turbulator data on aeroplane clone; caught by the clone-coverage guard test, now green).

## Notes

- Pre-existing, unrelated: slow test `test_rest_wing_vase_mode_step_export_workflow_via_wingconfig` fails on base `main` with an `UnboundLocalError('raw_ribs')` in `VaseModeWingCreator` → tracked separately in #941. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
