### PR TITLE
style(gh-947): turbulator preview — upper surface, distinct cyan, dotted

### DIFF
--- a/frontend/__tests__/buildTurbulatorTraces.test.ts
+++ b/frontend/__tests__/buildTurbulatorTraces.test.ts
@@ -61,16 +61,19 @@ describe("buildTurbulatorTraces", () => {
     expect(traces).toHaveLength(1);
   });
 
-  it("each trace is a scatter3d with two points (spanwise line)", () => {
+  it("each trace is a dotted scatter3d (markers) along the spanwise line", () => {
     const ctx = makeCtx([
       makeXsec({ turbulator: { form: "zigzag", height_mm: 0.3, position_root: 0.1, enabled: true } }),
       makeXsec({ xyz_le: [0, 0.3, 0], chord: 0.18, twist: 0, airfoil: "naca0012" }),
     ]);
     const [trace] = buildTurbulatorTraces(ctx);
     expect(trace.type).toBe("scatter3d");
-    expect(trace.x).toHaveLength(2);
-    expect(trace.y).toHaveLength(2);
-    expect(trace.z).toHaveLength(2);
+    // Dotted appearance: rendered as markers (scatter3d lines cannot be dashed).
+    expect(trace.mode).toBe("markers");
+    // Evenly spaced dots root→tip (N + 1 points).
+    expect(trace.x.length).toBeGreaterThan(2);
+    expect(trace.y).toHaveLength(trace.x.length);
+    expect(trace.z).toHaveLength(trace.x.length);
   });
 
   it("trace x-coordinates reflect position_root on root xsec", () => {
@@ -93,8 +96,9 @@ describe("buildTurbulatorTraces", () => {
       makeXsec({ xyz_le: [0, 1, 0], chord: 1.0, twist: 0, airfoil: "naca0012" }),
     ]);
     const [trace] = buildTurbulatorTraces(ctx);
-    // Tip xsec: xyz_le=[0,1,0], chord=1, position_tip=0.2 → x = 0 + 0.2*1 = 0.2
-    expect(trace.x[1]).toBeCloseTo(0.2, 5);
+    // Tip xsec: xyz_le=[0,1,0], chord=1, position_tip=0.2 → x = 0 + 0.2*1 = 0.2.
+    // The tip station is the LAST dot of the strip.
+    expect(trace.x.at(-1)).toBeCloseTo(0.2, 5);
   });
 
   it("falls back to position_root for tip when position_tip is not set", () => {
@@ -104,8 +108,8 @@ describe("buildTurbulatorTraces", () => {
       makeXsec({ xyz_le: [0, 1, 0], chord: 1.0, twist: 0, airfoil: "naca0012" }),
     ]);
     const [trace] = buildTurbulatorTraces(ctx);
-    // Tip uses position_root (0.15) as fallback
-    expect(trace.x[1]).toBeCloseTo(0.15, 5);
+    // Tip uses position_root (0.15) as fallback → last dot at 0.15
+    expect(trace.x.at(-1)).toBeCloseTo(0.15, 5);
   });
 
   it("falls back to position_root when position_tip is null", () => {
@@ -115,7 +119,7 @@ describe("buildTurbulatorTraces", () => {
       makeXsec({ xyz_le: [0, 1, 0], chord: 1.0, twist: 0, airfoil: "naca0012" }),
     ]);
     const [trace] = buildTurbulatorTraces(ctx);
-    expect(trace.x[1]).toBeCloseTo(0.12, 5);
+    expect(trace.x.at(-1)).toBeCloseTo(0.12, 5);
   });
 
   it("skips segment when turbulator has no position_root", () => {
@@ -151,14 +155,36 @@ describe("buildTurbulatorTraces", () => {
     expect(buildTurbulatorTraces(ctx)).toHaveLength(0);
   });
 
-  it("trace uses the amber turbulator color (line.color starts with #F)", () => {
+  it("trace uses a distinct cyan marker colour (not the airfoil orange)", () => {
     const ctx = makeCtx([
       makeXsec({ turbulator: { form: "zigzag", height_mm: 0.3, position_root: 0.1, enabled: true } }),
       makeXsec(),
     ]);
     const [trace] = buildTurbulatorTraces(ctx);
-    // COLOR_TURBULATOR = "#F5A623" — amber, distinct from TED green (#30A46C) / spar purple (#6E56CF)
-    expect((trace.line.color as string).toUpperCase().startsWith("#F")).toBe(true);
+    // COLOR_TURBULATOR = "#22D3EE" — bright cyan, deliberately far from the
+    // airfoil orange (#FF8400) / TED green (#30A46C) / spar purple (#6E56CF).
+    const color = (trace.marker.color as string).toUpperCase();
+    expect(color).toBe("#22D3EE");
+    expect(color).not.toBe("#FF8400");
+  });
+
+  it("draws the strip on the upper surface (z follows the airfoil upper ordinate)", () => {
+    // Provide an airfoil whose upper surface at x/c=0.3 is well above the chord
+    // line; the dots must sit at that height, not on the camber line (z=0).
+    const upperAf = {
+      x: [0, 0.3, 1], y: [0, 0.1, 0],
+      upper_x: [0, 0.3, 1], upper_y: [0, 0.1, 0],
+    };
+    const ctx = makeCtx(
+      [
+        makeXsec({ chord: 1.0, turbulator: { form: "zigzag", height_mm: 0.3, position_root: 0.3, enabled: true } }),
+        makeXsec({ xyz_le: [0, 1, 0], chord: 1.0 }),
+      ],
+      { airfoils: [upperAf, upperAf] as unknown as WingTraceCtx["airfoils"] },
+    );
+    const [trace] = buildTurbulatorTraces(ctx);
+    // upper_y(0.3) = 0.1, chord 1 → z ≈ 0.1 (not 0)
+    expect(trace.z[0]).toBeCloseTo(0.1, 5);
   });
 
   it("trace has showlegend: false and hoverinfo: skip", () => {

--- a/frontend/components/workbench/WingOutlineViewer.tsx
+++ b/frontend/components/workbench/WingOutlineViewer.tsx
@@ -131,7 +131,7 @@ const COLOR_SPANWISE = "#FF840060";
 const COLOR_SELECTED = "#E5484D";    // selected xsec/segment: red
 const COLOR_TED = "#30A46C";
 const COLOR_SPAR = "#6E56CF";        // purple
-const COLOR_TURBULATOR = "#F5A623";  // amber — distinct from TED green / spar purple
+const COLOR_TURBULATOR = "#22D3EE";  // bright cyan — deliberately far from airfoil orange / TED green / spar purple / selected red
 
 /** Shorthand for a scatter3d trace. */
 function scatter3d(
@@ -143,6 +143,22 @@ function scatter3d(
     mode: "lines",
     x, y, z,
     line: { color, width, ...(dash ? { dash } : {}) },
+    showlegend: false,
+    hoverinfo: "skip",
+  };
+}
+
+/** Dotted scatter3d trace (evenly spaced markers). scatter3d lines do not
+ *  support a `dash` style, so a dotted look is rendered as small markers. */
+function scatter3dDots(
+  x: number[], y: number[], z: number[],
+  color: string, size = 2.5,
+): PlotlyData {
+  return {
+    type: "scatter3d",
+    mode: "markers",
+    x, y, z,
+    marker: { color, size },
     showlegend: false,
     hoverinfo: "skip",
   };
@@ -337,10 +353,15 @@ function buildTEDTraces(ctx: WingTraceCtx): PlotlyData[] {
   return traces;
 }
 
-/** Turbulator strip outline — spanwise line on the upper surface at x/c position. */
+/** Number of dots drawn along a turbulator strip (dotted spanwise line). */
+const N_TURBULATOR_DOTS = 24;
+
+/** Turbulator strip — dotted spanwise line on the wing UPPER surface at the
+ *  x/c position. Drawn as markers (scatter3d lines cannot be dashed) in a
+ *  bright colour that stands out from the airfoil / TED / spar lines. */
 export function buildTurbulatorTraces(ctx: WingTraceCtx): PlotlyData[] {
   const traces: PlotlyData[] = [];
-  const { xsecs, dihedrals } = ctx;
+  const { xsecs, airfoils, dihedrals } = ctx;
 
   for (let i = 0; i < xsecs.length - 1; i++) {
     const turb = xsecs[i].turbulator as Record<string, unknown> | null | undefined;
@@ -352,16 +373,28 @@ export function buildTurbulatorTraces(ctx: WingTraceCtx): PlotlyData[] {
     // position_tip defaults to position_root (flat strip) when not set
     const posTip = (turb.position_tip as number | null | undefined) ?? posRoot;
 
-    // Sample upper surface at x/c = posRoot (root xsec) and x/c = posTip (tip xsec)
-    // Upper surface: y-coordinate is positive at a given x/c on the upper side.
-    // We use transformProfile with z-ordinate 0 (camber line approximation) which
-    // is sufficient for a visual indicator line.
-    const p1 = transformProfile([posRoot], [0], xsecs[i].chord, xsecs[i].twist, xsecs[i].xyz_le, dihedrals[i]);
-    const p2 = transformProfile([posTip], [0], xsecs[i + 1].chord, xsecs[i + 1].twist, xsecs[i + 1].xyz_le, dihedrals[i + 1]);
+    // Place the strip on the UPPER surface: look up the airfoil's upper-surface
+    // ordinate at the chordwise position and feed it as the profile z-ordinate
+    // (same pattern as the upper quarter-chord reference line). Falls back to
+    // the camber line (0) when airfoil coordinates are unavailable.
+    const afRoot = airfoils[i];
+    const afTip = airfoils[i + 1];
+    const zRoot = afRoot ? lerpLookup(afRoot.upper_x, afRoot.upper_y, posRoot) : 0;
+    const zTip = afTip ? lerpLookup(afTip.upper_x, afTip.upper_y, posTip) : 0;
 
-    traces.push(
-      scatter3d([p1.x[0], p2.x[0]], [p1.y[0], p2.y[0]], [p1.z[0], p2.z[0]], COLOR_TURBULATOR, 2.5),
-    );
+    const p1 = transformProfile([posRoot], [zRoot], xsecs[i].chord, xsecs[i].twist, xsecs[i].xyz_le, dihedrals[i]);
+    const p2 = transformProfile([posTip], [zTip], xsecs[i + 1].chord, xsecs[i + 1].twist, xsecs[i + 1].xyz_le, dihedrals[i + 1]);
+
+    // Evenly spaced dots from root to tip → dotted appearance.
+    const dx: number[] = [], dy: number[] = [], dz: number[] = [];
+    for (let k = 0; k <= N_TURBULATOR_DOTS; k++) {
+      const t = k / N_TURBULATOR_DOTS;
+      dx.push(p1.x[0] + (p2.x[0] - p1.x[0]) * t);
+      dy.push(p1.y[0] + (p2.y[0] - p1.y[0]) * t);
+      dz.push(p1.z[0] + (p2.z[0] - p1.z[0]) * t);
+    }
+
+    traces.push(scatter3dDots(dx, dy, dz, COLOR_TURBULATOR));
   }
 
   return traces;


### PR DESCRIPTION
## Summary

Refines how the turbulator is drawn in the construction preview (`WingOutlineViewer.tsx::buildTurbulatorTraces`), per request. Closes #947.

1. **Upper surface** — the strip now sits on the wing's upper surface (airfoil `upper_y` at the x/c via `lerpLookup`, the same pattern as the upper quarter-chord line) instead of the camber line (z=0).
2. **Distinct colour** — `#F5A623` (too close to the `#FF8400` accent) → bright cyan **`#22D3EE`**, clearly distinct from airfoil-orange / TED-green / spar-purple / selected-red.
3. **Dotted** — rendered as evenly spaced **markers** (Plotly scatter3d lines can't be dashed), which also matches the "dots" turbulator form.

## Verification
- `buildTurbulatorTraces` unit tests updated (markers/point-count, tip = last dot, cyan `marker.color`, new upper-surface z test) — **15 passed**; eslint clean.
- **Browser-verified** on the low-Re Olek wing: cyan dotted strip sits above the airfoil outline (upper surface), clearly distinct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)