### PR TITLE
fix(gh-1069): clone Turbulators in clone_aeroplane_subgraph

### DIFF
--- a/app/services/aeroplane_clone_service.py
+++ b/app/services/aeroplane_clone_service.py
@@ -36,6 +36,7 @@ from app.models.aeroplanemodel import (
     WingXSecSpareModel,
     WingXSecTedServoModel,
     WingXSecTrailingEdgeDeviceModel,
+    WingXSecTurbulatorModel,
 )
 from app.models.component_tree import ComponentTreeNodeModel
 from app.models.computation_config import AircraftComputationConfigModel
@@ -105,9 +106,7 @@ EXCLUDED_TABLES: dict[str, str] = {
     # ── versioning meta (managed by caller, not cloned into child) ───────────
     "branches": "versioning meta; managed by the versioning service",
     # ── construction artefacts (string FK, not int-FK cascade) ───────────────
-    "construction_plans": (
-        "soft string FK to aeroplanes; template-style, not per-version-copy"
-    ),
+    "construction_plans": ("soft string FK to aeroplanes; template-style, not per-version-copy"),
     "construction_parts": (
         "string aeroplane_id (no int FK); per-aeroplane but file-backed — "
         "not cloned to avoid stale file references"
@@ -209,7 +208,7 @@ def clone_aeroplane_subgraph(
     # We build an old-id → new-id map so loading_scenarios can remap
     # component_overrides (which store str(weight_item.id) as component_uuid).
     weight_id_map: dict[str, str] = {}  # str(old_id) → str(new_id)
-    for wi in (source.weight_items or []):
+    for wi in source.weight_items or []:
         new_wi = WeightItemModel(
             aeroplane_id=clone.id,
             name=wi.name,
@@ -225,7 +224,7 @@ def clone_aeroplane_subgraph(
         weight_id_map[str(wi.id)] = str(new_wi.id)
 
     # ── 3. Wings → xsecs → details → spares + TEDs + servos ─────────────────
-    for wing in (source.wings or []):
+    for wing in source.wings or []:
         new_wing = WingModel(
             aeroplane_id=clone.id,
             name=wing.name,
@@ -235,7 +234,7 @@ def clone_aeroplane_subgraph(
         db.add(new_wing)
         db.flush()
 
-        for xsec in (wing.x_secs or []):
+        for xsec in wing.x_secs or []:
             new_xsec = WingXSecModel(
                 wing_id=new_wing.id,
                 xyz_le=copy.deepcopy(xsec.xyz_le),
@@ -259,7 +258,7 @@ def clone_aeroplane_subgraph(
                 db.flush()
 
                 # Spares
-                for spare in (detail.spares or []):
+                for spare in detail.spares or []:
                     new_spare = WingXSecSpareModel(
                         wing_xsec_detail_id=new_detail.id,
                         sort_index=spare.sort_index,
@@ -273,6 +272,19 @@ def clone_aeroplane_subgraph(
                         spare_origin=copy.deepcopy(spare.spare_origin),
                     )
                     db.add(new_spare)
+
+                # Turbulator (gh-934) — optional one-to-one per detail (gh-1069)
+                turbulator = detail.turbulator
+                if turbulator is not None:
+                    new_turbulator = WingXSecTurbulatorModel(
+                        wing_xsec_detail_id=new_detail.id,
+                        form=turbulator.form,
+                        height_mm=turbulator.height_mm,
+                        position_root=turbulator.position_root,
+                        position_tip=turbulator.position_tip,
+                        enabled=turbulator.enabled,
+                    )
+                    db.add(new_turbulator)
 
                 # TED + servo
                 ted = detail.trailing_edge_device
@@ -325,7 +337,7 @@ def clone_aeroplane_subgraph(
                         db.add(new_servo)
 
     # ── 4. Fuselages → xsecs (null STEP paths) ───────────────────────────────
-    for fus in (source.fuselages or []):
+    for fus in source.fuselages or []:
         new_fus = FuselageModel(
             aeroplane_id=clone.id,
             name=fus.name,
@@ -336,7 +348,7 @@ def clone_aeroplane_subgraph(
         db.add(new_fus)
         db.flush()
 
-        for xsec in (fus.x_secs or []):
+        for xsec in fus.x_secs or []:
             new_xsec = FuselageXSecSuperEllipseModel(
                 fuselage_id=new_fus.id,
                 xyz=copy.deepcopy(xsec.xyz),
@@ -371,7 +383,7 @@ def clone_aeroplane_subgraph(
         db.add(new_mo)
 
     # ── 6. Design assumptions ─────────────────────────────────────────────────
-    for da in (source.design_assumptions or []):
+    for da in source.design_assumptions or []:
         new_da = DesignAssumptionModel(
             aeroplane_id=clone.id,
             parameter_name=da.parameter_name,
@@ -399,7 +411,7 @@ def clone_aeroplane_subgraph(
         db.add(new_cc)
 
     # ── 8. Stability results ──────────────────────────────────────────────────
-    for sr in (source.stability_results or []):
+    for sr in source.stability_results or []:
         new_sr = StabilityResultModel(
             aeroplane_id=clone.id,
             solver=sr.solver,
@@ -425,7 +437,7 @@ def clone_aeroplane_subgraph(
         db.add(new_sr)
 
     # ── 9. Loading scenarios (remap weight_item id refs in component_overrides)
-    for ls in (source.loading_scenarios or []):
+    for ls in source.loading_scenarios or []:
         new_overrides = _remap_component_overrides(ls.component_overrides, weight_id_map)
         new_ls = LoadingScenarioModel(
             aeroplane_id=clone.id,

--- a/app/tests/test_aeroplane_clone_behaviour.py
+++ b/app/tests/test_aeroplane_clone_behaviour.py
@@ -42,6 +42,7 @@ from app.models.aeroplanemodel import (
     WingXSecSpareModel,
     WingXSecTedServoModel,
     WingXSecTrailingEdgeDeviceModel,
+    WingXSecTurbulatorModel,
 )
 from app.models.component_tree import ComponentTreeNodeModel
 from app.models.computation_config import AircraftComputationConfigModel
@@ -51,6 +52,7 @@ from app.services.aeroplane_clone_service import clone_aeroplane_subgraph
 
 # Import all models so Base.metadata is complete
 import app.models.analysismodels  # noqa: F401
+
 # avl_geometry_events is event-listener code, not a model with its own table
 import app.models.avl_geometry_file  # noqa: F401
 import app.models.component  # noqa: F401
@@ -109,9 +111,7 @@ def _build_source(db: Session) -> AeroplaneModel:
     db.flush()
 
     # Wing + xsec + detail + spare + TED + servo
-    wing = WingModel(
-        aeroplane_id=src.id, name="main_wing", symmetric=True, design_model="flat"
-    )
+    wing = WingModel(aeroplane_id=src.id, name="main_wing", symmetric=True, design_model="flat")
     db.add(wing)
     db.flush()
 
@@ -175,6 +175,18 @@ def _build_source(db: Session) -> AeroplaneModel:
     db.add(servo)
     db.flush()
 
+    # Turbulator (gh-934) — per-cross-section optional element
+    turbulator = WingXSecTurbulatorModel(
+        wing_xsec_detail_id=detail.id,
+        form="zigzag",
+        height_mm=0.3,
+        position_root=0.07,
+        position_tip=0.1,
+        enabled=True,
+    )
+    db.add(turbulator)
+    db.flush()
+
     # Fuselage + xsec with step paths
     fus = FuselageModel(
         aeroplane_id=src.id,
@@ -213,9 +225,7 @@ def _build_source(db: Session) -> AeroplaneModel:
         aircraft_class="rc_trainer",
         component_overrides={
             "toggles": [{"component_uuid": str(wi.id), "enabled": True}],
-            "mass_overrides": [
-                {"component_uuid": str(wi.id), "mass_kg_override": 0.35}
-            ],
+            "mass_overrides": [{"component_uuid": str(wi.id), "mass_kg_override": 0.35}],
             "position_overrides": [],
             "adhoc_items": [],
         },
@@ -366,9 +376,7 @@ class TestCloneAeroplaneSubgraph:
         db_session.flush()
 
         # There should be exactly one wing on the clone
-        clone_wings = (
-            db_session.query(WingModel).filter(WingModel.aeroplane_id == clone.id).all()
-        )
+        clone_wings = db_session.query(WingModel).filter(WingModel.aeroplane_id == clone.id).all()
         assert len(clone_wings) == 1
         clone_wing = clone_wings[0]
 
@@ -377,9 +385,7 @@ class TestCloneAeroplaneSubgraph:
         db_session.flush()
 
         # Source wing unchanged
-        src_wings = (
-            db_session.query(WingModel).filter(WingModel.aeroplane_id == src.id).all()
-        )
+        src_wings = db_session.query(WingModel).filter(WingModel.aeroplane_id == src.id).all()
         assert src_wings[0].name == "main_wing"
 
     def test_wings_have_new_ids_and_point_to_clone(self, db_session):
@@ -414,9 +420,7 @@ class TestCloneAeroplaneSubgraph:
 
         src_xsec_ids = {
             x.id
-            for x in db_session.query(WingXSecModel).filter(
-                WingXSecModel.wing_id.in_(src_wing_ids)
-            )
+            for x in db_session.query(WingXSecModel).filter(WingXSecModel.wing_id.in_(src_wing_ids))
         }
         clone_xsec_ids = {
             x.id
@@ -489,6 +493,125 @@ class TestCloneAeroplaneSubgraph:
         assert src_servo_ids.isdisjoint(clone_servo_ids)
         assert len(clone_servo_ids) == 1
 
+    def test_turbulator_is_cloned_with_matching_fields(self, db_session):
+        """gh-1069: a turbulator (gh-934) on the source xsec detail must be
+        deep-copied onto the cloned detail with all fields preserved and a
+        new PK reparented to the clone's detail."""
+        src = _build_source(db_session)
+        clone = clone_aeroplane_subgraph(
+            db_session, src, immutable=False, branch_id=None, predecessor_id=None, root_id=None
+        )
+        db_session.flush()
+
+        # Resolve clone detail ids
+        clone_wing_ids = [
+            w.id for w in db_session.query(WingModel).filter(WingModel.aeroplane_id == clone.id)
+        ]
+        clone_xsec_ids = {
+            x.id
+            for x in db_session.query(WingXSecModel).filter(
+                WingXSecModel.wing_id.in_(clone_wing_ids)
+            )
+        }
+        clone_detail_ids = {
+            d.id
+            for d in db_session.query(WingXSecDetailModel).filter(
+                WingXSecDetailModel.wing_xsec_id.in_(clone_xsec_ids)
+            )
+        }
+
+        clone_turbs = (
+            db_session.query(WingXSecTurbulatorModel)
+            .filter(WingXSecTurbulatorModel.wing_xsec_detail_id.in_(clone_detail_ids))
+            .all()
+        )
+        assert len(clone_turbs) == 1, "Turbulator must survive the clone (gh-1069)"
+        turb = clone_turbs[0]
+        assert turb.form == "zigzag"
+        assert turb.height_mm == pytest.approx(0.3)
+        assert turb.position_root == pytest.approx(0.07)
+        assert turb.position_tip == pytest.approx(0.1)
+        assert turb.enabled is True
+
+    def test_turbulator_has_new_pk_and_independent(self, db_session):
+        """The cloned turbulator must be a distinct row from the source one."""
+        src = _build_source(db_session)
+        clone = clone_aeroplane_subgraph(
+            db_session, src, immutable=False, branch_id=None, predecessor_id=None, root_id=None
+        )
+        db_session.flush()
+
+        src_turb = (
+            db_session.query(WingXSecTurbulatorModel)
+            .join(
+                WingXSecDetailModel,
+                WingXSecTurbulatorModel.wing_xsec_detail_id == WingXSecDetailModel.id,
+            )
+            .join(WingXSecModel, WingXSecDetailModel.wing_xsec_id == WingXSecModel.id)
+            .join(WingModel, WingXSecModel.wing_id == WingModel.id)
+            .filter(WingModel.aeroplane_id == src.id)
+            .all()
+        )
+        clone_turb = (
+            db_session.query(WingXSecTurbulatorModel)
+            .join(
+                WingXSecDetailModel,
+                WingXSecTurbulatorModel.wing_xsec_detail_id == WingXSecDetailModel.id,
+            )
+            .join(WingXSecModel, WingXSecDetailModel.wing_xsec_id == WingXSecModel.id)
+            .join(WingModel, WingXSecModel.wing_id == WingModel.id)
+            .filter(WingModel.aeroplane_id == clone.id)
+            .all()
+        )
+        assert len(src_turb) == len(clone_turb) == 1
+        assert src_turb[0].id != clone_turb[0].id, "Clone turbulator must have a new PK"
+        assert src_turb[0].wing_xsec_detail_id != clone_turb[0].wing_xsec_detail_id, (
+            "Clone turbulator must be reparented to the clone's detail"
+        )
+
+    def test_clone_without_turbulator_is_fine(self, db_session):
+        """A detail with no turbulator must clone without creating one."""
+        src = _build_source(db_session)
+        # Remove the source turbulator before cloning
+        src_detail = (
+            db_session.query(WingXSecDetailModel)
+            .join(WingXSecModel, WingXSecDetailModel.wing_xsec_id == WingXSecModel.id)
+            .join(WingModel, WingXSecModel.wing_id == WingModel.id)
+            .filter(WingModel.aeroplane_id == src.id)
+            .first()
+        )
+        db_session.query(WingXSecTurbulatorModel).filter(
+            WingXSecTurbulatorModel.wing_xsec_detail_id == src_detail.id
+        ).delete()
+        db_session.flush()
+
+        clone = clone_aeroplane_subgraph(
+            db_session, src, immutable=False, branch_id=None, predecessor_id=None, root_id=None
+        )
+        db_session.flush()
+
+        clone_wing_ids = [
+            w.id for w in db_session.query(WingModel).filter(WingModel.aeroplane_id == clone.id)
+        ]
+        clone_xsec_ids = {
+            x.id
+            for x in db_session.query(WingXSecModel).filter(
+                WingXSecModel.wing_id.in_(clone_wing_ids)
+            )
+        }
+        clone_detail_ids = {
+            d.id
+            for d in db_session.query(WingXSecDetailModel).filter(
+                WingXSecDetailModel.wing_xsec_id.in_(clone_xsec_ids)
+            )
+        }
+        clone_turbs = (
+            db_session.query(WingXSecTurbulatorModel)
+            .filter(WingXSecTurbulatorModel.wing_xsec_detail_id.in_(clone_detail_ids))
+            .all()
+        )
+        assert clone_turbs == [], "No turbulator should be created when source has none"
+
     def test_fuselage_step_paths_are_nulled(self, db_session):
         src = _build_source(db_session)
         clone = clone_aeroplane_subgraph(
@@ -552,12 +675,12 @@ class TestCloneAeroplaneSubgraph:
         )
         db_session.flush()
 
-        src_wi = db_session.query(WeightItemModel).filter(
-            WeightItemModel.aeroplane_id == src.id
-        ).all()
-        clone_wi = db_session.query(WeightItemModel).filter(
-            WeightItemModel.aeroplane_id == clone.id
-        ).all()
+        src_wi = (
+            db_session.query(WeightItemModel).filter(WeightItemModel.aeroplane_id == src.id).all()
+        )
+        clone_wi = (
+            db_session.query(WeightItemModel).filter(WeightItemModel.aeroplane_id == clone.id).all()
+        )
 
         assert len(clone_wi) == len(src_wi)
         src_ids = {w.id for w in src_wi}
@@ -573,9 +696,9 @@ class TestCloneAeroplaneSubgraph:
         src = _build_source(db_session)
 
         # Capture the old weight-item id before cloning
-        src_wi = db_session.query(WeightItemModel).filter(
-            WeightItemModel.aeroplane_id == src.id
-        ).first()
+        src_wi = (
+            db_session.query(WeightItemModel).filter(WeightItemModel.aeroplane_id == src.id).first()
+        )
         old_wi_id_str = str(src_wi.id)
 
         clone = clone_aeroplane_subgraph(
@@ -584,15 +707,19 @@ class TestCloneAeroplaneSubgraph:
         db_session.flush()
 
         # New weight item id
-        new_wi = db_session.query(WeightItemModel).filter(
-            WeightItemModel.aeroplane_id == clone.id
-        ).first()
+        new_wi = (
+            db_session.query(WeightItemModel)
+            .filter(WeightItemModel.aeroplane_id == clone.id)
+            .first()
+        )
         new_wi_id_str = str(new_wi.id)
 
         # Loading scenario on the clone
-        clone_ls = db_session.query(LoadingScenarioModel).filter(
-            LoadingScenarioModel.aeroplane_id == clone.id
-        ).first()
+        clone_ls = (
+            db_session.query(LoadingScenarioModel)
+            .filter(LoadingScenarioModel.aeroplane_id == clone.id)
+            .first()
+        )
         assert clone_ls is not None
 
         overrides = clone_ls.component_overrides
@@ -656,8 +783,7 @@ class TestCloneAeroplaneSubgraph:
 
         # child.parent_id must point to the clone's root node (not the source's)
         assert child.parent_id == root_node.id, (
-            f"child.parent_id={child.parent_id} should equal "
-            f"clone root node id={root_node.id}"
+            f"child.parent_id={child.parent_id} should equal clone root node id={root_node.id}"
         )
 
     def test_component_tree_aeroplane_id_updated(self, db_session):
@@ -687,12 +813,16 @@ class TestCloneAeroplaneSubgraph:
 
         from app.models.aeroplanemodel import DesignAssumptionModel
 
-        src_das = db_session.query(DesignAssumptionModel).filter(
-            DesignAssumptionModel.aeroplane_id == src.id
-        ).all()
-        clone_das = db_session.query(DesignAssumptionModel).filter(
-            DesignAssumptionModel.aeroplane_id == clone.id
-        ).all()
+        src_das = (
+            db_session.query(DesignAssumptionModel)
+            .filter(DesignAssumptionModel.aeroplane_id == src.id)
+            .all()
+        )
+        clone_das = (
+            db_session.query(DesignAssumptionModel)
+            .filter(DesignAssumptionModel.aeroplane_id == clone.id)
+            .all()
+        )
 
         assert len(clone_das) == len(src_das) == 1
         assert clone_das[0].parameter_name == "cl_max"
@@ -705,12 +835,16 @@ class TestCloneAeroplaneSubgraph:
         )
         db_session.flush()
 
-        src_srs = db_session.query(StabilityResultModel).filter(
-            StabilityResultModel.aeroplane_id == src.id
-        ).all()
-        clone_srs = db_session.query(StabilityResultModel).filter(
-            StabilityResultModel.aeroplane_id == clone.id
-        ).all()
+        src_srs = (
+            db_session.query(StabilityResultModel)
+            .filter(StabilityResultModel.aeroplane_id == src.id)
+            .all()
+        )
+        clone_srs = (
+            db_session.query(StabilityResultModel)
+            .filter(StabilityResultModel.aeroplane_id == clone.id)
+            .all()
+        )
 
         assert len(clone_srs) == len(src_srs) == 1
         assert clone_srs[0].solver == "aerosandbox"
@@ -723,12 +857,16 @@ class TestCloneAeroplaneSubgraph:
         )
         db_session.flush()
 
-        src_mo = db_session.query(MissionObjectiveModel).filter(
-            MissionObjectiveModel.aeroplane_id == src.id
-        ).first()
-        clone_mo = db_session.query(MissionObjectiveModel).filter(
-            MissionObjectiveModel.aeroplane_id == clone.id
-        ).first()
+        src_mo = (
+            db_session.query(MissionObjectiveModel)
+            .filter(MissionObjectiveModel.aeroplane_id == src.id)
+            .first()
+        )
+        clone_mo = (
+            db_session.query(MissionObjectiveModel)
+            .filter(MissionObjectiveModel.aeroplane_id == clone.id)
+            .first()
+        )
 
         assert clone_mo is not None
         assert clone_mo.mission_type == "trainer"
@@ -741,12 +879,16 @@ class TestCloneAeroplaneSubgraph:
         )
         db_session.flush()
 
-        src_cc = db_session.query(AircraftComputationConfigModel).filter(
-            AircraftComputationConfigModel.aeroplane_id == src.id
-        ).first()
-        clone_cc = db_session.query(AircraftComputationConfigModel).filter(
-            AircraftComputationConfigModel.aeroplane_id == clone.id
-        ).first()
+        src_cc = (
+            db_session.query(AircraftComputationConfigModel)
+            .filter(AircraftComputationConfigModel.aeroplane_id == src.id)
+            .first()
+        )
+        clone_cc = (
+            db_session.query(AircraftComputationConfigModel)
+            .filter(AircraftComputationConfigModel.aeroplane_id == clone.id)
+            .first()
+        )
 
         assert clone_cc is not None
         assert clone_cc.coarse_alpha_step_deg == pytest.approx(1.0)
@@ -766,7 +908,9 @@ class TestCloneAeroplaneSubgraph:
 
         db_session.expire(src)
         db_session.refresh(src)
-        assert src.xyz_ref == [0.1, 0.0, 0.0], "Source xyz_ref must not be affected by clone mutation"
+        assert src.xyz_ref == [0.1, 0.0, 0.0], (
+            "Source xyz_ref must not be affected by clone mutation"
+        )
 
     def test_fuselage_xsecs_independent(self, db_session):
         src = _build_source(db_session)
@@ -775,19 +919,23 @@ class TestCloneAeroplaneSubgraph:
         )
         db_session.flush()
 
-        src_fus = db_session.query(FuselageModel).filter(
-            FuselageModel.aeroplane_id == src.id
-        ).first()
-        clone_fus = db_session.query(FuselageModel).filter(
-            FuselageModel.aeroplane_id == clone.id
-        ).first()
+        src_fus = (
+            db_session.query(FuselageModel).filter(FuselageModel.aeroplane_id == src.id).first()
+        )
+        clone_fus = (
+            db_session.query(FuselageModel).filter(FuselageModel.aeroplane_id == clone.id).first()
+        )
 
-        src_xsecs = db_session.query(FuselageXSecSuperEllipseModel).filter(
-            FuselageXSecSuperEllipseModel.fuselage_id == src_fus.id
-        ).all()
-        clone_xsecs = db_session.query(FuselageXSecSuperEllipseModel).filter(
-            FuselageXSecSuperEllipseModel.fuselage_id == clone_fus.id
-        ).all()
+        src_xsecs = (
+            db_session.query(FuselageXSecSuperEllipseModel)
+            .filter(FuselageXSecSuperEllipseModel.fuselage_id == src_fus.id)
+            .all()
+        )
+        clone_xsecs = (
+            db_session.query(FuselageXSecSuperEllipseModel)
+            .filter(FuselageXSecSuperEllipseModel.fuselage_id == clone_fus.id)
+            .all()
+        )
 
         assert len(clone_xsecs) == len(src_xsecs) == 1
         src_xsec_ids = {x.id for x in src_xsecs}


### PR DESCRIPTION
## Summary

`clone_aeroplane_subgraph` deep-copied spares, the trailing-edge device and its servo, but had **no copy block for the per-cross-section Turbulator** (gh-934). Every snapshot / branch / restore silently dropped turbulators — so the gh-1058 auto-snapshot safety net for the destructive spar split did **not** faithfully restore a turbulated wing.

## Root cause

The clone loop in `app/services/aeroplane_clone_service.py` iterates wings → xsecs → details and recreates spares + TED + servo, but never reads `detail.turbulator`. (`wing_xsec_turbulators` was already in the `CLONED_TABLES` whitelist, so the coverage test passed — but the actual copy code was missing.)

## Fix

Add a turbulator-copy block mirroring the spares/TED blocks: when the source detail has a turbulator, recreate a `WingXSecTurbulatorModel` on the cloned detail with all fields (`form`, `height_mm`, `position_root`, `position_tip`, `enabled`) and the FK reparented to the new detail.

## Tests (TDD — failing first)

- Extended the clone behaviour source builder with a turbulator.
- `test_turbulator_is_cloned_with_matching_fields` — turbulator survives the clone with all fields preserved (was failing before the fix).
- `test_turbulator_has_new_pk_and_independent` — new PK, FK reparented to clone detail (was failing before the fix).
- `test_clone_without_turbulator_is_fine` — a detail with no turbulator clones cleanly.

All versioning suites green (60 tests), clone-service fast coverage 99%, ruff clean.

Closes #1069

🤖 Generated with [Claude Code](https://claude.com/claude-code)