### PR TITLE
feat(gh-971): version-compare geometry parameter diff

### DIFF
--- a/docs/superpowers/specs/2026-06-13-geometry-param-diff-design.md
+++ b/docs/superpowers/specs/2026-06-13-geometry-param-diff-design.md
@@ -1,0 +1,146 @@
+# Version Compare — Geometry Parameter Diff ("what changed")
+
+**Date:** 2026-06-13
+**Status:** Design / approved (brainstorm)
+**Issue:** #971 (promotes the gh-963 "stretch")
+**Area:** Frontend — `frontend/components/workbench/VersionCompareView.tsx` (+ new util/hook/component)
+
+---
+
+## Problem
+
+The version-compare view shows metric **outcomes** (L/D, V_stall, AR, e …) and now
+discloses the analysis context (gh-963/#968), but it does not show WHICH design
+**inputs** changed between the two versions. A reviewer sees that L/D dropped but
+not that the tip chord shrank and a section was added. The persona UAT (hobbyist
++ pro) asked for a "what changed" parameter diff.
+
+## Goals
+
+- An expandable **"Geometry changes"** section in the compare view listing the
+  wing-geometry parameters that differ between the two compared versions.
+- Reuse the existing per-version full-geometry endpoint; **no backend change**.
+- Keep the compare endpoint lightweight (lazy-load only when the section opens).
+
+## Non-goals (YAGNI)
+
+- Field-level diff of sub-elements (spar dimensions, control-surface hinge/servo,
+  turbulator fields) — shown only as changed/added/removed **flags** in v1.
+- Fuselage / mass / component diff (a later scope).
+- Editing or 3D visualisation of the diff.
+- Backend payload changes to `/aeroplanes/compare`.
+
+## Scope (v1)
+
+Per wing, per section (segment, root→tip order), diff these **core params**:
+`chord`, `twist` (incidence), `dihedral`, `length`, `sweep`, `airfoil`. Plus:
+- **Section** added / removed / changed (align by index).
+- **Wing** added / removed / changed (align by `name`).
+- **Sub-elements** as presence/count flags: spar (`1 → 2 spars`), control surface
+  / trailing-edge device (`aileron → —`, `— → flap`, or `changed`), turbulator
+  (`on → off` / `changed`). No field-level detail.
+
+Units follow WingConfig (mm, degrees). Numeric tolerance to avoid float noise:
+`|Δ| > 0.05` (mm and degrees).
+
+---
+
+## Architecture (frontend-only)
+
+```
+VersionCompareView
+  └─ GeometryDiffSection (collapsed by default)
+        on expand → useGeometryDiff(nodeAUuid, nodeBUuid, wingNames)
+              └─ SWR fetch per wing per node:
+                 GET /aeroplanes/{uuid}/wings/{wing}/wingconfig   (existing, mm)
+              └─ computeGeometryDiff(wingsA, wingsB)  ← pure, testable
+        renders the A | param | B table (changes-only | show-all)
+```
+
+- **`frontend/lib/geometryDiff.ts`** — pure `computeGeometryDiff(wingsA, wingsB)`
+  + types. No React, no network. Aligns wings by name and sections by index;
+  emits a `GeometryDiff` (see below). Holds all diff logic + the tolerance.
+- **`frontend/hooks/useGeometryDiff.ts`** — lazy: only fetches when `enabled`
+  (section expanded). Fetches each wing's `WingConfig` for both node UUIDs via
+  SWR, memoises `computeGeometryDiff`. Returns `{ diff, isLoading, error }`.
+- **`frontend/components/workbench/GeometryDiffSection.tsx`** — the collapsible
+  section: header with change counts, the toggle, and the table. Reuses the
+  metric-compare 3-column grid styling (`A | param | B`, amber on change). Owns
+  the `expanded` and `showAll` state.
+- **Edit `VersionCompareView.tsx`** — render `<GeometryDiffSection nodeA={…}
+  nodeB={…} wingNamesA={…} wingNamesB={…} />` below the metric sections. Node
+  UUIDs come from `compareOut.node_a/_b.uuid`; wing names from each side's
+  `metrics.wing_names` (fallback: union).
+
+## Diff data model (`geometryDiff.ts`)
+
+```ts
+type ChangeKind = "changed" | "added" | "removed";
+interface ParamChange { key: string; a: string | null; b: string | null; }   // "chord", "162 mm" → "158 mm"
+interface SubElementFlag { key: string; kind: ChangeKind; a: string | null; b: string | null; } // spar/ctrl/turbulator
+interface SectionDiff {
+  index: number;
+  kind: ChangeKind;                 // section added/removed/changed
+  label: string;                    // "Section 3 · mid"
+  params: ParamChange[];            // only changed core params (changes-only); all (show-all)
+  flags: SubElementFlag[];
+}
+interface WingDiff { name: string; kind: ChangeKind; sections: SectionDiff[]; }
+interface GeometryDiff {
+  wings: WingDiff[];                // only changed wings in changes-only; all in show-all
+  counts: { sectionsChanged: number; sectionsAdded: number; sectionsRemoved: number };
+  hasAnyChange: boolean;
+}
+computeGeometryDiff(wingsA, wingsB, opts?: { showAll?: boolean }): GeometryDiff
+```
+
+- Section alignment by index; the shorter side's missing indices → `added`
+  (present in B) / `removed` (present in A).
+- A param is "changed" when both present and differ beyond tolerance; airfoil by
+  string equality. In **show-all**, every core param is emitted (changed flagged);
+  in **changes-only**, only changed params/sections/wings are kept.
+- Sub-element flags: compare counts/presence per section (spar count, TED
+  name/presence, turbulator enabled/presence).
+
+## UI
+
+- Collapsible row **"▸ Geometry changes — N changed · M added · K removed"** under
+  the metric sections; collapsed by default. Expanding triggers the lazy fetch
+  (spinner while loading; inline error block on failure — does not crash compare).
+- Body: 3-column grid (`A | param | B`) matching `MetricRow`. **Wing subheader**
+  rows, then **section subheader** rows, then one row per param/flag; changed
+  cells amber, added/removed shown with `—` on the empty side + a small badge.
+- **Toggle "Changes only / Show all"** (default changes-only). Show-all renders
+  every section and every core param for both sides (changes highlighted).
+- "No geometry changes." when `hasAnyChange` is false.
+
+## Data flow & errors
+
+`compareOut` already has `node_a/_b` (with `uuid`) and `metrics.wing_names`.
+On expand, `useGeometryDiff` fetches `GET /aeroplanes/{uuid}/wings/{wing}/wingconfig`
+for each wing of each node. A per-wing fetch failure → inline error in the
+section only. A wing present on one node only → wing added/removed (no fetch
+needed for the missing side).
+
+## Testing
+
+- **Unit (vitest)** `geometryDiff.test.ts`: each core-param change
+  (chord/twist/dihedral/length/sweep/airfoil); section add/remove; wing
+  add/remove; sub-element flags (spar count, TED presence, turbulator); identical
+  → `hasAnyChange=false`; tolerance (Δ=0.04 mm → no change, 0.06 → change);
+  changes-only vs show-all filtering.
+- **Component (vitest)** `GeometryDiffSection.test.tsx`: collapsed→expand lazy
+  fetch; loading / error / empty ("no changes") states; changes-only vs show-all
+  toggle; added/removed badges render.
+
+## Files
+
+| File | Change |
+|---|---|
+| `frontend/lib/geometryDiff.ts` | new — pure diff util + types |
+| `frontend/hooks/useGeometryDiff.ts` | new — lazy SWR fetch + memoised diff |
+| `frontend/components/workbench/GeometryDiffSection.tsx` | new — section + table + toggle |
+| `frontend/components/workbench/VersionCompareView.tsx` | edit — mount the section |
+| `frontend/__tests__/geometryDiff.test.ts`, `GeometryDiffSection.test.tsx` | new tests |
+
+No backend changes.

--- a/frontend/__tests__/GeometryDiffSection.test.tsx
+++ b/frontend/__tests__/GeometryDiffSection.test.tsx
@@ -1,0 +1,243 @@
+/**
+ * Unit tests for GeometryDiffSection (gh-971).
+ *
+ * The section is a collapsible row under the metric compare sections. It owns
+ * `expanded` + `showAll` state and delegates the lazy fetch+diff to
+ * useGeometryDiff. We mock the hook so no network/SWR is involved and assert:
+ *
+ *  - collapsed by default: only the header renders, the hook is called with
+ *    enabled=false (no fetch).
+ *  - expanding flips the hook to enabled=true and renders the diff table.
+ *  - loading shows a spinner.
+ *  - an error renders an inline block (does NOT throw / crash the view).
+ *  - "No geometry changes." when hasAnyChange is false.
+ *  - changed param cell is amber (data-differs); from→to values shown.
+ *  - added / removed section badges render with "—" on the empty side.
+ *  - "Changes only / Show all" toggle flips the showAll arg to the hook.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+
+import type { GeometryDiff } from "@/lib/geometryDiff";
+import type { UseGeometryDiffResult } from "@/hooks/useGeometryDiff";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) =>
+    React.createElement("span", { "data-icon": "true", ...props });
+  return { ChevronRight: icon, ChevronDown: icon, Loader2: icon };
+});
+
+const useGeometryDiffMock =
+  vi.fn<(...args: unknown[]) => UseGeometryDiffResult>();
+vi.mock("@/hooks/useGeometryDiff", () => ({
+  useGeometryDiff: (...args: unknown[]) => useGeometryDiffMock(...args),
+}));
+
+import { GeometryDiffSection } from "../components/workbench/GeometryDiffSection";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const CHANGED_DIFF: GeometryDiff = {
+  wings: [
+    {
+      name: "main_wing",
+      kind: "changed",
+      sections: [
+        {
+          index: 0,
+          kind: "changed",
+          label: "Section 1 · root",
+          params: [{ key: "root chord", a: "162 mm", b: "158 mm" }],
+          flags: [
+            { key: "control_surface", kind: "changed", a: "—", b: "aileron" },
+          ],
+        },
+        {
+          index: 1,
+          kind: "added",
+          label: "Section 2 · mid",
+          params: [],
+          flags: [],
+        },
+        {
+          index: 2,
+          kind: "removed",
+          label: "Section 3 · tip",
+          params: [],
+          flags: [],
+        },
+      ],
+    },
+  ],
+  counts: { sectionsChanged: 1, sectionsAdded: 1, sectionsRemoved: 1 },
+  hasAnyChange: true,
+};
+
+const EMPTY_DIFF: GeometryDiff = {
+  wings: [],
+  counts: { sectionsChanged: 0, sectionsAdded: 0, sectionsRemoved: 0 },
+  hasAnyChange: false,
+};
+
+function result(over: Partial<UseGeometryDiffResult> = {}): UseGeometryDiffResult {
+  return { diff: null, isLoading: false, error: null, ...over };
+}
+
+const PROPS = {
+  nodeAUuid: "aaa",
+  nodeBUuid: "bbb",
+  wingNames: ["main_wing"],
+  labelA: "Alpha",
+  labelB: "Beta",
+};
+
+function renderSection(over: Partial<UseGeometryDiffResult> = {}) {
+  useGeometryDiffMock.mockReturnValue(result(over));
+  return render(<GeometryDiffSection {...PROPS} />);
+}
+
+describe("GeometryDiffSection (gh-971)", () => {
+  beforeEach(() => {
+    useGeometryDiffMock.mockReset();
+  });
+
+  // -------------------------------------------------------------------------
+  // Collapsed by default — header only, no fetch
+  // -------------------------------------------------------------------------
+  it("renders the section testid", () => {
+    renderSection();
+    expect(screen.getByTestId("geometry-diff-section")).toBeDefined();
+  });
+
+  it("toggle button has aria-controls='geometry-diff-body'", () => {
+    renderSection();
+    const btn = screen.getByTestId("geometry-diff-header");
+    expect(btn.getAttribute("aria-controls")).toBe("geometry-diff-body");
+  });
+
+  it("expanded body has id='geometry-diff-body'", () => {
+    renderSection({ diff: CHANGED_DIFF });
+    fireEvent.click(screen.getByTestId("geometry-diff-header"));
+    const body = document.getElementById("geometry-diff-body");
+    expect(body).not.toBeNull();
+  });
+
+  it("is collapsed by default: the hook is called with enabled=false", () => {
+    renderSection();
+    // 4th positional arg = enabled
+    const call = useGeometryDiffMock.mock.calls[0];
+    expect(call[3]).toBe(false);
+  });
+
+  it("collapsed: does not render the diff table", () => {
+    renderSection({ diff: CHANGED_DIFF, isLoading: false });
+    expect(screen.queryByTestId("geometry-diff-table")).toBeNull();
+  });
+
+  it("shows the change counts in the header", () => {
+    renderSection({ diff: CHANGED_DIFF });
+    const header = screen.getByTestId("geometry-diff-header");
+    const text = header.textContent ?? "";
+    expect(text).toMatch(/1\s*changed/i);
+    expect(text).toMatch(/1\s*added/i);
+    expect(text).toMatch(/1\s*removed/i);
+  });
+
+  // -------------------------------------------------------------------------
+  // Expanding triggers the lazy fetch (enabled=true) + renders table
+  // -------------------------------------------------------------------------
+  it("expanding flips the hook to enabled=true", () => {
+    renderSection({ diff: CHANGED_DIFF });
+    fireEvent.click(screen.getByTestId("geometry-diff-header"));
+    const lastCall =
+      useGeometryDiffMock.mock.calls[useGeometryDiffMock.mock.calls.length - 1];
+    expect(lastCall[3]).toBe(true);
+  });
+
+  it("expanding renders the diff table with the wing subheader", () => {
+    renderSection({ diff: CHANGED_DIFF });
+    fireEvent.click(screen.getByTestId("geometry-diff-header"));
+    expect(screen.getByTestId("geometry-diff-table")).toBeDefined();
+    expect(screen.getByText("main_wing")).toBeDefined();
+  });
+
+  it("expanded: renders a changed param row with from→to values and amber flag", () => {
+    renderSection({ diff: CHANGED_DIFF });
+    fireEvent.click(screen.getByTestId("geometry-diff-header"));
+    const row = screen.getByTestId("geometry-diff-row-root chord");
+    expect(row.getAttribute("data-differs")).toBe("true");
+    const text = row.textContent ?? "";
+    expect(text).toMatch(/162 mm/);
+    expect(text).toMatch(/158 mm/);
+  });
+
+  it("expanded: renders added and removed section badges", () => {
+    renderSection({ diff: CHANGED_DIFF });
+    fireEvent.click(screen.getByTestId("geometry-diff-header"));
+    const table = screen.getByTestId("geometry-diff-table");
+    expect(within(table).getByText(/added/i)).toBeDefined();
+    expect(within(table).getByText(/removed/i)).toBeDefined();
+  });
+
+  it("expanded: a sub-element flag with empty side shows '—'", () => {
+    renderSection({ diff: CHANGED_DIFF });
+    fireEvent.click(screen.getByTestId("geometry-diff-header"));
+    const row = screen.getByTestId("geometry-diff-row-control_surface");
+    const text = row.textContent ?? "";
+    expect(text).toMatch(/—/);
+    expect(text).toMatch(/aileron/);
+  });
+
+  // -------------------------------------------------------------------------
+  // Loading / error / empty states
+  // -------------------------------------------------------------------------
+  it("expanded + loading: shows a spinner and no table", () => {
+    renderSection({ diff: null, isLoading: true });
+    fireEvent.click(screen.getByTestId("geometry-diff-header"));
+    expect(screen.getByTestId("geometry-diff-loading")).toBeDefined();
+    expect(screen.queryByTestId("geometry-diff-table")).toBeNull();
+  });
+
+  it("expanded + error: shows an inline error block and does not crash", () => {
+    renderSection({ diff: null, error: new Error("boom") });
+    fireEvent.click(screen.getByTestId("geometry-diff-header"));
+    const err = screen.getByTestId("geometry-diff-error");
+    expect(err).toBeDefined();
+    expect(err.textContent ?? "").toMatch(/boom|could not|failed/i);
+  });
+
+  it("expanded + no changes: shows 'No geometry changes.'", () => {
+    renderSection({ diff: EMPTY_DIFF });
+    fireEvent.click(screen.getByTestId("geometry-diff-header"));
+    expect(screen.getByText(/no geometry changes/i)).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Show-all toggle
+  // -------------------------------------------------------------------------
+  it("defaults to changes-only: the hook is called with showAll=false", () => {
+    renderSection({ diff: CHANGED_DIFF });
+    fireEvent.click(screen.getByTestId("geometry-diff-header"));
+    const lastCall =
+      useGeometryDiffMock.mock.calls[useGeometryDiffMock.mock.calls.length - 1];
+    // 5th positional arg = showAll
+    expect(lastCall[4]).toBe(false);
+  });
+
+  it("toggling 'Show all' flips the showAll arg to the hook to true", () => {
+    renderSection({ diff: CHANGED_DIFF });
+    fireEvent.click(screen.getByTestId("geometry-diff-header"));
+    fireEvent.click(screen.getByTestId("geometry-diff-showall-toggle"));
+    const lastCall =
+      useGeometryDiffMock.mock.calls[useGeometryDiffMock.mock.calls.length - 1];
+    expect(lastCall[4]).toBe(true);
+  });
+});

--- a/frontend/__tests__/VersionCompareView.test.tsx
+++ b/frontend/__tests__/VersionCompareView.test.tsx
@@ -27,7 +27,15 @@ import React from "react";
 vi.mock("lucide-react", () => {
   const icon = (props: Record<string, unknown>) =>
     React.createElement("span", { "data-icon": "true", ...props });
-  return { X: icon, ArrowLeftRight: icon };
+  // ChevronRight/ChevronDown/Loader2 are used by the child GeometryDiffSection
+  // (gh-971) which VersionCompareView now renders below the metric rows.
+  return {
+    X: icon,
+    ArrowLeftRight: icon,
+    ChevronRight: icon,
+    ChevronDown: icon,
+    Loader2: icon,
+  };
 });
 
 // metricsAdapters — use REAL adapters (not mocked); they are pure functions.

--- a/frontend/__tests__/geometryDiff.test.ts
+++ b/frontend/__tests__/geometryDiff.test.ts
@@ -1,0 +1,538 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeGeometryDiff,
+  type DiffWingInput,
+} from "@/lib/geometryDiff";
+import type { WingConfigSegment } from "@/hooks/useWingConfig";
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function segment(overrides: Partial<WingConfigSegment> = {}): WingConfigSegment {
+  return {
+    root_airfoil: {
+      airfoil: "naca2412",
+      chord: 200,
+      dihedral_as_rotation_in_degrees: 3,
+      incidence: 1,
+    },
+    tip_airfoil: {
+      airfoil: "naca2412",
+      chord: 150,
+      dihedral_as_rotation_in_degrees: 3,
+      incidence: 0,
+    },
+    length: 500,
+    sweep: 5,
+    spare_list: [],
+    trailing_edge_device: null,
+    turbulator: null,
+    ...overrides,
+  };
+}
+
+function wing(name: string, segments: WingConfigSegment[]): DiffWingInput {
+  return { name, config: { segments, nose_pnt: [0, 0, 0] } };
+}
+
+// ---------------------------------------------------------------------------
+// Core param changes — root airfoil keys renamed
+// ---------------------------------------------------------------------------
+
+describe("computeGeometryDiff — core param changes", () => {
+  /**
+   * NOTE on LCS alignment: the section signature uses (rootChord|length|rootAirfoil).
+   * Tests that change chord, length, or rootAirfoil between A and B will NOT match
+   * sections in the LCS (the sections appear as add+remove, not changed). Those params
+   * are tested via showAll=true or via the add/remove path.
+   *
+   * Tests for params NOT in the signature (incidence, dihedral, sweep, tipAirfoil,
+   * tipChord, tipIncidence, tipDihedral) can directly assert the "changed" path.
+   */
+
+  it("detects a root incidence change (deg) — not in LCS signature", () => {
+    const a = [wing("main", [segment({ root_airfoil: { airfoil: "naca2412", chord: 200, incidence: 1 } })])];
+    const b = [wing("main", [segment({ root_airfoil: { airfoil: "naca2412", chord: 200, incidence: 4 } })])];
+    const diff = computeGeometryDiff(a, b);
+    const incidence = diff.wings[0].sections[0].params.find((p) => p.key === "root incidence");
+    expect(incidence).toBeDefined();
+    expect(incidence!.a).toBe("1 deg");
+    expect(incidence!.b).toBe("4 deg");
+  });
+
+  it("detects a root dihedral change (deg) — not in LCS signature", () => {
+    const a = [wing("main", [segment({ root_airfoil: { airfoil: "naca2412", chord: 200, dihedral_as_rotation_in_degrees: 3 } })])];
+    const b = [wing("main", [segment({ root_airfoil: { airfoil: "naca2412", chord: 200, dihedral_as_rotation_in_degrees: 6 } })])];
+    const diff = computeGeometryDiff(a, b);
+    const dih = diff.wings[0].sections[0].params.find((p) => p.key === "root dihedral");
+    expect(dih).toBeDefined();
+    expect(dih!.a).toBe("3 deg");
+    expect(dih!.b).toBe("6 deg");
+  });
+
+  it("detects a sweep change with mm unit — not in LCS signature", () => {
+    const a = [wing("main", [segment({ sweep: 5 })])];
+    const b = [wing("main", [segment({ sweep: 12 })])];
+    const diff = computeGeometryDiff(a, b);
+    const sw = diff.wings[0].sections[0].params.find((p) => p.key === "sweep");
+    expect(sw).toBeDefined();
+    expect(sw!.a).toBe("5 mm");
+    expect(sw!.b).toBe("12 mm");
+  });
+
+  it("detects a tip chord change (mm) — not in LCS signature", () => {
+    const a = [wing("main", [segment({ tip_airfoil: { airfoil: "naca2412", chord: 150 } })])];
+    const b = [wing("main", [segment({ tip_airfoil: { airfoil: "naca2412", chord: 100 } })])];
+    const diff = computeGeometryDiff(a, b);
+    const tipChord = diff.wings[0].sections[0].params.find((p) => p.key === "tip chord");
+    expect(tipChord).toBeDefined();
+    expect(tipChord!.a).toBe("150 mm");
+    expect(tipChord!.b).toBe("100 mm");
+  });
+
+  it("detects a tip incidence change (deg) — not in LCS signature", () => {
+    const a = [wing("main", [segment({ tip_airfoil: { airfoil: "naca2412", chord: 150, incidence: 0 } })])];
+    const b = [wing("main", [segment({ tip_airfoil: { airfoil: "naca2412", chord: 150, incidence: 2 } })])];
+    const diff = computeGeometryDiff(a, b);
+    const tipInc = diff.wings[0].sections[0].params.find((p) => p.key === "tip incidence");
+    expect(tipInc).toBeDefined();
+    expect(tipInc!.a).toBe("0 deg");
+    expect(tipInc!.b).toBe("2 deg");
+  });
+
+  it("detects a tip airfoil change (string equality) — not in LCS signature", () => {
+    const a = [wing("main", [segment({ tip_airfoil: { airfoil: "naca2412", chord: 150 } })])];
+    const b = [wing("main", [segment({ tip_airfoil: { airfoil: "naca0012", chord: 150 } })])];
+    const diff = computeGeometryDiff(a, b);
+    const af = diff.wings[0].sections[0].params.find((p) => p.key === "tip airfoil");
+    expect(af).toBeDefined();
+    expect(af!.a).toBe("naca2412");
+    expect(af!.b).toBe("naca0012");
+  });
+
+  it("root chord and root airfoil are emitted in showAll mode even without a change", () => {
+    // Since chord/airfoil are in the LCS signature, verify they appear in showAll
+    const a = [wing("main", [segment()])];
+    const b = [wing("main", [segment({ root_airfoil: { airfoil: "naca2412", chord: 200, incidence: 2 } })])];
+    const diff = computeGeometryDiff(a, b, { showAll: true });
+    expect(diff.hasAnyChange).toBe(true);
+    const params = diff.wings[0].sections[0].params;
+    const chord = params.find((p) => p.key === "root chord");
+    expect(chord).toBeDefined();
+    expect(chord!.a).toBe("200 mm");
+    expect(chord!.b).toBe("200 mm");
+    const af = params.find((p) => p.key === "root airfoil");
+    expect(af).toBeDefined();
+    expect(af!.a).toBe("naca2412");
+    expect(af!.b).toBe("naca2412");
+  });
+
+  it("span appears as 'span' key (not 'length') in mm", () => {
+    // Length IS in the LCS signature; test span key via showAll on matched sections
+    const a = [wing("main", [segment({ root_airfoil: { airfoil: "naca2412", chord: 200 }, length: 500 })])];
+    const b = [wing("main", [segment({ root_airfoil: { airfoil: "naca2412", chord: 200, incidence: 2 }, length: 500 })])];
+    const diff = computeGeometryDiff(a, b, { showAll: true });
+    const span = diff.wings[0].sections[0].params.find((p) => p.key === "span");
+    expect(span).toBeDefined();
+    expect(span!.a).toBe("500 mm");
+    expect(span!.b).toBe("500 mm");
+    // "length" key must NOT appear (renamed to "span")
+    const len = diff.wings[0].sections[0].params.find((p) => p.key === "length");
+    expect(len).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// .dat suffix stripping
+// ---------------------------------------------------------------------------
+
+describe("computeGeometryDiff — .dat suffix stripping", () => {
+  it("strips .dat from root airfoil name in showAll display", () => {
+    // Root airfoil is in the LCS signature; use showAll to see the param even when unchanged
+    const a = [wing("main", [segment({ root_airfoil: { airfoil: "naca2412.dat", chord: 200, incidence: 1 } })])];
+    const b = [wing("main", [segment({ root_airfoil: { airfoil: "naca2412.dat", chord: 200, incidence: 2 } })])];
+    const diff = computeGeometryDiff(a, b, { showAll: true });
+    const af = diff.wings[0].sections[0].params.find((p) => p.key === "root airfoil");
+    expect(af).toBeDefined();
+    // ".dat" must be stripped from the display
+    expect(af!.a).toBe("naca2412");
+    expect(af!.b).toBe("naca2412");
+  });
+
+  it("strips .dat from tip airfoil name for display (tip airfoil not in LCS sig)", () => {
+    const a = [wing("main", [segment({ tip_airfoil: { airfoil: "clark-y.dat", chord: 150 } })])];
+    const b = [wing("main", [segment({ tip_airfoil: { airfoil: "e374.dat", chord: 150 } })])];
+    const diff = computeGeometryDiff(a, b);
+    const af = diff.wings[0].sections[0].params.find((p) => p.key === "tip airfoil");
+    expect(af).toBeDefined();
+    expect(af!.a).toBe("clark-y");
+    expect(af!.b).toBe("e374");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tolerance
+// ---------------------------------------------------------------------------
+
+describe("computeGeometryDiff — numeric tolerance", () => {
+  it("treats |Δ| = 0.04 as unchanged", () => {
+    const a = [wing("main", [segment({ length: 500 })])];
+    const b = [wing("main", [segment({ length: 500.04 })])];
+    const diff = computeGeometryDiff(a, b);
+    expect(diff.hasAnyChange).toBe(false);
+  });
+
+  it("treats |Δ| = 0.06 as changed", () => {
+    const a = [wing("main", [segment({ length: 500 })])];
+    const b = [wing("main", [segment({ length: 500.06 })])];
+    const diff = computeGeometryDiff(a, b);
+    expect(diff.hasAnyChange).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatNumber finite guard
+// ---------------------------------------------------------------------------
+
+describe("computeGeometryDiff — finite guard (NaN / Infinity)", () => {
+  it("renders '—' for NaN incidence and treats it as a change vs a finite value", () => {
+    // Use NaN incidence (NOT in LCS signature) so sections match by sig and diff is computed.
+    // Incidence is not part of the signature (root_chord|length|root_airfoil) so sections align.
+    const nanSeg: WingConfigSegment = {
+      ...segment(),
+      root_airfoil: { airfoil: "naca2412", chord: 200, incidence: NaN },
+    };
+    const a = [wing("main", [segment()])];
+    const b = [wing("main", [nanSeg])];
+    const diff = computeGeometryDiff(a, b);
+    expect(diff.hasAnyChange).toBe(true);
+    const params = diff.wings[0].sections[0].params;
+    const inc = params.find((p) => p.key === "root incidence");
+    expect(inc).toBeDefined();
+    // b's incidence is NaN, must display "—"
+    expect(inc!.b).toBe("—");
+    // a's incidence is 1 (default from segment()), must display normally
+    expect(inc!.a).toBe("1 deg");
+  });
+
+  it("renders '—' for NaN chord via formatMm guard", () => {
+    // Test the formatMm guard directly: if chord is NaN, display is "—"
+    // We test through a "removed" section display which still runs coreParams
+    // Here we just verify that a segment with all-default params (incl. chord) shows correctly
+    // and that NaN sweep renders "—"
+    const nanSweepSeg: WingConfigSegment = {
+      ...segment(),
+      sweep: NaN,
+    };
+    const a = [wing("main", [segment()])];
+    const b = [wing("main", [nanSweepSeg])];
+    const diff = computeGeometryDiff(a, b);
+    expect(diff.hasAnyChange).toBe(true);
+    const params = diff.wings[0].sections[0].params;
+    const sw = params.find((p) => p.key === "sweep");
+    expect(sw).toBeDefined();
+    expect(sw!.b).toBe("—");
+    expect(sw!.a).toBe("5 mm"); // default sweep from segment() fixture
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section label with position role
+// ---------------------------------------------------------------------------
+
+describe("computeGeometryDiff — section labels with position role", () => {
+  it("single section gets '· root' label", () => {
+    const a = [wing("main", [segment()])];
+    const b = [wing("main", [segment({ root_airfoil: { airfoil: "naca2412", chord: 100 } })])];
+    const diff = computeGeometryDiff(a, b);
+    expect(diff.wings[0].sections[0].label).toBe("Section 1 · root");
+  });
+
+  it("first section of multi gets '· root', last gets '· tip', middle gets '· mid'", () => {
+    // 3 sections each with unique signatures so LCS matches all 3 pairwise
+    const s1a = segment({ root_airfoil: { airfoil: "naca2412", chord: 200, incidence: 1 }, length: 500 });
+    const s1b = segment({ root_airfoil: { airfoil: "naca2412", chord: 200, incidence: 2 }, length: 500 });
+    const s2 = segment({ root_airfoil: { airfoil: "naca2412", chord: 160 }, length: 450 });
+    const s3 = segment({ root_airfoil: { airfoil: "naca2412", chord: 120 }, length: 400 });
+    const a = [wing("main", [s1a, s2, s3])];
+    const b = [wing("main", [s1b, s2, s3])];
+    const diff = computeGeometryDiff(a, b, { showAll: true });
+    const labels = diff.wings[0].sections.map((s) => s.label);
+    // Exactly 3 sections matched; labels reflect position
+    expect(labels).toHaveLength(3);
+    expect(labels[0]).toMatch(/· root$/);
+    expect(labels[1]).toMatch(/· mid$/);
+    expect(labels[2]).toMatch(/· tip$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LCS section alignment — insert in the middle must NOT cascade
+// ---------------------------------------------------------------------------
+
+describe("computeGeometryDiff — LCS section alignment", () => {
+  it("inserting a section in the middle shows exactly one 'added', others unchanged", () => {
+    // s1, s2, s3 have distinct signatures (chord differs)
+    const s1 = segment({ root_airfoil: { airfoil: "naca2412", chord: 200 }, length: 500 });
+    const s2 = segment({ root_airfoil: { airfoil: "naca2412", chord: 160 }, length: 480 });
+    const s3 = segment({ root_airfoil: { airfoil: "naca2412", chord: 120 }, length: 400 });
+    const sNEW = segment({ root_airfoil: { airfoil: "naca2412", chord: 180 }, length: 490 });
+
+    const wA = [wing("main", [s1, s2, s3])];
+    const wB = [wing("main", [s1, sNEW, s2, s3])];
+    const diff = computeGeometryDiff(wA, wB);
+
+    // Only sNEW is added; s1, s2, s3 are matched → unchanged
+    expect(diff.counts.sectionsAdded).toBe(1);
+    expect(diff.counts.sectionsRemoved).toBe(0);
+    expect(diff.counts.sectionsChanged).toBe(0);
+
+    // hasAnyChange because of the added section
+    expect(diff.hasAnyChange).toBe(true);
+
+    // The added section appears
+    const added = diff.wings[0].sections.find((s) => s.kind === "added");
+    expect(added).toBeDefined();
+
+    // No "changed" sections
+    const changed = diff.wings[0].sections.filter((s) => s.kind === "changed");
+    expect(changed).toHaveLength(0);
+  });
+
+  it("removing a section from the middle shows exactly one 'removed', others unchanged", () => {
+    const s1 = segment({ root_airfoil: { airfoil: "naca2412", chord: 200 }, length: 500 });
+    const s2 = segment({ root_airfoil: { airfoil: "naca2412", chord: 160 }, length: 480 });
+    const s3 = segment({ root_airfoil: { airfoil: "naca2412", chord: 120 }, length: 400 });
+
+    const wA = [wing("main", [s1, s2, s3])];
+    const wB = [wing("main", [s1, s3])];
+    const diff = computeGeometryDiff(wA, wB);
+
+    expect(diff.counts.sectionsRemoved).toBe(1);
+    expect(diff.counts.sectionsAdded).toBe(0);
+    expect(diff.counts.sectionsChanged).toBe(0);
+    expect(diff.hasAnyChange).toBe(true);
+
+    const removed = diff.wings[0].sections.find((s) => s.kind === "removed");
+    expect(removed).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section add / remove (positional fallback — same signatures)
+// ---------------------------------------------------------------------------
+
+describe("computeGeometryDiff — section add/remove (same-signature)", () => {
+  it("flags an added section (B longer, identical sigs)", () => {
+    const a = [wing("main", [segment()])];
+    const b = [wing("main", [segment(), segment()])];
+    const diff = computeGeometryDiff(a, b);
+    // One of the two matching sections is "added"
+    expect(diff.counts.sectionsAdded).toBe(1);
+    const added = diff.wings[0].sections.find((s) => s.kind === "added");
+    expect(added).toBeDefined();
+  });
+
+  it("flags a removed section (A longer, identical sigs)", () => {
+    const a = [wing("main", [segment(), segment()])];
+    const b = [wing("main", [segment()])];
+    const diff = computeGeometryDiff(a, b);
+    expect(diff.counts.sectionsRemoved).toBe(1);
+    const removed = diff.wings[0].sections.find((s) => s.kind === "removed");
+    expect(removed).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wing add / remove
+// ---------------------------------------------------------------------------
+
+describe("computeGeometryDiff — wing add/remove", () => {
+  it("flags an added wing (only in B)", () => {
+    const a = [wing("main", [segment()])];
+    const b = [wing("main", [segment()]), wing("tail", [segment()])];
+    const diff = computeGeometryDiff(a, b);
+    const added = diff.wings.find((w) => w.name === "tail");
+    expect(added).toBeDefined();
+    expect(added!.kind).toBe("added");
+    expect(diff.hasAnyChange).toBe(true);
+  });
+
+  it("flags a removed wing (only in A)", () => {
+    const a = [wing("main", [segment()]), wing("tail", [segment()])];
+    const b = [wing("main", [segment()])];
+    const diff = computeGeometryDiff(a, b);
+    const removed = diff.wings.find((w) => w.name === "tail");
+    expect(removed).toBeDefined();
+    expect(removed!.kind).toBe("removed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sub-element flags
+// ---------------------------------------------------------------------------
+
+describe("computeGeometryDiff — sub-element flags", () => {
+  it("flags a spar count change", () => {
+    const a = [wing("main", [segment({ spare_list: [{}] })])];
+    const b = [wing("main", [segment({ spare_list: [{}, {}] })])];
+    const diff = computeGeometryDiff(a, b);
+    const spar = diff.wings[0].sections[0].flags.find((f) => f.key === "spar");
+    expect(spar).toBeDefined();
+    expect(spar!.kind).toBe("changed");
+    expect(spar!.a).toBe("1 spar");
+    expect(spar!.b).toBe("2 spars");
+  });
+
+  it("flags a trailing-edge device presence change", () => {
+    const a = [wing("main", [segment({ trailing_edge_device: { name: "aileron" } })])];
+    const b = [wing("main", [segment({ trailing_edge_device: null })])];
+    const diff = computeGeometryDiff(a, b);
+    const ted = diff.wings[0].sections[0].flags.find((f) => f.key === "control_surface");
+    expect(ted).toBeDefined();
+    expect(ted!.kind).toBe("changed");
+    expect(ted!.a).toBe("aileron");
+    expect(ted!.b).toBe("—");
+  });
+
+  it("flags a turbulator presence change", () => {
+    const a = [wing("main", [segment({ turbulator: null })])];
+    const b = [wing("main", [segment({ turbulator: { x_c: 0.3 } })])];
+    const diff = computeGeometryDiff(a, b);
+    const turb = diff.wings[0].sections[0].flags.find((f) => f.key === "turbulator");
+    expect(turb).toBeDefined();
+    expect(turb!.kind).toBe("changed");
+    expect(turb!.a).toBe("—");
+    expect(turb!.b).toBe("on");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Identical inputs
+// ---------------------------------------------------------------------------
+
+describe("computeGeometryDiff — identical inputs", () => {
+  it("reports no change for identical wings", () => {
+    const a = [wing("main", [segment(), segment({ sweep: 8 })])];
+    const b = [wing("main", [segment(), segment({ sweep: 8 })])];
+    const diff = computeGeometryDiff(a, b);
+    expect(diff.hasAnyChange).toBe(false);
+    expect(diff.wings).toHaveLength(0);
+    expect(diff.counts).toEqual({
+      sectionsChanged: 0,
+      sectionsAdded: 0,
+      sectionsRemoved: 0,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Guard: missing root_airfoil / tip_airfoil
+// ---------------------------------------------------------------------------
+
+describe("computeGeometryDiff — missing airfoil guard", () => {
+  it("does not throw when root_airfoil is missing (legacy config)", () => {
+    // Force a segment with no root_airfoil
+    const badSeg = {
+      tip_airfoil: { airfoil: "naca2412", chord: 150 },
+      length: 500,
+      sweep: 5,
+    } as unknown as WingConfigSegment;
+    const a = [wing("main", [badSeg])];
+    const b = [wing("main", [segment()])];
+    expect(() => computeGeometryDiff(a, b)).not.toThrow();
+  });
+
+  it("does not throw when tip_airfoil is missing (legacy config)", () => {
+    const badSeg = {
+      root_airfoil: { airfoil: "naca2412", chord: 200 },
+      length: 500,
+      sweep: 5,
+    } as unknown as WingConfigSegment;
+    const a = [wing("main", [badSeg])];
+    const b = [wing("main", [segment()])];
+    expect(() => computeGeometryDiff(a, b)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// changes-only vs show-all filtering
+// ---------------------------------------------------------------------------
+
+describe("computeGeometryDiff — changes-only vs show-all", () => {
+  it("changes-only keeps only changed wings/sections/params (incidence change, same sig)", () => {
+    // Use incidence change (not in LCS signature) so sections match by sig and diff their params
+    const a = [
+      wing("main", [
+        segment({ root_airfoil: { airfoil: "n", chord: 200, incidence: 1 }, length: 500 }),
+        segment({ root_airfoil: { airfoil: "n", chord: 160, incidence: 0 }, length: 400 }),
+      ]),
+      wing("tail", [segment()]),
+    ];
+    const b = [
+      wing("main", [
+        segment({ root_airfoil: { airfoil: "n", chord: 200, incidence: 4 }, length: 500 }),
+        segment({ root_airfoil: { airfoil: "n", chord: 160, incidence: 0 }, length: 400 }),
+      ]),
+      wing("tail", [segment()]),
+    ];
+    const diff = computeGeometryDiff(a, b, { showAll: false });
+    // tail unchanged → dropped; main has one changed section only
+    expect(diff.wings).toHaveLength(1);
+    expect(diff.wings[0].name).toBe("main");
+    expect(diff.wings[0].sections).toHaveLength(1);
+    expect(diff.wings[0].sections[0].index).toBe(0);
+    // only the root incidence param is emitted (chord identical, sig-matched)
+    expect(diff.wings[0].sections[0].params.map((p) => p.key)).toEqual(["root incidence"]);
+  });
+
+  it("show-all emits every wing, section and core param", () => {
+    // Use distinct signatures so LCS matches sections positionally
+    const a = [
+      wing("main", [
+        segment({ root_airfoil: { airfoil: "n", chord: 200, incidence: 1 }, length: 500 }),
+        segment({ root_airfoil: { airfoil: "naca2412", chord: 160, incidence: 0 }, length: 400 }),
+      ]),
+      wing("tail", [segment()]),
+    ];
+    const b = [
+      wing("main", [
+        segment({ root_airfoil: { airfoil: "n", chord: 200, incidence: 4 }, length: 500 }),
+        segment({ root_airfoil: { airfoil: "naca2412", chord: 160, incidence: 0 }, length: 400 }),
+      ]),
+      wing("tail", [segment()]),
+    ];
+    const diff = computeGeometryDiff(a, b, { showAll: true });
+    // both wings present
+    expect(diff.wings.map((w) => w.name).sort()).toEqual(["main", "tail"]);
+    const main = diff.wings.find((w) => w.name === "main")!;
+    // both sections present
+    expect(main.sections).toHaveLength(2);
+    // every core param emitted for each section (10 params: root chord/inc/dih/af, tip chord/inc/dih/af, span, sweep)
+    const keys = main.sections[0].params.map((p) => p.key).sort();
+    expect(keys).toEqual([
+      "root airfoil",
+      "root chord",
+      "root dihedral",
+      "root incidence",
+      "span",
+      "sweep",
+      "tip airfoil",
+      "tip chord",
+      "tip dihedral",
+      "tip incidence",
+    ]);
+    // hasAnyChange still reflects real changes, not the show-all emission
+    expect(diff.hasAnyChange).toBe(true);
+  });
+
+  it("show-all on identical inputs still has hasAnyChange=false", () => {
+    const a = [wing("main", [segment()])];
+    const b = [wing("main", [segment()])];
+    const diff = computeGeometryDiff(a, b, { showAll: true });
+    expect(diff.hasAnyChange).toBe(false);
+    expect(diff.wings).toHaveLength(1);
+    expect(diff.wings[0].sections[0].params.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/__tests__/useGeometryDiff.test.ts
+++ b/frontend/__tests__/useGeometryDiff.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Unit tests for the useGeometryDiff hook (gh-971).
+ *
+ * The hook lazily fetches both compared nodes' WingConfig per wing (only when
+ * `enabled`) and returns a computed GeometryDiff. We mock the fetcher so no real
+ * network happens, and assert: lazy (no fetch when disabled), happy path (both
+ * sides fetched + diff computed), error surfacing, and 404→added/removed.
+ */
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+
+import { useGeometryDiff } from "@/hooks/useGeometryDiff";
+import type { WingConfig } from "@/hooks/useWingConfig";
+
+// Fresh SWR cache per render so error/data state never bleeds between tests.
+function wrapper({ children }: { children: React.ReactNode }) {
+  return React.createElement(
+    SWRConfig,
+    { value: { provider: () => new Map(), dedupingInterval: 0 } },
+    children,
+  );
+}
+
+// Mock the fetcher so the hook's SWR multi-fetch resolves from a path map.
+const fetchMock = vi.fn<(path: string) => Promise<unknown>>();
+vi.mock("@/lib/fetcher", () => ({
+  fetcher: (path: string) => fetchMock(path),
+  API_BASE: "http://localhost:8001",
+}));
+
+const NODE_A = "node-aaaa";
+const NODE_B = "node-bbbb";
+
+function makeConfig(incidence: number): WingConfig {
+  return {
+    segments: [
+      {
+        root_airfoil: { airfoil: "naca2412", chord: 200, incidence },
+        tip_airfoil: { airfoil: "naca2412", chord: 150, incidence: 0 },
+        length: 500,
+        sweep: 0,
+      },
+    ],
+    nose_pnt: [0, 0, 0],
+  };
+}
+
+function wingconfigPath(uuid: string, wing: string): string {
+  return `/aeroplanes/${uuid}/wings/${wing}/wingconfig`;
+}
+
+describe("useGeometryDiff", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it("fetches nothing and returns a null diff when disabled (lazy)", async () => {
+    const { result } = renderHook(() =>
+      useGeometryDiff(NODE_A, NODE_B, ["main_wing"], false),
+      { wrapper },
+    );
+
+    expect(result.current.diff).toBeNull();
+    expect(result.current.error).toBeNull();
+    // No SWR key → fetcher never invoked.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fetches both nodes' configs per wing and computes the diff when enabled", async () => {
+    // Use incidence values that differ (incidence is NOT in the LCS signature, so
+    // sections match by root_chord|length|airfoil and then differ on incidence).
+    fetchMock.mockImplementation((path: string) => {
+      if (path === wingconfigPath(NODE_A, "main_wing")) {
+        return Promise.resolve(makeConfig(0));
+      }
+      if (path === wingconfigPath(NODE_B, "main_wing")) {
+        return Promise.resolve(makeConfig(3));
+      }
+      return Promise.reject(new Error(`unexpected path ${path}`));
+    });
+
+    const { result } = renderHook(() =>
+      useGeometryDiff(NODE_A, NODE_B, ["main_wing"], true),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.diff).not.toBeNull();
+    });
+
+    // Both sides fetched.
+    expect(fetchMock).toHaveBeenCalledWith(wingconfigPath(NODE_A, "main_wing"));
+    expect(fetchMock).toHaveBeenCalledWith(wingconfigPath(NODE_B, "main_wing"));
+
+    const diff = result.current.diff!;
+    expect(diff.hasAnyChange).toBe(true);
+    expect(diff.wings).toHaveLength(1);
+    expect(diff.wings[0].name).toBe("main_wing");
+    const incidenceChange = diff.wings[0].sections[0].params.find(
+      (p) => p.key === "root incidence",
+    );
+    expect(incidenceChange).toBeDefined();
+    expect(incidenceChange?.a).toBe("0 deg");
+    expect(incidenceChange?.b).toBe("3 deg");
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces a non-404 fetch error", async () => {
+    fetchMock.mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(() =>
+      useGeometryDiff(NODE_A, NODE_B, ["main_wing"], true),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.error).not.toBeNull();
+    });
+    expect(result.current.error?.message).toContain("boom");
+    expect(result.current.diff).toBeNull();
+  });
+
+  it("fetches nothing when uuids are missing even if enabled", () => {
+    const { result } = renderHook(() =>
+      useGeometryDiff(null, NODE_B, ["main_wing"], true),
+      { wrapper },
+    );
+
+    expect(result.current.diff).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("404 on one node's wing → reports the wing as added (not an error)", async () => {
+    // NODE_A returns 404 (wing absent on side A) → wing appears only on B → "added"
+    fetchMock.mockImplementation((path: string) => {
+      if (path === wingconfigPath(NODE_A, "main_wing")) {
+        return Promise.reject(new Error("404 Not Found: /aeroplanes/node-aaaa/wings/main_wing/wingconfig"));
+      }
+      if (path === wingconfigPath(NODE_B, "main_wing")) {
+        return Promise.resolve(makeConfig(200));
+      }
+      return Promise.reject(new Error(`unexpected path ${path}`));
+    });
+
+    const { result } = renderHook(() =>
+      useGeometryDiff(NODE_A, NODE_B, ["main_wing"], true),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.diff).not.toBeNull();
+    });
+
+    // Must NOT error — 404 is handled gracefully
+    expect(result.current.error).toBeNull();
+
+    const diff = result.current.diff!;
+    expect(diff.hasAnyChange).toBe(true);
+    const wing = diff.wings.find((w) => w.name === "main_wing");
+    expect(wing).toBeDefined();
+    // Side A is null (404) → wing only on B → "added"
+    expect(wing!.kind).toBe("added");
+  });
+
+  it("404 on B's wing → reports the wing as removed", async () => {
+    fetchMock.mockImplementation((path: string) => {
+      if (path === wingconfigPath(NODE_A, "main_wing")) {
+        return Promise.resolve(makeConfig(200));
+      }
+      if (path === wingconfigPath(NODE_B, "main_wing")) {
+        return Promise.reject(new Error("404 Not Found: /aeroplanes/node-bbbb/wings/main_wing/wingconfig"));
+      }
+      return Promise.reject(new Error(`unexpected path ${path}`));
+    });
+
+    const { result } = renderHook(() =>
+      useGeometryDiff(NODE_A, NODE_B, ["main_wing"], true),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.diff).not.toBeNull();
+    });
+
+    expect(result.current.error).toBeNull();
+
+    const diff = result.current.diff!;
+    expect(diff.hasAnyChange).toBe(true);
+    const wing = diff.wings.find((w) => w.name === "main_wing");
+    expect(wing).toBeDefined();
+    expect(wing!.kind).toBe("removed");
+  });
+});

--- a/frontend/components/workbench/GeometryDiffSection.tsx
+++ b/frontend/components/workbench/GeometryDiffSection.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+/**
+ * Collapsible "Geometry changes" section for the version-compare view (gh-971).
+ *
+ * Sits BELOW the metric compare sections. Reuses the metric-compare 3-column
+ * grid styling (A | param | B, amber on change). It owns the `expanded` and
+ * `showAll` state and delegates the lazy fetch+diff to useGeometryDiff:
+ *
+ *   - Collapsed by default → the hook is called with enabled=false → NO fetch.
+ *   - On first expand → enabled=true → the hook fetches every wing's WingConfig
+ *     for both nodes and computes a pure GeometryDiff.
+ *   - `showAll` flips the diff between changes-only (default) and show-all
+ *     (every section + every core param, changes still highlighted amber).
+ *
+ * Failure is contained: an error renders an inline block inside the section, it
+ * never throws up into the compare view. Units are mm / degrees (WingConfig).
+ */
+
+import React, { useState } from "react";
+import { ChevronRight, ChevronDown, Loader2 } from "lucide-react";
+
+import { useGeometryDiff } from "@/hooks/useGeometryDiff";
+import type {
+  GeometryDiff,
+  WingDiff,
+  SectionDiff,
+  ChangeKind,
+} from "@/lib/geometryDiff";
+
+export interface GeometryDiffSectionProps {
+  readonly nodeAUuid: string | null;
+  readonly nodeBUuid: string | null;
+  readonly wingNames: string[];
+  readonly labelA: string;
+  readonly labelB: string;
+}
+
+// ---------------------------------------------------------------------------
+// Presentational helpers
+// ---------------------------------------------------------------------------
+
+/** "N changed · M added · K removed" summary for the collapsed header. */
+function summaryText(diff: GeometryDiff | null): string {
+  if (diff == null) return "";
+  const { sectionsChanged, sectionsAdded, sectionsRemoved } = diff.counts;
+  return `${sectionsChanged} changed · ${sectionsAdded} added · ${sectionsRemoved} removed`;
+}
+
+function KindBadge({ kind }: { readonly kind: ChangeKind }) {
+  if (kind === "changed") return null;
+  const cls =
+    kind === "added"
+      ? "bg-emerald-500/15 text-emerald-400"
+      : "bg-rose-500/15 text-rose-400";
+  return (
+    <span
+      className={`rounded-full px-1 py-0.5 text-[9px] font-medium ${cls}`}
+    >
+      {kind}
+    </span>
+  );
+}
+
+/** A | param | B value row, amber when the two sides differ. */
+interface DiffRowProps {
+  readonly paramKey: string;
+  readonly a: string | null;
+  readonly b: string | null;
+  readonly differs: boolean;
+  readonly kind?: ChangeKind;
+}
+
+function DiffRow({ paramKey, a, b, differs, kind }: DiffRowProps) {
+  const dash = "—";
+  return (
+    <div
+      className={`grid grid-cols-[1fr_auto_1fr] items-center gap-2 rounded px-2 py-1 font-[family-name:var(--font-geist-mono)] text-[11px] ${
+        differs ? "bg-amber-500/10" : ""
+      }`}
+      data-testid={`geometry-diff-row-${paramKey}`}
+      data-differs={differs ? "true" : undefined}
+    >
+      <span
+        className={`text-right ${differs ? "font-semibold text-foreground" : "text-muted-foreground"}`}
+      >
+        {a ?? dash}
+      </span>
+      <span className="flex min-w-[72px] items-center justify-center gap-1 text-center text-subtle-foreground">
+        {paramKey}
+        {kind != null && <KindBadge kind={kind} />}
+      </span>
+      <span
+        className={`text-left ${differs ? "font-semibold text-foreground" : "text-muted-foreground"}`}
+      >
+        {b ?? dash}
+      </span>
+    </div>
+  );
+}
+
+function SectionSubheader({ section }: { readonly section: SectionDiff }) {
+  return (
+    <div
+      className="mt-1 flex items-center gap-1.5 px-2 text-[10px] font-medium text-subtle-foreground"
+      data-testid={`geometry-diff-section-${section.index}`}
+    >
+      <span>{section.label}</span>
+      <KindBadge kind={section.kind} />
+    </div>
+  );
+}
+
+function WingBlock({ wing }: { readonly wing: WingDiff }) {
+  return (
+    <div className="mb-3">
+      <div className="mb-1 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-widest text-subtle-foreground">
+        <span>{wing.name}</span>
+        <KindBadge kind={wing.kind} />
+      </div>
+      <div className="flex flex-col gap-0.5">
+        {wing.sections.map((section) => (
+          <div key={section.index}>
+            <SectionSubheader section={section} />
+            {section.params.map((p) => (
+              <DiffRow
+                key={`${section.index}-p-${p.key}`}
+                paramKey={p.key}
+                a={p.a}
+                b={p.b}
+                differs={p.a !== p.b}
+              />
+            ))}
+            {section.flags.map((f) => (
+              <DiffRow
+                key={`${section.index}-f-${f.key}`}
+                paramKey={f.key}
+                a={f.a}
+                b={f.b}
+                differs={f.a !== f.b}
+                kind={f.kind}
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Section body (only mounted while expanded)
+// ---------------------------------------------------------------------------
+
+interface DiffBodyProps {
+  readonly diff: GeometryDiff | null;
+  readonly isLoading: boolean;
+  readonly error: Error | null;
+  readonly showAll: boolean;
+  readonly onToggleShowAll: () => void;
+}
+
+function DiffBody({ diff, isLoading, error, showAll, onToggleShowAll }: DiffBodyProps) {
+  if (isLoading) {
+    return (
+      <div
+        data-testid="geometry-diff-loading"
+        className="flex items-center gap-2 px-2 py-3 text-[11px] text-muted-foreground"
+      >
+        <Loader2 size={13} className="animate-spin" aria-hidden="true" />
+        Loading geometry changes…
+      </div>
+    );
+  }
+
+  if (error != null) {
+    return (
+      <div
+        role="alert"
+        data-testid="geometry-diff-error"
+        className="rounded border border-destructive/30 bg-destructive/10 p-3 text-[11px] text-destructive"
+      >
+        Could not load geometry changes: {error.message}
+      </div>
+    );
+  }
+
+  if (diff == null || !diff.hasAnyChange) {
+    return (
+      <p className="px-2 py-2 text-[11px] text-muted-foreground">
+        No geometry changes.
+      </p>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-2 flex justify-end px-2">
+        <button
+          type="button"
+          data-testid="geometry-diff-showall-toggle"
+          aria-pressed={showAll}
+          onClick={onToggleShowAll}
+          className="rounded border border-border px-2 py-0.5 text-[10px] text-muted-foreground hover:bg-sidebar-accent"
+        >
+          {showAll ? "Changes only" : "Show all"}
+        </button>
+      </div>
+      <div data-testid="geometry-diff-table">
+        {diff.wings.map((wing) => (
+          <WingBlock key={wing.name} wing={wing} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function GeometryDiffSection({
+  nodeAUuid,
+  nodeBUuid,
+  wingNames,
+  labelA,
+  labelB,
+}: GeometryDiffSectionProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [showAll, setShowAll] = useState(false);
+
+  // Lazy: the hook fetches only when `expanded` is true.
+  const { diff, isLoading, error } = useGeometryDiff(
+    nodeAUuid,
+    nodeBUuid,
+    wingNames,
+    expanded,
+    showAll,
+  );
+
+  const Chevron = expanded ? ChevronDown : ChevronRight;
+
+  return (
+    <div
+      data-testid="geometry-diff-section"
+      className="mt-4 border-t border-border pt-3"
+    >
+      <button
+        type="button"
+        data-testid="geometry-diff-header"
+        aria-expanded={expanded}
+        aria-controls="geometry-diff-body"
+        onClick={() => setExpanded((v) => !v)}
+        className="flex w-full items-center gap-1.5 text-left text-[11px] font-semibold text-foreground hover:text-primary"
+      >
+        <Chevron size={13} className="shrink-0 text-muted-foreground" aria-hidden="true" />
+        <span>Geometry changes</span>
+        <span className="font-normal text-muted-foreground">— {summaryText(diff)}</span>
+      </button>
+
+      {/* The metric-compare grid uses A | label | B; mirror the label row so
+          this section reads the same as the sections above it. */}
+      {expanded && (
+        <div id="geometry-diff-body">
+          <div
+            className="mt-2 mb-1 grid grid-cols-[1fr_auto_1fr] gap-2 px-2 text-[10px] font-medium text-subtle-foreground"
+            aria-hidden="true"
+          >
+            <span className="text-right">{labelA}</span>
+            <span className="min-w-[72px] text-center">param</span>
+            <span className="text-left">{labelB}</span>
+          </div>
+          <DiffBody
+            diff={diff}
+            isLoading={isLoading}
+            error={error}
+            showAll={showAll}
+            onToggleShowAll={() => setShowAll((v) => !v)}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/workbench/VersionCompareView.tsx
+++ b/frontend/components/workbench/VersionCompareView.tsx
@@ -19,7 +19,7 @@
  *   error       — error message string, or null
  */
 
-import React from "react";
+import React, { useMemo } from "react";
 import { X, ArrowLeftRight } from "lucide-react";
 import type { CompareOut, VersionNode } from "@/types/versioning";
 import type { ComputationContext } from "@/hooks/useComputationContext";
@@ -31,6 +31,7 @@ import {
   toTail,
 } from "@/lib/metricsAdapters";
 import { renderSymbol } from "@/components/workbench/renderSymbol";
+import { GeometryDiffSection } from "@/components/workbench/GeometryDiffSection";
 import { isAgentAuthor, authorLabel } from "@/lib/versionProvenance";
 import type { GaugeData, MetricItem } from "@/components/workbench/metrics-dashboard/metricsTypes";
 
@@ -105,6 +106,21 @@ function contextsDiverge(
 
 function nodeLabel(node: VersionNode): string {
   return node.version_label ?? node.name;
+}
+
+/** Wing names from a metrics dict (`wing_names: string[]`), or [] if absent. */
+function wingNamesOf(metrics: Record<string, unknown> | null): string[] {
+  const v = metrics?.["wing_names"];
+  if (!Array.isArray(v)) return [];
+  return v.filter((n): n is string => typeof n === "string");
+}
+
+/** Stable, de-duplicated union of both sides' wing names. */
+function unionWingNames(
+  metricsA: Record<string, unknown> | null,
+  metricsB: Record<string, unknown> | null,
+): string[] {
+  return Array.from(new Set([...wingNamesOf(metricsA), ...wingNamesOf(metricsB)]));
 }
 
 // ---------------------------------------------------------------------------
@@ -591,6 +607,12 @@ export function VersionCompareView({
   onClose,
   branchNameMap,
 }: VersionCompareViewProps) {
+  // Memoize the wing-name union so it isn't a new array on every render.
+  const wingNames = useMemo(
+    () => unionWingNames(compareOut?.metrics_a ?? null, compareOut?.metrics_b ?? null),
+    [compareOut?.metrics_a, compareOut?.metrics_b],
+  );
+
   return (
     <div
       aria-label="Version compare"
@@ -682,6 +704,13 @@ export function VersionCompareView({
                   <GeometryCompareRows ctxA={ctxA} ctxB={ctxB} labelA={labelA} labelB={labelB} />
                   <QualityCompareRows ctxA={ctxA} ctxB={ctxB} labelA={labelA} labelB={labelB} />
                   <TailCompareRows ctxA={ctxA} ctxB={ctxB} labelA={labelA} labelB={labelB} />
+                  <GeometryDiffSection
+                    nodeAUuid={compareOut.node_a.uuid}
+                    nodeBUuid={compareOut.node_b.uuid}
+                    wingNames={wingNames}
+                    labelA={labelA}
+                    labelB={labelB}
+                  />
                 </>
               );
             })()}

--- a/frontend/hooks/useGeometryDiff.ts
+++ b/frontend/hooks/useGeometryDiff.ts
@@ -1,0 +1,146 @@
+"use client";
+
+import { useMemo } from "react";
+import useSWR from "swr";
+
+import { fetcher } from "@/lib/fetcher";
+import type { WingConfig } from "@/hooks/useWingConfig";
+import {
+  computeGeometryDiff,
+  type DiffWingInput,
+  type GeometryDiff,
+} from "@/lib/geometryDiff";
+
+/**
+ * Lazy geometry-parameter diff for the version-compare view (gh-971).
+ *
+ * When `enabled` is false (the "Geometry changes" section is collapsed) this
+ * fetches NOTHING — the SWR key is null and `diff` is null. When enabled and
+ * both node UUIDs are present, it fetches every wing's WingConfig for both
+ * compared nodes (existing endpoint, mm units) and memoises a pure
+ * `computeGeometryDiff` over the results.
+ *
+ * `wingNames` is the union of both sides' wing names. A wing present on only
+ * one node yields a null config on the missing side (added/removed), which the
+ * pure diff handles by aligning on wing name.
+ *
+ * 404 handling: a 404 from one side means that wing is absent on that node
+ * (added or removed). `fetchConfigOrNull` catches 404 errors and returns null
+ * rather than propagating the error, so the diff can report added/removed
+ * correctly. Other HTTP errors still propagate to the SWR error state.
+ */
+
+function wingconfigPath(uuid: string, wingName: string): string {
+  return `/aeroplanes/${uuid}/wings/${wingName}/wingconfig`;
+}
+
+/** One fetched wing config keyed by node and name (null = absent for that node). */
+interface FetchedWing {
+  name: string;
+  configA: WingConfig | null;
+  configB: WingConfig | null;
+}
+
+/**
+ * Fetch a WingConfig, returning null for 404 (wing absent on this node).
+ * Other errors are rethrown so SWR can surface them.
+ */
+async function fetchConfigOrNull(
+  uuid: string,
+  name: string,
+): Promise<WingConfig | null> {
+  try {
+    return await fetcher<WingConfig>(wingconfigPath(uuid, name));
+  } catch (err) {
+    if (err instanceof Error) {
+      const m = err.message.match(/^(\d{3})\b/);
+      if (m && m[1] === "404") return null;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Fetch every (node, wing) WingConfig in parallel. A null config means the
+ * endpoint returned 404 for that side (wing absent); other failures propagate
+ * so SWR surfaces them as `error`.
+ */
+async function fetchAllConfigs(
+  uuidA: string,
+  uuidB: string,
+  wingNames: string[],
+): Promise<FetchedWing[]> {
+  return Promise.all(
+    wingNames.map(async (name) => {
+      const [configA, configB] = await Promise.all([
+        fetchConfigOrNull(uuidA, name),
+        fetchConfigOrNull(uuidB, name),
+      ]);
+      return { name, configA, configB };
+    }),
+  );
+}
+
+function toDiffInputs(fetched: FetchedWing[]): {
+  wingsA: DiffWingInput[];
+  wingsB: DiffWingInput[];
+} {
+  const wingsA: DiffWingInput[] = [];
+  const wingsB: DiffWingInput[] = [];
+  for (const { name, configA, configB } of fetched) {
+    if (configA) wingsA.push({ name, config: configA });
+    if (configB) wingsB.push({ name, config: configB });
+  }
+  return { wingsA, wingsB };
+}
+
+export interface UseGeometryDiffResult {
+  diff: GeometryDiff | null;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export function useGeometryDiff(
+  nodeAUuid: string | null,
+  nodeBUuid: string | null,
+  wingNames: string[],
+  enabled: boolean,
+  showAll: boolean = false,
+): UseGeometryDiffResult {
+  // De-duplicate while preserving original order for fetch + diff.
+  // Sort only for the SWR cache key (stability); the fetch order stays
+  // as the caller provided so wing display order is preserved.
+  const dedupedNames = useMemo(
+    () => Array.from(new Set(wingNames)),
+    [wingNames],
+  );
+
+  // Stable, sorted key string for SWR cache consistency.
+  const sortedKey = useMemo(
+    () => [...dedupedNames].sort((a, b) => a.localeCompare(b)).join(" "),
+    [dedupedNames],
+  );
+
+  const swrKey =
+    enabled && nodeAUuid && nodeBUuid && dedupedNames.length > 0
+      ? (["geometry-diff", nodeAUuid, nodeBUuid, sortedKey] as const)
+      : null;
+
+  const { data, error, isLoading } = useSWR<FetchedWing[], Error>(
+    swrKey,
+    () => fetchAllConfigs(nodeAUuid as string, nodeBUuid as string, dedupedNames),
+    { shouldRetryOnError: false },
+  );
+
+  const diff = useMemo<GeometryDiff | null>(() => {
+    if (!data) return null;
+    const { wingsA, wingsB } = toDiffInputs(data);
+    return computeGeometryDiff(wingsA, wingsB, { showAll });
+  }, [data, showAll]);
+
+  return {
+    diff,
+    isLoading: swrKey != null && isLoading,
+    error: error ?? null,
+  };
+}

--- a/frontend/lib/geometryDiff.ts
+++ b/frontend/lib/geometryDiff.ts
@@ -1,0 +1,514 @@
+/**
+ * Pure geometry parameter diff for the version-compare view (gh-971).
+ *
+ * Compares two sets of wing geometries (WingConfig objects, mm + degrees, the
+ * shape returned by GET /aeroplanes/{uuid}/wings/{wing}/wingconfig) and reports
+ * WHICH design inputs changed — per wing, per section, per core param — plus
+ * presence/count flags for sub-elements (spar / control-surface / turbulator).
+ *
+ * Pure: no React, no network. All diff logic + the numeric tolerance live here
+ * so the component/hook stay thin and the rules stay testable.
+ *
+ * Units follow WingConfig: chord/span in mm, incidence/dihedral in degrees,
+ * sweep in mm. Numeric tolerance |Δ| <= 0.05 is treated as unchanged to
+ * avoid float noise; airfoil compares by string equality.
+ *
+ * Section alignment is performed by SIGNATURE (root_chord|length|root_airfoil)
+ * using an LCS (Longest Common Subsequence) algorithm so that inserting a
+ * section in the middle does NOT cascade false "changed" on downstream sections.
+ */
+
+import type { WingConfig, WingConfigSegment } from "@/hooks/useWingConfig";
+
+// --- Public types ----------------------------------------------------------
+
+export type ChangeKind = "changed" | "added" | "removed";
+
+/** A single core-param diff, e.g. key="root chord", a="162 mm", b="158 mm". */
+export interface ParamChange {
+  key: string;
+  a: string | null;
+  b: string | null;
+}
+
+/** A sub-element presence/count flag (spar / control_surface / turbulator). */
+export interface SubElementFlag {
+  key: string;
+  kind: ChangeKind;
+  a: string | null;
+  b: string | null;
+}
+
+export interface SectionDiff {
+  index: number;
+  kind: ChangeKind;
+  label: string;
+  params: ParamChange[];
+  flags: SubElementFlag[];
+}
+
+export interface WingDiff {
+  name: string;
+  kind: ChangeKind;
+  sections: SectionDiff[];
+}
+
+export interface GeometryDiff {
+  wings: WingDiff[];
+  counts: {
+    sectionsChanged: number;
+    sectionsAdded: number;
+    sectionsRemoved: number;
+  };
+  hasAnyChange: boolean;
+}
+
+/** One named wing's full geometry, the unit the diff aligns by name. */
+export interface DiffWingInput {
+  name: string;
+  config: WingConfig;
+}
+
+export interface GeometryDiffOptions {
+  showAll?: boolean;
+}
+
+// --- Constants --------------------------------------------------------------
+
+/** |Δ| at or below this (mm or degrees) is float noise, not a change. */
+const NUMERIC_TOLERANCE = 0.05;
+
+// --- Formatting helpers -----------------------------------------------------
+
+/** Strip ".dat" suffix from airfoil file names for display. */
+function stripDat(name: string): string {
+  return name.endsWith(".dat") ? name.slice(0, -4) : name;
+}
+
+/**
+ * Format a number for display ("500", "1.5", "12.34").
+ * Returns "—" for non-finite values (NaN, ±Infinity).
+ */
+function formatNumber(value: number): string {
+  if (!Number.isFinite(value)) return "—";
+  // Round to 2 dp, then drop trailing zeros / dot.
+  const rounded = Math.round(value * 100) / 100;
+  return String(rounded);
+}
+
+function formatMm(value: number): string {
+  if (!Number.isFinite(value)) return "—";
+  return `${formatNumber(value)} mm`;
+}
+
+function formatDeg(value: number): string {
+  if (!Number.isFinite(value)) return "—";
+  return `${formatNumber(value)} deg`;
+}
+
+// --- Core param extraction --------------------------------------------------
+
+interface CoreParam {
+  key: string;
+  /** Numeric value used for tolerance comparison; null for string params. */
+  num: number | null;
+  /** Formatted display value. */
+  display: string;
+}
+
+/**
+ * Extract all core params for both root and tip airfoils of a segment.
+ * Guards against missing root_airfoil / tip_airfoil with ?? {}.
+ */
+function coreParams(seg: WingConfigSegment): CoreParam[] {
+  const af = seg.root_airfoil ?? {};
+  const rootChord = (af as { chord?: number }).chord ?? 0;
+  const rootIncidence = (af as { incidence?: number }).incidence ?? 0;
+  const rootDihedral = (af as { dihedral_as_rotation_in_degrees?: number }).dihedral_as_rotation_in_degrees ?? 0;
+  const rootAirfoil = stripDat((af as { airfoil?: string }).airfoil ?? "");
+
+  const taf = seg.tip_airfoil ?? {};
+  const tipChord = (taf as { chord?: number }).chord ?? 0;
+  const tipIncidence = (taf as { incidence?: number }).incidence ?? 0;
+  const tipDihedral = (taf as { dihedral_as_rotation_in_degrees?: number }).dihedral_as_rotation_in_degrees ?? 0;
+  const tipAirfoil = stripDat((taf as { airfoil?: string }).airfoil ?? "");
+
+  const span = seg.length ?? 0;
+  const sweep = seg.sweep ?? 0;
+
+  return [
+    { key: "root chord", num: rootChord, display: formatMm(rootChord) },
+    { key: "root incidence", num: rootIncidence, display: formatDeg(rootIncidence) },
+    { key: "root dihedral", num: rootDihedral, display: formatDeg(rootDihedral) },
+    { key: "root airfoil", num: null, display: rootAirfoil },
+    { key: "tip chord", num: tipChord, display: formatMm(tipChord) },
+    { key: "tip incidence", num: tipIncidence, display: formatDeg(tipIncidence) },
+    { key: "tip dihedral", num: tipDihedral, display: formatDeg(tipDihedral) },
+    { key: "tip airfoil", num: null, display: tipAirfoil },
+    { key: "span", num: span, display: formatMm(span) },
+    { key: "sweep", num: sweep, display: formatMm(sweep) },
+  ];
+}
+
+function paramChanged(a: CoreParam, b: CoreParam): boolean {
+  if (a.num !== null && b.num !== null) {
+    const aFin = Number.isFinite(a.num);
+    const bFin = Number.isFinite(b.num);
+    // One finite, one not → changed
+    if (aFin !== bFin) return true;
+    // Both non-finite → unchanged (treat as same)
+    if (!aFin && !bFin) return false;
+    // Both finite → numeric tolerance comparison
+    return Math.abs(a.num - b.num) > NUMERIC_TOLERANCE;
+  }
+  // string param (airfoil): exact equality
+  return a.display !== b.display;
+}
+
+// --- Section signature for LCS alignment ------------------------------------
+
+/**
+ * Compute a stable signature for a segment for use in LCS alignment.
+ * Uses root chord (rounded to nearest integer mm), length (rounded to
+ * nearest integer mm), and the root airfoil name. Rounding to integers
+ * tolerates minor float noise (e.g. 500 vs 500.04 both → 500) while
+ * still distinguishing meaningfully different sections.
+ */
+function sectionSignature(seg: WingConfigSegment): string {
+  const af = seg.root_airfoil ?? {};
+  const chord = Math.round((af as { chord?: number }).chord ?? 0);
+  const length = Math.round(seg.length ?? 0);
+  const airfoil = stripDat((af as { airfoil?: string }).airfoil ?? "");
+  return `${chord}|${length}|${airfoil}`;
+}
+
+/**
+ * LCS-align segsA and segsB by signature.
+ *
+ * Returns an array of pairs where each entry is either:
+ *   [segA, segB]  — matched pair (both defined)
+ *   [segA, null]  — removed (only in A)
+ *   [null, segB]  — added (only in B)
+ *
+ * The LCS is computed over signature strings. Matched pairs preserve the
+ * original segment data for detailed diffing.
+ */
+function lcsAlign(
+  segsA: WingConfigSegment[],
+  segsB: WingConfigSegment[],
+): Array<[WingConfigSegment | null, WingConfigSegment | null]> {
+  const sigsA = segsA.map(sectionSignature);
+  const sigsB = segsB.map(sectionSignature);
+  const m = sigsA.length;
+  const n = sigsB.length;
+
+  // Build LCS table
+  const dp: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      if (sigsA[i - 1] === sigsB[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1] + 1;
+      } else {
+        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+      }
+    }
+  }
+
+  // Trace back to build aligned pairs
+  const result: Array<[WingConfigSegment | null, WingConfigSegment | null]> = [];
+  let i = m;
+  let j = n;
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && sigsA[i - 1] === sigsB[j - 1]) {
+      result.unshift([segsA[i - 1], segsB[j - 1]]);
+      i--;
+      j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      result.unshift([null, segsB[j - 1]]);
+      j--;
+    } else {
+      result.unshift([segsA[i - 1], null]);
+      i--;
+    }
+  }
+
+  return result;
+}
+
+// --- Sub-element flag extraction --------------------------------------------
+
+function sparLabel(count: number): string {
+  return `${count} ${count === 1 ? "spar" : "spars"}`;
+}
+
+function tedName(ted: Record<string, unknown> | null | undefined): string {
+  if (ted == null) return "—";
+  const name = ted["name"];
+  if (typeof name === "string" && name.trim() !== "") return name;
+  return "on";
+}
+
+function turbulatorLabel(
+  turb: Record<string, unknown> | null | undefined,
+): string {
+  return turb == null ? "—" : "on";
+}
+
+function subElementFlags(
+  a: WingConfigSegment,
+  b: WingConfigSegment,
+  showAll: boolean,
+): SubElementFlag[] {
+  const flags: SubElementFlag[] = [];
+
+  const sparA = sparLabel(a.spare_list?.length ?? 0);
+  const sparB = sparLabel(b.spare_list?.length ?? 0);
+  if (showAll || sparA !== sparB) {
+    flags.push({
+      key: "spar",
+      kind: "changed",
+      a: sparA,
+      b: sparB,
+    });
+  }
+
+  const tedA = tedName(a.trailing_edge_device);
+  const tedB = tedName(b.trailing_edge_device);
+  if (showAll || tedA !== tedB) {
+    flags.push({
+      key: "control_surface",
+      kind: "changed",
+      a: tedA,
+      b: tedB,
+    });
+  }
+
+  const turbA = turbulatorLabel(a.turbulator);
+  const turbB = turbulatorLabel(b.turbulator);
+  if (showAll || turbA !== turbB) {
+    flags.push({
+      key: "turbulator",
+      kind: "changed",
+      a: turbA,
+      b: turbB,
+    });
+  }
+
+  return flags;
+}
+
+// --- Section diff -----------------------------------------------------------
+
+/**
+ * Generate a label for a section with its position role.
+ * Index 0 → "Section 1 · root", last index (totalSections-1) → "Section N · tip",
+ * middle → "Section k · mid".
+ */
+function sectionLabel(index: number, totalSections: number): string {
+  const num = index + 1;
+  if (totalSections === 1) return `Section ${num} · root`;
+  if (index === 0) return `Section ${num} · root`;
+  if (index === totalSections - 1) return `Section ${num} · tip`;
+  return `Section ${num} · mid`;
+}
+
+function diffPresentSection(
+  index: number,
+  totalSections: number,
+  a: WingConfigSegment,
+  b: WingConfigSegment,
+  showAll: boolean,
+): SectionDiff {
+  const paramsA = coreParams(a);
+  const paramsB = coreParams(b);
+
+  const params: ParamChange[] = [];
+  for (let i = 0; i < paramsA.length; i++) {
+    const pa = paramsA[i];
+    const pb = paramsB[i];
+    const changed = paramChanged(pa, pb);
+    if (showAll || changed) {
+      params.push({ key: pa.key, a: pa.display, b: pb.display });
+    }
+  }
+
+  const flags = subElementFlags(a, b, showAll);
+
+  return {
+    index,
+    kind: "changed",
+    label: sectionLabel(index, totalSections),
+    params,
+    flags,
+  };
+}
+
+// --- Wing diff --------------------------------------------------------------
+
+interface WingDiffResult {
+  diff: WingDiff;
+  sectionsChanged: number;
+  sectionsAdded: number;
+  sectionsRemoved: number;
+  changed: boolean;
+}
+
+function diffWing(
+  name: string,
+  a: WingConfig,
+  b: WingConfig,
+  showAll: boolean,
+): WingDiffResult {
+  const segsA = a.segments ?? [];
+  const segsB = b.segments ?? [];
+
+  // LCS-align sections by signature (not by index)
+  const aligned = lcsAlign(segsA, segsB);
+  const totalSections = aligned.length;
+
+  const sections: SectionDiff[] = [];
+  let sectionsChanged = 0;
+  let sectionsAdded = 0;
+  let sectionsRemoved = 0;
+
+  for (let i = 0; i < aligned.length; i++) {
+    const [segA, segB] = aligned[i];
+
+    if (segA && segB) {
+      const changed = sectionHasRealChange(segA, segB);
+      if (changed) sectionsChanged++;
+      if (showAll || changed) {
+        sections.push(diffPresentSection(i, totalSections, segA, segB, showAll));
+      }
+    } else if (segB && !segA) {
+      sectionsAdded++;
+      sections.push({
+        index: i,
+        kind: "added",
+        label: sectionLabel(i, totalSections),
+        params: [],
+        flags: [],
+      });
+    } else if (segA && !segB) {
+      sectionsRemoved++;
+      sections.push({
+        index: i,
+        kind: "removed",
+        label: sectionLabel(i, totalSections),
+        params: [],
+        flags: [],
+      });
+    }
+  }
+
+  const changed =
+    sectionsChanged > 0 || sectionsAdded > 0 || sectionsRemoved > 0;
+
+  return {
+    diff: { name, kind: "changed", sections },
+    sectionsChanged,
+    sectionsAdded,
+    sectionsRemoved,
+    changed,
+  };
+}
+
+function sectionHasRealChange(
+  a: WingConfigSegment,
+  b: WingConfigSegment,
+): boolean {
+  const paramsA = coreParams(a);
+  const paramsB = coreParams(b);
+  const paramChange = paramsA.some((pa, i) => paramChanged(pa, paramsB[i]));
+  const flagChange =
+    (a.spare_list?.length ?? 0) !== (b.spare_list?.length ?? 0) ||
+    tedName(a.trailing_edge_device) !== tedName(b.trailing_edge_device) ||
+    turbulatorLabel(a.turbulator) !== turbulatorLabel(b.turbulator);
+  return paramChange || flagChange;
+}
+
+// --- Top-level diff ---------------------------------------------------------
+
+/** Stable name order: A's wings first (in order), then B-only wings. */
+function orderedWingNames(
+  wingsA: DiffWingInput[],
+  wingsB: DiffWingInput[],
+): string[] {
+  const names: string[] = [];
+  const seen = new Set<string>();
+  for (const w of [...wingsA, ...wingsB]) {
+    if (!seen.has(w.name)) {
+      names.push(w.name);
+      seen.add(w.name);
+    }
+  }
+  return names;
+}
+
+/** Build a wing diff for a wing present on only one side (added/removed). */
+function presenceWing(
+  name: string,
+  kind: "added" | "removed",
+  config: WingConfig,
+): WingDiff {
+  const segs = config.segments ?? [];
+  const totalSections = segs.length;
+  return {
+    name,
+    kind,
+    sections: segs.map((_, i) => ({
+      index: i,
+      kind,
+      label: sectionLabel(i, totalSections),
+      params: [],
+      flags: [],
+    })),
+  };
+}
+
+export function computeGeometryDiff(
+  wingsA: DiffWingInput[],
+  wingsB: DiffWingInput[],
+  opts: GeometryDiffOptions = {},
+): GeometryDiff {
+  const showAll = opts.showAll ?? false;
+
+  const byNameA = new Map(wingsA.map((w) => [w.name, w]));
+  const byNameB = new Map(wingsB.map((w) => [w.name, w]));
+
+  const wings: WingDiff[] = [];
+  let sectionsChanged = 0;
+  let sectionsAdded = 0;
+  let sectionsRemoved = 0;
+  let hasAnyChange = false;
+
+  for (const name of orderedWingNames(wingsA, wingsB)) {
+    const a = byNameA.get(name);
+    const b = byNameB.get(name);
+
+    if (a && b) {
+      const res = diffWing(name, a.config, b.config, showAll);
+      sectionsChanged += res.sectionsChanged;
+      sectionsAdded += res.sectionsAdded;
+      sectionsRemoved += res.sectionsRemoved;
+      if (res.changed) hasAnyChange = true;
+      if (showAll || res.changed) {
+        wings.push(res.diff);
+      }
+    } else if (b && !a) {
+      hasAnyChange = true;
+      sectionsAdded += b.config.segments?.length ?? 0;
+      wings.push(presenceWing(name, "added", b.config));
+    } else if (a && !b) {
+      hasAnyChange = true;
+      sectionsRemoved += a.config.segments?.length ?? 0;
+      wings.push(presenceWing(name, "removed", a.config));
+    }
+  }
+
+  return {
+    wings,
+    counts: { sectionsChanged, sectionsAdded, sectionsRemoved },
+    hasAnyChange,
+  };
+}


### PR DESCRIPTION
Promotes the gh-963 "stretch". An expandable **"Geometry changes"** section in the version compare showing WHICH wing-geometry parameters changed between two versions — closing the loop from "metric changed" to "because this input changed". Built via a multi-agent workflow + persona UAT.

## What
- Pure `computeGeometryDiff` util + lazy `useGeometryDiff` hook (reuses `GET /aeroplanes/{uuid}/wings/{wing}/wingconfig`) + `GeometryDiffSection` (A|param|B table, changes-only with a Show-all toggle). Frontend-only.
- Diffs per section (root+tip): chord, incidence, dihedral, airfoil, span, sweep (mm/deg); section & wing add/remove; sub-elements (spar/control surface/turbulator) as flags.

## Review + persona-UAT findings incorporated
- **Section alignment by LCS over a geometry signature** (insert/remove no longer cascades into false "changed").
- **404 per (node,wing) → added/removed**, not a whole-panel error (verified live: an added h-stabilizer renders as "ADDED").
- **Tip-airfoil params** diffed (not just root); `incidence`/`span`/`sweep mm` labels+units; airfoil names stripped of `.dat`; section root/mid/tip roles.
- Defensive guards (missing airfoil, non-finite), a11y `aria-controls`, memoised wing-name union.

Deferred (ticketed): field-level sub-element diff **#972**, plain-language "why" hint **#973**.

## Verification
Frontend full suite **2036 green / 163 files** (Node 22), ESLint + `tsc --noEmit` clean. Live-UAT against real data (eHawk main vs v_tail).

Closes #971
Refs #963, #961

🤖 Generated with [Claude Code](https://claude.com/claude-code)