### PR TITLE
feat(gh-976,gh-977): Powertrain tab — solution table, filters, assumptions, shopping spec, feasible-region plot

### DIFF
--- a/frontend/__tests__/PowertrainTab.test.tsx
+++ b/frontend/__tests__/PowertrainTab.test.tsx
@@ -1,0 +1,444 @@
+/**
+ * Unit tests for PowertrainTab + usePowertrainSolutionSpace hook (gh-976, gh-977).
+ * Mocks: SWR hook, plotly.js-gl3d-dist-min, lucide-react.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+import type {
+  PowertrainSolutionSpaceResponse,
+  SolutionSpaceAssumptions,
+} from "@/hooks/usePowertrainSolutionSpace";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) =>
+    React.createElement("span", { ...props, "data-testid": "icon" });
+  return {
+    AlertTriangle: icon,
+    Loader2: icon,
+  };
+});
+
+// Plotly dynamic import — stub that records calls
+const plotlyReactMock = vi.fn().mockResolvedValue(undefined);
+vi.mock("plotly.js-gl3d-dist-min", () => ({
+  react: plotlyReactMock,
+  purge: vi.fn(),
+}));
+
+// SWR hook mock — mutable via the let-binding pattern
+let hookReturn: {
+  data: PowertrainSolutionSpaceResponse | null | undefined;
+  error: unknown;
+  isLoading: boolean;
+  mutate: ReturnType<typeof vi.fn>;
+};
+
+vi.mock("@/hooks/usePowertrainSolutionSpace", async (importActual) => {
+  const actual = await importActual<typeof import("@/hooks/usePowertrainSolutionSpace")>();
+  return {
+    ...actual,
+    usePowertrainSolutionSpace: () => hookReturn,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+function mkRow(
+  cell_count: number,
+  overrides: Partial<PowertrainSolutionSpaceResponse["rows"][number]> = {}
+): PowertrainSolutionSpaceResponse["rows"][number] {
+  return {
+    cell_count,
+    v_nom_v: cell_count * 3.7,
+    v_sag_v: cell_count * 3.5,
+    p_cruise_w: 100,
+    p_top_w: 300,
+    p_cruise_lo_w: 90,
+    p_cruise_hi_w: 110,
+    p_top_lo_w: 270,
+    p_top_hi_w: 330,
+    energy_wh: 20,
+    capacity_mah_min: 2000 / cell_count,
+    capacity_mah_min_lo: 1800 / cell_count,
+    capacity_mah_min_hi: 2200 / cell_count,
+    i_peak_a: 40 / cell_count,
+    i_peak_a_lo: 36 / cell_count,
+    i_peak_a_hi: 44 / cell_count,
+    c_min: 8 / cell_count,
+    c_min_lo: 7 / cell_count,
+    c_min_hi: 9 / cell_count,
+    esc_min_a: 56 / cell_count,
+    esc_min_a_lo: 50 / cell_count,
+    esc_min_a_hi: 62 / cell_count,
+    motor_peak_w: 300,
+    motor_cont_w: 100,
+    kv_approx: 1200 / cell_count,
+    has_motor_match: false,
+    has_battery_match: false,
+    has_esc_match: false,
+    ...overrides,
+  };
+}
+
+function mkRegion(cell_count: number): PowertrainSolutionSpaceResponse["feasible_regions"][number] {
+  return {
+    cell_count,
+    capacity_floor_mah: 1500 / cell_count,
+    i_peak_a: 40 / cell_count,
+    capacity_curve_mah: [500, 1000, 2000, 4000],
+    c_rate_curve: [20, 10, 5, 2.5],
+  };
+}
+
+function mkSpec(cell_count: number): PowertrainSolutionSpaceResponse["shopping_specs"][number] {
+  return {
+    cell_count,
+    battery_min_mah: 2000 / cell_count,
+    battery_min_c: 8 / cell_count,
+    battery_v_nom: cell_count * 3.7,
+    esc_min_a: 56 / cell_count,
+    motor_min_peak_w: 300,
+    motor_cont_w: 100,
+    kv_approx: 1200 / cell_count,
+  };
+}
+
+const MOCK_DATA: PowertrainSolutionSpaceResponse = {
+  rows: [mkRow(2), mkRow(3), mkRow(4), mkRow(6)],
+  feasible_regions: [mkRegion(2), mkRegion(3), mkRegion(4), mkRegion(6)],
+  shopping_specs: [mkSpec(2), mkSpec(3), mkSpec(4), mkSpec(6)],
+  p_aero_cruise_w: 80,
+  p_aero_top_w: 250,
+  energy_wh: 18.5,
+  v_cruise_mps: 14.0,
+  v_top_mps: 22.0,
+  t_target_min: 15,
+  assumptions_used: {},
+  warnings: [],
+};
+
+const MOCK_OK = { data: MOCK_DATA, error: null, isLoading: false, mutate: vi.fn() };
+const MOCK_LOADING = { data: undefined, error: null, isLoading: true, mutate: vi.fn() };
+const MOCK_ERROR_422 = {
+  data: null,
+  error: Object.assign(new Error("422"), { status: 422 }),
+  isLoading: false,
+  mutate: vi.fn(),
+};
+const MOCK_ERROR_500 = {
+  data: null,
+  error: Object.assign(new Error("500"), { status: 500 }),
+  isLoading: false,
+  mutate: vi.fn(),
+};
+
+// ---------------------------------------------------------------------------
+// Import component after mocks are set up
+// ---------------------------------------------------------------------------
+
+import { PowertrainTab } from "@/components/workbench/PowertrainTab";
+
+// ---------------------------------------------------------------------------
+// Hook query-string tests (import the real hook function, bypass SWR)
+// ---------------------------------------------------------------------------
+
+// Import the exported URL builder directly for pure unit tests (no hooks needed)
+import { buildSolutionSpaceUrl } from "@/hooks/usePowertrainSolutionSpace";
+
+describe("usePowertrainSolutionSpace — URL construction (buildSolutionSpaceUrl)", () => {
+  it("builds URL with cell_counts as repeated params", () => {
+    const assumptions: SolutionSpaceAssumptions = {
+      cell_counts: [2, 4, 6],
+      eta_prop_lo: 0.65,
+      eta_prop_hi: 0.78,
+      dod: 0.8,
+    };
+    const url = buildSolutionSpaceUrl("test-id", assumptions);
+
+    expect(url).not.toBeNull();
+    expect(url).toContain("cell_counts=2");
+    expect(url).toContain("cell_counts=4");
+    expect(url).toContain("cell_counts=6");
+    expect(url).toContain("eta_prop_lo=0.65");
+    expect(url).toContain("eta_prop_hi=0.78");
+    expect(url).toContain("dod=0.8");
+
+    // Verify all three cell counts present (repeated param pattern)
+    const qs = url!.split("?")[1];
+    const allParams = new URLSearchParams(qs);
+    expect(allParams.getAll("cell_counts")).toEqual(["2", "4", "6"]);
+
+    // Unused assumptions must not appear
+    expect(url).not.toContain("rho=");
+    expect(url).not.toContain("g=");
+  });
+
+  it("returns null when aeroplaneId is null", () => {
+    const url = buildSolutionSpaceUrl(null, { cell_counts: [3] });
+    expect(url).toBeNull();
+  });
+
+  it("encodes aeroplaneId correctly", () => {
+    const url = buildSolutionSpaceUrl("abc-123", {});
+    expect(url).toBe("/aeroplanes/abc-123/powertrain/solution-space");
+  });
+
+  it("omits query string when no assumptions are set", () => {
+    const url = buildSolutionSpaceUrl("my-plane", {});
+    expect(url).not.toContain("?");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PowertrainTab rendering tests
+// ---------------------------------------------------------------------------
+
+describe("PowertrainTab", () => {
+  beforeEach(() => {
+    hookReturn = MOCK_LOADING;
+    plotlyReactMock.mockClear();
+  });
+
+  it("shows loading spinner", () => {
+    hookReturn = MOCK_LOADING;
+    render(<PowertrainTab aeroplaneId="test-id" />);
+    expect(screen.getByText(/computing powertrain solution space/i)).toBeInTheDocument();
+  });
+
+  it("shows 422 error with recompute hint", () => {
+    hookReturn = MOCK_ERROR_422;
+    render(<PowertrainTab aeroplaneId="test-id" />);
+    expect(screen.getByText(/assumption recompute first/i)).toBeInTheDocument();
+  });
+
+  it("shows generic error for 500", () => {
+    hookReturn = MOCK_ERROR_500;
+    render(<PowertrainTab aeroplaneId="test-id" />);
+    expect(screen.getByText(/powertrain solution space unavailable/i)).toBeInTheDocument();
+  });
+
+  it("renders all cell-count rows from mock data", () => {
+    hookReturn = MOCK_OK;
+    render(<PowertrainTab aeroplaneId="test-id" />);
+    expect(screen.getByTestId("solution-row-2")).toBeInTheDocument();
+    expect(screen.getByTestId("solution-row-3")).toBeInTheDocument();
+    expect(screen.getByTestId("solution-row-4")).toBeInTheDocument();
+    expect(screen.getByTestId("solution-row-6")).toBeInTheDocument();
+  });
+
+  it("column Peak-A filter reduces visible rows", () => {
+    // 2S: i_peak_a = 40/2 = 20A; 3S ≈ 13.3A; 4S = 10A; 6S ≈ 6.7A
+    hookReturn = MOCK_OK;
+    render(<PowertrainTab aeroplaneId="test-id" />);
+
+    const filterInput = screen.getByTestId("filter-peak-a");
+    // Filter to Peak A ≤ 15 → hides 2S (20A) but keeps 3S (~13.3A), 4S, 6S
+    fireEvent.change(filterInput, { target: { value: "15" } });
+
+    expect(screen.queryByTestId("solution-row-2")).not.toBeInTheDocument();
+    expect(screen.getByTestId("solution-row-3")).toBeInTheDocument();
+    expect(screen.getByTestId("solution-row-4")).toBeInTheDocument();
+    expect(screen.getByTestId("solution-row-6")).toBeInTheDocument();
+  });
+
+  it("mAh filter reduces visible rows", () => {
+    // 2S: capacity_mah_min = 2000/2 = 1000; 3S ≈ 667; 4S = 500; 6S ≈ 333
+    hookReturn = MOCK_OK;
+    render(<PowertrainTab aeroplaneId="test-id" />);
+
+    const filterInput = screen.getByTestId("filter-mah");
+    // Filter mAh ≤ 350 → show only 6S (≈333); hide 2S/3S/4S
+    fireEvent.change(filterInput, { target: { value: "350" } });
+
+    expect(screen.queryByTestId("solution-row-2")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("solution-row-3")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("solution-row-4")).not.toBeInTheDocument();
+    expect(screen.getByTestId("solution-row-6")).toBeInTheDocument();
+  });
+
+  it("catalog-only toggle hides rows with no matches", () => {
+    // All rows in MOCK_DATA have has_motor_match/battery/esc = false
+    hookReturn = MOCK_OK;
+    render(<PowertrainTab aeroplaneId="test-id" />);
+
+    const toggle = screen.getByTestId("filter-catalog-only");
+    fireEvent.click(toggle);
+
+    // All rows should be hidden — empty message appears
+    expect(screen.getByTestId("solution-table-empty")).toBeInTheDocument();
+    expect(screen.queryByTestId("solution-row-2")).not.toBeInTheDocument();
+  });
+
+  it("catalog-only toggle keeps rows with at least one match", () => {
+    const dataWithMatch: PowertrainSolutionSpaceResponse = {
+      ...MOCK_DATA,
+      rows: [
+        mkRow(3, { has_motor_match: true }),
+        mkRow(4, { has_battery_match: false, has_motor_match: false, has_esc_match: false }),
+      ],
+      shopping_specs: [mkSpec(3), mkSpec(4)],
+      feasible_regions: [mkRegion(3), mkRegion(4)],
+    };
+    hookReturn = { data: dataWithMatch, error: null, isLoading: false, mutate: vi.fn() };
+    render(<PowertrainTab aeroplaneId="test-id" />);
+
+    const toggle = screen.getByTestId("filter-catalog-only");
+    fireEvent.click(toggle);
+
+    expect(screen.getByTestId("solution-row-3")).toBeInTheDocument();
+    expect(screen.queryByTestId("solution-row-4")).not.toBeInTheDocument();
+  });
+
+  it("clicking a row selects it and updates shopping spec", () => {
+    hookReturn = MOCK_OK;
+    render(<PowertrainTab aeroplaneId="test-id" />);
+
+    // Initially, 2S is auto-selected (first row)
+    const specLine2S = screen.getByTestId("shopping-spec-line");
+    expect(specLine2S).toHaveTextContent("2S");
+
+    // Click the 4S row
+    fireEvent.click(screen.getByTestId("solution-row-4"));
+
+    // Shopping spec should now show 4S
+    const specLine4S = screen.getByTestId("shopping-spec-line");
+    expect(specLine4S).toHaveTextContent("4S");
+  });
+
+  it("shopping spec shows correct values for selected row", () => {
+    hookReturn = MOCK_OK;
+    render(<PowertrainTab aeroplaneId="test-id" />);
+
+    // First row is 2S, auto-selected
+    const spec = screen.getByTestId("shopping-spec-line");
+    // 2S: battery_min_mah = 2000/2=1000, esc_min_a=56/2=28, battery_v_nom=7.4
+    expect(spec).toHaveTextContent("1000");
+    expect(spec).toHaveTextContent("28");
+    expect(spec).toHaveTextContent("7.4");
+  });
+
+  it("shows warnings banner when warnings are present", () => {
+    const dataWithWarnings: PowertrainSolutionSpaceResponse = {
+      ...MOCK_DATA,
+      warnings: ["Mission speed not set — using defaults.", "No polar data found."],
+    };
+    hookReturn = { data: dataWithWarnings, error: null, isLoading: false, mutate: vi.fn() };
+    render(<PowertrainTab aeroplaneId="test-id" />);
+
+    const banner = screen.getByTestId("powertrain-warnings");
+    expect(banner).toBeInTheDocument();
+    expect(banner).toHaveTextContent("Mission speed not set");
+    expect(banner).toHaveTextContent("No polar data found");
+  });
+
+  it("does not show warnings banner when warnings array is empty", () => {
+    hookReturn = MOCK_OK;
+    render(<PowertrainTab aeroplaneId="test-id" />);
+    expect(screen.queryByTestId("powertrain-warnings")).not.toBeInTheDocument();
+  });
+
+  it("renders the feasible-region plot container", () => {
+    hookReturn = MOCK_OK;
+    render(<PowertrainTab aeroplaneId="test-id" />);
+    expect(screen.getByTestId("powertrain-feasible-region-plot")).toBeInTheDocument();
+  });
+
+  it("renders assumption controls", () => {
+    hookReturn = MOCK_OK;
+    render(<PowertrainTab aeroplaneId="test-id" />);
+    expect(screen.getByTestId("assumption-controls")).toBeInTheDocument();
+  });
+
+  it("renders mission invariants when data is loaded", () => {
+    hookReturn = MOCK_OK;
+    render(<PowertrainTab aeroplaneId="test-id" />);
+    // V_cruise, V_top, t_target from MOCK_DATA
+    expect(screen.getByText("14.0 m/s")).toBeInTheDocument();
+    expect(screen.getByText("22.0 m/s")).toBeInTheDocument();
+    expect(screen.getByText("15 min")).toBeInTheDocument();
+    expect(screen.getByText("80 W")).toBeInTheDocument(); // p_aero_cruise_w
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FeasibleRegionPlot: Plotly trace construction (structural test)
+// ---------------------------------------------------------------------------
+
+describe("FeasibleRegionPlot — Plotly call structure", () => {
+  beforeEach(() => {
+    plotlyReactMock.mockClear();
+  });
+
+  it("calls Plotly.react with traces for each region", async () => {
+    hookReturn = MOCK_OK;
+    render(<PowertrainTab aeroplaneId="test-id" />);
+
+    // Wait for async Plotly import in useEffect
+    await new Promise((r) => setTimeout(r, 50));
+
+    // plotlyReactMock is called once by FeasibleRegionPlot
+    expect(plotlyReactMock).toHaveBeenCalled();
+
+    const [, traces] = plotlyReactMock.mock.calls[0];
+    // Should have traces for 4 regions: floor curve + vertical line + marker = 3 per region
+    expect(traces.length).toBeGreaterThanOrEqual(4 * 3);
+
+    // Verify marker traces have customdata (cell_count) for click selection
+    const markerTraces = traces.filter(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (t: any) => t.mode === "markers+text" && t.customdata != null
+    );
+    expect(markerTraces.length).toBe(4);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cellCounts = markerTraces.map((t: any) => t.customdata[0]);
+    expect(cellCounts).toContain(2);
+    expect(cellCounts).toContain(3);
+    expect(cellCounts).toContain(4);
+    expect(cellCounts).toContain(6);
+  });
+
+  it("highlights the auto-selected (first) cell count with star marker on initial render", async () => {
+    // On initial render, first row (2S) is auto-selected.
+    // Plotly should render the 2S marker as star and others as circle.
+    hookReturn = MOCK_OK;
+    render(<PowertrainTab aeroplaneId="test-id" />);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(plotlyReactMock).toHaveBeenCalled();
+    const [, traces] = plotlyReactMock.mock.calls[0];
+
+    // 2S marker → selected → star
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const markerFor2S = traces.find((t: any) => t.customdata?.[0] === 2);
+    expect(markerFor2S?.marker?.symbol).toBe("star");
+
+    // 4S marker → not selected → circle
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const markerFor4S = traces.find((t: any) => t.customdata?.[0] === 4);
+    expect(markerFor4S?.marker?.symbol).toBe("circle");
+  });
+
+  it("layout annotation contains mission metadata inside figure", async () => {
+    hookReturn = MOCK_OK;
+    render(<PowertrainTab aeroplaneId="test-id" />);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const [, , layout] = plotlyReactMock.mock.calls[0];
+    // Per project convention: mission params go INSIDE the figure (annotation)
+    const annotations = layout.annotations ?? [];
+    const missionAnnotation = annotations.find(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (a: any) => typeof a.text === "string" && a.text.includes("V_cruise")
+    );
+    expect(missionAnnotation).toBeDefined();
+    expect(missionAnnotation.text).toContain("V_top");
+    expect(missionAnnotation.text).toContain("14.0 m/s"); // v_cruise_mps from MOCK_DATA
+  });
+});

--- a/frontend/__tests__/PowertrainTab.test.tsx
+++ b/frontend/__tests__/PowertrainTab.test.tsx
@@ -69,14 +69,14 @@ function mkRow(
     capacity_mah_min_lo: 1800 / cell_count,
     capacity_mah_min_hi: 2200 / cell_count,
     i_peak_a: 40 / cell_count,
-    i_peak_a_lo: 36 / cell_count,
-    i_peak_a_hi: 44 / cell_count,
+    i_peak_lo_a: 36 / cell_count,
+    i_peak_hi_a: 44 / cell_count,
     c_min: 8 / cell_count,
     c_min_lo: 7 / cell_count,
     c_min_hi: 9 / cell_count,
     esc_min_a: 56 / cell_count,
-    esc_min_a_lo: 50 / cell_count,
-    esc_min_a_hi: 62 / cell_count,
+    esc_min_lo_a: 50 / cell_count,
+    esc_min_hi_a: 62 / cell_count,
     motor_peak_w: 300,
     motor_cont_w: 100,
     kv_approx: 1200 / cell_count,
@@ -237,8 +237,8 @@ describe("PowertrainTab", () => {
     expect(screen.getByTestId("solution-row-6")).toBeInTheDocument();
   });
 
-  it("column Peak-A filter reduces visible rows (conservative i_peak_a_hi)", () => {
-    // Filters compare against the CONSERVATIVE worst-case Peak A = i_peak_a_hi.
+  it("column Peak-A filter reduces visible rows (conservative i_peak_hi_a)", () => {
+    // Filters compare against the CONSERVATIVE worst-case Peak A = i_peak_hi_a.
     // 2S: 44/2 = 22A; 3S ≈ 14.67A; 4S = 11A; 6S ≈ 7.33A
     hookReturn = MOCK_OK;
     render(<PowertrainTab aeroplaneId="test-id" />);
@@ -323,7 +323,7 @@ describe("PowertrainTab", () => {
     render(<PowertrainTab aeroplaneId="test-id" />);
 
     // First row is 2S, auto-selected. Conservative (worst-case, rounded-up):
-    //   ESC   = ceil(esc_min_a_hi = 62/2 = 31)            = 31 A
+    //   ESC   = ceil(esc_min_hi_a = 62/2 = 31)            = 31 A
     //   mAh   = ceil(capacity_mah_min_hi = 2200/2 = 1100) = 1100 mAh
     //   C     = ceil(c_min_hi = 9/2 = 4.5)                = 5 C
     //   Motor = ceil(p_aero_top_w / eta_prop_lo = 250/0.65) = 385 W
@@ -605,26 +605,27 @@ describe("PowertrainTab — selection + input edge cases", () => {
 // ---------------------------------------------------------------------------
 
 describe("conservativeSpec / conservativeMotorW", () => {
-  it("uses _hi band and rounds UP so a part bought at the value is sufficient", () => {
-    // 2S mock row: i_peak_a_hi=22, esc_min_a_hi=31, c_min_hi=4.5, cap_hi=1100
+  it("uses the worst-case _hi band and rounds UP so a part bought at the value is sufficient", () => {
+    // 2S mock row (real field names): i_peak_hi_a=22, esc_min_hi_a=31,
+    // c_min_hi=4.5, capacity_mah_min_hi=1100
     const row = mkRow(2);
     const spec = conservativeSpec(row, 250, 0.65);
-    expect(spec.peakA).toBe(22); // i_peak_a_hi, not the mid i_peak_a (=20)
-    expect(spec.escMinA).toBe(31); // ceil(31)
-    expect(spec.minC).toBe(5); // ceil(4.5)
-    expect(spec.mahMin).toBe(1100); // ceil(1100)
+    expect(spec.peakA).toBe(22); // i_peak_hi_a, not the mid i_peak_a (=20)
+    expect(spec.escMinA).toBe(31); // ceil(esc_min_hi_a = 31)
+    expect(spec.minC).toBe(5); // ceil(c_min_hi = 4.5)
+    expect(spec.mahMin).toBe(1100); // ceil(capacity_mah_min_hi = 1100)
     expect(spec.motorW).toBe(385); // ceil(250 / 0.65)
   });
 
   it("does NOT divide mAh by DoD (DoD already in energy_wh upstream)", () => {
     // capacity_mah_min_hi is already the rated pack capacity; ceil only.
-    const row = mkRow(4); // cap_hi = 2200/4 = 550
+    const row = mkRow(4); // capacity_mah_min_hi = 2200/4 = 550
     const spec = conservativeSpec(row, 250, 0.65);
     expect(spec.mahMin).toBe(550);
   });
 
   it("rounds a fractional ceil example up (5.46A → 6A) like the real UAT data", () => {
-    const row = mkRow(2, { esc_min_a_hi: 5.46 });
+    const row = mkRow(2, { esc_min_hi_a: 5.46 });
     const spec = conservativeSpec(row, 250, 0.65);
     expect(spec.escMinA).toBe(6);
   });
@@ -632,6 +633,33 @@ describe("conservativeSpec / conservativeMotorW", () => {
   it("conservativeMotorW = ceil(pAeroTop / etaPropLo); degrades gracefully at eta<=0", () => {
     expect(conservativeMotorW(250, 0.65)).toBe(385);
     expect(conservativeMotorW(250, 0)).toBe(250); // no divide-by-zero
+  });
+
+  it("falls back to the mid value when the _hi band field is absent (contract drift)", () => {
+    // Simulate a backend that dropped the band fields: only mid values present.
+    // Strip the band keys via an unknown cast (object-literal @ts-expect-error
+    // can't target individual properties).
+    const base = mkRow(2) as unknown as Record<string, unknown>;
+    delete base.i_peak_hi_a;
+    delete base.esc_min_hi_a;
+    delete base.c_min_hi;
+    delete base.capacity_mah_min_hi;
+    const row = base as unknown as PowertrainSolutionSpaceResponse["rows"][number];
+    const spec = conservativeSpec(row, 250, 0.65);
+    // Falls back to mid: i_peak_a=20, esc_min_a=28→28, c_min=4→4, cap=1000→1000
+    expect(spec.peakA).toBe(20);
+    expect(spec.escMinA).toBe(28);
+    expect(spec.minC).toBe(4);
+    expect(spec.mahMin).toBe(1000);
+  });
+
+  it("returns null (renders '—') when neither band nor mid value is usable", () => {
+    const base = mkRow(2) as unknown as Record<string, unknown>;
+    delete base.i_peak_hi_a;
+    delete base.i_peak_a;
+    const row = base as unknown as PowertrainSolutionSpaceResponse["rows"][number];
+    const spec = conservativeSpec(row, 250, 0.65);
+    expect(spec.peakA).toBeNull();
   });
 });
 

--- a/frontend/__tests__/PowertrainTab.test.tsx
+++ b/frontend/__tests__/PowertrainTab.test.tsx
@@ -441,4 +441,140 @@ describe("FeasibleRegionPlot — Plotly call structure", () => {
     expect(missionAnnotation.text).toContain("V_top");
     expect(missionAnnotation.text).toContain("14.0 m/s"); // v_cruise_mps from MOCK_DATA
   });
+
+  it("reserves bottom margin so the metadata annotation is not clipped", async () => {
+    hookReturn = MOCK_OK;
+    render(<PowertrainTab aeroplaneId="test-id" />);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const [, , layout] = plotlyReactMock.mock.calls[0];
+    // Bottom annotation sits at y:-0.13; margin.b must be generous (>= 65)
+    // to keep it fully visible.
+    expect(layout.margin.b).toBeGreaterThanOrEqual(65);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// plotly_click listener: bind once, clean up on unmount (no accumulation)
+// ---------------------------------------------------------------------------
+
+describe("FeasibleRegionPlot — plotly_click listener lifecycle", () => {
+  beforeEach(() => {
+    plotlyReactMock.mockClear();
+  });
+
+  it("binds the click listener once and removes it on cleanup", async () => {
+    // Patch the jsdom container so it exposes Plotly's `.on()` / `.removeAllListeners()`.
+    const onSpy = vi.fn();
+    const removeAllSpy = vi.fn();
+    const origCreate = document.createElement.bind(document);
+    const createSpy = vi
+      .spyOn(document, "createElement")
+      .mockImplementation((tag: string, opts?: ElementCreationOptions) => {
+        const el = origCreate(tag, opts);
+        if (tag === "div") {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (el as any).on = onSpy;
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (el as any).removeAllListeners = removeAllSpy;
+        }
+        return el;
+      });
+
+    hookReturn = MOCK_OK;
+    const { unmount } = render(<PowertrainTab aeroplaneId="test-id" />);
+    await new Promise((r) => setTimeout(r, 50));
+
+    // The click handler is bound exactly once for plotly_click.
+    const clickBinds = onSpy.mock.calls.filter((c) => c[0] === "plotly_click");
+    expect(clickBinds.length).toBe(1);
+
+    unmount();
+    expect(removeAllSpy).toHaveBeenCalledWith("plotly_click");
+
+    createSpy.mockRestore();
+  });
+
+  it("does not re-bind the click listener when the selection changes", async () => {
+    const onSpy = vi.fn();
+    const removeAllSpy = vi.fn();
+    const origCreate = document.createElement.bind(document);
+    const createSpy = vi
+      .spyOn(document, "createElement")
+      .mockImplementation((tag: string, opts?: ElementCreationOptions) => {
+        const el = origCreate(tag, opts);
+        if (tag === "div") {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (el as any).on = onSpy;
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (el as any).removeAllListeners = removeAllSpy;
+        }
+        return el;
+      });
+
+    hookReturn = MOCK_OK;
+    render(<PowertrainTab aeroplaneId="test-id" />);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const bindsBefore = onSpy.mock.calls.filter((c) => c[0] === "plotly_click").length;
+    expect(bindsBefore).toBe(1);
+
+    // Change the selection by clicking a different table row.
+    fireEvent.click(screen.getByTestId("solution-row-4"));
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Selection change re-draws the figure (marker re-style) but must NOT
+    // re-bind the click listener — the effect that binds it does not depend
+    // on selectedCellCount.
+    const bindsAfter = onSpy.mock.calls.filter((c) => c[0] === "plotly_click").length;
+    expect(bindsAfter).toBe(1);
+
+    createSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Orphaned-selection reset + NaN-guarded numeric inputs
+// ---------------------------------------------------------------------------
+
+describe("PowertrainTab — selection + input edge cases", () => {
+  beforeEach(() => {
+    plotlyReactMock.mockClear();
+  });
+
+  it("resets the selection when the selected cell-count disappears from new data", () => {
+    hookReturn = MOCK_OK;
+    const { rerender } = render(<PowertrainTab aeroplaneId="test-id" />);
+
+    // Select 6S explicitly.
+    fireEvent.click(screen.getByTestId("solution-row-6"));
+    expect(screen.getByTestId("shopping-spec-line")).toHaveTextContent("6S");
+
+    // New data no longer contains 6S → selection must fall back to first row (3S).
+    const dataWithout6S: PowertrainSolutionSpaceResponse = {
+      ...MOCK_DATA,
+      rows: [mkRow(3), mkRow(4)],
+      feasible_regions: [mkRegion(3), mkRegion(4)],
+      shopping_specs: [mkSpec(3), mkSpec(4)],
+    };
+    hookReturn = { data: dataWithout6S, error: null, isLoading: false, mutate: vi.fn() };
+    rerender(<PowertrainTab aeroplaneId="test-id" />);
+
+    // Shopping spec now reflects the first available row (3S), not the orphaned 6S.
+    expect(screen.getByTestId("shopping-spec-line")).toHaveTextContent("3S");
+    expect(screen.queryByTestId("solution-row-6")).not.toBeInTheDocument();
+  });
+
+  it("clearing a numeric assumption input omits it (no NaN serialized)", () => {
+    hookReturn = MOCK_OK;
+    render(<PowertrainTab aeroplaneId="test-id" />);
+
+    const tTarget = screen.getByTestId("t-target-input") as HTMLInputElement;
+    // Clearing the field must NOT throw and must not leave a NaN; the value
+    // becomes undefined and the input falls back to its default on re-render
+    // (undefined → `assumptions.t_target_min ?? 15`).
+    fireEvent.change(tTarget, { target: { value: "" } });
+
+    expect((screen.getByTestId("t-target-input") as HTMLInputElement).value).toBe("15");
+  });
 });

--- a/frontend/__tests__/PowertrainTab.test.tsx
+++ b/frontend/__tests__/PowertrainTab.test.tsx
@@ -143,7 +143,11 @@ const MOCK_ERROR_500 = {
 // Import component after mocks are set up
 // ---------------------------------------------------------------------------
 
-import { PowertrainTab } from "@/components/workbench/PowertrainTab";
+import {
+  PowertrainTab,
+  conservativeSpec,
+  conservativeMotorW,
+} from "@/components/workbench/PowertrainTab";
 
 // ---------------------------------------------------------------------------
 // Hook query-string tests (import the real hook function, bypass SWR)
@@ -233,13 +237,14 @@ describe("PowertrainTab", () => {
     expect(screen.getByTestId("solution-row-6")).toBeInTheDocument();
   });
 
-  it("column Peak-A filter reduces visible rows", () => {
-    // 2S: i_peak_a = 40/2 = 20A; 3S ≈ 13.3A; 4S = 10A; 6S ≈ 6.7A
+  it("column Peak-A filter reduces visible rows (conservative i_peak_a_hi)", () => {
+    // Filters compare against the CONSERVATIVE worst-case Peak A = i_peak_a_hi.
+    // 2S: 44/2 = 22A; 3S ≈ 14.67A; 4S = 11A; 6S ≈ 7.33A
     hookReturn = MOCK_OK;
     render(<PowertrainTab aeroplaneId="test-id" />);
 
     const filterInput = screen.getByTestId("filter-peak-a");
-    // Filter to Peak A ≤ 15 → hides 2S (20A) but keeps 3S (~13.3A), 4S, 6S
+    // Filter to Peak A ≤ 15 → hides 2S (22A) but keeps 3S (~14.67A), 4S, 6S
     fireEvent.change(filterInput, { target: { value: "15" } });
 
     expect(screen.queryByTestId("solution-row-2")).not.toBeInTheDocument();
@@ -248,14 +253,15 @@ describe("PowertrainTab", () => {
     expect(screen.getByTestId("solution-row-6")).toBeInTheDocument();
   });
 
-  it("mAh filter reduces visible rows", () => {
-    // 2S: capacity_mah_min = 2000/2 = 1000; 3S ≈ 667; 4S = 500; 6S ≈ 333
+  it("mAh filter reduces visible rows (conservative ceil(capacity_mah_min_hi))", () => {
+    // Conservative mAh min = ceil(capacity_mah_min_hi = 2200/cell):
+    // 2S = 1100; 3S = ceil(733.3) = 734; 4S = 550; 6S = ceil(366.7) = 367
     hookReturn = MOCK_OK;
     render(<PowertrainTab aeroplaneId="test-id" />);
 
     const filterInput = screen.getByTestId("filter-mah");
-    // Filter mAh ≤ 350 → show only 6S (≈333); hide 2S/3S/4S
-    fireEvent.change(filterInput, { target: { value: "350" } });
+    // Filter mAh ≤ 400 → show only 6S (367); hide 2S/3S/4S
+    fireEvent.change(filterInput, { target: { value: "400" } });
 
     expect(screen.queryByTestId("solution-row-2")).not.toBeInTheDocument();
     expect(screen.queryByTestId("solution-row-3")).not.toBeInTheDocument();
@@ -312,16 +318,23 @@ describe("PowertrainTab", () => {
     expect(specLine4S).toHaveTextContent("4S");
   });
 
-  it("shopping spec shows correct values for selected row", () => {
+  it("shopping spec shows CONSERVATIVE rounded-up values for selected row", () => {
     hookReturn = MOCK_OK;
     render(<PowertrainTab aeroplaneId="test-id" />);
 
-    // First row is 2S, auto-selected
+    // First row is 2S, auto-selected. Conservative (worst-case, rounded-up):
+    //   ESC   = ceil(esc_min_a_hi = 62/2 = 31)            = 31 A
+    //   mAh   = ceil(capacity_mah_min_hi = 2200/2 = 1100) = 1100 mAh
+    //   C     = ceil(c_min_hi = 9/2 = 4.5)                = 5 C
+    //   Motor = ceil(p_aero_top_w / eta_prop_lo = 250/0.65) = 385 W
+    //   V_nom = 7.4 V, KV = 600 (from shopping spec)
     const spec = screen.getByTestId("shopping-spec-line");
-    // 2S: battery_min_mah = 2000/2=1000, esc_min_a=56/2=28, battery_v_nom=7.4
-    expect(spec).toHaveTextContent("1000");
-    expect(spec).toHaveTextContent("28");
+    expect(spec).toHaveTextContent("ESC ≥ 31 A");
+    expect(spec).toHaveTextContent("1100 mAh");
+    expect(spec).toHaveTextContent("≥5C");
+    expect(spec).toHaveTextContent("385 W");
     expect(spec).toHaveTextContent("7.4");
+    expect(spec).toHaveTextContent("600");
   });
 
   it("shows warnings banner when warnings are present", () => {
@@ -402,6 +415,14 @@ describe("FeasibleRegionPlot — Plotly call structure", () => {
     expect(cellCounts).toContain(3);
     expect(cellCounts).toContain(4);
     expect(cellCounts).toContain(6);
+
+    // Markers must sit at the CONSERVATIVE worst-case point
+    // (ceil(capacity_mah_min_hi), ceil(c_min_hi)). For 2S:
+    //   x = ceil(2200/2) = 1100, y = ceil(9/2 = 4.5) = 5
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const marker2S = markerTraces.find((t: any) => t.customdata[0] === 2);
+    expect(marker2S.x[0]).toBe(1100);
+    expect(marker2S.y[0]).toBe(5);
   });
 
   it("highlights the auto-selected (first) cell count with star marker on initial render", async () => {
@@ -576,5 +597,139 @@ describe("PowertrainTab — selection + input edge cases", () => {
     fireEvent.change(tTarget, { target: { value: "" } });
 
     expect((screen.getByTestId("t-target-input") as HTMLInputElement).value).toBe("15");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conservative (worst-case, rounded-up) minimum specs — pure functions
+// ---------------------------------------------------------------------------
+
+describe("conservativeSpec / conservativeMotorW", () => {
+  it("uses _hi band and rounds UP so a part bought at the value is sufficient", () => {
+    // 2S mock row: i_peak_a_hi=22, esc_min_a_hi=31, c_min_hi=4.5, cap_hi=1100
+    const row = mkRow(2);
+    const spec = conservativeSpec(row, 250, 0.65);
+    expect(spec.peakA).toBe(22); // i_peak_a_hi, not the mid i_peak_a (=20)
+    expect(spec.escMinA).toBe(31); // ceil(31)
+    expect(spec.minC).toBe(5); // ceil(4.5)
+    expect(spec.mahMin).toBe(1100); // ceil(1100)
+    expect(spec.motorW).toBe(385); // ceil(250 / 0.65)
+  });
+
+  it("does NOT divide mAh by DoD (DoD already in energy_wh upstream)", () => {
+    // capacity_mah_min_hi is already the rated pack capacity; ceil only.
+    const row = mkRow(4); // cap_hi = 2200/4 = 550
+    const spec = conservativeSpec(row, 250, 0.65);
+    expect(spec.mahMin).toBe(550);
+  });
+
+  it("rounds a fractional ceil example up (5.46A → 6A) like the real UAT data", () => {
+    const row = mkRow(2, { esc_min_a_hi: 5.46 });
+    const spec = conservativeSpec(row, 250, 0.65);
+    expect(spec.escMinA).toBe(6);
+  });
+
+  it("conservativeMotorW = ceil(pAeroTop / etaPropLo); degrades gracefully at eta<=0", () => {
+    expect(conservativeMotorW(250, 0.65)).toBe(385);
+    expect(conservativeMotorW(250, 0)).toBe(250); // no divide-by-zero
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Table renders the conservative values (not the mid band)
+// ---------------------------------------------------------------------------
+
+describe("SolutionTable — conservative cell values", () => {
+  beforeEach(() => {
+    plotlyReactMock.mockClear();
+  });
+
+  it("shows conservative ESC / mAh / Min C-rating / Peak A / Motor in the 2S row", () => {
+    hookReturn = MOCK_OK;
+    render(<PowertrainTab aeroplaneId="test-id" />);
+
+    const row2S = screen.getByTestId("solution-row-2");
+    // Conservative 2S: Peak 22.0, ESC 31, mAh 1100, Min C 5, Motor 385.
+    expect(row2S).toHaveTextContent("22.0");
+    expect(row2S).toHaveTextContent("31");
+    expect(row2S).toHaveTextContent("1100");
+    expect(row2S).toHaveTextContent("5");
+    expect(row2S).toHaveTextContent("385");
+  });
+
+  it("renames the C-min header to 'Min C-rating' with a guidance tooltip", () => {
+    hookReturn = MOCK_OK;
+    render(<PowertrainTab aeroplaneId="test-id" />);
+    const header = screen.getByText("Min C-rating");
+    expect(header).toBeInTheDocument();
+    expect(header).toHaveAttribute("title", "minimum battery C-rating you need");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hobbyist labels / guidance + Scholz scope note
+// ---------------------------------------------------------------------------
+
+describe("PowertrainTab — labels, guidance, scope note", () => {
+  beforeEach(() => {
+    plotlyReactMock.mockClear();
+  });
+
+  it("renders the Phase-1 scope disclaimer", () => {
+    hookReturn = MOCK_OK;
+    render(<PowertrainTab aeroplaneId="test-id" />);
+    const note = screen.getByTestId("powertrain-scope-note");
+    expect(note).toHaveTextContent(/Phase 1/i);
+    expect(note).toHaveTextContent(/static-thrust/i);
+    expect(note).toHaveTextContent(/Phase 2/i);
+  });
+
+  it("renders the hobbyist how-to callout above the table", () => {
+    hookReturn = MOCK_OK;
+    render(<PowertrainTab aeroplaneId="test-id" />);
+    const callout = screen.getByTestId("powertrain-table-callout");
+    expect(callout).toHaveTextContent(/Pick a cell count, then shop/i);
+    expect(callout).toHaveTextContent(/ESC ≥ ESC min/i);
+  });
+
+  it("labels the assumption controls for hobbyists (Prop efficiency, DoD tooltip)", () => {
+    hookReturn = MOCK_OK;
+    render(<PowertrainTab aeroplaneId="test-id" />);
+    expect(screen.getByText("Prop efficiency [lo / hi]")).toBeInTheDocument();
+    const dod = screen.getByText("DoD");
+    expect(dod).toHaveAttribute("title", "Depth of discharge — usable battery %");
+  });
+
+  it("marks the invariants row as 'Computed from mission'", () => {
+    hookReturn = MOCK_OK;
+    render(<PowertrainTab aeroplaneId="test-id" />);
+    expect(screen.getByTestId("invariants-source-label")).toHaveTextContent(
+      /Computed from mission/i
+    );
+  });
+
+  it("shows the V_top '(from Mission)' hint when v_top is auto-derived", () => {
+    hookReturn = MOCK_OK;
+    render(<PowertrainTab aeroplaneId="test-id" />);
+    // assumptions start with no v_top_mps → auto-derived.
+    expect(screen.getByTestId("v-top-from-mission")).toBeInTheDocument();
+
+    // Setting V_top removes the hint.
+    fireEvent.change(screen.getByTestId("v-top-input"), { target: { value: "25" } });
+    expect(screen.queryByTestId("v-top-from-mission")).not.toBeInTheDocument();
+  });
+
+  it("adds the 'on/above the curve' feasibility annotation to the plot", async () => {
+    hookReturn = MOCK_OK;
+    render(<PowertrainTab aeroplaneId="test-id" />);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const [, , layout] = plotlyReactMock.mock.calls[0];
+    const annotations = layout.annotations ?? [];
+    const feasNote = annotations.find(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (a: any) => typeof a.text === "string" && a.text.includes("on/above the curve")
+    );
+    expect(feasNote).toBeDefined();
   });
 });

--- a/frontend/__tests__/StabilityTab.test.tsx
+++ b/frontend/__tests__/StabilityTab.test.tsx
@@ -26,6 +26,7 @@ describe("AnalysisViewerPanel TABS (gh-567)", () => {
       "Streamlines",
       "Envelope",
       "Sizing",
+      "Powertrain",
     ]);
   });
 });

--- a/frontend/app/workbench/analysis/page.tsx
+++ b/frontend/app/workbench/analysis/page.tsx
@@ -67,6 +67,7 @@ export default function AnalysisPage() {
     "Envelope": "Flight Envelope",
     "Operating Points": "Operating Points",
     "Sizing": "Sizing",
+    "Powertrain": "Powertrain Solution Space",
   };
   const modalTitle = modalTitleByTab[activeTab];
 

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -11,10 +11,11 @@ import { buildSpeedPolarLayout } from "@/lib/speedPolarLayout";
 import type { StoredOperatingPoint, AVLTrimResult, AeroBuildupTrimResult, TrimConstraint, ControlSurface } from "@/hooks/useOperatingPoints";
 import { OperatingPointsPanel } from "@/components/workbench/OperatingPointsPanel";
 import { MatchingChartTab } from "@/components/workbench/MatchingChartTab";
+import { PowertrainTab } from "@/components/workbench/PowertrainTab";
 import { AnalysisStatusIndicator } from "./AnalysisStatusIndicator";
 import type { AnalysisStatus } from "@/hooks/useAnalysisStatus";
 
-const TABS = ["Assumptions", "Operating Points", "Polar", "Trefftz Plane", "Streamlines", "Envelope", "Sizing"] as const;
+const TABS = ["Assumptions", "Operating Points", "Polar", "Trefftz Plane", "Streamlines", "Envelope", "Sizing", "Powertrain"] as const;
 export type Tab = (typeof TABS)[number];
 export { TABS };
 
@@ -938,6 +939,7 @@ export function AnalysisViewerPanel({
     "Envelope",
     "Operating Points",
     "Sizing",
+    "Powertrain",
   ]);
   const showWingGate = !hasWings && COMPUTATION_TABS.has(activeTab);
 
@@ -1189,6 +1191,18 @@ export function AnalysisViewerPanel({
         <div className="flex flex-1 items-center justify-center bg-card-muted">
           <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-muted-foreground">
             Select an aeroplane to show the matching chart
+          </span>
+        </div>
+      )}
+
+      {activeTab === "Powertrain" && aeroplaneId && (
+        <PowertrainTab aeroplaneId={aeroplaneId} />
+      )}
+
+      {activeTab === "Powertrain" && !aeroplaneId && (
+        <div className="flex flex-1 items-center justify-center bg-card-muted">
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-muted-foreground">
+            Select an aeroplane to show the powertrain solution space
           </span>
         </div>
       )}

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -932,6 +932,11 @@ export function AnalysisViewerPanel({
     setMaximizedChart((prev) => (prev === id ? null : id));
   }
 
+  // gh-976/gh-977: "Powertrain" is intentionally NOT in this set. Unlike the
+  // aero tabs, powertrain sizing does not require wings to have an aero
+  // analysis run — the backend returns a design warning when mission/aero
+  // context is missing, and PowertrainTab surfaces those via its warnings
+  // banner. So it must render even without wings (no hard wing-gate block).
   const COMPUTATION_TABS = new Set<Tab>([
     "Polar",
     "Trefftz Plane",
@@ -939,7 +944,6 @@ export function AnalysisViewerPanel({
     "Envelope",
     "Operating Points",
     "Sizing",
-    "Powertrain",
   ]);
   const showWingGate = !hasWings && COMPUTATION_TABS.has(activeTab);
 

--- a/frontend/components/workbench/PowertrainTab.tsx
+++ b/frontend/components/workbench/PowertrainTab.tsx
@@ -184,7 +184,8 @@ function buildFeasibleRegionLayout(
     paper_bgcolor: "transparent",
     plot_bgcolor: "transparent",
     font: { color: "#A1A1AA", family: "JetBrains Mono, monospace", size: 10 },
-    margin: { l: 55, r: 15, t: 45, b: 50 },
+    // b:70 so the bottom mission-metadata annotation (y:-0.13) is fully visible.
+    margin: { l: 55, r: 15, t: 45, b: 70 },
     title: {
       text: "Capacity × C-rate feasible region",
       font: { color: "#E4E4E7", size: 12 },
@@ -240,6 +241,9 @@ function FeasibleRegionPlot({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const plotlyRef = useRef<any>(null);
 
+  // Draw effect: (re)render the figure. Depends on selectedCellCount so the
+  // marker re-styles (star ↔ circle) on selection — but this effect must NOT
+  // bind the click listener (that would accumulate handlers on every redraw).
   useEffect(() => {
     const node = containerRef.current;
     if (!node || regions.length === 0) return;
@@ -258,8 +262,29 @@ function FeasibleRegionPlot({
         responsive: true,
         displayModeBar: false,
       });
+    })();
 
-      // Click listener to select cell count from marker.
+    return () => {
+      disposed = true;
+    };
+  }, [regions, rows, selectedCellCount, vCruiseMps, vTopMps, tTargetMin]);
+
+  // Click effect: bind the marker → cell-count selection handler exactly once
+  // per (rows, onSelectCellCount) identity. It deliberately does NOT depend on
+  // selectedCellCount, so selecting a cell does not re-bind the listener.
+  // Cleanup removes the listener to prevent accumulation / leaks.
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node) return;
+
+    let disposed = false;
+
+    (async () => {
+      // Ensure Plotly has attached its event emitter to the node before we bind.
+      const Plotly = plotlyRef.current ?? (await import("plotly.js-gl3d-dist-min"));
+      plotlyRef.current = Plotly;
+      if (disposed) return;
+
       // Plotly attaches `.on()` to the container div — guard for jsdom / SSR.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const plotNode = node as any;
@@ -275,11 +300,15 @@ function FeasibleRegionPlot({
 
     return () => {
       disposed = true;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const plotNode = node as any;
+      if (typeof plotNode.removeAllListeners === "function") {
+        plotNode.removeAllListeners("plotly_click");
+      }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [regions, rows, selectedCellCount, vCruiseMps, vTopMps, tTargetMin]);
+  }, [rows, onSelectCellCount]);
 
-  // Cleanup
+  // Cleanup: purge the Plotly figure on unmount.
   useEffect(() => {
     const node = containerRef.current;
     return () => {
@@ -292,7 +321,7 @@ function FeasibleRegionPlot({
   return (
     <div
       ref={containerRef}
-      className="h-full min-h-0 w-full"
+      className="w-full"
       style={{ height: 320 }}
       data-testid="powertrain-feasible-region-plot"
     />
@@ -370,7 +399,7 @@ function SolutionTable({
             <th scope="col" className="py-2 pr-3">V_nom (V)</th>
             <th scope="col" className="py-2 pr-3">Motor (W)</th>
             <th scope="col" className="py-2 pr-3">Peak A</th>
-            <th scope="col" className="py-2 pr-3">ESC ≥A</th>
+            <th scope="col" className="py-2 pr-3">ESC min (A)</th>
             <th scope="col" className="py-2 pr-3">mAh min</th>
             <th scope="col" className="py-2 pr-3">C min</th>
             <th scope="col" className="py-2 pr-3">Wh</th>
@@ -434,7 +463,11 @@ function SolutionTable({
                 <td
                   className={`py-2 ${hasCatalog ? "text-emerald-400" : "text-muted-foreground"}`}
                 >
-                  {hasCatalog ? "✓" : "—"}
+                  {hasCatalog ? (
+                    <span aria-label="catalog match available">✓</span>
+                  ) : (
+                    "—"
+                  )}
                   {row.has_motor_match && (
                     <span
                       className="ml-1 text-[9px] text-emerald-400"
@@ -486,6 +519,47 @@ interface AssumptionControlsProps {
   readonly onChange: (next: SolutionSpaceAssumptions) => void;
 }
 
+/** A single numeric assumption input.
+ *
+ * Module-level (not re-created each render) so React keeps a stable element
+ * identity. Clearing the input yields `parseFloat("") === NaN`; we coerce that
+ * to `undefined` so the key is omitted from the assumptions object rather than
+ * serialized as `null` (which would mislead the backend into the "recompute
+ * first" path). Same omission semantics as the v_top_mps field.
+ */
+function NumField({
+  assumptions,
+  fieldKey,
+  value,
+  defaultVal,
+  onChange,
+  testId,
+}: Readonly<{
+  assumptions: SolutionSpaceAssumptions;
+  fieldKey: keyof SolutionSpaceAssumptions;
+  value: number | undefined;
+  defaultVal: number;
+  onChange: (next: SolutionSpaceAssumptions) => void;
+  testId?: string;
+}>) {
+  return (
+    <input
+      type="number"
+      value={value ?? defaultVal}
+      step={0.01}
+      onChange={(e) => {
+        const raw = e.target.value;
+        const parsed = parseFloat(raw);
+        const next: number | undefined =
+          raw === "" || Number.isNaN(parsed) ? undefined : parsed;
+        onChange({ ...assumptions, [fieldKey]: next });
+      }}
+      className="w-20 rounded border border-border bg-card-muted px-2 py-1 font-[family-name:var(--font-geist-sans)] text-[11px] text-foreground"
+      data-testid={testId}
+    />
+  );
+}
+
 function AssumptionControls({ assumptions, onChange }: AssumptionControlsProps) {
   const cellCounts = assumptions.cell_counts ?? DEFAULT_CELL_COUNTS;
 
@@ -494,24 +568,6 @@ function AssumptionControls({ assumptions, onChange }: AssumptionControlsProps) 
       ? cellCounts.filter((c) => c !== s)
       : [...cellCounts, s].sort((a, b) => a - b);
     onChange({ ...assumptions, cell_counts: next });
-  }
-
-  function numField(
-    key: keyof SolutionSpaceAssumptions,
-    value: number | undefined,
-    defaultVal: number
-  ) {
-    return (
-      <input
-        type="number"
-        value={value ?? defaultVal}
-        step={0.01}
-        onChange={(e) =>
-          onChange({ ...assumptions, [key]: parseFloat(e.target.value) })
-        }
-        className="w-20 rounded border border-border bg-card-muted px-2 py-1 font-[family-name:var(--font-geist-sans)] text-[11px] text-foreground"
-      />
-    );
   }
 
   return (
@@ -550,9 +606,21 @@ function AssumptionControls({ assumptions, onChange }: AssumptionControlsProps) 
           η_prop [lo / hi]
         </span>
         <div className="flex items-center gap-1">
-          {numField("eta_prop_lo", assumptions.eta_prop_lo, 0.65)}
+          <NumField
+            assumptions={assumptions}
+            fieldKey="eta_prop_lo"
+            value={assumptions.eta_prop_lo}
+            defaultVal={0.65}
+            onChange={onChange}
+          />
           <span className="text-muted-foreground">/</span>
-          {numField("eta_prop_hi", assumptions.eta_prop_hi, 0.78)}
+          <NumField
+            assumptions={assumptions}
+            fieldKey="eta_prop_hi"
+            value={assumptions.eta_prop_hi}
+            defaultVal={0.78}
+            onChange={onChange}
+          />
         </div>
       </div>
 
@@ -561,7 +629,13 @@ function AssumptionControls({ assumptions, onChange }: AssumptionControlsProps) 
         <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
           DoD
         </span>
-        {numField("dod", assumptions.dod, 0.8)}
+        <NumField
+          assumptions={assumptions}
+          fieldKey="dod"
+          value={assumptions.dod}
+          defaultVal={0.8}
+          onChange={onChange}
+        />
       </div>
 
       {/* ESC margin */}
@@ -569,7 +643,13 @@ function AssumptionControls({ assumptions, onChange }: AssumptionControlsProps) 
         <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
           ESC margin ×
         </span>
-        {numField("esc_margin", assumptions.esc_margin, 1.4)}
+        <NumField
+          assumptions={assumptions}
+          fieldKey="esc_margin"
+          value={assumptions.esc_margin}
+          defaultVal={1.4}
+          onChange={onChange}
+        />
       </div>
 
       {/* C margin */}
@@ -577,7 +657,13 @@ function AssumptionControls({ assumptions, onChange }: AssumptionControlsProps) 
         <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
           C margin ×
         </span>
-        {numField("c_margin", assumptions.c_margin, 1.25)}
+        <NumField
+          assumptions={assumptions}
+          fieldKey="c_margin"
+          value={assumptions.c_margin}
+          defaultVal={1.25}
+          onChange={onChange}
+        />
       </div>
 
       {/* Prop P/D preset */}
@@ -611,9 +697,14 @@ function AssumptionControls({ assumptions, onChange }: AssumptionControlsProps) 
           value={assumptions.t_target_min ?? 15}
           min={1}
           step={1}
-          onChange={(e) =>
-            onChange({ ...assumptions, t_target_min: parseFloat(e.target.value) })
-          }
+          onChange={(e) => {
+            const raw = e.target.value;
+            const parsed = parseFloat(raw);
+            onChange({
+              ...assumptions,
+              t_target_min: raw === "" || Number.isNaN(parsed) ? undefined : parsed,
+            });
+          }}
           className="w-20 rounded border border-border bg-card-muted px-2 py-1 font-[family-name:var(--font-geist-sans)] text-[11px] text-foreground"
           data-testid="t-target-input"
         />
@@ -778,6 +869,19 @@ export function PowertrainTab({ aeroplaneId }: Props) {
 
   const { data, isLoading, error } = usePowertrainSolutionSpace(aeroplaneId, assumptions);
 
+  // Reset an orphaned selection: if the selected cell-count no longer exists in
+  // the new rows (e.g. after an assumptions change removed it), clear it so the
+  // auto-select fallback (first row) takes over instead of pointing at nothing.
+  // Done during render (not in a useEffect) per the React 19 "adjust state when
+  // data changes" pattern — avoids the react-hooks/set-state-in-effect cascade.
+  if (
+    selectedCellCount != null &&
+    data != null &&
+    !data.rows.some((r) => r.cell_count === selectedCellCount)
+  ) {
+    setSelectedCellCount(null);
+  }
+
   // Auto-select the first row when data arrives and nothing is selected yet
   const firstCellCount = data?.rows[0]?.cell_count ?? null;
   const effectiveSelection = selectedCellCount ?? firstCellCount;
@@ -839,9 +943,9 @@ export function PowertrainTab({ aeroplaneId }: Props) {
               className="rounded-lg border border-orange-500/30 bg-orange-900/30 px-3 py-2"
               data-testid="powertrain-warnings"
             >
-              {data.warnings.map((w, i) => (
+              {data.warnings.map((w) => (
                 <p
-                  key={i}
+                  key={w}
                   className="font-[family-name:var(--font-geist-sans)] text-[10px] text-orange-400"
                 >
                   ⚠ {w}

--- a/frontend/components/workbench/PowertrainTab.tsx
+++ b/frontend/components/workbench/PowertrainTab.tsx
@@ -1,0 +1,893 @@
+"use client";
+
+import { useState, useMemo, useRef, useEffect } from "react";
+import { Loader2, AlertTriangle } from "lucide-react";
+import {
+  usePowertrainSolutionSpace,
+  type SolutionSpaceAssumptions,
+  type SolutionRow,
+  type FeasibleRegion,
+  type ShoppingSpec,
+} from "@/hooks/usePowertrainSolutionSpace";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface Props {
+  readonly aeroplaneId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Column-filter state
+// ---------------------------------------------------------------------------
+
+interface ColumnFilters {
+  maxPeakA: string;
+  maxMah: string;
+  maxEscA: string;
+  catalogOnly: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Plotly helpers
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type PlotlyTrace = Record<string, any>;
+
+const CELL_COLORS = [
+  "#FF8400",
+  "#3B82F6",
+  "#30A46C",
+  "#E5484D",
+  "#A78BFA",
+  "#F59E0B",
+  "#06B6D4",
+];
+
+function cellColor(idx: number): string {
+  return CELL_COLORS[idx % CELL_COLORS.length];
+}
+
+// ---------------------------------------------------------------------------
+// Trace builders (module-level to avoid sonar nested-functions violations)
+// ---------------------------------------------------------------------------
+
+function buildFloorCurveTrace(
+  region: FeasibleRegion,
+  color: string,
+  isSelected: boolean
+): PlotlyTrace {
+  return {
+    x: region.capacity_curve_mah,
+    y: region.c_rate_curve,
+    type: "scatter",
+    mode: "lines",
+    name: `${region.cell_count}S floor`,
+    line: {
+      color,
+      width: isSelected ? 2.5 : 1.5,
+      dash: isSelected ? "solid" : "dot",
+    },
+    legendgroup: `${region.cell_count}S`,
+    hovertemplate:
+      `<b>${region.cell_count}S</b><br>` +
+      `Capacity: %{x:.0f} mAh<br>Min C-rate: %{y:.1f}C<extra></extra>`,
+  };
+}
+
+function buildCapacityFloorLineTrace(
+  region: FeasibleRegion,
+  color: string,
+  cMax: number
+): PlotlyTrace {
+  return {
+    x: [region.capacity_floor_mah, region.capacity_floor_mah],
+    y: [0, cMax],
+    type: "scatter",
+    mode: "lines",
+    name: `${region.cell_count}S cap-floor`,
+    line: { color, width: 1, dash: "dot" },
+    legendgroup: `${region.cell_count}S`,
+    showlegend: false,
+    hovertemplate:
+      `<b>${region.cell_count}S</b><br>` +
+      `Min capacity: ${region.capacity_floor_mah.toFixed(0)} mAh<extra></extra>`,
+  };
+}
+
+function buildMarkerTrace(
+  region: FeasibleRegion,
+  row: SolutionRow,
+  color: string,
+  isSelected: boolean
+): PlotlyTrace {
+  return {
+    x: [row.capacity_mah_min],
+    y: [row.c_min],
+    type: "scatter",
+    mode: "markers+text",
+    name: `${region.cell_count}S`,
+    text: [`${region.cell_count}S`],
+    textposition: "top center",
+    textfont: { size: 9, color },
+    legendgroup: `${region.cell_count}S`,
+    marker: {
+      color,
+      size: isSelected ? 14 : 9,
+      symbol: isSelected ? "star" : "circle",
+      line: { color: isSelected ? "#fff" : color, width: isSelected ? 2 : 1 },
+    },
+    hovertemplate:
+      `<b>${region.cell_count}S</b><br>` +
+      `Capacity: ${row.capacity_mah_min.toFixed(0)} mAh<br>` +
+      `Min C-rate: ${row.c_min.toFixed(1)}C<extra></extra>`,
+    customdata: [region.cell_count],
+  };
+}
+
+function buildRegionAnnotations(
+  vCruiseMps: number,
+  vTopMps: number,
+  tTargetMin: number
+): PlotlyTrace[] {
+  const titleText =
+    `V_cruise = ${vCruiseMps.toFixed(1)} m/s  ·  ` +
+    `V_top = ${vTopMps.toFixed(1)} m/s  ·  ` +
+    `t = ${tTargetMin.toFixed(0)} min`;
+  return [
+    {
+      x: 0.01, y: -0.13, xref: "paper", yref: "paper",
+      xanchor: "left", yanchor: "top", showarrow: false,
+      font: { color: "#71717A", size: 9 },
+      text: titleText,
+    },
+    {
+      x: 0.99, y: 0.01, xref: "paper", yref: "paper",
+      xanchor: "right", yanchor: "bottom", showarrow: false,
+      font: { color: "#52525B", size: 9 },
+      text: "Feasible region: ↗ (more mAh or higher C-rate = OK)",
+    },
+  ];
+}
+
+function buildFeasibleRegionTraces(
+  regions: FeasibleRegion[],
+  rows: SolutionRow[],
+  selectedCellCount: number | null
+): PlotlyTrace[] {
+  const allCRates = regions.flatMap((r) => r.c_rate_curve).filter(isFinite);
+  const cMax = allCRates.length > 0 ? Math.max(...allCRates) * 1.15 : 30;
+
+  const traces: PlotlyTrace[] = [];
+  regions.forEach((region, idx) => {
+    const color = cellColor(idx);
+    const isSelected = region.cell_count === selectedCellCount;
+    const row = rows.find((r) => r.cell_count === region.cell_count);
+
+    traces.push(buildFloorCurveTrace(region, color, isSelected));
+    traces.push(buildCapacityFloorLineTrace(region, color, cMax));
+    if (row) {
+      traces.push(buildMarkerTrace(region, row, color, isSelected));
+    }
+  });
+  return traces;
+}
+
+function buildFeasibleRegionLayout(
+  vCruiseMps: number,
+  vTopMps: number,
+  tTargetMin: number
+) {
+  return {
+    paper_bgcolor: "transparent",
+    plot_bgcolor: "transparent",
+    font: { color: "#A1A1AA", family: "JetBrains Mono, monospace", size: 10 },
+    margin: { l: 55, r: 15, t: 45, b: 50 },
+    title: {
+      text: "Capacity × C-rate feasible region",
+      font: { color: "#E4E4E7", size: 12 },
+      x: 0.01,
+      xanchor: "left",
+    },
+    xaxis: {
+      title: { text: "Capacity [mAh]", font: { size: 11 } },
+      gridcolor: "#27272A",
+      zerolinecolor: "#3F3F46",
+    },
+    yaxis: {
+      title: { text: "Min C-rate [C]", font: { size: 11 } },
+      gridcolor: "#27272A",
+      zerolinecolor: "#3F3F46",
+      rangemode: "tozero",
+    },
+    legend: {
+      x: 0.99, y: 0.99, xanchor: "right", yanchor: "top",
+      bgcolor: "rgba(0,0,0,0.4)", bordercolor: "#3F3F46", borderwidth: 1,
+      font: { size: 10, color: "#A1A1AA" },
+    },
+    showlegend: true,
+    autosize: true,
+    annotations: buildRegionAnnotations(vCruiseMps, vTopMps, tTargetMin),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Feasible-Region Plotly plot (gh-977)
+// ---------------------------------------------------------------------------
+
+interface FeasibleRegionPlotProps {
+  readonly regions: FeasibleRegion[];
+  readonly rows: SolutionRow[];
+  readonly selectedCellCount: number | null;
+  readonly onSelectCellCount: (s: number) => void;
+  readonly vCruiseMps: number;
+  readonly vTopMps: number;
+  readonly tTargetMin: number;
+}
+
+function FeasibleRegionPlot({
+  regions,
+  rows,
+  selectedCellCount,
+  onSelectCellCount,
+  vCruiseMps,
+  vTopMps,
+  tTargetMin,
+}: FeasibleRegionPlotProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const plotlyRef = useRef<any>(null);
+
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node || regions.length === 0) return;
+
+    let disposed = false;
+
+    (async () => {
+      const Plotly = await import("plotly.js-gl3d-dist-min");
+      plotlyRef.current = Plotly;
+      if (disposed || !node) return;
+
+      const traces = buildFeasibleRegionTraces(regions, rows, selectedCellCount);
+      const layout = buildFeasibleRegionLayout(vCruiseMps, vTopMps, tTargetMin);
+
+      await Plotly.react(node, traces, layout, {
+        responsive: true,
+        displayModeBar: false,
+      });
+
+      // Click listener to select cell count from marker.
+      // Plotly attaches `.on()` to the container div — guard for jsdom / SSR.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const plotNode = node as any;
+      if (typeof plotNode.on === "function") {
+        plotNode.on("plotly_click", (eventData: { points: Array<{ customdata: number }> }) => {
+          const pt = eventData?.points?.[0];
+          if (pt?.customdata != null) {
+            onSelectCellCount(pt.customdata);
+          }
+        });
+      }
+    })();
+
+    return () => {
+      disposed = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [regions, rows, selectedCellCount, vCruiseMps, vTopMps, tTargetMin]);
+
+  // Cleanup
+  useEffect(() => {
+    const node = containerRef.current;
+    return () => {
+      if (node && plotlyRef.current) {
+        plotlyRef.current.purge(node);
+      }
+    };
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      className="h-full min-h-0 w-full"
+      style={{ height: 320 }}
+      data-testid="powertrain-feasible-region-plot"
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shopping spec line
+// ---------------------------------------------------------------------------
+
+function ShoppingSpecLine({
+  spec,
+}: Readonly<{ spec: ShoppingSpec | undefined }>) {
+  if (!spec) return null;
+  return (
+    <div
+      className="flex flex-wrap items-center gap-2 rounded-lg border border-border bg-card px-4 py-3 font-[family-name:var(--font-jetbrains-mono)] text-[12px]"
+      data-testid="shopping-spec-line"
+    >
+      <span className="text-muted-foreground">
+        Shopping spec ({spec.cell_count}S @ {spec.battery_v_nom.toFixed(1)} V):
+      </span>
+      <span className="text-orange-400">
+        ESC ≥ {spec.esc_min_a.toFixed(0)} A
+      </span>
+      <span className="text-muted-foreground">·</span>
+      <span className="text-blue-400">
+        Battery ≥ {spec.battery_min_mah.toFixed(0)} mAh @ ≥{spec.battery_min_c.toFixed(1)}C
+      </span>
+      <span className="text-muted-foreground">·</span>
+      <span className="text-emerald-400">
+        Motor ≥ {spec.motor_min_peak_w.toFixed(0)} W
+        {spec.kv_approx != null ? `, KV ≈ ${spec.kv_approx.toFixed(0)}` : ""}
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Solution table
+// ---------------------------------------------------------------------------
+
+interface SolutionTableProps {
+  readonly rows: SolutionRow[];
+  readonly filters: ColumnFilters;
+  readonly selectedCellCount: number | null;
+  readonly onSelectRow: (cellCount: number) => void;
+}
+
+function SolutionTable({
+  rows,
+  filters,
+  selectedCellCount,
+  onSelectRow,
+}: SolutionTableProps) {
+  const maxPeakA = filters.maxPeakA !== "" ? parseFloat(filters.maxPeakA) : null;
+  const maxMah = filters.maxMah !== "" ? parseFloat(filters.maxMah) : null;
+  const maxEscA = filters.maxEscA !== "" ? parseFloat(filters.maxEscA) : null;
+
+  const filtered = rows.filter((r) => {
+    if (filters.catalogOnly && !r.has_motor_match && !r.has_battery_match && !r.has_esc_match)
+      return false;
+    if (maxPeakA != null && r.i_peak_a > maxPeakA) return false;
+    if (maxMah != null && r.capacity_mah_min > maxMah) return false;
+    if (maxEscA != null && r.esc_min_a > maxEscA) return false;
+    return true;
+  });
+
+  return (
+    <div className="overflow-x-auto" data-testid="solution-table">
+      <table className="w-full border-collapse text-[11px]">
+        <thead>
+          <tr className="border-b border-border text-left font-[family-name:var(--font-geist-sans)] text-[10px] uppercase tracking-wider text-muted-foreground">
+            <th scope="col" className="py-2 pr-3">S</th>
+            <th scope="col" className="py-2 pr-3">V_nom (V)</th>
+            <th scope="col" className="py-2 pr-3">Motor (W)</th>
+            <th scope="col" className="py-2 pr-3">Peak A</th>
+            <th scope="col" className="py-2 pr-3">ESC ≥A</th>
+            <th scope="col" className="py-2 pr-3">mAh min</th>
+            <th scope="col" className="py-2 pr-3">C min</th>
+            <th scope="col" className="py-2 pr-3">Wh</th>
+            <th scope="col" className="py-2 pr-3">KV</th>
+            <th scope="col" className="py-2">Catalog</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.length === 0 && (
+            <tr>
+              <td
+                colSpan={10}
+                className="py-4 text-center font-[family-name:var(--font-geist-sans)] text-muted-foreground"
+                data-testid="solution-table-empty"
+              >
+                No solutions match the current filters.
+              </td>
+            </tr>
+          )}
+          {filtered.map((row) => {
+            const isSelected = row.cell_count === selectedCellCount;
+            const hasCatalog =
+              row.has_motor_match || row.has_battery_match || row.has_esc_match;
+            return (
+              <tr
+                key={row.cell_count}
+                onClick={() => onSelectRow(row.cell_count)}
+                className={`cursor-pointer border-b border-border/50 font-[family-name:var(--font-jetbrains-mono)] transition-colors hover:bg-sidebar-accent ${
+                  isSelected ? "bg-orange-500/10" : ""
+                }`}
+                data-testid={`solution-row-${row.cell_count}`}
+                aria-selected={isSelected}
+              >
+                <td className="py-2 pr-3 font-semibold text-orange-400">
+                  {row.cell_count}S
+                </td>
+                <td className="py-2 pr-3 text-foreground">
+                  {row.v_nom_v.toFixed(1)}
+                </td>
+                <td className="py-2 pr-3 text-foreground">
+                  {row.motor_peak_w.toFixed(0)}
+                </td>
+                <td className="py-2 pr-3 text-foreground">
+                  {row.i_peak_a.toFixed(1)}
+                </td>
+                <td className="py-2 pr-3 text-foreground">
+                  {row.esc_min_a.toFixed(0)}
+                </td>
+                <td className="py-2 pr-3 text-foreground">
+                  {row.capacity_mah_min.toFixed(0)}
+                </td>
+                <td className="py-2 pr-3 text-foreground">
+                  {row.c_min.toFixed(1)}
+                </td>
+                <td className="py-2 pr-3 text-foreground">
+                  {row.energy_wh.toFixed(1)}
+                </td>
+                <td className="py-2 pr-3 text-muted-foreground">
+                  {row.kv_approx != null ? row.kv_approx.toFixed(0) : "—"}
+                </td>
+                <td
+                  className={`py-2 ${hasCatalog ? "text-emerald-400" : "text-muted-foreground"}`}
+                >
+                  {hasCatalog ? "✓" : "—"}
+                  {row.has_motor_match && (
+                    <span
+                      className="ml-1 text-[9px] text-emerald-400"
+                      title="Motor match"
+                    >
+                      M
+                    </span>
+                  )}
+                  {row.has_battery_match && (
+                    <span
+                      className="ml-1 text-[9px] text-emerald-400"
+                      title="Battery match"
+                    >
+                      B
+                    </span>
+                  )}
+                  {row.has_esc_match && (
+                    <span
+                      className="ml-1 text-[9px] text-emerald-400"
+                      title="ESC match"
+                    >
+                      E
+                    </span>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Assumption controls
+// ---------------------------------------------------------------------------
+
+const DEFAULT_CELL_COUNTS = [2, 3, 4, 6];
+const PROP_PD_PRESETS = [
+  { label: "3D (0.50)", value: 0.5 },
+  { label: "Trainer (0.65)", value: 0.65 },
+  { label: "Soarer (0.80)", value: 0.8 },
+  { label: "Speed (1.00)", value: 1.0 },
+];
+
+interface AssumptionControlsProps {
+  readonly assumptions: SolutionSpaceAssumptions;
+  readonly onChange: (next: SolutionSpaceAssumptions) => void;
+}
+
+function AssumptionControls({ assumptions, onChange }: AssumptionControlsProps) {
+  const cellCounts = assumptions.cell_counts ?? DEFAULT_CELL_COUNTS;
+
+  function toggleCellCount(s: number) {
+    const next = cellCounts.includes(s)
+      ? cellCounts.filter((c) => c !== s)
+      : [...cellCounts, s].sort((a, b) => a - b);
+    onChange({ ...assumptions, cell_counts: next });
+  }
+
+  function numField(
+    key: keyof SolutionSpaceAssumptions,
+    value: number | undefined,
+    defaultVal: number
+  ) {
+    return (
+      <input
+        type="number"
+        value={value ?? defaultVal}
+        step={0.01}
+        onChange={(e) =>
+          onChange({ ...assumptions, [key]: parseFloat(e.target.value) })
+        }
+        className="w-20 rounded border border-border bg-card-muted px-2 py-1 font-[family-name:var(--font-geist-sans)] text-[11px] text-foreground"
+      />
+    );
+  }
+
+  return (
+    <div
+      className="flex flex-wrap items-start gap-4 rounded-xl border border-border bg-card px-4 py-3"
+      data-testid="assumption-controls"
+    >
+      {/* Cell count multi-select */}
+      <div className="flex flex-col gap-1">
+        <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
+          Cell count S
+        </span>
+        <div className="flex gap-1">
+          {[2, 3, 4, 5, 6, 7, 8].map((s) => (
+            <button
+              key={s}
+              type="button"
+              onClick={() => toggleCellCount(s)}
+              className={`rounded px-2 py-0.5 font-[family-name:var(--font-geist-sans)] text-[11px] transition-colors ${
+                cellCounts.includes(s)
+                  ? "bg-orange-500/20 text-orange-400"
+                  : "bg-card-muted text-muted-foreground hover:text-foreground"
+              }`}
+              data-testid={`cell-count-btn-${s}`}
+              aria-pressed={cellCounts.includes(s)}
+            >
+              {s}S
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* η_prop band */}
+      <div className="flex flex-col gap-1">
+        <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
+          η_prop [lo / hi]
+        </span>
+        <div className="flex items-center gap-1">
+          {numField("eta_prop_lo", assumptions.eta_prop_lo, 0.65)}
+          <span className="text-muted-foreground">/</span>
+          {numField("eta_prop_hi", assumptions.eta_prop_hi, 0.78)}
+        </div>
+      </div>
+
+      {/* DoD */}
+      <div className="flex flex-col gap-1">
+        <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
+          DoD
+        </span>
+        {numField("dod", assumptions.dod, 0.8)}
+      </div>
+
+      {/* ESC margin */}
+      <div className="flex flex-col gap-1">
+        <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
+          ESC margin ×
+        </span>
+        {numField("esc_margin", assumptions.esc_margin, 1.4)}
+      </div>
+
+      {/* C margin */}
+      <div className="flex flex-col gap-1">
+        <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
+          C margin ×
+        </span>
+        {numField("c_margin", assumptions.c_margin, 1.25)}
+      </div>
+
+      {/* Prop P/D preset */}
+      <div className="flex flex-col gap-1">
+        <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
+          Prop P/D (mission)
+        </span>
+        <select
+          value={String(assumptions.prop_pd ?? 0.65)}
+          onChange={(e) =>
+            onChange({ ...assumptions, prop_pd: parseFloat(e.target.value) })
+          }
+          className="rounded border border-border bg-card-muted px-2 py-1 font-[family-name:var(--font-geist-sans)] text-[11px] text-foreground"
+          data-testid="prop-pd-select"
+        >
+          {PROP_PD_PRESETS.map((p) => (
+            <option key={p.value} value={String(p.value)}>
+              {p.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* t_target_min */}
+      <div className="flex flex-col gap-1">
+        <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
+          Flight time (min)
+        </span>
+        <input
+          type="number"
+          value={assumptions.t_target_min ?? 15}
+          min={1}
+          step={1}
+          onChange={(e) =>
+            onChange({ ...assumptions, t_target_min: parseFloat(e.target.value) })
+          }
+          className="w-20 rounded border border-border bg-card-muted px-2 py-1 font-[family-name:var(--font-geist-sans)] text-[11px] text-foreground"
+          data-testid="t-target-input"
+        />
+      </div>
+
+      {/* v_top_mps */}
+      <div className="flex flex-col gap-1">
+        <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
+          V_top (m/s)
+        </span>
+        <input
+          type="number"
+          value={assumptions.v_top_mps ?? ""}
+          min={0}
+          step={0.5}
+          placeholder="auto"
+          onChange={(e) => {
+            const v = e.target.value;
+            onChange({
+              ...assumptions,
+              v_top_mps: v === "" ? undefined : parseFloat(v),
+            });
+          }}
+          className="w-20 rounded border border-border bg-card-muted px-2 py-1 font-[family-name:var(--font-geist-sans)] text-[11px] text-foreground"
+          data-testid="v-top-input"
+        />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Column filter bar
+// ---------------------------------------------------------------------------
+
+interface FilterBarProps {
+  readonly filters: ColumnFilters;
+  readonly onChange: (next: ColumnFilters) => void;
+}
+
+function FilterBar({ filters, onChange }: FilterBarProps) {
+  return (
+    <div
+      className="flex flex-wrap items-center gap-3 rounded-xl border border-border bg-card px-4 py-2"
+      data-testid="filter-bar"
+    >
+      <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
+        Filter:
+      </span>
+      <label className="flex items-center gap-1 font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
+        Peak A ≤
+        <input
+          type="number"
+          value={filters.maxPeakA}
+          placeholder="—"
+          min={0}
+          step={1}
+          onChange={(e) => onChange({ ...filters, maxPeakA: e.target.value })}
+          className="ml-1 w-16 rounded border border-border bg-card-muted px-1 py-0.5 text-[11px] text-foreground"
+          data-testid="filter-peak-a"
+        />
+      </label>
+      <label className="flex items-center gap-1 font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
+        mAh ≤
+        <input
+          type="number"
+          value={filters.maxMah}
+          placeholder="—"
+          min={0}
+          step={100}
+          onChange={(e) => onChange({ ...filters, maxMah: e.target.value })}
+          className="ml-1 w-20 rounded border border-border bg-card-muted px-1 py-0.5 text-[11px] text-foreground"
+          data-testid="filter-mah"
+        />
+      </label>
+      <label className="flex items-center gap-1 font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
+        ESC ≤
+        <input
+          type="number"
+          value={filters.maxEscA}
+          placeholder="—"
+          min={0}
+          step={1}
+          onChange={(e) => onChange({ ...filters, maxEscA: e.target.value })}
+          className="ml-1 w-16 rounded border border-border bg-card-muted px-1 py-0.5 text-[11px] text-foreground"
+          data-testid="filter-esc-a"
+        />
+      </label>
+      <label className="flex cursor-pointer items-center gap-1.5 font-[family-name:var(--font-geist-sans)] text-[11px] text-foreground">
+        <input
+          type="checkbox"
+          checked={filters.catalogOnly}
+          onChange={(e) => onChange({ ...filters, catalogOnly: e.target.checked })}
+          className="accent-orange-500"
+          data-testid="filter-catalog-only"
+        />
+        Catalog matches only
+      </label>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Invariants readout
+// ---------------------------------------------------------------------------
+
+interface InvariantsRowProps {
+  readonly pAeroCruiseW: number;
+  readonly pAeroTopW: number;
+  readonly energyWh: number;
+  readonly vCruiseMps: number;
+  readonly vTopMps: number;
+  readonly tTargetMin: number;
+}
+
+function InvariantsRow({
+  pAeroCruiseW,
+  pAeroTopW,
+  energyWh,
+  vCruiseMps,
+  vTopMps,
+  tTargetMin,
+}: InvariantsRowProps) {
+  return (
+    <div className="flex flex-wrap gap-4 rounded-xl border border-border bg-card px-4 py-3">
+      {[
+        { label: "V_cruise", value: `${vCruiseMps.toFixed(1)} m/s` },
+        { label: "V_top", value: `${vTopMps.toFixed(1)} m/s` },
+        { label: "t_target", value: `${tTargetMin.toFixed(0)} min` },
+        { label: "P_aero cruise", value: `${pAeroCruiseW.toFixed(0)} W` },
+        { label: "P_aero top", value: `${pAeroTopW.toFixed(0)} W` },
+        { label: "Energy (DoD-adj)", value: `${energyWh.toFixed(1)} Wh` },
+      ].map(({ label, value }) => (
+        <div key={label} className="flex flex-col gap-0.5">
+          <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
+            {label}
+          </span>
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] font-semibold text-foreground">
+            {value}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main PowertrainTab
+// ---------------------------------------------------------------------------
+
+export function PowertrainTab({ aeroplaneId }: Props) {
+  const [assumptions, setAssumptions] = useState<SolutionSpaceAssumptions>({
+    cell_counts: DEFAULT_CELL_COUNTS,
+  });
+  const [selectedCellCount, setSelectedCellCount] = useState<number | null>(null);
+  const [filters, setFilters] = useState<ColumnFilters>({
+    maxPeakA: "",
+    maxMah: "",
+    maxEscA: "",
+    catalogOnly: false,
+  });
+
+  const { data, isLoading, error } = usePowertrainSolutionSpace(aeroplaneId, assumptions);
+
+  // Auto-select the first row when data arrives and nothing is selected yet
+  const firstCellCount = data?.rows[0]?.cell_count ?? null;
+  const effectiveSelection = selectedCellCount ?? firstCellCount;
+
+  const selectedSpec = useMemo(
+    () => data?.shopping_specs.find((s) => s.cell_count === effectiveSelection),
+    [data, effectiveSelection]
+  );
+
+  return (
+    <div
+      className="flex flex-1 flex-col gap-4 overflow-auto bg-card-muted p-4"
+      data-testid="powertrain-tab"
+    >
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-foreground">
+          Powertrain Solution Space
+        </span>
+        <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
+          Capacity × C-rate feasible region · Shopping specs per cell count
+        </span>
+      </div>
+
+      {/* Assumption controls */}
+      <AssumptionControls assumptions={assumptions} onChange={setAssumptions} />
+
+      {/* Loading state */}
+      {isLoading && (
+        <div className="flex flex-1 items-center justify-center">
+          <Loader2 size={14} className="animate-spin text-muted-foreground" />
+          <span className="ml-2 font-[family-name:var(--font-geist-sans)] text-[12px] text-muted-foreground">
+            Computing powertrain solution space…
+          </span>
+        </div>
+      )}
+
+      {/* Error state */}
+      {error && !isLoading && (
+        <div
+          className="flex flex-1 items-center justify-center gap-2 rounded-xl border border-border bg-card p-4"
+          data-testid="powertrain-error"
+        >
+          <AlertTriangle size={14} className="text-orange-400" />
+          <span className="font-[family-name:var(--font-geist-sans)] text-[12px] text-muted-foreground">
+            {(error as { status?: number }).status === 422
+              ? "Run assumption recompute first — mission/aero parameters are needed to compute the powertrain solution space."
+              : "Powertrain solution space unavailable — set mass, mission speed and polar parameters first."}
+          </span>
+        </div>
+      )}
+
+      {/* Data state */}
+      {data && !isLoading && (
+        <>
+          {/* Warnings banner — always visible per spec */}
+          {data.warnings.length > 0 && (
+            <div
+              className="rounded-lg border border-orange-500/30 bg-orange-900/30 px-3 py-2"
+              data-testid="powertrain-warnings"
+            >
+              {data.warnings.map((w, i) => (
+                <p
+                  key={i}
+                  className="font-[family-name:var(--font-geist-sans)] text-[10px] text-orange-400"
+                >
+                  ⚠ {w}
+                </p>
+              ))}
+            </div>
+          )}
+
+          {/* Mission invariants */}
+          <InvariantsRow
+            pAeroCruiseW={data.p_aero_cruise_w}
+            pAeroTopW={data.p_aero_top_w}
+            energyWh={data.energy_wh}
+            vCruiseMps={data.v_cruise_mps}
+            vTopMps={data.v_top_mps}
+            tTargetMin={data.t_target_min}
+          />
+
+          {/* Feasible-region plot (gh-977) */}
+          {data.feasible_regions.length > 0 && (
+            <div className="rounded-xl border border-border bg-card p-2">
+              <FeasibleRegionPlot
+                regions={data.feasible_regions}
+                rows={data.rows}
+                selectedCellCount={effectiveSelection}
+                onSelectCellCount={setSelectedCellCount}
+                vCruiseMps={data.v_cruise_mps}
+                vTopMps={data.v_top_mps}
+                tTargetMin={data.t_target_min}
+              />
+            </div>
+          )}
+
+          {/* Filter bar + solution table */}
+          <FilterBar filters={filters} onChange={setFilters} />
+          <SolutionTable
+            rows={data.rows}
+            filters={filters}
+            selectedCellCount={effectiveSelection}
+            onSelectRow={setSelectedCellCount}
+          />
+
+          {/* Shopping spec for selected row */}
+          <ShoppingSpecLine spec={selectedSpec} />
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/workbench/PowertrainTab.tsx
+++ b/frontend/components/workbench/PowertrainTab.tsx
@@ -65,37 +65,75 @@ function cellColor(idx: number): string {
 // pack capacity — dividing again would double-count it.
 
 export interface ConservativeSpec {
-  /** Worst-case peak current [A] (low-η end of the band). */
-  peakA: number;
-  /** Minimum ESC current rating [A], rounded up. */
-  escMinA: number;
-  /** Minimum battery C-rating, rounded up. */
-  minC: number;
-  /** Minimum (rated pack) capacity [mAh], rounded up. */
-  mahMin: number;
-  /** Conservative shaft (motor) power [W], rounded up. */
-  motorW: number;
+  /** Worst-case peak current [A] (low-η end of the band); null if unavailable. */
+  peakA: number | null;
+  /** Minimum ESC current rating [A], rounded up; null if unavailable. */
+  escMinA: number | null;
+  /** Minimum battery C-rating, rounded up; null if unavailable. */
+  minC: number | null;
+  /** Minimum (rated pack) capacity [mAh], rounded up; null if unavailable. */
+  mahMin: number | null;
+  /** Conservative shaft (motor) power [W], rounded up; null if unavailable. */
+  motorW: number | null;
 }
 
-/** Conservative shaft power [W] = aero power at top speed / lowest prop η. */
-export function conservativeMotorW(pAeroTopW: number, etaPropLo: number): number {
-  if (etaPropLo <= 0 || Number.isNaN(etaPropLo)) return Math.ceil(pAeroTopW);
+/** First finite number from the candidates, or null if none is usable.
+ *
+ * Lets each conservative field degrade gracefully: prefer the worst-case `_hi`
+ * band, fall back to the mid value if the band field is absent (contract
+ * drift), then render "—" rather than crashing the tab.
+ */
+function firstFinite(...candidates: Array<number | null | undefined>): number | null {
+  for (const v of candidates) {
+    if (typeof v === "number" && Number.isFinite(v)) return v;
+  }
+  return null;
+}
+
+/** Math.ceil that tolerates null/undefined/non-finite, returning null. */
+function ceilOrNull(value: number | null): number | null {
+  return value == null ? null : Math.ceil(value);
+}
+
+/** Conservative shaft power [W] = aero power at top speed / lowest prop η.
+ *
+ * Returns null when the inputs are not usable so the caller can render "—".
+ */
+export function conservativeMotorW(
+  pAeroTopW: number | null | undefined,
+  etaPropLo: number | null | undefined
+): number | null {
+  if (pAeroTopW == null || !Number.isFinite(pAeroTopW)) return null;
+  if (etaPropLo == null || !Number.isFinite(etaPropLo) || etaPropLo <= 0) {
+    return Math.ceil(pAeroTopW);
+  }
   return Math.ceil(pAeroTopW / etaPropLo);
 }
 
-/** Build the conservative, rounded-up minimum specs for one solution row. */
+/** Build the conservative, rounded-up minimum specs for one solution row.
+ *
+ * Band field names match the backend SolutionRow schema EXACTLY:
+ *   i_peak_hi_a, esc_min_hi_a, c_min_hi, capacity_mah_min_hi.
+ * Each access falls back to the mid value (i_peak_a, esc_min_a, …) and finally
+ * to null, so a contract drift degrades to "—" instead of white-screening.
+ */
 export function conservativeSpec(
   row: SolutionRow,
-  pAeroTopW: number,
-  etaPropLo: number
+  pAeroTopW: number | null | undefined,
+  etaPropLo: number | null | undefined
 ): ConservativeSpec {
   return {
-    peakA: row.i_peak_a_hi,
-    escMinA: Math.ceil(row.esc_min_a_hi),
-    minC: Math.ceil(row.c_min_hi),
-    mahMin: Math.ceil(row.capacity_mah_min_hi),
+    peakA: firstFinite(row.i_peak_hi_a, row.i_peak_a),
+    escMinA: ceilOrNull(firstFinite(row.esc_min_hi_a, row.esc_min_a)),
+    minC: ceilOrNull(firstFinite(row.c_min_hi, row.c_min)),
+    mahMin: ceilOrNull(firstFinite(row.capacity_mah_min_hi, row.capacity_mah_min)),
     motorW: conservativeMotorW(pAeroTopW, etaPropLo),
   };
+}
+
+/** Format a possibly-null conservative number, rendering "—" when missing. */
+function fmtSpec(value: number | null, digits = 0): string {
+  return value == null ? "—" : value.toFixed(digits);
 }
 
 // ---------------------------------------------------------------------------
@@ -151,11 +189,14 @@ function buildMarkerTrace(
   color: string,
   isSelected: boolean
 ): PlotlyTrace {
-  // Marker sits at the CONSERVATIVE worst-case point (capacity_mah_min_hi,
-  // c_min_hi) so it lines up with the rounded-up minimum specs in the table
-  // and shopping spec. The worst case is the low-η end of the band.
-  const markerMah = Math.ceil(row.capacity_mah_min_hi);
-  const markerC = Math.ceil(row.c_min_hi);
+  // Marker sits at the CONSERVATIVE worst-case point (ceil(capacity_mah_min_hi),
+  // ceil(c_min_hi)) so it lines up with the rounded-up minimum specs in the
+  // table and shopping spec. Shares conservativeSpec() so the correct backend
+  // field names + null guards apply consistently. Plot inputs are not used here,
+  // so motorW is irrelevant to the marker (null pAeroTopW is fine).
+  const spec = conservativeSpec(row, null, null);
+  const markerMah = spec.mahMin;
+  const markerC = spec.minC;
   return {
     x: [markerMah],
     y: [markerC],
@@ -174,8 +215,8 @@ function buildMarkerTrace(
     },
     hovertemplate:
       `<b>${region.cell_count}S</b><br>` +
-      `Capacity ≥ ${markerMah} mAh<br>` +
-      `Min C-rating ≥ ${markerC}C<extra></extra>`,
+      `Capacity ≥ ${fmtSpec(markerMah)} mAh<br>` +
+      `Min C-rating ≥ ${fmtSpec(markerC)}C<extra></extra>`,
     customdata: [region.cell_count],
   };
 }
@@ -411,15 +452,15 @@ function ShoppingSpecLine({
         Shopping spec ({spec.cell_count}S @ {spec.battery_v_nom.toFixed(1)} V):
       </span>
       <span className="text-orange-400">
-        ESC ≥ {conservative.escMinA} A
+        ESC ≥ {fmtSpec(conservative.escMinA)} A
       </span>
       <span className="text-muted-foreground">·</span>
       <span className="text-blue-400">
-        Battery ≥ {conservative.mahMin} mAh @ ≥{conservative.minC}C
+        Battery ≥ {fmtSpec(conservative.mahMin)} mAh @ ≥{fmtSpec(conservative.minC)}C
       </span>
       <span className="text-muted-foreground">·</span>
       <span className="text-emerald-400">
-        Motor ≥ {conservative.motorW} W
+        Motor ≥ {fmtSpec(conservative.motorW)} W
         {spec.kv_approx != null ? `, KV ≈ ${spec.kv_approx.toFixed(0)}` : ""}
       </span>
     </div>
@@ -454,14 +495,16 @@ function SolutionTable({
   const maxEscA = filters.maxEscA !== "" ? parseFloat(filters.maxEscA) : null;
 
   // Filters compare against the CONSERVATIVE displayed values (the same numbers
-  // the user sees and shops against), not the mid-band internals.
+  // the user sees and shops against), not the mid-band internals. A null spec
+  // value (missing band field) is treated as "not excluded" so the row still
+  // shows (and renders "—") rather than silently vanishing.
   const filtered = rows.filter((r) => {
     if (filters.catalogOnly && !r.has_motor_match && !r.has_battery_match && !r.has_esc_match)
       return false;
     const spec = conservativeSpec(r, pAeroTopW, etaPropLo);
-    if (maxPeakA != null && spec.peakA > maxPeakA) return false;
-    if (maxMah != null && spec.mahMin > maxMah) return false;
-    if (maxEscA != null && spec.escMinA > maxEscA) return false;
+    if (maxPeakA != null && spec.peakA != null && spec.peakA > maxPeakA) return false;
+    if (maxMah != null && spec.mahMin != null && spec.mahMin > maxMah) return false;
+    if (maxEscA != null && spec.escMinA != null && spec.escMinA > maxEscA) return false;
     return true;
   });
 
@@ -526,19 +569,19 @@ function SolutionTable({
                   {row.v_nom_v.toFixed(1)}
                 </td>
                 <td className="py-2 pr-3 text-foreground">
-                  {spec.motorW}
+                  {fmtSpec(spec.motorW)}
                 </td>
                 <td className="py-2 pr-3 text-foreground">
-                  {spec.peakA.toFixed(1)}
+                  {fmtSpec(spec.peakA, 1)}
                 </td>
                 <td className="py-2 pr-3 text-foreground">
-                  {spec.escMinA}
+                  {fmtSpec(spec.escMinA)}
                 </td>
                 <td className="py-2 pr-3 text-foreground">
-                  {spec.mahMin}
+                  {fmtSpec(spec.mahMin)}
                 </td>
                 <td className="py-2 pr-3 text-foreground">
-                  {spec.minC}
+                  {fmtSpec(spec.minC)}
                 </td>
                 <td className="py-2 pr-3 text-foreground">
                   {row.energy_wh.toFixed(1)}

--- a/frontend/components/workbench/PowertrainTab.tsx
+++ b/frontend/components/workbench/PowertrainTab.tsx
@@ -51,6 +51,54 @@ function cellColor(idx: number): string {
 }
 
 // ---------------------------------------------------------------------------
+// Conservative (worst-case, low-η) minimum specs
+// ---------------------------------------------------------------------------
+//
+// The table / plot / shopping-spec columns are MINIMUM specs to buy: a part
+// bought at the shown value must be guaranteed sufficient across the whole
+// η_prop band. So we take the WORST case (the `_hi` band, which corresponds to
+// low prop efficiency → more current / capacity / C-rate) and round UP, so a
+// part chosen at the displayed number is never under-spec.
+//
+// NOTE on mAh: do NOT divide by DoD. DoD is already applied upstream in
+// `energy_wh` (E = P·t / DoD), so `capacity_mah_min_hi` is already the rated
+// pack capacity — dividing again would double-count it.
+
+export interface ConservativeSpec {
+  /** Worst-case peak current [A] (low-η end of the band). */
+  peakA: number;
+  /** Minimum ESC current rating [A], rounded up. */
+  escMinA: number;
+  /** Minimum battery C-rating, rounded up. */
+  minC: number;
+  /** Minimum (rated pack) capacity [mAh], rounded up. */
+  mahMin: number;
+  /** Conservative shaft (motor) power [W], rounded up. */
+  motorW: number;
+}
+
+/** Conservative shaft power [W] = aero power at top speed / lowest prop η. */
+export function conservativeMotorW(pAeroTopW: number, etaPropLo: number): number {
+  if (etaPropLo <= 0 || Number.isNaN(etaPropLo)) return Math.ceil(pAeroTopW);
+  return Math.ceil(pAeroTopW / etaPropLo);
+}
+
+/** Build the conservative, rounded-up minimum specs for one solution row. */
+export function conservativeSpec(
+  row: SolutionRow,
+  pAeroTopW: number,
+  etaPropLo: number
+): ConservativeSpec {
+  return {
+    peakA: row.i_peak_a_hi,
+    escMinA: Math.ceil(row.esc_min_a_hi),
+    minC: Math.ceil(row.c_min_hi),
+    mahMin: Math.ceil(row.capacity_mah_min_hi),
+    motorW: conservativeMotorW(pAeroTopW, etaPropLo),
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Trace builders (module-level to avoid sonar nested-functions violations)
 // ---------------------------------------------------------------------------
 
@@ -103,9 +151,14 @@ function buildMarkerTrace(
   color: string,
   isSelected: boolean
 ): PlotlyTrace {
+  // Marker sits at the CONSERVATIVE worst-case point (capacity_mah_min_hi,
+  // c_min_hi) so it lines up with the rounded-up minimum specs in the table
+  // and shopping spec. The worst case is the low-η end of the band.
+  const markerMah = Math.ceil(row.capacity_mah_min_hi);
+  const markerC = Math.ceil(row.c_min_hi);
   return {
-    x: [row.capacity_mah_min],
-    y: [row.c_min],
+    x: [markerMah],
+    y: [markerC],
     type: "scatter",
     mode: "markers+text",
     name: `${region.cell_count}S`,
@@ -121,8 +174,8 @@ function buildMarkerTrace(
     },
     hovertemplate:
       `<b>${region.cell_count}S</b><br>` +
-      `Capacity: ${row.capacity_mah_min.toFixed(0)} mAh<br>` +
-      `Min C-rate: ${row.c_min.toFixed(1)}C<extra></extra>`,
+      `Capacity ≥ ${markerMah} mAh<br>` +
+      `Min C-rating ≥ ${markerC}C<extra></extra>`,
     customdata: [region.cell_count],
   };
 }
@@ -148,6 +201,12 @@ function buildRegionAnnotations(
       xanchor: "right", yanchor: "bottom", showarrow: false,
       font: { color: "#52525B", size: 9 },
       text: "Feasible region: ↗ (more mAh or higher C-rate = OK)",
+    },
+    {
+      x: 0.99, y: 0.10, xref: "paper", yref: "paper",
+      xanchor: "right", yanchor: "bottom", showarrow: false,
+      font: { color: "#52525B", size: 9 },
+      text: "Feasible = on/above the curve (battery can supply enough current)",
     },
   ];
 }
@@ -334,8 +393,15 @@ function FeasibleRegionPlot({
 
 function ShoppingSpecLine({
   spec,
-}: Readonly<{ spec: ShoppingSpec | undefined }>) {
-  if (!spec) return null;
+  conservative,
+}: Readonly<{
+  spec: ShoppingSpec | undefined;
+  conservative: ConservativeSpec | undefined;
+}>) {
+  if (!spec || !conservative) return null;
+  // ESC / battery mAh / C-rating / motor W all use the CONSERVATIVE worst-case,
+  // rounded-up figures so a part bought at these values is never under-spec.
+  // Cell count, nominal voltage and KV come from the matching shopping spec.
   return (
     <div
       className="flex flex-wrap items-center gap-2 rounded-lg border border-border bg-card px-4 py-3 font-[family-name:var(--font-jetbrains-mono)] text-[12px]"
@@ -345,15 +411,15 @@ function ShoppingSpecLine({
         Shopping spec ({spec.cell_count}S @ {spec.battery_v_nom.toFixed(1)} V):
       </span>
       <span className="text-orange-400">
-        ESC ≥ {spec.esc_min_a.toFixed(0)} A
+        ESC ≥ {conservative.escMinA} A
       </span>
       <span className="text-muted-foreground">·</span>
       <span className="text-blue-400">
-        Battery ≥ {spec.battery_min_mah.toFixed(0)} mAh @ ≥{spec.battery_min_c.toFixed(1)}C
+        Battery ≥ {conservative.mahMin} mAh @ ≥{conservative.minC}C
       </span>
       <span className="text-muted-foreground">·</span>
       <span className="text-emerald-400">
-        Motor ≥ {spec.motor_min_peak_w.toFixed(0)} W
+        Motor ≥ {conservative.motorW} W
         {spec.kv_approx != null ? `, KV ≈ ${spec.kv_approx.toFixed(0)}` : ""}
       </span>
     </div>
@@ -369,6 +435,10 @@ interface SolutionTableProps {
   readonly filters: ColumnFilters;
   readonly selectedCellCount: number | null;
   readonly onSelectRow: (cellCount: number) => void;
+  /** Aero power at top speed [W] — feeds the conservative motor-W column. */
+  readonly pAeroTopW: number;
+  /** Low end of the prop-efficiency band — feeds the conservative motor-W. */
+  readonly etaPropLo: number;
 }
 
 function SolutionTable({
@@ -376,17 +446,22 @@ function SolutionTable({
   filters,
   selectedCellCount,
   onSelectRow,
+  pAeroTopW,
+  etaPropLo,
 }: SolutionTableProps) {
   const maxPeakA = filters.maxPeakA !== "" ? parseFloat(filters.maxPeakA) : null;
   const maxMah = filters.maxMah !== "" ? parseFloat(filters.maxMah) : null;
   const maxEscA = filters.maxEscA !== "" ? parseFloat(filters.maxEscA) : null;
 
+  // Filters compare against the CONSERVATIVE displayed values (the same numbers
+  // the user sees and shops against), not the mid-band internals.
   const filtered = rows.filter((r) => {
     if (filters.catalogOnly && !r.has_motor_match && !r.has_battery_match && !r.has_esc_match)
       return false;
-    if (maxPeakA != null && r.i_peak_a > maxPeakA) return false;
-    if (maxMah != null && r.capacity_mah_min > maxMah) return false;
-    if (maxEscA != null && r.esc_min_a > maxEscA) return false;
+    const spec = conservativeSpec(r, pAeroTopW, etaPropLo);
+    if (maxPeakA != null && spec.peakA > maxPeakA) return false;
+    if (maxMah != null && spec.mahMin > maxMah) return false;
+    if (maxEscA != null && spec.escMinA > maxEscA) return false;
     return true;
   });
 
@@ -401,10 +476,20 @@ function SolutionTable({
             <th scope="col" className="py-2 pr-3">Peak A</th>
             <th scope="col" className="py-2 pr-3">ESC min (A)</th>
             <th scope="col" className="py-2 pr-3">mAh min</th>
-            <th scope="col" className="py-2 pr-3">C min</th>
+            <th
+              scope="col"
+              className="py-2 pr-3"
+              title="minimum battery C-rating you need"
+            >
+              Min C-rating
+            </th>
             <th scope="col" className="py-2 pr-3">Wh</th>
-            <th scope="col" className="py-2 pr-3">KV</th>
-            <th scope="col" className="py-2">Catalog</th>
+            <th scope="col" className="py-2 pr-3" title="(pick nearest standard KV)">
+              KV
+            </th>
+            <th scope="col" className="py-2" title="(coming soon — parts DB)">
+              Catalog
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -423,6 +508,7 @@ function SolutionTable({
             const isSelected = row.cell_count === selectedCellCount;
             const hasCatalog =
               row.has_motor_match || row.has_battery_match || row.has_esc_match;
+            const spec = conservativeSpec(row, pAeroTopW, etaPropLo);
             return (
               <tr
                 key={row.cell_count}
@@ -440,19 +526,19 @@ function SolutionTable({
                   {row.v_nom_v.toFixed(1)}
                 </td>
                 <td className="py-2 pr-3 text-foreground">
-                  {row.motor_peak_w.toFixed(0)}
+                  {spec.motorW}
                 </td>
                 <td className="py-2 pr-3 text-foreground">
-                  {row.i_peak_a.toFixed(1)}
+                  {spec.peakA.toFixed(1)}
                 </td>
                 <td className="py-2 pr-3 text-foreground">
-                  {row.esc_min_a.toFixed(0)}
+                  {spec.escMinA}
                 </td>
                 <td className="py-2 pr-3 text-foreground">
-                  {row.capacity_mah_min.toFixed(0)}
+                  {spec.mahMin}
                 </td>
                 <td className="py-2 pr-3 text-foreground">
-                  {row.c_min.toFixed(1)}
+                  {spec.minC}
                 </td>
                 <td className="py-2 pr-3 text-foreground">
                   {row.energy_wh.toFixed(1)}
@@ -517,6 +603,8 @@ const PROP_PD_PRESETS = [
 interface AssumptionControlsProps {
   readonly assumptions: SolutionSpaceAssumptions;
   readonly onChange: (next: SolutionSpaceAssumptions) => void;
+  /** True when V_top is not user-set and is derived from the mission instead. */
+  readonly vTopAutoDerived: boolean;
 }
 
 /** A single numeric assumption input.
@@ -560,7 +648,11 @@ function NumField({
   );
 }
 
-function AssumptionControls({ assumptions, onChange }: AssumptionControlsProps) {
+function AssumptionControls({
+  assumptions,
+  onChange,
+  vTopAutoDerived,
+}: AssumptionControlsProps) {
   const cellCounts = assumptions.cell_counts ?? DEFAULT_CELL_COUNTS;
 
   function toggleCellCount(s: number) {
@@ -602,8 +694,11 @@ function AssumptionControls({ assumptions, onChange }: AssumptionControlsProps) 
 
       {/* η_prop band */}
       <div className="flex flex-col gap-1">
-        <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
-          η_prop [lo / hi]
+        <span
+          className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground"
+          title="Propeller efficiency band (low / high). Conservative minimum specs use the low end."
+        >
+          Prop efficiency [lo / hi]
         </span>
         <div className="flex items-center gap-1">
           <NumField
@@ -626,7 +721,10 @@ function AssumptionControls({ assumptions, onChange }: AssumptionControlsProps) 
 
       {/* DoD */}
       <div className="flex flex-col gap-1">
-        <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
+        <span
+          className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground"
+          title="Depth of discharge — usable battery %"
+        >
           DoD
         </span>
         <NumField
@@ -714,6 +812,11 @@ function AssumptionControls({ assumptions, onChange }: AssumptionControlsProps) 
       <div className="flex flex-col gap-1">
         <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
           V_top (m/s)
+          {vTopAutoDerived && (
+            <span className="ml-1 text-[9px] text-subtle-foreground" data-testid="v-top-from-mission">
+              (from Mission)
+            </span>
+          )}
         </span>
         <input
           type="number"
@@ -829,24 +932,33 @@ function InvariantsRow({
   tTargetMin,
 }: InvariantsRowProps) {
   return (
-    <div className="flex flex-wrap gap-4 rounded-xl border border-border bg-card px-4 py-3">
-      {[
-        { label: "V_cruise", value: `${vCruiseMps.toFixed(1)} m/s` },
-        { label: "V_top", value: `${vTopMps.toFixed(1)} m/s` },
-        { label: "t_target", value: `${tTargetMin.toFixed(0)} min` },
-        { label: "P_aero cruise", value: `${pAeroCruiseW.toFixed(0)} W` },
-        { label: "P_aero top", value: `${pAeroTopW.toFixed(0)} W` },
-        { label: "Energy (DoD-adj)", value: `${energyWh.toFixed(1)} Wh` },
-      ].map(({ label, value }) => (
-        <div key={label} className="flex flex-col gap-0.5">
-          <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
-            {label}
-          </span>
-          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] font-semibold text-foreground">
-            {value}
-          </span>
-        </div>
-      ))}
+    <div className="flex flex-col gap-2 rounded-xl border border-border bg-card px-4 py-3">
+      {/* Dim label so these read as derived values, not editable inputs. */}
+      <span
+        className="font-[family-name:var(--font-geist-sans)] text-[9px] uppercase tracking-wider text-subtle-foreground"
+        data-testid="invariants-source-label"
+      >
+        Computed from mission
+      </span>
+      <div className="flex flex-wrap gap-4">
+        {[
+          { label: "V_cruise", value: `${vCruiseMps.toFixed(1)} m/s` },
+          { label: "V_top", value: `${vTopMps.toFixed(1)} m/s` },
+          { label: "t_target", value: `${tTargetMin.toFixed(0)} min` },
+          { label: "P_aero cruise", value: `${pAeroCruiseW.toFixed(0)} W` },
+          { label: "P_aero top", value: `${pAeroTopW.toFixed(0)} W` },
+          { label: "Energy (DoD-adj)", value: `${energyWh.toFixed(1)} Wh` },
+        ].map(({ label, value }) => (
+          <div key={label} className="flex flex-col gap-0.5">
+            <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
+              {label}
+            </span>
+            <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] font-semibold text-foreground">
+              {value}
+            </span>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }
@@ -891,23 +1003,50 @@ export function PowertrainTab({ aeroplaneId }: Props) {
     [data, effectiveSelection]
   );
 
+  // Conservative (worst-case, rounded-up) figures for the selected row — used by
+  // the shopping-spec line so it shows the same minimums as the table/plot.
+  const etaPropLo = data?.assumptions_used.eta_prop_lo ?? 0.65;
+  const pAeroTopW = data?.p_aero_top_w ?? 0;
+  const selectedConservative = useMemo(() => {
+    const row = data?.rows.find((r) => r.cell_count === effectiveSelection);
+    return row ? conservativeSpec(row, pAeroTopW, etaPropLo) : undefined;
+  }, [data, effectiveSelection, pAeroTopW, etaPropLo]);
+
+  // V_top is auto-derived from the mission when the user hasn't set it.
+  const vTopAutoDerived = assumptions.v_top_mps == null;
+
   return (
     <div
       className="flex flex-1 flex-col gap-4 overflow-auto bg-card-muted p-4"
       data-testid="powertrain-tab"
     >
       {/* Header */}
-      <div className="flex items-center gap-3">
-        <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-foreground">
-          Powertrain Solution Space
-        </span>
-        <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
-          Capacity × C-rate feasible region · Shopping specs per cell count
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center gap-3">
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-foreground">
+            Powertrain Solution Space
+          </span>
+          <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
+            Capacity × C-rate feasible region · Shopping specs per cell count
+          </span>
+        </div>
+        {/* Scholz scope note — Phase 1 limitations are explicit, not implied. */}
+        <span
+          className="font-[family-name:var(--font-geist-sans)] text-[9px] text-subtle-foreground"
+          data-testid="powertrain-scope-note"
+        >
+          Phase 1: peak sizing from top speed only (static-thrust &amp; climb not
+          checked). Prop efficiency is an assumption band — APC prop model comes
+          in Phase 2.
         </span>
       </div>
 
       {/* Assumption controls */}
-      <AssumptionControls assumptions={assumptions} onChange={setAssumptions} />
+      <AssumptionControls
+        assumptions={assumptions}
+        onChange={setAssumptions}
+        vTopAutoDerived={vTopAutoDerived}
+      />
 
       {/* Loading state */}
       {isLoading && (
@@ -979,6 +1118,15 @@ export function PowertrainTab({ aeroplaneId }: Props) {
             </div>
           )}
 
+          {/* Hobbyist how-to callout above the table. */}
+          <p
+            className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground"
+            data-testid="powertrain-table-callout"
+          >
+            Pick a cell count, then shop: motor ≈ the KV shown, ESC ≥ ESC min (A),
+            battery ≥ mAh min at ≥ Min C-rating.
+          </p>
+
           {/* Filter bar + solution table */}
           <FilterBar filters={filters} onChange={setFilters} />
           <SolutionTable
@@ -986,10 +1134,12 @@ export function PowertrainTab({ aeroplaneId }: Props) {
             filters={filters}
             selectedCellCount={effectiveSelection}
             onSelectRow={setSelectedCellCount}
+            pAeroTopW={data.p_aero_top_w}
+            etaPropLo={etaPropLo}
           />
 
           {/* Shopping spec for selected row */}
-          <ShoppingSpecLine spec={selectedSpec} />
+          <ShoppingSpecLine spec={selectedSpec} conservative={selectedConservative} />
         </>
       )}
     </div>

--- a/frontend/hooks/usePowertrainSolutionSpace.ts
+++ b/frontend/hooks/usePowertrainSolutionSpace.ts
@@ -1,0 +1,152 @@
+"use client";
+
+import useSWR from "swr";
+import { fetcher } from "@/lib/fetcher";
+
+// ---------------------------------------------------------------------------
+// Types matching backend PowertrainSolutionSpaceResponse (gh-976)
+// ---------------------------------------------------------------------------
+
+export interface SolutionRow {
+  cell_count: number;
+  v_nom_v: number;
+  v_sag_v: number;
+  p_cruise_w: number;
+  p_top_w: number;
+  p_cruise_lo_w: number;
+  p_cruise_hi_w: number;
+  p_top_lo_w: number;
+  p_top_hi_w: number;
+  energy_wh: number;
+  capacity_mah_min: number;
+  capacity_mah_min_lo: number;
+  capacity_mah_min_hi: number;
+  i_peak_a: number;
+  i_peak_a_lo: number;
+  i_peak_a_hi: number;
+  c_min: number;
+  c_min_lo: number;
+  c_min_hi: number;
+  esc_min_a: number;
+  esc_min_a_lo: number;
+  esc_min_a_hi: number;
+  motor_peak_w: number;
+  motor_cont_w: number;
+  kv_approx: number | null;
+  has_motor_match: boolean;
+  has_battery_match: boolean;
+  has_esc_match: boolean;
+}
+
+export interface FeasibleRegion {
+  cell_count: number;
+  capacity_floor_mah: number;
+  i_peak_a: number;
+  capacity_curve_mah: number[];
+  c_rate_curve: number[];
+}
+
+export interface ShoppingSpec {
+  cell_count: number;
+  battery_min_mah: number;
+  battery_min_c: number;
+  battery_v_nom: number;
+  esc_min_a: number;
+  motor_min_peak_w: number;
+  motor_cont_w: number;
+  kv_approx: number | null;
+}
+
+export interface PowertrainSolutionSpaceResponse {
+  rows: SolutionRow[];
+  feasible_regions: FeasibleRegion[];
+  shopping_specs: ShoppingSpec[];
+  p_aero_cruise_w: number;
+  p_aero_top_w: number;
+  energy_wh: number;
+  v_cruise_mps: number;
+  v_top_mps: number;
+  t_target_min: number;
+  assumptions_used: SolutionSpaceAssumptions;
+  warnings: string[];
+}
+
+export interface SolutionSpaceAssumptions {
+  cell_counts?: number[];
+  eta_prop_lo?: number;
+  eta_prop_hi?: number;
+  eta_motor?: number;
+  eta_esc?: number;
+  dod?: number;
+  esc_margin?: number;
+  c_margin?: number;
+  load_rpm_factor?: number;
+  prop_pd?: number;
+  t_target_min?: number;
+  v_top_mps?: number;
+  rho?: number;
+  g?: number;
+}
+
+// ---------------------------------------------------------------------------
+// URL builder (extracted to keep hook's cognitive complexity ≤ 15)
+// ---------------------------------------------------------------------------
+
+function setIfDefined(
+  params: URLSearchParams,
+  key: string,
+  value: number | undefined | null
+): void {
+  if (value != null) params.set(key, String(value));
+}
+
+export function buildSolutionSpaceUrl(
+  aeroplaneId: string | null,
+  assumptions: SolutionSpaceAssumptions
+): string | null {
+  if (!aeroplaneId) return null;
+
+  const params = new URLSearchParams();
+
+  if (assumptions.cell_counts && assumptions.cell_counts.length > 0) {
+    for (const s of assumptions.cell_counts) {
+      params.append("cell_counts", String(s));
+    }
+  }
+  setIfDefined(params, "eta_prop_lo", assumptions.eta_prop_lo);
+  setIfDefined(params, "eta_prop_hi", assumptions.eta_prop_hi);
+  setIfDefined(params, "eta_motor", assumptions.eta_motor);
+  setIfDefined(params, "eta_esc", assumptions.eta_esc);
+  setIfDefined(params, "dod", assumptions.dod);
+  setIfDefined(params, "esc_margin", assumptions.esc_margin);
+  setIfDefined(params, "c_margin", assumptions.c_margin);
+  setIfDefined(params, "load_rpm_factor", assumptions.load_rpm_factor);
+  setIfDefined(params, "prop_pd", assumptions.prop_pd);
+  setIfDefined(params, "t_target_min", assumptions.t_target_min);
+  setIfDefined(params, "v_top_mps", assumptions.v_top_mps);
+  setIfDefined(params, "rho", assumptions.rho);
+  setIfDefined(params, "g", assumptions.g);
+
+  const base = `/aeroplanes/${encodeURIComponent(aeroplaneId)}/powertrain/solution-space`;
+  const qs = params.toString();
+  return qs ? `${base}?${qs}` : base;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function usePowertrainSolutionSpace(
+  aeroplaneId: string | null,
+  assumptions: SolutionSpaceAssumptions = {}
+) {
+  const url = buildSolutionSpaceUrl(aeroplaneId, assumptions);
+
+  const { data, error, isLoading, mutate } = useSWR<PowertrainSolutionSpaceResponse>(
+    url,
+    fetcher,
+    { revalidateOnFocus: false }
+  );
+
+  return { data, error, isLoading, mutate };
+}

--- a/frontend/hooks/usePowertrainSolutionSpace.ts
+++ b/frontend/hooks/usePowertrainSolutionSpace.ts
@@ -22,14 +22,14 @@ export interface SolutionRow {
   capacity_mah_min_lo: number;
   capacity_mah_min_hi: number;
   i_peak_a: number;
-  i_peak_a_lo: number;
-  i_peak_a_hi: number;
+  i_peak_lo_a: number;
+  i_peak_hi_a: number;
   c_min: number;
   c_min_lo: number;
   c_min_hi: number;
   esc_min_a: number;
-  esc_min_a_lo: number;
-  esc_min_a_hi: number;
+  esc_min_lo_a: number;
+  esc_min_hi_a: number;
   motor_peak_w: number;
   motor_cont_w: number;
   kv_approx: number | null;


### PR DESCRIPTION
Closes #976
Closes #977

Phase 1 frontend of the powertrain solution-space reframe (epic #197). New **Powertrain** tab (registered in AnalysisViewerPanel, mirrors MatchingChartTab) consuming `GET /aeroplanes/{id}/powertrain/solution-space`:
- **Filterable solution table** — one row per cell-count (S/V/Motor W/Peak A/ESC ≥A/mAh/min C/Wh/KV/catalog match); column filters (Peak A ≤, mAh ≤, ESC ≤, catalog-only).
- **Assumption controls** — cell-counts, η_prop band, DoD, ESC/C margins, prop P/D preset, t_target, v_top → re-fetch.
- **Shopping-spec line** for the selected cell-count.
- **Feasible-region Plotly plot** (capacity × C-rate): floor curves + capacity-floor lines + per-cell markers, two-way linked with the table selection; mission metadata inside the figure.
- **Warnings banner** (surfaces backend design warnings, e.g. missing context).

Spec: `docs/superpowers/specs/2026-06-13-powertrain-solution-space-design.md`

## Tests
22 new vitest tests (URL builder, table render/filter/selection, shopping spec, warnings, Plotly traces/markers/annotation). Full suite **2111 passed**. tsc clean, lint clean, no new dependency-cruiser violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)