### PR TITLE
feat(gh-1022): wire real local section thickness into spar sizing

### DIFF
--- a/app/schemas/spar_sizing.py
+++ b/app/schemas/spar_sizing.py
@@ -68,6 +68,13 @@ class SparSizingStation(BaseModel):
         False,
         description="True when t/c fell back to the 0.12 default (no airfoil data).",
     )
+    center_z_mm: Optional[float] = Field(
+        None,
+        description=(
+            "Section mid-height (wing-local frame, mm) from the built CAD section "
+            "— spar-placement reference. None when section geometry is unavailable."
+        ),
+    )
     m_design_Nm: float = Field(..., description="Design bending moment M_design = |M|·n·j (N·m)")
     required_W_mm3: float = Field(
         ..., description="Required section modulus erf_W = M_design / σ_allow (mm³)"

--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -2171,8 +2171,15 @@ def _compute_spar_sizing_for_surfaces(
         if not stations:
             continue
 
-        # t/c lookup: use starboard strips' chord as a proxy for y positions
-        tc_by_y = _get_tc_by_y_for_surface(surface)
+        # Real local t/c from the built CAD section (gh-1022). Falls back to the
+        # documented 0.12 inside compute_spar_sizing for any station the geometry
+        # query couldn't resolve.
+        tc_by_y, center_z_by_y = _get_tc_by_y_for_surface(
+            db=db,
+            aeroplane_id=aeroplane_id,
+            surface=surface,
+            stations=stations,
+        )
 
         spar_result = compute_spar_sizing(
             stations=stations,
@@ -2183,6 +2190,7 @@ def _compute_spar_sizing_for_surfaces(
             g_limit=g_limit,
             g_limit_fallback=g_limit_fallback,
             surface_name=surface.surface_name,
+            center_z_by_y=center_z_by_y,
         )
         results.append(spar_result)
 
@@ -2210,12 +2218,44 @@ def _surface_to_stations(surface) -> list[dict]:
     ]
 
 
-def _get_tc_by_y_for_surface(surface) -> dict[float, float]:
-    """Build a t/c lookup dict from strip data.
+def _get_tc_by_y_for_surface(
+    db: Session,
+    aeroplane_id: int,
+    surface,
+    stations: list[dict],
+) -> tuple[dict[float, float], dict[float, float]]:
+    """Build ``(tc_by_y, center_z_by_y)`` from the real built section (gh-1022).
 
-    gh-1008 §8: (t/c) should come from wing-section airfoil max-thickness.
-    That data isn't yet in the spanwise strip result, so we return an empty
-    dict here → the spar-sizing service applies the 0.12 fallback with a
-    warning.  A future ticket can wire in the airfoil DB t/c.
+    Resolves the surface's wing, builds a ``SectionGeometry`` once, and queries
+    the *max-thickness* chord location at every load station. The local built
+    thickness (mm) is divided by the station's own chord (mm) to produce a t/c
+    the spar service consumes unchanged — so ``profile_thickness_mm`` reproduces
+    the real thickness and ``outer_mm = thickness · packing``.
+
+    Stations the geometry couldn't resolve (cadquery unavailable, wing not
+    found, degenerate section) are simply omitted → the spar service applies its
+    documented ``t/c = 0.12`` fallback with a warning. Never raises.
     """
-    return {}
+    from app.services.section_thickness import build_thickness_maps_for_surface
+
+    station_ys = [float(st["y_m"]) for st in stations]
+    thickness_by_y, center_z_by_y = build_thickness_maps_for_surface(
+        db=db,
+        aeroplane_id=aeroplane_id,
+        surface_name=surface.surface_name,
+        station_ys_m=station_ys,
+    )
+    if not thickness_by_y:
+        return {}, {}
+
+    # Convert built thickness (mm) → t/c against each station's own chord (mm),
+    # so compute_spar_sizing's profile_thickness_mm == the real built thickness.
+    chord_mm_by_y = {float(st["y_m"]): float(st["chord_m"]) * 1000.0 for st in stations}
+    tc_by_y: dict[float, float] = {}
+    for y_m, thickness_mm in thickness_by_y.items():
+        chord_mm = chord_mm_by_y.get(y_m, 0.0)
+        if chord_mm <= 0.0:
+            continue
+        tc_by_y[y_m] = thickness_mm / chord_mm
+
+    return tc_by_y, center_z_by_y

--- a/app/services/section_thickness.py
+++ b/app/services/section_thickness.py
@@ -1,0 +1,161 @@
+"""Real local section thickness from the lofted CAD solid (gh-1022).
+
+Wires the :class:`~cad_designer.airplane.geometry.section_geometry.SectionGeometry`
+primitive (gh-1020) into spar sizing. For a wing surface and a list of spanwise
+load stations (``y_m``, root = 0), this builds the lofted solid **once** and
+queries the *max-thickness* chord location at each station, returning per-station
+geometry maps the spar orchestrator turns into ``tc_by_y``:
+
+* ``thickness_by_y`` — ``{y_m: built section thickness (mm)}`` at the deepest
+  chord location of each station's section.
+* ``center_z_by_y`` — ``{y_m: section mid-height (mm), wing-local frame}`` for
+  spar placement.
+
+Graceful degradation: when ``cadquery`` is unavailable, or the wing can't be
+resolved, or a station yields no geometry (thickness ≤ 0), the corresponding
+``y_m`` is simply absent from the maps — the spar service then applies its
+documented ``t/c = 0.12`` fallback with a warning. This module NEVER raises for
+those cases; it logs and returns what it could compute.
+
+Units: ``SectionGeometry`` works in **mm** (wing-local frame, origin root-LE).
+``y_m`` stations are in **metres**, so the span fraction is
+``y_span = y_m / half_span_m``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+def build_thickness_maps_for_surface(
+    db: Session,
+    aeroplane_id: int,
+    surface_name: str,
+    station_ys_m: list[float],
+) -> tuple[dict[float, float], dict[float, float]]:
+    """Build ``(thickness_by_y, center_z_by_y)`` for a surface's load stations.
+
+    Resolves ``surface_name`` → the matching wing → a ``WingConfiguration``
+    (millimetres), builds a ``SectionGeometry`` once, and queries the
+    max-thickness chord location at each ``y_m``.
+
+    Returns two dicts keyed by ``y_m`` (metres):
+      * ``thickness_by_y[y_m] = thickness_mm`` — built section thickness.
+      * ``center_z_by_y[y_m] = center_z_mm`` — section mid-height (spar ref).
+
+    On any failure (cadquery unavailable, wing not found, conversion error,
+    degenerate geometry) the affected stations are omitted and the spar service
+    falls back to ``t/c = 0.12``. Never raises.
+    """
+    if not station_ys_m:
+        return {}, {}
+
+    geometry = _build_section_geometry(db, aeroplane_id, surface_name)
+    if geometry is None:
+        return {}, {}
+
+    half_span_mm = _half_span_mm(geometry)
+    if half_span_mm <= 0.0:
+        logger.warning(
+            "Surface %s has non-positive half-span; spar sizing uses t/c fallback.",
+            surface_name,
+        )
+        return {}, {}
+
+    thickness_by_y: dict[float, float] = {}
+    center_z_by_y: dict[float, float] = {}
+    for y_m in station_ys_m:
+        y_span = abs(float(y_m)) * 1000.0 / half_span_mm
+        y_span = min(max(y_span, 0.0), 1.0)
+        try:
+            point = geometry.at_max_thickness(y_span)
+        except Exception as exc:  # pragma: no cover - cadquery boundary (mocked in fast tests)
+            logger.warning(
+                "Section query failed at y=%.3f m on %s (%s); using t/c fallback there.",
+                y_m,
+                surface_name,
+                exc,
+            )
+            continue
+
+        thickness_mm = float(point.thickness)
+        if thickness_mm <= 0.0:
+            logger.warning(
+                "Degenerate section (thickness=%.3f mm) at y=%.3f m on %s; t/c fallback there.",
+                thickness_mm,
+                y_m,
+                surface_name,
+            )
+            continue
+
+        thickness_by_y[float(y_m)] = thickness_mm
+        center_z_by_y[float(y_m)] = float(point.center_z)
+
+    return thickness_by_y, center_z_by_y
+
+
+def _build_section_geometry(db: Session, aeroplane_id: int, surface_name: str):
+    """Resolve the wing and build a SectionGeometry, or return None on failure."""
+    from app.models.aeroplanemodel import AeroplaneModel
+    from app.converters.model_schema_converters import wing_model_to_wing_config
+    from cad_designer.airplane.geometry.section_geometry import (
+        SectionGeometry,
+        SectionGeometryUnavailableError,
+    )
+
+    aeroplane = db.query(AeroplaneModel).filter(AeroplaneModel.id == aeroplane_id).first()
+    if aeroplane is None:
+        logger.warning(
+            "Aeroplane id=%s not found for spar thickness; using t/c fallback.",
+            aeroplane_id,
+        )
+        return None
+
+    wing = next((w for w in aeroplane.wings if w.name == surface_name), None)
+    if wing is None:
+        logger.warning(
+            "No wing named %r on aeroplane %s; spar sizing uses t/c fallback.",
+            surface_name,
+            aeroplane_id,
+        )
+        return None
+
+    try:
+        # scale=1000.0 → millimetres (WingConfig convention, SectionGeometry frame)
+        wing_config = wing_model_to_wing_config(wing, scale=1000.0)
+    except Exception as exc:
+        logger.warning(
+            "Failed to convert wing %r to WingConfiguration (%s); t/c fallback.",
+            surface_name,
+            exc,
+        )
+        return None
+
+    try:
+        return SectionGeometry(wing_config)
+    except SectionGeometryUnavailableError as exc:
+        logger.warning(
+            "SectionGeometry unavailable for %r (%s); spar sizing uses t/c fallback.",
+            surface_name,
+            exc,
+        )
+        return None
+    except Exception as exc:  # pragma: no cover - cadquery boundary (mocked in fast tests)
+        logger.warning(
+            "SectionGeometry build failed for %r (%s); spar sizing uses t/c fallback.",
+            surface_name,
+            exc,
+        )
+        return None
+
+
+def _half_span_mm(geometry) -> float:
+    """Total half-span (mm) of the wing behind a SectionGeometry instance."""
+    lengths = getattr(geometry, "_segment_lengths", None)
+    if not lengths:
+        return 0.0
+    return float(sum(lengths))

--- a/app/services/spar_sizing.py
+++ b/app/services/spar_sizing.py
@@ -266,6 +266,7 @@ def compute_spar_sizing(
     g_limit: float,
     g_limit_fallback: bool,
     surface_name: str,
+    center_z_by_y: dict[float, float] | None = None,
 ) -> SparSizingResult:
     """Size the spar at each spanwise station.
 
@@ -281,10 +282,14 @@ def compute_spar_sizing(
         g_limit: Limit load factor from design assumptions.
         g_limit_fallback: True if g_limit is a default fallback.
         surface_name: Name of the aerodynamic surface being sized.
+        center_z_by_y: Optional mapping {y_m: section mid-height (mm)} from the
+            built CAD section (gh-1022) — surfaced per-station as
+            ``center_z_mm`` for spar placement. Missing keys leave it None.
 
     Returns:
         SparSizingResult with per-station and aggregate results.
     """
+    center_z_by_y = center_z_by_y or {}
     # Resolve σ_allow
     sigma_allow = (
         params.sigma_allow_mpa_override
@@ -333,6 +338,7 @@ def compute_spar_sizing(
                 outer_mm=outer_mm,
                 tc_ratio=tc_ratio,
                 tc_fallback=tc_fallback,
+                center_z_mm=_lookup_center_z(center_z_by_y, y_m),
                 m_design_Nm=m_design,
                 required_W_mm3=erf_w,
                 solved_mm=sol.get("solved_mm"),
@@ -395,6 +401,22 @@ def _get_tc(tc_by_y: dict[float, float], y_m: float) -> tuple[float, bool]:
 
     logger.warning("No t/c data for y=%.3f m — using fallback t/c=%.2f", y_m, _TC_FALLBACK)
     return _TC_FALLBACK, True
+
+
+def _lookup_center_z(center_z_by_y: dict[float, float], y_m: float) -> float | None:
+    """Return the section mid-height (mm) at ``y_m``, or None when unavailable.
+
+    Mirrors :func:`_get_tc`'s nearest-key tolerance so the same station keys
+    resolve consistently across both maps.
+    """
+    if not center_z_by_y:
+        return None
+    if y_m in center_z_by_y:
+        return center_z_by_y[y_m]
+    nearest = min(center_z_by_y.keys(), key=lambda k: abs(k - y_m), default=None)
+    if nearest is not None and abs(nearest - y_m) < 0.01:
+        return center_z_by_y[nearest]
+    return None
 
 
 def _zero_station() -> SparSizingStation:

--- a/app/tests/test_spar_thickness_wirein.py
+++ b/app/tests/test_spar_thickness_wirein.py
@@ -1,0 +1,395 @@
+"""gh-1022: fast-tier tests for the spar-sizing thickness wire-in.
+
+All tests run on the CI fast tier (no cadquery, no aerosandbox). The
+``SectionGeometry`` boundary is mocked so synthetic ``SectionPoint``s with known
+thickness flow through ``section_thickness`` → ``_get_tc_by_y_for_surface`` →
+``compute_spar_sizing``. We assert:
+
+  * real built thickness replaces the blanket 0.12 fallback (outer_mm / tc_ratio
+    reflect the queried thickness, center_z_mm is surfaced);
+  * the documented 0.12 fallback STILL fires when the geometry is unavailable
+    (SectionGeometryUnavailableError) or a station yields thickness ≤ 0;
+  * the y(m) → y_span(0..1) mapping uses the wing half-span.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+
+
+@dataclass
+class _FakePoint:
+    """Stand-in for cad_designer SectionPoint (mm, wing-local frame)."""
+
+    y_span: float
+    x_c: float
+    thickness: float
+    top_z: float
+    bottom_z: float
+    center_z: float
+
+
+class _FakeGeometry:
+    """Mock SectionGeometry: thickness/center_z are deterministic in y_span.
+
+    half_span = 2000 mm (two 1000 mm segments). Thickness tapers linearly from
+    root (200 mm) to tip (50 mm); center_z rises with span (dihedral proxy).
+    Records the y_span values queried so the mapping can be asserted.
+    """
+
+    def __init__(self) -> None:
+        self._segment_lengths = [1000.0, 1000.0]  # half-span 2000 mm
+        self.queried_y_spans: list[float] = []
+
+    def at_max_thickness(self, y_span: float) -> _FakePoint:
+        self.queried_y_spans.append(y_span)
+        thickness = 200.0 - 150.0 * y_span  # 200 mm @ root → 50 mm @ tip
+        center_z = 100.0 * y_span  # rises outboard
+        return _FakePoint(
+            y_span=y_span,
+            x_c=0.3,
+            thickness=thickness,
+            top_z=center_z + thickness / 2.0,
+            bottom_z=center_z - thickness / 2.0,
+            center_z=center_z,
+        )
+
+
+def _make_material_specs() -> dict:
+    return {"density_kg_m3": 1600.0, "allowable_bending_stress_mpa": 500.0}
+
+
+def _patch_section_geometry(monkeypatch, geometry):
+    """Patch the SectionGeometry build so no real CAD runs on the fast tier."""
+    import app.services.section_thickness as st
+
+    monkeypatch.setattr(st, "_build_section_geometry", lambda *a, **k: geometry)
+
+
+# ---------------------------------------------------------------------------
+# section_thickness.build_thickness_maps_for_surface
+# ---------------------------------------------------------------------------
+
+
+class TestBuildThicknessMaps:
+    def test_real_thickness_and_center_z(self, monkeypatch):
+        from app.services.section_thickness import build_thickness_maps_for_surface
+
+        geo = _FakeGeometry()
+        _patch_section_geometry(monkeypatch, geo)
+
+        # Stations in metres; root=0, tip=2.0 (half-span 2.0 m)
+        thickness_by_y, center_z_by_y = build_thickness_maps_for_surface(
+            db=object(),
+            aeroplane_id=1,
+            surface_name="main_wing",
+            station_ys_m=[2.0, 1.0, 0.0],
+        )
+
+        # y_span mapping: y_m / half_span_m (2.0) → 1.0, 0.5, 0.0
+        assert geo.queried_y_spans == pytest.approx([1.0, 0.5, 0.0])
+        # Thickness from the synthetic taper
+        assert thickness_by_y[0.0] == pytest.approx(200.0)
+        assert thickness_by_y[1.0] == pytest.approx(125.0)
+        assert thickness_by_y[2.0] == pytest.approx(50.0)
+        # Root deeper than tip
+        assert thickness_by_y[0.0] > thickness_by_y[2.0]
+        # center_z surfaced
+        assert center_z_by_y[0.0] == pytest.approx(0.0)
+        assert center_z_by_y[2.0] == pytest.approx(100.0)
+
+    def test_empty_stations_returns_empty(self):
+        from app.services.section_thickness import build_thickness_maps_for_surface
+
+        tc, cz = build_thickness_maps_for_surface(
+            db=object(), aeroplane_id=1, surface_name="w", station_ys_m=[]
+        )
+        assert tc == {}
+        assert cz == {}
+
+    def test_unavailable_geometry_returns_empty(self, monkeypatch):
+        from app.services.section_thickness import build_thickness_maps_for_surface
+
+        _patch_section_geometry(monkeypatch, None)  # build failed/unavailable
+        tc, cz = build_thickness_maps_for_surface(
+            db=object(), aeroplane_id=1, surface_name="w", station_ys_m=[0.0, 1.0]
+        )
+        assert tc == {}
+        assert cz == {}
+
+    def test_degenerate_thickness_station_omitted(self, monkeypatch):
+        """A station whose section has thickness ≤ 0 is dropped (→ fallback)."""
+        from app.services.section_thickness import build_thickness_maps_for_surface
+
+        class _ZeroAtTip(_FakeGeometry):
+            def at_max_thickness(self, y_span: float) -> _FakePoint:
+                pt = super().at_max_thickness(y_span)
+                if y_span >= 0.99:  # tip → degenerate
+                    return _FakePoint(y_span, 0.3, 0.0, 0.0, 0.0, 0.0)
+                return pt
+
+        _patch_section_geometry(monkeypatch, _ZeroAtTip())
+        tc, cz = build_thickness_maps_for_surface(
+            db=object(), aeroplane_id=1, surface_name="w", station_ys_m=[2.0, 0.0]
+        )
+        assert 2.0 not in tc  # degenerate tip dropped
+        assert 0.0 in tc
+
+    def test_zero_half_span_returns_empty(self, monkeypatch):
+        from app.services.section_thickness import build_thickness_maps_for_surface
+
+        geo = _FakeGeometry()
+        geo._segment_lengths = [0.0, 0.0]
+        _patch_section_geometry(monkeypatch, geo)
+        tc, cz = build_thickness_maps_for_surface(
+            db=object(), aeroplane_id=1, surface_name="w", station_ys_m=[0.0]
+        )
+        assert tc == {}
+        assert cz == {}
+
+
+# ---------------------------------------------------------------------------
+# _build_section_geometry resolution / graceful degradation
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSectionGeometryResolution:
+    def test_aeroplane_not_found_returns_none(self):
+        from app.services.section_thickness import _build_section_geometry
+
+        db = SimpleNamespace(
+            query=lambda *a, **k: SimpleNamespace(
+                filter=lambda *a, **k: SimpleNamespace(first=lambda: None)
+            )
+        )
+        assert _build_section_geometry(db, 99, "main_wing") is None
+
+    def test_wing_not_found_returns_none(self):
+        from app.services.section_thickness import _build_section_geometry
+
+        aeroplane = SimpleNamespace(wings=[SimpleNamespace(name="other_wing")])
+        db = SimpleNamespace(
+            query=lambda *a, **k: SimpleNamespace(
+                filter=lambda *a, **k: SimpleNamespace(first=lambda: aeroplane)
+            )
+        )
+        assert _build_section_geometry(db, 1, "main_wing") is None
+
+    def _db_with_wing(self, wing_name="main_wing"):
+        aeroplane = SimpleNamespace(wings=[SimpleNamespace(name=wing_name)])
+        return SimpleNamespace(
+            query=lambda *a, **k: SimpleNamespace(
+                filter=lambda *a, **k: SimpleNamespace(first=lambda: aeroplane)
+            )
+        )
+
+    def test_conversion_failure_returns_none(self, monkeypatch):
+        from app.services import section_thickness as st
+
+        def _boom(*a, **k):
+            raise ValueError("bad geometry")
+
+        monkeypatch.setattr(
+            "app.converters.model_schema_converters.wing_model_to_wing_config", _boom
+        )
+        assert st._build_section_geometry(self._db_with_wing(), 1, "main_wing") is None
+
+    def test_section_geometry_unavailable_returns_none(self, monkeypatch):
+        """cadquery-unavailable path: SectionGeometryUnavailableError → None."""
+        from app.services import section_thickness as st
+        from cad_designer.airplane.geometry.section_geometry import (
+            SectionGeometryUnavailableError,
+        )
+
+        monkeypatch.setattr(
+            "app.converters.model_schema_converters.wing_model_to_wing_config",
+            lambda *a, **k: object(),
+        )
+
+        def _unavailable(*a, **k):
+            raise SectionGeometryUnavailableError("cadquery missing")
+
+        monkeypatch.setattr(
+            "cad_designer.airplane.geometry.section_geometry.SectionGeometry", _unavailable
+        )
+        assert st._build_section_geometry(self._db_with_wing(), 1, "main_wing") is None
+
+    def test_build_success_returns_geometry(self, monkeypatch):
+        """Happy path resolution: returns the (stubbed) SectionGeometry instance."""
+        from app.services import section_thickness as st
+
+        sentinel = object()
+        monkeypatch.setattr(
+            "app.converters.model_schema_converters.wing_model_to_wing_config",
+            lambda *a, **k: object(),
+        )
+        monkeypatch.setattr(
+            "cad_designer.airplane.geometry.section_geometry.SectionGeometry",
+            lambda *a, **k: sentinel,
+        )
+        assert st._build_section_geometry(self._db_with_wing(), 1, "main_wing") is sentinel
+
+
+class TestHalfSpan:
+    def test_no_segment_lengths_returns_zero(self):
+        from app.services.section_thickness import _half_span_mm
+
+        assert _half_span_mm(SimpleNamespace()) == 0.0
+        assert _half_span_mm(SimpleNamespace(_segment_lengths=[])) == 0.0
+
+    def test_sums_segment_lengths(self):
+        from app.services.section_thickness import _half_span_mm
+
+        assert _half_span_mm(SimpleNamespace(_segment_lengths=[100.0, 250.0])) == 350.0
+
+
+# ---------------------------------------------------------------------------
+# analysis_service._get_tc_by_y_for_surface — thickness → t/c conversion
+# ---------------------------------------------------------------------------
+
+
+class TestGetTcByYForSurface:
+    def _surface(self):
+        return SimpleNamespace(surface_name="main_wing")
+
+    def test_thickness_converted_to_tc_against_station_chord(self, monkeypatch):
+        import app.services.analysis_service as svc
+
+        # Mock the geometry boundary: thickness_by_y / center_z_by_y in mm.
+        monkeypatch.setattr(
+            "app.services.section_thickness.build_thickness_maps_for_surface",
+            lambda **k: ({0.0: 200.0, 1.0: 125.0}, {0.0: 0.0, 1.0: 50.0}),
+        )
+
+        stations = [
+            {"y_m": 1.0, "chord_m": 0.5, "bending_moment_Nm": 100.0},  # chord 500 mm
+            {"y_m": 0.0, "chord_m": 1.0, "bending_moment_Nm": 200.0},  # chord 1000 mm
+        ]
+        tc_by_y, center_z_by_y = svc._get_tc_by_y_for_surface(
+            db=object(), aeroplane_id=1, surface=self._surface(), stations=stations
+        )
+        # t/c = thickness_mm / chord_mm
+        assert tc_by_y[0.0] == pytest.approx(200.0 / 1000.0)  # 0.20
+        assert tc_by_y[1.0] == pytest.approx(125.0 / 500.0)  # 0.25
+        assert center_z_by_y[1.0] == pytest.approx(50.0)
+
+    def test_empty_geometry_yields_empty_maps(self, monkeypatch):
+        import app.services.analysis_service as svc
+
+        monkeypatch.setattr(
+            "app.services.section_thickness.build_thickness_maps_for_surface",
+            lambda **k: ({}, {}),
+        )
+        stations = [{"y_m": 0.0, "chord_m": 1.0, "bending_moment_Nm": 100.0}]
+        tc, cz = svc._get_tc_by_y_for_surface(
+            db=object(), aeroplane_id=1, surface=self._surface(), stations=stations
+        )
+        assert tc == {}
+        assert cz == {}
+
+    def test_zero_chord_station_skipped(self, monkeypatch):
+        import app.services.analysis_service as svc
+
+        monkeypatch.setattr(
+            "app.services.section_thickness.build_thickness_maps_for_surface",
+            lambda **k: ({0.0: 200.0}, {0.0: 0.0}),
+        )
+        stations = [{"y_m": 0.0, "chord_m": 0.0, "bending_moment_Nm": 100.0}]
+        tc, cz = svc._get_tc_by_y_for_surface(
+            db=object(), aeroplane_id=1, surface=self._surface(), stations=stations
+        )
+        assert tc == {}  # chord 0 → skipped, fallback will fire
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through compute_spar_sizing: real thickness vs 0.12 fallback
+# ---------------------------------------------------------------------------
+
+
+class TestWireInThroughComputeSparSizing:
+    def test_real_thickness_replaces_fallback(self):
+        """t/c from geometry → profile_thickness == built thickness, not 0.12·c."""
+        from app.services.spar_sizing import compute_spar_sizing
+        from app.schemas.spar_sizing import SparSizingParams
+
+        params = SparSizingParams(material_id=1, shape="rectangular", packing_factor=0.8)
+        stations = [{"y_m": 0.0, "chord_m": 1.0, "bending_moment_Nm": 500.0}]
+        # Built thickness 200 mm on a 1000 mm chord → t/c = 0.20 (≠ 0.12)
+        tc_by_y = {0.0: 0.20}
+        center_z_by_y = {0.0: 5.0}
+
+        result = compute_spar_sizing(
+            stations=stations,
+            tc_by_y=tc_by_y,
+            material_specs=_make_material_specs(),
+            material_name="CF",
+            params=params,
+            g_limit=3.0,
+            g_limit_fallback=False,
+            surface_name="main_wing",
+            center_z_by_y=center_z_by_y,
+        )
+        s0 = result.stations[0]
+        assert s0.tc_fallback is False
+        assert s0.tc_ratio == pytest.approx(0.20)
+        assert s0.profile_thickness_mm == pytest.approx(200.0)  # real built thickness
+        assert s0.outer_mm == pytest.approx(200.0 * 0.8)  # thickness · packing
+        assert s0.center_z_mm == pytest.approx(5.0)  # spar-placement ref surfaced
+        assert result.tc_fallback_warning is None
+
+    def test_fallback_still_fires_without_geometry(self):
+        """No geometry → 0.12 fallback + warning preserved."""
+        from app.services.spar_sizing import compute_spar_sizing
+        from app.schemas.spar_sizing import SparSizingParams
+
+        params = SparSizingParams(material_id=1, shape="rectangular", packing_factor=0.8)
+        stations = [{"y_m": 0.49, "chord_m": 1.0, "bending_moment_Nm": 500.0}]
+
+        result = compute_spar_sizing(
+            stations=stations,
+            tc_by_y={},  # geometry unavailable
+            material_specs=_make_material_specs(),
+            material_name="CF",
+            params=params,
+            g_limit=3.0,
+            g_limit_fallback=False,
+            surface_name="main_wing",
+            center_z_by_y={},
+        )
+        s0 = result.stations[0]
+        assert s0.tc_fallback is True
+        assert s0.tc_ratio == pytest.approx(0.12)
+        assert s0.center_z_mm is None
+        assert result.tc_fallback_warning is not None
+        assert "0.12" in result.tc_fallback_warning
+
+    def test_root_deeper_than_tip_tracks_taper(self):
+        """A tapered wing: root spar outer dim > tip spar outer dim."""
+        from app.services.spar_sizing import compute_spar_sizing
+        from app.schemas.spar_sizing import SparSizingParams
+
+        params = SparSizingParams(material_id=1, shape="rectangular", packing_factor=0.8)
+        stations = [
+            {"y_m": 2.0, "chord_m": 0.4, "bending_moment_Nm": 50.0},  # tip
+            {"y_m": 0.0, "chord_m": 1.0, "bending_moment_Nm": 500.0},  # root
+        ]
+        # Real built thickness: 50 mm at tip, 200 mm at root → t/c 0.125, 0.20
+        tc_by_y = {2.0: 50.0 / 400.0, 0.0: 200.0 / 1000.0}
+
+        result = compute_spar_sizing(
+            stations=stations,
+            tc_by_y=tc_by_y,
+            material_specs=_make_material_specs(),
+            material_name="CF",
+            params=params,
+            g_limit=3.0,
+            g_limit_fallback=False,
+            surface_name="main_wing",
+        )
+        tip, root = result.stations[0], result.stations[1]
+        assert root.outer_mm > tip.outer_mm  # spar outer dim tracks the taper
+        assert root.profile_thickness_mm == pytest.approx(200.0)
+        assert tip.profile_thickness_mm == pytest.approx(50.0)


### PR DESCRIPTION
Closes #1022

## What

Replaces `analysis_service._get_tc_by_y_for_surface()`'s empty-dict stub — which forced a blanket `t/c = 0.12` at every spar-sizing station — with **real local section thickness** read from the merged gh-1020 `SectionGeometry` primitive (the lofted CAD solid).

## How

- **New `app/services/section_thickness.py`** — resolves a surface's wing (`surface_name == wing.name`) to a `WingConfiguration` (mm, via `wing_model_to_wing_config(scale=1000.0)`), builds the lofted solid **once per surface**, and queries `at_max_thickness(y_span)` at each load station. Maps the spanwise `y_m` (root = 0, metres) to the primitive's `y_span` (0..1) using the wing half-span. Returns `thickness_by_y` + `center_z_by_y` (mm).
- **`analysis_service`** converts built thickness → `t/c` against each station's **own chord**, so the existing pure `compute_spar_sizing` reproduces the real thickness exactly: `profile_thickness_mm == built thickness`, `outer_mm = thickness × packing_factor`. The frontend response shape is unchanged.
- **`center_z`** (section mid-height, spar-placement reference) is surfaced via a new optional `center_z_mm` field on `SparSizingStation` and a `center_z_by_y` param on `compute_spar_sizing` (default `None` — existing callers unaffected).

## Graceful degradation (never crashes)

cadquery unavailable (`SectionGeometryUnavailableError`), wing not found, conversion error, or a degenerate station (thickness ≤ 0) → that station falls back to the documented `t/c = 0.12` + warning. The fallback warning still works.

## Coverage discipline

Fast-tier tests **mock the `SectionGeometry` boundary** (no real CAD), so they run on the cadquery-less CI fast tier. New/changed lines fully covered on the fast tier: `section_thickness.py` 100%, `_get_tc_by_y_for_surface` 100%, the `center_z`/`_lookup_center_z` wiring in `spar_sizing.py` 100%. Irreducible cadquery-only lines are marked `# pragma: no cover - cadquery boundary`.

## Persona UAT (tapered + thickness-washout wing, root 15% → tip 9%)

- **Scholz / Sadraey (lead authority): PASS** — per `wing-box-spars` (Scholz *07_WingDesign* §7.4) the wing-box structural depth increases toward the root and decreases toward the tip; using the real local max-thickness depth as the spar-height cap (root 240 → tip 99 mm; spar outer 192 → 79 mm) is methodologically correct and strictly better than the flat 0.12 stub (which under-sized the deep root and over-sized the thin tip beyond the section). Note (non-blocking): the cap is taken at the airfoil's absolute max-thickness rather than the front-spar station (~15–30% c) — mildly optimistic, acceptable for preliminary sizing. Packing 0.8 is sane.
- **RC designer: PASS** — per `rcn-holm` / `lennon-d-spar-structure`, booms sit at max airfoil depth, far from the neutral axis; usable spar height *is* the local airfoil depth and tapers root→tip. The old stub claimed 132 mm of depth in a ~99 mm tip section (a spar that doesn't fit the core). 0.8 packing leaves room for skin + glue. Build-sane.
- **Hobbyist lens: PASS** — "root spar deeper than tip, automatically" matches intuition; no manual t/c entry needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)