### PR TITLE
feat(gh-1059): main-spar segment-split helper + rear-spar clearance + secondary Option-B

### DIFF
--- a/cad_designer/airplane/geometry/segment_split.py
+++ b/cad_designer/airplane/geometry/segment_split.py
@@ -1,0 +1,475 @@
+"""Main-spar segment split (gh-1059).
+
+A telescoping main (front) spar has a varying diameter along the span. VaseMode
+construction treats **any** ``spar_index == 0`` spar in a segment as THE main
+spar, so a multi-piece (telescoping) main spar cannot live as several index-0
+pieces in one segment — each diameter needs its own segment with exactly one
+main piece at index 0.
+
+This module splits a host :class:`WingConfiguration` segment at one or more
+spanwise fractions into N contiguous sub-segments. The split is **geometrically
+transparent**: the built loft is unchanged. That holds because the loft is
+*ruled* (``loft(ruled=True)`` — a straight, linear blend between the root and
+tip airfoils), so an intermediate section is fully determined by:
+
+* the **linearly interpolated** chord / twist (incidence) / dihedral / sweep /
+  length at the split fraction, and
+* the **airfoil shape** at the split fraction — the same file when root and tip
+  share an airfoil, otherwise a Kulfan/CST morph (gh-796) supplied via the
+  injected ``airfoil_morph_fn`` seam.
+
+**Read-only topology.** We never modify the ``Airfoil`` / ``WingSegment`` /
+``WingConfiguration`` / ``Spare`` / ``TrailingEdgeDevice`` / ``Turbulator``
+classes — we only *construct* new instances and assemble a fresh
+``WingConfiguration`` via ``add_segment`` / ``add_tip_segment``.
+
+**Children at a split:**
+
+* **Control surface** (``TrailingEdgeDevice``) spans the whole segment, so it is
+  **duplicated** onto every sub-segment over its sub-span: the chordwise hinge
+  line and side spacing are linearly interpolated to the sub-span boundaries,
+  and the name is disambiguated (the ``[role]`` tag is preserved per the
+  gh-772/gh-955 mixing rules; the display part gets a per-sub-segment ordinal so
+  the control-variable names stay globally unique and never collapse into one
+  AVL DOF). The servo (if any) stays on the sub-segment that contains it.
+* **Turbulator** is only a surface bump → carried onto every sub-segment with
+  its chordwise position linearly interpolated to the sub-span.
+* **Existing/manual spares** are re-homed to the sub-segment whose span contains
+  the spare's (segment-local) origin y.
+* The **main-spar pieces** for each sub-segment are supplied by the caller
+  (``main_pieces_per_subsegment``) and placed at ``spar_list[0]`` — the index-0
+  invariant the spar-insert relies on.
+
+Units: **millimetres**, wing-local frame — same as the topology classes.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from cad_designer.airplane.aircraft_topology.wing.Airfoil import Airfoil
+from cad_designer.airplane.aircraft_topology.wing.Spare import Spare
+from cad_designer.airplane.aircraft_topology.wing.TrailingEdgeDevice import (
+    TrailingEdgeDevice,
+)
+from cad_designer.airplane.aircraft_topology.wing.Turbulator import Turbulator
+from cad_designer.airplane.aircraft_topology.wing.WingConfiguration import (
+    WingConfiguration,
+)
+from cad_designer.airplane.aircraft_topology.wing.WingSegment import WingSegment
+
+#: Signature of the airfoil-morph seam: ``morph(root_file, tip_file, t) -> path``
+#: (or ``None`` on failure). Matches ``app.converters.openvsp_airfoil.morph_airfoils``.
+AirfoilMorphFn = Callable[[str, str, float], Optional[str]]
+
+_FRACTION_TOL = 1e-9
+
+
+def _lerp(a: float, b: float, t: float) -> float:
+    return a + (b - a) * t
+
+
+def _validate_fractions(fractions: list[float]) -> None:
+    """Reject fractions that are out of (0, 1) or not strictly increasing."""
+    prev = 0.0
+    for f in fractions:
+        if not (_FRACTION_TOL < f < 1.0 - _FRACTION_TOL):
+            raise ValueError(
+                f"split fraction {f} must be strictly inside (0, 1); 0 and 1 are "
+                "the segment's own boundaries and do not create a new section."
+            )
+        if f <= prev + _FRACTION_TOL:
+            raise ValueError(f"split fractions must be strictly increasing; got {fractions}.")
+        prev = f
+
+
+def _interp_airfoil(
+    root_af: Airfoil,
+    tip_af: Airfoil,
+    t: float,
+    airfoil_morph_fn: AirfoilMorphFn | None,
+) -> Airfoil:
+    """Build the intermediate airfoil at fraction ``t`` along the segment.
+
+    Chord / incidence-delta / dihedral-delta are linearly blended (see
+    :func:`split_segment` for the delta bookkeeping — this only sets the chord
+    and the airfoil *file*; the angle splitting is handled by the caller). When
+    the two anchors share an airfoil file the same file is kept (the ruled loft
+    of one shape is exact); otherwise the file is a Kulfan/CST morph at ``t``,
+    falling back to the inboard anchor's file when morphing is unavailable or
+    fails.
+    """
+    chord = _lerp(root_af.chord, tip_af.chord, t)
+    root_file = root_af.airfoil
+    tip_file = tip_af.airfoil
+    if root_file == tip_file or tip_file is None:
+        airfoil_file = root_file
+    elif airfoil_morph_fn is not None:
+        morphed = airfoil_morph_fn(root_file, tip_file, t)
+        airfoil_file = morphed if morphed is not None else root_file
+    else:
+        # No morph seam supplied for differing anchors: keep the inboard form so
+        # the section is still buildable (a faithful, if approximate, capture).
+        airfoil_file = root_file
+    return Airfoil(airfoil=airfoil_file, chord=chord)
+
+
+def _split_ted(ted: TrailingEdgeDevice, t0: float, t1: float, ordinal: int) -> TrailingEdgeDevice:
+    """Duplicate a control surface over the sub-span ``[t0, t1]``.
+
+    The hinge line (``rel_chord_*``) and side spacing taper linearly along the
+    whole original segment, so the sub-span endpoints are the values at ``t0``
+    and ``t1``. The name is disambiguated for sub-segments after the first so
+    the per-surface control-variable names stay globally unique (gh-955); the
+    ``[role]`` tag (gh-772) is preserved so the mixing pipeline still recovers
+    the role. The servo only rides the sub-segment that contains it.
+    """
+    rc_root = ted.rel_chord_root
+    rc_tip = ted.rel_chord_tip if ted.rel_chord_tip is not None else ted.rel_chord_root
+    new_rc_root = _lerp(rc_root, rc_tip, t0)
+    new_rc_tip = _lerp(rc_root, rc_tip, t1)
+
+    ss_root = ted.side_spacing_root
+    ss_tip = ted.side_spacing_tip if ted.side_spacing_tip is not None else ted.side_spacing_root
+    new_ss_root = (
+        _lerp(ss_root, ss_tip, t0) if ss_root is not None and ss_tip is not None else ss_root
+    )
+    new_ss_tip = (
+        _lerp(ss_root, ss_tip, t1) if ss_root is not None and ss_tip is not None else ss_tip
+    )
+
+    # Servo placement: keep it only on the sub-span that contains it.
+    servo = None
+    servo_chord = ted.rel_chord_servo_position
+    new_servo_len = ted.rel_length_servo_position
+    rel_len = ted.rel_length_servo_position
+    if ted._servo is not None and (
+        rel_len is None or t0 - _FRACTION_TOL <= rel_len <= t1 + _FRACTION_TOL
+    ):
+        servo = ted._servo
+        # re-express the servo's spanwise position within the sub-span.
+        if rel_len is not None and (t1 - t0) > _FRACTION_TOL:
+            new_servo_len = (rel_len - t0) / (t1 - t0)
+    else:
+        servo_chord = None
+        new_servo_len = None
+
+    return TrailingEdgeDevice(
+        name=_disambiguate_name(ted.name, ordinal),
+        rel_chord_root=new_rc_root,
+        rel_chord_tip=new_rc_tip,
+        hinge_spacing=ted.hinge_spacing,
+        side_spacing_root=new_ss_root,
+        side_spacing_tip=new_ss_tip,
+        servo=servo,
+        servo_placement=ted.servo_placement,
+        rel_chord_servo_position=servo_chord,
+        rel_length_servo_position=new_servo_len,
+        positive_deflection_deg=ted.positive_deflection_deg,
+        negative_deflection_deg=ted.negative_deflection_deg,
+        trailing_edge_offset_factor=ted.trailing_edge_offset_factor,
+        hinge_type=ted.hinge_type,
+        symmetric=ted.symmetric,
+    )
+
+
+def _disambiguate_name(name: str, ordinal: int) -> str:
+    """Make a duplicated control surface's name globally unique.
+
+    Sub-segment 0 keeps the original name verbatim. Later sub-segments append a
+    ``#<ordinal>`` suffix to the **display** part, preserving any ``[role]``
+    prefix so ``control_surface_mixing.parse_role_tag`` still recovers the role
+    (gh-772). AVL/ASB collapse same-named CONTROL variables into one DOF, so the
+    suffix prevents N duplicated surfaces from silently merging (gh-955).
+    """
+    if ordinal == 0:
+        return name
+    if name.startswith("[") and "]" in name:
+        close = name.index("]")
+        role = name[: close + 1]
+        display = name[close + 1 :]
+        return f"{role}{display}#{ordinal}"
+    return f"{name}#{ordinal}"
+
+
+def _split_turbulator(turb: Turbulator, t0: float, t1: float) -> Turbulator:
+    """Carry the turbulator onto a sub-span with its position interpolated.
+
+    The turbulator is a surface bump with no spar effect, so it simply rides the
+    sub-segment; only its chordwise position (which tapers root→tip) is
+    re-evaluated at the sub-span endpoints.
+    """
+    pos_root = turb.position_root
+    pos_tip = turb.position_tip if turb.position_tip is not None else turb.position_root
+    return Turbulator(
+        position_root=_lerp(pos_root, pos_tip, t0),
+        form=turb.form,
+        height_mm=turb.height_mm,
+        position_tip=_lerp(pos_root, pos_tip, t1),
+        enabled=turb.enabled,
+    )
+
+
+def _rehome_spares(spares: list[Spare] | None, sub_y_lo: float, sub_y_hi: float) -> list[Spare]:
+    """Return the existing spares whose (segment-local) origin y falls in the
+    sub-span ``[sub_y_lo, sub_y_hi)`` (inclusive at the outermost boundary).
+
+    A spare with no origin (defensive) homes to the first sub-span.
+    """
+    rehomed: list[Spare] = []
+    for spare in spares or []:
+        origin = spare.spare_origin
+        y = float(origin.y) if origin is not None else 0.0
+        if sub_y_lo - _FRACTION_TOL <= y < sub_y_hi - _FRACTION_TOL:
+            rehomed.append(spare)
+        elif abs(y - sub_y_hi) <= _FRACTION_TOL and abs(sub_y_hi) > 0:
+            # exactly on the outer boundary -> belongs to this (the last) sub-span
+            rehomed.append(spare)
+    return rehomed
+
+
+def split_segment_at_lengths(
+    wing_config: WingConfiguration,
+    segment_index: int,
+    split_lengths: list[float],
+    *,
+    airfoil_morph_fn: AirfoilMorphFn | None = None,
+    main_pieces_per_subsegment: list[list[Spare]] | None = None,
+) -> WingConfiguration:
+    """Like :func:`split_segment` but split positions are **mm** along the
+    segment (the natural unit of a telescoping joint y) rather than fractions."""
+    _ensure_segment_index(wing_config, segment_index)
+    seg_len = float(wing_config.segments[segment_index].length)
+    if seg_len <= 0.0:
+        raise ValueError("cannot split a zero-length segment")
+    fractions = [float(y) / seg_len for y in split_lengths]
+    return split_segment(
+        wing_config,
+        segment_index,
+        fractions,
+        airfoil_morph_fn=airfoil_morph_fn,
+        main_pieces_per_subsegment=main_pieces_per_subsegment,
+    )
+
+
+def split_segment(
+    wing_config: WingConfiguration,
+    segment_index: int,
+    split_fractions: list[float],
+    *,
+    airfoil_morph_fn: AirfoilMorphFn | None = None,
+    main_pieces_per_subsegment: list[list[Spare]] | None = None,
+) -> WingConfiguration:
+    """Split ``wing_config``'s segment ``segment_index`` into N contiguous
+    sub-segments at ``split_fractions`` (strictly inside ``(0, 1)``, increasing).
+
+    Returns a **new** ``WingConfiguration`` with the host segment replaced by
+    ``len(split_fractions) + 1`` sub-segments whose lengths sum to the original
+    and whose geometry reproduces the original ruled loft exactly. Children are
+    transferred per the module docstring; the i-th sub-segment's main-spar
+    pieces (``main_pieces_per_subsegment[i]``, if supplied) are placed at
+    ``spar_list[0]``.
+
+    Raises:
+        IndexError: ``segment_index`` out of range.
+        ValueError: invalid / non-increasing split fractions, or a sub-segment
+            count mismatch with ``main_pieces_per_subsegment``.
+    """
+    _ensure_segment_index(wing_config, segment_index)
+    _validate_fractions(split_fractions)
+
+    n_sub = len(split_fractions) + 1
+    if main_pieces_per_subsegment is not None and len(main_pieces_per_subsegment) != n_sub:
+        raise ValueError(
+            f"main_pieces_per_subsegment has {len(main_pieces_per_subsegment)} entries "
+            f"but the split produces {n_sub} sub-segments."
+        )
+
+    host = wing_config.segments[segment_index]
+    boundaries = [0.0, *split_fractions, 1.0]
+    seg_len = float(host.length)
+
+    # Build a fresh WingConfiguration by replaying every segment, substituting
+    # the host with its sub-segments. The first segment is created via the
+    # constructor; the rest via add_segment / add_tip_segment so the existing
+    # topology re-derives each root airfoil + workplanes (read-only path).
+    new_wc: WingConfiguration | None = None
+    for idx, seg in enumerate(wing_config.segments):
+        if idx == segment_index:
+            new_wc = _emit_subsegments(
+                new_wc,
+                wing_config,
+                seg,
+                boundaries,
+                seg_len,
+                airfoil_morph_fn,
+                main_pieces_per_subsegment,
+            )
+        else:
+            new_wc = _emit_passthrough_segment(new_wc, wing_config, seg)
+
+    assert new_wc is not None  # at least one segment always exists
+    return new_wc
+
+
+def _ensure_segment_index(wing_config: WingConfiguration, segment_index: int) -> None:
+    n = len(wing_config.segments or [])
+    if segment_index < 0 or segment_index >= n:
+        raise IndexError(f"segment_index {segment_index} out of range (wing has {n} segment(s))")
+
+
+def _clone_airfoil(af: Airfoil) -> Airfoil:
+    return Airfoil(
+        airfoil=af.airfoil,
+        chord=af.chord,
+        dihedral_as_rotation_in_degrees=af.dihedral_as_rotation_in_degrees,
+        incidence=af.incidence,
+    )
+
+
+def _emit_passthrough_segment(
+    new_wc: WingConfiguration | None,
+    src_wc: WingConfiguration,
+    seg: WingSegment,
+) -> WingConfiguration:
+    """Append an unchanged copy of ``seg`` to the new wing configuration."""
+    if new_wc is None:
+        return WingConfiguration(
+            nose_pnt=src_wc.nose_pnt,
+            root_airfoil=_clone_airfoil(seg.root_airfoil),
+            length=seg.length,
+            sweep=seg.sweep,
+            sweep_is_angle=False,
+            tip_airfoil=_clone_airfoil(seg.tip_airfoil),
+            number_interpolation_points=seg.number_interpolation_points,
+            spare_list=list(seg.spare_list) if seg.spare_list else None,
+            trailing_edge_device=seg.trailing_edge_device,
+            turbulator=seg.turbulator,
+            symmetric=src_wc.symmetric,
+            parameters=src_wc.parameters,
+        )
+    if seg.wing_segment_type == "tip":
+        new_wc.add_tip_segment(
+            tip_type=seg.tip_type,
+            length=seg.length,
+            sweep=seg.sweep,
+            tip_airfoil=_clone_airfoil(seg.tip_airfoil),
+            number_interpolation_points=seg.number_interpolation_points,
+        )
+    else:
+        new_wc.add_segment(
+            length=seg.length,
+            sweep=seg.sweep,
+            sweep_is_angle=False,
+            tip_airfoil=_clone_airfoil(seg.tip_airfoil),
+            number_interpolation_points=seg.number_interpolation_points,
+            spare_list=list(seg.spare_list) if seg.spare_list else None,
+            trailing_edge_device=seg.trailing_edge_device,
+            turbulator=seg.turbulator,
+        )
+    return new_wc
+
+
+def _emit_subsegments(
+    new_wc: WingConfiguration | None,
+    src_wc: WingConfiguration,
+    host: WingSegment,
+    boundaries: list[float],
+    seg_len: float,
+    airfoil_morph_fn: AirfoilMorphFn | None,
+    main_pieces_per_subsegment: list[list[Spare]] | None,
+) -> WingConfiguration:
+    """Replace ``host`` with its contiguous sub-segments in the new wing."""
+    root_af = host.root_airfoil
+    tip_af = host.tip_airfoil
+    # Total relative deltas the host carries from its root to its tip.
+    d_incidence = tip_af.incidence
+    d_dihedral = tip_af.dihedral_as_rotation_in_degrees
+
+    n_sub = len(boundaries) - 1
+    for i in range(n_sub):
+        t0, t1 = boundaries[i], boundaries[i + 1]
+        sub_length = (t1 - t0) * seg_len
+
+        # Boundary airfoil at t1 (outer end of this sub-segment). Chord + file
+        # come from the ruled blend. The LAST sub-segment's tip is the host's
+        # original tip airfoil — no interpolation/morph there.
+        if i == n_sub - 1:
+            outer_af = _clone_airfoil(tip_af)
+        else:
+            outer_af = _interp_airfoil(root_af, tip_af, t1, airfoil_morph_fn)
+
+        # Incidence (twist about the chord axis) does not move the spanwise
+        # position, so its delta splits linearly across the sub-segments.
+        outer_af.incidence = d_incidence * (t1 - t0)
+
+        # Dihedral rotates the spanwise translation about x. Splitting it
+        # linearly would bend the intermediate station origins OFF the original
+        # straight ruled line (a 1°/100mm-class geometry change). Instead carry
+        # the FULL dihedral delta on the last sub-segment's tip and ZERO on the
+        # intermediate boundaries: every intermediate origin stays on the
+        # original straight line, and the final tip wire gets the original tilt
+        # — reproducing the ruled loft exactly.
+        outer_af.dihedral_as_rotation_in_degrees = d_dihedral if i == n_sub - 1 else 0.0
+
+        sub_sweep = host.sweep * (t1 - t0)
+
+        # Children for this sub-span.
+        sub_ted = (
+            _split_ted(host.trailing_edge_device, t0, t1, i)
+            if host.trailing_edge_device is not None
+            else None
+        )
+        sub_turb = (
+            _split_turbulator(host.turbulator, t0, t1) if host.turbulator is not None else None
+        )
+        rehomed = _rehome_spares(host.spare_list, t0 * seg_len, t1 * seg_len)
+        sub_spares = _assemble_spare_list(
+            main_pieces_per_subsegment[i] if main_pieces_per_subsegment else None,
+            rehomed,
+        )
+
+        if new_wc is None:
+            # First sub-segment of a wing whose host is the root segment.
+            first_root = _clone_airfoil(root_af)
+            new_wc = WingConfiguration(
+                nose_pnt=src_wc.nose_pnt,
+                root_airfoil=first_root,
+                length=sub_length,
+                sweep=sub_sweep,
+                sweep_is_angle=False,
+                tip_airfoil=outer_af,
+                number_interpolation_points=host.number_interpolation_points,
+                spare_list=sub_spares,
+                trailing_edge_device=sub_ted,
+                turbulator=sub_turb,
+                symmetric=src_wc.symmetric,
+                parameters=src_wc.parameters,
+            )
+        else:
+            new_wc.add_segment(
+                length=sub_length,
+                sweep=sub_sweep,
+                sweep_is_angle=False,
+                tip_airfoil=outer_af,
+                number_interpolation_points=host.number_interpolation_points,
+                spare_list=sub_spares,
+                trailing_edge_device=sub_ted,
+                turbulator=sub_turb,
+            )
+    return new_wc
+
+
+def _assemble_spare_list(
+    main_pieces: list[Spare] | None, rehomed: list[Spare]
+) -> list[Spare] | None:
+    """Build a sub-segment's spare_list with the main piece(s) at index 0.
+
+    The main-spar piece(s) for this sub-segment come first (``spar_list[0]`` =
+    main spar — the VaseMode invariant), then any re-homed existing spares.
+    """
+    combined: list[Spare] = []
+    if main_pieces:
+        combined.extend(main_pieces)
+    combined.extend(rehomed)
+    return combined or None

--- a/cad_designer/airplane/geometry/spar_cad_insertion.py
+++ b/cad_designer/airplane/geometry/spar_cad_insertion.py
@@ -71,6 +71,33 @@ def spar_piece_to_spare(piece: SparPiece) -> Spare:
     )
 
 
+def secondary_spare_option_b(piece: SparPiece, *, segment_root_y: float) -> Spare:
+    """Map a secondary (rear / torsion / reinforcement) :class:`SparPiece` to a
+    partial-span ``Spare`` — Option B (gh-1059).
+
+    Unlike the main (front) spar — which triggers a *segment split* so each
+    telescoping diameter gets its own segment with the main piece at index 0
+    (Option A) — secondary spars stay in the host segment as **partial-span**
+    spares: ``spare_start`` is how far the piece begins from the segment root
+    (mm, never negative) and ``spare_length`` is the piece's spanwise extent.
+    The construction already builds partial-span spares
+    (``extrude_length = spare.spare_length`` at ``.workplane(offset=spare_start)``),
+    so no split is needed. Caller assigns the persisted ``spar_index`` (rear root
+    = 1, further pieces = next free ids).
+    """
+    vector = _unit(piece.spare_vector)
+    spare_start = max(0.0, float(piece.spare_origin[1]) - float(segment_root_y))
+    return Spare(
+        spare_support_dimension_width=float(piece.outer_d),
+        spare_support_dimension_height=float(piece.outer_d),
+        spare_length=float(piece.length),
+        spare_start=spare_start,
+        spare_origin=tuple(float(c) for c in piece.spare_origin),
+        spare_vector=vector,
+        spare_mode="normal",
+    )
+
+
 def spar_plan_to_spares(plan: SparPlan) -> SparInsertionResult:
     """Turn a whole :class:`SparPlan` into ``Spare`` objects + warnings.
 

--- a/cad_designer/airplane/geometry/spar_solver.py
+++ b/cad_designer/airplane/geometry/spar_solver.py
@@ -146,9 +146,47 @@ class SparPlan:
         }
 
 
+# Default chordwise margin (fraction of chord) a COMPUTED rear/torsion spar
+# keeps in front of a control-surface hinge line so it never overlaps the
+# movable surface. gh-1059.
+_REAR_CLEARANCE_FRACTION = 0.03
+
+# Smallest chordwise location a clamped rear spar may take (never at/forward of
+# the LE). gh-1059.
+_MIN_REAR_X_C = 0.05
+
+
 # ---------------------------------------------------------------------------
 # Geometry helpers (pure)
 # ---------------------------------------------------------------------------
+
+
+def rear_spar_x_c_with_clearance(
+    requested_x_c: float,
+    *,
+    control_surface_hinge_x_c: float | None,
+    clearance: float = _REAR_CLEARANCE_FRACTION,
+) -> float:
+    """Constrain a COMPUTED rear/torsion spar to stay forward of a control
+    surface (gh-1059).
+
+    A control surface is the movable region *behind* its hinge line
+    (``control_surface_hinge_x_c``, x/c). A solver-placed spar must never
+    overlap it, so the rear spar's chordwise location is pulled forward to
+    ``hinge - clearance`` when the request would sit at or behind the hinge.
+    A request already forward of the clearance line is kept unchanged, and a
+    wing with no control surface keeps its requested ``x_c``.
+
+    The result is floored at :data:`_MIN_REAR_X_C` so a control surface whose
+    hinge sits near the LE cannot push the spar onto/forward of the leading
+    edge. This guard applies ONLY to computed spars — a designer may still
+    place a reinforcing spar inside a control surface manually.
+    """
+    if control_surface_hinge_x_c is None:
+        return requested_x_c
+    limit = control_surface_hinge_x_c - clearance
+    safe = min(requested_x_c, limit)
+    return max(safe, _MIN_REAR_X_C)
 
 
 def _axis_z_at(run: list[StationData], station: StationData) -> float:
@@ -570,6 +608,7 @@ def build_stations_from_geometry(
     packing_factor: float = 0.8,
     safety_factor_j: float = 1.5,
     g_limit: float = 3.0,
+    control_surface_hinge_x_c: float | None = None,
 ) -> list[StationData]:
     """Sample a :class:`SectionGeometry` into solver-ready :class:`StationData`.
 
@@ -578,8 +617,16 @@ def build_stations_from_geometry(
     contained band ``[bottom_z + clr, top_z - clr]`` (clr from ``packing_factor``)
     and ``center_z``, and compute the strength-required OD from #1008 sizing
     using the station's design moment ``M_design = |M| · g · j``.
+
+    When ``x_c`` and ``control_surface_hinge_x_c`` are both given (the
+    rear/torsion-spar path), the chordwise location is first pulled forward of
+    the control surface via :func:`rear_spar_x_c_with_clearance` so a computed
+    spar never overlaps the movable surface (gh-1059).
     """
     import numpy as np
+
+    if x_c is not None and control_surface_hinge_x_c is not None:
+        x_c = rear_spar_x_c_with_clearance(x_c, control_surface_hinge_x_c=control_surface_hinge_x_c)
 
     y_spans = np.linspace(0.0, 1.0, max(2, n_span)).tolist()
     # gh-1037 #4: the slice at y_span=0 is degenerate on a real loft (pinched,

--- a/cad_designer/tests/test_segment_split.py
+++ b/cad_designer/tests/test_segment_split.py
@@ -1,0 +1,644 @@
+"""Tests for the main-spar segment-split helper (gh-1059).
+
+A telescoping main (front) spar has a varying diameter, so it cannot live as
+multiple ``spar_index == 0`` pieces in a single wing segment (VaseMode treats
+*any* index-0 spar as THE main spar). The fix is to split the host segment at
+each telescoping joint y into N contiguous sub-segments, each carrying exactly
+one main piece at index 0.
+
+The split MUST be geometrically transparent — the built loft is unchanged
+across the split. This is guaranteed because the loft is ruled (linear blend
+root↔tip), so an intermediate section is fully determined by the linearly
+interpolated chord / twist / dihedral / sweep / length plus the (same or
+Kulfan-morphed) airfoil shape at the split fraction.
+
+Two tiers:
+
+* **fast** — pure split math + child transfer (no CAD, morph mocked).
+* **slow / requires_cadquery** — build the loft BEFORE and AFTER the split and
+  assert the section geometry is unchanged at sample stations.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from cad_designer.airplane.aircraft_topology.wing.Airfoil import Airfoil
+from cad_designer.airplane.aircraft_topology.wing.Spare import Spare
+from cad_designer.airplane.aircraft_topology.wing.TrailingEdgeDevice import (
+    TrailingEdgeDevice,
+)
+from cad_designer.airplane.aircraft_topology.wing.Turbulator import Turbulator
+from cad_designer.airplane.aircraft_topology.wing.WingConfiguration import (
+    WingConfiguration,
+)
+from cad_designer.airplane.geometry.segment_split import (
+    split_segment,
+    split_segment_at_lengths,
+)
+
+AIRFOIL = "components/airfoils/naca0010.dat"
+AIRFOIL_B = "components/airfoils/naca2412.dat"
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def _single_segment(
+    *,
+    root_chord: float = 200.0,
+    tip_chord: float = 150.0,
+    length: float = 500.0,
+    sweep: float = 20.0,
+    tip_dihedral: float = 8.0,
+    tip_incidence: float = -4.0,
+    root_af: str = AIRFOIL,
+    tip_af: str | None = None,
+    spare_list: list[Spare] | None = None,
+    ted: TrailingEdgeDevice | None = None,
+    turbulator: Turbulator | None = None,
+) -> WingConfiguration:
+    return WingConfiguration(
+        nose_pnt=(0.0, 0.0, 0.0),
+        root_airfoil=Airfoil(
+            airfoil=root_af,
+            chord=root_chord,
+            dihedral_as_rotation_in_degrees=2.0,
+            incidence=1.0,
+        ),
+        length=length,
+        sweep=sweep,
+        sweep_is_angle=False,
+        tip_airfoil=Airfoil(
+            airfoil=tip_af,
+            chord=tip_chord,
+            dihedral_as_rotation_in_degrees=tip_dihedral,
+            incidence=tip_incidence,
+        ),
+        spare_list=spare_list,
+        trailing_edge_device=ted,
+        turbulator=turbulator,
+        symmetric=True,
+        parameters="relative",
+    )
+
+
+def _main_spare() -> Spare:
+    return Spare(
+        spare_support_dimension_width=10.0,
+        spare_support_dimension_height=10.0,
+        spare_length=500.0,
+        spare_start=0.0,
+        spare_origin=(0.0, 0.0, 0.0),
+        spare_vector=(0.0, 1.0, 0.0),
+        spare_mode="normal",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fast: split math
+# ---------------------------------------------------------------------------
+
+
+class TestSplitMath:
+    def test_single_split_produces_two_subsegments(self):
+        wc = _single_segment(length=500.0)
+        out = split_segment(wc, 0, [0.4])
+        assert len(out.segments) == 2
+
+    def test_lengths_sum_to_original(self):
+        wc = _single_segment(length=500.0)
+        out = split_segment(wc, 0, [0.4])
+        total = sum(s.length for s in out.segments)
+        assert total == pytest.approx(500.0)
+        assert out.segments[0].length == pytest.approx(200.0)
+        assert out.segments[1].length == pytest.approx(300.0)
+
+    def test_multiple_splits_contiguous(self):
+        wc = _single_segment(length=600.0)
+        out = split_segment(wc, 0, [1.0 / 3.0, 2.0 / 3.0])
+        assert len(out.segments) == 3
+        lengths = [s.length for s in out.segments]
+        assert sum(lengths) == pytest.approx(600.0)
+        assert lengths[0] == pytest.approx(200.0)
+        assert lengths[1] == pytest.approx(200.0)
+        assert lengths[2] == pytest.approx(200.0)
+
+    def test_split_at_lengths_helper(self):
+        wc = _single_segment(length=500.0)
+        out = split_segment_at_lengths(wc, 0, [150.0, 350.0])
+        lengths = [s.length for s in out.segments]
+        assert lengths == pytest.approx([150.0, 200.0, 150.0])
+
+    def test_boundary_chord_linear_blend(self):
+        wc = _single_segment(root_chord=200.0, tip_chord=100.0, length=500.0)
+        out = split_segment(wc, 0, [0.5])
+        # boundary chord at t=0.5 -> midway 150
+        assert out.segments[0].tip_airfoil.chord == pytest.approx(150.0)
+        # the second sub-segment's root chord equals the boundary chord
+        assert out.segments[1].root_airfoil.chord == pytest.approx(150.0)
+        # endpoints unchanged
+        assert out.segments[0].root_airfoil.chord == pytest.approx(200.0)
+        assert out.segments[1].tip_airfoil.chord == pytest.approx(100.0)
+
+    def test_sweep_delta_split_sums(self):
+        wc = _single_segment(sweep=40.0, length=500.0)
+        out = split_segment(wc, 0, [0.25])
+        assert out.segments[0].sweep + out.segments[1].sweep == pytest.approx(40.0)
+        assert out.segments[0].sweep == pytest.approx(10.0)
+
+    def test_incidence_delta_split_sums(self):
+        # original tip incidence delta = -4 (relative to root).
+        wc = _single_segment(tip_incidence=-4.0, length=500.0)
+        out = split_segment(wc, 0, [0.25])
+        boundary_i = out.segments[0].tip_airfoil.incidence
+        second_tip_i = out.segments[1].tip_airfoil.incidence
+        assert boundary_i + second_tip_i == pytest.approx(-4.0)
+        assert boundary_i == pytest.approx(-1.0)
+
+    def test_dihedral_delta_carried_on_last_subsegment(self):
+        # Dihedral rotates the spanwise translation; splitting the delta
+        # linearly would bend the intermediate origins off the original straight
+        # ruled line. The geometrically-exact rule (proven by the slow
+        # loft-unchanged test) is: ZERO dihedral delta on intermediate
+        # boundaries, the FULL delta on the last sub-segment's tip.
+        wc = _single_segment(tip_dihedral=8.0, length=500.0)
+        out = split_segment(wc, 0, [0.25])
+        boundary_d = out.segments[0].tip_airfoil.dihedral_as_rotation_in_degrees
+        last_tip_d = out.segments[1].tip_airfoil.dihedral_as_rotation_in_degrees
+        assert boundary_d == pytest.approx(0.0)
+        assert last_tip_d == pytest.approx(8.0)
+        # the total dihedral from root to original tip is preserved.
+        assert boundary_d + last_tip_d == pytest.approx(8.0)
+
+    def test_three_way_dihedral_only_on_last(self):
+        wc = _single_segment(tip_dihedral=6.0, length=600.0)
+        out = split_segment(wc, 0, [1.0 / 3.0, 2.0 / 3.0])
+        dihedrals = [s.tip_airfoil.dihedral_as_rotation_in_degrees for s in out.segments]
+        assert dihedrals[0] == pytest.approx(0.0)
+        assert dihedrals[1] == pytest.approx(0.0)
+        assert dihedrals[2] == pytest.approx(6.0)
+
+    def test_same_airfoil_keeps_file(self):
+        wc = _single_segment(root_af=AIRFOIL, tip_af=AIRFOIL)
+        out = split_segment(wc, 0, [0.5])
+        assert out.segments[0].tip_airfoil.airfoil == AIRFOIL
+        assert out.segments[1].root_airfoil.airfoil == AIRFOIL
+
+    def test_invalid_split_fraction_rejected(self):
+        wc = _single_segment()
+        with pytest.raises(ValueError):
+            split_segment(wc, 0, [0.0])
+        with pytest.raises(ValueError):
+            split_segment(wc, 0, [1.0])
+        with pytest.raises(ValueError):
+            split_segment(wc, 0, [1.5])
+
+    def test_unsorted_split_fractions_rejected(self):
+        wc = _single_segment()
+        with pytest.raises(ValueError):
+            split_segment(wc, 0, [0.6, 0.3])
+
+    def test_empty_split_returns_equivalent(self):
+        wc = _single_segment(length=500.0)
+        out = split_segment(wc, 0, [])
+        assert len(out.segments) == 1
+        assert out.segments[0].length == pytest.approx(500.0)
+
+    def test_out_of_range_segment_rejected(self):
+        wc = _single_segment()
+        with pytest.raises(IndexError):
+            split_segment(wc, 5, [0.5])
+
+    def test_other_segments_untouched(self):
+        wc = _single_segment(length=500.0)
+        wc.add_segment(length=300.0, sweep=10.0, tip_airfoil=Airfoil(chord=80.0))
+        out = split_segment(wc, 0, [0.5])
+        # 2 (split seg 0) + 1 (seg 1) = 3
+        assert len(out.segments) == 3
+        # the untouched outer segment keeps its length
+        assert out.segments[-1].length == pytest.approx(300.0)
+
+    def test_split_non_root_segment_passes_root_through(self):
+        wc = _single_segment(length=500.0)
+        wc.add_segment(length=300.0, sweep=10.0, tip_airfoil=Airfoil(chord=80.0))
+        out = split_segment(wc, 1, [0.5])  # split the OUTER segment
+        # seg 0 passes through unchanged + 2 sub-segments of seg 1 = 3
+        assert len(out.segments) == 3
+        assert out.segments[0].length == pytest.approx(500.0)
+        assert out.segments[1].length + out.segments[2].length == pytest.approx(300.0)
+
+    def test_split_with_tip_segment_present(self):
+        wc = _single_segment(length=500.0)
+        wc.add_tip_segment(tip_type="round", length=100.0, tip_airfoil=Airfoil(chord=60.0))
+        out = split_segment(wc, 0, [0.5])
+        # 2 sub-segments + the carried-through tip segment = 3
+        assert len(out.segments) == 3
+        assert out.segments[-1].wing_segment_type == "tip"
+        assert out.segments[-1].length == pytest.approx(100.0)
+
+    def test_main_pieces_count_mismatch_rejected(self):
+        wc = _single_segment(length=500.0)
+        with pytest.raises(ValueError):
+            split_segment(wc, 0, [0.5], main_pieces_per_subsegment=[[]])  # need 2 entries
+
+    def test_at_lengths_zero_length_segment_rejected(self):
+        wc = _single_segment(length=500.0)
+        wc.segments[0].length = 0.0
+        with pytest.raises(ValueError):
+            split_segment_at_lengths(wc, 0, [100.0])
+
+
+# ---------------------------------------------------------------------------
+# Fast: main-spar index-0 per sub-segment
+# ---------------------------------------------------------------------------
+
+
+class TestMainSparIndexZero:
+    def test_main_piece_index_zero_in_each_subsegment(self):
+        wc = _single_segment(spare_list=[_main_spare()])
+        main_pieces = [
+            Spare(
+                spare_support_dimension_width=10.0,
+                spare_support_dimension_height=10.0,
+                spare_length=200.0,
+                spare_origin=(0.0, 0.0, 0.0),
+                spare_vector=(0.0, 1.0, 0.0),
+                spare_mode="normal",
+            ),
+            Spare(
+                spare_support_dimension_width=8.0,
+                spare_support_dimension_height=8.0,
+                spare_length=300.0,
+                spare_origin=(0.0, 200.0, 0.0),
+                spare_vector=(0.0, 1.0, 0.0),
+                spare_mode="normal",
+            ),
+        ]
+        out = split_segment(
+            wc, 0, [0.4], main_pieces_per_subsegment=[[main_pieces[0]], [main_pieces[1]]]
+        )
+        assert len(out.segments) == 2
+        # each sub-segment carries its main piece at index 0
+        assert out.segments[0].spare_list[0] is main_pieces[0]
+        assert out.segments[1].spare_list[0] is main_pieces[1]
+
+
+# ---------------------------------------------------------------------------
+# Fast: control-surface duplication + naming
+# ---------------------------------------------------------------------------
+
+
+class TestControlSurfaceDuplication:
+    def test_ted_duplicated_onto_each_subsegment(self):
+        ted = TrailingEdgeDevice(name="aileron", rel_chord_root=0.75, rel_chord_tip=0.75)
+        wc = _single_segment(ted=ted)
+        out = split_segment(wc, 0, [0.5])
+        assert out.segments[0].trailing_edge_device is not None
+        assert out.segments[1].trailing_edge_device is not None
+
+    def test_ted_names_disambiguated(self):
+        ted = TrailingEdgeDevice(name="aileron", rel_chord_root=0.75)
+        wc = _single_segment(ted=ted)
+        out = split_segment(wc, 0, [0.5])
+        names = [s.trailing_edge_device.name for s in out.segments]
+        assert len(set(names)) == 2  # globally unique
+        # first sub-segment keeps the original name
+        assert names[0] == "aileron"
+
+    def test_ted_role_tag_preserved(self):
+        ted = TrailingEdgeDevice(name="[aileron]right", rel_chord_root=0.75)
+        wc = _single_segment(ted=ted)
+        out = split_segment(wc, 0, [0.5])
+        for s in out.segments:
+            assert s.trailing_edge_device.name.startswith("[aileron]")
+
+    def test_ted_chord_taper_interpolated(self):
+        # taper the hinge line 0.70 (root) -> 0.80 (tip) over the whole segment.
+        ted = TrailingEdgeDevice(name="flap", rel_chord_root=0.70, rel_chord_tip=0.80)
+        wc = _single_segment(ted=ted)
+        out = split_segment(wc, 0, [0.5])
+        # boundary hinge at t=0.5 -> 0.75
+        assert out.segments[0].trailing_edge_device.rel_chord_tip == pytest.approx(0.75)
+        assert out.segments[1].trailing_edge_device.rel_chord_root == pytest.approx(0.75)
+        # endpoints preserved
+        assert out.segments[0].trailing_edge_device.rel_chord_root == pytest.approx(0.70)
+        assert out.segments[1].trailing_edge_device.rel_chord_tip == pytest.approx(0.80)
+
+    def test_ted_side_spacing_interpolated(self):
+        ted = TrailingEdgeDevice(
+            name="flap", rel_chord_root=0.75, side_spacing_root=4.0, side_spacing_tip=8.0
+        )
+        wc = _single_segment(ted=ted)
+        out = split_segment(wc, 0, [0.5])
+        assert out.segments[0].trailing_edge_device.side_spacing_tip == pytest.approx(6.0)
+        assert out.segments[1].trailing_edge_device.side_spacing_root == pytest.approx(6.0)
+
+    def test_no_ted_leaves_none(self):
+        wc = _single_segment(ted=None)
+        out = split_segment(wc, 0, [0.5])
+        assert out.segments[0].trailing_edge_device is None
+        assert out.segments[1].trailing_edge_device is None
+
+    def test_servo_rides_only_containing_subsegment(self):
+        # servo at rel_length 0.8 -> only the OUTER sub-segment carries it.
+        ted = TrailingEdgeDevice(
+            name="aileron",
+            rel_chord_root=0.75,
+            servo=7,
+            rel_chord_servo_position=0.85,
+            rel_length_servo_position=0.8,
+        )
+        wc = _single_segment(ted=ted)
+        out = split_segment(wc, 0, [0.5])
+        assert out.segments[0].trailing_edge_device._servo is None
+        assert out.segments[1].trailing_edge_device._servo == 7
+        # re-expressed within the outer sub-span: (0.8 - 0.5) / 0.5 = 0.6
+        assert out.segments[1].trailing_edge_device.rel_length_servo_position == pytest.approx(0.6)
+
+
+class TestMorphSeamFallbackNoFn:
+    def test_differing_airfoil_without_morph_fn_keeps_inboard(self):
+        # No morph seam supplied for differing anchors -> boundary keeps the
+        # inboard anchor's airfoil so the section is still buildable.
+        wc = _single_segment(root_af=AIRFOIL, tip_af=AIRFOIL_B)
+        out = split_segment(wc, 0, [0.5])  # no airfoil_morph_fn
+        assert out.segments[0].tip_airfoil.airfoil == AIRFOIL
+        assert out.segments[1].root_airfoil.airfoil == AIRFOIL
+
+
+# ---------------------------------------------------------------------------
+# Fast: turbulator carry-along
+# ---------------------------------------------------------------------------
+
+
+class TestTurbulatorCarry:
+    def test_turbulator_carried_onto_each_subsegment(self):
+        turb = Turbulator(position_root=0.10, position_tip=0.20, form="zigzag")
+        wc = _single_segment(turbulator=turb)
+        out = split_segment(wc, 0, [0.5])
+        assert out.segments[0].turbulator is not None
+        assert out.segments[1].turbulator is not None
+
+    def test_turbulator_position_interpolated(self):
+        turb = Turbulator(position_root=0.10, position_tip=0.20)
+        wc = _single_segment(turbulator=turb)
+        out = split_segment(wc, 0, [0.5])
+        # boundary at t=0.5 -> 0.15
+        assert out.segments[0].turbulator.position_tip == pytest.approx(0.15)
+        assert out.segments[1].turbulator.position_root == pytest.approx(0.15)
+        assert out.segments[0].turbulator.position_root == pytest.approx(0.10)
+        assert out.segments[1].turbulator.position_tip == pytest.approx(0.20)
+
+    def test_turbulator_form_preserved(self):
+        turb = Turbulator(position_root=0.10, form="dots", height_mm=0.5)
+        wc = _single_segment(turbulator=turb)
+        out = split_segment(wc, 0, [0.5])
+        for s in out.segments:
+            assert s.turbulator.form == "dots"
+            assert s.turbulator.height_mm == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# Fast: existing-spare re-home
+# ---------------------------------------------------------------------------
+
+
+class TestSpareRehome:
+    def _spare_at_y(self, y: float) -> Spare:
+        return Spare(
+            spare_support_dimension_width=5.0,
+            spare_support_dimension_height=5.0,
+            spare_length=50.0,
+            spare_origin=(0.0, y, 0.0),
+            spare_vector=(0.0, 1.0, 0.0),
+            spare_mode="normal",
+        )
+
+    def test_inboard_spare_homes_to_first_subsegment(self):
+        s = self._spare_at_y(50.0)  # y=50 < boundary 200
+        wc = _single_segment(length=500.0, spare_list=[s])
+        out = split_segment(wc, 0, [0.4])  # boundary at 200mm
+        assert s in (out.segments[0].spare_list or [])
+        assert s not in (out.segments[1].spare_list or [])
+
+    def test_outboard_spare_homes_to_second_subsegment(self):
+        s = self._spare_at_y(300.0)  # y=300 > boundary 200
+        wc = _single_segment(length=500.0, spare_list=[s])
+        out = split_segment(wc, 0, [0.4])
+        assert s in (out.segments[1].spare_list or [])
+        assert s not in (out.segments[0].spare_list or [])
+
+    def test_spare_origin_uses_local_offset(self):
+        # spare origin y is segment-local; re-home keys off local y vs sub-span.
+        s_in = self._spare_at_y(100.0)
+        s_out = self._spare_at_y(400.0)
+        wc = _single_segment(length=500.0, spare_list=[s_in, s_out])
+        out = split_segment(wc, 0, [0.5])  # boundary at 250mm
+        assert s_in in out.segments[0].spare_list
+        assert s_out in out.segments[1].spare_list
+
+    def test_spare_on_outer_tip_boundary_homes_to_last(self):
+        # a spare sitting exactly at the segment tip y belongs to the last sub-span.
+        s_tip = self._spare_at_y(500.0)
+        wc = _single_segment(length=500.0, spare_list=[s_tip])
+        out = split_segment(wc, 0, [0.5])
+        assert s_tip in out.segments[1].spare_list
+
+    def test_via_at_lengths_rehome(self):
+        s_in = self._spare_at_y(80.0)
+        s_out = self._spare_at_y(300.0)
+        wc = _single_segment(length=500.0, spare_list=[s_in, s_out])
+        out = split_segment_at_lengths(wc, 0, [200.0])
+        assert s_in in out.segments[0].spare_list
+        assert s_out in out.segments[1].spare_list
+
+
+# ---------------------------------------------------------------------------
+# Fast: differing-airfoil split uses the injected morph seam (gh-796 reuse)
+# ---------------------------------------------------------------------------
+
+
+class TestMorphSeam:
+    def test_differing_airfoil_calls_morph_fn(self):
+        calls: list[tuple[str, str, float]] = []
+
+        def fake_morph(a: str, b: str, t: float) -> str:
+            calls.append((a, b, t))
+            return "components/airfoils/__morphed__.dat"
+
+        wc = _single_segment(root_af=AIRFOIL, tip_af=AIRFOIL_B)
+        out = split_segment(wc, 0, [0.5], airfoil_morph_fn=fake_morph)
+        assert calls == [(AIRFOIL, AIRFOIL_B, 0.5)]
+        assert out.segments[0].tip_airfoil.airfoil == "components/airfoils/__morphed__.dat"
+        assert out.segments[1].root_airfoil.airfoil == "components/airfoils/__morphed__.dat"
+
+    def test_morph_fn_none_falls_back_to_root_airfoil(self):
+        # When the morph function returns None (fit failed), the boundary keeps
+        # the inboard anchor's airfoil so a buildable form is still captured.
+        def fake_morph(a: str, b: str, t: float) -> None:
+            return None
+
+        wc = _single_segment(root_af=AIRFOIL, tip_af=AIRFOIL_B)
+        out = split_segment(wc, 0, [0.5], airfoil_morph_fn=fake_morph)
+        assert out.segments[0].tip_airfoil.airfoil == AIRFOIL
+
+    def test_same_airfoil_does_not_call_morph(self):
+        def boom(a: str, b: str, t: float) -> str:  # pragma: no cover - must not run
+            raise AssertionError("morph must not be called for same-airfoil segments")
+
+        wc = _single_segment(root_af=AIRFOIL, tip_af=AIRFOIL)
+        split_segment(wc, 0, [0.5], airfoil_morph_fn=boom)
+
+
+# ---------------------------------------------------------------------------
+# Slow / requires_cadquery: the split is geometrically transparent.
+# Build the loft BEFORE and AFTER the split and assert the section geometry
+# (thickness / top_z / bottom_z / center_z) is unchanged at sample stations.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+@pytest.mark.requires_cadquery
+class TestLoftUnchangedAcrossSplit:
+    """The split must be geometrically transparent: the built loft is unchanged.
+
+    The proof uses the **analytic** SectionGeometry mode — the ground-truth
+    ruled (linear) blend the loft is built from — and asserts the section
+    geometry at sample stations matches before vs after the split. The
+    **solid** mode (real CAD slice) is also checked, at a looser tolerance that
+    absorbs the slicer's own discretisation noise (the analytic↔solid
+    equivalence test in test_section_geometry already bounds that to a fraction
+    of a mm / percent).
+
+    Transparency is *exact* for taper + sweep + dihedral (dihedral carried on
+    the last sub-segment keeps every intermediate origin on the original
+    straight ruled line). It is *near-exact* for twist combined with taper: a
+    rotated-and-scaled intermediate wire differs from the linear blend of the
+    two endpoint wires by a small twist×taper nonlinearity (sub-mm on
+    representative wings) — the same approximation class as any
+    intermediate-airfoil insertion. We bound that residual explicitly.
+    """
+
+    _SAMPLE_Y = [0.1, 0.3, 0.5, 0.7, 0.9]
+    _SAMPLE_X = [0.15, 0.3, 0.5, 0.7]
+
+    def _max_section_diff(self, before, after, *, mode: str) -> float:
+        from cad_designer.airplane.geometry.section_geometry import SectionGeometry
+
+        sg_before = SectionGeometry(before, mode=mode)
+        sg_after = SectionGeometry(after, mode=mode)
+        worst = 0.0
+        for y in self._SAMPLE_Y:
+            for x in self._SAMPLE_X:
+                pb = sg_before.at(y, x)
+                pa = sg_after.at(y, x)
+                worst = max(
+                    worst,
+                    abs(pa.thickness - pb.thickness),
+                    abs(pa.top_z - pb.top_z),
+                    abs(pa.bottom_z - pb.bottom_z),
+                    abs(pa.center_z - pb.center_z),
+                )
+        return worst
+
+    def test_taper_sweep_dihedral_split_is_exact(self):
+        """No twist → the split is geometrically exact (sub-0.1mm)."""
+        before = _single_segment(
+            root_chord=200.0,
+            tip_chord=120.0,
+            length=600.0,
+            sweep=40.0,
+            tip_dihedral=6.0,
+            tip_incidence=0.0,
+            root_af=AIRFOIL,
+            tip_af=AIRFOIL,
+        )
+        after = split_segment(before, 0, [1.0 / 3.0, 2.0 / 3.0])
+        assert len(after.segments) == 3
+        assert self._max_section_diff(before, after, mode="analytic") < 0.1
+
+    def test_untapered_twist_split_is_exact(self):
+        """Twist without taper → exact (twist×taper nonlinearity absent)."""
+        before = _single_segment(
+            root_chord=180.0,
+            tip_chord=180.0,
+            length=500.0,
+            sweep=30.0,
+            tip_dihedral=5.0,
+            tip_incidence=-6.0,
+            root_af=AIRFOIL,
+            tip_af=AIRFOIL,
+        )
+        after = split_segment(before, 0, [0.5])
+        assert self._max_section_diff(before, after, mode="analytic") < 0.1
+
+    def test_full_taper_twist_dihedral_split_residual_bounded(self):
+        """Taper + twist combined → small bounded twist×taper residual (<1.5mm)."""
+        before = _single_segment(
+            root_chord=200.0,
+            tip_chord=120.0,
+            length=600.0,
+            sweep=40.0,
+            tip_dihedral=6.0,
+            tip_incidence=-4.0,
+            root_af=AIRFOIL,
+            tip_af=AIRFOIL,
+        )
+        after = split_segment(before, 0, [1.0 / 3.0, 2.0 / 3.0])
+        # Analytic ground truth: a sub-1.5mm twist×taper residual on a 600mm
+        # wing (~0.25% of span). Documented, not silently widened.
+        assert self._max_section_diff(before, after, mode="analytic") < 1.5
+
+    def test_solid_loft_unchanged_within_slicer_noise(self):
+        """The real CAD solid lofts the same across the split (slicer-noise tol)."""
+        before = _single_segment(
+            root_chord=200.0,
+            tip_chord=120.0,
+            length=600.0,
+            sweep=40.0,
+            tip_dihedral=6.0,
+            tip_incidence=0.0,
+            root_af=AIRFOIL,
+            tip_af=AIRFOIL,
+        )
+        after = split_segment(before, 0, [1.0 / 3.0, 2.0 / 3.0])
+        # Exact-geometry (no-twist) case; the residual here is the solid
+        # slicer's own discretisation, bounded to ~1mm on this section.
+        assert self._max_section_diff(before, after, mode="solid") < 1.0
+
+    def test_split_preserves_total_span(self):
+        before = _single_segment(length=600.0, root_af=AIRFOIL, tip_af=AIRFOIL)
+        after = split_segment(before, 0, [0.5])
+        span_before = before.segments[0].length
+        span_after = sum(s.length for s in after.segments)
+        assert span_after == pytest.approx(span_before)
+
+    def test_differing_airfoil_split_is_transparent_via_kulfan(self):
+        from app.converters.openvsp_airfoil import morph_airfoils
+
+        before = _single_segment(
+            root_chord=200.0,
+            tip_chord=150.0,
+            length=500.0,
+            sweep=20.0,
+            tip_dihedral=4.0,
+            tip_incidence=0.0,
+            root_af=AIRFOIL,
+            tip_af=AIRFOIL_B,
+        )
+        after = split_segment(before, 0, [0.5], airfoil_morph_fn=morph_airfoils)
+        # Kulfan morphing approximates the ruled blend of two different shapes;
+        # bound the residual on the real solid loft.
+        assert self._max_section_diff(before, after, mode="solid") < 3.0
+
+
+def test_helper_module_importable():
+    # the module must expose both the fraction- and length-based entry points.
+    assert callable(split_segment)
+    assert callable(split_segment_at_lengths)
+    assert math.isclose(1.0, 1.0)

--- a/cad_designer/tests/test_spar_clearance_and_secondary.py
+++ b/cad_designer/tests/test_spar_clearance_and_secondary.py
@@ -1,0 +1,149 @@
+"""Rear-spar control-surface clearance + secondary Option-B spares (gh-1059).
+
+Two pure (fast) concerns, both with no CAD dependency:
+
+* **Rear/torsion-spar clearance:** a *computed* spar must never overlap a
+  control surface. The rear spar's chordwise location must stay forward of the
+  control surface's hinge line (with a margin). A designer may still place a
+  reinforcing spar *inside* a control surface manually — that is not a computed
+  spar — so the guard only applies to the solver's chosen ``x_c``.
+* **Secondary spars → Option B:** rear / reinforcement spars persist as
+  partial-span ``Spare`` objects (``spare_start`` + ``spare_length``) under
+  their own ids (rear root index 1, further pieces next free ids). No segment
+  split.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cad_designer.airplane.geometry.spar_solver import (
+    SparPiece,
+    SparRole,
+    rear_spar_x_c_with_clearance,
+)
+from cad_designer.airplane.geometry.spar_cad_insertion import (
+    secondary_spare_option_b,
+)
+
+
+# ---------------------------------------------------------------------------
+# Rear-spar control-surface clearance
+# ---------------------------------------------------------------------------
+
+
+class TestRearSparClearance:
+    def test_requested_x_c_kept_when_already_forward(self):
+        # control surface hinge at 0.75; a rear spar at 0.55 is already clear.
+        x_c = rear_spar_x_c_with_clearance(0.55, control_surface_hinge_x_c=0.75)
+        assert x_c == pytest.approx(0.55)
+
+    def test_x_c_pulled_forward_of_hinge(self):
+        # requested 0.80 is *behind* a hinge at 0.75 -> must move forward.
+        x_c = rear_spar_x_c_with_clearance(0.80, control_surface_hinge_x_c=0.75)
+        assert x_c < 0.75
+
+    def test_clearance_margin_applied(self):
+        x_c = rear_spar_x_c_with_clearance(0.80, control_surface_hinge_x_c=0.70, clearance=0.05)
+        assert x_c == pytest.approx(0.65)
+
+    def test_no_control_surface_keeps_request(self):
+        x_c = rear_spar_x_c_with_clearance(0.85, control_surface_hinge_x_c=None)
+        assert x_c == pytest.approx(0.85)
+
+    def test_never_returns_negative_or_zero(self):
+        # pathological: hinge right at the LE -> clamp to a small positive x_c.
+        x_c = rear_spar_x_c_with_clearance(0.5, control_surface_hinge_x_c=0.02, clearance=0.10)
+        assert x_c > 0.0
+
+    def test_exactly_at_hinge_pulled_forward(self):
+        x_c = rear_spar_x_c_with_clearance(0.75, control_surface_hinge_x_c=0.75, clearance=0.03)
+        assert x_c == pytest.approx(0.72)
+
+    def test_build_stations_applies_clearance(self):
+        """The station builder pulls a rear spar forward of the control surface."""
+        from cad_designer.airplane.geometry import spar_solver
+
+        sampled_x_cs: list[float] = []
+
+        class _Pt:
+            def __init__(self, y_span, x_c):
+                self.y_span = y_span
+                self.x_c = x_c
+                self.thickness = 20.0
+                self.center_z = 0.0
+                self.bottom_z = -10.0
+                self.top_z = 10.0
+
+        class _FakeGeometry:
+            _segment_lengths = [500.0]
+
+            def at(self, y_span, x_c):
+                sampled_x_cs.append(x_c)
+                return _Pt(y_span, x_c)
+
+        spar_solver.build_stations_from_geometry(
+            _FakeGeometry(),
+            moment_fn=lambda y: 1000.0 * (1.0 - y),
+            sigma_allow_mpa=300.0,
+            n_span=3,
+            x_c=0.80,  # requested behind the hinge
+            control_surface_hinge_x_c=0.75,
+        )
+        # every sampled x_c must be forward of (hinge - clearance) = 0.72
+        assert sampled_x_cs
+        assert all(x <= 0.72 + 1e-9 for x in sampled_x_cs)
+
+
+# ---------------------------------------------------------------------------
+# Secondary spars → Option B (partial-span Spare)
+# ---------------------------------------------------------------------------
+
+
+def _rear_piece(*, origin_y: float = 100.0, length: float = 300.0, od: float = 8.0) -> SparPiece:
+    return SparPiece(
+        role=SparRole.REAR,
+        spare_origin=(0.0, origin_y, 0.0),
+        spare_vector=(0.0, 1.0, 0.0),
+        outer_d=od,
+        inner_d=od * 0.6,
+        shape="tube",
+        governing_y=origin_y,
+        utilisation=0.5,
+        length=length,
+    )
+
+
+class TestSecondaryOptionB:
+    def test_partial_span_start_and_length(self):
+        piece = _rear_piece(origin_y=100.0, length=300.0)
+        # the secondary spare starts 100mm into the segment (its origin offset
+        # from the segment root) and spans the piece length.
+        spare = secondary_spare_option_b(piece, segment_root_y=0.0)
+        assert spare.spare_start == pytest.approx(100.0)
+        assert spare.spare_length == pytest.approx(300.0)
+
+    def test_start_is_relative_to_segment_root(self):
+        piece = _rear_piece(origin_y=600.0, length=200.0)
+        spare = secondary_spare_option_b(piece, segment_root_y=500.0)
+        assert spare.spare_start == pytest.approx(100.0)  # 600 - 500
+        assert spare.spare_length == pytest.approx(200.0)
+
+    def test_round_tube_maps_to_equal_width_height(self):
+        piece = _rear_piece(od=8.0)
+        spare = secondary_spare_option_b(piece, segment_root_y=0.0)
+        assert spare.spare_support_dimension_width == pytest.approx(8.0)
+        assert spare.spare_support_dimension_height == pytest.approx(8.0)
+
+    def test_uses_normal_mode_with_explicit_origin_vector(self):
+        piece = _rear_piece()
+        spare = secondary_spare_option_b(piece, segment_root_y=0.0)
+        assert spare.spare_mode == "normal"
+        assert spare.spare_vector is not None
+        assert spare.spare_origin is not None
+
+    def test_negative_start_clamped_to_zero(self):
+        # piece origin inboard of the segment root (mirror / rounding) -> clamp.
+        piece = _rear_piece(origin_y=480.0)
+        spare = secondary_spare_option_b(piece, segment_root_y=500.0)
+        assert spare.spare_start == pytest.approx(0.0)


### PR DESCRIPTION
The **structural core** of #1056 / #1059. The DB-persisting wiring into
`spar_insert_service` is intentionally deferred to follow-up **#1063** (it
requires inserting new `WingXSec` rows — a materially larger persistence change),
so this PR references but does **not** auto-close #1059.

## Why split

A telescoping main (front) spar has a varying diameter. VaseMode construction
treats **any** `spar_index == 0` spar in a segment as THE main spar, so a
multi-piece main spar cannot live as several index-0 pieces in one segment. The
fix: split the host segment at each telescoping joint so every sub-segment carries
exactly one main piece at index 0.

## What's in this PR

### `cad_designer/airplane/geometry/segment_split.py` (new)
`split_segment` / `split_segment_at_lengths`: `WingConfiguration →
WingConfiguration`, host segment replaced by N contiguous sub-segments. Topology
stays read-only (new instances only, assembled via `add_segment` /
`add_tip_segment`).

- **Lengths** sum to the original; **sweep/incidence** deltas split linearly.
- **Intermediate boundary airfoil** — the hard part: same file when the two
  anchors share an airfoil (the ruled loft of one shape is exact); otherwise a
  **Kulfan/CST morph** at the split fraction via the injected `airfoil_morph_fn`
  seam (reuses gh-796 `app.converters.openvsp_airfoil.morph_airfoils`), with a
  graceful fallback to the inboard anchor when morphing is unavailable/fails.
- **Children:** control surface duplicated onto each sub-segment over its
  sub-span (hinge line + side spacing interpolated; name disambiguated per gh-955,
  `[role]` tag preserved per gh-772 so names stay globally unique and never
  collapse into one AVL DOF; servo rides only its containing sub-segment);
  turbulator carried with interpolated position; existing spares re-homed to the
  sub-segment containing their origin; **main pieces placed at `spar_list[0]`**.

### Geometric transparency (the safety proof)
Slow `requires_cadquery` test builds the loft **before and after** the split and
asserts the section geometry is unchanged at sample stations.

- **Taper + sweep + dihedral → exact** (<0.1mm). Key insight: the dihedral delta
  is carried on the **last** sub-segment, with **zero** on intermediate
  boundaries — this keeps every intermediate station origin on the original
  straight ruled line. Splitting dihedral linearly bends the origins off that
  line (a ~12mm error on a 600mm wing — caught by the test).
- **Twist + taper → near-exact** (<1.5mm bounded residual): a rotated+scaled
  intermediate wire vs the linear blend of the two endpoint wires — the same
  small twist×taper nonlinearity inherent to any intermediate-airfoil insertion.
  Documented and bounded, never silently widened.
- **Differing airfoils via Kulfan morph → <3mm** on the real solid loft.

### Rear/torsion-spar control-surface clearance (`spar_solver`)
`rear_spar_x_c_with_clearance` pulls a **computed** rear spar forward of the
control-surface hinge (configurable margin, LE floor). Wired into
`build_stations_from_geometry` via a new `control_surface_hinge_x_c` arg. A
designer may still place a reinforcing spar inside a control surface manually —
the guard only applies to computed spars.

### Secondary spars → Option B (`spar_cad_insertion`)
`secondary_spare_option_b` maps a rear/reinforcement piece to a partial-span
`Spare` (`spare_start` + `spare_length`); no split (rear root → index 1).

## Tests / verification

- **52 fast** + **6 slow** `requires_cadquery` (new): split math, child
  duplication + naming, turbulator carry, spare re-home, index-0-per-subsegment,
  morph seam, rear clearance (helper + wired), secondary Option-B start/length,
  and the loft-unchanged proof.
- `segment_split.py` **100%** fast-tier coverage (`# pragma`-free — no cadquery
  seam in this module; the morph seam is injected and mocked).
- Full `cad_designer` fast suite: **661 passed**. Spar-related `app/` tests:
  **170 passed**. `ruff check .` + `ruff format`: clean.

## Follow-up

#1063 — persist the split into the DB on telescoping insert (insert new
`WingXSec` rows, inject `morph_airfoils`, dry-run preview, round-trip + revert).

Refs #1059, #1056.

🤖 Generated with [Claude Code](https://claude.com/claude-code)