### PR TITLE
feat(gh-1049): spar-plan → wing insert endpoint (dry-run preview + commit)

### DIFF
--- a/app/api/v2/endpoints/aeroanalysis.py
+++ b/app/api/v2/endpoints/aeroanalysis.py
@@ -23,6 +23,7 @@ from app.schemas.AeroplaneRequest import AnalysisToolUrlType, AlphaSweepRequest,
 from app.schemas.api_responses import StaticUrlResponse
 from app.schemas.aeroanalysisschema import OperatingPointSchema
 from app.schemas.section_geometry import SectionGeometryRequest, SectionGeometryResponse
+from app.schemas.spar_insert import SparInsertRequest, SparInsertResponse
 from app.schemas.spar_plan import SparPlanRequest, SparPlanResponse
 from app.schemas.spar_sizing import SparSizingParams
 from app.schemas.spanwise_loads import SpanwiseLoadsResponse, SpanwiseLoadsWithSizingResponse
@@ -30,6 +31,7 @@ from app.schemas.stability import StabilitySummaryResponse, StabilityResultRead
 from app.schemas.strip_forces import StripForcesResponse
 from app.services import analysis_service
 from app.services import section_geometry_service
+from app.services import spar_insert_service
 from app.services import spar_plan_service
 from app.services import stability_service
 from app.services.wing_service import get_aeroplane_or_raise
@@ -531,6 +533,45 @@ def get_airplane_spar_plan(
     """
     try:
         return spar_plan_service.compute_spar_plan(db, aeroplane_id, request)
+    except ServiceException as exc:
+        _raise_http_from_domain(exc)
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Unexpected error: {exc}"
+        ) from exc
+
+
+@router.post(
+    "/aeroplanes/{aeroplane_id}/spar-plan/insert",
+    response_model=SparInsertResponse,
+    tags=["analysis"],
+    operation_id="insert_airplane_spar_plan",
+)
+def insert_airplane_spar_plan(
+    aeroplane_id: Annotated[AeroPlaneID, Path(..., description=_DESC_AEROPLANE_ID)],
+    request: Annotated[
+        SparInsertRequest,
+        Body(..., description="Spar-insert request: spar-plan inputs + dry_run flag"),
+    ],
+    db: Annotated[Session, Depends(get_db)],
+) -> SparInsertResponse:
+    """Insert a computed spar plan into the wing as persisted spares (gh-1049).
+
+    Computes the buildable spar plan (#1031), maps each piece to a ``Spare``,
+    resolves its target segment from its spanwise span, and assigns the
+    ``spar_index`` invariant (front=0 in every segment, rear=1, reinforcement=2;
+    the same logical spar keeps its index across segments).
+
+    With ``dry_run=true`` (default) the planned insertions are returned WITHOUT
+    writing. With ``dry_run=false`` each spar piece is persisted, REPLACING any
+    existing spares in the target segments so the front spar lands at index 0.
+
+    Returns 404 when the aeroplane / wing does not exist, and 422 when section
+    geometry is unavailable, the material/strength inputs are invalid, or the
+    plan is infeasible (an infeasible plan is refused, not built).
+    """
+    try:
+        return spar_insert_service.insert_spar_plan(db, aeroplane_id, request)
     except ServiceException as exc:
         _raise_http_from_domain(exc)
     except Exception as exc:  # pragma: no cover - defensive fallback

--- a/app/schemas/spar_insert.py
+++ b/app/schemas/spar_insert.py
@@ -1,0 +1,115 @@
+"""Pydantic schemas for the spar-plan → wing insert endpoint (gh-1049).
+
+The insert endpoint reuses the :class:`app.schemas.spar_plan.SparPlanRequest`
+inputs (material + sizing + spanwise moments) and adds a ``dry_run`` flag plus
+the target wing. It computes the buildable :class:`SparPlan` (gh-1031), maps each
+piece to a persisted ``Spare`` (gh-1032), resolves the target segment from the
+piece's spanwise span, and assigns the **spar_index** invariant
+(front → 0, rear → 1, reinforcement → next) consistently across segments.
+
+**dry_run=true** → return the planned insertions WITHOUT writing. **dry_run=false**
+→ persist each via ``wing_service.create_spare`` honouring the assigned
+``sort_index``.
+
+Units: the plan is solved in mm; this API exposes piece dimensions in **metres**
+(project convention), matching :mod:`app.schemas.spar_plan`.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from app.schemas.spar_plan import SparPlanRequest
+
+
+class SparInsertRequest(SparPlanRequest):
+    """Request body for ``POST /aeroplanes/{id}/spar-plan/insert`` (gh-1049).
+
+    Same inputs as the spar-plan request plus a ``dry_run`` flag. When
+    ``dry_run`` is true the endpoint returns the planned insertions without
+    writing; when false it persists each spar piece as a ``Spare``.
+    """
+
+    dry_run: bool = Field(
+        True,
+        description=(
+            "When true (default) return the planned insertions WITHOUT writing. "
+            "When false, persist each spar piece as a Spare honouring the "
+            "spar_index invariant (front=0, rear=1, reinforcement=next)."
+        ),
+    )
+
+
+class PlannedSpareOut(BaseModel):
+    """One planned spar insertion. Dimensions in **metres**, wing-local frame."""
+
+    segment_index: int = Field(
+        ...,
+        description=(
+            "Target wing segment / cross-section index this piece is inserted "
+            "into (resolved from the piece's spanwise span)."
+        ),
+    )
+    spar_index: int = Field(
+        ...,
+        description=(
+            "The per-segment sort_index assigned to this spare. Front (main) spar "
+            "= 0 in every segment, rear = 1, reinforcement = next. The same "
+            "logical spar carries the same spar_index across every segment."
+        ),
+    )
+    role: str = Field(..., description="Structural role: 'front' (bending) or 'rear' (torsion).")
+    spare_support_dimension_width: float = Field(
+        ..., description="Spar bounding-box width = outer_d (m)."
+    )
+    spare_support_dimension_height: float = Field(
+        ..., description="Spar bounding-box height = outer_d (m)."
+    )
+    spare_length: float = Field(..., description="Spar piece length (m).")
+    outer_d: float = Field(..., description="Outer diameter (m).")
+    inner_d: float = Field(..., description="Inner diameter / bore (m); not modelled in the Spare.")
+    spare_origin: list[float] = Field(
+        ..., description="Piece root origin (x, y, z) in the wing-local frame (m)."
+    )
+    spare_vector: list[float] = Field(
+        ..., description="Unit direction vector the piece runs along (dimensionless)."
+    )
+    joint_note: Optional[str] = Field(
+        None,
+        description=("Joint to the next (tip-side) piece, e.g. 'telescoping'. None if last."),
+    )
+    feasible: bool = Field(
+        ..., description="False when the section cannot contain a round tube strong enough."
+    )
+
+
+class SparInsertResponse(BaseModel):
+    """Response for ``POST /aeroplanes/{id}/spar-plan/insert`` (gh-1049).
+
+    Lengths in metres. ``committed`` is false for a dry-run preview, true once
+    the spares have been persisted.
+    """
+
+    dry_run: bool = Field(..., description="Echo of the request dry_run flag.")
+    committed: bool = Field(
+        ...,
+        description="True when the spares were persisted; false for a dry-run preview.",
+    )
+    wing_name: str = Field(..., description="Name of the wing the spar was inserted into.")
+    planned_spares: list[PlannedSpareOut] = Field(
+        ...,
+        description="The planned (or persisted) spar insertions, in insertion order.",
+    )
+    warnings: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Faithful-representation warnings (telescoping overlap, bent-pin, "
+            "reinforcement+joiner, dropped bore) surfaced by the mapping."
+        ),
+    )
+    feasible: bool = Field(..., description="The plan's overall feasibility.")
+    infeasibility_reason: Optional[str] = Field(
+        None, description="Reason when the plan is infeasible; None otherwise."
+    )

--- a/app/services/spar_insert_service.py
+++ b/app/services/spar_insert_service.py
@@ -1,0 +1,286 @@
+"""Service for the spar-plan → wing insert endpoint (gh-1049).
+
+Compute a buildable :class:`~cad_designer.airplane.geometry.spar_solver.SparPlan`
+(reusing :func:`app.services.spar_plan_service.compute_spar_plan_object`), map
+each piece to a persisted ``Spare`` (reusing
+:func:`cad_designer.airplane.geometry.spar_cad_insertion.spar_piece_to_spare`),
+resolve each piece's target wing segment from its spanwise span, assign the
+per-segment ``sort_index`` per the **HARD INVARIANT**, and either preview
+(``dry_run=true``) or persist (``dry_run=false``) the result.
+
+HARD INVARIANT (cad_designer construction relies on it — verified against
+:class:`cad_designer.airplane.creator.wing.VaseModeWingCreator.VaseModeWingCreator`):
+``spare_list[0]`` is the **main spar**; it is the only spar that receives the
+vase-mode print slot and is built first. Therefore the **front (bending) spar
+MUST be ``spar_index = 0`` in every segment it occupies**, the **rear spar = 1**,
+and the **reinforcement = the next index (2)**. The same logical spar carries the
+same ``spar_index`` in every segment it passes through; telescoping pieces keep
+that spar's index within their segment.
+
+**Already-has-index-0 behaviour (REPLACE).** Inserting a fresh spar plan
+*replaces* every spare in each segment the plan writes to: each target segment is
+cleared first, then the plan's spares are appended in invariant order. This makes
+the front spar deterministically land at ``sort_index = 0`` and never silently
+corrupts an existing index-0 spar by shifting it to a non-zero slot.
+
+Units: the plan is solved in mm; the dry-run response exposes piece dimensions in
+**metres** (project convention). On commit, the metre values are handed to
+``wing_service.create_spare`` which converts back to mm for DB storage (gh-402).
+``spare_vector`` is a dimensionless unit direction and is never scaled.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app import schemas
+from app.core.exceptions import ValidationError
+from app.schemas.spar_insert import (
+    PlannedSpareOut,
+    SparInsertRequest,
+    SparInsertResponse,
+)
+from app.services.spar_plan_service import _resolve_wing, compute_spar_plan_object
+from app.services.wing_service import create_spare, get_aeroplane_or_raise
+from cad_designer.airplane.geometry.spar_cad_insertion import spar_plan_to_spares
+
+logger = logging.getLogger(__name__)
+
+_MM_TO_M = 0.001
+
+#: Per-invariant spar_index assignment by structural role / piece kind.
+_FRONT_INDEX = 0
+_REAR_INDEX = 1
+_REINFORCEMENT_INDEX = 2
+
+
+class _PlannedPiece:
+    """A solved SparPiece paired with its assigned (segment_index, spar_index)."""
+
+    __slots__ = ("piece", "spare", "segment_index", "spar_index")
+
+    def __init__(self, piece, spare, segment_index: int, spar_index: int):
+        self.piece = piece
+        self.spare = spare
+        self.segment_index = segment_index
+        self.spar_index = spar_index
+
+
+def _segment_lengths_mm(wing) -> list[float]:
+    """Return the wing's per-segment spanwise lengths (mm).
+
+    Builds the millimetre ``WingConfiguration`` and reads each segment's
+    ``length``. Kept as a seam so fast tests can stub the cadquery/converter
+    boundary.
+    """
+    from app.converters.model_schema_converters import wing_model_to_wing_config
+
+    wing_config = wing_model_to_wing_config(wing, scale=1000.0)
+    return [float(seg.length) for seg in (wing_config.segments or [])]
+
+
+def _segment_for_y(y_mm: float, segment_lengths_mm: list[float]) -> int:
+    """Resolve a spanwise position (mm, may be the piece root or governing_y) to
+    a segment index via accumulated segment lengths.
+
+    Segment ``i`` spans ``[sum(lengths[:i]), sum(lengths[:i+1]))``. A position at
+    or beyond the last boundary clamps to the last segment; a negative (mirror)
+    position clamps to the root segment 0.
+    """
+    if not segment_lengths_mm:
+        return 0
+    y = abs(float(y_mm))
+    upper = 0.0
+    for idx, length in enumerate(segment_lengths_mm):
+        upper += length
+        if y < upper:
+            return idx
+    return len(segment_lengths_mm) - 1
+
+
+def _spar_index_for(piece, *, is_reinforcement: bool) -> int:
+    """Assign the per-segment sort_index per the HARD INVARIANT."""
+    from cad_designer.airplane.geometry.spar_solver import SparRole
+
+    if is_reinforcement:
+        return _REINFORCEMENT_INDEX
+    if piece.role == SparRole.REAR:
+        return _REAR_INDEX
+    return _FRONT_INDEX
+
+
+def _piece_locate_y(piece) -> float:
+    """The spanwise position used to place a piece into a segment.
+
+    Prefer the piece root origin's y (where the straight piece starts); fall back
+    to ``governing_y``. Both are mm in the wing-local frame.
+    """
+    origin = getattr(piece, "spare_origin", None)
+    if origin is not None and len(origin) >= 2:
+        return float(origin[1])
+    return float(piece.governing_y)
+
+
+def _spare_to_metre_schema(piece, spare) -> schemas.SpareDetailSchema:
+    """Build a metre ``SpareDetailSchema`` from a mm SparPiece + its mapped Spare.
+
+    The mapped ``Spare`` is in mm; convert dimensional fields to metres so the
+    value matches the API convention consumed by ``create_spare`` (which then
+    converts back to mm for the DB).
+    """
+    return schemas.SpareDetailSchema(
+        spare_support_dimension_width=spare.spare_support_dimension_width * _MM_TO_M,
+        spare_support_dimension_height=spare.spare_support_dimension_height * _MM_TO_M,
+        spare_length=(spare.spare_length * _MM_TO_M if spare.spare_length is not None else None),
+        spare_start=spare.spare_start * _MM_TO_M,
+        spare_mode=spare.spare_mode,
+        spare_vector=list(spare.spare_vector) if spare.spare_vector is not None else None,
+        spare_origin=(
+            [c * _MM_TO_M for c in spare.spare_origin] if spare.spare_origin is not None else None
+        ),
+        spare_position_factor=None,
+    )
+
+
+def _planned_to_out(planned: _PlannedPiece) -> PlannedSpareOut:
+    """Build the metre dry-run/commit response item from a planned piece."""
+    piece = planned.piece
+    spare = planned.spare
+    return PlannedSpareOut(
+        segment_index=planned.segment_index,
+        spar_index=planned.spar_index,
+        role=piece.role.value,
+        spare_support_dimension_width=spare.spare_support_dimension_width * _MM_TO_M,
+        spare_support_dimension_height=spare.spare_support_dimension_height * _MM_TO_M,
+        spare_length=(spare.spare_length or 0.0) * _MM_TO_M,
+        outer_d=piece.outer_d * _MM_TO_M,
+        inner_d=piece.inner_d * _MM_TO_M,
+        spare_origin=[c * _MM_TO_M for c in spare.spare_origin],
+        spare_vector=list(spare.spare_vector),
+        joint_note=piece.joint_to_next,
+        feasible=piece.feasible,
+    )
+
+
+def _plan_pieces_in_invariant_order(plan):
+    """Yield ``(piece, is_reinforcement)`` in the order spares get appended.
+
+    Order matters: within each segment the FRONT spar must be appended FIRST so
+    it lands at ``sort_index = 0`` (the main spar slot). We emit all front
+    pieces, then all rear pieces, then the reinforcement.
+    """
+    for piece in plan.front_pieces:
+        yield piece, False
+    for piece in plan.rear_pieces:
+        yield piece, False
+    if plan.reinforcement is not None:
+        yield plan.reinforcement, True
+
+
+def _build_planned_pieces(plan, segment_lengths_mm: list[float]) -> list[_PlannedPiece]:
+    """Map every plan piece to a ``Spare``, resolve its segment, assign its index.
+
+    The mapping reuses :func:`spar_plan_to_spares` so warnings (telescoping,
+    bent-pin, reinforcement+joiner, dropped bore) stay faithful. We rebuild the
+    Spare list in invariant order and pair each Spare with its source piece.
+    """
+    mapping = spar_plan_to_spares(plan)
+    spares = list(mapping.spares)
+    ordered = list(_plan_pieces_in_invariant_order(plan))
+    if len(spares) != len(ordered):  # pragma: no cover - defensive: mapping mirrors order
+        raise ValidationError(
+            message="Spar plan mapping produced an unexpected number of spares.",
+        )
+
+    planned: list[_PlannedPiece] = []
+    for (piece, is_reinforcement), spare in zip(ordered, spares, strict=True):
+        segment_index = _segment_for_y(_piece_locate_y(piece), segment_lengths_mm)
+        spar_index = _spar_index_for(piece, is_reinforcement=is_reinforcement)
+        planned.append(_PlannedPiece(piece, spare, segment_index, spar_index))
+    return planned
+
+
+def _clear_plan_spares(db, wing, segment_index: int) -> None:
+    """Remove all existing spares from a segment's cross-section detail (REPLACE).
+
+    Inserting a fresh plan replaces existing spares in each target segment so the
+    front spar deterministically lands at sort_index 0 and existing indices are
+    never silently corrupted.
+    """
+    x_secs = wing.x_secs
+    if segment_index < 0 or segment_index >= len(x_secs):  # pragma: no cover - guarded upstream
+        return
+    detail = x_secs[segment_index].detail
+    if detail is None:
+        return
+    for spare in list(detail.spares):
+        db.delete(spare)
+    detail.spares.clear()
+    db.flush()
+
+
+def _persist_spares(db, aeroplane_uuid, wing, planned: list[_PlannedPiece]) -> None:
+    """Persist the planned spares, honouring the spar_index as sort_index.
+
+    Clears each target segment once (REPLACE), then appends the planned spares in
+    invariant order so ``create_spare``'s ``sort_index = len(spares)`` yields the
+    intended index (front first → 0, rear → 1, reinforcement → 2).
+    """
+    for segment_index in sorted({p.segment_index for p in planned}):
+        _clear_plan_spares(db, wing, segment_index)
+
+    for planned_piece in sorted(planned, key=lambda p: (p.segment_index, p.spar_index)):
+        spare_data = _spare_to_metre_schema(planned_piece.piece, planned_piece.spare)
+        create_spare(
+            db,
+            aeroplane_uuid,
+            wing.name,
+            planned_piece.segment_index,
+            spare_data,
+        )
+
+
+def insert_spar_plan(
+    db,
+    aeroplane_uuid,
+    request: SparInsertRequest,
+) -> SparInsertResponse:
+    """Compute a spar plan and insert it into the wing (dry-run or commit).
+
+    Raises:
+        NotFoundError: aeroplane or wing does not exist (-> 404).
+        ValidationError: section geometry unavailable, material/strength inputs
+            invalid, or the plan is infeasible (-> 422).
+    """
+    aeroplane = get_aeroplane_or_raise(db, aeroplane_uuid)
+    wing = _resolve_wing(aeroplane, request)
+
+    plan = compute_spar_plan_object(db, aeroplane_uuid, request, wing=wing)
+
+    if not plan.feasible:
+        raise ValidationError(
+            message=(
+                "Spar plan is infeasible and cannot be inserted: "
+                f"{plan.infeasibility_reason or 'no buildable round tube fits the section.'}"
+            ),
+            details={"infeasibility_reason": plan.infeasibility_reason},
+        )
+
+    segment_lengths_mm = _segment_lengths_mm(wing)
+    planned = _build_planned_pieces(plan, segment_lengths_mm)
+
+    committed = False
+    if not request.dry_run:
+        _persist_spares(db, aeroplane_uuid, wing, planned)
+        committed = True
+
+    mapping = spar_plan_to_spares(plan)
+    return SparInsertResponse(
+        dry_run=request.dry_run,
+        committed=committed,
+        wing_name=wing.name,
+        planned_spares=[_planned_to_out(p) for p in planned],
+        warnings=mapping.warnings,
+        feasible=plan.feasible,
+        infeasibility_reason=plan.infeasibility_reason,
+    )

--- a/app/services/spar_plan_service.py
+++ b/app/services/spar_plan_service.py
@@ -252,12 +252,22 @@ def _piece_to_out(piece) -> SparPieceOut:
     )
 
 
-def compute_spar_plan(
+def compute_spar_plan_object(
     db,
     aeroplane_uuid,
     request: SparPlanRequest,
-) -> SparPlanResponse:
-    """Solve the buildable spar plan for an aeroplane's wing (gh-1031).
+    wing=None,
+):
+    """Solve the buildable spar plan and return the in-memory ``SparPlan`` (mm).
+
+    Shared core of :func:`compute_spar_plan` (gh-1031) and the spar-insert
+    service (gh-1049). Returns the solver's millimetre :class:`SparPlan` so
+    callers can either serialise it (mm→m) or map it into ``Spare`` objects.
+
+    Args:
+        wing: when supplied, skip wing resolution (the insert service resolves
+            the wing itself for unit + segment work). Otherwise resolve via the
+            request.
 
     Raises:
         NotFoundError: aeroplane or wing does not exist (-> 404).
@@ -270,7 +280,8 @@ def compute_spar_plan(
     )
 
     aeroplane = get_aeroplane_or_raise(db, aeroplane_uuid)
-    wing = _resolve_wing(aeroplane, request)
+    if wing is None:
+        wing = _resolve_wing(aeroplane, request)
 
     sigma_allow = _resolve_sigma_allow(db, request)
     g_limit = _resolve_g_limit(db, aeroplane_uuid)
@@ -300,12 +311,27 @@ def compute_spar_plan(
         geometry, x_c=request.rear_x_over_chord, moment_fn=rear_moment_fn, **common
     )
 
-    plan = solve_spar_plan(
+    return solve_spar_plan(
         front_left=_mirror_to_left(front_right),
         front_right=front_right,
         rear_left=_mirror_to_left(rear_right),
         rear_right=rear_right,
     )
+
+
+def compute_spar_plan(
+    db,
+    aeroplane_uuid,
+    request: SparPlanRequest,
+) -> SparPlanResponse:
+    """Solve the buildable spar plan for an aeroplane's wing (gh-1031).
+
+    Raises:
+        NotFoundError: aeroplane or wing does not exist (-> 404).
+        ValidationError: section geometry unavailable, or material/strength
+            inputs invalid (-> 422).
+    """
+    plan = compute_spar_plan_object(db, aeroplane_uuid, request)
 
     return SparPlanResponse(
         front_pieces=[_piece_to_out(p) for p in plan.front_pieces],

--- a/app/tests/test_spar_insert_endpoint.py
+++ b/app/tests/test_spar_insert_endpoint.py
@@ -155,6 +155,21 @@ class TestSegmentResolution:
         # negative (mirror) clamps to the root segment
         assert spar_insert_service._segment_for_y(-10.0, lengths) == 0
 
+    def test_empty_segment_lengths_returns_root(self):
+        assert spar_insert_service._segment_for_y(123.0, []) == 0
+
+    def test_piece_locate_y_prefers_origin_then_governing(self):
+        piece = _piece(role=SparRole.FRONT, y=250.0, governing_y=900.0)
+        # origin y wins when present
+        assert spar_insert_service._piece_locate_y(piece) == pytest.approx(250.0)
+
+        # falls back to governing_y when origin is absent / too short
+        class _NoOrigin:
+            spare_origin = None
+            governing_y = 777.0
+
+        assert spar_insert_service._piece_locate_y(_NoOrigin()) == pytest.approx(777.0)
+
 
 # --------------------------------------------------------------------------
 # HARD spar_index invariant

--- a/app/tests/test_spar_insert_endpoint.py
+++ b/app/tests/test_spar_insert_endpoint.py
@@ -1,0 +1,407 @@
+"""gh-1049: Fast-tier tests for the spar-plan → wing insert endpoint + service.
+
+These run on the CI fast tier (no cadquery). We mock the solver/geometry
+boundary (``compute_spar_plan_object`` returns a synthetic :class:`SparPlan`) so
+the real lofted-solid build never runs, and assert:
+
+- segment resolution from a piece's spanwise span (governing_y → segment),
+- the HARD spar_index invariant (front=0 in every segment, same logical spar
+  same index across segments, rear=1, reinforcement next),
+- dry_run vs commit (commit calls create_spare with the correct sort_index and
+  metre dimensions),
+- infeasible plan → 422 refusal,
+- missing aeroplane / wing → 404,
+- unit conversion (mm plan → metre response),
+- the already-has-index-0 replace behaviour.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.v2.endpoints.aeroanalysis import insert_airplane_spar_plan
+from app.core.exceptions import NotFoundError, ValidationError
+from app.schemas.spar_insert import SparInsertRequest
+from app.schemas.spar_plan import MomentSample
+from app.services import spar_insert_service
+from cad_designer.airplane.geometry.spar_solver import SparPiece, SparPlan, SparRole
+
+
+# --------------------------------------------------------------------------
+# Stubs
+# --------------------------------------------------------------------------
+
+
+def _piece(role=SparRole.FRONT, y=100.0, governing_y=100.0, **kw):
+    defaults = dict(
+        role=role,
+        spare_origin=(0.0, y, 10.0),
+        spare_vector=(0.0, 1.0, 0.0),
+        outer_d=20.0,
+        inner_d=12.0,
+        shape="tube",
+        governing_y=governing_y,
+        utilisation=0.9,
+        length=400.0,
+    )
+    defaults.update(kw)
+    return SparPiece(**defaults)
+
+
+def _two_segment_plan():
+    """A plan whose front spar telescopes across two segments (root + outboard)."""
+    return SparPlan(
+        front_pieces=[
+            _piece(role=SparRole.FRONT, y=0.0, governing_y=50.0, joint_to_next="telescoping"),
+            _piece(role=SparRole.FRONT, y=600.0, governing_y=650.0, outer_d=16.0, inner_d=10.0),
+        ],
+        rear_pieces=[
+            _piece(role=SparRole.REAR, y=0.0, governing_y=50.0, outer_d=10.0, inner_d=6.0),
+        ],
+        front_joint="continuous",
+        rear_joint="continuous",
+    )
+
+
+def _single_segment_plan(with_reinforcement=False):
+    plan = SparPlan(
+        front_pieces=[_piece(role=SparRole.FRONT, y=0.0, governing_y=50.0)],
+        rear_pieces=[
+            _piece(role=SparRole.REAR, y=0.0, governing_y=50.0, outer_d=10.0, inner_d=6.0)
+        ],
+        front_joint="continuous",
+        rear_joint="continuous",
+    )
+    if with_reinforcement:
+        plan.front_joint = "reinforcement+joiner"
+        plan.reinforcement = _piece(
+            role=SparRole.FRONT, y=-50.0, governing_y=0.0, outer_d=22.0, inner_d=14.0
+        )
+    return plan
+
+
+def _wing(name="main_wing", segment_lengths_mm=(500.0,)):
+    """A stub wing whose config exposes segments with mm lengths."""
+    segments = [SimpleNamespace(length=length) for length in segment_lengths_mm]
+    # x_secs: one per segment + the terminal one.
+    x_secs = [SimpleNamespace(sort_index=i) for i in range(len(segment_lengths_mm) + 1)]
+    return SimpleNamespace(name=name, x_secs=x_secs, _segments=segments)
+
+
+def _aeroplane(wings):
+    return SimpleNamespace(wings=wings, uuid=uuid.uuid4())
+
+
+def _request(**overrides):
+    body = dict(
+        material_id=7,
+        moments=[
+            MomentSample(y_span=0.0, bending_moment_Nm=100.0),
+            MomentSample(y_span=1.0, bending_moment_Nm=0.0),
+        ],
+    )
+    body.update(overrides)
+    return SparInsertRequest(**body)
+
+
+@pytest.fixture()
+def plane_id():
+    return uuid.uuid4()
+
+
+def _patch_service(aeroplane, plan, wing=None):
+    """Patch the boundaries: aeroplane lookup, wing resolution, plan compute,
+    and the wing_config segment provider."""
+    wing = wing if wing is not None else aeroplane.wings[0]
+    return [
+        patch.object(spar_insert_service, "get_aeroplane_or_raise", return_value=aeroplane),
+        patch.object(spar_insert_service, "_resolve_wing", return_value=wing),
+        patch.object(spar_insert_service, "compute_spar_plan_object", return_value=plan),
+        patch.object(
+            spar_insert_service,
+            "_segment_lengths_mm",
+            return_value=[s.length for s in wing._segments],
+        ),
+    ]
+
+
+def _run(patches, fn):
+    if not patches:
+        return fn()
+    with patches[0]:
+        return _run(patches[1:], fn)
+
+
+# --------------------------------------------------------------------------
+# Segment resolution
+# --------------------------------------------------------------------------
+
+
+class TestSegmentResolution:
+    def test_resolves_governing_y_to_segment_index(self):
+        # boundaries: seg0 = [0, 500), seg1 = [500, 1100)
+        lengths = [500.0, 600.0]
+        assert spar_insert_service._segment_for_y(50.0, lengths) == 0
+        assert spar_insert_service._segment_for_y(499.0, lengths) == 0
+        assert spar_insert_service._segment_for_y(500.0, lengths) == 1
+        assert spar_insert_service._segment_for_y(650.0, lengths) == 1
+        # beyond the last boundary clamps to the last segment
+        assert spar_insert_service._segment_for_y(5000.0, lengths) == 1
+        # negative (mirror) clamps to the root segment
+        assert spar_insert_service._segment_for_y(-10.0, lengths) == 0
+
+
+# --------------------------------------------------------------------------
+# HARD spar_index invariant
+# --------------------------------------------------------------------------
+
+
+class TestSparIndexInvariant:
+    def test_front_is_index_zero_in_every_segment(self, plane_id):
+        aeroplane = _aeroplane([_wing(segment_lengths_mm=(500.0, 600.0))])
+        resp = _run(
+            _patch_service(aeroplane, _two_segment_plan()),
+            lambda: spar_insert_service.insert_spar_plan(
+                db=None, aeroplane_uuid=plane_id, request=_request(dry_run=True)
+            ),
+        )
+        front = [p for p in resp.planned_spares if p.role == "front"]
+        # front spar spans two segments (one piece each), index 0 in both
+        segs = {p.segment_index for p in front}
+        assert segs == {0, 1}
+        for p in front:
+            assert p.spar_index == 0
+
+    def test_rear_is_index_one(self, plane_id):
+        aeroplane = _aeroplane([_wing(segment_lengths_mm=(500.0, 600.0))])
+        resp = _run(
+            _patch_service(aeroplane, _two_segment_plan()),
+            lambda: spar_insert_service.insert_spar_plan(
+                db=None, aeroplane_uuid=plane_id, request=_request(dry_run=True)
+            ),
+        )
+        rear = [p for p in resp.planned_spares if p.role == "rear"]
+        assert rear
+        for p in rear:
+            assert p.spar_index == 1
+
+    def test_reinforcement_gets_next_index(self, plane_id):
+        aeroplane = _aeroplane([_wing(segment_lengths_mm=(500.0,))])
+        resp = _run(
+            _patch_service(aeroplane, _single_segment_plan(with_reinforcement=True)),
+            lambda: spar_insert_service.insert_spar_plan(
+                db=None, aeroplane_uuid=plane_id, request=_request(dry_run=True)
+            ),
+        )
+        # front=0, rear=1, reinforcement=2 (next), all in the root segment
+        by_role = {(p.role, p.spar_index) for p in resp.planned_spares}
+        assert ("front", 0) in by_role
+        assert ("rear", 1) in by_role
+        reinforcements = [p for p in resp.planned_spares if p.spar_index == 2]
+        assert len(reinforcements) == 1
+        assert reinforcements[0].role == "front"
+
+
+# --------------------------------------------------------------------------
+# dry_run vs commit
+# --------------------------------------------------------------------------
+
+
+class TestDryRunVsCommit:
+    def test_dry_run_does_not_persist(self, plane_id):
+        aeroplane = _aeroplane([_wing(segment_lengths_mm=(500.0,))])
+        with patch.object(spar_insert_service, "_persist_spares") as mock_persist:
+            resp = _run(
+                _patch_service(aeroplane, _single_segment_plan()),
+                lambda: spar_insert_service.insert_spar_plan(
+                    db=None, aeroplane_uuid=plane_id, request=_request(dry_run=True)
+                ),
+            )
+        mock_persist.assert_not_called()
+        assert resp.committed is False
+        assert resp.dry_run is True
+        assert len(resp.planned_spares) == 2
+
+    def test_commit_calls_create_spare_with_sort_index_and_metres(self, plane_id):
+        aeroplane = _aeroplane([_wing(segment_lengths_mm=(500.0,))])
+        captured = []
+
+        def fake_create_spare(db, aeroplane_uuid, wing_name, xsec_index, spare_data):
+            captured.append((xsec_index, spare_data))
+
+        with (
+            patch.object(spar_insert_service, "create_spare", side_effect=fake_create_spare),
+            patch.object(spar_insert_service, "_clear_plan_spares") as mock_clear,
+        ):
+            resp = _run(
+                _patch_service(aeroplane, _single_segment_plan()),
+                lambda: spar_insert_service.insert_spar_plan(
+                    db=None, aeroplane_uuid=plane_id, request=_request(dry_run=False)
+                ),
+            )
+        assert resp.committed is True
+        # both pieces persisted into segment 0
+        assert {c[0] for c in captured} == {0}
+        assert len(captured) == 2
+        # front piece: 20 mm OD -> 0.020 m metre dimensions handed to create_spare
+        front_spare = captured[0][1]
+        assert front_spare.spare_support_dimension_width == pytest.approx(0.020)
+        assert front_spare.spare_support_dimension_height == pytest.approx(0.020)
+        assert front_spare.spare_length == pytest.approx(0.400)
+        # spare_vector dimensionless, unchanged
+        assert front_spare.spare_vector == [0.0, 1.0, 0.0]
+        # mode 'normal' so the solved origin/vector are honoured verbatim
+        assert front_spare.spare_mode == "normal"
+        # existing plan spares cleared before insert (replace behaviour)
+        mock_clear.assert_called_once()
+
+
+# --------------------------------------------------------------------------
+# already-has-index-0 replace behaviour
+# --------------------------------------------------------------------------
+
+
+class TestReplaceExistingSpares:
+    def test_clear_called_for_each_target_segment_on_commit(self, plane_id):
+        aeroplane = _aeroplane([_wing(segment_lengths_mm=(500.0, 600.0))])
+        cleared_segments = []
+
+        with (
+            patch.object(spar_insert_service, "create_spare"),
+            patch.object(
+                spar_insert_service,
+                "_clear_plan_spares",
+                side_effect=lambda db, wing, seg_idx: cleared_segments.append(seg_idx),
+            ),
+        ):
+            _run(
+                _patch_service(aeroplane, _two_segment_plan()),
+                lambda: spar_insert_service.insert_spar_plan(
+                    db=None, aeroplane_uuid=plane_id, request=_request(dry_run=False)
+                ),
+            )
+        # both target segments cleared exactly once (no double-corruption)
+        assert sorted(set(cleared_segments)) == [0, 1]
+
+
+# --------------------------------------------------------------------------
+# Infeasible refusal + not-found
+# --------------------------------------------------------------------------
+
+
+class TestInfeasibleAndNotFound:
+    def test_infeasible_plan_raises_validation_error(self, plane_id):
+        aeroplane = _aeroplane([_wing(segment_lengths_mm=(500.0,))])
+        plan = _single_segment_plan()
+        plan.feasible = False
+        plan.infeasibility_reason = "required OD 96.5 mm exceeds section depth"
+        plan.front_pieces[0].feasible = False
+        with pytest.raises(ValidationError) as exc:
+            _run(
+                _patch_service(aeroplane, plan),
+                lambda: spar_insert_service.insert_spar_plan(
+                    db=None, aeroplane_uuid=plane_id, request=_request(dry_run=False)
+                ),
+            )
+        assert "exceeds section depth" in str(exc.value.message)
+
+    def test_infeasible_refused_even_for_dry_run(self, plane_id):
+        aeroplane = _aeroplane([_wing(segment_lengths_mm=(500.0,))])
+        plan = _single_segment_plan()
+        plan.feasible = False
+        plan.infeasibility_reason = "no tube fits"
+        with pytest.raises(ValidationError):
+            _run(
+                _patch_service(aeroplane, plan),
+                lambda: spar_insert_service.insert_spar_plan(
+                    db=None, aeroplane_uuid=plane_id, request=_request(dry_run=True)
+                ),
+            )
+
+    def test_aeroplane_not_found_propagates(self, plane_id):
+        with patch.object(
+            spar_insert_service,
+            "get_aeroplane_or_raise",
+            side_effect=NotFoundError(message="Aeroplane not found"),
+        ):
+            with pytest.raises(NotFoundError):
+                spar_insert_service.insert_spar_plan(
+                    db=None, aeroplane_uuid=plane_id, request=_request()
+                )
+
+    def test_wing_not_found_propagates(self, plane_id):
+        aeroplane = _aeroplane([_wing()])
+        with (
+            patch.object(spar_insert_service, "get_aeroplane_or_raise", return_value=aeroplane),
+            patch.object(
+                spar_insert_service,
+                "_resolve_wing",
+                side_effect=NotFoundError(message="Wing not found"),
+            ),
+        ):
+            with pytest.raises(NotFoundError):
+                spar_insert_service.insert_spar_plan(
+                    db=None, aeroplane_uuid=plane_id, request=_request()
+                )
+
+
+# --------------------------------------------------------------------------
+# Unit conversion (dry-run response is in metres)
+# --------------------------------------------------------------------------
+
+
+class TestUnitConversion:
+    def test_dry_run_dimensions_in_metres(self, plane_id):
+        aeroplane = _aeroplane([_wing(segment_lengths_mm=(500.0,))])
+        resp = _run(
+            _patch_service(aeroplane, _single_segment_plan()),
+            lambda: spar_insert_service.insert_spar_plan(
+                db=None, aeroplane_uuid=plane_id, request=_request(dry_run=True)
+            ),
+        )
+        front = next(p for p in resp.planned_spares if p.role == "front")
+        assert front.outer_d == pytest.approx(0.020)
+        assert front.inner_d == pytest.approx(0.012)
+        assert front.spare_length == pytest.approx(0.400)
+        assert front.spare_origin == pytest.approx([0.0, 0.0, 0.01])
+        assert front.spare_vector == [0.0, 1.0, 0.0]
+
+
+# --------------------------------------------------------------------------
+# Endpoint
+# --------------------------------------------------------------------------
+
+
+class TestInsertEndpoint:
+    def test_returns_response_on_success(self, plane_id):
+        with patch.object(
+            spar_insert_service, "insert_spar_plan", return_value="RESULT"
+        ) as mock_insert:
+            result = insert_airplane_spar_plan(aeroplane_id=plane_id, request=_request(), db=None)
+        assert result == "RESULT"
+        mock_insert.assert_called_once()
+
+    def test_raises_http_404_on_not_found(self, plane_id):
+        with patch.object(
+            spar_insert_service,
+            "insert_spar_plan",
+            side_effect=NotFoundError(message="Aeroplane not found"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                insert_airplane_spar_plan(aeroplane_id=plane_id, request=_request(), db=None)
+        assert exc_info.value.status_code == 404
+
+    def test_raises_http_422_on_infeasible(self, plane_id):
+        with patch.object(
+            spar_insert_service,
+            "insert_spar_plan",
+            side_effect=ValidationError(message="plan infeasible"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                insert_airplane_spar_plan(aeroplane_id=plane_id, request=_request(), db=None)
+        assert exc_info.value.status_code == 422

--- a/app/tests/test_spar_insert_integration.py
+++ b/app/tests/test_spar_insert_integration.py
@@ -1,0 +1,144 @@
+"""gh-1049: slow/requires_cadquery round-trip for the spar-insert endpoint.
+
+Builds a real eHawk main wing via ``/from-wingconfig`` (the single source of
+truth used by the other CAD integration tests), computes a real spar plan
+through the full solver + SectionGeometry path, inserts it (commit), and asserts
+the wing's cross-sections carry the inserted spares with the HARD INVARIANT held:
+the front (main) spar is ``sort_index = 0`` in every segment it occupies.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.models.component import ComponentModel
+from test.ehawk_workflow_helpers import _build_main_wing
+
+
+@pytest.fixture()
+def client(client_and_db):
+    test_client, _ = client_and_db
+    yield test_client
+
+
+def _build_ehawk_wingconfig_payload() -> dict:
+    repo_root = Path(__file__).resolve().parents[2]
+    airfoil_path = str((repo_root / "components" / "airfoils" / "mh32.dat").resolve())
+    wing_config = _build_main_wing(airfoil_path)
+    state = wing_config.__getstate__()
+
+    class _JsonSafeEncoder(json.JSONEncoder):
+        def default(self, obj):
+            if hasattr(obj, "toTuple"):
+                return list(obj.toTuple())
+            if hasattr(obj, "x") and hasattr(obj, "y") and hasattr(obj, "z"):
+                return [float(obj.x), float(obj.y), float(obj.z)]
+            try:
+                return float(obj)
+            except Exception:
+                return str(obj)
+
+    return json.loads(json.dumps(state, cls=_JsonSafeEncoder))
+
+
+def _first_material_id(session_local) -> int:
+    db = session_local()
+    try:
+        material = (
+            db.query(ComponentModel).filter(ComponentModel.component_type == "material").first()
+        )
+        assert material is not None, "expected a seeded structural material"
+        return material.id
+    finally:
+        db.close()
+
+
+@pytest.mark.slow
+@pytest.mark.requires_cadquery
+def test_spar_insert_commit_roundtrip_front_spar_index_zero(client_and_db):
+    test_client, session_local = client_and_db
+    client: TestClient = test_client
+    wing_name = "main_wing"
+
+    create_plane = test_client.post("/aeroplanes", params={"name": "spar insert RT"})
+    assert create_plane.status_code == 201, create_plane.text
+    aeroplane_id = create_plane.json()["id"]
+
+    create_wing = test_client.post(
+        f"/aeroplanes/{aeroplane_id}/wings/{wing_name}/from-wingconfig",
+        json=_build_ehawk_wingconfig_payload(),
+    )
+    assert create_wing.status_code == 201, create_wing.text
+
+    material_id = _first_material_id(session_local)
+    request_body = {
+        "material_id": material_id,
+        "wing_name": wing_name,
+        "moments": [
+            {"y_span": 0.0, "bending_moment_Nm": 4.0},
+            {"y_span": 0.5, "bending_moment_Nm": 1.5},
+            {"y_span": 1.0, "bending_moment_Nm": 0.0},
+        ],
+        "sigma_allow_mpa_override": 600.0,
+        "n_span": 6,
+        "packing_factor": 0.9,
+    }
+
+    # 1) dry-run preview: no writes.
+    preview = test_client.post(
+        f"/aeroplanes/{aeroplane_id}/spar-plan/insert",
+        json={**request_body, "dry_run": True},
+    )
+    assert preview.status_code == 200, preview.text
+    preview_json = preview.json()
+    assert preview_json["committed"] is False
+    assert preview_json["planned_spares"], "expected at least one planned spare"
+    # every front spar piece in the preview is index 0
+    front_preview = [p for p in preview_json["planned_spares"] if p["role"] == "front"]
+    assert front_preview
+    assert all(p["spar_index"] == 0 for p in front_preview)
+
+    # a dry run must not change the persisted spare count (the eHawk wing
+    # already ships with construction spares — dry run touches nothing).
+    wing_before = test_client.get(f"/aeroplanes/{aeroplane_id}/wings/{wing_name}").json()
+    spares_before = sum(len(x.get("spare_list") or []) for x in wing_before["x_secs"])
+    wing_before_again = test_client.get(f"/aeroplanes/{aeroplane_id}/wings/{wing_name}").json()
+    assert sum(len(x.get("spare_list") or []) for x in wing_before_again["x_secs"]) == spares_before
+
+    # 2) commit: persist the plan.
+    commit = test_client.post(
+        f"/aeroplanes/{aeroplane_id}/spar-plan/insert",
+        json={**request_body, "dry_run": False},
+    )
+    assert commit.status_code == 200, commit.text
+    commit_json = commit.json()
+    assert commit_json["committed"] is True
+
+    # the persisted wing now carries spares; the front spar is sort_index 0 in
+    # every segment it occupies (HARD INVARIANT).
+    wing_after = test_client.get(f"/aeroplanes/{aeroplane_id}/wings/{wing_name}").json()
+    total_spares = sum(len(x.get("spare_list") or []) for x in wing_after["x_secs"])
+    assert total_spares >= 1
+
+    # planned front piece per segment (front has one piece per segment here).
+    planned_front_by_seg = {
+        p["segment_index"]: p for p in commit_json["planned_spares"] if p["role"] == "front"
+    }
+    assert planned_front_by_seg, "expected at least one front spar piece"
+    for seg_idx, planned_front in planned_front_by_seg.items():
+        # spare_list is returned ordered by sort_index, so [0] is the main spar.
+        spare_list = wing_after["x_secs"][seg_idx].get("spare_list") or []
+        assert spare_list, f"segment {seg_idx} should carry a front spar"
+        main_spar = spare_list[0]
+        # the index-0 (main) spar in this segment IS the planned front spar:
+        # its bounding box equals the front piece OD (within metre tolerance).
+        assert main_spar["spare_support_dimension_width"] == pytest.approx(
+            planned_front["outer_d"], rel=1e-6, abs=1e-9
+        )
+        assert main_spar["spare_support_dimension_height"] == pytest.approx(
+            planned_front["outer_d"], rel=1e-6, abs=1e-9
+        )


### PR DESCRIPTION
Closes #1049 — part of epic #1048.

POST `/aeroplanes/{id}/spar-plan/insert` with `dry_run`. Maps the computed SparPlan to persisted Spares with the **HARD spar_index invariant**: front (main) spar = `sort_index 0` in every segment it occupies, rear = 1, reinforcement = 2; same logical spar keeps its index across all segments; telescoping pieces keep their spar's index. Already-has-index-0 → **REPLACE** (deterministic). `dry_run=true` previews (metres) without writing; `dry_run=false` persists via `create_spare`. Infeasible plan → 422; missing aeroplane/wing → 404.

Verified against cad_designer construction (index 0 = main spar). Tests: fast (mocked solver) cover the invariant, dry_run/commit, 422/404, unit conversion; slow `requires_cadquery` round-trip asserts front sort_index 0 in every segment. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)