### PR TITLE
chore(prop): backfill component mass_g from polar weight_g

### DIFF
--- a/app/services/prop_component_seed.py
+++ b/app/services/prop_component_seed.py
@@ -9,10 +9,15 @@ Key design points
 * **Keyed on ``model_ref``** — both ``PropellerPolarModel`` and
   ``ComponentModel`` already carry a ``model_ref`` column, so no migration
   is needed. The seed is idempotent: re-runs upsert by ``model_ref``.
-* **``mass_g`` stays NULL** — real masses arrive via #1000 (PROP-DATA xlsx).
-  No silent 0-fallback; the BoM marks such nodes as *mass unknown*.
+* **``mass_g`` is populated from the polar weight** — #1000 (PROP-DATA xlsx)
+  is done, so ``propeller_polars.weight_g`` now carries real prop masses in
+  grams. On create the component's ``mass_g`` is set from ``weight_g``; on
+  reseed a NULL ``mass_g`` is backfilled once the polar gains a weight.
+  ``weight_g`` and ``mass_g`` are both grams — no unit conversion.
+* **``mass_g`` stays NULL only when the polar has no weight** — there is no
+  silent 0-fallback; the BoM marks such nodes as *mass unknown*.
 * **User-entered mass is preserved** — a reseed never overwrites a non-null
-  ``mass_g`` back to NULL.
+  ``mass_g`` (neither back to NULL nor with the polar weight).
 
 The performance bridge (powertrain_performance) resolves a chosen propeller
 component back to its polar via the shared ``model_ref``.
@@ -57,6 +62,16 @@ def _specs_from_polar(polar: PropellerPolarModel) -> dict[str, object]:
     }
 
 
+def _mass_from_polar(polar: PropellerPolarModel) -> float | None:
+    """Prop mass in grams from the polar weight (#1000). May be ``None``.
+
+    ``weight_g`` and ``mass_g`` are both grams — no unit conversion. Returns
+    ``None`` when the polar has no weight; the caller keeps ``mass_g`` NULL
+    (no silent 0-fallback) so the BoM can mark the node *mass unknown*.
+    """
+    return polar.weight_g
+
+
 def seed_propeller_components(db: Session) -> SeedResult:
     """Upsert one ``propeller`` ComponentModel per propeller polar.
 
@@ -81,13 +96,17 @@ def seed_propeller_components(db: Session) -> SeedResult:
             .first()
         )
 
+        mass_g = _mass_from_polar(polar)
+
         if existing is None:
             comp = ComponentModel(
                 name=polar.name,
                 component_type=COMPONENT_TYPE,
                 manufacturer=polar.manufacturer,
                 description=None,
-                mass_g=None,  # real masses via #1000; no silent 0-fallback
+                # Populated from the polar weight (#1000); stays NULL when the
+                # polar has no weight — no silent 0-fallback.
+                mass_g=mass_g,
                 model_ref=polar.model_ref,
                 specs=specs,
             )
@@ -95,17 +114,22 @@ def seed_propeller_components(db: Session) -> SeedResult:
             result.created += 1
             continue
 
-        # Upsert: refresh catalog metadata from the polar, but never clobber a
-        # user-entered mass back to NULL and never touch a non-null mass.
+        # Upsert: refresh catalog metadata from the polar. Backfill a NULL mass
+        # from the polar weight, but never clobber a user-entered (non-null)
+        # mass — neither back to NULL nor with the polar weight.
+        backfill_mass = existing.mass_g is None and mass_g is not None
         changed = (
             existing.name != polar.name
             or existing.manufacturer != polar.manufacturer
             or (existing.specs or {}) != specs
+            or backfill_mass
         )
         if changed:
             existing.name = polar.name
             existing.manufacturer = polar.manufacturer
             existing.specs = specs
+            if backfill_mass:
+                existing.mass_g = mass_g
             result.updated += 1
         else:
             result.skipped += 1

--- a/app/tests/test_prop_component_seed.py
+++ b/app/tests/test_prop_component_seed.py
@@ -47,6 +47,7 @@ def _add_polar(
     pitch_in: float = 6.0,
     variant: str = "",
     blades: int = 2,
+    weight_g: float | None = None,
 ) -> PropellerPolarModel:
     p = PropellerPolarModel(
         manufacturer="APC",
@@ -56,6 +57,7 @@ def _add_polar(
         pitch_in=pitch_in,
         variant=variant,
         blades=blades,
+        weight_g=weight_g,
     )
     db.add(p)
     db.flush()
@@ -141,16 +143,71 @@ class TestSeedIdempotent:
 
     def test_does_not_clobber_user_set_mass(self, session: Session):
         """A user-entered mass must survive a reseed (only null masses stay null)."""
-        _add_polar(session, name="APC 9x6", model_ref="apc/9x6")
+        # Polar carries a weight (#1000) — the reseed must still NOT overwrite a
+        # user-entered mass with the polar weight.
+        _add_polar(session, name="APC 9x6", model_ref="apc/9x6", weight_g=42.0)
         seed_propeller_components(session)
         session.flush()
         comp = session.query(ComponentModel).filter_by(model_ref="apc/9x6").one()
-        comp.mass_g = 42.0
+        comp.mass_g = 99.0
         session.flush()
+        seed_propeller_components(session)
+        session.flush()
+        comp = session.query(ComponentModel).filter_by(model_ref="apc/9x6").one()
+        assert comp.mass_g == 99.0
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Mass backfill from polar weight (#1000 done → weight_g populated)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestMassFromPolarWeight:
+    def test_create_sets_mass_from_polar_weight(self, session: Session):
+        """On CREATE, mass_g is seeded from the polar's weight_g (grams, no conversion)."""
+        _add_polar(session, name="APC 9x6", model_ref="apc/9x6", weight_g=42.0)
         seed_propeller_components(session)
         session.flush()
         comp = session.query(ComponentModel).filter_by(model_ref="apc/9x6").one()
         assert comp.mass_g == 42.0
+
+    def test_upsert_preserves_user_mass_over_polar_weight(self, session: Session):
+        """A non-null (user) mass is never clobbered by the polar weight on reseed."""
+        _add_polar(session, name="APC 9x6", model_ref="apc/9x6", weight_g=42.0)
+        seed_propeller_components(session)
+        session.flush()
+        comp = session.query(ComponentModel).filter_by(model_ref="apc/9x6").one()
+        comp.mass_g = 99.0
+        session.flush()
+        seed_propeller_components(session)
+        session.flush()
+        comp = session.query(ComponentModel).filter_by(model_ref="apc/9x6").one()
+        assert comp.mass_g == 99.0
+
+    def test_upsert_backfills_null_mass_from_polar_weight(self, session: Session):
+        """A NULL mass is backfilled from the polar weight and counted as updated."""
+        # Seed first with no weight → component mass stays NULL.
+        polar = _add_polar(session, name="APC 9x6", model_ref="apc/9x6", weight_g=None)
+        seed_propeller_components(session)
+        session.flush()
+        comp = session.query(ComponentModel).filter_by(model_ref="apc/9x6").one()
+        assert comp.mass_g is None
+        # Polar weight arrives (#1000 import) → reseed backfills the NULL mass.
+        polar.weight_g = 42.0
+        session.flush()
+        result = seed_propeller_components(session)
+        session.flush()
+        assert result.updated == 1
+        comp = session.query(ComponentModel).filter_by(model_ref="apc/9x6").one()
+        assert comp.mass_g == 42.0
+
+    def test_mass_stays_null_when_polar_has_no_weight(self, session: Session):
+        """No silent 0-fallback — mass stays NULL when the polar has no weight."""
+        _add_polar(session, name="APC 9x6", model_ref="apc/9x6", weight_g=None)
+        seed_propeller_components(session)
+        session.flush()
+        comp = session.query(ComponentModel).filter_by(model_ref="apc/9x6").one()
+        assert comp.mass_g is None
 
 
 # ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Maintainer-authorized chore (no GH issue — tickets opted out).

Closes the gap left after #1000/#1012: seeded propeller components had `mass_g=null` even though `propeller_polars.weight_g` (grams, added by #1000) is now populated. This wires the seeder to read the polar weight.

## Behavior

`app/services/prop_component_seed.py` (`seed_propeller_components`):

- New helper `_mass_from_polar(polar)` returns `polar.weight_g` (may be `None`).
- **CREATE:** `mass_g = polar.weight_g` instead of hardcoded `None`.
- **UPSERT:** backfill `mass_g` from the polar weight **only** when `existing.mass_g is None and polar.weight_g is not None`; counted as an update. A user-entered (non-null) mass is never clobbered — neither back to `NULL` nor with the polar weight.
- No silent 0-fallback: if `weight_g` is `None`, `mass_g` stays `None` → BoM marks the node *mass unknown*.
- `weight_g` and `mass_g` are both grams — no unit conversion.

Docstring updated to reflect that #1000 is done and mass is now populated from the polar weight when available.

## Test plan

- [x] TDD: 4 new mass tests added to `app/tests/test_prop_component_seed.py` — failing first (create-from-weight, backfill-null), then green.
- [x] `pytest app/tests/test_prop_component_seed.py` → 11 passed, **100%** coverage on the changed module.
- [x] `ruff check` + `ruff format --check` clean.

```
app/services/prop_component_seed.py      50      0   100%
11 passed in 0.26s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)