### PR TITLE
feat(gh-1050): SparSizingPanel built-spar display + preview→confirm "Add spar to wing"

### DIFF
--- a/frontend/__tests__/SparBuiltAndInsert.test.tsx
+++ b/frontend/__tests__/SparBuiltAndInsert.test.tsx
@@ -1,0 +1,246 @@
+/**
+ * gh-1050: Unit tests for the built-spar display + preview→confirm
+ * "Add spar to wing" flow.
+ *
+ * Covers:
+ *  - BuiltSparSection: front (main/index 0) / rear / reinforcement groups,
+ *    joint labels, computed wall, infeasible banner.
+ *  - AddSparToWingFlow: feasibility gating (button disabled when infeasible),
+ *    dry-run preview (REPLACE warning + spar_index shown, front=0 highlighted),
+ *    confirm → commit (onCommitted fired), error path.
+ */
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import {
+  BuiltSparSection,
+  AddSparToWingFlow,
+} from "@/components/workbench/SparSizingPanel";
+import type {
+  SparPlanResult,
+  SparPieceOut,
+  SparInsertResult,
+} from "@/hooks/useSparPlan";
+
+function piece(over: Partial<SparPieceOut> = {}): SparPieceOut {
+  return {
+    role: "front",
+    spare_origin: [0, 0, 0],
+    spare_vector: [0, 1, 0],
+    outer_d: 0.0288,
+    inner_d: 0.024,
+    wall: 0.0024,
+    shape: "tube",
+    governing_y: 0,
+    utilisation: 0.5,
+    joint_to_next: null,
+    feasible: true,
+    infeasibility_reason: null,
+    ...over,
+  };
+}
+
+function feasiblePlan(): SparPlanResult {
+  return {
+    front_pieces: [
+      piece({ joint_to_next: "telescoping" }),
+      piece({ role: "front", joint_to_next: null }),
+    ],
+    rear_pieces: [piece({ role: "rear", outer_d: 0.012, inner_d: 0.008 })],
+    front_joint: "continuous",
+    rear_joint: "bent-pin",
+    reinforcement: piece({ role: "front", outer_d: 0.03, inner_d: 0.0 }),
+    feasible: true,
+    infeasibility_reason: null,
+  };
+}
+
+function previewResult(): SparInsertResult {
+  return {
+    dry_run: true,
+    committed: false,
+    wing_name: "Main Wing",
+    planned_spares: [
+      {
+        segment_index: 0,
+        spar_index: 0,
+        role: "front",
+        spare_support_dimension_width: 0.0288,
+        spare_support_dimension_height: 0.0288,
+        spare_length: 0.75,
+        outer_d: 0.0288,
+        inner_d: 0.024,
+        spare_origin: [0, 0, 0],
+        spare_vector: [0, 1, 0],
+        joint_note: "telescoping",
+        feasible: true,
+      },
+      {
+        segment_index: 1,
+        spar_index: 1,
+        role: "rear",
+        spare_support_dimension_width: 0.012,
+        spare_support_dimension_height: 0.012,
+        spare_length: 0.5,
+        outer_d: 0.012,
+        inner_d: 0.008,
+        spare_origin: [0, 0, 0],
+        spare_vector: [0, 1, 0],
+        joint_note: null,
+        feasible: true,
+      },
+    ],
+    warnings: ["telescoping overlap modelled as butt joint"],
+    feasible: true,
+    infeasibility_reason: null,
+  };
+}
+
+describe("BuiltSparSection (gh-1050)", () => {
+  it("renders front (main, index 0), rear and reinforcement groups", () => {
+    render(<BuiltSparSection plan={feasiblePlan()} />);
+    const front = screen.getByTestId("built-spar-group-front");
+    expect(front).toHaveTextContent(/main spar/i);
+    expect(front).toHaveTextContent("0");
+    expect(screen.getByTestId("built-spar-group-rear")).toHaveTextContent(/Rear/i);
+    expect(
+      screen.getByTestId("built-spar-group-reinforcement"),
+    ).toHaveTextContent(/reinforcement/i);
+  });
+
+  it("shows OD × ID with computed wall and joint labels", () => {
+    render(<BuiltSparSection plan={feasiblePlan()} />);
+    const rows = screen.getAllByTestId("built-spar-piece");
+    expect(rows[0]).toHaveTextContent("OD 28.8");
+    expect(rows[0]).toHaveTextContent("ID 24.0");
+    expect(rows[0]).toHaveTextContent("wall 2.4");
+    expect(rows[0]).toHaveTextContent(/Telescoping/);
+  });
+
+  it("renders an infeasible banner when the plan is not buildable", () => {
+    const plan = feasiblePlan();
+    plan.feasible = false;
+    plan.infeasibility_reason = "no tube fits at root";
+    render(<BuiltSparSection plan={plan} />);
+    expect(screen.getByTestId("built-spar-infeasible")).toHaveTextContent(
+      "no tube fits at root",
+    );
+  });
+});
+
+describe("AddSparToWingFlow (gh-1050)", () => {
+  it("disables the button when the plan is infeasible", () => {
+    const plan = feasiblePlan();
+    plan.feasible = false;
+    const onInsert = vi.fn();
+    render(<AddSparToWingFlow plan={plan} onInsert={onInsert} />);
+    expect(screen.getByTestId("add-spar-to-wing-button")).toBeDisabled();
+  });
+
+  it("dry-run preview shows REPLACE warning, spar_index and front=0 highlighted", async () => {
+    const onInsert = vi.fn().mockResolvedValue(previewResult());
+    render(<AddSparToWingFlow plan={feasiblePlan()} onInsert={onInsert} />);
+
+    fireEvent.click(screen.getByTestId("add-spar-to-wing-button"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("add-spar-preview-modal")).toBeInTheDocument(),
+    );
+    // first call is the dry-run preview
+    expect(onInsert).toHaveBeenCalledWith(true);
+
+    const warn = screen.getByTestId("add-spar-replace-warning");
+    expect(warn).toHaveTextContent(
+      "This replaces existing spars in segments 0, 1.",
+    );
+
+    const rows = screen.getAllByTestId("planned-spare-row");
+    expect(rows).toHaveLength(2);
+    // spar_index column shows 0 with the main marker
+    expect(rows[0]).toHaveTextContent("0 (main)");
+    expect(rows[1]).toHaveTextContent("1");
+    // mapping warnings surfaced
+    expect(screen.getByTestId("add-spar-warnings")).toHaveTextContent(
+      "telescoping overlap",
+    );
+  });
+
+  it("confirm calls commit (dry_run=false) and fires onCommitted", async () => {
+    const onInsert = vi
+      .fn()
+      .mockResolvedValueOnce(previewResult())
+      .mockResolvedValueOnce({ ...previewResult(), dry_run: false, committed: true });
+    const onCommitted = vi.fn();
+    render(
+      <AddSparToWingFlow
+        plan={feasiblePlan()}
+        onInsert={onInsert}
+        onCommitted={onCommitted}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("add-spar-to-wing-button"));
+    await waitFor(() =>
+      expect(screen.getByTestId("add-spar-confirm")).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByTestId("add-spar-confirm"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("add-spar-success")).toBeInTheDocument(),
+    );
+    expect(onInsert).toHaveBeenNthCalledWith(1, true);
+    expect(onInsert).toHaveBeenNthCalledWith(2, false);
+    expect(onCommitted).toHaveBeenCalledTimes(1);
+    // modal closed after commit
+    expect(screen.queryByTestId("add-spar-preview-modal")).toBeNull();
+  });
+
+  it("surfaces a commit error inside the modal and keeps it open", async () => {
+    const onInsert = vi
+      .fn()
+      .mockResolvedValueOnce(previewResult())
+      .mockRejectedValueOnce(new Error("Spar insert failed (422): bad plan"));
+    render(<AddSparToWingFlow plan={feasiblePlan()} onInsert={onInsert} />);
+
+    fireEvent.click(screen.getByTestId("add-spar-to-wing-button"));
+    await waitFor(() =>
+      expect(screen.getByTestId("add-spar-confirm")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("add-spar-confirm"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("add-spar-preview-error")).toHaveTextContent(
+        "bad plan",
+      ),
+    );
+    expect(screen.getByTestId("add-spar-preview-modal")).toBeInTheDocument();
+  });
+
+  it("surfaces a preview (dry-run) error outside the modal", async () => {
+    const onInsert = vi
+      .fn()
+      .mockRejectedValue(new Error("Spar insert failed: network down"));
+    render(<AddSparToWingFlow plan={feasiblePlan()} onInsert={onInsert} />);
+
+    fireEvent.click(screen.getByTestId("add-spar-to-wing-button"));
+    await waitFor(() =>
+      expect(screen.getByTestId("add-spar-error")).toHaveTextContent(
+        "network down",
+      ),
+    );
+    expect(screen.queryByTestId("add-spar-preview-modal")).toBeNull();
+  });
+
+  it("cancel closes the preview without committing", async () => {
+    const onInsert = vi.fn().mockResolvedValue(previewResult());
+    render(<AddSparToWingFlow plan={feasiblePlan()} onInsert={onInsert} />);
+    fireEvent.click(screen.getByTestId("add-spar-to-wing-button"));
+    await waitFor(() =>
+      expect(screen.getByTestId("add-spar-cancel")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("add-spar-cancel"));
+    expect(screen.queryByTestId("add-spar-preview-modal")).toBeNull();
+    expect(onInsert).toHaveBeenCalledTimes(1); // only the preview
+  });
+});

--- a/frontend/__tests__/SparSizingPanel.test.tsx
+++ b/frontend/__tests__/SparSizingPanel.test.tsx
@@ -265,4 +265,54 @@ describe("SparSizingPanel", () => {
     await waitFor(() => screen.getByTestId("spar-compute-button"));
     expect(screen.getByTestId("spar-compute-button")).toHaveTextContent("Computing…");
   });
+
+  // gh-1050: built-spar block + add-to-wing wiring inside the panel.
+  it("renders the built-spar block when a plan is provided", async () => {
+    const plan = {
+      front_pieces: [
+        {
+          role: "front",
+          spare_origin: [0, 0, 0],
+          spare_vector: [0, 1, 0],
+          outer_d: 0.0288,
+          inner_d: 0.024,
+          wall: 0.0024,
+          shape: "tube",
+          governing_y: 0,
+          utilisation: 0.5,
+          joint_to_next: null,
+          feasible: true,
+          infeasibility_reason: null,
+        },
+      ],
+      rear_pieces: [],
+      front_joint: "continuous",
+      rear_joint: "continuous",
+      reinforcement: null,
+      feasible: true,
+      infeasibility_reason: null,
+    };
+    const onInsert = vi.fn();
+    renderPanel({ plan, onInsert });
+    fireEvent.click(screen.getByTestId("spar-sizing-toggle"));
+    await waitFor(() => screen.getByTestId("built-spar-block"));
+    expect(screen.getByTestId("built-spar-section")).toBeInTheDocument();
+    expect(screen.getByTestId("add-spar-to-wing-button")).toBeInTheDocument();
+  });
+
+  it("hides the add-to-wing button when no onInsert handler is given", async () => {
+    const plan = {
+      front_pieces: [],
+      rear_pieces: [],
+      front_joint: "continuous",
+      rear_joint: "continuous",
+      reinforcement: null,
+      feasible: true,
+      infeasibility_reason: null,
+    };
+    renderPanel({ plan });
+    fireEvent.click(screen.getByTestId("spar-sizing-toggle"));
+    await waitFor(() => screen.getByTestId("built-spar-block"));
+    expect(screen.queryByTestId("add-spar-to-wing-button")).toBeNull();
+  });
 });

--- a/frontend/__tests__/sparPlanHelpers.test.ts
+++ b/frontend/__tests__/sparPlanHelpers.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Unit tests for the spar-plan pure helpers (gh-1050).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  buildMomentsFromLoads,
+  mToMm,
+  sparGroupLabel,
+  jointLabel,
+  pieceDimsLabel,
+  touchedSegments,
+  replaceWarning,
+} from "@/lib/sparPlanHelpers";
+import type { SpanwiseLoadsResult } from "@/hooks/useSpanwiseLoads";
+import type { PlannedSpareOut, SparPieceOut } from "@/hooks/useSparPlan";
+
+function loads(): SpanwiseLoadsResult {
+  return {
+    alpha: 2,
+    beta: 0,
+    velocity_mps: 30,
+    altitude_m: 0,
+    dynamic_pressure_Pa: 551,
+    surfaces: [
+      {
+        surface_name: "Main Wing",
+        starboard: [
+          { y_m: 0.0, chord_m: 0.3, shear_N: 100, bending_moment_Nm: 200 },
+          { y_m: 0.5, chord_m: 0.25, shear_N: 50, bending_moment_Nm: 80 },
+          { y_m: 1.0, chord_m: 0.2, shear_N: 0, bending_moment_Nm: 0 },
+        ],
+        port: [],
+        root_shear_N_starboard: 100,
+        root_shear_N_port: 100,
+        root_bending_moment_Nm_starboard: 200,
+        root_bending_moment_Nm_port: 200,
+      },
+    ],
+  };
+}
+
+describe("buildMomentsFromLoads", () => {
+  it("normalises y to a 0..1 span fraction and uses |M|", () => {
+    const m = buildMomentsFromLoads(loads());
+    expect(m).not.toBeNull();
+    expect(m!).toHaveLength(3);
+    expect(m![0]).toEqual({ y_span: 0, bending_moment_Nm: 200 });
+    expect(m![1]).toEqual({ y_span: 0.5, bending_moment_Nm: 80 });
+    expect(m![2]).toEqual({ y_span: 1, bending_moment_Nm: 0 });
+  });
+
+  it("returns null when there are no surfaces", () => {
+    expect(buildMomentsFromLoads(null)).toBeNull();
+    expect(buildMomentsFromLoads({ ...loads(), surfaces: [] })).toBeNull();
+  });
+
+  it("returns null when the span is degenerate (all y=0)", () => {
+    const l = loads();
+    l.surfaces[0].starboard = [
+      { y_m: 0, chord_m: 0.3, shear_N: 0, bending_moment_Nm: 10 },
+    ];
+    expect(buildMomentsFromLoads(l)).toBeNull();
+  });
+});
+
+describe("formatting helpers", () => {
+  it("mToMm converts metres to millimetres", () => {
+    expect(mToMm(0.0288)).toBe("28.8");
+    expect(mToMm(0.75, 0)).toBe("750");
+  });
+
+  it("sparGroupLabel marks the front as main spar index 0", () => {
+    expect(sparGroupLabel("front")).toContain("main spar");
+    expect(sparGroupLabel("front")).toContain("0");
+    expect(sparGroupLabel("rear")).toContain("Rear");
+    expect(sparGroupLabel("reinforcement")).toContain("reinforcement");
+  });
+
+  it("jointLabel maps tokens to readable phrases", () => {
+    expect(jointLabel(null)).toBe("Continuous");
+    expect(jointLabel("telescoping")).toBe("Telescoping");
+    expect(jointLabel("bent-pin")).toBe("Bent-pin");
+    expect(jointLabel("reinforcement+joiner")).toBe("Reinforcement + joiner");
+    expect(jointLabel("weird")).toBe("weird");
+  });
+
+  it("pieceDimsLabel shows OD, ID and computed wall in mm", () => {
+    const piece: SparPieceOut = {
+      role: "front",
+      spare_origin: [0, 0, 0],
+      spare_vector: [0, 1, 0],
+      outer_d: 0.0288,
+      inner_d: 0.024,
+      wall: 0.0024,
+      shape: "tube",
+      governing_y: 0,
+      utilisation: 0.5,
+      joint_to_next: null,
+      feasible: true,
+      infeasibility_reason: null,
+    };
+    const label = pieceDimsLabel(piece);
+    expect(label).toContain("OD 28.8");
+    expect(label).toContain("ID 24.0");
+    expect(label).toContain("wall 2.4");
+  });
+
+  it("pieceDimsLabel computes wall from OD/ID when wall missing", () => {
+    const piece = {
+      role: "front",
+      spare_origin: [0, 0, 0],
+      spare_vector: [0, 1, 0],
+      outer_d: 0.02,
+      inner_d: 0.01,
+      shape: "tube",
+      governing_y: 0,
+      utilisation: 0.5,
+      joint_to_next: null,
+      feasible: true,
+      infeasibility_reason: null,
+    } as unknown as SparPieceOut;
+    expect(pieceDimsLabel(piece)).toContain("wall 5.0");
+  });
+});
+
+describe("touchedSegments + replaceWarning", () => {
+  function planned(seg: number): PlannedSpareOut {
+    return {
+      segment_index: seg,
+      spar_index: 0,
+      role: "front",
+      spare_support_dimension_width: 0.02,
+      spare_support_dimension_height: 0.02,
+      spare_length: 0.5,
+      outer_d: 0.02,
+      inner_d: 0.0,
+      spare_origin: [0, 0, 0],
+      spare_vector: [0, 1, 0],
+      joint_note: null,
+      feasible: true,
+    };
+  }
+
+  it("returns sorted unique segment indices", () => {
+    expect(touchedSegments([planned(2), planned(0), planned(2), planned(1)])).toEqual([
+      0, 1, 2,
+    ]);
+  });
+
+  it("replaceWarning lists touched segments (plural)", () => {
+    expect(replaceWarning([planned(0), planned(1)])).toBe(
+      "This replaces existing spars in segments 0, 1.",
+    );
+  });
+
+  it("replaceWarning is singular for one segment", () => {
+    expect(replaceWarning([planned(3)])).toBe(
+      "This replaces existing spars in segment 3.",
+    );
+  });
+
+  it("replaceWarning is null when nothing is touched", () => {
+    expect(replaceWarning([])).toBeNull();
+    expect(touchedSegments([])).toEqual([]);
+  });
+});

--- a/frontend/__tests__/useSparPlan.test.ts
+++ b/frontend/__tests__/useSparPlan.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Unit tests for the useSparPlan hook (gh-1050).
+ *
+ * Mirrors useSparSizing: manual fetch-based POSTs to
+ *   - /aeroplanes/{id}/spar-plan          (run → buildable pieces)
+ *   - /aeroplanes/{id}/spar-plan/insert   (insert → dry_run preview / commit)
+ * Pins URL + request bodies, data passthrough, dry_run flag, and the
+ * loading/error state machine.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import {
+  useSparPlan,
+  type SparPlanParams,
+  type SparPlanResult,
+  type SparInsertResult,
+} from "@/hooks/useSparPlan";
+
+const FAKE_PLAN: SparPlanResult = {
+  front_pieces: [
+    {
+      role: "front",
+      spare_origin: [0, 0, 0],
+      spare_vector: [0, 1, 0],
+      outer_d: 0.0288,
+      inner_d: 0.024,
+      wall: 0.0024,
+      shape: "tube",
+      governing_y: 0,
+      utilisation: 0.5,
+      joint_to_next: "telescoping",
+      feasible: true,
+      infeasibility_reason: null,
+    },
+  ],
+  rear_pieces: [],
+  front_joint: "continuous",
+  rear_joint: "continuous",
+  reinforcement: null,
+  feasible: true,
+  infeasibility_reason: null,
+};
+
+const FAKE_INSERT: SparInsertResult = {
+  dry_run: true,
+  committed: false,
+  wing_name: "Main Wing",
+  planned_spares: [
+    {
+      segment_index: 0,
+      spar_index: 0,
+      role: "front",
+      spare_support_dimension_width: 0.0288,
+      spare_support_dimension_height: 0.0288,
+      spare_length: 0.75,
+      outer_d: 0.0288,
+      inner_d: 0.024,
+      spare_origin: [0, 0, 0],
+      spare_vector: [0, 1, 0],
+      joint_note: "telescoping",
+      feasible: true,
+    },
+  ],
+  warnings: [],
+  feasible: true,
+  infeasibility_reason: null,
+};
+
+const BASE: SparPlanParams = {
+  material_id: 7,
+  moments: [
+    { y_span: 0, bending_moment_Nm: 100 },
+    { y_span: 1, bending_moment_Nm: 0 },
+  ],
+};
+
+function okResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("useSparPlan (gh-1050)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not fetch and stays idle when aeroplaneId is null", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch");
+    const { result } = renderHook(() => useSparPlan(null));
+    await act(async () => {
+      await result.current.run(BASE);
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.current.plan).toBeNull();
+    expect(result.current.isRunning).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("POSTs to spar-plan with material_id + moments and passes data through", async () => {
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(okResponse(FAKE_PLAN));
+    const { result } = renderHook(() => useSparPlan("aero-1"));
+    await act(async () => {
+      await result.current.run(BASE);
+    });
+    const [url, options] = fetchSpy.mock.calls[0];
+    const u = new URL(String(url), "http://x");
+    expect(u.pathname).toContain("/aeroplanes/aero-1/spar-plan");
+    expect(options).toMatchObject({ method: "POST" });
+    const body = JSON.parse(options!.body as string);
+    expect(body.material_id).toBe(7);
+    expect(body.moments).toHaveLength(2);
+    expect(result.current.plan).toEqual(FAKE_PLAN);
+    expect(result.current.error).toBeNull();
+    expect(result.current.isRunning).toBe(false);
+  });
+
+  it("includes optional plan params when set", async () => {
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(okResponse(FAKE_PLAN));
+    const { result } = renderHook(() => useSparPlan("aero-1"));
+    await act(async () => {
+      await result.current.run({
+        ...BASE,
+        wing_name: "Main Wing",
+        safety_factor_j: 2,
+        packing_factor: 0.7,
+        sigma_allow_mpa_override: 350,
+        n_span: 8,
+      });
+    });
+    const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+    expect(body.wing_name).toBe("Main Wing");
+    expect(body.safety_factor_j).toBe(2);
+    expect(body.packing_factor).toBe(0.7);
+    expect(body.sigma_allow_mpa_override).toBe(350);
+    expect(body.n_span).toBe(8);
+  });
+
+  it("surfaces a plan 422 error readably and clears the plan", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({ error: { message: "infeasible plan" } }),
+        { status: 422, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const { result } = renderHook(() => useSparPlan("aero-1"));
+    await act(async () => {
+      await result.current.run(BASE);
+    });
+    expect(result.current.error).toContain("Spar plan — invalid request");
+    expect(result.current.error).toContain("infeasible plan");
+    expect(result.current.plan).toBeNull();
+  });
+
+  it("captures a throwing fetch on run as an error string", async () => {
+    vi.spyOn(global, "fetch").mockRejectedValue(new Error("network down"));
+    const { result } = renderHook(() => useSparPlan("aero-1"));
+    await act(async () => {
+      await result.current.run(BASE);
+    });
+    expect(result.current.error).toBe("network down");
+    expect(result.current.plan).toBeNull();
+  });
+
+  it("insert sends dry_run=true for a preview and returns the result", async () => {
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(okResponse(FAKE_INSERT));
+    const { result } = renderHook(() => useSparPlan("aero-1"));
+    let res: SparInsertResult | null = null;
+    await act(async () => {
+      res = await result.current.insert(BASE, true);
+    });
+    const [url, options] = fetchSpy.mock.calls[0];
+    const u = new URL(String(url), "http://x");
+    expect(u.pathname).toContain("/aeroplanes/aero-1/spar-plan/insert");
+    const body = JSON.parse(options!.body as string);
+    expect(body.dry_run).toBe(true);
+    expect(body.material_id).toBe(7);
+    expect(res).toEqual(FAKE_INSERT);
+  });
+
+  it("insert sends dry_run=false to commit", async () => {
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(okResponse({ ...FAKE_INSERT, committed: true, dry_run: false }));
+    const { result } = renderHook(() => useSparPlan("aero-1"));
+    let res: SparInsertResult | null = null;
+    await act(async () => {
+      res = await result.current.insert(BASE, false);
+    });
+    const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+    expect(body.dry_run).toBe(false);
+    expect(res!.committed).toBe(true);
+  });
+
+  it("insert rejects (throws) on a non-ok response", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: { message: "boom" } }), {
+        status: 422,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const { result } = renderHook(() => useSparPlan("aero-1"));
+    await expect(result.current.insert(BASE, false)).rejects.toThrow(/boom/);
+  });
+
+  it("insert throws when there is no aeroplane", async () => {
+    const { result } = renderHook(() => useSparPlan(null));
+    await expect(result.current.insert(BASE, true)).rejects.toThrow(
+      /No aeroplane/,
+    );
+  });
+});

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useRef, useEffect } from "react";
+import { useState, useMemo, useRef, useEffect, useCallback } from "react";
 import { AlertTriangle, Loader2, Maximize2, Minimize2, Settings } from "lucide-react";
 import type { AnalysisResult } from "@/hooks/useAnalysis";
 import type { StripForcesResult } from "@/hooks/useStripForces";
@@ -17,6 +17,9 @@ import type { SpanwiseLoadsResult } from "@/hooks/useSpanwiseLoads";
 import { SparSizingPanel, toSizingParams } from "@/components/workbench/SparSizingPanel";
 import type { SparSizingInputs } from "@/components/workbench/SparSizingPanel";
 import { useSparSizing } from "@/hooks/useSparSizing";
+import { useSparPlan, type SparPlanParams } from "@/hooks/useSparPlan";
+import { buildMomentsFromLoads } from "@/lib/sparPlanHelpers";
+import { useSWRConfig } from "swr";
 
 const TABS = ["Assumptions", "Operating Points", "Polar", "Trefftz Plane", "Spanwise Loads", "Streamlines", "Envelope", "Sizing"] as const;
 export type Tab = (typeof TABS)[number];
@@ -1070,10 +1073,19 @@ export function SpanwiseLoadsTabContent({
   const { result: sizingResult, isRunning: sizingRunning, error: sizingError, run: runSizing } =
     useSparSizing(aeroplaneId ?? null);
 
+  // gh-1050: buildable two-spar plan + preview→commit insert into the wing.
+  const { plan, run: runPlan, insert: insertPlan } = useSparPlan(aeroplaneId ?? null);
+  const { mutate } = useSWRConfig();
+  // Remember the sizing inputs the user last computed with so the plan + insert
+  // reuse the SAME material / safety / packing / sigma knobs.
+  const lastSizingParamsRef = useRef<SparPlanParams | null>(null);
+
   // g_limit comes from the first spar sizing result (after first compute)
   const firstSizing = sizingResult?.spar_sizing?.[0] ?? null;
   const gLimit = firstSizing?.g_limit ?? null;
   const gLimitFallback = firstSizing?.g_limit_fallback ?? false;
+  // The wing the plan/insert targets — the first surface (main wing).
+  const planWingName = spanwiseLoads?.surfaces?.[0]?.surface_name ?? null;
 
   const handleSparCompute = (inputs: SparSizingInputs) => {
     if (!spanwiseLoads) return;
@@ -1091,7 +1103,42 @@ export function SpanwiseLoadsTabContent({
       xyz_ref: [0, 0, 0],
     };
     runSizing(opParams, sizingParams);
+
+    // gh-1050: also compute the buildable plan from the SAME inputs. The
+    // moments distribution comes from the already-displayed spanwise loads
+    // M(y) — normalised to a 0..1 span fraction (buildMomentsFromLoads).
+    const moments = buildMomentsFromLoads(spanwiseLoads);
+    if (moments) {
+      const planParams: SparPlanParams = {
+        material_id: sizingParams.material_id,
+        moments,
+        wing_name: planWingName,
+        safety_factor_j: sizingParams.safety_factor_j,
+        packing_factor: sizingParams.packing_factor,
+        sigma_allow_mpa_override: sizingParams.sigma_allow_mpa_override ?? null,
+      };
+      lastSizingParamsRef.current = planParams;
+      runPlan(planParams);
+    }
   };
+
+  const handleInsert = useCallback(
+    (dryRun: boolean) => {
+      const params = lastSizingParamsRef.current;
+      if (!params) {
+        return Promise.reject(new Error("Compute the spar plan first"));
+      }
+      return insertPlan(params, dryRun);
+    },
+    [insertPlan],
+  );
+
+  const handleSparInserted = useCallback(() => {
+    // Refresh the wing construction so the new spares show in the tree / CAD.
+    if (!aeroplaneId || !planWingName) return;
+    mutate(`/aeroplanes/${aeroplaneId}/wings/${planWingName}/wingconfig`);
+    mutate(`/aeroplanes/${aeroplaneId}/wings/${planWingName}`);
+  }, [aeroplaneId, planWingName, mutate]);
 
   if (spanwiseLoadsLoading) {
     return (
@@ -1120,6 +1167,9 @@ export function SpanwiseLoadsTabContent({
           onCompute={handleSparCompute}
           gLimit={gLimit}
           gLimitFallback={gLimitFallback}
+          plan={plan}
+          onInsert={handleInsert}
+          onSparInserted={handleSparInserted}
         />
       </div>
     );

--- a/frontend/components/workbench/SparSizingPanel.tsx
+++ b/frontend/components/workbench/SparSizingPanel.tsx
@@ -11,9 +11,14 @@
  */
 
 import { useState, useCallback } from "react";
-import { ChevronDown, ChevronRight, AlertTriangle } from "lucide-react";
+import { ChevronDown, ChevronRight, AlertTriangle, Loader2 } from "lucide-react";
 
 import type { SparShape, SparSizingResult, SparSizingStation } from "@/hooks/useSparSizing";
+import type {
+  SparPlanResult,
+  SparPieceOut,
+  SparInsertResult,
+} from "@/hooks/useSparPlan";
 import { useComponents } from "@/hooks/useComponents";
 import {
   filterStructuralMaterials,
@@ -23,6 +28,13 @@ import {
   buildRootHeadline,
   buildMassSummary,
 } from "@/lib/sparSizingHelpers";
+import {
+  sparGroupLabel,
+  jointLabel,
+  pieceDimsLabel,
+  mToMm,
+  replaceWarning,
+} from "@/lib/sparPlanHelpers";
 
 // ---- Types -----------------------------------------------------------------
 
@@ -51,6 +63,15 @@ export interface SparSizingPanelProps {
   gLimit?: number | null;
   /** True when g_limit is a fallback default. */
   gLimitFallback?: boolean;
+  /** gh-1050: buildable spar plan (front/rear/reinforcement), or null. */
+  plan?: SparPlanResult | null;
+  /**
+   * gh-1050: insert the plan into the wing. dry_run=true → preview,
+   * dry_run=false → commit. When omitted, the "Add spar to wing" UI is hidden.
+   */
+  onInsert?: (dryRun: boolean) => Promise<SparInsertResult>;
+  /** gh-1050: called after a successful commit so the parent can refresh the tree. */
+  onSparInserted?: () => void;
 }
 
 // ---- Helpers ---------------------------------------------------------------
@@ -148,6 +169,295 @@ function SizingResultCard({ result }: { result: SparSizingResult }) {
   );
 }
 
+// ---- Built-spar display (gh-1050) ------------------------------------------
+
+/** One buildable piece row: dims (OD×ID×wall), joint, feasibility. */
+function BuiltSparPieceRow({
+  piece,
+  index,
+}: {
+  piece: SparPieceOut;
+  index: number;
+}) {
+  return (
+    <div
+      className="flex flex-wrap items-center gap-x-3 gap-y-0.5 border-b border-border/20 px-2 py-1 text-[12px] font-[family-name:var(--font-jetbrains-mono)]"
+      data-testid="built-spar-piece"
+    >
+      <span className="text-muted-foreground">#{index + 1}</span>
+      <span className="tabular-nums text-foreground">{pieceDimsLabel(piece)}</span>
+      <span className="text-muted-foreground">
+        joint: {jointLabel(piece.joint_to_next)}
+      </span>
+      <span className={piece.feasible ? "text-green-400" : "text-yellow-400"}>
+        {piece.feasible ? "OK" : (piece.infeasibility_reason ?? "infeasible")}
+      </span>
+    </div>
+  );
+}
+
+/** A spar group (front / rear / reinforcement) with its labelled pieces. */
+function BuiltSparGroup({
+  group,
+  pieces,
+}: {
+  group: "front" | "rear" | "reinforcement";
+  pieces: SparPieceOut[];
+}) {
+  if (pieces.length === 0) return null;
+  return (
+    <div className="space-y-0.5" data-testid={`built-spar-group-${group}`}>
+      <p
+        className={`text-[12px] font-[family-name:var(--font-jetbrains-mono)] ${
+          group === "front" ? "text-[#FF8400]" : "text-muted-foreground"
+        }`}
+      >
+        {sparGroupLabel(group)}
+      </p>
+      {pieces.map((p, i) => (
+        <BuiltSparPieceRow key={i} piece={p} index={i} />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Buildable-spar display: the two-spar plan grouped Front (main, index 0) /
+ * Rear / Reinforcement, each piece as OD × ID (wall) × length in mm, with
+ * joint type + feasibility. Exported for direct unit testing.
+ */
+export function BuiltSparSection({ plan }: { plan: SparPlanResult }) {
+  return (
+    <div
+      className="rounded border border-border/40 bg-card p-3 text-[13px] space-y-3"
+      data-testid="built-spar-section"
+    >
+      <p className="font-[family-name:var(--font-jetbrains-mono)] text-xs text-foreground">
+        Built spar (buildable pieces)
+      </p>
+      {!plan.feasible && (
+        <div
+          className="flex items-start gap-1 rounded bg-yellow-900/20 px-2 py-1 text-xs text-yellow-400"
+          data-testid="built-spar-infeasible"
+        >
+          <AlertTriangle size={12} className="mt-0.5 shrink-0" />
+          <span>{plan.infeasibility_reason ?? "Plan is not buildable as-is."}</span>
+        </div>
+      )}
+      <BuiltSparGroup group="front" pieces={plan.front_pieces} />
+      <BuiltSparGroup group="rear" pieces={plan.rear_pieces} />
+      <BuiltSparGroup
+        group="reinforcement"
+        pieces={plan.reinforcement ? [plan.reinforcement] : []}
+      />
+    </div>
+  );
+}
+
+// ---- Add-spar-to-wing preview → confirm flow (gh-1050) ---------------------
+
+export interface AddSparToWingFlowProps {
+  /** The buildable plan. Button is disabled when the plan is infeasible. */
+  plan: SparPlanResult;
+  /** dry_run=true → preview; dry_run=false → commit. Returns the result or throws. */
+  onInsert: (dryRun: boolean) => Promise<SparInsertResult>;
+  /** Called after a successful commit so the parent can refresh the wing/tree. */
+  onCommitted?: () => void;
+}
+
+/**
+ * "Add spar to wing" button → dry-run preview modal (per planned spare:
+ * segment, spar_index, dims, placement, joint) with a REPLACE warning →
+ * user confirm → commit. Exported for direct unit testing.
+ */
+export function AddSparToWingFlow({
+  plan,
+  onInsert,
+  onCommitted,
+}: AddSparToWingFlowProps) {
+  const [preview, setPreview] = useState<SparInsertResult | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [committed, setCommitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const openPreview = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    setCommitted(false);
+    try {
+      const res = await onInsert(true);
+      setPreview(res);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [onInsert]);
+
+  const confirm = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await onInsert(false);
+      setCommitted(true);
+      setPreview(null);
+      onCommitted?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [onInsert, onCommitted]);
+
+  const close = useCallback(() => {
+    setPreview(null);
+    setError(null);
+  }, []);
+
+  const warning = preview ? replaceWarning(preview.planned_spares) : null;
+
+  return (
+    <div className="space-y-2">
+      <button
+        className="rounded border border-[#FF8400] px-3 py-1.5 text-[12px] font-[family-name:var(--font-jetbrains-mono)] text-[#FF8400] hover:bg-[#FF8400]/10 disabled:opacity-40"
+        onClick={openPreview}
+        disabled={!plan.feasible || busy}
+        data-testid="add-spar-to-wing-button"
+        title={
+          plan.feasible ? undefined : "Plan is infeasible — cannot add to wing"
+        }
+      >
+        {busy && !preview ? "Loading preview…" : "Add spar to wing"}
+      </button>
+
+      {committed && (
+        <p
+          className="rounded bg-green-900/30 px-2 py-1 text-[12px] text-green-400 font-[family-name:var(--font-jetbrains-mono)]"
+          data-testid="add-spar-success"
+        >
+          Spar added to the wing.
+        </p>
+      )}
+
+      {error && !preview && (
+        <p
+          className="rounded bg-red-900/30 px-2 py-1 text-[12px] text-red-400 font-[family-name:var(--font-jetbrains-mono)]"
+          data-testid="add-spar-error"
+        >
+          {error}
+        </p>
+      )}
+
+      {preview && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+          data-testid="add-spar-preview-modal"
+        >
+          <div className="max-h-[80vh] w-full max-w-2xl overflow-auto rounded-lg border border-border bg-card p-5 space-y-4">
+            <h3 className="font-[family-name:var(--font-jetbrains-mono)] text-[14px] text-foreground">
+              Add spar to {preview.wing_name}
+            </h3>
+
+            {warning && (
+              <div
+                className="flex items-start gap-1 rounded bg-yellow-900/20 px-2 py-1.5 text-[12px] text-yellow-400"
+                data-testid="add-spar-replace-warning"
+              >
+                <AlertTriangle size={14} className="mt-0.5 shrink-0" />
+                <span>{warning}</span>
+              </div>
+            )}
+
+            {preview.warnings.length > 0 && (
+              <ul className="space-y-0.5" data-testid="add-spar-warnings">
+                {preview.warnings.map((w, i) => (
+                  <li
+                    key={i}
+                    className="text-[11px] text-yellow-400 font-[family-name:var(--font-jetbrains-mono)]"
+                  >
+                    • {w}
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[520px] border-collapse text-left">
+                <thead>
+                  <tr className="border-b border-border/50 text-[11px] text-muted-foreground font-[family-name:var(--font-jetbrains-mono)]">
+                    <th className="px-2 py-1">segment</th>
+                    <th className="px-2 py-1">spar_index</th>
+                    <th className="px-2 py-1">role</th>
+                    <th className="px-2 py-1">OD × ID (mm)</th>
+                    <th className="px-2 py-1">length (mm)</th>
+                    <th className="px-2 py-1">joint</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {preview.planned_spares.map((sp, i) => (
+                    <tr
+                      key={i}
+                      className="border-b border-border/30 font-[family-name:var(--font-jetbrains-mono)] text-[12px]"
+                      data-testid="planned-spare-row"
+                    >
+                      <td className="px-2 py-1 tabular-nums">{sp.segment_index}</td>
+                      <td
+                        className={`px-2 py-1 tabular-nums ${
+                          sp.spar_index === 0 ? "font-bold text-[#FF8400]" : ""
+                        }`}
+                      >
+                        {sp.spar_index}
+                        {sp.spar_index === 0 ? " (main)" : ""}
+                      </td>
+                      <td className="px-2 py-1">{sp.role}</td>
+                      <td className="px-2 py-1 tabular-nums">
+                        {mToMm(sp.outer_d)} × {mToMm(sp.inner_d)}
+                      </td>
+                      <td className="px-2 py-1 tabular-nums">
+                        {mToMm(sp.spare_length, 0)}
+                      </td>
+                      <td className="px-2 py-1">{jointLabel(sp.joint_note)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {error && (
+              <p
+                className="rounded bg-red-900/30 px-2 py-1 text-[12px] text-red-400 font-[family-name:var(--font-jetbrains-mono)]"
+                data-testid="add-spar-preview-error"
+              >
+                {error}
+              </p>
+            )}
+
+            <div className="flex items-center justify-end gap-2">
+              <button
+                className="rounded border border-border px-3 py-1.5 text-[12px] font-[family-name:var(--font-jetbrains-mono)] text-foreground hover:bg-card-muted/50"
+                onClick={close}
+                disabled={busy}
+                data-testid="add-spar-cancel"
+              >
+                Cancel
+              </button>
+              <button
+                className="flex items-center gap-1.5 rounded bg-[#FF8400] px-3 py-1.5 text-[12px] font-[family-name:var(--font-jetbrains-mono)] text-black hover:bg-[#FF8400]/80 disabled:opacity-50"
+                onClick={confirm}
+                disabled={busy || !preview.feasible}
+                data-testid="add-spar-confirm"
+              >
+                {busy && <Loader2 size={12} className="animate-spin" />}
+                Confirm &amp; add
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ---- Main Component --------------------------------------------------------
 
 /** Exported for unit testing (pure display layer). */
@@ -158,6 +468,9 @@ export function SparSizingPanel({
   onCompute,
   gLimit,
   gLimitFallback = false,
+  plan = null,
+  onInsert,
+  onSparInserted,
 }: SparSizingPanelProps) {
   const [open, setOpen] = useState(false);
   const [inputs, setInputs] = useState<SparSizingInputs>({
@@ -374,6 +687,20 @@ export function SparSizingPanel({
               {sizingResults.map((r, i) => (
                 <SizingResultCard key={i} result={r} />
               ))}
+            </div>
+          )}
+
+          {/* gh-1050: Built spar (buildable pieces) + Add to wing */}
+          {plan && (
+            <div className="space-y-3" data-testid="built-spar-block">
+              <BuiltSparSection plan={plan} />
+              {onInsert && (
+                <AddSparToWingFlow
+                  plan={plan}
+                  onInsert={onInsert}
+                  onCommitted={onSparInserted}
+                />
+              )}
             </div>
           )}
         </div>

--- a/frontend/hooks/useSparPlan.ts
+++ b/frontend/hooks/useSparPlan.ts
@@ -1,0 +1,173 @@
+// frontend/hooks/useSparPlan.ts
+// gh-1050: Buildable spar plan + preview→commit insert into the wing.
+//
+// Two manual fetch-based POSTs (mirroring useSparSizing):
+//   - run()    → POST /aeroplanes/{id}/spar-plan          (buildable pieces)
+//   - insert() → POST /aeroplanes/{id}/spar-plan/insert   (dry_run preview / commit)
+//
+// All dimensions in the responses are in METRES (project convention).
+
+"use client";
+
+import { useState, useCallback } from "react";
+import { API_BASE } from "@/lib/fetcher";
+import { parseApiError } from "@/lib/parseApiError";
+
+// ---- Request types (mirror app/schemas/spar_plan.py + spar_insert.py) -------
+
+export interface MomentSample {
+  y_span: number; // 0..1 across the semi-span (root=0, tip=1)
+  bending_moment_Nm: number;
+}
+
+export interface SparPlanParams {
+  material_id: number;
+  moments: MomentSample[];
+  wing_name?: string | null;
+  front_x_over_chord?: number | null;
+  rear_x_over_chord?: number;
+  n_span?: number;
+  packing_factor?: number;
+  safety_factor_j?: number;
+  sigma_allow_mpa_override?: number | null;
+}
+
+// ---- Response types: spar-plan (buildable pieces, metres) -------------------
+
+export interface SparPieceOut {
+  role: string; // "front" | "rear"
+  spare_origin: number[];
+  spare_vector: number[];
+  outer_d: number; // m
+  inner_d: number; // m
+  wall: number; // m
+  shape: string;
+  governing_y: number; // m
+  utilisation: number;
+  joint_to_next: string | null;
+  feasible: boolean;
+  infeasibility_reason: string | null;
+}
+
+export interface SparPlanResult {
+  front_pieces: SparPieceOut[];
+  rear_pieces: SparPieceOut[];
+  front_joint: string;
+  rear_joint: string;
+  reinforcement: SparPieceOut | null;
+  feasible: boolean;
+  infeasibility_reason: string | null;
+}
+
+// ---- Response types: insert (planned spares, metres) -----------------------
+
+export interface PlannedSpareOut {
+  segment_index: number;
+  spar_index: number;
+  role: string;
+  spare_support_dimension_width: number; // m (= outer_d)
+  spare_support_dimension_height: number; // m (= outer_d)
+  spare_length: number; // m
+  outer_d: number; // m
+  inner_d: number; // m
+  spare_origin: number[];
+  spare_vector: number[];
+  joint_note: string | null;
+  feasible: boolean;
+}
+
+export interface SparInsertResult {
+  dry_run: boolean;
+  committed: boolean;
+  wing_name: string;
+  planned_spares: PlannedSpareOut[];
+  warnings: string[];
+  feasible: boolean;
+  infeasibility_reason: string | null;
+}
+
+// ---- Body builder (shared by run + insert) ---------------------------------
+
+function buildPlanBody(params: SparPlanParams): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    material_id: params.material_id,
+    moments: params.moments,
+  };
+  if (params.wing_name != null) body.wing_name = params.wing_name;
+  if (params.front_x_over_chord != null)
+    body.front_x_over_chord = params.front_x_over_chord;
+  if (params.rear_x_over_chord != null)
+    body.rear_x_over_chord = params.rear_x_over_chord;
+  if (params.n_span != null) body.n_span = params.n_span;
+  if (params.packing_factor != null) body.packing_factor = params.packing_factor;
+  if (params.safety_factor_j != null)
+    body.safety_factor_j = params.safety_factor_j;
+  if (params.sigma_allow_mpa_override != null)
+    body.sigma_allow_mpa_override = params.sigma_allow_mpa_override;
+  return body;
+}
+
+// ---- Hook ------------------------------------------------------------------
+
+export function useSparPlan(aeroplaneId: string | null) {
+  const [plan, setPlan] = useState<SparPlanResult | null>(null);
+  const [isRunning, setIsRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = useCallback(
+    async (params: SparPlanParams) => {
+      if (!aeroplaneId) return;
+      setIsRunning(true);
+      setError(null);
+      setPlan(null);
+
+      try {
+        const res = await fetch(`${API_BASE}/aeroplanes/${aeroplaneId}/spar-plan`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(buildPlanBody(params)),
+        });
+        if (!res.ok) {
+          throw new Error(await parseApiError(res, "Spar plan"));
+        }
+        const data: SparPlanResult = await res.json();
+        setPlan(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setIsRunning(false);
+      }
+    },
+    [aeroplaneId],
+  );
+
+  // insert: dry_run=true → preview (no writes); dry_run=false → persist.
+  // Returns the result (or null on error). Errors are also surfaced on the
+  // returned promise so the caller can branch on success.
+  const insert = useCallback(
+    async (
+      params: SparPlanParams,
+      dryRun: boolean,
+    ): Promise<SparInsertResult> => {
+      if (!aeroplaneId) {
+        throw new Error("No aeroplane selected");
+      }
+      const body = { ...buildPlanBody(params), dry_run: dryRun };
+      const res = await fetch(
+        `${API_BASE}/aeroplanes/${aeroplaneId}/spar-plan/insert`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        },
+      );
+      if (!res.ok) {
+        throw new Error(await parseApiError(res, "Spar insert"));
+      }
+      return (await res.json()) as SparInsertResult;
+    },
+    [aeroplaneId],
+  );
+
+  return { plan, isRunning, error, run, insert };
+}

--- a/frontend/lib/sparPlanHelpers.ts
+++ b/frontend/lib/sparPlanHelpers.ts
@@ -1,0 +1,130 @@
+// frontend/lib/sparPlanHelpers.ts
+// gh-1050: Pure helpers for the buildable-spar plan display + insert preview.
+// Side-effect-free and DOM-free so they can be unit-tested directly.
+
+import type { SpanwiseLoadsResult } from "@/hooks/useSpanwiseLoads";
+import type {
+  MomentSample,
+  PlannedSpareOut,
+  SparPieceOut,
+} from "@/hooks/useSparPlan";
+
+// ---- Moments distribution from spanwise loads ------------------------------
+
+/**
+ * Build the spanwise bending-moment distribution (root→tip) the spar-plan
+ * endpoint expects, from the already-computed spanwise-loads result.
+ *
+ * The loads result exposes M(y) per strip on the starboard half of each
+ * surface as { y_m, bending_moment_Nm }. The spar-plan request wants
+ * y_span as a 0..1 span fraction, so we normalise y_m by the outermost
+ * (max) y_m of the chosen surface. Magnitudes are used (|M|) because the
+ * spar is sized on the bending-moment magnitude.
+ *
+ * Returns null when there is no usable distribution (no surfaces / strips /
+ * zero span), so the caller can keep the plan disabled.
+ */
+export function buildMomentsFromLoads(
+  loads: SpanwiseLoadsResult | null | undefined,
+  surfaceIndex = 0,
+): MomentSample[] | null {
+  const surf = loads?.surfaces?.[surfaceIndex];
+  if (!surf || surf.starboard.length === 0) return null;
+
+  const entries = [...surf.starboard].sort((a, b) => a.y_m - b.y_m);
+  const maxY = Math.max(...entries.map((e) => Math.abs(e.y_m)));
+  if (!Number.isFinite(maxY) || maxY <= 0) return null;
+
+  return entries.map((e) => ({
+    y_span: Math.min(1, Math.max(0, Math.abs(e.y_m) / maxY)),
+    bending_moment_Nm: Math.abs(e.bending_moment_Nm),
+  }));
+}
+
+// ---- Built-spar piece formatting -------------------------------------------
+
+/** Metres → millimetres, rounded for display. */
+export function mToMm(m: number, digits = 1): string {
+  return (m * 1000).toFixed(digits);
+}
+
+/**
+ * Human label for a spar group. The FRONT spar is the structural main spar
+ * (spar_index 0); call this out explicitly.
+ */
+export function sparGroupLabel(
+  group: "front" | "rear" | "reinforcement",
+): string {
+  switch (group) {
+    case "front":
+      return "Front (main spar · index 0)";
+    case "rear":
+      return "Rear (torsion spar · index 1)";
+    case "reinforcement":
+      return "Root reinforcement";
+  }
+}
+
+/**
+ * Human label for a joint type between/at spar pieces.
+ * Maps the backend's terse tokens to a readable phrase, falling back to the
+ * raw token for anything unknown.
+ */
+export function jointLabel(joint: string | null | undefined): string {
+  if (joint == null || joint === "") return "Continuous";
+  switch (joint) {
+    case "continuous":
+      return "Continuous";
+    case "telescoping":
+      return "Telescoping";
+    case "bent-pin":
+      return "Bent-pin";
+    case "reinforcement+joiner":
+      return "Reinforcement + joiner";
+    default:
+      return joint;
+  }
+}
+
+/**
+ * One-line dimension summary for a buildable piece:
+ * "OD 28.8 × ID 24.0 (wall 2.4) × L 750 mm".
+ * Wall is computed from OD/ID when the piece's wall is absent.
+ */
+export function pieceDimsLabel(piece: SparPieceOut): string {
+  const od = mToMm(piece.outer_d);
+  const id = mToMm(piece.inner_d);
+  const wall =
+    piece.wall != null && Number.isFinite(piece.wall)
+      ? piece.wall
+      : (piece.outer_d - piece.inner_d) / 2;
+  const wallStr = mToMm(wall);
+  // length is the run-length along spare_vector; not on the piece schema, so
+  // pieces show OD/ID/wall only (length lives on the planned-spare preview).
+  return `OD ${od} × ID ${id} (wall ${wallStr}) mm`;
+}
+
+// ---- Insert-preview: REPLACE warning ---------------------------------------
+
+/**
+ * The set of target segment indices a planned insert touches, sorted.
+ * Committing REPLACES every existing spar in these segments, so the preview
+ * must warn the user about exactly these segments.
+ */
+export function touchedSegments(planned: PlannedSpareOut[]): number[] {
+  const set = new Set<number>();
+  for (const p of planned) set.add(p.segment_index);
+  return [...set].sort((a, b) => a - b);
+}
+
+/**
+ * The REPLACE warning sentence for the preview, or null when nothing is
+ * touched. English UI per project convention.
+ */
+export function replaceWarning(planned: PlannedSpareOut[]): string | null {
+  const segs = touchedSegments(planned);
+  if (segs.length === 0) return null;
+  const list = segs.join(", ");
+  const noun = segs.length === 1 ? "segment" : "segments";
+  return `This replaces existing spars in ${noun} ${list}.`;
+}


### PR DESCRIPTION
## Summary
Adds a **Built spar** display and an **Add spar to wing** preview→confirm flow to the `SparSizingPanel` (Spanwise Loads tab). Builds on the merged #1049 insert endpoint and #1031 spar-plan endpoint.

## What's new
- **`useSparPlan` hook** — `POST /aeroplanes/{id}/spar-plan` (buildable pieces) + `POST /aeroplanes/{id}/spar-plan/insert` with `dry_run` (preview / commit), mirroring `useSparSizing`'s fetch/error pattern.
- **`sparPlanHelpers`** — `buildMomentsFromLoads` derives the spanwise `moments` distribution from the already-displayed spanwise-loads M(y) (`|M|`, `y` normalised to a 0..1 span fraction); display helpers (group/joint labels, OD×ID×wall, REPLACE warning).
- **`BuiltSparSection`** — renders the two-spar plan grouped **Front (main spar · index 0)** / **Rear** / **Reinforcement**, each piece as `OD × ID (wall) mm` with joint type (continuous / telescoping / bent-pin / reinforcement+joiner) + feasibility. Front clearly labelled as the main spar.
- **`AddSparToWingFlow`** — button disabled when the plan is infeasible; click → **dry-run preview** modal (`fixed inset-0 z-50`) listing per planned spare: segment, **spar_index** (front=0 highlighted as "(main)"), dims, length, joint — plus an explicit **"This replaces existing spars in segment(s) X, Y"** warning derived from the touched segments. Confirm → **commit**, success/error feedback, modal closes.
- **`AnalysisViewerPanel`** wiring — computes the plan from the SAME material/safety/packing/σ the user sizes with, sources `moments` from the displayed loads, and mutates the `wingconfig` / `wing` SWR keys after commit so the construction tree refreshes.

## Sourcing the `moments` distribution
The spanwise-loads result already exposes `surfaces[].starboard[]` as `{ y_m, bending_moment_Nm }`. `buildMomentsFromLoads` takes the main (first) surface, sorts root→tip, normalises `|y_m|` by the max to a 0..1 span fraction, and uses `|M|`. Same operating point as the sizing compute (gh-1008), no extra request.

## Tests
vitest — 45 spar tests (new + existing) green; full suite **2282 passed**. tsc + eslint clean on changed files. New `useSparPlan.ts` 95% / `sparPlanHelpers.ts` 97% statement coverage. Covers dry_run preview (REPLACE warning + spar_index, front=0), confirm→commit, feasibility gating, and error paths.

Closes #1050

🤖 Generated with [Claude Code](https://claude.com/claude-code)