### PR TITLE
feat(gh-1021): v2 section-geometry endpoint + schemas + service

### DIFF
--- a/app/api/v2/endpoints/aeroanalysis.py
+++ b/app/api/v2/endpoints/aeroanalysis.py
@@ -22,11 +22,13 @@ from app.db.session import get_db
 from app.schemas.AeroplaneRequest import AnalysisToolUrlType, AlphaSweepRequest, SimpleSweepRequest
 from app.schemas.api_responses import StaticUrlResponse
 from app.schemas.aeroanalysisschema import OperatingPointSchema
+from app.schemas.section_geometry import SectionGeometryRequest, SectionGeometryResponse
 from app.schemas.spar_sizing import SparSizingParams
 from app.schemas.spanwise_loads import SpanwiseLoadsResponse, SpanwiseLoadsWithSizingResponse
 from app.schemas.stability import StabilitySummaryResponse, StabilityResultRead
 from app.schemas.strip_forces import StripForcesResponse
 from app.services import analysis_service
+from app.services import section_geometry_service
 from app.services import stability_service
 from app.services.wing_service import get_aeroplane_or_raise
 from app.settings import Settings, get_settings
@@ -456,6 +458,41 @@ async def get_airplane_spanwise_loads(
         return await analysis_service.analyze_airplane_spanwise_loads(
             db, aeroplane_id, operating_point, solver=solver
         )
+    except ServiceException as exc:
+        _raise_http_from_domain(exc)
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Unexpected error: {exc}"
+        ) from exc
+
+
+@router.post(
+    "/aeroplanes/{aeroplane_id}/section-geometry",
+    response_model=SectionGeometryResponse,
+    tags=["analysis"],
+    operation_id="get_airplane_section_geometry",
+)
+def get_airplane_section_geometry(
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
+    request: Annotated[
+        SectionGeometryRequest,
+        Body(..., description="Section-geometry sampling request (all fields optional)"),
+    ],
+    db: Annotated[Session, Depends(get_db)],
+) -> SectionGeometryResponse:
+    """Sample the built section geometry of a wing (gh-1021).
+
+    Slices the real lofted CAD solid at parametric ``(y/span, x/c)`` locations
+    and returns thickness, upper/lower surface heights, and mid-height
+    (spar-placement reference) in **metres**. When the sample arrays are
+    omitted, an evenly spaced default grid is used. Set ``per_segment=true`` to
+    additionally receive a per-segment grid.
+
+    Returns 422 when section geometry is unavailable on this platform (cadquery
+    excluded on ``linux/aarch64``).
+    """
+    try:
+        return section_geometry_service.compute_section_geometry(db, aeroplane_id, request)
     except ServiceException as exc:
         _raise_http_from_domain(exc)
     except Exception as exc:  # pragma: no cover - defensive fallback

--- a/app/schemas/section_geometry.py
+++ b/app/schemas/section_geometry.py
@@ -1,0 +1,72 @@
+"""Pydantic request/response schemas for the section-geometry endpoint (gh-1021).
+
+The underlying :class:`cad_designer.airplane.geometry.section_geometry.SectionPoint`
+works in **millimetres** (wing-local frame). This API exposes lengths in
+**metres** (project convention) — the service converts mm -> m (x0.001).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class SectionGeometryRequest(BaseModel):
+    """Request body for ``POST /aeroplanes/{id}/section-geometry``.
+
+    All fields are optional. When ``y_over_span`` / ``x_over_chord`` are omitted
+    the service samples an evenly spaced default grid.
+    """
+
+    y_over_span: Optional[list[float]] = Field(
+        None,
+        description=(
+            "Spanwise sample fractions (0..1 across the semi-span). "
+            "Omit for an evenly spaced default grid."
+        ),
+    )
+    x_over_chord: Optional[list[float]] = Field(
+        None,
+        description=(
+            "Chordwise sample fractions (0..1 along the local chord). "
+            "Omit for an evenly spaced default grid."
+        ),
+    )
+    per_segment: bool = Field(
+        False,
+        description=("When true, also return a per-segment grid keyed by segment index."),
+    )
+    wing_name: Optional[str] = Field(
+        None,
+        description=(
+            "Name of the wing to query. When omitted, the aeroplane's first wing is used."
+        ),
+    )
+
+
+class SectionPointOut(BaseModel):
+    """A sampled point on the built wing section. Lengths in **metres**."""
+
+    y_span: float = Field(..., description="Span fraction 0..1 across the semi-span")
+    x_c: float = Field(..., description="Chord fraction 0..1 along the local chord")
+    thickness: float = Field(..., description="Vertical section extent at this chord location (m)")
+    top_z: float = Field(..., description="Upper surface height, wing frame (m)")
+    bottom_z: float = Field(..., description="Lower surface height, wing frame (m)")
+    center_z: float = Field(..., description="Section mid-height, spar-placement reference (m)")
+
+
+class SectionGeometryResponse(BaseModel):
+    """Response for ``POST /aeroplanes/{id}/section-geometry``."""
+
+    surface: list[SectionPointOut] = Field(
+        ...,
+        description="Whole-surface grid of sampled section points (metres).",
+    )
+    segments: Optional[dict[int, list[SectionPointOut]]] = Field(
+        None,
+        description=(
+            "Per-segment grids keyed by segment index. Present only when "
+            "per_segment=true was requested."
+        ),
+    )

--- a/app/services/section_geometry_service.py
+++ b/app/services/section_geometry_service.py
@@ -1,0 +1,117 @@
+"""Service for the section-geometry endpoint (gh-1021).
+
+Resolve an aeroplane id -> its wing -> a ``WingConfiguration`` (mm), build the
+:class:`cad_designer.airplane.geometry.section_geometry.SectionGeometry`
+primitive, sample it, and convert the millimetre results to metres for the API.
+
+The ``SectionGeometry`` construction needs cadquery (excluded on
+``linux/aarch64``). When unavailable it raises
+``SectionGeometryUnavailableError``; we translate that into a ``ValidationError``
+so the endpoint returns a clean 422 instead of crashing.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+from app.converters.model_schema_converters import wing_model_to_wing_config
+from app.core.exceptions import NotFoundError, ValidationError
+from app.schemas.section_geometry import (
+    SectionGeometryRequest,
+    SectionGeometryResponse,
+    SectionPointOut,
+)
+from app.services.wing_service import get_aeroplane_or_raise, get_wing_or_raise
+
+logger = logging.getLogger(__name__)
+
+_MM_TO_M = 0.001
+
+# Default grid resolution when the caller omits the sample arrays.
+_DEFAULT_N_SPAN = 11
+_DEFAULT_N_CHORD = 11
+# Per-segment default grid resolution.
+_DEFAULT_SEGMENT_N_SPAN = 5
+_DEFAULT_SEGMENT_N_CHORD = 11
+
+
+def _default_grid(n: int) -> list[float]:
+    """Evenly spaced fractions over the open-ended (0, 1] interior.
+
+    We avoid the exact endpoints (0.0 / 1.0) so samples land on the section
+    interior, where the chord ordinate reliably intersects the outline.
+    """
+    return [round(float(v), 6) for v in np.linspace(0.0, 1.0, n + 2)[1:-1]]
+
+
+def _to_out(point) -> SectionPointOut:
+    """Convert a millimetre ``SectionPoint`` to a metre ``SectionPointOut``."""
+    return SectionPointOut(
+        y_span=point.y_span,
+        x_c=point.x_c,
+        thickness=point.thickness * _MM_TO_M,
+        top_z=point.top_z * _MM_TO_M,
+        bottom_z=point.bottom_z * _MM_TO_M,
+        center_z=point.center_z * _MM_TO_M,
+    )
+
+
+def _build_section_geometry(wing_config):
+    """Construct the SectionGeometry primitive, translating the platform guard.
+
+    Kept as a thin seam so fast tests can monkeypatch the cadquery boundary.
+    """
+    from cad_designer.airplane.geometry.section_geometry import (
+        SectionGeometry,
+        SectionGeometryUnavailableError,
+    )
+
+    try:
+        return SectionGeometry(wing_config)
+    except SectionGeometryUnavailableError as exc:
+        raise ValidationError(
+            message=f"Section geometry is unavailable on this platform: {exc}",
+        ) from exc
+
+
+def compute_section_geometry(
+    db,
+    aeroplane_uuid,
+    request: SectionGeometryRequest,
+) -> SectionGeometryResponse:
+    """Sample the built section geometry of an aeroplane's wing.
+
+    Raises:
+        NotFoundError: aeroplane or wing does not exist (-> 404).
+        ValidationError: section geometry unavailable on this platform (-> 422).
+    """
+    aeroplane = get_aeroplane_or_raise(db, aeroplane_uuid)
+
+    if request.wing_name is not None:
+        wing = get_wing_or_raise(aeroplane, request.wing_name)
+    else:
+        if not aeroplane.wings:
+            raise NotFoundError(
+                message="Aeroplane has no wings to query section geometry for",
+                details={"aeroplane_id": str(aeroplane_uuid)},
+            )
+        wing = aeroplane.wings[0]
+
+    # WingConfiguration / SectionGeometry work in millimetres (scale=1000.0).
+    wing_config = wing_model_to_wing_config(wing, scale=1000.0)
+
+    geometry = _build_section_geometry(wing_config)
+
+    y_spans = request.y_over_span or _default_grid(_DEFAULT_N_SPAN)
+    x_cs = request.x_over_chord or _default_grid(_DEFAULT_N_CHORD)
+
+    surface = [_to_out(p) for p in geometry.sample(y_spans, x_cs)]
+
+    segments = None
+    if request.per_segment:
+        per_seg = geometry.per_segment(_DEFAULT_SEGMENT_N_SPAN, _DEFAULT_SEGMENT_N_CHORD)
+        segments = {idx: [_to_out(p) for p in points] for idx, points in per_seg.items()}
+
+    return SectionGeometryResponse(surface=surface, segments=segments)

--- a/app/tests/test_section_geometry_endpoint.py
+++ b/app/tests/test_section_geometry_endpoint.py
@@ -1,0 +1,335 @@
+"""gh-1021: Fast-tier tests for the section-geometry endpoint + service.
+
+These run on the CI fast tier (no cadquery). We mock the SectionGeometry
+boundary so the real lofted-solid build never runs. Endpoint functions are
+called directly (same pattern as test_spanwise_loads_endpoint.py) to avoid the
+router-registration guard in main.py.
+
+Coverage targets: default sampling, mm->m unit conversion, per_segment flag,
+explicit wing selection, and error paths (no wings, wing not found, aeroplane
+not found, cadquery-unavailable -> clean 422).
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.v2.endpoints.aeroanalysis import get_airplane_section_geometry
+from app.core.exceptions import NotFoundError, ValidationError
+from app.schemas.section_geometry import SectionGeometryRequest
+from app.services import section_geometry_service
+
+
+@dataclass(frozen=True)
+class _StubPoint:
+    """Mimics cad_designer SectionPoint (millimetres)."""
+
+    y_span: float
+    x_c: float
+    thickness: float
+    top_z: float
+    bottom_z: float
+    center_z: float
+
+
+class _StubGeometry:
+    """Records sample/per_segment calls and returns synthetic mm points."""
+
+    def __init__(self):
+        self.sample_calls: list[tuple[list[float], list[float]]] = []
+        self.per_segment_calls: list[tuple[int, int]] = []
+
+    def sample(self, y_spans, x_cs):
+        self.sample_calls.append((list(y_spans), list(x_cs)))
+        return [
+            _StubPoint(
+                y_span=y,
+                x_c=x,
+                thickness=120.0,
+                top_z=60.0,
+                bottom_z=-60.0,
+                center_z=0.0,
+            )
+            for y in y_spans
+            for x in x_cs
+        ]
+
+    def per_segment(self, n_span, n_chord):
+        self.per_segment_calls.append((n_span, n_chord))
+        return {
+            0: [
+                _StubPoint(
+                    y_span=0.1,
+                    x_c=0.3,
+                    thickness=100.0,
+                    top_z=50.0,
+                    bottom_z=-50.0,
+                    center_z=0.0,
+                )
+            ]
+        }
+
+
+@pytest.fixture()
+def plane_id():
+    return uuid.uuid4()
+
+
+def _aeroplane_with_wings(wing_names):
+    wings = [SimpleNamespace(name=n) for n in wing_names]
+    return SimpleNamespace(wings=wings, uuid=uuid.uuid4())
+
+
+def _patch_resolution(aeroplane, geometry):
+    """Patch the service's aeroplane resolution + SectionGeometry build."""
+    return (
+        patch.object(
+            section_geometry_service,
+            "get_aeroplane_or_raise",
+            return_value=aeroplane,
+        ),
+        patch.object(
+            section_geometry_service,
+            "wing_model_to_wing_config",
+            return_value=object(),
+        ),
+        patch.object(
+            section_geometry_service,
+            "_build_section_geometry",
+            return_value=geometry,
+        ),
+    )
+
+
+# --------------------------------------------------------------------------
+# Service-level tests
+# --------------------------------------------------------------------------
+
+
+class TestComputeSectionGeometryService:
+    def test_default_sampling_uses_even_grid(self, plane_id):
+        aeroplane = _aeroplane_with_wings(["main_wing"])
+        geom = _StubGeometry()
+        p_get, p_conv, p_build = _patch_resolution(aeroplane, geom)
+        with p_get, p_conv, p_build:
+            resp = section_geometry_service.compute_section_geometry(
+                db=None,
+                aeroplane_uuid=plane_id,
+                request=SectionGeometryRequest(),
+            )
+
+        # 11 x 11 default grid -> 121 surface points.
+        assert len(resp.surface) == 121
+        y_spans, x_cs = geom.sample_calls[0]
+        assert len(y_spans) == 11
+        assert len(x_cs) == 11
+        # Interior grid: never the exact endpoints.
+        assert all(0.0 < y < 1.0 for y in y_spans)
+        assert all(0.0 < x < 1.0 for x in x_cs)
+
+    def test_mm_to_m_conversion(self, plane_id):
+        aeroplane = _aeroplane_with_wings(["main_wing"])
+        geom = _StubGeometry()
+        p_get, p_conv, p_build = _patch_resolution(aeroplane, geom)
+        with p_get, p_conv, p_build:
+            resp = section_geometry_service.compute_section_geometry(
+                db=None,
+                aeroplane_uuid=plane_id,
+                request=SectionGeometryRequest(y_over_span=[0.5], x_over_chord=[0.3]),
+            )
+
+        pt = resp.surface[0]
+        # 120 mm thickness -> 0.120 m, 60 mm -> 0.060 m.
+        assert pt.thickness == pytest.approx(0.120)
+        assert pt.top_z == pytest.approx(0.060)
+        assert pt.bottom_z == pytest.approx(-0.060)
+        assert pt.center_z == pytest.approx(0.0)
+
+    def test_explicit_arrays_passed_through(self, plane_id):
+        aeroplane = _aeroplane_with_wings(["main_wing"])
+        geom = _StubGeometry()
+        p_get, p_conv, p_build = _patch_resolution(aeroplane, geom)
+        with p_get, p_conv, p_build:
+            section_geometry_service.compute_section_geometry(
+                db=None,
+                aeroplane_uuid=plane_id,
+                request=SectionGeometryRequest(y_over_span=[0.2, 0.8], x_over_chord=[0.25]),
+            )
+
+        assert geom.sample_calls[0] == ([0.2, 0.8], [0.25])
+
+    def test_per_segment_flag_returns_segments(self, plane_id):
+        aeroplane = _aeroplane_with_wings(["main_wing"])
+        geom = _StubGeometry()
+        p_get, p_conv, p_build = _patch_resolution(aeroplane, geom)
+        with p_get, p_conv, p_build:
+            resp = section_geometry_service.compute_section_geometry(
+                db=None,
+                aeroplane_uuid=plane_id,
+                request=SectionGeometryRequest(per_segment=True),
+            )
+
+        assert resp.segments is not None
+        assert 0 in resp.segments
+        assert resp.segments[0][0].thickness == pytest.approx(0.100)
+        assert len(geom.per_segment_calls) == 1
+
+    def test_per_segment_omitted_by_default(self, plane_id):
+        aeroplane = _aeroplane_with_wings(["main_wing"])
+        geom = _StubGeometry()
+        p_get, p_conv, p_build = _patch_resolution(aeroplane, geom)
+        with p_get, p_conv, p_build:
+            resp = section_geometry_service.compute_section_geometry(
+                db=None,
+                aeroplane_uuid=plane_id,
+                request=SectionGeometryRequest(),
+            )
+
+        assert resp.segments is None
+        assert geom.per_segment_calls == []
+
+    def test_named_wing_is_selected(self, plane_id):
+        aeroplane = _aeroplane_with_wings(["main_wing", "h_tail"])
+        geom = _StubGeometry()
+        with (
+            patch.object(
+                section_geometry_service, "get_aeroplane_or_raise", return_value=aeroplane
+            ),
+            patch.object(section_geometry_service, "get_wing_or_raise") as mock_get_wing,
+            patch.object(
+                section_geometry_service, "wing_model_to_wing_config", return_value=object()
+            ),
+            patch.object(section_geometry_service, "_build_section_geometry", return_value=geom),
+        ):
+            mock_get_wing.return_value = aeroplane.wings[1]
+            section_geometry_service.compute_section_geometry(
+                db=None,
+                aeroplane_uuid=plane_id,
+                request=SectionGeometryRequest(wing_name="h_tail"),
+            )
+            mock_get_wing.assert_called_once_with(aeroplane, "h_tail")
+
+    def test_no_wings_raises_not_found(self, plane_id):
+        aeroplane = _aeroplane_with_wings([])
+        with patch.object(
+            section_geometry_service, "get_aeroplane_or_raise", return_value=aeroplane
+        ):
+            with pytest.raises(NotFoundError):
+                section_geometry_service.compute_section_geometry(
+                    db=None,
+                    aeroplane_uuid=plane_id,
+                    request=SectionGeometryRequest(),
+                )
+
+    def test_aeroplane_not_found_propagates(self, plane_id):
+        with patch.object(
+            section_geometry_service,
+            "get_aeroplane_or_raise",
+            side_effect=NotFoundError(message="Aeroplane not found"),
+        ):
+            with pytest.raises(NotFoundError):
+                section_geometry_service.compute_section_geometry(
+                    db=None,
+                    aeroplane_uuid=plane_id,
+                    request=SectionGeometryRequest(),
+                )
+
+    def test_cadquery_unavailable_raises_validation_error(self, plane_id):
+        aeroplane = _aeroplane_with_wings(["main_wing"])
+        with (
+            patch.object(
+                section_geometry_service, "get_aeroplane_or_raise", return_value=aeroplane
+            ),
+            patch.object(
+                section_geometry_service, "wing_model_to_wing_config", return_value=object()
+            ),
+            patch.object(
+                section_geometry_service,
+                "_build_section_geometry",
+                side_effect=ValidationError(message="Section geometry is unavailable"),
+            ),
+        ):
+            with pytest.raises(ValidationError):
+                section_geometry_service.compute_section_geometry(
+                    db=None,
+                    aeroplane_uuid=plane_id,
+                    request=SectionGeometryRequest(),
+                )
+
+
+class TestBuildSectionGeometryBoundary:
+    """Cover the _build_section_geometry seam that translates the platform guard."""
+
+    def test_translates_unavailable_to_validation_error(self):
+        import cad_designer.airplane.geometry.section_geometry as sg
+
+        class _Boom:
+            def __init__(self, *a, **k):
+                raise sg.SectionGeometryUnavailableError("no cadquery")
+
+        with patch.object(sg, "SectionGeometry", _Boom):
+            with pytest.raises(ValidationError):
+                section_geometry_service._build_section_geometry(object())
+
+    def test_returns_constructed_instance(self):
+        import cad_designer.airplane.geometry.section_geometry as sg
+
+        sentinel = object()
+
+        with patch.object(sg, "SectionGeometry", lambda *a, **k: sentinel):
+            result = section_geometry_service._build_section_geometry(object())
+        assert result is sentinel
+
+
+# --------------------------------------------------------------------------
+# Endpoint-level tests
+# --------------------------------------------------------------------------
+
+
+class TestSectionGeometryEndpoint:
+    def test_returns_response_on_success(self, plane_id):
+        aeroplane = _aeroplane_with_wings(["main_wing"])
+        geom = _StubGeometry()
+        p_get, p_conv, p_build = _patch_resolution(aeroplane, geom)
+        with p_get, p_conv, p_build:
+            result = get_airplane_section_geometry(
+                aeroplane_id=plane_id,
+                request=SectionGeometryRequest(y_over_span=[0.5], x_over_chord=[0.3]),
+                db=None,
+            )
+        assert len(result.surface) == 1
+        assert result.surface[0].thickness == pytest.approx(0.120)
+
+    def test_raises_http_404_on_not_found(self, plane_id):
+        with patch.object(
+            section_geometry_service,
+            "compute_section_geometry",
+            side_effect=NotFoundError(message="Aeroplane not found"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                get_airplane_section_geometry(
+                    aeroplane_id=plane_id,
+                    request=SectionGeometryRequest(),
+                    db=None,
+                )
+        assert exc_info.value.status_code == 404
+
+    def test_raises_http_422_when_cadquery_unavailable(self, plane_id):
+        with patch.object(
+            section_geometry_service,
+            "compute_section_geometry",
+            side_effect=ValidationError(message="unavailable"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                get_airplane_section_geometry(
+                    aeroplane_id=plane_id,
+                    request=SectionGeometryRequest(),
+                    db=None,
+                )
+        assert exc_info.value.status_code == 422


### PR DESCRIPTION
## Summary

Implements the v2 section-geometry query endpoint (#1021), consuming the gh-1020 `SectionGeometry` primitive.

- **`app/schemas/section_geometry.py`** — `SectionGeometryRequest` (all optional: `y_over_span`, `x_over_chord`, `per_segment`, plus `wing_name`) and response models (`SectionGeometryResponse` / `SectionPointOut`) with thickness/top_z/bottom_z/center_z in **metres**.
- **`app/services/section_geometry_service.py`** — resolves aeroplane id → wing → `WingConfiguration` (mm, `scale=1000.0`), builds `SectionGeometry`, samples surface (default 11×11 interior grid) and optional per-segment grids, converts mm→m (×0.001). Catches `SectionGeometryUnavailableError` and raises `ValidationError` → clean **422**. Missing aeroplane/wing → `NotFoundError` → **404**.
- **`app/api/v2/endpoints/aeroanalysis.py`** — thin `POST /aeroplanes/{id}/section-geometry` route following the existing pattern.

## Coverage discipline

The cadquery boundary is isolated behind `_build_section_geometry`. Fast-tier tests **mock the SectionGeometry boundary** (no real loft build), so the new service/schema modules are fully exercised without cadquery. Covered: endpoint contract/status, default sampling, mm→m unit conversion, `per_segment` flag, named-wing selection, and error paths (no wings, aeroplane not found, cadquery unavailable → 422).

## Tests

- `app/tests/test_section_geometry_endpoint.py` — 14 fast tests, all green.
- New `app/services/section_geometry_service.py` + `app/schemas/section_geometry.py`: **100%** line coverage on the fast tier.
- Adjacent endpoint suites (spanwise/spar/aeroanalysis) re-run green (63 total).
- `ruff check` + `ruff format` clean.

Closes #1021

🤖 Generated with [Claude Code](https://claude.com/claude-code)