### PR TITLE
fix(gh-951): persist rib dihedral so it round-trips (incl. terminal rib)

### DIFF
--- a/alembic/versions/a1c9f3e7b210_gh951_add_dihedral_to_wing_xsecs.py
+++ b/alembic/versions/a1c9f3e7b210_gh951_add_dihedral_to_wing_xsecs.py
@@ -1,0 +1,35 @@
+"""gh-951: add explicit dihedral column to wing_xsecs
+
+Revision ID: a1c9f3e7b210
+Revises: 6eca6229ba65
+Create Date: 2026-06-10 09:00:00.000000
+
+Persists each rib's local-x rotation (dihedral, degrees) explicitly,
+mirroring how ``twist`` is already stored. The terminal rib's rotation
+is NOT encoded in the ASB ``xyz_le`` geometry (it moves no outboard
+station), so without an explicit column it cannot be reconstructed on
+read and is silently lost on the WingConfig round-trip (gh-951).
+
+Nullable: existing rows predate the column and keep the geometry-derived
+dihedral on read until they are next written.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'a1c9f3e7b210'
+down_revision: Union[str, None] = '6eca6229ba65'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('wing_xsecs', sa.Column('dihedral', sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('wing_xsecs', 'dihedral')

--- a/app/converters/model_schema_converters.py
+++ b/app/converters/model_schema_converters.py
@@ -632,6 +632,16 @@ def _hydrate_segment_from_xsec(
     segment.root_airfoil.airfoil = str(root_x_sec.airfoil)
     segment.tip_airfoil.airfoil = str(tip_x_sec.airfoil)
 
+    # Prefer the explicitly persisted dihedral over the value
+    # WingConfiguration.from_asb reconstructs from xyz_le geometry. The
+    # stored value is exact and also recovers the terminal rib's rotation,
+    # which leaves no trace in the geometry (gh-951). Legacy rows have
+    # dihedral=None and keep the geometry-derived reconstruction.
+    if root_x_sec.dihedral is not None:
+        segment.root_airfoil.dihedral_as_rotation_in_degrees = float(root_x_sec.dihedral)
+    if tip_x_sec.dihedral is not None:
+        segment.tip_airfoil.dihedral_as_rotation_in_degrees = float(tip_x_sec.dihedral)
+
     if root_x_sec.x_sec_type is not None:
         segment.wing_segment_type = root_x_sec.x_sec_type
     if root_x_sec.tip_type is not None:
@@ -953,6 +963,26 @@ def _build_segment_details(segment):
     )
 
 
+def _station_dihedral(wing_config: WingConfiguration, index: int) -> Optional[float]:
+    """Return the dihedral (deg) of the airfoil at cross-section ``index``.
+
+    An ASB wing has N+1 cross-sections for N segments. Station ``i`` is the
+    *root* airfoil of segment ``i`` for ``i < N`` and the *tip* airfoil of
+    the last segment for ``i == N`` (the terminal rib). The value is the
+    airfoil's own local-x rotation, persisted so it round-trips even when it
+    leaves no trace in the xyz_le geometry (gh-951).
+    """
+    segments = wing_config.segments or []
+    if not segments:
+        return None
+    if index < len(segments):
+        airfoil = segments[index].root_airfoil
+    else:
+        airfoil = segments[-1].tip_airfoil
+    value = getattr(airfoil, "dihedral_as_rotation_in_degrees", None)
+    return None if value is None else float(value)
+
+
 def wing_config_to_asb_wing_schema(
     wing_config: WingConfiguration,
     wing_name: str,
@@ -991,11 +1021,18 @@ def wing_config_to_asb_wing_schema(
                 turbulator,
             ) = _build_segment_details(segment)
 
+        # Persist the rib's own local-x rotation (dihedral) explicitly so it
+        # survives the round-trip even for the terminal rib, whose rotation
+        # is not encoded in xyz_le (gh-951). Station i's airfoil is the root
+        # of segment i for i < N, and the tip of the last segment for i == N.
+        dihedral = _station_dihedral(wing_config, index)
+
         x_secs.append(
             schemas.WingXSecSchema(
                 xyz_le=[float(value) for value in x_sec.xyz_le],
                 chord=float(x_sec.chord),
                 twist=float(x_sec.twist),
+                dihedral=dihedral,
                 airfoil=_normalize_airfoil_reference_for_schema(section_airfoil_ref),
                 control_surface=control_surface,
                 x_sec_type=x_sec_type,

--- a/app/models/aeroplanemodel.py
+++ b/app/models/aeroplanemodel.py
@@ -216,6 +216,13 @@ class WingXSecModel(Base):
     xyz_le = Column(JSON, nullable=False)  # Store as JSON array
     chord = Column(Float, nullable=False)
     twist = Column(Float, nullable=False)
+    # Local-x rotation (dihedral) of this rib, in degrees. Persisted
+    # explicitly — like ``twist`` — because the terminal rib's rotation is
+    # NOT encoded in the ASB ``xyz_le`` geometry (it moves no outboard
+    # station), so it cannot be reconstructed from positions (gh-951).
+    # Nullable: legacy rows predate the column and fall back to the
+    # geometry-derived dihedral on read.
+    dihedral = Column(Float, nullable=True, default=None)
     airfoil = Column(String, nullable=False)  # Store path or URL as string
 
     # Relationship with Wing

--- a/app/schemas/aeroplaneschema.py
+++ b/app/schemas/aeroplaneschema.py
@@ -535,6 +535,16 @@ class WingXSecSchema(BaseModel):
         description="Twist angle of the cross-section in degrees",
         examples=[5, 2, 0],
     )
+    dihedral: Optional[float] = Field(
+        None,
+        description=(
+            "Local-x rotation (dihedral) of this rib in degrees, persisted "
+            "explicitly so the terminal rib's rotation survives the round-trip "
+            "(it is not encoded in xyz_le). None for legacy rows, which fall "
+            "back to the geometry-derived dihedral (gh-951)."
+        ),
+        examples=[0, 3, -3],
+    )
     airfoil: str | HttpUrl = Field(
         ...,
         description="Airfoil dat file location of the cross-section (file or URL)",

--- a/app/tests/test_gh951_dihedral_persistence.py
+++ b/app/tests/test_gh951_dihedral_persistence.py
@@ -1,0 +1,107 @@
+"""gh-951: a rib's dihedral (local-x rotation) must survive DB persistence.
+
+Twist has always been stored explicitly per cross-section, so incidence
+round-trips. Dihedral used to be reconstructed from the xyz_le geometry,
+which cannot encode the *terminal* rib's own rotation (it moves no
+outboard station) — so it was silently lost on save. It is now persisted
+explicitly in the ``wing_xsecs.dihedral`` column. These tests exercise the
+full ``put_wing_as_wingconfig`` -> ``get_wing_as_wingconfig`` path against a
+real (in-memory) DB.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("aerosandbox")
+pytest.importorskip("cadquery")
+
+from app.schemas.wing import Airfoil, Segment, Wing  # noqa: E402
+from app.services.aeroplane_service import create_aeroplane  # noqa: E402
+from app.services.wing_service import (  # noqa: E402
+    get_wing_as_wingconfig,
+    put_wing_as_wingconfig,
+)
+
+
+def _make_session(client_and_db):
+    _, SessionLocal = client_and_db
+    return SessionLocal()
+
+
+def _wing_with_dihedral(terminal_tip_dihedral: float) -> Wing:
+    """A 2-segment wing carrying a dihedral on the terminal (outermost) rib."""
+
+    def _af(dihedral: float, incidence: float = 0.0) -> Airfoil:
+        return Airfoil(
+            airfoil="naca0015",
+            chord=200,
+            dihedral_as_rotation_in_degrees=dihedral,
+            incidence=incidence,
+        )
+
+    return Wing(
+        nose_pnt=[0, 0, 0],
+        symmetric=True,
+        segments=[
+            Segment(root_airfoil=_af(0), tip_airfoil=_af(5, incidence=1), length=300, sweep=0),
+            Segment(
+                root_airfoil=_af(5, incidence=1),
+                tip_airfoil=_af(terminal_tip_dihedral, incidence=2),
+                length=200,
+                sweep=10,
+            ),
+        ],
+    )
+
+
+def _put_get(db, uuid: str, wing: Wing) -> dict:
+    put_wing_as_wingconfig(db, uuid, "main_wing", wing, scale=0.001)
+    db.commit()
+    db.expire_all()
+    return get_wing_as_wingconfig(db, uuid, "main_wing")
+
+
+def test_terminal_rib_dihedral_persists(client_and_db):
+    """A 30 deg rotation on the outermost rib survives save + reload (gh-951)."""
+    db = _make_session(client_and_db)
+    plane = create_aeroplane(db, "gh951-plane")
+    db.commit()
+    db.refresh(plane)
+
+    out = _put_get(db, str(plane.uuid), _wing_with_dihedral(30.0))
+
+    terminal = out["segments"][-1]["tip_airfoil"]["dihedral_as_rotation_in_degrees"]
+    assert terminal == pytest.approx(30.0, abs=0.1)
+
+
+def test_inboard_dihedral_and_incidence_still_persist(client_and_db):
+    """The fix must not disturb inboard dihedral or any incidence."""
+    db = _make_session(client_and_db)
+    plane = create_aeroplane(db, "gh951-plane-2")
+    db.commit()
+    db.refresh(plane)
+
+    out = _put_get(db, str(plane.uuid), _wing_with_dihedral(30.0))
+
+    tip_dihedrals = [s["tip_airfoil"]["dihedral_as_rotation_in_degrees"] for s in out["segments"]]
+    tip_incidences = [s["tip_airfoil"]["incidence"] for s in out["segments"]]
+    assert tip_dihedrals[0] == pytest.approx(5.0, abs=0.1)
+    assert tip_dihedrals[1] == pytest.approx(30.0, abs=0.1)
+    assert tip_incidences == pytest.approx([1.0, 2.0], abs=0.05)
+
+
+def test_round_trip_is_idempotent(client_and_db):
+    """put(get(put(x))) leaves the dihedral unchanged — no drift on re-save."""
+    db = _make_session(client_and_db)
+    plane = create_aeroplane(db, "gh951-plane-3")
+    db.commit()
+    db.refresh(plane)
+    uuid = str(plane.uuid)
+
+    out1 = _put_get(db, uuid, _wing_with_dihedral(30.0))
+    out2 = _put_get(db, uuid, Wing.model_validate(out1))
+
+    d1 = [s["tip_airfoil"]["dihedral_as_rotation_in_degrees"] for s in out1["segments"]]
+    d2 = [s["tip_airfoil"]["dihedral_as_rotation_in_degrees"] for s in out2["segments"]]
+    assert d1 == pytest.approx(d2, abs=1e-6)

--- a/app/tests/test_wingconfig_roundtrip.py
+++ b/app/tests/test_wingconfig_roundtrip.py
@@ -86,10 +86,12 @@ def _assert_airfoil_match(
 ):
     """Assert that airfoil parameters survive the roundtrip within tolerance.
 
-    Terminal tip dihedral is inherently lossy: the ASB model stores only
-    xyz_le positions, and the last cross-section has no successor segment
-    to derive a dihedral direction from. WingConfiguration.from_asb sets
-    cum_d[n-1] = cum_d[n-2], making the terminal delta always 0.
+    The terminal tip dihedral used to be lossy (the ASB model stores only
+    xyz_le positions and the last cross-section has no outboard station to
+    derive a direction from). It is now persisted explicitly per rib — like
+    twist — so it round-trips exactly, including the terminal rib's own
+    local-x rotation (gh-951). The ``is_terminal_tip`` flag is kept for
+    signature compatibility but no longer relaxes any assertion.
     """
     assert roundtripped.incidence == pytest.approx(original.incidence, abs=tol_angle), (
         f"{label}: incidence {roundtripped.incidence} != {original.incidence}"
@@ -99,12 +101,11 @@ def _assert_airfoil_match(
         f"{label}: chord {roundtripped.chord} != {original.chord}"
     )
 
-    if not is_terminal_tip:
-        assert roundtripped.dihedral_as_rotation_in_degrees == pytest.approx(
-            original.dihedral_as_rotation_in_degrees, abs=0.1
-        ), (
-            f"{label}: dihedral {roundtripped.dihedral_as_rotation_in_degrees} != {original.dihedral_as_rotation_in_degrees}"
-        )
+    assert roundtripped.dihedral_as_rotation_in_degrees == pytest.approx(
+        original.dihedral_as_rotation_in_degrees, abs=0.1
+    ), (
+        f"{label}: dihedral {roundtripped.dihedral_as_rotation_in_degrees} != {original.dihedral_as_rotation_in_degrees}"
+    )
 
 
 def _assert_segment_match(orig_seg, rt_seg, seg_idx, *, total_segments=None):
@@ -289,6 +290,26 @@ class TestDihedralRoundtrip:
         wc, wc2 = _roundtrip(wing)
         for i in range(2):
             _assert_segment_match(wc.segments[i], wc2.segments[i], i, total_segments=2)
+
+    def test_terminal_tip_dihedral_roundtrips(self):
+        """The outermost rib's own local-x rotation (dihedral) must survive
+        the round-trip (gh-951).
+
+        In cad_designer a station's dihedral rotates the airfoil about its
+        local x-axis; for the terminal rib this is a real, meaningful
+        rotation (e.g. a rotated wing-cap mounted on the last rib) even
+        though it moves no outboard station and therefore is NOT encoded in
+        the ASB xyz_le geometry. It is persisted explicitly (like twist),
+        so it must come back unchanged.
+        """
+        wing = _wing(
+            _seg(root_dihedral=0, tip_dihedral=0, length=100),
+            _seg(root_dihedral=0, tip_dihedral=30, length=100),
+        )
+        _, wc2 = _roundtrip(wing)
+        assert wc2.segments[-1].tip_airfoil.dihedral_as_rotation_in_degrees == pytest.approx(
+            30.0, abs=0.1
+        )
 
 
 # ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Closes #951

## Problem
A cross-section's **twist** is stored explicitly in `wing_xsecs`, but its **dihedral** was not — it was reconstructed from the `xyz_le` geometry on read. That reconstruction (`atan2(Δz, Δy)`) cannot recover the **terminal** rib's own local-x rotation: the outermost station moves no outboard station, so its rotation leaves no trace in the geometry. Setting a dihedral on the last rib (e.g. a rotated wing-cap mounted on the tip rib) was silently dropped to `0` on save → reload.

Geometry and incidence already round-tripped correctly; only the terminal rib's dihedral was lost.

## Fix — give dihedral the same first-class persistence as twist
- **`wing_xsecs.dihedral`** nullable column (+ Alembic migration `a1c9f3e7b210`). Legacy `NULL` rows keep the geometry-derived reconstruction, so existing aircraft are unchanged until next write.
- **`WingXSecSchema.dihedral`** carries it through the converter pair.
- **`wing_config_to_asb_wing_schema`** writes each station's airfoil dihedral explicitly (root of segment `i` for `i<N`, tip of the last segment for `i==N`).
- **`_hydrate_segment_from_xsec`** prefers the stored value over `from_asb`'s geometry reconstruction on read.

cad_designer topology is untouched (read-only) — the fix lives entirely in the app converter/model/schema layer.

## Tests
- Strengthened `test_wingconfig_roundtrip.py`: dropped the obsolete `is_terminal_tip` dihedral exemption that had encoded the bug as "inherently lossy".
- New `test_gh951_dihedral_persistence.py`: DB `put`/`get` persistence for the terminal rib, inboard dihedral + incidence preserved, and round-trip idempotency.
- Verified the migration on a copy of the real dev DB (terminal `30° → 30°`).
- Fast tier: 4422 passed. (One unrelated flaky asb-VLM test — `test_vlm_strip_forces::test_result_has_avl_compatible_shape` — fails only under full-suite memory load; green in isolation, imports nothing in this diff.)