### PR TITLE
feat(gh-1031): v2 spar-plan endpoint + schemas

### DIFF
--- a/app/api/v2/endpoints/aeroanalysis.py
+++ b/app/api/v2/endpoints/aeroanalysis.py
@@ -23,12 +23,14 @@ from app.schemas.AeroplaneRequest import AnalysisToolUrlType, AlphaSweepRequest,
 from app.schemas.api_responses import StaticUrlResponse
 from app.schemas.aeroanalysisschema import OperatingPointSchema
 from app.schemas.section_geometry import SectionGeometryRequest, SectionGeometryResponse
+from app.schemas.spar_plan import SparPlanRequest, SparPlanResponse
 from app.schemas.spar_sizing import SparSizingParams
 from app.schemas.spanwise_loads import SpanwiseLoadsResponse, SpanwiseLoadsWithSizingResponse
 from app.schemas.stability import StabilitySummaryResponse, StabilityResultRead
 from app.schemas.strip_forces import StripForcesResponse
 from app.services import analysis_service
 from app.services import section_geometry_service
+from app.services import spar_plan_service
 from app.services import stability_service
 from app.services.wing_service import get_aeroplane_or_raise
 from app.settings import Settings, get_settings
@@ -493,6 +495,42 @@ def get_airplane_section_geometry(
     """
     try:
         return section_geometry_service.compute_section_geometry(db, aeroplane_id, request)
+    except ServiceException as exc:
+        _raise_http_from_domain(exc)
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Unexpected error: {exc}"
+        ) from exc
+
+
+@router.post(
+    "/aeroplanes/{aeroplane_id}/spar-plan",
+    response_model=SparPlanResponse,
+    tags=["analysis"],
+    operation_id="get_airplane_spar_plan",
+)
+def get_airplane_spar_plan(
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
+    request: Annotated[
+        SparPlanRequest,
+        Body(..., description="Spar-plan request: material + sizing + spanwise moments"),
+    ],
+    db: Annotated[Session, Depends(get_db)],
+) -> SparPlanResponse:
+    """Solve the buildable spar plan for a wing (gh-1031).
+
+    Reads the real lofted section envelope, the supplied spanwise bending-moment
+    distribution (#1002) and the #1008 material/sizing inputs, then returns the
+    front (bending) + rear (torsion) spar layout: each straight piece's origin,
+    direction, outer/inner diameter, governing station, utilisation, and the
+    joint type between pieces / across the root. **Lengths in metres.**
+
+    Returns 404 when the aeroplane / wing does not exist, and 422 when section
+    geometry is unavailable on this platform (cadquery excluded on
+    ``linux/aarch64``) or the material/strength inputs are invalid.
+    """
+    try:
+        return spar_plan_service.compute_spar_plan(db, aeroplane_id, request)
     except ServiceException as exc:
         _raise_http_from_domain(exc)
     except Exception as exc:  # pragma: no cover - defensive fallback

--- a/app/schemas/spar_plan.py
+++ b/app/schemas/spar_plan.py
@@ -1,0 +1,163 @@
+"""Pydantic request/response schemas for the spar-plan endpoint (gh-1031).
+
+The solver core (gh-1030,
+:mod:`cad_designer.airplane.geometry.spar_solver`) produces a ``SparPlan`` in
+**millimetres** (wing-local frame). This API exposes lengths in **metres**
+(project convention) — the service converts mm -> m (x0.001).
+
+The request carries the spar-layout knobs plus the spanwise bending-moment
+distribution (from the #1002 spanwise-loads endpoint) and the #1008 material /
+sizing inputs the solver needs to compute strength-required diameters.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class MomentSample(BaseModel):
+    """One spanwise bending-moment sample (from #1002 spanwise loads)."""
+
+    y_span: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Span fraction 0..1 across the semi-span (root=0, tip=1).",
+    )
+    bending_moment_Nm: float = Field(
+        ...,
+        description="Bending moment magnitude reference at this station (N·m).",
+    )
+
+
+class SparPlanRequest(BaseModel):
+    """Request body for ``POST /aeroplanes/{id}/spar-plan``.
+
+    The spanwise moment distribution (``moments``) comes from the #1002
+    spanwise-loads endpoint; the material + sizing knobs mirror #1008 spar
+    sizing. Layout knobs (``front_x_over_chord`` / ``rear_x_over_chord`` /
+    sampling ``n_span``) and clearance (``packing_factor``) are optional.
+    """
+
+    material_id: int = Field(
+        ...,
+        description=(
+            "ID of a Component with component_type='material' and "
+            "allowable_bending_stress_mpa set (used for strength sizing)."
+        ),
+    )
+    moments: list[MomentSample] = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Spanwise bending-moment distribution (root->tip) used to size the "
+            "strength-required spar diameter at each station."
+        ),
+    )
+    wing_name: Optional[str] = Field(
+        None,
+        description=("Name of the wing to plan. When omitted, the aeroplane's first wing is used."),
+    )
+    front_x_over_chord: Optional[float] = Field(
+        None,
+        gt=0.0,
+        lt=1.0,
+        description=(
+            "Chord fraction for the front (bending) spar. When omitted, the "
+            "section's max-thickness location is used."
+        ),
+    )
+    rear_x_over_chord: float = Field(
+        0.65,
+        gt=0.0,
+        lt=1.0,
+        description="Chord fraction for the rear (torsion) spar. Default 0.65.",
+    )
+    n_span: int = Field(
+        6,
+        ge=2,
+        le=200,
+        description="Number of spanwise sample stations per half (root->tip).",
+    )
+    packing_factor: float = Field(
+        0.8,
+        gt=0.0,
+        le=1.0,
+        description=(
+            "Fraction of the local section depth the spar may occupy; the "
+            "remainder is skin/glue clearance. Default 0.8."
+        ),
+    )
+    safety_factor_j: float = Field(
+        1.5,
+        gt=0.0,
+        description="Safety factor applied to M_design = |M|·g_limit·j.",
+    )
+    sigma_allow_mpa_override: Optional[float] = Field(
+        None,
+        gt=0.0,
+        description=(
+            "Override allowable bending stress (MPa). When None, the material's "
+            "allowable_bending_stress_mpa is used."
+        ),
+    )
+
+
+class SparPieceOut(BaseModel):
+    """One straight spar piece. Lengths in **metres**, wing-local frame."""
+
+    role: str = Field(..., description="Structural role: 'front' (bending) or 'rear' (torsion).")
+    spare_origin: list[float] = Field(
+        ...,
+        description="Piece root origin (x, y, z) in the wing-local frame (m).",
+    )
+    spare_vector: list[float] = Field(
+        ...,
+        description="Unit direction vector the piece runs along (dimensionless).",
+    )
+    outer_d: float = Field(..., description="Outer diameter (m).")
+    inner_d: float = Field(..., description="Inner diameter / bore (m); 0 for a solid rod.")
+    wall: float = Field(..., description="Wall thickness = (outer_d - inner_d)/2 (m).")
+    shape: str = Field(..., description="Cross-section shape (e.g. 'tube').")
+    governing_y: float = Field(
+        ...,
+        description="Spanwise position of the governing (highest-moment) station (m).",
+    )
+    utilisation: float = Field(
+        ...,
+        description="Fraction of the local containment band the piece OD uses (0..1).",
+    )
+    joint_to_next: Optional[str] = Field(
+        None,
+        description="Joint to the next (tip-side) piece, e.g. 'telescoping'. None if last.",
+    )
+
+
+class SparPlanResponse(BaseModel):
+    """Response for ``POST /aeroplanes/{id}/spar-plan`` (gh-1031). Lengths in metres."""
+
+    front_pieces: list[SparPieceOut] = Field(
+        ...,
+        description="Front (bending) spar pieces, root->tip.",
+    )
+    rear_pieces: list[SparPieceOut] = Field(
+        ...,
+        description="Rear (torsion) spar pieces, root->tip.",
+    )
+    front_joint: str = Field(
+        ...,
+        description="Front root joint: 'continuous' | 'reinforcement+joiner'.",
+    )
+    rear_joint: str = Field(
+        ...,
+        description="Rear root joint: 'continuous' | 'bent-pin'.",
+    )
+    reinforcement: Optional[SparPieceOut] = Field(
+        None,
+        description=(
+            "Short collinear root reinforcement piece, present when the front "
+            "halves cannot be a single collinear carry-through."
+        ),
+    )

--- a/app/services/spar_plan_service.py
+++ b/app/services/spar_plan_service.py
@@ -1,0 +1,226 @@
+"""Service for the spar-plan endpoint (gh-1031).
+
+Resolve an aeroplane id -> its wing -> a ``WingConfiguration`` (mm), build the
+:class:`cad_designer.airplane.geometry.section_geometry.SectionGeometry`
+primitive, sample it into solver stations (front + rear spar, both halves) via
+:func:`cad_designer.airplane.geometry.spar_solver.build_stations_from_geometry`,
+solve the layout with :func:`solve_spar_plan`, and convert the millimetre plan
+to metres for the API.
+
+The ``SectionGeometry`` construction needs cadquery (excluded on
+``linux/aarch64``). When unavailable it raises
+``SectionGeometryUnavailableError``; we translate that into a ``ValidationError``
+so the endpoint returns a clean 422 instead of crashing.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.converters.model_schema_converters import wing_model_to_wing_config
+from app.core.exceptions import NotFoundError, ValidationError
+from app.schemas.spar_plan import (
+    SparPieceOut,
+    SparPlanRequest,
+    SparPlanResponse,
+)
+from app.services.wing_service import get_aeroplane_or_raise, get_wing_or_raise
+
+logger = logging.getLogger(__name__)
+
+_MM_TO_M = 0.001
+
+#: Default manoeuvre load factor when no design assumption is set (mirrors
+#: analysis_service._G_LIMIT_DEFAULT).
+_G_LIMIT_DEFAULT = 3.0
+
+
+def _resolve_wing(aeroplane, request: SparPlanRequest):
+    """Pick the requested wing (by name) or the aeroplane's first wing."""
+    if request.wing_name is not None:
+        return get_wing_or_raise(aeroplane, request.wing_name)
+    if not aeroplane.wings:
+        raise NotFoundError(
+            message="Aeroplane has no wings to plan a spar for",
+            details={"aeroplane_id": str(getattr(aeroplane, "uuid", ""))},
+        )
+    return aeroplane.wings[0]
+
+
+def _resolve_sigma_allow(db, request: SparPlanRequest) -> float:
+    """Resolve the allowable bending stress (MPa) from the override or material.
+
+    Raises ValidationError (-> 422) when the material is missing or has no
+    positive allowable stress.
+    """
+    if request.sigma_allow_mpa_override is not None:
+        return float(request.sigma_allow_mpa_override)
+
+    from app.models.component import ComponentModel
+
+    material = (
+        db.query(ComponentModel)
+        .filter(
+            ComponentModel.id == request.material_id,
+            ComponentModel.component_type == "material",
+        )
+        .first()
+    )
+    if material is None:
+        raise ValidationError(
+            message=f"Material component ID={request.material_id} not found.",
+            details={"material_id": request.material_id},
+        )
+    specs = material.specs or {}
+    sigma_allow = specs.get("allowable_bending_stress_mpa")
+    if sigma_allow is None or sigma_allow <= 0:
+        raise ValidationError(
+            message=(
+                f"Material '{material.name}' has no positive allowable_bending_stress_mpa "
+                f"(got {sigma_allow}). Provide a positive sigma_allow_mpa_override or choose "
+                "a structural material."
+            ),
+            details={"material_id": request.material_id, "name": material.name},
+        )
+    return float(sigma_allow)
+
+
+def _resolve_g_limit(db, aeroplane_uuid) -> float:
+    """Resolve g_limit from design assumptions, falling back to the default."""
+    from app.services.design_assumptions_service import get_effective_assumption
+
+    g_limit_raw = get_effective_assumption(db, aeroplane_uuid, "g_limit")
+    if g_limit_raw is None:
+        logger.warning(
+            "No g_limit assumption for aeroplane %s — using default %.1f",
+            aeroplane_uuid,
+            _G_LIMIT_DEFAULT,
+        )
+        return _G_LIMIT_DEFAULT
+    return float(g_limit_raw)
+
+
+def _make_moment_fn(request: SparPlanRequest):
+    """Build a moment_fn(y_span) -> N·m from the supplied distribution.
+
+    Linear interpolation over the (sorted) span fractions; clamps outside the
+    sampled range to the nearest endpoint.
+    """
+    samples = sorted(request.moments, key=lambda m: m.y_span)
+    ys = [s.y_span for s in samples]
+    ms = [abs(s.bending_moment_Nm) for s in samples]
+
+    def moment_fn(y_span: float) -> float:
+        if y_span <= ys[0]:
+            return ms[0]
+        if y_span >= ys[-1]:
+            return ms[-1]
+        for i in range(1, len(ys)):
+            if y_span <= ys[i]:
+                lo_y, hi_y = ys[i - 1], ys[i]
+                lo_m, hi_m = ms[i - 1], ms[i]
+                span = hi_y - lo_y
+                if span <= 0.0:  # pragma: no cover - defensive: clamps prevent a leading dup hit
+                    return hi_m
+                t = (y_span - lo_y) / span
+                return lo_m + t * (hi_m - lo_m)
+        return ms[-1]  # pragma: no cover - unreachable given the clamps above
+
+    return moment_fn
+
+
+def _build_section_geometry(wing_config):
+    """Construct the SectionGeometry primitive, translating the platform guard.
+
+    Kept as a thin seam so fast tests can monkeypatch the cadquery boundary.
+    """
+    from cad_designer.airplane.geometry.section_geometry import (
+        SectionGeometry,
+        SectionGeometryUnavailableError,
+    )
+
+    try:
+        return SectionGeometry(wing_config)
+    except SectionGeometryUnavailableError as exc:
+        raise ValidationError(
+            message=f"Section geometry is unavailable on this platform: {exc}",
+        ) from exc
+
+
+def _mirror_to_left(stations):
+    """Return the port-half mirror of a starboard station list (y_mm negated)."""
+    import dataclasses
+
+    return [dataclasses.replace(s, y_mm=-s.y_mm) for s in stations]
+
+
+def _piece_to_out(piece) -> SparPieceOut:
+    """Convert a millimetre SparPiece to a metre SparPieceOut."""
+    return SparPieceOut(
+        role=piece.role.value,
+        spare_origin=[c * _MM_TO_M for c in piece.spare_origin],
+        spare_vector=list(piece.spare_vector),
+        outer_d=piece.outer_d * _MM_TO_M,
+        inner_d=piece.inner_d * _MM_TO_M,
+        wall=piece.wall * _MM_TO_M,
+        shape=piece.shape,
+        governing_y=piece.governing_y * _MM_TO_M,
+        utilisation=piece.utilisation,
+        joint_to_next=piece.joint_to_next,
+    )
+
+
+def compute_spar_plan(
+    db,
+    aeroplane_uuid,
+    request: SparPlanRequest,
+) -> SparPlanResponse:
+    """Solve the buildable spar plan for an aeroplane's wing (gh-1031).
+
+    Raises:
+        NotFoundError: aeroplane or wing does not exist (-> 404).
+        ValidationError: section geometry unavailable, or material/strength
+            inputs invalid (-> 422).
+    """
+    from cad_designer.airplane.geometry.spar_solver import (
+        build_stations_from_geometry,
+        solve_spar_plan,
+    )
+
+    aeroplane = get_aeroplane_or_raise(db, aeroplane_uuid)
+    wing = _resolve_wing(aeroplane, request)
+
+    sigma_allow = _resolve_sigma_allow(db, request)
+    g_limit = _resolve_g_limit(db, aeroplane_uuid)
+    moment_fn = _make_moment_fn(request)
+
+    # WingConfiguration / SectionGeometry work in millimetres (scale=1000.0).
+    wing_config = wing_model_to_wing_config(wing, scale=1000.0)
+    geometry = _build_section_geometry(wing_config)
+
+    common = dict(
+        moment_fn=moment_fn,
+        sigma_allow_mpa=sigma_allow,
+        n_span=request.n_span,
+        packing_factor=request.packing_factor,
+        safety_factor_j=request.safety_factor_j,
+        g_limit=g_limit,
+    )
+
+    front_right = build_stations_from_geometry(geometry, x_c=request.front_x_over_chord, **common)
+    rear_right = build_stations_from_geometry(geometry, x_c=request.rear_x_over_chord, **common)
+
+    plan = solve_spar_plan(
+        front_left=_mirror_to_left(front_right),
+        front_right=front_right,
+        rear_left=_mirror_to_left(rear_right),
+        rear_right=rear_right,
+    )
+
+    return SparPlanResponse(
+        front_pieces=[_piece_to_out(p) for p in plan.front_pieces],
+        rear_pieces=[_piece_to_out(p) for p in plan.rear_pieces],
+        front_joint=plan.front_joint,
+        rear_joint=plan.rear_joint,
+        reinforcement=_piece_to_out(plan.reinforcement) if plan.reinforcement else None,
+    )

--- a/app/tests/test_spar_plan_endpoint.py
+++ b/app/tests/test_spar_plan_endpoint.py
@@ -1,0 +1,443 @@
+"""gh-1031: Fast-tier tests for the spar-plan endpoint + service.
+
+These run on the CI fast tier (no cadquery). We mock the SectionGeometry build
+and the solver seam (build_stations_from_geometry / solve_spar_plan) so the real
+lofted-solid build never runs. Endpoint functions are called directly (same
+pattern as test_section_geometry_endpoint.py) to avoid the router-registration
+guard in main.py.
+
+Coverage targets: material/sigma resolution, g_limit fallback, moment_fn
+interpolation, mm->m unit conversion, default wing selection, named-wing
+selection, the cadquery-unavailable seam, and error paths (no wings, wing not
+found, aeroplane not found, material not found, no allowable stress).
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.v2.endpoints.aeroanalysis import get_airplane_spar_plan
+from app.core.exceptions import NotFoundError, ValidationError
+from app.schemas.spar_plan import MomentSample, SparPlanRequest
+from app.services import spar_plan_service
+from cad_designer.airplane.geometry.spar_solver import (
+    SparPiece,
+    SparPlan,
+    SparRole,
+)
+
+
+# --------------------------------------------------------------------------
+# Stubs
+# --------------------------------------------------------------------------
+
+
+def _piece(role=SparRole.FRONT, **kw):
+    defaults = dict(
+        role=role,
+        spare_origin=(0.0, 100.0, 10.0),
+        spare_vector=(0.0, 1.0, 0.0),
+        outer_d=20.0,
+        inner_d=12.0,
+        shape="tube",
+        governing_y=100.0,
+        utilisation=0.9,
+    )
+    defaults.update(kw)
+    return SparPiece(**defaults)
+
+
+def _stub_plan(with_reinforcement=False):
+    plan = SparPlan(
+        front_pieces=[_piece(role=SparRole.FRONT)],
+        rear_pieces=[_piece(role=SparRole.REAR, outer_d=10.0, inner_d=6.0)],
+        front_joint="continuous",
+        rear_joint="continuous",
+    )
+    if with_reinforcement:
+        plan.front_joint = "reinforcement+joiner"
+        plan.reinforcement = _piece(
+            role=SparRole.FRONT, spare_origin=(0.0, -50.0, 5.0), governing_y=0.0
+        )
+    return plan
+
+
+@dataclass
+class _StubStation:
+    y_mm: float
+
+
+def _basic_request(**overrides):
+    body = dict(
+        material_id=7,
+        moments=[
+            MomentSample(y_span=0.0, bending_moment_Nm=100.0),
+            MomentSample(y_span=1.0, bending_moment_Nm=0.0),
+        ],
+    )
+    body.update(overrides)
+    return SparPlanRequest(**body)
+
+
+def _aeroplane_with_wings(wing_names):
+    wings = [SimpleNamespace(name=n) for n in wing_names]
+    return SimpleNamespace(wings=wings, uuid=uuid.uuid4())
+
+
+@pytest.fixture()
+def plane_id():
+    return uuid.uuid4()
+
+
+def _patch_full(aeroplane, plan, stations=None, sigma=200.0, g_limit=4.0):
+    """Patch every external boundary the service touches."""
+    stations = stations if stations is not None else [_StubStation(0.0), _StubStation(500.0)]
+    return [
+        patch.object(spar_plan_service, "get_aeroplane_or_raise", return_value=aeroplane),
+        patch.object(spar_plan_service, "wing_model_to_wing_config", return_value=object()),
+        patch.object(spar_plan_service, "_build_section_geometry", return_value=object()),
+        patch.object(spar_plan_service, "_resolve_sigma_allow", return_value=sigma),
+        patch.object(spar_plan_service, "_resolve_g_limit", return_value=g_limit),
+        patch(
+            "cad_designer.airplane.geometry.spar_solver.build_stations_from_geometry",
+            return_value=stations,
+        ),
+        patch(
+            "cad_designer.airplane.geometry.spar_solver.solve_spar_plan",
+            return_value=plan,
+        ),
+    ]
+
+
+def _run(patches, fn):
+    if not patches:
+        return fn()
+    with patches[0]:
+        return _run(patches[1:], fn)
+
+
+# --------------------------------------------------------------------------
+# Service: happy path + conversion
+# --------------------------------------------------------------------------
+
+
+class TestComputeSparPlanService:
+    def test_returns_converted_plan(self, plane_id):
+        aeroplane = _aeroplane_with_wings(["main_wing"])
+        resp = _run(
+            _patch_full(aeroplane, _stub_plan()),
+            lambda: spar_plan_service.compute_spar_plan(
+                db=None, aeroplane_uuid=plane_id, request=_basic_request()
+            ),
+        )
+        assert len(resp.front_pieces) == 1
+        assert len(resp.rear_pieces) == 1
+        assert resp.front_joint == "continuous"
+        assert resp.rear_joint == "continuous"
+        assert resp.reinforcement is None
+
+    def test_mm_to_m_conversion(self, plane_id):
+        aeroplane = _aeroplane_with_wings(["main_wing"])
+        resp = _run(
+            _patch_full(aeroplane, _stub_plan()),
+            lambda: spar_plan_service.compute_spar_plan(
+                db=None, aeroplane_uuid=plane_id, request=_basic_request()
+            ),
+        )
+        fp = resp.front_pieces[0]
+        # 20 mm OD -> 0.020 m, 12 mm ID -> 0.012 m, wall (20-12)/2=4 mm -> 0.004 m.
+        assert fp.outer_d == pytest.approx(0.020)
+        assert fp.inner_d == pytest.approx(0.012)
+        assert fp.wall == pytest.approx(0.004)
+        # origin (0,100,10) mm -> (0,0.1,0.01) m
+        assert fp.spare_origin == pytest.approx([0.0, 0.1, 0.01])
+        # governing_y 100 mm -> 0.1 m
+        assert fp.governing_y == pytest.approx(0.1)
+        # direction vector is dimensionless (unchanged)
+        assert fp.spare_vector == [0.0, 1.0, 0.0]
+        assert fp.role == "front"
+
+    def test_reinforcement_converted_when_present(self, plane_id):
+        aeroplane = _aeroplane_with_wings(["main_wing"])
+        resp = _run(
+            _patch_full(aeroplane, _stub_plan(with_reinforcement=True)),
+            lambda: spar_plan_service.compute_spar_plan(
+                db=None, aeroplane_uuid=plane_id, request=_basic_request()
+            ),
+        )
+        assert resp.front_joint == "reinforcement+joiner"
+        assert resp.reinforcement is not None
+        assert resp.reinforcement.spare_origin == pytest.approx([0.0, -0.05, 0.005])
+
+    def test_named_wing_selected(self, plane_id):
+        aeroplane = _aeroplane_with_wings(["main_wing", "h_tail"])
+        with patch.object(
+            spar_plan_service, "get_wing_or_raise", return_value=aeroplane.wings[1]
+        ) as mock_get_wing:
+            _run(
+                _patch_full(aeroplane, _stub_plan()),
+                lambda: spar_plan_service.compute_spar_plan(
+                    db=None,
+                    aeroplane_uuid=plane_id,
+                    request=_basic_request(wing_name="h_tail"),
+                ),
+            )
+            mock_get_wing.assert_called_once_with(aeroplane, "h_tail")
+
+    def test_solver_receives_mirrored_left_halves(self, plane_id):
+        """The left-half stations must be the y-negated mirror of the right half."""
+        aeroplane = _aeroplane_with_wings(["main_wing"])
+        captured = {}
+
+        def fake_solve(front_left, front_right, rear_left, rear_right, **kw):
+            captured["front_left"] = front_left
+            captured["front_right"] = front_right
+            return _stub_plan()
+
+        stations = [_StubStation(0.0), _StubStation(500.0)]
+        patches = [
+            patch.object(spar_plan_service, "get_aeroplane_or_raise", return_value=aeroplane),
+            patch.object(spar_plan_service, "wing_model_to_wing_config", return_value=object()),
+            patch.object(spar_plan_service, "_build_section_geometry", return_value=object()),
+            patch.object(spar_plan_service, "_resolve_sigma_allow", return_value=200.0),
+            patch.object(spar_plan_service, "_resolve_g_limit", return_value=4.0),
+            patch(
+                "cad_designer.airplane.geometry.spar_solver.build_stations_from_geometry",
+                return_value=stations,
+            ),
+            patch(
+                "cad_designer.airplane.geometry.spar_solver.solve_spar_plan",
+                side_effect=fake_solve,
+            ),
+        ]
+        _run(
+            patches,
+            lambda: spar_plan_service.compute_spar_plan(
+                db=None, aeroplane_uuid=plane_id, request=_basic_request()
+            ),
+        )
+        assert [s.y_mm for s in captured["front_right"]] == [0.0, 500.0]
+        assert [s.y_mm for s in captured["front_left"]] == [0.0, -500.0]
+
+
+# --------------------------------------------------------------------------
+# Service: resolution helpers
+# --------------------------------------------------------------------------
+
+
+class TestResolveWing:
+    def test_no_wings_raises_not_found(self, plane_id):
+        aeroplane = _aeroplane_with_wings([])
+        with pytest.raises(NotFoundError):
+            spar_plan_service._resolve_wing(aeroplane, _basic_request())
+
+    def test_aeroplane_not_found_propagates(self, plane_id):
+        with patch.object(
+            spar_plan_service,
+            "get_aeroplane_or_raise",
+            side_effect=NotFoundError(message="Aeroplane not found"),
+        ):
+            with pytest.raises(NotFoundError):
+                spar_plan_service.compute_spar_plan(
+                    db=None, aeroplane_uuid=plane_id, request=_basic_request()
+                )
+
+
+class TestResolveSigmaAllow:
+    def test_override_wins(self):
+        req = _basic_request(sigma_allow_mpa_override=333.0)
+        assert spar_plan_service._resolve_sigma_allow(db=None, request=req) == 333.0
+
+    def test_material_value_used(self):
+        material = SimpleNamespace(name="CFRP", specs={"allowable_bending_stress_mpa": 250.0})
+        db = SimpleNamespace(
+            query=lambda *a: SimpleNamespace(
+                filter=lambda *a, **k: SimpleNamespace(first=lambda: material)
+            )
+        )
+        assert spar_plan_service._resolve_sigma_allow(db=db, request=_basic_request()) == 250.0
+
+    def test_material_not_found_raises_validation(self):
+        db = SimpleNamespace(
+            query=lambda *a: SimpleNamespace(
+                filter=lambda *a, **k: SimpleNamespace(first=lambda: None)
+            )
+        )
+        with pytest.raises(ValidationError):
+            spar_plan_service._resolve_sigma_allow(db=db, request=_basic_request())
+
+    def test_non_positive_sigma_raises_validation(self):
+        material = SimpleNamespace(name="foam", specs={"allowable_bending_stress_mpa": 0.0})
+        db = SimpleNamespace(
+            query=lambda *a: SimpleNamespace(
+                filter=lambda *a, **k: SimpleNamespace(first=lambda: material)
+            )
+        )
+        with pytest.raises(ValidationError):
+            spar_plan_service._resolve_sigma_allow(db=db, request=_basic_request())
+
+    def test_missing_specs_raises_validation(self):
+        material = SimpleNamespace(name="unknown", specs=None)
+        db = SimpleNamespace(
+            query=lambda *a: SimpleNamespace(
+                filter=lambda *a, **k: SimpleNamespace(first=lambda: material)
+            )
+        )
+        with pytest.raises(ValidationError):
+            spar_plan_service._resolve_sigma_allow(db=db, request=_basic_request())
+
+
+class TestResolveGLimit:
+    def test_uses_assumption_when_present(self, plane_id):
+        with patch(
+            "app.services.design_assumptions_service.get_effective_assumption",
+            return_value=5.0,
+        ):
+            assert spar_plan_service._resolve_g_limit(db=None, aeroplane_uuid=plane_id) == 5.0
+
+    def test_falls_back_to_default(self, plane_id):
+        with patch(
+            "app.services.design_assumptions_service.get_effective_assumption",
+            return_value=None,
+        ):
+            assert (
+                spar_plan_service._resolve_g_limit(db=None, aeroplane_uuid=plane_id)
+                == spar_plan_service._G_LIMIT_DEFAULT
+            )
+
+
+class TestMomentFn:
+    def test_interpolates_and_clamps(self):
+        req = _basic_request(
+            moments=[
+                MomentSample(y_span=0.0, bending_moment_Nm=100.0),
+                MomentSample(y_span=0.5, bending_moment_Nm=40.0),
+                MomentSample(y_span=1.0, bending_moment_Nm=0.0),
+            ]
+        )
+        fn = spar_plan_service._make_moment_fn(req)
+        assert fn(0.0) == pytest.approx(100.0)
+        assert fn(0.25) == pytest.approx(70.0)  # midpoint of 100..40
+        assert fn(0.5) == pytest.approx(40.0)
+        assert fn(1.0) == pytest.approx(0.0)
+        # clamp below / above the sampled range
+        assert fn(-1.0) == pytest.approx(100.0)
+        assert fn(2.0) == pytest.approx(0.0)
+
+    def test_uses_absolute_moment(self):
+        req = _basic_request(
+            moments=[
+                MomentSample(y_span=0.0, bending_moment_Nm=-80.0),
+                MomentSample(y_span=1.0, bending_moment_Nm=-20.0),
+            ]
+        )
+        fn = spar_plan_service._make_moment_fn(req)
+        assert fn(0.0) == pytest.approx(80.0)
+        assert fn(1.0) == pytest.approx(20.0)
+
+    def test_unsorted_input_is_sorted(self):
+        req = _basic_request(
+            moments=[
+                MomentSample(y_span=1.0, bending_moment_Nm=0.0),
+                MomentSample(y_span=0.0, bending_moment_Nm=100.0),
+            ]
+        )
+        fn = spar_plan_service._make_moment_fn(req)
+        assert fn(0.0) == pytest.approx(100.0)
+        assert fn(1.0) == pytest.approx(0.0)
+
+    def test_duplicate_y_resolves_to_first_match(self):
+        req = _basic_request(
+            moments=[
+                MomentSample(y_span=0.0, bending_moment_Nm=100.0),
+                MomentSample(y_span=0.5, bending_moment_Nm=60.0),
+                MomentSample(y_span=0.5, bending_moment_Nm=30.0),
+                MomentSample(y_span=1.0, bending_moment_Nm=0.0),
+            ]
+        )
+        fn = spar_plan_service._make_moment_fn(req)
+        # querying exactly the duplicated y resolves via the first matching pair
+        assert fn(0.5) == pytest.approx(60.0)
+        # interior of the second (post-duplicate) segment still interpolates
+        assert fn(0.75) == pytest.approx(15.0)
+
+
+class TestBuildSectionGeometryBoundary:
+    def test_translates_unavailable_to_validation_error(self):
+        import cad_designer.airplane.geometry.section_geometry as sg
+
+        class _Boom:
+            def __init__(self, *a, **k):
+                raise sg.SectionGeometryUnavailableError("no cadquery")
+
+        with patch.object(sg, "SectionGeometry", _Boom):
+            with pytest.raises(ValidationError):
+                spar_plan_service._build_section_geometry(object())
+
+    def test_returns_constructed_instance(self):
+        import cad_designer.airplane.geometry.section_geometry as sg
+
+        sentinel = object()
+        with patch.object(sg, "SectionGeometry", lambda *a, **k: sentinel):
+            assert spar_plan_service._build_section_geometry(object()) is sentinel
+
+    def test_cadquery_unavailable_surfaces_as_validation(self, plane_id):
+        aeroplane = _aeroplane_with_wings(["main_wing"])
+        with (
+            patch.object(spar_plan_service, "get_aeroplane_or_raise", return_value=aeroplane),
+            patch.object(spar_plan_service, "wing_model_to_wing_config", return_value=object()),
+            patch.object(spar_plan_service, "_resolve_sigma_allow", return_value=200.0),
+            patch.object(spar_plan_service, "_resolve_g_limit", return_value=3.0),
+            patch.object(
+                spar_plan_service,
+                "_build_section_geometry",
+                side_effect=ValidationError(message="unavailable"),
+            ),
+        ):
+            with pytest.raises(ValidationError):
+                spar_plan_service.compute_spar_plan(
+                    db=None, aeroplane_uuid=plane_id, request=_basic_request()
+                )
+
+
+# --------------------------------------------------------------------------
+# Endpoint
+# --------------------------------------------------------------------------
+
+
+class TestSparPlanEndpoint:
+    def test_returns_response_on_success(self, plane_id):
+        with patch.object(
+            spar_plan_service, "compute_spar_plan", return_value="RESULT"
+        ) as mock_compute:
+            result = get_airplane_spar_plan(
+                aeroplane_id=plane_id, request=_basic_request(), db=None
+            )
+        assert result == "RESULT"
+        mock_compute.assert_called_once()
+
+    def test_raises_http_404_on_not_found(self, plane_id):
+        with patch.object(
+            spar_plan_service,
+            "compute_spar_plan",
+            side_effect=NotFoundError(message="Aeroplane not found"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                get_airplane_spar_plan(aeroplane_id=plane_id, request=_basic_request(), db=None)
+        assert exc_info.value.status_code == 404
+
+    def test_raises_http_422_on_validation_error(self, plane_id):
+        with patch.object(
+            spar_plan_service,
+            "compute_spar_plan",
+            side_effect=ValidationError(message="unavailable"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                get_airplane_spar_plan(aeroplane_id=plane_id, request=_basic_request(), db=None)
+        assert exc_info.value.status_code == 422


### PR DESCRIPTION
## Summary

Implements issue #1031 — the v2 `spar-plan` endpoint + schemas, wrapping the
gh-1030 spar-vector solver for review/visualisation.

`POST /aeroplanes/{id}/spar-plan`:
- resolves aeroplane → wing → `WingConfiguration` (mm), mirroring the #1021
  section-geometry endpoint;
- gathers the #1002 spanwise bending-moment distribution (request body) and the
  #1008 material/sizing inputs (material → σ_allow, g_limit from design
  assumptions with a 3.0 fallback);
- builds front + rear solver stations for both halves via
  `build_stations_from_geometry`, solves with `solve_spar_plan`;
- returns the `SparPlan` (front/rear pieces with `spare_origin`, `spare_vector`,
  `outer_d`, `inner_d`/`wall`, `shape`, governing station, utilisation,
  `joint_to_next`, role; front/rear joint; optional reinforcement) — **lengths
  in metres** (mm → m ×0.001).

Error mapping: missing aeroplane/wing → 404; `SectionGeometryUnavailableError`
(cadquery excluded on `linux/aarch64`) and invalid material/strength inputs →
422.

## Files
- `app/schemas/spar_plan.py` — `SparPlanRequest` / `SparPlanResponse` / `SparPieceOut` / `MomentSample`
- `app/services/spar_plan_service.py` — orchestration + mm→m conversion
- `app/api/v2/endpoints/aeroanalysis.py` — thin route
- `app/tests/test_spar_plan_endpoint.py` — 24 fast-tier tests (mock solver/geometry boundary)

## Tests / coverage
- 24 new tests pass (`-m "not slow"`); section-geometry siblings still green.
- New service + schema files at **100%** fast-tier coverage; the two irreducible
  defensive branches carry `# pragma: no cover`.
- `ruff check` + `ruff format` clean.

Endpoint only — CAD insertion of the plan's `Spare`s is #1032.

Closes #1031

🤖 Generated with [Claude Code](https://claude.com/claude-code)