### PR TITLE
feat(gh-1020): cad_designer SectionGeometry primitive (slice lofted solid)

### DIFF
--- a/cad_designer/airplane/geometry/section_geometry.py
+++ b/cad_designer/airplane/geometry/section_geometry.py
@@ -59,6 +59,22 @@ class SectionPoint:
     center_z: float
 
 
+@dataclass(frozen=True)
+class _SlicedSection:
+    """A single section-plane cut, reusable across many ``x_c`` samples.
+
+    ``outline`` is the cut expressed in local ``(chord_u, height_v)`` (mm).
+    ``le_anchor`` + ``chord_unit`` recover the world chord line; ``up_z`` is the
+    section up-vector's world-z component (carries dihedral tilt into world z).
+    """
+
+    outline: list[tuple[float, float]]
+    chord_len: float
+    le_anchor: np.ndarray
+    chord_unit: np.ndarray
+    up_z: float
+
+
 # ---------------------------------------------------------------------------
 # Pure helpers (fast tier — no CAD)
 # ---------------------------------------------------------------------------
@@ -205,10 +221,10 @@ class SectionGeometry:
         chord_dir: np.ndarray,
         up_dir: np.ndarray,
         span_dir: np.ndarray,
-    ) -> tuple[list[tuple[float, float]], float, np.ndarray, np.ndarray]:
+    ) -> _SlicedSection:
         """Cut the solid with the section plane and return the outline expressed
-        in local ``(chord_u, height_v)`` coordinates, the chord length, and the
-        LE point + chord unit vector (world) needed to rebuild world ``z``.
+        in local ``(chord_u, height_v)`` coordinates plus the metadata needed to
+        rebuild world ``z`` at any chord ordinate.
         """
         from cad_designer.aerosandbox.slicing import _section_outline_edges
 
@@ -218,7 +234,7 @@ class SectionGeometry:
             tuple(float(c) for c in span_dir),
         )
         if not edges:
-            return [], 0.0, origin, chord_dir
+            return _SlicedSection([], 0.0, origin, chord_dir, float(up_dir[2]))
 
         pts_world: list[np.ndarray] = []
         for e in edges:
@@ -237,69 +253,54 @@ class SectionGeometry:
         le_anchor = origin + u_min * chord_dir
 
         outline = list(zip(u_all.tolist(), v_all.tolist(), strict=True))
-        return outline, chord_len, le_anchor, chord_dir
-
-    def _point_at(self, y_span: float, x_c: float) -> SectionPoint:
-        origin, chord_dir, span_dir, up_dir = self._station_frame(y_span)
-        outline, chord_len, le_anchor, chord_unit = self._slice_outline(
-            origin, chord_dir, up_dir, span_dir
+        return _SlicedSection(
+            outline=outline,
+            chord_len=chord_len,
+            le_anchor=le_anchor,
+            chord_unit=chord_dir,
+            up_z=float(up_dir[2]),
         )
-        if chord_len <= 0.0:
-            return SectionPoint(y_span, x_c, 0.0, 0.0, 0.0, 0.0)
 
-        top_v, bottom_v = _outline_to_top_bottom(outline, x_c, chord_len)
-        # Convert local v back to world z at the sampled chord ordinate.
-        chord_point = le_anchor + (x_c * chord_len) * chord_unit
+    def _section(self, y_span: float) -> _SlicedSection:
+        """Slice the solid at ``y_span`` and return the reusable section data."""
+        origin, chord_dir, span_dir, up_dir = self._station_frame(y_span)
+        return self._slice_outline(origin, chord_dir, up_dir, span_dir)
+
+    @staticmethod
+    def _point_from_section(section: _SlicedSection, y_span: float, x_c: float) -> SectionPoint:
+        """Read a SectionPoint off an already-sliced section at chord ``x_c``.
+
+        The local upper/lower heights ``v`` are projected into world ``z`` about
+        the chord-line z at that ordinate (``up_z`` carries the dihedral tilt).
+        """
+        if section.chord_len <= 0.0:
+            return SectionPoint(y_span, x_c, 0.0, 0.0, 0.0, 0.0)
+        top_v, bottom_v = _outline_to_top_bottom(section.outline, x_c, section.chord_len)
+        chord_point = section.le_anchor + (x_c * section.chord_len) * section.chord_unit
         base_z = float(chord_point[2])
-        # up_dir z-component scales the local v into world z.
-        up_z = float(up_dir[2])
-        top_z = base_z + top_v * up_z
-        bottom_z = base_z + bottom_v * up_z
-        thickness = abs(top_z - bottom_z)
-        center_z = (top_z + bottom_z) / 2.0
+        top_z = base_z + top_v * section.up_z
+        bottom_z = base_z + bottom_v * section.up_z
         return SectionPoint(
             y_span=y_span,
             x_c=x_c,
-            thickness=thickness,
+            thickness=abs(top_z - bottom_z),
             top_z=max(top_z, bottom_z),
             bottom_z=min(top_z, bottom_z),
-            center_z=center_z,
+            center_z=(top_z + bottom_z) / 2.0,
         )
 
     # -- public API --------------------------------------------------------
 
     def at(self, y_span: float, x_c: float) -> SectionPoint:
         """Section geometry at a single ``(y/span, x/c)`` location."""
-        return self._point_at(y_span, x_c)
+        return self._point_from_section(self._section(y_span), y_span, x_c)
 
     def sample(self, y_spans: list[float], x_cs: list[float]) -> list[SectionPoint]:
         """Sample a grid: slice each unique ``y_span`` once, read all ``x_c``."""
         points: list[SectionPoint] = []
         for y in y_spans:
-            origin, chord_dir, span_dir, up_dir = self._station_frame(y)
-            outline, chord_len, le_anchor, chord_unit = self._slice_outline(
-                origin, chord_dir, up_dir, span_dir
-            )
-            up_z = float(up_dir[2])
-            for x in x_cs:
-                if chord_len <= 0.0:
-                    points.append(SectionPoint(y, x, 0.0, 0.0, 0.0, 0.0))
-                    continue
-                top_v, bottom_v = _outline_to_top_bottom(outline, x, chord_len)
-                chord_point = le_anchor + (x * chord_len) * chord_unit
-                base_z = float(chord_point[2])
-                top_z = base_z + top_v * up_z
-                bottom_z = base_z + bottom_v * up_z
-                points.append(
-                    SectionPoint(
-                        y_span=y,
-                        x_c=x,
-                        thickness=abs(top_z - bottom_z),
-                        top_z=max(top_z, bottom_z),
-                        bottom_z=min(top_z, bottom_z),
-                        center_z=(top_z + bottom_z) / 2.0,
-                    )
-                )
+            section = self._section(y)
+            points.extend(self._point_from_section(section, y, x) for x in x_cs)
         return points
 
     def at_max_thickness(self, y_span: float) -> SectionPoint:
@@ -308,32 +309,12 @@ class SectionGeometry:
         Scans a chord grid and returns the point with the greatest thickness —
         the natural spar-placement reference.
         """
-        candidates = np.linspace(0.05, 0.6, 23)
-        best: SectionPoint | None = None
-        origin, chord_dir, span_dir, up_dir = self._station_frame(y_span)
-        outline, chord_len, le_anchor, chord_unit = self._slice_outline(
-            origin, chord_dir, up_dir, span_dir
-        )
-        up_z = float(up_dir[2])
-        if chord_len <= 0.0:
+        section = self._section(y_span)
+        if section.chord_len <= 0.0:
             return SectionPoint(y_span, 0.0, 0.0, 0.0, 0.0, 0.0)
-        for x in candidates:
-            top_v, bottom_v = _outline_to_top_bottom(outline, float(x), chord_len)
-            chord_point = le_anchor + (float(x) * chord_len) * chord_unit
-            base_z = float(chord_point[2])
-            top_z = base_z + top_v * up_z
-            bottom_z = base_z + bottom_v * up_z
-            thickness = abs(top_z - bottom_z)
-            if best is None or thickness > best.thickness:
-                best = SectionPoint(
-                    y_span=y_span,
-                    x_c=float(x),
-                    thickness=thickness,
-                    top_z=max(top_z, bottom_z),
-                    bottom_z=min(top_z, bottom_z),
-                    center_z=(top_z + bottom_z) / 2.0,
-                )
-        return best if best is not None else SectionPoint(y_span, 0.0, 0.0, 0.0, 0.0, 0.0)
+        candidates = np.linspace(0.05, 0.6, 23)
+        points = (self._point_from_section(section, y_span, float(x)) for x in candidates)
+        return max(points, key=lambda p: p.thickness)
 
     def per_segment(self, n_span: int, n_chord: int) -> dict[int, list[SectionPoint]]:
         """Grid of section points per segment.

--- a/cad_designer/airplane/geometry/section_geometry.py
+++ b/cad_designer/airplane/geometry/section_geometry.py
@@ -1,0 +1,356 @@
+"""Section-geometry primitive (gh-1020).
+
+Slice the **real lofted CAD solid** of a wing to recover, at a parametric
+location ``(y/span, x/c)``:
+
+* ``thickness`` — vertical extent of the built section at that chord location
+* ``top_z`` / ``bottom_z`` — upper / lower surface heights
+* ``center_z`` — section mid-height (spar-placement reference)
+
+Why slice the solid (rather than blend two airfoils analytically): the loft
+built by :class:`WingLoftCreator` already encodes every relative rotation
+(dihedral via R_x, incidence/twist via R_y, sweep via the plane origin) and the
+ruled loft between sections. Slicing gives the exact *built* geometry.
+
+Frame: wing-local, origin at the wing-root LE, ``z`` vertical (the world frame
+the loft is built in). Internally **millimetres** — the service layer converts
+to metres for the API (project convention).
+
+Platform guard: ``cadquery`` is excluded on ``linux/aarch64``. The import is
+lazy and a clear :class:`SectionGeometryUnavailableError` is raised when it is
+unavailable, so callers can return a 503/422 rather than crashing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from cad_designer.airplane.aircraft_topology.wing.WingConfiguration import (
+    WingConfiguration,
+)
+
+try:  # platform guard — cadquery is excluded on linux/aarch64
+    import cadquery as cq  # noqa: F401
+
+    _HAS_CADQUERY = True
+except ImportError:  # pragma: no cover - platform dependent
+    _HAS_CADQUERY = False
+
+
+class SectionGeometryUnavailableError(RuntimeError):
+    """Raised when section geometry cannot be computed because cadquery is
+    unavailable on this platform."""
+
+
+@dataclass(frozen=True)
+class SectionPoint:
+    """A sampled point on the built wing section.
+
+    All lengths in **millimetres**, wing-local frame (origin root-LE, z up).
+    """
+
+    y_span: float  # 0..1 across the whole surface (semi-span)
+    x_c: float  # 0..1 along the local chord
+    thickness: float
+    top_z: float
+    bottom_z: float
+    center_z: float
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (fast tier — no CAD)
+# ---------------------------------------------------------------------------
+
+
+def _y_span_to_segment(y_span: float, segment_lengths: list[float]) -> tuple[int, float]:
+    """Map a normalised span fraction to ``(segment_index, relative_length)``.
+
+    ``relative_length`` is the 0..1 position *within* that segment. ``y_span``
+    is clamped to ``[0, 1]``. The seam between two segments resolves to the end
+    (``relative_length == 1.0``) of the lower segment.
+    """
+    y = min(max(y_span, 0.0), 1.0)
+    total = float(sum(segment_lengths))
+    if total <= 0.0:
+        return 0, 0.0
+
+    target = y * total
+    acc = 0.0
+    for idx, seg_len in enumerate(segment_lengths):
+        seg_len = float(seg_len)
+        if seg_len <= 0.0:
+            continue
+        if target <= acc + seg_len or idx == len(segment_lengths) - 1:
+            rel = (target - acc) / seg_len
+            return idx, min(max(rel, 0.0), 1.0)
+        acc += seg_len
+    # fall through (all-zero lengths handled above)
+    return len(segment_lengths) - 1, 1.0
+
+
+def _outline_to_top_bottom(
+    outline: list[tuple[float, float]], x_c: float, chord_len: float
+) -> tuple[float, float]:
+    """Given a closed section outline in (chord_u, height_v) coordinates, return
+    ``(top_v, bottom_v)`` at chord position ``x_c * chord_len``.
+
+    The outline is a polyline (consecutive points around the loop). At the
+    target chord ordinate we collect every edge crossing and take the max
+    (top) and min (bottom). Pure geometry — no CAD dependency, so this runs on
+    the fast tier.
+    """
+    u_target = x_c * chord_len
+    crossings: list[float] = []
+    n = len(outline)
+    for i in range(n):
+        u0, v0 = outline[i]
+        u1, v1 = outline[(i + 1) % n]
+        umin, umax = (u0, u1) if u0 <= u1 else (u1, u0)
+        if u_target < umin - 1e-9 or u_target > umax + 1e-9:
+            continue
+        if abs(u1 - u0) < 1e-12:
+            crossings.extend((v0, v1))
+        else:
+            t = (u_target - u0) / (u1 - u0)
+            crossings.append(v0 + t * (v1 - v0))
+    if not crossings:
+        return 0.0, 0.0
+    return max(crossings), min(crossings)
+
+
+# ---------------------------------------------------------------------------
+# SectionGeometry — build once, slice many
+# ---------------------------------------------------------------------------
+
+
+class SectionGeometry:
+    """Build a wing's lofted solid once and slice it on demand.
+
+    ``sample`` groups requests by ``y_span`` so each section plane is cut once
+    and all ``x_c`` are read off the same outline.
+    """
+
+    def __init__(self, wing_config: WingConfiguration, points_per_edge: int = 80):
+        if not _HAS_CADQUERY:
+            raise SectionGeometryUnavailableError(
+                "cadquery is not available on this platform; section geometry cannot be computed."
+            )
+        self._wing_config = wing_config
+        self._points_per_edge = max(8, min(int(points_per_edge), 4096))
+        self._segment_lengths = [float(s.length) for s in wing_config.segments]
+        self._solid_shape = self._build_solid()
+
+    # -- build -------------------------------------------------------------
+
+    def _build_solid(self):
+        """Build the starboard (RIGHT) half loft once and return its shape.
+
+        RIGHT half keeps ``y >= 0`` so the span maps monotonically to ``y/span``.
+        """
+        from cad_designer.airplane.creator.wing.WingLoftCreator import (
+            WingLoftCreator,
+        )
+
+        result = WingLoftCreator(
+            "section_geometry.loft",
+            wing_index=0,
+            wing_config={0: self._wing_config},
+            wing_side="RIGHT",
+        ).create_shape()
+        workplane = next(iter(result.values()))
+        solids = workplane.solids().vals()
+        if not solids:
+            raise SectionGeometryUnavailableError("wing loft produced no solid to slice.")
+        return solids[0]
+
+    # -- station frame -----------------------------------------------------
+
+    def _station_frame(
+        self, y_span: float
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """Return ``(origin, chord_dir, span_dir, up_dir)`` for the section plane
+        at ``y_span``.
+
+        The frame is interpolated along the segment between its root and tip
+        workplanes. ``span_dir`` is the section-plane normal; ``chord_dir`` and
+        ``up_dir`` parameterise the cut outline.
+        """
+        idx, rel = _y_span_to_segment(y_span, self._segment_lengths)
+        root_plane = self._wing_config.get_wing_workplane(idx).plane
+        tip_plane = self._wing_config.get_wing_workplane(idx + 1).plane
+
+        o_root = np.array(root_plane.origin.toTuple())
+        o_tip = np.array(tip_plane.origin.toTuple())
+        origin = o_root + rel * (o_tip - o_root)
+
+        # Direction along the segment span = vector between its station LEs.
+        span_dir = o_tip - o_root
+        norm = np.linalg.norm(span_dir)
+        if norm < 1e-9:
+            span_dir = np.array(root_plane.yDir.toTuple())
+        else:
+            span_dir = span_dir / norm
+
+        chord_dir = np.array(root_plane.xDir.toTuple())
+        up_dir = np.array(root_plane.zDir.toTuple())
+        return origin, chord_dir, span_dir, up_dir
+
+    # -- slicing -----------------------------------------------------------
+
+    def _slice_outline(
+        self,
+        origin: np.ndarray,
+        chord_dir: np.ndarray,
+        up_dir: np.ndarray,
+        span_dir: np.ndarray,
+    ) -> tuple[list[tuple[float, float]], float, np.ndarray, np.ndarray]:
+        """Cut the solid with the section plane and return the outline expressed
+        in local ``(chord_u, height_v)`` coordinates, the chord length, and the
+        LE point + chord unit vector (world) needed to rebuild world ``z``.
+        """
+        from cad_designer.aerosandbox.slicing import _section_outline_edges
+
+        edges = _section_outline_edges(
+            self._solid_shape.wrapped,
+            tuple(float(c) for c in origin),
+            tuple(float(c) for c in span_dir),
+        )
+        if not edges:
+            return [], 0.0, origin, chord_dir
+
+        pts_world: list[np.ndarray] = []
+        for e in edges:
+            for k in range(self._points_per_edge):
+                t = k / float(self._points_per_edge - 1)
+                p = e.positionAt(t)
+                pts_world.append(np.array([p.x, p.y, p.z]))
+
+        # Project to local (u along chord_dir, v along up_dir) about a LE anchor.
+        # Anchor at the minimum chord projection so u starts at 0 at the LE.
+        u_all = np.array([float(np.dot(p - origin, chord_dir)) for p in pts_world])
+        v_all = np.array([float(np.dot(p - origin, up_dir)) for p in pts_world])
+        u_min = float(u_all.min())
+        u_all = u_all - u_min
+        chord_len = float(u_all.max())
+        le_anchor = origin + u_min * chord_dir
+
+        outline = list(zip(u_all.tolist(), v_all.tolist(), strict=True))
+        return outline, chord_len, le_anchor, chord_dir
+
+    def _point_at(self, y_span: float, x_c: float) -> SectionPoint:
+        origin, chord_dir, span_dir, up_dir = self._station_frame(y_span)
+        outline, chord_len, le_anchor, chord_unit = self._slice_outline(
+            origin, chord_dir, up_dir, span_dir
+        )
+        if chord_len <= 0.0:
+            return SectionPoint(y_span, x_c, 0.0, 0.0, 0.0, 0.0)
+
+        top_v, bottom_v = _outline_to_top_bottom(outline, x_c, chord_len)
+        # Convert local v back to world z at the sampled chord ordinate.
+        chord_point = le_anchor + (x_c * chord_len) * chord_unit
+        base_z = float(chord_point[2])
+        # up_dir z-component scales the local v into world z.
+        up_z = float(up_dir[2])
+        top_z = base_z + top_v * up_z
+        bottom_z = base_z + bottom_v * up_z
+        thickness = abs(top_z - bottom_z)
+        center_z = (top_z + bottom_z) / 2.0
+        return SectionPoint(
+            y_span=y_span,
+            x_c=x_c,
+            thickness=thickness,
+            top_z=max(top_z, bottom_z),
+            bottom_z=min(top_z, bottom_z),
+            center_z=center_z,
+        )
+
+    # -- public API --------------------------------------------------------
+
+    def at(self, y_span: float, x_c: float) -> SectionPoint:
+        """Section geometry at a single ``(y/span, x/c)`` location."""
+        return self._point_at(y_span, x_c)
+
+    def sample(self, y_spans: list[float], x_cs: list[float]) -> list[SectionPoint]:
+        """Sample a grid: slice each unique ``y_span`` once, read all ``x_c``."""
+        points: list[SectionPoint] = []
+        for y in y_spans:
+            origin, chord_dir, span_dir, up_dir = self._station_frame(y)
+            outline, chord_len, le_anchor, chord_unit = self._slice_outline(
+                origin, chord_dir, up_dir, span_dir
+            )
+            up_z = float(up_dir[2])
+            for x in x_cs:
+                if chord_len <= 0.0:
+                    points.append(SectionPoint(y, x, 0.0, 0.0, 0.0, 0.0))
+                    continue
+                top_v, bottom_v = _outline_to_top_bottom(outline, x, chord_len)
+                chord_point = le_anchor + (x * chord_len) * chord_unit
+                base_z = float(chord_point[2])
+                top_z = base_z + top_v * up_z
+                bottom_z = base_z + bottom_v * up_z
+                points.append(
+                    SectionPoint(
+                        y_span=y,
+                        x_c=x,
+                        thickness=abs(top_z - bottom_z),
+                        top_z=max(top_z, bottom_z),
+                        bottom_z=min(top_z, bottom_z),
+                        center_z=(top_z + bottom_z) / 2.0,
+                    )
+                )
+        return points
+
+    def at_max_thickness(self, y_span: float) -> SectionPoint:
+        """Section geometry at the *deepest* chord location on that section.
+
+        Scans a chord grid and returns the point with the greatest thickness —
+        the natural spar-placement reference.
+        """
+        candidates = np.linspace(0.05, 0.6, 23)
+        best: SectionPoint | None = None
+        origin, chord_dir, span_dir, up_dir = self._station_frame(y_span)
+        outline, chord_len, le_anchor, chord_unit = self._slice_outline(
+            origin, chord_dir, up_dir, span_dir
+        )
+        up_z = float(up_dir[2])
+        if chord_len <= 0.0:
+            return SectionPoint(y_span, 0.0, 0.0, 0.0, 0.0, 0.0)
+        for x in candidates:
+            top_v, bottom_v = _outline_to_top_bottom(outline, float(x), chord_len)
+            chord_point = le_anchor + (float(x) * chord_len) * chord_unit
+            base_z = float(chord_point[2])
+            top_z = base_z + top_v * up_z
+            bottom_z = base_z + bottom_v * up_z
+            thickness = abs(top_z - bottom_z)
+            if best is None or thickness > best.thickness:
+                best = SectionPoint(
+                    y_span=y_span,
+                    x_c=float(x),
+                    thickness=thickness,
+                    top_z=max(top_z, bottom_z),
+                    bottom_z=min(top_z, bottom_z),
+                    center_z=(top_z + bottom_z) / 2.0,
+                )
+        return best if best is not None else SectionPoint(y_span, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+    def per_segment(self, n_span: int, n_chord: int) -> dict[int, list[SectionPoint]]:
+        """Grid of section points per segment.
+
+        For each segment, sample ``n_span`` stations across that segment's own
+        span and ``n_chord`` chord positions. ``y_span`` on each point is the
+        global (whole-surface) span fraction.
+        """
+        n_span = max(1, int(n_span))
+        n_chord = max(1, int(n_chord))
+        x_cs = np.linspace(0.05, 0.95, n_chord).tolist()
+        total = float(sum(self._segment_lengths))
+        grid: dict[int, list[SectionPoint]] = {}
+        acc = 0.0
+        for idx, seg_len in enumerate(self._segment_lengths):
+            local_fracs = np.linspace(0.0, 1.0, n_span)
+            y_globals = [(acc + f * seg_len) / total if total > 0 else 0.0 for f in local_fracs]
+            grid[idx] = self.sample(y_globals, x_cs)
+            acc += seg_len
+        return grid

--- a/cad_designer/airplane/geometry/section_geometry.py
+++ b/cad_designer/airplane/geometry/section_geometry.py
@@ -100,8 +100,9 @@ def _y_span_to_segment(y_span: float, segment_lengths: list[float]) -> tuple[int
             rel = (target - acc) / seg_len
             return idx, min(max(rel, 0.0), 1.0)
         acc += seg_len
-    # fall through (all-zero lengths handled above)
-    return len(segment_lengths) - 1, 1.0
+    # Unreachable: total > 0 guarantees the last positive segment returns above;
+    # an all-zero list is handled by the total <= 0 guard. Defensive only.
+    return len(segment_lengths) - 1, 1.0  # pragma: no cover
 
 
 def _outline_to_top_bottom(
@@ -158,7 +159,7 @@ class SectionGeometry:
 
     # -- build -------------------------------------------------------------
 
-    def _build_solid(self):
+    def _build_solid(self):  # pragma: no cover - cadquery boundary, covered by requires_cadquery slow tests
         """Build the starboard (RIGHT) half loft once and return its shape.
 
         RIGHT half keeps ``y >= 0`` so the span maps monotonically to ``y/span``.
@@ -213,7 +214,7 @@ class SectionGeometry:
 
     # -- slicing -----------------------------------------------------------
 
-    def _slice_outline(
+    def _slice_outline(  # pragma: no cover - cadquery boundary, covered by requires_cadquery slow tests
         self,
         origin: np.ndarray,
         chord_dir: np.ndarray,
@@ -259,7 +260,7 @@ class SectionGeometry:
             up_z=float(up_dir[2]),
         )
 
-    def _section(self, y_span: float) -> _SlicedSection:
+    def _section(self, y_span: float) -> _SlicedSection:  # pragma: no cover - cadquery boundary (slow tests + mocked in fast)
         """Slice the solid at ``y_span`` and return the reusable section data."""
         origin, chord_dir, span_dir, up_dir = self._station_frame(y_span)
         return self._slice_outline(origin, chord_dir, up_dir, span_dir)

--- a/cad_designer/airplane/geometry/section_geometry.py
+++ b/cad_designer/airplane/geometry/section_geometry.py
@@ -23,6 +23,7 @@ unavailable, so callers can return a 503/422 rather than crashing.
 
 from __future__ import annotations
 
+import importlib.util
 from dataclasses import dataclass
 
 import numpy as np
@@ -31,12 +32,9 @@ from cad_designer.airplane.aircraft_topology.wing.WingConfiguration import (
     WingConfiguration,
 )
 
-try:  # platform guard — cadquery is excluded on linux/aarch64
-    import cadquery as cq  # noqa: F401
-
-    _HAS_CADQUERY = True
-except ImportError:  # pragma: no cover - platform dependent
-    _HAS_CADQUERY = False
+# Platform guard — cadquery is excluded on linux/aarch64. Probe without binding
+# an unused module-level name (keeps the import section lint-clean).
+_HAS_CADQUERY = importlib.util.find_spec("cadquery") is not None
 
 
 class SectionGeometryUnavailableError(RuntimeError):

--- a/cad_designer/tests/test_section_geometry.py
+++ b/cad_designer/tests/test_section_geometry.py
@@ -79,6 +79,16 @@ class TestYSpanToSegment:
         assert idx == 1
         assert rel == pytest.approx(1.0)
 
+    def test_all_zero_lengths_return_root(self):
+        # total <= 0 guard
+        assert _y_span_to_segment(0.5, [0.0, 0.0]) == (0, 0.0)
+
+    def test_skips_zero_length_segment(self):
+        # a leading zero-length segment is skipped; the station lands in seg 1
+        idx, rel = _y_span_to_segment(0.0, [0.0, 100.0])
+        assert idx == 1
+        assert rel == pytest.approx(0.0)
+
 
 # ---------------------------------------------------------------------------
 # Fast: outline -> top/bottom sampling
@@ -382,3 +392,36 @@ class TestStationFrameMath:
         sg._wing_config = self._wing_with_planes([root, tip])
         _, _, span_dir, _ = sg._station_frame(0.5)
         assert span_dir == pytest.approx([0.0, 1.0, 0.0])
+
+
+class TestOutlineToTopBottomEdges:
+    def test_no_crossings_returns_zeros(self):
+        # empty outline -> no edge crossings -> (0, 0)
+        assert _outline_to_top_bottom([], 0.5, 100.0) == (0.0, 0.0)
+
+    def test_chord_ordinate_outside_outline_returns_zeros(self):
+        outline = [(0.0, 5.0), (10.0, 5.0), (10.0, -5.0), (0.0, -5.0)]
+        # x_c * chord_len = 0.99 * 1.0 = 0.99 mm, well below the 0..10 outline span
+        assert _outline_to_top_bottom(outline, 50.0, 1.0) == (0.0, 0.0)
+
+
+class TestInitWithMockedCad:
+    """__init__ happy path with the CAD build mocked out (fast tier)."""
+
+    def test_init_sets_attributes_and_clamps_points_per_edge(self, monkeypatch):
+        import cad_designer.airplane.geometry.section_geometry as mod
+
+        monkeypatch.setattr(mod, "_HAS_CADQUERY", True)
+        monkeypatch.setattr(mod.SectionGeometry, "_build_solid", lambda self: "SOLID")
+
+        class _Seg:
+            def __init__(self, length):
+                self.length = length
+
+        class _Cfg:
+            segments = [_Seg(300.0), _Seg(700.0)]
+
+        sg = mod.SectionGeometry(_Cfg(), points_per_edge=99999)
+        assert sg._solid_shape == "SOLID"
+        assert sg._segment_lengths == [300.0, 700.0]
+        assert sg._points_per_edge == 4096  # clamped to the upper bound

--- a/cad_designer/tests/test_section_geometry.py
+++ b/cad_designer/tests/test_section_geometry.py
@@ -1,0 +1,202 @@
+"""Tests for the cad_designer SectionGeometry primitive (gh-1020).
+
+Two tiers:
+
+* **fast** — pure helper math (y/span -> segment mapping, outline -> top/bottom
+  sampling) that does NOT build any CAD. These run on the CI fast tier (no
+  cadquery) and protect the coverage gate.
+* **slow / requires_cadquery** — build the real lofted solid and slice it.
+  Asserts the built geometry matches the airfoil (root thickness ~= t/c * chord),
+  monotonic taper, and that twist/dihedral move the section as expected.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from cad_designer.airplane.geometry.section_geometry import (
+    SectionGeometry,
+    SectionGeometryUnavailableError,
+    SectionPoint,
+    _outline_to_top_bottom,
+    _y_span_to_segment,
+)
+from cad_designer.aerosandbox.wing_roundtrip_cases import (
+    configurator_wing,
+    single_segment_flat,
+    single_segment_with_dihedral,
+    single_segment_with_twist,
+    single_segment_with_twist_and_dihedral,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fast: pure y/span -> segment mapping
+# ---------------------------------------------------------------------------
+
+
+class TestYSpanToSegment:
+    def test_single_segment_root(self):
+        idx, rel = _y_span_to_segment(0.0, [500.0])
+        assert idx == 0
+        assert rel == pytest.approx(0.0)
+
+    def test_single_segment_tip(self):
+        idx, rel = _y_span_to_segment(1.0, [500.0])
+        assert idx == 0
+        assert rel == pytest.approx(1.0)
+
+    def test_single_segment_mid(self):
+        idx, rel = _y_span_to_segment(0.5, [500.0])
+        assert idx == 0
+        assert rel == pytest.approx(0.5)
+
+    def test_two_segments_boundary(self):
+        # equal-length segments: y_span=0.5 is the seam, resolves to end of seg 0
+        idx, rel = _y_span_to_segment(0.5, [500.0, 500.0])
+        assert idx == 0
+        assert rel == pytest.approx(1.0)
+
+    def test_two_segments_into_second(self):
+        idx, rel = _y_span_to_segment(0.75, [500.0, 500.0])
+        assert idx == 1
+        assert rel == pytest.approx(0.5)
+
+    def test_unequal_segments(self):
+        # lengths 300 + 700 = 1000; y_span 0.5 -> 500mm -> seg 1 at (500-300)/700
+        idx, rel = _y_span_to_segment(0.5, [300.0, 700.0])
+        assert idx == 1
+        assert rel == pytest.approx(200.0 / 700.0)
+
+    def test_clamps_below_zero(self):
+        idx, rel = _y_span_to_segment(-0.1, [500.0])
+        assert idx == 0
+        assert rel == pytest.approx(0.0)
+
+    def test_clamps_above_one(self):
+        idx, rel = _y_span_to_segment(1.5, [500.0, 500.0])
+        assert idx == 1
+        assert rel == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Fast: outline -> top/bottom sampling
+# ---------------------------------------------------------------------------
+
+
+class TestOutlineToTopBottom:
+    def _diamond_outline(self):
+        """A symmetric diamond cross-section in the section's (chord_u, z) plane.
+
+        chord runs 0..100, top/bottom peak at chord 50: top +20, bottom -20.
+        Returns a list of (chord_u, z) polyline points around the loop.
+        """
+        return [
+            (0.0, 0.0),
+            (50.0, 20.0),
+            (100.0, 0.0),
+            (50.0, -20.0),
+            (0.0, 0.0),
+        ]
+
+    def test_top_bottom_at_mid(self):
+        outline = self._diamond_outline()
+        top, bottom = _outline_to_top_bottom(outline, x_c=0.5, chord_len=100.0)
+        assert top == pytest.approx(20.0, abs=1e-6)
+        assert bottom == pytest.approx(-20.0, abs=1e-6)
+
+    def test_thickness_zero_at_le(self):
+        outline = self._diamond_outline()
+        top, bottom = _outline_to_top_bottom(outline, x_c=0.0, chord_len=100.0)
+        assert top == pytest.approx(0.0, abs=1e-6)
+        assert bottom == pytest.approx(0.0, abs=1e-6)
+
+    def test_quarter_chord(self):
+        outline = self._diamond_outline()
+        top, bottom = _outline_to_top_bottom(outline, x_c=0.25, chord_len=100.0)
+        # linear ramp from 0 (chord 0) to 20 (chord 50): at chord 25 -> 10
+        assert top == pytest.approx(10.0, abs=1e-6)
+        assert bottom == pytest.approx(-10.0, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Slow / requires_cadquery: real build + slice
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+@pytest.mark.requires_cadquery
+class TestSectionGeometryRealBuild:
+    def test_flat_root_thickness_matches_airfoil(self):
+        """NACA0010 (t/c=0.10), chord 200mm -> max thickness ~= 20mm."""
+        sg = SectionGeometry(single_segment_flat())
+        pt = sg.at_max_thickness(0.05)  # near root
+        assert pt.thickness == pytest.approx(20.0, rel=0.12)
+        # symmetric airfoil, no dihedral/twist -> centre near z=0
+        assert pt.center_z == pytest.approx(0.0, abs=2.0)
+
+    def test_flat_thickness_constant_along_span(self):
+        sg = SectionGeometry(single_segment_flat())
+        root = sg.at_max_thickness(0.1)
+        tip = sg.at_max_thickness(0.9)
+        # untapered -> thickness roughly constant
+        assert tip.thickness == pytest.approx(root.thickness, rel=0.12)
+
+    def test_taper_reduces_thickness(self):
+        """twist+dihedral case tapers 200 -> 150 chord; tip thinner than root."""
+        sg = SectionGeometry(single_segment_with_twist_and_dihedral())
+        root = sg.at_max_thickness(0.05)
+        tip = sg.at_max_thickness(0.95)
+        assert tip.thickness < root.thickness
+
+    def test_dihedral_lifts_center_z(self):
+        """+5 deg dihedral -> tip section centre is raised vs root."""
+        sg = SectionGeometry(single_segment_with_dihedral())
+        root = sg.at_max_thickness(0.05)
+        tip = sg.at_max_thickness(0.95)
+        assert tip.center_z > root.center_z + 5.0
+
+    def test_at_returns_section_point(self):
+        sg = SectionGeometry(single_segment_flat())
+        pt = sg.at(0.5, 0.3)
+        assert isinstance(pt, SectionPoint)
+        assert pt.thickness > 0
+        assert pt.top_z > pt.bottom_z
+        assert pt.center_z == pytest.approx((pt.top_z + pt.bottom_z) / 2.0)
+
+    def test_sample_slices_each_y_once(self):
+        sg = SectionGeometry(single_segment_flat())
+        pts = sg.sample([0.25, 0.75], [0.2, 0.3, 0.4])
+        assert len(pts) == 6  # 2 y * 3 x
+        for p in pts:
+            assert p.thickness > 0
+
+    def test_per_segment_grid(self):
+        sg = SectionGeometry(configurator_wing())
+        grid = sg.per_segment(n_span=3, n_chord=4)
+        assert set(grid.keys()) == {0, 1, 2}
+        for pts in grid.values():
+            assert len(pts) == 12  # 3 * 4
+
+    def test_twist_tilts_section(self):
+        """-10 deg tip twist tilts the section: top_z at LE differs from TE."""
+        sg = SectionGeometry(single_segment_with_twist())
+        le = sg.at(0.95, 0.05)
+        te = sg.at(0.95, 0.95)
+        # with washout the LE rises relative to the TE (or vice-versa) -> centres differ
+        assert abs(le.center_z - te.center_z) > 1.0
+
+
+# ---------------------------------------------------------------------------
+# Fast: platform guard (cadquery unavailable)
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformGuard:
+    def test_unavailable_raises_typed_error(self, monkeypatch):
+        import cad_designer.airplane.geometry.section_geometry as mod
+
+        monkeypatch.setattr(mod, "_HAS_CADQUERY", False)
+        with pytest.raises(SectionGeometryUnavailableError):
+            SectionGeometry(single_segment_flat())

--- a/cad_designer/tests/test_section_geometry.py
+++ b/cad_designer/tests/test_section_geometry.py
@@ -200,3 +200,185 @@ class TestPlatformGuard:
         monkeypatch.setattr(mod, "_HAS_CADQUERY", False)
         with pytest.raises(SectionGeometryUnavailableError):
             SectionGeometry(single_segment_flat())
+
+
+# ---------------------------------------------------------------------------
+# Fast: orchestration with the CAD slicing boundary mocked
+#
+# These exercise at()/sample()/at_max_thickness()/per_segment() and the
+# world-z reconstruction WITHOUT building any CAD, so the orchestration lines
+# are covered on the no-cadquery CI fast tier (protects the new_coverage gate).
+# ---------------------------------------------------------------------------
+
+
+from cad_designer.airplane.geometry.section_geometry import _SlicedSection  # noqa: E402
+
+
+def _bare_section_geometry(segment_lengths: list[float]) -> SectionGeometry:
+    """A SectionGeometry that skips __init__ (no CAD build)."""
+    sg = object.__new__(SectionGeometry)
+    sg._wing_config = None
+    sg._points_per_edge = 80
+    sg._segment_lengths = segment_lengths
+    sg._solid_shape = None
+    return sg
+
+
+def _flat_section(chord_len: float = 100.0) -> _SlicedSection:
+    """A flat-plate section: +-10 height over the whole chord, z up == 1."""
+    outline = [
+        (0.0, 10.0),
+        (chord_len, 10.0),
+        (chord_len, -10.0),
+        (0.0, -10.0),
+    ]
+    return _SlicedSection(
+        outline=outline,
+        chord_len=chord_len,
+        le_anchor=np.array([0.0, 0.0, 0.0]),
+        chord_unit=np.array([1.0, 0.0, 0.0]),
+        up_z=1.0,
+    )
+
+
+class TestPointFromSection:
+    def test_basic_thickness_and_center(self):
+        pt = SectionGeometry._point_from_section(_flat_section(), 0.3, 0.5)
+        assert pt.thickness == pytest.approx(20.0)
+        assert pt.top_z == pytest.approx(10.0)
+        assert pt.bottom_z == pytest.approx(-10.0)
+        assert pt.center_z == pytest.approx(0.0)
+        assert pt.x_c == 0.5
+        assert pt.y_span == 0.3
+
+    def test_empty_section_returns_zeros(self):
+        empty = _SlicedSection([], 0.0, np.zeros(3), np.array([1.0, 0, 0]), 1.0)
+        pt = SectionGeometry._point_from_section(empty, 0.1, 0.4)
+        assert pt.thickness == 0.0
+        assert pt.top_z == 0.0
+        assert pt.bottom_z == 0.0
+
+    def test_dihedral_up_z_lifts_world_z(self):
+        # chord line rising in world z (le_anchor.z varies via chord_unit)
+        section = _SlicedSection(
+            outline=[(0.0, 5.0), (100.0, 5.0), (100.0, -5.0), (0.0, -5.0)],
+            chord_len=100.0,
+            le_anchor=np.array([0.0, 0.0, 50.0]),  # whole section lifted 50mm
+            chord_unit=np.array([1.0, 0.0, 0.0]),
+            up_z=1.0,
+        )
+        pt = SectionGeometry._point_from_section(section, 0.9, 0.5)
+        assert pt.center_z == pytest.approx(50.0)
+
+
+class TestOrchestrationMocked:
+    def test_at_uses_section(self, monkeypatch):
+        sg = _bare_section_geometry([100.0])
+        monkeypatch.setattr(sg, "_section", lambda y: _flat_section())
+        pt = sg.at(0.5, 0.4)
+        assert pt.thickness == pytest.approx(20.0)
+
+    def test_sample_grid_cardinality(self, monkeypatch):
+        sg = _bare_section_geometry([100.0])
+        monkeypatch.setattr(sg, "_section", lambda y: _flat_section())
+        pts = sg.sample([0.2, 0.5, 0.8], [0.25, 0.5])
+        assert len(pts) == 6
+        assert all(p.thickness == pytest.approx(20.0) for p in pts)
+
+    def test_at_max_thickness_picks_deepest(self, monkeypatch):
+        # outline thicker in the middle so the scan must find the peak
+        def _tapered(_y):
+            return _SlicedSection(
+                outline=[(0.0, 0.0), (50.0, 30.0), (100.0, 0.0), (50.0, -30.0)],
+                chord_len=100.0,
+                le_anchor=np.array([0.0, 0.0, 0.0]),
+                chord_unit=np.array([1.0, 0.0, 0.0]),
+                up_z=1.0,
+            )
+
+        sg = _bare_section_geometry([100.0])
+        monkeypatch.setattr(sg, "_section", _tapered)
+        pt = sg.at_max_thickness(0.5)
+        # deepest is at chord 0.5 -> thickness 60
+        assert pt.thickness == pytest.approx(60.0, abs=6.0)
+        assert pt.x_c == pytest.approx(0.5, abs=0.06)
+
+    def test_at_max_thickness_empty_section(self, monkeypatch):
+        sg = _bare_section_geometry([100.0])
+        empty = _SlicedSection([], 0.0, np.zeros(3), np.array([1.0, 0, 0]), 1.0)
+        monkeypatch.setattr(sg, "_section", lambda y: empty)
+        pt = sg.at_max_thickness(0.5)
+        assert pt.thickness == 0.0
+
+    def test_per_segment_global_y_and_cardinality(self, monkeypatch):
+        sg = _bare_section_geometry([300.0, 700.0])
+        seen_y: list[float] = []
+
+        def _record(y):
+            seen_y.append(y)
+            return _flat_section()
+
+        monkeypatch.setattr(sg, "_section", _record)
+        grid = sg.per_segment(n_span=2, n_chord=3)
+        assert set(grid.keys()) == {0, 1}
+        assert len(grid[0]) == 6 and len(grid[1]) == 6
+        # global y for seg 1 tip must be 1.0 (whole-surface fraction)
+        assert max(seen_y) == pytest.approx(1.0)
+        # seg 0 root is 0.0
+        assert min(seen_y) == pytest.approx(0.0)
+
+
+class TestStationFrameMath:
+    """_station_frame with mocked workplanes (no CAD build)."""
+
+    def _fake_plane(self, origin, xdir, ydir, zdir):
+        class _V:
+            def __init__(self, t):
+                self._t = t
+
+            def toTuple(self):
+                return self._t
+
+        class _Plane:
+            pass
+
+        p = _Plane()
+        p.origin = _V(origin)
+        p.xDir = _V(xdir)
+        p.yDir = _V(ydir)
+        p.zDir = _V(zdir)
+        return p
+
+    def _wing_with_planes(self, planes):
+        class _WC:
+            def __init__(self, planes):
+                self._planes = planes
+
+            def get_wing_workplane(self, idx):
+                class _WP:
+                    def __init__(self, plane):
+                        self.plane = plane
+
+                return _WP(self._planes[idx])
+
+        return _WC(planes)
+
+    def test_flat_frame_span_is_y(self):
+        sg = _bare_section_geometry([500.0])
+        root = self._fake_plane((0, 0, 0), (1, 0, 0), (0, 1, 0), (0, 0, 1))
+        tip = self._fake_plane((0, 500, 0), (1, 0, 0), (0, 1, 0), (0, 0, 1))
+        sg._wing_config = self._wing_with_planes([root, tip])
+        origin, chord_dir, span_dir, up_dir = sg._station_frame(0.5)
+        assert origin == pytest.approx([0.0, 250.0, 0.0])
+        assert span_dir == pytest.approx([0.0, 1.0, 0.0])
+        assert chord_dir == pytest.approx([1.0, 0.0, 0.0])
+        assert up_dir == pytest.approx([0.0, 0.0, 1.0])
+
+    def test_degenerate_span_falls_back_to_ydir(self):
+        sg = _bare_section_geometry([500.0])
+        # root and tip share the same origin -> span vector is zero
+        root = self._fake_plane((0, 0, 0), (1, 0, 0), (0, 1, 0), (0, 0, 1))
+        tip = self._fake_plane((0, 0, 0), (1, 0, 0), (0, 1, 0), (0, 0, 1))
+        sg._wing_config = self._wing_with_planes([root, tip])
+        _, _, span_dir, _ = sg._station_frame(0.5)
+        assert span_dir == pytest.approx([0.0, 1.0, 0.0])


### PR DESCRIPTION
Closes #1020

First slice of epic #1019. A reusable `cad_designer` geometry primitive that **slices the real lofted CAD solid** to recover, at `(y/span, x/c)`: `thickness`, `top_z`, `bottom_z`, `center_z` (mm, wing-local frame, origin root-LE, z up).

## What
- New module `cad_designer/airplane/geometry/section_geometry.py` — **read-only topology respected** (no change to Airfoil/WingSegment/WingConfiguration; operates on them).
- `SectionGeometry(wing_config)` builds the loft **once** via `WingLoftCreator` (RIGHT half so y maps monotonically), then slices on demand:
  - `at(y_span, x_c)`, `sample(y_spans, x_cs)` (build-once-slice-many: each unique `y_span` cut once, all `x_c` read off the same outline), `per_segment(n_span, n_chord)`, `at_max_thickness(y_span)` (deepest chord ordinate — the spar reference).
- Cut along the **local section plane** per station (normal = local spanwise dir from the segment workplanes), so swept/twisted/dihedral wings are not distorted by an oblique constant-x cut.
- Lazy cadquery import + typed `SectionGeometryUnavailableError` platform guard (linux/aarch64).

## Tests
- **fast** (no CAD, protect the coverage gate): `_y_span_to_segment` mapping, `_outline_to_top_bottom` sampling, platform-guard error path.
- **slow / requires_cadquery**: real build+slice on NACA box wings — root thickness ≈ t/c·chord (NACA0010×200mm → ~20mm), taper reduces thickness, +5° dihedral lifts `center_z`, twist tilts the section.

## Test plan
- [x] `pytest cad_designer/tests/test_section_geometry.py` (12 fast + 8 slow) pass locally
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)