### PR TITLE
feat(gh-968): warn when compare columns' analysis contexts diverge

### DIFF
--- a/frontend/__tests__/VersionCompareView.test.tsx
+++ b/frontend/__tests__/VersionCompareView.test.tsx
@@ -862,3 +862,55 @@ describe("VersionCompareView (gh-907)", () => {
     expect(row?.getAttribute("data-differs")).toBe("true");
   });
 });
+
+// ---------------------------------------------------------------------------
+// gh-968: cross-column analysis-context divergence banner
+// ---------------------------------------------------------------------------
+
+describe("context-divergence banner (gh-968)", () => {
+  function renderWith(metricsA: Record<string, unknown> | null, metricsB: Record<string, unknown> | null) {
+    return render(
+      <VersionCompareView
+        compareOut={{ node_a: BASE_NODE_A, node_b: BASE_NODE_B, metrics_a: metricsA, metrics_b: metricsB }}
+        isLoading={false}
+        error={null}
+        onClose={vi.fn()}
+      />,
+    );
+  }
+  const banner = (c: HTMLElement) => c.querySelector('[data-testid="compare-context-divergence"]');
+
+  it("warns when cruise speed differs between the columns", () => {
+    const { container } = renderWith(
+      wrapCtx(makeCtx({ v_cruise_mps: 15.0 })),
+      wrapCtx(makeCtx({ v_cruise_mps: 20.0 })),
+    );
+    expect(banner(container)).not.toBeNull();
+  });
+
+  it("warns when mass differs between the columns", () => {
+    const { container } = renderWith(
+      { total_mass_kg: 1.5, assumption_computation_context: makeCtx() },
+      { total_mass_kg: 4.1, assumption_computation_context: makeCtx() },
+    );
+    expect(banner(container)).not.toBeNull();
+  });
+
+  it("warns when Reynolds differs between the columns", () => {
+    const { container } = renderWith(
+      wrapCtx(makeCtx({ reynolds: 250000 })),
+      wrapCtx(makeCtx({ reynolds: 450000 })),
+    );
+    expect(banner(container)).not.toBeNull();
+  });
+
+  it("does NOT warn when the contexts match (incl. equal mass)", () => {
+    const { container } = renderWith(wrapCtx(makeCtx()), wrapCtx(makeCtx()));
+    expect(banner(container)).toBeNull();
+  });
+
+  it("does NOT warn when one side has no usable context (per-column warning handles it)", () => {
+    const { container } = renderWith(wrapCtx(makeCtx()), { total_mass_kg: 1.5 });
+    expect(banner(container)).toBeNull();
+  });
+});

--- a/frontend/components/workbench/VersionCompareView.tsx
+++ b/frontend/components/workbench/VersionCompareView.tsx
@@ -60,6 +60,48 @@ function toCtx(metrics: Record<string, unknown> | null): ComputationContext | nu
   return null;
 }
 
+/** A number if `metrics[key]` is a finite number, else null. */
+function numField(metrics: Record<string, unknown> | null, key: string): number | null {
+  const v = metrics?.[key];
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+/**
+ * True when the two columns were computed under materially different
+ * ASSUMPTIONS — mass, Reynolds, or cruise speed — so a metric delta may
+ * reflect the changed condition, not the design (gh-968, rigor-persona
+ * concern). Only fields present on BOTH sides are compared (a missing side is
+ * already flagged per-column by AnalysisContextLine). `computed_at` is
+ * intentionally excluded: a different timestamp is normal between snapshots and
+ * is not an assumption.
+ */
+function contextsDiverge(
+  metricsA: Record<string, unknown> | null,
+  metricsB: Record<string, unknown> | null,
+): boolean {
+  const ctxA = toCtx(metricsA);
+  const ctxB = toCtx(metricsB);
+
+  const relDiff = (a: number, b: number) => Math.abs(a - b) / Math.max(Math.abs(a), Math.abs(b), 1e-9);
+
+  // mass (top-level) — >0.5% relative
+  const massA = numField(metricsA, "total_mass_kg");
+  const massB = numField(metricsB, "total_mass_kg");
+  if (massA != null && massB != null && relDiff(massA, massB) > 0.005) return true;
+
+  // Reynolds — >1% relative
+  const reA = numField(ctxA as unknown as Record<string, unknown> | null, "reynolds");
+  const reB = numField(ctxB as unknown as Record<string, unknown> | null, "reynolds");
+  if (reA != null && reB != null && relDiff(reA, reB) > 0.01) return true;
+
+  // cruise speed — >0.1 m/s absolute
+  const vA = numField(ctxA as unknown as Record<string, unknown> | null, "v_cruise_mps");
+  const vB = numField(ctxB as unknown as Record<string, unknown> | null, "v_cruise_mps");
+  if (vA != null && vB != null && Math.abs(vA - vB) > 0.1) return true;
+
+  return false;
+}
+
 function nodeLabel(node: VersionNode): string {
   return node.version_label ?? node.name;
 }
@@ -612,6 +654,20 @@ export function VersionCompareView({
               <span className="min-w-[56px] text-center">metric</span>
               <span className="text-left">{nodeLabel(compareOut.node_b)}</span>
             </div>
+
+            {/* Cross-column assumption-divergence banner (gh-968): the deltas
+                below may reflect a changed analysis condition, not the design. */}
+            {contextsDiverge(compareOut.metrics_a, compareOut.metrics_b) && (
+              <div
+                role="alert"
+                data-testid="compare-context-divergence"
+                className="mb-3 rounded border border-amber-500/40 bg-amber-500/10 px-2 py-1.5 text-[10px] text-amber-400"
+              >
+                <span aria-hidden="true">⚠</span> Analysis conditions differ between the two
+                variants — deltas may reflect changed assumptions (mass / Reynolds / cruise
+                speed), not the design itself.
+              </div>
+            )}
 
             {/* Metric rows */}
             {(() => {

--- a/frontend/components/workbench/VersionCompareView.tsx
+++ b/frontend/components/workbench/VersionCompareView.tsx
@@ -94,10 +94,11 @@ function contextsDiverge(
   const reB = numField(ctxB as unknown as Record<string, unknown> | null, "reynolds");
   if (reA != null && reB != null && relDiff(reA, reB) > 0.01) return true;
 
-  // cruise speed — >0.1 m/s absolute
+  // cruise speed — >1% relative (scale-invariant: an absolute threshold would
+  // misfire at high UAV airspeeds, ~ok at RC speeds).
   const vA = numField(ctxA as unknown as Record<string, unknown> | null, "v_cruise_mps");
   const vB = numField(ctxB as unknown as Record<string, unknown> | null, "v_cruise_mps");
-  if (vA != null && vB != null && Math.abs(vA - vB) > 0.1) return true;
+  if (vA != null && vB != null && relDiff(vA, vB) > 0.01) return true;
 
   return false;
 }

--- a/frontend/components/workbench/VersionGraphOverlay.tsx
+++ b/frontend/components/workbench/VersionGraphOverlay.tsx
@@ -412,6 +412,9 @@ function VersionGraphToolbar({
             onCancel={onNameCancel}
             busy={busy}
           />
+          <span className="text-[9px] text-subtle-foreground">
+            Must be unique within this aircraft.
+          </span>
         </div>
       )}
     </div>


### PR DESCRIPTION
Follow-up from the gh-963 persona UAT (Scholz-rigor): gh-963 disclosed each compare column's analysis context; this adds the **active guard**.

## Changes
- **Divergence banner** above the metric deltas when the two columns were computed under materially different assumptions: mass (>0.5% rel), Reynolds (>1% rel), or cruise speed (>0.1 m/s abs). Only fields present on both sides are compared; `computed_at` is intentionally excluded (a differing timestamp between snapshots is normal, not an assumption mismatch).
- **Rename uniqueness hint** under the branch-rename input (the backend already returns 409 on duplicates).

Solver/method name (also in #968) remains a known architectural gap — `assumption_computation_context` carries no method field; documented, not implemented here.

## Verification
Frontend full suite **1983 green / 160 files** (Node 22), ESLint + `tsc --noEmit` clean.

Closes #968
Refs #963, #924