### PR TITLE
fix(gh-1027): stop aerosandbox.OperatingPoint leak that polluted VLM strip-force tests

### DIFF
--- a/app/tests/test_turbulator_optimizer_endpoint_wiring.py
+++ b/app/tests/test_turbulator_optimizer_endpoint_wiring.py
@@ -38,6 +38,27 @@ import pytest
 # ---------------------------------------------------------------------------
 
 
+def _stub_operating_point(monkeypatch):
+    """Patch ``aerosandbox.OperatingPoint`` to build a lightweight SimpleNamespace.
+
+    Uses ``monkeypatch`` so the original attribute (and a stub aerosandbox
+    module, if one had to be created) is *always* restored at test teardown.
+    A raw ``sys.modules["aerosandbox"].OperatingPoint = ...`` assignment leaks
+    across tests and corrupts every later aerosandbox consumer in the same
+    process (gh-1027).
+    """
+    import sys
+    import types as _types
+
+    fake_op = lambda **kw: SimpleNamespace(**kw)  # noqa: E731
+    if "aerosandbox" not in sys.modules:
+        asb_mod = _types.ModuleType("aerosandbox")
+        asb_mod.OperatingPoint = fake_op
+        monkeypatch.setitem(sys.modules, "aerosandbox", asb_mod)
+    else:
+        monkeypatch.setattr(sys.modules["aerosandbox"], "OperatingPoint", fake_op, raising=False)
+
+
 def _make_stub_optimizer_result():
     from app.services.turbulator_optimizer_service import (
         SectionOptimizerResult,
@@ -47,9 +68,16 @@ def _make_stub_optimizer_result():
 
     sections = [
         SectionOptimizerResult(
-            y_m=0.1, chord_m=0.2, re_local=200_000, cl=0.6,
-            xtr_opt=0.4, cd_clean=0.030, cd_tripped=0.020, delta_cd=-0.010,
-            warnings=[], section_area_m2=0.10,
+            y_m=0.1,
+            chord_m=0.2,
+            re_local=200_000,
+            cl=0.6,
+            xtr_opt=0.4,
+            cd_clean=0.030,
+            cd_tripped=0.020,
+            delta_cd=-0.010,
+            warnings=[],
+            section_area_m2=0.10,
         )
     ]
     summary = TurbulatorOptimizerSummary(
@@ -63,8 +91,12 @@ def _make_stub_wsd():
 
     return [
         WingSectionData(
-            y_m=0.1, chord_m=0.2, cl=0.6, re_local=200_000,
-            airfoil_name="naca0012", section_area_m2=0.10,
+            y_m=0.1,
+            chord_m=0.2,
+            cl=0.6,
+            re_local=200_000,
+            airfoil_name="naca0012",
+            section_area_m2=0.10,
         )
     ]
 
@@ -244,30 +276,33 @@ class TestCallOptimizerWiring:
         stub_section_entry = SimpleNamespace(y_m=0.1, chord_m=0.2, cl=0.6)
 
         with (
-            patch("app.services.analysis_service.get_aeroplane_schema_or_raise",
-                  return_value=SimpleNamespace()),
-            patch("app.converters.model_schema_converters.aeroplane_schema_to_asb_airplane_async",
-                  return_value=stub_airplane),
-            patch("app.services.design_assumptions_service.get_effective_assumption",
-                  return_value=18.0),
-            patch("app.services.section_aoa_service.compute_section_aoa",
-                  return_value=[stub_section_entry]),
-            patch("app.services.turbulator_optimizer_service.build_wing_section_data",
-                  return_value=stub_wsd),
-            patch("app.services.turbulator_optimizer_service.run_turbulator_optimizer",
-                  return_value=stub_result),
+            patch(
+                "app.services.analysis_service.get_aeroplane_schema_or_raise",
+                return_value=SimpleNamespace(),
+            ),
+            patch(
+                "app.converters.model_schema_converters.aeroplane_schema_to_asb_airplane_async",
+                return_value=stub_airplane,
+            ),
+            patch(
+                "app.services.design_assumptions_service.get_effective_assumption",
+                return_value=18.0,
+            ),
+            patch(
+                "app.services.section_aoa_service.compute_section_aoa",
+                return_value=[stub_section_entry],
+            ),
+            patch(
+                "app.services.turbulator_optimizer_service.build_wing_section_data",
+                return_value=stub_wsd,
+            ),
+            patch(
+                "app.services.turbulator_optimizer_service.run_turbulator_optimizer",
+                return_value=stub_result,
+            ),
         ):
             # Also need to patch aerosandbox.OperatingPoint
-            import sys
-            import types as _types
-
-            if "aerosandbox" not in sys.modules:
-                asb_mod = _types.ModuleType("aerosandbox")
-                asb_mod.OperatingPoint = lambda **kw: SimpleNamespace(**kw)
-                sys.modules["aerosandbox"] = asb_mod
-            else:
-                original_op = sys.modules["aerosandbox"].__dict__.get("OperatingPoint")
-                sys.modules["aerosandbox"].OperatingPoint = lambda **kw: SimpleNamespace(**kw)
+            _stub_operating_point(monkeypatch)
 
             response = client.post(
                 f"/aeroplanes/{aeroplane.uuid}/turbulator/optimize",
@@ -290,20 +325,20 @@ class TestCallOptimizerWiring:
         empty_airplane = SimpleNamespace(wings=[])
 
         with (
-            patch("app.services.analysis_service.get_aeroplane_schema_or_raise",
-                  return_value=SimpleNamespace()),
-            patch("app.converters.model_schema_converters.aeroplane_schema_to_asb_airplane_async",
-                  return_value=empty_airplane),
-            patch("app.services.design_assumptions_service.get_effective_assumption",
-                  return_value=15.0),
+            patch(
+                "app.services.analysis_service.get_aeroplane_schema_or_raise",
+                return_value=SimpleNamespace(),
+            ),
+            patch(
+                "app.converters.model_schema_converters.aeroplane_schema_to_asb_airplane_async",
+                return_value=empty_airplane,
+            ),
+            patch(
+                "app.services.design_assumptions_service.get_effective_assumption",
+                return_value=15.0,
+            ),
         ):
-            import sys
-            import types as _types
-
-            if "aerosandbox" not in sys.modules:
-                asb_mod = _types.ModuleType("aerosandbox")
-                asb_mod.OperatingPoint = lambda **kw: SimpleNamespace(**kw)
-                sys.modules["aerosandbox"] = asb_mod
+            _stub_operating_point(monkeypatch)
 
             response = client.post(
                 f"/aeroplanes/{aeroplane.uuid}/turbulator/optimize",
@@ -323,24 +358,24 @@ class TestCallOptimizerWiring:
         stub_airplane = self._make_stub_asb_airplane()
 
         with (
-            patch("app.services.analysis_service.get_aeroplane_schema_or_raise",
-                  return_value=SimpleNamespace()),
-            patch("app.converters.model_schema_converters.aeroplane_schema_to_asb_airplane_async",
-                  return_value=stub_airplane),
-            patch("app.services.design_assumptions_service.get_effective_assumption",
-                  return_value=15.0),
-            patch("app.services.section_aoa_service.compute_section_aoa",
-                  side_effect=RuntimeError("AoA computation failed")),
+            patch(
+                "app.services.analysis_service.get_aeroplane_schema_or_raise",
+                return_value=SimpleNamespace(),
+            ),
+            patch(
+                "app.converters.model_schema_converters.aeroplane_schema_to_asb_airplane_async",
+                return_value=stub_airplane,
+            ),
+            patch(
+                "app.services.design_assumptions_service.get_effective_assumption",
+                return_value=15.0,
+            ),
+            patch(
+                "app.services.section_aoa_service.compute_section_aoa",
+                side_effect=RuntimeError("AoA computation failed"),
+            ),
         ):
-            import sys
-            import types as _types
-
-            if "aerosandbox" not in sys.modules:
-                asb_mod = _types.ModuleType("aerosandbox")
-                asb_mod.OperatingPoint = lambda **kw: SimpleNamespace(**kw)
-                sys.modules["aerosandbox"] = asb_mod
-            else:
-                sys.modules["aerosandbox"].OperatingPoint = lambda **kw: SimpleNamespace(**kw)
+            _stub_operating_point(monkeypatch)
 
             response = client.post(
                 f"/aeroplanes/{aeroplane.uuid}/turbulator/optimize",
@@ -360,24 +395,23 @@ class TestCallOptimizerWiring:
         stub_airplane = self._make_stub_asb_airplane()
 
         with (
-            patch("app.services.analysis_service.get_aeroplane_schema_or_raise",
-                  return_value=SimpleNamespace()),
-            patch("app.converters.model_schema_converters.aeroplane_schema_to_asb_airplane_async",
-                  return_value=stub_airplane),
-            patch("app.services.design_assumptions_service.get_effective_assumption",
-                  return_value=15.0),
-            patch("app.services.section_aoa_service.compute_section_aoa",
-                  return_value=[]),  # empty → ValidationDomainError
+            patch(
+                "app.services.analysis_service.get_aeroplane_schema_or_raise",
+                return_value=SimpleNamespace(),
+            ),
+            patch(
+                "app.converters.model_schema_converters.aeroplane_schema_to_asb_airplane_async",
+                return_value=stub_airplane,
+            ),
+            patch(
+                "app.services.design_assumptions_service.get_effective_assumption",
+                return_value=15.0,
+            ),
+            patch(
+                "app.services.section_aoa_service.compute_section_aoa", return_value=[]
+            ),  # empty → ValidationDomainError
         ):
-            import sys
-            import types as _types
-
-            if "aerosandbox" not in sys.modules:
-                asb_mod = _types.ModuleType("aerosandbox")
-                asb_mod.OperatingPoint = lambda **kw: SimpleNamespace(**kw)
-                sys.modules["aerosandbox"] = asb_mod
-            else:
-                sys.modules["aerosandbox"].OperatingPoint = lambda **kw: SimpleNamespace(**kw)
+            _stub_operating_point(monkeypatch)
 
             response = client.post(
                 f"/aeroplanes/{aeroplane.uuid}/turbulator/optimize",
@@ -407,28 +441,32 @@ class TestCallOptimizerWiring:
         stub_section_entry = SimpleNamespace(y_m=0.1, chord_m=0.2, cl=0.6)
 
         with (
-            patch("app.services.analysis_service.get_aeroplane_schema_or_raise",
-                  return_value=SimpleNamespace()),
-            patch("app.converters.model_schema_converters.aeroplane_schema_to_asb_airplane_async",
-                  return_value=stub_airplane),
-            patch("app.services.design_assumptions_service.get_effective_assumption",
-                  return_value=None),  # None → fallback to 15.0
-            patch("app.services.section_aoa_service.compute_section_aoa",
-                  return_value=[stub_section_entry]),
-            patch("app.services.turbulator_optimizer_service.build_wing_section_data",
-                  side_effect=_capture_build_wsd),
-            patch("app.services.turbulator_optimizer_service.run_turbulator_optimizer",
-                  return_value=stub_result),
+            patch(
+                "app.services.analysis_service.get_aeroplane_schema_or_raise",
+                return_value=SimpleNamespace(),
+            ),
+            patch(
+                "app.converters.model_schema_converters.aeroplane_schema_to_asb_airplane_async",
+                return_value=stub_airplane,
+            ),
+            patch(
+                "app.services.design_assumptions_service.get_effective_assumption",
+                return_value=None,
+            ),  # None → fallback to 15.0
+            patch(
+                "app.services.section_aoa_service.compute_section_aoa",
+                return_value=[stub_section_entry],
+            ),
+            patch(
+                "app.services.turbulator_optimizer_service.build_wing_section_data",
+                side_effect=_capture_build_wsd,
+            ),
+            patch(
+                "app.services.turbulator_optimizer_service.run_turbulator_optimizer",
+                return_value=stub_result,
+            ),
         ):
-            import sys
-            import types as _types
-
-            if "aerosandbox" not in sys.modules:
-                asb_mod = _types.ModuleType("aerosandbox")
-                asb_mod.OperatingPoint = lambda **kw: SimpleNamespace(**kw)
-                sys.modules["aerosandbox"] = asb_mod
-            else:
-                sys.modules["aerosandbox"].OperatingPoint = lambda **kw: SimpleNamespace(**kw)
+            _stub_operating_point(monkeypatch)
 
             response = client.post(
                 f"/aeroplanes/{aeroplane.uuid}/turbulator/optimize",


### PR DESCRIPTION
Closes #1027

## Root cause

`app/tests/test_turbulator_optimizer_endpoint_wiring.py` stubbed `aerosandbox.OperatingPoint` with a **raw, unrestored** module assignment:

```python
sys.modules["aerosandbox"].OperatingPoint = lambda **kw: SimpleNamespace(**kw)
```

(in 5 places; one even captured `original_op` but never restored it). Once any of those tests ran, `asb.OperatingPoint` produced a `types.SimpleNamespace` for the **rest of the process**. The real-solver `TestComputeVlmStripForces` tests then built their operating point via `asb.OperatingPoint(...)`, got a `SimpleNamespace`, and `VortexLatticeMethod` failed with:

```
AttributeError: 'types.SimpleNamespace' object has no attribute 'compute_freestream_velocity_geometry_axes'
```

This is pre-existing pollution (reproduced on `main`), order-dependent: the 5 tests pass standalone but fail in the full fast suite under serial ordering. CI's `xdist -n auto --dist worksteal` happened to distribute the tests so the pair didn't collide, masking it as a latent flake.

Minimal polluting pair confirmed:
```
pytest -p no:randomly app/tests/test_turbulator_optimizer_endpoint_wiring.py \
  app/tests/test_vlm_strip_forces.py::TestComputeVlmStripForces::test_result_has_avl_compatible_shape
```

## Fix

Routed all five stubs through a `_stub_operating_point(monkeypatch)` helper that uses `monkeypatch.setattr` / `monkeypatch.setitem`, so the original `OperatingPoint` (or a stub `aerosandbox` module, if one had to be created) is **always restored at teardown**. No production code changed; the fix addresses the actual leak rather than reordering or weakening any assertion.

## Verification

- Polluting pair: `test_vlm_strip_forces` now passes alongside the turbulator tests (previously failed).
- Producing test intact: `test_turbulator_optimizer_endpoint_wiring.py` 15 passed.
- `test_vlm_strip_forces.py` standalone: 16 passed.
- Full fast suite, serial (`pytest -p no:randomly -m "not slow and not e2e and not requires_cadquery"`): **5635 passed, 7 skipped, 2 xfailed, 0 failed** (was 5 failed / 5630 passed before the fix).
- `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)