### PR TITLE
feat(gh-1058): auto-snapshot before destructive spar insert-commit

### DIFF
--- a/app/api/v2/endpoints/aeroanalysis.py
+++ b/app/api/v2/endpoints/aeroanalysis.py
@@ -565,6 +565,10 @@ def insert_airplane_spar_plan(
     With ``dry_run=true`` (default) the planned insertions are returned WITHOUT
     writing. With ``dry_run=false`` each spar piece is persisted, REPLACING any
     existing spares in the target segments so the front spar lands at index 0.
+    Because that commit is destructive, an immutable snapshot of the head is
+    auto-created beforehand (gh-1058) and its id returned in ``snapshot_id`` so
+    the user can one-click revert via ``POST /aeroplanes/{snapshot_id}/restore``;
+    a dry-run takes no snapshot and returns ``snapshot_id = null``.
 
     Returns 404 when the aeroplane / wing does not exist, and 422 when section
     geometry is unavailable, the material/strength inputs are invalid, or the

--- a/app/schemas/spar_insert.py
+++ b/app/schemas/spar_insert.py
@@ -89,7 +89,9 @@ class SparInsertResponse(BaseModel):
     """Response for ``POST /aeroplanes/{id}/spar-plan/insert`` (gh-1049).
 
     Lengths in metres. ``committed`` is false for a dry-run preview, true once
-    the spares have been persisted.
+    the spares have been persisted. On commit (gh-1058) an immutable snapshot is
+    auto-created before the destructive REPLACE and its id is returned in
+    ``snapshot_id`` so the user can one-click revert; it is None on a dry-run.
     """
 
     dry_run: bool = Field(..., description="Echo of the request dry_run flag.")
@@ -112,4 +114,14 @@ class SparInsertResponse(BaseModel):
     feasible: bool = Field(..., description="The plan's overall feasibility.")
     infeasibility_reason: Optional[str] = Field(
         None, description="Reason when the plan is infeasible; None otherwise."
+    )
+    snapshot_id: Optional[int] = Field(
+        None,
+        description=(
+            "Integer PK of the immutable snapshot auto-created BEFORE the "
+            "destructive commit (gh-1058). The commit REPLACEs existing spares in "
+            "each touched segment; this snapshot captures the pre-insert state so "
+            "the user can one-click revert via POST /aeroplanes/{snapshot_id}/restore. "
+            "None on a dry-run preview (nothing was mutated, so nothing was snapshotted)."
+        ),
     )

--- a/app/services/spar_insert_service.py
+++ b/app/services/spar_insert_service.py
@@ -40,6 +40,7 @@ from app.schemas.spar_insert import (
     SparInsertRequest,
     SparInsertResponse,
 )
+from app.services import aeroplane_version_service
 from app.services.spar_plan_service import _resolve_wing, compute_spar_plan_object
 from app.services.wing_service import create_spare, get_aeroplane_or_raise
 from cad_designer.airplane.geometry.spar_cad_insertion import spar_plan_to_spares
@@ -47,6 +48,11 @@ from cad_designer.airplane.geometry.spar_cad_insertion import spar_plan_to_spare
 logger = logging.getLogger(__name__)
 
 _MM_TO_M = 0.001
+
+#: Version-label for the auto-snapshot taken before a destructive spar insert
+#: commit (gh-1058). The commit REPLACEs existing spares in each touched
+#: segment, so the head is frozen first to enable a one-click revert.
+_AUTOSNAPSHOT_LABEL = "Before spar insert"
 
 #: Per-invariant spar_index assignment by structural role / piece kind.
 _FRONT_INDEX = 0
@@ -252,6 +258,11 @@ def insert_spar_plan(
 ) -> SparInsertResponse:
     """Compute a spar plan and insert it into the wing (dry-run or commit).
 
+    On commit (``dry_run=false``) the wing is mutated destructively — existing
+    spares in every touched segment are REPLACEd. Before any mutation the head is
+    frozen as an immutable snapshot (gh-1058) so the user can one-click revert;
+    the snapshot id is returned in the response. A dry-run takes no snapshot.
+
     Raises:
         NotFoundError: aeroplane or wing does not exist (-> 404).
         ValidationError: section geometry unavailable, material/strength inputs
@@ -275,7 +286,19 @@ def insert_spar_plan(
     planned = _build_planned_pieces(plan, segment_lengths_mm)
 
     committed = False
+    snapshot_id: int | None = None
     if not request.dry_run:
+        # gh-1058: a commit REPLACEs (clears) existing spares in every touched
+        # segment — destructive. Freeze the current head as an immutable
+        # snapshot BEFORE mutating anything so the user can one-click revert.
+        # If snapshotting fails we abort the whole commit (never mutate without
+        # a recovery point); the exception propagates and get_db() rolls back.
+        snapshot_node = aeroplane_version_service.snapshot(
+            db,
+            aeroplane.id,
+            _AUTOSNAPSHOT_LABEL,
+        )
+        snapshot_id = snapshot_node.id
         _persist_spares(db, aeroplane_uuid, wing, planned)
         committed = True
 
@@ -288,4 +311,5 @@ def insert_spar_plan(
         warnings=mapping.warnings,
         feasible=plan.feasible,
         infeasibility_reason=plan.infeasibility_reason,
+        snapshot_id=snapshot_id,
     )

--- a/app/tests/test_spar_insert_endpoint.py
+++ b/app/tests/test_spar_insert_endpoint.py
@@ -93,8 +93,8 @@ def _wing(name="main_wing", segment_lengths_mm=(500.0,)):
     return SimpleNamespace(name=name, x_secs=x_secs, _segments=segments)
 
 
-def _aeroplane(wings):
-    return SimpleNamespace(wings=wings, uuid=uuid.uuid4())
+def _aeroplane(wings, node_id=42):
+    return SimpleNamespace(wings=wings, uuid=uuid.uuid4(), id=node_id)
 
 
 def _request(**overrides):
@@ -252,6 +252,11 @@ class TestDryRunVsCommit:
         with (
             patch.object(spar_insert_service, "create_spare", side_effect=fake_create_spare),
             patch.object(spar_insert_service, "_clear_plan_spares") as mock_clear,
+            patch.object(
+                spar_insert_service.aeroplane_version_service,
+                "snapshot",
+                return_value=SimpleNamespace(id=1),
+            ),
         ):
             resp = _run(
                 _patch_service(aeroplane, _single_segment_plan()),
@@ -293,6 +298,11 @@ class TestReplaceExistingSpares:
                 "_clear_plan_spares",
                 side_effect=lambda db, wing, seg_idx: cleared_segments.append(seg_idx),
             ),
+            patch.object(
+                spar_insert_service.aeroplane_version_service,
+                "snapshot",
+                return_value=SimpleNamespace(id=1),
+            ),
         ):
             _run(
                 _patch_service(aeroplane, _two_segment_plan()),
@@ -302,6 +312,85 @@ class TestReplaceExistingSpares:
             )
         # both target segments cleared exactly once (no double-corruption)
         assert sorted(set(cleared_segments)) == [0, 1]
+
+
+# --------------------------------------------------------------------------
+# Auto-snapshot before destructive commit (gh-1058)
+# --------------------------------------------------------------------------
+
+
+class TestAutoSnapshotBeforeCommit:
+    def test_commit_snapshots_once_before_persisting(self, plane_id):
+        """On commit a snapshot is taken EXACTLY ONCE, BEFORE any spare is
+        written, and its id is returned."""
+        aeroplane = _aeroplane([_wing(segment_lengths_mm=(500.0,))], node_id=99)
+        call_order: list[str] = []
+
+        def fake_snapshot(db, node_id, label, *args, **kwargs):
+            call_order.append("snapshot")
+            # snapshot() must run before any spare is persisted
+            assert "persist" not in call_order
+            assert node_id == 99
+            return SimpleNamespace(id=777)
+
+        def fake_persist(*args, **kwargs):
+            call_order.append("persist")
+
+        with (
+            patch.object(
+                spar_insert_service.aeroplane_version_service,
+                "snapshot",
+                side_effect=fake_snapshot,
+            ) as mock_snapshot,
+            patch.object(spar_insert_service, "_persist_spares", side_effect=fake_persist),
+        ):
+            resp = _run(
+                _patch_service(aeroplane, _single_segment_plan()),
+                lambda: spar_insert_service.insert_spar_plan(
+                    db=None, aeroplane_uuid=plane_id, request=_request(dry_run=False)
+                ),
+            )
+
+        mock_snapshot.assert_called_once()
+        assert call_order == ["snapshot", "persist"]
+        assert resp.committed is True
+        assert resp.snapshot_id == 777
+
+    def test_dry_run_does_not_snapshot(self, plane_id):
+        """A dry-run preview takes NO snapshot and returns snapshot_id=None."""
+        aeroplane = _aeroplane([_wing(segment_lengths_mm=(500.0,))])
+        with patch.object(
+            spar_insert_service.aeroplane_version_service, "snapshot"
+        ) as mock_snapshot:
+            resp = _run(
+                _patch_service(aeroplane, _single_segment_plan()),
+                lambda: spar_insert_service.insert_spar_plan(
+                    db=None, aeroplane_uuid=plane_id, request=_request(dry_run=True)
+                ),
+            )
+        mock_snapshot.assert_not_called()
+        assert resp.snapshot_id is None
+
+    def test_snapshot_failure_aborts_commit_without_mutating(self, plane_id):
+        """If snapshotting fails, the whole commit fails and NO spare is written
+        (don't mutate without a snapshot)."""
+        aeroplane = _aeroplane([_wing(segment_lengths_mm=(500.0,))])
+        with (
+            patch.object(
+                spar_insert_service.aeroplane_version_service,
+                "snapshot",
+                side_effect=RuntimeError("snapshot boom"),
+            ),
+            patch.object(spar_insert_service, "_persist_spares") as mock_persist,
+        ):
+            with pytest.raises(RuntimeError):
+                _run(
+                    _patch_service(aeroplane, _single_segment_plan()),
+                    lambda: spar_insert_service.insert_spar_plan(
+                        db=None, aeroplane_uuid=plane_id, request=_request(dry_run=False)
+                    ),
+                )
+        mock_persist.assert_not_called()
 
 
 # --------------------------------------------------------------------------

--- a/app/tests/test_spar_insert_integration.py
+++ b/app/tests/test_spar_insert_integration.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
+from app.models.aeroplanemodel import AeroplaneModel
 from app.models.component import ComponentModel
 from test.ehawk_workflow_helpers import _build_main_wing
 
@@ -55,6 +56,38 @@ def _first_material_id(session_local) -> int:
         return material.id
     finally:
         db.close()
+
+
+def _node_uuid(session_local, node_id: int) -> str:
+    """Resolve an aeroplane node's UUID from its integer PK."""
+    db = session_local()
+    try:
+        node = db.query(AeroplaneModel).filter(AeroplaneModel.id == node_id).first()
+        assert node is not None, f"node {node_id} not found"
+        return str(node.uuid)
+    finally:
+        db.close()
+
+
+def _spare_signature(wing_json: dict) -> list[tuple]:
+    """A comparable signature of a wing's spares across all cross-sections.
+
+    Uses the dimensional fields + origin/vector so two wings with the same spar
+    layout compare equal regardless of DB ids.
+    """
+    sig: list[tuple] = []
+    for x in wing_json["x_secs"]:
+        for s in x.get("spare_list") or []:
+            sig.append(
+                (
+                    round(s["spare_support_dimension_width"], 6),
+                    round(s["spare_support_dimension_height"], 6),
+                    round((s.get("spare_length") or 0.0), 6),
+                    tuple(round(c, 6) for c in (s.get("spare_origin") or [])),
+                    tuple(round(c, 6) for c in (s.get("spare_vector") or [])),
+                )
+            )
+    return sig
 
 
 @pytest.mark.slow
@@ -245,3 +278,84 @@ def test_spar_insert_commit_preserves_solved_origin_and_vector_gh1053(client_and
             f"seg{seg_idx}: persisted front/rear separation {persisted_sep} != "
             f"solved separation {planned_sep} (front {fo}, rear {ro})"
         )
+
+
+@pytest.mark.slow
+@pytest.mark.requires_cadquery
+def test_spar_insert_commit_autosnapshots_and_restore_recovers_pre_insert_gh1058(client_and_db):
+    """gh-1058: the destructive insert-commit auto-snapshots the head FIRST, and
+    restoring that snapshot recovers the EXACT pre-insert spares.
+
+    A dry-run must NOT snapshot (snapshot_id is null); a commit returns the
+    snapshot id, and POST /aeroplanes/{snapshot_id}/restore yields a head whose
+    spares match the pre-insert state byte-for-byte (within metre tolerance).
+    """
+    test_client, session_local = client_and_db
+    wing_name = "main_wing"
+
+    create_plane = test_client.post("/aeroplanes", params={"name": "spar insert autosnap RT"})
+    assert create_plane.status_code == 201, create_plane.text
+    aeroplane_id = create_plane.json()["id"]
+
+    create_wing = test_client.post(
+        f"/aeroplanes/{aeroplane_id}/wings/{wing_name}/from-wingconfig",
+        json=_build_ehawk_wingconfig_payload(),
+    )
+    assert create_wing.status_code == 201, create_wing.text
+
+    material_id = _first_material_id(session_local)
+    request_body = {
+        "material_id": material_id,
+        "wing_name": wing_name,
+        "moments": [
+            {"y_span": 0.0, "bending_moment_Nm": 4.0},
+            {"y_span": 0.5, "bending_moment_Nm": 1.5},
+            {"y_span": 1.0, "bending_moment_Nm": 0.0},
+        ],
+        "sigma_allow_mpa_override": 600.0,
+        "n_span": 6,
+        "packing_factor": 0.9,
+    }
+
+    # Capture the pre-insert spare layout (the eHawk wing ships construction
+    # spares that the destructive commit would REPLACE).
+    wing_pre = test_client.get(f"/aeroplanes/{aeroplane_id}/wings/{wing_name}").json()
+    pre_signature = _spare_signature(wing_pre)
+
+    # 1) dry-run preview must NOT snapshot.
+    preview = test_client.post(
+        f"/aeroplanes/{aeroplane_id}/spar-plan/insert",
+        json={**request_body, "dry_run": True},
+    )
+    assert preview.status_code == 200, preview.text
+    assert preview.json()["snapshot_id"] is None
+
+    # 2) commit auto-snapshots BEFORE mutating; returns the snapshot id.
+    commit = test_client.post(
+        f"/aeroplanes/{aeroplane_id}/spar-plan/insert",
+        json={**request_body, "dry_run": False},
+    )
+    assert commit.status_code == 200, commit.text
+    commit_json = commit.json()
+    assert commit_json["committed"] is True
+    snapshot_id = commit_json["snapshot_id"]
+    assert isinstance(snapshot_id, int), "commit must return an integer snapshot id"
+
+    # The head changed (spares were replaced by the inserted plan).
+    wing_post = test_client.get(f"/aeroplanes/{aeroplane_id}/wings/{wing_name}").json()
+    post_signature = _spare_signature(wing_post)
+    assert post_signature != pre_signature, "commit should have changed the spare layout"
+
+    # 3) restore the auto-snapshot → a new head carrying the PRE-insert spares.
+    restore = test_client.post(
+        f"/aeroplanes/{snapshot_id}/restore",
+        json={"name": "revert spar insert"},
+    )
+    assert restore.status_code == 201, restore.text
+    restored_head_id = restore.json()["head_id"]
+    restored_uuid = _node_uuid(session_local, restored_head_id)
+
+    wing_restored = test_client.get(f"/aeroplanes/{restored_uuid}/wings/{wing_name}").json()
+    assert _spare_signature(wing_restored) == pre_signature, (
+        "restoring the auto-snapshot must recover the exact pre-insert spares"
+    )


### PR DESCRIPTION
Closes #1058 — part of epic #1056.

The insert commit REPLACES existing spares in touched segments. It now auto-creates an immutable snapshot (`aeroplane_version_service.snapshot()`) BEFORE mutating and returns `snapshot_id`, so the user can one-click revert via `POST /aeroplanes/{snapshot_id}/restore`. dry_run takes no snapshot. Covers #1054 (no silent loss of manual spares).

🤖 Generated with [Claude Code](https://claude.com/claude-code)