### PR TITLE
feat(gh-1057): suppress Ø0 spar tip piece + per-piece spanwise extent (backend)

### DIFF
--- a/app/schemas/spar_plan.py
+++ b/app/schemas/spar_plan.py
@@ -185,6 +185,21 @@ class SparPieceOut(BaseModel):
         ...,
         description="Spanwise position of the governing (highest-moment) station (m).",
     )
+    y_start: float = Field(
+        ...,
+        description=(
+            "Spanwise position where this piece starts (root-side, m; root=0). "
+            "Equals the piece's spare_origin y (gh-1057)."
+        ),
+    )
+    y_end: float = Field(
+        ...,
+        description=(
+            "Spanwise position where this piece ends (tip-side, m). For a "
+            "telescoping run, the next piece's y_start equals this value, and "
+            "that is the telescoping joint position (gh-1057)."
+        ),
+    )
     utilisation: float = Field(
         ...,
         description=(

--- a/app/services/spar_plan_service.py
+++ b/app/services/spar_plan_service.py
@@ -235,7 +235,16 @@ def _mirror_to_left(stations):
 
 
 def _piece_to_out(piece) -> SparPieceOut:
-    """Convert a millimetre SparPiece to a metre SparPieceOut."""
+    """Convert a millimetre SparPiece to a metre SparPieceOut.
+
+    gh-1057: expose the piece's spanwise extent (``y_start``/``y_end``, m) so the
+    UI can show where each piece runs and where the telescoping joint sits. The
+    extent is derived from the piece's own geometry — the root is its
+    ``spare_origin`` y, the tip is that plus the piece length along its span
+    direction (``spare_vector`` y) — then converted mm->m.
+    """
+    y_start_mm = piece.spare_origin[1]
+    y_end_mm = y_start_mm + piece.length * piece.spare_vector[1]
     return SparPieceOut(
         role=piece.role.value,
         spare_origin=[c * _MM_TO_M for c in piece.spare_origin],
@@ -245,6 +254,8 @@ def _piece_to_out(piece) -> SparPieceOut:
         wall=piece.wall * _MM_TO_M,
         shape=piece.shape,
         governing_y=piece.governing_y * _MM_TO_M,
+        y_start=y_start_mm * _MM_TO_M,
+        y_end=y_end_mm * _MM_TO_M,
         utilisation=piece.utilisation,
         joint_to_next=piece.joint_to_next,
         feasible=piece.feasible,

--- a/app/tests/test_spar_plan_endpoint.py
+++ b/app/tests/test_spar_plan_endpoint.py
@@ -188,6 +188,48 @@ class TestComputeSparPlanService:
         assert fp.spare_vector == [0.0, 1.0, 0.0]
         assert fp.role == "front"
 
+    def test_y_start_end_populated_and_in_metres(self, plane_id):
+        # gh-1057: each piece exposes its spanwise extent (y_start..y_end, m) so
+        # the UI can show where the piece runs. Derived from spare_origin.y +
+        # length*vector.y, then converted mm->m.
+        aeroplane = _aeroplane_with_wings(["main_wing"])
+        plan = SparPlan(
+            front_pieces=[
+                _piece(
+                    role=SparRole.FRONT,
+                    spare_origin=(0.0, 0.0, 5.0),
+                    spare_vector=(0.0, 1.0, 0.0),
+                    length=300.0,
+                ),
+                _piece(
+                    role=SparRole.FRONT,
+                    spare_origin=(0.0, 300.0, 4.0),
+                    spare_vector=(0.0, 1.0, 0.0),
+                    length=600.0,
+                    joint_to_next=None,
+                ),
+            ],
+            rear_pieces=[],
+            front_joint="continuous",
+            rear_joint="continuous",
+        )
+        resp = _run(
+            _patch_full(aeroplane, plan),
+            lambda: spar_plan_service.compute_spar_plan(
+                db=None, aeroplane_uuid=plane_id, request=_basic_request()
+            ),
+        )
+        p0, p1 = resp.front_pieces
+        # mm->m: 0..300 mm -> 0..0.3 m ; 300..900 mm -> 0.3..0.9 m
+        assert p0.y_start == pytest.approx(0.0)
+        assert p0.y_end == pytest.approx(0.3)
+        assert p1.y_start == pytest.approx(0.3)
+        assert p1.y_end == pytest.approx(0.9)
+        # contiguous + monotonic
+        assert p0.y_end == pytest.approx(p1.y_start)
+        assert p0.y_end > p0.y_start
+        assert p1.y_end > p1.y_start
+
     def test_reinforcement_converted_when_present(self, plane_id):
         aeroplane = _aeroplane_with_wings(["main_wing"])
         resp = _run(

--- a/cad_designer/airplane/geometry/spar_cad_insertion.py
+++ b/cad_designer/airplane/geometry/spar_cad_insertion.py
@@ -138,9 +138,17 @@ def insert_spar_plan(
 
 
 def _emit_pieces(pieces: list[SparPiece], role_label: str, result: SparInsertionResult) -> None:
-    """Append one Spare per piece; warn (once) if the run is telescoping."""
+    """Append one Spare per piece; warn (once) if the run is telescoping.
+
+    gh-1045/#1057: skip any degenerate Ø0 piece — a zero-diameter tube is not a
+    physical structural object, so it must never reach the BOM / CAD build as a
+    phantom zero-size Spare. The solver already drops Ø0 pieces; this guard keeps
+    the insertion step safe for any caller that hands one in directly.
+    """
     telescoping = False
     for piece in pieces:
+        if piece.outer_d <= 0.0:
+            continue
         result.spares.append(spar_piece_to_spare(piece))
         if piece.joint_to_next == "telescoping":
             telescoping = True
@@ -148,7 +156,8 @@ def _emit_pieces(pieces: list[SparPiece], role_label: str, result: SparInsertion
         result.warnings.append(
             f"{role_label.capitalize()} spar is telescoping (multi-piece): each "
             "piece is emitted as its own Spare, but the telescoping overlap "
-            "(outer OD = inner ID) is plan metadata and is not modelled as a Spare."
+            "(OD_outer <= ID_inner - clearance) is plan metadata and is not "
+            "modelled as a Spare."
         )
 
 

--- a/cad_designer/airplane/geometry/spar_solver.py
+++ b/cad_designer/airplane/geometry/spar_solver.py
@@ -324,7 +324,35 @@ def plan_spar(stations: list[StationData], spec: SparSpec) -> list[SparPiece]:
         if idx < len(runs) - 1:
             piece.joint_to_next = "telescoping"
         built.append(piece)
-    return built
+    return _drop_zero_od_tip(built)
+
+
+def _drop_zero_od_tip(pieces: list[SparPiece]) -> list[SparPiece]:
+    """Drop degenerate Ø0 trailing pieces (gh-1045/#1057).
+
+    At the tip the bending moment M(y)->0, so the strength-required OD rounds to
+    0. A Ø0 tube is not a physical structural object — you cannot cut, order, or
+    glue it (the skin / D-tube closes the tip). Drop every trailing piece whose
+    ``outer_d <= 0`` and extend the new last real piece to the wing tip so the
+    remaining pieces stay contiguous root->tip. The previous piece no longer
+    telescopes into a non-existent piece, so its joint becomes continuous (None).
+    """
+    kept: list[SparPiece] = [p for p in pieces if p.outer_d > 0.0]
+    if not kept or len(kept) == len(pieces):
+        # all-zero -> no structural spar; or nothing to drop -> unchanged.
+        return kept if not kept else pieces
+
+    # The last real piece must run to the tip of the original (now-dropped) run.
+    dropped_tip = pieces[-1]
+    tip_y = dropped_tip.spare_origin[1] + dropped_tip.length * dropped_tip.spare_vector[1]
+    tip_z = dropped_tip.spare_origin[2] + dropped_tip.length * dropped_tip.spare_vector[2]
+    last = kept[-1]
+    origin = last.spare_origin
+    tip_point = (origin[0], tip_y, tip_z)
+    last.spare_vector = _unit_vector(origin, tip_point)
+    last.length = math.dist(origin, tip_point)
+    last.joint_to_next = None
+    return kept
 
 
 def _bore_for(run: _Run, spec: SparSpec, od: float) -> float:

--- a/cad_designer/tests/test_spar_cad_insertion.py
+++ b/cad_designer/tests/test_spar_cad_insertion.py
@@ -125,6 +125,20 @@ def test_plan_to_spares_empty_plan_yields_no_spares_no_warnings():
     assert result.warnings == []
 
 
+def test_plan_to_spares_skips_zero_od_phantom_piece():
+    # gh-1045/#1057: a Ø0 piece is not a physical part — it must never become a
+    # Spare on the BOM / CAD build, even if handed in directly.
+    plan = SparPlan(
+        front_pieces=[
+            _piece(role=SparRole.FRONT, outer_d=14.0),
+            _piece(role=SparRole.FRONT, outer_d=0.0, inner_d=0.0),
+        ]
+    )
+    result = spar_plan_to_spares(plan)
+    assert len(result.spares) == 1
+    assert all(s.spare_support_dimension_width > 0.0 for s in result.spares)
+
+
 def test_plan_to_spares_warns_on_telescoping_joint():
     plan = SparPlan(
         front_pieces=[

--- a/cad_designer/tests/test_spar_solver.py
+++ b/cad_designer/tests/test_spar_solver.py
@@ -426,8 +426,13 @@ class TestRearTorsionDistinctFromFront:
         # The rear OD tracks the torsion-derived station, not the bending one.
         assert rear_root_od == pytest.approx(12.0)
 
-    def test_zero_torsion_rear_is_minimal(self):
-        """Zero torsion (+ no secondary bending) -> a minimal rear member."""
+    def test_zero_torsion_rear_emits_no_pieces(self):
+        """Zero torsion (+ no secondary bending) -> no physical rear member.
+
+        gh-1045/#1057: a Ø0 rear spar is not a structural object. Rather than
+        emit a phantom Ø0 piece (the old behaviour), the solver emits no rear
+        pieces at all, and the plan stays feasible.
+        """
         rear = [
             _station(0.0, y_mm=0.0, band=(-50.0, 50.0), required_od=0.0),
             _station(1.0, y_mm=500.0, band=(-50.0, 50.0), required_od=0.0),
@@ -438,8 +443,90 @@ class TestRearTorsionDistinctFromFront:
             rear_left=[_mirror(s) for s in rear],
             rear_right=rear,
         )
-        assert plan.rear_pieces[0].outer_d == pytest.approx(0.0)
+        assert plan.rear_pieces == []
         assert plan.feasible is True
+
+
+class TestZeroOdTipPieceSuppressed:
+    """gh-1045/#1057: the solver must NOT emit a Ø0 terminal tip piece.
+
+    At the tip the bending moment M(y)->0, so the strength-required OD rounds to
+    0. The old solver emitted that as a feasible Ø0 piece — a phantom part you
+    cannot cut, order, or glue. The fix drops the degenerate trailing piece and
+    runs the previous (last real) piece to the tip with a continuous joint.
+    """
+
+    def _tapered_to_zero_tip(self) -> list[StationData]:
+        # required OD decays to 0 at the very tip (the normal physical case).
+        return [
+            _station(0.0, y_mm=0.0, band=(-60.0, 60.0), required_od=80.0),
+            _station(0.33, y_mm=300.0, band=(-30.0, 30.0), required_od=55.0),
+            _station(0.66, y_mm=600.0, band=(-15.0, 15.0), required_od=28.0),
+            _station(1.0, y_mm=900.0, band=(-8.0, 8.0), required_od=0.0),
+        ]
+
+    def test_no_zero_od_piece_emitted(self):
+        pieces = plan_spar(self._tapered_to_zero_tip(), SparSpec(role=SparRole.FRONT))
+        assert pieces
+        for p in pieces:
+            assert p.outer_d > 0.0, f"Ø0 piece emitted: {p}"
+
+    def test_pieces_cover_root_to_tip_without_gap(self):
+        # The remaining pieces must still cover the whole span root->tip with no
+        # gap. Telescoping pieces overlap rootward (a joint IS an overlap region),
+        # so the invariant is coverage, not abutment: the next piece must start at
+        # or before the previous piece's tip, and the union reaches the tip.
+        pieces = plan_spar(self._tapered_to_zero_tip(), SparSpec(role=SparRole.FRONT))
+        covered_to = pieces[0].spare_origin[1] + pieces[0].length * pieces[0].spare_vector[1]
+        for outer in pieces[1:]:
+            assert outer.spare_origin[1] <= covered_to + 1e-9, (
+                f"gap before piece starting at {outer.spare_origin[1]} "
+                f"(covered only to {covered_to})"
+            )
+            covered_to = max(
+                covered_to,
+                outer.spare_origin[1] + outer.length * outer.spare_vector[1],
+            )
+        assert pieces[0].spare_origin[1] == pytest.approx(0.0)  # starts at root
+        assert covered_to == pytest.approx(900.0)  # union reaches the tip
+
+    def test_last_piece_runs_to_the_tip(self):
+        # After dropping the Ø0 tip piece, the new last real piece must reach the
+        # wing tip (y=900), not stop short where the Ø0 run began.
+        pieces = plan_spar(self._tapered_to_zero_tip(), SparSpec(role=SparRole.FRONT))
+        last = pieces[-1]
+        last_tip_y = last.spare_origin[1] + last.length * last.spare_vector[1]
+        assert last_tip_y == pytest.approx(900.0)
+
+    def test_last_piece_joint_is_continuous(self):
+        # The previous piece no longer telescopes into a non-existent piece.
+        pieces = plan_spar(self._tapered_to_zero_tip(), SparSpec(role=SparRole.FRONT))
+        assert pieces[-1].joint_to_next is None
+
+    def test_all_zero_od_yields_no_pieces(self):
+        # A spar whose every station needs Ø0 (e.g. zero torsion rear) is not a
+        # structural object at all — emit nothing rather than a phantom part.
+        stations = [
+            _station(0.0, y_mm=0.0, band=(-50.0, 50.0), required_od=0.0),
+            _station(1.0, y_mm=500.0, band=(-50.0, 50.0), required_od=0.0),
+        ]
+        pieces = plan_spar(stations, SparSpec(role=SparRole.FRONT))
+        assert pieces == []
+
+    def test_plan_has_no_zero_od_rear_pieces(self):
+        rear = [
+            _station(0.0, y_mm=0.0, band=(-50.0, 50.0), required_od=12.0),
+            _station(0.5, y_mm=250.0, band=(-50.0, 50.0), required_od=4.0),
+            _station(1.0, y_mm=500.0, band=(-50.0, 50.0), required_od=0.0),
+        ]
+        plan = solve_spar_plan(
+            front_left=_uniform_stations(),
+            front_right=_uniform_stations(),
+            rear_left=[_mirror(s) for s in rear],
+            rear_right=rear,
+        )
+        for p in plan.rear_pieces:
+            assert p.outer_d > 0.0
 
 
 def _mirror(s: StationData) -> StationData:


### PR DESCRIPTION
Backend half of #1057. Frontend display is a separate later task and is not touched here.

Closes #1057
Closes #1045

## #1045 — suppress the Ø0 tip piece
At the tip the bending moment M(y)→0, so the strength-required OD rounds to 0. The solver used to emit a phantom terminal `SparPiece` with `outer_d == 0` marked feasible — a part you cannot cut, order, or glue.

**Handled by DROP (preferred option in the issue):** `plan_spar` now drops every trailing piece with `outer_d <= 0` (`_drop_zero_od_tip`) and extends the new last real piece to the wing tip, resetting its `joint_to_next` to continuous (`None`) so it no longer telescopes into a non-existent piece. An all-Ø0 spar (e.g. a zero-torsion rear) emits no pieces at all.

The insert path is fixed **transitively** (the solver no longer produces Ø0 pieces). `_emit_pieces` additionally skips any `outer_d <= 0` piece defensively, and its stale telescoping-overlap warning text is corrected to the gh-1037 invariant (`OD_outer <= ID_inner - clearance`).

Telescoping pieces overlap rootward by design (a joint *is* an overlap region), so the post-fix invariant is **coverage** root→tip (no gap, union reaches the tip), not abutment.

## Per-piece spanwise extent
Added `y_start` / `y_end` (metres, spanwise, root=0) to `SparPieceOut`, derived in `_piece_to_out` from `spare_origin.y + length·vector.y` (mm→m). For a telescoping run the next piece's `y_start` is the joint position the UI will show. Existing fields kept. `app/schemas/spar_insert.py` is untouched (owned by a separate ticket).

## Tests / coverage
- New solver class `TestZeroOdTipPieceSuppressed`: no Ø0 piece emitted, coverage root→tip without gap, last piece runs to the tip, last joint continuous, all-zero → empty, no Ø0 rear pieces.
- Updated the old `test_zero_torsion_rear_*` test that encoded the wrong Ø0 behaviour.
- Insertion guard test (Ø0 phantom piece never becomes a Spare).
- Service test for `y_start`/`y_end` populated, in metres, contiguous and monotonic.
- Fast suites green: backend app 5305 passed / 7 skipped, cad_designer 617 passed. `spar_plan_service.py` 100% coverage; new `spar_solver` lines fully covered. `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)