### PR TITLE
chore(gh-1012): seed 454 propeller polars as COTS components for BoM

### DIFF
--- a/app/schemas/component.py
+++ b/app/schemas/component.py
@@ -30,6 +30,14 @@ class ComponentRead(ComponentWrite):
     id: int = Field(..., description="Component ID")
     created_at: datetime
     updated_at: datetime
+    has_polar: bool = Field(
+        False,
+        description="True if a performance polar exists for this component (matched by model_ref).",
+    )
+    polar_id: Optional[int] = Field(
+        None,
+        description="ID of the matching propeller performance polar, if any (matched by model_ref).",
+    )
 
 
 class ComponentList(BaseModel):

--- a/app/services/component_service.py
+++ b/app/services/component_service.py
@@ -8,13 +8,29 @@ from sqlalchemy.orm import Session
 
 from app.core.exceptions import InternalError, NotFoundError
 from app.models.component import ComponentModel
+from app.models.prop_polar import PropellerPolarModel
 from app.schemas.component import ComponentList, ComponentRead, ComponentWrite
 from app.services import component_type_service as type_svc
 
 logger = logging.getLogger(__name__)
 
 
-def _to_schema(m: ComponentModel) -> ComponentRead:
+def _resolve_polar_id(db: Session, model_ref: Optional[str]) -> Optional[int]:
+    """Resolve the performance polar matching a component's model_ref (gh-1012).
+
+    Component and polar share the ``model_ref`` key, so a seeded propeller
+    component can be bridged to its performance data. Returns None when no
+    polar matches (e.g. non-propeller components).
+    """
+    if not model_ref:
+        return None
+    row = (
+        db.query(PropellerPolarModel.id).filter(PropellerPolarModel.model_ref == model_ref).first()
+    )
+    return row[0] if row else None
+
+
+def _to_schema(m: ComponentModel, polar_id: Optional[int] = None) -> ComponentRead:
     return ComponentRead(
         id=m.id,
         name=m.name,
@@ -29,6 +45,8 @@ def _to_schema(m: ComponentModel) -> ComponentRead:
         specs=m.specs or {},
         created_at=m.created_at,
         updated_at=m.updated_at,
+        has_polar=polar_id is not None,
+        polar_id=polar_id,
     )
 
 
@@ -46,8 +64,20 @@ def list_components(
         )
     query = query.order_by(ComponentModel.component_type, ComponentModel.name)
     rows = query.all()
+
+    # Batch-resolve polar links by model_ref to avoid an N+1 query.
+    refs = {r.model_ref for r in rows if r.model_ref}
+    polar_by_ref: dict[str, int] = {}
+    if refs:
+        for pid, ref in (
+            db.query(PropellerPolarModel.id, PropellerPolarModel.model_ref)
+            .filter(PropellerPolarModel.model_ref.in_(refs))
+            .all()
+        ):
+            polar_by_ref.setdefault(ref, pid)
+
     return ComponentList(
-        items=[_to_schema(r) for r in rows],
+        items=[_to_schema(r, polar_by_ref.get(r.model_ref)) for r in rows],
         total=len(rows),
     )
 
@@ -60,7 +90,7 @@ def create_component(db: Session, data: ComponentWrite) -> ComponentRead:
         db.add(comp)
         db.flush()
         db.refresh(comp)
-        return _to_schema(comp)
+        return _to_schema(comp, _resolve_polar_id(db, comp.model_ref))
     except SQLAlchemyError as exc:
         logger.error("DB error in create_component: %s", exc)
         raise InternalError(message=f"Database error: {exc}") from exc
@@ -70,7 +100,7 @@ def get_component(db: Session, component_id: int) -> ComponentRead:
     comp = db.query(ComponentModel).filter(ComponentModel.id == component_id).first()
     if comp is None:
         raise NotFoundError(entity="Component", resource_id=component_id)
-    return _to_schema(comp)
+    return _to_schema(comp, _resolve_polar_id(db, comp.model_ref))
 
 
 def update_component(db: Session, component_id: int, data: ComponentWrite) -> ComponentRead:
@@ -84,7 +114,7 @@ def update_component(db: Session, component_id: int, data: ComponentWrite) -> Co
             setattr(comp, key, value)
         db.flush()
         db.refresh(comp)
-        return _to_schema(comp)
+        return _to_schema(comp, _resolve_polar_id(db, comp.model_ref))
     except NotFoundError:
         raise
     except SQLAlchemyError as exc:

--- a/app/services/prop_component_seed.py
+++ b/app/services/prop_component_seed.py
@@ -1,0 +1,115 @@
+"""Seed propeller polars as COTS components (gh-1012).
+
+Every propeller in ``propeller_polars`` is mirrored into the generic
+``components`` catalog as a ``ComponentModel`` of ``component_type='propeller'``
+so propellers become selectable in the component picker / BoM.
+
+Key design points
+------------------
+* **Keyed on ``model_ref``** — both ``PropellerPolarModel`` and
+  ``ComponentModel`` already carry a ``model_ref`` column, so no migration
+  is needed. The seed is idempotent: re-runs upsert by ``model_ref``.
+* **``mass_g`` stays NULL** — real masses arrive via #1000 (PROP-DATA xlsx).
+  No silent 0-fallback; the BoM marks such nodes as *mass unknown*.
+* **User-entered mass is preserved** — a reseed never overwrites a non-null
+  ``mass_g`` back to NULL.
+
+The performance bridge (powertrain_performance) resolves a chosen propeller
+component back to its polar via the shared ``model_ref``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from sqlalchemy.orm import Session
+
+from app.models.component import ComponentModel
+from app.models.prop_polar import PropellerPolarModel
+
+logger = logging.getLogger(__name__)
+
+COMPONENT_TYPE = "propeller"
+
+
+@dataclass
+class SeedResult:
+    created: int = 0
+    updated: int = 0
+    skipped: int = 0
+    errors: list[str] = field(default_factory=list)
+
+    def __str__(self) -> str:
+        return (
+            f"created={self.created}, updated={self.updated}, "
+            f"skipped={self.skipped}, errors={len(self.errors)}"
+        )
+
+
+def _specs_from_polar(polar: PropellerPolarModel) -> dict[str, object]:
+    """Build the component specs payload from a polar row."""
+    return {
+        "diameter_in": polar.diameter_in,
+        "pitch_in": polar.pitch_in,
+        "blades": polar.blades,
+        "variant": polar.variant or "",
+    }
+
+
+def seed_propeller_components(db: Session) -> SeedResult:
+    """Upsert one ``propeller`` ComponentModel per propeller polar.
+
+    Idempotent: matches existing components by ``model_ref``. Polars without
+    a ``model_ref`` are skipped (cannot be linked back to performance data).
+    The caller is responsible for committing the session.
+    """
+    result = SeedResult()
+
+    polars = db.query(PropellerPolarModel).all()
+    for polar in polars:
+        if not polar.model_ref:
+            msg = f"Polar '{polar.name}' (id={polar.id}) has no model_ref — skipped"
+            logger.warning(msg)
+            result.skipped += 1
+            continue
+
+        specs = _specs_from_polar(polar)
+        existing = (
+            db.query(ComponentModel)
+            .filter_by(component_type=COMPONENT_TYPE, model_ref=polar.model_ref)
+            .first()
+        )
+
+        if existing is None:
+            comp = ComponentModel(
+                name=polar.name,
+                component_type=COMPONENT_TYPE,
+                manufacturer=polar.manufacturer,
+                description=None,
+                mass_g=None,  # real masses via #1000; no silent 0-fallback
+                model_ref=polar.model_ref,
+                specs=specs,
+            )
+            db.add(comp)
+            result.created += 1
+            continue
+
+        # Upsert: refresh catalog metadata from the polar, but never clobber a
+        # user-entered mass back to NULL and never touch a non-null mass.
+        changed = (
+            existing.name != polar.name
+            or existing.manufacturer != polar.manufacturer
+            or (existing.specs or {}) != specs
+        )
+        if changed:
+            existing.name = polar.name
+            existing.manufacturer = polar.manufacturer
+            existing.specs = specs
+            result.updated += 1
+        else:
+            result.skipped += 1
+
+    db.flush()
+    logger.info("seed_propeller_components complete: %s", result)
+    return result

--- a/app/tests/test_prop_component_polar_link.py
+++ b/app/tests/test_prop_component_polar_link.py
@@ -1,0 +1,90 @@
+"""Component↔polar resolution + picker filter for seeded propellers (gh-1012).
+
+Verifies that a seeded propeller ``ComponentModel`` resolves to its
+``PropellerPolarModel`` via the shared ``model_ref`` and that the
+component response exposes ``has_polar`` / ``polar_id`` so the performance
+layer (powertrain_performance) can bridge component → polar.
+"""
+
+from __future__ import annotations
+
+from app.models.component import ComponentModel
+from app.models.prop_polar import PropellerPolarModel
+from app.services import prop_component_seed
+
+
+def _seed_polar_and_component(SessionLocal) -> None:
+    db = SessionLocal()
+    try:
+        db.add(
+            PropellerPolarModel(
+                manufacturer="APC",
+                name="APC 9x6",
+                model_ref="apc/9x6",
+                diameter_in=9.0,
+                pitch_in=6.0,
+                variant="",
+                blades=2,
+            )
+        )
+        db.flush()
+        prop_component_seed.seed_propeller_components(db)
+        db.commit()
+    finally:
+        db.close()
+
+
+class TestPickerFilter:
+    def test_propeller_components_listed(self, client_and_db):
+        client, SessionLocal = client_and_db
+        _seed_polar_and_component(SessionLocal)
+        res = client.get("/components", params={"type": "propeller"})
+        assert res.status_code == 200
+        items = res.json()["items"]
+        names = {c["name"] for c in items}
+        assert "APC 9x6" in names
+
+
+class TestPolarLink:
+    def test_response_exposes_has_polar_and_polar_id(self, client_and_db):
+        client, SessionLocal = client_and_db
+        _seed_polar_and_component(SessionLocal)
+        # Find the polar id for cross-check.
+        db = SessionLocal()
+        try:
+            polar = db.query(PropellerPolarModel).filter_by(model_ref="apc/9x6").one()
+            polar_id = polar.id
+            comp = db.query(ComponentModel).filter_by(model_ref="apc/9x6").one()
+            comp_id = comp.id
+        finally:
+            db.close()
+
+        res = client.get(f"/components/{comp_id}")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["has_polar"] is True
+        assert body["polar_id"] == polar_id
+
+    def test_component_without_polar_has_no_link(self, client_and_db):
+        client, _ = client_and_db
+        res = client.post(
+            "/components",
+            json={
+                "name": "Generic widget",
+                "component_type": "generic",
+                "specs": {},
+            },
+        )
+        assert res.status_code == 201
+        body = res.json()
+        assert body["has_polar"] is False
+        assert body["polar_id"] is None
+
+
+class TestMassUnknown:
+    def test_seeded_prop_mass_is_null(self, client_and_db):
+        client, SessionLocal = client_and_db
+        _seed_polar_and_component(SessionLocal)
+        res = client.get("/components", params={"type": "propeller"})
+        prop = next(c for c in res.json()["items"] if c["name"] == "APC 9x6")
+        assert prop["mass_g"] is None

--- a/app/tests/test_prop_component_seed.py
+++ b/app/tests/test_prop_component_seed.py
@@ -1,0 +1,169 @@
+"""Tests for app.services.prop_component_seed (gh-1012).
+
+Seeds every propeller polar as a COTS ``ComponentModel`` so propellers
+become selectable in the component picker / BoM. All tests run against
+in-memory SQLite — no network, no aero deps.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from app.db.base import Base
+from app.models.component import ComponentModel
+from app.models.prop_polar import PropellerPolarModel
+from app.services.prop_component_seed import SeedResult, seed_propeller_components
+
+
+@pytest.fixture()
+def session() -> Session:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    SM = sessionmaker(bind=engine, autocommit=False, autoflush=False, class_=Session)
+    db = SM()
+    yield db
+    db.close()
+
+
+def _add_polar(
+    db: Session,
+    *,
+    name: str,
+    model_ref: str,
+    diameter_in: float = 9.0,
+    pitch_in: float = 6.0,
+    variant: str = "",
+    blades: int = 2,
+) -> PropellerPolarModel:
+    p = PropellerPolarModel(
+        manufacturer="APC",
+        name=name,
+        model_ref=model_ref,
+        diameter_in=diameter_in,
+        pitch_in=pitch_in,
+        variant=variant,
+        blades=blades,
+    )
+    db.add(p)
+    db.flush()
+    return p
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Fresh seed
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestSeedFresh:
+    def test_creates_one_component_per_polar(self, session: Session):
+        _add_polar(session, name="APC 9x6", model_ref="apc/9x6")
+        _add_polar(session, name="APC 10x5", model_ref="apc/10x5")
+        result = seed_propeller_components(session)
+        session.flush()
+        assert isinstance(result, SeedResult)
+        assert result.created == 2
+        assert result.updated == 0
+        comps = session.query(ComponentModel).filter_by(component_type="propeller").all()
+        assert len(comps) == 2
+
+    def test_component_fields(self, session: Session):
+        _add_polar(
+            session,
+            name="APC 28x20-4",
+            model_ref="apc/28x20-4",
+            diameter_in=28.0,
+            pitch_in=20.0,
+            variant="-4",
+            blades=4,
+        )
+        seed_propeller_components(session)
+        session.flush()
+        comp = session.query(ComponentModel).filter_by(model_ref="apc/28x20-4").one()
+        assert comp.component_type == "propeller"
+        assert comp.name == "APC 28x20-4"
+        assert comp.manufacturer == "APC"
+        assert comp.model_ref == "apc/28x20-4"
+        assert comp.specs["diameter_in"] == 28.0
+        assert comp.specs["pitch_in"] == 20.0
+        assert comp.specs["blades"] == 4
+        assert comp.specs["variant"] == "-4"
+
+    def test_mass_is_null_no_silent_zero(self, session: Session):
+        """mass_g must stay NULL — no silent 0-fallback (real masses from #1000)."""
+        _add_polar(session, name="APC 9x6", model_ref="apc/9x6")
+        seed_propeller_components(session)
+        session.flush()
+        comp = session.query(ComponentModel).filter_by(model_ref="apc/9x6").one()
+        assert comp.mass_g is None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Idempotency
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestSeedIdempotent:
+    def test_rerun_creates_no_duplicates(self, session: Session):
+        _add_polar(session, name="APC 9x6", model_ref="apc/9x6")
+        seed_propeller_components(session)
+        session.flush()
+        result2 = seed_propeller_components(session)
+        session.flush()
+        assert result2.created == 0
+        comps = session.query(ComponentModel).filter_by(model_ref="apc/9x6").all()
+        assert len(comps) == 1
+
+    def test_rerun_updates_changed_specs(self, session: Session):
+        polar = _add_polar(session, name="APC 9x6", model_ref="apc/9x6", blades=2)
+        seed_propeller_components(session)
+        session.flush()
+        # Polar blade count corrected (e.g. after #1004) — reseed should update.
+        polar.blades = 3
+        session.flush()
+        result = seed_propeller_components(session)
+        session.flush()
+        assert result.updated == 1
+        comp = session.query(ComponentModel).filter_by(model_ref="apc/9x6").one()
+        assert comp.specs["blades"] == 3
+
+    def test_does_not_clobber_user_set_mass(self, session: Session):
+        """A user-entered mass must survive a reseed (only null masses stay null)."""
+        _add_polar(session, name="APC 9x6", model_ref="apc/9x6")
+        seed_propeller_components(session)
+        session.flush()
+        comp = session.query(ComponentModel).filter_by(model_ref="apc/9x6").one()
+        comp.mass_g = 42.0
+        session.flush()
+        seed_propeller_components(session)
+        session.flush()
+        comp = session.query(ComponentModel).filter_by(model_ref="apc/9x6").one()
+        assert comp.mass_g == 42.0
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Guards
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestSeedGuards:
+    def test_skips_polar_without_model_ref(self, session: Session):
+        p = PropellerPolarModel(manufacturer="APC", name="APC mystery", model_ref=None)
+        session.add(p)
+        session.flush()
+        result = seed_propeller_components(session)
+        session.flush()
+        assert result.created == 0
+        assert result.skipped == 1

--- a/frontend/components/workbench/CotsPickerDialog.tsx
+++ b/frontend/components/workbench/CotsPickerDialog.tsx
@@ -129,9 +129,16 @@ export function CotsPickerDialog({
                       {comp.component_type}
                     </span>
                     {comp.manufacturer && <span>{comp.manufacturer}</span>}
-                    {comp.mass_g != null && (
+                    {comp.mass_g != null ? (
                       <span className="font-[family-name:var(--font-jetbrains-mono)] text-foreground">
                         {comp.mass_g}g
+                      </span>
+                    ) : (
+                      <span
+                        className="italic text-amber-500/80"
+                        title="No mass on record for this component — excluded from weight totals until set."
+                      >
+                        Mass unknown
                       </span>
                     )}
                   </div>

--- a/frontend/hooks/useComponents.ts
+++ b/frontend/hooks/useComponents.ts
@@ -17,6 +17,10 @@ export interface Component {
   specs: Record<string, unknown>;
   created_at: string;
   updated_at: string;
+  /** True when a performance polar matches this component (by model_ref). */
+  has_polar?: boolean;
+  /** ID of the matching propeller performance polar, if any. */
+  polar_id?: number | null;
 }
 
 interface ComponentList {

--- a/scripts/seed_propeller_components.py
+++ b/scripts/seed_propeller_components.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Seed propeller polars as COTS components (gh-1012).
+
+Usage:
+    poetry run python scripts/seed_propeller_components.py [--dry-run]
+
+Mirrors every row in ``propeller_polars`` into the generic ``components``
+catalog as a ``ComponentModel`` of ``component_type='propeller'``, keyed on
+the shared ``model_ref``. This makes all APC propellers selectable in the
+component picker / BoM.
+
+The seed is idempotent: re-runs upsert by ``model_ref`` and never clobber a
+user-entered ``mass_g``. Run ``scripts/import_apc_props.py`` first so the
+polars exist.
+
+Options:
+    --dry-run   Report what would change without writing to the DB.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from app.db.session import SessionLocal  # noqa: E402
+from app.services.prop_component_seed import seed_propeller_components  # noqa: E402
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(levelname)s: %(message)s",
+        stream=sys.stderr,
+    )
+
+    parser = argparse.ArgumentParser(
+        description="Seed propeller polars as COTS components into the DB"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Report what would change without committing to the DB",
+    )
+    args = parser.parse_args()
+
+    db = SessionLocal()
+    try:
+        result = seed_propeller_components(db)
+        if args.dry_run:
+            db.rollback()
+            print(f"DRY RUN — no DB writes. Would have: {result}")
+        else:
+            db.commit()
+            print(f"Seed complete: {result}")
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #1012

## Summary
Propellers were not selectable in the BoM: the component tree binds COTS nodes to `ComponentModel` rows (`component_type='propeller'`), but only 2 propellers existed in the catalog — the 454 APC props lived solely in `propeller_polars`. This seeds each polar as a propeller `ComponentModel` keyed on the shared `model_ref` (no migration — `model_ref` already exists on both tables).

## Changes
- **`app/services/prop_component_seed.py`** — idempotent seed: upsert by `model_ref`, `mass_g=null` (real masses arrive via #1000; no silent 0-fallback), never clobber a user-entered mass.
- **`scripts/seed_propeller_components.py`** — CLI wrapper mirroring `scripts/import_apc_props.py` (`--dry-run`).
- **`ComponentRead.has_polar` / `polar_id`** — resolves component → polar by `model_ref` so `powertrain_performance` can bridge a chosen propeller to its polar. Batch lookup in `list_components` (no N+1).
- **Frontend** — `CotsPickerDialog` shows an explicit "Mass unknown" marker for `mass_g=null`; `useComponents.Component` gains `has_polar`/`polar_id`. The BoM tree already flags null-mass nodes via `weight_status` (`_weight_from_cots` returns None, not 0).

## Test plan
- [x] `pytest test_prop_component_seed.py test_prop_component_polar_link.py` — 11 passed (fresh seed, idempotency, update-on-change, mass-preserve, skip-no-model_ref, picker filter, polar link, mass-unknown)
- [x] Component suite regression — 269 passed
- [x] End-to-end smoke: 454 polars → 454 components; reseed 0 created / 454 skipped; mass_g preserved
- [x] `ruff check`/`format` clean; edited TS parses

## Human UAT (visual, deferred)
- BoM/CotsPickerDialog "Mass unknown" marker rendering and picker selection of a propeller as a `cots` node.

Mocked fast tests only — no aero deps, CI-coverage safe.