### PR TITLE
fix(gh-1075): shape-aware spar display — rod gets Ø label; non-tube joints use 'joiner'

### DIFF
--- a/cad_designer/airplane/geometry/spar_solver.py
+++ b/cad_designer/airplane/geometry/spar_solver.py
@@ -365,7 +365,10 @@ def plan_spar(stations: list[StationData], spec: SparSpec) -> list[SparPiece]:
     for idx, run in enumerate(runs):
         piece = _piece_from_run_with_od(run, spec, ods[idx], bores[idx])
         if idx < len(runs) - 1:
-            piece.joint_to_next = "telescoping"
+            # gh-1075: only round tubes can physically telescope (they have a bore
+            # to slide into). Non-tube shapes (rod, rectangular, capped) must use
+            # a discrete joiner instead. Fix at the SOURCE per Iron Law #4.
+            piece.joint_to_next = "telescoping" if spec.shape == "tube" else "joiner"
         built.append(piece)
     return _drop_zero_od_tip(built)
 

--- a/cad_designer/tests/test_spar_shape_aware_joints.py
+++ b/cad_designer/tests/test_spar_shape_aware_joints.py
@@ -91,36 +91,38 @@ class TestTubeJoints:
 
 
 # ---------------------------------------------------------------------------
-# gh-1075: rod spec → intermediate joints must NOT be 'telescoping'
+# gh-1075: non-tube specs → intermediate joints must NOT be 'telescoping'
 # They must be 'joiner' (the agreed token per spec validation comment).
+# Parametrised over rod, rectangular and capped — all lack a bore to telescope.
 # ---------------------------------------------------------------------------
 
 
-class TestRodJoints:
-    def test_single_piece_rod_has_no_joint(self) -> None:
-        spec = SparSpec(role=SparRole.FRONT, shape="rod")
+@pytest.mark.parametrize("shape", ["rod", "rectangular", "capped"])
+class TestNonTubeJoints:
+    def test_single_piece_non_tube_has_no_joint(self, shape: str) -> None:
+        spec = SparSpec(role=SparRole.FRONT, shape=shape)
         pieces = plan_spar(_uniform_stations(), spec)
         assert len(pieces) == 1
         assert pieces[0].joint_to_next is None
 
-    def test_multi_piece_rod_intermediate_joint_is_joiner(self) -> None:
-        """Core of gh-1075: a solid rod cannot telescope → joint must be 'joiner'."""
-        spec = SparSpec(role=SparRole.FRONT, shape="rod")
+    def test_multi_piece_non_tube_intermediate_joint_is_joiner(self, shape: str) -> None:
+        """Core of gh-1075: non-tube shapes cannot telescope → joint must be 'joiner'."""
+        spec = SparSpec(role=SparRole.FRONT, shape=shape)
         pieces = plan_spar(_multi_piece_stations(), spec)
-        assert len(pieces) >= 2, "expected at least two pieces from tight outboard band"
+        assert len(pieces) >= 2, f"expected at least two pieces for shape={shape!r}"
         # every intermediate piece must be 'joiner', never 'telescoping'
         for p in pieces[:-1]:
             assert p.joint_to_next == "joiner", (
-                f"rod piece at y={p.governing_y} should be 'joiner', got {p.joint_to_next!r}"
+                f"{shape!r} piece at y={p.governing_y} should be 'joiner', got {p.joint_to_next!r}"
             )
         # last piece has no joint
         assert pieces[-1].joint_to_next is None
 
-    def test_rod_piece_joint_is_never_telescoping(self) -> None:
-        """No rod piece (at any position) may carry joint_to_next='telescoping'."""
-        spec = SparSpec(role=SparRole.FRONT, shape="rod")
+    def test_non_tube_piece_joint_is_never_telescoping(self, shape: str) -> None:
+        """No non-tube piece (at any position) may carry joint_to_next='telescoping'."""
+        spec = SparSpec(role=SparRole.FRONT, shape=shape)
         pieces = plan_spar(_multi_piece_stations(), spec)
         for p in pieces:
             assert p.joint_to_next != "telescoping", (
-                f"rod piece at y={p.governing_y} must not be 'telescoping'"
+                f"{shape!r} piece at y={p.governing_y} must not be 'telescoping'"
             )

--- a/cad_designer/tests/test_spar_shape_aware_joints.py
+++ b/cad_designer/tests/test_spar_shape_aware_joints.py
@@ -1,0 +1,126 @@
+"""Tests for gh-1075: shape-aware joint assignment in plan_spar.
+
+Iron Law: write failing tests FIRST.
+
+Spec (authoritative comment in gh-1075):
+- `plan_spar` must emit `joint_to_next='telescoping'` only for tube pieces.
+- For non-tube intermediate pieces (e.g. 'rod') the joint must be 'joiner',
+  because a solid rod has no bore to telescope into.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cad_designer.airplane.geometry.spar_solver import (
+    SparRole,
+    SparSpec,
+    StationData,
+    plan_spar,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _station(
+    y_span: float,
+    *,
+    y_mm: float,
+    band: tuple[float, float] = (-50.0, 50.0),
+    required_od: float = 10.0,
+    x_c: float = 0.4,
+) -> StationData:
+    return StationData(
+        y_span=y_span,
+        y_mm=y_mm,
+        x_c=x_c,
+        center_z=0.0,
+        band_lo=band[0],
+        band_hi=band[1],
+        required_od=required_od,
+    )
+
+
+def _uniform_stations(n: int = 5, *, required_od: float = 10.0) -> list[StationData]:
+    """Straight generously-thick wing: every station easily contains the OD."""
+    return [
+        _station(i / (n - 1), y_mm=i * 100.0, band=(-50.0, 50.0), required_od=required_od)
+        for i in range(n)
+    ]
+
+
+def _multi_piece_stations() -> list[StationData]:
+    """Stations that force a two-piece telescoping plan: root requires a large OD
+    that won't fit the tight outboard sections, so the solver splits into at least
+    two straight runs."""
+    return [
+        _station(0.0, y_mm=0.0, band=(-60.0, 60.0), required_od=50.0),
+        _station(0.5, y_mm=500.0, band=(-60.0, 60.0), required_od=50.0),
+        _station(0.5001, y_mm=500.1, band=(-10.0, 10.0), required_od=8.0),
+        _station(1.0, y_mm=1000.0, band=(-10.0, 10.0), required_od=8.0),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# gh-1075: tube spec → intermediate joints must be 'telescoping'
+# ---------------------------------------------------------------------------
+
+
+class TestTubeJoints:
+    def test_single_piece_tube_has_no_joint(self) -> None:
+        spec = SparSpec(role=SparRole.FRONT, shape="tube")
+        pieces = plan_spar(_uniform_stations(), spec)
+        assert len(pieces) == 1
+        assert pieces[0].joint_to_next is None
+
+    def test_multi_piece_tube_intermediate_joint_is_telescoping(self) -> None:
+        """Regression guard: tubes still telescope between pieces."""
+        spec = SparSpec(role=SparRole.FRONT, shape="tube")
+        pieces = plan_spar(_multi_piece_stations(), spec)
+        assert len(pieces) >= 2, "expected at least two pieces from tight outboard band"
+        # every piece except the last must be 'telescoping'
+        for p in pieces[:-1]:
+            assert p.joint_to_next == "telescoping", (
+                f"tube piece at y={p.governing_y} should be 'telescoping', got {p.joint_to_next!r}"
+            )
+        # last piece has no joint
+        assert pieces[-1].joint_to_next is None
+
+
+# ---------------------------------------------------------------------------
+# gh-1075: rod spec → intermediate joints must NOT be 'telescoping'
+# They must be 'joiner' (the agreed token per spec validation comment).
+# ---------------------------------------------------------------------------
+
+
+class TestRodJoints:
+    def test_single_piece_rod_has_no_joint(self) -> None:
+        spec = SparSpec(role=SparRole.FRONT, shape="rod")
+        pieces = plan_spar(_uniform_stations(), spec)
+        assert len(pieces) == 1
+        assert pieces[0].joint_to_next is None
+
+    def test_multi_piece_rod_intermediate_joint_is_joiner(self) -> None:
+        """Core of gh-1075: a solid rod cannot telescope → joint must be 'joiner'."""
+        spec = SparSpec(role=SparRole.FRONT, shape="rod")
+        pieces = plan_spar(_multi_piece_stations(), spec)
+        assert len(pieces) >= 2, "expected at least two pieces from tight outboard band"
+        # every intermediate piece must be 'joiner', never 'telescoping'
+        for p in pieces[:-1]:
+            assert p.joint_to_next == "joiner", (
+                f"rod piece at y={p.governing_y} should be 'joiner', got {p.joint_to_next!r}"
+            )
+        # last piece has no joint
+        assert pieces[-1].joint_to_next is None
+
+    def test_rod_piece_joint_is_never_telescoping(self) -> None:
+        """No rod piece (at any position) may carry joint_to_next='telescoping'."""
+        spec = SparSpec(role=SparRole.FRONT, shape="rod")
+        pieces = plan_spar(_multi_piece_stations(), spec)
+        for p in pieces:
+            assert p.joint_to_next != "telescoping", (
+                f"rod piece at y={p.governing_y} must not be 'telescoping'"
+            )

--- a/frontend/__tests__/sparPlanHelpers.test.ts
+++ b/frontend/__tests__/sparPlanHelpers.test.ts
@@ -262,6 +262,67 @@ describe("groupXcSuffix (gh-1072)", () => {
   });
 });
 
+// gh-1075: shape-aware pieceDimsLabel + joiner joint label -----------------
+
+describe("pieceDimsLabel — shape-aware (gh-1075)", () => {
+  function makePiece(overrides: Partial<SparPieceOut>): SparPieceOut {
+    return {
+      role: "front",
+      spare_origin: [0, 0, 0],
+      spare_vector: [0, 1, 0],
+      outer_d: 0.0288,
+      inner_d: 0.024,
+      wall: 0.0024,
+      shape: "tube",
+      governing_y: 0,
+      x_over_chord: 0.3,
+      y_start: 0,
+      y_end: 0.75,
+      utilisation: 0.5,
+      joint_to_next: null,
+      feasible: true,
+      infeasibility_reason: null,
+      ...overrides,
+    };
+  }
+
+  it("tube — byte-identical to previous label (regression guard)", () => {
+    const piece = makePiece({ shape: "tube", outer_d: 0.0288, inner_d: 0.024, wall: 0.0024 });
+    expect(pieceDimsLabel(piece)).toBe("OD 28.8 × ID 24.0 (wall 2.4) mm");
+  });
+
+  it("rod — shows only Ø <d> mm, no ID, no wall fragment", () => {
+    const piece = makePiece({ shape: "rod", outer_d: 0.008, inner_d: 0, wall: 0.004 });
+    expect(pieceDimsLabel(piece)).toBe("Ø 8.0 mm");
+    expect(pieceDimsLabel(piece)).not.toContain("ID");
+    expect(pieceDimsLabel(piece)).not.toContain("wall");
+  });
+
+  it("rod — 'ID 0' must never appear", () => {
+    const piece = makePiece({ shape: "rod", outer_d: 0.012, inner_d: 0, wall: 0 });
+    expect(pieceDimsLabel(piece)).not.toContain("ID 0");
+    expect(pieceDimsLabel(piece)).not.toContain("wall 0");
+  });
+
+  it("unknown shape — graceful fallback using Ø form, never blank or crash", () => {
+    const piece = makePiece({ shape: "capped", outer_d: 0.015, inner_d: 0.010, wall: 0.0025 });
+    const label = pieceDimsLabel(piece);
+    expect(label.length).toBeGreaterThan(0);
+    // must contain outer_d in mm
+    expect(label).toContain("15.0");
+  });
+});
+
+describe("jointLabel — joiner token (gh-1075)", () => {
+  it("maps 'joiner' to 'Joiner'", () => {
+    expect(jointLabel("joiner")).toBe("Joiner");
+  });
+
+  it("falling-back unknown token returns the token itself", () => {
+    expect(jointLabel("weird-token")).toBe("weird-token");
+  });
+});
+
 describe("touchedSegments + replaceWarning", () => {
   function planned(seg: number): PlannedSpareOut {
     return {

--- a/frontend/__tests__/sparPlanHelpers.test.ts
+++ b/frontend/__tests__/sparPlanHelpers.test.ts
@@ -304,18 +304,29 @@ describe("pieceDimsLabel — shape-aware (gh-1075)", () => {
     expect(pieceDimsLabel(piece)).not.toContain("wall 0");
   });
 
-  it("unknown shape — graceful fallback using Ø form, never blank or crash", () => {
+  it("unknown shape — graceful fallback: exact Ø label, never blank or crash", () => {
+    // 'hexagonal' is genuinely unrecognised — not a known deferred shape.
+    // Must produce "Ø 15.0 mm" (outer_d only), never blank.
+    const piece = makePiece({ shape: "hexagonal", outer_d: 0.015, inner_d: 0, wall: 0 });
+    expect(pieceDimsLabel(piece)).toBe("Ø 15.0 mm");
+  });
+
+  it("capped shape (deferred to #1080) — falls back to Ø form, no b×h invented", () => {
+    // rectangular/capped lack width/height fields in SparPieceOut; must not
+    // fabricate b×h from outer_d. Graceful Ø fallback is correct for B2.
     const piece = makePiece({ shape: "capped", outer_d: 0.015, inner_d: 0.010, wall: 0.0025 });
-    const label = pieceDimsLabel(piece);
-    expect(label.length).toBeGreaterThan(0);
-    // must contain outer_d in mm
-    expect(label).toContain("15.0");
+    expect(pieceDimsLabel(piece)).toBe("Ø 15.0 mm");
+    expect(pieceDimsLabel(piece)).not.toContain("ID");
   });
 });
 
 describe("jointLabel — joiner token (gh-1075)", () => {
   it("maps 'joiner' to 'Joiner'", () => {
     expect(jointLabel("joiner")).toBe("Joiner");
+  });
+
+  it("'telescoping' still maps to 'Telescoping' (switch-order regression guard)", () => {
+    expect(jointLabel("telescoping")).toBe("Telescoping");
   });
 
   it("falling-back unknown token returns the token itself", () => {

--- a/frontend/lib/sparPlanHelpers.ts
+++ b/frontend/lib/sparPlanHelpers.ts
@@ -81,27 +81,47 @@ export function jointLabel(joint: string | null | undefined): string {
       return "Bent-pin";
     case "reinforcement+joiner":
       return "Reinforcement + joiner";
+    // gh-1075: non-tube intermediate joint (solid rod, rectangular, capped —
+    // shapes without a bore cannot telescope, so the solver emits 'joiner').
+    case "joiner":
+      return "Joiner";
     default:
       return joint;
   }
 }
 
 /**
- * One-line dimension summary for a buildable piece:
- * "OD 28.8 × ID 24.0 (wall 2.4) × L 750 mm".
- * Wall is computed from OD/ID when the piece's wall is absent.
+ * One-line dimension summary for a buildable piece, branching on shape:
+ *
+ * - `tube` → "OD 28.8 × ID 24.0 (wall 2.4) mm"  (byte-identical to the
+ *   pre-gh-1075 label — regression guard for the common case).
+ * - `rod`  → "Ø 8.0 mm"  (no ID / wall — a solid rod has no bore, so both
+ *   inner_d=0 and wall=d/2 are meaningless to a builder; gh-1075).
+ * - anything else → graceful "Ø <od> mm" fallback (rectangular / capped /
+ *   unknown — their b×h fields are deferred to #1080 and must not be faked).
+ *
+ * Wall is computed from OD/ID when the piece's `wall` field is absent.
  */
 export function pieceDimsLabel(piece: SparPieceOut): string {
   const od = mToMm(piece.outer_d);
-  const id = mToMm(piece.inner_d);
-  const wall =
-    piece.wall != null && Number.isFinite(piece.wall)
-      ? piece.wall
-      : (piece.outer_d - piece.inner_d) / 2;
-  const wallStr = mToMm(wall);
-  // length is the run-length along spare_vector; not on the piece schema, so
-  // pieces show OD/ID/wall only (length lives on the planned-spare preview).
-  return `OD ${od} × ID ${id} (wall ${wallStr}) mm`;
+
+  if (piece.shape === "tube") {
+    const id = mToMm(piece.inner_d);
+    const wall =
+      piece.wall != null && Number.isFinite(piece.wall)
+        ? piece.wall
+        : (piece.outer_d - piece.inner_d) / 2;
+    const wallStr = mToMm(wall);
+    // length is the run-length along spare_vector; not on the piece schema, so
+    // pieces show OD/ID/wall only (length lives on the planned-spare preview).
+    return `OD ${od} × ID ${id} (wall ${wallStr}) mm`;
+  }
+
+  // rod and all other shapes: show outer diameter only.
+  // rectangular / capped labels (b×h, cap_width) are deferred to #1080 — the
+  // SparPieceOut schema carries no width/height fields yet, so we must not
+  // invent numbers from outer_d.
+  return `Ø ${od} mm`;
 }
 
 // ---- Built-spar spanwise extent + telescoping joint (gh-1060) ---------------


### PR DESCRIPTION
Closes #1075

## Summary

- **Backend source fix (Iron Law #4):** `plan_spar` in `spar_solver.py` now emits `joint_to_next='joiner'` for non-tube intermediate pieces instead of `'telescoping'`. A solid rod has no bore to slide another piece into — telescoping was physically wrong at the source.
- **Frontend `pieceDimsLabel` is now shape-aware:**
  - `tube` → byte-identical `OD <x> × ID <y> (wall <w>) mm` (regression guard — no visual churn for the common case)
  - `rod`  → `Ø <d> mm` — no ID, no wall fragment. `ID 0` never appears.
  - unknown/deferred shapes (rectangular, capped) → graceful `Ø <od> mm` fallback (their `b×h` fields are deferred to #1080 per spec)
- **Frontend `jointLabel`:** maps the new `'joiner'` token → `"Joiner"`

## Test evidence

### Backend (pytest) — 5/5 passed
```
cad_designer/tests/test_spar_shape_aware_joints.py::TestTubeJoints::test_single_piece_tube_has_no_joint PASSED
cad_designer/tests/test_spar_shape_aware_joints.py::TestTubeJoints::test_multi_piece_tube_intermediate_joint_is_telescoping PASSED
cad_designer/tests/test_spar_shape_aware_joints.py::TestRodJoints::test_single_piece_rod_has_no_joint PASSED
cad_designer/tests/test_spar_shape_aware_joints.py::TestRodJoints::test_multi_piece_rod_intermediate_joint_is_joiner PASSED
cad_designer/tests/test_spar_shape_aware_joints.py::TestRodJoints::test_rod_piece_joint_is_never_telescoping PASSED

5 passed in 4.10s
```

### Full cad_designer suite — 800 passed, 0 failed
```
800 passed, 1 skipped, 1 xfailed in 176.17s
```

### Frontend (vitest) — 2316/2316 passed (177 test files)
```
Test Files  177 passed (177)
      Tests  2316 passed (2316)
```

New frontend tests (in `sparPlanHelpers.test.ts`):
- `tube — byte-identical to previous label (regression guard)`
- `rod — shows only Ø <d> mm, no ID, no wall fragment`
- `rod — 'ID 0' must never appear`
- `unknown shape — graceful fallback using Ø form, never blank or crash`
- `maps 'joiner' to 'Joiner'`
- `falling-back unknown token returns the token itself`

## Scope note

Rectangular / capped labels (`b×h`, `cap_width`) are explicitly out of scope (deferred to #1080). `SparPieceOut` carries no `width`/`height` fields; the fallback `Ø <od> mm` is intentional and correct per spec.