### PR TITLE
feat(gh-197): Powertrain Sizing Modal in Component-Auswahl Tab

### DIFF
--- a/app/api/v2/endpoints/aeroplane/__init__.py
+++ b/app/api/v2/endpoints/aeroplane/__init__.py
@@ -27,6 +27,7 @@ from .forward_cg import router as forward_cg_router
 from .speed_polar import router as speed_polar_router
 from .turbulator_optimizer import router as turbulator_optimizer_router
 from .powertrain_solution_space import router as powertrain_solution_space_router
+from .powertrain_sizing_modal import router as powertrain_sizing_modal_router
 
 # Include the routers
 router.include_router(base_router)
@@ -51,3 +52,4 @@ router.include_router(forward_cg_router)
 router.include_router(speed_polar_router)
 router.include_router(turbulator_optimizer_router)
 router.include_router(powertrain_solution_space_router)
+router.include_router(powertrain_sizing_modal_router)

--- a/app/api/v2/endpoints/aeroplane/powertrain_sizing_modal.py
+++ b/app/api/v2/endpoints/aeroplane/powertrain_sizing_modal.py
@@ -1,0 +1,75 @@
+"""Powertrain Sizing Modal endpoint (gh-197).
+
+GET /aeroplanes/{aeroplane_id}/powertrain/sizing-modal-params
+
+Returns the pre-filled defaults for the frontend Powertrain Sizing Modal:
+  - aero parameters (cd0, s_ref_m2) from the gh-924 computation context
+  - motor catalog (brushless_motor components with efficiency_pct)
+  - warnings when values are defaulted
+"""
+
+from typing import Annotated
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Path, status
+from pydantic import UUID4
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import NotFoundError, ServiceException, ValidationError
+from app.db.session import get_db
+from app.schemas.powertrain_sizing_modal import PowertrainModalParamsResponse
+from app.services import powertrain_sizing_modal_service as svc
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _raise_http(exc: ServiceException) -> None:
+    if isinstance(exc, NotFoundError):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=exc.message) from exc
+    if isinstance(exc, ValidationError):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=exc.message
+        ) from exc
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=exc.message
+    ) from exc
+
+
+@router.get(
+    "/aeroplanes/{aeroplane_id}/powertrain/sizing-modal-params",
+    status_code=status.HTTP_200_OK,
+    tags=["powertrain"],
+    operation_id="get_powertrain_sizing_modal_params",
+    summary=(
+        "Return pre-filled defaults for the Powertrain Sizing Modal "
+        "(cd0, s_ref_m2, motors with efficiency, warnings)"
+    ),
+    responses={
+        404: {"description": "Aeroplane not found"},
+        500: {"description": "Internal server error"},
+    },
+)
+async def get_powertrain_sizing_modal_params(
+    aeroplane_id: Annotated[UUID4, Path(..., description="The ID of the aeroplane")],
+    db: Annotated[Session, Depends(get_db)],
+) -> PowertrainModalParamsResponse:
+    """Return pre-filled defaults for the Powertrain Sizing Modal.
+
+    The frontend uses this response to pre-populate the modal dialog fields:
+    - altitude_m: defaults to 0.0 (sea level) — editable
+    - cd0: from assumption_computation_context (gh-924), editable
+    - s_ref_m2: from assumption_computation_context, read-only display
+    - eta_prop: default 0.65 (placeholder until prop-finder Phase 2, #199), editable
+    - eta_motor: default 0.85 (brushless typical), editable per motor selection
+    - motors: brushless_motor catalog sorted by name, with efficiency_pct
+    - warnings: notes about any defaulted parameters
+    """
+    try:
+        return svc.get_modal_params(db, aeroplane_id)
+    except ServiceException as exc:
+        _raise_http(exc)
+    except Exception as exc:
+        logger.exception("Unexpected error in get_powertrain_sizing_modal_params: %s", exc)
+        raise HTTPException(status_code=500, detail=f"Unexpected error: {exc}") from exc

--- a/app/schemas/powertrain_sizing_modal.py
+++ b/app/schemas/powertrain_sizing_modal.py
@@ -1,0 +1,89 @@
+"""Schemas for the Powertrain Sizing Modal (gh-197).
+
+Provides pre-filled defaults for the modal dialog and the motor suggestion list.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class MotorSuggestion(BaseModel):
+    """A brushless motor from the component catalog, enriched for the modal."""
+
+    id: int = Field(..., description="Component ID")
+    name: str = Field(..., description="Motor name / model number")
+    manufacturer: Optional[str] = Field(None, description="Manufacturer name")
+    mass_g: Optional[float] = Field(None, ge=0, description="Mass in grams")
+    efficiency_pct: float = Field(
+        ...,
+        ge=0,
+        le=100,
+        description=(
+            "Motor efficiency in percent. Read from specs.efficiency_pct when present; "
+            "falls back to the brushless-motor default (85%)."
+        ),
+    )
+    kv: Optional[float] = Field(None, gt=0, description="Motor KV (RPM/V)")
+    max_power_w: Optional[float] = Field(None, ge=0, description="Peak shaft power rating in W")
+    description: Optional[str] = Field(None, description="Free-text description")
+
+
+class PowertrainModalParamsResponse(BaseModel):
+    """Pre-filled defaults for the Powertrain Sizing Modal (gh-197).
+
+    All editable fields in the modal have a suggested value here.  The frontend
+    should populate the dialog with these and let the user override before
+    calling POST /powertrain/sizing.
+    """
+
+    altitude_m: float = Field(
+        0.0,
+        ge=0,
+        description="Operating altitude in m (default from mission context, fallback 0).",
+    )
+    cd0: float = Field(
+        ...,
+        ge=0,
+        description=(
+            "Zero-lift drag coefficient — from assumption_computation_context "
+            "(gh-924 single source of truth), editable in the modal."
+        ),
+    )
+    s_ref_m2: float = Field(
+        ...,
+        gt=0,
+        description=(
+            "Wing reference area in m² — from assumption_computation_context. "
+            "Displayed read-only in the modal (constructive constraint)."
+        ),
+    )
+    eta_prop: float = Field(
+        0.65,
+        gt=0,
+        le=1.0,
+        description="Propeller efficiency (editable; prop-finder is out of scope for Phase 1).",
+    )
+    eta_motor: float = Field(
+        ...,
+        gt=0,
+        le=1.0,
+        description=(
+            "Motor efficiency as a fraction (e.g. 0.85). "
+            "Editable; motor-specific value read from specs.efficiency_pct when a "
+            "motor is selected."
+        ),
+    )
+    motors: list[MotorSuggestion] = Field(
+        default_factory=list,
+        description="Brushless motors from the component library, sorted by name.",
+    )
+    warnings: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Informational notes about defaulted parameters (e.g. when "
+            "assumption_computation_context is missing and RC-typical fallbacks are used)."
+        ),
+    )

--- a/app/services/powertrain_sizing_modal_service.py
+++ b/app/services/powertrain_sizing_modal_service.py
@@ -67,8 +67,9 @@ def _motor_to_suggestion(m: ComponentModel) -> MotorSuggestion:
     raw_eff = specs.get("efficiency_pct")
     efficiency_pct = float(raw_eff) if raw_eff is not None else DEFAULT_MOTOR_ETA * 100.0
 
-    # Normalise gear_ratio: D-Drive motors store gear_ratio in specs (gh-986).
-    # The KV displayed in the modal is the motor's raw KV (before gearing).
+    # D-Drive motors store gear_ratio in specs (gh-986); the KV shown in the
+    # modal is the raw motor KV from specs (before any gearing) — the designer
+    # is picking the motor, not the propulsion output shaft.
     raw_kv = specs.get("kv")
     kv = float(raw_kv) if raw_kv is not None else None
 

--- a/app/services/powertrain_sizing_modal_service.py
+++ b/app/services/powertrain_sizing_modal_service.py
@@ -1,0 +1,133 @@
+"""Powertrain Sizing Modal Service (gh-197).
+
+Returns the pre-filled defaults for the Powertrain Sizing Modal dialog:
+  - cd0 / s_ref_m2 from the aeroplane's assumption_computation_context (gh-924)
+  - motors from the brushless_motor component catalog with efficiency_pct
+  - warnings when values are defaulted (same pattern as gh-960)
+
+The caller (endpoint) resolves the aeroplane by UUID and passes it in.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import NotFoundError
+from app.models.aeroplanemodel import AeroplaneModel
+from app.models.component import ComponentModel
+from app.schemas.powertrain_sizing_modal import (
+    MotorSuggestion,
+    PowertrainModalParamsResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+# Brushless motor defaults — typical high-quality RC/UAV motor.
+DEFAULT_MOTOR_ETA: float = 0.85  # 85 % shaft efficiency (editable in modal)
+DEFAULT_ETA_PROP: float = 0.65  # Placeholder; prop-finder is Phase 2 (#199)
+
+# RC-typical aero fallbacks (mirrors powertrain_sizing_service)
+_DEFAULT_CD0: float = 0.03
+_DEFAULT_S_REF_M2: float = 0.5
+
+
+def _resolve_cd0(ctx: dict[str, Any]) -> tuple[float, str | None]:
+    """Return (cd0, warning_or_None) from the gh-924 computation context."""
+    val = ctx.get("cd0")
+    if val is not None and float(val) > 0:
+        return float(val), None
+    return _DEFAULT_CD0, (
+        "cd0 not available in aerodynamic analysis context — using RC-typical default "
+        f"({_DEFAULT_CD0}). Run recompute to get an accurate value."
+    )
+
+
+def _resolve_s_ref(ctx: dict[str, Any]) -> tuple[float, str | None]:
+    """Return (s_ref_m2, warning_or_None) from the gh-924 computation context."""
+    val = ctx.get("s_ref_m2")
+    if val is not None and float(val) > 0:
+        return float(val), None
+    return _DEFAULT_S_REF_M2, (
+        "s_ref_m2 not available in aerodynamic analysis context — using RC-typical "
+        f"default ({_DEFAULT_S_REF_M2} m²). Run recompute to get the real wing area."
+    )
+
+
+def _motor_to_suggestion(m: ComponentModel) -> MotorSuggestion:
+    """Convert a ComponentModel (brushless_motor) to a MotorSuggestion.
+
+    efficiency_pct comes from specs['efficiency_pct'] when present; otherwise
+    the brushless-motor default (DEFAULT_MOTOR_ETA × 100) is used so the
+    dialog always has a sensible starting value.
+    """
+    specs: dict[str, Any] = m.specs or {}
+    raw_eff = specs.get("efficiency_pct")
+    efficiency_pct = float(raw_eff) if raw_eff is not None else DEFAULT_MOTOR_ETA * 100.0
+
+    # Normalise gear_ratio: D-Drive motors store gear_ratio in specs (gh-986).
+    # The KV displayed in the modal is the motor's raw KV (before gearing).
+    raw_kv = specs.get("kv")
+    kv = float(raw_kv) if raw_kv is not None else None
+
+    raw_power = specs.get("max_power_w") or specs.get("max_continuous_power_w")
+    max_power_w = float(raw_power) if raw_power is not None else None
+
+    return MotorSuggestion(
+        id=m.id,
+        name=m.name,
+        manufacturer=m.manufacturer,
+        mass_g=m.mass_g,
+        efficiency_pct=efficiency_pct,
+        kv=kv,
+        max_power_w=max_power_w,
+        description=m.description,
+    )
+
+
+def get_modal_params(db: Session, aeroplane_uuid) -> PowertrainModalParamsResponse:
+    """Return pre-filled defaults for the Powertrain Sizing Modal.
+
+    Raises
+    ------
+    NotFoundError
+        When the aeroplane UUID does not exist in the database.
+    """
+    aeroplane: AeroplaneModel | None = (
+        db.query(AeroplaneModel).filter(AeroplaneModel.uuid == aeroplane_uuid).first()
+    )
+    if aeroplane is None:
+        raise NotFoundError(entity="Aeroplane", resource_id=aeroplane_uuid)
+
+    ctx: dict[str, Any] = getattr(aeroplane, "assumption_computation_context", None) or {}
+
+    cd0, cd0_warn = _resolve_cd0(ctx)
+    s_ref_m2, sref_warn = _resolve_s_ref(ctx)
+
+    warnings: list[str] = [w for w in [cd0_warn, sref_warn] if w is not None]
+
+    # Default motor efficiency: prefer the motor-level default; the user overrides
+    # this in the modal when they select a specific motor (its efficiency_pct from
+    # specs is pre-populated by the motor list).
+    eta_motor = DEFAULT_MOTOR_ETA
+
+    # Motor catalog
+    motors_raw: list[ComponentModel] = (
+        db.query(ComponentModel).filter(ComponentModel.component_type == "brushless_motor").all()
+    )
+    motors = sorted(
+        [_motor_to_suggestion(m) for m in motors_raw],
+        key=lambda m: m.name,
+    )
+
+    return PowertrainModalParamsResponse(
+        altitude_m=0.0,  # no altitude field in current mission model; default sea-level
+        cd0=cd0,
+        s_ref_m2=s_ref_m2,
+        eta_prop=DEFAULT_ETA_PROP,
+        eta_motor=eta_motor,
+        motors=motors,
+        warnings=warnings,
+    )

--- a/app/tests/test_powertrain_sizing_modal_params.py
+++ b/app/tests/test_powertrain_sizing_modal_params.py
@@ -1,0 +1,211 @@
+"""Tests for the powertrain sizing modal params endpoint (gh-197).
+
+The endpoint returns pre-filled defaults for the Powertrain Sizing Modal:
+  - altitude_m: from mission context (fallback 0.0)
+  - cd0: from assumption_computation_context (fallback RC default with warning)
+  - s_ref_m2: from assumption_computation_context (fallback with warning)
+  - motors: list of brushless_motor components with efficiency_pct from specs
+  - warnings: forwarded from context resolution
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.schemas.powertrain_sizing_modal import (
+    MotorSuggestion,
+    PowertrainModalParamsResponse,
+)
+from app.services.powertrain_sizing_modal_service import (
+    get_modal_params,
+    DEFAULT_MOTOR_ETA,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_aeroplane(
+    aero_uuid=None,
+    ctx: dict | None = None,
+):
+    plane = SimpleNamespace(
+        uuid=aero_uuid or uuid.uuid4(),
+        assumption_computation_context=ctx or {},
+    )
+    return plane
+
+
+def _make_motor(
+    motor_id: int = 1,
+    name: str = "D-Power M2826/10",
+    mass_g: float = 50.0,
+    manufacturer: str = "D-Power",
+    specs: dict | None = None,
+):
+    return SimpleNamespace(
+        id=motor_id,
+        name=name,
+        mass_g=mass_g,
+        manufacturer=manufacturer,
+        description=None,
+        specs=specs or {},
+    )
+
+
+def _make_db(aeroplane=None, motors=None):
+    db = MagicMock()
+    call_count = {"n": 0}
+
+    aeroplane_chain = MagicMock()
+    aeroplane_chain.filter.return_value = aeroplane_chain
+    aeroplane_chain.first.return_value = aeroplane
+
+    motor_chain = MagicMock()
+    motor_chain.filter.return_value = motor_chain
+    motor_chain.all.return_value = motors or []
+
+    queries = [aeroplane_chain, motor_chain]
+
+    def _query_side(model):
+        idx = call_count["n"]
+        call_count["n"] += 1
+        return queries[idx]
+
+    db.query.side_effect = _query_side
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Tests: PowertrainModalParamsResponse schema
+# ---------------------------------------------------------------------------
+
+
+class TestPowertrainModalParamsResponse:
+    def test_schema_has_required_fields(self):
+        resp = PowertrainModalParamsResponse(
+            altitude_m=0.0,
+            cd0=0.03,
+            s_ref_m2=0.5,
+            eta_prop=0.65,
+            eta_motor=DEFAULT_MOTOR_ETA,
+            motors=[],
+            warnings=[],
+        )
+        assert resp.altitude_m == 0.0
+        assert resp.cd0 == 0.03
+        assert resp.s_ref_m2 == 0.5
+        assert resp.eta_prop == 0.65
+        assert resp.eta_motor == DEFAULT_MOTOR_ETA
+        assert resp.motors == []
+        assert resp.warnings == []
+
+    def test_motor_suggestion_carries_efficiency(self):
+        m = MotorSuggestion(
+            id=1,
+            name="Motor A",
+            manufacturer="ACME",
+            mass_g=55.0,
+            efficiency_pct=85.0,
+            kv=1200,
+            max_power_w=350.0,
+        )
+        assert m.efficiency_pct == 85.0
+        assert m.kv == 1200
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_modal_params service
+# ---------------------------------------------------------------------------
+
+
+class TestGetModalParams:
+    def test_missing_aeroplane_raises(self):
+        db = _make_db(aeroplane=None, motors=[])
+        with pytest.raises(Exception, match="not found|Not Found"):
+            get_modal_params(db, uuid.uuid4())
+
+    def test_empty_context_uses_defaults_and_warns(self):
+        plane = _make_aeroplane(ctx={})
+        db = _make_db(aeroplane=plane, motors=[])
+
+        result = get_modal_params(db, plane.uuid)
+
+        assert result.altitude_m == 0.0  # default
+        # cd0 and s_ref_m2 use RC defaults, warnings are emitted
+        assert result.cd0 > 0
+        assert result.s_ref_m2 > 0
+        assert len(result.warnings) >= 1  # at least one param was defaulted
+
+    def test_context_cd0_and_sref_are_used(self):
+        plane = _make_aeroplane(ctx={"cd0": 0.025, "s_ref_m2": 0.42})
+        db = _make_db(aeroplane=plane, motors=[])
+
+        result = get_modal_params(db, plane.uuid)
+
+        assert result.cd0 == pytest.approx(0.025)
+        assert result.s_ref_m2 == pytest.approx(0.42)
+        # cd0 and s_ref present → no warning for those
+        cd0_warnings = [w for w in result.warnings if "cd0" in w.lower()]
+        sref_warnings = [w for w in result.warnings if "s_ref" in w.lower()]
+        assert cd0_warnings == []
+        assert sref_warnings == []
+
+    def test_motors_included_with_efficiency_from_specs(self):
+        plane = _make_aeroplane(ctx={"cd0": 0.03, "s_ref_m2": 0.5})
+        motor = _make_motor(
+            motor_id=42,
+            name="D-Power M2826",
+            mass_g=55.0,
+            specs={"kv": 1100, "efficiency_pct": 82.0, "max_power_w": 320.0},
+        )
+        db = _make_db(aeroplane=plane, motors=[motor])
+
+        result = get_modal_params(db, plane.uuid)
+
+        assert len(result.motors) == 1
+        m = result.motors[0]
+        assert m.id == 42
+        assert m.name == "D-Power M2826"
+        assert m.kv == 1100
+        assert m.efficiency_pct == pytest.approx(82.0)
+        assert m.max_power_w == pytest.approx(320.0)
+
+    def test_motors_without_efficiency_use_default(self):
+        plane = _make_aeroplane(ctx={"cd0": 0.03, "s_ref_m2": 0.5})
+        motor = _make_motor(motor_id=5, specs={})  # no efficiency_pct in specs
+        db = _make_db(aeroplane=plane, motors=[motor])
+
+        result = get_modal_params(db, plane.uuid)
+
+        assert len(result.motors) == 1
+        assert result.motors[0].efficiency_pct == pytest.approx(DEFAULT_MOTOR_ETA * 100)
+
+    def test_default_eta_motor_is_brushless_typical(self):
+        # Brushless motors typically 85% efficiency
+        assert 0.80 <= DEFAULT_MOTOR_ETA <= 0.92
+
+    def test_eta_prop_default_returned(self):
+        plane = _make_aeroplane(ctx={})
+        db = _make_db(aeroplane=plane, motors=[])
+
+        result = get_modal_params(db, plane.uuid)
+
+        assert 0.50 <= result.eta_prop <= 0.90
+
+    def test_multiple_motors_all_returned(self):
+        plane = _make_aeroplane(ctx={"cd0": 0.03, "s_ref_m2": 0.5})
+        motors = [
+            _make_motor(motor_id=i, name=f"Motor {i}", specs={"kv": 900 + i * 100})
+            for i in range(5)
+        ]
+        db = _make_db(aeroplane=plane, motors=motors)
+
+        result = get_modal_params(db, plane.uuid)
+        assert len(result.motors) == 5

--- a/frontend/__tests__/ComponentsPage.test.tsx
+++ b/frontend/__tests__/ComponentsPage.test.tsx
@@ -24,8 +24,28 @@ vi.mock("lucide-react", () => {
     Box: icon, Lock: icon, Unlock: icon, Upload: icon,
     FolderPlus: icon, Check: icon, GripVertical: icon,
     Pencil: icon, Scale: icon,
+    // gh-197: PowertrainSizingModal uses Zap, ExternalLink, AlertTriangle
+    Zap: icon, ExternalLink: icon, AlertTriangle: icon,
   };
 });
+
+vi.mock("@/hooks/usePowertrainSizingModal", () => ({
+  usePowertrainModalParams: () => ({
+    data: null,
+    error: null,
+    isLoading: false,
+    mutate: vi.fn(),
+  }),
+  runPowertrainSizing: vi.fn().mockResolvedValue({ recommendations: [], warnings: [] }),
+}));
+
+vi.mock("@/hooks/useMissionObjectives", () => ({
+  useMissionObjectives: () => ({
+    data: null,
+    error: null,
+    isLoading: false,
+  }),
+}));
 
 // Stub SWR-backed hooks so the page can render without a real backend.
 vi.mock("@/hooks/useComponents", () => ({

--- a/frontend/__tests__/PowertrainSizingModal.test.tsx
+++ b/frontend/__tests__/PowertrainSizingModal.test.tsx
@@ -1,0 +1,416 @@
+/**
+ * Unit tests for PowertrainSizingModal (gh-197).
+ *
+ * Tests cover:
+ *  - Button presence in ComponentsPage header
+ *  - Modal opens on button click
+ *  - Aero params (cd0, s_ref) pre-filled and displayed
+ *  - Warnings banner when defaults are used
+ *  - Motor picker table renders and allows selection
+ *  - Motor selection updates eta_motor display
+ *  - Run Sizing button calls the API
+ *  - Results table renders candidates
+ *  - Add to Component Tree calls addTreeNode and closes modal
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import type { PowertrainModalParamsResponse } from "@/hooks/usePowertrainSizingModal";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("lucide-react", () => {
+  const icon = (props: Record<string, unknown>) =>
+    React.createElement("span", { ...props, "data-testid": "icon" });
+  return {
+    Package: icon, Search: icon, Plus: icon, Settings: icon, Trash2: icon,
+    X: icon, Loader2: icon, ChevronDown: icon, ChevronRight: icon,
+    Box: icon, Lock: icon, Unlock: icon, Upload: icon,
+    FolderPlus: icon, Check: icon, GripVertical: icon,
+    Pencil: icon, Scale: icon, Zap: icon, AlertTriangle: icon,
+    ExternalLink: icon,
+  };
+});
+
+// Mutable SWR return for powertrain modal params
+let modalParamsReturn: {
+  data: PowertrainModalParamsResponse | null | undefined;
+  error: unknown;
+  isLoading: boolean;
+  mutate: ReturnType<typeof vi.fn>;
+} = {
+  data: undefined,
+  error: null,
+  isLoading: false,
+  mutate: vi.fn(),
+};
+
+const runPowertrainSizingMock = vi.fn();
+vi.mock("@/hooks/usePowertrainSizingModal", () => ({
+  usePowertrainModalParams: () => modalParamsReturn,
+  runPowertrainSizing: (...args: unknown[]) => runPowertrainSizingMock(...args),
+}));
+
+vi.mock("@/hooks/useMissionObjectives", () => ({
+  useMissionObjectives: () => ({
+    data: { target_cruise_mps: 18.0 },
+    error: null,
+    isLoading: false,
+  }),
+}));
+
+const addTreeNodeMock = vi.fn().mockResolvedValue({});
+vi.mock("@/hooks/useComponentTree", () => ({
+  useComponentTree: () => ({
+    tree: [],
+    totalNodes: 0,
+    error: null,
+    isLoading: false,
+    mutate: vi.fn(),
+  }),
+  addTreeNode: (...args: unknown[]) => addTreeNodeMock(...args),
+  deleteTreeNode: vi.fn().mockResolvedValue(undefined),
+  moveTreeNode: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("@/hooks/useComponents", () => ({
+  useComponents: () => ({
+    components: [],
+    total: 0,
+    error: null,
+    isLoading: false,
+    mutate: vi.fn(),
+  }),
+  deleteComponent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/hooks/useConstructionParts", () => ({
+  useConstructionParts: () => ({
+    parts: [],
+    total: 0,
+    error: null,
+    isLoading: false,
+    mutate: vi.fn(),
+  }),
+  uploadConstructionPart: vi.fn().mockResolvedValue({}),
+  deleteConstructionPart: vi.fn().mockResolvedValue(undefined),
+  updateConstructionPart: vi.fn().mockResolvedValue({}),
+  lockConstructionPart: vi.fn().mockResolvedValue({}),
+  unlockConstructionPart: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("@/components/workbench/AeroplaneContext", () => ({
+  useAeroplaneContext: () => ({
+    aeroplaneId: "aero-1",
+    selectedWing: null,
+    selectedXsecIndex: null,
+    selectedFuselage: null,
+    selectedFuselageXsecIndex: null,
+    treeMode: "wingconfig",
+    setAeroplaneId: vi.fn(),
+    selectWing: vi.fn(),
+    selectXsec: vi.fn(),
+    selectFuselage: vi.fn(),
+    selectFuselageXsec: vi.fn(),
+    setTreeMode: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/fetcher", () => ({
+  API_BASE: "http://localhost:8001",
+  fetcher: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const DEFAULTS: PowertrainModalParamsResponse = {
+  altitude_m: 0.0,
+  cd0: 0.025,
+  s_ref_m2: 0.42,
+  eta_prop: 0.65,
+  eta_motor: 0.85,
+  motors: [
+    {
+      id: 1,
+      name: "D-Power M2826/10",
+      manufacturer: "D-Power",
+      mass_g: 55.0,
+      efficiency_pct: 83.0,
+      kv: 1100,
+      max_power_w: 350.0,
+      description: null,
+    },
+    {
+      id: 2,
+      name: "D-Power M2228/05",
+      manufacturer: "D-Power",
+      mass_g: 35.0,
+      efficiency_pct: 80.0,
+      kv: 1800,
+      max_power_w: 170.0,
+      description: null,
+    },
+  ],
+  warnings: [],
+};
+
+const DEFAULTS_WITH_WARNINGS: PowertrainModalParamsResponse = {
+  ...DEFAULTS,
+  warnings: ["cd0 not available in aerodynamic analysis context — using RC-typical default (0.03)."],
+};
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+async function openSizingModal(): Promise<void> {
+  const user = userEvent.setup();
+  const btn = screen.getByTestId("powertrain-sizing-btn");
+  await user.click(btn);
+}
+
+// ---------------------------------------------------------------------------
+// Tests: ComponentsPage integration
+// ---------------------------------------------------------------------------
+
+import ComponentsPage from "@/app/workbench/components/page";
+
+describe("ComponentsPage — Powertrain Sizing button", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    modalParamsReturn = {
+      data: DEFAULTS,
+      error: null,
+      isLoading: false,
+      mutate: vi.fn(),
+    };
+  });
+
+  it("renders the Powertrain Sizing button when aeroplane is selected", () => {
+    render(<ComponentsPage />);
+    expect(screen.getByTestId("powertrain-sizing-btn")).toBeTruthy();
+  });
+
+  it("opens the Powertrain Sizing modal on button click", async () => {
+    render(<ComponentsPage />);
+    await openSizingModal();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("powertrain-sizing-modal")).toBeTruthy();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: PowertrainSizingModal component in isolation
+// ---------------------------------------------------------------------------
+
+import { PowertrainSizingModal } from "@/components/workbench/PowertrainSizingModal";
+
+const onCloseMock = vi.fn();
+const onTreeMutateMock = vi.fn();
+
+function renderModal(overrides: Partial<PowertrainModalParamsResponse> = {}) {
+  modalParamsReturn = {
+    data: { ...DEFAULTS, ...overrides },
+    error: null,
+    isLoading: false,
+    mutate: vi.fn(),
+  };
+
+  return render(
+    <PowertrainSizingModal
+      open={true}
+      aeroplaneId="aero-1"
+      onClose={onCloseMock}
+      onTreeMutate={onTreeMutateMock}
+    />
+  );
+}
+
+describe("PowertrainSizingModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    runPowertrainSizingMock.mockResolvedValue({
+      recommendations: [],
+      warnings: [],
+    });
+  });
+
+  it("renders the modal with the correct aria-label", () => {
+    renderModal();
+    const dialog = screen.getByRole("dialog", { name: /Powertrain Sizing/i });
+    expect(dialog).toBeTruthy();
+  });
+
+  it("shows the Roxxy Fibel link", () => {
+    renderModal();
+    const link = screen.getByTestId("roxxy-fibel-link");
+    expect(link.getAttribute("href")).toContain("multiplex-rc.de");
+    expect(link.getAttribute("target")).toBe("_blank");
+  });
+
+  it("displays cd0 from defaults", () => {
+    renderModal();
+    const cd0Input = screen.getByTestId("input-cd0") as HTMLInputElement;
+    expect(parseFloat(cd0Input.value)).toBeCloseTo(0.025, 3);
+  });
+
+  it("displays s_ref as read-only", () => {
+    renderModal();
+    const srefInput = screen.getByTestId("input-sref") as HTMLInputElement;
+    expect(parseFloat(srefInput.value)).toBeCloseTo(0.42, 2);
+    expect(srefInput.readOnly).toBe(true);
+  });
+
+  it("shows warnings banner when warnings are present", () => {
+    renderModal({ warnings: ["cd0 defaulted to 0.03"] });
+    expect(screen.getByTestId("modal-warnings")).toBeTruthy();
+    expect(screen.getByText(/cd0 defaulted/i)).toBeTruthy();
+  });
+
+  it("renders the motor table with catalog motors", () => {
+    renderModal();
+    expect(screen.getByTestId("motor-table")).toBeTruthy();
+    expect(screen.getByTestId("motor-row-1")).toBeTruthy();
+    expect(screen.getByTestId("motor-row-2")).toBeTruthy();
+  });
+
+  it("filters motors by search", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    const searchInput = screen.getByTestId("motor-search");
+    await user.type(searchInput, "M2826");
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("motor-row-1")).toBeTruthy(); // M2826/10 matches
+      expect(screen.queryByTestId("motor-row-2")).toBeNull();   // M2228/05 does not match
+    });
+  });
+
+  it("shows notice after motor selection", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.click(screen.getByTestId("motor-row-1"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("motor-selected-notice")).toBeTruthy();
+    });
+  });
+
+  it("calls runPowertrainSizing when Run Sizing is clicked", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.click(screen.getByTestId("run-sizing-btn"));
+
+    await waitFor(() => {
+      expect(runPowertrainSizingMock).toHaveBeenCalledWith(
+        "aero-1",
+        expect.objectContaining({
+          cd0: 0.025,
+          s_ref_m2: 0.42,
+          eta_prop: 0.65,
+          eta_motor: 0.85,
+          altitude_m: 0.0,
+        })
+      );
+    });
+  });
+
+  it("renders results table when candidates are returned", async () => {
+    runPowertrainSizingMock.mockResolvedValue({
+      recommendations: [
+        {
+          motor_id: 1,
+          motor_name: "D-Power M2826/10",
+          esc_id: 10,
+          esc_name: "YGE 60A",
+          battery_id: 20,
+          battery_name: "Turnigy 2200",
+          propeller: null,
+          estimated_flight_time_min: 12.5,
+          estimated_cruise_power_w: 85.0,
+          estimated_top_speed_ms: 25.0,
+          confidence: 0.72,
+        },
+      ],
+      warnings: [],
+    });
+
+    const user = userEvent.setup();
+    renderModal();
+    await user.click(screen.getByTestId("run-sizing-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("results-section")).toBeTruthy();
+      // Motor name appears in both motor table and results table — getAllByText handles both
+      expect(screen.getAllByText("D-Power M2826/10").length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it("calls addTreeNode and onTreeMutate when Add to Component Tree is clicked", async () => {
+    runPowertrainSizingMock.mockResolvedValue({
+      recommendations: [
+        {
+          motor_id: 1,
+          motor_name: "D-Power M2826/10",
+          esc_id: 10,
+          esc_name: "YGE 60A",
+          battery_id: 20,
+          battery_name: "Turnigy 2200",
+          propeller: null,
+          estimated_flight_time_min: 12.5,
+          estimated_cruise_power_w: 85.0,
+          estimated_top_speed_ms: 25.0,
+          confidence: 0.72,
+        },
+      ],
+      warnings: [],
+    });
+
+    const user = userEvent.setup();
+    renderModal();
+    await user.click(screen.getByTestId("run-sizing-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("results-section")).toBeTruthy();
+    });
+
+    // Select the candidate row
+    const candidateRow = screen.getByTestId("candidate-row-1-20");
+    await user.click(candidateRow);
+
+    // Click add to tree
+    const addBtn = screen.getByTestId("add-to-tree-btn");
+    await user.click(addBtn);
+
+    await waitFor(() => {
+      expect(addTreeNodeMock).toHaveBeenCalledWith(
+        "aero-1",
+        expect.objectContaining({ node_type: "cots", component_id: 1 })
+      );
+      expect(addTreeNodeMock).toHaveBeenCalledWith(
+        "aero-1",
+        expect.objectContaining({ node_type: "cots", component_id: 10 })
+      );
+      expect(onTreeMutateMock).toHaveBeenCalled();
+      expect(onCloseMock).toHaveBeenCalled();
+    });
+  });
+
+  it("closes when the close button is clicked", async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.click(screen.getByTestId("modal-close-btn"));
+    expect(onCloseMock).toHaveBeenCalled();
+  });
+});

--- a/frontend/__tests__/PowertrainSizingModal.test.tsx
+++ b/frontend/__tests__/PowertrainSizingModal.test.tsx
@@ -14,7 +14,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import type { PowertrainModalParamsResponse } from "@/hooks/usePowertrainSizingModal";
@@ -158,11 +158,6 @@ const DEFAULTS: PowertrainModalParamsResponse = {
     },
   ],
   warnings: [],
-};
-
-const DEFAULTS_WITH_WARNINGS: PowertrainModalParamsResponse = {
-  ...DEFAULTS,
-  warnings: ["cd0 not available in aerodynamic analysis context — using RC-typical default (0.03)."],
 };
 
 // ---------------------------------------------------------------------------

--- a/frontend/app/workbench/components/page.tsx
+++ b/frontend/app/workbench/components/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Package, Search, Plus, Settings, Trash2, Box } from "lucide-react";
+import { Package, Search, Plus, Settings, Trash2, Box, Zap } from "lucide-react";
 import { PillToggle, type PillToggleOption } from "@/components/ui/PillToggle";
 import { WorkbenchTwoPanel } from "@/components/workbench/WorkbenchTwoPanel";
 import { ComponentTree } from "@/components/workbench/ComponentTree";
@@ -10,6 +10,7 @@ import { ConstructionPartsGrid } from "@/components/workbench/ConstructionPartsG
 import { ConstructionPartUploadDialog } from "@/components/workbench/ConstructionPartUploadDialog";
 import { NodePropertyPanel } from "@/components/workbench/NodePropertyPanel";
 import { ComponentTypeManagementDialog } from "@/components/workbench/ComponentTypeManagementDialog";
+import { PowertrainSizingModal } from "@/components/workbench/PowertrainSizingModal";
 import { useAeroplaneContext } from "@/components/workbench/AeroplaneContext";
 import { useComponents, deleteComponent, type Component } from "@/hooks/useComponents";
 import {
@@ -42,6 +43,7 @@ export default function ComponentsPage() {
   const [editDialog, setEditDialog] = useState<{ open: boolean; component: Component | null }>({ open: false, component: null });
   const [typesDialog, setTypesDialog] = useState(false);
   const [uploadOpen, setUploadOpen] = useState(false);
+  const [sizingModalOpen, setSizingModalOpen] = useState(false);
   const { mutate: mutateParts } = useConstructionParts(aeroplaneId);
 
   // The pencil icon on each tree row opens a property-edit modal. We keep
@@ -100,6 +102,17 @@ export default function ComponentsPage() {
             {total} items
           </span>
           <span className="flex-1" />
+          {aeroplaneId && (
+            <button
+              onClick={() => setSizingModalOpen(true)}
+              className="flex items-center gap-1.5 rounded-full border border-border bg-card-muted px-3 py-2 text-[13px] text-foreground hover:bg-sidebar-accent"
+              title="Open Powertrain Sizing wizard"
+              data-testid="powertrain-sizing-btn"
+            >
+              <Zap size={14} className="text-orange-400" />
+              Powertrain Sizing
+            </button>
+          )}
           <button
             onClick={() => setTypesDialog(true)}
             className="flex items-center gap-1.5 rounded-full border border-border bg-card-muted px-3 py-2 text-[13px] text-foreground hover:bg-sidebar-accent"
@@ -269,6 +282,15 @@ export default function ComponentsPage() {
       open={typesDialog}
       onClose={() => setTypesDialog(false)}
     />
+
+    {sizingModalOpen && aeroplaneId && (
+      <PowertrainSizingModal
+        open={sizingModalOpen}
+        aeroplaneId={aeroplaneId}
+        onClose={() => setSizingModalOpen(false)}
+        onTreeMutate={() => mutateTree()}
+      />
+    )}
     </>
   );
 }

--- a/frontend/components/workbench/PowertrainSizingModal.tsx
+++ b/frontend/components/workbench/PowertrainSizingModal.tsx
@@ -1,0 +1,760 @@
+"use client";
+
+/**
+ * PowertrainSizingModal (gh-197)
+ *
+ * Interactive dialog that guides the designer through the electric powertrain
+ * sizing process, following the Roxxy Motoren Fibel methodology:
+ *
+ *   https://www.multiplex-rc.de/userdata/filegallery/original/87_roxxy-motoren-fibel-web.pdf
+ *
+ * The modal:
+ *  1. Pre-fills parameters from the aeroplane's analysis context (gh-924):
+ *       - cd0, s_ref_m2 (from ASB)
+ *       - altitude, eta_prop, eta_motor (editable defaults)
+ *  2. Displays the brushless_motor catalog filtered from the component library.
+ *  3. The user picks a motor → motor efficiency is pre-filled from specs.efficiency_pct.
+ *  4. On "Run Sizing", calls POST /powertrain/sizing with the current params.
+ *  5. Shows the top recommendations sorted by confidence.
+ *  6. On "Add to Component Tree", adds the chosen motor (and ESC if matched)
+ *     as cots nodes at the tree root.
+ *
+ * Prop-finder (#199 / #615) is out of scope — eta_prop is an editable field.
+ */
+
+import { useState, useCallback, useEffect } from "react";
+import { X, Loader2, AlertTriangle, ExternalLink, Check, Zap } from "lucide-react";
+import {
+  usePowertrainModalParams,
+  runPowertrainSizing,
+  type MotorSuggestion,
+  type PowertrainCandidate,
+} from "@/hooks/usePowertrainSizingModal";
+import { useMissionObjectives } from "@/hooks/useMissionObjectives";
+import { addTreeNode } from "@/hooks/useComponentTree";
+import { useDialog } from "@/hooks/useDialog";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const ROXXY_FIBEL_URL =
+  "https://www.multiplex-rc.de/userdata/filegallery/original/87_roxxy-motoren-fibel-web.pdf";
+
+// Default mission parameters when not available from context
+const DEFAULT_CRUISE_MPS = 15.0;
+const DEFAULT_TOP_SPEED_MPS = 25.0;
+const DEFAULT_FLIGHT_TIME_MIN = 15.0;
+const DEFAULT_AIRFRAME_MASS_KG = 1.5;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface Props {
+  readonly open: boolean;
+  readonly onClose: () => void;
+  readonly aeroplaneId: string;
+  readonly onTreeMutate: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// NumericField — a small labeled numeric input
+// ---------------------------------------------------------------------------
+
+interface NumericFieldProps {
+  readonly label: string;
+  readonly value: number;
+  readonly onChange: (v: number) => void;
+  readonly step?: number;
+  readonly min?: number;
+  readonly max?: number;
+  readonly unit?: string;
+  readonly readOnly?: boolean;
+  readonly testId?: string;
+}
+
+function NumericField({
+  label,
+  value,
+  onChange,
+  step = 0.01,
+  min,
+  max,
+  unit,
+  readOnly = false,
+  testId,
+}: NumericFieldProps) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
+        {label}
+      </span>
+      <div className="flex items-center gap-1">
+        <input
+          type="number"
+          value={value}
+          step={step}
+          min={min}
+          max={max}
+          readOnly={readOnly}
+          onChange={(e) => {
+            const n = parseFloat(e.target.value);
+            if (!Number.isNaN(n)) onChange(n);
+          }}
+          className={`w-24 rounded border border-border px-2 py-1 font-[family-name:var(--font-jetbrains-mono)] text-[11px] text-foreground ${
+            readOnly
+              ? "bg-sidebar-accent text-muted-foreground"
+              : "bg-card-muted"
+          }`}
+          data-testid={testId}
+        />
+        {unit && (
+          <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
+            {unit}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// MotorRow — one row in the motor picker list
+// ---------------------------------------------------------------------------
+
+interface MotorRowProps {
+  readonly motor: MotorSuggestion;
+  readonly isSelected: boolean;
+  readonly onSelect: () => void;
+}
+
+function MotorRow({ motor, isSelected, onSelect }: MotorRowProps) {
+  return (
+    <tr
+      onClick={onSelect}
+      className={`cursor-pointer border-b border-border/50 font-[family-name:var(--font-jetbrains-mono)] text-[11px] transition-colors hover:bg-sidebar-accent ${
+        isSelected ? "bg-orange-500/10" : ""
+      }`}
+      data-testid={`motor-row-${motor.id}`}
+      aria-selected={isSelected}
+    >
+      <td className="py-1.5 pr-3">
+        {isSelected && (
+          <Check size={10} className="inline text-orange-400" />
+        )}
+      </td>
+      <td className="py-1.5 pr-3 font-semibold text-foreground">{motor.name}</td>
+      <td className="py-1.5 pr-3 text-muted-foreground">{motor.manufacturer ?? "—"}</td>
+      <td className="py-1.5 pr-3 text-foreground">
+        {motor.kv != null ? `${Math.round(motor.kv)} KV` : "—"}
+      </td>
+      <td className="py-1.5 pr-3 text-foreground">
+        {motor.max_power_w != null ? `${Math.round(motor.max_power_w)} W` : "—"}
+      </td>
+      <td className="py-1.5 pr-3 text-foreground">
+        {motor.efficiency_pct.toFixed(0)}%
+      </td>
+      <td className="py-1.5 text-muted-foreground">
+        {motor.mass_g != null ? `${motor.mass_g}g` : "—"}
+      </td>
+    </tr>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CandidateRow — one row in the results table
+// ---------------------------------------------------------------------------
+
+interface CandidateRowProps {
+  readonly candidate: PowertrainCandidate;
+  readonly isSelected: boolean;
+  readonly onSelect: () => void;
+}
+
+function CandidateRow({ candidate, isSelected, onSelect }: CandidateRowProps) {
+  const conf = Math.round(candidate.confidence * 100);
+  return (
+    <tr
+      onClick={onSelect}
+      className={`cursor-pointer border-b border-border/50 font-[family-name:var(--font-jetbrains-mono)] text-[11px] transition-colors hover:bg-sidebar-accent ${
+        isSelected ? "bg-orange-500/10" : ""
+      }`}
+      data-testid={`candidate-row-${candidate.motor_id ?? "nomoby"}-${candidate.battery_id ?? "nobat"}`}
+      aria-selected={isSelected}
+    >
+      <td className="py-1.5 pr-3">
+        {isSelected && <Check size={10} className="inline text-orange-400" />}
+      </td>
+      <td className="py-1.5 pr-3 text-foreground">{candidate.motor_name ?? "—"}</td>
+      <td className="py-1.5 pr-3 text-muted-foreground">{candidate.esc_name ?? "—"}</td>
+      <td className="py-1.5 pr-3 text-muted-foreground">{candidate.battery_name ?? "—"}</td>
+      <td className="py-1.5 pr-3 text-emerald-400">
+        {candidate.estimated_flight_time_min.toFixed(1)} min
+      </td>
+      <td className="py-1.5 pr-3 text-foreground">
+        {candidate.estimated_cruise_power_w.toFixed(0)} W
+      </td>
+      <td className="py-1.5">
+        <span
+          className={`inline-block rounded-full px-2 py-0.5 text-[9px] ${
+            conf >= 60
+              ? "bg-emerald-900/40 text-emerald-400"
+              : conf >= 30
+              ? "bg-orange-900/40 text-orange-400"
+              : "bg-zinc-800 text-muted-foreground"
+          }`}
+        >
+          {conf}%
+        </span>
+      </td>
+    </tr>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main PowertrainSizingModal
+// ---------------------------------------------------------------------------
+
+export function PowertrainSizingModal({
+  open,
+  onClose,
+  aeroplaneId,
+  onTreeMutate,
+}: Props) {
+  const { dialogRef, handleClose } = useDialog(open, onClose);
+
+  // Fetch pre-filled defaults
+  const { data: defaults, isLoading: defaultsLoading, error: defaultsError } =
+    usePowertrainModalParams(open ? aeroplaneId : null);
+
+  // Fetch mission for cruise speed / mass defaults
+  const { data: mission } = useMissionObjectives(open ? aeroplaneId : null);
+
+  // ---------------------------------------------------------------------------
+  // Form state — initialized from defaults when they arrive
+  // ---------------------------------------------------------------------------
+  const [altitude, setAltitude] = useState(0.0);
+  const [cd0, setCd0] = useState(0.03);
+  const [etaProp, setEtaProp] = useState(0.65);
+  const [etaMotor, setEtaMotor] = useState(0.85);
+  const [airframeMass, setAirframeMass] = useState(DEFAULT_AIRFRAME_MASS_KG);
+  const [cruiseSpeed, setCruiseSpeed] = useState(DEFAULT_CRUISE_MPS);
+  const [topSpeed, setTopSpeed] = useState(DEFAULT_TOP_SPEED_MPS);
+  const [flightTime, setFlightTime] = useState(DEFAULT_FLIGHT_TIME_MIN);
+
+  // Initialize form when defaults arrive (only once on open)
+  const [initialized, setInitialized] = useState(false);
+
+  useEffect(() => {
+    if (open && defaults && !initialized) {
+      setAltitude(defaults.altitude_m);
+      setCd0(defaults.cd0);
+      setEtaProp(defaults.eta_prop);
+      setEtaMotor(defaults.eta_motor);
+      setInitialized(true);
+    }
+    if (!open) {
+      setInitialized(false);
+    }
+  }, [open, defaults, initialized]);
+
+  // Pre-fill mission cruise speed when mission loads
+  useEffect(() => {
+    if (open && mission?.target_cruise_mps && !initialized) {
+      setCruiseSpeed(mission.target_cruise_mps);
+      setTopSpeed(Math.round(mission.target_cruise_mps * 1.5 * 10) / 10);
+    }
+  }, [open, mission, initialized]);
+
+  // ---------------------------------------------------------------------------
+  // Motor picker
+  // ---------------------------------------------------------------------------
+  const [selectedMotorId, setSelectedMotorId] = useState<number | null>(null);
+  const [motorSearch, setMotorSearch] = useState("");
+
+  const handleSelectMotor = useCallback(
+    (m: MotorSuggestion) => {
+      setSelectedMotorId(m.id);
+      setEtaMotor(m.efficiency_pct / 100);
+    },
+    []
+  );
+
+  const filteredMotors = (defaults?.motors ?? []).filter(
+    (m) =>
+      !motorSearch ||
+      m.name.toLowerCase().includes(motorSearch.toLowerCase()) ||
+      (m.manufacturer ?? "").toLowerCase().includes(motorSearch.toLowerCase())
+  );
+
+  // ---------------------------------------------------------------------------
+  // Sizing run
+  // ---------------------------------------------------------------------------
+  const [candidates, setCandidates] = useState<PowertrainCandidate[]>([]);
+  const [sizingWarnings, setSizingWarnings] = useState<string[]>([]);
+  const [sizing, setSizing] = useState(false);
+  const [sizingError, setSizingError] = useState<string | null>(null);
+
+  const handleRunSizing = useCallback(async () => {
+    setSizing(true);
+    setSizingError(null);
+    try {
+      const result = await runPowertrainSizing(aeroplaneId, {
+        airframe_mass_kg: airframeMass,
+        target_cruise_speed_ms: cruiseSpeed,
+        target_top_speed_ms: topSpeed > cruiseSpeed ? topSpeed : cruiseSpeed * 1.5,
+        target_flight_time_min: flightTime,
+        altitude_m: altitude,
+        cd0,
+        s_ref_m2: defaults?.s_ref_m2,
+        eta_prop: etaProp,
+        eta_motor: etaMotor,
+      });
+      setCandidates(result.recommendations);
+      setSizingWarnings(result.warnings);
+    } catch (err) {
+      setSizingError(err instanceof Error ? err.message : "Sizing failed");
+    } finally {
+      setSizing(false);
+    }
+  }, [
+    aeroplaneId,
+    airframeMass,
+    cruiseSpeed,
+    topSpeed,
+    flightTime,
+    altitude,
+    cd0,
+    defaults?.s_ref_m2,
+    etaProp,
+    etaMotor,
+  ]);
+
+  // ---------------------------------------------------------------------------
+  // Candidate selection + add to tree
+  // ---------------------------------------------------------------------------
+  const [selectedCandidateIdx, setSelectedCandidateIdx] = useState<number | null>(null);
+  const [adding, setAdding] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+
+  const handleAddToTree = useCallback(async () => {
+    if (selectedCandidateIdx == null) return;
+    const candidate = candidates[selectedCandidateIdx];
+    if (!candidate) return;
+
+    setAdding(true);
+    setAddError(null);
+    try {
+      // Add motor node (cots)
+      if (candidate.motor_id != null) {
+        await addTreeNode(aeroplaneId, {
+          node_type: "cots",
+          name: candidate.motor_name ?? "Motor",
+          component_id: candidate.motor_id,
+          quantity: 1,
+        });
+      }
+      // Add ESC node (cots) if matched
+      if (candidate.esc_id != null) {
+        await addTreeNode(aeroplaneId, {
+          node_type: "cots",
+          name: candidate.esc_name ?? "ESC",
+          component_id: candidate.esc_id,
+          quantity: 1,
+        });
+      }
+      onTreeMutate();
+      onClose();
+    } catch (err) {
+      setAddError(err instanceof Error ? err.message : "Add to tree failed");
+    } finally {
+      setAdding(false);
+    }
+  }, [aeroplaneId, candidates, selectedCandidateIdx, onTreeMutate, onClose]);
+
+  // ---------------------------------------------------------------------------
+  // s_ref display (read-only)
+  // ---------------------------------------------------------------------------
+  const sRefDisplay = defaults?.s_ref_m2 ?? null;
+
+  // ---------------------------------------------------------------------------
+  // Warnings: combine defaults warnings + sizing warnings
+  // ---------------------------------------------------------------------------
+  const allWarnings = [
+    ...(defaults?.warnings ?? []),
+    ...(initialized ? [] : []),
+    ...sizingWarnings,
+  ];
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className="m-auto bg-transparent backdrop:bg-black/60"
+      onClose={handleClose}
+      aria-label="Powertrain Sizing"
+    >
+      <div
+        className="flex max-h-[90vh] w-[780px] flex-col gap-4 overflow-y-auto rounded-2xl border border-border bg-card p-6 shadow-2xl"
+        data-testid="powertrain-sizing-modal"
+      >
+        {/* Header */}
+        <div className="flex items-center gap-3">
+          <Zap size={16} className="text-orange-400" />
+          <span className="font-[family-name:var(--font-jetbrains-mono)] text-[16px] text-foreground">
+            Powertrain Sizing
+          </span>
+          <span className="flex-1" />
+          <a
+            href={ROXXY_FIBEL_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            title="Roxxy Motoren Fibel — sizing reference"
+            className="flex items-center gap-1 rounded-full border border-border px-3 py-1.5 font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground hover:bg-sidebar-accent hover:text-foreground"
+            data-testid="roxxy-fibel-link"
+          >
+            <ExternalLink size={11} />
+            Roxxy Fibel
+          </a>
+          <button
+            onClick={onClose}
+            className="flex size-8 items-center justify-center rounded-full text-muted-foreground hover:bg-sidebar-accent"
+            aria-label="Close"
+            data-testid="modal-close-btn"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Loading state */}
+        {defaultsLoading && (
+          <div className="flex items-center gap-2 py-4 text-muted-foreground">
+            <Loader2 size={14} className="animate-spin" />
+            <span className="font-[family-name:var(--font-geist-sans)] text-[12px]">
+              Loading aero parameters…
+            </span>
+          </div>
+        )}
+
+        {/* Defaults error */}
+        {defaultsError && !defaultsLoading && (
+          <div className="flex items-center gap-2 rounded-lg border border-orange-500/30 bg-orange-900/20 px-3 py-2">
+            <AlertTriangle size={12} className="text-orange-400" />
+            <span className="font-[family-name:var(--font-geist-sans)] text-[11px] text-orange-400">
+              Could not load aero parameters. Using defaults.
+            </span>
+          </div>
+        )}
+
+        {/* Warnings banner */}
+        {allWarnings.length > 0 && (
+          <div
+            className="rounded-lg border border-orange-500/30 bg-orange-900/20 px-3 py-2"
+            data-testid="modal-warnings"
+          >
+            {allWarnings.map((w) => (
+              <p
+                key={w}
+                className="font-[family-name:var(--font-geist-sans)] text-[10px] text-orange-400"
+              >
+                ⚠ {w}
+              </p>
+            ))}
+          </div>
+        )}
+
+        {/* ── Section 1: Aerodynamic parameters ── */}
+        <section>
+          <h2 className="mb-2 font-[family-name:var(--font-geist-sans)] text-[11px] uppercase tracking-wider text-muted-foreground">
+            Aerodynamic Parameters
+          </h2>
+          <div className="flex flex-wrap gap-4 rounded-xl border border-border bg-card-muted p-4">
+            <NumericField
+              label="Altitude (m)"
+              value={altitude}
+              onChange={setAltitude}
+              step={100}
+              min={0}
+              unit="m"
+              testId="input-altitude"
+            />
+            <NumericField
+              label="Drag Coefficient (cd0)"
+              value={cd0}
+              onChange={setCd0}
+              step={0.001}
+              min={0}
+              testId="input-cd0"
+            />
+            {sRefDisplay != null && (
+              <NumericField
+                label="Wing Area (m²)"
+                value={sRefDisplay}
+                onChange={() => undefined}
+                step={0.01}
+                unit="m²"
+                readOnly
+                testId="input-sref"
+              />
+            )}
+            <NumericField
+              label="Prop Efficiency (η_prop)"
+              value={etaProp}
+              onChange={setEtaProp}
+              step={0.01}
+              min={0.1}
+              max={1.0}
+              testId="input-eta-prop"
+            />
+            <NumericField
+              label="Motor Efficiency (η_motor)"
+              value={etaMotor}
+              onChange={setEtaMotor}
+              step={0.01}
+              min={0.1}
+              max={1.0}
+              testId="input-eta-motor"
+            />
+          </div>
+          <p className="mt-1 font-[family-name:var(--font-geist-sans)] text-[9px] text-subtle-foreground">
+            cd0 and wing area from aerodynamic analysis (gh-924). Prop efficiency is a
+            placeholder — see prop-finder Phase 2 (#199).
+          </p>
+        </section>
+
+        {/* ── Section 2: Mission parameters ── */}
+        <section>
+          <h2 className="mb-2 font-[family-name:var(--font-geist-sans)] text-[11px] uppercase tracking-wider text-muted-foreground">
+            Mission Parameters
+          </h2>
+          <div className="flex flex-wrap gap-4 rounded-xl border border-border bg-card-muted p-4">
+            <NumericField
+              label="Airframe Mass (kg)"
+              value={airframeMass}
+              onChange={setAirframeMass}
+              step={0.1}
+              min={0.1}
+              unit="kg"
+              testId="input-airframe-mass"
+            />
+            <NumericField
+              label="Cruise Speed (m/s)"
+              value={cruiseSpeed}
+              onChange={setCruiseSpeed}
+              step={0.5}
+              min={1}
+              unit="m/s"
+              testId="input-cruise-speed"
+            />
+            <NumericField
+              label="Top Speed (m/s)"
+              value={topSpeed}
+              onChange={setTopSpeed}
+              step={0.5}
+              min={1}
+              unit="m/s"
+              testId="input-top-speed"
+            />
+            <NumericField
+              label="Flight Time (min)"
+              value={flightTime}
+              onChange={setFlightTime}
+              step={1}
+              min={1}
+              unit="min"
+              testId="input-flight-time"
+            />
+          </div>
+        </section>
+
+        {/* ── Section 3: Motor picker ── */}
+        <section>
+          <h2 className="mb-2 font-[family-name:var(--font-geist-sans)] text-[11px] uppercase tracking-wider text-muted-foreground">
+            Motor Selection (Optional)
+          </h2>
+          <p className="mb-2 font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
+            Pick a motor to pre-fill its efficiency. The sizing will match compatible
+            ESC/battery combos from the catalog.
+          </p>
+          {/* Motor search */}
+          <div className="mb-2 flex items-center gap-2 rounded-xl border border-border bg-input px-3 py-1.5">
+            <input
+              type="text"
+              value={motorSearch}
+              onChange={(e) => setMotorSearch(e.target.value)}
+              placeholder="Filter motors…"
+              className="flex-1 bg-transparent text-[11px] text-foreground outline-none placeholder:text-subtle-foreground"
+              data-testid="motor-search"
+            />
+          </div>
+          {/* Motor table */}
+          <div
+            className="max-h-40 overflow-y-auto rounded-xl border border-border bg-card"
+            data-testid="motor-table"
+          >
+            {filteredMotors.length === 0 && (
+              <p className="py-4 text-center font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground">
+                {(defaults?.motors ?? []).length === 0
+                  ? "No brushless motors in the component library yet."
+                  : "No motors match your filter."}
+              </p>
+            )}
+            {filteredMotors.length > 0 && (
+              <table className="w-full border-collapse">
+                <thead>
+                  <tr className="border-b border-border font-[family-name:var(--font-geist-sans)] text-[9px] uppercase tracking-wider text-muted-foreground">
+                    <th scope="col" className="py-1.5 pr-3 text-left w-4" />
+                    <th scope="col" className="py-1.5 pr-3 text-left">Motor</th>
+                    <th scope="col" className="py-1.5 pr-3 text-left">Brand</th>
+                    <th scope="col" className="py-1.5 pr-3 text-left">KV</th>
+                    <th scope="col" className="py-1.5 pr-3 text-left">Max P</th>
+                    <th scope="col" className="py-1.5 pr-3 text-left">Eff.</th>
+                    <th scope="col" className="py-1.5 text-left">Mass</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filteredMotors.map((m) => (
+                    <MotorRow
+                      key={m.id}
+                      motor={m}
+                      isSelected={selectedMotorId === m.id}
+                      onSelect={() => handleSelectMotor(m)}
+                    />
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+          {selectedMotorId != null && (
+            <p
+              className="mt-1 font-[family-name:var(--font-geist-sans)] text-[9px] text-emerald-400"
+              data-testid="motor-selected-notice"
+            >
+              Motor efficiency pre-filled from specs (η_motor = {etaMotor.toFixed(2)}).
+            </p>
+          )}
+        </section>
+
+        {/* ── Run button ── */}
+        <div className="flex items-center gap-3">
+          <button
+            onClick={handleRunSizing}
+            disabled={sizing}
+            className="flex items-center gap-2 rounded-full bg-primary px-5 py-2 font-[family-name:var(--font-geist-sans)] text-[13px] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+            data-testid="run-sizing-btn"
+          >
+            {sizing ? (
+              <Loader2 size={13} className="animate-spin" />
+            ) : (
+              <Zap size={13} />
+            )}
+            {sizing ? "Computing…" : "Run Sizing"}
+          </button>
+          {sizingError && (
+            <span className="font-[family-name:var(--font-geist-sans)] text-[11px] text-destructive">
+              {sizingError}
+            </span>
+          )}
+        </div>
+
+        {/* ── Section 4: Results ── */}
+        {candidates.length > 0 && (
+          <section data-testid="results-section">
+            <h2 className="mb-2 font-[family-name:var(--font-geist-sans)] text-[11px] uppercase tracking-wider text-muted-foreground">
+              Motor + Battery Recommendations
+            </h2>
+            <p className="mb-2 font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
+              Sorted by confidence. Select a combination, then click &ldquo;Add to
+              Component Tree&rdquo;.
+            </p>
+            <div className="overflow-x-auto rounded-xl border border-border bg-card">
+              <table className="w-full border-collapse">
+                <thead>
+                  <tr className="border-b border-border font-[family-name:var(--font-geist-sans)] text-[9px] uppercase tracking-wider text-muted-foreground">
+                    <th scope="col" className="py-1.5 pr-3 text-left w-4" />
+                    <th scope="col" className="py-1.5 pr-3 text-left">Motor</th>
+                    <th scope="col" className="py-1.5 pr-3 text-left">ESC</th>
+                    <th scope="col" className="py-1.5 pr-3 text-left">Battery</th>
+                    <th scope="col" className="py-1.5 pr-3 text-left">Flight Time</th>
+                    <th scope="col" className="py-1.5 pr-3 text-left">Cruise Power</th>
+                    <th scope="col" className="py-1.5 text-left">Confidence</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {candidates.map((c, idx) => (
+                    <CandidateRow
+                      key={`${c.motor_id}-${c.battery_id}-${idx}`}
+                      candidate={c}
+                      isSelected={selectedCandidateIdx === idx}
+                      onSelect={() => setSelectedCandidateIdx(idx)}
+                    />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
+
+        {candidates.length === 0 && !sizing && sizingError == null && initialized && (
+          <p
+            className="font-[family-name:var(--font-geist-sans)] text-[11px] text-muted-foreground"
+            data-testid="no-candidates-note"
+          >
+            Click &ldquo;Run Sizing&rdquo; to compute motor/battery recommendations from the
+            component library.
+          </p>
+        )}
+
+        {/* ── Add to tree footer ── */}
+        <div className="flex items-center justify-between gap-3 border-t border-border pt-3">
+          <div className="flex flex-col gap-0.5">
+            {addError && (
+              <span className="font-[family-name:var(--font-geist-sans)] text-[11px] text-destructive">
+                {addError}
+              </span>
+            )}
+            {selectedCandidateIdx != null && candidates[selectedCandidateIdx] && (
+              <span className="font-[family-name:var(--font-geist-sans)] text-[10px] text-muted-foreground">
+                Will add:{" "}
+                <span className="text-foreground">
+                  {candidates[selectedCandidateIdx].motor_name ?? "motor"}
+                </span>
+                {candidates[selectedCandidateIdx].esc_id != null && (
+                  <>
+                    {" "}
+                    + <span className="text-foreground">{candidates[selectedCandidateIdx].esc_name ?? "ESC"}</span>
+                  </>
+                )}
+              </span>
+            )}
+          </div>
+          <div className="flex gap-2">
+            <button
+              onClick={onClose}
+              className="rounded-full border border-border px-4 py-2 font-[family-name:var(--font-geist-sans)] text-[12px] text-muted-foreground hover:bg-sidebar-accent"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleAddToTree}
+              disabled={selectedCandidateIdx == null || adding}
+              className="flex items-center gap-2 rounded-full bg-primary px-4 py-2 font-[family-name:var(--font-geist-sans)] text-[12px] text-primary-foreground hover:opacity-90 disabled:opacity-40"
+              data-testid="add-to-tree-btn"
+            >
+              {adding ? (
+                <Loader2 size={12} className="animate-spin" />
+              ) : (
+                <Check size={12} />
+              )}
+              Add to Component Tree
+            </button>
+          </div>
+        </div>
+      </div>
+    </dialog>
+  );
+}

--- a/frontend/components/workbench/PowertrainSizingModal.tsx
+++ b/frontend/components/workbench/PowertrainSizingModal.tsx
@@ -166,6 +166,13 @@ function MotorRow({ motor, isSelected, onSelect }: MotorRowProps) {
 // CandidateRow — one row in the results table
 // ---------------------------------------------------------------------------
 
+/** Map a confidence 0–100 value to a Tailwind class string for the badge. */
+function confidenceClass(conf: number): string {
+  if (conf >= 60) return "bg-emerald-900/40 text-emerald-400";
+  if (conf >= 30) return "bg-orange-900/40 text-orange-400";
+  return "bg-zinc-800 text-muted-foreground";
+}
+
 interface CandidateRowProps {
   readonly candidate: PowertrainCandidate;
   readonly isSelected: boolean;
@@ -197,13 +204,7 @@ function CandidateRow({ candidate, isSelected, onSelect }: CandidateRowProps) {
       </td>
       <td className="py-1.5">
         <span
-          className={`inline-block rounded-full px-2 py-0.5 text-[9px] ${
-            conf >= 60
-              ? "bg-emerald-900/40 text-emerald-400"
-              : conf >= 30
-              ? "bg-orange-900/40 text-orange-400"
-              : "bg-zinc-800 text-muted-foreground"
-          }`}
+          className={`inline-block rounded-full px-2 py-0.5 text-[9px] ${confidenceClass(conf)}`}
         >
           {conf}%
         </span>

--- a/frontend/components/workbench/PowertrainSizingModal.tsx
+++ b/frontend/components/workbench/PowertrainSizingModal.tsx
@@ -383,7 +383,6 @@ export function PowertrainSizingModal({
   // ---------------------------------------------------------------------------
   const allWarnings = [
     ...(defaults?.warnings ?? []),
-    ...(initialized ? [] : []),
     ...sizingWarnings,
   ];
 

--- a/frontend/hooks/usePowertrainSizingModal.ts
+++ b/frontend/hooks/usePowertrainSizingModal.ts
@@ -1,0 +1,106 @@
+"use client";
+
+import useSWR from "swr";
+import { fetcher, API_BASE } from "@/lib/fetcher";
+
+// ---------------------------------------------------------------------------
+// Types matching backend PowertrainModalParamsResponse (gh-197)
+// ---------------------------------------------------------------------------
+
+export interface MotorSuggestion {
+  id: number;
+  name: string;
+  manufacturer: string | null;
+  mass_g: number | null;
+  efficiency_pct: number;
+  kv: number | null;
+  max_power_w: number | null;
+  description: string | null;
+}
+
+export interface PowertrainModalParamsResponse {
+  altitude_m: number;
+  cd0: number;
+  s_ref_m2: number;
+  eta_prop: number;
+  eta_motor: number;
+  motors: MotorSuggestion[];
+  warnings: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Hook: fetch pre-filled modal params
+// ---------------------------------------------------------------------------
+
+export function usePowertrainModalParams(aeroplaneId: string | null) {
+  const url = aeroplaneId
+    ? `/aeroplanes/${encodeURIComponent(aeroplaneId)}/powertrain/sizing-modal-params`
+    : null;
+
+  const { data, error, isLoading, mutate } = useSWR<PowertrainModalParamsResponse>(
+    url,
+    fetcher,
+    { revalidateOnFocus: false }
+  );
+
+  return { data, error, isLoading, mutate };
+}
+
+// ---------------------------------------------------------------------------
+// Types for the powertrain sizing POST request/response (gh-490)
+// ---------------------------------------------------------------------------
+
+export interface PowertrainSizingRequest {
+  airframe_mass_kg: number;
+  target_cruise_speed_ms: number;
+  target_top_speed_ms: number;
+  target_flight_time_min: number;
+  altitude_m?: number;
+  cd0?: number;
+  s_ref_m2?: number;
+  eta_prop?: number;
+  eta_motor?: number;
+  eta_esc?: number;
+}
+
+export interface PowertrainCandidate {
+  motor_id: number | null;
+  motor_name: string | null;
+  esc_id: number | null;
+  esc_name: string | null;
+  battery_id: number | null;
+  battery_name: string | null;
+  propeller: string | null;
+  estimated_flight_time_min: number;
+  estimated_cruise_power_w: number;
+  estimated_top_speed_ms: number;
+  confidence: number;
+}
+
+export interface PowertrainSizingResponse {
+  recommendations: PowertrainCandidate[];
+  warnings: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Imperative sizing POST (called on "Run" button)
+// ---------------------------------------------------------------------------
+
+export async function runPowertrainSizing(
+  aeroplaneId: string,
+  body: PowertrainSizingRequest
+): Promise<PowertrainSizingResponse> {
+  const res = await fetch(
+    `${API_BASE}/aeroplanes/${encodeURIComponent(aeroplaneId)}/powertrain/sizing`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Powertrain sizing failed: ${res.status} ${res.statusText}: ${text}`);
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary

- Adds a **Powertrain Sizing** button to the Component Library header (visible when an aeroplane is selected)
- Clicking the button opens a 5-section modal dialog guiding the designer through electric powertrain sizing, per the [Roxxy Motoren Fibel](https://www.multiplex-rc.de/userdata/filegallery/original/87_roxxy-motoren-fibel-web.pdf) methodology
- Dialog pre-fills `cd0` and `s_ref_m2` from `assumption_computation_context` (gh-924 single source of truth); shows ⚠ warnings when values are defaulted (gh-960 pattern)
- Motor efficiency reads `specs.efficiency_pct` from `brushless_motor` catalog (available since gh-986 D-Power import); falls back to 85%
- Motor picker table shows all `brushless_motor` catalog entries with KV, max power, efficiency, and mass; filterable by name/brand; selecting a motor pre-fills η_motor
- "Run Sizing" calls the existing `POST /aeroplanes/{id}/powertrain/sizing` endpoint with the current form values and displays the top recommendations sorted by confidence
- "Add to Component Tree" adds the selected motor + ESC as `cots` nodes at the tree root, then closes the dialog
- Prop-finder (#199/#615) is out of scope — `eta_prop` is an editable placeholder field with a tooltip note
- Roxxy Fibel link in the dialog header

## Backend changes

| File | Change |
|------|--------|
| `app/schemas/powertrain_sizing_modal.py` | New: `MotorSuggestion`, `PowertrainModalParamsResponse` |
| `app/services/powertrain_sizing_modal_service.py` | New: `get_modal_params()` — resolves aero context, motor catalog |
| `app/api/v2/endpoints/aeroplane/powertrain_sizing_modal.py` | New: `GET /aeroplanes/{id}/powertrain/sizing-modal-params` |
| `app/api/v2/endpoints/aeroplane/__init__.py` | Registers new router |
| `app/tests/test_powertrain_sizing_modal_params.py` | 10 new unit tests (TDD) |

## Frontend changes

| File | Change |
|------|--------|
| `frontend/hooks/usePowertrainSizingModal.ts` | New: `usePowertrainModalParams` SWR hook + `runPowertrainSizing` POST + types |
| `frontend/components/workbench/PowertrainSizingModal.tsx` | New: full 5-section modal component |
| `frontend/app/workbench/components/page.tsx` | Adds "Powertrain Sizing" button + mounts modal outside `WorkbenchTwoPanel` |
| `frontend/__tests__/PowertrainSizingModal.test.tsx` | 14 new vitest tests |
| `frontend/__tests__/ComponentsPage.test.tsx` | Updated to mock Zap/ExternalLink icons + new hooks |

## Sizing computation (for UAT)

The modal computes:

1. **Aero inputs** (all editable except Wing Area which is read-only):
   - `altitude_m` → air density via ISA (`ρ = 1.225 × exp(−h/8500)`)
   - `cd0` → zero-lift drag from ASB analysis context
   - `s_ref_m2` → wing area from ASB (read-only display, constructive constraint)
   - `eta_prop` → propeller efficiency (placeholder, default 0.65)
   - `eta_motor` → motor shaft efficiency (pre-filled from selected motor's `efficiency_pct`, default 85%)

2. **Mission inputs** (all editable):
   - `airframe_mass_kg`, `cruise_speed_ms`, `top_speed_ms`, `flight_time_min`

3. **Backend call**: `POST /aeroplanes/{id}/powertrain/sizing` with above params → service sweeps every `brushless_motor × battery` pair in the catalog, computes cruise power via `P = ½ρV³SC_D / η_total` (endurance-service physics), estimates flight time, matches ESC, scores confidence.

4. **Results** are sorted by confidence (flight-time / target ratio). The user selects one combo and clicks "Add to Component Tree" → motor + ESC are added as `cots` nodes.

## Test plan

- [x] 10 backend unit tests pass (`test_powertrain_sizing_modal_params.py`)
- [x] 14 frontend vitest tests pass (`PowertrainSizingModal.test.tsx`)
- [x] 4 existing `ComponentsPage.test.tsx` tests still pass
- [x] Full frontend suite: 2178/2178 tests pass
- [x] `ruff check` clean
- [ ] Manual smoke test: start backend `:8001` + frontend from worktree, open Component-Auswahl tab with an aeroplane that has analysis results, click "Powertrain Sizing" — verify aero params are pre-filled from analysis, motor list shows D-Power motors from catalog, "Run Sizing" returns recommendations

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)