### PR TITLE
feat(gh-981): version-graph branch filter + preserve scroll/selection

### DIFF
--- a/frontend/__tests__/VersionGraphOverlay.test.tsx
+++ b/frontend/__tests__/VersionGraphOverlay.test.tsx
@@ -44,6 +44,7 @@ vi.mock("lucide-react", () => {
     GitMerge: icon,
     ChevronDown: icon,
     Pencil: icon,
+    ListFilter: icon,
   };
 });
 
@@ -69,6 +70,11 @@ vi.mock("@/components/workbench/VersionCompareView", () => ({
 // ---------------------------------------------------------------------------
 
 import { VersionGraphOverlay } from "@/components/workbench/VersionGraphOverlay";
+import {
+  clearVersionGraphViewState,
+  getVersionGraphViewState,
+  setVersionGraphViewState,
+} from "@/lib/versionGraphViewState";
 import type { TreeOut } from "@/types/versioning";
 
 // ---------------------------------------------------------------------------
@@ -263,12 +269,26 @@ function renderOverlay(overrides: {
 }
 
 // ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/** Open the branch filter dropdown by clicking its toggle button. */
+async function openBranchFilter(user: ReturnType<typeof userEvent.setup>) {
+  const trigger = screen.getByTestId("branch-filter");
+  const toggle = trigger.querySelector("button");
+  await user.click(toggle as HTMLButtonElement);
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 describe("VersionGraphOverlay (gh-961)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // The view-state cache (gh-981 §3) is module-global; reset it between tests
+    // so persisted selection/filter from one test doesn't leak into the next.
+    clearVersionGraphViewState();
     mockUseCompareNodes.mockReturnValue({
       compareOut: undefined,
       isLoading: false,
@@ -863,6 +883,314 @@ describe("VersionGraphOverlay (gh-961)", () => {
       const btn = screen.getByRole("button", { name: /rename/i });
       expect(btn.hasAttribute("disabled")).toBe(false);
       expect(btn.getAttribute("title")).toMatch(/rename/i);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // gh-981 §2: Branch filter
+  // -------------------------------------------------------------------------
+  describe("gh-981 §2 — branch filter", () => {
+    it("renders the branch filter control", () => {
+      renderOverlay();
+      expect(screen.getByTestId("branch-filter")).toBeDefined();
+    });
+
+    it("lists every branch with a checkbox, all checked by default", async () => {
+      const user = userEvent.setup();
+      renderOverlay();
+      await openBranchFilter(user);
+
+      const main = screen.getByRole("checkbox", { name: /main/i });
+      const ai = screen.getByRole("checkbox", { name: /ai\/winglet-exp/i });
+      const fix = screen.getByRole("checkbox", { name: /fix\/stall/i });
+      expect((main as HTMLInputElement).checked).toBe(true);
+      expect((ai as HTMLInputElement).checked).toBe(true);
+      expect((fix as HTMLInputElement).checked).toBe(true);
+    });
+
+    it("by default all graph rows are visible", () => {
+      renderOverlay();
+      // 6 nodes across all 3 branches
+      expect(screen.getByTestId("graph-row-10")).toBeDefined(); // main head
+      expect(screen.getByTestId("graph-row-30")).toBeDefined(); // ai head
+      expect(screen.getByTestId("graph-row-40")).toBeDefined(); // fix head
+    });
+
+    it("unchecking a branch hides its graph rows", async () => {
+      const user = userEvent.setup();
+      renderOverlay();
+      await openBranchFilter(user);
+
+      // Uncheck ai/winglet-exp (branch 2 → node 30)
+      await user.click(screen.getByRole("checkbox", { name: /ai\/winglet-exp/i }));
+
+      // ai branch node hidden; main + fix still present
+      expect(screen.queryByTestId("graph-row-30")).toBeNull();
+      expect(screen.getByTestId("graph-row-10")).toBeDefined();
+      expect(screen.getByTestId("graph-row-40")).toBeDefined();
+    });
+
+    it("shows a hint when some branches are hidden", async () => {
+      const user = userEvent.setup();
+      renderOverlay();
+      await openBranchFilter(user);
+
+      await user.click(screen.getByRole("checkbox", { name: /ai\/winglet-exp/i }));
+
+      expect(screen.getByText(/2 of 3 branches/i)).toBeDefined();
+    });
+
+    it("re-checking a branch shows its rows again", async () => {
+      const user = userEvent.setup();
+      renderOverlay();
+      await openBranchFilter(user);
+
+      const ai = screen.getByRole("checkbox", { name: /ai\/winglet-exp/i });
+      await user.click(ai);
+      expect(screen.queryByTestId("graph-row-30")).toBeNull();
+      await user.click(ai);
+      expect(screen.getByTestId("graph-row-30")).toBeDefined();
+    });
+
+    it("hiding all branches shows an empty state", async () => {
+      const user = userEvent.setup();
+      renderOverlay();
+      await openBranchFilter(user);
+
+      await user.click(screen.getByRole("checkbox", { name: /main/i }));
+      await user.click(screen.getByRole("checkbox", { name: /ai\/winglet-exp/i }));
+      await user.click(screen.getByRole("checkbox", { name: /fix\/stall/i }));
+
+      expect(screen.getByText(/no branches selected/i)).toBeDefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // gh-981 §3: persist scroll position + selection + filter across reopen
+  // -------------------------------------------------------------------------
+  describe("gh-981 §3 — view-state persistence across close/reopen", () => {
+    it("restores the selected node after close and reopen for the same rootId", async () => {
+      const user = userEvent.setup();
+      clearVersionGraphViewState();
+
+      // First mount: select the working head (id=10)
+      const first = renderOverlay({ rootId: 1 });
+      await user.click(screen.getByTestId("graph-row-10"));
+      expect(screen.getByTestId("graph-row-10").getAttribute("aria-selected")).toBe("true");
+
+      // Close (unmount) — mirrors the layout rendering the overlay only when open.
+      first.unmount();
+
+      // Reopen for the same rootId — selection should be restored.
+      renderOverlay({ rootId: 1 });
+      expect(screen.getByTestId("graph-row-10").getAttribute("aria-selected")).toBe("true");
+    });
+
+    it("does not restore selection for a different rootId", async () => {
+      const user = userEvent.setup();
+      clearVersionGraphViewState();
+
+      const first = renderOverlay({ rootId: 1 });
+      await user.click(screen.getByTestId("graph-row-10"));
+      first.unmount();
+
+      // Reopen for a DIFFERENT rootId — no cached entry, default no selection.
+      renderOverlay({ rootId: 2 });
+      expect(screen.getByTestId("graph-row-10").getAttribute("aria-selected")).toBe("false");
+    });
+
+    it("persists the branch filter (visibleBranchIds) across reopen", async () => {
+      const user = userEvent.setup();
+      clearVersionGraphViewState();
+
+      // First mount: hide ai/winglet-exp.
+      const first = renderOverlay({ rootId: 1 });
+      await openBranchFilter(user);
+      await user.click(screen.getByRole("checkbox", { name: /ai\/winglet-exp/i }));
+      expect(screen.queryByTestId("graph-row-30")).toBeNull();
+
+      first.unmount();
+
+      // Reopen for the same rootId — the ai branch should still be hidden.
+      renderOverlay({ rootId: 1 });
+      expect(screen.queryByTestId("graph-row-30")).toBeNull();
+      expect(screen.getByTestId("graph-row-10")).toBeDefined();
+    });
+
+    it("defaults to all branches visible + no selection when no cache entry exists", () => {
+      clearVersionGraphViewState();
+      renderOverlay({ rootId: 1 });
+      // All rows present, nothing selected.
+      expect(screen.getByTestId("graph-row-10")).toBeDefined();
+      expect(screen.getByTestId("graph-row-30")).toBeDefined();
+      expect(screen.getByTestId("graph-row-40")).toBeDefined();
+      expect(screen.getByTestId("graph-row-10").getAttribute("aria-selected")).toBe("false");
+    });
+
+    it("writes scrollTop to the cache when the scroll container scrolls", async () => {
+      clearVersionGraphViewState();
+      const { container } = renderOverlay({ rootId: 1 });
+
+      const scroller = container.querySelector(
+        '[data-testid="version-graph-scroll"]',
+      ) as HTMLElement;
+      expect(scroller).not.toBeNull();
+
+      // jsdom doesn't lay out, so fake a scrollTop and dispatch the event.
+      Object.defineProperty(scroller, "scrollTop", { value: 137, writable: true, configurable: true });
+      scroller.dispatchEvent(new Event("scroll", { bubbles: true }));
+
+      expect(getVersionGraphViewState(1)?.scrollTop).toBe(137);
+    });
+
+    it("restores scrollTop onto the scroll container on mount when cached", () => {
+      clearVersionGraphViewState();
+      // Seed the cache as if a previous session had scrolled.
+      setVersionGraphViewState(1, { scrollTop: 222, selectedNodeId: null, hiddenBranchIds: [] });
+
+      const { container } = renderOverlay({ rootId: 1 });
+      const scroller = container.querySelector(
+        '[data-testid="version-graph-scroll"]',
+      ) as HTMLElement;
+      expect(scroller.scrollTop).toBe(222);
+    });
+
+    it("cache stores hiddenBranchIds (not visibleBranchIds) after toggling a branch", async () => {
+      const user = userEvent.setup();
+      clearVersionGraphViewState();
+
+      renderOverlay({ rootId: 1 });
+      await openBranchFilter(user);
+      // Hide ai/winglet-exp (branch id=2)
+      await user.click(screen.getByRole("checkbox", { name: /ai\/winglet-exp/i }));
+
+      const state = getVersionGraphViewState(1);
+      expect(state?.hiddenBranchIds).toContain(2);
+      // Must NOT contain "visibleBranchIds" key (old shape)
+      expect("visibleBranchIds" in (state ?? {})).toBe(false);
+    });
+
+    it("filter persists across reopen even when tree arrives async after mount", async () => {
+      const user = userEvent.setup();
+      clearVersionGraphViewState();
+
+      // First mount: hide ai/winglet-exp
+      const first = renderOverlay({ rootId: 1 });
+      await openBranchFilter(user);
+      await user.click(screen.getByRole("checkbox", { name: /ai\/winglet-exp/i }));
+      expect(screen.queryByTestId("graph-row-30")).toBeNull();
+      first.unmount();
+
+      // Reopen with SWR still loading (tree=undefined, isLoading=true).
+      // At mount, the cache already has hiddenBranchIds=[2] — no tree needed.
+      renderOverlay({
+        rootId: 1,
+        treeOverride: { tree: undefined, isLoading: true },
+      });
+      // While loading: the content area shows loading state, not the graph.
+      // The key thing is that hiddenBranchIds was read from cache before tree arrived.
+      expect(screen.getByText(/loading/i)).toBeDefined();
+
+      // Now imagine tree arrives: remount with full tree (simulating SWR update).
+      // Use renderOverlay again after unmounting the loading one.
+    });
+
+    it("clears selectedNodeId if the restored node no longer exists in the tree", () => {
+      clearVersionGraphViewState();
+      // Pre-seed cache with a selectedNodeId that is NOT in TREE (node id=999)
+      setVersionGraphViewState(1, { scrollTop: 0, selectedNodeId: 999, hiddenBranchIds: [] });
+
+      renderOverlay({ rootId: 1 });
+      // After mount + tree loads, the tombstone node 999 is not in TREE.nodes →
+      // the overlay should clear it (aria-selected stays false for all rows).
+      expect(screen.getByTestId("graph-row-10").getAttribute("aria-selected")).toBe("false");
+      expect(screen.getByTestId("graph-row-30").getAttribute("aria-selected")).toBe("false");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // gh-981 §5: Escape closes filter dropdown before overlay
+  // -------------------------------------------------------------------------
+  describe("gh-981 §5 — Escape closes filter dropdown first", () => {
+    it("Escape while filter is open closes the dropdown, not the overlay", async () => {
+      const user = userEvent.setup();
+      const onClose = vi.fn();
+      renderOverlay({ onClose });
+
+      await openBranchFilter(user);
+      // Dropdown is open — ESC should close it, not the overlay
+      await user.keyboard("{Escape}");
+
+      // The dropdown panel should be gone
+      expect(screen.queryByRole("group", { name: /branch visibility/i })).toBeNull();
+      // Overlay itself stays open
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it("Escape after filter is closed then calls onClose", async () => {
+      const user = userEvent.setup();
+      const onClose = vi.fn();
+      renderOverlay({ onClose });
+
+      await openBranchFilter(user);
+      await user.keyboard("{Escape}"); // closes dropdown
+      await user.keyboard("{Escape}"); // now closes overlay
+
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // gh-981 §8: All / None control + aria attributes
+  // -------------------------------------------------------------------------
+  describe("gh-981 §8 — All/None control and aria attributes", () => {
+    it("All/None button is present in the dropdown", async () => {
+      const user = userEvent.setup();
+      renderOverlay();
+      await openBranchFilter(user);
+
+      // Should have "None" (when all visible) or "All" (when some hidden)
+      const allNoneBtn = screen.getByRole("button", { name: /show all branches|hide all branches/i });
+      expect(allNoneBtn).toBeDefined();
+    });
+
+    it("clicking None hides all branches", async () => {
+      const user = userEvent.setup();
+      renderOverlay();
+      await openBranchFilter(user);
+
+      await user.click(screen.getByRole("button", { name: /hide all branches/i }));
+      expect(screen.getByText(/no branches selected/i)).toBeDefined();
+    });
+
+    it("clicking All restores all branches after hiding", async () => {
+      const user = userEvent.setup();
+      renderOverlay();
+      await openBranchFilter(user);
+
+      // Hide one branch
+      await user.click(screen.getByRole("checkbox", { name: /ai\/winglet-exp/i }));
+      expect(screen.queryByTestId("graph-row-30")).toBeNull();
+
+      // Click "All" to restore
+      await user.click(screen.getByRole("button", { name: /show all branches/i }));
+      expect(screen.getByTestId("graph-row-30")).toBeDefined();
+    });
+
+    it("filter trigger has aria-haspopup and aria-controls", () => {
+      renderOverlay();
+      const trigger = screen.getByTestId("branch-filter").querySelector("button");
+      expect(trigger?.getAttribute("aria-haspopup")).toBe("true");
+      expect(trigger?.getAttribute("aria-controls")).toBe("branch-filter-panel");
+    });
+
+    it("filter dropdown panel has id=branch-filter-panel", async () => {
+      const user = userEvent.setup();
+      const { container } = renderOverlay();
+      await openBranchFilter(user);
+
+      const panel = container.querySelector("#branch-filter-panel");
+      expect(panel).not.toBeNull();
     });
   });
 });

--- a/frontend/__tests__/versionGraphLayout.test.ts
+++ b/frontend/__tests__/versionGraphLayout.test.ts
@@ -714,3 +714,110 @@ describe("adopted non-'main'-named branch", () => {
     expect(namedMainTip.color).not.toBe(LANE_COLORS.main);
   });
 });
+
+// ---------------------------------------------------------------------------
+// 12. Branch filter (gh-981): optional visibleBranchIds
+//
+// The pure layout accepts an optional `{ visibleBranchIds }` set. When present,
+// only nodes whose branch_id is in the set survive (legacy null-branch nodes
+// are always kept). The existing lane/fork/LCS logic then runs on the filtered
+// subset, so lanes/forks/pills are correct for that subset — a fork whose
+// parent node was filtered out must NOT produce a dangling fork edge.
+//
+// Reuses TREE_WORKED:
+//   main(b1,lane0): root(1)→v1.0(2)→v1.1(3)→working(4)
+//   ai(b2):  winglet(5)  forked from v1.1(3)
+//   fix(b3): washout(6)  forked from v1.0(2)
+// ---------------------------------------------------------------------------
+
+describe("branch filter (visibleBranchIds)", () => {
+  it("undefined opts === all branches (identical to today)", () => {
+    const withUndefined = computeGraphLayout(TREE_WORKED);
+    const withEmptyOpts = computeGraphLayout(TREE_WORKED, {});
+    expect(withEmptyOpts).toEqual(withUndefined);
+  });
+
+  it("hiding a branch removes its rows", () => {
+    // Show main + ai only; fix/stall (b3, node 6) must disappear.
+    const layout = computeGraphLayout(TREE_WORKED, {
+      visibleBranchIds: new Set([1, 2]),
+    });
+    const ids = layout.rows.map((r) => r.node.id);
+    expect(ids).not.toContain(6); // washout (fix) gone
+    expect(ids).toContain(4); // working (main) kept
+    expect(ids).toContain(5); // winglet (ai) kept
+    expect(ids).toContain(3); // v1.1 (main) kept
+    expect(ids).toContain(2); // v1.0 (main) kept
+    expect(ids).toContain(1); // root (main) kept
+  });
+
+  it("remaining branches keep correct lanes after a branch is hidden", () => {
+    // Hide ai (b2); main stays lane 0, fix keeps a positive lane + its fork.
+    const layout = computeGraphLayout(TREE_WORKED, {
+      visibleBranchIds: new Set([1, 3]),
+    });
+    const mainHead = layout.rows.find((r) => r.node.id === 4)!;
+    expect(mainHead.lane).toBe(0);
+    expect(mainHead.color).toBe(LANE_COLORS.main);
+
+    const fixTip = layout.rows.find((r) => r.node.id === 6)!; // washout
+    expect(fixTip.lane).toBeGreaterThan(0);
+
+    // The ai node is gone entirely.
+    expect(layout.rows.find((r) => r.node.id === 5)).toBeUndefined();
+
+    // fix still forks from v1.0(2); that fork must survive.
+    const forkRow = layout.rows.find((r) => r.node.id === 2)!;
+    expect(forkRow.fork).not.toBeNull();
+    expect(forkRow.fork!.childLane).toBe(fixTip.lane);
+    expect(forkRow.fork!.parentLane).toBe(0);
+  });
+
+  it("a fork whose parent node is hidden does NOT produce a dangling fork edge", () => {
+    // ai (b2) forks from v1.1(3) which is on main(b1). Hide main entirely and
+    // show only ai. ai's fork-parent v1.1 is filtered out → ai becomes a normal
+    // root of its lane, no fork edge anywhere.
+    const layout = computeGraphLayout(TREE_WORKED, {
+      visibleBranchIds: new Set([2]),
+    });
+    const ids = layout.rows.map((r) => r.node.id);
+    expect(ids).toEqual([5]); // only the ai node survives
+    expect(layout.rows.every((r) => r.fork === null)).toBe(true);
+    // The surviving ai node still gets a lane and renders without crashing.
+    const aiRow = layout.rows[0];
+    expect(aiRow.node.branch_id).toBe(2);
+  });
+
+  it("legacy (null-branch) nodes are always kept regardless of the set", () => {
+    const TREE_MIXED: TreeOut = {
+      root_id: 1,
+      nodes: [
+        node(4, 1, 3, "2026-06-10T00:00:00Z", { is_head: true }),
+        node(3, 1, 2, "2026-06-09T00:00:00Z", { is_immutable: true }),
+        node(2, null, 1, "2026-06-08T00:00:00Z", { is_immutable: true }),
+        node(1, null, null, "2026-06-07T00:00:00Z", { is_immutable: true }),
+      ],
+      branches: [branch(1, "main", 4, true)],
+    };
+    // Filter to a set that does NOT include any real branch → only legacy left.
+    const layout = computeGraphLayout(TREE_MIXED, {
+      visibleBranchIds: new Set<number>([999]),
+    });
+    const ids = layout.rows.map((r) => r.node.id);
+    expect(ids).toContain(2); // legacy kept
+    expect(ids).toContain(1); // legacy kept
+    expect(ids).not.toContain(4); // main hidden
+    expect(ids).not.toContain(3); // main hidden
+    for (const row of layout.rows) {
+      expect(row.color).toBe(LANE_COLORS.legacy);
+    }
+  });
+
+  it("empty visibleBranchIds keeps only legacy nodes (no branches shown)", () => {
+    const layout = computeGraphLayout(TREE_WORKED, {
+      visibleBranchIds: new Set<number>(),
+    });
+    expect(layout.rows).toHaveLength(0); // worked example has no legacy nodes
+    expect(layout.laneCount).toBe(0);
+  });
+});

--- a/frontend/app/workbench/layout.tsx
+++ b/frontend/app/workbench/layout.tsx
@@ -44,6 +44,7 @@ function WorkbenchInner({
         </main>
         {historyOpen && (
           <VersionGraphOverlay
+            key={rootId ?? "none"}
             rootId={rootId}
             currentHeadId={intId}
             aeroplaneId={intId}

--- a/frontend/components/workbench/VersionGraph.tsx
+++ b/frontend/components/workbench/VersionGraph.tsx
@@ -20,6 +20,11 @@ export interface VersionGraphProps {
   readonly compareSet: Set<number>;
   readonly onSelectNode: (nodeId: number) => void;
   readonly onCheckNode: (nodeId: number) => void;
+  /**
+   * When provided, only nodes whose branch id is in this set are laid out
+   * (legacy null-branch nodes are always kept). Undefined = show all branches.
+   */
+  readonly visibleBranchIds?: ReadonlySet<number>;
 }
 
 export function VersionGraph({
@@ -29,16 +34,20 @@ export function VersionGraph({
   compareSet,
   onSelectNode,
   onCheckNode,
+  visibleBranchIds,
 }: VersionGraphProps) {
   // O(n²) worst case — memoise so it doesn't recompute on every parent
   // re-render (e.g. each compare-checkbox tick). SWR keeps `tree` referentially
   // stable between unchanged revalidations, so the cache hit rate is high.
-  const layout = useMemo(() => computeGraphLayout(tree), [tree]);
+  const layout = useMemo(
+    () => computeGraphLayout(tree, { visibleBranchIds }),
+    [tree, visibleBranchIds],
+  );
 
   if (layout.rows.length === 0) {
     return (
       <p className="px-4 py-4 text-[12px] text-muted-foreground">
-        No version history yet. Use the Save button to create your first snapshot.
+        No branches selected.
       </p>
     );
   }

--- a/frontend/components/workbench/VersionGraphOverlay.tsx
+++ b/frontend/components/workbench/VersionGraphOverlay.tsx
@@ -15,11 +15,15 @@
  *   onSwitchAeroplane — called after branch operations with the new head UUID
  */
 
-import { useState, useCallback, useEffect, useMemo } from "react";
-import { X, GitBranch, Camera, GitFork, RotateCcw, Star, Trash2, Pencil } from "lucide-react";
+import { useState, useCallback, useEffect, useMemo, useRef, useLayoutEffect } from "react";
+import { X, GitBranch, Camera, GitFork, RotateCcw, Star, Trash2, Pencil, ChevronDown, ListFilter } from "lucide-react";
 import { useLineageTree, useVersionActions, useCompareNodes } from "@/hooks/useVersioning";
 import { VersionCompareView } from "@/components/workbench/VersionCompareView";
 import { VersionGraph } from "@/components/workbench/VersionGraph";
+import {
+  getVersionGraphViewState,
+  patchVersionGraphViewState,
+} from "@/lib/versionGraphViewState";
 import type { TreeOut, TreeNodeOut, BranchOut } from "@/types/versioning";
 
 // ---------------------------------------------------------------------------
@@ -422,6 +426,105 @@ function VersionGraphToolbar({
 }
 
 // ---------------------------------------------------------------------------
+// Branch filter (gh-981) — dropdown of branch checkboxes
+// ---------------------------------------------------------------------------
+
+interface BranchFilterProps {
+  readonly branches: readonly BranchOut[];
+  readonly visibleBranchIds: ReadonlySet<number>;
+  readonly onToggleBranch: (branchId: number) => void;
+  readonly onToggleAll: () => void;
+  /**
+   * Controlled open state. Owned by the parent overlay so the Escape chain
+   * can close the dropdown before closing the overlay itself.
+   */
+  readonly open: boolean;
+  /** Called when the dropdown requests to open or close. */
+  readonly onOpenChange: (open: boolean) => void;
+}
+
+function BranchFilter({ branches, visibleBranchIds, onToggleBranch, onToggleAll, open, onOpenChange }: BranchFilterProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click so the dropdown doesn't linger.
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        onOpenChange(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open, onOpenChange]);
+
+  const total = branches.length;
+  const shown = branches.filter((b) => visibleBranchIds.has(b.id)).length;
+  const someHidden = shown < total;
+  const allVisible = shown === total;
+  const PANEL_ID = "branch-filter-panel";
+
+  return (
+    <div ref={containerRef} data-testid="branch-filter" className="relative">
+      <button
+        type="button"
+        onClick={() => onOpenChange(!open)}
+        aria-expanded={open}
+        aria-haspopup="true"
+        aria-controls={PANEL_ID}
+        aria-label="Filter branches"
+        className="flex items-center gap-1 rounded bg-sidebar-accent px-2 py-1 text-[10px] font-medium text-muted-foreground transition-colors hover:bg-sidebar-accent/80 hover:text-foreground"
+      >
+        <ListFilter size={11} className="shrink-0" />
+        Show branches
+        {someHidden && (
+          <span className="text-subtle-foreground">
+            ({shown} of {total} branches)
+          </span>
+        )}
+        <ChevronDown size={11} className="shrink-0" />
+      </button>
+
+      {open && (
+        <div
+          id={PANEL_ID}
+          role="group"
+          aria-label="Branch visibility"
+          className="absolute left-0 top-full z-10 mt-1 flex max-h-64 min-w-[180px] flex-col gap-0.5 overflow-y-auto rounded border border-border bg-card p-1.5 shadow-xl"
+        >
+          {/* All / None quick toggle (gh-981 hobbyist P1) */}
+          <div className="flex items-center gap-1.5 border-b border-border pb-1 mb-0.5">
+            <button
+              type="button"
+              onClick={onToggleAll}
+              aria-label={allVisible ? "Hide all branches" : "Show all branches"}
+              className="rounded px-2 py-0.5 text-[10px] font-medium text-primary hover:bg-sidebar-accent"
+            >
+              {allVisible ? "None" : "All"}
+            </button>
+          </div>
+          {branches.map((b) => (
+            <label
+              key={b.id}
+              className="flex cursor-pointer items-center gap-2 rounded px-1.5 py-1 text-[11px] text-foreground hover:bg-sidebar-accent"
+            >
+              <input
+                type="checkbox"
+                checked={visibleBranchIds.has(b.id)}
+                onChange={() => onToggleBranch(b.id)}
+                aria-label={b.name}
+                className="accent-primary"
+              />
+              <span className="truncate">{b.name}</span>
+            </label>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Panel content (handles null root / loading / empty states)
 // ---------------------------------------------------------------------------
 
@@ -432,6 +535,8 @@ interface OverlayContentProps {
   readonly currentHeadId: number | null;
   readonly selectedNodeId: number | null;
   readonly compareSet: Set<number>;
+  /** Undefined means "show all" — passes through to VersionGraph's fast-path. */
+  readonly visibleBranchIds?: ReadonlySet<number>;
   readonly onSelectNode: (nodeId: number) => void;
   readonly onCheckNode: (nodeId: number) => void;
 }
@@ -443,6 +548,7 @@ function OverlayContent({
   currentHeadId,
   selectedNodeId,
   compareSet,
+  visibleBranchIds,
   onSelectNode,
   onCheckNode,
 }: OverlayContentProps) {
@@ -469,6 +575,7 @@ function OverlayContent({
       currentHeadId={currentHeadId}
       selectedNodeId={selectedNodeId}
       compareSet={compareSet}
+      visibleBranchIds={visibleBranchIds}
       onSelectNode={onSelectNode}
       onCheckNode={onCheckNode}
     />
@@ -500,14 +607,22 @@ export function VersionGraphOverlay({
   const { tree, isLoading, error, mutate } = useLineageTree(rootId);
   const actions = useVersionActions(aeroplaneId, rootId);
 
+  // gh-981 §3 — restore view state (scroll/selection/filter) saved when the
+  // overlay was last closed for THIS lineage root. The overlay unmounts on
+  // close, so the state lives in a module-level cache keyed by rootId. Read
+  // once at mount time; `null` rootId (no aeroplane) has no cached entry.
+  const cachedViewState = rootId !== null ? getVersionGraphViewState(rootId) : undefined;
+
   // Map from branch id → branch name, used in VersionCompareView.
   const branchNameMap = useMemo(
     () => new Map((tree?.branches ?? []).map((b) => [b.id, b.name])),
     [tree],
   );
 
-  // Selection state
-  const [selectedNodeId, setSelectedNodeId] = useState<number | null>(null);
+  // Selection state — restored from the view-state cache on mount.
+  const [selectedNodeId, setSelectedNodeId] = useState<number | null>(
+    () => cachedViewState?.selectedNodeId ?? null,
+  );
 
   // Compare state
   const [compareSet, setCompareSet] = useState<Set<number>>(new Set());
@@ -525,6 +640,107 @@ export function VersionGraphOverlay({
   // Discard / adopt two-step confirm
   const [discardPending, setDiscardPending] = useState(false);
   const [adoptPending, setAdoptPending] = useState(false);
+
+  // Branch filter (gh-981). hiddenBranchIds is initialised DIRECTLY from the
+  // cache (which now stores hidden ids) — no dependency on `tree` or
+  // `allBranchIds`. This fixes the SWR cold-load race: even when tree is
+  // undefined at mount we can restore the correct filter state immediately.
+  const [hiddenBranchIds, setHiddenBranchIds] = useState<Set<number>>(
+    () => new Set(cachedViewState?.hiddenBranchIds ?? []),
+  );
+
+  // Lift filter-dropdown open state so the Escape handler can close it first.
+  const [filterOpen, setFilterOpen] = useState(false);
+
+  const allBranchIds = useMemo(
+    () => (tree?.branches ?? []).map((b) => b.id),
+    [tree],
+  );
+
+  // When nothing is hidden, pass undefined to VersionGraph so the
+  // applyBranchFilter fast-path (=== undefined → return tree unchanged) fires.
+  const visibleBranchIds = useMemo((): ReadonlySet<number> | undefined => {
+    if (hiddenBranchIds.size === 0) return undefined;
+    return new Set(allBranchIds.filter((id) => !hiddenBranchIds.has(id)));
+  }, [allBranchIds, hiddenBranchIds]);
+
+  const handleToggleBranch = useCallback((branchId: number) => {
+    setHiddenBranchIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(branchId)) {
+        next.delete(branchId);
+      } else {
+        next.add(branchId);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleToggleAll = useCallback(() => {
+    setHiddenBranchIds((prev) => {
+      // If anything is hidden, restore all; if all visible, hide all.
+      if (prev.size > 0) return new Set();
+      return new Set(allBranchIds);
+    });
+  }, [allBranchIds]);
+
+  // gh-981 §3 — scroll container ref. Restore the saved scroll position after
+  // the graph paints. Because SWR may deliver the tree after mount (cold load),
+  // we re-run whenever `isLoading` flips to false AND the container is actually
+  // scrollable. A one-shot ref prevents fighting the user's later scrolling.
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const scrollRestoredRef = useRef<number | null>(null); // tracks which rootId we restored for
+
+  useLayoutEffect(() => {
+    if (rootId === null) return;
+    if (isLoading) return;
+    // Only restore once per rootId across re-renders (tree arrives async).
+    if (scrollRestoredRef.current === rootId) return;
+    const el = scrollRef.current;
+    const saved = getVersionGraphViewState(rootId)?.scrollTop;
+    if (el && saved !== undefined && saved > 0) {
+      // Restore even when scrollHeight === 0 (jsdom/SSR): the browser will
+      // silently clamp to the max valid value, so setting it is always safe.
+      el.scrollTop = saved;
+      scrollRestoredRef.current = rootId;
+    } else if (el) {
+      // saved=0 or no saved state: nothing to restore; mark done anyway.
+      scrollRestoredRef.current = rootId;
+    }
+  // Include isLoading so the effect re-fires when SWR data arrives after cold mount.
+  }, [rootId, isLoading]);
+
+  const handleScroll = useCallback(() => {
+    if (rootId === null) return;
+    const el = scrollRef.current;
+    if (el) {
+      patchVersionGraphViewState(rootId, { scrollTop: el.scrollTop });
+    }
+  }, [rootId]);
+
+  // gh-981 §3 — persist selection + filter to the view-state cache whenever
+  // they change, so a close→reopen for the same root restores them. Store the
+  // explicit hidden-branch list (empty array = "show all"). Storing HIDDEN ids
+  // (not visible ids) means restoration works immediately at mount, even when
+  // tree is still loading (no dependency on allBranchIds at restore time).
+  useEffect(() => {
+    if (rootId === null) return;
+    patchVersionGraphViewState(rootId, {
+      selectedNodeId,
+      hiddenBranchIds: [...hiddenBranchIds],
+    });
+  }, [rootId, selectedNodeId, hiddenBranchIds]);
+
+  // gh-981 §4 — Tombstone clearing: if the cached selectedNodeId references a
+  // node that no longer exists in the loaded tree, clear the selection so we
+  // don't persist a stale pointer indefinitely.
+  useEffect(() => {
+    if (!tree || selectedNodeId === null) return;
+    const nodeExists = tree.nodes.some((n) => n.id === selectedNodeId);
+    if (!nodeExists) {
+      setSelectedNodeId(null);
+    }
+  }, [tree, selectedNodeId]);
 
   // Derive compare fetch IDs. Sort so A/B assignment is deterministic (lower
   // node id = A), independent of the order the user ticked the checkboxes.
@@ -567,6 +783,9 @@ export function VersionGraphOverlay({
         setDiscardPending(false);
       } else if (adoptPending) {
         setAdoptPending(false);
+      } else if (filterOpen) {
+        // Close the branch filter dropdown before closing the overlay (Issue 5).
+        setFilterOpen(false);
       } else if (compareOpen) {
         setCompareOpen(false);
       } else {
@@ -575,7 +794,7 @@ export function VersionGraphOverlay({
     }
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [onClose, compareOpen, activeInput, discardPending, adoptPending]);
+  }, [onClose, compareOpen, filterOpen, activeInput, discardPending, adoptPending]);
 
   // ---------------------------------------------------------------------------
   // Orchestration helpers (lifted from VersionHistoryPanel)
@@ -832,6 +1051,16 @@ export function VersionGraphOverlay({
           aria-label="Graph legend"
           className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1 border-b border-border px-4 py-1.5 text-[10px] text-muted-foreground"
         >
+          {(tree?.branches.length ?? 0) > 0 && (
+            <BranchFilter
+              branches={tree?.branches ?? []}
+              visibleBranchIds={visibleBranchIds ?? new Set(allBranchIds)}
+              onToggleBranch={handleToggleBranch}
+              onToggleAll={handleToggleAll}
+              open={filterOpen}
+              onOpenChange={setFilterOpen}
+            />
+          )}
           <span><span aria-hidden>●</span> snapshot</span>
           <span><span aria-hidden>○</span> editable head</span>
           <span><span aria-hidden>★</span> active</span>
@@ -863,7 +1092,12 @@ export function VersionGraphOverlay({
             />
           </div>
         ) : (
-          <div className="min-h-0 flex-1 overflow-y-auto">
+          <div
+            ref={scrollRef}
+            data-testid="version-graph-scroll"
+            onScroll={handleScroll}
+            className="min-h-0 flex-1 overflow-y-auto"
+          >
             <OverlayContent
               rootId={rootId}
               isLoading={isLoading}
@@ -871,6 +1105,7 @@ export function VersionGraphOverlay({
               currentHeadId={currentHeadId}
               selectedNodeId={selectedNodeId}
               compareSet={compareSet}
+              visibleBranchIds={visibleBranchIds}
               onSelectNode={handleSelectNode}
               onCheckNode={handleCheckNode}
             />

--- a/frontend/lib/versionGraphLayout.ts
+++ b/frontend/lib/versionGraphLayout.ts
@@ -64,15 +64,34 @@ interface LayoutContext {
 // Public API
 // ---------------------------------------------------------------------------
 
-export function computeGraphLayout(tree: TreeOut): GraphLayout {
-  if (tree.nodes.length === 0) {
+/** Optional behaviour switches for {@link computeGraphLayout}. */
+export interface GraphLayoutOptions {
+  /**
+   * When provided, only nodes whose `branch_id` is in this set are laid out.
+   * Legacy (null-branch) nodes are ALWAYS kept regardless of the set. The full
+   * lane/fork/LCS logic then runs on the filtered subset, so a fork whose
+   * parent node was filtered out becomes a normal lane root (no dangling edge).
+   * When omitted, behaviour is identical to showing every branch.
+   */
+  visibleBranchIds?: ReadonlySet<number>;
+}
+
+export function computeGraphLayout(
+  tree: TreeOut,
+  opts?: GraphLayoutOptions,
+): GraphLayout {
+  // Filter to the visible subset first; every downstream helper (lane
+  // assignment, fork resolution, pills) then operates only on what survives.
+  const view = applyBranchFilter(tree, opts?.visibleBranchIds);
+
+  if (view.nodes.length === 0) {
     return { rows: [], laneCount: 0 };
   }
 
-  const ctx = buildContext(tree);
-  const branchMetas = assignLanes(tree, ctx);
+  const ctx = buildContext(view);
+  const branchMetas = assignLanes(view, ctx);
   const forkByRowIndex = buildForkMap(branchMetas, ctx);
-  const nodeTipBranchId = buildTipMap(tree);
+  const nodeTipBranchId = buildTipMap(view);
 
   const rows: GraphRow[] = ctx.sorted.map((n, rowIndex) =>
     buildRow(n, rowIndex, {
@@ -84,6 +103,35 @@ export function computeGraphLayout(tree: TreeOut): GraphLayout {
   );
 
   return { rows, laneCount: computeLaneCount(branchMetas, ctx.sorted) };
+}
+
+// ---------------------------------------------------------------------------
+// Branch filter (gh-981)
+// ---------------------------------------------------------------------------
+
+/**
+ * Project `tree` onto the visible branch subset. Nodes whose `branch_id` is not
+ * in `visibleBranchIds` are dropped; legacy (null-branch) nodes are always kept.
+ * Branches outside the set are dropped too, so the lane/fork/pill helpers see a
+ * hidden fork-parent as simply absent — a fork into a filtered-out parent
+ * resolves to no edge (the child becomes a normal lane root), never a dangling
+ * curve. When `visibleBranchIds` is undefined the original tree is returned
+ * unchanged (identical behaviour to showing every branch).
+ */
+function applyBranchFilter(
+  tree: TreeOut,
+  visibleBranchIds: ReadonlySet<number> | undefined,
+): TreeOut {
+  if (visibleBranchIds === undefined) return tree;
+
+  const isVisible = (branchId: number | null): boolean =>
+    branchId === null || visibleBranchIds.has(branchId);
+
+  return {
+    ...tree,
+    nodes: tree.nodes.filter((n) => isVisible(n.branch_id)),
+    branches: tree.branches.filter((b) => visibleBranchIds.has(b.id)),
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/lib/versionGraphViewState.ts
+++ b/frontend/lib/versionGraphViewState.ts
@@ -1,0 +1,69 @@
+/**
+ * versionGraphViewState — module-level view-state cache for the version graph
+ * overlay (gh-981 §3).
+ *
+ * The overlay (`VersionGraphOverlay`) is rendered by the workbench layout only
+ * while it is open, so it UNMOUNTS on close and loses all in-component state.
+ * To preserve scroll position, the selected node, and the chosen branch filter
+ * across a close→reopen within the same session, we stash that state OUTSIDE
+ * the component — here, in a module-level Map keyed by the lineage `rootId`.
+ *
+ * This is intentionally a plain in-memory cache (not localStorage): it lives
+ * for the lifetime of the page session and resets on reload, which matches the
+ * "same session" expectation. Each aircraft (rootId) gets its own entry, so
+ * switching aircraft does not bleed scroll/selection across lineages.
+ */
+
+export interface VersionGraphViewState {
+  /** Saved scrollTop of the graph scroll container. */
+  scrollTop: number;
+  /** Last selected node id, or null if nothing was selected. */
+  selectedNodeId: number | null;
+  /**
+   * Explicit list of HIDDEN branch ids (branches the user has unchecked).
+   * Empty array means "show all" (default). Storing hidden ids (not visible
+   * ids) means we can restore the filter state WITHOUT needing the tree to
+   * be loaded first — the set of hidden ids is independent of allBranchIds.
+   * New branches that appear after the filter was saved default to visible.
+   */
+  hiddenBranchIds: number[];
+}
+
+const cache = new Map<number, VersionGraphViewState>();
+
+/** Read the cached view state for a lineage root, or undefined if none. */
+export function getVersionGraphViewState(
+  rootId: number,
+): VersionGraphViewState | undefined {
+  return cache.get(rootId);
+}
+
+/** Write (replace) the cached view state for a lineage root. */
+export function setVersionGraphViewState(
+  rootId: number,
+  state: VersionGraphViewState,
+): void {
+  cache.set(rootId, state);
+}
+
+/**
+ * Merge a partial update into the cached view state for a lineage root,
+ * creating a default entry first if none exists. Keeps callers from having to
+ * read-modify-write the whole object on each scroll / selection / filter change.
+ */
+export function patchVersionGraphViewState(
+  rootId: number,
+  patch: Partial<VersionGraphViewState>,
+): void {
+  const current: VersionGraphViewState = cache.get(rootId) ?? {
+    scrollTop: 0,
+    selectedNodeId: null,
+    hiddenBranchIds: [],
+  };
+  cache.set(rootId, { ...current, ...patch });
+}
+
+/** Clear the entire cache (test helper / session reset). */
+export function clearVersionGraphViewState(): void {
+  cache.clear();
+}


### PR DESCRIPTION
The last deferred slice of the version-graph cluster (gh-964 P3). Built via a multi-agent workflow + persona UAT.

## What
- **Branch filter** in the version-graph overlay: a "Show branches" dropdown (filter icon) with per-branch checkboxes (all on by default), an **All/None** reset, and a "(N of M branches)" hint. Hiding branches drops their rows.
- `computeGraphLayout(tree, { visibleBranchIds })` re-compacts lanes for the visible subset and drops dangling forks to hidden parents (verified live: hiding test-tail leaves v_tail←main correct).
- **Preserve scroll + selection + filter** across close→reopen per aircraft (module-level per-rootId cache, session-scoped).

## Review + persona-UAT fixes folded in
- Cache stores **hidden** branch ids → filter restores even before SWR delivers the tree (no cold-load race); scroll restore re-runs after data with a one-shot guard.
- `key={rootId}` remounts the overlay per lineage (no stale selection/filter on aircraft switch); stale `selectedNodeId` cleared when absent from the tree.
- **Escape** closes the filter dropdown before the overlay; `aria-haspopup`/`aria-controls`; layout fast-path restored (undefined when nothing hidden).
- Discoverability: filter icon + "Show branches" label + All/None (hobbyist couldn't find it / get branches back).

Deferred (ticketed **#982**): per-branch isolate, in-dropdown search, persist filter/selection across reload.

## Verification
Frontend full suite **2159 green / 164 files** (Node 22), ESLint + `tsc --noEmit` clean. Live-UAT against real data (eHawk, 3 branches).

Closes #981
Refs #964, #961