### PR TITLE
fix(gh-1037): assemblable spar plans — telescoping direction, splits, infeasibility, root-slice guard

### DIFF
--- a/app/schemas/spar_plan.py
+++ b/app/schemas/spar_plan.py
@@ -127,11 +127,22 @@ class SparPieceOut(BaseModel):
     )
     utilisation: float = Field(
         ...,
-        description="Fraction of the local containment band the piece OD uses (0..1).",
+        description=(
+            "Fraction of the local containment band the piece OD uses. A value "
+            ">1 means no round tube strong enough fits the section (see feasible)."
+        ),
     )
     joint_to_next: Optional[str] = Field(
         None,
         description="Joint to the next (tip-side) piece, e.g. 'telescoping'. None if last.",
+    )
+    feasible: bool = Field(
+        True,
+        description="False when the section cannot contain a round tube strong enough.",
+    )
+    infeasibility_reason: Optional[str] = Field(
+        None,
+        description="Human-readable reason when the piece is infeasible; None otherwise.",
     )
 
 
@@ -160,4 +171,16 @@ class SparPlanResponse(BaseModel):
             "Short collinear root reinforcement piece, present when the front "
             "halves cannot be a single collinear carry-through."
         ),
+    )
+    feasible: bool = Field(
+        True,
+        description=(
+            "False when any spar piece cannot contain a round tube strong enough "
+            "(see infeasibility_reason). A feasible=False plan is not buildable "
+            "as-is."
+        ),
+    )
+    infeasibility_reason: Optional[str] = Field(
+        None,
+        description="Reason for the first infeasible piece, or None when the plan is feasible.",
     )

--- a/app/services/spar_plan_service.py
+++ b/app/services/spar_plan_service.py
@@ -167,6 +167,8 @@ def _piece_to_out(piece) -> SparPieceOut:
         governing_y=piece.governing_y * _MM_TO_M,
         utilisation=piece.utilisation,
         joint_to_next=piece.joint_to_next,
+        feasible=piece.feasible,
+        infeasibility_reason=piece.infeasibility_reason,
     )
 
 
@@ -223,4 +225,6 @@ def compute_spar_plan(
         front_joint=plan.front_joint,
         rear_joint=plan.rear_joint,
         reinforcement=_piece_to_out(plan.reinforcement) if plan.reinforcement else None,
+        feasible=plan.feasible,
+        infeasibility_reason=plan.infeasibility_reason,
     )

--- a/app/tests/test_spar_plan_endpoint.py
+++ b/app/tests/test_spar_plan_endpoint.py
@@ -141,6 +141,31 @@ class TestComputeSparPlanService:
         assert resp.front_joint == "continuous"
         assert resp.rear_joint == "continuous"
         assert resp.reinforcement is None
+        # gh-1037: a feasible plan reports feasible truthfully.
+        assert resp.feasible is True
+        assert resp.infeasibility_reason is None
+        assert resp.front_pieces[0].feasible is True
+
+    def test_infeasible_plan_propagates_to_response(self, plane_id):
+        # gh-1037: when the solver marks a piece/plan infeasible, the API must
+        # report it (not return a fake feasible plan).
+        aeroplane = _aeroplane_with_wings(["main_wing"])
+        plan = _stub_plan()
+        plan.front_pieces[0].feasible = False
+        plan.front_pieces[0].infeasibility_reason = "required OD 96.5 mm exceeds section depth"
+        plan.front_pieces[0].utilisation = 2.6
+        plan.feasible = False
+        plan.infeasibility_reason = plan.front_pieces[0].infeasibility_reason
+        resp = _run(
+            _patch_full(aeroplane, plan),
+            lambda: spar_plan_service.compute_spar_plan(
+                db=None, aeroplane_uuid=plane_id, request=_basic_request()
+            ),
+        )
+        assert resp.feasible is False
+        assert "exceeds section depth" in resp.infeasibility_reason
+        assert resp.front_pieces[0].feasible is False
+        assert resp.front_pieces[0].utilisation == pytest.approx(2.6)
 
     def test_mm_to_m_conversion(self, plane_id):
         aeroplane = _aeroplane_with_wings(["main_wing"])

--- a/cad_designer/airplane/geometry/spar_solver.py
+++ b/cad_designer/airplane/geometry/spar_solver.py
@@ -36,6 +36,11 @@ from app.services.spar_sizing import required_section_modulus, solve_dimension
 # than this absolute slack (mm) forces a split. Small float tolerance.
 _FIT_TOL_MM = 1e-6
 
+# Span fraction used to sample the root station instead of the degenerate
+# y_span=0 slice (gh-1037 #4). Small enough to still represent the max-moment
+# root, large enough to land on a valid (non-pinched) section.
+_ROOT_EPS = 1e-3
+
 
 class SparRole(str, Enum):
     """Which structural spar a plan/piece belongs to."""
@@ -72,6 +77,10 @@ class SparSpec:
     role: SparRole
     shape: str = "tube"  # round tube (telescoping- and bent-pin-friendly)
     wall_factor: float = 0.6  # piece ID = wall_factor * OD when no strength ID given
+    #: Radial clearance (mm) at a telescoping joint: the tip-side piece OD must
+    #: be at least this much smaller than the root-side piece bore so it can
+    #: slide in (glue gap / slip fit). gh-1037.
+    telescope_clearance_mm: float = 0.5
 
 
 @dataclass
@@ -88,6 +97,8 @@ class SparPiece:
     utilisation: float
     length: float = 0.0  # mm, root→tip span of this straight piece (#1032)
     joint_to_next: str | None = None  # "telescoping" between consecutive pieces
+    feasible: bool = True  # gh-1037: False when no round tube strong enough fits
+    infeasibility_reason: str | None = None
 
     @property
     def wall(self) -> float:
@@ -106,6 +117,8 @@ class SparPiece:
             "utilisation": self.utilisation,
             "length": self.length,
             "joint_to_next": self.joint_to_next,
+            "feasible": self.feasible,
+            "infeasibility_reason": self.infeasibility_reason,
         }
 
 
@@ -118,6 +131,8 @@ class SparPlan:
     front_joint: str = "continuous"  # continuous | reinforcement+joiner
     rear_joint: str = "continuous"  # continuous | bent-pin
     reinforcement: SparPiece | None = None
+    feasible: bool = True  # gh-1037: False when any piece cannot contain a strong tube
+    infeasibility_reason: str | None = None
 
     def to_dict(self) -> dict:
         return {
@@ -126,6 +141,8 @@ class SparPlan:
             "front_joint": self.front_joint,
             "rear_joint": self.rear_joint,
             "reinforcement": self.reinforcement.to_dict() if self.reinforcement else None,
+            "feasible": self.feasible,
+            "infeasibility_reason": self.infeasibility_reason,
         }
 
 
@@ -197,72 +214,133 @@ def _unit_vector(
 # ---------------------------------------------------------------------------
 
 
+@dataclass
+class _Run:
+    """A straight-piece run during fitting.
+
+    ``stations`` are every station the straight tube physically covers (used for
+    containment fit and length). ``governing`` are the stations whose strength
+    drives the piece's OD/bore — this *excludes* a station borrowed from an
+    inboard neighbour as a telescoping overlap, since the inner piece reinforces
+    the spar there.
+    """
+
+    stations: list[StationData]
+    governing: list[StationData]
+
+
+def _split_into_runs(stations: list[StationData]) -> list[_Run]:
+    """Break the station list into straight-piece runs (root→tip).
+
+    Partition the stations greedily: extend a run while a straight tube of the
+    run's governing OD (the most-inboard, highest-moment station it covers)
+    stays inside EVERY covered station's band; on failure start the next run at
+    the breaking station. This yields a clean partition (no station appears in
+    two runs).
+
+    A partition run may collapse to a single station — physically a zero-length
+    piece, which is not a structural object (gh-1037 #2). We repair that by
+    overlapping such a run **rootward** into the previous run's tip station: the
+    telescoping joint *is* an overlap region, so a piece legitimately reaches
+    back to its inboard neighbour's boundary. The borrowed root station extends
+    the piece's geometry but does not drive its governing OD.
+    """
+    partitions: list[list[StationData]] = []
+    run: list[StationData] = [stations[0]]
+    for st in stations[1:]:
+        candidate = run + [st]
+        if _run_fits(_governing_od(candidate), candidate):
+            run = candidate
+            continue
+        partitions.append(run)
+        run = [st]
+    partitions.append(run)
+
+    runs: list[_Run] = []
+    for idx, part in enumerate(partitions):
+        if len(part) == 1 and idx > 0:
+            # borrow the inboard neighbour's tip as a rootward overlap
+            runs.append(_Run(stations=[partitions[idx - 1][-1], *part], governing=list(part)))
+        elif len(part) == 1 and len(partitions) > 1:
+            # single root partition: borrow the next neighbour's root tipward
+            runs.append(_Run(stations=[*part, partitions[idx + 1][0]], governing=list(part)))
+        else:
+            runs.append(_Run(stations=list(part), governing=list(part)))
+    return runs
+
+
 def plan_spar(stations: list[StationData], spec: SparSpec) -> list[SparPiece]:
     """Greedy root→tip fit into straight telescoping pieces.
 
-    Extend a piece while a straight tube of the piece's governing OD (the
-    most-inboard, highest-moment station it covers) stays inside EVERY covered
-    station's band. On failure → close the piece, start the next; the joint is
-    **telescoping** (next piece OD = this piece ID).
+    Split the stations into straight runs (:func:`_split_into_runs`), then size
+    each piece. The telescoping relation runs **inboard**: the tip-side (outer)
+    piece must slide INTO the root-side (inner) piece's bore, so
 
-    Confirmed priority rule: keep a piece going only while its strength-required
-    OD fits the local section at every covered station. Otherwise split +
-    telescope. **Strength beats part-count.**
+        ``OD_outer ≤ ID_inner − clearance``
+
+    and OD is **non-increasing outboard** (root ≥ tip), consistent with the
+    bending moment M(y). We size the pieces tip→root: each piece's OD is its own
+    strength-required OD, then each inner (root-side) piece's bore is grown to
+    admit the adjacent outer piece's OD plus clearance, and the inner OD grows
+    to keep a sane wall around that bore (gh-1037 #1). When a piece's required OD
+    cannot be contained by its section, it is marked infeasible with a reason
+    rather than emitting a fake feasible plan (gh-1037 #3).
+
+    Confirmed priority rule: keep a piece continuous only while its
+    strength-required OD fits the local section at every covered station.
+    Otherwise split + telescope. **Strength beats part-count.**
     """
     if not stations:
         return []
 
-    pieces: list[SparPiece] = []
-    run: list[StationData] = [stations[0]]
+    runs = _split_into_runs(stations)
 
-    for st in stations[1:]:
-        candidate = run + [st]
-        governing_od = _governing_od(candidate)
-        # A straight tube of the governing OD must stay inside every covered
-        # station's band along the candidate's own straight root→tip axis.
-        if _run_fits(governing_od, candidate):
-            run = candidate
-            continue
-        # Close the current run, telescope into the next.
-        pieces.append(run)  # placeholder, filled below
-        run = [st]
+    # Base OD per piece = the piece's own strength-required (governing) OD.
+    ods = [_governing_od(r.governing) for r in runs]
 
-    pieces.append(run)
+    # Propagate the bore demand INBOARD (tip→root): each inner piece must admit
+    # the outer piece's OD plus clearance through its bore. The inner bore sets a
+    # floor on the inner OD (bore + a minimal wall), so the root piece grows to
+    # satisfy the whole telescoping stack. This also enforces OD non-increasing
+    # outboard.
+    bores: list[float] = [0.0] * len(runs)
+    # tip piece (last): bore is purely strength-driven.
+    bores[-1] = _bore_for(runs[-1], spec, ods[-1])
+    # inner pieces (root→tip order, processed tip→root): each must admit the
+    # adjacent outer piece's OD plus clearance through its bore, AND keep at
+    # least the strength-required bore, AND a minimal wall around the bore.
+    for i in range(len(runs) - 2, -1, -1):
+        telescope_bore = ods[i + 1] + 2.0 * spec.telescope_clearance_mm
+        strength_bore = _bore_for(runs[i], spec, ods[i])
+        bore = max(telescope_bore, strength_bore)
+        min_od_for_bore = bore + 2.0 * spec.telescope_clearance_mm
+        if ods[i] < min_od_for_bore:
+            ods[i] = min_od_for_bore
+        bores[i] = bore
 
-    # Convert station-runs to SparPieces, wiring telescoping IDs.
     built: list[SparPiece] = []
-    prev_inner: float | None = None
-    for idx, run_stations in enumerate(pieces):
-        od = _governing_od(run_stations)
-        if prev_inner is not None:
-            # telescoping: this (outer/tip-side) piece OD = previous piece ID.
-            # If strength needs more than the previous bore, the previous piece
-            # was sized too small — but strength beats part-count, so this OD is
-            # max(prev_inner, strength OD). Keep the bore relation by widening.
-            od = max(prev_inner, od)
-        inner_d = _bore_for(run_stations, spec, od)
-        piece = _piece_from_run_with_od(run_stations, spec, od, inner_d)
-        built.append(piece)
-        if idx < len(pieces) - 1:
+    for idx, run in enumerate(runs):
+        piece = _piece_from_run_with_od(run, spec, ods[idx], bores[idx])
+        if idx < len(runs) - 1:
             piece.joint_to_next = "telescoping"
-        prev_inner = inner_d
+        built.append(piece)
     return built
 
 
-def _bore_for(run: list[StationData], spec: SparSpec, od: float) -> float:
+def _bore_for(run: _Run, spec: SparSpec, od: float) -> float:
     """Strength-driven bore for a tube of outer diameter ``od``.
 
     Uses #1008 tube sizing at the governing station so the bore reflects the
     real load; falls back to a fixed wall fraction when sizing can't solve a
     feasible bore (e.g. strength wants a solid).
     """
-    governing = run[0]
-    # Reconstruct a required section modulus consistent with the station's
-    # required_od (the strength OD already encodes the moment). The bore is the
-    # largest inner diameter that still meets strength at this OD.
+    governing_od = _governing_od(run.governing)
+    # Reconstruct a required section modulus consistent with the governing
+    # station's required_od (the strength OD already encodes the moment). The
+    # bore is the largest inner diameter that still meets strength at this OD.
     # required_od was sized as a *rod-equivalent*; for a tube of larger OD we
     # can hollow it. Use solve_dimension's tube path with the governing W.
-    erf_w = required_section_modulus_from_od(governing.required_od)
+    erf_w = required_section_modulus_from_od(governing_od)
     sol = solve_dimension(shape="tube", erf_w=erf_w, outer_mm=od)
     if sol["feasible"] and sol["inner_mm"] is not None:
         return float(sol["inner_mm"])
@@ -279,18 +357,32 @@ def required_section_modulus_from_od(od: float) -> float:
     return od**3 / 10.0
 
 
-def _piece_from_run_with_od(
-    run: list[StationData], spec: SparSpec, od: float, inner_d: float
-) -> SparPiece:
-    governing = run[0]
-    root = run[0]
-    tip = run[-1]
+def _piece_from_run_with_od(run: _Run, spec: SparSpec, od: float, inner_d: float) -> SparPiece:
+    governing = run.governing[0]
+    root = run.stations[0]
+    tip = run.stations[-1]
     origin = (0.0, root.y_mm, root.center_z)
     tip_point = (0.0, tip.y_mm, tip.center_z)
     vector = _unit_vector(origin, tip_point)
     length = math.dist(origin, tip_point)
-    tightest = _max_od_for_run(run)
-    utilisation = min(1.0, od / tightest) if tightest > 0 else 1.0
+    tightest = _max_od_for_run(run.stations)
+    # Honest utilisation (gh-1037 #3): the fraction of the tightest containment
+    # band the piece OD uses. It may exceed 1 when no round tube strong enough
+    # fits — we report that truthfully instead of clamping to a fake 1.0. When
+    # the band has literally no room (tightest == 0) we floor the denominator to
+    # a tiny value so the ratio is large-but-finite (JSON-serialisable) and
+    # still clearly signals infeasibility.
+    utilisation = od / max(tightest, _FIT_TOL_MM)
+    feasible = od <= tightest + _FIT_TOL_MM and tightest > 0
+    reason: str | None = None
+    if not feasible:
+        depth = max(0.0, governing.band_hi - governing.band_lo)
+        reason = (
+            f"required OD {od:.1f} mm exceeds section depth {depth:.1f} mm at "
+            f"y={governing.y_mm:.0f} mm; increase root depth/chord or reduce "
+            "design load — a round tube is the least efficient bending member, "
+            "consider a capped/box spar"
+        )
     return SparPiece(
         role=spec.role,
         spare_origin=origin,
@@ -301,6 +393,8 @@ def _piece_from_run_with_od(
         governing_y=governing.y_mm,
         utilisation=utilisation,
         length=length,
+        feasible=feasible,
+        infeasibility_reason=reason,
     )
 
 
@@ -420,6 +514,15 @@ def solve_spar_plan(
         else:
             plan.rear_joint = "bent-pin"
 
+    # --- feasibility roll-up (gh-1037 #3) ---
+    all_pieces = [*plan.front_pieces, *plan.rear_pieces]
+    if plan.reinforcement is not None:
+        all_pieces.append(plan.reinforcement)
+    infeasible = [p for p in all_pieces if not p.feasible]
+    if infeasible:
+        plan.feasible = False
+        plan.infeasibility_reason = infeasible[0].infeasibility_reason
+
     return plan
 
 
@@ -451,6 +554,13 @@ def build_stations_from_geometry(
     import numpy as np
 
     y_spans = np.linspace(0.0, 1.0, max(2, n_span)).tolist()
+    # gh-1037 #4: the slice at y_span=0 is degenerate on a real loft (pinched,
+    # zero-thickness centreline section) and would poison the governing
+    # (max-moment) root station. Sample the root at y_span=eps instead so the
+    # root sizing uses a valid section while still representing the highest
+    # moment.
+    if y_spans and y_spans[0] <= 0.0:
+        y_spans[0] = _ROOT_EPS
     stations: list[StationData] = []
     for y_span in y_spans:
         if x_c is None:

--- a/cad_designer/tests/test_spar_solver.py
+++ b/cad_designer/tests/test_spar_solver.py
@@ -116,10 +116,12 @@ class TestTelescopingSplit:
         ]
         pieces = plan_spar(stations, SparSpec(role=SparRole.FRONT))
         assert len(pieces) >= 2
-        # telescoping: outer piece OD == inner piece ID
+        # telescoping: the tip-side (outer) piece must slide INTO the root-side
+        # (inner) piece's bore — OD_outer <= ID_inner (gh-1037: the old
+        # equal-OD/ID convention let a fat tip into a narrow bore).
         inner, outer = pieces[0], pieces[1]
         assert inner.joint_to_next == "telescoping"
-        assert outer.outer_d == pytest.approx(inner.inner_d, abs=1e-6)
+        assert outer.outer_d <= inner.inner_d + 1e-9
         # strength beats part-count: each piece's OD still meets its governing station
         assert inner.outer_d >= 30.0 - 1e-9
 
@@ -270,6 +272,179 @@ class TestEdgeCases:
         assert len(pieces) == 1
         # a hollow tube: bore strictly between 0 and OD
         assert 0.0 < pieces[0].inner_d < pieces[0].outer_d
+
+
+# ---------------------------------------------------------------------------
+# Fast: gh-1037 — assemblable telescoping, no zero-length, honest infeasibility
+# ---------------------------------------------------------------------------
+
+
+def _telescoping_joints(pieces):
+    """Yield (inner, outer) consecutive piece pairs joined telescoping."""
+    for inner, outer in zip(pieces, pieces[1:], strict=False):
+        if inner.joint_to_next == "telescoping":
+            yield inner, outer
+
+
+class TestTelescopingAssemblable:
+    """gh-1037 #1: a telescoping joint needs OD_outer <= ID_inner - clearance.
+
+    The tip-side piece must physically slide INTO the root-side bore. The old
+    ``max(prev_inner, strength_od)`` rule produced the inverse (fat tip into a
+    narrow bore), which cannot be assembled.
+    """
+
+    def test_outer_od_fits_inside_inner_bore_with_clearance(self):
+        # A monotonic taper that forces multiple telescoping splits. Both
+        # adjacent pieces have strong required OD (> 0.6 * OD_prev).
+        stations = [
+            _station(0.0, y_mm=0.0, band=(-60.0, 60.0), required_od=80.0),
+            _station(0.33, y_mm=300.0, band=(-30.0, 30.0), required_od=55.0),
+            _station(0.66, y_mm=600.0, band=(-15.0, 15.0), required_od=28.0),
+            _station(1.0, y_mm=900.0, band=(-8.0, 8.0), required_od=14.0),
+        ]
+        pieces = plan_spar(stations, SparSpec(role=SparRole.FRONT))
+        joints = list(_telescoping_joints(pieces))
+        assert joints, "expected at least one telescoping joint"
+        for inner, outer in joints:
+            # the UAT falsification criterion
+            assert outer.outer_d <= inner.inner_d + 1e-9, (
+                f"telescoping joint inverted: outer OD {outer.outer_d:.2f} > "
+                f"inner ID {inner.inner_d:.2f}"
+            )
+
+    def test_od_non_increasing_outboard(self):
+        # Root piece OD >= tip piece OD: no load-path inversion (M(y) decreases).
+        stations = [
+            _station(0.0, y_mm=0.0, band=(-60.0, 60.0), required_od=80.0),
+            _station(0.33, y_mm=300.0, band=(-30.0, 30.0), required_od=55.0),
+            _station(0.66, y_mm=600.0, band=(-15.0, 15.0), required_od=28.0),
+            _station(1.0, y_mm=900.0, band=(-8.0, 8.0), required_od=14.0),
+        ]
+        pieces = plan_spar(stations, SparSpec(role=SparRole.FRONT))
+        ods = [p.outer_d for p in pieces]
+        assert ods == sorted(ods, reverse=True), f"OD not non-increasing outboard: {ods}"
+
+    def test_single_root_partition_borrows_tipward_no_zero_length(self):
+        # The root interval alone cannot hold the root OD (tip band collapses
+        # immediately), so the root partition is a single station. It must
+        # borrow the next station tipward rather than emit a zero-length piece.
+        stations = [
+            _station(0.0, y_mm=0.0, band=(-50.0, 50.0), required_od=60.0),
+            _station(0.5, y_mm=250.0, band=(-8.0, 8.0), required_od=14.0),
+            _station(1.0, y_mm=500.0, band=(-7.0, 7.0), required_od=12.0),
+        ]
+        pieces = plan_spar(stations, SparSpec(role=SparRole.FRONT))
+        assert pieces
+        for p in pieces:
+            assert p.length > 0.0
+        # root piece governed by the root station's required OD
+        assert pieces[0].outer_d >= 60.0 - 1e-9
+
+    def test_no_zero_length_piece_emitted(self):
+        # gh-1037 #2: per-station over-splitting must never emit length==0 pieces.
+        stations = [
+            _station(0.0, y_mm=0.0, band=(-60.0, 60.0), required_od=80.0),
+            _station(0.25, y_mm=200.0, band=(-40.0, 40.0), required_od=60.0),
+            _station(0.5, y_mm=400.0, band=(-22.0, 22.0), required_od=40.0),
+            _station(0.75, y_mm=600.0, band=(-12.0, 12.0), required_od=22.0),
+            _station(1.0, y_mm=800.0, band=(-6.0, 6.0), required_od=11.0),
+        ]
+        pieces = plan_spar(stations, SparSpec(role=SparRole.FRONT))
+        assert pieces
+        for p in pieces:
+            assert p.length > 0.0, f"zero-length piece emitted: {p}"
+
+
+class TestInfeasibilityReporting:
+    """gh-1037 #3: when no round tube strong enough fits, report infeasible."""
+
+    def test_section_too_shallow_for_required_od_is_infeasible(self):
+        # required OD ~96 mm into a ~37 mm depth band: physically impossible.
+        stations = [
+            _station(0.0, y_mm=0.0, band=(-18.5, 18.5), required_od=96.5),
+            _station(1.0, y_mm=500.0, band=(-12.0, 12.0), required_od=40.0),
+        ]
+        pieces = plan_spar(stations, SparSpec(role=SparRole.FRONT))
+        assert pieces
+        root = pieces[0]
+        assert root.feasible is False
+        assert root.infeasibility_reason is not None
+        assert "exceeds" in root.infeasibility_reason.lower()
+        # honest reporting: utilisation may exceed 1 on an impossible section,
+        # never a fake 1.0.
+        assert root.utilisation > 1.0
+
+    def test_plan_marks_infeasible_when_any_piece_infeasible(self):
+        left = [
+            _station(0.0, y_mm=0.0, band=(-18.5, 18.5), required_od=96.5),
+            _station(1.0, y_mm=-500.0, band=(-12.0, 12.0), required_od=40.0),
+        ]
+        right = [
+            _station(0.0, y_mm=0.0, band=(-18.5, 18.5), required_od=96.5),
+            _station(1.0, y_mm=500.0, band=(-12.0, 12.0), required_od=40.0),
+        ]
+        plan = solve_spar_plan(front_left=left, front_right=right)
+        assert plan.feasible is False
+        assert plan.infeasibility_reason is not None
+
+    def test_feasible_plan_reports_feasible(self):
+        plan = solve_spar_plan(front_left=_uniform_stations(), front_right=_uniform_stations())
+        assert plan.feasible is True
+        assert plan.infeasibility_reason is None
+        for p in plan.front_pieces:
+            assert p.feasible is True
+            assert p.utilisation <= 1.0 + 1e-9
+
+
+class TestDegenerateRootSliceGuard:
+    """gh-1037 #4: a zero-thickness slice at y_span=0 must not poison the
+    governing (root) station. Sample at y_span=eps instead."""
+
+    def test_epsilon_guard_skips_degenerate_root_slice(self):
+        from cad_designer.airplane.geometry import spar_solver
+
+        class _Pt:
+            def __init__(self, y_span, thickness, center_z=0.0):
+                self.y_span = y_span
+                self.x_c = 0.4
+                self.thickness = thickness
+                self.center_z = center_z
+                self.bottom_z = center_z - thickness / 2.0
+                self.top_z = center_z + thickness / 2.0
+
+        class _FakeGeometry:
+            # half-span used by _half_span_mm
+            _segment_lengths = [500.0]
+
+            def at_max_thickness(self, y_span):
+                # y=0 is a pinched, zero-thickness slice; everything outboard
+                # is a healthy linearly-tapering section.
+                if y_span <= 0.0:
+                    return _Pt(0.0, 0.0)
+                return _Pt(y_span, thickness=40.0 * (1.0 - 0.5 * y_span))
+
+        stations = spar_solver.build_stations_from_geometry(
+            _FakeGeometry(),
+            moment_fn=lambda y: 100.0 * (1.0 - y),
+            sigma_allow_mpa=300.0,
+            n_span=5,
+        )
+        assert stations, "expected sampled stations"
+        # the governing (most-inboard) station must come from a valid,
+        # non-degenerate slice — its band must have positive depth.
+        root = stations[0]
+        assert root.band_hi - root.band_lo > 0.0
+        assert root.required_od > 0.0
+        # The governing station stays at the ROOT (the max-moment station): the
+        # solver must sample at y_span≈eps rather than discard the root slice and
+        # let an outboard station become governing. eps is small (<0.05).
+        assert root.y_span < 0.05, (
+            f"root station drifted outboard to y_span={root.y_span}; degenerate "
+            "root slice was dropped instead of eps-sampled"
+        )
+        # the eps-sampled root must carry the highest moment-driven OD
+        assert root.required_od == max(s.required_od for s in stations)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the four execution defects in the #1029 spar-vector solver that produced physically impossible / garbage plans for non-trivial wings (found by persona UAT). The layout logic was sound; the numerical execution was wrong. All in `cad_designer/airplane/geometry/spar_solver.py`.

### Defects fixed
1. **Telescoping joint inverted (OD_outer > ID_inner).** Replaced the `max(prev_inner, strength_od)` rule with **inboard bore-demand propagation**: sized tip→root, each inner piece's ID ≥ adjacent outer piece's OD + slip-fit clearance; the root piece grows to satisfy the whole stack. OD is now **non-increasing outboard** (root ≥ tip), consistent with M(y).
2. **Per-station over-splitting + zero-length pieces.** Clean greedy partition; single-station partitions are repaired by overlapping into a neighbour (the telescoping overlap region). No emitted piece has `length == 0`.
3. **No infeasibility reporting (fake utilisation = 1.0).** `SparPiece`/`SparPlan` gain `feasible` + `infeasibility_reason`. Sections that can't contain a strong-enough round tube are marked **infeasible** with a reason; utilisation is reported truthfully (may exceed 1). Surfaced through `SparPlanResponse` schema + `spar_plan_service`.
4. **Degenerate root slice.** The zero-thickness `y_span=0` slice that poisoned the governing root station is replaced with an ε-sample (`y_span=1e-3`) so the max-moment station uses a valid section.

### TDD evidence (failing-tests-first)
New fast tests written first and confirmed red (5 failed pre-fix): telescoping `OD_outer ≤ ID_inner`, OD non-increasing outboard, no zero-length pieces, infeasible-section reporting (feasible=False + reason + utilisation>1), and the ε-guard (root station stays at the max-moment station). Then production code fixed until green.

### Before/after on the UAT falsification criteria (real lofted wing, root M=8000 N·m)
- **Before:** inner ID 57.9 / next OD 91.7 (cannot assemble), zero-length pieces, `feasible`/utilisation-1.0 on an impossible section.
- **After:** every telescoping joint satisfies `OD_outer ≤ ID_inner`; OD non-increasing outboard; no zero-length pieces; the over-loaded thin wing is honestly **infeasible** (utilisation up to ~21×) instead of a fake feasible plan. Modest-moment wing stays one continuous feasible piece (util 0.66), root sampled at ε.

### Tests
- Fast tier: 64 related tests pass (24 solver + endpoint + cad-insertion). Full fast suite: **5853 passed, 7 skipped, 2 xfailed, 0 failures**.
- Slow / requires_cadquery: 4 solver + insertion tests pass (real lofted wings).
- Updated the two #1030 tests that encoded the buggy equal-OD/ID convention to the correct `OD_outer ≤ ID_inner` relation — no correct assertion weakened.
- `ruff check .`: All checks passed. `ruff format`: clean.
- New decision logic is pure + fast-tested (cadquery seam mocked); `# pragma: no cover` only on the pre-existing cadquery geometry boundary.

Out of scope: rear-spar torsion sizing (#1038).

Closes #1037

🤖 Generated with [Claude Code](https://claude.com/claude-code)