### PR TITLE
feat(gh-1072): show each spar's chordwise position (% chord) in the built-spar display

### DIFF
--- a/app/schemas/spar_plan.py
+++ b/app/schemas/spar_plan.py
@@ -185,6 +185,16 @@ class SparPieceOut(BaseModel):
         ...,
         description="Spanwise position of the governing (highest-moment) station (m).",
     )
+    x_over_chord: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "gh-1072: chordwise location (x/c, 0..1) this piece was placed at. "
+            "Front (main) ≈ the section max-thickness location; rear (torsion) = "
+            "the requested rear x/c clamped forward of the control-surface hinge."
+        ),
+    )
     y_start: float = Field(
         ...,
         description=(

--- a/app/services/spar_plan_service.py
+++ b/app/services/spar_plan_service.py
@@ -254,6 +254,8 @@ def _piece_to_out(piece) -> SparPieceOut:
         wall=piece.wall * _MM_TO_M,
         shape=piece.shape,
         governing_y=piece.governing_y * _MM_TO_M,
+        # gh-1072: x/c is a dimensionless chord fraction — pass through unscaled.
+        x_over_chord=piece.x_over_chord,
         y_start=y_start_mm * _MM_TO_M,
         y_end=y_end_mm * _MM_TO_M,
         utilisation=piece.utilisation,

--- a/app/tests/test_spar_plan_endpoint.py
+++ b/app/tests/test_spar_plan_endpoint.py
@@ -230,6 +230,26 @@ class TestComputeSparPlanService:
         assert p0.y_end > p0.y_start
         assert p1.y_end > p1.y_start
 
+    def test_x_over_chord_carried_to_out(self, plane_id):
+        # gh-1072: the chordwise location each piece was placed at flows through
+        # to the API verbatim (dimensionless fraction, not converted mm->m).
+        aeroplane = _aeroplane_with_wings(["main_wing"])
+        plan = SparPlan(
+            front_pieces=[_piece(role=SparRole.FRONT, x_over_chord=0.30)],
+            rear_pieces=[_piece(role=SparRole.REAR, outer_d=10.0, inner_d=6.0, x_over_chord=0.62)],
+            front_joint="continuous",
+            rear_joint="continuous",
+        )
+        resp = _run(
+            _patch_full(aeroplane, plan),
+            lambda: spar_plan_service.compute_spar_plan(
+                db=None, aeroplane_uuid=plane_id, request=_basic_request()
+            ),
+        )
+        # front sits at ~max-thickness x/c; rear at the clamped rear x/c.
+        assert resp.front_pieces[0].x_over_chord == pytest.approx(0.30)
+        assert resp.rear_pieces[0].x_over_chord == pytest.approx(0.62)
+
     def test_reinforcement_converted_when_present(self, plane_id):
         aeroplane = _aeroplane_with_wings(["main_wing"])
         resp = _run(

--- a/cad_designer/airplane/geometry/spar_solver.py
+++ b/cad_designer/airplane/geometry/spar_solver.py
@@ -95,6 +95,10 @@ class SparPiece:
     shape: str
     governing_y: float
     utilisation: float
+    #: gh-1072: chordwise location (x/c, 0..1) this piece was placed at — the
+    #: governing (root-side) station's ``x_c``. Front ≈ section max-thickness;
+    #: rear = the requested rear x/c clamped forward of the control surface.
+    x_over_chord: float = 0.0
     length: float = 0.0  # mm, root→tip span of this straight piece (#1032)
     joint_to_next: str | None = None  # "telescoping" between consecutive pieces
     feasible: bool = True  # gh-1037: False when no round tube strong enough fits
@@ -115,6 +119,7 @@ class SparPiece:
             "shape": self.shape,
             "governing_y": self.governing_y,
             "utilisation": self.utilisation,
+            "x_over_chord": self.x_over_chord,
             "length": self.length,
             "joint_to_next": self.joint_to_next,
             "feasible": self.feasible,
@@ -458,6 +463,7 @@ def _piece_from_run_with_od(run: _Run, spec: SparSpec, od: float, inner_d: float
         shape=spec.shape,
         governing_y=governing.y_mm,
         utilisation=utilisation,
+        x_over_chord=governing.x_c,
         length=length,
         feasible=feasible,
         infeasibility_reason=reason,
@@ -540,6 +546,7 @@ def _reinforcement_piece(
         shape=spec.shape,
         governing_y=0.0,
         utilisation=1.0,
+        x_over_chord=left[0].x_c,
         length=2.0 * reach,  # spans symmetrically across the root (y=-reach → +reach)
     )
 

--- a/cad_designer/tests/test_spar_solver.py
+++ b/cad_designer/tests/test_spar_solver.py
@@ -40,12 +40,13 @@ def _station(
     center_z: float = 0.0,
     band: tuple[float, float] = (-50.0, 50.0),
     required_od: float = 10.0,
+    x_c: float = 0.4,
 ) -> StationData:
     """A single station with explicit containment band + required strength OD."""
     return StationData(
         y_span=y_span,
         y_mm=y_mm,
-        x_c=0.4,
+        x_c=x_c,
         center_z=center_z,
         band_lo=band[0],
         band_hi=band[1],
@@ -664,3 +665,51 @@ class TestSparSolverRealBuild:
         ]
         plan = solve_spar_plan(front_left=left, front_right=right, rear_left=left, rear_right=right)
         assert plan.rear_joint == "bent-pin"
+
+
+# ---------------------------------------------------------------------------
+# Fast: x_over_chord carried onto each piece (gh-1072)
+# ---------------------------------------------------------------------------
+
+
+class TestPieceCarriesXOverChord:
+    """Each built piece records the chordwise x/c of its governing station."""
+
+    def test_continuous_piece_takes_governing_station_x_c(self):
+        stations = [
+            _station(i / 4, y_mm=i * 100.0, band=(-50.0, 50.0), required_od=10.0, x_c=0.30)
+            for i in range(5)
+        ]
+        pieces = plan_spar(stations, SparSpec(role=SparRole.FRONT))
+        assert len(pieces) == 1
+        # front spar sits at the section max-thickness location (~0.30c here).
+        assert pieces[0].x_over_chord == pytest.approx(0.30)
+
+    def test_rear_piece_takes_clamped_x_c(self):
+        # rear/torsion spar pulled forward of a hinge → clamped x/c (e.g. 0.62)
+        stations = [
+            _station(i / 4, y_mm=i * 100.0, band=(-50.0, 50.0), required_od=10.0, x_c=0.62)
+            for i in range(5)
+        ]
+        pieces = plan_spar(stations, SparSpec(role=SparRole.REAR))
+        assert len(pieces) == 1
+        assert pieces[0].x_over_chord == pytest.approx(0.62)
+
+    def test_x_over_chord_in_to_dict(self):
+        stations = _uniform_stations(5)
+        piece = plan_spar(stations, SparSpec(role=SparRole.FRONT))[0]
+        d = piece.to_dict()
+        assert d["x_over_chord"] == pytest.approx(piece.x_over_chord)
+
+    def test_reinforcement_piece_carries_root_x_c(self):
+        left = [
+            _station(0.0, y_mm=0.0, center_z=0.0, band=(-50.0, 50.0), x_c=0.31),
+            _station(0.5, y_mm=-200.0, center_z=0.0, band=(-50.0, 50.0), x_c=0.31),
+        ]
+        right = [
+            _station(0.0, y_mm=0.0, center_z=40.0, band=(-50.0, 50.0), x_c=0.31),
+            _station(0.5, y_mm=200.0, center_z=40.0, band=(-50.0, 50.0), x_c=0.31),
+        ]
+        plan = solve_spar_plan(front_left=left, front_right=right)
+        assert plan.reinforcement is not None
+        assert plan.reinforcement.x_over_chord == pytest.approx(0.31)

--- a/frontend/__tests__/SparBuiltAndInsert.test.tsx
+++ b/frontend/__tests__/SparBuiltAndInsert.test.tsx
@@ -32,6 +32,7 @@ function piece(over: Partial<SparPieceOut> = {}): SparPieceOut {
     wall: 0.0024,
     shape: "tube",
     governing_y: 0,
+    x_over_chord: 0.3,
     utilisation: 0.5,
     joint_to_next: null,
     feasible: true,
@@ -119,6 +120,45 @@ describe("BuiltSparSection (gh-1050)", () => {
     expect(rows[0]).toHaveTextContent("ID 24.0");
     expect(rows[0]).toHaveTextContent("wall 2.4");
     expect(rows[0]).toHaveTextContent(/Telescoping/);
+  });
+
+  it("shows the chordwise position (% chord) per spar (gh-1072)", () => {
+    const plan: SparPlanResult = {
+      front_pieces: [piece({ x_over_chord: 0.3, joint_to_next: null })],
+      rear_pieces: [piece({ role: "rear", x_over_chord: 0.62 })],
+      front_joint: "continuous",
+      rear_joint: "continuous",
+      reinforcement: null,
+      feasible: true,
+      infeasibility_reason: null,
+    };
+    render(<BuiltSparSection plan={plan} />);
+    // constant x/c → shown once on the group label.
+    expect(screen.getByTestId("built-spar-group-front")).toHaveTextContent(
+      "30% c",
+    );
+    expect(screen.getByTestId("built-spar-group-rear")).toHaveTextContent(
+      "62% c",
+    );
+  });
+
+  it("shows per-piece % chord when the front spar's x/c varies (gh-1072)", () => {
+    const plan: SparPlanResult = {
+      front_pieces: [
+        piece({ x_over_chord: 0.28, joint_to_next: "telescoping" }),
+        piece({ x_over_chord: 0.34, joint_to_next: null }),
+      ],
+      rear_pieces: [],
+      front_joint: "continuous",
+      rear_joint: "continuous",
+      reinforcement: null,
+      feasible: true,
+      infeasibility_reason: null,
+    };
+    render(<BuiltSparSection plan={plan} />);
+    const rows = screen.getAllByTestId("built-spar-piece");
+    expect(rows[0]).toHaveTextContent("28% c");
+    expect(rows[1]).toHaveTextContent("34% c");
   });
 
   it("renders an infeasible banner when the plan is not buildable", () => {

--- a/frontend/__tests__/SparSizingPanel.test.tsx
+++ b/frontend/__tests__/SparSizingPanel.test.tsx
@@ -279,6 +279,7 @@ describe("SparSizingPanel", () => {
           wall: 0.0024,
           shape: "tube",
           governing_y: 0,
+          x_over_chord: 0.3,
           y_start: 0,
           y_end: 0.75,
           utilisation: 0.5,

--- a/frontend/__tests__/sparPlanHelpers.test.ts
+++ b/frontend/__tests__/sparPlanHelpers.test.ts
@@ -14,6 +14,9 @@ import {
   pieceJointLabel,
   splitNote,
   snapshotNote,
+  formatXOverChord,
+  pieceXcLabel,
+  groupXcSuffix,
 } from "@/lib/sparPlanHelpers";
 import type { SpanwiseLoadsResult } from "@/hooks/useSpanwiseLoads";
 import type { PlannedSpareOut, SparPieceOut } from "@/hooks/useSparPlan";
@@ -98,6 +101,7 @@ describe("formatting helpers", () => {
       wall: 0.0024,
       shape: "tube",
       governing_y: 0,
+      x_over_chord: 0.3,
       y_start: 0,
       y_end: 0.75,
       utilisation: 0.5,
@@ -141,6 +145,7 @@ function gh1060Piece(over: Partial<SparPieceOut>): SparPieceOut {
     wall: 0.0024,
     shape: "tube",
     governing_y: 0,
+    x_over_chord: 0.3,
     utilisation: 0.5,
     joint_to_next: null,
     feasible: true,
@@ -213,6 +218,47 @@ describe("snapshotNote (gh-1060)", () => {
 
   it("formats the snapshot id", () => {
     expect(snapshotNote(42)).toBe("Snapshot #42 created");
+  });
+});
+
+// gh-1072: chordwise position (% chord) of each spar -------------------------
+
+describe("formatXOverChord (gh-1072)", () => {
+  it("renders a 0..1 fraction as a whole-percent chord", () => {
+    expect(formatXOverChord(0.3)).toBe("30% c");
+    expect(formatXOverChord(0.62)).toBe("62% c");
+  });
+
+  it("rounds to a whole percent", () => {
+    expect(formatXOverChord(0.305)).toBe("31% c");
+    expect(formatXOverChord(0.624)).toBe("62% c");
+  });
+});
+
+describe("pieceXcLabel (gh-1072)", () => {
+  const p = gh1060Piece;
+
+  it("shows the piece's chordwise position as a percent", () => {
+    expect(pieceXcLabel(p({ x_over_chord: 0.3 }))).toBe("@ 30% c");
+    expect(pieceXcLabel(p({ x_over_chord: 0.62 }))).toBe("@ 62% c");
+  });
+});
+
+describe("groupXcSuffix (gh-1072)", () => {
+  const p = gh1060Piece;
+
+  it("returns a single suffix when every piece shares the same x/c", () => {
+    const pieces = [p({ x_over_chord: 0.3 }), p({ x_over_chord: 0.3 })];
+    expect(groupXcSuffix(pieces)).toBe(" · @ 30% c");
+  });
+
+  it("returns null when the x/c varies between pieces (shown per piece)", () => {
+    const pieces = [p({ x_over_chord: 0.3 }), p({ x_over_chord: 0.4 })];
+    expect(groupXcSuffix(pieces)).toBeNull();
+  });
+
+  it("returns null for an empty group", () => {
+    expect(groupXcSuffix([])).toBeNull();
   });
 });
 

--- a/frontend/__tests__/useSparPlan.test.ts
+++ b/frontend/__tests__/useSparPlan.test.ts
@@ -27,6 +27,7 @@ const FAKE_PLAN: SparPlanResult = {
       wall: 0.0024,
       shape: "tube",
       governing_y: 0,
+      x_over_chord: 0.3,
       y_start: 0,
       y_end: 0.75,
       utilisation: 0.5,

--- a/frontend/components/workbench/SparSizingPanel.tsx
+++ b/frontend/components/workbench/SparSizingPanel.tsx
@@ -38,6 +38,8 @@ import {
   snapshotNote,
   mToMm,
   replaceWarning,
+  pieceXcLabel,
+  groupXcSuffix,
 } from "@/lib/sparPlanHelpers";
 
 // ---- Types -----------------------------------------------------------------
@@ -189,10 +191,13 @@ function BuiltSparPieceRow({
   piece,
   next,
   index,
+  showXc,
 }: {
   piece: SparPieceOut;
   next: SparPieceOut | null;
   index: number;
+  /** gh-1072: show this piece's % chord inline (the group's x/c varies). */
+  showXc: boolean;
 }) {
   return (
     <div
@@ -201,6 +206,11 @@ function BuiltSparPieceRow({
     >
       <span className="text-muted-foreground">#{index + 1}</span>
       <span className="tabular-nums text-foreground">{pieceDimsLabel(piece)}</span>
+      {showXc && (
+        <span className="tabular-nums text-muted-foreground">
+          {pieceXcLabel(piece)}
+        </span>
+      )}
       <span className="tabular-nums text-muted-foreground">
         {pieceExtentLabel(piece)}
       </span>
@@ -223,6 +233,9 @@ function BuiltSparGroup({
   pieces: SparPieceOut[];
 }) {
   if (pieces.length === 0) return null;
+  // gh-1072: when every piece shares the same chordwise position, show it once
+  // on the group label; otherwise show it per piece (xcSuffix is null).
+  const xcSuffix = groupXcSuffix(pieces);
   return (
     <div className="space-y-0.5" data-testid={`built-spar-group-${group}`}>
       <p
@@ -231,6 +244,7 @@ function BuiltSparGroup({
         }`}
       >
         {sparGroupLabel(group)}
+        {xcSuffix}
       </p>
       {pieces.map((p, i) => (
         <BuiltSparPieceRow
@@ -238,6 +252,7 @@ function BuiltSparGroup({
           piece={p}
           next={pieces[i + 1] ?? null}
           index={i}
+          showXc={xcSuffix == null}
         />
       ))}
     </div>

--- a/frontend/hooks/useSparPlan.ts
+++ b/frontend/hooks/useSparPlan.ts
@@ -43,6 +43,9 @@ export interface SparPieceOut {
   wall: number; // m
   shape: string;
   governing_y: number; // m
+  // gh-1072: chordwise location (x/c, 0..1) this piece was placed at. Front
+  // (main) ≈ section max-thickness; rear (torsion) = clamped rear x/c.
+  x_over_chord: number;
   // gh-1057/gh-1060: spanwise extent of this piece (metres, root=0). For a
   // telescoping run the NEXT piece's y_start is the telescoping joint position.
   y_start: number; // m

--- a/frontend/lib/sparPlanHelpers.ts
+++ b/frontend/lib/sparPlanHelpers.ts
@@ -128,6 +128,41 @@ export function pieceJointLabel(
   return `${jointLabel(piece.joint_to_next)} @ ${mToMm(next.y_start, 0)} mm`;
 }
 
+// ---- Built-spar chordwise position (% chord) (gh-1072) ----------------------
+
+/**
+ * Format a chordwise fraction (x/c, 0..1) as a whole-percent chord label,
+ * e.g. 0.30 → "30% c". Rounded to the nearest percent (a sub-percent
+ * difference between stations is not meaningful for placement display).
+ */
+export function formatXOverChord(xOverChord: number): string {
+  return `${Math.round(xOverChord * 100)}% c`;
+}
+
+/**
+ * Per-piece chordwise-position label, e.g. "@ 30% c". Used when the x/c
+ * varies between pieces of a spar so each row carries its own position.
+ */
+export function pieceXcLabel(piece: SparPieceOut): string {
+  return `@ ${formatXOverChord(piece.x_over_chord)}`;
+}
+
+/**
+ * Group-level chordwise suffix appended to the spar group label when every
+ * piece in the group shares the same (rounded) chordwise position, e.g.
+ * " · @ 30% c". Returns null when the group is empty or the position varies
+ * between pieces — in that case the per-piece {@link pieceXcLabel} is shown.
+ */
+export function groupXcSuffix(pieces: SparPieceOut[]): string | null {
+  if (pieces.length === 0) return null;
+  const first = Math.round(pieces[0].x_over_chord * 100);
+  const constant = pieces.every(
+    (p) => Math.round(p.x_over_chord * 100) === first,
+  );
+  if (!constant) return null;
+  return ` · @ ${formatXOverChord(pieces[0].x_over_chord)}`;
+}
+
 // ---- Insert-preview: segment split + snapshot notes (gh-1060) ---------------
 
 /**


### PR DESCRIPTION
Closes #1072.

The built-spar list now shows the chordwise position (% of chord) each spar was computed at:
- **Front (main) spar:** the section max-thickness x/c (deepest location).
- **Rear (torsion) spar:** the actually-used x/c (requested rear x/c, pulled forward of the control-surface hinge via rear_spar_x_c_with_clearance when present).

Backend carries the used x/c onto each SparPiece and exposes `x_over_chord` on SparPieceOut; frontend renders it (e.g. "@ 30% c"). Tests both sides (63 backend + 47 frontend spar tests pass); ruff/tsc/eslint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)