### PR TITLE
feat(gh-1008): spar sizing from spanwise loads (tube/rod/rect/capped; Pine + CF)

### DIFF
--- a/alembic/versions/a1b2c3d4e5f6_gh1008_material_structural_fields_and_seed.py
+++ b/alembic/versions/a1b2c3d4e5f6_gh1008_material_structural_fields_and_seed.py
@@ -1,0 +1,187 @@
+"""gh-1008: add structural fields to material type + seed Pine + Carbon Fiber
+
+Extends the 'material' ComponentType schema additively with:
+  - allowable_bending_stress_mpa (number, MPa) — for spar sizing
+  - youngs_modulus_gpa (number, GPa, optional) — for future deflection
+
+Both fields are optional so existing 3D-print material rows stay valid.
+
+Seeds two structural materials as Component rows:
+  - Pine (Kiefer, Güte A): density=500, σ_allow=39 MPa, E=11 GPa
+  - Carbon Fiber: density=1600, σ_allow=500 MPa, E=120 GPa
+
+Revision ID: a1b2c3d4e5f6
+Revises: ee9fd32e8e90
+Create Date: 2026-06-16 08:00:00.000000
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "ee9fd32e8e90"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# New property definitions added to the 'material' schema
+_NEW_PROPS = [
+    {
+        "name": "allowable_bending_stress_mpa",
+        "label": "Allowable Bending Stress",
+        "type": "number",
+        "unit": "MPa",
+        "required": False,
+        "min": 0.0,
+        "description": "σ_allow for spar sizing (MPa). Compression governs for wood.",
+    },
+    {
+        "name": "youngs_modulus_gpa",
+        "label": "Young's Modulus",
+        "type": "number",
+        "unit": "GPa",
+        "required": False,
+        "min": 0.0,
+        "description": "E for future deflection checks (GPa).",
+    },
+]
+
+_NEW_PROP_NAMES = {p["name"] for p in _NEW_PROPS}
+
+# Structural material seeds
+_NOW = datetime.now(timezone.utc).isoformat()
+
+_STRUCTURAL_MATERIALS = [
+    {
+        "name": "Pine (structural)",
+        "component_type": "material",
+        "manufacturer": None,
+        "description": "Kiefer Güte A — structural spar material. σ_allow = 39 MPa (compression).",
+        "mass_g": None,
+        "bbox_x_mm": None,
+        "bbox_y_mm": None,
+        "bbox_z_mm": None,
+        "model_ref": None,
+        "specs": json.dumps(
+            {
+                "density_kg_m3": 500.0,
+                "allowable_bending_stress_mpa": 39.0,
+                "youngs_modulus_gpa": 11.0,
+            }
+        ),
+        "created_at": _NOW,
+        "updated_at": _NOW,
+    },
+    {
+        "name": "Carbon Fiber (structural)",
+        "component_type": "material",
+        "manufacturer": None,
+        "description": "Carbon fiber tube/spar — conservative σ_allow=500 MPa (buckling-aware).",
+        "mass_g": None,
+        "bbox_x_mm": None,
+        "bbox_y_mm": None,
+        "bbox_z_mm": None,
+        "model_ref": None,
+        "specs": json.dumps(
+            {
+                "density_kg_m3": 1600.0,
+                "allowable_bending_stress_mpa": 500.0,
+                "youngs_modulus_gpa": 120.0,
+            }
+        ),
+        "created_at": _NOW,
+        "updated_at": _NOW,
+    },
+]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # 1. Extend the 'material' ComponentType schema additively
+    row = conn.execute(
+        sa.text("SELECT id, schema_def FROM component_types WHERE name = 'material'")
+    ).fetchone()
+
+    if row is not None:
+        type_id, raw_schema = row[0], row[1]
+        # schema_def may be stored as JSON string or already parsed list
+        if isinstance(raw_schema, str):
+            try:
+                current_schema = json.loads(raw_schema)
+            except json.JSONDecodeError:
+                current_schema = []
+        elif isinstance(raw_schema, list):
+            current_schema = raw_schema
+        else:
+            current_schema = []
+
+        existing_names = {p.get("name") for p in current_schema if isinstance(p, dict)}
+        for prop in _NEW_PROPS:
+            if prop["name"] not in existing_names:
+                current_schema.append(prop)
+
+        conn.execute(
+            sa.text("UPDATE component_types SET schema_def = :schema WHERE id = :id"),
+            {"schema": json.dumps(current_schema), "id": type_id},
+        )
+
+    # 2. Seed structural material components (idempotent by name)
+    components_table = sa.table(
+        "components",
+        sa.column("name"),
+        sa.column("component_type"),
+        sa.column("manufacturer"),
+        sa.column("description"),
+        sa.column("mass_g"),
+        sa.column("bbox_x_mm"),
+        sa.column("bbox_y_mm"),
+        sa.column("bbox_z_mm"),
+        sa.column("model_ref"),
+        sa.column("specs"),
+        sa.column("created_at"),
+        sa.column("updated_at"),
+    )
+    for mat in _STRUCTURAL_MATERIALS:
+        existing = conn.execute(
+            sa.text("SELECT id FROM components WHERE name = :name AND component_type = 'material'"),
+            {"name": mat["name"]},
+        ).fetchone()
+        if existing is None:
+            conn.execute(components_table.insert(), mat)
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    # Remove seeded components
+    for mat in _STRUCTURAL_MATERIALS:
+        conn.execute(
+            sa.text("DELETE FROM components WHERE name = :name AND component_type = 'material'"),
+            {"name": mat["name"]},
+        )
+
+    # Remove added props from material schema
+    row = conn.execute(
+        sa.text("SELECT id, schema_def FROM component_types WHERE name = 'material'")
+    ).fetchone()
+    if row is not None:
+        type_id, raw_schema = row[0], row[1]
+        if isinstance(raw_schema, str):
+            try:
+                current_schema = json.loads(raw_schema)
+            except json.JSONDecodeError:
+                current_schema = []
+        else:
+            current_schema = raw_schema or []
+
+        pruned = [p for p in current_schema if p.get("name") not in _NEW_PROP_NAMES]
+        conn.execute(
+            sa.text("UPDATE component_types SET schema_def = :schema WHERE id = :id"),
+            {"schema": json.dumps(pruned), "id": type_id},
+        )

--- a/alembic/versions/e2a35c6eac69_gh1008_material_structural_fields_and_seed.py
+++ b/alembic/versions/e2a35c6eac69_gh1008_material_structural_fields_and_seed.py
@@ -24,7 +24,7 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "a1b2c3d4e5f6"
+revision: str = "e2a35c6eac69"
 down_revision: Union[str, None] = "ee9fd32e8e90"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
@@ -105,7 +105,7 @@ def upgrade() -> None:
 
     # 1. Extend the 'material' ComponentType schema additively
     row = conn.execute(
-        sa.text("SELECT id, schema_def FROM component_types WHERE name = 'material'")
+        sa.text("SELECT id, \"schema\" FROM component_types WHERE name = 'material'")
     ).fetchone()
 
     if row is not None:
@@ -127,7 +127,7 @@ def upgrade() -> None:
                 current_schema.append(prop)
 
         conn.execute(
-            sa.text("UPDATE component_types SET schema_def = :schema WHERE id = :id"),
+            sa.text("UPDATE component_types SET \"schema\" = :schema WHERE id = :id"),
             {"schema": json.dumps(current_schema), "id": type_id},
         )
 
@@ -168,7 +168,7 @@ def downgrade() -> None:
 
     # Remove added props from material schema
     row = conn.execute(
-        sa.text("SELECT id, schema_def FROM component_types WHERE name = 'material'")
+        sa.text("SELECT id, \"schema\" FROM component_types WHERE name = 'material'")
     ).fetchone()
     if row is not None:
         type_id, raw_schema = row[0], row[1]
@@ -182,6 +182,6 @@ def downgrade() -> None:
 
         pruned = [p for p in current_schema if p.get("name") not in _NEW_PROP_NAMES]
         conn.execute(
-            sa.text("UPDATE component_types SET schema_def = :schema WHERE id = :id"),
+            sa.text("UPDATE component_types SET \"schema\" = :schema WHERE id = :id"),
             {"schema": json.dumps(pruned), "id": type_id},
         )

--- a/app/api/v2/endpoints/aeroanalysis.py
+++ b/app/api/v2/endpoints/aeroanalysis.py
@@ -478,7 +478,9 @@ async def get_airplane_spanwise_loads_with_sizing(
         Literal["vlm", "avl"],
         Query(description="Strip-force solver: 'vlm' (default, in-process) or 'avl' (subprocess)"),
     ] = "vlm",
-    material_id: Annotated[int, Query(description="Material component ID for spar sizing")] = None,
+    material_id: Annotated[
+        int | None, Query(description="Material component ID for spar sizing")
+    ] = None,
     shape: Annotated[
         Literal["tube", "rod", "rectangular", "capped"],
         Query(description="Spar cross-section shape"),

--- a/app/api/v2/endpoints/aeroanalysis.py
+++ b/app/api/v2/endpoints/aeroanalysis.py
@@ -22,7 +22,8 @@ from app.db.session import get_db
 from app.schemas.AeroplaneRequest import AnalysisToolUrlType, AlphaSweepRequest, SimpleSweepRequest
 from app.schemas.api_responses import StaticUrlResponse
 from app.schemas.aeroanalysisschema import OperatingPointSchema
-from app.schemas.spanwise_loads import SpanwiseLoadsResponse
+from app.schemas.spar_sizing import SparSizingParams
+from app.schemas.spanwise_loads import SpanwiseLoadsResponse, SpanwiseLoadsWithSizingResponse
 from app.schemas.stability import StabilitySummaryResponse, StabilityResultRead
 from app.schemas.strip_forces import StripForcesResponse
 from app.services import analysis_service
@@ -454,6 +455,77 @@ async def get_airplane_spanwise_loads(
     try:
         return await analysis_service.analyze_airplane_spanwise_loads(
             db, aeroplane_id, operating_point, solver=solver
+        )
+    except ServiceException as exc:
+        _raise_http_from_domain(exc)
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Unexpected error: {exc}"
+        ) from exc
+
+
+@router.post(
+    "/aeroplanes/{aeroplane_id}/spanwise_loads_with_sizing",
+    response_model=SpanwiseLoadsWithSizingResponse,
+    tags=["analysis"],
+    operation_id="get_airplane_spanwise_loads_with_spar_sizing",
+)
+async def get_airplane_spanwise_loads_with_sizing(
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
+    operating_point: Annotated[OperatingPointSchema, Body(..., description="The operating point")],
+    db: Annotated[Session, Depends(get_db)],
+    solver: Annotated[
+        Literal["vlm", "avl"],
+        Query(description="Strip-force solver: 'vlm' (default, in-process) or 'avl' (subprocess)"),
+    ] = "vlm",
+    material_id: Annotated[int, Query(description="Material component ID for spar sizing")] = None,
+    shape: Annotated[
+        Literal["tube", "rod", "rectangular", "capped"],
+        Query(description="Spar cross-section shape"),
+    ] = "tube",
+    safety_factor_j: Annotated[
+        float, Query(gt=0, description="Safety factor j (default 1.5)")
+    ] = 1.5,
+    packing_factor: Annotated[
+        float, Query(gt=0, le=1.0, description="Packing factor (default 0.8)")
+    ] = 0.8,
+    sigma_allow_mpa_override: Annotated[
+        float | None,
+        Query(gt=0, description="Override σ_allow (MPa). If omitted, material value used."),
+    ] = None,
+    cap_width_mm: Annotated[
+        float | None, Query(gt=0, description="Cap/flange width b (mm) — required for shape=capped")
+    ] = None,
+) -> SpanwiseLoadsWithSizingResponse:
+    """Return spanwise loads + spar-sizing results for all surfaces (gh-1008).
+
+    Extends the spanwise-loads endpoint with per-surface spar dimensioning.
+    The spar is sized at each strip station using the design bending moment
+    M_design = |M(y)| · g_limit · j, where g_limit comes from the aeroplane's
+    design assumptions (fallback: 3.0 with a warning).
+
+    Shapes: tube (Da=outer → solve wall), rod (solve d), rectangular (h=outer → solve b),
+    capped (H=outer, cap_width_mm=b → solve gurt thickness).
+
+    The material must be a Component of type 'material' with
+    allowable_bending_stress_mpa set.
+    """
+    if material_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="material_id is required for spar sizing",
+        )
+    spar_params = SparSizingParams(
+        material_id=material_id,
+        shape=shape,
+        safety_factor_j=safety_factor_j,
+        packing_factor=packing_factor,
+        sigma_allow_mpa_override=sigma_allow_mpa_override,
+        cap_width_mm=cap_width_mm,
+    )
+    try:
+        return await analysis_service.analyze_airplane_spanwise_loads(
+            db, aeroplane_id, operating_point, solver=solver, spar_params=spar_params
         )
     except ServiceException as exc:
         _raise_http_from_domain(exc)

--- a/app/schemas/spanwise_loads.py
+++ b/app/schemas/spanwise_loads.py
@@ -10,6 +10,8 @@ from typing import Optional
 
 from pydantic import BaseModel, Field
 
+from app.schemas.spar_sizing import SparSizingResult
+
 
 class SpanwiseLoadEntry(BaseModel):
     """Per-strip structural loads referenced to the wing root."""
@@ -69,6 +71,14 @@ class SpanwiseLoadsResponse(BaseModel):
     """Full spanwise shear + bending-moment response for one operating point (gh-1002)."""
 
     alpha: float = Field(..., description="Angle of attack used for the run (deg)")
+    beta: float = Field(
+        0.0,
+        description=(
+            "Sideslip angle used for the run (deg). Echoed so a follow-up spar-sizing "
+            "request reuses the same operating point (sideslip changes the spanwise "
+            "lift distribution)."
+        ),
+    )
     velocity_mps: float = Field(..., description="Freestream velocity (m/s)")
     altitude_m: float = Field(..., description="Altitude (m)")
     dynamic_pressure_Pa: float = Field(
@@ -85,13 +95,9 @@ class SpanwiseLoadsWithSizingResponse(SpanwiseLoadsResponse):
     Returned by the endpoint when ``spar_params`` are supplied in the request body.
     Each element in ``spar_sizing`` corresponds to one surface in ``surfaces``
     (by position and ``surface_name``).
-
-    Import note: SparSizingResult is imported inline to avoid circular imports
-    between spanwise_loads and spar_sizing schemas.
     """
 
-    # Use Any to avoid import-time circular dependency; validated at runtime.
-    spar_sizing: Optional[list] = Field(
+    spar_sizing: Optional[list[SparSizingResult]] = Field(
         None,
         description=(
             "Per-surface spar-sizing results (list of SparSizingResult). "

--- a/app/schemas/spanwise_loads.py
+++ b/app/schemas/spanwise_loads.py
@@ -1,6 +1,12 @@
-"""Pydantic schemas for spanwise shear + bending-moment distribution (gh-1002)."""
+"""Pydantic schemas for spanwise shear + bending-moment distribution (gh-1002).
+
+gh-1008: Extended with SpanwiseLoadsWithSizingResponse for the optional
+spar-sizing block returned when sizing params are supplied to the endpoint.
+"""
 
 from __future__ import annotations
+
+from typing import Optional
 
 from pydantic import BaseModel, Field
 
@@ -70,4 +76,25 @@ class SpanwiseLoadsResponse(BaseModel):
     )
     surfaces: list[SurfaceSpanwiseLoads] = Field(
         ..., description="Per-surface spanwise load distributions"
+    )
+
+
+class SpanwiseLoadsWithSizingResponse(SpanwiseLoadsResponse):
+    """Spanwise loads response extended with per-surface spar-sizing results (gh-1008).
+
+    Returned by the endpoint when ``spar_params`` are supplied in the request body.
+    Each element in ``spar_sizing`` corresponds to one surface in ``surfaces``
+    (by position and ``surface_name``).
+
+    Import note: SparSizingResult is imported inline to avoid circular imports
+    between spanwise_loads and spar_sizing schemas.
+    """
+
+    # Use Any to avoid import-time circular dependency; validated at runtime.
+    spar_sizing: Optional[list] = Field(
+        None,
+        description=(
+            "Per-surface spar-sizing results (list of SparSizingResult). "
+            "Present only when spar_params were supplied."
+        ),
     )

--- a/app/schemas/spar_sizing.py
+++ b/app/schemas/spar_sizing.py
@@ -1,0 +1,143 @@
+"""Pydantic schemas for spar-sizing from spanwise loads (gh-1008)."""
+
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+SparShape = Literal["tube", "rod", "rectangular", "capped"]
+
+
+class SparSizingParams(BaseModel):
+    """Parameters that drive the spar-sizing computation."""
+
+    material_id: int = Field(
+        ...,
+        description=(
+            "ID of a Component with component_type='material' and allowable_bending_stress_mpa set."
+        ),
+    )
+    shape: SparShape = Field(
+        ...,
+        description="Cross-section shape: tube | rod | rectangular | capped",
+    )
+    sigma_allow_mpa_override: Optional[float] = Field(
+        None,
+        gt=0,
+        description=(
+            "Override allowable bending stress (MPa). When None, the material's "
+            "allowable_bending_stress_mpa is used."
+        ),
+    )
+    safety_factor_j: float = Field(
+        1.5,
+        gt=0,
+        description="Safety factor applied to M_design = |M(y)| · g_limit · j.",
+    )
+    packing_factor: float = Field(
+        0.8,
+        gt=0,
+        le=1.0,
+        description=(
+            "Fraction of the local airfoil thickness that the spar outer dimension "
+            "may occupy. Default 0.8."
+        ),
+    )
+    cap_width_mm: Optional[float] = Field(
+        None,
+        gt=0,
+        description=("Flange/cap width b (mm) — required for shape='capped', ignored otherwise."),
+    )
+
+
+class SparSizingStation(BaseModel):
+    """Spar-sizing result at one spanwise station."""
+
+    y_m: float = Field(..., description="Spanwise position from root (m)")
+    chord_m: float = Field(..., description="Local chord (m)")
+    profile_thickness_mm: float = Field(
+        ..., description="Local airfoil thickness = chord · (t/c) (mm)"
+    )
+    outer_mm: float = Field(
+        ...,
+        description="Spar outer dimension = profile_thickness · packing (mm)",
+    )
+    tc_ratio: float = Field(..., description="Thickness-to-chord ratio used at this station")
+    tc_fallback: bool = Field(
+        False,
+        description="True when t/c fell back to the 0.12 default (no airfoil data).",
+    )
+    m_design_Nm: float = Field(..., description="Design bending moment M_design = |M|·n·j (N·m)")
+    required_W_mm3: float = Field(
+        ..., description="Required section modulus erf_W = M_design / σ_allow (mm³)"
+    )
+
+    # Shape-specific solved dimension
+    solved_mm: Optional[float] = Field(
+        None,
+        description=(
+            "The solved free dimension (mm): wall thickness for Tube; d for Rod; "
+            "width b for Rectangular; gurt thickness for Capped. None if infeasible."
+        ),
+    )
+    feasible: bool = Field(
+        ...,
+        description=(
+            "True when the solved dimension satisfies the geometric constraints "
+            "(e.g., tube wall > 0, rod fits within profile, capped gurt > 0)."
+        ),
+    )
+    infeasibility_reason: Optional[str] = Field(
+        None,
+        description="Human-readable reason when feasible=False.",
+    )
+    cross_section_area_mm2: Optional[float] = Field(
+        None,
+        description="Cross-section area of the spar at this station (mm²), for mass integration.",
+    )
+
+
+class SparSizingResult(BaseModel):
+    """Full spar-sizing result for one surface (gh-1008)."""
+
+    surface_name: str = Field(..., description="Name of the aerodynamic surface sized")
+    shape: SparShape = Field(..., description="Cross-section shape used")
+    material_name: str = Field(..., description="Material component name")
+    sigma_allow_mpa: float = Field(..., description="Allowable bending stress used (MPa)")
+    density_kg_m3: float = Field(..., description="Material density used (kg/m³)")
+    g_limit: float = Field(..., description="Limit load factor from design assumptions (g)")
+    g_limit_fallback: bool = Field(
+        False,
+        description="True when g_limit fell back to the default 3.0 (no assumption row).",
+    )
+    safety_factor_j: float = Field(..., description="Safety factor j applied")
+    packing_factor: float = Field(..., description="Packing factor applied")
+
+    stations: list[SparSizingStation] = Field(
+        ...,
+        description=(
+            "Per-station sizing results, ordered from tip to root "
+            "(index 0 = tip, last index = innermost strip)."
+        ),
+    )
+    root_station: SparSizingStation = Field(
+        ..., description="Sizing at the root station (worst case for a typical wing)."
+    )
+
+    # Mass estimates (half-span and full)
+    spar_mass_half_kg: float = Field(
+        ...,
+        description="Estimated spar mass for one half-span (kg), trapezoidal integration.",
+    )
+    spar_mass_full_kg: float = Field(
+        ..., description="Estimated full-span spar mass = 2 · half (kg)."
+    )
+
+    tc_fallback_warning: Optional[str] = Field(
+        None,
+        description=(
+            "Present when one or more stations used the t/c = 0.12 fallback. "
+            "Lists station y-positions where fallback was applied."
+        ),
+    )

--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -2057,6 +2057,7 @@ async def analyze_airplane_spanwise_loads(
         result_with_meta["velocity_mps"] = float(resolved_op.velocity)
         result_with_meta["altitude_m"] = float(resolved_op.altitude)
         result_with_meta["alpha"] = float(resolved_op.alpha)
+        result_with_meta["beta"] = float(resolved_op.beta)
 
         spanwise_response = compute_spanwise_loads(
             strip_forces_result=result_with_meta,
@@ -2112,7 +2113,6 @@ def _compute_spar_sizing_for_surfaces(
     Raises ValidationError when the material is not found or has no σ_allow.
     """
     from app.models.component import ComponentModel
-    from app.schemas.spar_sizing import SparSizingParams
     from app.services.spar_sizing import compute_spar_sizing
     from app.services.design_assumptions_service import get_effective_assumption
     from app.core.exceptions import ValidationError
@@ -2132,14 +2132,19 @@ def _compute_spar_sizing_for_surfaces(
             details={"material_id": spar_params.material_id},
         )
     material_specs = material.specs or {}
-    if (
-        spar_params.sigma_allow_mpa_override is None
-        and "allowable_bending_stress_mpa" not in material_specs
-    ):
+    # Resolve the effective allowable stress and reject non-positive values. The
+    # material schema permits allowable_bending_stress_mpa=0 (min=0), which would
+    # make required_section_modulus divide by zero → 500. Surface a clear 422
+    # instead (gh-1008 review).
+    sigma_allow = spar_params.sigma_allow_mpa_override
+    if sigma_allow is None:
+        sigma_allow = material_specs.get("allowable_bending_stress_mpa")
+    if sigma_allow is None or sigma_allow <= 0:
         raise ValidationError(
             message=(
-                f"Material '{material.name}' has no allowable_bending_stress_mpa. "
-                "Provide sigma_allow_mpa_override or choose a structural material."
+                f"Material '{material.name}' has no positive allowable_bending_stress_mpa "
+                f"(got {sigma_allow}). Provide a positive sigma_allow_mpa_override or choose "
+                "a structural material."
             ),
             details={"material_id": spar_params.material_id, "name": material.name},
         )

--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -1989,17 +1989,27 @@ async def analyze_airplane_spanwise_loads(
     aeroplane_uuid,
     operating_point: OperatingPointSchema,
     solver: str = "vlm",
+    spar_params=None,
 ):
     """Integrate strip forces into spanwise shear + bending-moment distribution (gh-1002).
 
     Reuses the strip-forces computation path and then applies the pure
     ``compute_spanwise_loads`` integrator.  No new aerodynamic model.
 
+    When ``spar_params`` (a ``SparSizingParams``) are provided, the response is
+    extended with per-surface spar-sizing results (gh-1008).
+
+    Args:
+        spar_params: Optional SparSizingParams.  When supplied, returns a
+            ``SpanwiseLoadsWithSizingResponse``; otherwise a plain
+            ``SpanwiseLoadsResponse``.
+
     Returns:
-        SpanwiseLoadsResponse with per-surface shear/BM distributions.
+        SpanwiseLoadsResponse (no spar_params) or SpanwiseLoadsWithSizingResponse.
 
     Raises:
         NotFoundError: If the aeroplane does not exist.
+        ValidationError: If the material_id is not found in the Component DB.
         InternalError: If the strip-forces or integration step fails.
     """
     import aerosandbox as asb
@@ -2048,10 +2058,28 @@ async def analyze_airplane_spanwise_loads(
         result_with_meta["altitude_m"] = float(resolved_op.altitude)
         result_with_meta["alpha"] = float(resolved_op.alpha)
 
-        return compute_spanwise_loads(
+        spanwise_response = compute_spanwise_loads(
             strip_forces_result=result_with_meta,
             q=q_dyn,
         )
+
+        if spar_params is None:
+            return spanwise_response
+
+        # gh-1008: compute spar sizing for each surface
+        from app.schemas.spanwise_loads import SpanwiseLoadsWithSizingResponse
+
+        spar_results = _compute_spar_sizing_for_surfaces(
+            db=db,
+            aeroplane_id=aircraft.id,
+            spanwise_response=spanwise_response,
+            spar_params=spar_params,
+        )
+        return SpanwiseLoadsWithSizingResponse(
+            **spanwise_response.model_dump(),
+            spar_sizing=spar_results,
+        )
+
     except ServiceException:
         raise
     except Exception as e:
@@ -2060,3 +2088,129 @@ async def analyze_airplane_spanwise_loads(
             aeroplane_uuid,
         )
         raise InternalError(message=f"Spanwise loads error: {e}") from e
+
+
+# ---------------------------------------------------------------------------
+# gh-1008: spar sizing orchestration helpers
+# ---------------------------------------------------------------------------
+
+#: Default g_limit (manoeuvre load factor) when no design assumption is set.
+_G_LIMIT_DEFAULT = 3.0
+#: Fallback t/c ratio when section airfoil data is unavailable.
+_TC_FALLBACK = 0.12
+
+
+def _compute_spar_sizing_for_surfaces(
+    db: Session,
+    aeroplane_id: int,
+    spanwise_response,
+    spar_params,
+) -> list:
+    """Resolve material, g_limit, t/c, and run compute_spar_sizing per surface.
+
+    Returns a list of SparSizingResult (one per surface).
+    Raises ValidationError when the material is not found or has no σ_allow.
+    """
+    from app.models.component import ComponentModel
+    from app.schemas.spar_sizing import SparSizingParams
+    from app.services.spar_sizing import compute_spar_sizing
+    from app.services.design_assumptions_service import get_effective_assumption
+    from app.core.exceptions import ValidationError
+
+    # --- Material lookup ---
+    material = (
+        db.query(ComponentModel)
+        .filter(
+            ComponentModel.id == spar_params.material_id,
+            ComponentModel.component_type == "material",
+        )
+        .first()
+    )
+    if material is None:
+        raise ValidationError(
+            message=f"Material component ID={spar_params.material_id} not found.",
+            details={"material_id": spar_params.material_id},
+        )
+    material_specs = material.specs or {}
+    if (
+        spar_params.sigma_allow_mpa_override is None
+        and "allowable_bending_stress_mpa" not in material_specs
+    ):
+        raise ValidationError(
+            message=(
+                f"Material '{material.name}' has no allowable_bending_stress_mpa. "
+                "Provide sigma_allow_mpa_override or choose a structural material."
+            ),
+            details={"material_id": spar_params.material_id, "name": material.name},
+        )
+
+    # --- g_limit from design assumptions (gh-960 pattern) ---
+    g_limit_raw = get_effective_assumption(db, aeroplane_id, "g_limit")
+    if g_limit_raw is None:
+        logger.warning(
+            "No g_limit assumption for aeroplane %s — using default %.1f",
+            aeroplane_id,
+            _G_LIMIT_DEFAULT,
+        )
+        g_limit = _G_LIMIT_DEFAULT
+        g_limit_fallback = True
+    else:
+        g_limit = float(g_limit_raw)
+        g_limit_fallback = False
+
+    results = []
+    for surface in spanwise_response.surfaces:
+        # Build station list from the starboard half (primary design loads)
+        # Use the half with the larger root BM (max of starboard / port)
+        stations = _surface_to_stations(surface)
+        if not stations:
+            continue
+
+        # t/c lookup: use starboard strips' chord as a proxy for y positions
+        tc_by_y = _get_tc_by_y_for_surface(surface)
+
+        spar_result = compute_spar_sizing(
+            stations=stations,
+            tc_by_y=tc_by_y,
+            material_specs=material_specs,
+            material_name=material.name,
+            params=spar_params,
+            g_limit=g_limit,
+            g_limit_fallback=g_limit_fallback,
+            surface_name=surface.surface_name,
+        )
+        results.append(spar_result)
+
+    return results
+
+
+def _surface_to_stations(surface) -> list[dict]:
+    """Convert a SurfaceSpanwiseLoads into station dicts for compute_spar_sizing.
+
+    Uses the half-span with the larger root bending moment.
+    Size on max(|M_sb|, |M_pt|) per spec §5.
+    """
+    if abs(surface.root_bending_moment_Nm_starboard) >= abs(surface.root_bending_moment_Nm_port):
+        entries = surface.starboard
+    else:
+        entries = surface.port
+
+    return [
+        {
+            "y_m": e.y_m,
+            "chord_m": e.chord_m,
+            "bending_moment_Nm": e.bending_moment_Nm,
+        }
+        for e in entries
+    ]
+
+
+def _get_tc_by_y_for_surface(surface) -> dict[float, float]:
+    """Build a t/c lookup dict from strip data.
+
+    gh-1008 §8: (t/c) should come from wing-section airfoil max-thickness.
+    That data isn't yet in the spanwise strip result, so we return an empty
+    dict here → the spar-sizing service applies the 0.12 fallback with a
+    warning.  A future ticket can wire in the airfoil DB t/c.
+    """
+    return {}

--- a/app/services/component_type_service.py
+++ b/app/services/component_type_service.py
@@ -618,7 +618,7 @@ def _patch_material_structural_fields(db: Session, full_schema: list[dict[str, A
 _STRUCTURAL_MATERIAL_SEEDS: list[dict[str, Any]] = [
     {
         "name": "Pine (structural)",
-        "description": "Kiefer Güte A — structural spar material. σ_allow = 39 MPa (compression).",
+        "description": "Pine, Grade A — structural spar material. σ_allow = 39 MPa (compression).",
         "specs": {
             "density_kg_m3": 500.0,
             "allowable_bending_stress_mpa": 39.0,

--- a/app/services/component_type_service.py
+++ b/app/services/component_type_service.py
@@ -315,6 +315,25 @@ DEFAULT_SEED_TYPES: list[dict[str, Any]] = [
                 "options": ["volume", "surface"],
                 "default": "volume",
             },
+            # gh-1008: additive structural spar-sizing fields (both optional)
+            {
+                "name": "allowable_bending_stress_mpa",
+                "label": "Allowable Bending Stress",
+                "type": "number",
+                "unit": "MPa",
+                "required": False,
+                "min": 0.0,
+                "description": "σ_allow for spar sizing (MPa). Compression governs for wood.",
+            },
+            {
+                "name": "youngs_modulus_gpa",
+                "label": "Young's Modulus",
+                "type": "number",
+                "unit": "GPa",
+                "required": False,
+                "min": 0.0,
+                "description": "E for future deflection checks (GPa).",
+            },
         ],
     },
     {
@@ -548,10 +567,16 @@ def seed_default_types(db: Session) -> None:
 
     Idempotent — safe to call multiple times (used by the test DB fixture).
     Seeded types carry deletable=False so users cannot remove them.
+
+    Also updates the 'material' type schema to add gh-1008 structural fields
+    if they aren't already present in the existing schema.
     """
     existing = {row[0] for row in db.query(ComponentTypeModel.name).all()}
     for seed in DEFAULT_SEED_TYPES:
         if seed["name"] in existing:
+            # gh-1008: patch in structural fields for the material type if missing
+            if seed["name"] == "material":
+                _patch_material_structural_fields(db, seed["schema"])
             continue
         db.add(
             ComponentTypeModel(
@@ -562,3 +587,77 @@ def seed_default_types(db: Session) -> None:
                 deletable=False,
             )
         )
+
+
+def _patch_material_structural_fields(db: Session, full_schema: list[dict[str, Any]]) -> None:
+    """Ensure the 'material' ComponentType has gh-1008 structural fields.
+
+    Adds allowable_bending_stress_mpa and youngs_modulus_gpa if missing.
+    Idempotent. Called from seed_default_types so existing test DBs get
+    the new fields without a full DB rebuild.
+    """
+    row = db.query(ComponentTypeModel).filter(ComponentTypeModel.name == "material").first()
+    if row is None:
+        return
+    current = _normalize_schema(row.schema_def)
+    existing_names = {p.get("name") for p in current if isinstance(p, dict)}
+    changed = False
+    for prop in full_schema:
+        if isinstance(prop, dict) and prop.get("name") not in existing_names:
+            current.append(prop)
+            changed = True
+    if changed:
+        row.schema_def = current
+        db.flush()
+
+
+# ---------------------------------------------------------------------------
+# Structural materials seed (gh-1008)
+# ---------------------------------------------------------------------------
+
+_STRUCTURAL_MATERIAL_SEEDS: list[dict[str, Any]] = [
+    {
+        "name": "Pine (structural)",
+        "description": "Kiefer Güte A — structural spar material. σ_allow = 39 MPa (compression).",
+        "specs": {
+            "density_kg_m3": 500.0,
+            "allowable_bending_stress_mpa": 39.0,
+            "youngs_modulus_gpa": 11.0,
+        },
+    },
+    {
+        "name": "Carbon Fiber (structural)",
+        "description": "Carbon fiber tube/spar — conservative σ_allow=500 MPa (buckling-aware).",
+        "specs": {
+            "density_kg_m3": 1600.0,
+            "allowable_bending_stress_mpa": 500.0,
+            "youngs_modulus_gpa": 120.0,
+        },
+    },
+]
+
+
+def seed_structural_materials(db: Session) -> None:
+    """Seed Pine and Carbon Fiber structural materials if not already present.
+
+    Idempotent — safe to call multiple times.  Used by the test DB fixture
+    and the Alembic migration (gh-1008).
+    """
+    for mat in _STRUCTURAL_MATERIAL_SEEDS:
+        existing = (
+            db.query(ComponentModel)
+            .filter(
+                ComponentModel.name == mat["name"],
+                ComponentModel.component_type == "material",
+            )
+            .first()
+        )
+        if existing is None:
+            db.add(
+                ComponentModel(
+                    name=mat["name"],
+                    component_type="material",
+                    description=mat["description"],
+                    specs=mat["specs"],
+                )
+            )

--- a/app/services/spanwise_loads.py
+++ b/app/services/spanwise_loads.py
@@ -112,6 +112,7 @@ def compute_spanwise_loads(
         or []
     )
     alpha = float(strip_forces_result.get("alpha", 0.0))
+    beta = float(strip_forces_result.get("beta", 0.0))
     velocity_mps = float(strip_forces_result.get("velocity_mps", 0.0))
     altitude_m = float(strip_forces_result.get("altitude_m", 0.0))
 
@@ -156,6 +157,7 @@ def compute_spanwise_loads(
 
     return SpanwiseLoadsResponse(
         alpha=alpha,
+        beta=beta,
         velocity_mps=velocity_mps,
         altitude_m=altitude_m,
         dynamic_pressure_Pa=q,

--- a/app/services/spar_sizing.py
+++ b/app/services/spar_sizing.py
@@ -1,0 +1,410 @@
+"""Spar-sizing from spanwise bending-moment distribution (gh-1008).
+
+Pure module — no aerosandbox, no database dependencies.
+Fast-tier unit-testable.
+
+Reference: kirch Hauptholm (https://www.flugmodellbau-kirch.de/Hauptholm.htm)
+and the user's section-modulus scan.
+
+Design formula:
+  M_design(y) = |M(y)| · g_limit · j
+  erf_W = M_design / σ_allow
+  outer = chord(y) · (t/c)(y) · packing
+  → solve free dimension per shape
+
+Units:
+  Inputs: M in N·m, σ in MPa (N/mm²), dimensions in mm.
+  W is in mm³.
+  Mass is in kg.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any
+
+from app.schemas.spar_sizing import SparSizingParams, SparSizingResult, SparSizingStation
+
+logger = logging.getLogger(__name__)
+
+# Fallback t/c ratio when airfoil data is unavailable.
+_TC_FALLBACK = 0.12
+
+
+# ---------------------------------------------------------------------------
+# Section-modulus formulas (dimensions in mm, W in mm³)
+# ---------------------------------------------------------------------------
+
+
+def section_modulus_rectangular(b: float, h: float) -> float:
+    """Section modulus for a solid rectangular spar b×h (mm).
+
+    W = b · h² / 6   [mm³]
+    """
+    return b * h**2 / 6.0
+
+
+def section_modulus_capped(b: float, H: float, h: float) -> float:
+    """Section modulus for a capped (I-beam / C-beam) spar.
+
+    b = flange width, H = outer height, h = inner gap height (all mm).
+    W = b · (H³ − h³) / (6 · H)   [mm³]
+    """
+    return b * (H**3 - h**3) / (6.0 * H)
+
+
+def section_modulus_rod(d: float) -> float:
+    """Section modulus for a solid round rod of diameter d (mm).
+
+    W = d³ / 10   [mm³]
+    """
+    return d**3 / 10.0
+
+
+def section_modulus_tube(Da: float, Di: float) -> float:
+    """Section modulus for a circular tube (outer Da, inner Di, mm).
+
+    W = π · (Da⁴ − Di⁴) / (32 · Da)   [mm³]
+    """
+    return math.pi * (Da**4 - Di**4) / (32.0 * Da)
+
+
+# ---------------------------------------------------------------------------
+# Required section modulus
+# ---------------------------------------------------------------------------
+
+
+def required_section_modulus(m_design_Nm: float, sigma_allow_mpa: float) -> float:
+    """Compute the required section modulus erf_W (mm³).
+
+    erf_W = M_design [N·m] × 1000 [mm/m] / σ_allow [N/mm²]
+    """
+    return m_design_Nm * 1000.0 / sigma_allow_mpa
+
+
+# ---------------------------------------------------------------------------
+# solve_dimension — solves the free spar dimension for each shape
+# ---------------------------------------------------------------------------
+
+
+def solve_dimension(
+    shape: str,
+    erf_w: float,
+    outer_mm: float,
+    cap_width_mm: float | None = None,
+) -> dict[str, Any]:
+    """Solve the free spar dimension for the given shape.
+
+    The outer dimension (outer_mm) is fixed by the local airfoil thickness.
+    The free dimension is derived analytically.
+
+    Returns a dict with keys:
+      - solved_mm: float | None
+      - feasible: bool
+      - infeasibility_reason: str | None
+      - cross_section_area_mm2: float | None
+      - inner_mm: float | None   (Tube only — Di)
+
+    Shape dispatch:
+      tube:        Da = outer, solve Di → wall = (Da-Di)/2
+      rod:         solve d = (10·erf_w)^(1/3), check d ≤ outer
+      rectangular: h = outer, solve b = 6·erf_w / h²
+      capped:      H = outer, b = cap_width_mm, solve h = (H³-6·H·erf_w/b)^(1/3),
+                   gurt = (H-h)/2
+    """
+    if shape == "tube":
+        return _solve_tube(erf_w, outer_mm)
+    elif shape == "rod":
+        return _solve_rod(erf_w, outer_mm)
+    elif shape == "rectangular":
+        return _solve_rectangular(erf_w, outer_mm)
+    elif shape == "capped":
+        if cap_width_mm is None:
+            raise ValueError("cap_width_mm is required for shape='capped'")
+        return _solve_capped(erf_w, outer_mm, cap_width_mm)
+    else:
+        raise ValueError(f"Unknown spar shape: {shape!r}")
+
+
+def _solve_tube(erf_w: float, outer_mm: float) -> dict[str, Any]:
+    Da = outer_mm
+    discriminant = Da**4 - 32.0 * erf_w * Da / math.pi
+    if discriminant < 0.0:
+        return {
+            "solved_mm": None,
+            "feasible": False,
+            "infeasibility_reason": "solid needed — required W exceeds tube capacity at this outer diameter",
+            "cross_section_area_mm2": None,
+            "inner_mm": None,
+        }
+    Di = discriminant**0.25
+    wall = (Da - Di) / 2.0
+    area = math.pi * (Da**2 - Di**2) / 4.0
+    return {
+        "solved_mm": wall,
+        "feasible": True,
+        "infeasibility_reason": None,
+        "cross_section_area_mm2": area,
+        "inner_mm": Di,
+    }
+
+
+def _solve_rod(erf_w: float, outer_mm: float) -> dict[str, Any]:
+    d = (10.0 * erf_w) ** (1.0 / 3.0)
+    if d > outer_mm + 1e-9:
+        return {
+            "solved_mm": d,
+            "feasible": False,
+            "infeasibility_reason": (
+                f"rod too big — required d={d:.1f} mm exceeds profile thickness {outer_mm:.1f} mm"
+            ),
+            "cross_section_area_mm2": math.pi * d**2 / 4.0,
+            "inner_mm": None,
+        }
+    area = math.pi * d**2 / 4.0
+    return {
+        "solved_mm": d,
+        "feasible": True,
+        "infeasibility_reason": None,
+        "cross_section_area_mm2": area,
+        "inner_mm": None,
+    }
+
+
+def _solve_rectangular(erf_w: float, outer_mm: float) -> dict[str, Any]:
+    h = outer_mm
+    b = 6.0 * erf_w / h**2 if h > 0.0 else 0.0
+    area = b * h
+    return {
+        "solved_mm": b,
+        "feasible": True,
+        "infeasibility_reason": None,
+        "cross_section_area_mm2": area,
+        "inner_mm": None,
+    }
+
+
+def _solve_capped(erf_w: float, outer_mm: float, cap_width_mm: float) -> dict[str, Any]:
+    H = outer_mm
+    b = cap_width_mm
+    inner_cube = H**3 - 6.0 * H * erf_w / b
+    if inner_cube < 0.0:
+        return {
+            "solved_mm": None,
+            "feasible": False,
+            "infeasibility_reason": (
+                f"capped spar infeasible — H³={H**3:.1f} < 6·H·W/b={6 * H * erf_w / b:.1f}; "
+                "increase H or b"
+            ),
+            "cross_section_area_mm2": None,
+            "inner_mm": None,
+        }
+    h = inner_cube ** (1.0 / 3.0)
+    gurt = (H - h) / 2.0
+    area = 2.0 * b * gurt  # two flanges (upper + lower)
+    return {
+        "solved_mm": gurt,
+        "feasible": True,
+        "infeasibility_reason": None,
+        "cross_section_area_mm2": area,
+        "inner_mm": h,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Mass integration
+# ---------------------------------------------------------------------------
+
+
+def spar_mass_half_kg(
+    ys_m: list[float],
+    areas_mm2: list[float],
+    density_kg_m3: float,
+) -> float:
+    """Estimate spar mass for a half-span by trapezoidal integration.
+
+    Args:
+        ys_m: Spanwise positions in metres, ordered tip-to-root (decreasing).
+              May also be root-to-tip — only absolute differences matter.
+        areas_mm2: Cross-section area at each station (mm²), same order as ys_m.
+        density_kg_m3: Material density in kg/m³.
+
+    Returns:
+        Estimated half-span spar mass in kg.
+    """
+    if len(ys_m) < 2:
+        return 0.0
+
+    total_mass = 0.0
+    for i in range(len(ys_m) - 1):
+        dy = abs(ys_m[i] - ys_m[i + 1])  # segment length (m)
+        avg_area_mm2 = (areas_mm2[i] + areas_mm2[i + 1]) / 2.0
+        avg_area_m2 = avg_area_mm2 * 1e-6  # mm² → m²
+        volume_m3 = avg_area_m2 * dy
+        total_mass += density_kg_m3 * volume_m3
+
+    return total_mass
+
+
+# ---------------------------------------------------------------------------
+# compute_spar_sizing — main pure orchestrator
+# ---------------------------------------------------------------------------
+
+
+def compute_spar_sizing(
+    stations: list[dict[str, Any]],
+    tc_by_y: dict[float, float],
+    material_specs: dict[str, Any],
+    material_name: str,
+    params: SparSizingParams,
+    g_limit: float,
+    g_limit_fallback: bool,
+    surface_name: str,
+) -> SparSizingResult:
+    """Size the spar at each spanwise station.
+
+    Args:
+        stations: List of dicts with keys ``y_m``, ``chord_m``,
+            ``bending_moment_Nm`` — ordered tip-to-root (outboard first).
+        tc_by_y: Mapping {y_m (float, rounded): t/c ratio} from wing-section
+            airfoil data.  Missing entries trigger the 0.12 fallback.
+        material_specs: The ``specs`` dict from the ComponentRead (real schema
+            keys: ``density_kg_m3``, ``allowable_bending_stress_mpa``).
+        material_name: Human-readable material name for the result.
+        params: SparSizingParams with shape, j, packing, etc.
+        g_limit: Limit load factor from design assumptions.
+        g_limit_fallback: True if g_limit is a default fallback.
+        surface_name: Name of the aerodynamic surface being sized.
+
+    Returns:
+        SparSizingResult with per-station and aggregate results.
+    """
+    # Resolve σ_allow
+    sigma_allow = (
+        params.sigma_allow_mpa_override
+        if params.sigma_allow_mpa_override is not None
+        else float(material_specs["allowable_bending_stress_mpa"])
+    )
+    density = float(material_specs["density_kg_m3"])
+
+    sized_stations: list[SparSizingStation] = []
+    tc_fallback_ys: list[float] = []
+
+    for st in stations:
+        y_m = float(st["y_m"])
+        chord_m = float(st["chord_m"])
+        bm = float(st["bending_moment_Nm"])
+
+        # t/c lookup with fallback
+        tc_ratio, tc_fallback = _get_tc(tc_by_y, y_m)
+        if tc_fallback:
+            tc_fallback_ys.append(y_m)
+
+        # Design moment (always positive)
+        m_design = abs(bm) * g_limit * params.safety_factor_j
+
+        # Required section modulus
+        erf_w = required_section_modulus(m_design, sigma_allow)
+
+        # Outer dimension (mm) = chord (m → mm) · t/c · packing
+        chord_mm = chord_m * 1000.0
+        profile_thickness_mm = chord_mm * tc_ratio
+        outer_mm = profile_thickness_mm * params.packing_factor
+
+        # Solve free dimension
+        sol = solve_dimension(
+            shape=params.shape,
+            erf_w=erf_w,
+            outer_mm=outer_mm,
+            cap_width_mm=params.cap_width_mm,
+        )
+
+        sized_stations.append(
+            SparSizingStation(
+                y_m=y_m,
+                chord_m=chord_m,
+                profile_thickness_mm=profile_thickness_mm,
+                outer_mm=outer_mm,
+                tc_ratio=tc_ratio,
+                tc_fallback=tc_fallback,
+                m_design_Nm=m_design,
+                required_W_mm3=erf_w,
+                solved_mm=sol.get("solved_mm"),
+                feasible=sol["feasible"],
+                infeasibility_reason=sol.get("infeasibility_reason"),
+                cross_section_area_mm2=sol.get("cross_section_area_mm2"),
+            )
+        )
+
+    # Root station = innermost (last in outboard-first list)
+    root_station = sized_stations[-1] if sized_stations else _zero_station()
+
+    # Spar mass — trapezoidal over the half-span
+    ys = [s.y_m for s in sized_stations]
+    areas = [
+        s.cross_section_area_mm2 if s.cross_section_area_mm2 is not None else 0.0
+        for s in sized_stations
+    ]
+    half_mass = spar_mass_half_kg(ys_m=ys, areas_mm2=areas, density_kg_m3=density)
+
+    # t/c fallback warning
+    tc_warn: str | None = None
+    if tc_fallback_ys:
+        ys_str = ", ".join(f"{y:.2f}" for y in tc_fallback_ys)
+        tc_warn = (
+            f"t/c=0.12 fallback applied at y={ys_str} m — no airfoil thickness data available."
+        )
+
+    return SparSizingResult(
+        surface_name=surface_name,
+        shape=params.shape,
+        material_name=material_name,
+        sigma_allow_mpa=sigma_allow,
+        density_kg_m3=density,
+        g_limit=g_limit,
+        g_limit_fallback=g_limit_fallback,
+        safety_factor_j=params.safety_factor_j,
+        packing_factor=params.packing_factor,
+        stations=sized_stations,
+        root_station=root_station,
+        spar_mass_half_kg=half_mass,
+        spar_mass_full_kg=half_mass * 2.0,
+        tc_fallback_warning=tc_warn,
+    )
+
+
+def _get_tc(tc_by_y: dict[float, float], y_m: float) -> tuple[float, bool]:
+    """Return (tc_ratio, is_fallback) for a given spanwise position.
+
+    Tries exact match then nearest key within 1 cm tolerance.
+    Falls back to 0.12 with warning when nothing is found.
+    """
+    if y_m in tc_by_y:
+        return tc_by_y[y_m], False
+
+    # Nearest-key lookup (within 10 mm)
+    nearest = min(tc_by_y.keys(), key=lambda k: abs(k - y_m), default=None)
+    if nearest is not None and abs(nearest - y_m) < 0.01:
+        return tc_by_y[nearest], False
+
+    logger.warning("No t/c data for y=%.3f m — using fallback t/c=%.2f", y_m, _TC_FALLBACK)
+    return _TC_FALLBACK, True
+
+
+def _zero_station() -> SparSizingStation:
+    """Return a zeroed station for the edge case of no stations."""
+    return SparSizingStation(
+        y_m=0.0,
+        chord_m=0.0,
+        profile_thickness_mm=0.0,
+        outer_mm=0.0,
+        tc_ratio=_TC_FALLBACK,
+        tc_fallback=True,
+        m_design_Nm=0.0,
+        required_W_mm3=0.0,
+        solved_mm=None,
+        feasible=False,
+        infeasibility_reason="No stations provided",
+        cross_section_area_mm2=None,
+    )

--- a/app/services/spar_sizing.py
+++ b/app/services/spar_sizing.py
@@ -79,7 +79,12 @@ def required_section_modulus(m_design_Nm: float, sigma_allow_mpa: float) -> floa
     """Compute the required section modulus erf_W (mm³).
 
     erf_W = M_design [N·m] × 1000 [mm/m] / σ_allow [N/mm²]
+
+    Raises ValueError on σ_allow ≤ 0 (callers resolve σ from a material whose
+    schema permits 0; guard here so we never divide by zero — gh-1008 review).
     """
+    if sigma_allow_mpa <= 0:
+        raise ValueError(f"sigma_allow must be positive, got {sigma_allow_mpa}")
     return m_design_Nm * 1000.0 / sigma_allow_mpa
 
 

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -46,7 +46,7 @@ from app.models.aeroplanemodel import (
 )
 from app.models.analysismodels import OperatingPointModel
 from app.services import cad_service
-from app.services.component_type_service import seed_default_types
+from app.services.component_type_service import seed_default_types, seed_structural_materials
 from app.services.mission_objective_service import seed_mission_presets
 
 
@@ -144,6 +144,7 @@ def client_and_db() -> Tuple[TestClient, sessionmaker]:
     _seed_session = TestingSessionLocal()
     try:
         seed_default_types(_seed_session)
+        seed_structural_materials(_seed_session)  # gh-1008: Pine + Carbon Fiber
         seed_mission_presets(_seed_session)
         _seed_session.commit()
     finally:

--- a/app/tests/test_components_and_versions.py
+++ b/app/tests/test_components_and_versions.py
@@ -47,14 +47,19 @@ class TestComponentLibraryCRUD:
         assert "id" in body
 
     def test_list_components(self, client: TestClient):
+        # The components table is not empty at baseline: gh-1008 seeds the
+        # structural materials (Pine + Carbon Fiber) into every DB. Assert
+        # relative to that baseline rather than assuming an empty table.
+        baseline = client.get("/components").json()["total"]
+
         client.post("/components", json=MOTOR_PAYLOAD)
 
         resp = client.get("/components")
         assert resp.status_code == 200
         body = resp.json()
         assert "items" in body
-        assert body["total"] == 1
-        assert body["items"][0]["name"] == "Motor X"
+        assert body["total"] == baseline + 1
+        assert any(item["name"] == "Motor X" for item in body["items"])
 
     def test_list_components_filtered_by_type(self, client: TestClient):
         client.post("/components", json=MOTOR_PAYLOAD)

--- a/app/tests/test_material_structural_seed.py
+++ b/app/tests/test_material_structural_seed.py
@@ -1,0 +1,152 @@
+"""Tests for the gh-1008 structural-material seeding and material-type
+schema patching in component_type_service.
+
+Covers:
+- seed_structural_materials: Pine + Carbon Fiber seeded with the expected
+  structural specs, and idempotency (no duplicates on re-seed).
+- _patch_material_structural_fields: adds the structural fields to an
+  existing 'material' type that predates gh-1008, is idempotent, and is a
+  no-op when no 'material' type exists.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.models.component import ComponentModel
+from app.models.component_type import ComponentTypeModel
+from app.services.component_type_service import (
+    _patch_material_structural_fields,
+    seed_default_types,
+    seed_structural_materials,
+)
+
+pytestmark = pytest.mark.integration
+
+_STRUCTURAL_FIELDS = {"allowable_bending_stress_mpa", "youngs_modulus_gpa"}
+
+
+def _materials(db):
+    return (
+        db.query(ComponentModel)
+        .filter(ComponentModel.component_type == "material")
+        .all()
+    )
+
+
+def test_structural_materials_seeded_with_specs(client_and_db):
+    _, SessionLocal = client_and_db
+    db = SessionLocal()
+    try:
+        names = {m.name for m in _materials(db)}
+        assert "Pine (structural)" in names
+        assert "Carbon Fiber (structural)" in names
+
+        cf = next(m for m in _materials(db) if m.name == "Carbon Fiber (structural)")
+        assert cf.specs["allowable_bending_stress_mpa"] == 500.0
+        assert cf.specs["youngs_modulus_gpa"] == 120.0
+        assert cf.specs["density_kg_m3"] == 1600.0
+    finally:
+        db.close()
+
+
+def test_seed_structural_materials_is_idempotent(client_and_db):
+    _, SessionLocal = client_and_db
+    db = SessionLocal()
+    try:
+        before = len(_materials(db))
+        # conftest already seeded once; seeding again must not duplicate.
+        seed_structural_materials(db)
+        db.commit()
+        assert len(_materials(db)) == before
+    finally:
+        db.close()
+
+
+def test_material_type_has_structural_fields(client_and_db):
+    _, SessionLocal = client_and_db
+    db = SessionLocal()
+    try:
+        row = (
+            db.query(ComponentTypeModel)
+            .filter(ComponentTypeModel.name == "material")
+            .first()
+        )
+        names = {p["name"] for p in row.schema_def if isinstance(p, dict)}
+        assert _STRUCTURAL_FIELDS.issubset(names)
+    finally:
+        db.close()
+
+
+def test_patch_adds_missing_structural_fields_to_legacy_material_type(client_and_db):
+    """Simulate a pre-gh-1008 DB whose material type lacks the new fields."""
+    _, SessionLocal = client_and_db
+    db = SessionLocal()
+    try:
+        row = (
+            db.query(ComponentTypeModel)
+            .filter(ComponentTypeModel.name == "material")
+            .first()
+        )
+        full_schema = list(row.schema_def)
+        # Strip the gh-1008 fields to mimic a legacy schema.
+        legacy = [
+            p
+            for p in full_schema
+            if not (isinstance(p, dict) and p.get("name") in _STRUCTURAL_FIELDS)
+        ]
+        row.schema_def = legacy
+        db.flush()
+        assert not _STRUCTURAL_FIELDS.issubset(
+            {p["name"] for p in row.schema_def if isinstance(p, dict)}
+        )
+
+        # Patch should re-add them (changed=True branch).
+        _patch_material_structural_fields(db, full_schema)
+        db.commit()
+
+        row2 = (
+            db.query(ComponentTypeModel)
+            .filter(ComponentTypeModel.name == "material")
+            .first()
+        )
+        names = {p["name"] for p in row2.schema_def if isinstance(p, dict)}
+        assert _STRUCTURAL_FIELDS.issubset(names)
+    finally:
+        db.close()
+
+
+def test_reseed_default_types_patches_existing_material_type(client_and_db):
+    """Re-running seed_default_types on a DB that already has the types must
+    hit the 'already exists' branch and keep the material structural fields."""
+    _, SessionLocal = client_and_db
+    db = SessionLocal()
+    try:
+        type_count_before = db.query(ComponentTypeModel).count()
+        seed_default_types(db)  # second call → exercises the patch-on-existing path
+        db.commit()
+        # No duplicate types created.
+        assert db.query(ComponentTypeModel).count() == type_count_before
+        row = (
+            db.query(ComponentTypeModel)
+            .filter(ComponentTypeModel.name == "material")
+            .first()
+        )
+        names = {p["name"] for p in row.schema_def if isinstance(p, dict)}
+        assert _STRUCTURAL_FIELDS.issubset(names)
+    finally:
+        db.close()
+
+
+def test_patch_is_noop_when_no_material_type(client_and_db):
+    _, SessionLocal = client_and_db
+    db = SessionLocal()
+    try:
+        db.query(ComponentTypeModel).filter(
+            ComponentTypeModel.name == "material"
+        ).delete()
+        db.flush()
+        # Must return cleanly without raising when there is no material type.
+        _patch_material_structural_fields(db, [{"name": "youngs_modulus_gpa"}])
+    finally:
+        db.close()

--- a/app/tests/test_spar_sizing_endpoint.py
+++ b/app/tests/test_spar_sizing_endpoint.py
@@ -1,0 +1,516 @@
+"""gh-1008: Endpoint + service integration tests for spar sizing.
+
+All tests run on the CI fast tier:
+- Endpoint tests mock analyze_airplane_spanwise_loads_with_sizing at the boundary.
+- Material-seed tests use the real test DB fixture (no aerosandbox).
+- Service orchestration tests mock spanwise/aero deps.
+
+Recurring mock-correctness lesson: the strip_forces mock MUST use the
+real data-structure keys (surfaces / strips with Yle/Area/cl/Chord).
+Material specs must use real ComponentRead.specs keys:
+  density_kg_m3, allowable_bending_stress_mpa.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.core.exceptions import InternalError, NotFoundError
+from app.schemas.aeroanalysisschema import OperatingPointSchema
+from app.schemas.spar_sizing import SparSizingParams, SparSizingResult, SparSizingStation
+from app.schemas.spanwise_loads import (
+    SpanwiseLoadEntry,
+    SpanwiseLoadsResponse,
+    SurfaceSpanwiseLoads,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_spanwise_response(
+    root_bm: float = 1000.0,
+) -> SpanwiseLoadsResponse:
+    entry = SpanwiseLoadEntry(y_m=0.0, chord_m=0.4, shear_N=500.0, bending_moment_Nm=root_bm)
+    surf = SurfaceSpanwiseLoads(
+        surface_name="main_wing",
+        starboard=[entry],
+        port=[],
+        root_shear_N_starboard=500.0,
+        root_shear_N_port=0.0,
+        root_bending_moment_Nm_starboard=root_bm,
+        root_bending_moment_Nm_port=0.0,
+    )
+    return SpanwiseLoadsResponse(
+        alpha=2.0,
+        velocity_mps=30.0,
+        altitude_m=0.0,
+        dynamic_pressure_Pa=551.25,
+        surfaces=[surf],
+    )
+
+
+def _make_spar_station(y: float = 0.0) -> SparSizingStation:
+    return SparSizingStation(
+        y_m=y,
+        chord_m=0.4,
+        profile_thickness_mm=48.0,
+        outer_mm=38.4,
+        tc_ratio=0.12,
+        tc_fallback=False,
+        m_design_Nm=4500.0,
+        required_W_mm3=9000.0,
+        solved_mm=2.0,
+        feasible=True,
+        infeasibility_reason=None,
+        cross_section_area_mm2=120.0,
+    )
+
+
+def _make_spar_result() -> SparSizingResult:
+    station = _make_spar_station()
+    return SparSizingResult(
+        surface_name="main_wing",
+        shape="tube",
+        material_name="Carbon Fiber (structural)",
+        sigma_allow_mpa=500.0,
+        density_kg_m3=1600.0,
+        g_limit=3.0,
+        g_limit_fallback=False,
+        safety_factor_j=1.5,
+        packing_factor=0.8,
+        stations=[station],
+        root_station=station,
+        spar_mass_half_kg=0.05,
+        spar_mass_full_kg=0.10,
+        tc_fallback_warning=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoint tests (no spar params → plain spanwise response)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def plane_id():
+    return uuid.uuid4()
+
+
+@pytest.fixture()
+def op():
+    return OperatingPointSchema.model_construct(
+        velocity=30.0,
+        alpha=2.0,
+        altitude=0.0,
+        beta=0.0,
+        xyz_ref=[0.0, 0.0, 0.0],
+        p=0.0,
+        q=0.0,
+        r=0.0,
+    )
+
+
+class TestGetAirplaneSpanwiseLoadsWithoutSizing:
+    """Endpoint without spar params returns plain SpanwiseLoadsResponse."""
+
+    def test_no_spar_params_returns_spanwise_only(self, plane_id, op):
+        from app.api.v2.endpoints.aeroanalysis import get_airplane_spanwise_loads
+
+        mock_response = _make_spanwise_response()
+        with patch(
+            "app.services.analysis_service.analyze_airplane_spanwise_loads",
+            new=AsyncMock(return_value=mock_response),
+        ):
+            result = asyncio.run(
+                get_airplane_spanwise_loads(
+                    aeroplane_id=plane_id,
+                    operating_point=op,
+                    db=None,
+                    solver="vlm",
+                )
+            )
+        assert isinstance(result, SpanwiseLoadsResponse)
+        assert not hasattr(result, "spar_sizing") or result.spar_sizing is None
+
+
+# ---------------------------------------------------------------------------
+# SpanwiseLoadsWithSizingResponse
+# ---------------------------------------------------------------------------
+
+
+class TestSpanwiseLoadsWithSizingResponse:
+    """Test the extended response schema."""
+
+    def test_schema_fields(self):
+        from app.schemas.spanwise_loads import SpanwiseLoadsWithSizingResponse
+
+        spanwise = _make_spanwise_response()
+        spar = _make_spar_result()
+        resp = SpanwiseLoadsWithSizingResponse(
+            **spanwise.model_dump(),
+            spar_sizing=[spar],
+        )
+        assert resp.spar_sizing is not None
+        assert len(resp.spar_sizing) == 1
+        assert resp.spar_sizing[0].shape == "tube"
+        assert resp.spar_sizing[0].root_station.feasible is True
+
+    def test_schema_without_sizing(self):
+        from app.schemas.spanwise_loads import SpanwiseLoadsWithSizingResponse
+
+        spanwise = _make_spanwise_response()
+        resp = SpanwiseLoadsWithSizingResponse(**spanwise.model_dump(), spar_sizing=None)
+        assert resp.spar_sizing is None
+
+
+# ---------------------------------------------------------------------------
+# Material seed / schema tests (uses real test DB)
+# ---------------------------------------------------------------------------
+
+
+class TestMaterialSeedGh1008:
+    """Verify the structural material seeds are present after conftest setup."""
+
+    def test_pine_seeded(self, client_and_db):
+        _, session_factory = client_and_db
+        from app.models.component import ComponentModel
+
+        with session_factory() as db:
+            pine = (
+                db.query(ComponentModel)
+                .filter(
+                    ComponentModel.name == "Pine (structural)",
+                    ComponentModel.component_type == "material",
+                )
+                .first()
+            )
+        assert pine is not None
+        assert pine.specs["density_kg_m3"] == pytest.approx(500.0)
+        assert pine.specs["allowable_bending_stress_mpa"] == pytest.approx(39.0)
+        assert pine.specs["youngs_modulus_gpa"] == pytest.approx(11.0)
+
+    def test_carbon_fiber_seeded(self, client_and_db):
+        _, session_factory = client_and_db
+        from app.models.component import ComponentModel
+
+        with session_factory() as db:
+            cf = (
+                db.query(ComponentModel)
+                .filter(
+                    ComponentModel.name == "Carbon Fiber (structural)",
+                    ComponentModel.component_type == "material",
+                )
+                .first()
+            )
+        assert cf is not None
+        assert cf.specs["density_kg_m3"] == pytest.approx(1600.0)
+        assert cf.specs["allowable_bending_stress_mpa"] == pytest.approx(500.0)
+        assert cf.specs["youngs_modulus_gpa"] == pytest.approx(120.0)
+
+    def test_material_type_has_structural_fields(self, client_and_db):
+        _, session_factory = client_and_db
+        from app.models.component_type import ComponentTypeModel
+        from app.services.component_type_service import _normalize_schema
+
+        with session_factory() as db:
+            mat_type = (
+                db.query(ComponentTypeModel).filter(ComponentTypeModel.name == "material").first()
+            )
+        assert mat_type is not None
+        schema = _normalize_schema(mat_type.schema_def)
+        names = {p.get("name") for p in schema}
+        assert "allowable_bending_stress_mpa" in names, f"Missing field in {names}"
+        assert "youngs_modulus_gpa" in names, f"Missing field in {names}"
+
+    def test_existing_material_rows_still_valid(self, client_and_db):
+        """3D-print material rows (density only, no σ_allow) stay valid."""
+        _, session_factory = client_and_db
+        from app.models.component import ComponentModel
+
+        with session_factory() as db:
+            # Create a 3D-print-only material
+            mat = ComponentModel(
+                name="PLA Test",
+                component_type="material",
+                specs={"density_kg_m3": 1240.0},
+            )
+            db.add(mat)
+            db.commit()
+            db.refresh(mat)
+
+            loaded = db.query(ComponentModel).filter(ComponentModel.name == "PLA Test").first()
+        assert loaded is not None
+        assert loaded.specs["density_kg_m3"] == pytest.approx(1240.0)
+        # No allowable_bending_stress_mpa → should be absent, not error
+        assert "allowable_bending_stress_mpa" not in loaded.specs
+
+
+# ---------------------------------------------------------------------------
+# analyze_airplane_spanwise_loads_with_sizing service tests
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeSpanwiseLoadsWithSizing:
+    """Cover the spar-sizing orchestration layer on the fast CI tier."""
+
+    def _make_resolved_op(self):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            velocity=30.0,
+            alpha=2.0,
+            beta=0.0,
+            p=0.0,
+            q=0.0,
+            r=0.0,
+            altitude=0.0,
+            xyz_ref=[0.0, 0.0, 0.0],
+        )
+
+    def test_no_spar_params_returns_spanwise_response(self, plane_id, op):
+        """Without spar params, returns plain SpanwiseLoadsResponse."""
+        import sys
+        from app.services import analysis_service
+
+        canned_result = {
+            "surfaces": [
+                {
+                    "surface_name": "main_wing",
+                    "strips": [
+                        {"Yle": 0.5, "Area": 0.1, "cl": 100.0, "Chord": 0.3},
+                        {"Yle": -0.5, "Area": 0.1, "cl": 100.0, "Chord": 0.3},
+                    ],
+                }
+            ],
+        }
+        resolved = self._make_resolved_op()
+        asb_mock = MagicMock()
+        asb_mock.Atmosphere.return_value.density.return_value = 1.225
+
+        with (
+            patch.dict(sys.modules, {"aerosandbox": asb_mock}),
+            patch.object(analysis_service, "get_aeroplane_or_raise", return_value=MagicMock(id=1)),
+            patch.object(
+                analysis_service, "get_aeroplane_schema_or_raise", return_value=MagicMock()
+            ),
+            patch.object(
+                analysis_service.operating_point_resolver,
+                "resolve_operating_point",
+                return_value=resolved,
+            ),
+            patch.object(
+                analysis_service, "aeroplane_schema_to_asb_airplane_async", return_value=MagicMock()
+            ),
+            patch(
+                "app.services.vlm_strip_forces.compute_vlm_strip_forces", return_value=canned_result
+            ),
+        ):
+            result = asyncio.run(
+                analysis_service.analyze_airplane_spanwise_loads(
+                    db=MagicMock(),
+                    aeroplane_uuid=plane_id,
+                    operating_point=op,
+                    solver="vlm",
+                )
+            )
+
+        assert isinstance(result, SpanwiseLoadsResponse)
+
+    def test_with_spar_params_returns_extended_response(self, plane_id, op):
+        """With spar params, returns SpanwiseLoadsWithSizingResponse."""
+        import sys
+        from app.services import analysis_service
+        from app.schemas.spanwise_loads import SpanwiseLoadsWithSizingResponse
+
+        canned_result = {
+            "surfaces": [
+                {
+                    "surface_name": "main_wing",
+                    "strips": [
+                        {"Yle": 0.5, "Area": 0.1, "cl": 100.0, "Chord": 0.3},
+                    ],
+                }
+            ],
+        }
+        resolved = self._make_resolved_op()
+        asb_mock = MagicMock()
+        asb_mock.Atmosphere.return_value.density.return_value = 1.225
+
+        # Mock the DB to return a material with the real specs keys
+        mock_db = MagicMock()
+        mock_material = MagicMock()
+        mock_material.name = "Carbon Fiber (structural)"
+        mock_material.specs = {
+            "density_kg_m3": 1600.0,
+            "allowable_bending_stress_mpa": 500.0,
+            "youngs_modulus_gpa": 120.0,
+        }
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_material
+
+        spar_params = SparSizingParams(material_id=1, shape="rectangular")
+
+        with (
+            patch.dict(sys.modules, {"aerosandbox": asb_mock}),
+            patch.object(analysis_service, "get_aeroplane_or_raise", return_value=MagicMock(id=1)),
+            patch.object(
+                analysis_service, "get_aeroplane_schema_or_raise", return_value=MagicMock()
+            ),
+            patch.object(
+                analysis_service.operating_point_resolver,
+                "resolve_operating_point",
+                return_value=resolved,
+            ),
+            patch.object(
+                analysis_service, "aeroplane_schema_to_asb_airplane_async", return_value=MagicMock()
+            ),
+            patch(
+                "app.services.vlm_strip_forces.compute_vlm_strip_forces", return_value=canned_result
+            ),
+            patch(
+                "app.services.design_assumptions_service.get_effective_assumption", return_value=3.0
+            ),
+        ):
+            result = asyncio.run(
+                analysis_service.analyze_airplane_spanwise_loads(
+                    db=mock_db,
+                    aeroplane_uuid=plane_id,
+                    operating_point=op,
+                    solver="vlm",
+                    spar_params=spar_params,
+                )
+            )
+
+        assert isinstance(result, SpanwiseLoadsWithSizingResponse)
+        assert result.spar_sizing is not None
+        assert len(result.spar_sizing) >= 1
+        assert result.spar_sizing[0].material_name == "Carbon Fiber (structural)"
+
+    def test_material_not_found_raises_422(self, plane_id, op):
+        """When material_id not in DB → raises ValidationError."""
+        import sys
+        from app.services import analysis_service
+        from app.core.exceptions import ValidationError
+
+        canned_result = {
+            "surfaces": [
+                {
+                    "surface_name": "main_wing",
+                    "strips": [{"Yle": 0.5, "Area": 0.1, "cl": 100.0, "Chord": 0.3}],
+                }
+            ],
+        }
+        resolved = self._make_resolved_op()
+        asb_mock = MagicMock()
+        asb_mock.Atmosphere.return_value.density.return_value = 1.225
+
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = None  # not found
+
+        spar_params = SparSizingParams(material_id=999, shape="tube")
+
+        with (
+            patch.dict(sys.modules, {"aerosandbox": asb_mock}),
+            patch.object(analysis_service, "get_aeroplane_or_raise", return_value=MagicMock(id=1)),
+            patch.object(
+                analysis_service, "get_aeroplane_schema_or_raise", return_value=MagicMock()
+            ),
+            patch.object(
+                analysis_service.operating_point_resolver,
+                "resolve_operating_point",
+                return_value=resolved,
+            ),
+            patch.object(
+                analysis_service, "aeroplane_schema_to_asb_airplane_async", return_value=MagicMock()
+            ),
+            patch(
+                "app.services.vlm_strip_forces.compute_vlm_strip_forces", return_value=canned_result
+            ),
+            patch(
+                "app.services.design_assumptions_service.get_effective_assumption", return_value=3.0
+            ),
+        ):
+            with pytest.raises((ValidationError, Exception)) as exc:
+                asyncio.run(
+                    analysis_service.analyze_airplane_spanwise_loads(
+                        db=mock_db,
+                        aeroplane_uuid=plane_id,
+                        operating_point=op,
+                        solver="vlm",
+                        spar_params=spar_params,
+                    )
+                )
+        # Material ID 999 not found → should raise ValidationError or similar
+        assert exc is not None
+
+    def test_g_limit_fallback_used_when_no_assumption(self, plane_id, op):
+        """When get_effective_assumption returns None → g_limit=3.0 fallback, warning set."""
+        import sys
+        from app.services import analysis_service
+        from app.schemas.spanwise_loads import SpanwiseLoadsWithSizingResponse
+
+        canned_result = {
+            "surfaces": [
+                {
+                    "surface_name": "main_wing",
+                    "strips": [{"Yle": 0.5, "Area": 0.1, "cl": 100.0, "Chord": 0.3}],
+                }
+            ],
+        }
+        resolved = self._make_resolved_op()
+        asb_mock = MagicMock()
+        asb_mock.Atmosphere.return_value.density.return_value = 1.225
+
+        mock_db = MagicMock()
+        mock_material = MagicMock()
+        mock_material.name = "Carbon Fiber (structural)"
+        mock_material.specs = {
+            "density_kg_m3": 1600.0,
+            "allowable_bending_stress_mpa": 500.0,
+        }
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_material
+
+        spar_params = SparSizingParams(material_id=1, shape="rectangular")
+
+        with (
+            patch.dict(sys.modules, {"aerosandbox": asb_mock}),
+            patch.object(analysis_service, "get_aeroplane_or_raise", return_value=MagicMock(id=1)),
+            patch.object(
+                analysis_service, "get_aeroplane_schema_or_raise", return_value=MagicMock()
+            ),
+            patch.object(
+                analysis_service.operating_point_resolver,
+                "resolve_operating_point",
+                return_value=resolved,
+            ),
+            patch.object(
+                analysis_service, "aeroplane_schema_to_asb_airplane_async", return_value=MagicMock()
+            ),
+            patch(
+                "app.services.vlm_strip_forces.compute_vlm_strip_forces", return_value=canned_result
+            ),
+            patch(
+                "app.services.design_assumptions_service.get_effective_assumption",
+                return_value=None,
+            ),
+        ):  # <-- no assumption row
+            result = asyncio.run(
+                analysis_service.analyze_airplane_spanwise_loads(
+                    db=mock_db,
+                    aeroplane_uuid=plane_id,
+                    operating_point=op,
+                    solver="vlm",
+                    spar_params=spar_params,
+                )
+            )
+
+        assert isinstance(result, SpanwiseLoadsWithSizingResponse)
+        assert result.spar_sizing[0].g_limit_fallback is True
+        assert result.spar_sizing[0].g_limit == pytest.approx(3.0)

--- a/app/tests/test_spar_sizing_service.py
+++ b/app/tests/test_spar_sizing_service.py
@@ -1,0 +1,560 @@
+"""gh-1008: Unit tests for the pure spar-sizing service.
+
+All tests run on the CI fast tier (no aerosandbox, no DB).
+The spar-sizing service is pure — it operates only on floats.
+
+Reference values are hand-computed from the kirch W-formula scan:
+  - Rectangular:  W = b·h²/6  → b = 6·W/h²
+  - Capped:       W = b(H³-h³)/(6H)  → h = (H³ - 6·H·W/b)^(1/3)
+  - Rod:          W = d³/10  → d = (10·W)^(1/3)
+  - Tube:         W = π(Da⁴-Di⁴)/(32·Da)  → Di = (Da⁴ - 32·W·Da/π)^(1/4)
+
+Units: all mm for dimensions, mm³ for W.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Section-modulus helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSectionModulus:
+    """section_modulus_* helpers — known inputs → known W (mm³)."""
+
+    def test_rectangular_known_value(self):
+        """b=20, h=40 → W = 20·40²/6 = 5333.33 mm³."""
+        from app.services.spar_sizing import section_modulus_rectangular
+
+        w = section_modulus_rectangular(b=20.0, h=40.0)
+        assert w == pytest.approx(20.0 * 40.0**2 / 6.0, rel=1e-6)
+
+    def test_capped_known_value(self):
+        """b=20, H=40, h=35 → W = 20·(40³-35³)/(6·40)."""
+        from app.services.spar_sizing import section_modulus_capped
+
+        b, H, h = 20.0, 40.0, 35.0
+        expected = b * (H**3 - h**3) / (6.0 * H)
+        assert section_modulus_capped(b=b, H=H, h=h) == pytest.approx(expected, rel=1e-6)
+
+    def test_rod_known_value(self):
+        """d=30 → W = 30³/10 = 2700 mm³."""
+        from app.services.spar_sizing import section_modulus_rod
+
+        assert section_modulus_rod(d=30.0) == pytest.approx(30.0**3 / 10.0, rel=1e-6)
+
+    def test_tube_known_value(self):
+        """Da=30, Di=24 → W = π(30⁴-24⁴)/(32·30)."""
+        from app.services.spar_sizing import section_modulus_tube
+
+        Da, Di = 30.0, 24.0
+        expected = math.pi * (Da**4 - Di**4) / (32.0 * Da)
+        assert section_modulus_tube(Da=Da, Di=Di) == pytest.approx(expected, rel=1e-6)
+
+    def test_tube_solid_limit(self):
+        """Di=0 (solid rod) → W = π·Da³/32."""
+        from app.services.spar_sizing import section_modulus_tube
+
+        Da = 30.0
+        # Solid: W = π·Da⁴/(32·Da) = π·Da³/32
+        expected = math.pi * Da**3 / 32.0
+        assert section_modulus_tube(Da=Da, Di=0.0) == pytest.approx(expected, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# required_section_modulus
+# ---------------------------------------------------------------------------
+
+
+class TestRequiredSectionModulus:
+    """erf_W = M_design / sigma_allow, with proper unit conversion."""
+
+    def test_basic(self):
+        """M=1000 N·m, σ=100 MPa → erf_W = 1000·1000 / 100 = 10000 mm³."""
+        from app.services.spar_sizing import required_section_modulus
+
+        # M is in N·m → N·mm = *1000; σ_allow in N/mm² (MPa)
+        # erf_W = M[N·m] * 1000 / σ[MPa] (mm³)
+        w = required_section_modulus(m_design_Nm=1000.0, sigma_allow_mpa=100.0)
+        assert w == pytest.approx(10_000.0, rel=1e-6)
+
+    def test_zero_moment(self):
+        from app.services.spar_sizing import required_section_modulus
+
+        assert required_section_modulus(m_design_Nm=0.0, sigma_allow_mpa=100.0) == pytest.approx(
+            0.0
+        )
+
+    def test_pine_values(self):
+        """M=100 N·m, σ=39 MPa (Pine) → erf_W = 100·1000/39 ≈ 2564.1 mm³."""
+        from app.services.spar_sizing import required_section_modulus
+
+        w = required_section_modulus(m_design_Nm=100.0, sigma_allow_mpa=39.0)
+        assert w == pytest.approx(100.0 * 1000.0 / 39.0, rel=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# solve_dimension — Rectangular
+# ---------------------------------------------------------------------------
+
+
+class TestSolveDimensionRectangular:
+    """h = outer, solve b = 6·erf_W / h²."""
+
+    def test_rectangular_feasible(self):
+        """erf_W=5000 mm³, outer=40 mm → b = 6·5000/1600 = 18.75 mm."""
+        from app.services.spar_sizing import solve_dimension
+
+        result = solve_dimension(shape="rectangular", erf_w=5000.0, outer_mm=40.0)
+        assert result["feasible"] is True
+        assert result["solved_mm"] == pytest.approx(6.0 * 5000.0 / 40.0**2, rel=1e-5)
+        assert "cross_section_area_mm2" in result
+
+    def test_rectangular_zero_erf_w(self):
+        """Zero required W → b ≈ 0, feasible (no moment → no stress)."""
+        from app.services.spar_sizing import solve_dimension
+
+        result = solve_dimension(shape="rectangular", erf_w=0.0, outer_mm=30.0)
+        assert result["feasible"] is True
+        assert result["solved_mm"] == pytest.approx(0.0, abs=1e-9)
+
+    def test_rectangular_cross_section_area(self):
+        """Cross-section area = b × h."""
+        from app.services.spar_sizing import solve_dimension
+
+        erf_w = 6000.0
+        outer = 40.0
+        result = solve_dimension(shape="rectangular", erf_w=erf_w, outer_mm=outer)
+        b = result["solved_mm"]
+        expected_area = b * outer  # b × h
+        assert result["cross_section_area_mm2"] == pytest.approx(expected_area, rel=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# solve_dimension — Rod
+# ---------------------------------------------------------------------------
+
+
+class TestSolveDimensionRod:
+    """d = (10·erf_W)^(1/3); feasible if d ≤ outer."""
+
+    def test_rod_feasible(self):
+        """erf_W=1000 mm³, outer=50 mm → d = (10·1000)^(1/3) = 21.54 mm ≤ 50 → feasible."""
+        from app.services.spar_sizing import solve_dimension
+
+        result = solve_dimension(shape="rod", erf_w=1000.0, outer_mm=50.0)
+        expected_d = (10.0 * 1000.0) ** (1.0 / 3.0)
+        assert result["feasible"] is True
+        assert result["solved_mm"] == pytest.approx(expected_d, rel=1e-5)
+
+    def test_rod_too_big(self):
+        """erf_W=100000 mm³, outer=20 mm → d ≫ 20 → infeasible."""
+        from app.services.spar_sizing import solve_dimension
+
+        result = solve_dimension(shape="rod", erf_w=100_000.0, outer_mm=20.0)
+        assert result["feasible"] is False
+        assert result["infeasibility_reason"] is not None
+        assert (
+            "too big" in result["infeasibility_reason"].lower()
+            or "rod" in result["infeasibility_reason"].lower()
+        )
+
+    def test_rod_exactly_at_limit(self):
+        """d exactly == outer → feasible (edge case)."""
+        from app.services.spar_sizing import solve_dimension
+
+        outer = 30.0
+        # erf_W = d³/10 = 30³/10 = 2700
+        erf_w = outer**3 / 10.0
+        result = solve_dimension(shape="rod", erf_w=erf_w, outer_mm=outer)
+        assert result["feasible"] is True
+        assert result["solved_mm"] == pytest.approx(outer, rel=1e-5)
+
+    def test_rod_cross_section_area_feasible(self):
+        """Area = π·d²/4 when feasible."""
+        from app.services.spar_sizing import solve_dimension
+
+        result = solve_dimension(shape="rod", erf_w=1000.0, outer_mm=50.0)
+        d = result["solved_mm"]
+        assert result["cross_section_area_mm2"] == pytest.approx(math.pi * d**2 / 4.0, rel=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# solve_dimension — Tube
+# ---------------------------------------------------------------------------
+
+
+class TestSolveDimensionTube:
+    """Da = outer; Di = (Da⁴ - 32·erf_W·Da/π)^(1/4); wall = (Da-Di)/2."""
+
+    def test_tube_feasible(self):
+        """Da=30, erf_W=1000 → Di and wall computed correctly."""
+        from app.services.spar_sizing import solve_dimension
+
+        Da = 30.0
+        erf_w = 1000.0
+        under_radical = Da**4 - 32.0 * erf_w * Da / math.pi
+        Di_expected = under_radical ** (1.0 / 4.0)
+        wall_expected = (Da - Di_expected) / 2.0
+
+        result = solve_dimension(shape="tube", erf_w=erf_w, outer_mm=Da)
+        assert result["feasible"] is True
+        assert result["solved_mm"] == pytest.approx(wall_expected, rel=1e-5)
+        assert result.get("inner_mm") == pytest.approx(Di_expected, rel=1e-5)
+
+    def test_tube_solid_needed(self):
+        """When 32·erf_W·Da/π >= Da⁴ → Di imaginary → solid needed."""
+        from app.services.spar_sizing import solve_dimension
+
+        # Tiny Da, huge erf_W
+        result = solve_dimension(shape="tube", erf_w=1_000_000.0, outer_mm=10.0)
+        assert result["feasible"] is False
+        assert "solid" in result["infeasibility_reason"].lower()
+
+    def test_tube_area_is_annular(self):
+        """Area = π(Da²-Di²)/4."""
+        from app.services.spar_sizing import solve_dimension
+
+        Da = 40.0
+        result = solve_dimension(shape="tube", erf_w=2000.0, outer_mm=Da)
+        if result["feasible"]:
+            Di = result["inner_mm"]
+            expected = math.pi * (Da**2 - Di**2) / 4.0
+            assert result["cross_section_area_mm2"] == pytest.approx(expected, rel=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# solve_dimension — Capped
+# ---------------------------------------------------------------------------
+
+
+class TestSolveDimensionCapped:
+    """H = outer; h = (H³ - 6·H·erf_W/b)^(1/3); gurt = (H-h)/2."""
+
+    def test_capped_feasible(self):
+        """H=40, b=20, erf_W=2000 → h = (64000 - 6·40·2000/20)^(1/3)."""
+        from app.services.spar_sizing import solve_dimension
+
+        H, b, erf_w = 40.0, 20.0, 2000.0
+        inner = H**3 - 6.0 * H * erf_w / b
+        h_expected = inner ** (1.0 / 3.0)
+        gurt_expected = (H - h_expected) / 2.0
+
+        result = solve_dimension(shape="capped", erf_w=erf_w, outer_mm=H, cap_width_mm=b)
+        assert result["feasible"] is True
+        assert result["solved_mm"] == pytest.approx(gurt_expected, rel=1e-4)
+
+    def test_capped_infeasible(self):
+        """When H³ < 6·H·erf_W/b → infeasible."""
+        from app.services.spar_sizing import solve_dimension
+
+        # H=10, b=5, erf_W=1000000 → H³=1000, 6·10·1000000/5=12000000 → infeasible
+        result = solve_dimension(shape="capped", erf_w=1_000_000.0, outer_mm=10.0, cap_width_mm=5.0)
+        assert result["feasible"] is False
+        assert result["infeasibility_reason"] is not None
+
+    def test_capped_requires_cap_width(self):
+        """ValueError when cap_width_mm is None for capped shape."""
+        from app.services.spar_sizing import solve_dimension
+
+        with pytest.raises((ValueError, TypeError)):
+            solve_dimension(shape="capped", erf_w=1000.0, outer_mm=40.0, cap_width_mm=None)
+
+    def test_capped_cross_section_area(self):
+        """Cross-section = b(H-h) + b·h is full rectangle minus inner rectangle.
+        Actually: area = b·H - b·h = b·(H-h) for flanges only model.
+        Spec §4 is W for upper+lower flanges of width b each.
+        We use: area ≈ 2·b·gurt (two flanges).
+        """
+        from app.services.spar_sizing import solve_dimension
+
+        H, b, erf_w = 40.0, 20.0, 2000.0
+        result = solve_dimension(shape="capped", erf_w=erf_w, outer_mm=H, cap_width_mm=b)
+        if result["feasible"]:
+            gurt = result["solved_mm"]
+            expected = 2.0 * b * gurt  # two flanges
+            assert result["cross_section_area_mm2"] == pytest.approx(expected, rel=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# compute_spar_sizing — integration test (pure, no DB/aero)
+# ---------------------------------------------------------------------------
+
+
+def _make_material_specs(
+    density_kg_m3: float = 1600.0,
+    allowable_bending_stress_mpa: float = 500.0,
+    youngs_modulus_gpa: float = 120.0,
+) -> dict[str, Any]:
+    """Build a material specs dict using the REAL ComponentRead.specs keys."""
+    return {
+        "density_kg_m3": density_kg_m3,
+        "allowable_bending_stress_mpa": allowable_bending_stress_mpa,
+        "youngs_modulus_gpa": youngs_modulus_gpa,
+    }
+
+
+def _make_component_read(
+    id: int = 1,
+    name: str = "Carbon Fiber",
+    density_kg_m3: float = 1600.0,
+    allowable_bending_stress_mpa: float = 500.0,
+) -> dict[str, Any]:
+    """Minimal ComponentRead-compatible dict (real schema keys from app/schemas/component.py)."""
+    return {
+        "id": id,
+        "name": name,
+        "component_type": "material",
+        "manufacturer": None,
+        "description": None,
+        "mass_g": None,
+        "bbox_x_mm": None,
+        "bbox_y_mm": None,
+        "bbox_z_mm": None,
+        "model_ref": None,
+        "specs": _make_material_specs(density_kg_m3, allowable_bending_stress_mpa),
+        "created_at": "2025-01-01T00:00:00",
+        "updated_at": "2025-01-01T00:00:00",
+    }
+
+
+class TestComputeSparSizing:
+    """Integration test for compute_spar_sizing — pure, no aero/DB deps."""
+
+    def _make_stations(self) -> list[dict[str, Any]]:
+        """Three stations: tip, mid, root — simplified for testing."""
+        return [
+            # Outboard (tip, low M)
+            {"y_m": 2.0, "chord_m": 0.2, "bending_moment_Nm": 100.0},
+            # Mid
+            {"y_m": 1.0, "chord_m": 0.3, "bending_moment_Nm": 500.0},
+            # Root
+            {"y_m": 0.0, "chord_m": 0.4, "bending_moment_Nm": 1000.0},
+        ]
+
+    def test_tube_sizing_feasible(self):
+        """Tube spar sizing with parameters that produce a feasible tube at root.
+
+        Large chord (0.5 m, t/c=0.15 → outer=60 mm) + low moment (100 N·m) + CF
+        ensures the tube is feasible: Da⁴ > 32·erf_W·Da/π.
+        """
+        from app.services.spar_sizing import compute_spar_sizing
+        from app.schemas.spar_sizing import SparSizingParams
+
+        params = SparSizingParams(
+            material_id=1,
+            shape="tube",
+            safety_factor_j=1.5,
+            packing_factor=0.8,
+        )
+        # Stations where tube IS feasible: large chord, low moment, thick profile
+        stations = [
+            {"y_m": 1.0, "chord_m": 0.4, "bending_moment_Nm": 50.0},  # outer=48 mm
+            {"y_m": 0.0, "chord_m": 0.5, "bending_moment_Nm": 100.0},  # outer=60 mm
+        ]
+        tc_by_y = {1.0: 0.15, 0.0: 0.15}
+        material_specs = _make_material_specs()  # CF σ=500
+        material_name = "Carbon Fiber"
+        g_limit = 3.0
+        g_limit_fallback = False
+
+        result = compute_spar_sizing(
+            stations=stations,
+            tc_by_y=tc_by_y,
+            material_specs=material_specs,
+            material_name=material_name,
+            params=params,
+            g_limit=g_limit,
+            g_limit_fallback=g_limit_fallback,
+            surface_name="main_wing",
+        )
+
+        assert result.shape == "tube"
+        assert result.material_name == "Carbon Fiber"
+        assert result.g_limit == pytest.approx(3.0)
+        assert result.g_limit_fallback is False
+        assert len(result.stations) == 2
+        assert result.root_station.y_m == pytest.approx(0.0)
+        assert result.root_station.m_design_Nm == pytest.approx(100.0 * 3.0 * 1.5)
+        # Root station must be feasible with these parameters
+        assert result.root_station.feasible is True
+        # Mass should be positive (at least root station has area)
+        assert result.spar_mass_half_kg > 0
+        assert result.spar_mass_full_kg == pytest.approx(result.spar_mass_half_kg * 2.0, rel=1e-6)
+
+    def test_rectangular_root_station(self):
+        """Root station must produce the right required_W."""
+        from app.services.spar_sizing import compute_spar_sizing
+        from app.schemas.spar_sizing import SparSizingParams
+
+        params = SparSizingParams(
+            material_id=1,
+            shape="rectangular",
+            safety_factor_j=1.5,
+            packing_factor=0.8,
+        )
+        stations = [{"y_m": 0.0, "chord_m": 0.5, "bending_moment_Nm": 2000.0}]
+        tc_by_y = {0.0: 0.15}
+        material_specs = _make_material_specs(
+            density_kg_m3=500.0, allowable_bending_stress_mpa=39.0
+        )
+
+        result = compute_spar_sizing(
+            stations=stations,
+            tc_by_y=tc_by_y,
+            material_specs=material_specs,
+            material_name="Pine",
+            params=params,
+            g_limit=3.0,
+            g_limit_fallback=False,
+            surface_name="main_wing",
+        )
+
+        # M_design = 2000 · 3.0 · 1.5 = 9000 N·m
+        # erf_W = 9000·1000 / 39 = 230769.2 mm³
+        assert result.root_station.m_design_Nm == pytest.approx(9000.0, rel=1e-5)
+        assert result.root_station.required_W_mm3 == pytest.approx(9000.0 * 1000.0 / 39.0, rel=1e-4)
+        # outer = chord · tc · packing = 500 · 0.15 · 0.8 = 60 mm
+        assert result.root_station.outer_mm == pytest.approx(60.0, rel=1e-5)
+
+    def test_tc_fallback_applied_with_warning(self):
+        """When tc_by_y doesn't contain a station y, t/c=0.12 fallback fires."""
+        from app.services.spar_sizing import compute_spar_sizing
+        from app.schemas.spar_sizing import SparSizingParams
+
+        params = SparSizingParams(material_id=1, shape="rod")
+        stations = [{"y_m": 1.5, "chord_m": 0.3, "bending_moment_Nm": 100.0}]
+        # tc_by_y is empty → fallback
+        result = compute_spar_sizing(
+            stations=stations,
+            tc_by_y={},
+            material_specs=_make_material_specs(),
+            material_name="CF",
+            params=params,
+            g_limit=4.0,
+            g_limit_fallback=False,
+            surface_name="main_wing",
+        )
+
+        assert result.stations[0].tc_fallback is True
+        assert result.stations[0].tc_ratio == pytest.approx(0.12)
+        assert result.tc_fallback_warning is not None
+        assert (
+            "1.5" in result.tc_fallback_warning or "fallback" in result.tc_fallback_warning.lower()
+        )
+
+    def test_g_limit_fallback_propagated(self):
+        from app.services.spar_sizing import compute_spar_sizing
+        from app.schemas.spar_sizing import SparSizingParams
+
+        params = SparSizingParams(material_id=1, shape="rectangular")
+        stations = [{"y_m": 0.0, "chord_m": 0.3, "bending_moment_Nm": 500.0}]
+        result = compute_spar_sizing(
+            stations=stations,
+            tc_by_y={0.0: 0.12},
+            material_specs=_make_material_specs(),
+            material_name="CF",
+            params=params,
+            g_limit=3.0,
+            g_limit_fallback=True,  # <-- fallback
+            surface_name="main_wing",
+        )
+        assert result.g_limit_fallback is True
+
+    def test_sigma_override_used_over_material(self):
+        """When sigma_allow_mpa_override is set, it overrides material's value."""
+        from app.services.spar_sizing import compute_spar_sizing
+        from app.schemas.spar_sizing import SparSizingParams
+
+        # Material has σ=500, but override is 200
+        params = SparSizingParams(
+            material_id=1,
+            shape="rectangular",
+            sigma_allow_mpa_override=200.0,
+        )
+        stations = [{"y_m": 0.0, "chord_m": 0.3, "bending_moment_Nm": 500.0}]
+        result = compute_spar_sizing(
+            stations=stations,
+            tc_by_y={0.0: 0.12},
+            material_specs=_make_material_specs(allowable_bending_stress_mpa=500.0),
+            material_name="CF",
+            params=params,
+            g_limit=3.0,
+            g_limit_fallback=False,
+            surface_name="main_wing",
+        )
+        assert result.sigma_allow_mpa == pytest.approx(200.0)
+        # erf_W at root with override
+        m_design = 500.0 * 3.0 * 1.5
+        expected_erf_w = m_design * 1000.0 / 200.0
+        assert result.root_station.required_W_mm3 == pytest.approx(expected_erf_w, rel=1e-4)
+
+    def test_uses_max_abs_bending_moment(self):
+        """The service should handle |M| (absolute value used for M_design)."""
+        from app.services.spar_sizing import compute_spar_sizing
+        from app.schemas.spar_sizing import SparSizingParams
+
+        params = SparSizingParams(material_id=1, shape="rectangular")
+        # bending_moment_Nm is negative (port side convention)
+        stations = [{"y_m": 0.0, "chord_m": 0.3, "bending_moment_Nm": -800.0}]
+        result = compute_spar_sizing(
+            stations=stations,
+            tc_by_y={0.0: 0.12},
+            material_specs=_make_material_specs(),
+            material_name="CF",
+            params=params,
+            g_limit=3.0,
+            g_limit_fallback=False,
+            surface_name="main_wing",
+        )
+        # M_design must use |M|
+        assert result.root_station.m_design_Nm == pytest.approx(abs(-800.0) * 3.0 * 1.5, rel=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# spar_mass estimation
+# ---------------------------------------------------------------------------
+
+
+class TestSparMass:
+    """spar_mass trapezoidal integration."""
+
+    def test_constant_section_mass(self):
+        """Uniform cross-section along span → mass = density · area · span."""
+        from app.services.spar_sizing import spar_mass_half_kg
+
+        # 3 stations equally spaced at y=0,1,2 m, area=100 mm² each
+        ys = [2.0, 1.0, 0.0]  # outboard first (tip to root order matches stations list)
+        areas = [100.0, 100.0, 100.0]  # mm²
+        density = 1600.0  # kg/m³
+
+        # span = 2 m, area = 100 mm² = 100e-6 m²
+        # mass = density · area · span = 1600 · 100e-6 · 2 = 0.32 kg
+        mass = spar_mass_half_kg(ys_m=ys, areas_mm2=areas, density_kg_m3=density)
+        assert mass == pytest.approx(0.32, rel=1e-4)
+
+    def test_tapered_section(self):
+        """Two stations: tip area=50, root area=200, span=1 m → trapezoidal."""
+        from app.services.spar_sizing import spar_mass_half_kg
+
+        ys = [1.0, 0.0]
+        areas = [50.0, 200.0]
+        density = 1000.0
+
+        # avg area = (50+200)/2 = 125 mm², span = 1 m, area in m² = 125e-6
+        # mass = 1000 · 125e-6 · 1 = 0.125 kg
+        mass = spar_mass_half_kg(ys_m=ys, areas_mm2=areas, density_kg_m3=density)
+        assert mass == pytest.approx(0.125, rel=1e-4)
+
+    def test_zero_span(self):
+        """Single station → no span → mass = 0."""
+        from app.services.spar_sizing import spar_mass_half_kg
+
+        mass = spar_mass_half_kg(ys_m=[0.0], areas_mm2=[100.0], density_kg_m3=1600.0)
+        assert mass == pytest.approx(0.0)

--- a/app/tests/test_spar_sizing_service.py
+++ b/app/tests/test_spar_sizing_service.py
@@ -98,6 +98,16 @@ class TestRequiredSectionModulus:
         w = required_section_modulus(m_design_Nm=100.0, sigma_allow_mpa=39.0)
         assert w == pytest.approx(100.0 * 1000.0 / 39.0, rel=1e-5)
 
+    def test_zero_sigma_raises_not_divides_by_zero(self):
+        """σ_allow=0 (the material schema permits min=0) must raise ValueError,
+        not ZeroDivisionError → caller maps to a 422 (gh-1008 review)."""
+        from app.services.spar_sizing import required_section_modulus
+
+        with pytest.raises(ValueError, match="sigma_allow must be positive"):
+            required_section_modulus(m_design_Nm=100.0, sigma_allow_mpa=0.0)
+        with pytest.raises(ValueError):
+            required_section_modulus(m_design_Nm=100.0, sigma_allow_mpa=-5.0)
+
 
 # ---------------------------------------------------------------------------
 # solve_dimension — Rectangular

--- a/frontend/__tests__/SpanwiseLoadsTabContent.test.tsx
+++ b/frontend/__tests__/SpanwiseLoadsTabContent.test.tsx
@@ -70,6 +70,7 @@ vi.mock("plotly.js-gl3d-dist-min", () => ({
 function makeLoads(overrides: Partial<SpanwiseLoadsResult> = {}): SpanwiseLoadsResult {
   return {
     alpha: 2.0,
+    beta: 0.0,
     velocity_mps: 30.0,
     altitude_m: 0.0,
     dynamic_pressure_Pa: 551.25,

--- a/frontend/__tests__/SpanwiseLoadsTabContent.test.tsx
+++ b/frontend/__tests__/SpanwiseLoadsTabContent.test.tsx
@@ -33,8 +33,31 @@ vi.mock("lucide-react", () => {
     RefreshCw: icon,
     Square: icon,
     ArrowLeftRight: icon,
+    // gh-1008: SparSizingPanel uses these icons
+    ChevronDown: icon,
+    ChevronRight: icon,
   };
 });
+
+// gh-1008: Mock useSparSizing and SparSizingPanel so existing tests don't need
+// to deal with the spar-sizing hook and component tree.
+vi.mock("@/hooks/useSparSizing", () => ({
+  useSparSizing: () => ({
+    result: null,
+    isRunning: false,
+    error: null,
+    run: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useComponents", () => ({
+  useComponents: () => ({ components: [], total: 0, error: null, isLoading: false, mutate: vi.fn() }),
+}));
+
+vi.mock("@/components/workbench/SparSizingPanel", () => ({
+  SparSizingPanel: () => React.createElement("div", { "data-testid": "spar-sizing-panel-stub" }),
+  toSizingParams: () => null,
+}));
 
 const plotlyReact = vi.fn().mockResolvedValue(undefined);
 const plotlyPurge = vi.fn();

--- a/frontend/__tests__/SparSizingPanel.test.tsx
+++ b/frontend/__tests__/SparSizingPanel.test.tsx
@@ -1,0 +1,268 @@
+// frontend/__tests__/SparSizingPanel.test.tsx
+// gh-1008: Unit tests for the SparSizingPanel component.
+// Tests the pure UI logic: collapse/expand, material dropdown (mocked),
+// shape-adaptive inputs, feasibility flags, g_limit warning.
+
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SparSizingPanel } from "@/components/workbench/SparSizingPanel";
+import type { SparSizingResult, SparSizingStation } from "@/hooks/useSparSizing";
+import type { SparSizingPanelProps } from "@/components/workbench/SparSizingPanel";
+
+// Mock useComponents so tests don't need a real API
+vi.mock("@/hooks/useComponents", () => ({
+  useComponents: () => ({
+    components: [
+      {
+        id: 1,
+        name: "Carbon Fiber (structural)",
+        component_type: "material",
+        manufacturer: null,
+        description: null,
+        mass_g: null,
+        bbox_x_mm: null,
+        bbox_y_mm: null,
+        bbox_z_mm: null,
+        model_ref: null,
+        specs: {
+          density_kg_m3: 1600,
+          allowable_bending_stress_mpa: 500,
+          youngs_modulus_gpa: 120,
+        },
+        created_at: "2025-01-01T00:00:00",
+        updated_at: "2025-01-01T00:00:00",
+      },
+      {
+        id: 2,
+        name: "Pine (structural)",
+        component_type: "material",
+        manufacturer: null,
+        description: null,
+        mass_g: null,
+        bbox_x_mm: null,
+        bbox_y_mm: null,
+        bbox_z_mm: null,
+        model_ref: null,
+        specs: {
+          density_kg_m3: 500,
+          allowable_bending_stress_mpa: 39,
+          youngs_modulus_gpa: 11,
+        },
+        created_at: "2025-01-01T00:00:00",
+        updated_at: "2025-01-01T00:00:00",
+      },
+      {
+        id: 3,
+        name: "PLA (3D print)",
+        component_type: "material",
+        manufacturer: null,
+        description: null,
+        mass_g: null,
+        bbox_x_mm: null,
+        bbox_y_mm: null,
+        bbox_z_mm: null,
+        model_ref: null,
+        specs: { density_kg_m3: 1240 }, // no σ_allow → should NOT appear
+        created_at: "2025-01-01T00:00:00",
+        updated_at: "2025-01-01T00:00:00",
+      },
+    ],
+    total: 3,
+    error: null,
+    isLoading: false,
+    mutate: vi.fn(),
+  }),
+}));
+
+// ---- Fixtures --------------------------------------------------------------
+
+function makeStation(overrides: Partial<SparSizingStation> = {}): SparSizingStation {
+  return {
+    y_m: 0.0,
+    chord_m: 0.4,
+    profile_thickness_mm: 48.0,
+    outer_mm: 38.4,
+    tc_ratio: 0.12,
+    tc_fallback: false,
+    m_design_Nm: 4500.0,
+    required_W_mm3: 9000.0,
+    solved_mm: 2.5,
+    feasible: true,
+    infeasibility_reason: null,
+    cross_section_area_mm2: 120.0,
+    ...overrides,
+  };
+}
+
+function makeResult(overrides: Partial<SparSizingResult> = {}): SparSizingResult {
+  const st = makeStation();
+  return {
+    surface_name: "main_wing",
+    shape: "tube",
+    material_name: "Carbon Fiber (structural)",
+    sigma_allow_mpa: 500,
+    density_kg_m3: 1600,
+    g_limit: 4.0,
+    g_limit_fallback: false,
+    safety_factor_j: 1.5,
+    packing_factor: 0.8,
+    stations: [st],
+    root_station: st,
+    spar_mass_half_kg: 0.045,
+    spar_mass_full_kg: 0.09,
+    tc_fallback_warning: null,
+    ...overrides,
+  };
+}
+
+function renderPanel(props: Partial<SparSizingPanelProps> = {}) {
+  const onCompute = vi.fn();
+  render(
+    <SparSizingPanel
+      sizingResults={null}
+      isRunning={false}
+      error={null}
+      onCompute={onCompute}
+      {...props}
+    />,
+  );
+  return { onCompute };
+}
+
+// ---- Tests -----------------------------------------------------------------
+
+describe("SparSizingPanel", () => {
+  it("renders collapsed by default", () => {
+    renderPanel();
+    expect(screen.getByText("Spar Sizing")).toBeInTheDocument();
+    expect(screen.queryByTestId("spar-material-select")).not.toBeInTheDocument();
+  });
+
+  it("expands when header is clicked", async () => {
+    renderPanel();
+    fireEvent.click(screen.getByTestId("spar-sizing-toggle"));
+    await waitFor(() => {
+      expect(screen.getByTestId("spar-material-select")).toBeInTheDocument();
+    });
+  });
+
+  it("shows only structural materials (with σ_allow) in dropdown", async () => {
+    renderPanel();
+    fireEvent.click(screen.getByTestId("spar-sizing-toggle"));
+    await waitFor(() => {
+      expect(screen.getByTestId("spar-material-select")).toBeInTheDocument();
+    });
+    const select = screen.getByTestId("spar-material-select") as HTMLSelectElement;
+    const options = Array.from(select.options).map((o) => o.text);
+    expect(options).toContain("Carbon Fiber (structural)");
+    expect(options).toContain("Pine (structural)");
+    // PLA has no σ_allow → must NOT appear
+    expect(options).not.toContain("PLA (3D print)");
+  });
+
+  it("auto-fills σ_allow when material is selected", async () => {
+    renderPanel();
+    fireEvent.click(screen.getByTestId("spar-sizing-toggle"));
+    await waitFor(() => screen.getByTestId("spar-material-select"));
+
+    const select = screen.getByTestId("spar-material-select");
+    fireEvent.change(select, { target: { value: "1" } }); // Carbon Fiber id=1
+
+    const sigmaInput = screen.getByTestId("spar-sigma-input") as HTMLInputElement;
+    expect(sigmaInput.value).toBe("500");
+  });
+
+  it("shows cap width input only for capped shape", async () => {
+    renderPanel();
+    fireEvent.click(screen.getByTestId("spar-sizing-toggle"));
+    await waitFor(() => screen.getByTestId("spar-shape-select"));
+
+    // Default shape=tube → no cap width
+    expect(screen.queryByTestId("spar-capwidth-input")).not.toBeInTheDocument();
+
+    // Switch to capped
+    fireEvent.change(screen.getByTestId("spar-shape-select"), {
+      target: { value: "capped" },
+    });
+    expect(screen.getByTestId("spar-capwidth-input")).toBeInTheDocument();
+
+    // Switch to rod → cap width disappears
+    fireEvent.change(screen.getByTestId("spar-shape-select"), {
+      target: { value: "rod" },
+    });
+    expect(screen.queryByTestId("spar-capwidth-input")).not.toBeInTheDocument();
+  });
+
+  it("compute button is disabled when no material selected", async () => {
+    renderPanel();
+    fireEvent.click(screen.getByTestId("spar-sizing-toggle"));
+    await waitFor(() => screen.getByTestId("spar-compute-button"));
+    const btn = screen.getByTestId("spar-compute-button") as HTMLButtonElement;
+    expect(btn).toBeDisabled();
+  });
+
+  it("compute button enabled after material selected", async () => {
+    renderPanel();
+    fireEvent.click(screen.getByTestId("spar-sizing-toggle"));
+    await waitFor(() => screen.getByTestId("spar-material-select"));
+    fireEvent.change(screen.getByTestId("spar-material-select"), { target: { value: "1" } });
+    const btn = screen.getByTestId("spar-compute-button") as HTMLButtonElement;
+    expect(btn).not.toBeDisabled();
+  });
+
+  it("calls onCompute with inputs when button clicked", async () => {
+    const { onCompute } = renderPanel();
+    fireEvent.click(screen.getByTestId("spar-sizing-toggle"));
+    await waitFor(() => screen.getByTestId("spar-material-select"));
+    fireEvent.change(screen.getByTestId("spar-material-select"), { target: { value: "2" } }); // Pine
+    fireEvent.click(screen.getByTestId("spar-compute-button"));
+    expect(onCompute).toHaveBeenCalledOnce();
+    const [inputs] = onCompute.mock.calls[0];
+    expect(inputs.materialId).toBe(2);
+    expect(inputs.shape).toBe("tube");
+  });
+
+  it("shows error when error prop is set", async () => {
+    renderPanel({ error: "Material not found" });
+    fireEvent.click(screen.getByTestId("spar-sizing-toggle"));
+    await waitFor(() => screen.getByTestId("spar-error"));
+    expect(screen.getByTestId("spar-error")).toHaveTextContent("Material not found");
+  });
+
+  it("shows results when sizingResults provided", async () => {
+    const result = makeResult();
+    renderPanel({ sizingResults: [result] });
+    fireEvent.click(screen.getByTestId("spar-sizing-toggle"));
+    await waitFor(() => screen.getByTestId("spar-results"));
+    expect(screen.getByTestId("spar-results")).toBeInTheDocument();
+    // Should contain surface name
+    expect(screen.getByText("main_wing")).toBeInTheDocument();
+  });
+
+  it("shows g_limit fallback warning", async () => {
+    const result = makeResult({ g_limit: 3.0, g_limit_fallback: true });
+    renderPanel({ sizingResults: [result] });
+    fireEvent.click(screen.getByTestId("spar-sizing-toggle"));
+    await waitFor(() => screen.getByTestId("g-limit-fallback-warning"));
+    expect(screen.getByTestId("g-limit-fallback-warning")).toBeInTheDocument();
+    expect(screen.getByTestId("g-limit-fallback-warning")).toHaveTextContent("default");
+  });
+
+  it("shows tc fallback warning", async () => {
+    const result = makeResult({
+      tc_fallback_warning: "t/c=0.12 fallback applied at y=1.50 m",
+    });
+    renderPanel({ sizingResults: [result] });
+    fireEvent.click(screen.getByTestId("spar-sizing-toggle"));
+    await waitFor(() => screen.getByTestId("tc-fallback-warning"));
+    expect(screen.getByTestId("tc-fallback-warning")).toHaveTextContent("1.50");
+  });
+
+  it("displays 'Computing…' when isRunning", async () => {
+    renderPanel({ isRunning: true });
+    fireEvent.click(screen.getByTestId("spar-sizing-toggle"));
+    await waitFor(() => screen.getByTestId("spar-compute-button"));
+    expect(screen.getByTestId("spar-compute-button")).toHaveTextContent("Computing…");
+  });
+});

--- a/frontend/__tests__/SparSizingPanel.test.tsx
+++ b/frontend/__tests__/SparSizingPanel.test.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { SparSizingPanel } from "@/components/workbench/SparSizingPanel";
 import type { SparSizingResult, SparSizingStation } from "@/hooks/useSparSizing";
 import type { SparSizingPanelProps } from "@/components/workbench/SparSizingPanel";

--- a/frontend/__tests__/sparSizingHelpers.test.ts
+++ b/frontend/__tests__/sparSizingHelpers.test.ts
@@ -1,0 +1,257 @@
+// frontend/__tests__/sparSizingHelpers.test.ts
+// gh-1008: Unit tests for pure spar-sizing helper functions.
+// No DOM, no network — pure TypeScript logic.
+
+import { describe, it, expect } from "vitest";
+
+import {
+  filterStructuralMaterials,
+  getSigmaAllow,
+  getDensity,
+  solvedDimLabel,
+  feasibilityLabel,
+  allStationsFeasible,
+  buildRootHeadline,
+  buildMassSummary,
+  buildSizingAnnotationText,
+} from "@/lib/sparSizingHelpers";
+import type { Component } from "@/hooks/useComponents";
+import type { SparSizingResult, SparSizingStation } from "@/hooks/useSparSizing";
+
+// ---- Fixtures --------------------------------------------------------------
+
+function makeMaterial(
+  id: number,
+  name: string,
+  specs: Record<string, unknown> = {},
+): Component {
+  return {
+    id,
+    name,
+    component_type: "material",
+    manufacturer: null,
+    description: null,
+    mass_g: null,
+    bbox_x_mm: null,
+    bbox_y_mm: null,
+    bbox_z_mm: null,
+    model_ref: null,
+    specs,
+    created_at: "2025-01-01T00:00:00",
+    updated_at: "2025-01-01T00:00:00",
+  };
+}
+
+function makeStation(overrides: Partial<SparSizingStation> = {}): SparSizingStation {
+  return {
+    y_m: 0.0,
+    chord_m: 0.4,
+    profile_thickness_mm: 48.0,
+    outer_mm: 38.4,
+    tc_ratio: 0.12,
+    tc_fallback: false,
+    m_design_Nm: 4500.0,
+    required_W_mm3: 9000.0,
+    solved_mm: 2.5,
+    feasible: true,
+    infeasibility_reason: null,
+    cross_section_area_mm2: 120.0,
+    ...overrides,
+  };
+}
+
+function makeResult(overrides: Partial<SparSizingResult> = {}): SparSizingResult {
+  const st = makeStation();
+  return {
+    surface_name: "main_wing",
+    shape: "tube",
+    material_name: "Carbon Fiber (structural)",
+    sigma_allow_mpa: 500.0,
+    density_kg_m3: 1600.0,
+    g_limit: 4.0,
+    g_limit_fallback: false,
+    safety_factor_j: 1.5,
+    packing_factor: 0.8,
+    stations: [st],
+    root_station: st,
+    spar_mass_half_kg: 0.045,
+    spar_mass_full_kg: 0.09,
+    tc_fallback_warning: null,
+    ...overrides,
+  };
+}
+
+// ---- filterStructuralMaterials ---------------------------------------------
+
+describe("filterStructuralMaterials", () => {
+  it("returns only material components with allowable_bending_stress_mpa > 0", () => {
+    const components: Component[] = [
+      makeMaterial(1, "Carbon Fiber", {
+        density_kg_m3: 1600,
+        allowable_bending_stress_mpa: 500,
+      }),
+      makeMaterial(2, "PLA (3D print)", { density_kg_m3: 1240 }), // no σ_allow
+      makeMaterial(3, "Pine", {
+        density_kg_m3: 500,
+        allowable_bending_stress_mpa: 39,
+      }),
+      makeMaterial(4, "Servo", { torque_kg_cm: 5 }), // wrong type in specs (but type filter should catch it)
+    ];
+    // Override component_type for the servo
+    components[3].component_type = "servo";
+
+    const result = filterStructuralMaterials(components);
+    expect(result.map((c) => c.id)).toEqual([1, 3]);
+  });
+
+  it("excludes materials with allowable_bending_stress_mpa = 0", () => {
+    const comps = [
+      makeMaterial(1, "Bad", { density_kg_m3: 100, allowable_bending_stress_mpa: 0 }),
+    ];
+    expect(filterStructuralMaterials(comps)).toHaveLength(0);
+  });
+
+  it("returns empty array when no structural materials present", () => {
+    expect(filterStructuralMaterials([])).toHaveLength(0);
+    expect(
+      filterStructuralMaterials([makeMaterial(1, "PLA", { density_kg_m3: 1240 })]),
+    ).toHaveLength(0);
+  });
+});
+
+// ---- getSigmaAllow ---------------------------------------------------------
+
+describe("getSigmaAllow", () => {
+  it("returns the numeric value", () => {
+    const mat = makeMaterial(1, "CF", { allowable_bending_stress_mpa: 500 });
+    expect(getSigmaAllow(mat)).toBe(500);
+  });
+
+  it("returns null when field is missing", () => {
+    const mat = makeMaterial(1, "PLA", { density_kg_m3: 1240 });
+    expect(getSigmaAllow(mat)).toBeNull();
+  });
+
+  it("returns null when field is a string", () => {
+    const mat = makeMaterial(1, "Bad", { allowable_bending_stress_mpa: "500" });
+    expect(getSigmaAllow(mat)).toBeNull();
+  });
+});
+
+// ---- getDensity ------------------------------------------------------------
+
+describe("getDensity", () => {
+  it("returns numeric density", () => {
+    const mat = makeMaterial(1, "CF", { density_kg_m3: 1600 });
+    expect(getDensity(mat)).toBe(1600);
+  });
+
+  it("returns null when missing", () => {
+    expect(getDensity(makeMaterial(1, "x", {}))).toBeNull();
+  });
+});
+
+// ---- solvedDimLabel --------------------------------------------------------
+
+describe("solvedDimLabel", () => {
+  it.each([
+    ["tube", "Wall t (mm)"],
+    ["rod", "d (mm)"],
+    ["rectangular", "Width b (mm)"],
+    ["capped", "Gurt t (mm)"],
+  ] as const)("shape=%s → %s", (shape, expected) => {
+    expect(solvedDimLabel(shape)).toBe(expected);
+  });
+});
+
+// ---- feasibilityLabel ------------------------------------------------------
+
+describe("feasibilityLabel", () => {
+  it("returns 'OK' when feasible", () => {
+    expect(feasibilityLabel(makeStation({ feasible: true }))).toBe("OK");
+  });
+
+  it("returns infeasibility_reason when infeasible", () => {
+    const st = makeStation({ feasible: false, infeasibility_reason: "rod too big — d=42 mm" });
+    expect(feasibilityLabel(st)).toBe("rod too big — d=42 mm");
+  });
+
+  it("returns 'infeasible' fallback when no reason provided", () => {
+    const st = makeStation({ feasible: false, infeasibility_reason: null });
+    expect(feasibilityLabel(st)).toBe("infeasible");
+  });
+});
+
+// ---- allStationsFeasible ---------------------------------------------------
+
+describe("allStationsFeasible", () => {
+  it("returns true when all stations feasible", () => {
+    const result = makeResult({ stations: [makeStation(), makeStation()] });
+    expect(allStationsFeasible(result)).toBe(true);
+  });
+
+  it("returns false when any station infeasible", () => {
+    const result = makeResult({
+      stations: [makeStation(), makeStation({ feasible: false })],
+    });
+    expect(allStationsFeasible(result)).toBe(false);
+  });
+});
+
+// ---- buildRootHeadline -----------------------------------------------------
+
+describe("buildRootHeadline", () => {
+  it("contains M_design, required W, outer, and solved dim", () => {
+    const result = makeResult();
+    const text = buildRootHeadline(result);
+    expect(text).toContain("M_design");
+    expect(text).toContain("4500");
+    expect(text).toContain("Required W");
+    expect(text).toContain("9000");
+    expect(text).toContain("Outer");
+    expect(text).toContain("38.4");
+    expect(text).toContain("Wall t (mm)"); // shape=tube
+    expect(text).toContain("2.50"); // solved_mm
+  });
+
+  it("shows — for null solved_mm", () => {
+    const result = makeResult({
+      root_station: makeStation({ solved_mm: null, feasible: false }),
+    });
+    expect(buildRootHeadline(result)).toContain("—");
+  });
+});
+
+// ---- buildMassSummary ------------------------------------------------------
+
+describe("buildMassSummary", () => {
+  it("contains half and full mass", () => {
+    const result = makeResult({ spar_mass_half_kg: 0.045, spar_mass_full_kg: 0.09 });
+    const text = buildMassSummary(result);
+    expect(text).toContain("0.045");
+    expect(text).toContain("0.090");
+    expect(text.toLowerCase()).toContain("half");
+    expect(text.toLowerCase()).toContain("full");
+  });
+});
+
+// ---- buildSizingAnnotationText --------------------------------------------
+
+describe("buildSizingAnnotationText", () => {
+  it("contains material, shape, sigma, n, j, packing", () => {
+    const result = makeResult();
+    const text = buildSizingAnnotationText(result);
+    expect(text).toContain("Carbon Fiber");
+    expect(text).toContain("tube");
+    expect(text).toContain("500");
+    expect(text).toContain("1600");
+    expect(text).toContain("4.0"); // g_limit (toFixed(1) → "4.0")
+    expect(text).toContain("1.5"); // j
+    expect(text).toContain("0.8"); // packing
+  });
+
+  it("marks fallback g_limit with (default)", () => {
+    const result = makeResult({ g_limit: 3.0, g_limit_fallback: true });
+    expect(buildSizingAnnotationText(result)).toContain("(default)");
+  });
+});

--- a/frontend/__tests__/useSpanwiseLoads.test.ts
+++ b/frontend/__tests__/useSpanwiseLoads.test.ts
@@ -15,6 +15,7 @@ import {
 
 const FAKE_RESULT: SpanwiseLoadsResult = {
   alpha: 5.0,
+  beta: 0.0,
   velocity_mps: 20.0,
   altitude_m: 100.0,
   dynamic_pressure_Pa: 242.0,

--- a/frontend/__tests__/useSparSizing.test.ts
+++ b/frontend/__tests__/useSparSizing.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Unit tests for the useSparSizing hook (gh-1008).
+ *
+ * Mirrors useSpanwiseLoads: a manual fetch-based POST to
+ * /aeroplanes/{id}/spanwise_loads_with_sizing. Pins URL + query-string
+ * building for the sizing params (material_id, shape, and the optional
+ * safety_factor_j / packing_factor / sigma_allow_mpa_override / cap_width_mm),
+ * the operating-point request body, data passthrough, and the
+ * loading/error state machine.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import {
+  useSparSizing,
+  type SpanwiseLoadsWithSizingResult,
+  type SparSizingParams,
+} from "@/hooks/useSparSizing";
+
+const FAKE_RESULT: SpanwiseLoadsWithSizingResult = {
+  alpha: 2.0,
+  velocity_mps: 30.0,
+  altitude_m: 0.0,
+  dynamic_pressure_Pa: 551.25,
+  surfaces: [],
+  spar_sizing: [
+    {
+      surface_name: "Main Wing",
+      shape: "tube",
+      material_name: "Carbon Fiber",
+      sigma_allow_mpa: 500,
+      density_kg_m3: 1600,
+      g_limit: 4,
+      g_limit_fallback: false,
+      safety_factor_j: 1.5,
+      packing_factor: 0.8,
+      stations: [],
+      root_station: {
+        y_m: 0,
+        chord_m: 0.3,
+        profile_thickness_mm: 36,
+        outer_mm: 28.8,
+        tc_ratio: 0.12,
+        tc_fallback: false,
+        m_design_Nm: 24000,
+        required_W_mm3: 48000,
+        solved_mm: 0.5,
+        feasible: true,
+        infeasibility_reason: null,
+        cross_section_area_mm2: 45,
+      },
+      spar_mass_half_kg: 0.4,
+      spar_mass_full_kg: 0.8,
+      tc_fallback_warning: null,
+    },
+  ],
+};
+
+const BASE_OP = {
+  velocity: 30,
+  alpha: 2,
+  beta: 0,
+  altitude: 0,
+  xyz_ref: [0.183, 0, 0],
+};
+
+const BASE_SIZING: SparSizingParams = {
+  material_id: 7,
+  shape: "tube",
+};
+
+function okResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("useSparSizing (gh-1008)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not fetch and stays idle when aeroplaneId is null", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch");
+    const { result } = renderHook(() => useSparSizing(null));
+
+    await act(async () => {
+      await result.current.run(BASE_OP, BASE_SIZING);
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.current.result).toBeNull();
+    expect(result.current.isRunning).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("POSTs to spanwise_loads_with_sizing with required query params + op body", async () => {
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(okResponse(FAKE_RESULT));
+    const { result } = renderHook(() => useSparSizing("aero-1"));
+
+    await act(async () => {
+      await result.current.run(BASE_OP, BASE_SIZING);
+    });
+
+    const [url, options] = fetchSpy.mock.calls[0];
+    const u = new URL(String(url), "http://x");
+    expect(u.pathname).toContain("/aeroplanes/aero-1/spanwise_loads_with_sizing");
+    expect(u.searchParams.get("material_id")).toBe("7");
+    expect(u.searchParams.get("shape")).toBe("tube");
+    // optional params omitted when not provided
+    expect(u.searchParams.has("safety_factor_j")).toBe(false);
+    expect(u.searchParams.has("packing_factor")).toBe(false);
+    expect(u.searchParams.has("sigma_allow_mpa_override")).toBe(false);
+    expect(u.searchParams.has("cap_width_mm")).toBe(false);
+
+    expect(options).toMatchObject({ method: "POST" });
+    const body = JSON.parse(options!.body as string);
+    expect(body).toMatchObject({ velocity: 30, alpha: 2, beta: 0, altitude: 0 });
+    expect("operating_point_id" in body).toBe(false);
+
+    expect(result.current.result).toEqual(FAKE_RESULT);
+    expect(result.current.error).toBeNull();
+    expect(result.current.isRunning).toBe(false);
+  });
+
+  it("includes all optional sizing params and operating_point_id when set", async () => {
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(okResponse(FAKE_RESULT));
+    const { result } = renderHook(() => useSparSizing("aero-1"));
+
+    await act(async () => {
+      await result.current.run(
+        { ...BASE_OP, operating_point_id: 42 },
+        {
+          material_id: 3,
+          shape: "capped",
+          safety_factor_j: 2,
+          packing_factor: 0.7,
+          sigma_allow_mpa_override: 350,
+          cap_width_mm: 10,
+        },
+      );
+    });
+
+    const [url, options] = fetchSpy.mock.calls[0];
+    const u = new URL(String(url), "http://x");
+    expect(u.searchParams.get("material_id")).toBe("3");
+    expect(u.searchParams.get("shape")).toBe("capped");
+    expect(u.searchParams.get("safety_factor_j")).toBe("2");
+    expect(u.searchParams.get("packing_factor")).toBe("0.7");
+    expect(u.searchParams.get("sigma_allow_mpa_override")).toBe("350");
+    expect(u.searchParams.get("cap_width_mm")).toBe("10");
+
+    const body = JSON.parse(options!.body as string);
+    expect(body.operating_point_id).toBe(42);
+  });
+
+  it("surfaces a 422 validation error readably and clears the result", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: "validation_error",
+            message: "sigma_allow must be positive, got 0",
+          },
+        }),
+        { status: 422, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const { result } = renderHook(() => useSparSizing("aero-1"));
+
+    await act(async () => {
+      await result.current.run(BASE_OP, {
+        ...BASE_SIZING,
+        sigma_allow_mpa_override: 0,
+      });
+    });
+
+    expect(result.current.error).toContain("Spar sizing — invalid request");
+    expect(result.current.error).toContain("sigma_allow must be positive");
+    expect(result.current.result).toBeNull();
+    expect(result.current.isRunning).toBe(false);
+  });
+
+  it("captures a throwing fetch as an error string", async () => {
+    vi.spyOn(global, "fetch").mockRejectedValue(new Error("network down"));
+    const { result } = renderHook(() => useSparSizing("aero-1"));
+
+    await act(async () => {
+      await result.current.run(BASE_OP, BASE_SIZING);
+    });
+
+    expect(result.current.error).toBe("network down");
+    expect(result.current.result).toBeNull();
+    expect(result.current.isRunning).toBe(false);
+  });
+});

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -1079,11 +1079,14 @@ export function SpanwiseLoadsTabContent({
     if (!spanwiseLoads) return;
     const sizingParams = toSizingParams(inputs);
     if (!sizingParams) return;
-    // Use the same op params that produced the current spanwise loads
+    // Use the SAME op that produced the displayed loads so the spar is sized on
+    // the same M(y). beta matters (sideslip changes the spanwise lift
+    // distribution); xyz_ref does NOT (root bending moment is referenced to the
+    // wing root via |Yle|, and cl(y) is independent of the moment ref point).
     const opParams = {
       velocity: spanwiseLoads.velocity_mps,
       alpha: spanwiseLoads.alpha,
-      beta: 0,
+      beta: spanwiseLoads.beta,
       altitude: spanwiseLoads.altitude_m,
       xyz_ref: [0, 0, 0],
     };

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -14,6 +14,9 @@ import { MatchingChartTab } from "@/components/workbench/MatchingChartTab";
 import { AnalysisStatusIndicator } from "./AnalysisStatusIndicator";
 import type { AnalysisStatus } from "@/hooks/useAnalysisStatus";
 import type { SpanwiseLoadsResult } from "@/hooks/useSpanwiseLoads";
+import { SparSizingPanel, toSizingParams } from "@/components/workbench/SparSizingPanel";
+import type { SparSizingInputs } from "@/components/workbench/SparSizingPanel";
+import { useSparSizing } from "@/hooks/useSparSizing";
 
 const TABS = ["Assumptions", "Operating Points", "Polar", "Trefftz Plane", "Spanwise Loads", "Streamlines", "Envelope", "Sizing"] as const;
 export type Tab = (typeof TABS)[number];
@@ -1054,14 +1057,39 @@ function SpanwiseLoadsChart({
   );
 }
 
-/** Tab content for the Spanwise Loads tab (gh-1002). Exported for unit testing. */
+/** Tab content for the Spanwise Loads tab (gh-1002, gh-1008). Exported for unit testing. */
 export function SpanwiseLoadsTabContent({
   spanwiseLoadsLoading,
   spanwiseLoads,
+  aeroplaneId,
 }: Readonly<{
   spanwiseLoadsLoading?: boolean;
   spanwiseLoads?: SpanwiseLoadsResult | null;
+  aeroplaneId?: string | null;
 }>) {
+  const { result: sizingResult, isRunning: sizingRunning, error: sizingError, run: runSizing } =
+    useSparSizing(aeroplaneId ?? null);
+
+  // g_limit comes from the first spar sizing result (after first compute)
+  const firstSizing = sizingResult?.spar_sizing?.[0] ?? null;
+  const gLimit = firstSizing?.g_limit ?? null;
+  const gLimitFallback = firstSizing?.g_limit_fallback ?? false;
+
+  const handleSparCompute = (inputs: SparSizingInputs) => {
+    if (!spanwiseLoads) return;
+    const sizingParams = toSizingParams(inputs);
+    if (!sizingParams) return;
+    // Use the same op params that produced the current spanwise loads
+    const opParams = {
+      velocity: spanwiseLoads.velocity_mps,
+      alpha: spanwiseLoads.alpha,
+      beta: 0,
+      altitude: spanwiseLoads.altitude_m,
+      xyz_ref: [0, 0, 0],
+    };
+    runSizing(opParams, sizingParams);
+  };
+
   if (spanwiseLoadsLoading) {
     return (
       <div className="flex flex-1 items-center justify-center">
@@ -1078,7 +1106,20 @@ export function SpanwiseLoadsTabContent({
     );
   }
   if ((spanwiseLoads?.surfaces.length ?? 0) > 0) {
-    return <SpanwiseLoadsChart loads={spanwiseLoads!} />;
+    return (
+      <div className="flex flex-1 flex-col gap-4">
+        <SpanwiseLoadsChart loads={spanwiseLoads!} />
+        {/* gh-1008: Spar Sizing collapsible panel below the V/M chart */}
+        <SparSizingPanel
+          sizingResults={sizingResult?.spar_sizing ?? null}
+          isRunning={sizingRunning}
+          error={sizingError}
+          onCompute={handleSparCompute}
+          gLimit={gLimit}
+          gLimitFallback={gLimitFallback}
+        />
+      </div>
+    );
   }
   return (
     <div className="flex flex-1 flex-col items-center justify-center gap-4">
@@ -1389,6 +1430,7 @@ export function AnalysisViewerPanel({
           <SpanwiseLoadsTabContent
             spanwiseLoadsLoading={spanwiseLoadsLoading}
             spanwiseLoads={spanwiseLoads}
+            aeroplaneId={aeroplaneId}
           />
         </div>
       )}

--- a/frontend/components/workbench/SparSizingPanel.tsx
+++ b/frontend/components/workbench/SparSizingPanel.tsx
@@ -62,10 +62,8 @@ function parsePositiveFloat(s: string, fallback: number): number {
 
 function StationRow({
   station,
-  solvedLabel,
 }: {
   station: SparSizingStation;
-  solvedLabel: string;
 }) {
   const feasOk = station.feasible;
   return (
@@ -141,7 +139,7 @@ function SizingResultCard({ result }: { result: SparSizingResult }) {
             {[...result.stations]
               .sort((a, b) => a.y_m - b.y_m) // root first (ascending y)
               .map((st, idx) => (
-                <StationRow key={idx} station={st} solvedLabel={solvedLabel} />
+                <StationRow key={idx} station={st} />
               ))}
           </tbody>
         </table>

--- a/frontend/components/workbench/SparSizingPanel.tsx
+++ b/frontend/components/workbench/SparSizingPanel.tsx
@@ -1,0 +1,411 @@
+"use client";
+
+/**
+ * SparSizingPanel — gh-1008
+ *
+ * Collapsible panel displayed below the Spanwise Loads V/M chart.
+ * Lets the user choose material + shape, then calls the spar-sizing
+ * endpoint and shows the tapered per-station results.
+ *
+ * All UI text is English per project convention.
+ */
+
+import { useState, useCallback } from "react";
+import { ChevronDown, ChevronRight, AlertTriangle } from "lucide-react";
+
+import type { SparShape, SparSizingResult, SparSizingStation } from "@/hooks/useSparSizing";
+import { useComponents } from "@/hooks/useComponents";
+import {
+  filterStructuralMaterials,
+  getSigmaAllow,
+  solvedDimLabel,
+  feasibilityLabel,
+  buildRootHeadline,
+  buildMassSummary,
+} from "@/lib/sparSizingHelpers";
+
+// ---- Types -----------------------------------------------------------------
+
+export interface SparSizingInputs {
+  materialId: number | null;
+  shape: SparShape;
+  sigmaAllowOverride: string; // editable string; empty → use material value
+  safetyFactorJ: string;
+  packingFactor: string;
+  capWidthMm: string; // only for capped
+}
+
+export interface SparSizingPanelProps {
+  /** Current spar sizing results, or null when not yet computed. */
+  sizingResults: SparSizingResult[] | null;
+  /** Whether the sizing computation is running. */
+  isRunning: boolean;
+  /** Error message from the last run, if any. */
+  error: string | null;
+  /**
+   * Called when the user clicks "Compute Spar Sizing".
+   * The parent is responsible for calling useSparSizing.run().
+   */
+  onCompute: (inputs: SparSizingInputs) => void;
+  /** g_limit from design assumptions (shown read-only). */
+  gLimit?: number | null;
+  /** True when g_limit is a fallback default. */
+  gLimitFallback?: boolean;
+}
+
+// ---- Helpers ---------------------------------------------------------------
+
+function parsePositiveFloat(s: string, fallback: number): number {
+  const v = parseFloat(s);
+  return Number.isFinite(v) && v > 0 ? v : fallback;
+}
+
+function StationRow({
+  station,
+  solvedLabel,
+}: {
+  station: SparSizingStation;
+  solvedLabel: string;
+}) {
+  const feasOk = station.feasible;
+  return (
+    <tr className="border-b border-border/30 font-[family-name:var(--font-jetbrains-mono)] text-[12px]">
+      <td className="px-2 py-1 tabular-nums">{station.y_m.toFixed(2)}</td>
+      <td className="px-2 py-1 tabular-nums">{(station.chord_m * 1000).toFixed(0)}</td>
+      <td className="px-2 py-1 tabular-nums">{station.outer_mm.toFixed(1)}</td>
+      <td className="px-2 py-1 tabular-nums">{station.required_W_mm3.toFixed(0)}</td>
+      <td className="px-2 py-1 tabular-nums">
+        {station.solved_mm != null ? station.solved_mm.toFixed(2) : "—"}
+      </td>
+      <td
+        className={`px-2 py-1 ${feasOk ? "text-green-400" : "text-yellow-400"}`}
+        title={station.infeasibility_reason ?? undefined}
+      >
+        {feasOk ? "OK" : feasibilityLabel(station)}
+      </td>
+    </tr>
+  );
+}
+
+function SizingResultCard({ result }: { result: SparSizingResult }) {
+  const solvedLabel = solvedDimLabel(result.shape);
+  return (
+    <div className="rounded border border-border/40 bg-card p-3 text-[13px] space-y-3">
+      {/* Root headline */}
+      <div className="space-y-1">
+        <p className="text-xs text-muted-foreground font-[family-name:var(--font-jetbrains-mono)]">
+          Surface: <span className="text-foreground">{result.surface_name}</span>
+        </p>
+        <p className="font-[family-name:var(--font-jetbrains-mono)] text-xs text-muted-foreground">
+          {buildRootHeadline(result)}
+        </p>
+        <p className="font-[family-name:var(--font-jetbrains-mono)] text-xs text-foreground">
+          {buildMassSummary(result)}
+        </p>
+      </div>
+
+      {/* Warnings */}
+      {result.g_limit_fallback && (
+        <div
+          className="flex items-start gap-1 rounded bg-yellow-900/20 px-2 py-1 text-xs text-yellow-400"
+          data-testid="g-limit-fallback-warning"
+        >
+          <AlertTriangle size={12} className="mt-0.5 shrink-0" />
+          <span>g_limit = {result.g_limit} (default — no design assumption set)</span>
+        </div>
+      )}
+      {result.tc_fallback_warning && (
+        <div
+          className="flex items-start gap-1 rounded bg-yellow-900/20 px-2 py-1 text-xs text-yellow-400"
+          data-testid="tc-fallback-warning"
+        >
+          <AlertTriangle size={12} className="mt-0.5 shrink-0" />
+          <span>{result.tc_fallback_warning}</span>
+        </div>
+      )}
+
+      {/* Per-station table */}
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[480px] border-collapse text-left">
+          <thead>
+            <tr className="border-b border-border/50 text-[11px] text-muted-foreground font-[family-name:var(--font-jetbrains-mono)]">
+              <th className="px-2 py-1">y (m)</th>
+              <th className="px-2 py-1">chord (mm)</th>
+              <th className="px-2 py-1">outer (mm)</th>
+              <th className="px-2 py-1">req. W (mm³)</th>
+              <th className="px-2 py-1">{solvedLabel}</th>
+              <th className="px-2 py-1">status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {[...result.stations]
+              .sort((a, b) => a.y_m - b.y_m) // root first (ascending y)
+              .map((st, idx) => (
+                <StationRow key={idx} station={st} solvedLabel={solvedLabel} />
+              ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// ---- Main Component --------------------------------------------------------
+
+/** Exported for unit testing (pure display layer). */
+export function SparSizingPanel({
+  sizingResults,
+  isRunning,
+  error,
+  onCompute,
+  gLimit,
+  gLimitFallback = false,
+}: SparSizingPanelProps) {
+  const [open, setOpen] = useState(false);
+  const [inputs, setInputs] = useState<SparSizingInputs>({
+    materialId: null,
+    shape: "tube",
+    sigmaAllowOverride: "",
+    safetyFactorJ: "1.5",
+    packingFactor: "0.80",
+    capWidthMm: "",
+  });
+
+  // Only material components with allowable_bending_stress_mpa
+  const { components } = useComponents("material");
+  const structuralMaterials = filterStructuralMaterials(components);
+
+  const handleMaterialChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const id = parseInt(e.target.value, 10);
+      if (!Number.isFinite(id)) {
+        setInputs((prev) => ({ ...prev, materialId: null, sigmaAllowOverride: "" }));
+        return;
+      }
+      const mat = structuralMaterials.find((m) => m.id === id) ?? null;
+      const sigma = mat ? (getSigmaAllow(mat) ?? "") : "";
+      setInputs((prev) => ({
+        ...prev,
+        materialId: id,
+        sigmaAllowOverride: sigma !== "" ? String(sigma) : "",
+      }));
+    },
+    [structuralMaterials],
+  );
+
+  const handleShapeChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    setInputs((prev) => ({
+      ...prev,
+      shape: e.target.value as SparShape,
+      capWidthMm: "",
+    }));
+  }, []);
+
+  const handleCompute = useCallback(() => {
+    onCompute(inputs);
+  }, [inputs, onCompute]);
+
+  const inputClass =
+    "h-7 rounded border border-border bg-background px-2 py-1 text-[12px] font-[family-name:var(--font-jetbrains-mono)] text-foreground focus:outline-none focus:ring-1 focus:ring-[#FF8400]/60";
+  const labelClass =
+    "block text-[11px] font-[family-name:var(--font-jetbrains-mono)] text-muted-foreground mb-0.5";
+
+  return (
+    <div className="rounded border border-border/40 bg-card" data-testid="spar-sizing-panel">
+      {/* Collapsible header */}
+      <button
+        className="flex w-full items-center gap-2 px-4 py-2 text-left text-[13px] font-[family-name:var(--font-jetbrains-mono)] text-foreground hover:bg-card-muted/50"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        data-testid="spar-sizing-toggle"
+      >
+        {open ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+        <span>Spar Sizing</span>
+        {sizingResults && sizingResults.length > 0 && (
+          <span className="ml-auto text-[11px] text-muted-foreground">
+            {sizingResults.length} surface{sizingResults.length !== 1 ? "s" : ""}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="border-t border-border/30 px-4 py-3 space-y-4">
+          {/* Inputs */}
+          <div className="grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-3 lg:grid-cols-4">
+            {/* Material */}
+            <div className="col-span-2 sm:col-span-1 lg:col-span-1">
+              <label className={labelClass}>Material</label>
+              <select
+                className={`${inputClass} w-full`}
+                value={inputs.materialId ?? ""}
+                onChange={handleMaterialChange}
+                data-testid="spar-material-select"
+              >
+                <option value="">— select —</option>
+                {structuralMaterials.map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Shape */}
+            <div>
+              <label className={labelClass}>Spar shape</label>
+              <select
+                className={`${inputClass} w-full`}
+                value={inputs.shape}
+                onChange={handleShapeChange}
+                data-testid="spar-shape-select"
+              >
+                <option value="tube">Tube</option>
+                <option value="rod">Rod</option>
+                <option value="rectangular">Rectangular spar</option>
+                <option value="capped">Capped spar</option>
+              </select>
+            </div>
+
+            {/* σ_allow */}
+            <div>
+              <label className={labelClass}>σ_allow (MPa)</label>
+              <input
+                type="number"
+                className={`${inputClass} w-full`}
+                value={inputs.sigmaAllowOverride}
+                onChange={(e) =>
+                  setInputs((prev) => ({ ...prev, sigmaAllowOverride: e.target.value }))
+                }
+                placeholder="from material"
+                min={0}
+                step={1}
+                data-testid="spar-sigma-input"
+              />
+            </div>
+
+            {/* g_limit (read-only) */}
+            <div>
+              <label className={labelClass}>
+                n (limit){gLimitFallback && <span className="ml-1 text-yellow-400">⚠</span>}
+              </label>
+              <input
+                type="text"
+                className={`${inputClass} w-full cursor-not-allowed opacity-60`}
+                value={gLimit != null ? gLimit.toFixed(1) : "3.0 (default)"}
+                readOnly
+                data-testid="spar-glimit-display"
+              />
+            </div>
+
+            {/* Safety factor j */}
+            <div>
+              <label className={labelClass}>Safety factor j</label>
+              <input
+                type="number"
+                className={`${inputClass} w-full`}
+                value={inputs.safetyFactorJ}
+                onChange={(e) =>
+                  setInputs((prev) => ({ ...prev, safetyFactorJ: e.target.value }))
+                }
+                min={1}
+                step={0.1}
+                data-testid="spar-j-input"
+              />
+            </div>
+
+            {/* Packing factor */}
+            <div>
+              <label className={labelClass}>Packing factor</label>
+              <input
+                type="number"
+                className={`${inputClass} w-full`}
+                value={inputs.packingFactor}
+                onChange={(e) =>
+                  setInputs((prev) => ({ ...prev, packingFactor: e.target.value }))
+                }
+                min={0.01}
+                max={1.0}
+                step={0.01}
+                data-testid="spar-packing-input"
+              />
+            </div>
+
+            {/* Cap width — only for capped */}
+            {inputs.shape === "capped" && (
+              <div>
+                <label className={labelClass}>Cap width b (mm)</label>
+                <input
+                  type="number"
+                  className={`${inputClass} w-full`}
+                  value={inputs.capWidthMm}
+                  onChange={(e) =>
+                    setInputs((prev) => ({ ...prev, capWidthMm: e.target.value }))
+                  }
+                  min={1}
+                  step={1}
+                  placeholder="required"
+                  data-testid="spar-capwidth-input"
+                />
+              </div>
+            )}
+          </div>
+
+          {/* Compute button */}
+          <button
+            className="rounded bg-[#FF8400] px-3 py-1.5 text-[12px] font-[family-name:var(--font-jetbrains-mono)] text-black hover:bg-[#FF8400]/80 disabled:opacity-50"
+            onClick={handleCompute}
+            disabled={isRunning || inputs.materialId == null}
+            data-testid="spar-compute-button"
+          >
+            {isRunning ? "Computing…" : "Compute Spar Sizing"}
+          </button>
+
+          {/* Error */}
+          {error && (
+            <p
+              className="rounded bg-red-900/30 px-2 py-1 text-[12px] text-red-400 font-[family-name:var(--font-jetbrains-mono)]"
+              data-testid="spar-error"
+            >
+              {error}
+            </p>
+          )}
+
+          {/* Results */}
+          {sizingResults && sizingResults.length > 0 && (
+            <div className="space-y-3" data-testid="spar-results">
+              {sizingResults.map((r, i) => (
+                <SizingResultCard key={i} result={r} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default SparSizingPanel;
+
+// ---- Utility for external use (avoids prop-drilling) -----------------------
+
+/**
+ * Convert SparSizingInputs to the query params required by useSparSizing.run().
+ * Returns null when required fields are missing (materialId).
+ */
+export function toSizingParams(inputs: SparSizingInputs): import("@/hooks/useSparSizing").SparSizingParams | null {
+  if (inputs.materialId == null) return null;
+  return {
+    material_id: inputs.materialId,
+    shape: inputs.shape,
+    safety_factor_j: parsePositiveFloat(inputs.safetyFactorJ, 1.5),
+    packing_factor: parsePositiveFloat(inputs.packingFactor, 0.8),
+    sigma_allow_mpa_override:
+      inputs.sigmaAllowOverride !== ""
+        ? parsePositiveFloat(inputs.sigmaAllowOverride, 0) || undefined
+        : undefined,
+    cap_width_mm:
+      inputs.shape === "capped" && inputs.capWidthMm !== ""
+        ? parsePositiveFloat(inputs.capWidthMm, 0) || undefined
+        : undefined,
+  };
+}

--- a/frontend/hooks/useSpanwiseLoads.ts
+++ b/frontend/hooks/useSpanwiseLoads.ts
@@ -28,6 +28,7 @@ export interface SurfaceSpanwiseLoads {
 
 export interface SpanwiseLoadsResult {
   alpha: number;
+  beta: number;
   velocity_mps: number;
   altitude_m: number;
   dynamic_pressure_Pa: number;

--- a/frontend/hooks/useSparSizing.ts
+++ b/frontend/hooks/useSparSizing.ts
@@ -1,0 +1,133 @@
+// frontend/hooks/useSparSizing.ts
+// gh-1008: Spar sizing from spanwise loads.
+// Calls POST /aeroplanes/{id}/spanwise_loads_with_sizing
+
+"use client";
+
+import { useState, useCallback } from "react";
+import { API_BASE } from "@/lib/fetcher";
+import { parseApiError } from "@/lib/parseApiError";
+import type { SpanwiseLoadsParams } from "@/hooks/useSpanwiseLoads";
+
+// ---- Types (mirrors app/schemas/spar_sizing.py) ----------------------------
+
+export type SparShape = "tube" | "rod" | "rectangular" | "capped";
+
+export interface SparSizingStation {
+  y_m: number;
+  chord_m: number;
+  profile_thickness_mm: number;
+  outer_mm: number;
+  tc_ratio: number;
+  tc_fallback: boolean;
+  m_design_Nm: number;
+  required_W_mm3: number;
+  solved_mm: number | null;
+  feasible: boolean;
+  infeasibility_reason: string | null;
+  cross_section_area_mm2: number | null;
+}
+
+export interface SparSizingResult {
+  surface_name: string;
+  shape: SparShape;
+  material_name: string;
+  sigma_allow_mpa: number;
+  density_kg_m3: number;
+  g_limit: number;
+  g_limit_fallback: boolean;
+  safety_factor_j: number;
+  packing_factor: number;
+  stations: SparSizingStation[];
+  root_station: SparSizingStation;
+  spar_mass_half_kg: number;
+  spar_mass_full_kg: number;
+  tc_fallback_warning: string | null;
+}
+
+export interface SpanwiseLoadsWithSizingResult {
+  alpha: number;
+  velocity_mps: number;
+  altitude_m: number;
+  dynamic_pressure_Pa: number;
+  surfaces: unknown[];
+  spar_sizing: SparSizingResult[] | null;
+}
+
+// ---- Spar sizing parameters ------------------------------------------------
+
+export interface SparSizingParams {
+  material_id: number;
+  shape: SparShape;
+  sigma_allow_mpa_override?: number | null;
+  safety_factor_j?: number;
+  packing_factor?: number;
+  cap_width_mm?: number | null;
+}
+
+// ---- Hook ------------------------------------------------------------------
+
+export function useSparSizing(aeroplaneId: string | null) {
+  const [result, setResult] = useState<SpanwiseLoadsWithSizingResult | null>(null);
+  const [isRunning, setIsRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = useCallback(
+    async (
+      opParams: SpanwiseLoadsParams,
+      sizingParams: SparSizingParams,
+    ) => {
+      if (!aeroplaneId) return;
+      setIsRunning(true);
+      setError(null);
+      setResult(null);
+
+      try {
+        // Build query string for sizing params
+        const qs = new URLSearchParams();
+        qs.set("material_id", String(sizingParams.material_id));
+        qs.set("shape", sizingParams.shape);
+        if (sizingParams.safety_factor_j != null)
+          qs.set("safety_factor_j", String(sizingParams.safety_factor_j));
+        if (sizingParams.packing_factor != null)
+          qs.set("packing_factor", String(sizingParams.packing_factor));
+        if (sizingParams.sigma_allow_mpa_override != null)
+          qs.set("sigma_allow_mpa_override", String(sizingParams.sigma_allow_mpa_override));
+        if (sizingParams.cap_width_mm != null)
+          qs.set("cap_width_mm", String(sizingParams.cap_width_mm));
+
+        const requestBody: Record<string, unknown> = {
+          velocity: opParams.velocity,
+          alpha: opParams.alpha,
+          beta: opParams.beta,
+          altitude: opParams.altitude,
+          xyz_ref: opParams.xyz_ref,
+        };
+        if (opParams.operating_point_id != null) {
+          requestBody.operating_point_id = opParams.operating_point_id;
+        }
+
+        const res = await fetch(
+          `${API_BASE}/aeroplanes/${aeroplaneId}/spanwise_loads_with_sizing?${qs}`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(requestBody),
+          },
+        );
+        if (!res.ok) {
+          throw new Error(await parseApiError(res, "Spar sizing"));
+        }
+        const data: SpanwiseLoadsWithSizingResult = await res.json();
+        setResult(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setIsRunning(false);
+      }
+    },
+    [aeroplaneId],
+  );
+
+  return { result, isRunning, error, run };
+}

--- a/frontend/lib/sparSizingHelpers.ts
+++ b/frontend/lib/sparSizingHelpers.ts
@@ -1,0 +1,122 @@
+// frontend/lib/sparSizingHelpers.ts
+// gh-1008: Pure helper functions for the Spar Sizing panel.
+// All functions are side-effect-free and testable without a DOM.
+
+import type { SparShape, SparSizingResult, SparSizingStation } from "@/hooks/useSparSizing";
+import type { Component } from "@/hooks/useComponents";
+
+// ---- Material filtering ----------------------------------------------------
+
+/**
+ * Filter material components to those with allowable_bending_stress_mpa set.
+ * A material is eligible for spar sizing when its specs contain a positive
+ * allowable_bending_stress_mpa value.
+ */
+export function filterStructuralMaterials(components: Component[]): Component[] {
+  return components.filter((c) => {
+    if (c.component_type !== "material") return false;
+    const stress = c.specs["allowable_bending_stress_mpa"];
+    return typeof stress === "number" && stress > 0;
+  });
+}
+
+/**
+ * Extract σ_allow (MPa) from a material component's specs.
+ * Returns null when the material has no allowable_bending_stress_mpa.
+ */
+export function getSigmaAllow(material: Component): number | null {
+  const v = material.specs["allowable_bending_stress_mpa"];
+  return typeof v === "number" ? v : null;
+}
+
+/**
+ * Extract density (kg/m³) from a material component's specs.
+ * Returns null when the field is missing.
+ */
+export function getDensity(material: Component): number | null {
+  const v = material.specs["density_kg_m3"];
+  return typeof v === "number" ? v : null;
+}
+
+// ---- Shape-adaptive column label -------------------------------------------
+
+/**
+ * Return the label for the "solved dimension" column, which is shape-dependent.
+ *
+ * - tube:        "Wall t (mm)"
+ * - rod:         "d (mm)"
+ * - rectangular: "Width b (mm)"
+ * - capped:      "Gurt t (mm)"
+ */
+export function solvedDimLabel(shape: SparShape): string {
+  switch (shape) {
+    case "tube":
+      return "Wall t (mm)";
+    case "rod":
+      return "d (mm)";
+    case "rectangular":
+      return "Width b (mm)";
+    case "capped":
+      return "Gurt t (mm)";
+  }
+}
+
+// ---- Feasibility summary ---------------------------------------------------
+
+/**
+ * Return a summary string for a station's feasibility status.
+ * Used as table cell text and for accessibility.
+ */
+export function feasibilityLabel(station: SparSizingStation): string {
+  if (station.feasible) return "OK";
+  return station.infeasibility_reason ?? "infeasible";
+}
+
+/**
+ * True when all stations in a result are feasible.
+ */
+export function allStationsFeasible(result: SparSizingResult): boolean {
+  return result.stations.every((s) => s.feasible);
+}
+
+// ---- Root headline text ----------------------------------------------------
+
+/**
+ * Build the root-station headline text shown above the per-station table.
+ * Echoes compute inputs inside the text (project Plotly-metadata convention).
+ */
+export function buildRootHeadline(result: SparSizingResult): string {
+  const root = result.root_station;
+  const mStr = root.m_design_Nm.toFixed(0);
+  const wStr = root.required_W_mm3.toFixed(0);
+  const outerStr = root.outer_mm.toFixed(1);
+  const solvedStr = root.solved_mm != null ? root.solved_mm.toFixed(2) : "—";
+  const dimLabel = solvedDimLabel(result.shape);
+  return (
+    `M_design = ${mStr} N·m  |  Required W = ${wStr} mm³  |  ` +
+    `Outer = ${outerStr} mm  |  ${dimLabel} = ${solvedStr}`
+  );
+}
+
+// ---- Mass summary text -----------------------------------------------------
+
+export function buildMassSummary(result: SparSizingResult): string {
+  const half = result.spar_mass_half_kg.toFixed(3);
+  const full = result.spar_mass_full_kg.toFixed(3);
+  return `Est. spar mass: ${half} kg (half-span) / ${full} kg (full)`;
+}
+
+// ---- Sigma/g_limit display -------------------------------------------------
+
+/**
+ * Build parameter echo text for the spar-sizing inputs.
+ * Used as the Plotly figure annotation when displaying the result.
+ */
+export function buildSizingAnnotationText(result: SparSizingResult): string {
+  const lines = [
+    `Material: ${result.material_name}  |  Shape: ${result.shape}`,
+    `σ_allow = ${result.sigma_allow_mpa} MPa  |  ρ = ${result.density_kg_m3} kg/m³`,
+    `n_lim = ${result.g_limit.toFixed(1)}${result.g_limit_fallback ? " (default)" : ""}  |  j = ${result.safety_factor_j}  |  packing = ${result.packing_factor}`,
+  ];
+  return lines.join("<br>");
+}


### PR DESCRIPTION
Closes #1008

## Summary

- **Pure spar-sizing service** (`app/services/spar_sizing.py`): implements all four section-modulus formulas from the kirch/scan design spec — Rectangular (b·h²/6), Capped (b·(H³−h³)/(6H)), Rod (d³/10), Tube (π(Da⁴−Di⁴)/(32·Da)) — plus `solve_dimension`, `spar_mass_half_kg` (trapezoidal), and `compute_spar_sizing`. Pure, no aero/DB dep → fast-tier.
- **Material extension**: Alembic migration `a1b2c3d4e5f6` adds `allowable_bending_stress_mpa` + `youngs_modulus_gpa` (both optional, additive) to the `material` component type, and seeds **Pine** (σ=39 MPa, ρ=500 kg/m³, E=11 GPa) and **Carbon Fiber** (σ=500 MPa, ρ=1600, E=120 GPa).
- **New endpoint** `POST /aeroplanes/{id}/spanwise_loads_with_sizing`: extends the gh-1002 endpoint with spar sizing params (material_id, shape, j, packing, σ_override, cap_width_mm). `g_limit` from design assumptions (gh-960 pattern: fallback 3.0 + warning). Returns `SpanwiseLoadsWithSizingResponse` with `spar_sizing` list.
- **Frontend**: `SparSizingPanel` collapsible below the V/M chart — material dropdown (structural materials only filtered by `allowable_bending_stress_mpa`), σ_allow autofill, shape-adaptive inputs, per-station table with feasibility flags + spar mass estimate.

## Architecture notes

- The `SpanwiseLoadsTabContent` component now accepts `aeroplaneId` and integrates `useSparSizing`. The existing spanwise-loads endpoint is **unchanged** for backward compatibility; spar sizing has its own new endpoint.
- t/c data: returns empty dict → spar-sizing service applies t/c=0.12 fallback with explicit warning. A future ticket can wire in airfoil DB thickness (per spec §8 follow-up).
- All mock shapes in tests use real data-structure keys per the recurring-lesson note in the spec.

## Test plan

- [x] `poetry run pytest app/tests/test_spar_sizing_service.py` — 31 pure unit tests (all 4 shapes, W formulas, feasibility, mass, fallbacks)
- [x] `poetry run pytest app/tests/test_spar_sizing_endpoint.py` — 11 tests (DB seeds, extended response, service mocks with real struct keys)
- [x] `poetry run pytest app/tests/ -m "not slow"` — full fast-tier passes (5074 tests collected, all pass)
- [x] `vitest run` — 2234 frontend tests pass (171 files), including 30 pure helper tests + 13 SparSizingPanel component tests
- [x] `ruff check` and `ruff format --check` on all new files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)