### PR TITLE
fix(gh-992,gh-993): make powertrain sizing work end-to-end + seed LiPo batteries

### DIFF
--- a/app/services/powertrain_sizing_service.py
+++ b/app/services/powertrain_sizing_service.py
@@ -105,18 +105,24 @@ def _find_matching_esc(escs: list, min_current_a: float):
     """Return the first ESC that can handle the required current, or None."""
     for esc in escs:
         esc_specs = esc.specs or {}
-        if esc_specs.get("max_continuous_a", 0) >= min_current_a:
+        # gh-986 catalog stores continuous current under continuous_current_a;
+        # fall back to legacy max_continuous_a for older entries (gh-992).
+        cont_a = esc_specs.get("continuous_current_a", esc_specs.get("max_continuous_a", 0)) or 0
+        if cont_a >= min_current_a:
             return esc
     return None
 
 
 def _compute_confidence(flight_time_min: float, target_flight_time_min: float) -> float:
-    """Compute a confidence score for a motor+battery combo based on flight time."""
-    time_ratio = min(flight_time_min / target_flight_time_min, 1.5)
-    confidence = min(time_ratio / 1.5, 1.0)
-    if flight_time_min < target_flight_time_min * 0.5:
-        confidence *= 0.3
-    return confidence
+    """Confidence that a motor+battery combo meets the flight-time target.
+
+    Smoothly scales with achieved/target ratio: meeting the target → 1.0,
+    falling linearly toward 0 as flight time drops. No discontinuity
+    (gh-992: the old /1.5 scaling capped an on-target combo at 0.667 and had a
+    3.3x cliff at 50% of target)."""
+    if target_flight_time_min <= 0:
+        return 0.0
+    return min(flight_time_min / target_flight_time_min, 1.0)
 
 
 def _resolve_aero_params(
@@ -207,7 +213,19 @@ def _evaluate_motor_battery_combo(
     battery_mass_kg = (battery.mass_g or 0) / 1000.0
     battery_specs = battery.specs or {}
     capacity_mah = battery_specs.get("capacity_mah", 0)
-    voltage = battery_specs.get("voltage", battery_specs.get("nominal_voltage", 11.1))
+    # The battery component_type schema stores nominal voltage as voltage_v
+    # (gh-992); fall back to legacy keys, then derive from cell count (3.7 V/cell
+    # nominal), then a 3S default — so a schema-valid battery isn't mis-read as 11.1 V.
+    cells = battery_specs.get("cells")
+    voltage = battery_specs.get("voltage_v")
+    if voltage is None:
+        voltage = battery_specs.get("voltage")
+    if voltage is None:
+        voltage = battery_specs.get("nominal_voltage")
+    if voltage is None and cells:
+        voltage = cells * 3.7
+    if voltage is None:
+        voltage = 11.1
 
     if capacity_mah <= 0 or voltage <= 0:
         return None
@@ -268,7 +286,20 @@ def size_powertrain(
     escs = db.query(ComponentModel).filter(ComponentModel.component_type == "esc").all()
 
     if not motors or not batteries:
-        return PowertrainSizingResponse(recommendations=[], warnings=[])
+        # gh-992: never return a silent empty table — explain why so the UI can
+        # tell the user what is missing instead of looking broken.
+        empty_warnings: list[str] = []
+        if not motors:
+            empty_warnings.append(
+                "No brushless motors in the component catalog — add motors "
+                "(e.g. import the D-Power catalog) to size a powertrain."
+            )
+        if not batteries:
+            empty_warnings.append(
+                "No batteries in the component catalog — add LiPo batteries to "
+                "compute flight time and current draw."
+            )
+        return PowertrainSizingResponse(recommendations=[], warnings=empty_warnings)
 
     # Resolve aero params once; collect warnings (gh-960)
     ctx = getattr(aeroplane, "assumption_computation_context", None) or {}

--- a/app/tests/test_powertrain_sizing_service.py
+++ b/app/tests/test_powertrain_sizing_service.py
@@ -181,6 +181,14 @@ class TestFindMatchingEsc:
         result = _find_matching_esc([esc_empty], 5.0)
         assert result is None
 
+    def test_matches_real_gh986_continuous_current_a_key(self):
+        """Regression (gh-992): the gh-986 catalog stores ESC continuous current
+        under 'continuous_current_a', not 'max_continuous_a'. The matcher must
+        read it, otherwise every candidate gets esc=None."""
+        esc = SimpleNamespace(id=9, name="AVICON 20A", specs={"continuous_current_a": 20.0})
+        assert _find_matching_esc([esc], 18.0) is esc
+        assert _find_matching_esc([esc], 25.0) is None
+
 
 # --------------------------------------------------------------------------- #
 # _compute_confidence
@@ -188,42 +196,43 @@ class TestFindMatchingEsc:
 
 
 class TestComputeConfidence:
-    def test_exact_target_returns_two_thirds(self):
-        """When flight_time == target, ratio = 1.0, confidence = 1.0/1.5 ~ 0.667."""
-        conf = _compute_confidence(10.0, 10.0)
-        assert conf == pytest.approx(1.0 / 1.5, abs=1e-6)
+    """gh-992: confidence scales smoothly with achieved/target flight time —
+    meeting the target → 1.0, falling linearly toward 0, with no discontinuity.
+    (Previously /1.5 scaling capped on-target at 0.667 with a 3.3x cliff at 50%.)"""
 
-    def test_one_and_a_half_times_target_returns_one(self):
-        """When flight_time == 1.5 * target, ratio capped at 1.5, confidence = 1.0."""
-        conf = _compute_confidence(15.0, 10.0)
-        assert conf == pytest.approx(1.0)
+    def test_exact_target_returns_full_confidence(self):
+        """Meeting the flight-time target exactly must score ~1.0, not 0.667."""
+        assert _compute_confidence(10.0, 10.0) == pytest.approx(1.0)
 
-    def test_over_1_5x_target_still_capped_at_one(self):
-        conf = _compute_confidence(20.0, 10.0)
-        assert conf == pytest.approx(1.0)
+    def test_above_target_capped_at_one(self):
+        assert _compute_confidence(15.0, 10.0) == pytest.approx(1.0)
+        assert _compute_confidence(20.0, 10.0) == pytest.approx(1.0)
 
-    def test_half_target_applies_penalty(self):
-        """At exactly half the target, the 0.3 penalty applies."""
-        conf = _compute_confidence(5.0, 10.0)
-        base = min((5.0 / 10.0) / 1.5, 1.0)  # 0.333...
-        # flight_time < target * 0.5 is False (5.0 < 5.0 is False)
-        assert conf == pytest.approx(base, abs=1e-6)
+    def test_below_target_scales_linearly(self):
+        assert _compute_confidence(5.0, 10.0) == pytest.approx(0.5)
+        assert _compute_confidence(4.0, 10.0) == pytest.approx(0.4)
 
-    def test_below_half_target_applies_penalty(self):
-        """Below half the target, confidence is penalized by 0.3."""
-        conf = _compute_confidence(4.0, 10.0)
-        base = min((4.0 / 10.0) / 1.5, 1.0)
-        expected = base * 0.3
-        assert conf == pytest.approx(expected, abs=1e-6)
+    def test_no_discontinuity_at_half_target(self):
+        """The old 50%-boundary 3.3x cliff must be gone: values are continuous."""
+        just_below = _compute_confidence(4.99, 10.0)
+        at_half = _compute_confidence(5.0, 10.0)
+        just_above = _compute_confidence(5.01, 10.0)
+        assert at_half - just_below < 0.01
+        assert just_above - at_half < 0.01
+
+    def test_monotonic_increasing(self):
+        prev = -1.0
+        for t in [1.0, 3.0, 5.0, 7.0, 9.0, 10.0]:
+            c = _compute_confidence(t, 10.0)
+            assert c >= prev
+            prev = c
 
     def test_very_small_flight_time_low_confidence(self):
-        conf = _compute_confidence(0.5, 10.0)
-        assert conf < 0.1
+        assert _compute_confidence(0.5, 10.0) < 0.1
 
-    def test_zero_target_raises(self):
-        """Zero target causes ZeroDivisionError (production should guard)."""
-        with pytest.raises(ZeroDivisionError):
-            _compute_confidence(10.0, 0.0)
+    def test_zero_target_returns_zero(self):
+        """Zero/negative target is guarded (no ZeroDivisionError) → 0.0 (gh-992)."""
+        assert _compute_confidence(10.0, 0.0) == 0.0
 
 
 # --------------------------------------------------------------------------- #
@@ -337,6 +346,36 @@ class TestEvaluateMotorBatteryCombo:
         assert result is not None
         assert result.estimated_top_speed_ms == pytest.approx(33.3, abs=0.1)
 
+    def test_battery_uses_voltage_v_schema_key(self):
+        """Regression (gh-992): the battery component_type schema stores nominal
+        voltage as 'voltage_v'. A 6S pack (22.2 V) must not be mis-read as the
+        11.1 V default — that would 2x the cruise current and halve flight time."""
+        cap = 5000
+        b_22v = SimpleNamespace(
+            id=11, name="6S", mass_g=700.0, specs={"capacity_mah": cap, "voltage_v": 22.2}
+        )
+        b_default = SimpleNamespace(
+            id=12, name="noV", mass_g=700.0, specs={"capacity_mah": cap}
+        )
+        motor = _make_motor()
+        req = _default_request()
+        r_22v = _eval_combo_defaults(motor, b_22v, [], req)
+        r_default = _eval_combo_defaults(motor, b_default, [], req)
+        assert r_22v is not None and r_default is not None
+        # Higher pack voltage → lower cruise current → longer flight time than the
+        # 11.1 V default fallback, proving voltage_v was actually read.
+        assert r_22v.estimated_flight_time_min > r_default.estimated_flight_time_min
+
+    def test_battery_voltage_derived_from_cells(self):
+        """When only 'cells' is present, voltage derives as cells x 3.7 V (gh-992)."""
+        battery = SimpleNamespace(
+            id=13, name="cellsOnly", mass_g=400.0, specs={"capacity_mah": 3000, "cells": 4}
+        )
+        motor = _make_motor()
+        result = _eval_combo_defaults(motor, battery, [], _default_request())
+        assert result is not None
+        assert result.estimated_cruise_power_w > 0
+
 
 # --------------------------------------------------------------------------- #
 # size_powertrain (integration with mocked DB)
@@ -394,6 +433,8 @@ class TestSizePowertrain:
         result = size_powertrain(db, aeroplane.uuid, request)
         assert isinstance(result, PowertrainSizingResponse)
         assert result.recommendations == []
+        # gh-992: empty result must explain itself, not be silent.
+        assert any("motor" in w.lower() for w in result.warnings)
 
     def test_no_batteries_returns_empty(self):
         aeroplane = SimpleNamespace(uuid=uuid.uuid4())
@@ -403,6 +444,8 @@ class TestSizePowertrain:
 
         result = size_powertrain(db, aeroplane.uuid, request)
         assert result.recommendations == []
+        # gh-992: tell the user the battery catalog is empty instead of a silent table.
+        assert any("batter" in w.lower() for w in result.warnings)
 
     def test_single_valid_combo_returns_one_candidate(self):
         aeroplane = SimpleNamespace(uuid=uuid.uuid4())

--- a/app/tests/test_powertrain_warnings.py
+++ b/app/tests/test_powertrain_warnings.py
@@ -299,8 +299,9 @@ class TestSizePowertrainWarnings:
         assert len(result.warnings) == 2
         assert all(any(key in w for w in result.warnings) for key in ("aspect_ratio", "s_ref_m2"))
 
-    def test_empty_catalog_returns_empty_with_no_warnings(self):
-        """When no motors/batteries, warnings are empty (no sizing performed)."""
+    def test_empty_catalog_returns_empty_with_explanatory_warnings(self):
+        """When no motors/batteries, the result must explain why instead of being
+        a silent empty table (gh-992: surfaced by UAT of #197)."""
         plane = self._make_plane(context=None)
         db = _mock_db_session(aeroplane=plane, motors=[], batteries=[])
         request = _default_request()
@@ -308,4 +309,5 @@ class TestSizePowertrainWarnings:
         result = size_powertrain(db, plane.uuid, request)
 
         assert result.recommendations == []
-        assert result.warnings == []
+        assert any("motor" in w.lower() for w in result.warnings)
+        assert any("batter" in w.lower() for w in result.warnings)

--- a/data/cots/generic_batteries.json
+++ b/data/cots/generic_batteries.json
@@ -1,0 +1,82 @@
+[
+  {
+    "manufacturer": "Generic",
+    "name": "Generic LiPo 2S 1300 30C",
+    "component_type": "battery",
+    "mass_g": 75,
+    "source_version": "generic RC LiPo reference (gh-993)",
+    "specs": {"capacity_mah": 1300, "cells": 2, "c_rate": 30, "voltage_v": 7.4}
+  },
+  {
+    "manufacturer": "Generic",
+    "name": "Generic LiPo 3S 1300 30C",
+    "component_type": "battery",
+    "mass_g": 110,
+    "source_version": "generic RC LiPo reference (gh-993)",
+    "specs": {"capacity_mah": 1300, "cells": 3, "c_rate": 30, "voltage_v": 11.1}
+  },
+  {
+    "manufacturer": "Generic",
+    "name": "Generic LiPo 3S 2200 30C",
+    "component_type": "battery",
+    "mass_g": 185,
+    "source_version": "generic RC LiPo reference (gh-993)",
+    "specs": {"capacity_mah": 2200, "cells": 3, "c_rate": 30, "voltage_v": 11.1}
+  },
+  {
+    "manufacturer": "Generic",
+    "name": "Generic LiPo 3S 3300 30C",
+    "component_type": "battery",
+    "mass_g": 270,
+    "source_version": "generic RC LiPo reference (gh-993)",
+    "specs": {"capacity_mah": 3300, "cells": 3, "c_rate": 30, "voltage_v": 11.1}
+  },
+  {
+    "manufacturer": "Generic",
+    "name": "Generic LiPo 4S 2200 35C",
+    "component_type": "battery",
+    "mass_g": 245,
+    "source_version": "generic RC LiPo reference (gh-993)",
+    "specs": {"capacity_mah": 2200, "cells": 4, "c_rate": 35, "voltage_v": 14.8}
+  },
+  {
+    "manufacturer": "Generic",
+    "name": "Generic LiPo 4S 3300 35C",
+    "component_type": "battery",
+    "mass_g": 330,
+    "source_version": "generic RC LiPo reference (gh-993)",
+    "specs": {"capacity_mah": 3300, "cells": 4, "c_rate": 35, "voltage_v": 14.8}
+  },
+  {
+    "manufacturer": "Generic",
+    "name": "Generic LiPo 4S 5000 30C",
+    "component_type": "battery",
+    "mass_g": 480,
+    "source_version": "generic RC LiPo reference (gh-993)",
+    "specs": {"capacity_mah": 5000, "cells": 4, "c_rate": 30, "voltage_v": 14.8}
+  },
+  {
+    "manufacturer": "Generic",
+    "name": "Generic LiPo 6S 3300 30C",
+    "component_type": "battery",
+    "mass_g": 490,
+    "source_version": "generic RC LiPo reference (gh-993)",
+    "specs": {"capacity_mah": 3300, "cells": 6, "c_rate": 30, "voltage_v": 22.2}
+  },
+  {
+    "manufacturer": "Generic",
+    "name": "Generic LiPo 6S 5000 30C",
+    "component_type": "battery",
+    "mass_g": 700,
+    "source_version": "generic RC LiPo reference (gh-993)",
+    "specs": {"capacity_mah": 5000, "cells": 6, "c_rate": 30, "voltage_v": 22.2}
+  },
+  {
+    "manufacturer": "Generic",
+    "name": "Generic LiPo 6S 6000 30C",
+    "component_type": "battery",
+    "mass_g": 840,
+    "source_version": "generic RC LiPo reference (gh-993)",
+    "specs": {"capacity_mah": 6000, "cells": 6, "c_rate": 30, "voltage_v": 22.2}
+  }
+]


### PR DESCRIPTION
Found in 3-persona UAT of #197 against the running app — sizing returned **zero** recommendations.

## Fixes (gh-992)
- **ESC match key:** read `continuous_current_a` (gh-986 key), not `max_continuous_a` → ESC now matched (was always null).
- **Battery voltage key:** read `voltage_v` (battery schema key) with cells×3.7 fallback → non-3S packs no longer mis-read as 11.1 V; explicit 0 still rejected.
- **Confidence metric:** smooth `min(t/t_target, 1.0)` — meeting target → 1.0 (was 0.667), removed the 3.3× cliff at 50%, zero-target guarded.
- **No silent empty table:** empty result returns explanatory `warnings`.

## Seed (gh-993)
- `data/cots/generic_batteries.json` — 10 generic RC LiPo packs (2S–6S) so the motor×battery sweep has batteries.

## Verification
Live: `POST .../powertrain/sizing` now returns 10 recommendations with ESC matched (AVICON 60A). 60 backend unit tests pass.

## Note (not in this PR)
The user's local dev DB contains test-fixture motors ('Test Motor'/'WtMotor') that pollute results — dev-data hygiene, not a code defect (other DBs unaffected).

Closes #992
Closes #993