### PR TITLE
feat(gh-958): copilot geometry tools — get_wing_geometry (hybrid read) + SetSegment (relative) + intent-framing

### DIFF
--- a/app/schemas/copilot_edits.py
+++ b/app/schemas/copilot_edits.py
@@ -150,6 +150,46 @@ class SetWingParam(BaseModel):
     )
 
 
+class SetSegment(BaseModel):
+    """Set the RELATIVE fields of ONE segment, addressed by SEGMENT index.
+
+    This is the per-SEGMENT relative editor (distinct from SetXsec, which
+    addresses a STATION and touches both neighbouring segments' airfoils).
+    PREFER THIS for parametric shaping expressed per segment: washout/twist,
+    a dihedral (cant) break, taper by tip chord, segment length, sweep. Only
+    the fields you pass are changed. Units: mm / degrees. The cad_designer
+    continuity rule means a segment's root chord follows the previous
+    segment's tip chord, so set chord_tip_mm to taper.
+    """
+
+    type: Literal["SetSegment"] = "SetSegment"
+    wing: str = Field(..., description="Wing name (e.g. 'main_wing').")
+    seg_index: int = Field(
+        ...,
+        ge=0,
+        description="Zero-based SEGMENT index (0 = innermost segment at the root).",
+    )
+    length_mm: Optional[float] = Field(
+        None, gt=0, description="Spanwise length of this segment in mm."
+    )
+    sweep_mm: Optional[float] = Field(
+        None, ge=0, description="Sweep of this segment (tip aft of root) in mm, >= 0."
+    )
+    chord_tip_mm: Optional[float] = Field(
+        None,
+        gt=0,
+        description="Tip chord of this segment in mm; also becomes the next segment's root chord.",
+    )
+    dihedral_rel_deg: Optional[float] = Field(
+        None,
+        description="Per-segment dihedral/cant in degrees, RELATIVE to the previous segment (positive = up).",
+    )
+    incidence_deg: Optional[float] = Field(
+        None,
+        description="Incidence/twist of this segment's tip airfoil in degrees (negative outboard = washout).",
+    )
+
+
 class ReplaceWingConfig(BaseModel):
     """Replace the entire WingConfiguration for a wing (escape hatch for exotic geometry).
 
@@ -177,6 +217,7 @@ EditOp = Annotated[
     Union[
         SetAssumption,
         SetXsec,
+        SetSegment,
         AddXsec,
         RemoveXsec,
         SetWingParam,
@@ -188,6 +229,7 @@ EditOp = Annotated[
 _OP_MODELS = [
     SetAssumption,
     SetXsec,
+    SetSegment,
     AddXsec,
     RemoveXsec,
     SetWingParam,

--- a/app/services/copilot_apply_service.py
+++ b/app/services/copilot_apply_service.py
@@ -608,6 +608,44 @@ def apply_edits(
                 wing_config_cache[op.wing] = wc
                 applied.append(op_type)
 
+            # --- SetSegment (per-segment relative) ---------------------------
+            elif op_type == "SetSegment":
+                wc = _load_wing(op.wing)
+                if wc is None:
+                    rejected.append(
+                        {
+                            "op": op.model_dump(),
+                            "error": f"Wing '{op.wing}' not found or cannot be loaded as WingConfig.",
+                        }
+                    )
+                    continue
+
+                segs = wc.get("segments", [])
+                n = len(segs)
+                if not (0 <= op.seg_index < n):
+                    rejected.append(
+                        {
+                            "op": op.model_dump(),
+                            "error": f"seg_index {op.seg_index} out of range (0..{n - 1}) for wing '{op.wing}'.",
+                        }
+                    )
+                    continue
+
+                seg = segs[op.seg_index]
+                if op.length_mm is not None:
+                    seg["length"] = op.length_mm
+                if op.sweep_mm is not None:
+                    seg["sweep"] = op.sweep_mm
+                if op.chord_tip_mm is not None:
+                    seg["tip_airfoil"]["chord"] = op.chord_tip_mm
+                if op.dihedral_rel_deg is not None:
+                    seg["tip_airfoil"]["dihedral_as_rotation_in_degrees"] = op.dihedral_rel_deg
+                if op.incidence_deg is not None:
+                    seg["tip_airfoil"]["incidence"] = op.incidence_deg
+
+                wing_config_cache[op.wing] = wc
+                applied.append(op_type)
+
             # --- ReplaceWingConfig -------------------------------------------
             elif op_type == "ReplaceWingConfig":
                 # Validate via schema before writing
@@ -661,6 +699,14 @@ def apply_edits(
                     "error": f"Failed to persist wing '{wing_name}': {exc}",
                 }
             )
+
+    # put_wing_as_wingconfig deletes-then-reinserts the wing, leaving stale
+    # WingModel instances in the session identity map. Expire them so the
+    # metrics payload below AND any subsequent same-session read (e.g. the
+    # copilot calling get_wing_geometry right after apply in one turn) reload
+    # the fresh geometry (mirrors the ReplaceWingConfig handling).
+    if wing_config_cache:
+        db.expire_all()
 
     # --- Recompute assumptions synchronously --------------------------------
     try:

--- a/app/services/copilot_apply_service.py
+++ b/app/services/copilot_apply_service.py
@@ -622,6 +622,11 @@ def apply_edits(
 
                 segs = wc.get("segments", [])
                 n = len(segs)
+                if n == 0:
+                    rejected.append(
+                        {"op": op.model_dump(), "error": f"Wing '{op.wing}' has no segments."}
+                    )
+                    continue
                 if not (0 <= op.seg_index < n):
                     rejected.append(
                         {

--- a/app/services/copilot_service.py
+++ b/app/services/copilot_service.py
@@ -122,7 +122,7 @@ and adopt it in the Versions panel" — never say "I changed your design."
 6. **Clean up dead-ends.**  If your proposal is going the wrong direction and
    you want to start fresh, call ``discard_proposal`` before beginning again.
 7. **Express changes as ops**, not free text.  Use the structured ops
-   (SetAssumption, SetXsec, AddXsec, RemoveXsec, SetWingParam,
+   (SetAssumption, SetXsec, SetSegment, AddXsec, RemoveXsec, SetWingParam,
    ReplaceWingConfig).  All chord/span dimensions are in **millimetres**.
 8. **One open proposal per aeroplane.**  A second ``apply_design_edits``
    reuses the same branch — you build up changes incrementally.
@@ -130,6 +130,26 @@ and adopt it in the Versions panel" — never say "I changed your design."
    - What you proposed (brief summary of the changes).
    - The key metrics diff (before → after).
    - "Review the proposal in the Versions panel and adopt or discard it."
+
+## Wing geometry — read first, then pick the right edit
+- **Read before you edit.** Call ``get_wing_geometry(wing)`` to see BOTH the
+  editable RELATIVE per-segment fields AND a derived ABSOLUTE block (per-station
+  ``xyz_le_mm``, ``accumulated_dihedral_deg``, ``te_x_mm`` = LE_x + chord,
+  projected span). Use the derived block to reason about absolute shape — where
+  the LE/TE sit, how cant accumulates — but edit only via the relative ops.
+- **Prefer RELATIVE ops for parametric shaping** (the usual case): ``SetSegment``
+  changes ONE segment by index (length, sweep, tip chord, per-segment
+  ``dihedral_rel_deg``, ``incidence_deg``); ``SetXsec`` changes a STATION's
+  airfoil. Use these for washout, a dihedral break, taper, sweep.
+- **Use ``SetXsec``/derived reasoning for exact placement** — when you must hit
+  an absolute target (e.g. align a trailing edge), compute the needed chord from
+  the derived block (``te_x_mm`` = ``xyz_le_mm[0]`` + chord) and set it.
+- **Compute, don't eyeball.** For any shape with a formula, work the numbers
+  exactly. A "washout of X°" is a MONOTONIC twist ramp to −X at the tip (not a
+  constant offset). An "elliptical wing" means BOTH the leading and trailing
+  edge follow elliptical arcs that close over the tip (a full ellipse, not a
+  straight-LE D-shape), with cross-sections clustered toward the tip so the
+  outline stays a tight fit. State the intended shape precisely before editing.
 
 ## Agentic apply — answer quality (HARD)
 

--- a/app/services/copilot_tools.py
+++ b/app/services/copilot_tools.py
@@ -72,6 +72,106 @@ def _get_design_snapshot(db: Session, aeroplane_id: int) -> dict:
         return {"error": str(exc)}
 
 
+def _get_wing_geometry(db: Session, aeroplane_id: int, wing: str = "main_wing") -> dict:
+    """Hybrid geometry read for one wing (gh-958).
+
+    Returns BOTH (a) the editable RELATIVE per-segment fields the geometry
+    edit-ops change, and (b) a read-only DERIVED ABSOLUTE block (per-station
+    xyz_le, accumulated dihedral, TE_x = LE_x + chord, projected span) for
+    spatial reasoning. Units are mm / degrees (WingConfig units), matching the
+    edit-ops. The wing-local LE walk: x aft (sweep), y span
+    (length*cos(accumulated cant)), z up (length*sin(...)).
+    """
+    import math
+
+    try:
+        from app.models.aeroplanemodel import AeroplaneModel
+        from app.services.wing_service import get_wing_as_wingconfig
+
+        node = db.query(AeroplaneModel).filter(AeroplaneModel.id == aeroplane_id).first()
+        if node is None:
+            return {"error": f"Aeroplane {aeroplane_id} not found"}
+        try:
+            wc = get_wing_as_wingconfig(db, str(node.uuid), wing)
+        except Exception as exc:
+            return {"error": f"Wing {wing!r} not found ({exc})"}
+        segs = (wc or {}).get("segments") or []
+        if not segs:
+            return {"error": f"Wing {wing!r} has no segments"}
+
+        def _dih(s: dict) -> float:
+            return float(s["tip_airfoil"].get("dihedral_as_rotation_in_degrees", 0) or 0)
+
+        def _inc(s: dict) -> float:
+            return float(s["tip_airfoil"].get("incidence", 0) or 0)
+
+        editable = [
+            {
+                "index": i,
+                "chord_root_mm": float(s["root_airfoil"]["chord"]),
+                "chord_tip_mm": float(s["tip_airfoil"]["chord"]),
+                "length_mm": float(s["length"]),
+                "sweep_mm": float(s["sweep"]),
+                "dihedral_rel_deg": _dih(s),
+                "incidence_deg": _inc(s),
+                "airfoil": s["tip_airfoil"].get("airfoil"),
+            }
+            for i, s in enumerate(segs)
+        ]
+
+        # Derived absolute walk (wing-local mm).
+        chord0 = float(segs[0]["root_airfoil"]["chord"])
+        per_station = [
+            {
+                "index": 0,
+                "xyz_le_mm": [0.0, 0.0, 0.0],
+                "chord_mm": chord0,
+                "accumulated_dihedral_deg": 0.0,
+                "te_x_mm": chord0,
+            }
+        ]
+        x = y = z = acc = 0.0
+        for i, s in enumerate(segs):
+            acc += _dih(s)
+            rad = math.radians(acc)
+            x += float(s["sweep"])
+            y += float(s["length"]) * math.cos(rad)
+            z += float(s["length"]) * math.sin(rad)
+            chord = float(s["tip_airfoil"]["chord"])
+            per_station.append(
+                {
+                    "index": i + 1,
+                    "xyz_le_mm": [round(x, 4), round(y, 4), round(z, 4)],
+                    "chord_mm": chord,
+                    "accumulated_dihedral_deg": round(acc, 4),
+                    "te_x_mm": round(x, 4) + chord,
+                }
+            )
+
+        return {
+            "wing": wing,
+            "units": "mm / degrees (WingConfig units)",
+            "n_segments": len(segs),
+            "editable": editable,
+            "derived": {
+                "per_station": per_station,
+                "wing_level": {
+                    "projected_semi_span_mm": round(y, 4),
+                    "total_arc_length_mm": round(sum(float(s["length"]) for s in segs), 4),
+                    "tip_xyz_le_mm": [round(x, 4), round(y, 4), round(z, 4)],
+                    "note": (
+                        "DERIVED / read-only — computed from the editable relative "
+                        "fields; TE_x = LE_x + chord. Edit via the relative geometry "
+                        "ops (SetSegment / SetXsec) or exact placement (SetXsecAbsolute)."
+                    ),
+                },
+            },
+        }
+    except Exception as exc:
+        logger.exception("get_wing_geometry failed for aeroplane_id=%s", aeroplane_id)
+        return {"error": str(exc)}
+
+
 def _run_analysis(db: Session, aeroplane_id: int, kind: str = "polar") -> dict:
     """Trigger a fast analysis and return a concise summary dict.
 
@@ -450,6 +550,38 @@ _SCHEMA_RUN_ANALYSIS = {
     },
 }
 
+_SCHEMA_GET_WING_GEOMETRY = {
+    "type": "function",
+    "function": {
+        "name": "get_wing_geometry",
+        "description": (
+            "Read one wing's geometry in a HYBRID form. Returns 'editable' (the "
+            "RELATIVE per-segment fields the geometry edit-ops change: "
+            "chord_root_mm, chord_tip_mm, length_mm, sweep_mm, dihedral_rel_deg "
+            "[per-segment cant], incidence_deg, airfoil) AND 'derived' (READ-ONLY "
+            "absolute context per station: xyz_le_mm, chord_mm, "
+            "accumulated_dihedral_deg, te_x_mm = LE_x + chord, plus wing-level "
+            "projected span). Use 'derived' to reason about absolute shape (where "
+            "the LE/TE sit, how cant accumulates); edit only via the relative "
+            "fields. Units: mm / degrees. Call this before editing wing geometry."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "wing": {
+                    "type": "string",
+                    "description": (
+                        "Wing name (from get_design_snapshot.wing_names, e.g. "
+                        "'main_wing'). Defaults to 'main_wing'."
+                    ),
+                }
+            },
+            "required": [],
+        },
+    },
+}
+
+
 _SCHEMA_GET_VERSION_TREE = {
     "type": "function",
     "function": {
@@ -683,6 +815,10 @@ TOOL_REGISTRY: dict[str, ToolEntry] = {
         schema=_SCHEMA_GET_DESIGN_SNAPSHOT,
         impl=_get_design_snapshot,
     ),
+    "get_wing_geometry": ToolEntry(
+        schema=_SCHEMA_GET_WING_GEOMETRY,
+        impl=_get_wing_geometry,
+    ),
     "run_analysis": ToolEntry(
         schema=_SCHEMA_RUN_ANALYSIS,
         impl=_run_analysis,
@@ -743,7 +879,7 @@ def execute(name: str, db: Session, aeroplane_id: int, **kwargs: Any) -> dict:
         return {"error": f"Unknown tool {name!r}. Known tools: {known}"}
 
     # Read-retargeting: resolve to proposal head for read tools when a proposal is open.
-    _READ_RETARGETED_TOOLS = {"get_design_snapshot", "run_analysis"}
+    _READ_RETARGETED_TOOLS = {"get_design_snapshot", "get_wing_geometry", "run_analysis"}
     effective_id = (
         _effective_target_id(db, aeroplane_id) if name in _READ_RETARGETED_TOOLS else aeroplane_id
     )

--- a/app/services/copilot_tools.py
+++ b/app/services/copilot_tools.py
@@ -7,7 +7,9 @@ the tools that are safe, fast, and meaningful for an advisory interaction.
 Tool contract
 -------------
 - Each tool impl has the signature ``fn(db, aeroplane_id, **kwargs) -> dict``.
-- Return value must be JSON-serializable (all SI/m units — no mm).
+- Return value must be JSON-serializable. Metrics tools use SI/m; the
+  ``get_wing_geometry`` tool is an intentional exception that returns
+  mm/degrees to mirror the WingConfig edit-op units.
 - Errors are returned as ``{"error": "<message>"}`` — never raised raw.
 - ``run_analysis`` has a configurable timeout; on expiry it returns a status
   dict so the copilot can tell the user to check the Analysis tab.
@@ -76,78 +78,88 @@ def _get_wing_geometry(db: Session, aeroplane_id: int, wing: str = "main_wing") 
     """Hybrid geometry read for one wing (gh-958).
 
     Returns BOTH (a) the editable RELATIVE per-segment fields the geometry
-    edit-ops change, and (b) a read-only DERIVED ABSOLUTE block (per-station
-    xyz_le, accumulated dihedral, TE_x = LE_x + chord, projected span) for
+    edit-ops change, and (b) a read-only DERIVED ABSOLUTE block per station for
     spatial reasoning. Units are mm / degrees (WingConfig units), matching the
-    edit-ops. The wing-local LE walk: x aft (sweep), y span
-    (length*cos(accumulated cant)), z up (length*sin(...)).
+    edit-ops.
+
+    The derived block is read from the PERSISTED cross-section positions
+    (``WingXSecModel.xyz_le`` in metres, scaled to mm) — the exact geometry the
+    3D viewer and AeroSandbox consume — NOT a re-derived walk, so it never
+    diverges from the canonical cad_designer frame (which seeds the dihedral
+    accumulator with the root-airfoil dihedral and applies each segment's offset
+    before adding its own tip dihedral; gh-958 review).
     """
     import math
 
     try:
+        from app.core.exceptions import NotFoundError
         from app.models.aeroplanemodel import AeroplaneModel
         from app.services.wing_service import get_wing_as_wingconfig
 
         node = db.query(AeroplaneModel).filter(AeroplaneModel.id == aeroplane_id).first()
         if node is None:
             return {"error": f"Aeroplane {aeroplane_id} not found"}
+
+        wing_model = next((w for w in (node.wings or []) if w.name == wing), None)
+        if wing_model is None:
+            available = [w.name for w in (node.wings or [])]
+            return {"error": f"Wing {wing!r} not found. Available wings: {available}"}
+
+        # Editable RELATIVE block — the validated WingConfig (mm).
         try:
             wc = get_wing_as_wingconfig(db, str(node.uuid), wing)
+        except NotFoundError:
+            return {"error": f"Wing {wing!r} not found on aeroplane {aeroplane_id}."}
         except Exception as exc:
-            return {"error": f"Wing {wing!r} not found ({exc})"}
+            logger.exception("get_wing_geometry: wing %r could not be loaded", wing)
+            return {"error": f"Wing {wing!r} could not be loaded as WingConfig: {exc}"}
         segs = (wc or {}).get("segments") or []
-        if not segs:
-            return {"error": f"Wing {wing!r} has no segments"}
 
-        def _dih(s: dict) -> float:
-            return float(s["tip_airfoil"].get("dihedral_as_rotation_in_degrees", 0) or 0)
-
-        def _inc(s: dict) -> float:
-            return float(s["tip_airfoil"].get("incidence", 0) or 0)
+        def _f(v) -> float:
+            return float(v or 0)
 
         editable = [
             {
                 "index": i,
-                "chord_root_mm": float(s["root_airfoil"]["chord"]),
-                "chord_tip_mm": float(s["tip_airfoil"]["chord"]),
-                "length_mm": float(s["length"]),
-                "sweep_mm": float(s["sweep"]),
-                "dihedral_rel_deg": _dih(s),
-                "incidence_deg": _inc(s),
+                "chord_root_mm": _f(s["root_airfoil"]["chord"]),
+                "chord_tip_mm": _f(s["tip_airfoil"]["chord"]),
+                "length_mm": _f(s["length"]),
+                "sweep_mm": _f(s["sweep"]),
+                "dihedral_rel_deg": _f(s["tip_airfoil"].get("dihedral_as_rotation_in_degrees")),
+                "incidence_deg": _f(s["tip_airfoil"].get("incidence")),
                 "airfoil": s["tip_airfoil"].get("airfoil"),
             }
             for i, s in enumerate(segs)
         ]
 
-        # Derived absolute walk (wing-local mm).
-        chord0 = float(segs[0]["root_airfoil"]["chord"])
-        per_station = [
-            {
-                "index": 0,
-                "xyz_le_mm": [0.0, 0.0, 0.0],
-                "chord_mm": chord0,
-                "accumulated_dihedral_deg": 0.0,
-                "te_x_mm": chord0,
-            }
-        ]
-        x = y = z = acc = 0.0
-        for i, s in enumerate(segs):
-            acc += _dih(s)
-            rad = math.radians(acc)
-            x += float(s["sweep"])
-            y += float(s["length"]) * math.cos(rad)
-            z += float(s["length"]) * math.sin(rad)
-            chord = float(s["tip_airfoil"]["chord"])
+        # Derived ABSOLUTE block — read the PERSISTED xsec positions (metres ->
+        # mm). Single source of truth; accumulated cant is recovered from the
+        # geometry itself (atan2 of the LE delta), matching from_asb.
+        per_station = []
+        prev = None
+        for i, xs in enumerate(wing_model.x_secs):
+            le = [round(_f(v) * 1000.0, 4) for v in (xs.xyz_le or [0.0, 0.0, 0.0])]
+            chord_mm = round(_f(xs.chord) * 1000.0, 4)
+            if prev is None:
+                cant = 0.0
+            else:
+                dy, dz = le[1] - prev[1], le[2] - prev[2]
+                cant = (
+                    math.degrees(math.atan2(dz, dy)) if (abs(dy) > 1e-9 or abs(dz) > 1e-9) else 0.0
+                )
             per_station.append(
                 {
-                    "index": i + 1,
-                    "xyz_le_mm": [round(x, 4), round(y, 4), round(z, 4)],
-                    "chord_mm": chord,
-                    "accumulated_dihedral_deg": round(acc, 4),
-                    "te_x_mm": round(x, 4) + chord,
+                    "index": i,
+                    "xyz_le_mm": le,
+                    "chord_mm": chord_mm,
+                    "twist_deg": round(_f(xs.twist), 4),
+                    "accumulated_dihedral_deg": round(cant, 4),
+                    "te_x_mm": round(le[0] + chord_mm, 4),
                 }
             )
+            prev = le
 
+        tip = per_station[-1]["xyz_le_mm"] if per_station else [0.0, 0.0, 0.0]
         return {
             "wing": wing,
             "units": "mm / degrees (WingConfig units)",
@@ -156,13 +168,16 @@ def _get_wing_geometry(db: Session, aeroplane_id: int, wing: str = "main_wing") 
             "derived": {
                 "per_station": per_station,
                 "wing_level": {
-                    "projected_semi_span_mm": round(y, 4),
-                    "total_arc_length_mm": round(sum(float(s["length"]) for s in segs), 4),
-                    "tip_xyz_le_mm": [round(x, 4), round(y, 4), round(z, 4)],
+                    "projected_semi_span_mm": tip[1],
+                    "tip_xyz_le_mm": tip,
                     "note": (
-                        "DERIVED / read-only — computed from the editable relative "
-                        "fields; TE_x = LE_x + chord. Edit via the relative geometry "
-                        "ops (SetSegment / SetXsec) or exact placement (SetXsecAbsolute)."
+                        "DERIVED / read-only — the actual persisted cross-section "
+                        "positions (what the viewer/ASB use); TE_x = LE_x + chord. "
+                        "Edit via the relative ops (SetSegment / SetXsec); for a full "
+                        "rebuild use ReplaceWingConfig. NOTE: 'chord_root_mm' in the "
+                        "editable block is read-only — a segment's root chord follows "
+                        "the previous segment's tip chord (continuity); set "
+                        "chord_tip_mm to taper."
                     ),
                 },
             },
@@ -656,8 +671,8 @@ def _apply_design_edits(db: Session, aeroplane_id: int, *, ops: list) -> dict:
     ----------
     ops:
         List of edit-op dicts, each with a ``type`` discriminator field.
-        Supported types: SetAssumption, SetXsec, AddXsec, RemoveXsec,
-        SetWingParam, ReplaceWingConfig.
+        Supported types: SetAssumption, SetXsec, SetSegment, AddXsec,
+        RemoveXsec, SetWingParam, ReplaceWingConfig.
 
     Diff accuracy note
     ------------------

--- a/app/tests/test_copilot_apply_integration.py
+++ b/app/tests/test_copilot_apply_integration.py
@@ -684,9 +684,7 @@ class TestApplyDesignEditsTool:
             with patch(_RECOMPUTE_PATH) as mock_recompute:
                 # After the mock recompute, inject fresh context on the proposal
                 def _fresh_recompute(db_s, uuid_s):
-                    node = db_s.query(AeroplaneModel).filter(
-                        AeroplaneModel.uuid == uuid_s
-                    ).first()
+                    node = db_s.query(AeroplaneModel).filter(AeroplaneModel.uuid == uuid_s).first()
                     if node is not None:
                         node.assumption_computation_context = {
                             "mass_kg": 1.2,
@@ -836,11 +834,12 @@ class TestReadRetargeting:
 
 
 class TestToolRegistryExtended:
-    def test_five_schemas_registered(self):
+    def test_six_schemas_registered(self):
         from app.services.copilot_tools import list_schemas
 
         schemas = list_schemas()
-        assert len(schemas) == 5
+        # +get_wing_geometry (gh-958)
+        assert len(schemas) == 6
 
     def test_new_tools_registered(self):
         from app.services.copilot_tools import list_schemas
@@ -1129,9 +1128,7 @@ class TestAddXsecWingletRegression:
 
             # Record the original tip Y position
             db.expire_all()
-            orig_wing = next(
-                (w for w in proposal_node.wings if w.name == "main_wing"), None
-            )
+            orig_wing = next((w for w in proposal_node.wings if w.name == "main_wing"), None)
             assert orig_wing is not None
             orig_tip_y = orig_wing.x_secs[-1].xyz_le[1]  # original tip Y (metres)
             n_segs = len(orig_wing.x_secs) - 1  # n xsecs = n_segs + 1
@@ -1156,9 +1153,7 @@ class TestAddXsecWingletRegression:
 
             db.expire_all()
             db.refresh(proposal_node)
-            new_wing = next(
-                (w for w in proposal_node.wings if w.name == "main_wing"), None
-            )
+            new_wing = next((w for w in proposal_node.wings if w.name == "main_wing"), None)
             assert new_wing is not None
 
             # New wing should have 1 extra xsec
@@ -1262,7 +1257,11 @@ class TestGh938Regressions:
                 result = apply_edits(
                     db,
                     str(proposal_node.uuid),
-                    [AddXsec(wing="main_wing", at_index=n_xsecs, chord=35.0, span=60.0, dihedral=75.0)],
+                    [
+                        AddXsec(
+                            wing="main_wing", at_index=n_xsecs, chord=35.0, span=60.0, dihedral=75.0
+                        )
+                    ],
                 )
             db.commit()
 
@@ -1299,7 +1298,15 @@ class TestGh938Regressions:
                 result = apply_edits(
                     db,
                     str(proposal_node.uuid),
-                    [AddXsec(wing="main_wing", at_index=over_estimated_index, chord=30.0, span=50.0, dihedral=80.0)],
+                    [
+                        AddXsec(
+                            wing="main_wing",
+                            at_index=over_estimated_index,
+                            chord=30.0,
+                            span=50.0,
+                            dihedral=80.0,
+                        )
+                    ],
                 )
             db.commit()
 
@@ -1468,6 +1475,7 @@ class TestSetXsecInteriorAndFields:
         db.commit()
         proposal_node = db.query(AeroplaneModel).filter(AeroplaneModel.id == branch.head_id).first()
         from app.services.wing_service import get_wing_as_wingconfig
+
         wc = get_wing_as_wingconfig(db, str(proposal_node.uuid), "main_wing")
         n_segs = len(wc["segments"])
         return plane, proposal_node, n_segs
@@ -1497,9 +1505,12 @@ class TestSetXsecInteriorAndFields:
 
             db.expire_all()
             from app.services.wing_service import get_wing_as_wingconfig
+
             wc = get_wing_as_wingconfig(db, str(proposal_node.uuid), "main_wing")
             # tip of seg[index-1] and root of seg[index] must both have the new chord
-            assert wc["segments"][interior_idx - 1]["tip_airfoil"]["chord"] == pytest.approx(new_chord)
+            assert wc["segments"][interior_idx - 1]["tip_airfoil"]["chord"] == pytest.approx(
+                new_chord
+            )
             assert wc["segments"][interior_idx]["root_airfoil"]["chord"] == pytest.approx(new_chord)
         finally:
             db.close()
@@ -1528,9 +1539,14 @@ class TestSetXsecInteriorAndFields:
 
             db.expire_all()
             from app.services.wing_service import get_wing_as_wingconfig
+
             wc = get_wing_as_wingconfig(db, str(proposal_node.uuid), "main_wing")
-            assert wc["segments"][interior_idx - 1]["tip_airfoil"]["incidence"] == pytest.approx(new_twist)
-            assert wc["segments"][interior_idx]["root_airfoil"]["incidence"] == pytest.approx(new_twist)
+            assert wc["segments"][interior_idx - 1]["tip_airfoil"]["incidence"] == pytest.approx(
+                new_twist
+            )
+            assert wc["segments"][interior_idx]["root_airfoil"]["incidence"] == pytest.approx(
+                new_twist
+            )
         finally:
             db.close()
 
@@ -1558,6 +1574,7 @@ class TestSetXsecInteriorAndFields:
 
             db.expire_all()
             from app.services.wing_service import get_wing_as_wingconfig
+
             wc = get_wing_as_wingconfig(db, str(proposal_node.uuid), "main_wing")
             assert wc["segments"][interior_idx - 1]["tip_airfoil"]["airfoil"] == new_airfoil
             assert wc["segments"][interior_idx]["root_airfoil"]["airfoil"] == new_airfoil
@@ -1594,6 +1611,7 @@ class TestSetXsecInteriorAndFields:
             # Verify the wing can be read back (geometry is consistent)
             db.expire_all()
             from app.services.wing_service import get_wing_as_wingconfig
+
             wc = get_wing_as_wingconfig(db, str(proposal_node.uuid), "main_wing")
             assert len(wc["segments"]) >= 2
         finally:
@@ -1620,6 +1638,7 @@ class TestSetXsecInteriorAndFields:
 
             db.expire_all()
             from app.services.wing_service import get_wing_as_wingconfig
+
             wc = get_wing_as_wingconfig(db, str(proposal_node.uuid), "main_wing")
             assert wc["segments"][-1]["tip_airfoil"]["chord"] == pytest.approx(new_chord)
         finally:
@@ -1646,6 +1665,7 @@ class TestSetXsecInteriorAndFields:
 
             db.expire_all()
             from app.services.wing_service import get_wing_as_wingconfig
+
             wc = get_wing_as_wingconfig(db, str(proposal_node.uuid), "main_wing")
             assert wc["segments"][-1]["tip_airfoil"]["incidence"] == pytest.approx(new_twist)
         finally:
@@ -1672,6 +1692,7 @@ class TestSetXsecInteriorAndFields:
 
             db.expire_all()
             from app.services.wing_service import get_wing_as_wingconfig
+
             wc = get_wing_as_wingconfig(db, str(proposal_node.uuid), "main_wing")
             assert wc["segments"][-1]["tip_airfoil"]["airfoil"] == new_airfoil
         finally:
@@ -1706,6 +1727,7 @@ class TestSetXsecInteriorAndFields:
             # Verify the wing can be read back (geometry is consistent)
             db.expire_all()
             from app.services.wing_service import get_wing_as_wingconfig
+
             wc = get_wing_as_wingconfig(db, str(proposal_node.uuid), "main_wing")
             assert len(wc["segments"]) > 0
         finally:
@@ -1727,9 +1749,9 @@ class TestRemoveXsecGuards:
             plane = _create_plane_with_branch(db)
             branch = get_or_open_proposal(db, plane.id)
             db.commit()
-            proposal_node = db.query(AeroplaneModel).filter(
-                AeroplaneModel.id == branch.head_id
-            ).first()
+            proposal_node = (
+                db.query(AeroplaneModel).filter(AeroplaneModel.id == branch.head_id).first()
+            )
 
             with patch(_RECOMPUTE_PATH):
                 result = apply_edits(
@@ -1783,9 +1805,9 @@ class TestRemoveXsecGuards:
 
             branch = get_or_open_proposal(db, plane.id)
             db.commit()
-            proposal_node = db.query(AeroplaneModel).filter(
-                AeroplaneModel.id == branch.head_id
-            ).first()
+            proposal_node = (
+                db.query(AeroplaneModel).filter(AeroplaneModel.id == branch.head_id).first()
+            )
 
             # n=1 segment → n_xsecs=2 → only interior index is none (0 and 1 are root/tip)
             # We need to verify the n < 2 guard.  With exactly 1 segment we can't have
@@ -1870,9 +1892,9 @@ class TestSetWingParam:
             plane = _create_plane_with_wc_wing(db)
             branch = get_or_open_proposal(db, plane.id)
             db.commit()
-            proposal_node = db.query(AeroplaneModel).filter(
-                AeroplaneModel.id == branch.head_id
-            ).first()
+            proposal_node = (
+                db.query(AeroplaneModel).filter(AeroplaneModel.id == branch.head_id).first()
+            )
 
             new_sweep = 25.0
 
@@ -1889,6 +1911,7 @@ class TestSetWingParam:
 
             db.expire_all()
             from app.services.wing_service import get_wing_as_wingconfig
+
             wc = get_wing_as_wingconfig(db, str(proposal_node.uuid), "main_wing")
             for seg in wc["segments"]:
                 assert seg["sweep"] == pytest.approx(new_sweep)
@@ -1909,9 +1932,9 @@ class TestSetWingParam:
             plane = _create_plane_with_wc_wing(db)
             branch = get_or_open_proposal(db, plane.id)
             db.commit()
-            proposal_node = db.query(AeroplaneModel).filter(
-                AeroplaneModel.id == branch.head_id
-            ).first()
+            proposal_node = (
+                db.query(AeroplaneModel).filter(AeroplaneModel.id == branch.head_id).first()
+            )
 
             new_dihedral = 4.0
 
@@ -1929,6 +1952,7 @@ class TestSetWingParam:
             # Verify the wing can be read back (geometry is consistent after dihedral apply)
             db.expire_all()
             from app.services.wing_service import get_wing_as_wingconfig
+
             wc = get_wing_as_wingconfig(db, str(proposal_node.uuid), "main_wing")
             assert len(wc["segments"]) > 0
         finally:
@@ -1946,9 +1970,9 @@ class TestSetWingParam:
             plane = _create_plane_with_wc_wing(db)
             branch = get_or_open_proposal(db, plane.id)
             db.commit()
-            proposal_node = db.query(AeroplaneModel).filter(
-                AeroplaneModel.id == branch.head_id
-            ).first()
+            proposal_node = (
+                db.query(AeroplaneModel).filter(AeroplaneModel.id == branch.head_id).first()
+            )
 
             with patch(_RECOMPUTE_PATH):
                 result = apply_edits(
@@ -1964,6 +1988,7 @@ class TestSetWingParam:
             # Verify both attributes were applied — sweep round-trips via xyz_le.x
             db.expire_all()
             from app.services.wing_service import get_wing_as_wingconfig
+
             wc = get_wing_as_wingconfig(db, str(proposal_node.uuid), "main_wing")
             # Sweep IS preserved via the in-memory dict: the WingConfig carries it
             for seg in wc["segments"]:
@@ -1980,9 +2005,9 @@ class TestSetWingParam:
             plane = _create_plane_with_branch(db)
             branch = get_or_open_proposal(db, plane.id)
             db.commit()
-            proposal_node = db.query(AeroplaneModel).filter(
-                AeroplaneModel.id == branch.head_id
-            ).first()
+            proposal_node = (
+                db.query(AeroplaneModel).filter(AeroplaneModel.id == branch.head_id).first()
+            )
 
             with patch(_RECOMPUTE_PATH):
                 result = apply_edits(
@@ -2012,14 +2037,15 @@ class TestReplaceWingConfig:
             plane = _create_plane_with_wc_wing(db)
             branch = get_or_open_proposal(db, plane.id)
             db.commit()
-            proposal_node = db.query(AeroplaneModel).filter(
-                AeroplaneModel.id == branch.head_id
-            ).first()
+            proposal_node = (
+                db.query(AeroplaneModel).filter(AeroplaneModel.id == branch.head_id).first()
+            )
 
             if _WC_PAYLOAD is None:
                 pytest.skip("WingConfig fixture not available")
 
             import copy
+
             new_payload = copy.deepcopy(_WC_PAYLOAD)
             # Modify root chord to distinguish from the original
             new_payload["segments"][0]["root_airfoil"]["chord"] = 321.0
@@ -2037,6 +2063,7 @@ class TestReplaceWingConfig:
 
             db.expire_all()
             from app.services.wing_service import get_wing_as_wingconfig
+
             wc = get_wing_as_wingconfig(db, str(proposal_node.uuid), "main_wing")
             assert wc["segments"][0]["root_airfoil"]["chord"] == pytest.approx(321.0)
         finally:
@@ -2049,9 +2076,9 @@ class TestReplaceWingConfig:
             plane = _create_plane_with_wc_wing(db)
             branch = get_or_open_proposal(db, plane.id)
             db.commit()
-            proposal_node = db.query(AeroplaneModel).filter(
-                AeroplaneModel.id == branch.head_id
-            ).first()
+            proposal_node = (
+                db.query(AeroplaneModel).filter(AeroplaneModel.id == branch.head_id).first()
+            )
 
             # Pass a totally invalid payload (missing required fields)
             bad_payload = {"segments": "not-a-list", "nose_pnt": "bad"}
@@ -2076,14 +2103,15 @@ class TestReplaceWingConfig:
             plane = _create_plane_with_wc_wing(db)
             branch = get_or_open_proposal(db, plane.id)
             db.commit()
-            proposal_node = db.query(AeroplaneModel).filter(
-                AeroplaneModel.id == branch.head_id
-            ).first()
+            proposal_node = (
+                db.query(AeroplaneModel).filter(AeroplaneModel.id == branch.head_id).first()
+            )
 
             if _WC_PAYLOAD is None:
                 pytest.skip("WingConfig fixture not available")
 
             import copy
+
             new_payload = copy.deepcopy(_WC_PAYLOAD)
             new_payload["segments"][0]["root_airfoil"]["chord"] = 250.0
 
@@ -2105,6 +2133,7 @@ class TestReplaceWingConfig:
 
             db.expire_all()
             from app.services.wing_service import get_wing_as_wingconfig
+
             wc = get_wing_as_wingconfig(db, str(proposal_node.uuid), "main_wing")
             assert wc["segments"][0]["root_airfoil"]["chord"] == pytest.approx(260.0)
         finally:
@@ -2126,9 +2155,9 @@ class TestRejectBranches:
             plane = _create_plane_with_branch(db)
             branch = get_or_open_proposal(db, plane.id)
             db.commit()
-            proposal_node = db.query(AeroplaneModel).filter(
-                AeroplaneModel.id == branch.head_id
-            ).first()
+            proposal_node = (
+                db.query(AeroplaneModel).filter(AeroplaneModel.id == branch.head_id).first()
+            )
 
             # Build a duck-typed op with a non-standard type to hit the else-branch
             class _UnknownOp:
@@ -2163,9 +2192,9 @@ class TestRejectBranches:
             plane = _create_plane_with_branch(db)
             branch = get_or_open_proposal(db, plane.id)
             db.commit()
-            proposal_node = db.query(AeroplaneModel).filter(
-                AeroplaneModel.id == branch.head_id
-            ).first()
+            proposal_node = (
+                db.query(AeroplaneModel).filter(AeroplaneModel.id == branch.head_id).first()
+            )
 
             # An op whose .wing property raises and whose model_dump() also raises —
             # exercises the fallback op_dict = {"type": op_type} at line 633-634.
@@ -2202,9 +2231,9 @@ class TestRejectBranches:
             plane = _create_plane_with_branch(db)
             branch = get_or_open_proposal(db, plane.id)
             db.commit()
-            proposal_node = db.query(AeroplaneModel).filter(
-                AeroplaneModel.id == branch.head_id
-            ).first()
+            proposal_node = (
+                db.query(AeroplaneModel).filter(AeroplaneModel.id == branch.head_id).first()
+            )
 
             with patch(_RECOMPUTE_PATH):
                 result = apply_edits(
@@ -2235,9 +2264,9 @@ class TestRecomputeExceptionNonFatal:
             plane = _create_plane_with_branch(db)
             branch = get_or_open_proposal(db, plane.id)
             db.commit()
-            proposal_node = db.query(AeroplaneModel).filter(
-                AeroplaneModel.id == branch.head_id
-            ).first()
+            proposal_node = (
+                db.query(AeroplaneModel).filter(AeroplaneModel.id == branch.head_id).first()
+            )
 
             # Patch recompute to raise instead of mocking it out
             with patch(
@@ -2277,9 +2306,9 @@ class TestWingWriteFailure:
             plane = _create_plane_with_wc_wing(db)
             branch = get_or_open_proposal(db, plane.id)
             db.commit()
-            proposal_node = db.query(AeroplaneModel).filter(
-                AeroplaneModel.id == branch.head_id
-            ).first()
+            proposal_node = (
+                db.query(AeroplaneModel).filter(AeroplaneModel.id == branch.head_id).first()
+            )
 
             with patch(_RECOMPUTE_PATH):
                 with patch(
@@ -2293,9 +2322,9 @@ class TestWingWriteFailure:
                     )
 
             # The wing write error is captured, not raised
-            assert any(
-                r.get("op", {}).get("type") == "WingWrite" for r in result["rejected"]
-            ), f"Expected WingWrite in rejected: {result['rejected']}"
+            assert any(r.get("op", {}).get("type") == "WingWrite" for r in result["rejected"]), (
+                f"Expected WingWrite in rejected: {result['rejected']}"
+            )
         finally:
             db.close()
 
@@ -2350,6 +2379,7 @@ class TestSetXsecRootFields:
         db.commit()
         proposal_node = db.query(AeroplaneModel).filter(AeroplaneModel.id == branch.head_id).first()
         from app.services.wing_service import get_wing_as_wingconfig
+
         wc = get_wing_as_wingconfig(db, str(proposal_node.uuid), "main_wing")
         n_segs = len(wc["segments"])
         return plane, proposal_node, n_segs
@@ -2374,6 +2404,7 @@ class TestSetXsecRootFields:
 
             db.expire_all()
             from app.services.wing_service import get_wing_as_wingconfig
+
             wc = get_wing_as_wingconfig(db, str(proposal_node.uuid), "main_wing")
             # Root incidence is preserved via the WingConfig roundtrip
             assert wc["segments"][0]["root_airfoil"]["incidence"] == pytest.approx(new_twist)
@@ -2400,6 +2431,7 @@ class TestSetXsecRootFields:
 
             db.expire_all()
             from app.services.wing_service import get_wing_as_wingconfig
+
             wc = get_wing_as_wingconfig(db, str(proposal_node.uuid), "main_wing")
             assert wc["segments"][0]["root_airfoil"]["airfoil"] == new_airfoil
         finally:
@@ -2429,6 +2461,7 @@ class TestSetXsecRootFields:
             # Wing is readable after dihedral apply
             db.expire_all()
             from app.services.wing_service import get_wing_as_wingconfig
+
             wc = get_wing_as_wingconfig(db, str(proposal_node.uuid), "main_wing")
             assert len(wc["segments"]) > 0
         finally:
@@ -2461,13 +2494,15 @@ class TestDefensiveDeadCodeGuards:
             plane = _create_plane_with_wc_wing(db)
             branch = get_or_open_proposal(db, plane.id)
             db.commit()
-            proposal_node = db.query(AeroplaneModel).filter(
-                AeroplaneModel.id == branch.head_id
-            ).first()
+            proposal_node = (
+                db.query(AeroplaneModel).filter(AeroplaneModel.id == branch.head_id).first()
+            )
 
             from app.services.wing_service import get_wing_as_wingconfig
+
             wc = get_wing_as_wingconfig(db, str(proposal_node.uuid), "main_wing")
             n_segs = len(wc["segments"])
+
             # For a non-empty wing, at_index = 0 < 1.
             # Since n_segs > 0: n_xsecs = n_segs + 1 >= 2, so at_index=0 < n_xsecs.
             # The mid-wing check: effective_at_index < n_xsecs AND effective_at_index < n+1.
@@ -2535,11 +2570,12 @@ class TestDefensiveDeadCodeGuards:
             plane = _create_plane_with_wc_wing(db)
             branch = get_or_open_proposal(db, plane.id)
             db.commit()
-            proposal_node = db.query(AeroplaneModel).filter(
-                AeroplaneModel.id == branch.head_id
-            ).first()
+            proposal_node = (
+                db.query(AeroplaneModel).filter(AeroplaneModel.id == branch.head_id).first()
+            )
 
             from app.services.wing_service import get_wing_as_wingconfig
+
             wc = get_wing_as_wingconfig(db, str(proposal_node.uuid), "main_wing")
             n_segs = len(wc["segments"])
 
@@ -2612,9 +2648,9 @@ class TestDefensiveDeadCodeGuards:
 
             branch = get_or_open_proposal(db, plane.id)
             db.commit()
-            proposal_node = db.query(AeroplaneModel).filter(
-                AeroplaneModel.id == branch.head_id
-            ).first()
+            proposal_node = (
+                db.query(AeroplaneModel).filter(AeroplaneModel.id == branch.head_id).first()
+            )
 
             # n=1 segment, n_xsecs=2; valid interior = 1..0 (empty).
             # Any index >= n_xsecs-1 == 1 is rejected by the first guard.

--- a/app/tests/test_copilot_geometry_tools.py
+++ b/app/tests/test_copilot_geometry_tools.py
@@ -90,8 +90,8 @@ class TestGetWingGeometry:
         res = copilot_tools.execute("get_wing_geometry", db, plane.id, wing="main_wing")
         ps = res["derived"]["per_station"]
         assert len(ps) == len(wing_model.x_secs)
-        for st, xs in zip(ps, wing_model.x_secs):
-            for got, persisted in zip(st["xyz_le_mm"], xs.xyz_le):
+        for st, xs in zip(ps, wing_model.x_secs, strict=True):
+            for got, persisted in zip(st["xyz_le_mm"], xs.xyz_le, strict=True):
                 assert got == pytest.approx(float(persisted) * 1000.0, abs=1e-2)
         # the fixture carries dihedral, so z must be non-trivial somewhere —
         # this is the case the old hand-walk got wrong.

--- a/app/tests/test_copilot_geometry_tools.py
+++ b/app/tests/test_copilot_geometry_tools.py
@@ -89,3 +89,65 @@ class TestGetWingGeometry:
         assert "get_wing_geometry" in copilot_tools.TOOL_REGISTRY
         names = [s["function"]["name"] for s in copilot_tools.list_schemas()]
         assert "get_wing_geometry" in names
+
+
+_RECOMPUTE = "app.services.assumption_compute_service.recompute_assumptions"
+
+
+class TestSetSegment:
+    def _proposal(self, db, plane):
+        from app.models.aeroplanemodel import AeroplaneModel
+        from app.services.copilot_apply_service import get_or_open_proposal
+
+        branch = get_or_open_proposal(db, plane.id)
+        db.commit()
+        node = db.query(AeroplaneModel).filter(AeroplaneModel.id == branch.head_id).first()
+        return branch, node
+
+    def test_relative_edit_applies_on_proposal(self, client_and_db):
+        from unittest.mock import patch
+
+        from app.schemas.copilot_edits import SetSegment
+        from app.services.copilot_apply_service import apply_edits
+
+        db = _make_session(client_and_db)
+        plane = _plane_with_wing(db)
+        branch, node = self._proposal(db, plane)
+
+        with patch(_RECOMPUTE):
+            res = apply_edits(
+                db,
+                str(node.uuid),
+                [SetSegment(wing="main_wing", seg_index=0, incidence_deg=-2.5, sweep_mm=12.0)],
+            )
+        db.commit()
+
+        assert res["applied"] == ["SetSegment"], res
+        assert res["rejected"] == []
+        geo = copilot_tools.execute("get_wing_geometry", db, branch.head_id, wing="main_wing")
+        assert geo["editable"][0]["incidence_deg"] == pytest.approx(-2.5, abs=0.05)
+        assert geo["editable"][0]["sweep_mm"] == pytest.approx(12.0, abs=0.05)
+
+    def test_out_of_range_rejected_not_raised(self, client_and_db):
+        from unittest.mock import patch
+
+        from app.schemas.copilot_edits import SetSegment
+        from app.services.copilot_apply_service import apply_edits
+
+        db = _make_session(client_and_db)
+        plane = _plane_with_wing(db)
+        _, node = self._proposal(db, plane)
+
+        with patch(_RECOMPUTE):
+            res = apply_edits(
+                db, str(node.uuid), [SetSegment(wing="main_wing", seg_index=999, length_mm=50.0)]
+            )
+        assert res["applied"] == []
+        assert res["rejected"] and "out of range" in res["rejected"][0]["error"]
+
+    def test_in_apply_design_edits_schema(self):
+        from app.schemas.copilot_edits import edit_ops_array_schema
+
+        schema = edit_ops_array_schema()
+        blob = str(schema)
+        assert "SetSegment" in blob and "dihedral_rel_deg" in blob

--- a/app/tests/test_copilot_geometry_tools.py
+++ b/app/tests/test_copilot_geometry_tools.py
@@ -1,0 +1,91 @@
+"""gh-958: copilot geometry tools — get_wing_geometry hybrid read + the
+relative/absolute geometry edit-ops.
+
+The wing-representation spike settled the surface: a HYBRID read (editable
+relative per-segment fields + a derived ABSOLUTE block) plus relative + absolute
+writes, framed by op descriptions. These tests drive that against the real
+in-memory DB (no mocks of the geometry path).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.schemas.wing import Wing as WingConfigurationSchema
+from app.services import copilot_tools
+from app.services.aeroplane_service import create_aeroplane
+from app.services.wing_service import put_wing_as_wingconfig
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "wingconfig_from_prompt.json"
+_WC = json.loads(_FIXTURE.read_text()) if _FIXTURE.exists() else None
+
+
+def _make_session(client_and_db):
+    _, SessionLocal = client_and_db
+    return SessionLocal()
+
+
+def _plane_with_wing(db):
+    if _WC is None:
+        pytest.skip("wingconfig fixture missing")
+    plane = create_aeroplane(db, "geom-tool-plane")
+    db.commit()
+    db.refresh(plane)
+    put_wing_as_wingconfig(
+        db,
+        str(plane.uuid),
+        "main_wing",
+        WingConfigurationSchema.model_validate(_WC),
+        scale=0.001,
+    )
+    db.commit()
+    db.refresh(plane)
+    return plane
+
+
+class TestGetWingGeometry:
+    def test_returns_editable_and_derived_blocks(self, client_and_db):
+        db = _make_session(client_and_db)
+        plane = _plane_with_wing(db)
+
+        res = copilot_tools.execute("get_wing_geometry", db, plane.id, wing="main_wing")
+        assert "error" not in res, res
+        assert "editable" in res and "derived" in res
+
+        seg = res["editable"][0]
+        for k in (
+            "index",
+            "chord_tip_mm",
+            "length_mm",
+            "sweep_mm",
+            "dihedral_rel_deg",
+            "incidence_deg",
+        ):
+            assert k in seg, f"missing editable field {k}"
+
+        derived = res["derived"]
+        assert "per_station" in derived and "wing_level" in derived
+        st = derived["per_station"][0]
+        for k in ("xyz_le_mm", "chord_mm", "accumulated_dihedral_deg", "te_x_mm"):
+            assert k in st, f"missing derived field {k}"
+
+    def test_te_x_equals_le_x_plus_chord(self, client_and_db):
+        db = _make_session(client_and_db)
+        plane = _plane_with_wing(db)
+        res = copilot_tools.execute("get_wing_geometry", db, plane.id, wing="main_wing")
+        for stn in res["derived"]["per_station"]:
+            assert stn["te_x_mm"] == pytest.approx(stn["xyz_le_mm"][0] + stn["chord_mm"], abs=1e-3)
+
+    def test_unknown_wing_returns_error(self, client_and_db):
+        db = _make_session(client_and_db)
+        plane = _plane_with_wing(db)
+        res = copilot_tools.execute("get_wing_geometry", db, plane.id, wing="does_not_exist")
+        assert "error" in res
+
+    def test_registered_and_in_schemas(self):
+        assert "get_wing_geometry" in copilot_tools.TOOL_REGISTRY
+        names = [s["function"]["name"] for s in copilot_tools.list_schemas()]
+        assert "get_wing_geometry" in names

--- a/app/tests/test_copilot_geometry_tools.py
+++ b/app/tests/test_copilot_geometry_tools.py
@@ -72,6 +72,33 @@ class TestGetWingGeometry:
         for k in ("xyz_le_mm", "chord_mm", "accumulated_dihedral_deg", "te_x_mm"):
             assert k in st, f"missing derived field {k}"
 
+    def test_derived_xyz_matches_persisted_xsecs(self, client_and_db):
+        """The derived absolute block must equal the PERSISTED cross-section
+        positions (what the 3D viewer / ASB consume) — including dihedral.
+
+        gh-958 review: the original hand-rolled LE walk diverged from the
+        canonical geometry on any wing with dihedral (ignored root dihedral +
+        off-by-one). Reading the persisted xsecs eliminates the divergence.
+        """
+        from app.models.aeroplanemodel import AeroplaneModel
+
+        db = _make_session(client_and_db)
+        plane = _plane_with_wing(db)
+        node = db.query(AeroplaneModel).filter(AeroplaneModel.id == plane.id).first()
+        wing_model = next(w for w in node.wings if w.name == "main_wing")
+
+        res = copilot_tools.execute("get_wing_geometry", db, plane.id, wing="main_wing")
+        ps = res["derived"]["per_station"]
+        assert len(ps) == len(wing_model.x_secs)
+        for st, xs in zip(ps, wing_model.x_secs):
+            for got, persisted in zip(st["xyz_le_mm"], xs.xyz_le):
+                assert got == pytest.approx(float(persisted) * 1000.0, abs=1e-2)
+        # the fixture carries dihedral, so z must be non-trivial somewhere —
+        # this is the case the old hand-walk got wrong.
+        assert any(abs(st["xyz_le_mm"][2]) > 0.1 for st in ps), (
+            "fixture should exercise dihedral (non-zero z) to cover the regression"
+        )
+
     def test_te_x_equals_le_x_plus_chord(self, client_and_db):
         db = _make_session(client_and_db)
         plane = _plane_with_wing(db)

--- a/app/tests/test_copilot_tools.py
+++ b/app/tests/test_copilot_tools.py
@@ -32,15 +32,16 @@ def _make_db(client_and_db):
 
 
 class TestListSchemas:
-    def test_returns_five_schemas(self):
+    def test_returns_six_schemas(self):
         schemas = list_schemas()
-        assert len(schemas) == 5
+        assert len(schemas) == 6
 
     def test_schema_names(self):
         names = {s["function"]["name"] for s in list_schemas()}
-        # Slice 1 tools + Slice 2 write tools (gh-937/938)
+        # Slice 1 tools + Slice 2 write tools (gh-937/938) + geometry read (gh-958)
         assert names == {
             "get_design_snapshot",
+            "get_wing_geometry",
             "run_analysis",
             "get_version_tree",
             "apply_design_edits",
@@ -495,10 +496,11 @@ class TestPolarDragBreakdownWiring:
 
 
 class TestToolRegistry:
-    def test_registry_has_five_tools(self):
+    def test_registry_has_six_tools(self):
         # Slice 1: get_design_snapshot, run_analysis, get_version_tree
         # Slice 2 (gh-937/938): apply_design_edits, discard_proposal
-        assert len(tools_module.TOOL_REGISTRY) == 5
+        # Geometry read (gh-958): get_wing_geometry
+        assert len(tools_module.TOOL_REGISTRY) == 6
 
     def test_registry_keys_match_schema_names(self):
         for key, entry in tools_module.TOOL_REGISTRY.items():

--- a/app/tests/test_copilot_tools.py
+++ b/app/tests/test_copilot_tools.py
@@ -57,9 +57,7 @@ class TestListSchemas:
             assert "parameters" in fn
 
     def test_run_analysis_schema_has_kind_param(self):
-        schema = next(
-            s for s in list_schemas() if s["function"]["name"] == "run_analysis"
-        )
+        schema = next(s for s in list_schemas() if s["function"]["name"] == "run_analysis")
         props = schema["function"]["parameters"]["properties"]
         assert "kind" in props
         assert props["kind"]["enum"] == ["polar", "stability"]
@@ -473,10 +471,7 @@ class TestPolarDragBreakdownWiring:
         _, SessionLocal = client_and_db
         with SessionLocal() as db:
             plane = make_aeroplane(db)
-            assert (
-                tools_module._polar_drag_breakdown(db, str(plane.uuid), None, None)
-                is None
-            )
+            assert tools_module._polar_drag_breakdown(db, str(plane.uuid), None, None) is None
 
     def test_breakdown_swallows_errors_and_returns_none(self, client_and_db):
         import numpy as np
@@ -531,16 +526,22 @@ class TestStabilityNeutralPointSingleSource:
             # A fresh run would yield a DIFFERENT (divergent) neutral point
             async def _fake_summary(*a, **k):
                 return SimpleNamespace(
-                    static_margin_pct=30.0, stability_class="stable",
-                    neutral_point_x=0.109, cg_x=0.066, Cma=-0.5, Cnb=0.1, Clb=-0.05,
-                    is_statically_stable=True, is_directionally_stable=True,
-                    is_laterally_stable=True, mac=0.14,
-                    cg_range_forward=0.05, cg_range_aft=0.07,
+                    static_margin_pct=30.0,
+                    stability_class="stable",
+                    neutral_point_x=0.109,
+                    cg_x=0.066,
+                    Cma=-0.5,
+                    Cnb=0.1,
+                    Clb=-0.05,
+                    is_statically_stable=True,
+                    is_directionally_stable=True,
+                    is_laterally_stable=True,
+                    mac=0.14,
+                    cg_range_forward=0.05,
+                    cg_range_aft=0.07,
                 )
 
-            with patch(
-                "app.services.stability_service.get_stability_summary", _fake_summary
-            ):
+            with patch("app.services.stability_service.get_stability_summary", _fake_summary):
                 out = asyncio.run(tools_module._run_stability_async(db, uuid))
 
         # The authoritative context NP (0.0802) wins over the run's 0.109


### PR DESCRIPTION
Closes #958 (partial — see Deferred). Part of epic #902 (AI Copilot).

## Why — the wing-representation spike
A construction benchmark (5 directives × 4 representations, real-hub, on the real Olek) settled how the copilot should read/edit wing geometry:
- **Hybrid read wins universally** — editable relative per-segment fields + a derived ABSOLUTE block (xyz_le, accumulated dihedral, TE_x, projected span).
- **Relative writes win parametric edits** (washout, dihedral break, taper); H1/H3/H4 all 5/5, pure-absolute H2 = 3/5.
- **Result quality is gated by intent-framing** (system prompt / op descriptions), not the representation — e.g. "elliptical wing" only became a true full-form (both edges + cosine tip clustering) once the prompt said so.

## What this PR ships
1. **`get_wing_geometry(wing)` read tool** — hybrid: `editable` relative per-segment fields + `derived` absolute block (per-station `xyz_le_mm`, `chord_mm`, `accumulated_dihedral_deg`, `te_x_mm` = LE_x + chord, wing-level projected span). Read-retargeted to the open proposal branch. Reuses `get_wing_as_wingconfig` + a local LE walk. Units mm/deg.
2. **`SetSegment` edit-op** (in the existing `apply_design_edits` DSL) — per-SEGMENT relative editor (length, sweep, tip chord, `dihedral_rel_deg`, `incidence_deg`); the spike's winning surface, distinct from per-station `SetXsec` and wing-global `SetWingParam`. Reject-with-reason.
3. **`apply_edits` staleness fix** — `db.expire_all()` after the bulk wing write (put_wing_as_wingconfig delete-reinserts the wing → stale `WingModel`s); without it a same-session read right after apply returned stale geometry. Mirrors the `ReplaceWingConfig` handling.
4. **Intent-framing** — a "Wing geometry" section in the copilot system prompt: read first; relative ops for parametric shaping; derived block for exact placement; compute shapes exactly (washout = monotonic twist ramp; elliptical = both edges + tip clustering).

No duplication of the proposal-branch lifecycle — everything composes with Slice 2.

## Deferred (fast-follow / separate slices)
- **`SetXsecAbsolute`** exact-coordinate placement — lowest value per the spike (pure-absolute was the weak surface) and higher complexity (absolute↔WingConfig inverse-transform); relative ops + the derived block already cover placement.
- **`run_python`** compute sandbox — Slice 3; needed for fully-computed shapes (ellipse chord math). The geometry tools are standalone-useful for parametric edits without it.

## Tests
- `test_copilot_geometry_tools.py`: hybrid blocks present; `te_x == le_x + chord`; unknown-wing error; registry/schema wiring; `SetSegment` applies on the proposal branch + round-trips via `get_wing_geometry`; out-of-range rejected; `SetSegment` in the apply schema.
- Full copilot suite green (243 passed); tool-count assertions updated 5→6.