### PR TITLE
feat(gh-952): toggle Enter behavior (send vs newline) in copilot chat

### DIFF
--- a/frontend/__tests__/CopilotStrip.test.tsx
+++ b/frontend/__tests__/CopilotStrip.test.tsx
@@ -7,7 +7,7 @@
  * - Assert rendering of message bubbles, streaming text, tool chips, errors,
  *   and disabled state when no aeroplane is selected.
  */
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
@@ -603,5 +603,184 @@ describe("CopilotStrip — send interaction", () => {
     await user.click(screen.getByRole("button", { name: "Expand copilot panel" }));
 
     expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Enter key toggle (gh-952)
+// ---------------------------------------------------------------------------
+
+describe("CopilotStrip — Enter key toggle", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockCtx();
+    mockCopilot({ sendMessage: vi.fn().mockResolvedValue(undefined) });
+  });
+
+  // Helper: open panel and return textarea + fresh sendMessage mock
+  async function openPanel() {
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    mockCopilot({ sendMessage });
+    const user = userEvent.setup();
+    render(<CopilotStrip />);
+    await user.click(screen.getByRole("button", { name: "Expand copilot panel" }));
+    const textarea = screen.getByRole("textbox", { name: "Copilot input" });
+    return { user, textarea, sendMessage };
+  }
+
+  // ---- Default mode (enterToSend = true, localStorage unset) ---------------
+
+  it("default mode: Enter sends the message", async () => {
+    const { user, textarea, sendMessage } = await openPanel();
+    await user.type(textarea, "my question");
+    // clear the send calls from typing then fire Enter
+    sendMessage.mockClear();
+    await user.keyboard("{Enter}");
+    expect(sendMessage).toHaveBeenCalledWith("my question");
+  });
+
+  it("default mode: Shift+Enter does NOT send", async () => {
+    const { user, textarea, sendMessage } = await openPanel();
+    await user.type(textarea, "multiline");
+    sendMessage.mockClear();
+    await user.keyboard("{Shift>}{Enter}{/Shift}");
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("default mode: Cmd+Enter sends", async () => {
+    const { user, textarea, sendMessage } = await openPanel();
+    await user.type(textarea, "cmd test");
+    sendMessage.mockClear();
+    await user.keyboard("{Meta>}{Enter}{/Meta}");
+    expect(sendMessage).toHaveBeenCalledWith("cmd test");
+  });
+
+  it("default mode: Ctrl+Enter sends", async () => {
+    const { user, textarea, sendMessage } = await openPanel();
+    await user.type(textarea, "ctrl test");
+    sendMessage.mockClear();
+    await user.keyboard("{Control>}{Enter}{/Control}");
+    expect(sendMessage).toHaveBeenCalledWith("ctrl test");
+  });
+
+  // ---- Alternative mode (enterToSend = false) ------------------------------
+
+  it("alt mode (localStorage false): Enter does NOT send", async () => {
+    localStorage.setItem("copilot:enter-to-send", "false");
+    const { user, textarea, sendMessage } = await openPanel();
+    await user.type(textarea, "alt question");
+    sendMessage.mockClear();
+    await user.keyboard("{Enter}");
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("alt mode (localStorage false): Cmd+Enter sends", async () => {
+    localStorage.setItem("copilot:enter-to-send", "false");
+    const { user, textarea, sendMessage } = await openPanel();
+    await user.type(textarea, "cmd alt test");
+    sendMessage.mockClear();
+    await user.keyboard("{Meta>}{Enter}{/Meta}");
+    expect(sendMessage).toHaveBeenCalledWith("cmd alt test");
+  });
+
+  it("alt mode (localStorage false): Send button sends", async () => {
+    localStorage.setItem("copilot:enter-to-send", "false");
+    const { user, textarea, sendMessage } = await openPanel();
+    await user.type(textarea, "button test");
+    sendMessage.mockClear();
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    expect(sendMessage).toHaveBeenCalledWith("button test");
+  });
+
+  // ---- Toggle button -------------------------------------------------------
+
+  it("toggle button has aria-label and aria-pressed reflecting default state", async () => {
+    await openPanel();
+    const toggleBtn = screen.getByRole("button", { name: "Enter sends message" });
+    expect(toggleBtn).toHaveAttribute("aria-pressed", "true");
+    expect(toggleBtn).toHaveAttribute("aria-label");
+  });
+
+  it("clicking toggle flips aria-pressed", async () => {
+    const { user } = await openPanel();
+    const toggleBtn = screen.getByRole("button", { name: "Enter sends message" });
+    await user.click(toggleBtn);
+    // After toggle, Enter inserts newline — label and pressed state change
+    expect(screen.getByRole("button", { name: "Enter inserts newline" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("clicking toggle writes copilot:enter-to-send to localStorage", async () => {
+    const { user } = await openPanel();
+    const toggleBtn = screen.getByRole("button", { name: "Enter sends message" });
+    await user.click(toggleBtn);
+    expect(localStorage.getItem("copilot:enter-to-send")).toBe("false");
+  });
+
+  it("clicking toggle twice restores original state and updates localStorage", async () => {
+    const { user } = await openPanel();
+    const btn1 = screen.getByRole("button", { name: "Enter sends message" });
+    await user.click(btn1);
+    const btn2 = screen.getByRole("button", { name: "Enter inserts newline" });
+    await user.click(btn2);
+    expect(screen.getByRole("button", { name: "Enter sends message" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(localStorage.getItem("copilot:enter-to-send")).toBe("true");
+  });
+
+  it("mounting with localStorage=false starts in alt mode (aria-pressed=false)", async () => {
+    localStorage.setItem("copilot:enter-to-send", "false");
+    await openPanel();
+    expect(
+      screen.getByRole("button", { name: "Enter inserts newline" }),
+    ).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("mounting with localStorage=true starts in default mode (aria-pressed=true)", async () => {
+    localStorage.setItem("copilot:enter-to-send", "true");
+    await openPanel();
+    expect(
+      screen.getByRole("button", { name: "Enter sends message" }),
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+
+  // ---- Toggle via click then Enter behavior --------------------------------
+
+  it("after clicking toggle to alt mode, Enter does NOT send", async () => {
+    const { user, textarea, sendMessage } = await openPanel();
+    const toggleBtn = screen.getByRole("button", { name: "Enter sends message" });
+    await user.click(toggleBtn);
+    await user.type(textarea, "no send");
+    sendMessage.mockClear();
+    await user.keyboard("{Enter}");
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  // ---- IME composition guard -----------------------------------------------
+
+  it("IME: Enter with isComposing=true does NOT send in default mode", async () => {
+    const { textarea, sendMessage } = await openPanel();
+    await userEvent.type(textarea, "kanji");
+    sendMessage.mockClear();
+    // userEvent can't set isComposing; use fireEvent directly
+    fireEvent.keyDown(textarea, { key: "Enter", isComposing: true });
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  // ---- Hint text -----------------------------------------------------------
+
+  it("default mode shows 'Enter to send' hint text", async () => {
+    await openPanel();
+    expect(screen.getByText(/Enter to send/)).toBeInTheDocument();
+  });
+
+  it("alt mode shows 'Cmd+Enter to send' hint text", async () => {
+    localStorage.setItem("copilot:enter-to-send", "false");
+    await openPanel();
+    expect(screen.getByText(/Cmd\+Enter to send/)).toBeInTheDocument();
   });
 });

--- a/frontend/components/workbench/CopilotStrip.tsx
+++ b/frontend/components/workbench/CopilotStrip.tsx
@@ -331,7 +331,7 @@ export function CopilotStrip({ onOpenHistory }: CopilotStripProps = {}) {
   // Hint text depends on current mode; "responding" takes precedence
   let inputHint = enterToSend
     ? "Enter to send · Shift+Enter for newline"
-    : "Shift+Enter / Enter for newline · Cmd+Enter to send";
+    : "Shift+Enter / Enter for newline · Ctrl/Cmd+Enter to send";
   if (isSending) inputHint = "Copilot is responding…";
 
   return (
@@ -429,7 +429,10 @@ export function CopilotStrip({ onOpenHistory }: CopilotStripProps = {}) {
             />
 
             <div className="flex items-center justify-between gap-2">
-              <span className="text-[11px] text-muted-foreground">
+              {/* suppressHydrationWarning: initial value is read from localStorage
+                  on the client, so it intentionally differs from the server's
+                  default render for users who switched to alt mode. */}
+              <span className="text-[11px] text-muted-foreground" suppressHydrationWarning>
                 {inputHint}
               </span>
               <div className="flex shrink-0 items-center gap-1.5">
@@ -440,6 +443,7 @@ export function CopilotStrip({ onOpenHistory }: CopilotStripProps = {}) {
                   aria-label={enterToSend ? "Enter sends message" : "Enter inserts newline"}
                   title={enterToSend ? "Enter sends message (click to switch)" : "Enter inserts newline (click to switch)"}
                   className="flex h-7 w-7 items-center justify-center rounded-lg border border-border bg-card-muted text-muted-foreground hover:bg-sidebar-accent aria-pressed:text-primary"
+                  suppressHydrationWarning
                 >
                   <CornerDownLeft size={12} />
                 </button>

--- a/frontend/components/workbench/CopilotStrip.tsx
+++ b/frontend/components/workbench/CopilotStrip.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useState, useEffect, useCallback } from "react";
-import { Send, ChevronUp, ChevronDown, Bot, User, AlertCircle, Settings, Star, Trash2 } from "lucide-react";
+import { Send, ChevronUp, ChevronDown, Bot, User, AlertCircle, Settings, Star, Trash2, CornerDownLeft } from "lucide-react";
 import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
 import { useCopilot } from "@/hooks/useCopilot";
 import type { CopilotMessageRead } from "@/hooks/useCopilot";
@@ -201,6 +201,45 @@ function CopilotProposalBanner({
 }
 
 // ---------------------------------------------------------------------------
+// useEnterToSend — persists the "Enter sends" vs "Enter = newline" preference
+// ---------------------------------------------------------------------------
+
+const ENTER_TO_SEND_KEY = "copilot:enter-to-send";
+
+function readEnterToSend(): boolean {
+  if (typeof window === "undefined") return true;
+  try {
+    const stored = localStorage.getItem(ENTER_TO_SEND_KEY);
+    if (stored !== null) return stored === "true";
+  } catch {
+    // localStorage unavailable (SSR, private mode, etc.)
+  }
+  return true;
+}
+
+function useEnterToSend() {
+  // Lazy initializer: reads localStorage once on mount. SSR-safe because the
+  // guard is inside readEnterToSend(). No useEffect needed → no set-state-in-effect lint.
+  const [enterToSend, setEnterToSend] = useState<boolean>(readEnterToSend);
+
+  const toggle = useCallback(() => {
+    setEnterToSend((prev) => {
+      const next = !prev;
+      try {
+        if (typeof window !== "undefined") {
+          localStorage.setItem(ENTER_TO_SEND_KEY, String(next));
+        }
+      } catch {
+        // ignore
+      }
+      return next;
+    });
+  }, []);
+
+  return { enterToSend, toggle };
+}
+
+// ---------------------------------------------------------------------------
 // CopilotStrip
 // ---------------------------------------------------------------------------
 
@@ -223,6 +262,8 @@ export function CopilotStrip({ onOpenHistory }: CopilotStripProps = {}) {
     sendMessage,
     clearError,
   } = useCopilot(aeroplaneId);
+
+  const { enterToSend, toggle: toggleEnterToSend } = useEnterToSend();
 
   const { proposal } = useCopilotProposal(aeroplaneId);
 
@@ -247,12 +288,19 @@ export function CopilotStrip({ onOpenHistory }: CopilotStripProps = {}) {
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+      if (e.key !== "Enter") return;
+      // Never interfere with IME composition (CJK, etc.)
+      if (e.nativeEvent.isComposing) return;
+      // Shift+Enter always inserts newline — let browser handle it
+      if (e.shiftKey) return;
+      // Cmd/Ctrl+Enter sends in both modes; plain Enter sends only in default mode
+      if (e.metaKey || e.ctrlKey || enterToSend) {
         e.preventDefault();
         void handleSend();
       }
+      // Alt mode: plain Enter falls through to browser default (newline)
     },
-    [handleSend],
+    [handleSend, enterToSend],
   );
 
   const handleProposalAdopt = useCallback(async () => {
@@ -279,6 +327,12 @@ export function CopilotStrip({ onOpenHistory }: CopilotStripProps = {}) {
   const messages = history?.messages ?? [];
   const hasContent =
     messages.length > 0 || streamingText.length > 0 || !!activeToolLabel;
+
+  // Hint text depends on current mode; "responding" takes precedence
+  let inputHint = enterToSend
+    ? "Enter to send · Shift+Enter for newline"
+    : "Shift+Enter / Enter for newline · Cmd+Enter to send";
+  if (isSending) inputHint = "Copilot is responding…";
 
   return (
     <footer className="shrink-0 border-t border-border bg-sidebar">
@@ -374,20 +428,32 @@ export function CopilotStrip({ onOpenHistory }: CopilotStripProps = {}) {
               aria-label="Copilot input"
             />
 
-            <div className="flex items-center justify-between">
+            <div className="flex items-center justify-between gap-2">
               <span className="text-[11px] text-muted-foreground">
-                {isSending ? "Copilot is responding…" : "Cmd+Enter to send"}
+                {inputHint}
               </span>
-              <button
-                type="button"
-                onClick={() => { void handleSend(); }}
-                disabled={noAeroplane || isSending || !inputText.trim()}
-                aria-label="Send message"
-                className="flex items-center gap-1.5 rounded-lg border border-border bg-card-muted px-3 py-1.5 text-[12px] text-foreground hover:bg-sidebar-accent disabled:opacity-40"
-              >
-                <Send size={12} />
-                Send
-              </button>
+              <div className="flex shrink-0 items-center gap-1.5">
+                <button
+                  type="button"
+                  onClick={toggleEnterToSend}
+                  aria-pressed={enterToSend}
+                  aria-label={enterToSend ? "Enter sends message" : "Enter inserts newline"}
+                  title={enterToSend ? "Enter sends message (click to switch)" : "Enter inserts newline (click to switch)"}
+                  className="flex h-7 w-7 items-center justify-center rounded-lg border border-border bg-card-muted text-muted-foreground hover:bg-sidebar-accent aria-pressed:text-primary"
+                >
+                  <CornerDownLeft size={12} />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { void handleSend(); }}
+                  disabled={noAeroplane || isSending || !inputText.trim()}
+                  aria-label="Send message"
+                  className="flex items-center gap-1.5 rounded-lg border border-border bg-card-muted px-3 py-1.5 text-[12px] text-foreground hover:bg-sidebar-accent disabled:opacity-40"
+                >
+                  <Send size={12} />
+                  Send
+                </button>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Closes #952

## What
The copilot chat input gets a persisted footer toggle for Enter behavior:
- **Default** (`enterToSend = true`): Enter sends · Shift+Enter newline · Cmd/Ctrl+Enter sends
- **Alternative**: Enter newline · Shift+Enter newline · Cmd/Ctrl+Enter sends

Send button always sends. IME composition (`isComposing`) never sends. Choice persisted in `localStorage` (`copilot:enter-to-send`, default `true`).

## How
- `useEnterToSend()` hook: lazy localStorage initializer (SSR-safe, no effect) + `toggle()` that persists.
- `handleKeyDown`: early-return non-Enter → IME guard → Shift=newline → (Cmd/Ctrl || enterToSend)=send → else newline.
- Footer toggle button: `aria-pressed`, `aria-label`, lucide `CornerDownLeft`, active = primary color. Mode-aware hint text.

## Tests
17 new vitest cases (both modes, toggle + persistence, a11y, IME). Full suite **1884 passed**. `tsc` no new errors, lint clean, no new dependency-cruiser violations. New-code coverage on CopilotStrip.tsx ~81% lines / 87% branches.

## Out of scope
Global keyboard settings, server-side persistence, other shortcuts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)