### PR TITLE
fix(gh-1042): resolve relative API base in useOperatingPoints refresh()

### DIFF
--- a/frontend/__tests__/useOperatingPoints.relativeBase.test.ts
+++ b/frontend/__tests__/useOperatingPoints.relativeBase.test.ts
@@ -1,0 +1,54 @@
+/**
+ * gh-1042: useOperatingPoints.refresh() must build a valid URL even when the
+ * API base is a RELATIVE path prefix (e.g. "/main/backend" on the multi-stage
+ * ngrok deploy). `new URL(str)` with a single argument requires an absolute
+ * URL, so a relative API base threw '"/main/backend/operating_points" cannot
+ * be parsed as a URL'. We mock the API base to the relative prefix and assert
+ * refresh() fetches the resolved URL instead of throwing.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+
+// Force a RELATIVE API base, as the multi-stage deploy injects.
+vi.mock("@/lib/fetcher", () => ({ API_BASE: "/main/backend" }));
+
+import { useOperatingPoints } from "@/hooks/useOperatingPoints";
+
+describe("useOperatingPoints refresh() with a relative API base (gh-1042)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("resolves the relative base against the page origin and fetches it", async () => {
+    // Fresh Response per call — refresh runs on mount and again explicitly,
+    // and a single Response body can only be read once.
+    const fetchSpy = vi.spyOn(global, "fetch").mockImplementation(
+      async () =>
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    const { result } = renderHook(() => useOperatingPoints("7"));
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    // refresh runs once on mount + once explicitly; without the fix new URL()
+    // throws before fetch, so any fetch call proves the relative base resolved.
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    const arg = fetchSpy.mock.calls.at(-1)![0] as URL;
+    const url = new URL(String(arg));
+    // The relative "/main/backend" prefix is preserved in the resolved path.
+    expect(url.pathname).toBe("/main/backend/operating_points");
+    expect(url.searchParams.get("aircraft_id")).toBe("7");
+    // No "cannot be parsed as a URL" error leaked into hook state.
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/frontend/hooks/useOperatingPoints.ts
+++ b/frontend/hooks/useOperatingPoints.ts
@@ -231,7 +231,12 @@ export function useOperatingPoints(
     setIsLoading(true);
     setError(null);
     try {
-      const url = new URL(`${API_BASE}/operating_points`);
+      // API_BASE may be a relative path prefix on the multi-stage deploy
+      // (e.g. "/main/backend"), which is not an absolute URL — new URL() needs
+      // a base to resolve it. An absolute API_BASE ignores the base. (gh-1042)
+      const urlBase =
+        typeof window === "undefined" ? "http://localhost" : window.location.origin;
+      const url = new URL(`${API_BASE}/operating_points`, urlBase);
       url.searchParams.set("aircraft_id", aeroplaneId);
       const res = await fetch(url);
       if (res.status === 404) {

--- a/frontend/hooks/useOperatingPoints.ts
+++ b/frontend/hooks/useOperatingPoints.ts
@@ -233,10 +233,9 @@ export function useOperatingPoints(
     try {
       // API_BASE may be a relative path prefix on the multi-stage deploy
       // (e.g. "/main/backend"), which is not an absolute URL — new URL() needs
-      // a base to resolve it. An absolute API_BASE ignores the base. (gh-1042)
-      const urlBase =
-        typeof window === "undefined" ? "http://localhost" : window.location.origin;
-      const url = new URL(`${API_BASE}/operating_points`, urlBase);
+      // a base to resolve it. An absolute API_BASE ignores the base. refresh()
+      // is client-only (effects/events), so window is always defined. (gh-1042)
+      const url = new URL(`${API_BASE}/operating_points`, window.location.origin);
       url.searchParams.set("aircraft_id", aeroplaneId);
       const res = await fetch(url);
       if (res.status === 404) {

--- a/frontend/hooks/useOperatingPoints.ts
+++ b/frontend/hooks/useOperatingPoints.ts
@@ -235,7 +235,7 @@ export function useOperatingPoints(
       // (e.g. "/main/backend"), which is not an absolute URL — new URL() needs
       // a base to resolve it. An absolute API_BASE ignores the base. refresh()
       // is client-only (effects/events), so window is always defined. (gh-1042)
-      const url = new URL(`${API_BASE}/operating_points`, window.location.origin);
+      const url = new URL(`${API_BASE}/operating_points`, globalThis.location.origin);
       url.searchParams.set("aircraft_id", aeroplaneId);
       const res = await fetch(url);
       if (res.status === 404) {


### PR DESCRIPTION
Closes #1042

On the multi-stage ngrok deploy the frontend API base is a relative path prefix (`NEXT_PUBLIC_API_URL=/main/backend`). `new URL(`${API_BASE}/operating_points`)` with a single argument requires an absolute URL → it threw **'"/main/backend/operating_points" cannot be parsed as a URL'** on the live /main/ stage. (Works locally only because API_BASE defaults to the absolute `http://localhost:8001`.)

**Fix:** pass `window.location.origin` as the base so a relative prefix resolves; an absolute API base ignores the base. This was the only production use of `new URL()` with API_BASE.

**Test:** failing-first vitest mocks a relative `API_BASE=/main/backend` and asserts `refresh()` fetches `/main/backend/operating_points?aircraft_id=…` with no error (fails without the fix — fetch never called because new URL throws).

🤖 Generated with [Claude Code](https://claude.com/claude-code)