### PR TITLE
fix(gh-1053): preserve solved normal-mode spar origin/vector on commit

### DIFF
--- a/app/converters/model_schema_converters.py
+++ b/app/converters/model_schema_converters.py
@@ -6,8 +6,13 @@ from typing import Any, List, Optional
 import aerosandbox as asb
 import numpy as np
 from aerosandbox import FuselageXSec
+from cadquery import Vector
 
 from app import schemas
+from app.converters.spare_origin_preservation import (
+    scale_db_origin_to_config,
+    should_preserve_normal_spare,
+)
 from app.models import AeroplaneModel, WingModel
 from app.models.aeroplanemodel import FuselageModel
 from app.schemas import AeroplaneSchema
@@ -668,6 +673,7 @@ def _hydrate_segment_from_xsec(
 def _hydrate_wing_configuration_details(
     wing_config: WingConfiguration,
     wing_schema: schemas.AsbWingSchema,
+    scale: float = 1.0,
 ) -> None:
     for segment_index, segment in enumerate(wing_config.segments or []):
         if segment_index >= len(wing_schema.x_secs) - 1:
@@ -678,7 +684,7 @@ def _hydrate_wing_configuration_details(
             wing_schema.x_secs[segment_index + 1],
         )
 
-    _resolve_spare_vectors_and_origins(wing_config)
+    _resolve_spare_vectors_and_origins(wing_config, scale=scale)
 
 
 def _can_follow_previous_spare(
@@ -711,9 +717,35 @@ def _resolve_single_spare(
         wing_config._set_standard_spare_origin_vector(segment_index, spare)
 
 
-def _resolve_spare_vectors_and_origins(wing_config: WingConfiguration) -> None:
+def _preserve_normal_spare_geometry(spare, scale: float) -> None:
+    """Honour a ``normal``-mode spare's solved origin/vector verbatim (gh-1053).
+
+    The spar-insert solver writes an explicit, solved ``spare_origin`` (DB mm)
+    and ``spare_vector`` (dimensionless) with ``spare_mode="normal"``. The DB
+    origin is rescaled into the config's geometry ``scale`` (mm→m at scale=1.0,
+    verbatim mm at scale=1000.0); the vector is normalised but never scaled.
+    """
+    origin_mm = spare.spare_origin.toTuple()
+    spare.spare_origin = Vector(scale_db_origin_to_config(origin_mm, scale))
+    spare.spare_vector = spare.spare_vector.normalized()
+
+
+def _resolve_spare_vectors_and_origins(wing_config: WingConfiguration, scale: float = 1.0) -> None:
     for segment_index, segment in enumerate(wing_config.segments or []):
         for spare_index, spare in enumerate(segment.spare_list or []):
+            # gh-1053: a ``normal``-mode spare carrying an explicit solved
+            # origin + vector (the spar-insert solver's output) is preserved
+            # verbatim — clearing + recomputing it would collapse the solved
+            # front/rear couple onto the forced 0.25c default. The unit-leak
+            # guard below still applies to every other spare.
+            if should_preserve_normal_spare(
+                spare.spare_mode,
+                None if spare.spare_origin is None else spare.spare_origin.toTuple(),
+                None if spare.spare_vector is None else spare.spare_vector.toTuple(),
+            ):
+                _preserve_normal_spare_geometry(spare, scale)
+                continue
+
             # Always recompute from the current geometry so the result
             # matches whatever scale the WingConfiguration was built with.
             # Clear both vector and origin: a DB-cached origin (meters)
@@ -888,7 +920,7 @@ def asb_wing_schema_to_wing_config(
         geometry_scaled_schema, wing_key=getattr(asb_wing, "name", "w") or "w"
     )
     wing_config = WingConfiguration.from_asb(xsecs, geometry_scaled_schema.symmetric)
-    _hydrate_wing_configuration_details(wing_config, asb_wing)
+    _hydrate_wing_configuration_details(wing_config, asb_wing, scale=scale)
     return wing_config
 
 

--- a/app/converters/spare_origin_preservation.py
+++ b/app/converters/spare_origin_preservation.py
@@ -1,0 +1,78 @@
+"""Pure helpers for preserving solver-supplied spare geometry on conversion.
+
+gh-1053: A ``normal``-mode spare created by the spar-insert solver carries an
+explicit, solved ``spare_origin`` + ``spare_vector``. The model→config converter
+(:func:`app.converters.model_schema_converters._resolve_spare_vectors_and_origins`)
+otherwise clears and recomputes every spare's geometry (the gh-352/gh-362
+unit-leak guard), which collapses the solved front/rear couple onto the default
+quarter-chord station. These helpers decide *when* a spare's explicit geometry
+must be honoured verbatim and *how* its origin scales between the DB (mm) and a
+``WingConfiguration`` built at an arbitrary geometry ``scale``.
+
+This module deliberately has **no** CadQuery / AeroSandbox imports so the
+decision logic is unit-testable in the CI fast tier (which excludes those
+heavy dependencies).
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+# mm → m. The DB stores ``spare_origin`` in millimetres (gh-402); a
+# ``WingConfiguration`` geometry is built from a metre base scaled by ``scale``.
+_MM_TO_M = 0.001
+
+# A 3-vector is "explicit" only when all three components are present.
+_VECTOR_LEN = 3
+
+
+def _is_explicit_triplet(value: object) -> bool:
+    """True when ``value`` is a length-3 sequence of finite numbers."""
+    if value is None:
+        return False
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return False
+    if len(value) != _VECTOR_LEN:
+        return False
+    try:
+        return all(float(component) == float(component) for component in value)  # not-NaN
+    except (TypeError, ValueError):
+        return False
+
+
+def should_preserve_normal_spare(
+    spare_mode: object,
+    spare_origin: object,
+    spare_vector: object,
+) -> bool:
+    """Whether a spare's explicit origin + vector must be honoured verbatim.
+
+    Only ``normal``-mode spares that already carry a fully explicit
+    ``spare_origin`` AND ``spare_vector`` are preserved. ``standard`` /
+    ``follow`` / ``*_backward`` spares always go through the recompute path so
+    the gh-352/gh-362 unit-leak guard stays intact for them.
+    """
+    return (
+        spare_mode == "normal"
+        and _is_explicit_triplet(spare_origin)
+        and _is_explicit_triplet(spare_vector)
+    )
+
+
+def scale_db_origin_to_config(
+    spare_origin_mm: Sequence[float],
+    scale: float,
+) -> tuple[float, float, float]:
+    """Scale a DB ``spare_origin`` (mm) into a config built at geometry ``scale``.
+
+    The config geometry is a metre base multiplied by ``scale`` (``scale=1.0``
+    → metres, ``scale=1000.0`` → millimetres). The DB origin is millimetres, so
+    its metre value is ``mm * _MM_TO_M`` and its config value is that times
+    ``scale``. Hence ``scale=1.0`` → mm→m, ``scale=1000.0`` → verbatim mm.
+    """
+    factor = _MM_TO_M * scale
+    return (
+        float(spare_origin_mm[0]) * factor,
+        float(spare_origin_mm[1]) * factor,
+        float(spare_origin_mm[2]) * factor,
+    )

--- a/app/services/spar_insert_service.py
+++ b/app/services/spar_insert_service.py
@@ -184,6 +184,11 @@ def _build_planned_pieces(plan, segment_lengths_mm: list[float]) -> list[_Planne
     bent-pin, reinforcement+joiner, dropped bore) stay faithful. We rebuild the
     Spare list in invariant order and pair each Spare with its source piece.
     """
+    # NOTE (gh-1053 adjacent / owned by gh-1045): the solver can emit a Ø0
+    # terminal tip piece (outer_d == 0) at the zero-moment tip. That phantom
+    # zero-size Spare is tracked and fixed in gh-1045 ("spar solver emits a Ø0
+    # terminal tip piece"); it is deliberately NOT suppressed here to avoid two
+    # competing fixes for the same defect.
     mapping = spar_plan_to_spares(plan)
     spares = list(mapping.spares)
     ordered = list(_plan_pieces_in_invariant_order(plan))

--- a/app/tests/test_spar_insert_integration.py
+++ b/app/tests/test_spar_insert_integration.py
@@ -142,3 +142,106 @@ def test_spar_insert_commit_roundtrip_front_spar_index_zero(client_and_db):
         assert main_spar["spare_support_dimension_height"] == pytest.approx(
             planned_front["outer_d"], rel=1e-6, abs=1e-9
         )
+
+
+@pytest.mark.slow
+@pytest.mark.requires_cadquery
+def test_spar_insert_commit_preserves_solved_origin_and_vector_gh1053(client_and_db):
+    """gh-1053: the committed front AND rear spars must land where the SOLVER
+    placed them — at DISTINCT chordwise stations — not both collapsed onto the
+    forced 0.25c default by the standard recompute.
+
+    Asserts the persisted ``spare_origin`` / ``spare_vector`` equal the planned
+    (preview) values within mm tolerance, for the front AND the rear spar, in
+    every segment that carries both. Before the fix the rear spar's origin is
+    overwritten with the front's quarter-chord origin (stacked), so this fails.
+    """
+    test_client, session_local = client_and_db
+    wing_name = "main_wing"
+
+    create_plane = test_client.post("/aeroplanes", params={"name": "spar insert origin RT"})
+    assert create_plane.status_code == 201, create_plane.text
+    aeroplane_id = create_plane.json()["id"]
+
+    create_wing = test_client.post(
+        f"/aeroplanes/{aeroplane_id}/wings/{wing_name}/from-wingconfig",
+        json=_build_ehawk_wingconfig_payload(),
+    )
+    assert create_wing.status_code == 201, create_wing.text
+
+    material_id = _first_material_id(session_local)
+    request_body = {
+        "material_id": material_id,
+        "wing_name": wing_name,
+        "moments": [
+            {"y_span": 0.0, "bending_moment_Nm": 4.0},
+            {"y_span": 0.5, "bending_moment_Nm": 1.5},
+            {"y_span": 1.0, "bending_moment_Nm": 0.0},
+        ],
+        "sigma_allow_mpa_override": 600.0,
+        "n_span": 6,
+        "packing_factor": 0.9,
+    }
+
+    commit = test_client.post(
+        f"/aeroplanes/{aeroplane_id}/spar-plan/insert",
+        json={**request_body, "dry_run": False},
+    )
+    assert commit.status_code == 200, commit.text
+    commit_json = commit.json()
+    assert commit_json["committed"] is True
+
+    planned = commit_json["planned_spares"]
+    front_by_seg = {p["segment_index"]: p for p in planned if p["role"] == "front"}
+    rear_by_seg = {p["segment_index"]: p for p in planned if p["role"] == "rear"}
+    # We need at least one segment carrying BOTH a front and a rear spar so the
+    # "distinct chordwise station" invariant is meaningful.
+    shared_segments = sorted(set(front_by_seg) & set(rear_by_seg))
+    assert shared_segments, "expected at least one segment with both a front and rear spar"
+
+    wing_after = test_client.get(f"/aeroplanes/{aeroplane_id}/wings/{wing_name}").json()
+
+    def _assert_origin_vector(persisted, planned_piece, label):
+        po = persisted["spare_origin"]
+        plo = planned_piece["spare_origin"]
+        assert po is not None, f"{label}: persisted origin is None"
+        for axis, (got, want) in enumerate(zip(po, plo, strict=True)):
+            assert got == pytest.approx(want, abs=1e-3), (
+                f"{label}: origin axis {axis} persisted {got} != planned {want}"
+            )
+        pv = persisted["spare_vector"]
+        plv = planned_piece["spare_vector"]
+        assert pv is not None, f"{label}: persisted vector is None"
+        for axis, (got, want) in enumerate(zip(pv, plv, strict=True)):
+            assert got == pytest.approx(want, abs=1e-3), (
+                f"{label}: vector axis {axis} persisted {got} != planned {want}"
+            )
+
+    for seg_idx in shared_segments:
+        spare_list = wing_after["x_secs"][seg_idx].get("spare_list") or []
+        # Invariant: front = sort_index 0, rear = sort_index 1.
+        assert len(spare_list) >= 2, f"segment {seg_idx} should carry front + rear"
+        front_persisted = spare_list[0]
+        rear_persisted = spare_list[1]
+
+        _assert_origin_vector(front_persisted, front_by_seg[seg_idx], f"seg{seg_idx} front")
+        _assert_origin_vector(rear_persisted, rear_by_seg[seg_idx], f"seg{seg_idx} rear")
+
+        # The whole point of the two-spar plan: front and rear stay at the
+        # solver's DISTINCT stations, NOT stacked on the same 0.25c origin.
+        # The persisted front↔rear separation must equal the SOLVED separation
+        # (before the fix the rear was overwritten with the front's 0.25c
+        # origin, so the persisted separation collapsed to ~0).
+        fo = front_persisted["spare_origin"]
+        ro = rear_persisted["spare_origin"]
+        pfo = front_by_seg[seg_idx]["spare_origin"]
+        pro = rear_by_seg[seg_idx]["spare_origin"]
+        persisted_sep = max(abs(fo[i] - ro[i]) for i in range(3))
+        planned_sep = max(abs(pfo[i] - pro[i]) for i in range(3))
+        assert planned_sep > 1e-6, (
+            f"seg{seg_idx}: solver itself produced no front/rear separation — bad fixture"
+        )
+        assert persisted_sep == pytest.approx(planned_sep, abs=1e-3), (
+            f"seg{seg_idx}: persisted front/rear separation {persisted_sep} != "
+            f"solved separation {planned_sep} (front {fo}, rear {ro})"
+        )

--- a/app/tests/test_spare_origin_preservation.py
+++ b/app/tests/test_spare_origin_preservation.py
@@ -1,0 +1,68 @@
+"""Fast (no CadQuery / AeroSandbox) unit tests for gh-1053 normal-mode
+spare-geometry preservation decision + DB(mm)→config(scale) origin scaling.
+
+These guard the core of the gh-1053 fix in the CI fast tier, which excludes the
+heavy CAD/aero dependencies that the full converter path needs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.converters.spare_origin_preservation import (
+    scale_db_origin_to_config,
+    should_preserve_normal_spare,
+)
+
+
+class TestShouldPreserveNormalSpare:
+    def test_normal_with_explicit_origin_and_vector_is_preserved(self):
+        assert should_preserve_normal_spare("normal", [40.5, 0.75, 3.69], [0.0, 0.9999, 0.0155])
+
+    @pytest.mark.parametrize(
+        "mode", ["standard", "follow", "standard_backward", "orthogonal_backward"]
+    )
+    def test_non_normal_modes_are_never_preserved(self, mode):
+        # gh-352/gh-362 guard: these always go through recompute.
+        assert not should_preserve_normal_spare(mode, [40.5, 0.75, 3.69], [0.0, 1.0, 0.0])
+
+    def test_normal_without_origin_is_not_preserved(self):
+        assert not should_preserve_normal_spare("normal", None, [0.0, 1.0, 0.0])
+
+    def test_normal_without_vector_is_not_preserved(self):
+        assert not should_preserve_normal_spare("normal", [40.5, 0.75, 3.69], None)
+
+    def test_partial_origin_is_not_preserved(self):
+        assert not should_preserve_normal_spare("normal", [40.5, 0.75], [0.0, 1.0, 0.0])
+
+    def test_none_mode_is_not_preserved(self):
+        assert not should_preserve_normal_spare(None, [40.5, 0.75, 3.69], [0.0, 1.0, 0.0])
+
+    def test_non_sequence_origin_is_not_preserved(self):
+        # A scalar (or any non-sequence) is not an explicit triplet.
+        assert not should_preserve_normal_spare("normal", 40.5, [0.0, 1.0, 0.0])
+
+    def test_string_origin_is_not_preserved(self):
+        # A 3-char string is a Sequence of len 3 but not numeric coords.
+        assert not should_preserve_normal_spare("normal", "abc", [0.0, 1.0, 0.0])
+
+    def test_nan_component_is_not_preserved(self):
+        assert not should_preserve_normal_spare(
+            "normal", [float("nan"), 0.75, 3.69], [0.0, 1.0, 0.0]
+        )
+
+    def test_non_numeric_component_is_not_preserved(self):
+        # A component that cannot be coerced to float (TypeError) → not preserved.
+        assert not should_preserve_normal_spare("normal", [object(), 0.75, 3.69], [0.0, 1.0, 0.0])
+
+
+class TestScaleDbOriginToConfig:
+    def test_scale_one_converts_mm_to_metres(self):
+        # DB mm → metre-scale config (scale=1.0): the recompute path.
+        out = scale_db_origin_to_config([40.5, 750.0, 3690.0], scale=1.0)
+        assert out == pytest.approx((0.0405, 0.75, 3.69))
+
+    def test_scale_thousand_keeps_mm_verbatim(self):
+        # DB mm → mm-scale config (scale=1000.0): the CAD path.
+        out = scale_db_origin_to_config([40.5, 750.0, 3690.0], scale=1000.0)
+        assert out == pytest.approx((40.5, 750.0, 3690.0))


### PR DESCRIPTION
## Summary

Fixes #1053: the spar-insert **commit** path discarded the solver's solved geometry, collapsing the front (~0.30c) and rear (0.65c) spars onto the same 0.25c station — only the OD survived. The dry-run preview was correct; only the persisted geometry was wrong.

## Root cause

`create_spare` → `_recompute_spare_vectors` → `wing_model_to_wing_config` → `_resolve_spare_vectors_and_origins` (`app/converters/model_schema_converters.py`) unconditionally cleared `spare_origin`/`spare_vector` (the gh-352/gh-362 unit-leak guard) and routed `spare_mode="normal"` through `_set_standard_spare_origin_vector`, which forces `spare_position_factor = 0.25` and recomputes a standard origin. So both front and rear persisted at `0.25 × chord` (eHawk seg0: x = 40.5 mm), stacked.

## Fix

`_resolve_spare_vectors_and_origins` now **preserves** a `normal`-mode spare that already carries an explicit `spare_origin` + `spare_vector`: it rescales the DB-mm origin into the config's geometry `scale` (mm→m at `scale=1.0`, verbatim mm at `scale=1000.0`) and normalises the dimensionless vector, instead of clearing + recomputing. `scale` is threaded through `_hydrate_wing_configuration_details`.

The decision predicate + origin scaling live in a new **dependency-free** helper (`app/converters/spare_origin_preservation.py`) so they are covered in the CI fast tier (which excludes CadQuery/AeroSandbox).

`standard` / `follow` / `*_backward` spares are untouched — they still go through the clear+recompute path, so the **gh-352/gh-362 unit-leak guard stays intact** (those regression tests remain green).

The zero-OD terminal tip piece is the separate defect owned by #1045 and is **referenced, not duplicated**.

## Tests

- **Failing-first regression** (slow / requires_cadquery): `test_spar_insert_commit_preserves_solved_origin_and_vector_gh1053` asserts the persisted origin/vector of the FRONT and REAR spar equal the solved values within mm tolerance and that their separation matches the solved separation (not collapsed). Verified red before the fix (persisted x = 0.0405 m = forced 0.25c vs solved 0.0) and green after.
- **Fast unit tests** for the pure preservation helper — 100% module coverage.
- gh-352/gh-362 unit-leak tests + all spar/wing/converter suites pass; full fast tier: 5691 passed.

Closes #1053

🤖 Generated with [Claude Code](https://claude.com/claude-code)