### PR TITLE
feat(gh-939): copilot proposal-pending affordance in CopilotStrip (Slice 2)

### DIFF
--- a/frontend/__tests__/CopilotProposalBanner.test.tsx
+++ b/frontend/__tests__/CopilotProposalBanner.test.tsx
@@ -1,0 +1,364 @@
+/**
+ * Unit tests for the CopilotStrip copilot-proposal affordance (gh-939).
+ *
+ * Coverage:
+ * 1. Proposal detection: branch with created_by="copilot" & !is_main → pending
+ * 2. No copilot branch → banner hidden
+ * 3. Copilot branch that IS main → banner hidden (already adopted)
+ * 4. Banner renders Review / Adopt / Discard buttons when pending
+ * 5. Review button visible when onOpenHistory prop is provided; hidden when absent
+ * 6. Adopt button calls adoptBranch mutation + revalidates
+ * 7. Discard button calls discardBranch mutation + revalidates
+ * 8. Banner hidden when aeroplaneId is null
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import React from "react";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be hoisted before component imports
+// ---------------------------------------------------------------------------
+
+vi.mock("@/components/workbench/AeroplaneContext", () => ({
+  useAeroplaneContext: vi.fn(),
+}));
+
+vi.mock("@/hooks/useCopilot", () => ({
+  useCopilot: vi.fn(),
+  toolLabel: (name: string) => `tool:${name}`,
+}));
+
+const mockUseAeroplanes = vi.fn();
+vi.mock("@/hooks/useAeroplanes", () => ({
+  useAeroplanes: () => mockUseAeroplanes(),
+}));
+
+const mockUseLineageTree = vi.fn();
+const mockUseVersionActions = vi.fn();
+vi.mock("@/hooks/useVersioning", () => ({
+  useLineageTree: (...args: unknown[]) => mockUseLineageTree(...args),
+  useVersionActions: (...args: unknown[]) => mockUseVersionActions(...args),
+  useCompareNodes: vi.fn(() => ({ compareOut: undefined, isLoading: false, error: undefined })),
+}));
+
+// Streamdown — used inside CopilotStrip's AssistantBubble; stub to avoid markdown deps in JSDOM.
+vi.mock("streamdown", () => ({
+  Streamdown: ({ children }: { children: React.ReactNode }) =>
+    React.createElement("span", {}, children),
+  defaultRemarkPlugins: { gfm: "gfm", codeMeta: "codeMeta" },
+}));
+
+vi.mock("remark-math", () => ({ default: {} }));
+vi.mock("remark-breaks", () => ({ default: {} }));
+vi.mock("rehype-katex", () => ({ default: {} }));
+
+// ---------------------------------------------------------------------------
+// Lazy imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
+import { useCopilot } from "@/hooks/useCopilot";
+import type { UseCopilotReturn } from "@/hooks/useCopilot";
+import { CopilotStrip } from "@/components/workbench/CopilotStrip";
+import type { TreeOut } from "@/types/versioning";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const AEROPLANE_CTX_WITH_ID = {
+  aeroplaneId: "aero-uuid-1" as string | null,
+  hydrated: true,
+  selectedWing: null,
+  selectedXsecIndex: null,
+  selectedFuselage: null,
+  selectedFuselageXsecIndex: null,
+  treeMode: "wingconfig" as const,
+  pickerOpen: false,
+  lastImportWarnings: null,
+  setAeroplaneId: vi.fn(),
+  selectWing: vi.fn(),
+  selectXsec: vi.fn(),
+  selectFuselage: vi.fn(),
+  selectFuselageXsec: vi.fn(),
+  setTreeMode: vi.fn(),
+  openPicker: vi.fn(),
+  closePicker: vi.fn(),
+  setLastImportWarnings: vi.fn(),
+};
+
+const COPILOT_DEFAULT: UseCopilotReturn = {
+  history: undefined,
+  historyLoading: false,
+  historyError: null,
+  streamingText: "",
+  activeToolLabel: null,
+  errorMessage: null,
+  isSending: false,
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+  clearError: vi.fn(),
+};
+
+/** Aeroplane with versioning metadata. */
+const FAKE_AEROPLANE = {
+  id: "aero-uuid-1",
+  name: "Test Plane",
+  total_mass_kg: null,
+  created_at: "2026-06-01T00:00:00Z",
+  updated_at: "2026-06-01T00:00:00Z",
+  int_id: 10,
+  root_id: 10,
+  branch_name: "main",
+  is_main_branch: true,
+};
+
+/** Tree with a copilot branch (pending proposal). */
+const TREE_WITH_COPILOT_BRANCH: TreeOut = {
+  root_id: 10,
+  nodes: [
+    {
+      id: 10,
+      uuid: "aaa",
+      name: "Test Plane",
+      branch_id: 1,
+      predecessor_id: null,
+      root_id: 10,
+      is_immutable: false,
+      is_head: true,
+      version_label: null,
+      version_note: null,
+      created_by: "human",
+      created_at: "2026-06-01T00:00:00Z",
+    },
+    {
+      id: 20,
+      uuid: "bbb",
+      name: "Test Plane",
+      branch_id: 2,
+      predecessor_id: 10,
+      root_id: 10,
+      is_immutable: false,
+      is_head: true,
+      version_label: null,
+      version_note: null,
+      created_by: "copilot",
+      created_at: "2026-06-02T00:00:00Z",
+    },
+  ],
+  branches: [
+    {
+      id: 1,
+      root_id: 10,
+      head_id: 10,
+      name: "main",
+      is_main: true,
+      created_by: "human",
+      created_at: "2026-06-01T00:00:00Z",
+    },
+    {
+      id: 2,
+      root_id: 10,
+      head_id: 20,
+      name: "copilot/wing-tweak",
+      is_main: false,
+      created_by: "copilot",
+      created_at: "2026-06-02T00:00:00Z",
+    },
+  ],
+};
+
+/** Tree where the copilot branch IS already main (should NOT show banner). */
+const TREE_COPILOT_BRANCH_IS_MAIN: TreeOut = {
+  root_id: 10,
+  nodes: [],
+  branches: [
+    {
+      id: 1,
+      root_id: 10,
+      head_id: 10,
+      name: "copilot/already-main",
+      is_main: true,    // <-- already main, not pending
+      created_by: "copilot",
+      created_at: "2026-06-01T00:00:00Z",
+    },
+  ],
+};
+
+/** Tree with no copilot branch at all. */
+const TREE_NO_COPILOT_BRANCH: TreeOut = {
+  root_id: 10,
+  nodes: [],
+  branches: [
+    {
+      id: 1,
+      root_id: 10,
+      head_id: 10,
+      name: "main",
+      is_main: true,
+      created_by: "human",
+      created_at: "2026-06-01T00:00:00Z",
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Setup helpers
+// ---------------------------------------------------------------------------
+
+const mockAdoptBranch = vi.fn();
+const mockDiscardBranch = vi.fn();
+
+function setupMocksWithTree(tree: TreeOut | undefined, aeroplaneId: string | null = "aero-uuid-1") {
+  vi.mocked(useAeroplaneContext).mockReturnValue({
+    ...AEROPLANE_CTX_WITH_ID,
+    aeroplaneId,
+  });
+  vi.mocked(useCopilot).mockReturnValue(COPILOT_DEFAULT);
+  mockUseAeroplanes.mockReturnValue({
+    aeroplanes: aeroplaneId ? [FAKE_AEROPLANE] : [],
+    createAeroplane: vi.fn(),
+    deleteAeroplane: vi.fn(),
+  });
+  mockUseLineageTree.mockReturnValue({
+    tree,
+    isLoading: false,
+    error: undefined,
+    mutate: vi.fn(),
+  });
+  mockUseVersionActions.mockReturnValue({
+    snapshot: vi.fn(),
+    createBranch: vi.fn(),
+    adoptBranch: mockAdoptBranch,
+    restore: vi.fn(),
+    discardBranch: mockDiscardBranch,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAdoptBranch.mockResolvedValue({ id: 2, root_id: 10, head_id: 10, name: "copilot/wing-tweak", is_main: true, created_by: "copilot", created_at: "2026-06-02T00:00:00Z" });
+  mockDiscardBranch.mockResolvedValue(undefined);
+});
+
+// ---------------------------------------------------------------------------
+// 1. Proposal detection: copilot branch (not main) → banner shown
+// ---------------------------------------------------------------------------
+
+describe("CopilotStrip — proposal detection", () => {
+  it("shows the proposal banner when a non-main copilot branch exists in the tree", () => {
+    setupMocksWithTree(TREE_WITH_COPILOT_BRANCH);
+    render(<CopilotStrip />);
+    expect(screen.getByTestId("copilot-proposal-banner")).toBeInTheDocument();
+    expect(screen.getByText("Copilot proposal pending")).toBeInTheDocument();
+  });
+
+  it("hides the banner when there is no copilot branch", () => {
+    setupMocksWithTree(TREE_NO_COPILOT_BRANCH);
+    render(<CopilotStrip />);
+    expect(screen.queryByTestId("copilot-proposal-banner")).toBeNull();
+  });
+
+  it("hides the banner when the copilot branch is already is_main=true", () => {
+    setupMocksWithTree(TREE_COPILOT_BRANCH_IS_MAIN);
+    render(<CopilotStrip />);
+    expect(screen.queryByTestId("copilot-proposal-banner")).toBeNull();
+  });
+
+  it("hides the banner when no aeroplane is selected", () => {
+    setupMocksWithTree(undefined, null);
+    vi.mocked(useAeroplaneContext).mockReturnValue({
+      ...AEROPLANE_CTX_WITH_ID,
+      aeroplaneId: null,
+    });
+    render(<CopilotStrip />);
+    expect(screen.queryByTestId("copilot-proposal-banner")).toBeNull();
+  });
+
+  it("hides the banner when the lineage tree is not yet loaded (undefined)", () => {
+    setupMocksWithTree(undefined);
+    render(<CopilotStrip />);
+    expect(screen.queryByTestId("copilot-proposal-banner")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Banner renders Review / Adopt / Discard
+// ---------------------------------------------------------------------------
+
+describe("CopilotStrip — proposal banner buttons", () => {
+  it("renders Adopt and Discard buttons", () => {
+    setupMocksWithTree(TREE_WITH_COPILOT_BRANCH);
+    render(<CopilotStrip />);
+    expect(screen.getByRole("button", { name: "Adopt copilot proposal" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Discard copilot proposal" })).toBeInTheDocument();
+  });
+
+  it("shows Review button when onOpenHistory prop is provided", () => {
+    setupMocksWithTree(TREE_WITH_COPILOT_BRANCH);
+    render(<CopilotStrip onOpenHistory={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Review copilot proposal" })).toBeInTheDocument();
+  });
+
+  it("hides Review button when onOpenHistory prop is not provided", () => {
+    setupMocksWithTree(TREE_WITH_COPILOT_BRANCH);
+    render(<CopilotStrip />);
+    expect(screen.queryByRole("button", { name: "Review copilot proposal" })).toBeNull();
+  });
+
+  it("calls onOpenHistory when Review is clicked", async () => {
+    const onOpenHistory = vi.fn();
+    setupMocksWithTree(TREE_WITH_COPILOT_BRANCH);
+    const user = userEvent.setup();
+    render(<CopilotStrip onOpenHistory={onOpenHistory} />);
+    await user.click(screen.getByRole("button", { name: "Review copilot proposal" }));
+    expect(onOpenHistory).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Adopt mutation
+// ---------------------------------------------------------------------------
+
+describe("CopilotStrip — Adopt action", () => {
+  it("calls adoptBranch with the proposal branch id when Adopt is clicked", async () => {
+    setupMocksWithTree(TREE_WITH_COPILOT_BRANCH);
+    const user = userEvent.setup();
+    render(<CopilotStrip />);
+    await user.click(screen.getByRole("button", { name: "Adopt copilot proposal" }));
+    await waitFor(() => expect(mockAdoptBranch).toHaveBeenCalledWith(2));
+  });
+
+  it("revalidates after adopt (useVersionActions handles revalidation automatically)", async () => {
+    setupMocksWithTree(TREE_WITH_COPILOT_BRANCH);
+    const user = userEvent.setup();
+    render(<CopilotStrip />);
+    await user.click(screen.getByRole("button", { name: "Adopt copilot proposal" }));
+    await waitFor(() => expect(mockAdoptBranch).toHaveBeenCalledOnce());
+    // useVersionActions internally calls globalMutate for the tree and aeroplanes list.
+    // This is verified in useVersioning.test.tsx; here we only verify the mutation is called.
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Discard mutation
+// ---------------------------------------------------------------------------
+
+describe("CopilotStrip — Discard action", () => {
+  it("calls discardBranch with the proposal branch id when Discard is clicked", async () => {
+    setupMocksWithTree(TREE_WITH_COPILOT_BRANCH);
+    const user = userEvent.setup();
+    render(<CopilotStrip />);
+    await user.click(screen.getByRole("button", { name: "Discard copilot proposal" }));
+    await waitFor(() => expect(mockDiscardBranch).toHaveBeenCalledWith(2));
+  });
+
+  it("revalidates after discard", async () => {
+    setupMocksWithTree(TREE_WITH_COPILOT_BRANCH);
+    const user = userEvent.setup();
+    render(<CopilotStrip />);
+    await user.click(screen.getByRole("button", { name: "Discard copilot proposal" }));
+    await waitFor(() => expect(mockDiscardBranch).toHaveBeenCalledOnce());
+  });
+});

--- a/frontend/app/workbench/layout.tsx
+++ b/frontend/app/workbench/layout.tsx
@@ -55,7 +55,7 @@ function WorkbenchInner({
         <div className="shrink-0 px-4 pb-2">
           <MetricsDashboardContainer />
         </div>
-        <CopilotStrip />
+        <CopilotStrip onOpenHistory={handleOpenHistory} />
       </div>
       <UnsavedChangesModal />
       <AeroplanePickerHost />

--- a/frontend/components/workbench/CopilotStrip.tsx
+++ b/frontend/components/workbench/CopilotStrip.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useRef, useState, useEffect, useCallback } from "react";
-import { Send, ChevronUp, ChevronDown, Bot, User, AlertCircle } from "lucide-react";
+import { Send, ChevronUp, ChevronDown, Bot, User, AlertCircle, Settings, Star, Trash2 } from "lucide-react";
 import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
 import { useCopilot } from "@/hooks/useCopilot";
 import type { CopilotMessageRead } from "@/hooks/useCopilot";
+import { useCopilotProposal } from "@/hooks/useCopilotProposal";
 import { Streamdown, defaultRemarkPlugins } from "streamdown";
 import type { MathPlugin, PluginConfig, UrlTransform } from "streamdown";
 import type { PluggableList } from "unified";
@@ -130,10 +131,88 @@ function ErrorBanner({
 }
 
 // ---------------------------------------------------------------------------
+// CopilotProposalBanner
+// ---------------------------------------------------------------------------
+
+interface CopilotProposalBannerProps {
+  branchName: string;
+  onReview?: () => void;
+  onAdopt: () => void;
+  onDiscard: () => void;
+  busy: boolean;
+}
+
+function CopilotProposalBanner({
+  branchName,
+  onReview,
+  onAdopt,
+  onDiscard,
+  busy,
+}: CopilotProposalBannerProps) {
+  return (
+    <div
+      className="flex items-center gap-2 border-t border-primary/30 bg-primary/5 px-6 py-1.5"
+      role="status"
+      aria-label="Copilot proposal pending"
+      data-testid="copilot-proposal-banner"
+    >
+      <Settings size={12} className="shrink-0 text-primary" aria-hidden />
+      <span className="flex-1 truncate text-[11px] font-medium text-primary">
+        Copilot proposal pending
+      </span>
+      <span className="hidden max-w-[120px] truncate text-[10px] text-muted-foreground sm:block">
+        {branchName}
+      </span>
+      <div className="flex shrink-0 items-center gap-1">
+        {onReview && (
+          <button
+            type="button"
+            onClick={onReview}
+            disabled={busy}
+            aria-label="Review copilot proposal"
+            className="rounded px-2 py-0.5 text-[10px] font-medium text-primary ring-1 ring-primary/40 hover:bg-primary/10 disabled:opacity-50"
+          >
+            Review
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() => { void onAdopt(); }}
+          disabled={busy}
+          aria-label="Adopt copilot proposal"
+          className="flex items-center gap-1 rounded bg-primary px-2 py-0.5 text-[10px] font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+        >
+          <Star size={9} aria-hidden />
+          Adopt
+        </button>
+        <button
+          type="button"
+          onClick={() => { void onDiscard(); }}
+          disabled={busy}
+          aria-label="Discard copilot proposal"
+          className="flex items-center gap-1 rounded px-2 py-0.5 text-[10px] text-destructive ring-1 ring-destructive/30 hover:bg-destructive/10 disabled:opacity-50"
+        >
+          <Trash2 size={9} aria-hidden />
+          Discard
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // CopilotStrip
 // ---------------------------------------------------------------------------
 
-export function CopilotStrip() {
+interface CopilotStripProps {
+  /**
+   * Called when the user clicks "Review" on a pending copilot proposal.
+   * If not provided, the Review button is hidden.
+   */
+  onOpenHistory?: () => void;
+}
+
+export function CopilotStrip({ onOpenHistory }: CopilotStripProps = {}) {
   const { aeroplaneId } = useAeroplaneContext();
   const {
     history,
@@ -145,6 +224,9 @@ export function CopilotStrip() {
     clearError,
   } = useCopilot(aeroplaneId);
 
+  const { proposal } = useCopilotProposal(aeroplaneId);
+
+  const [proposalBusy, setProposalBusy] = useState(false);
   const [open, setOpen] = useState(false);
   const [inputText, setInputText] = useState("");
   const threadEndRef = useRef<HTMLDivElement>(null);
@@ -173,6 +255,26 @@ export function CopilotStrip() {
     [handleSend],
   );
 
+  const handleProposalAdopt = useCallback(async () => {
+    if (!proposal) return;
+    setProposalBusy(true);
+    try {
+      await proposal.adopt();
+    } finally {
+      setProposalBusy(false);
+    }
+  }, [proposal]);
+
+  const handleProposalDiscard = useCallback(async () => {
+    if (!proposal) return;
+    setProposalBusy(true);
+    try {
+      await proposal.discard();
+    } finally {
+      setProposalBusy(false);
+    }
+  }, [proposal]);
+
   const noAeroplane = !aeroplaneId;
   const messages = history?.messages ?? [];
   const hasContent =
@@ -180,6 +282,16 @@ export function CopilotStrip() {
 
   return (
     <footer className="shrink-0 border-t border-border bg-sidebar">
+      {/* Copilot proposal pending banner (gh-939) */}
+      {proposal && (
+        <CopilotProposalBanner
+          branchName={proposal.branch.name}
+          onReview={onOpenHistory}
+          onAdopt={handleProposalAdopt}
+          onDiscard={handleProposalDiscard}
+          busy={proposalBusy}
+        />
+      )}
       {/* Slim handle bar — always visible */}
       <div className="flex h-10 items-center gap-3 px-6">
         <span className="text-[13px] text-subtle-foreground">

--- a/frontend/hooks/useCopilotProposal.ts
+++ b/frontend/hooks/useCopilotProposal.ts
@@ -1,0 +1,111 @@
+"use client";
+
+/**
+ * useCopilotProposal (gh-939)
+ *
+ * Detects a pending "copilot proposal" branch for the current aeroplane:
+ * a branch in the lineage tree with `created_by === "copilot"` and
+ * `is_main === false`.
+ *
+ * Reuses `useLineageTree` and `useVersionActions` from the shipped #907
+ * versioning hooks — no new API endpoints.
+ *
+ * The hook is disabled (returns null) when:
+ * - no aeroplane is selected
+ * - the lineage tree is not yet available (legacy pre-versioning aeroplane)
+ * - no copilot branch exists in the tree
+ */
+
+import { useMemo } from "react";
+import { useAeroplanes } from "@/hooks/useAeroplanes";
+import { useLineageTree, useVersionActions } from "@/hooks/useVersioning";
+import type { BranchOut } from "@/types/versioning";
+
+// ---------------------------------------------------------------------------
+// Return type
+// ---------------------------------------------------------------------------
+
+export interface CopilotProposal {
+  /** The copilot branch. */
+  branch: BranchOut;
+  /** Adopt the proposal (promotes it to is_main). */
+  adopt: () => Promise<void>;
+  /** Discard the proposal (deletes the branch). */
+  discard: () => Promise<void>;
+  /** True while an adopt/discard action is in flight. */
+  busy: boolean;
+}
+
+export interface UseCopilotProposalResult {
+  /** Non-null when a pending copilot proposal branch exists. */
+  proposal: CopilotProposal | null;
+  /** True while the lineage tree is loading. */
+  isLoading: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * @param aeroplaneId  UUID string from AeroplaneContext (or null).
+ * @param onAdoptComplete  Optional callback fired after a successful adopt.
+ * @param onDiscardComplete  Optional callback fired after a successful discard.
+ */
+export function useCopilotProposal(
+  aeroplaneId: string | null,
+  onAdoptComplete?: () => void,
+  onDiscardComplete?: () => void,
+): UseCopilotProposalResult {
+  const { aeroplanes } = useAeroplanes();
+
+  // Resolve the current aeroplane's integer root_id from the aeroplanes list.
+  const currentAeroplane = useMemo(
+    () => aeroplanes.find((a) => a.id === aeroplaneId) ?? null,
+    [aeroplanes, aeroplaneId],
+  );
+
+  const intId = currentAeroplane?.int_id ?? null;
+  const rootId = currentAeroplane?.root_id ?? null;
+
+  const { tree, isLoading } = useLineageTree(rootId);
+
+  // Find the first non-main branch created by "copilot".
+  const proposalBranch = useMemo<BranchOut | null>(() => {
+    if (!tree) return null;
+    return (
+      tree.branches.find(
+        (b) => b.created_by === "copilot" && !b.is_main,
+      ) ?? null
+    );
+  }, [tree]);
+
+  // Version actions (adopt/discard) — revalidates tree + aeroplanes list.
+  const actions = useVersionActions(intId, rootId);
+
+  // Stable proposal object — only changes when the branch identity changes.
+  const proposal = useMemo<CopilotProposal | null>(() => {
+    if (!proposalBranch) return null;
+
+    const branchId = proposalBranch.id;
+
+    return {
+      branch: proposalBranch,
+      busy: false, // caller can track busy locally; actions throw on error
+      adopt: async () => {
+        await actions.adoptBranch(branchId);
+        onAdoptComplete?.();
+      },
+      discard: async () => {
+        await actions.discardBranch(branchId);
+        onDiscardComplete?.();
+      },
+    };
+  }, [proposalBranch, actions, onAdoptComplete, onDiscardComplete]);
+
+  if (!aeroplaneId) {
+    return { proposal: null, isLoading: false };
+  }
+
+  return { proposal, isLoading };
+}


### PR DESCRIPTION
## Summary
#902 Slice 2 frontend (#939): a light **"Copilot proposal pending"** affordance in the `CopilotStrip`. When the agentic-apply copilot has prepared a change on a `copilot-proposal` branch, the user gets Review / Adopt / Discard — **reusing the shipped #901/#907 versioning UI**, no new compare/adopt UI.

- **`useCopilotProposal(aeroplaneId)`** — detects a pending proposal by scanning the **existing** lineage tree (`useLineageTree` from #907) for a branch with `created_by === "copilot"` && `is_main === false`. No new endpoint.
- **`CopilotProposalBanner`** in `CopilotStrip` — Review (opens VersionHistoryPanel/compare), Adopt, Discard. Adopt/Discard delegate to the shipped `useVersionActions` mutations, which revalidate the tree so the banner clears.
- Hidden when no aeroplane or no pending proposal.

## Tests
Node 22: **tsc clean, eslint clean (--max-warnings=0), vitest 1799 passed** (+13 new for the banner: detection, render, adopt/discard wiring, hidden states; the 29 existing CopilotStrip tests preserved).

Closes #939 · part of #902 Slice 2. Backend (#937/#938 → #943) + 3-persona UAT (#940). Live proposal-flow UX gets a browser pass in the UAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)