### PR TITLE
feat(gh-963,gh-964): compare traceability + version-graph UX polish

### DIFF
--- a/app/api/v2/endpoints/versioning.py
+++ b/app/api/v2/endpoints/versioning.py
@@ -28,6 +28,7 @@ from app.core.exceptions import (
 from app.db.session import get_db
 from app.schemas.versioning import (
     BranchOut,
+    BranchRenameRequest,
     BranchRequest,
     CompareOut,
     SnapshotRequest,
@@ -230,6 +231,31 @@ async def discard_branch(
     lineage root.
     """
     _call(svc.discard_branch, db, branch_id)
+
+
+@router.patch(
+    "/branches/{branch_id}",
+    status_code=status.HTTP_200_OK,
+    tags=_TAGS_VERSIONING,
+    operation_id="rename_branch",
+    responses={
+        404: {"description": "Branch not found"},
+        409: {"description": "Branch name already used in this lineage"},
+        422: {"description": "Validation error — e.g. empty name"},
+    },
+)
+async def rename_branch(
+    branch_id: Annotated[int, Path(..., description="Integer PK of the branch to rename")],
+    body: Annotated[BranchRenameRequest, Body(...)],
+    db: Annotated[Session, Depends(get_db)],
+) -> BranchOut:
+    """Rename a branch within its lineage.
+
+    The name is stripped of leading/trailing whitespace.  Returns 409 if
+    another branch in the same lineage already has the target name.
+    """
+    branch = _call(svc.rename_branch, db, branch_id, body.name)
+    return _branch_to_schema(branch)
 
 
 @router.get(

--- a/app/schemas/versioning.py
+++ b/app/schemas/versioning.py
@@ -35,6 +35,14 @@ class BranchRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class BranchRenameRequest(BaseModel):
+    """Body for PATCH /branches/{branch_id}."""
+
+    name: str = Field(..., min_length=1, description="New branch name")
+
+    model_config = ConfigDict(extra="forbid")
+
+
 class VersionNode(BaseModel):
     """A single node in the version lineage graph.
 

--- a/app/services/aeroplane_version_service.py
+++ b/app/services/aeroplane_version_service.py
@@ -456,6 +456,62 @@ def list_tree(
     return nodes, branches
 
 
+def rename_branch(db: Session, branch_id: int, name: str) -> BranchModel:
+    """Rename a branch within its lineage.
+
+    Strips *name*; raises ValidationError if the result is empty.  Raises
+    ConflictError if another branch with the same ``root_id`` already has that
+    name (uniqueness enforced at the application level — no DB migration
+    required).
+
+    Returns the updated branch.
+
+    Raises
+    ------
+    NotFoundError
+        If *branch_id* does not exist.
+    ValidationError
+        If the stripped *name* is empty.
+    ConflictError
+        If a **different** branch in the same lineage already uses that name.
+    """
+    branch = _get_branch(db, branch_id)
+
+    stripped = name.strip()
+    if not stripped:
+        raise ValidationError(
+            message="Branch name must not be empty",
+            details={"branch_id": branch_id, "name": name},
+        )
+
+    # Uniqueness check within the lineage (app-level, no DB constraint).
+    conflict = (
+        db.query(BranchModel)
+        .filter(
+            BranchModel.root_id == branch.root_id,
+            BranchModel.name == stripped,
+            BranchModel.id != branch_id,
+        )
+        .first()
+    )
+    if conflict is not None:
+        raise ConflictError(
+            message="A branch with that name already exists in this lineage",
+            details={"branch_id": branch_id, "conflicting_branch_id": conflict.id, "name": stripped},
+        )
+
+    branch.name = stripped
+    db.flush()
+
+    logger.info(
+        "rename_branch: branch %s renamed to %r (root_id=%s)",
+        branch_id,
+        stripped,
+        branch.root_id,
+    )
+    return branch
+
+
 def list_aeroplanes_heads_only(db: Session) -> list[AeroplaneModel]:
     """Return only branch-head aeroplane nodes (``heads_only=True`` mode).
 

--- a/app/tests/test_aeroplane_version_service.py
+++ b/app/tests/test_aeroplane_version_service.py
@@ -34,6 +34,7 @@ from app.services.aeroplane_version_service import (
     discard_branch,
     list_aeroplanes_heads_only,
     list_tree,
+    rename_branch,
     restore,
     snapshot,
 )
@@ -711,6 +712,77 @@ def test_create_aeroplane_snapshot_works(db: Session):
     side = create_branch(db, plane.id, name="experiment")
     db.commit()
     assert side.root_id == plane.id
+
+
+# ---------------------------------------------------------------------------
+# 12. rename_branch
+# ---------------------------------------------------------------------------
+
+
+def test_rename_branch_happy_path(db: Session):
+    """rename_branch changes the branch name and returns the updated branch."""
+    root, branch = _make_root(db, "rename-test")
+
+    updated = rename_branch(db, branch.id, "new-name")
+    db.commit()
+    db.refresh(branch)
+
+    assert updated.name == "new-name"
+    assert branch.name == "new-name"
+
+
+def test_rename_branch_not_found_raises(db: Session):
+    """rename_branch raises NotFoundError for an unknown branch_id."""
+    with pytest.raises(NotFoundError):
+        rename_branch(db, 99999, "any-name")
+
+
+def test_rename_branch_empty_name_raises(db: Session):
+    """rename_branch raises ValidationError when the stripped name is empty."""
+    root, branch = _make_root(db, "empty-name-test")
+
+    with pytest.raises(ValidationError):
+        rename_branch(db, branch.id, "   ")
+
+
+def test_rename_branch_whitespace_only_name_raises(db: Session):
+    """rename_branch strips whitespace before validation."""
+    root, branch = _make_root(db, "ws-test")
+
+    with pytest.raises(ValidationError):
+        rename_branch(db, branch.id, "\t\n")
+
+
+def test_rename_branch_conflict_with_sibling_raises(db: Session):
+    """rename_branch raises ConflictError when another branch in the same lineage has the same name."""
+    root, main_branch = _make_root(db, "conflict-test")
+    side = create_branch(db, root.id, name="side")
+    db.commit()
+
+    # Trying to rename 'side' to 'main' (the existing name) must fail.
+    with pytest.raises(ConflictError):
+        rename_branch(db, side.id, "main")
+
+
+def test_rename_branch_same_name_is_allowed(db: Session):
+    """rename_branch to the same name (self) must not raise ConflictError."""
+    root, branch = _make_root(db, "same-name-test")
+
+    # Should not raise — self-rename is idempotent.
+    updated = rename_branch(db, branch.id, "main")
+    db.commit()
+
+    assert updated.name == "main"
+
+
+def test_rename_branch_strips_whitespace(db: Session):
+    """rename_branch strips leading/trailing whitespace from the name."""
+    root, branch = _make_root(db, "strip-test")
+
+    updated = rename_branch(db, branch.id, "  polished  ")
+    db.commit()
+
+    assert updated.name == "polished"
 
 
 # ---------------------------------------------------------------------------

--- a/app/tests/test_versioning_api_http.py
+++ b/app/tests/test_versioning_api_http.py
@@ -63,3 +63,62 @@ def test_snapshot_and_branch_over_http(client_and_db):
     branch = client.post(f"/aeroplanes/{a_id}/branch", json={"name": "http-branch"})
     assert branch.status_code in (200, 201), branch.text
     assert branch.json().get("name") == "http-branch"
+
+
+def _seed_branch(SessionLocal):
+    """Create an aeroplane with main branch and return (branch_id, aeroplane_id)."""
+    from app.models.aeroplanemodel import BranchModel
+    db = SessionLocal()
+    try:
+        ap = aeroplane_service.create_aeroplane(db, "Rename-Test")
+        db.commit()
+        db.refresh(ap)
+        br = db.query(BranchModel).filter(BranchModel.head_id == ap.id).first()
+        return br.id, ap.id
+    finally:
+        db.close()
+
+
+def _seed_aeroplane_with_two_branches(SessionLocal):
+    """Create an aeroplane with main branch + a side branch; return side_branch_id."""
+    db = SessionLocal()
+    try:
+        ap = aeroplane_service.create_aeroplane(db, "TwoBranch-Test")
+        db.commit()
+        db.refresh(ap)
+        side = vs.create_branch(db, ap.id, "original-side")
+        db.commit()
+        db.refresh(side)
+        return side.id
+    finally:
+        db.close()
+
+
+def test_rename_branch_returns_200_with_updated_name(client_and_db):
+    """PATCH /branches/{id} with a valid name returns 200 and the renamed branch."""
+    client, SessionLocal = client_and_db
+    branch_id, _ap_id = _seed_branch(SessionLocal)
+
+    resp = client.patch(f"/branches/{branch_id}", json={"name": "renamed-main"})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["name"] == "renamed-main"
+    assert body["id"] == branch_id
+
+
+def test_rename_branch_unknown_id_returns_404(client_and_db):
+    """PATCH /branches/{id} for a nonexistent branch returns 404."""
+    client, _ = client_and_db
+
+    resp = client.patch("/branches/999999", json={"name": "ghost"})
+    assert resp.status_code == 404, resp.text
+
+
+def test_rename_branch_duplicate_name_returns_409(client_and_db):
+    """PATCH /branches/{id} to a name already used by a sibling branch returns 409."""
+    client, SessionLocal = client_and_db
+    side_branch_id = _seed_aeroplane_with_two_branches(SessionLocal)
+
+    # Try to rename the side branch to "main" (which the main branch already has).
+    resp = client.patch(f"/branches/{side_branch_id}", json={"name": "main"})
+    assert resp.status_code == 409, resp.text

--- a/frontend/__tests__/VersionCompareView.test.tsx
+++ b/frontend/__tests__/VersionCompareView.test.tsx
@@ -565,12 +565,12 @@ describe("VersionCompareView (gh-907)", () => {
         />,
       );
 
-      // The branch pill for node_a (branch_id=1) must carry title="1"
+      // The branch pill carries a self-explanatory id tooltip ("branch id: N").
       const pills = container.querySelectorAll('[data-testid="compare-branch-pill-A"], [data-testid="compare-branch-pill-B"]');
       expect(pills.length).toBe(2);
       const titlesInPills = Array.from(pills).map((el) => el.getAttribute("title"));
-      expect(titlesInPills).toContain("1");
-      expect(titlesInPills).toContain("2");
+      expect(titlesInPills).toContain("branch id: 1");
+      expect(titlesInPills).toContain("branch id: 2");
     });
 
     it("falls back to 'branch <id>' when branch not in branchNameMap", () => {
@@ -747,17 +747,14 @@ describe("VersionCompareView (gh-907)", () => {
   // 13. Warning renders when assumption_computation_context is absent
   // -------------------------------------------------------------------------
   describe("no-analysis-context warning (gh-963)", () => {
-    it("renders warning for side A when metrics_a has no assumption_computation_context", () => {
-      // metrics_a without assumption_computation_context key, but with
-      // enough fields that the fallback toCtx() path works for the metric rows.
-      const flatCtx = makeCtx() as unknown as Record<string, unknown>;
-      const metricsWithoutCtxKey: Record<string, unknown> = { ...flatCtx, total_mass_kg: 1.5 };
-      // Explicitly remove assumption_computation_context if present
-      delete metricsWithoutCtxKey["assumption_computation_context"];
+    it("renders warning for side A when metrics_a has no usable operating point", () => {
+      // Only mass present — no operating-point fields anywhere (no nested
+      // context, no flat reynolds/v_cruise/computed_at). Must warn, not render
+      // mass alone (metrics aren't comparable without the conditions).
       const compareOut: CompareOut = {
         node_a: BASE_NODE_A,
         node_b: BASE_NODE_B,
-        metrics_a: metricsWithoutCtxKey,
+        metrics_a: { total_mass_kg: 1.5 },
         metrics_b: wrapCtx(makeCtx()),
       };
 
@@ -772,7 +769,30 @@ describe("VersionCompareView (gh-907)", () => {
 
       const ctxBlockA = container.querySelector('[data-testid="compare-analysis-context-A"]');
       expect(ctxBlockA).not.toBeNull();
-      // Should contain a warning about no analysis context
+      const text = ctxBlockA?.textContent ?? "";
+      expect(text).toMatch(/no analysis context|values may not be comparable/i);
+    });
+
+    it("renders warning when assumption_computation_context is an empty object", () => {
+      // Present-but-empty context: the key exists but carries no operating
+      // point — must warn rather than render a blank line.
+      const compareOut: CompareOut = {
+        node_a: BASE_NODE_A,
+        node_b: BASE_NODE_B,
+        metrics_a: { assumption_computation_context: {}, total_mass_kg: 1.5 },
+        metrics_b: wrapCtx(makeCtx()),
+      };
+
+      const { container } = render(
+        <VersionCompareView
+          compareOut={compareOut}
+          isLoading={false}
+          error={null}
+          onClose={vi.fn()}
+        />,
+      );
+
+      const ctxBlockA = container.querySelector('[data-testid="compare-analysis-context-A"]');
       const text = ctxBlockA?.textContent ?? "";
       expect(text).toMatch(/no analysis context|values may not be comparable/i);
     });

--- a/frontend/__tests__/VersionCompareView.test.tsx
+++ b/frontend/__tests__/VersionCompareView.test.tsx
@@ -10,6 +10,10 @@
  * 6. Error state shows the error text.
  * 7. Close button calls onClose.
  * 8. Renders gracefully when metrics_a / metrics_b are null (no crash).
+ * 11. branchNameMap: branch NAME shown instead of "branch <id>".
+ * 12. analysis-context line shows mass / Re / v_cruise when present.
+ * 13. Warning renders when assumption_computation_context is absent.
+ * 14. Metric body still renders with branchNameMap prop (regression).
  */
 
 import { describe, it, expect, vi } from "vitest";
@@ -515,5 +519,326 @@ describe("VersionCompareView (gh-907)", () => {
       const wrapper = container.querySelector('[data-testid="version-compare-view"]');
       expect(wrapper).not.toBeNull();
     });
+  });
+
+  // -------------------------------------------------------------------------
+  // 11. branchNameMap: branch NAME shown instead of "branch <id>"
+  // -------------------------------------------------------------------------
+  describe("branchNameMap (gh-963)", () => {
+    it("shows the branch NAME from branchNameMap instead of 'branch <id>'", () => {
+      const compareOut = makeCompareOut(makeCtx(), makeCtx());
+      // node_a has branch_id=1, node_b has branch_id=2
+      const branchNameMap = new Map([
+        [1, "main"],
+        [2, "winglet-experiment"],
+      ]);
+
+      render(
+        <VersionCompareView
+          compareOut={compareOut}
+          isLoading={false}
+          error={null}
+          onClose={vi.fn()}
+          branchNameMap={branchNameMap}
+        />,
+      );
+
+      // Should show branch names, not raw ids
+      expect(screen.getByText("main")).toBeDefined();
+      expect(screen.getByText("winglet-experiment")).toBeDefined();
+      // Should NOT show "branch 1" or "branch 2" as text
+      expect(screen.queryByText(/^branch\s+1$/i)).toBeNull();
+      expect(screen.queryByText(/^branch\s+2$/i)).toBeNull();
+    });
+
+    it("branch pill has numeric id as title tooltip", () => {
+      const compareOut = makeCompareOut(makeCtx(), makeCtx());
+      const branchNameMap = new Map([[1, "main"], [2, "winglet-experiment"]]);
+
+      const { container } = render(
+        <VersionCompareView
+          compareOut={compareOut}
+          isLoading={false}
+          error={null}
+          onClose={vi.fn()}
+          branchNameMap={branchNameMap}
+        />,
+      );
+
+      // The branch pill for node_a (branch_id=1) must carry title="1"
+      const pills = container.querySelectorAll('[data-testid="compare-branch-pill-A"], [data-testid="compare-branch-pill-B"]');
+      expect(pills.length).toBe(2);
+      const titlesInPills = Array.from(pills).map((el) => el.getAttribute("title"));
+      expect(titlesInPills).toContain("1");
+      expect(titlesInPills).toContain("2");
+    });
+
+    it("falls back to 'branch <id>' when branch not in branchNameMap", () => {
+      const compareOut = makeCompareOut(makeCtx(), makeCtx());
+      // Provide map for branch 1 only; branch 2 is absent
+      const branchNameMap = new Map([[1, "main"]]);
+
+      render(
+        <VersionCompareView
+          compareOut={compareOut}
+          isLoading={false}
+          error={null}
+          onClose={vi.fn()}
+          branchNameMap={branchNameMap}
+        />,
+      );
+
+      // Branch 1 is named; branch 2 falls back to "branch 2"
+      expect(screen.getByText("main")).toBeDefined();
+      expect(screen.getByText(/branch\s+2/i)).toBeDefined();
+    });
+
+    it("shows 'legacy' when branch_id is null (even with branchNameMap)", () => {
+      const nodeWithNullBranch: VersionNode = { ...BASE_NODE_A, branch_id: null };
+      const compareOut: CompareOut = {
+        node_a: nodeWithNullBranch,
+        node_b: BASE_NODE_B,
+        metrics_a: null,
+        metrics_b: null,
+      };
+      const branchNameMap = new Map([[2, "winglet-experiment"]]);
+
+      render(
+        <VersionCompareView
+          compareOut={compareOut}
+          isLoading={false}
+          error={null}
+          onClose={vi.fn()}
+          branchNameMap={branchNameMap}
+        />,
+      );
+
+      expect(screen.getByText("legacy")).toBeDefined();
+    });
+
+    it("without branchNameMap still shows 'branch <id>' (regression)", () => {
+      const compareOut = makeCompareOut(makeCtx(), makeCtx());
+
+      render(
+        <VersionCompareView
+          compareOut={compareOut}
+          isLoading={false}
+          error={null}
+          onClose={vi.fn()}
+        />,
+      );
+
+      // No branchNameMap → raw id fallback
+      expect(screen.getByText(/branch\s+1/i)).toBeDefined();
+      expect(screen.getByText(/branch\s+2/i)).toBeDefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 12. Analysis-context line shows mass / Re / v_cruise when present
+  // -------------------------------------------------------------------------
+  describe("analysis-context disclosure (gh-963)", () => {
+    it("renders analysis-context block for side A with mass, Re, v_cruise", () => {
+      const ctxA = makeCtx({ v_cruise_mps: 18.5, reynolds: 300000 });
+      const compareOut: CompareOut = {
+        node_a: BASE_NODE_A,
+        node_b: BASE_NODE_B,
+        metrics_a: { total_mass_kg: 2.3, assumption_computation_context: ctxA },
+        metrics_b: null,
+      };
+
+      const { container } = render(
+        <VersionCompareView
+          compareOut={compareOut}
+          isLoading={false}
+          error={null}
+          onClose={vi.fn()}
+        />,
+      );
+
+      const ctxBlockA = container.querySelector('[data-testid="compare-analysis-context-A"]');
+      expect(ctxBlockA).not.toBeNull();
+      const text = ctxBlockA?.textContent ?? "";
+      expect(text).toMatch(/2\.3\s*kg/);
+      expect(text).toMatch(/Re/i);
+      expect(text).toMatch(/300.?000|3\.0?e\+?5|300k/i);
+      expect(text).toMatch(/v_cruise.*18\.5|18\.5.*m\/s/i);
+    });
+
+    it("renders analysis-context block for side B with mass, Re, v_cruise", () => {
+      const ctxB = makeCtx({ v_cruise_mps: 22.0, reynolds: 450000 });
+      const compareOut: CompareOut = {
+        node_a: BASE_NODE_A,
+        node_b: BASE_NODE_B,
+        metrics_a: null,
+        metrics_b: { total_mass_kg: 4.1, assumption_computation_context: ctxB },
+      };
+
+      const { container } = render(
+        <VersionCompareView
+          compareOut={compareOut}
+          isLoading={false}
+          error={null}
+          onClose={vi.fn()}
+        />,
+      );
+
+      const ctxBlockB = container.querySelector('[data-testid="compare-analysis-context-B"]');
+      expect(ctxBlockB).not.toBeNull();
+      const text = ctxBlockB?.textContent ?? "";
+      expect(text).toMatch(/4\.1\s*kg/);
+      expect(text).toMatch(/Re/i);
+      expect(text).toMatch(/22\.0|22\s*m\/s/i);
+    });
+
+    it("includes a short date from computed_at in the context line", () => {
+      const ctxA = makeCtx({ computed_at: "2026-03-14T09:00:00Z" });
+      const compareOut: CompareOut = {
+        node_a: BASE_NODE_A,
+        node_b: BASE_NODE_B,
+        metrics_a: { total_mass_kg: 1.0, assumption_computation_context: ctxA },
+        metrics_b: null,
+      };
+
+      const { container } = render(
+        <VersionCompareView
+          compareOut={compareOut}
+          isLoading={false}
+          error={null}
+          onClose={vi.fn()}
+        />,
+      );
+
+      const ctxBlockA = container.querySelector('[data-testid="compare-analysis-context-A"]');
+      const text = ctxBlockA?.textContent ?? "";
+      // Should contain some date-related text for 2026-03-14
+      expect(text).toMatch(/2026|Mar|14/i);
+    });
+
+    it("skips mass part when total_mass_kg is absent", () => {
+      const ctxA = makeCtx({ v_cruise_mps: 15.0, reynolds: 250000 });
+      const compareOut: CompareOut = {
+        node_a: BASE_NODE_A,
+        node_b: BASE_NODE_B,
+        // No total_mass_kg
+        metrics_a: { assumption_computation_context: ctxA },
+        metrics_b: null,
+      };
+
+      const { container } = render(
+        <VersionCompareView
+          compareOut={compareOut}
+          isLoading={false}
+          error={null}
+          onClose={vi.fn()}
+        />,
+      );
+
+      const ctxBlockA = container.querySelector('[data-testid="compare-analysis-context-A"]');
+      const text = ctxBlockA?.textContent ?? "";
+      // Should not mention kg
+      expect(text).not.toMatch(/kg/i);
+      // But should still have Re and v_cruise
+      expect(text).toMatch(/Re/i);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 13. Warning renders when assumption_computation_context is absent
+  // -------------------------------------------------------------------------
+  describe("no-analysis-context warning (gh-963)", () => {
+    it("renders warning for side A when metrics_a has no assumption_computation_context", () => {
+      // metrics_a without assumption_computation_context key, but with
+      // enough fields that the fallback toCtx() path works for the metric rows.
+      const flatCtx = makeCtx() as unknown as Record<string, unknown>;
+      const metricsWithoutCtxKey: Record<string, unknown> = { ...flatCtx, total_mass_kg: 1.5 };
+      // Explicitly remove assumption_computation_context if present
+      delete metricsWithoutCtxKey["assumption_computation_context"];
+      const compareOut: CompareOut = {
+        node_a: BASE_NODE_A,
+        node_b: BASE_NODE_B,
+        metrics_a: metricsWithoutCtxKey,
+        metrics_b: wrapCtx(makeCtx()),
+      };
+
+      const { container } = render(
+        <VersionCompareView
+          compareOut={compareOut}
+          isLoading={false}
+          error={null}
+          onClose={vi.fn()}
+        />,
+      );
+
+      const ctxBlockA = container.querySelector('[data-testid="compare-analysis-context-A"]');
+      expect(ctxBlockA).not.toBeNull();
+      // Should contain a warning about no analysis context
+      const text = ctxBlockA?.textContent ?? "";
+      expect(text).toMatch(/no analysis context|values may not be comparable/i);
+    });
+
+    it("renders warning for side B when metrics_b is null", () => {
+      const compareOut: CompareOut = {
+        node_a: BASE_NODE_A,
+        node_b: BASE_NODE_B,
+        metrics_a: wrapCtx(makeCtx()),
+        metrics_b: null,
+      };
+
+      const { container } = render(
+        <VersionCompareView
+          compareOut={compareOut}
+          isLoading={false}
+          error={null}
+          onClose={vi.fn()}
+        />,
+      );
+
+      const ctxBlockB = container.querySelector('[data-testid="compare-analysis-context-B"]');
+      expect(ctxBlockB).not.toBeNull();
+      const text = ctxBlockB?.textContent ?? "";
+      expect(text).toMatch(/no analysis context|values may not be comparable/i);
+    });
+
+    it("does NOT render warning for side A when assumption_computation_context is present", () => {
+      const compareOut = makeCompareOut(makeCtx(), makeCtx());
+
+      const { container } = render(
+        <VersionCompareView
+          compareOut={compareOut}
+          isLoading={false}
+          error={null}
+          onClose={vi.fn()}
+        />,
+      );
+
+      const ctxBlockA = container.querySelector('[data-testid="compare-analysis-context-A"]');
+      const text = ctxBlockA?.textContent ?? "";
+      expect(text).not.toMatch(/no analysis context/i);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 14. Metric rows still render with branchNameMap prop (regression)
+  // -------------------------------------------------------------------------
+  it("metric rows still render when branchNameMap is provided (regression)", () => {
+    const branchNameMap = new Map([[1, "main"], [2, "feature-x"]]);
+    const ctxA = makeCtx({ v_cruise_mps: 15.0 });
+    const ctxB = makeCtx({ v_cruise_mps: 20.0 });
+    const compareOut = makeCompareOut(ctxA, ctxB);
+
+    const { container } = render(
+      <VersionCompareView
+        compareOut={compareOut}
+        isLoading={false}
+        error={null}
+        onClose={vi.fn()}
+        branchNameMap={branchNameMap}
+      />,
+    );
+
+    const row = container.querySelector('[data-testid="compare-row-V_cruise"]');
+    expect(row).not.toBeNull();
+    expect(row?.getAttribute("data-differs")).toBe("true");
   });
 });

--- a/frontend/__tests__/VersionGraphOverlay.test.tsx
+++ b/frontend/__tests__/VersionGraphOverlay.test.tsx
@@ -43,6 +43,7 @@ vi.mock("lucide-react", () => {
     Camera: icon,
     GitMerge: icon,
     ChevronDown: icon,
+    Pencil: icon,
   };
 });
 
@@ -205,6 +206,7 @@ const DEFAULT_ACTIONS = {
   adoptBranch: vi.fn().mockResolvedValue({ id: 2, head_id: 30, is_main: true }),
   restore: vi.fn().mockResolvedValue({ id: 5, head_id: 20, name: "restored" }),
   discardBranch: vi.fn().mockResolvedValue(undefined),
+  renameBranch: vi.fn().mockResolvedValue({ id: 2, name: "new-name" }),
 };
 
 // ---------------------------------------------------------------------------
@@ -558,7 +560,7 @@ describe("VersionGraphOverlay (gh-961)", () => {
 
     await user.click(screen.getByRole("button", { name: /discard/i }));
 
-    expect(screen.getByText(/delete all nodes/i)).toBeDefined();
+    expect(screen.getByText(/active design is not affected/i)).toBeDefined();
     expect(discardBranch).not.toHaveBeenCalled();
   });
 
@@ -640,5 +642,227 @@ describe("VersionGraphOverlay (gh-961)", () => {
     await user.click(screen.getByRole("button", { name: /confirm snapshot/i }));
 
     await waitFor(() => expect(snapshot).toHaveBeenCalledOnce());
+  });
+
+  // -------------------------------------------------------------------------
+  // gh-964 § 1: Plain-language tooltips on every toolbar button
+  // -------------------------------------------------------------------------
+  describe("gh-964 §1 — plain-language tooltips", () => {
+    it("Snapshot button has a tooltip when disabled (no selection)", () => {
+      renderOverlay();
+      const btn = screen.getByRole("button", { name: /snapshot/i });
+      expect(btn.getAttribute("title")).toBeTruthy();
+    });
+
+    it("Snapshot enabled on editable head has action tooltip", async () => {
+      const user = userEvent.setup();
+      renderOverlay();
+      const row = screen.getByTestId("graph-row-10");
+      await user.click(row);
+      const btn = screen.getByRole("button", { name: /snapshot/i });
+      expect(btn.hasAttribute("disabled")).toBe(false);
+      expect(btn.getAttribute("title")).toMatch(/checkpoint/i);
+    });
+
+    it("Branch from enabled has action tooltip", async () => {
+      const user = userEvent.setup();
+      renderOverlay();
+      const row = screen.getByTestId("graph-row-10");
+      await user.click(row);
+      const btn = screen.getByRole("button", { name: /branch from/i });
+      expect(btn.hasAttribute("disabled")).toBe(false);
+      expect(btn.getAttribute("title")).toMatch(/variant/i);
+    });
+
+    it("Restore enabled on snapshot has action tooltip", async () => {
+      const user = userEvent.setup();
+      renderOverlay();
+      // select snapshot v1.1 (id 20)
+      const row = screen.getByTestId("graph-row-20");
+      await user.click(row);
+      const btn = screen.getByRole("button", { name: /restore/i });
+      expect(btn.hasAttribute("disabled")).toBe(false);
+      expect(btn.getAttribute("title")).toMatch(/branch/i);
+    });
+
+    it("Adopt enabled has action tooltip", async () => {
+      const user = userEvent.setup();
+      renderOverlay();
+      // select non-main branch head (winglet draft, id 30)
+      const row = screen.getByTestId("graph-row-30");
+      await user.click(row);
+      const btn = screen.getByRole("button", { name: /adopt/i });
+      expect(btn.hasAttribute("disabled")).toBe(false);
+      expect(btn.getAttribute("title")).toMatch(/active/i);
+    });
+
+    it("Discard enabled has action tooltip", async () => {
+      const user = userEvent.setup();
+      renderOverlay();
+      const row = screen.getByTestId("graph-row-30");
+      await user.click(row);
+      const btn = screen.getByRole("button", { name: /discard/i });
+      expect(btn.hasAttribute("disabled")).toBe(false);
+      expect(btn.getAttribute("title")).toMatch(/delete/i);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // gh-964 § 2: Clearer confirmations
+  // -------------------------------------------------------------------------
+  describe("gh-964 §2 — clearer confirmations", () => {
+    it("discard confirm copy includes the branch name", async () => {
+      const user = userEvent.setup();
+      renderOverlay();
+      // Select winglet-exp branch head (non-main)
+      const row = screen.getByTestId("graph-row-30");
+      await user.click(row);
+      await user.click(screen.getByRole("button", { name: /discard/i }));
+      // Confirm copy names the branch and reassures the active design is safe
+      const confirm = screen.getByText(/active design is not affected/i);
+      expect(confirm.textContent).toMatch(/ai\/winglet-exp/i);
+    });
+
+    it("adopt has a two-step confirm naming the branch", async () => {
+      const user = userEvent.setup();
+      const adoptBranch = vi.fn().mockResolvedValue({ id: 2, head_id: 30, is_main: true });
+      renderOverlay({ actionsOverride: { adoptBranch } });
+
+      const row = screen.getByTestId("graph-row-30");
+      await user.click(row);
+
+      // First click should show confirm step, NOT call adoptBranch yet
+      await user.click(screen.getByRole("button", { name: /adopt/i }));
+      expect(adoptBranch).not.toHaveBeenCalled();
+
+      // The confirm copy should name the branch and mention the active design
+      const confirm = screen.getByText(/the active design\?/i);
+      expect(confirm.textContent).toMatch(/ai\/winglet-exp/i);
+      expect(confirm.textContent).toMatch(/main/i);
+    });
+
+    it("confirming adopt calls adoptBranch with the correct branchId", async () => {
+      const user = userEvent.setup();
+      const adoptBranch = vi.fn().mockResolvedValue({ id: 2, head_id: 30, is_main: true });
+      renderOverlay({ actionsOverride: { adoptBranch } });
+
+      const row = screen.getByTestId("graph-row-30");
+      await user.click(row);
+
+      await user.click(screen.getByRole("button", { name: /adopt/i }));
+      await user.click(screen.getByRole("button", { name: /confirm adopt/i }));
+
+      await waitFor(() => expect(adoptBranch).toHaveBeenCalledOnce());
+      expect(adoptBranch).toHaveBeenCalledWith(2);
+    });
+
+    it("cancelling adopt confirm does not call adoptBranch", async () => {
+      const user = userEvent.setup();
+      const adoptBranch = vi.fn().mockResolvedValue({ id: 2, head_id: 30, is_main: true });
+      renderOverlay({ actionsOverride: { adoptBranch } });
+
+      const row = screen.getByTestId("graph-row-30");
+      await user.click(row);
+
+      await user.click(screen.getByRole("button", { name: /adopt/i }));
+      await user.click(screen.getByRole("button", { name: /cancel adopt/i }));
+
+      expect(adoptBranch).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // gh-964 § 3: Legend + sorted-by-date note
+  // -------------------------------------------------------------------------
+  describe("gh-964 §3 — legend and sorted-by-date note", () => {
+    it("renders the version graph legend element", () => {
+      renderOverlay();
+      expect(screen.getByTestId("version-graph-legend")).toBeDefined();
+    });
+
+    it("legend contains snapshot glyph and editable head glyph", () => {
+      renderOverlay();
+      const legend = screen.getByTestId("version-graph-legend");
+      expect(legend.textContent).toMatch(/snapshot/i);
+      expect(legend.textContent).toMatch(/editable/i);
+    });
+
+    it("sorted-by-date note is present near the legend", () => {
+      renderOverlay();
+      expect(screen.getByText(/sorted by date/i)).toBeDefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // gh-964 § 4: Branch rename
+  // -------------------------------------------------------------------------
+  describe("gh-964 §4 — branch rename", () => {
+    it("Rename button is disabled when no branch is selected", () => {
+      renderOverlay();
+      expect(screen.getByRole("button", { name: /rename/i }).hasAttribute("disabled")).toBe(true);
+    });
+
+    it("Rename button is enabled when a non-main branch is selected", async () => {
+      const user = userEvent.setup();
+      renderOverlay();
+      const row = screen.getByTestId("graph-row-30");
+      await user.click(row);
+      expect(screen.getByRole("button", { name: /rename/i }).hasAttribute("disabled")).toBe(false);
+    });
+
+    it("clicking Rename shows the name input pre-filled with current branch name", async () => {
+      const user = userEvent.setup();
+      renderOverlay();
+      const row = screen.getByTestId("graph-row-30");
+      await user.click(row);
+      await user.click(screen.getByRole("button", { name: /rename/i }));
+      const input = screen.getByRole("textbox", { name: /rename branch/i });
+      expect(input).toBeDefined();
+      // Should be pre-filled with current branch name
+      expect((input as HTMLInputElement).value).toBe("ai/winglet-exp");
+    });
+
+    it("confirming rename calls renameBranch with (branchId, newName)", async () => {
+      const user = userEvent.setup();
+      const renameBranch = vi.fn().mockResolvedValue({ id: 2, name: "new-name" });
+      renderOverlay({ actionsOverride: { renameBranch } });
+      const row = screen.getByTestId("graph-row-30");
+      await user.click(row);
+      await user.click(screen.getByRole("button", { name: /rename/i }));
+
+      const input = screen.getByRole("textbox", { name: /rename branch/i });
+      await user.clear(input);
+      await user.type(input, "new-name");
+      await user.click(screen.getByRole("button", { name: /confirm rename/i }));
+
+      await waitFor(() => expect(renameBranch).toHaveBeenCalledOnce());
+      expect(renameBranch).toHaveBeenCalledWith(2, "new-name");
+    });
+
+    it("Escape while rename input is open closes input, not the overlay", async () => {
+      const user = userEvent.setup();
+      const onClose = vi.fn();
+      renderOverlay({ onClose });
+
+      const row = screen.getByTestId("graph-row-30");
+      await user.click(row);
+      await user.click(screen.getByRole("button", { name: /rename/i }));
+      expect(screen.getByRole("textbox", { name: /rename branch/i })).toBeDefined();
+
+      await user.keyboard("{Escape}");
+
+      expect(screen.queryByRole("textbox", { name: /rename branch/i })).toBeNull();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it("Rename button has an action tooltip", async () => {
+      const user = userEvent.setup();
+      renderOverlay();
+      const row = screen.getByTestId("graph-row-30");
+      await user.click(row);
+      const btn = screen.getByRole("button", { name: /rename/i });
+      expect(btn.hasAttribute("disabled")).toBe(false);
+      expect(btn.getAttribute("title")).toMatch(/rename/i);
+    });
   });
 });

--- a/frontend/components/workbench/VersionCompareView.tsx
+++ b/frontend/components/workbench/VersionCompareView.tsx
@@ -315,6 +315,90 @@ function MetricRow({ symbol, valA, valB, labelA, labelB, differs }: MetricRowPro
 }
 
 // ---------------------------------------------------------------------------
+// Analysis-context disclosure line (gh-963)
+// ---------------------------------------------------------------------------
+
+interface AnalysisContextLineProps {
+  readonly metrics: Record<string, unknown> | null;
+  readonly side: "A" | "B";
+}
+
+/**
+ * Small muted line disclosing the computation assumptions behind the metrics
+ * column. Sourced from metrics.total_mass_kg and
+ * metrics.assumption_computation_context.
+ *
+ * If assumption_computation_context is absent or empty, renders an amber
+ * warning instead so the reviewer knows the values may not be comparable.
+ */
+function AnalysisContextLine({ metrics, side }: AnalysisContextLineProps) {
+  const testId = `compare-analysis-context-${side}`;
+
+  // Extract computation context from metrics
+  const ctx =
+    metrics != null &&
+    metrics["assumption_computation_context"] != null &&
+    typeof metrics["assumption_computation_context"] === "object"
+      ? (metrics["assumption_computation_context"] as ComputationContext)
+      : null;
+
+  const hasContext = ctx != null;
+
+  if (!hasContext) {
+    return (
+      <div
+        data-testid={testId}
+        className="pl-6 mt-1 text-[9px] text-amber-400"
+      >
+        ⚠ no analysis context — values may not be comparable
+      </div>
+    );
+  }
+
+  // Build the disclosure parts
+  const parts: string[] = [];
+
+  const massKg =
+    metrics != null && typeof metrics["total_mass_kg"] === "number"
+      ? (metrics["total_mass_kg"] as number)
+      : null;
+  if (massKg != null) {
+    parts.push(`${massKg} kg`);
+  }
+
+  if (ctx.reynolds != null) {
+    parts.push(`Re≈${Math.round(ctx.reynolds).toLocaleString("en-GB")}`);
+  }
+
+  if (ctx.v_cruise_mps != null) {
+    parts.push(`v_cruise ${ctx.v_cruise_mps.toFixed(1)} m/s`);
+  }
+
+  if (ctx.computed_at) {
+    try {
+      const d = new Date(ctx.computed_at);
+      const shortDate = d.toLocaleDateString("en-GB", {
+        day: "numeric",
+        month: "short",
+        year: "numeric",
+      });
+      parts.push(shortDate);
+    } catch {
+      parts.push(ctx.computed_at);
+    }
+  }
+
+  return (
+    <div
+      data-testid={testId}
+      className="pl-6 mt-1 text-[9px] text-subtle-foreground"
+    >
+      {parts.join(" · ")}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Node identity header (gh-961) — disambiguates even when version_label is
 // shared between both sides.
 // ---------------------------------------------------------------------------
@@ -342,6 +426,8 @@ function formatTimestamp(iso: string): string {
 interface NodeIdentityHeaderProps {
   readonly node: VersionNode;
   readonly side: "A" | "B";
+  readonly branchNameMap?: ReadonlyMap<number, string>;
+  readonly metrics: Record<string, unknown> | null;
 }
 
 /**
@@ -357,7 +443,7 @@ interface NodeIdentityHeaderProps {
  *   - author chip (created_by)
  *   - timestamp (created_at, formatted)
  */
-function NodeIdentityHeader({ node, side }: NodeIdentityHeaderProps) {
+function NodeIdentityHeader({ node, side, branchNameMap, metrics }: NodeIdentityHeaderProps) {
   const isAi = isAgentAuthor(node.created_by);
   const sideColor =
     side === "A"
@@ -406,10 +492,23 @@ function NodeIdentityHeader({ node, side }: NodeIdentityHeaderProps) {
         <span className="rounded bg-muted/60 px-1 py-0.5 font-[family-name:var(--font-geist-mono)] text-[9px] text-muted-foreground">
           #{node.id}
         </span>
-        {/* Branch */}
-        <span className="rounded bg-muted/60 px-1 py-0.5 font-[family-name:var(--font-geist-mono)] text-[9px] text-muted-foreground">
-          {node.branch_id != null ? `branch ${node.branch_id}` : "legacy"}
-        </span>
+        {/* Branch — show name from map when available, raw id as tooltip */}
+        {node.branch_id != null ? (
+          <span
+            data-testid={`compare-branch-pill-${side}`}
+            title={String(node.branch_id)}
+            className="rounded bg-muted/60 px-1 py-0.5 font-[family-name:var(--font-geist-mono)] text-[9px] text-muted-foreground"
+          >
+            {branchNameMap?.get(node.branch_id) ?? `branch ${node.branch_id}`}
+          </span>
+        ) : (
+          <span
+            data-testid={`compare-branch-pill-${side}`}
+            className="rounded bg-muted/60 px-1 py-0.5 font-[family-name:var(--font-geist-mono)] text-[9px] text-muted-foreground"
+          >
+            legacy
+          </span>
+        )}
         {/* Author */}
         <span className="rounded bg-muted/60 px-1 py-0.5 font-[family-name:var(--font-geist-mono)] text-[9px] text-muted-foreground">
           {authorLabel(node.created_by)}
@@ -432,6 +531,9 @@ function NodeIdentityHeader({ node, side }: NodeIdentityHeaderProps) {
           {node.version_note}
         </p>
       )}
+
+      {/* Analysis-context disclosure line */}
+      <AnalysisContextLine metrics={metrics} side={side} />
     </div>
   );
 }
@@ -445,6 +547,8 @@ export interface VersionCompareViewProps {
   readonly isLoading: boolean;
   readonly error: string | null;
   readonly onClose: () => void;
+  /** Map from branch id → branch name, used to display human-readable branch names. */
+  readonly branchNameMap?: ReadonlyMap<number, string>;
 }
 
 export function VersionCompareView({
@@ -452,6 +556,7 @@ export function VersionCompareView({
   isLoading,
   error,
   onClose,
+  branchNameMap,
 }: VersionCompareViewProps) {
   return (
     <div
@@ -491,11 +596,21 @@ export function VersionCompareView({
           <>
             {/* Column headers */}
             <div className="mb-4 grid grid-cols-[1fr_auto_1fr] items-center gap-2">
-              <NodeIdentityHeader node={compareOut.node_a} side="A" />
+              <NodeIdentityHeader
+                node={compareOut.node_a}
+                side="A"
+                branchNameMap={branchNameMap}
+                metrics={compareOut.metrics_a}
+              />
               <div className="flex h-6 w-6 items-center justify-center text-muted-foreground/40">
                 <ArrowLeftRight size={11} />
               </div>
-              <NodeIdentityHeader node={compareOut.node_b} side="B" />
+              <NodeIdentityHeader
+                node={compareOut.node_b}
+                side="B"
+                branchNameMap={branchNameMap}
+                metrics={compareOut.metrics_b}
+              />
             </div>
 
             {/* Column label row */}

--- a/frontend/components/workbench/VersionCompareView.tsx
+++ b/frontend/components/workbench/VersionCompareView.tsx
@@ -38,18 +38,26 @@ import type { GaugeData, MetricItem } from "@/components/workbench/metrics-dashb
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Cast the opaque metrics dict to ComputationContext for the adapters. */
+/**
+ * Cast the opaque metrics dict to ComputationContext for the adapters.
+ *
+ * The backend returns `assumption_computation_context` as a nested field, OR
+ * the dict IS the context directly (flat). Either way we only treat it as a
+ * real context when it carries the geometry the metric adapters require
+ * (`mac_m`); a sparse/empty dict returns null so the adapters render "–" and
+ * the disclosure line warns, instead of crashing on a missing field.
+ */
 function toCtx(metrics: Record<string, unknown> | null): ComputationContext | null {
   if (metrics == null) return null;
-  // The backend returns assumption_computation_context as a nested field in
-  // the metrics dict, OR the dict IS the computation context directly.
-  // Try both shapes, falling back to treating the whole dict as a ctx.
   const nested = metrics["assumption_computation_context"];
-  if (nested != null && typeof nested === "object") {
-    return nested as ComputationContext;
+  const candidate =
+    nested != null && typeof nested === "object"
+      ? (nested as Record<string, unknown>)
+      : metrics;
+  if (typeof candidate["mac_m"] === "number") {
+    return candidate as unknown as ComputationContext;
   }
-  // Treat the metrics dict itself as the computation context.
-  return metrics as unknown as ComputationContext;
+  return null;
 }
 
 function nodeLabel(node: VersionNode): string {
@@ -334,65 +342,47 @@ interface AnalysisContextLineProps {
 function AnalysisContextLine({ metrics, side }: AnalysisContextLineProps) {
   const testId = `compare-analysis-context-${side}`;
 
-  // Extract computation context from metrics
-  const ctx =
-    metrics != null &&
-    metrics["assumption_computation_context"] != null &&
-    typeof metrics["assumption_computation_context"] === "object"
-      ? (metrics["assumption_computation_context"] as ComputationContext)
-      : null;
+  // Use the same extraction as the metric rows (incl. the flat-payload
+  // fallback) so the disclosure line and the numbers below it never disagree.
+  const ctx = toCtx(metrics);
 
-  const hasContext = ctx != null;
-
-  if (!hasContext) {
-    return (
-      <div
-        data-testid={testId}
-        className="pl-6 mt-1 text-[9px] text-amber-400"
-      >
-        ⚠ no analysis context — values may not be comparable
-      </div>
+  // Aero operating-point fields are the real "analysis context". Each is
+  // type-guarded because `ctx` is an unchecked cast — a malformed payload must
+  // not crash the column.
+  const aeroParts: string[] = [];
+  if (ctx != null && typeof ctx.reynolds === "number") {
+    aeroParts.push(`Re≈${Math.round(ctx.reynolds).toLocaleString("en-GB")}`);
+  }
+  if (ctx != null && typeof ctx.v_cruise_mps === "number") {
+    aeroParts.push(`v_cruise ${ctx.v_cruise_mps.toFixed(1)} m/s`);
+  }
+  if (ctx != null && typeof ctx.computed_at === "string" && ctx.computed_at) {
+    const d = new Date(ctx.computed_at);
+    aeroParts.push(
+      Number.isNaN(d.getTime())
+        ? ctx.computed_at
+        : d.toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" }),
     );
   }
 
-  // Build the disclosure parts
-  const parts: string[] = [];
+  // No usable operating point → warn, rather than render a blank/misleading
+  // line or mass alone (metrics aren't comparable without the conditions).
+  if (aeroParts.length === 0) {
+    return (
+      <div data-testid={testId} className="pl-6 mt-1 text-[9px] text-amber-400">
+        <span aria-hidden="true">⚠</span> no analysis context — values may not be comparable
+      </div>
+    );
+  }
 
   const massKg =
     metrics != null && typeof metrics["total_mass_kg"] === "number"
       ? (metrics["total_mass_kg"] as number)
       : null;
-  if (massKg != null) {
-    parts.push(`${massKg} kg`);
-  }
-
-  if (ctx.reynolds != null) {
-    parts.push(`Re≈${Math.round(ctx.reynolds).toLocaleString("en-GB")}`);
-  }
-
-  if (ctx.v_cruise_mps != null) {
-    parts.push(`v_cruise ${ctx.v_cruise_mps.toFixed(1)} m/s`);
-  }
-
-  if (ctx.computed_at) {
-    try {
-      const d = new Date(ctx.computed_at);
-      const shortDate = d.toLocaleDateString("en-GB", {
-        day: "numeric",
-        month: "short",
-        year: "numeric",
-      });
-      parts.push(shortDate);
-    } catch {
-      parts.push(ctx.computed_at);
-    }
-  }
+  const parts = massKg != null ? [`${massKg} kg`, ...aeroParts] : aeroParts;
 
   return (
-    <div
-      data-testid={testId}
-      className="pl-6 mt-1 text-[9px] text-subtle-foreground"
-    >
+    <div data-testid={testId} className="pl-6 mt-1 text-[9px] text-subtle-foreground">
       {parts.join(" · ")}
     </div>
   );
@@ -496,7 +486,7 @@ function NodeIdentityHeader({ node, side, branchNameMap, metrics }: NodeIdentity
         {node.branch_id != null ? (
           <span
             data-testid={`compare-branch-pill-${side}`}
-            title={String(node.branch_id)}
+            title={`branch id: ${node.branch_id}`}
             className="rounded bg-muted/60 px-1 py-0.5 font-[family-name:var(--font-geist-mono)] text-[9px] text-muted-foreground"
           >
             {branchNameMap?.get(node.branch_id) ?? `branch ${node.branch_id}`}

--- a/frontend/components/workbench/VersionGraphOverlay.tsx
+++ b/frontend/components/workbench/VersionGraphOverlay.tsx
@@ -394,15 +394,25 @@ function VersionGraphToolbar({
         />
       )}
       {activeInput === "rename" && (
-        <NameInput
-          placeholder="branch name"
-          ariaLabel="Rename branch"
-          initialValue={selectedBranch?.name ?? ""}
-          confirmAriaLabel="Confirm rename"
-          onConfirm={onNameConfirm}
-          onCancel={onNameCancel}
-          busy={busy}
-        />
+        <div className="flex flex-col gap-1">
+          {/* Name the rename target explicitly so it's unambiguous which branch
+              is affected, regardless of any compare checkboxes that are set. */}
+          <span className="text-[10px] text-muted-foreground">
+            Rename branch{" "}
+            <span className="font-medium text-foreground">
+              &ldquo;{selectedBranch?.name}&rdquo;
+            </span>
+          </span>
+          <NameInput
+            placeholder="branch name"
+            ariaLabel={`Rename branch ${selectedBranch?.name ?? ""}`}
+            initialValue={selectedBranch?.name ?? ""}
+            confirmAriaLabel="Confirm rename"
+            onConfirm={onNameConfirm}
+            onCancel={onNameCancel}
+            busy={busy}
+          />
+        </div>
       )}
     </div>
   );

--- a/frontend/components/workbench/VersionGraphOverlay.tsx
+++ b/frontend/components/workbench/VersionGraphOverlay.tsx
@@ -285,7 +285,7 @@ function VersionGraphToolbar({
             title={getAdoptTitle()}
           />
         ) : (
-          <span className="flex items-center gap-1.5">
+          <div className="flex items-center gap-1.5">
             <span className="text-[11px] font-medium text-foreground" aria-live="polite">
               Make &quot;{selectedBranchName}&quot; the active design? The current main becomes a normal branch.
             </span>
@@ -307,7 +307,7 @@ function VersionGraphToolbar({
             >
               Cancel
             </button>
-          </span>
+          </div>
         )}
 
         {/* Discard — two-step confirm naming the branch */}
@@ -321,7 +321,7 @@ function VersionGraphToolbar({
             destructive
           />
         ) : (
-          <span className="flex items-center gap-1.5">
+          <div className="flex items-center gap-1.5">
             <span className="text-[11px] font-medium text-destructive" aria-live="polite">
               Delete branch &quot;{selectedBranchName}&quot; and its versions? Your active design is not affected.
             </span>
@@ -343,7 +343,7 @@ function VersionGraphToolbar({
             >
               Cancel
             </button>
-          </span>
+          </div>
         )}
 
         {/* Spacer */}
@@ -825,6 +825,8 @@ export function VersionGraphOverlay({
             date, NOT causality — lane colour encodes the branch. */}
         <div
           data-testid="version-graph-legend"
+          role="note"
+          aria-label="Graph legend"
           className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1 border-b border-border px-4 py-1.5 text-[10px] text-muted-foreground"
         >
           <span><span aria-hidden>●</span> snapshot</span>

--- a/frontend/components/workbench/VersionGraphOverlay.tsx
+++ b/frontend/components/workbench/VersionGraphOverlay.tsx
@@ -15,8 +15,8 @@
  *   onSwitchAeroplane — called after branch operations with the new head UUID
  */
 
-import { useState, useCallback, useEffect } from "react";
-import { X, GitBranch, Camera, GitFork, RotateCcw, Star, Trash2 } from "lucide-react";
+import { useState, useCallback, useEffect, useMemo } from "react";
+import { X, GitBranch, Camera, GitFork, RotateCcw, Star, Trash2, Pencil } from "lucide-react";
 import { useLineageTree, useVersionActions, useCompareNodes } from "@/hooks/useVersioning";
 import { VersionCompareView } from "@/components/workbench/VersionCompareView";
 import { VersionGraph } from "@/components/workbench/VersionGraph";
@@ -29,6 +29,7 @@ import type { TreeOut, TreeNodeOut, BranchOut } from "@/types/versioning";
 interface NameInputProps {
   placeholder?: string;
   ariaLabel?: string;
+  initialValue?: string;
   onConfirm: (name: string) => void;
   onCancel: () => void;
   busy: boolean;
@@ -39,13 +40,14 @@ interface NameInputProps {
 function NameInput({
   placeholder,
   ariaLabel = "Branch name",
+  initialValue = "",
   onConfirm,
   onCancel,
   busy,
   confirmLabel = "OK",
   confirmAriaLabel = "Confirm branch name",
 }: NameInputProps) {
-  const [value, setValue] = useState("");
+  const [value, setValue] = useState(initialValue);
 
   return (
     <div className="flex gap-1.5 mt-1">
@@ -131,7 +133,7 @@ function ToolbarButton({
 // Toolbar
 // ---------------------------------------------------------------------------
 
-type ToolbarAction = "snapshot" | "branchFrom" | "restore" | "adopt" | "discard" | null;
+type ToolbarAction = "snapshot" | "branchFrom" | "restore" | "adopt" | "discard" | "rename" | null;
 
 interface VersionGraphToolbarProps {
   readonly selectedNode: TreeNodeOut | null;
@@ -139,12 +141,15 @@ interface VersionGraphToolbarProps {
   readonly compareSet: Set<number>;
   readonly busy: boolean;
   readonly discardPending: boolean;
+  readonly adoptPending: boolean;
   readonly activeInput: ToolbarAction;
   readonly onActionClick: (action: ToolbarAction) => void;
   readonly onNameConfirm: (name: string) => void;
   readonly onNameCancel: () => void;
   readonly onConfirmDiscard: () => void;
   readonly onCancelDiscard: () => void;
+  readonly onConfirmAdopt: () => void;
+  readonly onCancelAdopt: () => void;
   readonly onOpenCompare: () => void;
 }
 
@@ -154,12 +159,15 @@ function VersionGraphToolbar({
   compareSet,
   busy,
   discardPending,
+  adoptPending,
   activeInput,
   onActionClick,
   onNameConfirm,
   onNameCancel,
   onConfirmDiscard,
   onCancelDiscard,
+  onConfirmAdopt,
+  onCancelAdopt,
   onOpenCompare,
 }: VersionGraphToolbarProps) {
   // Derive enable rules from spec toolbar table
@@ -180,33 +188,49 @@ function VersionGraphToolbar({
   // Adopt / Discard: selected node's branch is not main
   const adoptEnabled = hasSelection && !isOnMain && !busy;
   const discardEnabled = hasSelection && !isOnMain && !busy;
+  // Rename: a branch is selected
+  const renameEnabled = selectedBranch !== null && !busy;
 
   const compareCount = compareSet.size;
   const compareEnabled = compareCount === 2 && !busy;
 
+  const selectedBranchName = selectedBranch?.name ?? "this branch";
+
+  // Plain-language action tooltips (gh-964 §1). When a button is disabled we
+  // surface the reason WHY; otherwise we explain what the action does.
   const getSnapshotTitle = () => {
     if (!hasSelection) return "Select a node first";
     if (isSnapshot) return "Cannot snapshot an immutable node";
     if (!isEditableHead) return "Only the editable head can be snapshotted";
-    return undefined;
+    return "Save an immutable checkpoint of the current design";
+  };
+
+  const getBranchFromTitle = () => {
+    if (!hasSelection) return "Select a node first";
+    return "Start a new variant from the selected version";
   };
 
   const getRestoreTitle = () => {
     if (!hasSelection) return "Select a node first";
     if (!isSnapshot) return "Only snapshot nodes can be restored";
-    return undefined;
+    return "Create a new editable branch from this snapshot";
   };
 
   const getAdoptTitle = () => {
     if (!hasSelection) return "Select a node first";
     if (isOnMain) return "This branch is already main";
-    return undefined;
+    return "Make this branch the active design (main); the current main becomes a normal branch";
   };
 
   const getDiscardTitle = () => {
     if (!hasSelection) return "Select a node first";
     if (isOnMain) return "Cannot discard the main branch";
-    return undefined;
+    return "Delete this branch and its versions — does not affect the active design";
+  };
+
+  const getRenameTitle = () => {
+    if (selectedBranch === null) return "Select a branch first";
+    return "Rename this branch";
   };
 
   return (
@@ -227,7 +251,7 @@ function VersionGraphToolbar({
           icon={<GitFork size={12} />}
           onClick={() => onActionClick("branchFrom")}
           disabled={!branchFromEnabled}
-          title={!hasSelection ? "Select a node first" : undefined}
+          title={getBranchFromTitle()}
         />
 
         {/* Restore */}
@@ -239,19 +263,54 @@ function VersionGraphToolbar({
           title={getRestoreTitle()}
         />
 
+        {/* Rename */}
+        <ToolbarButton
+          label="Rename"
+          icon={<Pencil size={12} />}
+          onClick={() => onActionClick("rename")}
+          disabled={!renameEnabled}
+          title={getRenameTitle()}
+        />
+
         {/* Separator */}
         <div className="h-5 w-px bg-border" />
 
-        {/* Adopt */}
-        <ToolbarButton
-          label="Adopt"
-          icon={<Star size={12} />}
-          onClick={() => onActionClick("adopt")}
-          disabled={!adoptEnabled}
-          title={getAdoptTitle()}
-        />
+        {/* Adopt — two-step confirm naming the branch */}
+        {!adoptPending ? (
+          <ToolbarButton
+            label="Adopt"
+            icon={<Star size={12} />}
+            onClick={() => onActionClick("adopt")}
+            disabled={!adoptEnabled}
+            title={getAdoptTitle()}
+          />
+        ) : (
+          <span className="flex items-center gap-1.5">
+            <span className="text-[11px] font-medium text-foreground" aria-live="polite">
+              Make &quot;{selectedBranchName}&quot; the active design? The current main becomes a normal branch.
+            </span>
+            <button
+              type="button"
+              onClick={onConfirmAdopt}
+              disabled={busy}
+              aria-label="Confirm adopt"
+              className="rounded bg-primary px-2 py-1 text-[11px] font-medium text-primary-foreground disabled:opacity-50"
+            >
+              Yes, adopt
+            </button>
+            <button
+              type="button"
+              onClick={onCancelAdopt}
+              disabled={busy}
+              aria-label="Cancel adopt"
+              className="rounded bg-sidebar-accent px-2 py-1 text-[11px] text-muted-foreground disabled:opacity-50"
+            >
+              Cancel
+            </button>
+          </span>
+        )}
 
-        {/* Discard */}
+        {/* Discard — two-step confirm naming the branch */}
         {!discardPending ? (
           <ToolbarButton
             label="Discard"
@@ -264,7 +323,7 @@ function VersionGraphToolbar({
         ) : (
           <span className="flex items-center gap-1.5">
             <span className="text-[11px] font-medium text-destructive" aria-live="polite">
-              Delete all nodes?
+              Delete branch &quot;{selectedBranchName}&quot; and its versions? Your active design is not affected.
             </span>
             <button
               type="button"
@@ -329,6 +388,17 @@ function VersionGraphToolbar({
           placeholder={`restored-from-${selectedNode?.version_label ?? selectedNode?.id ?? "snapshot"}`}
           ariaLabel="Branch name"
           confirmAriaLabel="Confirm branch name"
+          onConfirm={onNameConfirm}
+          onCancel={onNameCancel}
+          busy={busy}
+        />
+      )}
+      {activeInput === "rename" && (
+        <NameInput
+          placeholder="branch name"
+          ariaLabel="Rename branch"
+          initialValue={selectedBranch?.name ?? ""}
+          confirmAriaLabel="Confirm rename"
           onConfirm={onNameConfirm}
           onCancel={onNameCancel}
           busy={busy}
@@ -417,6 +487,12 @@ export function VersionGraphOverlay({
   const { tree, isLoading, error, mutate } = useLineageTree(rootId);
   const actions = useVersionActions(aeroplaneId, rootId);
 
+  // Map from branch id → branch name, used in VersionCompareView.
+  const branchNameMap = useMemo(
+    () => new Map((tree?.branches ?? []).map((b) => [b.id, b.name])),
+    [tree],
+  );
+
   // Selection state
   const [selectedNodeId, setSelectedNodeId] = useState<number | null>(null);
 
@@ -430,11 +506,12 @@ export function VersionGraphOverlay({
 
   // Toolbar inline input
   const [activeInput, setActiveInput] = useState<
-    "snapshot" | "branchFrom" | "restore" | null
+    "snapshot" | "branchFrom" | "restore" | "rename" | null
   >(null);
 
-  // Discard confirm
+  // Discard / adopt two-step confirm
   const [discardPending, setDiscardPending] = useState(false);
+  const [adoptPending, setAdoptPending] = useState(false);
 
   // Derive compare fetch IDs. Sort so A/B assignment is deterministic (lower
   // node id = A), independent of the order the user ticked the checkboxes.
@@ -475,6 +552,8 @@ export function VersionGraphOverlay({
         setActiveInput(null);
       } else if (discardPending) {
         setDiscardPending(false);
+      } else if (adoptPending) {
+        setAdoptPending(false);
       } else if (compareOpen) {
         setCompareOpen(false);
       } else {
@@ -483,7 +562,7 @@ export function VersionGraphOverlay({
     }
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [onClose, compareOpen, activeInput, discardPending]);
+  }, [onClose, compareOpen, activeInput, discardPending, adoptPending]);
 
   // ---------------------------------------------------------------------------
   // Orchestration helpers (lifted from VersionHistoryPanel)
@@ -546,6 +625,7 @@ export function VersionGraphOverlay({
     setActionError(null);
     setActiveInput(null);
     setDiscardPending(false);
+    setAdoptPending(false);
   }, []);
 
   const handleCheckNode = useCallback((nodeId: number) => {
@@ -566,26 +646,24 @@ export function VersionGraphOverlay({
   // ---------------------------------------------------------------------------
 
   const handleToolbarActionClick = useCallback(
-    (action: "snapshot" | "branchFrom" | "restore" | "adopt" | "discard" | null) => {
+    (action: "snapshot" | "branchFrom" | "restore" | "adopt" | "discard" | "rename" | null) => {
       if (action === "adopt") {
         if (!selectedBranch) {
           setActionError("No branch selected — cannot adopt.");
           return;
         }
-        void runBranchOp(
-          () => actions.adoptBranch(selectedBranch.id),
-          (branch) => branch.head_id,
-        );
+        // Two-step confirm: show the confirm copy first (mirrors discard).
+        setAdoptPending(true);
         return;
       }
       if (action === "discard") {
         setDiscardPending(true);
         return;
       }
-      // snapshot / branchFrom / restore → show inline input
-      setActiveInput(action as "snapshot" | "branchFrom" | "restore" | null);
+      // snapshot / branchFrom / restore / rename → show inline input
+      setActiveInput(action as "snapshot" | "branchFrom" | "restore" | "rename" | null);
     },
-    [selectedBranch, actions, runBranchOp],
+    [selectedBranch],
   );
 
   const handleNameConfirm = useCallback(
@@ -621,9 +699,18 @@ export function VersionGraphOverlay({
           (branch) => branch.head_id,
         );
         setActiveInput(null);
+        return;
+      }
+      if (activeInput === "rename") {
+        if (!selectedBranch) {
+          setActionError("No branch selected — cannot rename.");
+          return;
+        }
+        await run(() => actions.renameBranch(selectedBranch.id, name));
+        setActiveInput(null);
       }
     },
-    [activeInput, aeroplaneId, selectedNode, actions, run, runBranchOp],
+    [activeInput, aeroplaneId, selectedNode, selectedBranch, actions, run, runBranchOp],
   );
 
   const handleNameCancel = useCallback(() => {
@@ -641,6 +728,22 @@ export function VersionGraphOverlay({
 
   const handleCancelDiscard = useCallback(() => {
     setDiscardPending(false);
+  }, []);
+
+  const handleConfirmAdopt = useCallback(() => {
+    if (!selectedBranch) {
+      setActionError("No branch selected — cannot adopt.");
+      return;
+    }
+    setAdoptPending(false);
+    void runBranchOp(
+      () => actions.adoptBranch(selectedBranch.id),
+      (branch) => branch.head_id,
+    );
+  }, [selectedBranch, actions, runBranchOp]);
+
+  const handleCancelAdopt = useCallback(() => {
+    setAdoptPending(false);
   }, []);
 
   // ---------------------------------------------------------------------------
@@ -696,14 +799,32 @@ export function VersionGraphOverlay({
           compareSet={compareSet}
           busy={busy}
           discardPending={discardPending}
+          adoptPending={adoptPending}
           activeInput={activeInput}
           onActionClick={handleToolbarActionClick}
           onNameConfirm={(name) => { void handleNameConfirm(name); }}
           onNameCancel={handleNameCancel}
           onConfirmDiscard={handleConfirmDiscard}
           onCancelDiscard={handleCancelDiscard}
+          onConfirmAdopt={handleConfirmAdopt}
+          onCancelAdopt={handleCancelAdopt}
           onOpenCompare={() => setCompareOpen(true)}
         />
+
+        {/* Legend + sorted-by-date note (gh-964 §3). The vertical order is by
+            date, NOT causality — lane colour encodes the branch. */}
+        <div
+          data-testid="version-graph-legend"
+          className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1 border-b border-border px-4 py-1.5 text-[10px] text-muted-foreground"
+        >
+          <span><span aria-hidden>●</span> snapshot</span>
+          <span><span aria-hidden>○</span> editable head</span>
+          <span><span aria-hidden>★</span> active</span>
+          <span><span aria-hidden>⎇</span> branch</span>
+          <span>colour = branch</span>
+          <span className="flex-1" />
+          <span className="italic">Sorted by date · lane colour = branch</span>
+        </div>
 
         {/* Error banner */}
         {(actionError ?? error) && (
@@ -723,6 +844,7 @@ export function VersionGraphOverlay({
               isLoading={compareLoading}
               error={compareError?.message ?? null}
               onClose={() => setCompareOpen(false)}
+              branchNameMap={branchNameMap}
             />
           </div>
         ) : (

--- a/frontend/hooks/useVersioning.ts
+++ b/frontend/hooks/useVersioning.ts
@@ -79,6 +79,12 @@ export interface UseVersionActionsResult {
    * Revalidates the lineage tree and the aeroplanes list.
    */
   discardBranch: (branchId: number) => Promise<void>;
+
+  /**
+   * Rename a branch.
+   * Revalidates the lineage tree and the aeroplanes list.
+   */
+  renameBranch: (branchId: number, name: string) => Promise<BranchOut>;
 }
 
 /**
@@ -155,12 +161,22 @@ export function useVersionActions(
     [revalidateAll],
   );
 
+  const renameBranchAction = useCallback(
+    async (branchId: number, name: string): Promise<BranchOut> => {
+      const branch = await api.renameBranch(branchId, name);
+      await revalidateAll();
+      return branch;
+    },
+    [revalidateAll],
+  );
+
   return {
     snapshot: snapshotAction,
     createBranch: createBranchAction,
     adoptBranch: adoptBranchAction,
     restore: restoreAction,
     discardBranch: discardBranchAction,
+    renameBranch: renameBranchAction,
   };
 }
 

--- a/frontend/lib/versioning-api.ts
+++ b/frontend/lib/versioning-api.ts
@@ -126,3 +126,24 @@ export async function getLineageTree(rootId: number): Promise<TreeOut> {
 export async function compareNodes(a: number, b: number): Promise<CompareOut> {
   return getJson<CompareOut>(`/aeroplanes/compare?a=${a}&b=${b}`);
 }
+
+/**
+ * PATCH /branches/{id}
+ * Rename a branch. Returns the updated BranchOut.
+ * 404 — unknown branch; 409 — duplicate name in lineage; 422 — empty name.
+ */
+export async function renameBranch(
+  branchId: number,
+  name: string,
+): Promise<BranchOut> {
+  const res = await fetch(`${API_BASE}/branches/${branchId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name }),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`PATCH /branches/${branchId} failed: ${res.status} ${res.statusText}: ${text}`);
+  }
+  return res.json() as Promise<BranchOut>;
+}


### PR DESCRIPTION
Follow-ups from the gh-961 version-graph persona UAT.

## gh-963 — compare traceability
- Branch **names** (from the lineage tree) instead of raw `branch_id`, id kept as a tooltip.
- Per-column **analysis context** (mass · Re · v_cruise · computed-at from `assumption_computation_context`); when a side has no context, a `⚠ no analysis context — values may not be comparable` warning replaces bare numbers (rigor-persona concern).

## gh-964 — hobbyist-friendly overlay UX
- Plain-language **tooltips** on every toolbar action.
- **Discard** confirm names the branch + reassures it doesn't affect the active design; **Adopt** is now a two-step confirm stating the main hand-over.
- **Legend** (● snapshot · ○ editable head · ★ active · ⎇ branch · colour = branch) + `Sorted by date · lane colour = branch` note.
- **Branch rename**: new `PATCH /branches/{id}` endpoint (`rename_branch` service + `BranchRenameRequest`, app-level name uniqueness → 404/409/422) and a Rename toolbar action prefilled with the current name.

**Deferred** (still tracked): long-history branch filter / preserve-scroll (#964 P3); param-level "what changed" diff (#963 stretch).

## Verification
- Backend: 43 versioning tests green, ruff clean.
- Frontend: full suite **1977 green / 160 files** (Node 22), ESLint clean, `tsc --noEmit` clean.
- Rebased onto main (incl. #962) so the new frontend `tsc` CI step passes.

Closes #963
Closes #964
Refs #961, #924

🤖 Generated with [Claude Code](https://claude.com/claude-code)