### PR TITLE
fix(gh-1067,gh-1068): segment split — no spare lost + geometrically transparent twist

### DIFF
--- a/cad_designer/airplane/geometry/segment_split.py
+++ b/cad_designer/airplane/geometry/segment_split.py
@@ -12,8 +12,13 @@ transparent**: the built loft is unchanged. That holds because the loft is
 *ruled* (``loft(ruled=True)`` — a straight, linear blend between the root and
 tip airfoils), so an intermediate section is fully determined by:
 
-* the **linearly interpolated** chord / twist (incidence) / dihedral / sweep /
-  length at the split fraction, and
+* the **linearly interpolated** chord / sweep / length at the split fraction,
+* the **dihedral** carried on the last sub-segment (intermediate boundaries get
+  zero) so every intermediate origin stays on the original straight ruled line,
+* the **twist (incidence)** split so each boundary's chord-weighted twist matches
+  the original ruled blend — a plain linear twist split drifts a tapered host's
+  section center_z by ~0.7mm (gh-1068), so the per-sub-segment delta is the
+  difference of ``_boundary_twist_cumulative`` instead, and
 * the **airfoil shape** at the split fraction — the same file when root and tip
   share an airfoil, otherwise a Kulfan/CST morph (gh-796) supplied via the
   injected ``airfoil_morph_fn`` seam.
@@ -45,6 +50,7 @@ Units: **millimetres**, wing-local frame — same as the topology classes.
 
 from __future__ import annotations
 
+import math
 from typing import Callable, Optional
 
 from cad_designer.airplane.aircraft_topology.wing.Airfoil import Airfoil
@@ -67,6 +73,53 @@ _FRACTION_TOL = 1e-9
 
 def _lerp(a: float, b: float, t: float) -> float:
     return a + (b - a) * t
+
+
+def _boundary_twist_cumulative(
+    boundaries: list[float],
+    root_twist_cum: float,
+    tip_twist_cum: float,
+    root_chord: float,
+    tip_chord: float,
+) -> list[float]:
+    """Cumulative twist (deg) at each split boundary that keeps the built ruled
+    loft unchanged for a tapered+twisted host (gh-1068).
+
+    ``root_twist_cum`` / ``tip_twist_cum`` are the host root/tip wires' *absolute*
+    cumulative twist (``theta_accum`` in the loft frame — the host root's value
+    plus, for the tip, the host's own incidence delta).
+
+    The host loft is a *ruled* (point-wise linear) blend of its root and tip
+    wires. A surface point's world-z carries a ``chord · sin(twist)`` term from
+    the chordwise offset of the twisted section. Over the span that term blends
+    **linearly** between the two end wires:
+
+        z_term(t) ∝ (1 - t) · c_root · sin(θ_root) + t · c_tip · sin(θ_tip)
+
+    where ``c(t) = lerp(c_root, c_tip, t)`` is the (linear) ruled chord. An
+    inserted intermediate wire at fraction ``t`` has its own ``c(t) · sin(θ)``,
+    so to reproduce the blend exactly its twist must satisfy
+
+        sin(θ(t)) = [ (1-t)·c_root·sin(θ_root) + t·c_tip·sin(θ_tip) ] / c(t)
+
+    For an untapered host this is the blended-up-vector twist (within a sub-0.01°
+    sin-arc of the plain linear split); for a tapered host it removes the ~0.7mm
+    center_z drift the linear split caused. The per-sub-segment incidence delta
+    is the difference of consecutive returned values, so a constant inboard-chain
+    twist offset cancels and does not affect the result.
+    """
+    s_root = root_chord * math.sin(math.radians(root_twist_cum))
+    s_tip = tip_chord * math.sin(math.radians(tip_twist_cum))
+    out: list[float] = []
+    for t in boundaries:
+        chord = _lerp(root_chord, tip_chord, t)
+        if chord <= 0.0:
+            out.append(_lerp(root_twist_cum, tip_twist_cum, t))
+            continue
+        s = _lerp(s_root, s_tip, t) / chord
+        s = max(-1.0, min(1.0, s))
+        out.append(math.degrees(math.asin(s)))
+    return out
 
 
 def _validate_fractions(fractions: list[float]) -> None:
@@ -210,20 +263,43 @@ def _split_turbulator(turb: Turbulator, t0: float, t1: float) -> Turbulator:
     )
 
 
-def _rehome_spares(spares: list[Spare] | None, sub_y_lo: float, sub_y_hi: float) -> list[Spare]:
+def _rehome_spares(
+    spares: list[Spare] | None,
+    sub_y_lo: float,
+    sub_y_hi: float,
+    *,
+    is_first: bool | None = None,
+    is_last: bool = False,
+) -> list[Spare]:
     """Return the existing spares whose (segment-local) origin y falls in the
-    sub-span ``[sub_y_lo, sub_y_hi)`` (inclusive at the outermost boundary).
+    sub-span ``[sub_y_lo, sub_y_hi)``.
 
-    A spare with no origin (defensive) homes to the first sub-span.
+    No spare may ever be lost by a split (gh-1067 — data loss). A spare's local
+    origin y can land slightly **below the segment root** (e.g. ``-0.6mm`` after
+    a DB round-trip reconstructs a manual root spare from the dihedral geometry),
+    or exactly at ``0``. Such root-side spares — the most load-critical location
+    (the main joiner tube at the root) — clamp to the **first** sub-span. A spare
+    at or beyond the outermost tip clamps to the **last** sub-span. A spare with
+    no origin (defensive) homes to the first sub-span.
+
+    ``is_first`` / ``is_last`` mark the root-most / tip-most sub-spans so the
+    out-of-range clamps only fire once and no spare is double-counted or dropped.
+    When ``is_first`` is not given it defaults to ``sub_y_lo == 0`` (the root).
     """
+    if is_first is None:
+        is_first = abs(sub_y_lo) <= _FRACTION_TOL  # this sub-span starts at root
     rehomed: list[Spare] = []
     for spare in spares or []:
         origin = spare.spare_origin
         y = float(origin.y) if origin is not None else 0.0
-        if sub_y_lo - _FRACTION_TOL <= y < sub_y_hi - _FRACTION_TOL:
-            rehomed.append(spare)
-        elif abs(y - sub_y_hi) <= _FRACTION_TOL and abs(sub_y_hi) > 0:
-            # exactly on the outer boundary -> belongs to this (the last) sub-span
+        in_span = sub_y_lo - _FRACTION_TOL <= y < sub_y_hi - _FRACTION_TOL
+        on_outer = abs(y - sub_y_hi) <= _FRACTION_TOL and abs(sub_y_hi) > 0
+        # Clamp a root-side (< root) spare onto the first sub-span and a
+        # past-the-tip (>= outer) spare onto the last sub-span, so neither is
+        # ever dropped by falling through every sub-span (gh-1067).
+        below_root_to_first = is_first and y < sub_y_lo
+        beyond_tip_to_last = is_last and y >= sub_y_hi
+        if in_span or on_outer or below_root_to_first or beyond_tip_to_last:
             rehomed.append(spare)
     return rehomed
 
@@ -386,6 +462,23 @@ def _emit_subsegments(
     d_incidence = tip_af.incidence
     d_dihedral = tip_af.dihedral_as_rotation_in_degrees
 
+    # gh-1068: cumulative twist (R_y) at each split boundary that keeps the
+    # *built ruled loft unchanged* even when the host is tapered. See
+    # :func:`_boundary_twist_cumulative` for the why (a plain linear twist split
+    # drifts the section center_z by ~0.7mm on a washout+taper wing).
+    # The loft rotates each wire by the *cumulative* twist (theta_accum): the
+    # host root wire by ``root_af.incidence`` and the host tip wire by
+    # ``root_af.incidence + tip_af.incidence``. The chord-weighting below needs
+    # those absolute cumulative angles; the inboard-chain offset cancels in the
+    # per-sub-segment deltas.
+    twist_cum = _boundary_twist_cumulative(
+        boundaries,
+        root_af.incidence,
+        root_af.incidence + tip_af.incidence,
+        root_af.chord,
+        tip_af.chord,
+    )
+
     n_sub = len(boundaries) - 1
     for i in range(n_sub):
         t0, t1 = boundaries[i], boundaries[i + 1]
@@ -400,8 +493,13 @@ def _emit_subsegments(
             outer_af = _interp_airfoil(root_af, tip_af, t1, airfoil_morph_fn)
 
         # Incidence (twist about the chord axis) does not move the spanwise
-        # position, so its delta splits linearly across the sub-segments.
-        outer_af.incidence = d_incidence * (t1 - t0)
+        # position, but for a *tapered* host the section's world-z is driven by
+        # ``chord · sin(twist)``, which is nonlinear in the span fraction. The
+        # per-sub-segment incidence delta is therefore the difference of the
+        # chord-weighted cumulative twist at the two boundaries (not a plain
+        # linear split), so the inserted intermediate wire reproduces the
+        # original ruled blend of the two end wires (gh-1068).
+        outer_af.incidence = twist_cum[i + 1] - twist_cum[i]
 
         # Dihedral rotates the spanwise translation about x. Splitting it
         # linearly would bend the intermediate station origins OFF the original
@@ -423,7 +521,13 @@ def _emit_subsegments(
         sub_turb = (
             _split_turbulator(host.turbulator, t0, t1) if host.turbulator is not None else None
         )
-        rehomed = _rehome_spares(host.spare_list, t0 * seg_len, t1 * seg_len)
+        rehomed = _rehome_spares(
+            host.spare_list,
+            t0 * seg_len,
+            t1 * seg_len,
+            is_first=(i == 0),
+            is_last=(i == n_sub - 1),
+        )
         sub_spares = _assemble_spare_list(
             main_pieces_per_subsegment[i] if main_pieces_per_subsegment else None,
             rehomed,

--- a/cad_designer/tests/test_segment_split.py
+++ b/cad_designer/tests/test_segment_split.py
@@ -152,13 +152,44 @@ class TestSplitMath:
         assert out.segments[0].sweep == pytest.approx(10.0)
 
     def test_incidence_delta_split_sums(self):
+        # The cumulative twist root->tip is always preserved across the split.
         # original tip incidence delta = -4 (relative to root).
         wc = _single_segment(tip_incidence=-4.0, length=500.0)
         out = split_segment(wc, 0, [0.25])
         boundary_i = out.segments[0].tip_airfoil.incidence
         second_tip_i = out.segments[1].tip_airfoil.incidence
         assert boundary_i + second_tip_i == pytest.approx(-4.0)
-        assert boundary_i == pytest.approx(-1.0)
+
+    def test_incidence_split_near_linear_when_untapered(self):
+        # gh-1068: without taper the chord-weighted twist split is ~the plain
+        # linear split (boundary at fraction 0.25 of -4 ~= -1.0). It is the
+        # blended-up-vector value rather than the linear angle, so it differs by
+        # a sub-0.01deg sin-arc term — geometrically correct, not a regression.
+        wc = _single_segment(root_chord=180.0, tip_chord=180.0, tip_incidence=-4.0, length=500.0)
+        out = split_segment(wc, 0, [0.25])
+        assert out.segments[0].tip_airfoil.incidence == pytest.approx(-1.0, abs=0.01)
+
+    def test_incidence_split_is_chord_weighted_when_tapered(self):
+        # gh-1068: with taper the per-sub-segment twist is NOT the linear split
+        # (-1.0) but the chord-weighted value that keeps the built ruled loft's
+        # center_z unchanged (the section's world-z carries a chord*sin(twist)
+        # term that is nonlinear for a tapered host). Sum is still preserved.
+        wc = _single_segment(root_chord=200.0, tip_chord=150.0, tip_incidence=-4.0, length=500.0)
+        out = split_segment(wc, 0, [0.25])
+        boundary_i = out.segments[0].tip_airfoil.incidence
+        second_tip_i = out.segments[1].tip_airfoil.incidence
+        assert boundary_i + second_tip_i == pytest.approx(-4.0)
+        assert boundary_i != pytest.approx(-1.0)  # not the buggy linear split
+        assert boundary_i == pytest.approx(-0.79977, abs=1e-4)
+
+    def test_boundary_twist_cumulative_degenerate_zero_chord(self):
+        # gh-1068: the chord-weighting falls back to a plain linear twist blend
+        # when the (degenerate) ruled chord at a boundary is zero, so the helper
+        # never divides by zero.
+        from cad_designer.airplane.geometry.segment_split import _boundary_twist_cumulative
+
+        out = _boundary_twist_cumulative([0.0, 0.5, 1.0], 0.0, -4.0, 0.0, 0.0)
+        assert out == pytest.approx([0.0, -2.0, -4.0])
 
     def test_dihedral_delta_carried_on_last_subsegment(self):
         # Dihedral rotates the spanwise translation; splitting the delta
@@ -457,6 +488,45 @@ class TestSpareRehome:
         assert s_in in out.segments[0].spare_list
         assert s_out in out.segments[1].spare_list
 
+    def test_exactly_root_y_spare_survives_on_first_subsegment(self):
+        # gh-1067: a spare at exactly y=0 (segment root) must not be dropped.
+        s_root = self._spare_at_y(0.0)
+        wc = _single_segment(length=500.0, spare_list=[s_root])
+        out = split_segment(wc, 0, [0.4])
+        assert s_root in (out.segments[0].spare_list or [])
+        assert s_root not in (out.segments[1].spare_list or [])
+
+    def test_negative_root_y_spare_survives_on_first_subsegment(self):
+        # gh-1067 (DATA LOSS): the DB round-trip reconstructs a manual root spare
+        # with a slightly negative local y (e.g. -0.6mm from dihedral geometry).
+        # That spare is the most load-critical (main joiner tube at the root) and
+        # must clamp to the root sub-segment, never be silently dropped.
+        s_neg = self._spare_at_y(-0.6266)
+        wc = _single_segment(length=500.0, spare_list=[s_neg])
+        out = split_segment(wc, 0, [0.4])
+        assert s_neg in (out.segments[0].spare_list or [])
+        assert s_neg not in (out.segments[1].spare_list or [])
+
+    def test_no_spare_is_lost_across_split(self):
+        # gh-1067: total spare count must be conserved across a split (no silent
+        # drop), including a negative-y root spare alongside ordinary ones.
+        s_neg = self._spare_at_y(-0.6266)
+        s_mid = self._spare_at_y(150.0)
+        s_out = self._spare_at_y(400.0)
+        wc = _single_segment(length=500.0, spare_list=[s_neg, s_mid, s_out])
+        out = split_segment(wc, 0, [0.4])
+        rehomed = [sp for seg in out.segments for sp in (seg.spare_list or [])]
+        for s in (s_neg, s_mid, s_out):
+            assert s in rehomed
+
+    def test_rehome_helper_keeps_negative_root_y(self):
+        # gh-1067 minimal repro from the ticket: _rehome_spares must not drop a
+        # spare whose local origin y is slightly negative for the first sub-span.
+        from cad_designer.airplane.geometry.segment_split import _rehome_spares
+
+        s = self._spare_at_y(-0.6266)
+        assert len(_rehome_spares([s], 0.0, 200.0)) == 1
+
 
 # ---------------------------------------------------------------------------
 # Fast: differing-airfoil split uses the injected morph seam (gh-796 reuse)
@@ -593,6 +663,45 @@ class TestLoftUnchangedAcrossSplit:
         # Analytic ground truth: a sub-1.5mm twist×taper residual on a 600mm
         # wing (~0.25% of span). Documented, not silently widened.
         assert self._max_section_diff(before, after, mode="analytic") < 1.5
+
+    def test_twist_taper_washout_split_center_z_unchanged(self):
+        """gh-1068: a twist+taper (washout) host split must keep intermediate
+        section center_z on the original ruled loft.
+
+        The bug: incidence was split *linearly*, but a section's world-z carries
+        a ``chord·sin(twist)`` term that is nonlinear for a tapered host, so the
+        inserted intermediate wire drifted the center_z by up to ~0.7-0.9mm. The
+        chord-weighted twist split keeps it within µm-class tolerance.
+        """
+        before = _single_segment(
+            root_chord=200.0,
+            tip_chord=120.0,  # taper — the bug needs taper AND twist
+            length=1200.0,
+            sweep=0.0,
+            tip_dihedral=5.0,
+            tip_incidence=-4.0,  # 4 deg washout root->tip
+            root_af=AIRFOIL,
+            tip_af=AIRFOIL,
+        )
+        after = split_segment(before, 0, [533.0 / 1200.0])
+        assert len(after.segments) == 2
+        # center_z must match pre-split within a tight tolerance (was ~0.7mm).
+        assert self._max_section_diff(before, after, mode="analytic") <= 0.1
+
+    def test_twist_taper_washout_split_center_z_unchanged_solid(self):
+        """gh-1068: confirmed in the REAL solid ruled loft, not just analytic."""
+        before = _single_segment(
+            root_chord=200.0,
+            tip_chord=120.0,
+            length=1200.0,
+            sweep=0.0,
+            tip_dihedral=5.0,
+            tip_incidence=-4.0,
+            root_af=AIRFOIL,
+            tip_af=AIRFOIL,
+        )
+        after = split_segment(before, 0, [533.0 / 1200.0])
+        assert self._max_section_diff(before, after, mode="solid") <= 0.1
 
     def test_solid_loft_unchanged_within_slicer_noise(self):
         """The real CAD solid lofts the same across the split (slicer-noise tol)."""


### PR DESCRIPTION
Fixes two bugs in `cad_designer/airplane/geometry/segment_split.py`, both found by the epic-#1056 E2E UAT on the merged main-spar segment split.

## #1067 — split drops root-side manual spares (DATA LOSS)
`_rehome_spares` dropped a manual spare whose segment-local `spare_origin.y` is slightly **negative** (e.g. `-0.6266mm` — the value a DB round-trip reconstructs for a manual root spare from the dihedral geometry). The condition `sub_y_lo - tol <= y < sub_y_hi - tol` is false for `y < 0` on the first sub-span (`sub_y_lo == 0`), so the spare fell through *every* sub-span and was silently lost. The root is the most load-critical location (main joiner tube).

**Fix:** clamp root-side spares (`y < root`) onto the first sub-span and past-the-tip spares (`y >= outer`) onto the last sub-span, via new `is_first`/`is_last` markers, so **no spare is ever dropped**.

Proof: `_rehome_spares([y=-0.6266], 0, 533) -> 1` (was `0`).

## #1068 — twist split shifts section center_z up to ~0.7mm (invariant violation)
`_emit_subsegments` split incidence (twist) **linearly**. A section's world-z carries a `chord·sin(twist)` term that is **nonlinear for a tapered host**, so inserting an intermediate wire drifted the *built* (solid ruled loft) section `center_z` by up to ~0.7mm on a washout+taper wing — violating the documented "built loft unchanged" guarantee. (Mirroring the dihedral carry-on-last is wrong for twist — twist does not move spanwise positions; verified it makes the drift far worse.)

**Fix:** split twist by the **chord-weighted cumulative angle** (`_boundary_twist_cumulative`): `sin θ(t) = [(1-t)·c_root·sin θ_root + t·c_tip·sin θ_tip] / c(t)`, so each inserted wire reproduces the original ruled blend. Untapered hosts stay within a sub-0.01° sin-arc of the old linear split.

Proof (taper+washout, split at y=533/1200): worst `center_z` delta **analytic 0.013mm / solid 0.026mm** (was ~0.7mm).

## TDD / tests
- Failing-first confirmed for both (fast `_rehome_spares` negative-y + conservation → red without fix; slow twist+taper loft-unchanged → red without fix).
- Replaced the prior `test_incidence_delta_split_sums` `== -1.0` assertion (it encoded the buggy linear split) with sum-preserved + untapered-near-linear + tapered-chord-weighted invariants. All other prior tests kept green.
- New slow/`requires_cadquery` `center_z`-unchanged tests (analytic + solid) reuse the loft-unchanged harness.
- Fast-tier coverage of `segment_split.py`: **100%**. Full cad_designer fast suite (676) green; slow loft-unchanged suite (8) green; spar-insert + spare-preservation suites green. `ruff check`/`format` clean.

Closes #1067
Closes #1068

🤖 Generated with [Claude Code](https://claude.com/claude-code)