### PR TITLE
fix(gh-962): unblock frontend production build type-check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -272,6 +272,10 @@ jobs:
         run: npm run lint
         working-directory: frontend
 
+      - name: Type-check (tsc)
+        run: npx tsc --noEmit
+        working-directory: frontend
+
       - name: Run unit tests with coverage
         run: npm run test:unit -- --coverage
         working-directory: frontend

--- a/frontend/components/workbench/AeroplaneTree.tsx
+++ b/frontend/components/workbench/AeroplaneTree.tsx
@@ -147,7 +147,9 @@ function buildTurbulatorNode(
   const turb = xsec.turbulator;
   if (!turb || typeof turb !== "object") return null;
 
-  const turbObj = turb as Record<string, unknown>;
+  // `turb` is a typed Turbulator; go through `unknown` to read its dynamic
+  // fields as a record (the runtime type-guards below keep this safe).
+  const turbObj = turb as unknown as Record<string, unknown>;
   const form = (turbObj.form as string) ?? "zigzag";
   const posRoot = typeof turbObj.position_root === "number"
     ? (turbObj.position_root as number).toFixed(2)


### PR DESCRIPTION
## Summary
`npm run build` (frontend) failed its TypeScript step on `main`: `AeroplaneTree.tsx:150` cast a typed `Turbulator` directly to `Record<string, unknown>` (no type overlap). Compilation succeeded; only `tsc` failed — and CI never ran `tsc`/`build`, so it slipped through.

## Changes
- Cast through `unknown` (`turb as unknown as Record<string, unknown>`); the existing runtime `typeof` guards keep field access safe.
- Add a **Type-check (tsc)** step to the frontend CI job (after lint, before unit tests) so a broken build type-check fails CI going forward.

## Verification
`npx tsc --noEmit` → exit 0; `npm run build` compiles + type-checks clean (Node 22).

Closes #962