### PR TITLE
feat(gh-1038): size the rear spar from torsion, not bending

### DIFF
--- a/app/schemas/spar_plan.py
+++ b/app/schemas/spar_plan.py
@@ -32,6 +32,27 @@ class MomentSample(BaseModel):
     )
 
 
+class TorsionSample(BaseModel):
+    """One spanwise torsion sample for the rear (torsion) spar (gh-1038).
+
+    ``torsion_moment_Nm`` is the section torsion T(y) about the front-spar line
+    (the wing's pitching moment carried into the structure). The rear spar
+    reacts this couple over the front–rear spar spacing — see
+    :func:`app.services.spar_plan_service._make_rear_moment_fn`.
+    """
+
+    y_span: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Span fraction 0..1 across the semi-span (root=0, tip=1).",
+    )
+    torsion_moment_Nm: float = Field(
+        ...,
+        description="Section torsion magnitude T(y) about the front spar line (N·m).",
+    )
+
+
 class SparPlanRequest(BaseModel):
     """Request body for ``POST /aeroplanes/{id}/spar-plan``.
 
@@ -39,6 +60,14 @@ class SparPlanRequest(BaseModel):
     spanwise-loads endpoint; the material + sizing knobs mirror #1008 spar
     sizing. Layout knobs (``front_x_over_chord`` / ``rear_x_over_chord`` /
     sampling ``n_span``) and clearance (``packing_factor``) are optional.
+
+    gh-1038: the **rear** spar is sized from TORSION, not the primary bending
+    moment. Supply ``torsion_moments`` (T(y) about the front spar) and the rear
+    spar is sized for the couple T(y) reacted over the front–rear spar spacing
+    (plus ``rear_secondary_bending_fraction`` of the bending moment). When no
+    torsion distribution is given, a documented proxy
+    T(y) ≈ ``pitching_moment_proxy_ratio`` · M(y) is used. The front spar stays
+    bending-driven via ``moments``.
     """
 
     material_id: int = Field(
@@ -101,6 +130,37 @@ class SparPlanRequest(BaseModel):
         description=(
             "Override allowable bending stress (MPa). When None, the material's "
             "allowable_bending_stress_mpa is used."
+        ),
+    )
+    torsion_moments: Optional[list[TorsionSample]] = Field(
+        None,
+        description=(
+            "gh-1038: Spanwise torsion distribution T(y) about the front spar "
+            "(N·m). The REAR spar is sized for this couple reacted over the "
+            "front–rear spar spacing. When omitted, a documented proxy "
+            "T(y) ≈ pitching_moment_proxy_ratio · M(y) is used instead."
+        ),
+    )
+    rear_secondary_bending_fraction: float = Field(
+        0.0,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "gh-1038: Fraction of the bending moment M(y) the rear spar also "
+            "carries as genuine secondary bending, added on top of the torsion "
+            "reaction. Default 0 (rear is torsion-only)."
+        ),
+    )
+    pitching_moment_proxy_ratio: float = Field(
+        0.10,
+        ge=0.0,
+        description=(
+            "gh-1038: Used ONLY when torsion_moments is not supplied. Proxy "
+            "ratio T(y)/M(y) ≈ |Cm|/|CL| · 1 representing the section torsion "
+            "as a fraction of the bending moment. Default 0.10 (a typical "
+            "cambered-airfoil pitching-moment-to-bending ratio). Replace with a "
+            "real T(y) from the strip pitching moments when available "
+            "(follow-up #1002 extension)."
         ),
     )
 

--- a/app/services/spar_plan_service.py
+++ b/app/services/spar_plan_service.py
@@ -34,6 +34,17 @@ _MM_TO_M = 0.001
 #: analysis_service._G_LIMIT_DEFAULT).
 _G_LIMIT_DEFAULT = 3.0
 
+#: gh-1038: Front-spar chord fraction assumed for the torsion-couple spacing
+#: when ``front_x_over_chord`` is None (front sits at section max-thickness,
+#: typically ~0.30c on common airfoils). Used only to derive the front–rear
+#: spar spacing for the rear torsion reaction; the front spar itself still
+#: samples the real max-thickness location.
+_DEFAULT_FRONT_X_C = 0.30
+
+#: Smallest front–rear spacing fraction we will divide by, so a degenerate
+#: layout (front≈rear) cannot produce an infinite torsion reaction.
+_MIN_SPAR_SPACING = 0.05
+
 
 def _resolve_wing(aeroplane, request: SparPlanRequest):
     """Pick the requested wing (by name) or the aeroplane's first wing."""
@@ -100,33 +111,102 @@ def _resolve_g_limit(db, aeroplane_uuid) -> float:
     return float(g_limit_raw)
 
 
+def _make_interpolator(ys: list[float], values: list[float]):
+    """Build a clamped piecewise-linear interpolator over sorted ``ys``.
+
+    Values outside the sampled range clamp to the nearest endpoint. Shared by
+    the front bending driver and the rear torsion driver (gh-1038).
+    """
+
+    def interp(y_span: float) -> float:
+        if y_span <= ys[0]:
+            return values[0]
+        if y_span >= ys[-1]:
+            return values[-1]
+        for i in range(1, len(ys)):
+            if y_span <= ys[i]:
+                lo_y, hi_y = ys[i - 1], ys[i]
+                lo_v, hi_v = values[i - 1], values[i]
+                span = hi_y - lo_y
+                if span <= 0.0:  # pragma: no cover - defensive: clamps prevent a leading dup hit
+                    return hi_v
+                t = (y_span - lo_y) / span
+                return lo_v + t * (hi_v - lo_v)
+        return values[-1]  # pragma: no cover - unreachable given the clamps above
+
+    return interp
+
+
 def _make_moment_fn(request: SparPlanRequest):
-    """Build a moment_fn(y_span) -> N·m from the supplied distribution.
+    """Build the FRONT (bending) moment_fn(y_span) -> N·m.
 
     Linear interpolation over the (sorted) span fractions; clamps outside the
-    sampled range to the nearest endpoint.
+    sampled range to the nearest endpoint. The front spar stays bending-driven
+    (gh-1038 keeps this unchanged).
     """
     samples = sorted(request.moments, key=lambda m: m.y_span)
     ys = [s.y_span for s in samples]
     ms = [abs(s.bending_moment_Nm) for s in samples]
+    return _make_interpolator(ys, ms)
 
-    def moment_fn(y_span: float) -> float:
-        if y_span <= ys[0]:
-            return ms[0]
-        if y_span >= ys[-1]:
-            return ms[-1]
-        for i in range(1, len(ys)):
-            if y_span <= ys[i]:
-                lo_y, hi_y = ys[i - 1], ys[i]
-                lo_m, hi_m = ms[i - 1], ms[i]
-                span = hi_y - lo_y
-                if span <= 0.0:  # pragma: no cover - defensive: clamps prevent a leading dup hit
-                    return hi_m
-                t = (y_span - lo_y) / span
-                return lo_m + t * (hi_m - lo_m)
-        return ms[-1]  # pragma: no cover - unreachable given the clamps above
 
-    return moment_fn
+def _spar_spacing_fraction(request: SparPlanRequest) -> float:
+    """Front–rear spar chordwise spacing as a fraction of chord (gh-1038).
+
+    The torsion couple T(y) is reacted by the front+rear pair over this
+    spacing, so the rear-spar reaction force ∝ T(y) / spacing. When the front
+    spar location is unset (max-thickness), assume :data:`_DEFAULT_FRONT_X_C`.
+    Floored at :data:`_MIN_SPAR_SPACING` so a degenerate layout can't blow up.
+    """
+    front_x = request.front_x_over_chord
+    if front_x is None:
+        front_x = _DEFAULT_FRONT_X_C
+    spacing = request.rear_x_over_chord - front_x
+    return max(abs(spacing), _MIN_SPAR_SPACING)
+
+
+def _make_rear_moment_fn(request: SparPlanRequest):
+    """Build the REAR (torsion) sizing-moment fn(y_span) -> N·m (gh-1038).
+
+    The rear spar's real job is to react the wing's torsion couple, NOT the
+    primary bending moment. The front+rear pair forms a couple against wing
+    twist: the rear member carries a reaction ≈ ``T(y) / spacing`` where
+    ``spacing`` is the chordwise front–rear distance (fraction of chord). Any
+    genuine secondary bending is added on top
+    (``rear_secondary_bending_fraction`` · M(y)).
+
+    Torsion source priority:
+
+    1. ``request.torsion_moments`` — an explicit T(y) about the front spar
+       (ideally integrated from the strip pitching moments; #1002 currently
+       carries only V/M, so this is supplied by the caller).
+    2. Documented proxy — when no T(y) is given, estimate
+       T(y) ≈ ``pitching_moment_proxy_ratio`` · M(y). This keeps the rear spar
+       torsion-driven (front ≠ rear) rather than silently a bending twin.
+       **Follow-up:** extend #1002 to integrate section pitching moments into a
+       real T(y) and feed it here, retiring the proxy.
+    """
+    spacing = _spar_spacing_fraction(request)
+    secondary_fraction = request.rear_secondary_bending_fraction
+    bending_fn = _make_moment_fn(request)
+
+    if request.torsion_moments:
+        samples = sorted(request.torsion_moments, key=lambda t: t.y_span)
+        ys = [s.y_span for s in samples]
+        ts = [abs(s.torsion_moment_Nm) for s in samples]
+        torsion_fn = _make_interpolator(ys, ts)
+    else:
+        proxy_ratio = request.pitching_moment_proxy_ratio
+
+        def torsion_fn(y_span: float) -> float:
+            return proxy_ratio * bending_fn(y_span)
+
+    def rear_moment_fn(y_span: float) -> float:
+        reaction = torsion_fn(y_span) / spacing
+        secondary = secondary_fraction * bending_fn(y_span)
+        return reaction + secondary
+
+    return rear_moment_fn
 
 
 def _build_section_geometry(wing_config):
@@ -194,14 +274,18 @@ def compute_spar_plan(
 
     sigma_allow = _resolve_sigma_allow(db, request)
     g_limit = _resolve_g_limit(db, aeroplane_uuid)
-    moment_fn = _make_moment_fn(request)
+    # gh-1038: front spar = bending moment; rear spar = torsion couple reacted
+    # over the front–rear spar spacing (+ optional secondary bending). The two
+    # spars are sized from DIFFERENT load distributions so the rear is no longer
+    # a near-twin of the front.
+    front_moment_fn = _make_moment_fn(request)
+    rear_moment_fn = _make_rear_moment_fn(request)
 
     # WingConfiguration / SectionGeometry work in millimetres (scale=1000.0).
     wing_config = wing_model_to_wing_config(wing, scale=1000.0)
     geometry = _build_section_geometry(wing_config)
 
     common = dict(
-        moment_fn=moment_fn,
         sigma_allow_mpa=sigma_allow,
         n_span=request.n_span,
         packing_factor=request.packing_factor,
@@ -209,8 +293,12 @@ def compute_spar_plan(
         g_limit=g_limit,
     )
 
-    front_right = build_stations_from_geometry(geometry, x_c=request.front_x_over_chord, **common)
-    rear_right = build_stations_from_geometry(geometry, x_c=request.rear_x_over_chord, **common)
+    front_right = build_stations_from_geometry(
+        geometry, x_c=request.front_x_over_chord, moment_fn=front_moment_fn, **common
+    )
+    rear_right = build_stations_from_geometry(
+        geometry, x_c=request.rear_x_over_chord, moment_fn=rear_moment_fn, **common
+    )
 
     plan = solve_spar_plan(
         front_left=_mirror_to_left(front_right),

--- a/app/tests/test_spar_plan_rear_torsion.py
+++ b/app/tests/test_spar_plan_rear_torsion.py
@@ -1,0 +1,219 @@
+"""gh-1038: the rear spar is sized from TORSION, not the primary bending moment.
+
+The merged #1029 solver built BOTH the front and rear stations from the same
+bending-moment distribution, so the rear spar came out a near-twin of the front.
+The rear spar's real job is to react the torsion couple (front+rear form the
+couple against wing twist) reacted over the front–rear spar spacing, plus any
+genuine secondary bending.
+
+These are fast-tier tests (no cadquery): they exercise the service's rear
+moment-driver construction (``_make_rear_moment_fn``) and verify that the
+``build_stations_from_geometry`` seam is called with a DIFFERENT moment_fn for
+the rear spar than for the front. The torsion source and the spacing reaction
+are pure functions, so every branch is covered without a real lofted solid.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from app.schemas.spar_plan import MomentSample, SparPlanRequest, TorsionSample
+from app.services import spar_plan_service
+
+
+@dataclass
+class _StubStation:
+    y_mm: float
+
+
+def _basic_request(**overrides):
+    body = dict(
+        material_id=7,
+        moments=[
+            MomentSample(y_span=0.0, bending_moment_Nm=100.0),
+            MomentSample(y_span=1.0, bending_moment_Nm=0.0),
+        ],
+    )
+    body.update(overrides)
+    return SparPlanRequest(**body)
+
+
+# ---------------------------------------------------------------------------
+# The torsion driver itself (pure)
+# ---------------------------------------------------------------------------
+
+
+class TestMakeRearMomentFn:
+    def test_explicit_torsion_reacted_over_spar_spacing(self):
+        """With an explicit T(y), the rear sizing-moment is T(y)/spacing.
+
+        spacing = rear_x_over_chord - front_x_over_chord (chord fraction).
+        front=0.25, rear=0.65 -> spacing 0.40 -> rear M = T / 0.40.
+        """
+        req = _basic_request(
+            front_x_over_chord=0.25,
+            rear_x_over_chord=0.65,
+            torsion_moments=[
+                TorsionSample(y_span=0.0, torsion_moment_Nm=20.0),
+                TorsionSample(y_span=1.0, torsion_moment_Nm=0.0),
+            ],
+            rear_secondary_bending_fraction=0.0,
+        )
+        fn = spar_plan_service._make_rear_moment_fn(req)
+        # root: T=20 reacted over spacing 0.40 -> 50 N·m
+        assert fn(0.0) == pytest.approx(50.0)
+        # tip: zero torsion -> zero
+        assert fn(1.0) == pytest.approx(0.0)
+
+    def test_rear_differs_from_front_bending(self):
+        """On a wing with real pitching moment the rear driver != front driver."""
+        req = _basic_request(
+            front_x_over_chord=0.25,
+            rear_x_over_chord=0.65,
+            torsion_moments=[
+                TorsionSample(y_span=0.0, torsion_moment_Nm=20.0),
+                TorsionSample(y_span=1.0, torsion_moment_Nm=0.0),
+            ],
+        )
+        front = spar_plan_service._make_moment_fn(req)
+        rear = spar_plan_service._make_rear_moment_fn(req)
+        assert rear(0.0) != pytest.approx(front(0.0))
+
+    def test_secondary_bending_adds_to_torsion(self):
+        """Genuine secondary bending is added on top of the torsion reaction."""
+        req = _basic_request(
+            front_x_over_chord=0.25,
+            rear_x_over_chord=0.65,
+            torsion_moments=[
+                TorsionSample(y_span=0.0, torsion_moment_Nm=20.0),
+                TorsionSample(y_span=1.0, torsion_moment_Nm=0.0),
+            ],
+            rear_secondary_bending_fraction=0.1,  # 10% of bending
+        )
+        fn = spar_plan_service._make_rear_moment_fn(req)
+        # torsion part 50 + secondary 0.1*100 = 10 -> 60
+        assert fn(0.0) == pytest.approx(60.0)
+
+    def test_zero_torsion_falls_back_to_secondary_only(self):
+        """Zero torsion -> rear sized by secondary bending only (minimal)."""
+        req = _basic_request(
+            front_x_over_chord=0.25,
+            rear_x_over_chord=0.65,
+            torsion_moments=[
+                TorsionSample(y_span=0.0, torsion_moment_Nm=0.0),
+                TorsionSample(y_span=1.0, torsion_moment_Nm=0.0),
+            ],
+            rear_secondary_bending_fraction=0.05,
+        )
+        fn = spar_plan_service._make_rear_moment_fn(req)
+        assert fn(0.0) == pytest.approx(5.0)  # 0.05 * 100
+        assert fn(1.0) == pytest.approx(0.0)
+
+    def test_no_torsion_supplied_uses_documented_proxy(self):
+        """When no T(y) is supplied, derive a defensible proxy from bending.
+
+        T(y) ≈ pitching_moment_proxy_ratio · M(y); the rear driver is then that
+        proxy reacted over the spar spacing. The proxy must be SMALLER than the
+        front bending moment (the couple is a fraction of the primary load), so
+        front≠rear still holds.
+        """
+        req = _basic_request(
+            front_x_over_chord=0.25,
+            rear_x_over_chord=0.65,
+            pitching_moment_proxy_ratio=0.10,
+        )
+        front = spar_plan_service._make_moment_fn(req)
+        rear = spar_plan_service._make_rear_moment_fn(req)
+        # proxy T(0)=0.10*100=10; reacted over 0.40 -> 25 N·m
+        assert rear(0.0) == pytest.approx(25.0)
+        assert rear(0.0) != pytest.approx(front(0.0))
+
+    def test_front_unset_uses_default_front_fraction_for_spacing(self):
+        """When front_x_over_chord is None the spacing uses a default front x/c.
+
+        The front spar then sits at the section max-thickness location, whose x/c
+        is unknown a-priori; the spacing falls back to a sane default so the
+        torsion reaction is still well-defined.
+        """
+        req = _basic_request(
+            front_x_over_chord=None,
+            rear_x_over_chord=0.65,
+            torsion_moments=[
+                TorsionSample(y_span=0.0, torsion_moment_Nm=20.0),
+                TorsionSample(y_span=1.0, torsion_moment_Nm=0.0),
+            ],
+        )
+        fn = spar_plan_service._make_rear_moment_fn(req)
+        # default front x/c (DEFAULT_FRONT_X_C) -> spacing = 0.65 - default
+        spacing = 0.65 - spar_plan_service._DEFAULT_FRONT_X_C
+        assert fn(0.0) == pytest.approx(20.0 / spacing)
+
+
+# ---------------------------------------------------------------------------
+# Integration into compute_spar_plan: rear uses a DIFFERENT driver
+# ---------------------------------------------------------------------------
+
+
+class TestRearSparUsesTorsionDriver:
+    def _patches(self, captured):
+        aeroplane = SimpleNamespace(wings=[SimpleNamespace(name="w")], uuid=uuid.uuid4())
+
+        def fake_build(geometry, *, x_c=None, moment_fn=None, **kw):
+            # Record which moment_fn was used per x_c so we can compare drivers.
+            captured.setdefault("calls", []).append((x_c, moment_fn(0.0)))
+            return [_StubStation(0.0), _StubStation(500.0)]
+
+        from cad_designer.airplane.geometry.spar_solver import SparPlan
+
+        return aeroplane, [
+            patch.object(spar_plan_service, "get_aeroplane_or_raise", return_value=aeroplane),
+            patch.object(spar_plan_service, "wing_model_to_wing_config", return_value=object()),
+            patch.object(spar_plan_service, "_build_section_geometry", return_value=object()),
+            patch.object(spar_plan_service, "_resolve_sigma_allow", return_value=200.0),
+            patch.object(spar_plan_service, "_resolve_g_limit", return_value=3.0),
+            patch(
+                "cad_designer.airplane.geometry.spar_solver.build_stations_from_geometry",
+                side_effect=fake_build,
+            ),
+            patch(
+                "cad_designer.airplane.geometry.spar_solver.solve_spar_plan",
+                return_value=SparPlan(),
+            ),
+        ]
+
+    @staticmethod
+    def _run(patches, fn):
+        if not patches:
+            return fn()
+        with patches[0]:
+            return TestRearSparUsesTorsionDriver._run(patches[1:], fn)
+
+    def test_front_and_rear_receive_different_moment_fns(self):
+        captured: dict = {}
+        aeroplane, patches = self._patches(captured)
+        req = _basic_request(
+            front_x_over_chord=0.25,
+            rear_x_over_chord=0.65,
+            torsion_moments=[
+                TorsionSample(y_span=0.0, torsion_moment_Nm=20.0),
+                TorsionSample(y_span=1.0, torsion_moment_Nm=0.0),
+            ],
+        )
+        self._run(
+            patches,
+            lambda: spar_plan_service.compute_spar_plan(
+                db=None, aeroplane_uuid=aeroplane.uuid, request=req
+            ),
+        )
+        calls = dict(captured["calls"])
+        front_val = calls[0.25]
+        rear_val = calls[0.65]
+        # front sees the bending moment (100); rear sees the torsion reaction.
+        assert front_val == pytest.approx(100.0)
+        assert rear_val == pytest.approx(50.0)
+        assert front_val != pytest.approx(rear_val)

--- a/cad_designer/tests/test_spar_solver.py
+++ b/cad_designer/tests/test_spar_solver.py
@@ -397,6 +397,63 @@ class TestInfeasibilityReporting:
             assert p.utilisation <= 1.0 + 1e-9
 
 
+class TestRearTorsionDistinctFromFront:
+    """gh-1038: when the rear stations are sized from a (smaller) torsion-derived
+    OD, the rear spar must come out DIFFERENT from the bending-driven front — not
+    a near-twin. The service builds the rear stations from T(y)/spacing; here we
+    feed the solver the resulting (smaller) required_od directly."""
+
+    def test_torsion_sized_rear_is_smaller_than_bending_front(self):
+        # Front: bending-driven fat root OD.
+        front = [
+            _station(0.0, y_mm=0.0, band=(-50.0, 50.0), required_od=40.0),
+            _station(1.0, y_mm=500.0, band=(-50.0, 50.0), required_od=10.0),
+        ]
+        # Rear: torsion couple is a fraction of bending -> markedly smaller OD.
+        rear = [
+            _station(0.0, y_mm=0.0, band=(-50.0, 50.0), required_od=12.0),
+            _station(1.0, y_mm=500.0, band=(-50.0, 50.0), required_od=4.0),
+        ]
+        plan = solve_spar_plan(
+            front_left=[_mirror(s) for s in front],
+            front_right=front,
+            rear_left=[_mirror(s) for s in rear],
+            rear_right=rear,
+        )
+        front_root_od = plan.front_pieces[0].outer_d
+        rear_root_od = plan.rear_pieces[0].outer_d
+        assert rear_root_od < front_root_od
+        # The rear OD tracks the torsion-derived station, not the bending one.
+        assert rear_root_od == pytest.approx(12.0)
+
+    def test_zero_torsion_rear_is_minimal(self):
+        """Zero torsion (+ no secondary bending) -> a minimal rear member."""
+        rear = [
+            _station(0.0, y_mm=0.0, band=(-50.0, 50.0), required_od=0.0),
+            _station(1.0, y_mm=500.0, band=(-50.0, 50.0), required_od=0.0),
+        ]
+        plan = solve_spar_plan(
+            front_left=_uniform_stations(),
+            front_right=_uniform_stations(),
+            rear_left=[_mirror(s) for s in rear],
+            rear_right=rear,
+        )
+        assert plan.rear_pieces[0].outer_d == pytest.approx(0.0)
+        assert plan.feasible is True
+
+
+def _mirror(s: StationData) -> StationData:
+    return StationData(
+        y_span=s.y_span,
+        y_mm=-s.y_mm,
+        x_c=s.x_c,
+        center_z=s.center_z,
+        band_lo=s.band_lo,
+        band_hi=s.band_hi,
+        required_od=s.required_od,
+    )
+
+
 class TestDegenerateRootSliceGuard:
     """gh-1037 #4: a zero-thickness slice at y_span=0 must not poison the
     governing (root) station. Sample at y_span=eps instead."""


### PR DESCRIPTION
## What

The merged #1029 spar-vector solver built **both** front and rear spar stations from the **same bending-moment distribution**, so the rear spar came out a near-twin of the front. The rear spar's real job is to react the **torsion couple** (front+rear form the couple against wing twist), not the primary bending moment ([[wing-box-spars]] "Torsional Rigidity").

This gives the rear spar a **torsion-based sizing driver** while keeping the front spar bending-driven.

## How

- **Schema** (`app/schemas/spar_plan.py`) — backward-compatible additions:
  - `torsion_moments`: optional `T(y)` (N·m) about the front spar.
  - `rear_secondary_bending_fraction` (default 0): genuine secondary bending the rear also carries.
  - `pitching_moment_proxy_ratio` (default 0.10): used only when no `torsion_moments` supplied.
- **Service** (`app/services/spar_plan_service.py`):
  - New `_make_rear_moment_fn`: rear sizing-moment `M_rear ≈ T(y)/spacing + secondary·M(y)`, where `spacing = rear_x/c − front_x/c` (the front–rear spar spacing — exactly the couple lever arm).
  - `compute_spar_plan` now feeds the front and rear spars **different** load distributions.
  - Shared interpolator extracted (`_make_interpolator`); `_make_moment_fn` (front) unchanged in behaviour.
- **Solver core** (`cad_designer/.../spar_solver.py`): **unchanged** — it already accepts any `moment_fn`. The fix is entirely in the load distribution fed to the rear stations.

## Torsion source + follow-up

#1002 currently carries only spanwise **V/M** — there is no section pitching-moment / `cm` flowing into the spar plan. A real `T(y)` integrated from the strip pitching moments needs an upstream #1002 extension (out of scope here). In-scope:
1. **Explicit `torsion_moments`** when the caller supplies them.
2. **Documented proxy** `T(y) ≈ pitching_moment_proxy_ratio · M(y)` otherwise — keeps the rear torsion-driven (front ≠ rear) rather than a silent bending twin.

**Follow-up:** extend #1002 to integrate section pitching moments into a real `T(y)` and feed it here, retiring the proxy.

## Tests

- Fast tier (no cadquery): rear sized by torsion (front≠rear), explicit `T(y)` reacted over spacing, secondary bending added, zero-torsion → minimal rear, proxy fallback, front/rear receive different `moment_fn`s end-to-end.
- Solver tier: torsion-sized rear smaller than bending front; zero-torsion rear minimal.
- **100% coverage** on both changed modules (fast tier). Slow `requires_cadquery` solver tests re-run green.

Closes #1038

🤖 Generated with [Claude Code](https://claude.com/claude-code)