### PR TITLE
fix(gh-990): sizing modal shows KV=null for all motors (wrong specs key)

### DIFF
--- a/app/services/powertrain_sizing_modal_service.py
+++ b/app/services/powertrain_sizing_modal_service.py
@@ -70,7 +70,7 @@ def _motor_to_suggestion(m: ComponentModel) -> MotorSuggestion:
     # D-Drive motors store gear_ratio in specs (gh-986); the KV shown in the
     # modal is the raw motor KV from specs (before any gearing) — the designer
     # is picking the motor, not the propulsion output shaft.
-    raw_kv = specs.get("kv")
+    raw_kv = specs.get("kv_rpm_per_volt", specs.get("kv"))
     kv = float(raw_kv) if raw_kv is not None else None
 
     raw_power = specs.get("max_power_w") or specs.get("max_continuous_power_w")

--- a/app/tests/test_powertrain_sizing_modal_params.py
+++ b/app/tests/test_powertrain_sizing_modal_params.py
@@ -177,6 +177,27 @@ class TestGetModalParams:
         assert m.efficiency_pct == pytest.approx(82.0)
         assert m.max_power_w == pytest.approx(320.0)
 
+    def test_kv_read_from_real_gh986_specs_key(self):
+        """Regression (gh-990): real catalog data stores KV under
+        'kv_rpm_per_volt' (gh-986 schema), not 'kv'. The modal must read it,
+        otherwise every motor shows KV=null in the UI."""
+        plane = _make_aeroplane(ctx={"cd0": 0.03, "s_ref_m2": 0.5})
+        motor = _make_motor(
+            motor_id=37,
+            name="AL 28-09",
+            specs={
+                "kv_rpm_per_volt": 980,
+                "io_no_load_a": 0.7,
+                "continuous_current_a": 12.0,
+                "max_current_a": 14.0,
+            },
+        )
+        db = _make_db(aeroplane=plane, motors=[motor])
+
+        result = get_modal_params(db, plane.uuid)
+
+        assert result.motors[0].kv == pytest.approx(980.0)
+
     def test_motors_without_efficiency_use_default(self):
         plane = _make_aeroplane(ctx={"cd0": 0.03, "s_ref_m2": 0.5})
         motor = _make_motor(motor_id=5, specs={})  # no efficiency_pct in specs


### PR DESCRIPTION
Fast-follow to #197, found during 3-persona UAT against the running app.

`_motor_to_suggestion` read `specs['kv']` but gh-986 catalog data stores KV under `specs['kv_rpm_per_volt']` → every motor returned `kv: null`. Now reads the real key (with `kv` fallback). Added a regression test using real gh-986 spec keys.

Closes #990