### PR TITLE
feat(gh-960): surface defaulted aero params in powertrain sizing

### DIFF
--- a/app/schemas/powertrain_sizing.py
+++ b/app/schemas/powertrain_sizing.py
@@ -54,3 +54,10 @@ class PowertrainSizingResponse(BaseModel):
         default_factory=list,
         description="Powertrain candidates sorted by confidence descending",
     )
+    warnings: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Informational notes about assumptions made during sizing, e.g. when "
+            "aerodynamic parameters were not provided and RC-typical defaults were used."
+        ),
+    )

--- a/app/services/powertrain_sizing_service.py
+++ b/app/services/powertrain_sizing_service.py
@@ -4,13 +4,19 @@ Refactored for gh-490 (Model A): the catalog sweep logic is preserved, but the
 power-required physics are now delegated to endurance_service._power_required
 instead of relying on hardcoded geometry constants.
 
-The hardcoded geometry constants and the simplified power helper have been
-replaced by a call to endurance_service._power_required with per-combo
-aerodynamic parameters (gh-490 Model A).
+gh-960: when aerodynamic parameters (cd0, e_oswald, AR, S_ref) are not supplied
+in the request, the service now:
+  1. Prefers values from the aeroplane's assumption_computation_context
+     (single source of truth, gh-924).
+  2. Falls back to RC-typical defaults when neither request nor context provides
+     a value, and appends a descriptive warning to the response.
 """
+
+from __future__ import annotations
 
 import logging
 import math
+from typing import Any
 
 from sqlalchemy.orm import Session
 
@@ -33,6 +39,12 @@ from app.services.endurance_service import (
 logger = logging.getLogger(__name__)
 
 AIR_DENSITY_SEA_LEVEL = RHO_SEA_LEVEL  # kept for backward compat with existing tests
+
+# RC-typical defaults used when neither request nor aeroplane context provides a value.
+_DEFAULT_CD0 = 0.03
+_DEFAULT_E_OSWALD = 0.8
+_DEFAULT_AR = 8.0
+_DEFAULT_S_REF_M2 = 0.5
 
 
 def _air_density(altitude_m: float) -> float:
@@ -107,13 +119,89 @@ def _compute_confidence(flight_time_min: float, target_flight_time_min: float) -
     return confidence
 
 
+def _resolve_aero_params(
+    request: PowertrainSizingRequest,
+    context: dict[str, Any] | None,
+) -> tuple[float, float, float, float, list[str]]:
+    """Resolve aerodynamic parameters with a 3-tier priority (gh-960).
+
+    Priority order per parameter:
+      1. Explicit request field (user-supplied → most trusted)
+      2. aeroplane.assumption_computation_context (computed from analysis, gh-924)
+      3. RC-typical default → emits a warning note
+
+    Returns
+    -------
+    (cd0, e_oswald, ar, s_ref_m2, warnings)
+    """
+    ctx = context or {}
+    warnings: list[str] = []
+
+    def _pick(
+        request_val: float | None,
+        ctx_key: str,
+        default: float,
+        label: str,
+        param_name: str,
+    ) -> float:
+        if request_val is not None:
+            return request_val
+        ctx_val = ctx.get(ctx_key)
+        if ctx_val is not None:
+            return float(ctx_val)
+        warnings.append(
+            f"{label} not provided — assumed {default} (RC-typical). "
+            f"Provide {param_name} in the request or run an aerodynamic analysis "
+            f"to get an accurate power estimate."
+        )
+        return default
+
+    cd0 = _pick(
+        request.cd0,
+        "cd0",
+        _DEFAULT_CD0,
+        "Zero-lift drag coefficient (cd0)",
+        "cd0",
+    )
+    e_oswald = _pick(
+        request.e_oswald,
+        "e_oswald",
+        _DEFAULT_E_OSWALD,
+        "Oswald efficiency factor (e_oswald)",
+        "e_oswald",
+    )
+    ar = _pick(
+        request.aspect_ratio,
+        "aspect_ratio",
+        _DEFAULT_AR,
+        "Wing aspect ratio (aspect_ratio)",
+        "aspect_ratio",
+    )
+    s_ref_m2 = _pick(
+        request.s_ref_m2,
+        "s_ref_m2",
+        _DEFAULT_S_REF_M2,
+        "Wing reference area (s_ref_m2)",
+        "s_ref_m2",
+    )
+
+    return cd0, e_oswald, ar, s_ref_m2, warnings
+
+
 def _evaluate_motor_battery_combo(
-    motor, battery, escs: list, request: PowertrainSizingRequest
+    motor,
+    battery,
+    escs: list,
+    request: PowertrainSizingRequest,
+    cd0: float,
+    e_oswald: float,
+    ar: float,
+    s_ref_m2: float,
 ) -> PowertrainCandidate | None:
     """Evaluate a single motor+battery combination; return a candidate or None.
 
-    Aerodynamic geometry (cd0, e_oswald, ar, s_ref) comes from the request
-    or reasonable RC defaults.  Physics are computed via endurance_service.
+    Aerodynamic geometry (cd0, e_oswald, ar, s_ref) are resolved once by the
+    caller via _resolve_aero_params and passed in — no per-combo resolution.
     """
     motor_mass_kg = (motor.mass_g or 0) / 1000.0
     battery_mass_kg = (battery.mass_g or 0) / 1000.0
@@ -126,11 +214,6 @@ def _evaluate_motor_battery_combo(
 
     total_mass = request.airframe_mass_kg + motor_mass_kg + battery_mass_kg
 
-    # Pull aerodynamic geometry from request fields (Optional; fall back to RC-typical defaults)
-    cd0: float = request.cd0 if request.cd0 is not None else 0.03
-    e_oswald: float = request.e_oswald if request.e_oswald is not None else 0.8
-    ar: float = request.aspect_ratio if request.aspect_ratio is not None else 8.0
-    s_ref_m2: float = request.s_ref_m2 if request.s_ref_m2 is not None else 0.5
     eta_prop: float = request.eta_prop if request.eta_prop is not None else DEFAULT_ETA_PROP
     eta_motor: float = request.eta_motor if request.eta_motor is not None else DEFAULT_ETA_MOTOR
     eta_esc: float = request.eta_esc if request.eta_esc is not None else DEFAULT_ETA_ESC
@@ -185,14 +268,20 @@ def size_powertrain(
     escs = db.query(ComponentModel).filter(ComponentModel.component_type == "esc").all()
 
     if not motors or not batteries:
-        return PowertrainSizingResponse(recommendations=[])
+        return PowertrainSizingResponse(recommendations=[], warnings=[])
+
+    # Resolve aero params once; collect warnings (gh-960)
+    ctx = getattr(aeroplane, "assumption_computation_context", None) or {}
+    cd0, e_oswald, ar, s_ref_m2, warnings = _resolve_aero_params(request, ctx)
 
     candidates: list[PowertrainCandidate] = []
     for motor in motors:
         for battery in batteries:
-            candidate = _evaluate_motor_battery_combo(motor, battery, escs, request)
+            candidate = _evaluate_motor_battery_combo(
+                motor, battery, escs, request, cd0, e_oswald, ar, s_ref_m2
+            )
             if candidate is not None:
                 candidates.append(candidate)
 
     candidates.sort(key=lambda c: c.confidence, reverse=True)
-    return PowertrainSizingResponse(recommendations=candidates[:10])
+    return PowertrainSizingResponse(recommendations=candidates[:10], warnings=warnings)

--- a/app/tests/test_powertrain_sizing_service.py
+++ b/app/tests/test_powertrain_sizing_service.py
@@ -17,6 +17,10 @@ from app.schemas.powertrain_sizing import (
 )
 from app.services.powertrain_sizing_service import (
     AIR_DENSITY_SEA_LEVEL,
+    _DEFAULT_AR,
+    _DEFAULT_CD0,
+    _DEFAULT_E_OSWALD,
+    _DEFAULT_S_REF_M2,
     _air_density,
     _compute_confidence,
     _evaluate_motor_battery_combo,
@@ -24,6 +28,21 @@ from app.services.powertrain_sizing_service import (
     _required_power_w,
     size_powertrain,
 )
+
+
+# Convenience wrapper: call _evaluate_motor_battery_combo with RC defaults for
+# tests that don't exercise the aero-param resolution path.
+def _eval_combo_defaults(motor, battery, escs, request):
+    return _evaluate_motor_battery_combo(
+        motor,
+        battery,
+        escs,
+        request,
+        cd0=_DEFAULT_CD0,
+        e_oswald=_DEFAULT_E_OSWALD,
+        ar=_DEFAULT_AR,
+        s_ref_m2=_DEFAULT_S_REF_M2,
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -219,7 +238,7 @@ class TestEvaluateMotorBatteryCombo:
         escs = [_make_esc(max_continuous_a=50.0)]
         request = _default_request()
 
-        result = _evaluate_motor_battery_combo(motor, battery, escs, request)
+        result = _eval_combo_defaults(motor, battery, escs, request)
 
         assert result is not None
         assert isinstance(result, PowertrainCandidate)
@@ -234,33 +253,33 @@ class TestEvaluateMotorBatteryCombo:
     def test_zero_capacity_battery_returns_none(self):
         motor = _make_motor()
         battery = _make_battery(capacity_mah=0)
-        result = _evaluate_motor_battery_combo(motor, battery, [], _default_request())
+        result = _eval_combo_defaults(motor, battery, [], _default_request())
         assert result is None
 
     def test_zero_voltage_battery_returns_none(self):
         motor = _make_motor()
         battery = _make_battery(voltage=0)
-        result = _evaluate_motor_battery_combo(motor, battery, [], _default_request())
+        result = _eval_combo_defaults(motor, battery, [], _default_request())
         assert result is None
 
     def test_negative_capacity_returns_none(self):
         motor = _make_motor()
         battery = _make_battery(capacity_mah=-100)
-        result = _evaluate_motor_battery_combo(motor, battery, [], _default_request())
+        result = _eval_combo_defaults(motor, battery, [], _default_request())
         assert result is None
 
     def test_current_exceeds_max_returns_none(self):
         motor = _make_motor()
         battery = _make_battery()
         request = _default_request(max_current_draw_a=0.1)  # very low limit
-        result = _evaluate_motor_battery_combo(motor, battery, [], request)
+        result = _eval_combo_defaults(motor, battery, [], request)
         assert result is None
 
     def test_no_max_current_constraint(self):
         motor = _make_motor()
         battery = _make_battery()
         request = _default_request(max_current_draw_a=None)
-        result = _evaluate_motor_battery_combo(motor, battery, [], request)
+        result = _eval_combo_defaults(motor, battery, [], request)
         assert result is not None
 
     def test_esc_matched_when_available(self):
@@ -269,7 +288,7 @@ class TestEvaluateMotorBatteryCombo:
         esc = _make_esc(esc_id=99, name="BigESC", max_continuous_a=100.0)
         request = _default_request()
 
-        result = _evaluate_motor_battery_combo(motor, battery, [esc], request)
+        result = _eval_combo_defaults(motor, battery, [esc], request)
         assert result is not None
         assert result.esc_id == 99
         assert result.esc_name == "BigESC"
@@ -280,7 +299,7 @@ class TestEvaluateMotorBatteryCombo:
         esc = _make_esc(max_continuous_a=0.001)  # too small
         request = _default_request()
 
-        result = _evaluate_motor_battery_combo(motor, battery, [esc], request)
+        result = _eval_combo_defaults(motor, battery, [esc], request)
         assert result is not None
         assert result.esc_id is None
         assert result.esc_name is None
@@ -288,13 +307,13 @@ class TestEvaluateMotorBatteryCombo:
     def test_motor_with_no_mass(self):
         motor = _make_motor(mass_g=0.0)
         battery = _make_battery()
-        result = _evaluate_motor_battery_combo(motor, battery, [], _default_request())
+        result = _eval_combo_defaults(motor, battery, [], _default_request())
         assert result is not None
 
     def test_motor_with_none_mass(self):
         motor = SimpleNamespace(id=1, name="NoMass", mass_g=None)
         battery = _make_battery()
-        result = _evaluate_motor_battery_combo(motor, battery, [], _default_request())
+        result = _eval_combo_defaults(motor, battery, [], _default_request())
         assert result is not None
 
     def test_battery_uses_nominal_voltage_fallback(self):
@@ -306,7 +325,7 @@ class TestEvaluateMotorBatteryCombo:
             specs={"capacity_mah": 2200, "nominal_voltage": 14.8},
         )
         motor = _make_motor()
-        result = _evaluate_motor_battery_combo(motor, battery, [], _default_request())
+        result = _eval_combo_defaults(motor, battery, [], _default_request())
         assert result is not None
         assert result.estimated_cruise_power_w > 0
 
@@ -314,7 +333,7 @@ class TestEvaluateMotorBatteryCombo:
         motor = _make_motor()
         battery = _make_battery()
         request = _default_request(target_top_speed_ms=33.3)
-        result = _evaluate_motor_battery_combo(motor, battery, [], request)
+        result = _eval_combo_defaults(motor, battery, [], request)
         assert result is not None
         assert result.estimated_top_speed_ms == pytest.approx(33.3, abs=0.1)
 

--- a/app/tests/test_powertrain_warnings.py
+++ b/app/tests/test_powertrain_warnings.py
@@ -1,0 +1,311 @@
+"""Tests for gh-960: warnings channel in PowertrainSizingResponse.
+
+Verifies that the service emits descriptive warnings when aero parameters
+fall back to RC-typical defaults, and prefers values from the aeroplane's
+assumption_computation_context (gh-924 single source of truth).
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.schemas.powertrain_sizing import (
+    PowertrainSizingRequest,
+    PowertrainSizingResponse,
+)
+from app.services.powertrain_sizing_service import (
+    _DEFAULT_CD0,
+    _DEFAULT_E_OSWALD,
+    _DEFAULT_AR,
+    _DEFAULT_S_REF_M2,
+    _resolve_aero_params,
+    size_powertrain,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _make_motor(motor_id: int = 1, name: str = "Motor A", mass_g: float = 50.0):
+    return SimpleNamespace(id=motor_id, name=name, mass_g=mass_g)
+
+
+def _make_battery(
+    battery_id: int = 10,
+    name: str = "Battery A",
+    mass_g: float = 200.0,
+    capacity_mah: int = 2200,
+    voltage: float = 11.1,
+):
+    return SimpleNamespace(
+        id=battery_id,
+        name=name,
+        mass_g=mass_g,
+        specs={"capacity_mah": capacity_mah, "voltage": voltage},
+    )
+
+
+def _default_request(**overrides) -> PowertrainSizingRequest:
+    defaults = dict(
+        airframe_mass_kg=2.0,
+        target_cruise_speed_ms=15.0,
+        target_top_speed_ms=25.0,
+        target_flight_time_min=10.0,
+    )
+    defaults.update(overrides)
+    return PowertrainSizingRequest(**defaults)
+
+
+def _mock_db_session(aeroplane=None, motors=None, batteries=None, escs=None):
+    db = MagicMock()
+    call_count = {"n": 0}
+
+    def _build_chain(result):
+        chain = MagicMock()
+        chain.filter.return_value = chain
+        chain.first.return_value = result if not isinstance(result, list) else None
+        chain.all.return_value = result if isinstance(result, list) else []
+        return chain
+
+    queries = [
+        _build_chain(aeroplane),
+        _build_chain(motors or []),
+        _build_chain(batteries or []),
+        _build_chain(escs or []),
+    ]
+
+    def _side(model):
+        idx = call_count["n"]
+        call_count["n"] += 1
+        return queries[idx]
+
+    db.query.side_effect = _side
+    return db
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# PowertrainSizingResponse.warnings field
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestPowertrainSizingResponseWarningsField:
+    def test_warnings_field_exists_and_defaults_empty(self):
+        r = PowertrainSizingResponse(recommendations=[])
+        assert hasattr(r, "warnings")
+        assert r.warnings == []
+
+    def test_warnings_field_accepts_strings(self):
+        r = PowertrainSizingResponse(
+            recommendations=[],
+            warnings=["Test warning 1", "Test warning 2"],
+        )
+        assert len(r.warnings) == 2
+
+    def test_response_serialises_warnings(self):
+        r = PowertrainSizingResponse(
+            recommendations=[],
+            warnings=["e_oswald assumed 0.8"],
+        )
+        d = r.model_dump()
+        assert "warnings" in d
+        assert d["warnings"] == ["e_oswald assumed 0.8"]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _resolve_aero_params
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestResolveAeroParams:
+    """Unit tests for the 3-tier priority resolver."""
+
+    def test_all_from_request_no_warnings(self):
+        request = _default_request(
+            cd0=0.02,
+            e_oswald=0.75,
+            aspect_ratio=9.0,
+            s_ref_m2=0.6,
+        )
+        cd0, e, ar, s, warnings = _resolve_aero_params(request, context=None)
+        assert cd0 == pytest.approx(0.02)
+        assert e == pytest.approx(0.75)
+        assert ar == pytest.approx(9.0)
+        assert s == pytest.approx(0.6)
+        assert warnings == []
+
+    def test_request_wins_over_context(self):
+        request = _default_request(e_oswald=0.70)
+        ctx = {"e_oswald": 0.85, "cd0": 0.025, "aspect_ratio": 7.0, "s_ref_m2": 0.45}
+        cd0, e, ar, s, warnings = _resolve_aero_params(request, context=ctx)
+        assert e == pytest.approx(0.70)  # request wins
+        # other params come from context (no defaults triggered)
+        assert cd0 == pytest.approx(0.025)
+        assert ar == pytest.approx(7.0)
+        assert s == pytest.approx(0.45)
+        assert warnings == []
+
+    def test_context_preferred_over_default(self):
+        request = _default_request()  # no aero params
+        ctx = {"e_oswald": 0.78, "cd0": 0.035, "aspect_ratio": 8.0, "s_ref_m2": 0.40}
+        cd0, e, ar, s, warnings = _resolve_aero_params(request, context=ctx)
+        assert e == pytest.approx(0.78)
+        assert cd0 == pytest.approx(0.035)
+        assert warnings == []  # no defaults triggered
+
+    def test_missing_e_oswald_emits_warning(self):
+        request = _default_request()  # no e_oswald
+        cd0, e, ar, s, warnings = _resolve_aero_params(request, context={})
+        assert e == pytest.approx(_DEFAULT_E_OSWALD)
+        assert any("e_oswald" in w for w in warnings)
+
+    def test_missing_cd0_emits_warning(self):
+        request = _default_request()
+        cd0, e, ar, s, warnings = _resolve_aero_params(request, context={})
+        assert cd0 == pytest.approx(_DEFAULT_CD0)
+        assert any("cd0" in w for w in warnings)
+
+    def test_missing_aspect_ratio_emits_warning(self):
+        request = _default_request()
+        cd0, e, ar, s, warnings = _resolve_aero_params(request, context={})
+        assert ar == pytest.approx(_DEFAULT_AR)
+        assert any("aspect_ratio" in w for w in warnings)
+
+    def test_missing_s_ref_emits_warning(self):
+        request = _default_request()
+        cd0, e, ar, s, warnings = _resolve_aero_params(request, context={})
+        assert s == pytest.approx(_DEFAULT_S_REF_M2)
+        assert any("s_ref_m2" in w for w in warnings)
+
+    def test_no_params_four_warnings(self):
+        request = _default_request()
+        _, _, _, _, warnings = _resolve_aero_params(request, context=None)
+        assert len(warnings) == 4
+
+    def test_partial_context_only_missing_emit_warning(self):
+        """When context has cd0 + e_oswald but not AR/s_ref → 2 warnings."""
+        request = _default_request()
+        ctx = {"cd0": 0.028, "e_oswald": 0.80}
+        _, _, ar, s, warnings = _resolve_aero_params(request, context=ctx)
+        assert ar == pytest.approx(_DEFAULT_AR)
+        assert s == pytest.approx(_DEFAULT_S_REF_M2)
+        assert len(warnings) == 2
+        assert all(any(key in w for w in warnings) for key in ("aspect_ratio", "s_ref_m2"))
+
+    def test_all_from_context_no_warnings(self):
+        request = _default_request()
+        ctx = {
+            "cd0": 0.030,
+            "e_oswald": 0.80,
+            "aspect_ratio": 8.0,
+            "s_ref_m2": 0.50,
+        }
+        _, _, _, _, warnings = _resolve_aero_params(request, context=ctx)
+        assert warnings == []
+
+    def test_none_context_triggers_all_defaults(self):
+        request = _default_request()
+        _, _, _, _, warnings = _resolve_aero_params(request, context=None)
+        assert len(warnings) == 4
+
+    def test_warning_mentions_default_value(self):
+        request = _default_request()
+        _, e, _, _, warnings = _resolve_aero_params(request, context=None)
+        e_warning = next(w for w in warnings if "e_oswald" in w)
+        assert str(_DEFAULT_E_OSWALD) in e_warning
+
+    def test_warning_suggests_what_to_provide(self):
+        request = _default_request()
+        _, _, _, _, warnings = _resolve_aero_params(request, context=None)
+        for w in warnings:
+            assert "e_oswald" in w or "cd0" in w or "aspect_ratio" in w or "s_ref_m2" in w
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# size_powertrain integration (mocked DB)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestSizePowertrainWarnings:
+    def _make_plane(self, context=None):
+        plane = SimpleNamespace(uuid=uuid.uuid4())
+        plane.assumption_computation_context = context
+        return plane
+
+    def test_no_aero_params_response_has_warnings(self):
+        plane = self._make_plane(context=None)
+        motor = _make_motor()
+        battery = _make_battery()
+        db = _mock_db_session(aeroplane=plane, motors=[motor], batteries=[battery])
+        request = _default_request()  # no aero params
+
+        result = size_powertrain(db, plane.uuid, request)
+
+        assert isinstance(result.warnings, list)
+        assert len(result.warnings) > 0
+        assert any("e_oswald" in w for w in result.warnings)
+
+    def test_with_e_oswald_no_e_oswald_warning(self):
+        plane = self._make_plane(context=None)
+        motor = _make_motor()
+        battery = _make_battery()
+        db = _mock_db_session(aeroplane=plane, motors=[motor], batteries=[battery])
+        request = _default_request(
+            e_oswald=0.75,
+            cd0=0.025,
+            aspect_ratio=8.5,
+            s_ref_m2=0.45,
+        )
+
+        result = size_powertrain(db, plane.uuid, request)
+
+        # No warnings when all aero params are provided
+        assert result.warnings == []
+
+    def test_context_prevents_default_warnings(self):
+        ctx = {
+            "cd0": 0.030,
+            "e_oswald": 0.80,
+            "aspect_ratio": 8.0,
+            "s_ref_m2": 0.50,
+        }
+        plane = self._make_plane(context=ctx)
+        motor = _make_motor()
+        battery = _make_battery()
+        db = _mock_db_session(aeroplane=plane, motors=[motor], batteries=[battery])
+        request = _default_request()  # no explicit aero params
+
+        result = size_powertrain(db, plane.uuid, request)
+
+        # Context fully covered — no warnings
+        assert result.warnings == []
+
+    def test_partial_context_emits_only_missing_warnings(self):
+        """Context has cd0 and e_oswald but not AR and s_ref → 2 warnings."""
+        ctx = {"cd0": 0.028, "e_oswald": 0.78}
+        plane = self._make_plane(context=ctx)
+        motor = _make_motor()
+        battery = _make_battery()
+        db = _mock_db_session(aeroplane=plane, motors=[motor], batteries=[battery])
+        request = _default_request()
+
+        result = size_powertrain(db, plane.uuid, request)
+
+        assert len(result.warnings) == 2
+        assert all(any(key in w for w in result.warnings) for key in ("aspect_ratio", "s_ref_m2"))
+
+    def test_empty_catalog_returns_empty_with_no_warnings(self):
+        """When no motors/batteries, warnings are empty (no sizing performed)."""
+        plane = self._make_plane(context=None)
+        db = _mock_db_session(aeroplane=plane, motors=[], batteries=[])
+        request = _default_request()
+
+        result = size_powertrain(db, plane.uuid, request)
+
+        assert result.recommendations == []
+        assert result.warnings == []


### PR DESCRIPTION
## Summary

Adds a `warnings: list[str]` channel to `PowertrainSizingResponse` and populates it whenever aerodynamic parameters fall back to RC-typical defaults. Implements the gh-924 single-source-of-truth preference: computed context values take priority over bare RC defaults.

- **Schema** (`app/schemas/powertrain_sizing.py`): `warnings: list[str]` field on `PowertrainSizingResponse`
- **Service** (`app/services/powertrain_sizing_service.py`): new `_resolve_aero_params()` function with 3-tier priority — `(1) request field > (2) aeroplane.assumption_computation_context > (3) RC default + warning`; `_evaluate_motor_battery_combo` now accepts pre-resolved aero params
- **21 new tests** (`test_powertrain_warnings.py`): schema field, 3-tier resolver, integration tests (no aero params → warnings; all params provided → no warnings; context prevents defaults; partial context → only missing params warn)
- **Frontend**: the new `warnings` field is additive and backward-compatible; `PowertrainTab` (solution space, gh-975) already has a warnings display channel

## Test plan

- [x] `poetry run pytest app/tests/test_powertrain_sizing_service.py app/tests/test_powertrain_warnings.py` → 60 passed
- [x] `cd frontend && npm run test:unit` → 2164 passed (Node 22)
- [x] Request without `e_oswald` → warning present in response
- [x] Request with all aero params → `warnings == []`
- [x] Aeroplane with `assumption_computation_context` → warnings suppressed

Closes #960

🤖 Generated with [Claude Code](https://claude.com/claude-code)