### PR TITLE
fix(gh-956): surface design warning instead of silently defaulting Oswald e to 0.8

### DIFF
--- a/app/api/v2/endpoints/aeroplane/matching_chart.py
+++ b/app/api/v2/endpoints/aeroplane/matching_chart.py
@@ -94,12 +94,15 @@ def _resolve_aircraft_params(
         "mass_kg": mass_kg,
         "t_static_N": t_static_n,
         "cd0": cd0,
-        "e_oswald": e_oswald if e_oswald else 0.8,
         "ar": ar if ar else 7.0,
         "cl_max_clean": cl_max,
         "cl_max_takeoff": cl_max,  # clean CL_max for TO (conservative)
         "cl_max_landing": cl_max * 1.3,  # rough flaps factor for landing
     }
+    # gh-956: pass e_oswald only when a real computed value is available.
+    # When absent, the service will emit a design warning and fall back to 0.8.
+    if e_oswald is not None and e_oswald > 0:
+        aircraft["e_oswald"] = e_oswald
     if s_ref_m2 is not None and s_ref_m2 > 0:
         aircraft["s_ref_m2"] = s_ref_m2
     if b_ref_m is not None:

--- a/app/api/v2/endpoints/aeroplane/matching_chart.py
+++ b/app/api/v2/endpoints/aeroplane/matching_chart.py
@@ -101,8 +101,8 @@ def _resolve_aircraft_params(
     }
     # gh-956: pass e_oswald only when a real computed value is available.
     # When absent, the service will emit a design warning and fall back to 0.8.
-    if e_oswald is not None and e_oswald > 0:
-        aircraft["e_oswald"] = e_oswald
+    if e_oswald is not None and float(e_oswald) > 0:
+        aircraft["e_oswald"] = float(e_oswald)
     if s_ref_m2 is not None and s_ref_m2 > 0:
         aircraft["s_ref_m2"] = s_ref_m2
     if b_ref_m is not None:

--- a/app/services/matching_chart_service.py
+++ b/app/services/matching_chart_service.py
@@ -760,11 +760,15 @@ def compute_chart(
     defaults = _mode_defaults(mode)
 
     # --- gh-956: Resolve Oswald factor ONCE (before any branch that reads e) -
-    # When no computed e_oswald is available, surface a design warning instead
-    # of silently defaulting (gh-924 single-source-of-truth policy).
+    # Treat a missing OR non-physical (<= 0) value as "not computed": fall back
+    # to the default AND surface a design warning instead of silently defaulting
+    # (gh-924 single-source-of-truth policy). Guarding <= 0 here — not just at the
+    # endpoint — keeps compute_chart robust for any direct caller (k = 1/(pi*AR*e)
+    # would otherwise blow up to inf/nan when e == 0).
+    e: float
     _e_provided = aircraft.get("e_oswald", aircraft.get("e"))
-    if _e_provided is None:
-        e: float = DEFAULT_E_OSWALD
+    if _e_provided is None or float(_e_provided) <= 0:
+        e = DEFAULT_E_OSWALD
         warnings.append(
             "Oswald factor e not computed — using default 0.8. "
             "Run assumption recompute for an accurate induced-drag estimate."

--- a/app/services/matching_chart_service.py
+++ b/app/services/matching_chart_service.py
@@ -72,6 +72,10 @@ _WS_MIN: float = 10.0  # N/m² — lower bound for W/S sweep
 _WS_MAX: float = 1500.0  # N/m² — upper bound
 _WS_STEPS: int = 200  # number of points in W/S sweep
 
+# gh-956: default Oswald factor used when no computed value is available.
+# Consumers should surface a design warning rather than silently using this.
+DEFAULT_E_OSWALD: float = 0.8
+
 # ---------------------------------------------------------------------------
 # Constraint colors (Tailwind-compatible hex — matches frontend dark theme)
 # ---------------------------------------------------------------------------
@@ -755,6 +759,19 @@ def compute_chart(
     warnings: list[str] = []
     defaults = _mode_defaults(mode)
 
+    # --- gh-956: Resolve Oswald factor ONCE (before any branch that reads e) -
+    # When no computed e_oswald is available, surface a design warning instead
+    # of silently defaulting (gh-924 single-source-of-truth policy).
+    _e_provided = aircraft.get("e_oswald", aircraft.get("e"))
+    if _e_provided is None:
+        e: float = DEFAULT_E_OSWALD
+        warnings.append(
+            "Oswald factor e not computed — using default 0.8. "
+            "Run assumption recompute for an accurate induced-drag estimate."
+        )
+    else:
+        e = float(_e_provided)
+
     # --- Resolve parameters -------------------------------------------------
     s_rwy: float = s_runway if s_runway is not None else defaults["s_runway"]
     v_s: float = v_s_target if v_s_target is not None else defaults["v_s_target"]
@@ -768,12 +785,11 @@ def compute_chart(
     elif "v_md_mps" in aircraft and aircraft["v_md_mps"]:
         v_cruise = float(aircraft["v_md_mps"])
     else:
-        # Estimate cruise as V_md from polar parameters
-        cd0 = float(aircraft.get("cd0", 0.03))
-        e = float(aircraft.get("e_oswald", 0.8))
-        ar = float(aircraft.get("ar", 7.0))
+        # Estimate cruise as V_md from polar parameters; reuse the already-resolved e
+        cd0_for_est = float(aircraft.get("cd0", 0.03))
+        ar_for_est = float(aircraft.get("ar", aircraft.get("aspect_ratio", 7.0)))
         # V_md at an approximate midpoint W/S = 500 N/m²
-        v_cruise = _v_md(500.0, cd0=cd0, e=e, ar=ar, rho=rho)
+        v_cruise = _v_md(500.0, cd0=cd0_for_est, e=e, ar=ar_for_est, rho=rho)
         warnings.append(
             f"v_cruise_mps not specified — estimated from polar as {v_cruise:.1f} m/s. "
             "Set v_cruise_mps in aircraft dict for accurate cruise constraint."
@@ -781,7 +797,7 @@ def compute_chart(
 
     # --- Extract polar parameters -------------------------------------------
     cd0: float = float(aircraft.get("cd0", 0.03))
-    e: float = float(aircraft.get("e_oswald", aircraft.get("e", 0.8)))
+    # e is already resolved above (with design warning if absent)
     ar: float = float(aircraft.get("ar", aircraft.get("aspect_ratio", 7.0)))
 
     cl_max_clean: float = float(aircraft.get("cl_max_clean", aircraft.get("cl_max", 1.4)))

--- a/app/tests/test_matching_chart.py
+++ b/app/tests/test_matching_chart.py
@@ -1561,10 +1561,41 @@ class TestOswaldEWarning:
             # No v_cruise_mps either — triggers v_cruise estimation branch too
         }
         chart = compute_chart(aircraft_no_e, mode="uav_runway")
+        # Match the exact Oswald-fallback phrasing; the v_cruise-estimate warning
+        # also fires here but formats a velocity, never "using default 0.8".
         oswald_warnings = [
             w for w in chart["warnings"]
-            if "oswald" in w.lower() or "0.8" in w
+            if "using default 0.8" in w
         ]
         assert len(oswald_warnings) <= 1, (
             f"Oswald warning must appear at most once; got: {oswald_warnings}"
         )
+
+    def test_nonphysical_e_oswald_emits_warning_and_defaults(self):
+        """A direct caller passing e_oswald <= 0 (uncomputed sentinel) must get
+        the design warning + 0.8 fallback, not a blown-up e=0 model."""
+        compute_chart = _service()
+        base = {
+            "mass_kg": 1088.0,
+            "t_static_N": 1900.0,
+            "s_ref_m2": 16.17,
+            "ar": 7.32,
+            "cd0": 0.031,
+            "cl_max_clean": 1.6,
+            "cl_max_takeoff": 1.6,
+            "cl_max_landing": 2.1,
+            "v_cruise_mps": 55.0,
+        }
+        chart_08 = compute_chart({**base, "e_oswald": 0.8}, mode="uav_runway")
+        for bad_e in (0.0, -0.3):
+            chart = compute_chart({**base, "e_oswald": bad_e}, mode="uav_runway")
+            oswald_warnings = [w for w in chart["warnings"] if "using default 0.8" in w]
+            assert len(oswald_warnings) == 1, (
+                f"e_oswald={bad_e} must trigger the Oswald fallback warning; "
+                f"got: {chart['warnings']}"
+            )
+            # e<=0 must be treated exactly like the 0.8 default: identical
+            # e-dependent constraint curves and design point (no inf/nan from
+            # k = 1/(pi*AR*e) blowing up at e == 0).
+            assert chart["constraints"] == chart_08["constraints"]
+            assert chart["design_point"] == chart_08["design_point"]

--- a/app/tests/test_matching_chart.py
+++ b/app/tests/test_matching_chart.py
@@ -1446,3 +1446,125 @@ class TestPhaseBBackwardCompatibility:
         assert len(chart_acro["constraints"]) > len(chart_no), (
             "Profile-aware chart should add RC-additive constraints"
         )
+
+
+# ===========================================================================
+# gh-956: Oswald-factor design warning instead of silent 0.8 default
+# ===========================================================================
+
+
+class TestOswaldEWarning:
+    """compute_chart must warn (not silently default) when e_oswald is absent.
+
+    Policy (gh-924 + design-error-feedback): when the polar core has not
+    computed e_oswald the service appends a design warning and still
+    computes with the 0.8 fallback, but the warning surfaces to the caller.
+    """
+
+    # --- Test A: missing e_oswald → warning emitted, chart still computes ---
+
+    def test_missing_e_oswald_emits_design_warning(self):
+        """aircraft dict with NO e_oswald/e key → Oswald warning in result['warnings']."""
+        compute_chart = _service()
+        aircraft_no_e = {
+            "mass_kg": 1088.0,
+            "t_static_N": 1900.0,
+            "s_ref_m2": 16.17,
+            "ar": 7.32,
+            "cd0": 0.031,
+            "cl_max_clean": 1.6,
+            "cl_max_takeoff": 1.6,
+            "cl_max_landing": 2.1,
+            "v_cruise_mps": 55.0,
+            # deliberately NO e_oswald, NO e
+        }
+        chart = compute_chart(aircraft_no_e, mode="uav_runway")
+        # Chart must still complete
+        assert "constraints" in chart
+        assert chart["feasibility"] in {"feasible", "infeasible_below_constraints"}
+        # The design warning must be present
+        oswald_warnings = [
+            w for w in chart["warnings"]
+            if "oswald" in w.lower() or "0.8" in w or "e not" in w.lower()
+        ]
+        assert len(oswald_warnings) >= 1, (
+            f"Expected an Oswald design warning when e_oswald is absent; "
+            f"got warnings: {chart['warnings']}"
+        )
+
+    def test_missing_e_oswald_uses_0_8_fallback(self):
+        """Aircraft without e_oswald should compute identically to e_oswald=0.8."""
+        compute_chart = _service()
+        aircraft_no_e = {
+            "mass_kg": 1088.0,
+            "t_static_N": 1900.0,
+            "s_ref_m2": 16.17,
+            "ar": 7.32,
+            "cd0": 0.031,
+            "cl_max_clean": 1.6,
+            "cl_max_takeoff": 1.6,
+            "cl_max_landing": 2.1,
+            "v_cruise_mps": 55.0,
+        }
+        aircraft_explicit_08 = {**aircraft_no_e, "e_oswald": 0.8}
+        chart_no_e = compute_chart(aircraft_no_e, mode="uav_runway")
+        chart_08 = compute_chart(aircraft_explicit_08, mode="uav_runway")
+        # Design points must be identical (same e used)
+        assert chart_no_e["design_point"]["ws_n_m2"] == pytest.approx(
+            chart_08["design_point"]["ws_n_m2"], abs=1.0
+        )
+        assert chart_no_e["design_point"]["t_w"] == pytest.approx(
+            chart_08["design_point"]["t_w"], rel=1e-6
+        )
+
+    # --- Test B: e_oswald provided → NO Oswald-fallback warning ---------------
+
+    def test_provided_e_oswald_no_warning(self):
+        """aircraft dict WITH e_oswald=0.7 must NOT emit an Oswald-fallback warning."""
+        compute_chart = _service()
+        aircraft_with_e = {
+            "mass_kg": 1088.0,
+            "t_static_N": 1900.0,
+            "s_ref_m2": 16.17,
+            "ar": 7.32,
+            "cd0": 0.031,
+            "e_oswald": 0.7,
+            "cl_max_clean": 1.6,
+            "cl_max_takeoff": 1.6,
+            "cl_max_landing": 2.1,
+            "v_cruise_mps": 55.0,
+        }
+        chart = compute_chart(aircraft_with_e, mode="uav_runway")
+        oswald_warnings = [
+            w for w in chart["warnings"]
+            if "oswald" in w.lower() or (
+                "0.8" in w and ("default" in w.lower() or "using" in w.lower())
+            )
+        ]
+        assert len(oswald_warnings) == 0, (
+            f"No Oswald warning expected when e_oswald=0.7 is provided; "
+            f"got: {oswald_warnings}"
+        )
+
+    def test_warning_emitted_at_most_once(self):
+        """The Oswald design warning must appear at most once (no duplicates)."""
+        compute_chart = _service()
+        aircraft_no_e = {
+            "mass_kg": 1088.0,
+            "t_static_N": 1900.0,
+            "s_ref_m2": 16.17,
+            "ar": 7.32,
+            "cd0": 0.031,
+            "cl_max_clean": 1.6,
+            "cl_max_takeoff": 1.6,
+            "cl_max_landing": 2.1,
+            # No v_cruise_mps either — triggers v_cruise estimation branch too
+        }
+        chart = compute_chart(aircraft_no_e, mode="uav_runway")
+        oswald_warnings = [
+            w for w in chart["warnings"]
+            if "oswald" in w.lower() or "0.8" in w
+        ]
+        assert len(oswald_warnings) <= 1, (
+            f"Oswald warning must appear at most once; got: {oswald_warnings}"
+        )

--- a/app/tests/test_matching_chart_endpoint.py
+++ b/app/tests/test_matching_chart_endpoint.py
@@ -381,3 +381,140 @@ class TestMatchingChartEndpointAdditional:
         with pytest.raises(HTTPException) as exc_info:
             _raise_http_from_domain(ServiceException("generic"))
         assert exc_info.value.status_code == 422
+
+
+# ===========================================================================
+# gh-956: _resolve_aircraft_params Oswald e passthrough
+# ===========================================================================
+
+
+class TestResolveAircraftParamsOswald:
+    """_resolve_aircraft_params must pass e_oswald through when present and omit
+    it when absent, so compute_chart's warning logic fires correctly.
+    """
+
+    def _make_plane_with_context(self, session, ctx: dict) -> "AeroplaneModel":
+        """Create aeroplane with a given assumption_computation_context."""
+        plane = make_aeroplane(session, name=f"oswald-test-{uuid.uuid4().hex[:6]}")
+        _seed_assumption(session, plane.id, "mass", 500.0)
+        _seed_assumption(session, plane.id, "cl_max", 1.4)
+        _seed_assumption(session, plane.id, "cd0", 0.032)
+        _seed_assumption(session, plane.id, "t_static_N", 800.0)
+        plane.assumption_computation_context = ctx
+        session.flush()
+        session.commit()
+        return plane
+
+    # --- Test C: no e_oswald in context → key absent in returned dict ---------
+
+    def test_no_e_oswald_in_context_key_absent_in_aircraft_dict(self, client_and_db):
+        """When assumption_computation_context has no e_oswald, the key must be
+        ABSENT from the aircraft dict returned by _resolve_aircraft_params — NOT
+        silently defaulted to 0.8.
+        """
+        from app.api.v2.endpoints.aeroplane.matching_chart import _resolve_aircraft_params
+
+        _client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            # Context without e_oswald
+            plane = self._make_plane_with_context(db, {
+                "s_ref_m2": 1.5,
+                "aspect_ratio": 7.0,
+                "v_md_mps": 20.0,
+                # deliberately no e_oswald
+            })
+            aircraft = _resolve_aircraft_params(db, plane, v_cruise_override=None)
+
+        assert "e_oswald" not in aircraft, (
+            f"e_oswald must be absent when context has no e_oswald; "
+            f"got aircraft['e_oswald'] = {aircraft.get('e_oswald')!r}"
+        )
+
+    def test_e_oswald_in_context_passed_through(self, client_and_db):
+        """When context has e_oswald=0.62, the returned dict must have e_oswald=0.62."""
+        from app.api.v2.endpoints.aeroplane.matching_chart import _resolve_aircraft_params
+
+        _client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = self._make_plane_with_context(db, {
+                "s_ref_m2": 1.5,
+                "aspect_ratio": 7.0,
+                "e_oswald": 0.62,
+                "v_md_mps": 20.0,
+            })
+            aircraft = _resolve_aircraft_params(db, plane, v_cruise_override=None)
+
+        assert "e_oswald" in aircraft, "e_oswald must be present when context provides it"
+        assert aircraft["e_oswald"] == pytest.approx(0.62, abs=1e-9)
+
+    def test_zero_or_negative_e_oswald_treated_as_absent(self, client_and_db):
+        """A zero or negative e_oswald in context is treated as uncomputed (key absent)."""
+        from app.api.v2.endpoints.aeroplane.matching_chart import _resolve_aircraft_params
+
+        _client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = self._make_plane_with_context(db, {
+                "s_ref_m2": 1.5,
+                "aspect_ratio": 7.0,
+                "e_oswald": 0.0,  # invalid / uncomputed
+                "v_md_mps": 20.0,
+            })
+            aircraft = _resolve_aircraft_params(db, plane, v_cruise_override=None)
+
+        assert "e_oswald" not in aircraft, (
+            f"e_oswald=0.0 (uncomputed sentinel) must not be forwarded; "
+            f"got aircraft['e_oswald'] = {aircraft.get('e_oswald')!r}"
+        )
+
+    # --- End-to-end: endpoint emits Oswald warning when context has no e ------
+
+    def test_endpoint_emits_oswald_warning_when_context_missing_e(self, client_and_db):
+        """GET matching-chart on a plane with no e_oswald in context → Oswald warning
+        in response JSON warnings list.
+        """
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = self._make_plane_with_context(db, {
+                "s_ref_m2": 1.5,
+                "aspect_ratio": 7.0,
+                "v_cruise_mps": 20.0,
+                # no e_oswald
+            })
+            aeroplane_uuid = str(plane.uuid)
+
+        resp = client.get(f"/aeroplanes/{aeroplane_uuid}/matching-chart")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        oswald_warnings = [
+            w for w in data.get("warnings", [])
+            if "oswald" in w.lower() or "0.8" in w
+        ]
+        assert len(oswald_warnings) >= 1, (
+            f"Expected an Oswald design warning in response; got warnings: {data.get('warnings')}"
+        )
+
+    def test_endpoint_no_oswald_warning_when_e_provided(self, client_and_db):
+        """GET matching-chart on a plane with e_oswald=0.75 → no Oswald fallback warning."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = self._make_plane_with_context(db, {
+                "s_ref_m2": 1.5,
+                "aspect_ratio": 7.0,
+                "e_oswald": 0.75,
+                "v_cruise_mps": 20.0,
+            })
+            aeroplane_uuid = str(plane.uuid)
+
+        resp = client.get(f"/aeroplanes/{aeroplane_uuid}/matching-chart")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        oswald_warnings = [
+            w for w in data.get("warnings", [])
+            if "oswald" in w.lower() or (
+                "0.8" in w and ("default" in w.lower() or "using" in w.lower())
+            )
+        ]
+        assert len(oswald_warnings) == 0, (
+            f"No Oswald warning expected when e_oswald=0.75 is in context; "
+            f"got: {oswald_warnings}"
+        )


### PR DESCRIPTION
Closes #956

## Bug
The matching-chart path set the Oswald factor `e = 0.8` whenever no computed value was available — no calculation, no warning — contradicting the gh-924 single-source-of-truth / design-error-feedback policy.

## Fix
- `matching_chart_service.compute_chart`: resolve `e` **once** (module const `DEFAULT_E_OSWALD`); when `aircraft` has no `e_oswald`/`e`, use 0.8 **and** append a design warning to the existing `warnings` list. The v_cruise-estimate branch reuses the resolved `e` (locals renamed to avoid shadowing).
- `matching_chart` endpoint `_resolve_aircraft_params`: stop injecting 0.8; pass the context's computed `e_oswald` through, **omitting** the key when absent so the service's warning fires.

Result: when `e` isn't computed, the chart response carries a clear "Oswald factor e not computed — using default 0.8 …" warning instead of silently presenting an unmarked estimate.

## Scope
Matching chart only. Powertrain sizing deferred (its `e_oswald` is a user-supplied request field with a documented RC default; surfacing requires a response-schema addition) — see issue note.

## Tests
9 new fast tests (service: missing-e → warning + 0.8, present-e → no warning; endpoint helper: omits e when absent, passes through when present, end-to-end warning). Matching-chart suite **130 passed**; regression `-k "matching or powertrain or assumption or design_speed"` **338 passed**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)