### PR TITLE
style(gh-949): turbulator preview — dotted line instead of markers

### DIFF
--- a/frontend/__tests__/buildTurbulatorTraces.test.ts
+++ b/frontend/__tests__/buildTurbulatorTraces.test.ts
@@ -61,19 +61,21 @@ describe("buildTurbulatorTraces", () => {
     expect(traces).toHaveLength(1);
   });
 
-  it("each trace is a dotted scatter3d (markers) along the spanwise line", () => {
+  it("each trace is a dotted scatter3d line (root → tip)", () => {
     const ctx = makeCtx([
       makeXsec({ turbulator: { form: "zigzag", height_mm: 0.3, position_root: 0.1, enabled: true } }),
       makeXsec({ xyz_le: [0, 0.3, 0], chord: 0.18, twist: 0, airfoil: "naca0012" }),
     ]);
     const [trace] = buildTurbulatorTraces(ctx);
     expect(trace.type).toBe("scatter3d");
-    // Dotted appearance: rendered as markers (scatter3d lines cannot be dashed).
-    expect(trace.mode).toBe("markers");
-    // Evenly spaced dots root→tip (N + 1 points).
-    expect(trace.x.length).toBeGreaterThan(2);
-    expect(trace.y).toHaveLength(trace.x.length);
-    expect(trace.z).toHaveLength(trace.x.length);
+    expect(trace.mode).toBe("lines");
+    // Dotted appearance via line.dash (scatter3d supports dash, as the spar
+    // edge lines do) — not individual markers.
+    expect(trace.line.dash).toBe("dot");
+    // Single 2-point spanwise line.
+    expect(trace.x).toHaveLength(2);
+    expect(trace.y).toHaveLength(2);
+    expect(trace.z).toHaveLength(2);
   });
 
   it("trace x-coordinates reflect position_root on root xsec", () => {
@@ -163,7 +165,7 @@ describe("buildTurbulatorTraces", () => {
     const [trace] = buildTurbulatorTraces(ctx);
     // COLOR_TURBULATOR = "#22D3EE" — bright cyan, deliberately far from the
     // airfoil orange (#FF8400) / TED green (#30A46C) / spar purple (#6E56CF).
-    const color = (trace.marker.color as string).toUpperCase();
+    const color = (trace.line.color as string).toUpperCase();
     expect(color).toBe("#22D3EE");
     expect(color).not.toBe("#FF8400");
   });

--- a/frontend/components/workbench/WingOutlineViewer.tsx
+++ b/frontend/components/workbench/WingOutlineViewer.tsx
@@ -148,21 +148,6 @@ function scatter3d(
   };
 }
 
-/** Dotted scatter3d trace (evenly spaced markers). scatter3d lines do not
- *  support a `dash` style, so a dotted look is rendered as small markers. */
-function scatter3dDots(
-  x: number[], y: number[], z: number[],
-  color: string, size = 2.5,
-): PlotlyData {
-  return {
-    type: "scatter3d",
-    mode: "markers",
-    x, y, z,
-    marker: { color, size },
-    showlegend: false,
-    hoverinfo: "skip",
-  };
-}
 
 // ── Wing trace context shared across sub-builders ────────────────
 
@@ -353,12 +338,10 @@ function buildTEDTraces(ctx: WingTraceCtx): PlotlyData[] {
   return traces;
 }
 
-/** Number of dots drawn along a turbulator strip (dotted spanwise line). */
-const N_TURBULATOR_DOTS = 24;
-
-/** Turbulator strip — dotted spanwise line on the wing UPPER surface at the
- *  x/c position. Drawn as markers (scatter3d lines cannot be dashed) in a
- *  bright colour that stands out from the airfoil / TED / spar lines. */
+/** Turbulator strip — a dotted spanwise line on the wing UPPER surface at the
+ *  x/c position, in a bright colour that stands out from the airfoil / TED /
+ *  spar lines. Rendered as a dotted line (scatter3d `line.dash`, same as the
+ *  spar edge lines), not individual markers. */
 export function buildTurbulatorTraces(ctx: WingTraceCtx): PlotlyData[] {
   const traces: PlotlyData[] = [];
   const { xsecs, airfoils, dihedrals } = ctx;
@@ -385,16 +368,9 @@ export function buildTurbulatorTraces(ctx: WingTraceCtx): PlotlyData[] {
     const p1 = transformProfile([posRoot], [zRoot], xsecs[i].chord, xsecs[i].twist, xsecs[i].xyz_le, dihedrals[i]);
     const p2 = transformProfile([posTip], [zTip], xsecs[i + 1].chord, xsecs[i + 1].twist, xsecs[i + 1].xyz_le, dihedrals[i + 1]);
 
-    // Evenly spaced dots from root to tip → dotted appearance.
-    const dx: number[] = [], dy: number[] = [], dz: number[] = [];
-    for (let k = 0; k <= N_TURBULATOR_DOTS; k++) {
-      const t = k / N_TURBULATOR_DOTS;
-      dx.push(p1.x[0] + (p2.x[0] - p1.x[0]) * t);
-      dy.push(p1.y[0] + (p2.y[0] - p1.y[0]) * t);
-      dz.push(p1.z[0] + (p2.z[0] - p1.z[0]) * t);
-    }
-
-    traces.push(scatter3dDots(dx, dy, dz, COLOR_TURBULATOR));
+    traces.push(
+      scatter3d([p1.x[0], p2.x[0]], [p1.y[0], p2.y[0]], [p1.z[0], p2.z[0]], COLOR_TURBULATOR, 2.5, "dot"),
+    );
   }
 
   return traces;


### PR DESCRIPTION
## Summary
Draw the turbulator strip as a continuous **dotted line** instead of individual markers (the previous #947 approach). Closes #949.

Plotly `scatter3d` **does** support `line.dash` — the spar edge lines already use it — so the strip is now a single 2-point `scatter3d` line with `dash: "dot"` (like the spars), keeping the upper-surface placement and bright cyan `#22D3EE`.

## Verification
- `buildTurbulatorTraces` unit tests updated (mode `lines`, `line.dash: "dot"`, `line.color` cyan, 2-point line) — 15 passed; eslint clean.
- Browser-verified on the low-Re Olek wing; live Plotly data confirms `mode: "lines", dash: "dot", color: "#22D3EE"` (not markers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)