### PR TITLE
feat(gh-997): Spektrum Avian brushless motor catalog (16 motors, power in watts)

### DIFF
--- a/app/tests/test_cots_import.py
+++ b/app/tests/test_cots_import.py
@@ -285,3 +285,43 @@ class TestImportResult:
         assert "updated=1" in s
         assert "skipped=5" in s
         assert "errors=0" in s
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Committed COTS snapshots are valid + importable (gh-986 spec §9)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestCommittedSnapshots:
+    """Guard the committed data/cots/*.json snapshots (reimport sources)."""
+
+    def _load(self, name: str) -> list[dict]:
+        import json
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parents[2]
+        return json.loads((repo_root / "data" / "cots" / name).read_text(encoding="utf-8"))
+
+    def test_spektrum_avian_snapshot_valid_and_imports(self, session):
+        """Spektrum Avian (gh-997): 16 brushless motors with power-in-watts;
+        every record validates and imports cleanly with no errors."""
+        records = self._load("spektrum_avian.json")
+        assert len(records) == 16
+        for rec in records:
+            assert rec["component_type"] == "brushless_motor"
+            assert _validate_record(rec) is None, rec.get("name")
+            # Spektrum publishes power (W), not current — the solver's keys.
+            assert rec["specs"]["max_power_w"] > rec["specs"]["max_continuous_power_w"] - 1
+            assert rec["specs"]["kv_rpm_per_volt"] > 0
+
+        result = import_snapshot(session, records)
+        assert result.imported == 16
+        assert not result.errors
+
+    def test_generic_batteries_snapshot_valid(self, session):
+        """LiPo battery seed (gh-993) imports cleanly."""
+        records = self._load("generic_batteries.json")
+        assert len(records) >= 1
+        result = import_snapshot(session, records)
+        assert result.imported == len(records)
+        assert not result.errors

--- a/data/cots/spektrum_avian.json
+++ b/data/cots/spektrum_avian.json
@@ -1,0 +1,162 @@
+[
+  {
+    "manufacturer": "Spektrum",
+    "name": "Avian 2813-1750Kv",
+    "component_type": "brushless_motor",
+    "mass_g": 20,
+    "bbox_x_mm": 28, "bbox_y_mm": 28, "bbox_z_mm": 13,
+    "model_ref": "spektrum/SPMXAM4502",
+    "source_version": "Spektrum Avian Spec Chart 326912.1 (2022)",
+    "specs": {"kv_rpm_per_volt": 1750, "max_continuous_power_w": 60, "max_power_w": 100, "cells_lipo_min": 2, "cells_lipo_max": 3, "shaft_diameter_mm": 3.0, "art_no": "SPMXAM4502"}
+  },
+  {
+    "manufacturer": "Spektrum",
+    "name": "Avian 2830-950Kv",
+    "component_type": "brushless_motor",
+    "mass_g": 54,
+    "bbox_x_mm": 28, "bbox_y_mm": 28, "bbox_z_mm": 30,
+    "model_ref": "spektrum/SPMXAM4560",
+    "source_version": "Spektrum Avian Spec Chart 326912.1 (2022)",
+    "specs": {"kv_rpm_per_volt": 950, "max_continuous_power_w": 160, "max_power_w": 250, "cells_lipo_min": 2, "cells_lipo_max": 3, "shaft_diameter_mm": 3.0, "art_no": "SPMXAM4560"}
+  },
+  {
+    "manufacturer": "Spektrum",
+    "name": "Avian 3530-1250Kv",
+    "component_type": "brushless_motor",
+    "mass_g": 71,
+    "bbox_x_mm": 35, "bbox_y_mm": 35, "bbox_z_mm": 30,
+    "model_ref": "spektrum/SPMXAM4595",
+    "source_version": "Spektrum Avian Spec Chart 326912.1 (2022)",
+    "specs": {"kv_rpm_per_volt": 1250, "max_continuous_power_w": 220, "max_power_w": 350, "cells_lipo_min": 2, "cells_lipo_max": 3, "shaft_diameter_mm": 4.0, "art_no": "SPMXAM4595"}
+  },
+  {
+    "manufacturer": "Spektrum",
+    "name": "Avian 3536-1200Kv",
+    "component_type": "brushless_motor",
+    "mass_g": 102,
+    "bbox_x_mm": 35, "bbox_y_mm": 35, "bbox_z_mm": 36,
+    "model_ref": "spektrum/SPMXAM4620",
+    "source_version": "Spektrum Avian Spec Chart 326912.1 (2022)",
+    "specs": {"kv_rpm_per_volt": 1200, "max_continuous_power_w": 310, "max_power_w": 510, "cells_lipo_min": 3, "cells_lipo_max": 4, "shaft_diameter_mm": 4.0, "art_no": "SPMXAM4620"}
+  },
+  {
+    "manufacturer": "Spektrum",
+    "name": "Avian EF1 Race 3545-1250Kv",
+    "component_type": "brushless_motor",
+    "mass_g": 159,
+    "bbox_x_mm": 35, "bbox_y_mm": 35, "bbox_z_mm": 45,
+    "model_ref": "spektrum/SPMXAM4630",
+    "source_version": "Spektrum Avian Spec Chart 326912.1 (2022)",
+    "specs": {"kv_rpm_per_volt": 1250, "max_continuous_power_w": 700, "max_power_w": 1000, "cells_lipo_min": 2, "cells_lipo_max": 4, "shaft_diameter_mm": 5.0, "art_no": "SPMXAM4630"}
+  },
+  {
+    "manufacturer": "Spektrum",
+    "name": "Avian 4240-1000Kv",
+    "component_type": "brushless_motor",
+    "mass_g": 125,
+    "bbox_x_mm": 42, "bbox_y_mm": 42, "bbox_z_mm": 40,
+    "model_ref": "spektrum/SPMXAM4675",
+    "source_version": "Spektrum Avian Spec Chart 326912.1 (2022)",
+    "specs": {"kv_rpm_per_volt": 1000, "max_continuous_power_w": 375, "max_power_w": 625, "cells_lipo_min": 3, "cells_lipo_max": 4, "shaft_diameter_mm": 5.0, "art_no": "SPMXAM4675"}
+  },
+  {
+    "manufacturer": "Spektrum",
+    "name": "Avian 4250-800Kv",
+    "component_type": "brushless_motor",
+    "mass_g": 198,
+    "bbox_x_mm": 42, "bbox_y_mm": 42, "bbox_z_mm": 50,
+    "model_ref": "spektrum/SPMXAM4700",
+    "source_version": "Spektrum Avian Spec Chart 326912.1 (2022)",
+    "specs": {"kv_rpm_per_volt": 800, "max_continuous_power_w": 600, "max_power_w": 1000, "cells_lipo_min": 3, "cells_lipo_max": 4, "shaft_diameter_mm": 5.0, "art_no": "SPMXAM4700"}
+  },
+  {
+    "manufacturer": "Spektrum",
+    "name": "Avian 4260-480Kv",
+    "component_type": "brushless_motor",
+    "mass_g": 268,
+    "bbox_x_mm": 42, "bbox_y_mm": 42, "bbox_z_mm": 60,
+    "model_ref": "spektrum/SPMXAM4715",
+    "source_version": "Spektrum Avian Spec Chart 326912.1 (2022)",
+    "specs": {"kv_rpm_per_volt": 480, "max_continuous_power_w": 810, "max_power_w": 1350, "cells_lipo_min": 5, "cells_lipo_max": 6, "shaft_diameter_mm": 5.0, "art_no": "SPMXAM4715"}
+  },
+  {
+    "manufacturer": "Spektrum",
+    "name": "Avian 4260-800Kv",
+    "component_type": "brushless_motor",
+    "mass_g": 268,
+    "bbox_x_mm": 42, "bbox_y_mm": 42, "bbox_z_mm": 60,
+    "model_ref": "spektrum/SPMXAM4725",
+    "source_version": "Spektrum Avian Spec Chart 326912.1 (2022)",
+    "specs": {"kv_rpm_per_volt": 800, "max_continuous_power_w": 810, "max_power_w": 1350, "cells_lipo_min": 5, "cells_lipo_max": 6, "shaft_diameter_mm": 5.0, "art_no": "SPMXAM4725"}
+  },
+  {
+    "manufacturer": "Spektrum",
+    "name": "Avian 5055-500Kv",
+    "component_type": "brushless_motor",
+    "mass_g": 298,
+    "bbox_x_mm": 50, "bbox_y_mm": 50, "bbox_z_mm": 55,
+    "model_ref": "spektrum/SPMXAM4740",
+    "source_version": "Spektrum Avian Spec Chart 326912.1 (2022)",
+    "specs": {"kv_rpm_per_volt": 500, "max_continuous_power_w": 900, "max_power_w": 1500, "cells_lipo_min": 5, "cells_lipo_max": 6, "shaft_diameter_mm": 8.0, "art_no": "SPMXAM4740"}
+  },
+  {
+    "manufacturer": "Spektrum",
+    "name": "Avian 5055-650Kv",
+    "component_type": "brushless_motor",
+    "mass_g": 298,
+    "bbox_x_mm": 50, "bbox_y_mm": 50, "bbox_z_mm": 55,
+    "model_ref": "spektrum/SPMXAM4745",
+    "source_version": "Spektrum Avian Spec Chart 326912.1 (2022)",
+    "specs": {"kv_rpm_per_volt": 650, "max_continuous_power_w": 900, "max_power_w": 1500, "cells_lipo_min": 5, "cells_lipo_max": 6, "shaft_diameter_mm": 8.0, "art_no": "SPMXAM4745"}
+  },
+  {
+    "manufacturer": "Spektrum",
+    "name": "Avian 5065-450Kv",
+    "component_type": "brushless_motor",
+    "mass_g": 400,
+    "bbox_x_mm": 50, "bbox_y_mm": 50, "bbox_z_mm": 65,
+    "model_ref": "spektrum/SPMXAM4770",
+    "source_version": "Spektrum Avian Spec Chart 326912.1 (2022)",
+    "specs": {"kv_rpm_per_volt": 450, "max_continuous_power_w": 1200, "max_power_w": 2000, "cells_lipo_min": 5, "cells_lipo_max": 6, "shaft_diameter_mm": 8.0, "art_no": "SPMXAM4770"}
+  },
+  {
+    "manufacturer": "Spektrum",
+    "name": "Avian 6362-250Kv",
+    "component_type": "brushless_motor",
+    "mass_g": 634,
+    "bbox_x_mm": 63, "bbox_y_mm": 63, "bbox_z_mm": 62,
+    "model_ref": "spektrum/SPMXAM4795",
+    "source_version": "Spektrum Avian Spec Chart 326912.1 (2022)",
+    "specs": {"kv_rpm_per_volt": 250, "max_continuous_power_w": 1900, "max_power_w": 3150, "cells_lipo_min": 9, "cells_lipo_max": 12, "shaft_diameter_mm": 8.0, "art_no": "SPMXAM4795"}
+  },
+  {
+    "manufacturer": "Spektrum",
+    "name": "Avian 6362-200Kv",
+    "component_type": "brushless_motor",
+    "mass_g": 635,
+    "bbox_x_mm": 63, "bbox_y_mm": 63, "bbox_z_mm": 62,
+    "model_ref": "spektrum/SPMXAM4796",
+    "source_version": "Spektrum Avian Spec Chart 326912.1 (2022)",
+    "specs": {"kv_rpm_per_volt": 200, "max_continuous_power_w": 1450, "max_power_w": 2300, "cells_lipo_min": 10, "cells_lipo_max": 12, "shaft_diameter_mm": 10.0, "art_no": "SPMXAM4796"}
+  },
+  {
+    "manufacturer": "Spektrum",
+    "name": "Avian 8075-230Kv",
+    "component_type": "brushless_motor",
+    "mass_g": 1250,
+    "bbox_x_mm": 80, "bbox_y_mm": 80, "bbox_z_mm": 75,
+    "model_ref": "spektrum/SPMXAM4800",
+    "source_version": "Spektrum Avian Spec Chart 326912.1 (2022)",
+    "specs": {"kv_rpm_per_volt": 230, "max_continuous_power_w": 3750, "max_power_w": 6250, "cells_lipo_min": 9, "cells_lipo_max": 15, "shaft_diameter_mm": 10.0, "art_no": "SPMXAM4800"}
+  },
+  {
+    "manufacturer": "Spektrum",
+    "name": "Avian 8085-160Kv",
+    "component_type": "brushless_motor",
+    "mass_g": 1480,
+    "bbox_x_mm": 80, "bbox_y_mm": 80, "bbox_z_mm": 85,
+    "model_ref": "spektrum/SPMXAM4805",
+    "source_version": "Spektrum Avian Spec Chart 326912.1 (2022)",
+    "specs": {"kv_rpm_per_volt": 160, "max_continuous_power_w": 4400, "max_power_w": 7500, "cells_lipo_min": 9, "cells_lipo_max": 15, "shaft_diameter_mm": 10.0, "art_no": "SPMXAM4805"}
+  }
+]


### PR DESCRIPTION
Adds the Spektrum Avian line (16 outrunners) from the official spec chart (Horizon Hobby 326912.1, 2022).

**Why it's valuable:** Spektrum publishes **power in watts** (Constant/Burst → `max_continuous_power_w`/`max_power_w`) — exactly the keys the powertrain solver reads, which the gh-986 D-Power data did not provide (it gave amps). Complementary catalog.

Mapped: kv_rpm_per_volt, max_power_w, max_continuous_power_w, cells_lipo_min/max, mass_g, bbox, shaft_diameter_mm, art_no. Absent from datasheet (optional, left null): max_current_a, continuous_current_a, io_no_load_a, efficiency_pct, static_thrust_g.

No schema change (fields exist since gh-986). Committed `data/cots/spektrum_avian.json` = reimport source; verified import = 16, 0 errors. Adds snapshot-validation tests for Spektrum + the gh-993 batteries.

Closes #997