### PR TITLE
feat(gh-975): powertrain solution-space service + schemas + v2 endpoint (Phase 1)

### DIFF
--- a/app/api/v2/endpoints/aeroplane/__init__.py
+++ b/app/api/v2/endpoints/aeroplane/__init__.py
@@ -26,6 +26,7 @@ from .sm_suggestions import router as sm_suggestions_router
 from .forward_cg import router as forward_cg_router
 from .speed_polar import router as speed_polar_router
 from .turbulator_optimizer import router as turbulator_optimizer_router
+from .powertrain_solution_space import router as powertrain_solution_space_router
 
 # Include the routers
 router.include_router(base_router)
@@ -49,3 +50,4 @@ router.include_router(sm_suggestions_router)
 router.include_router(forward_cg_router)
 router.include_router(speed_polar_router)
 router.include_router(turbulator_optimizer_router)
+router.include_router(powertrain_solution_space_router)

--- a/app/api/v2/endpoints/aeroplane/powertrain_solution_space.py
+++ b/app/api/v2/endpoints/aeroplane/powertrain_solution_space.py
@@ -12,7 +12,7 @@ cell_counts is a multi-value Query param (e.g. ?cell_counts=2&cell_counts=4).
 from __future__ import annotations
 
 import logging
-from typing import Annotated, NoReturn, cast
+from typing import Annotated, NoReturn
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
 from pydantic import UUID4
@@ -55,6 +55,7 @@ def _get_aeroplane(db: Session, aeroplane_id: UUID4) -> AeroplaneModel:
 @router.get(
     "/aeroplanes/{aeroplane_id}/powertrain/solution-space",
     operation_id="get_powertrain_solution_space",
+    response_model=PowertrainSolutionSpaceResponse,
     tags=["powertrain"],
     summary="Compute powertrain required-spec solution space from mission + aero",
     responses={

--- a/app/api/v2/endpoints/aeroplane/powertrain_solution_space.py
+++ b/app/api/v2/endpoints/aeroplane/powertrain_solution_space.py
@@ -1,0 +1,198 @@
+"""Powertrain solution-space endpoint (gh-975).
+
+GET /aeroplanes/{aeroplane_id}/powertrain/solution-space
+
+Thin endpoint — delegates entirely to
+``app.services.powertrain_solution_space_service.compute_solution_space``.
+
+All tunable assumptions are exposed as query parameters with spec defaults.
+cell_counts is a multi-value Query param (e.g. ?cell_counts=2&cell_counts=4).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated, NoReturn, cast
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
+from pydantic import UUID4
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import InternalError, NotFoundError, ServiceException
+from app.db.session import get_db
+from app.models.aeroplanemodel import AeroplaneModel
+from app.schemas.powertrain_solution_space import (
+    PowertrainSolutionSpaceResponse,
+    SolutionSpaceAssumptions,
+)
+from app.services.powertrain_solution_space_service import compute_solution_space
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _raise_http_from_domain(exc: ServiceException) -> NoReturn:
+    """Map domain exceptions to HTTP status codes."""
+    if isinstance(exc, NotFoundError):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=exc.message) from exc
+    if isinstance(exc, InternalError):
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=exc.message
+        ) from exc
+    # ValidationError / ValidationDomainError → 422
+    raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)) from exc
+
+
+def _get_aeroplane(db: Session, aeroplane_id: UUID4) -> AeroplaneModel:
+    """Resolve aeroplane by UUID or raise HTTP 404."""
+    plane = db.query(AeroplaneModel).filter(AeroplaneModel.uuid == str(aeroplane_id)).first()
+    if plane is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Aeroplane not found")
+    return plane
+
+
+@router.get(
+    "/aeroplanes/{aeroplane_id}/powertrain/solution-space",
+    operation_id="get_powertrain_solution_space",
+    tags=["powertrain"],
+    summary="Compute powertrain required-spec solution space from mission + aero",
+    responses={
+        404: {"description": "Aeroplane not found"},
+        422: {"description": "Invalid assumptions (e.g. V_top ≤ V_cruise, t_target ≤ 0)"},
+    },
+)
+async def get_powertrain_solution_space(
+    aeroplane_id: Annotated[UUID4, Path(..., description="Aeroplane UUID")],
+    db: Annotated[Session, Depends(get_db)],
+    # ----- Tunable assumption query params (all optional — spec defaults apply) -----
+    cell_counts: Annotated[
+        list[int] | None,
+        Query(description="LiPo cell counts to evaluate, e.g. ?cell_counts=2&cell_counts=4"),
+    ] = None,
+    eta_prop_lo: Annotated[
+        float | None,
+        Query(ge=0.01, le=0.99, description="Lower bound of propeller efficiency band"),
+    ] = None,
+    eta_prop_hi: Annotated[
+        float | None,
+        Query(ge=0.01, le=0.99, description="Upper bound of propeller efficiency band"),
+    ] = None,
+    eta_motor: Annotated[
+        float | None,
+        Query(ge=0.01, le=0.99, description="Motor efficiency"),
+    ] = None,
+    eta_esc: Annotated[
+        float | None,
+        Query(ge=0.01, le=0.99, description="ESC efficiency"),
+    ] = None,
+    dod: Annotated[
+        float | None,
+        Query(ge=0.01, le=1.0, description="Depth of discharge (usable fraction)"),
+    ] = None,
+    esc_margin: Annotated[
+        float | None,
+        Query(ge=1.0, description="ESC current rating margin multiplier"),
+    ] = None,
+    c_margin: Annotated[
+        float | None,
+        Query(ge=1.0, description="Battery C-rate margin multiplier"),
+    ] = None,
+    load_rpm_factor: Annotated[
+        float | None,
+        Query(ge=0.5, le=1.0, description="Motor shaft RPM under load vs. no-load"),
+    ] = None,
+    prop_pd: Annotated[
+        float | None,
+        Query(ge=0.3, le=1.5, description="Prop pitch/diameter ratio"),
+    ] = None,
+    t_target_min: Annotated[
+        float | None,
+        Query(gt=0, description="Target flight time [minutes]"),
+    ] = None,
+    v_top_mps: Annotated[
+        float | None,
+        Query(
+            gt=0,
+            description=(
+                "Top speed [m/s] for peak-power sizing. "
+                "Defaults to 1.4 × V_cruise when not supplied."
+            ),
+        ),
+    ] = None,
+    rho: Annotated[
+        float | None,
+        Query(gt=0, description="Air density [kg/m³] (ISA sea-level default 1.225)"),
+    ] = None,
+    g: Annotated[
+        float | None,
+        Query(gt=0, description="Gravitational acceleration [m/s²]"),
+    ] = None,
+) -> PowertrainSolutionSpaceResponse:
+    """Compute the powertrain solution space for an aeroplane.
+
+    Returns the *required* component-spec envelope (per LiPo cell count, across
+    an η_prop band) derived from mission + aero in the gh-924 computation context.
+
+    **Data sources (single source of truth — gh-924):**
+    - Aero invariants (cd0, e_oswald, AR, S_ref, V_cruise) come from
+      ``assumption_computation_context`` (populated by the recompute endpoint).
+    - Mass comes from the design assumption ``mass``.
+    - Tunable assumptions (η bands, DoD, cell counts, t_target, V_top) are
+      query parameters with spec defaults.
+
+    **Design warnings** are emitted (not errors) when aero context is missing
+    or uncomputed — consistent with gh-956.
+
+    **Validation errors (422):**
+    - V_top ≤ V_cruise
+    - t_target ≤ 0
+    """
+    try:
+        plane = _get_aeroplane(db, aeroplane_id)
+
+        # Build assumptions: start with defaults, apply any provided overrides.
+        assumptions_kwargs: dict = {}
+        if cell_counts is not None:
+            assumptions_kwargs["cell_counts"] = cell_counts
+        if eta_prop_lo is not None:
+            assumptions_kwargs["eta_prop_lo"] = eta_prop_lo
+        if eta_prop_hi is not None:
+            assumptions_kwargs["eta_prop_hi"] = eta_prop_hi
+        if eta_motor is not None:
+            assumptions_kwargs["eta_motor"] = eta_motor
+        if eta_esc is not None:
+            assumptions_kwargs["eta_esc"] = eta_esc
+        if dod is not None:
+            assumptions_kwargs["dod"] = dod
+        if esc_margin is not None:
+            assumptions_kwargs["esc_margin"] = esc_margin
+        if c_margin is not None:
+            assumptions_kwargs["c_margin"] = c_margin
+        if load_rpm_factor is not None:
+            assumptions_kwargs["load_rpm_factor"] = load_rpm_factor
+        if prop_pd is not None:
+            assumptions_kwargs["prop_pd"] = prop_pd
+        if t_target_min is not None:
+            assumptions_kwargs["t_target_min"] = t_target_min
+        if v_top_mps is not None:
+            assumptions_kwargs["v_top_mps"] = v_top_mps
+        if rho is not None:
+            assumptions_kwargs["rho"] = rho
+        if g is not None:
+            assumptions_kwargs["g"] = g
+
+        assumptions = SolutionSpaceAssumptions(**assumptions_kwargs)
+
+        return compute_solution_space(db, plane, assumptions)
+
+    except ServiceException as exc:
+        _raise_http_from_domain(exc)
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover — defensive fallback
+        logger.exception("Unexpected error in get_powertrain_solution_space: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Unexpected error: {exc}",
+        ) from exc

--- a/app/schemas/powertrain_solution_space.py
+++ b/app/schemas/powertrain_solution_space.py
@@ -136,20 +136,22 @@ class SolutionRow(BaseModel):
     i_peak_lo_a: float = Field(description="Peak current — low side of band [A]")
     i_peak_hi_a: float = Field(description="Peak current — high side of band [A]")
 
-    # C-rate
-    c_min: float = Field(description="Minimum C-rate required (mid η)")
-    c_min_lo: float = Field(description="Minimum C-rate — low side of band")
-    c_min_hi: float = Field(description="Minimum C-rate — high side of band")
+    # C-rate (includes the c_margin safety factor — the value to shop for)
+    c_min: float = Field(description="Required C-rate incl. c_margin (mid η)")
+    c_min_lo: float = Field(description="Required C-rate incl. c_margin — low side of band")
+    c_min_hi: float = Field(description="Required C-rate incl. c_margin — high side of band")
 
     # ESC
     esc_min_a: float = Field(description="Minimum ESC continuous current rating [A] (mid η)")
     esc_min_lo_a: float = Field(description="ESC minimum — low side of band [A]")
     esc_min_hi_a: float = Field(description="ESC minimum — high side of band [A]")
 
-    # Motor
-    motor_peak_w: float = Field(description="Motor peak power required [W] (= P_aero at V_top)")
+    # Motor — required mechanical SHAFT power (P_aero / η_prop), not aerodynamic power
+    motor_peak_w: float = Field(
+        description="Motor peak shaft power required [W] (= P_aero(V_top) / η_prop_mid)"
+    )
     motor_cont_w: float = Field(
-        description="Motor continuous power required [W] (≈ P_aero at V_cruise)"
+        description="Motor continuous shaft power required [W] (= P_aero(V_cruise) / η_prop_mid)"
     )
 
     # KV (approximate; Phase 1 — marked approximate per spec)
@@ -164,7 +166,8 @@ class SolutionRow(BaseModel):
 
     # Catalog match flags
     has_motor_match: bool = Field(
-        default=False, description="True if a catalog motor meets motor_peak_w"
+        default=False,
+        description="True if a catalog motor's shaft-power rating meets motor_peak_w",
     )
     has_battery_match: bool = Field(
         default=False,
@@ -204,11 +207,15 @@ class ShoppingSpec(BaseModel):
 
     cell_count: int
     battery_min_mah: float
-    battery_min_c: float
+    battery_min_c: float = Field(description="Required C-rate incl. c_margin")
     battery_v_nom: float
     esc_min_a: float
-    motor_min_peak_w: float
-    motor_cont_w: float
+    motor_min_peak_w: float = Field(
+        description="Required motor peak SHAFT power [W] (P_aero / η_prop_mid)"
+    )
+    motor_cont_w: float = Field(
+        description="Required motor continuous SHAFT power [W] (P_aero / η_prop_mid)"
+    )
     kv_approx: float | None
 
 

--- a/app/schemas/powertrain_solution_space.py
+++ b/app/schemas/powertrain_solution_space.py
@@ -1,0 +1,246 @@
+"""Pydantic v2 schemas for the powertrain solution-space endpoint (gh-975).
+
+Public surface
+--------------
+SolutionSpaceAssumptions   — overridable inputs with documented defaults
+SolutionRow                — one row per cell-count S, spanning the η_prop band
+FeasibleRegion             — capacity floor and C-rate floor curve per cell-count
+ShoppingSpec               — minimum-spec summary for copy-paste shopping
+PowertrainSolutionSpaceResponse — full endpoint response
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import BaseModel, Field
+
+
+class SolutionSpaceAssumptions(BaseModel):
+    """Tunable assumptions for the solution-space computation.
+
+    All fields have spec defaults. Pass any subset to override.
+    """
+
+    cell_counts: list[int] = Field(
+        default=[2, 3, 4, 6],
+        description="LiPo cell counts to evaluate (e.g. [2, 3, 4, 6])",
+    )
+    eta_prop_lo: float = Field(
+        default=0.65,
+        ge=0.01,
+        le=0.99,
+        description="Lower bound of propeller efficiency band",
+    )
+    eta_prop_hi: float = Field(
+        default=0.78,
+        ge=0.01,
+        le=0.99,
+        description="Upper bound of propeller efficiency band",
+    )
+    eta_motor: float = Field(
+        default=0.85,
+        ge=0.01,
+        le=0.99,
+        description="Motor efficiency (brushless outrunner typical)",
+    )
+    eta_esc: float = Field(
+        default=0.94,
+        ge=0.01,
+        le=0.99,
+        description="ESC efficiency (modern ESC typical)",
+    )
+    dod: float = Field(
+        default=0.80,
+        ge=0.01,
+        le=1.0,
+        description="Depth of discharge (usable fraction of rated capacity)",
+    )
+    esc_margin: float = Field(
+        default=1.4,
+        ge=1.0,
+        description="ESC current rating margin multiplier (ESC_min = I_peak × esc_margin)",
+    )
+    c_margin: float = Field(
+        default=1.25,
+        ge=1.0,
+        description="Battery C-rate margin multiplier",
+    )
+    load_rpm_factor: float = Field(
+        default=0.85,
+        ge=0.5,
+        le=1.0,
+        description="Motor shaft RPM under load vs. no-load (V_nom × KV × factor)",
+    )
+    prop_pd: float = Field(
+        default=0.65,
+        ge=0.3,
+        le=1.5,
+        description=("Prop pitch/diameter ratio. Trainer: 0.65, 3D: 0.5, glider: 0.8, speed: 1.0"),
+    )
+    t_target_min: float = Field(
+        default=10.0,
+        gt=0,
+        description="Target flight time [minutes]",
+    )
+    v_top_mps: float | None = Field(
+        default=None,
+        gt=0,
+        description=(
+            "Top speed [m/s] for peak-power sizing. Defaults to 1.4 × V_cruise when not supplied."
+        ),
+    )
+    rho: float = Field(
+        default=1.225,
+        gt=0,
+        description="Air density [kg/m³] (ISA sea-level default)",
+    )
+    g: float = Field(
+        default=9.80665,
+        gt=0,
+        description="Gravitational acceleration [m/s²]",
+    )
+
+
+class SolutionRow(BaseModel):
+    """Computed specs for one cell-count S, spanning the η_prop band.
+
+    Scalar fields are computed at the mid-point of the η_prop band
+    (eta_prop_lo + eta_prop_hi) / 2.  Fields with ``_lo`` / ``_hi``
+    suffixes are band extremes — _lo uses eta_prop_hi (more efficient →
+    less current) and _hi uses eta_prop_lo (less efficient → more current).
+    """
+
+    cell_count: int = Field(description="Number of LiPo cells (S)")
+    v_nom_v: float = Field(description="Nominal pack voltage [V] = S × 3.7")
+    v_sag_v: float = Field(description="Pack voltage under load [V] = S × 3.5")
+
+    # Electrical power
+    p_cruise_w: float = Field(description="Electrical power at cruise speed [W] (mid η)")
+    p_top_w: float = Field(description="Peak electrical power at top speed [W] (mid η)")
+    p_cruise_lo_w: float = Field(description="Electrical cruise power — low side of band [W]")
+    p_cruise_hi_w: float = Field(description="Electrical cruise power — high side of band [W]")
+    p_top_lo_w: float = Field(description="Peak electrical power — low side of band [W]")
+    p_top_hi_w: float = Field(description="Peak electrical power — high side of band [W]")
+
+    # Energy
+    energy_wh: float = Field(description="Required energy [Wh] at mid η")
+
+    # Battery
+    capacity_mah_min: float = Field(description="Minimum battery capacity [mAh] (mid η)")
+    capacity_mah_min_lo: float = Field(description="Minimum capacity — low side of band [mAh]")
+    capacity_mah_min_hi: float = Field(description="Minimum capacity — high side of band [mAh]")
+
+    # Peak current
+    i_peak_a: float = Field(description="Peak battery current [A] (mid η)")
+    i_peak_lo_a: float = Field(description="Peak current — low side of band [A]")
+    i_peak_hi_a: float = Field(description="Peak current — high side of band [A]")
+
+    # C-rate
+    c_min: float = Field(description="Minimum C-rate required (mid η)")
+    c_min_lo: float = Field(description="Minimum C-rate — low side of band")
+    c_min_hi: float = Field(description="Minimum C-rate — high side of band")
+
+    # ESC
+    esc_min_a: float = Field(description="Minimum ESC continuous current rating [A] (mid η)")
+    esc_min_lo_a: float = Field(description="ESC minimum — low side of band [A]")
+    esc_min_hi_a: float = Field(description="ESC minimum — high side of band [A]")
+
+    # Motor
+    motor_peak_w: float = Field(description="Motor peak power required [W] (= P_aero at V_top)")
+    motor_cont_w: float = Field(
+        description="Motor continuous power required [W] (≈ P_aero at V_cruise)"
+    )
+
+    # KV (approximate; Phase 1 — marked approximate per spec)
+    kv_approx: float | None = Field(
+        default=None,
+        description=(
+            "Approximate motor KV [RPM/V]. "
+            "KV ≈ RPM_target / (V_nom × load_rpm_factor). "
+            "Phase 1 estimate — depends on prop_pd and V_top."
+        ),
+    )
+
+    # Catalog match flags
+    has_motor_match: bool = Field(
+        default=False, description="True if a catalog motor meets motor_peak_w"
+    )
+    has_battery_match: bool = Field(
+        default=False,
+        description="True if a catalog battery meets capacity_mah_min and c_min",
+    )
+    has_esc_match: bool = Field(default=False, description="True if a catalog ESC meets esc_min_a")
+
+
+class FeasibleRegion(BaseModel):
+    """Feasible region in the (capacity [mAh], C-rate) plane for one cell-count.
+
+    The region is open toward higher mAh and higher C-rate (more is always OK).
+    The boundary consists of:
+    - A vertical floor at capacity_floor_mah (energy constraint).
+    - A hyperbolic curve C ≥ i_peak_a / (capacity_mah / 1000) (current constraint).
+    """
+
+    cell_count: int
+    capacity_floor_mah: float = Field(
+        description="Minimum capacity [mAh] (energy-budget constraint)"
+    )
+    i_peak_a: float = Field(description="Peak current [A] that determines the C-rate hyperbola")
+    # Sample points on the C-rate hyperbola for plotting.
+    # capacity_curve_mah[i] → c_rate_curve[i]
+    capacity_curve_mah: list[float] = Field(
+        default_factory=list,
+        description="Sample capacity values [mAh] for the C-rate hyperbola",
+    )
+    c_rate_curve: list[float] = Field(
+        default_factory=list,
+        description="Corresponding minimum C-rates for the hyperbola samples",
+    )
+
+
+class ShoppingSpec(BaseModel):
+    """Minimum-spec summary for a selected cell-count — copy-paste to online shop."""
+
+    cell_count: int
+    battery_min_mah: float
+    battery_min_c: float
+    battery_v_nom: float
+    esc_min_a: float
+    motor_min_peak_w: float
+    motor_cont_w: float
+    kv_approx: float | None
+
+
+class PowertrainSolutionSpaceResponse(BaseModel):
+    """Full response from GET /aeroplanes/{id}/powertrain/solution-space."""
+
+    rows: list[SolutionRow] = Field(description="One row per requested cell-count S")
+    feasible_regions: list[FeasibleRegion] = Field(
+        description="Feasible (capacity, C) region per cell-count"
+    )
+    shopping_specs: list[ShoppingSpec] = Field(description="Minimum shopping spec per cell-count")
+    # Invariants (aero-side, independent of cell count)
+    p_aero_cruise_w: Annotated[float, Field(description="Aerodynamic power at cruise speed [W]")]
+    p_aero_top_w: Annotated[float, Field(description="Aerodynamic power at top speed [W]")]
+    energy_wh: Annotated[
+        float,
+        Field(
+            description=(
+                "Required energy [Wh] at mid-η, accounting for DoD. Independent of cell-count."
+            )
+        ),
+    ]
+    v_cruise_mps: float = Field(description="Cruise speed used [m/s]")
+    v_top_mps: float = Field(description="Top speed used for peak sizing [m/s]")
+    t_target_min: float = Field(description="Target flight time [minutes]")
+    assumptions_used: SolutionSpaceAssumptions = Field(
+        description="Effective assumptions used for this computation"
+    )
+    warnings: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Design warnings — e.g. missing context values. "
+            "Non-empty means results may be based on fallback defaults."
+        ),
+    )

--- a/app/services/powertrain_solution_space_service.py
+++ b/app/services/powertrain_solution_space_service.py
@@ -116,28 +116,34 @@ def _p_elec(p_aero_w: float, eta_prop: float, eta_motor: float, eta_esc: float) 
 def _per_cell(
     *,
     s: int,
-    p_cruise_elec_w: float,
     p_top_elec_w: float,
     energy_wh: float,
-    eta_motor: float,
-    eta_esc: float,
     esc_margin: float,
+    c_margin: float,
     load_rpm_factor: float,
     v_top_mps: float,
     prop_pd: float,
-) -> dict[str, float]:
-    """Derive per-cell-count specs.  Returns a plain dict (used for both mid and band)."""
+) -> dict[str, float | None]:
+    """Derive per-cell-count specs.  Returns a plain dict (used for both mid and band).
+
+    ``p_top_elec_w`` is the *battery* electrical power at V_top
+    (already P_aero / (η_prop·η_motor·η_esc)).  Battery current is therefore
+    simply ``I = P_bat / V_sag`` — no further division by η_motor·η_esc
+    (that would double-count the efficiencies, gh-978 BLOCKER).
+    """
     v_nom = s * CELL_V_NOM
     v_sag = s * CELL_V_SAG
 
-    # Peak current drawn from battery at top speed
-    i_peak = p_top_elec_w / (v_sag * eta_motor * eta_esc)
+    # Peak battery current drawn at top speed.  P_top_elec is already battery
+    # power, so current = power / sag-voltage (no extra efficiency division).
+    i_peak = p_top_elec_w / v_sag
 
     # Capacity (energy budget)
     cap_mah = energy_wh / v_nom * 1000.0
 
-    # C-rate floor
-    c_min = i_peak / (cap_mah / 1000.0) if cap_mah > 0 else float("inf")
+    # Required C-rate the designer must shop for: raw physical C × margin.
+    raw_c = i_peak / (cap_mah / 1000.0) if cap_mah > 0 else float("inf")
+    c_min = raw_c * c_margin
 
     # ESC minimum rating
     esc_min = i_peak * esc_margin
@@ -180,11 +186,12 @@ def _build_hyperbola(
 # ---------------------------------------------------------------------------
 
 
-def _catalog_motor_match(db: Session, motor_peak_w: float) -> bool:
-    """Return True if any brushless_motor in the catalog meets motor_peak_w.
+def _catalog_motor_match(db: Session, motor_shaft_peak_w: float) -> bool:
+    """Return True if any brushless_motor can deliver the required shaft power.
 
-    Checks specs.max_power_w; falls back to specs.kv_rpm_v presence as an
-    existence check only when max_power_w is absent.
+    ``motor_shaft_peak_w`` is the required mechanical shaft power
+    (P_aero / η_prop), not the aerodynamic power.  Motor catalog ratings
+    (max_power_w) are shaft-power ratings, so the comparison is apples-to-apples.
     """
     motors = (
         db.query(ComponentModel).filter(ComponentModel.component_type == "brushless_motor").all()
@@ -192,7 +199,7 @@ def _catalog_motor_match(db: Session, motor_peak_w: float) -> bool:
     for m in motors:
         specs: dict[str, Any] = m.specs or {}
         max_power = specs.get("max_power_w") or specs.get("max_continuous_power_w")
-        if max_power is not None and float(max_power) >= motor_peak_w:
+        if max_power is not None and float(max_power) >= motor_shaft_peak_w:
             return True
     return False
 
@@ -298,16 +305,18 @@ def compute_solution_space(
     else:
         mass_kg = float(mass_kg_raw)
 
-    # Also read cd0 from design assumptions (fallback to context, then default)
-    cd0_raw = get_effective_assumption(db, plane_id, "cd0")
-    if cd0_raw is not None and float(cd0_raw) > 0:
-        cd0 = float(cd0_raw)
+    # cd0: gh-924 single source of truth — read from the computation context
+    # first (where e/AR/s_ref also come from), fall back to the design
+    # assumption, then warn if neither is available.
+    cd0_ctx = ctx.get("cd0")
+    if cd0_ctx is not None and float(cd0_ctx) > 0:
+        cd0 = float(cd0_ctx)
     else:
-        cd0_ctx = ctx.get("cd0")
-        if cd0_ctx is not None and float(cd0_ctx) > 0:
-            cd0 = float(cd0_ctx)
+        cd0_raw = get_effective_assumption(db, plane_id, "cd0")
+        if cd0_raw is not None and float(cd0_raw) > 0:
+            cd0 = float(cd0_raw)
         else:
-            warnings.append("cd0 not set in design assumptions or context. Using fallback 0.03.")
+            warnings.append("cd0 not set in context or design assumptions. Using fallback 0.03.")
             cd0 = float(PARAMETER_DEFAULTS.get("cd0", 0.03))
 
     v_cruise_mps = v_cruise_ctx
@@ -372,12 +381,10 @@ def compute_solution_space(
         # Mid-η values
         mid = _per_cell(
             s=s,
-            p_cruise_elec_w=p_cruise_mid,
             p_top_elec_w=p_top_mid,
             energy_wh=energy_wh,
-            eta_motor=assumptions.eta_motor,
-            eta_esc=assumptions.eta_esc,
             esc_margin=assumptions.esc_margin,
+            c_margin=assumptions.c_margin,
             load_rpm_factor=assumptions.load_rpm_factor,
             v_top_mps=v_top_mps,
             prop_pd=assumptions.prop_pd,
@@ -386,12 +393,10 @@ def compute_solution_space(
         # Low-η band extreme (lo η_prop → higher currents/more capacity needed)
         lo_band = _per_cell(
             s=s,
-            p_cruise_elec_w=p_cruise_lo_e,
             p_top_elec_w=p_top_lo_e,
             energy_wh=p_cruise_lo_e * t_target_h / assumptions.dod,
-            eta_motor=assumptions.eta_motor,
-            eta_esc=assumptions.eta_esc,
             esc_margin=assumptions.esc_margin,
+            c_margin=assumptions.c_margin,
             load_rpm_factor=assumptions.load_rpm_factor,
             v_top_mps=v_top_mps,
             prop_pd=assumptions.prop_pd,
@@ -400,19 +405,21 @@ def compute_solution_space(
         # High-η band extreme (hi η_prop → lower currents/less capacity needed)
         hi_band = _per_cell(
             s=s,
-            p_cruise_elec_w=p_cruise_hi_e,
             p_top_elec_w=p_top_hi_e,
             energy_wh=p_cruise_hi_e * t_target_h / assumptions.dod,
-            eta_motor=assumptions.eta_motor,
-            eta_esc=assumptions.eta_esc,
             esc_margin=assumptions.esc_margin,
+            c_margin=assumptions.c_margin,
             load_rpm_factor=assumptions.load_rpm_factor,
             v_top_mps=v_top_mps,
             prop_pd=assumptions.prop_pd,
         )
 
+        # Required motor SHAFT power (P_aero / η_prop), not aerodynamic power.
+        motor_peak_shaft_w = p_aero_top / eta_mid
+        motor_cont_shaft_w = p_aero_cruise / eta_mid
+
         # Catalog matches
-        has_motor = _catalog_motor_match(db, p_aero_top)
+        has_motor = _catalog_motor_match(db, motor_peak_shaft_w)
         has_batt = _catalog_battery_match(db, mid["cap_mah"], mid["c_min"])
         has_esc = _catalog_esc_match(db, mid["esc_min"])
 
@@ -440,8 +447,8 @@ def compute_solution_space(
             esc_min_a=mid["esc_min"],
             esc_min_lo_a=hi_band["esc_min"],
             esc_min_hi_a=lo_band["esc_min"],
-            motor_peak_w=p_aero_top,
-            motor_cont_w=p_aero_cruise,
+            motor_peak_w=motor_peak_shaft_w,
+            motor_cont_w=motor_cont_shaft_w,
             kv_approx=mid["kv_approx"],
             has_motor_match=has_motor,
             has_battery_match=has_batt,
@@ -469,8 +476,8 @@ def compute_solution_space(
                 battery_min_c=mid["c_min"],
                 battery_v_nom=mid["v_nom"],
                 esc_min_a=mid["esc_min"],
-                motor_min_peak_w=p_aero_top,
-                motor_cont_w=p_aero_cruise,
+                motor_min_peak_w=motor_peak_shaft_w,
+                motor_cont_w=motor_cont_shaft_w,
                 kv_approx=mid["kv_approx"],
             )
         )

--- a/app/services/powertrain_solution_space_service.py
+++ b/app/services/powertrain_solution_space_service.py
@@ -1,0 +1,490 @@
+"""Powertrain solution-space service (gh-975).
+
+Computes the *required* component-spec envelope from mission + aero
+(reframe from the old catalog sweep).  Pure Python — no CadQuery or
+AeroSandbox imports — so it runs in the CI fast tier.
+
+Public API
+----------
+compute_solution_space(db, plane, assumptions) -> PowertrainSolutionSpaceResponse
+
+Physics model (spec-exact)
+--------------------------
+All equations from the spec doc (2026-06-13-powertrain-solution-space-design.md):
+
+  C_L(V) = 2·m·g / (ρ·V²·S_ref)
+  C_D(V) = cd0 + C_L² / (π·e·AR)
+  P_aero(V) = ½·ρ·V³·S_ref·C_D(V)
+  P_elec(V) = P_aero(V) / (η_prop·η_motor·η_esc)
+
+  Energy  E_Wh = P_elec(V_cruise) · (t_target_h) / DoD
+
+  Per cell-count S:
+    V_nom = S × 3.7  [V]
+    V_sag = S × 3.5  [V]  (under load)
+    I_peak  = P_top  / (V_sag · η_motor · η_esc)
+    cap_mAh = E_Wh  / V_nom × 1000
+    C_min   = I_peak / (cap_mAh / 1000)
+    ESC_min = I_peak × esc_margin
+    KV ≈ RPM_target / (V_nom × load_rpm_factor)
+       where RPM_target = V_top / (prop_d_m × prop_pd) × 60   [approximate]
+       and   prop_d_m   = 0.3  [m]  (fixed Phase-1 estimate — see note below)
+
+Note on KV: Phase 1 uses a fixed prop diameter estimate (0.30 m) as a
+first approximation.  This is documented as approximate in the schema.
+Phase 2 (#615) will replace this with APC performance data.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any, cast
+
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import ValidationDomainError
+from app.models.aeroplanemodel import AeroplaneModel
+from app.models.component import ComponentModel
+from app.schemas.design_assumption import PARAMETER_DEFAULTS
+from app.schemas.powertrain_solution_space import (
+    FeasibleRegion,
+    PowertrainSolutionSpaceResponse,
+    ShoppingSpec,
+    SolutionRow,
+    SolutionSpaceAssumptions,
+)
+from app.services.design_assumptions_service import get_effective_assumption
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Physical constants
+# ---------------------------------------------------------------------------
+G_DEFAULT = 9.80665  # m/s²  (overridable via assumptions.g)
+RHO_DEFAULT = 1.225  # kg/m³ (ISA sea-level, overridable via assumptions.rho)
+
+# Nominal / sag cell voltages for LiPo
+CELL_V_NOM = 3.7  # V  nominal (mid-discharge)
+CELL_V_SAG = 3.5  # V  under peak load
+
+# Phase-1 prop diameter estimate (see module docstring)
+_PHASE1_PROP_DIAMETER_M = 0.30
+
+# Number of sample points for the feasible-region C-rate hyperbola
+_HYPERBOLA_SAMPLES = 40
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _p_aero(
+    rho: float,
+    v: float,
+    mass_kg: float,
+    g: float,
+    cd0: float,
+    e: float,
+    ar: float,
+    s_ref: float,
+) -> float:
+    """Aerodynamic power [W] in level flight at speed v [m/s].
+
+    P_aero = ½·ρ·V³·S_ref·C_D
+    C_L    = 2·m·g / (ρ·V²·S_ref)
+    C_D    = cd0 + C_L² / (π·e·AR)
+    """
+    if v <= 0:
+        return float("inf")
+    q = 0.5 * rho * v * v
+    cl = (mass_kg * g) / (q * s_ref)
+    k = 1.0 / (math.pi * e * ar)
+    cd = cd0 + k * cl * cl
+    return q * s_ref * cd * v
+
+
+def _p_elec(p_aero_w: float, eta_prop: float, eta_motor: float, eta_esc: float) -> float:
+    """Electrical power [W] = P_aero / (η_prop · η_motor · η_esc)."""
+    eta = eta_prop * eta_motor * eta_esc
+    if eta <= 0:
+        return float("inf")
+    return p_aero_w / eta
+
+
+def _per_cell(
+    *,
+    s: int,
+    p_cruise_elec_w: float,
+    p_top_elec_w: float,
+    energy_wh: float,
+    eta_motor: float,
+    eta_esc: float,
+    esc_margin: float,
+    load_rpm_factor: float,
+    v_top_mps: float,
+    prop_pd: float,
+) -> dict[str, float]:
+    """Derive per-cell-count specs.  Returns a plain dict (used for both mid and band)."""
+    v_nom = s * CELL_V_NOM
+    v_sag = s * CELL_V_SAG
+
+    # Peak current drawn from battery at top speed
+    i_peak = p_top_elec_w / (v_sag * eta_motor * eta_esc)
+
+    # Capacity (energy budget)
+    cap_mah = energy_wh / v_nom * 1000.0
+
+    # C-rate floor
+    c_min = i_peak / (cap_mah / 1000.0) if cap_mah > 0 else float("inf")
+
+    # ESC minimum rating
+    esc_min = i_peak * esc_margin
+
+    # KV approximation (Phase 1, documented approximate)
+    # RPM_target ≈ V_top / (D × pitch/D) × 60  where D is Phase-1 estimate
+    # KV = RPM_target / (V_nom × load_rpm_factor)
+    prop_d = _PHASE1_PROP_DIAMETER_M
+    rpm_target = (v_top_mps / (prop_d * prop_pd)) * 60.0  # rev/min
+    kv_approx = rpm_target / (v_nom * load_rpm_factor) if v_nom > 0 else None
+
+    return {
+        "v_nom": v_nom,
+        "v_sag": v_sag,
+        "i_peak": i_peak,
+        "cap_mah": cap_mah,
+        "c_min": c_min,
+        "esc_min": esc_min,
+        "kv_approx": kv_approx,
+    }
+
+
+def _build_hyperbola(
+    i_peak: float, cap_floor_mah: float, n: int = _HYPERBOLA_SAMPLES
+) -> tuple[list[float], list[float]]:
+    """Sample points on the C-rate hyperbola C = I_peak / (cap_mAh/1000).
+
+    The x-axis starts at cap_floor_mah and extends to 4× for plotting room.
+    """
+    if cap_floor_mah <= 0 or i_peak <= 0:
+        return [], []
+    cap_max = cap_floor_mah * 4.0
+    caps = [cap_floor_mah + (cap_max - cap_floor_mah) * i / (n - 1) for i in range(n)]
+    c_rates = [i_peak / (c / 1000.0) for c in caps]
+    return caps, c_rates
+
+
+# ---------------------------------------------------------------------------
+# Catalog matching helpers
+# ---------------------------------------------------------------------------
+
+
+def _catalog_motor_match(db: Session, motor_peak_w: float) -> bool:
+    """Return True if any brushless_motor in the catalog meets motor_peak_w.
+
+    Checks specs.max_power_w; falls back to specs.kv_rpm_v presence as an
+    existence check only when max_power_w is absent.
+    """
+    motors = (
+        db.query(ComponentModel).filter(ComponentModel.component_type == "brushless_motor").all()
+    )
+    for m in motors:
+        specs: dict[str, Any] = m.specs or {}
+        max_power = specs.get("max_power_w") or specs.get("max_continuous_power_w")
+        if max_power is not None and float(max_power) >= motor_peak_w:
+            return True
+    return False
+
+
+def _catalog_battery_match(db: Session, cap_mah_min: float, c_min: float) -> bool:
+    """Return True if any battery in the catalog meets capacity AND C-rate floors."""
+    batteries = db.query(ComponentModel).filter(ComponentModel.component_type == "battery").all()
+    for b in batteries:
+        specs: dict[str, Any] = b.specs or {}
+        cap = specs.get("capacity_mah")
+        c_rating = specs.get("c_rating") or specs.get("discharge_c")
+        if cap is not None and c_rating is not None:
+            if float(cap) >= cap_mah_min and float(c_rating) >= c_min:
+                return True
+    return False
+
+
+def _catalog_esc_match(db: Session, esc_min_a: float) -> bool:
+    """Return True if any ESC in the catalog meets the minimum current rating."""
+    escs = db.query(ComponentModel).filter(ComponentModel.component_type == "esc").all()
+    for e in escs:
+        specs: dict[str, Any] = e.specs or {}
+        max_a = specs.get("max_current_a") or specs.get("continuous_current_a")
+        if max_a is not None and float(max_a) >= esc_min_a:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def compute_solution_space(
+    db: Session,
+    plane: AeroplaneModel,
+    assumptions: SolutionSpaceAssumptions,
+) -> PowertrainSolutionSpaceResponse:
+    """Compute powertrain solution space for an aeroplane.
+
+    Parameters
+    ----------
+    db          : open SQLAlchemy session
+    plane       : resolved AeroplaneModel (must have .id and .assumption_computation_context)
+    assumptions : tunable overrides (SolutionSpaceAssumptions with defaults)
+
+    Returns
+    -------
+    PowertrainSolutionSpaceResponse
+
+    Raises
+    ------
+    ValidationDomainError
+        When V_top ≤ V_cruise or t_target ≤ 0 (domain-level validation).
+    """
+    warnings: list[str] = []
+    plane_id: int = cast(int, plane.id)
+    ctx: dict[str, Any] = cast(dict[str, Any], plane.assumption_computation_context or {})
+
+    # ------------------------------------------------------------------
+    # 1. Read aero invariants from the gh-924 context
+    # ------------------------------------------------------------------
+    s_ref_m2: float | None = ctx.get("s_ref_m2")
+    e_oswald: float | None = ctx.get("e_oswald")
+    ar: float | None = ctx.get("aspect_ratio")
+    v_cruise_ctx: float | None = ctx.get("v_cruise_mps") or ctx.get("v_md_mps")
+
+    if s_ref_m2 is None or s_ref_m2 <= 0:
+        warnings.append(
+            "s_ref_m2 missing or zero in assumption_computation_context — "
+            "run recompute first. Using fallback 0.25 m²."
+        )
+        s_ref_m2 = 0.25  # minimal RC plane fallback
+
+    if e_oswald is None or e_oswald <= 0:
+        warnings.append(
+            "e_oswald missing/uncomputed in assumption_computation_context — "
+            "run recompute first. Using fallback 0.75."
+        )
+        e_oswald = 0.75
+
+    if ar is None or ar <= 0:
+        warnings.append(
+            "aspect_ratio missing/uncomputed in assumption_computation_context — "
+            "run recompute first. Using fallback 7.0."
+        )
+        ar = 7.0
+
+    if v_cruise_ctx is None or v_cruise_ctx <= 0:
+        warnings.append(
+            "v_cruise_mps / v_md_mps missing in assumption_computation_context — "
+            "run recompute first. Using fallback 15.0 m/s."
+        )
+        v_cruise_ctx = 15.0
+
+    # ------------------------------------------------------------------
+    # 2. Read mass from design assumptions (same pattern as matching_chart)
+    # ------------------------------------------------------------------
+    mass_kg_raw = get_effective_assumption(db, plane_id, "mass")
+    if mass_kg_raw is None or float(mass_kg_raw) <= 0:
+        warnings.append("mass not set in design assumptions. Using fallback 1.5 kg.")
+        mass_kg = float(PARAMETER_DEFAULTS.get("mass", 1.5))
+    else:
+        mass_kg = float(mass_kg_raw)
+
+    # Also read cd0 from design assumptions (fallback to context, then default)
+    cd0_raw = get_effective_assumption(db, plane_id, "cd0")
+    if cd0_raw is not None and float(cd0_raw) > 0:
+        cd0 = float(cd0_raw)
+    else:
+        cd0_ctx = ctx.get("cd0")
+        if cd0_ctx is not None and float(cd0_ctx) > 0:
+            cd0 = float(cd0_ctx)
+        else:
+            warnings.append("cd0 not set in design assumptions or context. Using fallback 0.03.")
+            cd0 = float(PARAMETER_DEFAULTS.get("cd0", 0.03))
+
+    v_cruise_mps = v_cruise_ctx
+
+    # ------------------------------------------------------------------
+    # 3. Resolve V_top and t_target from assumptions
+    # ------------------------------------------------------------------
+    t_target_min = assumptions.t_target_min
+    if t_target_min <= 0:
+        raise ValidationDomainError(f"t_target_min must be > 0, got {t_target_min}")
+
+    v_top_mps = assumptions.v_top_mps
+    if v_top_mps is None:
+        v_top_mps = v_cruise_mps * 1.4  # spec default
+
+    if v_top_mps <= v_cruise_mps:
+        raise ValidationDomainError(
+            f"V_top ({v_top_mps:.2f} m/s) must be greater than V_cruise ({v_cruise_mps:.2f} m/s)."
+        )
+
+    rho = assumptions.rho
+    g = assumptions.g
+
+    # ------------------------------------------------------------------
+    # 4. Compute aerodynamic invariants
+    # ------------------------------------------------------------------
+    p_aero_cruise = _p_aero(rho, v_cruise_mps, mass_kg, g, cd0, e_oswald, ar, s_ref_m2)
+    p_aero_top = _p_aero(rho, v_top_mps, mass_kg, g, cd0, e_oswald, ar, s_ref_m2)
+
+    t_target_h = t_target_min / 60.0
+
+    # ------------------------------------------------------------------
+    # 5. Per-cell-count rows (spanning η_prop band)
+    # ------------------------------------------------------------------
+    eta_mid = (assumptions.eta_prop_lo + assumptions.eta_prop_hi) / 2.0
+
+    # Electrical power at mid, lo, hi (lo η_prop → hi P_elec)
+    p_cruise_mid = _p_elec(p_aero_cruise, eta_mid, assumptions.eta_motor, assumptions.eta_esc)
+    p_top_mid = _p_elec(p_aero_top, eta_mid, assumptions.eta_motor, assumptions.eta_esc)
+
+    p_cruise_lo_e = _p_elec(
+        p_aero_cruise, assumptions.eta_prop_lo, assumptions.eta_motor, assumptions.eta_esc
+    )
+    p_cruise_hi_e = _p_elec(
+        p_aero_cruise, assumptions.eta_prop_hi, assumptions.eta_motor, assumptions.eta_esc
+    )
+    p_top_lo_e = _p_elec(
+        p_aero_top, assumptions.eta_prop_lo, assumptions.eta_motor, assumptions.eta_esc
+    )
+    p_top_hi_e = _p_elec(
+        p_aero_top, assumptions.eta_prop_hi, assumptions.eta_motor, assumptions.eta_esc
+    )
+
+    # Energy [Wh] using mid-η cruise power
+    energy_wh = p_cruise_mid * t_target_h / assumptions.dod
+
+    rows: list[SolutionRow] = []
+    feasible_regions: list[FeasibleRegion] = []
+    shopping_specs: list[ShoppingSpec] = []
+
+    for s in assumptions.cell_counts:
+        # Mid-η values
+        mid = _per_cell(
+            s=s,
+            p_cruise_elec_w=p_cruise_mid,
+            p_top_elec_w=p_top_mid,
+            energy_wh=energy_wh,
+            eta_motor=assumptions.eta_motor,
+            eta_esc=assumptions.eta_esc,
+            esc_margin=assumptions.esc_margin,
+            load_rpm_factor=assumptions.load_rpm_factor,
+            v_top_mps=v_top_mps,
+            prop_pd=assumptions.prop_pd,
+        )
+
+        # Low-η band extreme (lo η_prop → higher currents/more capacity needed)
+        lo_band = _per_cell(
+            s=s,
+            p_cruise_elec_w=p_cruise_lo_e,
+            p_top_elec_w=p_top_lo_e,
+            energy_wh=p_cruise_lo_e * t_target_h / assumptions.dod,
+            eta_motor=assumptions.eta_motor,
+            eta_esc=assumptions.eta_esc,
+            esc_margin=assumptions.esc_margin,
+            load_rpm_factor=assumptions.load_rpm_factor,
+            v_top_mps=v_top_mps,
+            prop_pd=assumptions.prop_pd,
+        )
+
+        # High-η band extreme (hi η_prop → lower currents/less capacity needed)
+        hi_band = _per_cell(
+            s=s,
+            p_cruise_elec_w=p_cruise_hi_e,
+            p_top_elec_w=p_top_hi_e,
+            energy_wh=p_cruise_hi_e * t_target_h / assumptions.dod,
+            eta_motor=assumptions.eta_motor,
+            eta_esc=assumptions.eta_esc,
+            esc_margin=assumptions.esc_margin,
+            load_rpm_factor=assumptions.load_rpm_factor,
+            v_top_mps=v_top_mps,
+            prop_pd=assumptions.prop_pd,
+        )
+
+        # Catalog matches
+        has_motor = _catalog_motor_match(db, p_aero_top)
+        has_batt = _catalog_battery_match(db, mid["cap_mah"], mid["c_min"])
+        has_esc = _catalog_esc_match(db, mid["esc_min"])
+
+        row = SolutionRow(
+            cell_count=s,
+            v_nom_v=mid["v_nom"],
+            v_sag_v=mid["v_sag"],
+            p_cruise_w=p_cruise_mid,
+            p_top_w=p_top_mid,
+            # Band: lo band has higher power (less efficient η), hi band has lower power
+            p_cruise_lo_w=p_cruise_hi_e,  # hi-η side → lower power needed (lo side of power range)
+            p_cruise_hi_w=p_cruise_lo_e,  # lo-η side → higher power needed
+            p_top_lo_w=p_top_hi_e,
+            p_top_hi_w=p_top_lo_e,
+            energy_wh=energy_wh,
+            capacity_mah_min=mid["cap_mah"],
+            capacity_mah_min_lo=hi_band["cap_mah"],  # hi-η → lower cap needed
+            capacity_mah_min_hi=lo_band["cap_mah"],  # lo-η → more cap needed
+            i_peak_a=mid["i_peak"],
+            i_peak_lo_a=hi_band["i_peak"],
+            i_peak_hi_a=lo_band["i_peak"],
+            c_min=mid["c_min"],
+            c_min_lo=hi_band["c_min"],
+            c_min_hi=lo_band["c_min"],
+            esc_min_a=mid["esc_min"],
+            esc_min_lo_a=hi_band["esc_min"],
+            esc_min_hi_a=lo_band["esc_min"],
+            motor_peak_w=p_aero_top,
+            motor_cont_w=p_aero_cruise,
+            kv_approx=mid["kv_approx"],
+            has_motor_match=has_motor,
+            has_battery_match=has_batt,
+            has_esc_match=has_esc,
+        )
+        rows.append(row)
+
+        # Feasible region
+        cap_floor = mid["cap_mah"]
+        caps, c_rates = _build_hyperbola(mid["i_peak"], cap_floor)
+        feasible_regions.append(
+            FeasibleRegion(
+                cell_count=s,
+                capacity_floor_mah=cap_floor,
+                i_peak_a=mid["i_peak"],
+                capacity_curve_mah=caps,
+                c_rate_curve=c_rates,
+            )
+        )
+
+        shopping_specs.append(
+            ShoppingSpec(
+                cell_count=s,
+                battery_min_mah=cap_floor,
+                battery_min_c=mid["c_min"],
+                battery_v_nom=mid["v_nom"],
+                esc_min_a=mid["esc_min"],
+                motor_min_peak_w=p_aero_top,
+                motor_cont_w=p_aero_cruise,
+                kv_approx=mid["kv_approx"],
+            )
+        )
+
+    return PowertrainSolutionSpaceResponse(
+        rows=rows,
+        feasible_regions=feasible_regions,
+        shopping_specs=shopping_specs,
+        p_aero_cruise_w=p_aero_cruise,
+        p_aero_top_w=p_aero_top,
+        energy_wh=energy_wh,
+        v_cruise_mps=v_cruise_mps,
+        v_top_mps=v_top_mps,
+        t_target_min=t_target_min,
+        assumptions_used=assumptions,
+        warnings=warnings,
+    )

--- a/app/services/powertrain_solution_space_service.py
+++ b/app/services/powertrain_solution_space_service.py
@@ -123,7 +123,7 @@ def _per_cell(
     load_rpm_factor: float,
     v_top_mps: float,
     prop_pd: float,
-) -> dict[str, float | None]:
+) -> dict[str, float]:
     """Derive per-cell-count specs.  Returns a plain dict (used for both mid and band).
 
     ``p_top_elec_w`` is the *battery* electrical power at V_top
@@ -151,9 +151,12 @@ def _per_cell(
     # KV approximation (Phase 1, documented approximate)
     # RPM_target ≈ V_top / (D × pitch/D) × 60  where D is Phase-1 estimate
     # KV = RPM_target / (V_nom × load_rpm_factor)
+    # v_nom = S · 3.7 is always > 0 for any valid cell count S ≥ 1, so kv_approx
+    # is always a float; the defensive fallback (0.0) only guards a degenerate
+    # zero-voltage case that real inputs never reach.
     prop_d = _PHASE1_PROP_DIAMETER_M
     rpm_target = (v_top_mps / (prop_d * prop_pd)) * 60.0  # rev/min
-    kv_approx = rpm_target / (v_nom * load_rpm_factor) if v_nom > 0 else None
+    kv_approx = rpm_target / (v_nom * load_rpm_factor) if v_nom > 0 else 0.0
 
     return {
         "v_nom": v_nom,

--- a/app/tests/test_powertrain_solution_space.py
+++ b/app/tests/test_powertrain_solution_space.py
@@ -482,6 +482,187 @@ class TestBandInvariant:
 
 
 # ===========================================================================
+# 8b. I_peak absolute hand-calc (no double-counting of efficiencies)
+# ===========================================================================
+
+
+class TestIPeakHandCalc:
+    """I_peak must be battery current = P_battery / V_sag.
+
+    P_top_elec is ALREADY battery electrical power (P_aero / (η_prop·η_motor·η_esc)).
+    Battery current is simply I = P_bat / V_sag — dividing again by η_motor·η_esc
+    double-counts the efficiencies and underestimates the current by that factor.
+    """
+
+    def test_i_peak_absolute_value(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            assumptions = _default_assumptions()
+            result = compute_solution_space(db, plane, assumptions)
+
+        # Reconstruct the mid-η battery power at V_top from the response.
+        eta_mid = (assumptions.eta_prop_lo + assumptions.eta_prop_hi) / 2.0
+        p_aero_top = result.p_aero_top_w
+        p_bat_top = _p_elec(p_aero_top, eta_mid, assumptions.eta_motor, assumptions.eta_esc)
+
+        for row in result.rows:
+            v_sag = row.cell_count * 3.5
+            expected_i = p_bat_top / v_sag
+            assert row.i_peak_a == pytest.approx(expected_i, rel=1e-6), (
+                f"S={row.cell_count}: i_peak {row.i_peak_a:.3f} ≠ "
+                f"P_bat/V_sag {expected_i:.3f}"
+            )
+
+    def test_esc_min_follows_i_peak(self, client_and_db):
+        """esc_min must equal i_peak × esc_margin (with the corrected i_peak)."""
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            assumptions = _default_assumptions()
+            result = compute_solution_space(db, plane, assumptions)
+
+        for row in result.rows:
+            assert row.esc_min_a == pytest.approx(
+                row.i_peak_a * assumptions.esc_margin, rel=1e-6
+            )
+
+    def test_region_c_floor_uses_corrected_i_peak(self, client_and_db):
+        """Feasible-region i_peak must match the (corrected) row i_peak."""
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            assumptions = _default_assumptions()
+            result = compute_solution_space(db, plane, assumptions)
+
+        by_cells = {fr.cell_count: fr for fr in result.feasible_regions}
+        for row in result.rows:
+            fr = by_cells[row.cell_count]
+            assert fr.i_peak_a == pytest.approx(row.i_peak_a, rel=1e-6)
+
+
+# ===========================================================================
+# 8c. c_margin is applied to the required c_min
+# ===========================================================================
+
+
+class TestCMarginApplied:
+    def test_c_min_includes_margin(self, client_and_db):
+        """Required c_min = (I_peak / (cap_mAh/1000)) × c_margin."""
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            assumptions = _default_assumptions(c_margin=1.25)
+            result = compute_solution_space(db, plane, assumptions)
+
+        for row in result.rows:
+            raw_c = row.i_peak_a / (row.capacity_mah_min / 1000.0)
+            assert row.c_min == pytest.approx(raw_c * 1.25, rel=1e-6), (
+                f"S={row.cell_count}: c_min {row.c_min:.3f} should include 1.25× margin"
+            )
+
+    def test_c_margin_scales_c_min(self, client_and_db):
+        """Increasing c_margin must increase the reported c_min proportionally."""
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            res_a = compute_solution_space(db, plane, _default_assumptions(c_margin=1.0))
+            res_b = compute_solution_space(db, plane, _default_assumptions(c_margin=2.0))
+
+        c_a = {r.cell_count: r.c_min for r in res_a.rows}
+        c_b = {r.cell_count: r.c_min for r in res_b.rows}
+        for s in c_a:
+            assert c_b[s] == pytest.approx(c_a[s] * 2.0, rel=1e-6)
+
+    def test_shopping_spec_c_includes_margin(self, client_and_db):
+        """ShoppingSpec.battery_min_c must carry the margin too."""
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            assumptions = _default_assumptions(c_margin=1.25)
+            result = compute_solution_space(db, plane, assumptions)
+
+        by_cells = {r.cell_count: r for r in result.rows}
+        for spec in result.shopping_specs:
+            assert spec.battery_min_c == pytest.approx(by_cells[spec.cell_count].c_min, rel=1e-6)
+
+
+# ===========================================================================
+# 8d. motor_peak_w is shaft power (P_aero / eta_prop), not P_aero
+# ===========================================================================
+
+
+class TestMotorShaftPower:
+    def test_motor_peak_is_shaft_power(self, client_and_db):
+        """motor_peak_w = P_aero(V_top) / eta_prop_mid (required shaft power)."""
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            assumptions = _default_assumptions()
+            result = compute_solution_space(db, plane, assumptions)
+
+        eta_mid = (assumptions.eta_prop_lo + assumptions.eta_prop_hi) / 2.0
+        expected = result.p_aero_top_w / eta_mid
+        for row in result.rows:
+            assert row.motor_peak_w == pytest.approx(expected, rel=1e-6), (
+                f"motor_peak_w {row.motor_peak_w:.2f} ≠ shaft power {expected:.2f}"
+            )
+
+    def test_motor_cont_is_shaft_power(self, client_and_db):
+        """motor_cont_w = P_aero(V_cruise) / eta_prop_mid."""
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            assumptions = _default_assumptions()
+            result = compute_solution_space(db, plane, assumptions)
+
+        eta_mid = (assumptions.eta_prop_lo + assumptions.eta_prop_hi) / 2.0
+        expected = result.p_aero_cruise_w / eta_mid
+        for row in result.rows:
+            assert row.motor_cont_w == pytest.approx(expected, rel=1e-6)
+
+    def test_shopping_spec_motor_is_shaft_power(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            assumptions = _default_assumptions()
+            result = compute_solution_space(db, plane, assumptions)
+
+        eta_mid = (assumptions.eta_prop_lo + assumptions.eta_prop_hi) / 2.0
+        expected = result.p_aero_top_w / eta_mid
+        for spec in result.shopping_specs:
+            assert spec.motor_min_peak_w == pytest.approx(expected, rel=1e-6)
+
+    def test_motor_match_compares_against_shaft_power(self, client_and_db):
+        """A motor that beats P_aero but NOT shaft power must NOT match."""
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            assumptions = _default_assumptions()
+            pre = compute_solution_space(db, plane, assumptions)
+            eta_mid = (assumptions.eta_prop_lo + assumptions.eta_prop_hi) / 2.0
+            p_aero_top = pre.p_aero_top_w
+            shaft = p_aero_top / eta_mid
+            # Motor between P_aero and shaft power → insufficient for shaft demand.
+            mid_power = (p_aero_top + shaft) / 2.0
+            _seed_brushless_motor(db, max_power_w=mid_power)
+            db.commit()
+
+        with SessionLocal() as db:
+            plane2 = (
+                db.query(AeroplaneModel)
+                .filter(AeroplaneModel.name == "sol-space-test")
+                .first()
+            )
+            result = compute_solution_space(db, plane2, assumptions)
+
+        for row in result.rows:
+            assert row.has_motor_match is False, (
+                "Motor below shaft-power requirement must not match"
+            )
+
+
+# ===========================================================================
 # 9. Shopping spec
 # ===========================================================================
 

--- a/app/tests/test_powertrain_solution_space.py
+++ b/app/tests/test_powertrain_solution_space.py
@@ -1,0 +1,675 @@
+"""Tests for powertrain solution-space service + endpoint (gh-975).
+
+Acceptance Criteria (from GH #975 and the spec):
+1. Invariant hand-calc: P_aero(V_cruise), E_Wh match formula.
+2. More S → lower I_peak, lower min mAh, same Wh (voltage up → current down).
+3. Feasible floors: capacity_floor_mah > 0, hyperbola points non-empty.
+4. Catalog match: motor ✓ when a qualifying motor is present;
+   battery/esc absent in empty DB → no match, no crash.
+5. Missing context → warnings list non-empty, computation still returns.
+6. Validation errors: V_top ≤ V_cruise → ValidationDomainError;
+   t_target ≤ 0 → ValidationDomainError.
+7. Endpoint returns the full schema + respects assumption overrides.
+8. Band invariant: i_peak_hi ≥ i_peak_mid ≥ i_peak_lo (more η → less current).
+"""
+
+from __future__ import annotations
+
+import math
+import uuid
+
+import pytest
+from pydantic import ValidationError as PydanticValidationError
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import ValidationDomainError
+from app.models.aeroplanemodel import AeroplaneModel, DesignAssumptionModel
+from app.models.component import ComponentModel
+from app.schemas.powertrain_solution_space import SolutionSpaceAssumptions
+from app.services.powertrain_solution_space_service import (
+    _p_aero,
+    _p_elec,
+    compute_solution_space,
+)
+from app.tests.conftest import make_aeroplane
+
+# ---------------------------------------------------------------------------
+# Constants matching the service
+# ---------------------------------------------------------------------------
+G = 9.80665
+RHO = 1.225
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_assumption(session: Session, aeroplane_id: int, param: str, value: float) -> None:
+    row = DesignAssumptionModel(
+        aeroplane_id=aeroplane_id,
+        parameter_name=param,
+        estimate_value=value,
+        active_source="ESTIMATE",
+    )
+    session.add(row)
+    session.flush()
+
+
+def _make_rc_plane(session: Session, name: str = "sol-space-test") -> AeroplaneModel:
+    """Create a small RC trainer with a fully-populated computation context."""
+    plane = make_aeroplane(session, name=name)
+    _seed_assumption(session, plane.id, "mass", 1.5)
+    _seed_assumption(session, plane.id, "cd0", 0.035)
+    plane.assumption_computation_context = {
+        "s_ref_m2": 0.40,
+        "e_oswald": 0.78,
+        "aspect_ratio": 8.0,
+        "v_cruise_mps": 14.0,
+        "v_md_mps": 14.0,
+    }
+    session.flush()
+    session.commit()
+    return plane
+
+
+def _make_plane_no_context(session: Session) -> AeroplaneModel:
+    """Create an aeroplane with NO computation context at all."""
+    plane = make_aeroplane(session, name="no-ctx-plane")
+    session.commit()
+    return plane
+
+
+def _default_assumptions(**overrides) -> SolutionSpaceAssumptions:
+    defaults = {
+        "cell_counts": [2, 3, 4, 6],
+        "eta_prop_lo": 0.65,
+        "eta_prop_hi": 0.78,
+        "eta_motor": 0.85,
+        "eta_esc": 0.94,
+        "dod": 0.80,
+        "esc_margin": 1.4,
+        "c_margin": 1.25,
+        "load_rpm_factor": 0.85,
+        "prop_pd": 0.65,
+        "t_target_min": 10.0,
+        "v_top_mps": 22.0,  # > v_cruise=14.0
+    }
+    defaults.update(overrides)
+    return SolutionSpaceAssumptions(**defaults)
+
+
+def _seed_brushless_motor(session: Session, max_power_w: float) -> ComponentModel:
+    m = ComponentModel(
+        name="Test Motor",
+        component_type="brushless_motor",
+        specs={"max_power_w": max_power_w, "kv_rpm_v": 900},
+    )
+    session.add(m)
+    session.flush()
+    return m
+
+
+# ===========================================================================
+# 1. Unit tests for internal helpers (_p_aero, _p_elec)
+# ===========================================================================
+
+
+class TestPhysicsHelpers:
+    def test_p_aero_formula(self):
+        """Hand-calc: P_aero at V=14 m/s for a 1.5 kg RC plane."""
+        mass = 1.5
+        v = 14.0
+        cd0 = 0.035
+        e = 0.78
+        ar = 8.0
+        s_ref = 0.40
+
+        q = 0.5 * RHO * v * v
+        cl = (mass * G) / (q * s_ref)
+        k = 1.0 / (math.pi * e * ar)
+        cd = cd0 + k * cl * cl
+        expected = q * s_ref * cd * v
+
+        result = _p_aero(RHO, v, mass, G, cd0, e, ar, s_ref)
+        assert abs(result - expected) < 1e-6, f"P_aero {result:.3f} ≠ expected {expected:.3f}"
+
+    def test_p_aero_zero_speed_returns_inf(self):
+        assert _p_aero(RHO, 0, 1.5, G, 0.03, 0.78, 8.0, 0.4) == float("inf")
+
+    def test_p_elec_formula(self):
+        """P_elec = P_aero / (η_prop · η_motor · η_esc)."""
+        p_aero = 50.0
+        eta = 0.72 * 0.85 * 0.94
+        expected = p_aero / eta
+        result = _p_elec(p_aero, 0.72, 0.85, 0.94)
+        assert abs(result - expected) < 1e-6
+
+
+# ===========================================================================
+# 2. Invariant hand-calc tests on compute_solution_space
+# ===========================================================================
+
+
+class TestInvariants:
+    def test_energy_wh_matches_formula(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            assumptions = _default_assumptions(t_target_min=10.0)
+            result = compute_solution_space(db, plane, assumptions)
+
+        # Hand-calc: P_elec at cruise (mid η = (0.65+0.78)/2 = 0.715)
+        eta_mid = (0.65 + 0.78) / 2.0
+        p_aero_cruise = _p_aero(RHO, 14.0, 1.5, G, 0.035, 0.78, 8.0, 0.40)
+        p_cruise_elec = _p_elec(p_aero_cruise, eta_mid, 0.85, 0.94)
+        expected_wh = p_cruise_elec * (10.0 / 60.0) / 0.80
+
+        assert abs(result.energy_wh - expected_wh) < 0.5, (
+            f"energy_wh {result.energy_wh:.2f} ≠ hand-calc {expected_wh:.2f}"
+        )
+
+    def test_p_aero_cruise_and_top_in_response(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            assumptions = _default_assumptions()
+            result = compute_solution_space(db, plane, assumptions)
+
+        assert result.p_aero_cruise_w > 0
+        assert result.p_aero_top_w > result.p_aero_cruise_w, (
+            "Top speed > cruise → P_aero(top) should exceed P_aero(cruise)"
+        )
+
+    def test_v_top_default_is_1_4x_cruise(self, client_and_db):
+        """When v_top_mps not supplied, service uses 1.4 × V_cruise."""
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            assumptions = _default_assumptions(v_top_mps=None)
+            result = compute_solution_space(db, plane, assumptions)
+
+        assert abs(result.v_top_mps - 14.0 * 1.4) < 0.01
+
+
+# ===========================================================================
+# 3. Cell-count monotonicity (more S → lower I_peak, lower mAh, same Wh)
+# ===========================================================================
+
+
+class TestCellCountMonotonicity:
+    def test_more_S_lower_i_peak(self, client_and_db):
+        """More cells → higher voltage → less current at same power."""
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            assumptions = _default_assumptions(cell_counts=[2, 3, 4, 6])
+            result = compute_solution_space(db, plane, assumptions)
+
+        i_peaks = {r.cell_count: r.i_peak_a for r in result.rows}
+        assert i_peaks[2] > i_peaks[3] > i_peaks[4] > i_peaks[6], (
+            f"I_peak should decrease with S: {i_peaks}"
+        )
+
+    def test_more_S_lower_capacity_min(self, client_and_db):
+        """More cells → higher V_nom → less mAh needed for same Wh."""
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            assumptions = _default_assumptions(cell_counts=[2, 3, 4, 6])
+            result = compute_solution_space(db, plane, assumptions)
+
+        caps = {r.cell_count: r.capacity_mah_min for r in result.rows}
+        assert caps[2] > caps[3] > caps[4] > caps[6], (
+            f"capacity_mah_min should decrease with S: {caps}"
+        )
+
+    def test_same_energy_wh_across_cell_counts(self, client_and_db):
+        """Energy [Wh] is independent of cell count (same flight time / cruise power)."""
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            assumptions = _default_assumptions(cell_counts=[2, 3, 4, 6])
+            result = compute_solution_space(db, plane, assumptions)
+
+        # The response's top-level energy_wh is the shared value
+        wh_ref = result.energy_wh
+        assert wh_ref > 0
+
+        # Verify mAh × V_nom = same Wh for all S (within float precision)
+        for row in result.rows:
+            wh_derived = row.capacity_mah_min / 1000.0 * row.v_nom_v
+            assert abs(wh_derived - wh_ref) < 0.05, (
+                f"S={row.cell_count}: mAh×V_nom={wh_derived:.3f} ≠ E_Wh={wh_ref:.3f}"
+            )
+
+
+# ===========================================================================
+# 4. Feasible regions
+# ===========================================================================
+
+
+class TestFeasibleRegions:
+    def test_feasible_regions_count_matches_cell_counts(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            assumptions = _default_assumptions(cell_counts=[3, 4])
+            result = compute_solution_space(db, plane, assumptions)
+
+        assert len(result.feasible_regions) == 2
+
+    def test_capacity_floor_positive(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            assumptions = _default_assumptions()
+            result = compute_solution_space(db, plane, assumptions)
+
+        for fr in result.feasible_regions:
+            assert fr.capacity_floor_mah > 0, f"S={fr.cell_count}: floor ≤ 0"
+
+    def test_hyperbola_points_non_empty(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            assumptions = _default_assumptions()
+            result = compute_solution_space(db, plane, assumptions)
+
+        for fr in result.feasible_regions:
+            assert len(fr.capacity_curve_mah) > 0, f"S={fr.cell_count}: no curve points"
+            assert len(fr.c_rate_curve) == len(fr.capacity_curve_mah)
+
+    def test_hyperbola_is_decreasing(self, client_and_db):
+        """C-rate hyperbola: more capacity → lower required C-rate."""
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            assumptions = _default_assumptions()
+            result = compute_solution_space(db, plane, assumptions)
+
+        for fr in result.feasible_regions:
+            c_rates = fr.c_rate_curve
+            for i in range(1, len(c_rates)):
+                assert c_rates[i] <= c_rates[i - 1], (
+                    f"S={fr.cell_count}: C-rate should decrease as capacity increases"
+                )
+
+
+# ===========================================================================
+# 5. Catalog matching
+# ===========================================================================
+
+
+class TestCatalogMatch:
+    def test_motor_match_when_qualifying_motor_present(self, client_and_db):
+        """A motor with max_power_w ≥ P_aero_top should flag has_motor_match=True."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            assumptions = _default_assumptions()
+            # First get the expected P_aero_top
+            result_no_motor = compute_solution_space(db, plane, assumptions)
+            p_top = result_no_motor.p_aero_top_w
+            # Seed a motor that clearly meets the spec
+            _seed_brushless_motor(db, max_power_w=p_top * 2.0)
+            db.commit()
+
+        with SessionLocal() as db:
+            plane2 = (
+                db.query(AeroplaneModel).filter(AeroplaneModel.name == "sol-space-test").first()
+            )
+            result = compute_solution_space(db, plane2, assumptions)
+
+        for row in result.rows:
+            assert row.has_motor_match is True, (
+                f"S={row.cell_count}: expected motor match with P_top={p_top:.0f}W"
+            )
+
+    def test_no_crash_when_battery_esc_absent(self, client_and_db):
+        """With 0 batteries and 0 ESCs in DB, should return False matches gracefully."""
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            assumptions = _default_assumptions()
+            result = compute_solution_space(db, plane, assumptions)
+
+        for row in result.rows:
+            assert row.has_battery_match is False
+            assert row.has_esc_match is False
+
+    def test_motor_no_match_when_underpowered(self, client_and_db):
+        """A motor with max_power_w < P_aero_top should not match."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            assumptions = _default_assumptions()
+            result_pre = compute_solution_space(db, plane, assumptions)
+            p_top = result_pre.p_aero_top_w
+            _seed_brushless_motor(db, max_power_w=p_top * 0.1)  # underpowered
+            db.commit()
+
+        with SessionLocal() as db:
+            plane2 = (
+                db.query(AeroplaneModel).filter(AeroplaneModel.name == "sol-space-test").first()
+            )
+            result = compute_solution_space(db, plane2, assumptions)
+
+        for row in result.rows:
+            assert row.has_motor_match is False
+
+
+# ===========================================================================
+# 6. Missing context → design warnings
+# ===========================================================================
+
+
+class TestMissingContextWarnings:
+    def test_missing_context_produces_warnings(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_plane_no_context(db)
+            assumptions = _default_assumptions(v_top_mps=25.0)
+            result = compute_solution_space(db, plane, assumptions)
+
+        assert len(result.warnings) > 0, "Expected warnings when context is empty"
+
+    def test_missing_context_warns_about_s_ref(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_plane_no_context(db)
+            assumptions = _default_assumptions(v_top_mps=25.0)
+            result = compute_solution_space(db, plane, assumptions)
+
+        warning_text = " ".join(result.warnings)
+        assert "s_ref_m2" in warning_text.lower() or "s_ref" in warning_text.lower()
+
+    def test_missing_context_still_returns_rows(self, client_and_db):
+        """Even with missing context, we get rows (fallback defaults used)."""
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_plane_no_context(db)
+            assumptions = _default_assumptions(v_top_mps=25.0)
+            result = compute_solution_space(db, plane, assumptions)
+
+        assert len(result.rows) == len(assumptions.cell_counts)
+
+    def test_missing_e_oswald_warns(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = make_aeroplane(db, name="partial-ctx-plane")
+            _seed_assumption(db, plane.id, "mass", 1.5)
+            # Context has s_ref but missing e_oswald
+            plane.assumption_computation_context = {
+                "s_ref_m2": 0.40,
+                "aspect_ratio": 8.0,
+                "v_cruise_mps": 14.0,
+                # e_oswald intentionally absent
+            }
+            db.flush()
+            db.commit()
+            assumptions = _default_assumptions()
+            result = compute_solution_space(db, plane, assumptions)
+
+        warning_text = " ".join(result.warnings).lower()
+        assert "e_oswald" in warning_text
+
+
+# ===========================================================================
+# 7. Validation errors
+# ===========================================================================
+
+
+class TestValidationErrors:
+    def test_v_top_equal_v_cruise_raises(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            # V_top = V_cruise = 14.0 → should raise
+            assumptions = _default_assumptions(v_top_mps=14.0)
+            with pytest.raises(ValidationDomainError, match="V_top"):
+                compute_solution_space(db, plane, assumptions)
+
+    def test_v_top_below_v_cruise_raises(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            assumptions = _default_assumptions(v_top_mps=10.0)  # < 14.0
+            with pytest.raises(ValidationDomainError):
+                compute_solution_space(db, plane, assumptions)
+
+    def test_negative_t_target_rejected_by_schema(self):
+        """Pydantic should reject t_target_min ≤ 0 at schema level."""
+        with pytest.raises(PydanticValidationError):
+            _default_assumptions(t_target_min=-5.0)
+
+    def test_zero_t_target_rejected_by_schema(self):
+        with pytest.raises(PydanticValidationError):
+            _default_assumptions(t_target_min=0.0)
+
+
+# ===========================================================================
+# 8. Band invariant: i_peak_hi ≥ i_peak_mid ≥ i_peak_lo
+# ===========================================================================
+
+
+class TestBandInvariant:
+    def test_band_ordering(self, client_and_db):
+        """Low η_prop → more current (high end). High η_prop → less current (low end)."""
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            assumptions = _default_assumptions()
+            result = compute_solution_space(db, plane, assumptions)
+
+        for row in result.rows:
+            assert row.i_peak_hi_a >= row.i_peak_a >= row.i_peak_lo_a, (
+                f"S={row.cell_count}: band ordering violated: "
+                f"hi={row.i_peak_hi_a:.2f} mid={row.i_peak_a:.2f} lo={row.i_peak_lo_a:.2f}"
+            )
+
+    def test_cap_band_ordering(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            assumptions = _default_assumptions()
+            result = compute_solution_space(db, plane, assumptions)
+
+        for row in result.rows:
+            assert row.capacity_mah_min_hi >= row.capacity_mah_min >= row.capacity_mah_min_lo, (
+                f"S={row.cell_count}: cap band ordering violated"
+            )
+
+
+# ===========================================================================
+# 9. Shopping spec
+# ===========================================================================
+
+
+class TestShoppingSpec:
+    def test_shopping_spec_count_matches(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            assumptions = _default_assumptions(cell_counts=[3, 4])
+            result = compute_solution_space(db, plane, assumptions)
+
+        assert len(result.shopping_specs) == 2
+
+    def test_shopping_spec_fields_positive(self, client_and_db):
+        _, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = _make_rc_plane(db)
+            assumptions = _default_assumptions()
+            result = compute_solution_space(db, plane, assumptions)
+
+        for spec in result.shopping_specs:
+            assert spec.battery_min_mah > 0
+            assert spec.battery_min_c > 0
+            assert spec.esc_min_a > 0
+            assert spec.motor_min_peak_w > 0
+
+
+# ===========================================================================
+# 10. Endpoint tests
+# ===========================================================================
+
+
+def _seed_assumption_db(session, aeroplane_id, param, value):
+    row = DesignAssumptionModel(
+        aeroplane_id=aeroplane_id,
+        parameter_name=param,
+        estimate_value=value,
+        active_source="ESTIMATE",
+    )
+    session.add(row)
+    session.flush()
+
+
+class TestEndpoint:
+    def _make_plane_for_endpoint(self, session: Session) -> AeroplaneModel:
+        plane = make_aeroplane(session, name="ep-test-plane")
+        _seed_assumption_db(session, plane.id, "mass", 1.5)
+        _seed_assumption_db(session, plane.id, "cd0", 0.035)
+        plane.assumption_computation_context = {
+            "s_ref_m2": 0.40,
+            "e_oswald": 0.78,
+            "aspect_ratio": 8.0,
+            "v_cruise_mps": 14.0,
+        }
+        session.flush()
+        session.commit()
+        return plane
+
+    def test_returns_200_with_schema(self, client_and_db):
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = self._make_plane_for_endpoint(db)
+            aeroplane_uuid = str(plane.uuid)
+
+        resp = client.get(
+            f"/aeroplanes/{aeroplane_uuid}/powertrain/solution-space",
+            params={"v_top_mps": 22.0, "t_target_min": 10.0},
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+
+        required_top = {
+            "rows",
+            "feasible_regions",
+            "shopping_specs",
+            "warnings",
+            "p_aero_cruise_w",
+            "p_aero_top_w",
+            "energy_wh",
+            "v_cruise_mps",
+            "v_top_mps",
+            "t_target_min",
+            "assumptions_used",
+        }
+        missing = required_top - data.keys()
+        assert not missing, f"Missing top-level keys: {missing}"
+
+    def test_rows_count_matches_default_cell_counts(self, client_and_db):
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = self._make_plane_for_endpoint(db)
+            aeroplane_uuid = str(plane.uuid)
+
+        resp = client.get(
+            f"/aeroplanes/{aeroplane_uuid}/powertrain/solution-space",
+            params={"v_top_mps": 22.0, "t_target_min": 10.0},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        # Default cell_counts = [2, 3, 4, 6] → 4 rows
+        assert len(data["rows"]) == 4
+
+    def test_override_cell_counts(self, client_and_db):
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = self._make_plane_for_endpoint(db)
+            aeroplane_uuid = str(plane.uuid)
+
+        resp = client.get(
+            f"/aeroplanes/{aeroplane_uuid}/powertrain/solution-space",
+            params={"v_top_mps": 22.0, "t_target_min": 10.0, "cell_counts": [3, 6]},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["rows"]) == 2
+        cell_counts_returned = [r["cell_count"] for r in data["rows"]]
+        assert sorted(cell_counts_returned) == [3, 6]
+
+    def test_404_missing_aeroplane(self, client_and_db):
+        client, _ = client_and_db
+        missing = str(uuid.uuid4())
+        resp = client.get(
+            f"/aeroplanes/{missing}/powertrain/solution-space",
+            params={"v_top_mps": 22.0},
+        )
+        assert resp.status_code == 404
+
+    def test_422_v_top_below_cruise(self, client_and_db):
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = self._make_plane_for_endpoint(db)
+            aeroplane_uuid = str(plane.uuid)
+
+        # V_top = 5.0 < V_cruise = 14.0 → domain error
+        resp = client.get(
+            f"/aeroplanes/{aeroplane_uuid}/powertrain/solution-space",
+            params={"v_top_mps": 5.0, "t_target_min": 10.0},
+        )
+        assert resp.status_code == 422
+
+    def test_override_t_target(self, client_and_db):
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = self._make_plane_for_endpoint(db)
+            aeroplane_uuid = str(plane.uuid)
+
+        resp = client.get(
+            f"/aeroplanes/{aeroplane_uuid}/powertrain/solution-space",
+            params={"v_top_mps": 22.0, "t_target_min": 20.0},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["t_target_min"] == 20.0
+
+    def test_warnings_present_for_missing_context(self, client_and_db):
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = make_aeroplane(db, name="ep-no-ctx")
+            db.commit()
+            aeroplane_uuid = str(plane.uuid)
+
+        resp = client.get(
+            f"/aeroplanes/{aeroplane_uuid}/powertrain/solution-space",
+            params={"v_top_mps": 25.0, "t_target_min": 10.0},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["warnings"]) > 0
+
+    def test_eta_prop_override(self, client_and_db):
+        """Override eta_prop_lo/hi and verify the response reflects it."""
+        client, SessionLocal = client_and_db
+        with SessionLocal() as db:
+            plane = self._make_plane_for_endpoint(db)
+            aeroplane_uuid = str(plane.uuid)
+
+        resp = client.get(
+            f"/aeroplanes/{aeroplane_uuid}/powertrain/solution-space",
+            params={
+                "v_top_mps": 22.0,
+                "t_target_min": 10.0,
+                "eta_prop_lo": 0.70,
+                "eta_prop_hi": 0.80,
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        used = data["assumptions_used"]
+        assert used["eta_prop_lo"] == 0.70
+        assert used["eta_prop_hi"] == 0.80


### PR DESCRIPTION
Closes #975

Phase 1, Ticket 1 (backend) of the powertrain solution-space reframe. New pure-Python service that computes the required component-spec envelope from mission+aero in the gh-924 context — per cell-count over an η_prop band, feasible floors (min mAh, min C), catalog matches, design warning when context is missing. New `GET /aeroplanes/{id}/powertrain/solution-space`.

Spec: `docs/superpowers/specs/2026-06-13-powertrain-solution-space-design.md`

## Tests
36 new fast-tier tests (invariants vs hand calc, per-cell derivation, band ordering, feasible floors, catalog match, missing-context warning, validation, endpoint overrides). Regression slice 374 passed. ruff clean. New-code coverage: schemas 100% / service 86% / endpoint 83%.

Blocks #976, #977. Part of epic #197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)