### PR TITLE
feat(gh-972,gh-973): geometry-diff field-level detail + plain-language hints

### DIFF
--- a/frontend/__tests__/GeometryDiffSection.test.tsx
+++ b/frontend/__tests__/GeometryDiffSection.test.tsx
@@ -79,12 +79,14 @@ const CHANGED_DIFF: GeometryDiff = {
   ],
   counts: { sectionsChanged: 1, sectionsAdded: 1, sectionsRemoved: 1 },
   hasAnyChange: true,
+  hints: [],
 };
 
 const EMPTY_DIFF: GeometryDiff = {
   wings: [],
   counts: { sectionsChanged: 0, sectionsAdded: 0, sectionsRemoved: 0 },
   hasAnyChange: false,
+  hints: [],
 };
 
 function result(over: Partial<UseGeometryDiffResult> = {}): UseGeometryDiffResult {
@@ -275,8 +277,10 @@ const DIFF_WITH_SPAR_FIELDS: GeometryDiff = {
   ],
   counts: { sectionsChanged: 1, sectionsAdded: 0, sectionsRemoved: 0 },
   hasAnyChange: true,
+  hints: [],
 };
 
+/** DIFF_WITH_HINTS: pre-computed hints embedded in the diff object (gh-973). */
 const DIFF_WITH_HINTS: GeometryDiff = {
   wings: [
     {
@@ -298,6 +302,7 @@ const DIFF_WITH_HINTS: GeometryDiff = {
   ],
   counts: { sectionsChanged: 1, sectionsAdded: 0, sectionsRemoved: 0 },
   hasAnyChange: true,
+  hints: ["More taper (tip chord ↓)"],
 };
 
 describe("GeometryDiffSection — gh-972 sub-element field sub-rows", () => {
@@ -344,7 +349,7 @@ describe("GeometryDiffSection — gh-972 sub-element field sub-rows", () => {
 });
 
 // ---------------------------------------------------------------------------
-// GH #973 — hint block renders with hedge text
+// GH #973 — hint block renders with hedge text and aria attributes
 // ---------------------------------------------------------------------------
 
 describe("GeometryDiffSection — gh-973 hints block", () => {
@@ -359,6 +364,22 @@ describe("GeometryDiffSection — gh-973 hints block", () => {
     expect(screen.getByTestId("geometry-diff-hints")).toBeDefined();
   });
 
+  it("hint block has role='note'", () => {
+    useGeometryDiffMock.mockReturnValue(result({ diff: DIFF_WITH_HINTS }));
+    render(<GeometryDiffSection {...PROPS} />);
+    fireEvent.click(screen.getByTestId("geometry-diff-header"));
+    const hintsBlock = screen.getByTestId("geometry-diff-hints");
+    expect(hintsBlock.getAttribute("role")).toBe("note");
+  });
+
+  it("hint block has aria-label='Geometry observations'", () => {
+    useGeometryDiffMock.mockReturnValue(result({ diff: DIFF_WITH_HINTS }));
+    render(<GeometryDiffSection {...PROPS} />);
+    fireEvent.click(screen.getByTestId("geometry-diff-header"));
+    const hintsBlock = screen.getByTestId("geometry-diff-hints");
+    expect(hintsBlock.getAttribute("aria-label")).toBe("Geometry observations");
+  });
+
   it("hint block contains the hedge prefix text", () => {
     useGeometryDiffMock.mockReturnValue(result({ diff: DIFF_WITH_HINTS }));
     render(<GeometryDiffSection {...PROPS} />);
@@ -367,7 +388,17 @@ describe("GeometryDiffSection — gh-973 hints block", () => {
     expect(hintsBlock.textContent ?? "").toMatch(/rough guide|verify with analysis/i);
   });
 
-  it("hint block is NOT rendered when there are no hints (e.g. no changes)", () => {
+  it("hint block renders diff.hints (from the diff object, not derived separately)", () => {
+    // DIFF_WITH_HINTS has hints: ["More taper (tip chord ↓)"] pre-computed
+    useGeometryDiffMock.mockReturnValue(result({ diff: DIFF_WITH_HINTS }));
+    render(<GeometryDiffSection {...PROPS} />);
+    fireEvent.click(screen.getByTestId("geometry-diff-header"));
+    const hintsBlock = screen.getByTestId("geometry-diff-hints");
+    expect(hintsBlock.textContent ?? "").toMatch(/taper/i);
+  });
+
+  it("hint block is NOT rendered when diff.hints is empty", () => {
+    // EMPTY_DIFF has hints: []
     useGeometryDiffMock.mockReturnValue(result({ diff: EMPTY_DIFF }));
     render(<GeometryDiffSection {...PROPS} />);
     fireEvent.click(screen.getByTestId("geometry-diff-header"));
@@ -381,11 +412,16 @@ describe("GeometryDiffSection — gh-973 hints block", () => {
     expect(screen.queryByTestId("geometry-diff-hints")).toBeNull();
   });
 
-  it("taper hint text visible in hints block", () => {
-    useGeometryDiffMock.mockReturnValue(result({ diff: DIFF_WITH_HINTS }));
+  it("hints from diff with no change params shows no hint block (hints:[])", () => {
+    const diffNoHints: GeometryDiff = {
+      wings: [{ name: "main", kind: "changed", sections: [{ index: 0, kind: "changed", label: "Section 1 · root", params: [], flags: [] }] }],
+      counts: { sectionsChanged: 1, sectionsAdded: 0, sectionsRemoved: 0 },
+      hasAnyChange: true,
+      hints: [],
+    };
+    useGeometryDiffMock.mockReturnValue(result({ diff: diffNoHints }));
     render(<GeometryDiffSection {...PROPS} />);
     fireEvent.click(screen.getByTestId("geometry-diff-header"));
-    const hintsBlock = screen.getByTestId("geometry-diff-hints");
-    expect(hintsBlock.textContent ?? "").toMatch(/taper/i);
+    expect(screen.queryByTestId("geometry-diff-hints")).toBeNull();
   });
 });

--- a/frontend/__tests__/GeometryDiffSection.test.tsx
+++ b/frontend/__tests__/GeometryDiffSection.test.tsx
@@ -241,3 +241,151 @@ describe("GeometryDiffSection (gh-971)", () => {
     expect(lastCall[4]).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// GH #972 — sub-element field sub-rows render under a flag
+// ---------------------------------------------------------------------------
+
+const DIFF_WITH_SPAR_FIELDS: GeometryDiff = {
+  wings: [
+    {
+      name: "main_wing",
+      kind: "changed",
+      sections: [
+        {
+          index: 0,
+          kind: "changed",
+          label: "Section 1 · root",
+          params: [],
+          flags: [
+            {
+              key: "spar",
+              kind: "changed",
+              a: "1 spar",
+              b: "1 spar",
+              fields: [
+                { key: "spar 1 position", a: "0.3", b: "0.4" },
+                { key: "spar 1 width", a: "10 mm", b: "12 mm" },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  counts: { sectionsChanged: 1, sectionsAdded: 0, sectionsRemoved: 0 },
+  hasAnyChange: true,
+};
+
+const DIFF_WITH_HINTS: GeometryDiff = {
+  wings: [
+    {
+      name: "main_wing",
+      kind: "changed",
+      sections: [
+        {
+          index: 0,
+          kind: "changed",
+          label: "Section 1 · root",
+          params: [
+            { key: "root chord", a: "200 mm", b: "200 mm" },
+            { key: "tip chord", a: "150 mm", b: "100 mm" },
+          ],
+          flags: [],
+        },
+      ],
+    },
+  ],
+  counts: { sectionsChanged: 1, sectionsAdded: 0, sectionsRemoved: 0 },
+  hasAnyChange: true,
+};
+
+describe("GeometryDiffSection — gh-972 sub-element field sub-rows", () => {
+  beforeEach(() => {
+    useGeometryDiffMock.mockReset();
+  });
+
+  it("renders spar field sub-rows beneath the flag row when expanded", () => {
+    useGeometryDiffMock.mockReturnValue(result({ diff: DIFF_WITH_SPAR_FIELDS }));
+    render(<GeometryDiffSection {...PROPS} />);
+    fireEvent.click(screen.getByTestId("geometry-diff-header"));
+    // The spar flag row renders
+    expect(screen.getByTestId("geometry-diff-row-spar")).toBeDefined();
+    // Sub-rows render with testids for the fields
+    expect(screen.getByTestId("geometry-diff-subrow-spar 1 position")).toBeDefined();
+    expect(screen.getByTestId("geometry-diff-subrow-spar 1 width")).toBeDefined();
+  });
+
+  it("sub-row shows the from→to values", () => {
+    useGeometryDiffMock.mockReturnValue(result({ diff: DIFF_WITH_SPAR_FIELDS }));
+    render(<GeometryDiffSection {...PROPS} />);
+    fireEvent.click(screen.getByTestId("geometry-diff-header"));
+    const posRow = screen.getByTestId("geometry-diff-subrow-spar 1 position");
+    const text = posRow.textContent ?? "";
+    expect(text).toMatch(/0\.3/);
+    expect(text).toMatch(/0\.4/);
+  });
+
+  it("sub-row is marked data-differs=true when values differ", () => {
+    useGeometryDiffMock.mockReturnValue(result({ diff: DIFF_WITH_SPAR_FIELDS }));
+    render(<GeometryDiffSection {...PROPS} />);
+    fireEvent.click(screen.getByTestId("geometry-diff-header"));
+    const posRow = screen.getByTestId("geometry-diff-subrow-spar 1 position");
+    expect(posRow.getAttribute("data-differs")).toBe("true");
+  });
+
+  it("no sub-rows when flags have no fields array", () => {
+    useGeometryDiffMock.mockReturnValue(result({ diff: CHANGED_DIFF }));
+    render(<GeometryDiffSection {...PROPS} />);
+    fireEvent.click(screen.getByTestId("geometry-diff-header"));
+    // CHANGED_DIFF has control_surface flag with no fields → no subrow testid present
+    expect(screen.queryByTestId(/geometry-diff-subrow/)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GH #973 — hint block renders with hedge text
+// ---------------------------------------------------------------------------
+
+describe("GeometryDiffSection — gh-973 hints block", () => {
+  beforeEach(() => {
+    useGeometryDiffMock.mockReset();
+  });
+
+  it("renders geometry-diff-hints block when hints are present + section expanded", () => {
+    useGeometryDiffMock.mockReturnValue(result({ diff: DIFF_WITH_HINTS }));
+    render(<GeometryDiffSection {...PROPS} />);
+    fireEvent.click(screen.getByTestId("geometry-diff-header"));
+    expect(screen.getByTestId("geometry-diff-hints")).toBeDefined();
+  });
+
+  it("hint block contains the hedge prefix text", () => {
+    useGeometryDiffMock.mockReturnValue(result({ diff: DIFF_WITH_HINTS }));
+    render(<GeometryDiffSection {...PROPS} />);
+    fireEvent.click(screen.getByTestId("geometry-diff-header"));
+    const hintsBlock = screen.getByTestId("geometry-diff-hints");
+    expect(hintsBlock.textContent ?? "").toMatch(/rough guide|verify with analysis/i);
+  });
+
+  it("hint block is NOT rendered when there are no hints (e.g. no changes)", () => {
+    useGeometryDiffMock.mockReturnValue(result({ diff: EMPTY_DIFF }));
+    render(<GeometryDiffSection {...PROPS} />);
+    fireEvent.click(screen.getByTestId("geometry-diff-header"));
+    expect(screen.queryByTestId("geometry-diff-hints")).toBeNull();
+  });
+
+  it("hint block is NOT rendered when section is collapsed", () => {
+    useGeometryDiffMock.mockReturnValue(result({ diff: DIFF_WITH_HINTS }));
+    render(<GeometryDiffSection {...PROPS} />);
+    // do NOT click to expand
+    expect(screen.queryByTestId("geometry-diff-hints")).toBeNull();
+  });
+
+  it("taper hint text visible in hints block", () => {
+    useGeometryDiffMock.mockReturnValue(result({ diff: DIFF_WITH_HINTS }));
+    render(<GeometryDiffSection {...PROPS} />);
+    fireEvent.click(screen.getByTestId("geometry-diff-header"));
+    const hintsBlock = screen.getByTestId("geometry-diff-hints");
+    expect(hintsBlock.textContent ?? "").toMatch(/taper/i);
+  });
+});

--- a/frontend/__tests__/geometryDiff.test.ts
+++ b/frontend/__tests__/geometryDiff.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
 import {
   computeGeometryDiff,
+  geometryDiffHints,
   type DiffWingInput,
+  type GeometryDiff,
 } from "@/lib/geometryDiff";
 import type { WingConfigSegment } from "@/hooks/useWingConfig";
 
@@ -534,5 +536,465 @@ describe("computeGeometryDiff — changes-only vs show-all", () => {
     expect(diff.hasAnyChange).toBe(false);
     expect(diff.wings).toHaveLength(1);
     expect(diff.wings[0].sections[0].params.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GH #972 — field-level sub-element diff: spar fields
+// ---------------------------------------------------------------------------
+
+/** A typed spar object matching the expected spare_list item shape */
+function spar(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    spare_position_factor: 0.25,
+    spare_support_dimension_width: 10,
+    spare_support_dimension_height: 15,
+    spare_start: 50,
+    spare_length: 400,
+    spare_mode: "C",
+    ...overrides,
+  };
+}
+
+describe("computeGeometryDiff — gh-972 spar field-level diff", () => {
+  it("emits fields with changed spar position_factor (changes-only)", () => {
+    const a = [wing("main", [segment({ spare_list: [spar({ spare_position_factor: 0.3 })] })])];
+    const b = [wing("main", [segment({ spare_list: [spar({ spare_position_factor: 0.4 })] })])];
+    const diff = computeGeometryDiff(a, b);
+    const sparFlag = diff.wings[0].sections[0].flags.find((f) => f.key === "spar");
+    expect(sparFlag).toBeDefined();
+    expect(sparFlag!.fields).toBeDefined();
+    const posField = sparFlag!.fields!.find((f) => f.key === "spar 1 position");
+    expect(posField).toBeDefined();
+    expect(posField!.a).toBe("0.3");
+    expect(posField!.b).toBe("0.4");
+  });
+
+  it("emits changed width/height dimension fields for a spar", () => {
+    const a = [wing("main", [segment({ spare_list: [spar({ spare_support_dimension_width: 10, spare_support_dimension_height: 15 })] })])];
+    const b = [wing("main", [segment({ spare_list: [spar({ spare_support_dimension_width: 12, spare_support_dimension_height: 20 })] })])];
+    const diff = computeGeometryDiff(a, b);
+    const sparFlag = diff.wings[0].sections[0].flags.find((f) => f.key === "spar");
+    expect(sparFlag!.fields).toBeDefined();
+    const wField = sparFlag!.fields!.find((f) => f.key === "spar 1 width");
+    expect(wField).toBeDefined();
+    expect(wField!.a).toBe("10 mm");
+    expect(wField!.b).toBe("12 mm");
+    const hField = sparFlag!.fields!.find((f) => f.key === "spar 1 height");
+    expect(hField).toBeDefined();
+    expect(hField!.a).toBe("15 mm");
+    expect(hField!.b).toBe("20 mm");
+  });
+
+  it("emits changed start/length fields for a spar", () => {
+    const a = [wing("main", [segment({ spare_list: [spar({ spare_start: 50, spare_length: 400 })] })])];
+    const b = [wing("main", [segment({ spare_list: [spar({ spare_start: 60, spare_length: 350 })] })])];
+    const diff = computeGeometryDiff(a, b);
+    const sparFlag = diff.wings[0].sections[0].flags.find((f) => f.key === "spar");
+    expect(sparFlag!.fields).toBeDefined();
+    const startField = sparFlag!.fields!.find((f) => f.key === "spar 1 start");
+    expect(startField).toBeDefined();
+    expect(startField!.a).toBe("50 mm");
+    expect(startField!.b).toBe("60 mm");
+    const lenField = sparFlag!.fields!.find((f) => f.key === "spar 1 length");
+    expect(lenField).toBeDefined();
+    expect(lenField!.a).toBe("400 mm");
+    expect(lenField!.b).toBe("350 mm");
+  });
+
+  it("emits 'added' kind for a spar that exists only in B (count 0→1)", () => {
+    const a = [wing("main", [segment({ spare_list: [] })])];
+    const b = [wing("main", [segment({ spare_list: [spar()] })])];
+    const diff = computeGeometryDiff(a, b);
+    const sparFlag = diff.wings[0].sections[0].flags.find((f) => f.key === "spar");
+    expect(sparFlag).toBeDefined();
+    expect(sparFlag!.kind).toBe("added");
+  });
+
+  it("emits 'removed' kind for a spar that exists only in A (count 1→0)", () => {
+    const a = [wing("main", [segment({ spare_list: [spar()] })])];
+    const b = [wing("main", [segment({ spare_list: [] })])];
+    const diff = computeGeometryDiff(a, b);
+    const sparFlag = diff.wings[0].sections[0].flags.find((f) => f.key === "spar");
+    expect(sparFlag).toBeDefined();
+    expect(sparFlag!.kind).toBe("removed");
+  });
+
+  it("showAll emits all spar fields even when unchanged", () => {
+    const a = [wing("main", [segment({ spare_list: [spar()], root_airfoil: { airfoil: "naca2412", chord: 200, incidence: 1 } })])];
+    const b = [wing("main", [segment({ spare_list: [spar()], root_airfoil: { airfoil: "naca2412", chord: 200, incidence: 2 } })])];
+    const diff = computeGeometryDiff(a, b, { showAll: true });
+    const sparFlag = diff.wings[0].sections[0].flags.find((f) => f.key === "spar");
+    expect(sparFlag).toBeDefined();
+    expect(sparFlag!.fields).toBeDefined();
+    // All 6 fields should be present
+    const fieldKeys = sparFlag!.fields!.map((f) => f.key);
+    expect(fieldKeys).toContain("spar 1 position");
+    expect(fieldKeys).toContain("spar 1 width");
+    expect(fieldKeys).toContain("spar 1 height");
+    expect(fieldKeys).toContain("spar 1 start");
+    expect(fieldKeys).toContain("spar 1 length");
+    expect(fieldKeys).toContain("spar 1 mode");
+  });
+
+  it("changes-only emits fields only for changed spar fields", () => {
+    // position changes, width/height/start/length/mode unchanged
+    const a = [wing("main", [segment({ spare_list: [spar({ spare_position_factor: 0.25 })] })])];
+    const b = [wing("main", [segment({ spare_list: [spar({ spare_position_factor: 0.35 })] })])];
+    const diff = computeGeometryDiff(a, b);
+    const sparFlag = diff.wings[0].sections[0].flags.find((f) => f.key === "spar");
+    expect(sparFlag!.fields).toBeDefined();
+    const fieldKeys = sparFlag!.fields!.map((f) => f.key);
+    expect(fieldKeys).toContain("spar 1 position");
+    // width/height/start/length/mode are unchanged → NOT emitted in changes-only
+    expect(fieldKeys).not.toContain("spar 1 width");
+    expect(fieldKeys).not.toContain("spar 1 height");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GH #972 — field-level sub-element diff: TED (trailing edge device) fields
+// ---------------------------------------------------------------------------
+
+describe("computeGeometryDiff — gh-972 TED field-level diff", () => {
+  it("emits changed hinge_type and deflection_deg fields for TED", () => {
+    const a = [wing("main", [segment({ trailing_edge_device: {
+      name: "aileron", role: "aileron", rel_chord_root: 0.25, rel_chord_tip: 0.25,
+      positive_deflection_deg: 20, negative_deflection_deg: -15,
+      hinge_type: "plain", servo_placement: "wing", servo_index: 0,
+    } })])];
+    const b = [wing("main", [segment({ trailing_edge_device: {
+      name: "aileron", role: "aileron", rel_chord_root: 0.25, rel_chord_tip: 0.25,
+      positive_deflection_deg: 25, negative_deflection_deg: -20,
+      hinge_type: "slotted", servo_placement: "wing", servo_index: 0,
+    } })])];
+    const diff = computeGeometryDiff(a, b);
+    const tedFlag = diff.wings[0].sections[0].flags.find((f) => f.key === "control_surface");
+    expect(tedFlag).toBeDefined();
+    expect(tedFlag!.fields).toBeDefined();
+    const hingeField = tedFlag!.fields!.find((f) => f.key === "control surface hinge_type");
+    expect(hingeField).toBeDefined();
+    expect(hingeField!.a).toBe("plain");
+    expect(hingeField!.b).toBe("slotted");
+    const posDefField = tedFlag!.fields!.find((f) => f.key === "control surface positive_deflection_deg");
+    expect(posDefField).toBeDefined();
+    expect(posDefField!.a).toBe("20");
+    expect(posDefField!.b).toBe("25");
+  });
+
+  it("emits only the name field changed when TED is renamed but otherwise identical", () => {
+    const baseTed = {
+      name: "aileron", role: "aileron", rel_chord_root: 0.25, rel_chord_tip: 0.25,
+      positive_deflection_deg: 20, negative_deflection_deg: -15,
+      hinge_type: "plain", servo_placement: "wing", servo_index: 0,
+    };
+    const a = [wing("main", [segment({ trailing_edge_device: baseTed })])];
+    const b = [wing("main", [segment({ trailing_edge_device: { ...baseTed, name: "flap" } })])];
+    const diff = computeGeometryDiff(a, b);
+    const tedFlag = diff.wings[0].sections[0].flags.find((f) => f.key === "control_surface");
+    expect(tedFlag!.fields).toBeDefined();
+    const nameField = tedFlag!.fields!.find((f) => f.key === "control surface name");
+    expect(nameField).toBeDefined();
+    expect(nameField!.a).toBe("aileron");
+    expect(nameField!.b).toBe("flap");
+    // All other fields unchanged → not in changes-only fields list
+    const fieldKeys = tedFlag!.fields!.map((f) => f.key);
+    expect(fieldKeys.filter((k) => k !== "control surface name")).toHaveLength(0);
+  });
+
+  it("emits moved-but-same-name TED fields (rel_chord changed)", () => {
+    const baseTed = {
+      name: "aileron", role: "aileron", rel_chord_root: 0.25, rel_chord_tip: 0.25,
+      positive_deflection_deg: 20, negative_deflection_deg: -15,
+      hinge_type: "plain", servo_placement: "wing", servo_index: 0,
+    };
+    const a = [wing("main", [segment({ trailing_edge_device: baseTed })])];
+    const b = [wing("main", [segment({ trailing_edge_device: { ...baseTed, rel_chord_root: 0.35, rel_chord_tip: 0.35 } })])];
+    const diff = computeGeometryDiff(a, b);
+    const tedFlag = diff.wings[0].sections[0].flags.find((f) => f.key === "control_surface");
+    expect(tedFlag!.fields).toBeDefined();
+    const rootField = tedFlag!.fields!.find((f) => f.key === "control surface rel_chord_root");
+    expect(rootField).toBeDefined();
+    expect(rootField!.a).toBe("0.25");
+    expect(rootField!.b).toBe("0.35");
+  });
+
+  it("showAll emits all TED fields even when unchanged (one-sided unchanged TED)", () => {
+    const ted = {
+      name: "aileron", role: "aileron", rel_chord_root: 0.25, rel_chord_tip: 0.25,
+      positive_deflection_deg: 20, negative_deflection_deg: -15,
+      hinge_type: "plain", servo_placement: "wing", servo_index: 0,
+    };
+    // make a non-TED change so section is matched and shown
+    const a = [wing("main", [segment({ trailing_edge_device: ted, root_airfoil: { airfoil: "naca2412", chord: 200, incidence: 1 } })])];
+    const b = [wing("main", [segment({ trailing_edge_device: ted, root_airfoil: { airfoil: "naca2412", chord: 200, incidence: 2 } })])];
+    const diff = computeGeometryDiff(a, b, { showAll: true });
+    const tedFlag = diff.wings[0].sections[0].flags.find((f) => f.key === "control_surface");
+    expect(tedFlag!.fields).toBeDefined();
+    const fieldKeys = tedFlag!.fields!.map((f) => f.key);
+    expect(fieldKeys).toContain("control surface name");
+    expect(fieldKeys).toContain("control surface hinge_type");
+    expect(fieldKeys).toContain("control surface positive_deflection_deg");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GH #972 — field-level sub-element diff: turbulator fields
+// ---------------------------------------------------------------------------
+
+describe("computeGeometryDiff — gh-972 turbulator field-level diff", () => {
+  it("emits changed turbulator fields (form, height_mm, position_root)", () => {
+    const a = [wing("main", [segment({ turbulator: {
+      form: "wire", height_mm: 1.0, position_root: 0.2, position_tip: 0.2, enabled: true,
+    } })])];
+    const b = [wing("main", [segment({ turbulator: {
+      form: "tape", height_mm: 1.5, position_root: 0.3, position_tip: 0.2, enabled: true,
+    } })])];
+    const diff = computeGeometryDiff(a, b);
+    const turbFlag = diff.wings[0].sections[0].flags.find((f) => f.key === "turbulator");
+    expect(turbFlag).toBeDefined();
+    expect(turbFlag!.fields).toBeDefined();
+    const formField = turbFlag!.fields!.find((f) => f.key === "turbulator form");
+    expect(formField).toBeDefined();
+    expect(formField!.a).toBe("wire");
+    expect(formField!.b).toBe("tape");
+    const heightField = turbFlag!.fields!.find((f) => f.key === "turbulator height_mm");
+    expect(heightField).toBeDefined();
+    expect(heightField!.a).toBe("1");
+    expect(heightField!.b).toBe("1.5");
+    const rootPosField = turbFlag!.fields!.find((f) => f.key === "turbulator position_root");
+    expect(rootPosField).toBeDefined();
+    expect(rootPosField!.a).toBe("0.2");
+    expect(rootPosField!.b).toBe("0.3");
+  });
+
+  it("emits changed turbulator enabled field (true → false)", () => {
+    const a = [wing("main", [segment({ turbulator: { form: "wire", height_mm: 1.0, position_root: 0.2, position_tip: 0.2, enabled: true } })])];
+    const b = [wing("main", [segment({ turbulator: { form: "wire", height_mm: 1.0, position_root: 0.2, position_tip: 0.2, enabled: false } })])];
+    const diff = computeGeometryDiff(a, b);
+    const turbFlag = diff.wings[0].sections[0].flags.find((f) => f.key === "turbulator");
+    expect(turbFlag!.fields).toBeDefined();
+    const enabledField = turbFlag!.fields!.find((f) => f.key === "turbulator enabled");
+    expect(enabledField).toBeDefined();
+    expect(enabledField!.a).toBe("true");
+    expect(enabledField!.b).toBe("false");
+  });
+
+  it("showAll emits all turbulator fields even when unchanged", () => {
+    const turb = { form: "wire", height_mm: 1.0, position_root: 0.2, position_tip: 0.2, enabled: true };
+    const a = [wing("main", [segment({ turbulator: turb, root_airfoil: { airfoil: "naca2412", chord: 200, incidence: 1 } })])];
+    const b = [wing("main", [segment({ turbulator: turb, root_airfoil: { airfoil: "naca2412", chord: 200, incidence: 2 } })])];
+    const diff = computeGeometryDiff(a, b, { showAll: true });
+    const turbFlag = diff.wings[0].sections[0].flags.find((f) => f.key === "turbulator");
+    expect(turbFlag!.fields).toBeDefined();
+    const fieldKeys = turbFlag!.fields!.map((f) => f.key);
+    expect(fieldKeys).toContain("turbulator form");
+    expect(fieldKeys).toContain("turbulator height_mm");
+    expect(fieldKeys).toContain("turbulator position_root");
+    expect(fieldKeys).toContain("turbulator position_tip");
+    expect(fieldKeys).toContain("turbulator enabled");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GH #972 — guard: missing/null sub-elements must not throw
+// ---------------------------------------------------------------------------
+
+describe("computeGeometryDiff — gh-972 null/missing sub-element guards", () => {
+  it("does not throw when spare_list items have no fields (empty objects)", () => {
+    const a = [wing("main", [segment({ spare_list: [{}] })])];
+    const b = [wing("main", [segment({ spare_list: [{}] })])];
+    expect(() => computeGeometryDiff(a, b, { showAll: true })).not.toThrow();
+  });
+
+  it("does not throw when trailing_edge_device is null on both sides", () => {
+    const a = [wing("main", [segment({ trailing_edge_device: null })])];
+    const b = [wing("main", [segment({ trailing_edge_device: null })])];
+    expect(() => computeGeometryDiff(a, b, { showAll: true })).not.toThrow();
+  });
+
+  it("does not throw when turbulator is null on both sides", () => {
+    const a = [wing("main", [segment({ turbulator: null })])];
+    const b = [wing("main", [segment({ turbulator: null })])];
+    expect(() => computeGeometryDiff(a, b, { showAll: true })).not.toThrow();
+  });
+
+  it("does not throw when spare_list is missing entirely", () => {
+    const aSegNoList = { ...segment() };
+    delete (aSegNoList as Partial<WingConfigSegment>).spare_list;
+    const a = [wing("main", [aSegNoList as WingConfigSegment])];
+    const b = [wing("main", [segment()])];
+    expect(() => computeGeometryDiff(a, b)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GH #973 — geometryDiffHints
+// ---------------------------------------------------------------------------
+
+/** Minimal diff builder for hint tests */
+function makeSection(index: number, params: Array<{ key: string; a: string | null; b: string | null }>, kind: "changed" | "added" | "removed" = "changed") {
+  return { index, kind, label: `Section ${index + 1}`, params, flags: [] };
+}
+
+function makeDiff(wings: GeometryDiff["wings"]): GeometryDiff {
+  const changed = wings.flatMap((w) => w.sections).filter((s) => s.kind === "changed").length;
+  const added = wings.flatMap((w) => w.sections).filter((s) => s.kind === "added").length;
+  const removed = wings.flatMap((w) => w.sections).filter((s) => s.kind === "removed").length;
+  return {
+    wings,
+    counts: { sectionsChanged: changed, sectionsAdded: added, sectionsRemoved: removed },
+    hasAnyChange: changed > 0 || added > 0 || removed > 0,
+  };
+}
+
+describe("geometryDiffHints — gh-973", () => {
+  it("returns empty array for no changes", () => {
+    const diff = makeDiff([]);
+    expect(geometryDiffHints(diff)).toEqual([]);
+  });
+
+  it("detects tip chord decrease while root chord roughly unchanged → taper hint", () => {
+    const diff = makeDiff([{
+      name: "main",
+      kind: "changed",
+      sections: [makeSection(0, [
+        { key: "root chord", a: "200 mm", b: "200 mm" },
+        { key: "tip chord", a: "150 mm", b: "100 mm" },
+      ])],
+    }]);
+    const hints = geometryDiffHints(diff);
+    expect(hints.some((h) => /taper/i.test(h))).toBe(true);
+    expect(hints.some((h) => /tip chord/i.test(h))).toBe(true);
+  });
+
+  it("does NOT emit taper hint when root chord also decreased significantly", () => {
+    const diff = makeDiff([{
+      name: "main",
+      kind: "changed",
+      sections: [makeSection(0, [
+        { key: "root chord", a: "200 mm", b: "160 mm" },
+        { key: "tip chord", a: "150 mm", b: "100 mm" },
+      ])],
+    }]);
+    const hints = geometryDiffHints(diff);
+    expect(hints.some((h) => /taper/i.test(h))).toBe(false);
+  });
+
+  it("detects tip incidence more negative than root → washout hint", () => {
+    const diff = makeDiff([{
+      name: "main",
+      kind: "changed",
+      sections: [makeSection(0, [
+        { key: "root incidence", a: "2 deg", b: "2 deg" },
+        { key: "tip incidence", a: "1 deg", b: "-1 deg" },
+      ])],
+    }]);
+    const hints = geometryDiffHints(diff);
+    expect(hints.some((h) => /washout/i.test(h))).toBe(true);
+  });
+
+  it("does NOT emit washout hint when tip incidence increased", () => {
+    const diff = makeDiff([{
+      name: "main",
+      kind: "changed",
+      sections: [makeSection(0, [
+        { key: "tip incidence", a: "0 deg", b: "2 deg" },
+      ])],
+    }]);
+    const hints = geometryDiffHints(diff);
+    expect(hints.some((h) => /washout/i.test(h))).toBe(false);
+  });
+
+  it("detects last section added → span hint", () => {
+    const diff = makeDiff([{
+      name: "main",
+      kind: "changed",
+      sections: [
+        makeSection(0, [], "changed"),
+        makeSection(1, [], "added"),
+      ],
+    }]);
+    const hints = geometryDiffHints(diff);
+    expect(hints.some((h) => /span/i.test(h) || /tip section/i.test(h))).toBe(true);
+  });
+
+  it("does NOT emit span hint when an added section is NOT the last one", () => {
+    const diff = makeDiff([{
+      name: "main",
+      kind: "changed",
+      sections: [
+        makeSection(0, [], "added"),
+        makeSection(1, [], "changed"),
+      ],
+    }]);
+    const hints = geometryDiffHints(diff);
+    expect(hints.some((h) => /longer span/i.test(h))).toBe(false);
+  });
+
+  it("detects dihedral increase → dihedral hint", () => {
+    const diff = makeDiff([{
+      name: "main",
+      kind: "changed",
+      sections: [makeSection(0, [
+        { key: "root dihedral", a: "3 deg", b: "6 deg" },
+      ])],
+    }]);
+    const hints = geometryDiffHints(diff);
+    expect(hints.some((h) => /dihedral/i.test(h))).toBe(true);
+  });
+
+  it("does NOT emit dihedral hint when dihedral decreased", () => {
+    const diff = makeDiff([{
+      name: "main",
+      kind: "changed",
+      sections: [makeSection(0, [
+        { key: "root dihedral", a: "6 deg", b: "3 deg" },
+      ])],
+    }]);
+    const hints = geometryDiffHints(diff);
+    expect(hints.some((h) => /dihedral/i.test(h))).toBe(false);
+  });
+
+  it("detects airfoil change → polar hint", () => {
+    const diff = makeDiff([{
+      name: "main",
+      kind: "changed",
+      sections: [makeSection(0, [
+        { key: "root airfoil", a: "naca2412", b: "clark-y" },
+      ])],
+    }]);
+    const hints = geometryDiffHints(diff);
+    expect(hints.some((h) => /airfoil/i.test(h) && /polar/i.test(h))).toBe(true);
+  });
+
+  it("returns at most 5 hints", () => {
+    // Trigger all 5 rules simultaneously
+    const diff = makeDiff([{
+      name: "main",
+      kind: "changed",
+      sections: [
+        makeSection(0, [
+          { key: "root chord", a: "200 mm", b: "200 mm" },
+          { key: "tip chord", a: "150 mm", b: "100 mm" },
+          { key: "root incidence", a: "2 deg", b: "2 deg" },
+          { key: "tip incidence", a: "1 deg", b: "-1 deg" },
+          { key: "root dihedral", a: "3 deg", b: "7 deg" },
+          { key: "root airfoil", a: "naca2412", b: "clark-y" },
+        ]),
+        makeSection(1, [], "added"),
+      ],
+    }]);
+    const hints = geometryDiffHints(diff);
+    expect(hints.length).toBeLessThanOrEqual(5);
+  });
+
+  it("returns empty array for a diff with no change params", () => {
+    const diff = makeDiff([{
+      name: "main",
+      kind: "changed",
+      sections: [makeSection(0, [], "changed")],
+    }]);
+    expect(geometryDiffHints(diff)).toEqual([]);
   });
 });

--- a/frontend/__tests__/geometryDiff.test.ts
+++ b/frontend/__tests__/geometryDiff.test.ts
@@ -1,9 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   computeGeometryDiff,
-  geometryDiffHints,
   type DiffWingInput,
-  type GeometryDiff,
 } from "@/lib/geometryDiff";
 import type { WingConfigSegment } from "@/hooks/useWingConfig";
 
@@ -393,7 +391,7 @@ describe("computeGeometryDiff — sub-element flags", () => {
     const diff = computeGeometryDiff(a, b);
     const ted = diff.wings[0].sections[0].flags.find((f) => f.key === "control_surface");
     expect(ted).toBeDefined();
-    expect(ted!.kind).toBe("changed");
+    expect(ted!.kind).toBe("removed");
     expect(ted!.a).toBe("aileron");
     expect(ted!.b).toBe("—");
   });
@@ -404,7 +402,7 @@ describe("computeGeometryDiff — sub-element flags", () => {
     const diff = computeGeometryDiff(a, b);
     const turb = diff.wings[0].sections[0].flags.find((f) => f.key === "turbulator");
     expect(turb).toBeDefined();
-    expect(turb!.kind).toBe("changed");
+    expect(turb!.kind).toBe("added");
     expect(turb!.a).toBe("—");
     expect(turb!.b).toBe("on");
   });
@@ -541,16 +539,21 @@ describe("computeGeometryDiff — changes-only vs show-all", () => {
 
 // ---------------------------------------------------------------------------
 // GH #972 — field-level sub-element diff: spar fields
+// Spar dimensional values (width/height/start/length) are in METRES (API converts
+// mm → m). The diff multiplies by 1000 before formatting and tolerance comparison.
 // ---------------------------------------------------------------------------
 
-/** A typed spar object matching the expected spare_list item shape */
+/**
+ * A typed spar object matching the expected spare_list item shape.
+ * Dimensional fields are in METRES (as returned by the wingconfig API).
+ */
 function spar(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
     spare_position_factor: 0.25,
-    spare_support_dimension_width: 10,
-    spare_support_dimension_height: 15,
-    spare_start: 50,
-    spare_length: 400,
+    spare_support_dimension_width: 0.010,   // 10 mm in metres
+    spare_support_dimension_height: 0.015,  // 15 mm in metres
+    spare_start: 0.050,                     // 50 mm in metres
+    spare_length: 0.400,                    // 400 mm in metres
     spare_mode: "C",
     ...overrides,
   };
@@ -570,9 +573,10 @@ describe("computeGeometryDiff — gh-972 spar field-level diff", () => {
     expect(posField!.b).toBe("0.4");
   });
 
-  it("emits changed width/height dimension fields for a spar", () => {
-    const a = [wing("main", [segment({ spare_list: [spar({ spare_support_dimension_width: 10, spare_support_dimension_height: 15 })] })])];
-    const b = [wing("main", [segment({ spare_list: [spar({ spare_support_dimension_width: 12, spare_support_dimension_height: 20 })] })])];
+  it("emits changed width/height dimension fields for a spar (metres → mm conversion)", () => {
+    // API returns metres; diff should display in mm
+    const a = [wing("main", [segment({ spare_list: [spar({ spare_support_dimension_width: 0.010, spare_support_dimension_height: 0.015 })] })])];
+    const b = [wing("main", [segment({ spare_list: [spar({ spare_support_dimension_width: 0.012, spare_support_dimension_height: 0.020 })] })])];
     const diff = computeGeometryDiff(a, b);
     const sparFlag = diff.wings[0].sections[0].flags.find((f) => f.key === "spar");
     expect(sparFlag!.fields).toBeDefined();
@@ -586,9 +590,9 @@ describe("computeGeometryDiff — gh-972 spar field-level diff", () => {
     expect(hField!.b).toBe("20 mm");
   });
 
-  it("emits changed start/length fields for a spar", () => {
-    const a = [wing("main", [segment({ spare_list: [spar({ spare_start: 50, spare_length: 400 })] })])];
-    const b = [wing("main", [segment({ spare_list: [spar({ spare_start: 60, spare_length: 350 })] })])];
+  it("emits changed start/length fields for a spar (metres → mm conversion)", () => {
+    const a = [wing("main", [segment({ spare_list: [spar({ spare_start: 0.050, spare_length: 0.400 })] })])];
+    const b = [wing("main", [segment({ spare_list: [spar({ spare_start: 0.060, spare_length: 0.350 })] })])];
     const diff = computeGeometryDiff(a, b);
     const sparFlag = diff.wings[0].sections[0].flags.find((f) => f.key === "spar");
     expect(sparFlag!.fields).toBeDefined();
@@ -600,6 +604,21 @@ describe("computeGeometryDiff — gh-972 spar field-level diff", () => {
     expect(lenField).toBeDefined();
     expect(lenField!.a).toBe("400 mm");
     expect(lenField!.b).toBe("350 mm");
+  });
+
+  it("detects a width change that would be missed without metres→mm conversion", () => {
+    // 0.00442 m and 0.00500 m differ by 0.00058 m — below the raw 0.05 tolerance,
+    // but in mm they are 4.42 mm vs 5.00 mm → Δ=0.58 mm > tolerance → should be reported.
+    const a = [wing("main", [segment({ spare_list: [spar({ spare_support_dimension_width: 0.00442 })] })])];
+    const b = [wing("main", [segment({ spare_list: [spar({ spare_support_dimension_width: 0.00500 })] })])];
+    const diff = computeGeometryDiff(a, b);
+    const sparFlag = diff.wings[0].sections[0].flags.find((f) => f.key === "spar");
+    expect(sparFlag).toBeDefined();
+    expect(sparFlag!.fields).toBeDefined();
+    const wField = sparFlag!.fields!.find((f) => f.key === "spar 1 width");
+    expect(wField).toBeDefined();
+    expect(wField!.a).toBe("4.42 mm");
+    expect(wField!.b).toBe("5 mm");
   });
 
   it("emits 'added' kind for a spar that exists only in B (count 0→1)", () => {
@@ -618,6 +637,19 @@ describe("computeGeometryDiff — gh-972 spar field-level diff", () => {
     const sparFlag = diff.wings[0].sections[0].flags.find((f) => f.key === "spar");
     expect(sparFlag).toBeDefined();
     expect(sparFlag!.kind).toBe("removed");
+  });
+
+  it("count differs (1→2): shows count change, NO field sub-rows", () => {
+    // A has 1 spar, B has 2 — positional pairing is unsafe, so no field rows
+    const a = [wing("main", [segment({ spare_list: [spar({ spare_support_dimension_width: 0.010 })] })])];
+    const b = [wing("main", [segment({ spare_list: [spar({ spare_support_dimension_width: 0.010 }), spar({ spare_support_dimension_width: 0.012 })] })])];
+    const diff = computeGeometryDiff(a, b);
+    const sparFlag = diff.wings[0].sections[0].flags.find((f) => f.key === "spar");
+    expect(sparFlag).toBeDefined();
+    expect(sparFlag!.a).toBe("1 spar");
+    expect(sparFlag!.b).toBe("2 spars");
+    // No field sub-rows when count differs
+    expect(sparFlag!.fields == null || sparFlag!.fields.length === 0).toBe(true);
   });
 
   it("showAll emits all spar fields even when unchanged", () => {
@@ -649,6 +681,32 @@ describe("computeGeometryDiff — gh-972 spar field-level diff", () => {
     // width/height/start/length/mode are unchanged → NOT emitted in changes-only
     expect(fieldKeys).not.toContain("spar 1 width");
     expect(fieldKeys).not.toContain("spar 1 height");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GH #972 — spare_position_factor tight tolerance (0.005, not 0.05)
+// ---------------------------------------------------------------------------
+
+describe("computeGeometryDiff — spare_position_factor tight tolerance", () => {
+  it("detects a 0.006 change in position_factor (above 0.005 tight tolerance)", () => {
+    const a = [wing("main", [segment({ spare_list: [spar({ spare_position_factor: 0.300 })] })])];
+    const b = [wing("main", [segment({ spare_list: [spar({ spare_position_factor: 0.306 })] })])];
+    const diff = computeGeometryDiff(a, b);
+    const sparFlag = diff.wings[0].sections[0].flags.find((f) => f.key === "spar");
+    expect(sparFlag!.fields).toBeDefined();
+    const posField = sparFlag!.fields!.find((f) => f.key === "spar 1 position");
+    expect(posField).toBeDefined();
+  });
+
+  it("treats a 0.004 change in position_factor as noise (below 0.005 tight tolerance)", () => {
+    // Only difference is position_factor changes by 0.004 — should be noise, no change
+    const a = [wing("main", [segment({ spare_list: [spar({ spare_position_factor: 0.300 })] })])];
+    const b = [wing("main", [segment({ spare_list: [spar({ spare_position_factor: 0.304 })] })])];
+    const diff = computeGeometryDiff(a, b);
+    // No other changes → no section change detected → wings is empty in changes-only mode
+    expect(diff.hasAnyChange).toBe(false);
+    expect(diff.wings).toHaveLength(0);
   });
 });
 
@@ -736,6 +794,34 @@ describe("computeGeometryDiff — gh-972 TED field-level diff", () => {
     expect(fieldKeys).toContain("control surface hinge_type");
     expect(fieldKeys).toContain("control surface positive_deflection_deg");
   });
+
+  it("kind='added' when TED is only on side B", () => {
+    const a = [wing("main", [segment({ trailing_edge_device: null })])];
+    const b = [wing("main", [segment({ trailing_edge_device: { name: "aileron" } })])];
+    const diff = computeGeometryDiff(a, b);
+    const tedFlag = diff.wings[0].sections[0].flags.find((f) => f.key === "control_surface");
+    expect(tedFlag).toBeDefined();
+    expect(tedFlag!.kind).toBe("added");
+  });
+
+  it("kind='removed' when TED is only on side A", () => {
+    const a = [wing("main", [segment({ trailing_edge_device: { name: "aileron" } })])];
+    const b = [wing("main", [segment({ trailing_edge_device: null })])];
+    const diff = computeGeometryDiff(a, b);
+    const tedFlag = diff.wings[0].sections[0].flags.find((f) => f.key === "control_surface");
+    expect(tedFlag).toBeDefined();
+    expect(tedFlag!.kind).toBe("removed");
+  });
+
+  it("kind='changed' when TED is present on both sides", () => {
+    const baseTed = { name: "aileron", hinge_type: "plain" };
+    const a = [wing("main", [segment({ trailing_edge_device: baseTed })])];
+    const b = [wing("main", [segment({ trailing_edge_device: { ...baseTed, hinge_type: "slotted" } })])];
+    const diff = computeGeometryDiff(a, b);
+    const tedFlag = diff.wings[0].sections[0].flags.find((f) => f.key === "control_surface");
+    expect(tedFlag).toBeDefined();
+    expect(tedFlag!.kind).toBe("changed");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -794,6 +880,33 @@ describe("computeGeometryDiff — gh-972 turbulator field-level diff", () => {
     expect(fieldKeys).toContain("turbulator position_tip");
     expect(fieldKeys).toContain("turbulator enabled");
   });
+
+  it("kind='added' when turbulator is only on side B", () => {
+    const a = [wing("main", [segment({ turbulator: null })])];
+    const b = [wing("main", [segment({ turbulator: { form: "wire" } })])];
+    const diff = computeGeometryDiff(a, b);
+    const turbFlag = diff.wings[0].sections[0].flags.find((f) => f.key === "turbulator");
+    expect(turbFlag).toBeDefined();
+    expect(turbFlag!.kind).toBe("added");
+  });
+
+  it("kind='removed' when turbulator is only on side A", () => {
+    const a = [wing("main", [segment({ turbulator: { form: "wire" } })])];
+    const b = [wing("main", [segment({ turbulator: null })])];
+    const diff = computeGeometryDiff(a, b);
+    const turbFlag = diff.wings[0].sections[0].flags.find((f) => f.key === "turbulator");
+    expect(turbFlag).toBeDefined();
+    expect(turbFlag!.kind).toBe("removed");
+  });
+
+  it("kind='changed' when turbulator is present on both sides", () => {
+    const a = [wing("main", [segment({ turbulator: { form: "wire" } })])];
+    const b = [wing("main", [segment({ turbulator: { form: "tape" } })])];
+    const diff = computeGeometryDiff(a, b);
+    const turbFlag = diff.wings[0].sections[0].flags.find((f) => f.key === "turbulator");
+    expect(turbFlag).toBeDefined();
+    expect(turbFlag!.kind).toBe("changed");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -829,172 +942,134 @@ describe("computeGeometryDiff — gh-972 null/missing sub-element guards", () =>
 });
 
 // ---------------------------------------------------------------------------
-// GH #973 — geometryDiffHints
+// GH #973 — hints embedded in GeometryDiff (computed from raw values per section)
 // ---------------------------------------------------------------------------
 
-/** Minimal diff builder for hint tests */
-function makeSection(index: number, params: Array<{ key: string; a: string | null; b: string | null }>, kind: "changed" | "added" | "removed" = "changed") {
-  return { index, kind, label: `Section ${index + 1}`, params, flags: [] };
-}
-
-function makeDiff(wings: GeometryDiff["wings"]): GeometryDiff {
-  const changed = wings.flatMap((w) => w.sections).filter((s) => s.kind === "changed").length;
-  const added = wings.flatMap((w) => w.sections).filter((s) => s.kind === "added").length;
-  const removed = wings.flatMap((w) => w.sections).filter((s) => s.kind === "removed").length;
-  return {
-    wings,
-    counts: { sectionsChanged: changed, sectionsAdded: added, sectionsRemoved: removed },
-    hasAnyChange: changed > 0 || added > 0 || removed > 0,
-  };
-}
-
-describe("geometryDiffHints — gh-973", () => {
-  it("returns empty array for no changes", () => {
-    const diff = makeDiff([]);
-    expect(geometryDiffHints(diff)).toEqual([]);
+describe("computeGeometryDiff — gh-973 hints (raw per-section, no string parsing)", () => {
+  it("diff.hints is an array (always present)", () => {
+    const a = [wing("main", [segment()])];
+    const b = [wing("main", [segment()])];
+    const diff = computeGeometryDiff(a, b);
+    expect(Array.isArray(diff.hints)).toBe(true);
   });
 
-  it("detects tip chord decrease while root chord roughly unchanged → taper hint", () => {
-    const diff = makeDiff([{
-      name: "main",
-      kind: "changed",
-      sections: [makeSection(0, [
-        { key: "root chord", a: "200 mm", b: "200 mm" },
-        { key: "tip chord", a: "150 mm", b: "100 mm" },
-      ])],
-    }]);
-    const hints = geometryDiffHints(diff);
-    expect(hints.some((h) => /taper/i.test(h))).toBe(true);
-    expect(hints.some((h) => /tip chord/i.test(h))).toBe(true);
+  it("returns empty hints array when there are no changes", () => {
+    const a = [wing("main", [segment()])];
+    const b = [wing("main", [segment()])];
+    const diff = computeGeometryDiff(a, b);
+    expect(diff.hints).toEqual([]);
+  });
+
+  it("taper hint: tip chord decreased, root chord ~unchanged", () => {
+    // tip chord not in LCS signature, so sections match and we can diff
+    const a = [wing("main", [segment({ tip_airfoil: { airfoil: "naca2412", chord: 150 } })])];
+    const b = [wing("main", [segment({ tip_airfoil: { airfoil: "naca2412", chord: 100 } })])];
+    const diff = computeGeometryDiff(a, b);
+    expect(diff.hints.some((h) => /taper/i.test(h))).toBe(true);
+  });
+
+  it("taper hint works in changes-only mode (uses raw values, not params list)", () => {
+    // The tip chord change IS emitted in changes-only, but the hint must come from
+    // raw values inside computeGeometryDiff, not from searching diff.wings[].sections[].params
+    const a = [wing("main", [segment({ tip_airfoil: { airfoil: "naca2412", chord: 150 } })])];
+    const b = [wing("main", [segment({ tip_airfoil: { airfoil: "naca2412", chord: 100 } })])];
+    const diff = computeGeometryDiff(a, b, { showAll: false });
+    expect(diff.hints.some((h) => /taper/i.test(h))).toBe(true);
   });
 
   it("does NOT emit taper hint when root chord also decreased significantly", () => {
-    const diff = makeDiff([{
-      name: "main",
-      kind: "changed",
-      sections: [makeSection(0, [
-        { key: "root chord", a: "200 mm", b: "160 mm" },
-        { key: "tip chord", a: "150 mm", b: "100 mm" },
-      ])],
-    }]);
-    const hints = geometryDiffHints(diff);
-    expect(hints.some((h) => /taper/i.test(h))).toBe(false);
+    // root chord is in LCS signature; change it → sections appear as add+remove, not matched.
+    // Use incidence change on root to force the match, then also change root chord via showAll test.
+    // Simplest: use showAll so the section is present; but raw values show root also dropped.
+    // We use the same-sig trick: keep chord/length/airfoil the same in sig, only change
+    // incidence and also supply a separate root_chord via showAll mode is not needed here.
+    // Actually, use tip chord changes while keeping root chord sig stable, but ALSO change
+    // root chord to simulate both dropping. Since root chord IS in signature, we must use
+    // a segment that has the same sig but a different root chord... which is impossible by design.
+    // INSTEAD: use a multi-section wing where one section's tip decreases but root also decreases.
+    // We use the `accumulateSectionHints` path directly by changing tip chord while ALSO having
+    // root chord change (we override root_airfoil chord — that will change the sig, so sections
+    // appear as added+removed, not matched → no hint accumulated from matchedPairs).
+    // The simplest test: a segment where tip_chord goes down by 50mm but root_chord also goes
+    // down by 50mm (same proportion → NOT more taper). Since root chord is in sig, changing it
+    // means sections DON'T match in LCS → they appear as added+removed → no taper hint.
+    const a = [wing("main", [segment({ root_airfoil: { airfoil: "naca2412", chord: 200 }, tip_airfoil: { airfoil: "naca2412", chord: 150 } })])];
+    const b = [wing("main", [segment({ root_airfoil: { airfoil: "naca2412", chord: 160 }, tip_airfoil: { airfoil: "naca2412", chord: 110 } })])];
+    const diff = computeGeometryDiff(a, b);
+    // Sections don't match by sig (root chord changed) → added+removed, not taper
+    expect(diff.hints.some((h) => /taper/i.test(h))).toBe(false);
   });
 
-  it("detects tip incidence more negative than root → washout hint", () => {
-    const diff = makeDiff([{
-      name: "main",
-      kind: "changed",
-      sections: [makeSection(0, [
-        { key: "root incidence", a: "2 deg", b: "2 deg" },
-        { key: "tip incidence", a: "1 deg", b: "-1 deg" },
-      ])],
-    }]);
-    const hints = geometryDiffHints(diff);
-    expect(hints.some((h) => /washout/i.test(h))).toBe(true);
+  it("washout hint: ONLY the outermost section's tip incidence decreased", () => {
+    // 2-section wing; only the last (outermost) section's tip incidence decreases
+    const s1a = segment({ root_airfoil: { airfoil: "naca2412", chord: 200, incidence: 1 }, length: 500, tip_airfoil: { airfoil: "naca2412", chord: 150, incidence: 1 } });
+    const s1b = segment({ root_airfoil: { airfoil: "naca2412", chord: 200, incidence: 1 }, length: 500, tip_airfoil: { airfoil: "naca2412", chord: 150, incidence: 1 } });
+    const s2a = segment({ root_airfoil: { airfoil: "naca2412", chord: 160 }, length: 400, tip_airfoil: { airfoil: "naca2412", chord: 120, incidence: 2 } });
+    const s2b = segment({ root_airfoil: { airfoil: "naca2412", chord: 160 }, length: 400, tip_airfoil: { airfoil: "naca2412", chord: 120, incidence: -1 } });
+    const a = [wing("main", [s1a, s2a])];
+    const b = [wing("main", [s1b, s2b])];
+    const diff = computeGeometryDiff(a, b);
+    expect(diff.hints.some((h) => /washout/i.test(h))).toBe(true);
   });
 
-  it("does NOT emit washout hint when tip incidence increased", () => {
-    const diff = makeDiff([{
-      name: "main",
-      kind: "changed",
-      sections: [makeSection(0, [
-        { key: "tip incidence", a: "0 deg", b: "2 deg" },
-      ])],
-    }]);
-    const hints = geometryDiffHints(diff);
-    expect(hints.some((h) => /washout/i.test(h))).toBe(false);
+  it("does NOT emit washout hint when only a non-tip section's incidence decreases", () => {
+    // 2-section wing; first (non-tip) section tip incidence decreases, last unchanged
+    const s1a = segment({ root_airfoil: { airfoil: "naca2412", chord: 200, incidence: 1 }, length: 500, tip_airfoil: { airfoil: "naca2412", chord: 150, incidence: 2 } });
+    const s1b = segment({ root_airfoil: { airfoil: "naca2412", chord: 200, incidence: 1 }, length: 500, tip_airfoil: { airfoil: "naca2412", chord: 150, incidence: -1 } });
+    const s2 = segment({ root_airfoil: { airfoil: "naca2412", chord: 160 }, length: 400 }); // unchanged
+    const a = [wing("main", [s1a, s2])];
+    const b = [wing("main", [s1b, s2])];
+    const diff = computeGeometryDiff(a, b);
+    // Washout only from the outermost section (s2 here), which is unchanged
+    expect(diff.hints.some((h) => /washout/i.test(h))).toBe(false);
   });
 
-  it("detects last section added → span hint", () => {
-    const diff = makeDiff([{
-      name: "main",
-      kind: "changed",
-      sections: [
-        makeSection(0, [], "changed"),
-        makeSection(1, [], "added"),
-      ],
-    }]);
-    const hints = geometryDiffHints(diff);
-    expect(hints.some((h) => /span/i.test(h) || /tip section/i.test(h))).toBe(true);
+  it("span hint: last section added at the tip", () => {
+    const s1 = segment({ root_airfoil: { airfoil: "naca2412", chord: 200 }, length: 500 });
+    const sNew = segment({ root_airfoil: { airfoil: "naca2412", chord: 160 }, length: 400 });
+    const a = [wing("main", [s1])];
+    const b = [wing("main", [s1, sNew])];
+    const diff = computeGeometryDiff(a, b);
+    expect(diff.hints.some((h) => /span/i.test(h) || /tip section/i.test(h))).toBe(true);
   });
 
-  it("does NOT emit span hint when an added section is NOT the last one", () => {
-    const diff = makeDiff([{
-      name: "main",
-      kind: "changed",
-      sections: [
-        makeSection(0, [], "added"),
-        makeSection(1, [], "changed"),
-      ],
-    }]);
-    const hints = geometryDiffHints(diff);
-    expect(hints.some((h) => /longer span/i.test(h))).toBe(false);
+  it("dihedral hint: a section's dihedral increased", () => {
+    // root dihedral NOT in LCS signature, so sections match
+    const a = [wing("main", [segment({ root_airfoil: { airfoil: "naca2412", chord: 200, dihedral_as_rotation_in_degrees: 3 } })])];
+    const b = [wing("main", [segment({ root_airfoil: { airfoil: "naca2412", chord: 200, dihedral_as_rotation_in_degrees: 7 } })])];
+    const diff = computeGeometryDiff(a, b);
+    expect(diff.hints.some((h) => /dihedral/i.test(h))).toBe(true);
   });
 
-  it("detects dihedral increase → dihedral hint", () => {
-    const diff = makeDiff([{
-      name: "main",
-      kind: "changed",
-      sections: [makeSection(0, [
-        { key: "root dihedral", a: "3 deg", b: "6 deg" },
-      ])],
-    }]);
-    const hints = geometryDiffHints(diff);
-    expect(hints.some((h) => /dihedral/i.test(h))).toBe(true);
+  it("airfoil changed hint: tip airfoil change triggers re-run polar", () => {
+    // tip airfoil not in LCS signature, so sections match and hint fires
+    const a = [wing("main", [segment({ tip_airfoil: { airfoil: "naca2412", chord: 150 } })])];
+    const b = [wing("main", [segment({ tip_airfoil: { airfoil: "clark-y", chord: 150 } })])];
+    const diff = computeGeometryDiff(a, b);
+    expect(diff.hints.some((h) => /airfoil/i.test(h) && /polar/i.test(h))).toBe(true);
   });
 
-  it("does NOT emit dihedral hint when dihedral decreased", () => {
-    const diff = makeDiff([{
-      name: "main",
-      kind: "changed",
-      sections: [makeSection(0, [
-        { key: "root dihedral", a: "6 deg", b: "3 deg" },
-      ])],
-    }]);
-    const hints = geometryDiffHints(diff);
-    expect(hints.some((h) => /dihedral/i.test(h))).toBe(false);
+  it("no cross-entity hint: a root chord change on one section should NOT create a taper hint if tip chord on SAME section is unchanged", () => {
+    // Root chord changes (different LCS sig → add+remove, not change) — but tip unchanged.
+    // Taper hint must NOT fire because tip didn't decrease relative to root of SAME section.
+    const a = [wing("main", [segment({ root_airfoil: { airfoil: "naca2412", chord: 200 }, tip_airfoil: { airfoil: "naca2412", chord: 150 } })])];
+    const b = [wing("main", [segment({ root_airfoil: { airfoil: "naca2412", chord: 180 }, tip_airfoil: { airfoil: "naca2412", chord: 150 } })])];
+    // Root chord in sig → sections don't match → appears as add+remove, not matched
+    // accumulateSectionHints is only called for matched pairs → no taper
+    const diff = computeGeometryDiff(a, b);
+    expect(diff.hints.some((h) => /taper/i.test(h))).toBe(false);
   });
 
-  it("detects airfoil change → polar hint", () => {
-    const diff = makeDiff([{
-      name: "main",
-      kind: "changed",
-      sections: [makeSection(0, [
-        { key: "root airfoil", a: "naca2412", b: "clark-y" },
-      ])],
-    }]);
-    const hints = geometryDiffHints(diff);
-    expect(hints.some((h) => /airfoil/i.test(h) && /polar/i.test(h))).toBe(true);
-  });
-
-  it("returns at most 5 hints", () => {
-    // Trigger all 5 rules simultaneously
-    const diff = makeDiff([{
-      name: "main",
-      kind: "changed",
-      sections: [
-        makeSection(0, [
-          { key: "root chord", a: "200 mm", b: "200 mm" },
-          { key: "tip chord", a: "150 mm", b: "100 mm" },
-          { key: "root incidence", a: "2 deg", b: "2 deg" },
-          { key: "tip incidence", a: "1 deg", b: "-1 deg" },
-          { key: "root dihedral", a: "3 deg", b: "7 deg" },
-          { key: "root airfoil", a: "naca2412", b: "clark-y" },
-        ]),
-        makeSection(1, [], "added"),
-      ],
-    }]);
-    const hints = geometryDiffHints(diff);
-    expect(hints.length).toBeLessThanOrEqual(5);
-  });
-
-  it("returns empty array for a diff with no change params", () => {
-    const diff = makeDiff([{
-      name: "main",
-      kind: "changed",
-      sections: [makeSection(0, [], "changed")],
-    }]);
-    expect(geometryDiffHints(diff)).toEqual([]);
+  it("max 5 hints", () => {
+    // Create a scenario that would trigger multiple hints simultaneously
+    // tip chord decreases (taper), dihedral increases, airfoil changes, add a tip section (span)
+    // We need 2-section wing with both sections changing for washout+taper
+    const s1a = segment({ root_airfoil: { airfoil: "naca2412", chord: 200, dihedral_as_rotation_in_degrees: 3 }, length: 500, tip_airfoil: { airfoil: "naca2412", chord: 150, incidence: 0 } });
+    const s1b = segment({ root_airfoil: { airfoil: "clark-y", chord: 200, dihedral_as_rotation_in_degrees: 7 }, length: 500, tip_airfoil: { airfoil: "clark-y", chord: 100, incidence: -2 } });
+    const sNew = segment({ root_airfoil: { airfoil: "naca2412", chord: 160 }, length: 400 });
+    const a = [wing("main", [s1a])];
+    const b = [wing("main", [s1b, sNew])];
+    const diff = computeGeometryDiff(a, b);
+    expect(diff.hints.length).toBeLessThanOrEqual(5);
   });
 });

--- a/frontend/__tests__/useGeometryDiff.test.ts
+++ b/frontend/__tests__/useGeometryDiff.test.ts
@@ -192,4 +192,40 @@ describe("useGeometryDiff", () => {
     expect(wing).toBeDefined();
     expect(wing!.kind).toBe("removed");
   });
+
+  it("malformed payload (structurally bad 200): surfaces error via error channel, does not white-screen", async () => {
+    // Return a config where segment entries are null — coreParams(null) will throw
+    // inside computeGeometryDiff. The hook must catch it and surface it via `error`,
+    // leaving `diff` null (never crashing the render).
+    fetchMock.mockImplementation((path: string) => {
+      if (path === wingconfigPath(NODE_A, "main_wing")) {
+        return Promise.resolve(makeConfig(0));
+      }
+      if (path === wingconfigPath(NODE_B, "main_wing")) {
+        // Structurally broken: segment entry is null → sectionSignature(null) throws
+        return Promise.resolve({ segments: [null], nose_pnt: [0, 0, 0] } as unknown as WingConfig);
+      }
+      return Promise.reject(new Error(`unexpected path ${path}`));
+    });
+
+    const { result } = renderHook(
+      () => useGeometryDiff(NODE_A, NODE_B, ["main_wing"], true),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      // Either error is set (crash contained) or diff is non-null (no throw)
+      expect(
+        result.current.error !== null || result.current.diff !== null,
+      ).toBe(true);
+    });
+
+    // If computeGeometryDiff threw, it must surface via the error channel.
+    if (result.current.error !== null) {
+      expect(result.current.diff).toBeNull();
+      expect(result.current.error).toBeInstanceOf(Error);
+    }
+    // (If the garbage happened not to throw, that's also acceptable — the point is
+    // it must NOT crash the hook/render.)
+  });
 });

--- a/frontend/components/workbench/GeometryDiffSection.tsx
+++ b/frontend/components/workbench/GeometryDiffSection.tsx
@@ -21,7 +21,6 @@ import React, { useState } from "react";
 import { ChevronRight, ChevronDown, Loader2 } from "lucide-react";
 
 import { useGeometryDiff } from "@/hooks/useGeometryDiff";
-import { geometryDiffHints } from "@/lib/geometryDiff";
 import type {
   GeometryDiff,
   WingDiff,
@@ -120,7 +119,7 @@ function SubFieldRow({ paramKey, a, b }: { readonly paramKey: string; readonly a
   return (
     <div
       className={`grid grid-cols-[1fr_auto_1fr] items-center gap-2 rounded pl-6 pr-2 py-0.5 font-[family-name:var(--font-geist-mono)] text-[10px] ${
-        differs ? "bg-amber-500/8" : ""
+        differs ? "bg-amber-500/10" : ""
       }`}
       data-testid={`geometry-diff-subrow-${paramKey}`}
       data-differs={differs ? "true" : undefined}
@@ -195,10 +194,12 @@ function WingBlock({ wing }: { readonly wing: WingDiff }) {
 
 /** Conservative geometry hints block (gh-973). */
 function HintsBlock({ diff }: { readonly diff: GeometryDiff }) {
-  const hints = geometryDiffHints(diff);
+  const hints = diff.hints;
   if (hints.length === 0) return null;
   return (
     <div
+      role="note"
+      aria-label="Geometry observations"
       data-testid="geometry-diff-hints"
       className="mt-3 rounded border border-border/50 bg-sidebar-accent/30 px-3 py-2 text-[10px] text-muted-foreground"
     >

--- a/frontend/components/workbench/GeometryDiffSection.tsx
+++ b/frontend/components/workbench/GeometryDiffSection.tsx
@@ -21,11 +21,13 @@ import React, { useState } from "react";
 import { ChevronRight, ChevronDown, Loader2 } from "lucide-react";
 
 import { useGeometryDiff } from "@/hooks/useGeometryDiff";
+import { geometryDiffHints } from "@/lib/geometryDiff";
 import type {
   GeometryDiff,
   WingDiff,
   SectionDiff,
   ChangeKind,
+  SubElementFlag,
 } from "@/lib/geometryDiff";
 
 export interface GeometryDiffSectionProps {
@@ -111,6 +113,52 @@ function SectionSubheader({ section }: { readonly section: SectionDiff }) {
   );
 }
 
+/** Indented sub-row for field-level detail beneath a sub-element flag row. */
+function SubFieldRow({ paramKey, a, b }: { readonly paramKey: string; readonly a: string | null; readonly b: string | null }) {
+  const dash = "—";
+  const differs = a !== b;
+  return (
+    <div
+      className={`grid grid-cols-[1fr_auto_1fr] items-center gap-2 rounded pl-6 pr-2 py-0.5 font-[family-name:var(--font-geist-mono)] text-[10px] ${
+        differs ? "bg-amber-500/8" : ""
+      }`}
+      data-testid={`geometry-diff-subrow-${paramKey}`}
+      data-differs={differs ? "true" : undefined}
+    >
+      <span className={`text-right ${differs ? "font-medium text-foreground/80" : "text-muted-foreground/70"}`}>
+        {a ?? dash}
+      </span>
+      <span className="min-w-[72px] text-center text-[9px] text-subtle-foreground/70">{paramKey}</span>
+      <span className={`text-left ${differs ? "font-medium text-foreground/80" : "text-muted-foreground/70"}`}>
+        {b ?? dash}
+      </span>
+    </div>
+  );
+}
+
+function FlagWithFields({ flagItem, sectionIndex }: { readonly flagItem: SubElementFlag; readonly sectionIndex: number }) {
+  return (
+    <>
+      <DiffRow
+        key={`${sectionIndex}-f-${flagItem.key}`}
+        paramKey={flagItem.key}
+        a={flagItem.a}
+        b={flagItem.b}
+        differs={flagItem.a !== flagItem.b}
+        kind={flagItem.kind}
+      />
+      {flagItem.fields?.map((field) => (
+        <SubFieldRow
+          key={`${sectionIndex}-sf-${field.key}`}
+          paramKey={field.key}
+          a={field.a}
+          b={field.b}
+        />
+      ))}
+    </>
+  );
+}
+
 function WingBlock({ wing }: { readonly wing: WingDiff }) {
   return (
     <div className="mb-3">
@@ -132,18 +180,34 @@ function WingBlock({ wing }: { readonly wing: WingDiff }) {
               />
             ))}
             {section.flags.map((f) => (
-              <DiffRow
+              <FlagWithFields
                 key={`${section.index}-f-${f.key}`}
-                paramKey={f.key}
-                a={f.a}
-                b={f.b}
-                differs={f.a !== f.b}
-                kind={f.kind}
+                flagItem={f}
+                sectionIndex={section.index}
               />
             ))}
           </div>
         ))}
       </div>
+    </div>
+  );
+}
+
+/** Conservative geometry hints block (gh-973). */
+function HintsBlock({ diff }: { readonly diff: GeometryDiff }) {
+  const hints = geometryDiffHints(diff);
+  if (hints.length === 0) return null;
+  return (
+    <div
+      data-testid="geometry-diff-hints"
+      className="mt-3 rounded border border-border/50 bg-sidebar-accent/30 px-3 py-2 text-[10px] text-muted-foreground"
+    >
+      <span className="font-medium text-subtle-foreground">Rough guide (verify with analysis):</span>
+      <ul className="mt-1 list-inside list-disc space-y-0.5">
+        {hints.map((h) => (
+          <li key={h}>{h}</li>
+        ))}
+      </ul>
     </div>
   );
 }
@@ -211,6 +275,7 @@ function DiffBody({ diff, isLoading, error, showAll, onToggleShowAll }: DiffBody
           <WingBlock key={wing.name} wing={wing} />
         ))}
       </div>
+      <HintsBlock diff={diff} />
     </div>
   );
 }

--- a/frontend/hooks/useGeometryDiff.ts
+++ b/frontend/hooks/useGeometryDiff.ts
@@ -132,15 +132,22 @@ export function useGeometryDiff(
     { shouldRetryOnError: false },
   );
 
-  const diff = useMemo<GeometryDiff | null>(() => {
-    if (!data) return null;
-    const { wingsA, wingsB } = toDiffInputs(data);
-    return computeGeometryDiff(wingsA, wingsB, { showAll });
+  // Compute diff and any parse error together in one memo — avoids calling
+  // setState from a memo (which triggers an infinite loop lint error).
+  const [diff, diffError] = useMemo<[GeometryDiff | null, Error | null]>(() => {
+    if (!data) return [null, null];
+    try {
+      const { wingsA, wingsB } = toDiffInputs(data);
+      return [computeGeometryDiff(wingsA, wingsB, { showAll }), null];
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error(String(err));
+      return [null, e];
+    }
   }, [data, showAll]);
 
   return {
     diff,
     isLoading: swrKey != null && isLoading,
-    error: error ?? null,
+    error: diffError ?? error ?? null,
   };
 }

--- a/frontend/lib/geometryDiff.ts
+++ b/frontend/lib/geometryDiff.ts
@@ -37,6 +37,8 @@ export interface SubElementFlag {
   kind: ChangeKind;
   a: string | null;
   b: string | null;
+  /** Field-level detail: changed (or all, in showAll mode) fields of this sub-element. */
+  fields?: ParamChange[];
 }
 
 export interface SectionDiff {
@@ -254,6 +256,232 @@ function turbulatorLabel(
   return turb == null ? "—" : "on";
 }
 
+// --- Field-level helpers for numeric tolerance comparison -------------------
+
+function numericFieldChanged(a: unknown, b: unknown): boolean {
+  if (typeof a === "number" && typeof b === "number") {
+    if (!Number.isFinite(a) || !Number.isFinite(b)) return a !== b;
+    return Math.abs(a - b) > NUMERIC_TOLERANCE;
+  }
+  return String(a ?? "") !== String(b ?? "");
+}
+
+function formatFieldValue(value: unknown, unit?: "mm"): string {
+  if (value == null) return "—";
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) return "—";
+    const rounded = Math.round(value * 100) / 100;
+    const s = String(rounded);
+    return unit === "mm" ? `${s} mm` : s;
+  }
+  return String(value);
+}
+
+// --- Spar field-level diff --------------------------------------------------
+
+function sparFieldDiff(
+  sparA: Record<string, unknown>,
+  sparB: Record<string, unknown>,
+  sparIndex: number,
+  showAll: boolean,
+): ParamChange[] {
+  const n = sparIndex + 1;
+  const fields: Array<{ key: string; aVal: unknown; bVal: unknown; unit?: "mm" }> = [
+    { key: `spar ${n} position`, aVal: sparA["spare_position_factor"], bVal: sparB["spare_position_factor"] },
+    { key: `spar ${n} width`, aVal: sparA["spare_support_dimension_width"], bVal: sparB["spare_support_dimension_width"], unit: "mm" },
+    { key: `spar ${n} height`, aVal: sparA["spare_support_dimension_height"], bVal: sparB["spare_support_dimension_height"], unit: "mm" },
+    { key: `spar ${n} start`, aVal: sparA["spare_start"], bVal: sparB["spare_start"], unit: "mm" },
+    { key: `spar ${n} length`, aVal: sparA["spare_length"], bVal: sparB["spare_length"], unit: "mm" },
+    { key: `spar ${n} mode`, aVal: sparA["spare_mode"], bVal: sparB["spare_mode"] },
+  ];
+
+  const result: ParamChange[] = [];
+  for (const f of fields) {
+    const changed = numericFieldChanged(f.aVal, f.bVal);
+    if (showAll || changed) {
+      result.push({
+        key: f.key,
+        a: formatFieldValue(f.aVal, f.unit),
+        b: formatFieldValue(f.bVal, f.unit),
+      });
+    }
+  }
+  return result;
+}
+
+function sparFlags(
+  a: WingConfigSegment,
+  b: WingConfigSegment,
+  showAll: boolean,
+): SubElementFlag | null {
+  const listA = (a.spare_list ?? []) as Record<string, unknown>[];
+  const listB = (b.spare_list ?? []) as Record<string, unknown>[];
+  const countA = listA.length;
+  const countB = listB.length;
+  const labelA = sparLabel(countA);
+  const labelB = sparLabel(countB);
+
+  // Determine overall kind
+  let kind: ChangeKind = "changed";
+  if (countA === 0 && countB > 0) kind = "added";
+  else if (countA > 0 && countB === 0) kind = "removed";
+
+  if (!showAll && labelA === labelB) {
+    // Count unchanged; still check fields to see if any changed
+    const fields: ParamChange[] = [];
+    const sharedCount = Math.min(countA, countB);
+    for (let i = 0; i < sharedCount; i++) {
+      const sparA = listA[i] ?? {};
+      const sparB = listB[i] ?? {};
+      fields.push(...sparFieldDiff(sparA, sparB, i, false));
+    }
+    if (fields.length === 0) return null;
+    return { key: "spar", kind, a: labelA, b: labelB, fields };
+  }
+
+  const fields: ParamChange[] = [];
+  const sharedCount = Math.min(countA, countB);
+  for (let i = 0; i < sharedCount; i++) {
+    const sparA = listA[i] ?? {};
+    const sparB = listB[i] ?? {};
+    fields.push(...sparFieldDiff(sparA, sparB, i, showAll));
+  }
+
+  return {
+    key: "spar",
+    kind,
+    a: labelA,
+    b: labelB,
+    fields: fields.length > 0 ? fields : undefined,
+  };
+}
+
+// --- TED field-level diff ---------------------------------------------------
+
+const TED_FIELDS: Array<{ key: string; prop: string }> = [
+  { key: "control surface name", prop: "name" },
+  { key: "control surface role", prop: "role" },
+  { key: "control surface rel_chord_root", prop: "rel_chord_root" },
+  { key: "control surface rel_chord_tip", prop: "rel_chord_tip" },
+  { key: "control surface positive_deflection_deg", prop: "positive_deflection_deg" },
+  { key: "control surface negative_deflection_deg", prop: "negative_deflection_deg" },
+  { key: "control surface hinge_type", prop: "hinge_type" },
+  { key: "control surface servo_placement", prop: "servo_placement" },
+  { key: "control surface servo_index", prop: "servo_index" },
+];
+
+function tedFieldDiff(
+  tedA: Record<string, unknown>,
+  tedB: Record<string, unknown>,
+  showAll: boolean,
+): ParamChange[] {
+  const result: ParamChange[] = [];
+  for (const f of TED_FIELDS) {
+    const aVal = tedA[f.prop];
+    const bVal = tedB[f.prop];
+    const changed = numericFieldChanged(aVal, bVal);
+    if (showAll || changed) {
+      result.push({
+        key: f.key,
+        a: formatFieldValue(aVal),
+        b: formatFieldValue(bVal),
+      });
+    }
+  }
+  return result;
+}
+
+function tedFlag(
+  a: WingConfigSegment,
+  b: WingConfigSegment,
+  showAll: boolean,
+): SubElementFlag | null {
+  const tedA = a.trailing_edge_device;
+  const tedB = b.trailing_edge_device;
+  const labelA = tedName(tedA);
+  const labelB = tedName(tedB);
+
+  const bothPresent = tedA != null && tedB != null;
+  const labelChanged = labelA !== labelB;
+
+  if (!showAll && !labelChanged && !bothPresent) return null;
+
+  if (!showAll && !labelChanged && !bothPresent) return null;
+
+  const fields: ParamChange[] = bothPresent
+    ? tedFieldDiff(tedA as Record<string, unknown>, tedB as Record<string, unknown>, showAll)
+    : [];
+
+  // In changes-only mode: if label is same AND no field changes → skip
+  if (!showAll && !labelChanged && fields.length === 0) return null;
+
+  return {
+    key: "control_surface",
+    kind: "changed",
+    a: labelA,
+    b: labelB,
+    fields: fields.length > 0 ? fields : undefined,
+  };
+}
+
+// --- Turbulator field-level diff --------------------------------------------
+
+const TURBULATOR_FIELDS: Array<{ key: string; prop: string }> = [
+  { key: "turbulator form", prop: "form" },
+  { key: "turbulator height_mm", prop: "height_mm" },
+  { key: "turbulator position_root", prop: "position_root" },
+  { key: "turbulator position_tip", prop: "position_tip" },
+  { key: "turbulator enabled", prop: "enabled" },
+];
+
+function turbulatorFieldDiff(
+  turbA: Record<string, unknown>,
+  turbB: Record<string, unknown>,
+  showAll: boolean,
+): ParamChange[] {
+  const result: ParamChange[] = [];
+  for (const f of TURBULATOR_FIELDS) {
+    const aVal = turbA[f.prop];
+    const bVal = turbB[f.prop];
+    const changed = numericFieldChanged(aVal, bVal);
+    if (showAll || changed) {
+      result.push({
+        key: f.key,
+        a: formatFieldValue(aVal),
+        b: formatFieldValue(bVal),
+      });
+    }
+  }
+  return result;
+}
+
+function turbulatorFlag(
+  a: WingConfigSegment,
+  b: WingConfigSegment,
+  showAll: boolean,
+): SubElementFlag | null {
+  const turbA = a.turbulator;
+  const turbB = b.turbulator;
+  const labelA = turbulatorLabel(turbA);
+  const labelB = turbulatorLabel(turbB);
+  const labelChanged = labelA !== labelB;
+  const bothPresent = turbA != null && turbB != null;
+
+  const fields: ParamChange[] = bothPresent
+    ? turbulatorFieldDiff(turbA as Record<string, unknown>, turbB as Record<string, unknown>, showAll)
+    : [];
+
+  if (!showAll && !labelChanged && fields.length === 0) return null;
+
+  return {
+    key: "turbulator",
+    kind: "changed",
+    a: labelA,
+    b: labelB,
+    fields: fields.length > 0 ? fields : undefined,
+  };
+}
+
 function subElementFlags(
   a: WingConfigSegment,
   b: WingConfigSegment,
@@ -261,38 +489,14 @@ function subElementFlags(
 ): SubElementFlag[] {
   const flags: SubElementFlag[] = [];
 
-  const sparA = sparLabel(a.spare_list?.length ?? 0);
-  const sparB = sparLabel(b.spare_list?.length ?? 0);
-  if (showAll || sparA !== sparB) {
-    flags.push({
-      key: "spar",
-      kind: "changed",
-      a: sparA,
-      b: sparB,
-    });
-  }
+  const spar = sparFlags(a, b, showAll);
+  if (spar != null) flags.push(spar);
 
-  const tedA = tedName(a.trailing_edge_device);
-  const tedB = tedName(b.trailing_edge_device);
-  if (showAll || tedA !== tedB) {
-    flags.push({
-      key: "control_surface",
-      kind: "changed",
-      a: tedA,
-      b: tedB,
-    });
-  }
+  const ted = tedFlag(a, b, showAll);
+  if (ted != null) flags.push(ted);
 
-  const turbA = turbulatorLabel(a.turbulator);
-  const turbB = turbulatorLabel(b.turbulator);
-  if (showAll || turbA !== turbB) {
-    flags.push({
-      key: "turbulator",
-      kind: "changed",
-      a: turbA,
-      b: turbB,
-    });
-  }
+  const turb = turbulatorFlag(a, b, showAll);
+  if (turb != null) flags.push(turb);
 
   return flags;
 }
@@ -420,11 +624,43 @@ function sectionHasRealChange(
   const paramsA = coreParams(a);
   const paramsB = coreParams(b);
   const paramChange = paramsA.some((pa, i) => paramChanged(pa, paramsB[i]));
-  const flagChange =
-    (a.spare_list?.length ?? 0) !== (b.spare_list?.length ?? 0) ||
-    tedName(a.trailing_edge_device) !== tedName(b.trailing_edge_device) ||
-    turbulatorLabel(a.turbulator) !== turbulatorLabel(b.turbulator);
-  return paramChange || flagChange;
+  if (paramChange) return true;
+
+  // Count-level changes
+  const sparCountChange = (a.spare_list?.length ?? 0) !== (b.spare_list?.length ?? 0);
+  const tedLabelChange = tedName(a.trailing_edge_device) !== tedName(b.trailing_edge_device);
+  const turbLabelChange = turbulatorLabel(a.turbulator) !== turbulatorLabel(b.turbulator);
+  if (sparCountChange || tedLabelChange || turbLabelChange) return true;
+
+  // Field-level changes in spars
+  const listA = (a.spare_list ?? []) as Record<string, unknown>[];
+  const listB = (b.spare_list ?? []) as Record<string, unknown>[];
+  for (let i = 0; i < Math.min(listA.length, listB.length); i++) {
+    const f = sparFieldDiff(listA[i] ?? {}, listB[i] ?? {}, i, false);
+    if (f.length > 0) return true;
+  }
+
+  // Field-level changes in TED (when both present and label same)
+  if (a.trailing_edge_device != null && b.trailing_edge_device != null) {
+    const f = tedFieldDiff(
+      a.trailing_edge_device as Record<string, unknown>,
+      b.trailing_edge_device as Record<string, unknown>,
+      false,
+    );
+    if (f.length > 0) return true;
+  }
+
+  // Field-level changes in turbulator (when both present and label same)
+  if (a.turbulator != null && b.turbulator != null) {
+    const f = turbulatorFieldDiff(
+      a.turbulator as Record<string, unknown>,
+      b.turbulator as Record<string, unknown>,
+      false,
+    );
+    if (f.length > 0) return true;
+  }
+
+  return false;
 }
 
 // --- Top-level diff ---------------------------------------------------------
@@ -511,4 +747,115 @@ export function computeGeometryDiff(
     counts: { sectionsChanged, sectionsAdded, sectionsRemoved },
     hasAnyChange,
   };
+}
+
+// --- GH #973: Plain-language geometry hints ---------------------------------
+
+/**
+ * Parse a display value like "200 mm" → 200, or "2 deg" → 2.
+ * Returns null if not parseable.
+ */
+function parseDisplayNum(display: string | null): number | null {
+  if (display == null || display === "—") return null;
+  const n = parseFloat(display);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Find a param by key across all sections of all wings in the diff.
+ * Returns all matched ParamChange entries.
+ */
+function allParams(diff: GeometryDiff, key: string): Array<{ a: string | null; b: string | null }> {
+  const result: Array<{ a: string | null; b: string | null }> = [];
+  for (const wing of diff.wings) {
+    for (const section of wing.sections) {
+      for (const p of section.params) {
+        if (p.key === key) result.push(p);
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Returns a small set of conservative, geometric hints derived from the diff.
+ * NOT aerodynamic predictions — only geometric observations.
+ * At most 5 hints. Only emits when clearly true from the diff data.
+ */
+export function geometryDiffHints(diff: GeometryDiff): string[] {
+  const hints: string[] = [];
+
+  // Rule 1: tip chord decreased while root chord roughly unchanged → more taper
+  const rootChords = allParams(diff, "root chord");
+  const tipChords = allParams(diff, "tip chord");
+  const rootUnchanged = rootChords.every((p) => {
+    const a = parseDisplayNum(p.a);
+    const b = parseDisplayNum(p.b);
+    if (a == null || b == null) return false;
+    return Math.abs(a - b) <= NUMERIC_TOLERANCE * 10; // allow ~0.5 mm
+  });
+  const tipDecreased = tipChords.some((p) => {
+    const a = parseDisplayNum(p.a);
+    const b = parseDisplayNum(p.b);
+    if (a == null || b == null) return false;
+    return b < a - NUMERIC_TOLERANCE;
+  });
+  if (rootChords.length > 0 && rootUnchanged && tipDecreased) {
+    hints.push("More taper (tip chord ↓)");
+  }
+
+  if (hints.length >= 5) return hints;
+
+  // Rule 2: tip incidence decreased / more negative than root → washout
+  const tipIncidences = allParams(diff, "tip incidence");
+  const tipIncDecreased = tipIncidences.some((p) => {
+    const a = parseDisplayNum(p.a);
+    const b = parseDisplayNum(p.b);
+    if (a == null || b == null) return false;
+    return b < a - NUMERIC_TOLERANCE;
+  });
+  if (tipIncDecreased) {
+    hints.push("More washout at the tip");
+  }
+
+  if (hints.length >= 5) return hints;
+
+  // Rule 3: section added at the last position → longer span
+  for (const wing of diff.wings) {
+    const sections = wing.sections;
+    if (sections.length === 0) continue;
+    const last = sections[sections.length - 1];
+    if (last.kind === "added") {
+      hints.push("Longer span (tip section added)");
+      break;
+    }
+  }
+
+  if (hints.length >= 5) return hints;
+
+  // Rule 4: dihedral increased
+  const dihedrals = allParams(diff, "root dihedral");
+  const dihedralIncreased = dihedrals.some((p) => {
+    const a = parseDisplayNum(p.a);
+    const b = parseDisplayNum(p.b);
+    if (a == null || b == null) return false;
+    return b > a + NUMERIC_TOLERANCE;
+  });
+  if (dihedralIncreased) {
+    hints.push("More dihedral");
+  }
+
+  if (hints.length >= 5) return hints;
+
+  // Rule 5: any airfoil changed → re-run polar
+  const rootAirfoils = allParams(diff, "root airfoil");
+  const tipAirfoils = allParams(diff, "tip airfoil");
+  const anyAirfoilChanged = [...rootAirfoils, ...tipAirfoils].some(
+    (p) => p.a !== p.b && p.a != null && p.b != null,
+  );
+  if (anyAirfoilChanged) {
+    hints.push("Airfoil changed — re-run the polar");
+  }
+
+  return hints;
 }

--- a/frontend/lib/geometryDiff.ts
+++ b/frontend/lib/geometryDiff.ts
@@ -16,6 +16,15 @@
  * Section alignment is performed by SIGNATURE (root_chord|length|root_airfoil)
  * using an LCS (Longest Common Subsequence) algorithm so that inserting a
  * section in the middle does NOT cascade false "changed" on downstream sections.
+ *
+ * gh-402: spar dimensional fields (width/height/start/length) come from the API
+ * in METRES (the API converts mm→m). They are multiplied by 1000 before both
+ * display formatting and tolerance comparison so the diff works in mm.
+ * spare_position_factor (0–1 fraction) and spare_mode (string) are NOT converted.
+ *
+ * Hints (gh-973) are computed per-section from RAW numeric values inside
+ * computeGeometryDiff, deduped, and stored in GeometryDiff.hints. No
+ * string-parsing needed; the old geometryDiffHints() export is removed.
  */
 
 import type { WingConfig, WingConfigSegment } from "@/hooks/useWingConfig";
@@ -63,6 +72,8 @@ export interface GeometryDiff {
     sectionsRemoved: number;
   };
   hasAnyChange: boolean;
+  /** Conservative per-section geometric observations. Max 5, deduped. */
+  hints: string[];
 }
 
 /** One named wing's full geometry, the unit the diff aligns by name. */
@@ -79,6 +90,9 @@ export interface GeometryDiffOptions {
 
 /** |Δ| at or below this (mm or degrees) is float noise, not a change. */
 const NUMERIC_TOLERANCE = 0.05;
+
+/** Tight tolerance for spare_position_factor (0–1 fraction, not mm). */
+const POSITION_FACTOR_TOLERANCE = 0.005;
 
 // --- Formatting helpers -----------------------------------------------------
 
@@ -258,10 +272,10 @@ function turbulatorLabel(
 
 // --- Field-level helpers for numeric tolerance comparison -------------------
 
-function numericFieldChanged(a: unknown, b: unknown): boolean {
+function numericFieldChanged(a: unknown, b: unknown, tol: number = NUMERIC_TOLERANCE): boolean {
   if (typeof a === "number" && typeof b === "number") {
     if (!Number.isFinite(a) || !Number.isFinite(b)) return a !== b;
-    return Math.abs(a - b) > NUMERIC_TOLERANCE;
+    return Math.abs(a - b) > tol;
   }
   return String(a ?? "") !== String(b ?? "");
 }
@@ -279,6 +293,12 @@ function formatFieldValue(value: unknown, unit?: "mm"): string {
 
 // --- Spar field-level diff --------------------------------------------------
 
+/**
+ * gh-402: spar dimensional fields arrive from the API in metres (mm stored in
+ * DB but converted to m by the API layer). Multiply by 1000 before display and
+ * tolerance comparison so everything is in mm. spare_position_factor (0–1) and
+ * spare_mode (string) are NOT converted.
+ */
 function sparFieldDiff(
   sparA: Record<string, unknown>,
   sparB: Record<string, unknown>,
@@ -286,18 +306,55 @@ function sparFieldDiff(
   showAll: boolean,
 ): ParamChange[] {
   const n = sparIndex + 1;
-  const fields: Array<{ key: string; aVal: unknown; bVal: unknown; unit?: "mm" }> = [
-    { key: `spar ${n} position`, aVal: sparA["spare_position_factor"], bVal: sparB["spare_position_factor"] },
-    { key: `spar ${n} width`, aVal: sparA["spare_support_dimension_width"], bVal: sparB["spare_support_dimension_width"], unit: "mm" },
-    { key: `spar ${n} height`, aVal: sparA["spare_support_dimension_height"], bVal: sparB["spare_support_dimension_height"], unit: "mm" },
-    { key: `spar ${n} start`, aVal: sparA["spare_start"], bVal: sparB["spare_start"], unit: "mm" },
-    { key: `spar ${n} length`, aVal: sparA["spare_length"], bVal: sparB["spare_length"], unit: "mm" },
+
+  // Dimensional fields: metres → mm conversion factor
+  const M_TO_MM = 1000;
+
+  const widthA = typeof sparA["spare_support_dimension_width"] === "number"
+    ? sparA["spare_support_dimension_width"] * M_TO_MM
+    : sparA["spare_support_dimension_width"];
+  const widthB = typeof sparB["spare_support_dimension_width"] === "number"
+    ? sparB["spare_support_dimension_width"] * M_TO_MM
+    : sparB["spare_support_dimension_width"];
+
+  const heightA = typeof sparA["spare_support_dimension_height"] === "number"
+    ? sparA["spare_support_dimension_height"] * M_TO_MM
+    : sparA["spare_support_dimension_height"];
+  const heightB = typeof sparB["spare_support_dimension_height"] === "number"
+    ? sparB["spare_support_dimension_height"] * M_TO_MM
+    : sparB["spare_support_dimension_height"];
+
+  const startA = typeof sparA["spare_start"] === "number"
+    ? sparA["spare_start"] * M_TO_MM
+    : sparA["spare_start"];
+  const startB = typeof sparB["spare_start"] === "number"
+    ? sparB["spare_start"] * M_TO_MM
+    : sparB["spare_start"];
+
+  const lengthA = typeof sparA["spare_length"] === "number"
+    ? sparA["spare_length"] * M_TO_MM
+    : sparA["spare_length"];
+  const lengthB = typeof sparB["spare_length"] === "number"
+    ? sparB["spare_length"] * M_TO_MM
+    : sparB["spare_length"];
+
+  const fields: Array<{ key: string; aVal: unknown; bVal: unknown; unit?: "mm"; tol?: number }> = [
+    {
+      key: `spar ${n} position`,
+      aVal: sparA["spare_position_factor"],
+      bVal: sparB["spare_position_factor"],
+      tol: POSITION_FACTOR_TOLERANCE,
+    },
+    { key: `spar ${n} width`, aVal: widthA, bVal: widthB, unit: "mm" },
+    { key: `spar ${n} height`, aVal: heightA, bVal: heightB, unit: "mm" },
+    { key: `spar ${n} start`, aVal: startA, bVal: startB, unit: "mm" },
+    { key: `spar ${n} length`, aVal: lengthA, bVal: lengthB, unit: "mm" },
     { key: `spar ${n} mode`, aVal: sparA["spare_mode"], bVal: sparB["spare_mode"] },
   ];
 
   const result: ParamChange[] = [];
   for (const f of fields) {
-    const changed = numericFieldChanged(f.aVal, f.bVal);
+    const changed = numericFieldChanged(f.aVal, f.bVal, f.tol ?? NUMERIC_TOLERANCE);
     if (showAll || changed) {
       result.push({
         key: f.key,
@@ -327,7 +384,13 @@ function sparFlags(
   else if (countA > 0 && countB === 0) kind = "removed";
 
   if (!showAll && labelA === labelB) {
-    // Count unchanged; still check fields to see if any changed
+    // Count unchanged; still check fields to see if any changed.
+    // Only emit field diffs when counts are equal (index alignment is safe).
+    if (countA !== countB) {
+      // Counts differ but labels happen to be equal — shouldn't happen with
+      // sparLabel, but guard anyway.
+      return { key: "spar", kind, a: labelA, b: labelB };
+    }
     const fields: ParamChange[] = [];
     const sharedCount = Math.min(countA, countB);
     for (let i = 0; i < sharedCount; i++) {
@@ -339,6 +402,21 @@ function sparFlags(
     return { key: "spar", kind, a: labelA, b: labelB, fields };
   }
 
+  // showAll=true OR label changed (count changed).
+  // When counts differ, do NOT emit positional field sub-rows — pairing by
+  // index is unsafe (an insert at position k would corrupt every spar after k).
+  if (countA !== countB) {
+    return {
+      key: "spar",
+      kind,
+      a: labelA,
+      b: labelB,
+      // fields deliberately empty/undefined — count mismatch makes positional
+      // field-pairing meaningless.
+    };
+  }
+
+  // Counts equal — safe to pair by index.
   const fields: ParamChange[] = [];
   const sharedCount = Math.min(countA, countB);
   for (let i = 0; i < sharedCount; i++) {
@@ -404,7 +482,10 @@ function tedFlag(
   const bothPresent = tedA != null && tedB != null;
   const labelChanged = labelA !== labelB;
 
-  if (!showAll && !labelChanged && !bothPresent) return null;
+  // Determine kind from presence
+  let kind: ChangeKind = "changed";
+  if (tedA == null && tedB != null) kind = "added";
+  else if (tedA != null && tedB == null) kind = "removed";
 
   if (!showAll && !labelChanged && !bothPresent) return null;
 
@@ -417,7 +498,7 @@ function tedFlag(
 
   return {
     key: "control_surface",
-    kind: "changed",
+    kind,
     a: labelA,
     b: labelB,
     fields: fields.length > 0 ? fields : undefined,
@@ -467,6 +548,11 @@ function turbulatorFlag(
   const labelChanged = labelA !== labelB;
   const bothPresent = turbA != null && turbB != null;
 
+  // Determine kind from presence
+  let kind: ChangeKind = "changed";
+  if (turbA == null && turbB != null) kind = "added";
+  else if (turbA != null && turbB == null) kind = "removed";
+
   const fields: ParamChange[] = bothPresent
     ? turbulatorFieldDiff(turbA as Record<string, unknown>, turbB as Record<string, unknown>, showAll)
     : [];
@@ -475,7 +561,7 @@ function turbulatorFlag(
 
   return {
     key: "turbulator",
-    kind: "changed",
+    kind,
     a: labelA,
     b: labelB,
     fields: fields.length > 0 ? fields : undefined,
@@ -547,6 +633,68 @@ function diffPresentSection(
   };
 }
 
+// --- Per-section hint accumulation (gh-973) ---------------------------------
+
+/**
+ * Accumulate geometric hints from a matched section pair using raw numeric
+ * values. Called during section alignment inside diffWing so hints are based
+ * on the same data used for the diff — not re-parsed from formatted strings.
+ *
+ * Rules (conservative, per-section):
+ *   - taper: tip chord decreased while root chord ~unchanged (≤5 mm shift)
+ *   - dihedral: a section's dihedral increased
+ *   - airfoil changed: any airfoil changed → "re-run the polar"
+ *
+ * Washout and span are evaluated at the wing level (after alignment), not here.
+ */
+function accumulateSectionHints(
+  a: WingConfigSegment,
+  b: WingConfigSegment,
+  hints: Set<string>,
+): void {
+  if (hints.size >= 5) return;
+
+  const afA = a.root_airfoil ?? {};
+  const afB = b.root_airfoil ?? {};
+  const tafA = a.tip_airfoil ?? {};
+  const tafB = b.tip_airfoil ?? {};
+
+  const rootChordA = (afA as { chord?: number }).chord ?? 0;
+  const rootChordB = (afB as { chord?: number }).chord ?? 0;
+  const tipChordA = (tafA as { chord?: number }).chord ?? 0;
+  const tipChordB = (tafB as { chord?: number }).chord ?? 0;
+
+  // Taper: tip chord decreased while root chord roughly unchanged (≤5 mm)
+  const rootUnchanged = Math.abs(rootChordA - rootChordB) <= NUMERIC_TOLERANCE * 100; // 5 mm
+  const tipDecreased = tipChordB < tipChordA - NUMERIC_TOLERANCE;
+  if (rootUnchanged && tipDecreased) {
+    hints.add("More taper (tip chord ↓)");
+  }
+
+  if (hints.size >= 5) return;
+
+  // Dihedral increased
+  const dihA = (afA as { dihedral_as_rotation_in_degrees?: number }).dihedral_as_rotation_in_degrees ?? 0;
+  const dihB = (afB as { dihedral_as_rotation_in_degrees?: number }).dihedral_as_rotation_in_degrees ?? 0;
+  if (dihB > dihA + NUMERIC_TOLERANCE) {
+    hints.add("More dihedral");
+  }
+
+  if (hints.size >= 5) return;
+
+  // Airfoil changed (root or tip)
+  const rootAirfoilA = stripDat((afA as { airfoil?: string }).airfoil ?? "");
+  const rootAirfoilB = stripDat((afB as { airfoil?: string }).airfoil ?? "");
+  const tipAirfoilA = stripDat((tafA as { airfoil?: string }).airfoil ?? "");
+  const tipAirfoilB = stripDat((tafB as { airfoil?: string }).airfoil ?? "");
+  if (
+    (rootAirfoilA !== rootAirfoilB && rootAirfoilA !== "" && rootAirfoilB !== "") ||
+    (tipAirfoilA !== tipAirfoilB && tipAirfoilA !== "" && tipAirfoilB !== "")
+  ) {
+    hints.add("Airfoil changed — re-run the polar");
+  }
+}
+
 // --- Wing diff --------------------------------------------------------------
 
 interface WingDiffResult {
@@ -555,6 +703,88 @@ interface WingDiffResult {
   sectionsAdded: number;
   sectionsRemoved: number;
   changed: boolean;
+  hints: Set<string>;
+}
+
+/** Check whether any spar, TED, or turbulator field-level diff exists. */
+function subElementHasFieldChange(
+  a: WingConfigSegment,
+  b: WingConfigSegment,
+): boolean {
+  // Field-level changes in spars (only when counts match — safe to pair by index)
+  const listA = (a.spare_list ?? []) as Record<string, unknown>[];
+  const listB = (b.spare_list ?? []) as Record<string, unknown>[];
+  if (listA.length === listB.length) {
+    for (let i = 0; i < listA.length; i++) {
+      const f = sparFieldDiff(listA[i] ?? {}, listB[i] ?? {}, i, false);
+      if (f.length > 0) return true;
+    }
+  }
+  // Field-level changes in TED
+  if (a.trailing_edge_device != null && b.trailing_edge_device != null) {
+    const f = tedFieldDiff(
+      a.trailing_edge_device as Record<string, unknown>,
+      b.trailing_edge_device as Record<string, unknown>,
+      false,
+    );
+    if (f.length > 0) return true;
+  }
+  // Field-level changes in turbulator
+  if (a.turbulator != null && b.turbulator != null) {
+    const f = turbulatorFieldDiff(
+      a.turbulator as Record<string, unknown>,
+      b.turbulator as Record<string, unknown>,
+      false,
+    );
+    if (f.length > 0) return true;
+  }
+  return false;
+}
+
+function sectionHasRealChange(
+  a: WingConfigSegment,
+  b: WingConfigSegment,
+): boolean {
+  const paramsA = coreParams(a);
+  const paramsB = coreParams(b);
+  if (paramsA.some((pa, i) => paramChanged(pa, paramsB[i]))) return true;
+
+  // Count-level changes
+  const sparCountChange = (a.spare_list?.length ?? 0) !== (b.spare_list?.length ?? 0);
+  const tedLabelChange = tedName(a.trailing_edge_device) !== tedName(b.trailing_edge_device);
+  const turbLabelChange = turbulatorLabel(a.turbulator) !== turbulatorLabel(b.turbulator);
+  if (sparCountChange || tedLabelChange || turbLabelChange) return true;
+
+  return subElementHasFieldChange(a, b);
+}
+
+/** Accumulate wing-level hints (washout from outermost section, span from tip addition). */
+function accumulateWingHints(
+  aligned: Array<[WingConfigSegment | null, WingConfigSegment | null]>,
+  hints: Set<string>,
+): void {
+  // Washout: ONLY the outermost (last) matched section's tip incidence decreased.
+  const matchedPairs: Array<[WingConfigSegment, WingConfigSegment]> = [];
+  for (const [segA, segB] of aligned) {
+    if (segA && segB) matchedPairs.push([segA, segB]);
+  }
+  if (matchedPairs.length > 0 && hints.size < 5) {
+    const [lastA, lastB] = matchedPairs[matchedPairs.length - 1];
+    const tafA = lastA.tip_airfoil ?? {};
+    const tafB = lastB.tip_airfoil ?? {};
+    const tipIncA = (tafA as { incidence?: number }).incidence ?? 0;
+    const tipIncB = (tafB as { incidence?: number }).incidence ?? 0;
+    if (tipIncB < tipIncA - NUMERIC_TOLERANCE) {
+      hints.add("More washout at the tip");
+    }
+  }
+  // Span: last section in the aligned list was added at the tip.
+  if (aligned.length > 0 && hints.size < 5) {
+    const [lastA, lastB] = aligned[aligned.length - 1];
+    if (!lastA && lastB) {
+      hints.add("Longer span (tip section added)");
+    }
+  }
 }
 
 function diffWing(
@@ -574,93 +804,39 @@ function diffWing(
   let sectionsChanged = 0;
   let sectionsAdded = 0;
   let sectionsRemoved = 0;
+  const hints = new Set<string>();
 
   for (let i = 0; i < aligned.length; i++) {
     const [segA, segB] = aligned[i];
-
     if (segA && segB) {
       const changed = sectionHasRealChange(segA, segB);
-      if (changed) sectionsChanged++;
+      if (changed) {
+        sectionsChanged++;
+        accumulateSectionHints(segA, segB, hints);
+      }
       if (showAll || changed) {
         sections.push(diffPresentSection(i, totalSections, segA, segB, showAll));
       }
-    } else if (segB && !segA) {
+    } else if (segB) {
       sectionsAdded++;
-      sections.push({
-        index: i,
-        kind: "added",
-        label: sectionLabel(i, totalSections),
-        params: [],
-        flags: [],
-      });
-    } else if (segA && !segB) {
+      sections.push({ index: i, kind: "added", label: sectionLabel(i, totalSections), params: [], flags: [] });
+    } else if (segA) {
       sectionsRemoved++;
-      sections.push({
-        index: i,
-        kind: "removed",
-        label: sectionLabel(i, totalSections),
-        params: [],
-        flags: [],
-      });
+      sections.push({ index: i, kind: "removed", label: sectionLabel(i, totalSections), params: [], flags: [] });
     }
   }
 
-  const changed =
-    sectionsChanged > 0 || sectionsAdded > 0 || sectionsRemoved > 0;
+  accumulateWingHints(aligned, hints);
 
+  const changed = sectionsChanged > 0 || sectionsAdded > 0 || sectionsRemoved > 0;
   return {
     diff: { name, kind: "changed", sections },
     sectionsChanged,
     sectionsAdded,
     sectionsRemoved,
     changed,
+    hints,
   };
-}
-
-function sectionHasRealChange(
-  a: WingConfigSegment,
-  b: WingConfigSegment,
-): boolean {
-  const paramsA = coreParams(a);
-  const paramsB = coreParams(b);
-  const paramChange = paramsA.some((pa, i) => paramChanged(pa, paramsB[i]));
-  if (paramChange) return true;
-
-  // Count-level changes
-  const sparCountChange = (a.spare_list?.length ?? 0) !== (b.spare_list?.length ?? 0);
-  const tedLabelChange = tedName(a.trailing_edge_device) !== tedName(b.trailing_edge_device);
-  const turbLabelChange = turbulatorLabel(a.turbulator) !== turbulatorLabel(b.turbulator);
-  if (sparCountChange || tedLabelChange || turbLabelChange) return true;
-
-  // Field-level changes in spars
-  const listA = (a.spare_list ?? []) as Record<string, unknown>[];
-  const listB = (b.spare_list ?? []) as Record<string, unknown>[];
-  for (let i = 0; i < Math.min(listA.length, listB.length); i++) {
-    const f = sparFieldDiff(listA[i] ?? {}, listB[i] ?? {}, i, false);
-    if (f.length > 0) return true;
-  }
-
-  // Field-level changes in TED (when both present and label same)
-  if (a.trailing_edge_device != null && b.trailing_edge_device != null) {
-    const f = tedFieldDiff(
-      a.trailing_edge_device as Record<string, unknown>,
-      b.trailing_edge_device as Record<string, unknown>,
-      false,
-    );
-    if (f.length > 0) return true;
-  }
-
-  // Field-level changes in turbulator (when both present and label same)
-  if (a.turbulator != null && b.turbulator != null) {
-    const f = turbulatorFieldDiff(
-      a.turbulator as Record<string, unknown>,
-      b.turbulator as Record<string, unknown>,
-      false,
-    );
-    if (f.length > 0) return true;
-  }
-
-  return false;
 }
 
 // --- Top-level diff ---------------------------------------------------------
@@ -702,6 +878,33 @@ function presenceWing(
   };
 }
 
+interface DiffAccumulator {
+  wings: WingDiff[];
+  sectionsChanged: number;
+  sectionsAdded: number;
+  sectionsRemoved: number;
+  hasAnyChange: boolean;
+  allHints: Set<string>;
+}
+
+function processMatchedWing(
+  name: string,
+  a: DiffWingInput,
+  b: DiffWingInput,
+  showAll: boolean,
+  acc: DiffAccumulator,
+): void {
+  const res = diffWing(name, a.config, b.config, showAll);
+  acc.sectionsChanged += res.sectionsChanged;
+  acc.sectionsAdded += res.sectionsAdded;
+  acc.sectionsRemoved += res.sectionsRemoved;
+  if (res.changed) acc.hasAnyChange = true;
+  if (showAll || res.changed) acc.wings.push(res.diff);
+  for (const h of res.hints) {
+    if (acc.allHints.size < 5) acc.allHints.add(h);
+  }
+}
+
 export function computeGeometryDiff(
   wingsA: DiffWingInput[],
   wingsB: DiffWingInput[],
@@ -712,150 +915,36 @@ export function computeGeometryDiff(
   const byNameA = new Map(wingsA.map((w) => [w.name, w]));
   const byNameB = new Map(wingsB.map((w) => [w.name, w]));
 
-  const wings: WingDiff[] = [];
-  let sectionsChanged = 0;
-  let sectionsAdded = 0;
-  let sectionsRemoved = 0;
-  let hasAnyChange = false;
+  const acc: DiffAccumulator = {
+    wings: [],
+    sectionsChanged: 0,
+    sectionsAdded: 0,
+    sectionsRemoved: 0,
+    hasAnyChange: false,
+    allHints: new Set<string>(),
+  };
 
   for (const name of orderedWingNames(wingsA, wingsB)) {
     const a = byNameA.get(name);
     const b = byNameB.get(name);
 
     if (a && b) {
-      const res = diffWing(name, a.config, b.config, showAll);
-      sectionsChanged += res.sectionsChanged;
-      sectionsAdded += res.sectionsAdded;
-      sectionsRemoved += res.sectionsRemoved;
-      if (res.changed) hasAnyChange = true;
-      if (showAll || res.changed) {
-        wings.push(res.diff);
-      }
-    } else if (b && !a) {
-      hasAnyChange = true;
-      sectionsAdded += b.config.segments?.length ?? 0;
-      wings.push(presenceWing(name, "added", b.config));
-    } else if (a && !b) {
-      hasAnyChange = true;
-      sectionsRemoved += a.config.segments?.length ?? 0;
-      wings.push(presenceWing(name, "removed", a.config));
+      processMatchedWing(name, a, b, showAll, acc);
+    } else if (b) {
+      acc.hasAnyChange = true;
+      acc.sectionsAdded += b.config.segments?.length ?? 0;
+      acc.wings.push(presenceWing(name, "added", b.config));
+    } else if (a) {
+      acc.hasAnyChange = true;
+      acc.sectionsRemoved += a.config.segments?.length ?? 0;
+      acc.wings.push(presenceWing(name, "removed", a.config));
     }
   }
 
   return {
-    wings,
-    counts: { sectionsChanged, sectionsAdded, sectionsRemoved },
-    hasAnyChange,
+    wings: acc.wings,
+    counts: { sectionsChanged: acc.sectionsChanged, sectionsAdded: acc.sectionsAdded, sectionsRemoved: acc.sectionsRemoved },
+    hasAnyChange: acc.hasAnyChange,
+    hints: Array.from(acc.allHints),
   };
-}
-
-// --- GH #973: Plain-language geometry hints ---------------------------------
-
-/**
- * Parse a display value like "200 mm" → 200, or "2 deg" → 2.
- * Returns null if not parseable.
- */
-function parseDisplayNum(display: string | null): number | null {
-  if (display == null || display === "—") return null;
-  const n = parseFloat(display);
-  return Number.isFinite(n) ? n : null;
-}
-
-/**
- * Find a param by key across all sections of all wings in the diff.
- * Returns all matched ParamChange entries.
- */
-function allParams(diff: GeometryDiff, key: string): Array<{ a: string | null; b: string | null }> {
-  const result: Array<{ a: string | null; b: string | null }> = [];
-  for (const wing of diff.wings) {
-    for (const section of wing.sections) {
-      for (const p of section.params) {
-        if (p.key === key) result.push(p);
-      }
-    }
-  }
-  return result;
-}
-
-/**
- * Returns a small set of conservative, geometric hints derived from the diff.
- * NOT aerodynamic predictions — only geometric observations.
- * At most 5 hints. Only emits when clearly true from the diff data.
- */
-export function geometryDiffHints(diff: GeometryDiff): string[] {
-  const hints: string[] = [];
-
-  // Rule 1: tip chord decreased while root chord roughly unchanged → more taper
-  const rootChords = allParams(diff, "root chord");
-  const tipChords = allParams(diff, "tip chord");
-  const rootUnchanged = rootChords.every((p) => {
-    const a = parseDisplayNum(p.a);
-    const b = parseDisplayNum(p.b);
-    if (a == null || b == null) return false;
-    return Math.abs(a - b) <= NUMERIC_TOLERANCE * 10; // allow ~0.5 mm
-  });
-  const tipDecreased = tipChords.some((p) => {
-    const a = parseDisplayNum(p.a);
-    const b = parseDisplayNum(p.b);
-    if (a == null || b == null) return false;
-    return b < a - NUMERIC_TOLERANCE;
-  });
-  if (rootChords.length > 0 && rootUnchanged && tipDecreased) {
-    hints.push("More taper (tip chord ↓)");
-  }
-
-  if (hints.length >= 5) return hints;
-
-  // Rule 2: tip incidence decreased / more negative than root → washout
-  const tipIncidences = allParams(diff, "tip incidence");
-  const tipIncDecreased = tipIncidences.some((p) => {
-    const a = parseDisplayNum(p.a);
-    const b = parseDisplayNum(p.b);
-    if (a == null || b == null) return false;
-    return b < a - NUMERIC_TOLERANCE;
-  });
-  if (tipIncDecreased) {
-    hints.push("More washout at the tip");
-  }
-
-  if (hints.length >= 5) return hints;
-
-  // Rule 3: section added at the last position → longer span
-  for (const wing of diff.wings) {
-    const sections = wing.sections;
-    if (sections.length === 0) continue;
-    const last = sections[sections.length - 1];
-    if (last.kind === "added") {
-      hints.push("Longer span (tip section added)");
-      break;
-    }
-  }
-
-  if (hints.length >= 5) return hints;
-
-  // Rule 4: dihedral increased
-  const dihedrals = allParams(diff, "root dihedral");
-  const dihedralIncreased = dihedrals.some((p) => {
-    const a = parseDisplayNum(p.a);
-    const b = parseDisplayNum(p.b);
-    if (a == null || b == null) return false;
-    return b > a + NUMERIC_TOLERANCE;
-  });
-  if (dihedralIncreased) {
-    hints.push("More dihedral");
-  }
-
-  if (hints.length >= 5) return hints;
-
-  // Rule 5: any airfoil changed → re-run polar
-  const rootAirfoils = allParams(diff, "root airfoil");
-  const tipAirfoils = allParams(diff, "tip airfoil");
-  const anyAirfoilChanged = [...rootAirfoils, ...tipAirfoils].some(
-    (p) => p.a !== p.b && p.a != null && p.b != null,
-  );
-  if (anyAirfoilChanged) {
-    hints.push("Airfoil changed — re-run the polar");
-  }
-
-  return hints;
 }


### PR DESCRIPTION
Two gh-971 follow-ups for the version-compare geometry diff.

## gh-972 — field-level sub-element diff
`SubElementFlag` gains `fields?: ParamChange[]`. Spars diff position/width/height/start/length/mode; control surfaces diff name/role/hinge/deflection/servo (fixes "compared by name only" — rename-only and moved-same-name now read correctly); turbulator diffs form/height/position/enabled. Rendered as indented sub-rows under each flag.

## gh-973 — plain-language hints
A small set of conservative, per-section GEOMETRIC hints (more taper / washout / longer span / more dihedral / airfoil changed), computed inside `computeGeometryDiff` from raw values (no cross-entity pooling), shown as a muted "Rough guide (verify with analysis)" note.

## Review fixes incorporated
- **Spar fields are metres** in WingConfig (gh-402) → ×1000 to mm before display + tolerance (were silently swallowed/`"0 mm"`).
- Spar field rows suppressed when count differs (no index cascade); tight tolerance for the 0–1 position factor.
- Hints reworked to per-section/raw (was a cross-wing/section pool that could assert a hint no section showed); washout only on the outermost section.
- TED/turbulator flag kind from presence; `computeGeometryDiff` wrapped in try/catch in the hook (malformed payload → inline error, not a crash); a11y role/aria; Tailwind class fix.

## Verification
Frontend full suite **2089 green / 163 files** (Node 22), ESLint + `tsc --noEmit` clean.

Closes #972
Closes #973
Refs #971