### PR TITLE
chore(pytest): exclude .worktrees from collection

### DIFF
--- a/app/tests/test_pytest_config.py
+++ b/app/tests/test_pytest_config.py
@@ -1,0 +1,39 @@
+"""Guard the pytest collection config (maintainer-authorized chore).
+
+A root-level ``pytest`` run recurses into sibling git worktrees kept
+under ``.worktrees/`` (concurrent WIP whose test files share basenames
+with the main checkout), which trips "import file mismatch" collection
+errors. ``.worktrees`` must therefore be listed in ``norecursedirs``.
+
+This is a config regression guard: if someone drops ``.worktrees`` from
+``norecursedirs`` the multi-worktree collection error comes back. The
+clean CI checkout has no sibling worktrees, so the error itself is not
+reproducible there — we assert the config value instead.
+"""
+
+from __future__ import annotations
+
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+def _norecursedirs() -> list[str]:
+    pyproject = REPO_ROOT / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    return data["tool"]["pytest"]["ini_options"]["norecursedirs"]
+
+
+def test_worktrees_excluded_from_collection() -> None:
+    """`.worktrees` must be excluded so root-level pytest skips sibling worktrees."""
+    assert ".worktrees" in _norecursedirs()
+
+
+def test_existing_exclusions_preserved() -> None:
+    """The pre-existing exclusions stay in place (no regression)."""
+    dirs = _norecursedirs()
+    assert "external" in dirs
+    assert ".claude" in dirs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,12 +77,12 @@ pydeps = "^3.0.3"
 pyright = "^1.1.409"
 
 [tool.pytest.ini_options]
-# `.claude` holds worktrees from in-flight feature work whose test
-# files have the same basenames as those in the main checkout. Under
-# pytest-xdist that causes "import file mismatch" collection errors.
-# Excluding here so local runs are robust; CI uses fresh clones with
-# no such pollution.
-norecursedirs = ["external", ".claude"]
+# `.claude` and `.worktrees` hold sibling git worktrees from in-flight
+# feature work whose test files share basenames with the main checkout.
+# A root-level `pytest` recurses into them and trips "import file
+# mismatch" collection errors (worse under pytest-xdist). Excluding here
+# keeps local runs robust; CI uses fresh clones with no such pollution.
+norecursedirs = ["external", ".claude", ".worktrees"]
 addopts = "--ignore=docker_smoke_test.py"
 # Ensure the project root is on sys.path so `from app.*` works in
 # non-installed layouts (poetry package-mode=false).


### PR DESCRIPTION
## Summary

Maintainer-authorized chore (no GH issue — tickets opted out).

A root-level `pytest -m "not slow"` recurses into sibling git worktrees kept under `.worktrees/` (concurrent WIP whose test files share basenames with the main checkout) → `import file mismatch` collection errors (worse under pytest-xdist).

## Change

`pyproject.toml` `[tool.pytest.ini_options]`:

```diff
-norecursedirs = ["external", ".claude"]
+norecursedirs = ["external", ".claude", ".worktrees"]
```

Inline comment refreshed to name the real directory — worktrees live under `.worktrees/`, not just `.claude/`.

No dependency change → **no poetry.lock change**.

## Test plan

- [x] Config regression guard added: `app/tests/test_pytest_config.py` (asserts `.worktrees` present in `norecursedirs`, existing exclusions preserved). Failing first against the old value, then green.
- [x] `app/tests` still collects clean: **5272 tests collected, 0 errors**.
- [x] Root-level `pytest --collect-only` no longer references `.worktrees` (verified against the real concurrent worktrees on the maintainer's machine).
- [x] `ruff check` + `ruff format --check` clean.

The multi-worktree collection error is not reproducible in CI's clean checkout (no sibling worktrees there) — that is expected; the test asserts the config value instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)