### PR TITLE
feat(gh-1060): built-spar y-extent + joint, segment-split preview, snapshot/revert UI

### DIFF
--- a/frontend/__tests__/SparBuiltAndInsert.test.tsx
+++ b/frontend/__tests__/SparBuiltAndInsert.test.tsx
@@ -36,6 +36,8 @@ function piece(over: Partial<SparPieceOut> = {}): SparPieceOut {
     joint_to_next: null,
     feasible: true,
     infeasibility_reason: null,
+    y_start: 0,
+    y_end: 0.75,
     ...over,
   };
 }
@@ -93,6 +95,8 @@ function previewResult(): SparInsertResult {
     warnings: ["telescoping overlap modelled as butt joint"],
     feasible: true,
     infeasibility_reason: null,
+    snapshot_id: null,
+    planned_segment_lengths: [0.75, 0.45],
   };
 }
 
@@ -125,6 +129,45 @@ describe("BuiltSparSection (gh-1050)", () => {
     expect(screen.getByTestId("built-spar-infeasible")).toHaveTextContent(
       "no tube fits at root",
     );
+  });
+
+  // gh-1060: spanwise extent + telescoping joint position --------------------
+
+  it("shows each piece's spanwise extent in mm", () => {
+    const plan = feasiblePlan();
+    plan.front_pieces = [
+      piece({ joint_to_next: "telescoping", y_start: 0, y_end: 0.75 }),
+      piece({ joint_to_next: null, y_start: 0.7, y_end: 1.2 }),
+    ];
+    render(<BuiltSparSection plan={plan} />);
+    const rows = screen.getAllByTestId("built-spar-piece");
+    expect(rows[0]).toHaveTextContent("span 0 → 750 mm");
+    expect(rows[1]).toHaveTextContent("span 700 → 1200 mm");
+  });
+
+  it("shows the telescoping joint position from the next piece's y_start", () => {
+    const plan = feasiblePlan();
+    plan.front_pieces = [
+      piece({ joint_to_next: "telescoping", y_start: 0, y_end: 0.75 }),
+      piece({ joint_to_next: null, y_start: 0.7, y_end: 1.2 }),
+    ];
+    render(<BuiltSparSection plan={plan} />);
+    const rows = screen.getAllByTestId("built-spar-piece");
+    // joint position = next piece's y_start (the overlap region) = 700 mm
+    expect(rows[0]).toHaveTextContent("Telescoping @ 700 mm");
+  });
+
+  it("labels the last piece 'to tip — no joint'", () => {
+    const plan = feasiblePlan();
+    plan.front_pieces = [
+      piece({ joint_to_next: "telescoping", y_start: 0, y_end: 0.75 }),
+      piece({ joint_to_next: null, y_start: 0.7, y_end: 1.2 }),
+    ];
+    render(<BuiltSparSection plan={plan} />);
+    const rows = screen.getAllByTestId("built-spar-piece");
+    expect(rows[1]).toHaveTextContent("to tip — no joint");
+    // the old "Continuous" wording is gone for the last piece
+    expect(rows[1]).not.toHaveTextContent("Continuous");
   });
 });
 
@@ -242,5 +285,155 @@ describe("AddSparToWingFlow (gh-1050)", () => {
     fireEvent.click(screen.getByTestId("add-spar-cancel"));
     expect(screen.queryByTestId("add-spar-preview-modal")).toBeNull();
     expect(onInsert).toHaveBeenCalledTimes(1); // only the preview
+  });
+});
+
+// gh-1060: segment-split preview + snapshot/revert ---------------------------
+
+describe("AddSparToWingFlow — split preview + snapshot/revert (gh-1060)", () => {
+  it("preview shows the segment split note when planned_segment_lengths splits", async () => {
+    const onInsert = vi.fn().mockResolvedValue(previewResult());
+    render(<AddSparToWingFlow plan={feasiblePlan()} onInsert={onInsert} />);
+    fireEvent.click(screen.getByTestId("add-spar-to-wing-button"));
+    await waitFor(() =>
+      expect(screen.getByTestId("add-spar-preview-modal")).toBeInTheDocument(),
+    );
+    const split = screen.getByTestId("add-spar-split-note");
+    expect(split).toHaveTextContent(/Main spar telescopes/i);
+    expect(split).toHaveTextContent(/split into 2 sub-segments/i);
+    expect(split).toHaveTextContent("750");
+    expect(split).toHaveTextContent("450");
+    expect(split).toHaveTextContent(/snapshot/i);
+  });
+
+  it("preview omits the split note when the front spar is single-piece", async () => {
+    const onInsert = vi
+      .fn()
+      .mockResolvedValue({ ...previewResult(), planned_segment_lengths: [0.75] });
+    render(<AddSparToWingFlow plan={feasiblePlan()} onInsert={onInsert} />);
+    fireEvent.click(screen.getByTestId("add-spar-to-wing-button"));
+    await waitFor(() =>
+      expect(screen.getByTestId("add-spar-preview-modal")).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId("add-spar-split-note")).toBeNull();
+  });
+
+  it("commit surfaces snapshot_id with a Revert button", async () => {
+    const onInsert = vi
+      .fn()
+      .mockResolvedValueOnce(previewResult())
+      .mockResolvedValueOnce({
+        ...previewResult(),
+        dry_run: false,
+        committed: true,
+        snapshot_id: 77,
+      });
+    render(<AddSparToWingFlow plan={feasiblePlan()} onInsert={onInsert} />);
+    fireEvent.click(screen.getByTestId("add-spar-to-wing-button"));
+    await waitFor(() =>
+      expect(screen.getByTestId("add-spar-confirm")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("add-spar-confirm"));
+    await waitFor(() =>
+      expect(screen.getByTestId("add-spar-success")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("add-spar-success")).toHaveTextContent(
+      "Snapshot #77 created",
+    );
+    expect(screen.getByTestId("add-spar-revert-button")).toBeInTheDocument();
+  });
+
+  it("Revert calls onRevert with the snapshot id and refreshes on success", async () => {
+    const onInsert = vi
+      .fn()
+      .mockResolvedValueOnce(previewResult())
+      .mockResolvedValueOnce({
+        ...previewResult(),
+        dry_run: false,
+        committed: true,
+        snapshot_id: 77,
+      });
+    const onRevert = vi.fn().mockResolvedValue(undefined);
+    const onCommitted = vi.fn();
+    render(
+      <AddSparToWingFlow
+        plan={feasiblePlan()}
+        onInsert={onInsert}
+        onRevert={onRevert}
+        onCommitted={onCommitted}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("add-spar-to-wing-button"));
+    await waitFor(() =>
+      expect(screen.getByTestId("add-spar-confirm")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("add-spar-confirm"));
+    await waitFor(() =>
+      expect(screen.getByTestId("add-spar-revert-button")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("add-spar-revert-button"));
+    await waitFor(() => expect(onRevert).toHaveBeenCalledWith(77));
+    await waitFor(() =>
+      expect(screen.getByTestId("add-spar-reverted")).toBeInTheDocument(),
+    );
+  });
+
+  it("surfaces a revert error", async () => {
+    const onInsert = vi
+      .fn()
+      .mockResolvedValueOnce(previewResult())
+      .mockResolvedValueOnce({
+        ...previewResult(),
+        dry_run: false,
+        committed: true,
+        snapshot_id: 77,
+      });
+    const onRevert = vi
+      .fn()
+      .mockRejectedValue(new Error("restore failed (422): not a snapshot"));
+    render(
+      <AddSparToWingFlow
+        plan={feasiblePlan()}
+        onInsert={onInsert}
+        onRevert={onRevert}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("add-spar-to-wing-button"));
+    await waitFor(() =>
+      expect(screen.getByTestId("add-spar-confirm")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("add-spar-confirm"));
+    await waitFor(() =>
+      expect(screen.getByTestId("add-spar-revert-button")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("add-spar-revert-button"));
+    await waitFor(() =>
+      expect(screen.getByTestId("add-spar-revert-error")).toHaveTextContent(
+        "not a snapshot",
+      ),
+    );
+  });
+
+  it("does not show a Revert button when commit returns no snapshot_id", async () => {
+    const onInsert = vi
+      .fn()
+      .mockResolvedValueOnce({ ...previewResult(), planned_segment_lengths: [0.75] })
+      .mockResolvedValueOnce({
+        ...previewResult(),
+        dry_run: false,
+        committed: true,
+        snapshot_id: null,
+        planned_segment_lengths: [0.75],
+      });
+    render(<AddSparToWingFlow plan={feasiblePlan()} onInsert={onInsert} />);
+    fireEvent.click(screen.getByTestId("add-spar-to-wing-button"));
+    await waitFor(() =>
+      expect(screen.getByTestId("add-spar-confirm")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("add-spar-confirm"));
+    await waitFor(() =>
+      expect(screen.getByTestId("add-spar-success")).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId("add-spar-revert-button")).toBeNull();
   });
 });

--- a/frontend/__tests__/SparSizingPanel.test.tsx
+++ b/frontend/__tests__/SparSizingPanel.test.tsx
@@ -279,6 +279,8 @@ describe("SparSizingPanel", () => {
           wall: 0.0024,
           shape: "tube",
           governing_y: 0,
+          y_start: 0,
+          y_end: 0.75,
           utilisation: 0.5,
           joint_to_next: null,
           feasible: true,

--- a/frontend/__tests__/sparPlanHelpers.test.ts
+++ b/frontend/__tests__/sparPlanHelpers.test.ts
@@ -10,6 +10,10 @@ import {
   pieceDimsLabel,
   touchedSegments,
   replaceWarning,
+  pieceExtentLabel,
+  pieceJointLabel,
+  splitNote,
+  snapshotNote,
 } from "@/lib/sparPlanHelpers";
 import type { SpanwiseLoadsResult } from "@/hooks/useSpanwiseLoads";
 import type { PlannedSpareOut, SparPieceOut } from "@/hooks/useSparPlan";
@@ -94,6 +98,8 @@ describe("formatting helpers", () => {
       wall: 0.0024,
       shape: "tube",
       governing_y: 0,
+      y_start: 0,
+      y_end: 0.75,
       utilisation: 0.5,
       joint_to_next: null,
       feasible: true,
@@ -120,6 +126,93 @@ describe("formatting helpers", () => {
       infeasibility_reason: null,
     } as unknown as SparPieceOut;
     expect(pieceDimsLabel(piece)).toContain("wall 5.0");
+  });
+});
+
+// gh-1060: spanwise extent + telescoping joint + split / snapshot notes -------
+
+function gh1060Piece(over: Partial<SparPieceOut>): SparPieceOut {
+  return {
+    role: "front",
+    spare_origin: [0, 0, 0],
+    spare_vector: [0, 1, 0],
+    outer_d: 0.0288,
+    inner_d: 0.024,
+    wall: 0.0024,
+    shape: "tube",
+    governing_y: 0,
+    utilisation: 0.5,
+    joint_to_next: null,
+    feasible: true,
+    infeasibility_reason: null,
+    y_start: 0,
+    y_end: 0.75,
+    ...over,
+  } as SparPieceOut;
+}
+
+describe("pieceExtentLabel (gh-1060)", () => {
+  const p = gh1060Piece;
+
+  it("shows the spanwise extent in mm (root=0)", () => {
+    expect(pieceExtentLabel(p({ y_start: 0, y_end: 0.75 }))).toBe(
+      "span 0 → 750 mm",
+    );
+  });
+
+  it("rounds extents to whole mm", () => {
+    expect(pieceExtentLabel(p({ y_start: 0.75, y_end: 1.2 }))).toBe(
+      "span 750 → 1200 mm",
+    );
+  });
+});
+
+describe("pieceJointLabel (gh-1060)", () => {
+  const p = gh1060Piece;
+
+  it("shows the telescoping joint position from the next piece's y_start", () => {
+    const piece = p({ joint_to_next: "telescoping", y_end: 0.75 });
+    const next = p({ y_start: 0.7 }); // overlap rootward → joint = next.y_start
+    expect(pieceJointLabel(piece, next)).toBe("Telescoping @ 700 mm");
+  });
+
+  it("falls back to the readable joint label when there is a next piece but no telescoping", () => {
+    const piece = p({ joint_to_next: "bent-pin" });
+    const next = p({ y_start: 0.9 });
+    expect(pieceJointLabel(piece, next)).toBe("Bent-pin @ 900 mm");
+  });
+
+  it("shows 'to tip — no joint' for the last piece", () => {
+    const piece = p({ joint_to_next: null });
+    expect(pieceJointLabel(piece, undefined)).toBe("to tip — no joint");
+  });
+});
+
+describe("splitNote (gh-1060)", () => {
+  it("returns null when there is no split (single-piece front spar)", () => {
+    expect(splitNote(null)).toBeNull();
+    expect(splitNote([])).toBeNull();
+    expect(splitNote([0.75])).toBeNull(); // single sub-segment = no split
+  });
+
+  it("describes the split with sub-segment count + lengths in mm", () => {
+    const note = splitNote([0.75, 0.45]);
+    expect(note).toContain("Main spar telescopes");
+    expect(note).toContain("split into 2 sub-segments");
+    expect(note).toContain("750");
+    expect(note).toContain("450");
+    expect(note).toContain("snapshot");
+  });
+});
+
+describe("snapshotNote (gh-1060)", () => {
+  it("returns null when there is no snapshot id", () => {
+    expect(snapshotNote(null)).toBeNull();
+    expect(snapshotNote(undefined)).toBeNull();
+  });
+
+  it("formats the snapshot id", () => {
+    expect(snapshotNote(42)).toBe("Snapshot #42 created");
   });
 });
 

--- a/frontend/__tests__/useSparPlan.test.ts
+++ b/frontend/__tests__/useSparPlan.test.ts
@@ -27,6 +27,8 @@ const FAKE_PLAN: SparPlanResult = {
       wall: 0.0024,
       shape: "tube",
       governing_y: 0,
+      y_start: 0,
+      y_end: 0.75,
       utilisation: 0.5,
       joint_to_next: "telescoping",
       feasible: true,
@@ -64,6 +66,8 @@ const FAKE_INSERT: SparInsertResult = {
   warnings: [],
   feasible: true,
   infeasibility_reason: null,
+  snapshot_id: null,
+  planned_segment_lengths: null,
 };
 
 const BASE: SparPlanParams = {
@@ -214,6 +218,38 @@ describe("useSparPlan (gh-1050)", () => {
     const { result } = renderHook(() => useSparPlan(null));
     await expect(result.current.insert(BASE, true)).rejects.toThrow(
       /No aeroplane/,
+    );
+  });
+
+  // gh-1060: snapshot revert ------------------------------------------------
+
+  it("restoreSnapshot POSTs to /aeroplanes/{snapshot_id}/restore with a name", async () => {
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(okResponse({ id: 99, name: "revert" }));
+    const { result } = renderHook(() => useSparPlan("aero-1"));
+    await act(async () => {
+      await result.current.restoreSnapshot(55);
+    });
+    const [url, options] = fetchSpy.mock.calls[0];
+    const u = new URL(String(url), "http://x");
+    expect(u.pathname).toContain("/aeroplanes/55/restore");
+    expect(options).toMatchObject({ method: "POST" });
+    const body = JSON.parse(options!.body as string);
+    expect(typeof body.name).toBe("string");
+    expect(body.name.length).toBeGreaterThan(0);
+  });
+
+  it("restoreSnapshot throws readably on a non-ok response", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: { message: "not a snapshot" } }), {
+        status: 422,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const { result } = renderHook(() => useSparPlan("aero-1"));
+    await expect(result.current.restoreSnapshot(55)).rejects.toThrow(
+      /not a snapshot/,
     );
   });
 });

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -1074,7 +1074,12 @@ export function SpanwiseLoadsTabContent({
     useSparSizing(aeroplaneId ?? null);
 
   // gh-1050: buildable two-spar plan + preview→commit insert into the wing.
-  const { plan, run: runPlan, insert: insertPlan } = useSparPlan(aeroplaneId ?? null);
+  const {
+    plan,
+    run: runPlan,
+    insert: insertPlan,
+    restoreSnapshot,
+  } = useSparPlan(aeroplaneId ?? null);
   const { mutate } = useSWRConfig();
   // Remember the sizing inputs the user last computed with so the plan + insert
   // reuse the SAME material / safety / packing / sigma knobs.
@@ -1140,6 +1145,19 @@ export function SpanwiseLoadsTabContent({
     mutate(`/aeroplanes/${aeroplaneId}/wings/${planWingName}`);
   }, [aeroplaneId, planWingName, mutate]);
 
+  // gh-1060: revert a destructive commit by restoring its pre-insert snapshot,
+  // then refresh the wing/construction so the tree + CAD reflect the rollback.
+  const handleSparRevert = useCallback(
+    async (snapshotId: number) => {
+      await restoreSnapshot(snapshotId);
+      if (aeroplaneId && planWingName) {
+        mutate(`/aeroplanes/${aeroplaneId}/wings/${planWingName}/wingconfig`);
+        mutate(`/aeroplanes/${aeroplaneId}/wings/${planWingName}`);
+      }
+    },
+    [restoreSnapshot, aeroplaneId, planWingName, mutate],
+  );
+
   if (spanwiseLoadsLoading) {
     return (
       <div className="flex flex-1 items-center justify-center">
@@ -1170,6 +1188,7 @@ export function SpanwiseLoadsTabContent({
           plan={plan}
           onInsert={handleInsert}
           onSparInserted={handleSparInserted}
+          onRevert={handleSparRevert}
         />
       </div>
     );

--- a/frontend/components/workbench/SparSizingPanel.tsx
+++ b/frontend/components/workbench/SparSizingPanel.tsx
@@ -32,6 +32,10 @@ import {
   sparGroupLabel,
   jointLabel,
   pieceDimsLabel,
+  pieceExtentLabel,
+  pieceJointLabel,
+  splitNote,
+  snapshotNote,
   mToMm,
   replaceWarning,
 } from "@/lib/sparPlanHelpers";
@@ -72,6 +76,11 @@ export interface SparSizingPanelProps {
   onInsert?: (dryRun: boolean) => Promise<SparInsertResult>;
   /** gh-1050: called after a successful commit so the parent can refresh the tree. */
   onSparInserted?: () => void;
+  /**
+   * gh-1060: revert a destructive commit by restoring its pre-insert snapshot.
+   * When omitted, the Revert affordance is hidden.
+   */
+  onRevert?: (snapshotId: number) => Promise<void>;
 }
 
 // ---- Helpers ---------------------------------------------------------------
@@ -171,12 +180,18 @@ function SizingResultCard({ result }: { result: SparSizingResult }) {
 
 // ---- Built-spar display (gh-1050) ------------------------------------------
 
-/** One buildable piece row: dims (OD×ID×wall), joint, feasibility. */
+/**
+ * One buildable piece row: dims (OD×ID×wall), spanwise extent, joint,
+ * feasibility. gh-1060: the joint position for a telescoping piece is the
+ * NEXT piece's y_start; the last piece (no next) reads "to tip — no joint".
+ */
 function BuiltSparPieceRow({
   piece,
+  next,
   index,
 }: {
   piece: SparPieceOut;
+  next: SparPieceOut | null;
   index: number;
 }) {
   return (
@@ -186,8 +201,11 @@ function BuiltSparPieceRow({
     >
       <span className="text-muted-foreground">#{index + 1}</span>
       <span className="tabular-nums text-foreground">{pieceDimsLabel(piece)}</span>
+      <span className="tabular-nums text-muted-foreground">
+        {pieceExtentLabel(piece)}
+      </span>
       <span className="text-muted-foreground">
-        joint: {jointLabel(piece.joint_to_next)}
+        joint: {pieceJointLabel(piece, next)}
       </span>
       <span className={piece.feasible ? "text-green-400" : "text-yellow-400"}>
         {piece.feasible ? "OK" : (piece.infeasibility_reason ?? "infeasible")}
@@ -215,7 +233,12 @@ function BuiltSparGroup({
         {sparGroupLabel(group)}
       </p>
       {pieces.map((p, i) => (
-        <BuiltSparPieceRow key={i} piece={p} index={i} />
+        <BuiltSparPieceRow
+          key={i}
+          piece={p}
+          next={pieces[i + 1] ?? null}
+          index={i}
+        />
       ))}
     </div>
   );
@@ -263,6 +286,12 @@ export interface AddSparToWingFlowProps {
   onInsert: (dryRun: boolean) => Promise<SparInsertResult>;
   /** Called after a successful commit so the parent can refresh the wing/tree. */
   onCommitted?: () => void;
+  /**
+   * gh-1060: revert a destructive commit by restoring its pre-insert snapshot.
+   * Called with the snapshot id surfaced on the commit result; should refresh
+   * the wing/construction data on success. Throws on error.
+   */
+  onRevert?: (snapshotId: number) => Promise<void>;
 }
 
 /**
@@ -274,16 +303,25 @@ export function AddSparToWingFlow({
   plan,
   onInsert,
   onCommitted,
+  onRevert,
 }: AddSparToWingFlowProps) {
   const [preview, setPreview] = useState<SparInsertResult | null>(null);
   const [busy, setBusy] = useState(false);
   const [committed, setCommitted] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // gh-1060: snapshot id surfaced on a destructive commit, the revert state,
+  // and any revert error.
+  const [snapshotId, setSnapshotId] = useState<number | null>(null);
+  const [reverted, setReverted] = useState(false);
+  const [revertError, setRevertError] = useState<string | null>(null);
 
   const openPreview = useCallback(async () => {
     setBusy(true);
     setError(null);
     setCommitted(false);
+    setSnapshotId(null);
+    setReverted(false);
+    setRevertError(null);
     try {
       const res = await onInsert(true);
       setPreview(res);
@@ -298,8 +336,9 @@ export function AddSparToWingFlow({
     setBusy(true);
     setError(null);
     try {
-      await onInsert(false);
+      const res = await onInsert(false);
       setCommitted(true);
+      setSnapshotId(res.snapshot_id ?? null);
       setPreview(null);
       onCommitted?.();
     } catch (err) {
@@ -309,12 +348,28 @@ export function AddSparToWingFlow({
     }
   }, [onInsert, onCommitted]);
 
+  const revert = useCallback(async () => {
+    if (snapshotId == null || !onRevert) return;
+    setBusy(true);
+    setRevertError(null);
+    try {
+      await onRevert(snapshotId);
+      setReverted(true);
+    } catch (err) {
+      setRevertError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [snapshotId, onRevert]);
+
   const close = useCallback(() => {
     setPreview(null);
     setError(null);
   }, []);
 
   const warning = preview ? replaceWarning(preview.planned_spares) : null;
+  const previewSplit = preview ? splitNote(preview.planned_segment_lengths) : null;
+  const committedSnapshot = snapshotNote(snapshotId);
 
   return (
     <div className="space-y-2">
@@ -331,12 +386,40 @@ export function AddSparToWingFlow({
       </button>
 
       {committed && (
-        <p
-          className="rounded bg-green-900/30 px-2 py-1 text-[12px] text-green-400 font-[family-name:var(--font-jetbrains-mono)]"
+        <div
+          className="rounded bg-green-900/30 px-2 py-1.5 text-[12px] text-green-400 font-[family-name:var(--font-jetbrains-mono)] space-y-1"
           data-testid="add-spar-success"
         >
-          Spar added to the wing.
-        </p>
+          <p>
+            Spar added to the wing.
+            {committedSnapshot && (
+              <span className="ml-1 text-foreground">{committedSnapshot}.</span>
+            )}
+          </p>
+          {snapshotId != null && !reverted && (
+            <button
+              className="rounded border border-border px-2 py-0.5 text-[11px] text-foreground hover:bg-card-muted/50 disabled:opacity-50"
+              onClick={revert}
+              disabled={busy || !onRevert}
+              data-testid="add-spar-revert-button"
+            >
+              Revert
+            </button>
+          )}
+          {reverted && (
+            <p className="text-foreground" data-testid="add-spar-reverted">
+              Reverted to the pre-insert snapshot.
+            </p>
+          )}
+          {revertError && (
+            <p
+              className="text-red-400"
+              data-testid="add-spar-revert-error"
+            >
+              {revertError}
+            </p>
+          )}
+        </div>
       )}
 
       {error && !preview && (
@@ -365,6 +448,16 @@ export function AddSparToWingFlow({
               >
                 <AlertTriangle size={14} className="mt-0.5 shrink-0" />
                 <span>{warning}</span>
+              </div>
+            )}
+
+            {previewSplit && (
+              <div
+                className="flex items-start gap-1 rounded bg-[#FF8400]/10 px-2 py-1.5 text-[12px] text-[#FF8400]"
+                data-testid="add-spar-split-note"
+              >
+                <AlertTriangle size={14} className="mt-0.5 shrink-0" />
+                <span>{previewSplit}</span>
               </div>
             )}
 
@@ -471,6 +564,7 @@ export function SparSizingPanel({
   plan = null,
   onInsert,
   onSparInserted,
+  onRevert,
 }: SparSizingPanelProps) {
   const [open, setOpen] = useState(false);
   const [inputs, setInputs] = useState<SparSizingInputs>({
@@ -699,6 +793,7 @@ export function SparSizingPanel({
                   plan={plan}
                   onInsert={onInsert}
                   onCommitted={onSparInserted}
+                  onRevert={onRevert}
                 />
               )}
             </div>

--- a/frontend/hooks/useSparPlan.ts
+++ b/frontend/hooks/useSparPlan.ts
@@ -43,6 +43,10 @@ export interface SparPieceOut {
   wall: number; // m
   shape: string;
   governing_y: number; // m
+  // gh-1057/gh-1060: spanwise extent of this piece (metres, root=0). For a
+  // telescoping run the NEXT piece's y_start is the telescoping joint position.
+  y_start: number; // m
+  y_end: number; // m
   utilisation: number;
   joint_to_next: string | null;
   feasible: boolean;
@@ -84,6 +88,13 @@ export interface SparInsertResult {
   warnings: string[];
   feasible: boolean;
   infeasibility_reason: string | null;
+  // gh-1058: PK of the auto-snapshot taken BEFORE the destructive commit so the
+  // user can one-click revert. Null on a dry-run (nothing was mutated).
+  snapshot_id: number | null;
+  // gh-1063: when the main (front) spar telescopes the host segment is SPLIT at
+  // each joint; these are the resulting per-sub-segment spanwise lengths (m),
+  // root→tip. Null/single-element when no split happens.
+  planned_segment_lengths: number[] | null;
 }
 
 // ---- Body builder (shared by run + insert) ---------------------------------
@@ -169,5 +180,29 @@ export function useSparPlan(aeroplaneId: string | null) {
     [aeroplaneId],
   );
 
-  return { plan, isRunning, error, run, insert };
+  // gh-1060: revert a destructive insert-commit by restoring its pre-insert
+  // snapshot. POST /aeroplanes/{snapshot_id}/restore forks an editable head
+  // from the immutable snapshot (BranchRequest body: name + created_by).
+  // Throws readably on a non-ok response so the caller can surface the error.
+  const restoreSnapshot = useCallback(
+    async (snapshotId: number): Promise<void> => {
+      const res = await fetch(
+        `${API_BASE}/aeroplanes/${snapshotId}/restore`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "Revert spar insert",
+            created_by: "human",
+          }),
+        },
+      );
+      if (!res.ok) {
+        throw new Error(await parseApiError(res, "Snapshot restore"));
+      }
+    },
+    [],
+  );
+
+  return { plan, isRunning, error, run, insert, restoreSnapshot };
 }

--- a/frontend/lib/sparPlanHelpers.ts
+++ b/frontend/lib/sparPlanHelpers.ts
@@ -104,6 +104,62 @@ export function pieceDimsLabel(piece: SparPieceOut): string {
   return `OD ${od} × ID ${id} (wall ${wallStr}) mm`;
 }
 
+// ---- Built-spar spanwise extent + telescoping joint (gh-1060) ---------------
+
+/**
+ * The piece's spanwise extent in mm (root=0): "span 0 → 750 mm". Uses the
+ * gh-1057 y_start/y_end fields. Extents are rounded to whole mm.
+ */
+export function pieceExtentLabel(piece: SparPieceOut): string {
+  return `span ${mToMm(piece.y_start, 0)} → ${mToMm(piece.y_end, 0)} mm`;
+}
+
+/**
+ * The joint label for a built piece. For an intermediate piece, the joint
+ * position is the NEXT piece's y_start (the telescoping overlap region begins
+ * there): e.g. "Telescoping @ 700 mm". The last piece (no next) runs to the
+ * tip with no joint → "to tip — no joint".
+ */
+export function pieceJointLabel(
+  piece: SparPieceOut,
+  next: SparPieceOut | null | undefined,
+): string {
+  if (next == null) return "to tip — no joint";
+  return `${jointLabel(piece.joint_to_next)} @ ${mToMm(next.y_start, 0)} mm`;
+}
+
+// ---- Insert-preview: segment split + snapshot notes (gh-1060) ---------------
+
+/**
+ * A note describing the planned main-spar segment split, or null when there is
+ * no split. A split exists only when the host segment is divided into >1
+ * sub-segment (the main spar telescopes). Lengths are shown in mm and the note
+ * mentions the auto-snapshot the commit takes.
+ */
+export function splitNote(
+  plannedSegmentLengths: number[] | null | undefined,
+): string | null {
+  if (plannedSegmentLengths == null) return null;
+  const n = plannedSegmentLengths.length;
+  if (n <= 1) return null;
+  const lengths = plannedSegmentLengths.map((l) => mToMm(l, 0)).join(", ");
+  return (
+    `Main spar telescopes → the segment will be split into ${n} sub-segments ` +
+    `(lengths ${lengths} mm); a snapshot will be taken so you can revert.`
+  );
+}
+
+/**
+ * "Snapshot #N created" for a committed insert, or null when there is no
+ * snapshot id (dry-run, or a non-destructive commit that took none).
+ */
+export function snapshotNote(
+  snapshotId: number | null | undefined,
+): string | null {
+  if (snapshotId == null) return null;
+  return `Snapshot #${snapshotId} created`;
+}
+
 // ---- Insert-preview: REPLACE warning ---------------------------------------
 
 /**


### PR DESCRIPTION
Closes #1060

Extends the `SparSizingPanel` preview→confirm flow to consume the gh-1057 / gh-1058 / gh-1063 backend contracts.

## What changed

### 1. Built-spar display — spanwise extent + joint
- Each piece now shows its spanwise extent `y_start → y_end` (mm) via `pieceExtentLabel`.
- The telescoping joint position is the **next piece's `y_start`** (the overlap region): e.g. `Telescoping @ 700 mm` via `pieceJointLabel`.
- The last piece's label is now **"to tip — no joint"** (was "Continuous"). Ø0 tip pieces are already suppressed server-side (#1057).

### 2. Preview shows the segment split
- In the dry-run preview modal, when `planned_segment_lengths` indicates a split (> 1 sub-segment), a note is shown: *"Main spar telescopes → the segment will be split into N sub-segments (lengths … mm); a snapshot will be taken so you can revert."* (`splitNote`).
- Existing REPLACE warning / spar_index / planned-spare table preserved.

### 3. Snapshot + revert
- After a successful commit, the success banner surfaces **"Snapshot #N created"** (`snapshotNote`) with a **Revert** button.
- Revert calls `POST /aeroplanes/{snapshot_id}/restore` via the new `restoreSnapshot` action on `useSparPlan`, then refreshes the wing/construction SWR data. Success ("Reverted to the pre-insert snapshot.") and error paths handled.
- No Revert button when the commit returns no `snapshot_id`.

### Types
- `SparPieceOut` gains `y_start` / `y_end`.
- `SparInsertResult` gains `snapshot_id` + `planned_segment_lengths`.

## Tests (vitest, Node 22)
- Helper unit tests: extent, telescoping joint, "to tip — no joint", split note, snapshot note.
- Hook tests: `restoreSnapshot` URL/body + error path.
- Component tests: extent + joint rendering, split preview note (+ omitted when single-piece), commit surfaces snapshot id + Revert, revert calls restore + refreshes, revert error, no-snapshot case.
- Full frontend suite: 2302 passing. `tsc --noEmit` and `eslint` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)