### PR TITLE
feat: Powertrain as a top-level workbench tab (after Analysis, before Components)

### DIFF
--- a/frontend/__tests__/PowertrainPage.test.tsx
+++ b/frontend/__tests__/PowertrainPage.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/components/workbench/AeroplaneContext", () => ({
+  useAeroplaneContext: vi.fn(),
+}));
+vi.mock("@/components/workbench/PowertrainTab", () => ({
+  PowertrainTab: ({ aeroplaneId }: { aeroplaneId: string }) => (
+    <div data-testid="powertrain-tab">{aeroplaneId}</div>
+  ),
+}));
+
+import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
+import PowertrainPage from "@/app/workbench/powertrain/page";
+
+const mockCtx = useAeroplaneContext as unknown as ReturnType<typeof vi.fn>;
+
+describe("PowertrainPage — top-level workbench tab", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("renders the PowertrainTab for the selected aeroplane", () => {
+    mockCtx.mockReturnValue({ aeroplaneId: "aero-42" });
+    render(<PowertrainPage />);
+    expect(screen.getByTestId("powertrain-tab")).toHaveTextContent("aero-42");
+  });
+
+  it("shows a placeholder when no aeroplane is selected", () => {
+    mockCtx.mockReturnValue({ aeroplaneId: null });
+    render(<PowertrainPage />);
+    expect(screen.getByText(/No aeroplane selected/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("powertrain-tab")).toBeNull();
+  });
+});

--- a/frontend/__tests__/StabilityTab.test.tsx
+++ b/frontend/__tests__/StabilityTab.test.tsx
@@ -26,7 +26,6 @@ describe("AnalysisViewerPanel TABS (gh-567)", () => {
       "Streamlines",
       "Envelope",
       "Sizing",
-      "Powertrain",
     ]);
   });
 });

--- a/frontend/__tests__/WorkbenchNav.test.tsx
+++ b/frontend/__tests__/WorkbenchNav.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { STEPS } from "@/components/workbench/Header";
+
+describe("Workbench top-level nav — Powertrain step", () => {
+  it("places Powertrain as a top-level step immediately after Analysis and before Components", () => {
+    const labels = STEPS.map((s) => s.label);
+    const analysis = labels.indexOf("Analysis");
+    const powertrain = labels.indexOf("Powertrain");
+    const components = labels.indexOf("Components");
+
+    expect(powertrain).toBeGreaterThan(-1);
+    expect(powertrain).toBe(analysis + 1);
+    expect(components).toBe(powertrain + 1);
+  });
+
+  it("links Powertrain to its own top-level route", () => {
+    const step = STEPS.find((s) => s.label === "Powertrain");
+    expect(step?.href).toBe("/workbench/powertrain");
+  });
+
+  it("numbers the steps sequentially (1..n)", () => {
+    STEPS.forEach((step, i) => expect(step.num).toBe(i + 1));
+  });
+});

--- a/frontend/app/workbench/analysis/page.tsx
+++ b/frontend/app/workbench/analysis/page.tsx
@@ -67,7 +67,6 @@ export default function AnalysisPage() {
     "Envelope": "Flight Envelope",
     "Operating Points": "Operating Points",
     "Sizing": "Sizing",
-    "Powertrain": "Powertrain Solution Space",
   };
   const modalTitle = modalTitleByTab[activeTab];
 

--- a/frontend/app/workbench/powertrain/page.tsx
+++ b/frontend/app/workbench/powertrain/page.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
+import { PowertrainTab } from "@/components/workbench/PowertrainTab";
+
+/**
+ * Top-level "Powertrain" workbench step (between Analysis and Components).
+ * Promoted out of the Analysis sub-tabs (gh-976/gh-977) to a first-class tab.
+ */
+export default function PowertrainPage() {
+  const { aeroplaneId } = useAeroplaneContext();
+
+  if (!aeroplaneId) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <span className="text-[13px] text-muted-foreground">No aeroplane selected</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-1 flex-col overflow-auto">
+      <PowertrainTab aeroplaneId={aeroplaneId} />
+    </div>
+  );
+}

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -11,11 +11,10 @@ import { buildSpeedPolarLayout } from "@/lib/speedPolarLayout";
 import type { StoredOperatingPoint, AVLTrimResult, AeroBuildupTrimResult, TrimConstraint, ControlSurface } from "@/hooks/useOperatingPoints";
 import { OperatingPointsPanel } from "@/components/workbench/OperatingPointsPanel";
 import { MatchingChartTab } from "@/components/workbench/MatchingChartTab";
-import { PowertrainTab } from "@/components/workbench/PowertrainTab";
 import { AnalysisStatusIndicator } from "./AnalysisStatusIndicator";
 import type { AnalysisStatus } from "@/hooks/useAnalysisStatus";
 
-const TABS = ["Assumptions", "Operating Points", "Polar", "Trefftz Plane", "Streamlines", "Envelope", "Sizing", "Powertrain"] as const;
+const TABS = ["Assumptions", "Operating Points", "Polar", "Trefftz Plane", "Streamlines", "Envelope", "Sizing"] as const;
 export type Tab = (typeof TABS)[number];
 export { TABS };
 
@@ -932,11 +931,6 @@ export function AnalysisViewerPanel({
     setMaximizedChart((prev) => (prev === id ? null : id));
   }
 
-  // gh-976/gh-977: "Powertrain" is intentionally NOT in this set. Unlike the
-  // aero tabs, powertrain sizing does not require wings to have an aero
-  // analysis run — the backend returns a design warning when mission/aero
-  // context is missing, and PowertrainTab surfaces those via its warnings
-  // banner. So it must render even without wings (no hard wing-gate block).
   const COMPUTATION_TABS = new Set<Tab>([
     "Polar",
     "Trefftz Plane",
@@ -1195,18 +1189,6 @@ export function AnalysisViewerPanel({
         <div className="flex flex-1 items-center justify-center bg-card-muted">
           <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-muted-foreground">
             Select an aeroplane to show the matching chart
-          </span>
-        </div>
-      )}
-
-      {activeTab === "Powertrain" && aeroplaneId && (
-        <PowertrainTab aeroplaneId={aeroplaneId} />
-      )}
-
-      {activeTab === "Powertrain" && !aeroplaneId && (
-        <div className="flex flex-1 items-center justify-center bg-card-muted">
-          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[13px] text-muted-foreground">
-            Select an aeroplane to show the powertrain solution space
           </span>
         </div>
       )}

--- a/frontend/components/workbench/Header.tsx
+++ b/frontend/components/workbench/Header.tsx
@@ -17,12 +17,13 @@ import { useAeroplanes } from "@/hooks/useAeroplanes";
 import { useVersionActions } from "@/hooks/useVersioning";
 import { SnapshotDialog } from "./SnapshotDialog";
 
-const STEPS = [
+export const STEPS = [
   { num: 1, label: "Mission", href: "/workbench/mission" },
   { num: 2, label: "Construction", href: "/workbench" },
   { num: 3, label: "Analysis", href: "/workbench/analysis" },
-  { num: 4, label: "Components", href: "/workbench/components" },
-  { num: 5, label: "Plans", href: "/workbench/construction-plans" },
+  { num: 4, label: "Powertrain", href: "/workbench/powertrain" },
+  { num: 5, label: "Components", href: "/workbench/components" },
+  { num: 6, label: "Plans", href: "/workbench/construction-plans" },
 ] as const;
 
 function branchIndicatorClass(isAiBranch: boolean, isMainBranch: boolean | null): string {


### PR DESCRIPTION
Promotes the Powertrain solution-space view from an Analysis **sub-tab** to a **first-class top-level workbench step**, between *Analysis* and *Components*.

## Changes
- `Header.tsx`: insert `Powertrain` nav step at position 4 (renumber Components→5, Plans→6); `STEPS` exported for testing.
- New route `app/workbench/powertrain/page.tsx` mounting `PowertrainTab` (with no-aeroplane placeholder), inside the existing workbench layout (Header + context + metrics + copilot).
- `AnalysisViewerPanel.tsx`: remove `Powertrain` from `TABS`, its render blocks, the import, and the obsolete COMPUTATION_TABS comment.
- `analysis/page.tsx`: drop `Powertrain` from `modalTitleByTab`.

## Tests / verification
- New `WorkbenchNav.test.tsx` (Powertrain is the step after Analysis, before Components; route + sequential numbering) and `PowertrainPage.test.tsx` (renders tab / placeholder). Updated `StabilityTab.test.tsx` TABS snapshot.
- Full suite **2164 passed**, tsc clean, lint clean, no new dependency-cruiser violations.
- Browser-verified: top nav = Mission · Construction · Analysis · **Powertrain** · Components · Plans; clicking it routes to `/workbench/powertrain` and renders the tab; Analysis no longer has a Powertrain sub-tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)