### PR TITLE
fix(gh-1009): post-merge review fixes — BEC decimal parse, lint, labels, dialog

### DIFF
--- a/alembic/versions/a3f8c1d2e4b5_gh1009_esc_schema_enrichment_english_bec_toggles.py
+++ b/alembic/versions/a3f8c1d2e4b5_gh1009_esc_schema_enrichment_english_bec_toggles.py
@@ -94,8 +94,8 @@ def _parse_bec_output(raw: str | None) -> dict[str, bool | float]:
                 raw,
             )
 
-    # Extract current token: e.g. "4A", "8A"
-    current_match = re.search(r"(\d+)\s*[Aa]", raw)
+    # Extract current token: e.g. "4A", "8A", "1.5A" (decimals must not truncate)
+    current_match = re.search(r"(\d+\.?\d*)\s*[Aa]", raw)
     if current_match:
         result["bec_current_a"] = float(current_match.group(1))
 
@@ -166,8 +166,18 @@ _NEW_ESC_SCHEMA: list[dict] = [
     },
     {"name": "cells_lipo_min", "label": "LiPo Cells Min", "type": "number", "unit": "S"},
     {"name": "cells_lipo_max", "label": "LiPo Cells Max", "type": "number", "unit": "S"},
-    {"name": "cells_nixx_min", "label": "NiXX Cells Min", "type": "number", "unit": "cells"},
-    {"name": "cells_nixx_max", "label": "NiXX Cells Max", "type": "number", "unit": "cells"},
+    {
+        "name": "cells_nixx_min",
+        "label": "NiXX (NiCd/NiMH) Cells Min",
+        "type": "number",
+        "unit": "cells",
+    },
+    {
+        "name": "cells_nixx_max",
+        "label": "NiXX (NiCd/NiMH) Cells Max",
+        "type": "number",
+        "unit": "cells",
+    },
     {"name": "cells_liion_min", "label": "Li-Ion/LiHV Cells Min", "type": "number", "unit": "S"},
     {"name": "cells_liion_max", "label": "Li-Ion/LiHV Cells Max", "type": "number", "unit": "S"},
     {"name": "bec_voltage_5v", "label": "BEC 5.0 V", "type": "boolean"},

--- a/app/services/component_type_service.py
+++ b/app/services/component_type_service.py
@@ -473,13 +473,13 @@ DEFAULT_SEED_TYPES: list[dict[str, Any]] = [
             {"name": "cells_lipo_max", "label": "LiPo Cells Max", "type": "number", "unit": "S"},
             {
                 "name": "cells_nixx_min",
-                "label": "NiXX Cells Min",
+                "label": "NiXX (NiCd/NiMH) Cells Min",
                 "type": "number",
                 "unit": "cells",
             },
             {
                 "name": "cells_nixx_max",
-                "label": "NiXX Cells Max",
+                "label": "NiXX (NiCd/NiMH) Cells Max",
                 "type": "number",
                 "unit": "cells",
             },

--- a/app/tests/test_dpower_avicon_esc_snapshot.py
+++ b/app/tests/test_dpower_avicon_esc_snapshot.py
@@ -38,7 +38,9 @@ def _load_dpower() -> list[dict]:
 
 def _avicon_escs(records: list[dict]) -> list[dict]:
     """Return all ESC records whose name starts with 'AVICON'."""
-    return [r for r in records if r.get("component_type") == "esc" and r["name"].startswith("AVICON")]
+    return [
+        r for r in records if r.get("component_type") == "esc" and r["name"].startswith("AVICON")
+    ]
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -81,47 +83,25 @@ class TestDpowerAviconEscSnapshot:
 
     def test_every_avicon_esc_has_cells_nixx_min(self):
         """Every AVICON ESC record must have cells_nixx_min in its specs."""
-        missing = [
-            r["name"]
-            for r in self.avicon_escs
-            if "cells_nixx_min" not in r["specs"]
-        ]
-        assert not missing, (
-            f"AVICON ESC entries missing cells_nixx_min: {missing}"
-        )
+        missing = [r["name"] for r in self.avicon_escs if "cells_nixx_min" not in r["specs"]]
+        assert not missing, f"AVICON ESC entries missing cells_nixx_min: {missing}"
 
     def test_every_avicon_esc_has_cells_nixx_max(self):
         """Every AVICON ESC record must have cells_nixx_max in its specs."""
-        missing = [
-            r["name"]
-            for r in self.avicon_escs
-            if "cells_nixx_max" not in r["specs"]
-        ]
-        assert not missing, (
-            f"AVICON ESC entries missing cells_nixx_max: {missing}"
-        )
+        missing = [r["name"] for r in self.avicon_escs if "cells_nixx_max" not in r["specs"]]
+        assert not missing, f"AVICON ESC entries missing cells_nixx_max: {missing}"
 
     def test_every_avicon_esc_has_bec_current_a(self):
         """Every AVICON ESC record must have bec_current_a in its specs."""
-        missing = [
-            r["name"]
-            for r in self.avicon_escs
-            if "bec_current_a" not in r["specs"]
-        ]
-        assert not missing, (
-            f"AVICON ESC entries missing bec_current_a: {missing}"
-        )
+        missing = [r["name"] for r in self.avicon_escs if "bec_current_a" not in r["specs"]]
+        assert not missing, f"AVICON ESC entries missing bec_current_a: {missing}"
 
     def test_every_avicon_esc_bec_voltage_5v_is_true(self):
         """Every AVICON ESC must have bec_voltage_5v=True (AVICON BEC supports 5V)."""
         non_compliant = [
-            r["name"]
-            for r in self.avicon_escs
-            if r["specs"].get("bec_voltage_5v") is not True
+            r["name"] for r in self.avicon_escs if r["specs"].get("bec_voltage_5v") is not True
         ]
-        assert not non_compliant, (
-            f"AVICON ESC entries without bec_voltage_5v=True: {non_compliant}"
-        )
+        assert not non_compliant, f"AVICON ESC entries without bec_voltage_5v=True: {non_compliant}"
 
     def test_no_esc_entry_has_removed_keys(self):
         """No ESC spec in dpower.json may contain bec_output, bec_voltage_v, or cells."""
@@ -131,9 +111,7 @@ class TestDpowerAviconEscSnapshot:
             found = REMOVED_KEYS & set(r["specs"].keys())
             if found:
                 violators[r["name"]] = sorted(found)
-        assert not violators, (
-            f"ESC entries still contain removed keys: {violators}"
-        )
+        assert not violators, f"ESC entries still contain removed keys: {violators}"
 
     def test_avicon_standard_series_cells_nixx_range(self):
         """AVICON standard series (not PRO) must have cells_nixx_min=5, cells_nixx_max=12."""
@@ -143,9 +121,7 @@ class TestDpowerAviconEscSnapshot:
             for r in standard
             if r["specs"].get("cells_nixx_min") != 5 or r["specs"].get("cells_nixx_max") != 12
         ]
-        assert not wrong, (
-            f"AVICON standard ESC entries with wrong NiXX range: {wrong}"
-        )
+        assert not wrong, f"AVICON standard ESC entries with wrong NiXX range: {wrong}"
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -223,5 +199,7 @@ class TestDpowerSnapshotImport:
         assert total_after_first == total_after_second, (
             "Row count changed on second import — not idempotent"
         )
-        assert result2.imported == 0, f"Second import should have imported=0, got {result2.imported}"
+        assert result2.imported == 0, (
+            f"Second import should have imported=0, got {result2.imported}"
+        )
         assert result2.errors == [], f"Second import errors: {result2.errors}"

--- a/app/tests/test_migration_gh1009.py
+++ b/app/tests/test_migration_gh1009.py
@@ -8,12 +8,10 @@ a single Python file with plain SQLAlchemy calls via op.get_bind()).
 
 from __future__ import annotations
 
-import importlib
+import importlib.util
 import json
-import re
 
 import pytest
-import sqlalchemy as sa
 from sqlalchemy import create_engine, text
 from sqlalchemy.pool import StaticPool
 
@@ -162,21 +160,6 @@ def _get_component_specs(conn, row_id: int) -> dict:
 
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Fake Alembic op.get_bind() shim
-# ──────────────────────────────────────────────────────────────────────────────
-
-
-class _FakeOp:
-    """Minimal shim so migration functions can call op.get_bind()."""
-
-    def __init__(self, conn):
-        self._conn = conn
-
-    def get_bind(self):
-        return self._conn
-
-
-# ──────────────────────────────────────────────────────────────────────────────
 # Pure-function unit tests (no Alembic runner)
 # ──────────────────────────────────────────────────────────────────────────────
 
@@ -207,6 +190,12 @@ class TestParseBecOutput:
         assert result.get("bec_voltage_5v") is True
         assert result.get("bec_voltage_6v") is True
         assert result.get("bec_current_a") == 4
+
+    def test_decimal_current_is_not_truncated(self, migration):
+        # Regression (gh-1009 review): "1.5A" must parse to 1.5, not 5.0.
+        result = migration._parse_bec_output("5V / 1.5A")
+        assert result.get("bec_voltage_5v") is True
+        assert result.get("bec_current_a") == 1.5
 
     def test_single_voltage_5v_8a(self, migration):
         result = migration._parse_bec_output("5V / 8A")

--- a/frontend/app/workbench/components/page.tsx
+++ b/frontend/app/workbench/components/page.tsx
@@ -251,6 +251,13 @@ export default function ComponentsPage() {
      * child — WorkbenchTwoPanel only renders its first two children and
      * silently drops the rest. See gh#57-fav regression tests.
      */}
+    {/*
+     * Conditionally mounted (not just `open={false}`): the dialog seeds all
+     * its state — name, mass, bbox dimensions, specs — once on mount, so it
+     * MUST be unmounted on close and remounted fresh per edit. Do not change
+     * this to keep it always-mounted, or fields will show the previously
+     * edited component's stale values. See ComponentEditDialog mount contract.
+     */}
     {editDialog.open && (
       <ComponentEditDialog
         open={editDialog.open}

--- a/frontend/components/workbench/ComponentEditDialog.tsx
+++ b/frontend/components/workbench/ComponentEditDialog.tsx
@@ -279,6 +279,7 @@ export function ComponentEditDialog({
                 id="ce-bbox-x"
                 data-bbox="bbox_x_mm"
                 type="number"
+                min={0}
                 value={bboxX}
                 onChange={(e) => setBboxX(e.target.value)}
                 className="w-full rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
@@ -290,6 +291,7 @@ export function ComponentEditDialog({
                 id="ce-bbox-y"
                 data-bbox="bbox_y_mm"
                 type="number"
+                min={0}
                 value={bboxY}
                 onChange={(e) => setBboxY(e.target.value)}
                 className="w-full rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"
@@ -301,6 +303,7 @@ export function ComponentEditDialog({
                 id="ce-bbox-z"
                 data-bbox="bbox_z_mm"
                 type="number"
+                min={0}
                 value={bboxZ}
                 onChange={(e) => setBboxZ(e.target.value)}
                 className="w-full rounded-xl border border-border bg-input px-3 py-2 text-[13px] text-foreground"


### PR DESCRIPTION
## Summary

Post-merge fixes for the **#1009 ESC component enrichment** feature. The feature shipped via #1015, but the implementation workflow's review + persona-UAT surfaced real issues that were merged with it and are now live on `main`. This PR lands those fixes. No behavior of the feature changes for users beyond the label clarification and decimal-parse correctness.

## Changes

**Backend / migration**
- **Correctness:** BEC current parse regex `(\d+)\s*[Aa]` truncated decimals (`"1.5A"` → `5.0`). Now `(\d+\.?\d*)`. Added a red→green regression test (`test_decimal_current_is_not_truncated`). AVICON data uses integer `4A`, so no shipped data was mis-migrated — this is preventive.
- **Lint debt:** `app/tests/test_dpower_avicon_esc_snapshot.py` shipped unformatted and fails `ruff format --check`; reformatted.
- **Test robustness:** `import importlib.util` (previously used without importing it); removed dead `_FakeOp` class and unused `re` / `sa` imports.
- **Labels:** `NiXX` → `NiXX (NiCd/NiMH)` in both the seed (`component_type_service.py`) and the migration `schema_def`, per hobbyist UAT friction.

**Frontend**
- `min={0}` on the three bbox L/W/H number inputs (negative dimensions are nonsensical).
- Comment at the `ComponentEditDialog` call-site documenting the conditional-mount contract (state seeds once on mount → must remount per edit). Confirms the reviewer's stale-state concern is already handled by `{editDialog.open && <…/>}`.

## Testing

- `poetry run pytest app/tests/test_esc_schema_gh1009.py app/tests/test_cots_esc_gh1009.py app/tests/test_migration_gh1009.py app/tests/test_dpower_avicon_esc_snapshot.py -q` → **55 passed**.
- New decimal test verified red (before regex fix) → green (after).
- `ruff check` / `ruff format --check` clean on all changed files.

## Notes / out of scope

- Editing the already-merged migration `a3f8c1d2e4b5` in place: revision id unchanged, so the chain (gh-1000 chained onto it) stays intact.
- Pre-existing, unrelated: `alembic/env.py:1` `E401` (`import os, sys`) already fails `ruff check` on `main` — left untouched.
- Pre-existing flaky-test isolation bug filed separately as **#1024** (not caused by #1009).

Refs #1009.
