### PR TITLE
feat(gh-1083): import Höllein wood construction stock as COTS components

### DIFF
--- a/alembic/versions/d8015f98814c_gh1083_wood_stock_types_and_abachi.py
+++ b/alembic/versions/d8015f98814c_gh1083_wood_stock_types_and_abachi.py
@@ -1,0 +1,177 @@
+"""gh-1083: seed Höllein wood construction-stock component types + Abachi material
+
+Adds four seeded, non-deletable component types for raw building stock:
+  - veneer
+  - strip
+  - triangular_strip
+  - grooved_strip
+
+Each carries a required ``material`` enum that references a material component
+(``Pine (structural)`` or ``Abachi``) holding the density. Mass is not baked
+into the stock item — it derives downstream from the bbox dimensions × the
+referenced material's density.
+
+Also seeds the ``Abachi`` material component (density ≈ 390 kg/m³), referenced
+by the Abachi veneer/grooved stock. (``Pine (structural)`` already exists from
+gh-1008.)
+
+The type/material definitions are intentionally duplicated here (rather than
+imported from app code) so replaying this migration is not tied to the current
+application code — matching the convention of 28a13fbeac90 and e2a35c6eac69.
+
+Revision ID: d8015f98814c
+Revises: b7d4e2a91c33
+Create Date: 2026-06-22 20:45:00.000000
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d8015f98814c"
+down_revision: Union[str, None] = "b7d4e2a91c33"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_NOW = datetime.now(timezone.utc).isoformat()
+
+_MATERIAL_OPTIONS = ["Pine (structural)", "Abachi"]
+
+_MATERIAL_PROP = {
+    "name": "material",
+    "label": "Material",
+    "type": "enum",
+    "options": _MATERIAL_OPTIONS,
+    "required": True,
+    "description": "Referenced material component carrying the density for mass estimation.",
+}
+_PRICE_PROP = {"name": "price_eur", "label": "Price", "type": "number", "unit": "EUR", "min": 0.0}
+_SKU_PROP = {"name": "sku", "label": "SKU / Art.-No.", "type": "string"}
+_SOURCE_PROP = {"name": "source_url", "label": "Source URL", "type": "string"}
+_PACK_PROP = {
+    "name": "pack_qty",
+    "label": "Pack quantity",
+    "type": "number",
+    "min": 1,
+    "description": "Units per pack (VE).",
+}
+_GROOVE_PROP = {
+    "name": "groove_mm",
+    "label": "Groove size",
+    "type": "number",
+    "unit": "mm",
+    "min": 0.0,
+}
+
+_BASE = [_MATERIAL_PROP, _PRICE_PROP, _SKU_PROP, _SOURCE_PROP]
+
+_WOOD_TYPES = [
+    {
+        "name": "veneer",
+        "label": "Veneer",
+        "description": "Sheet veneer stock (e.g. Abachi facing). bbox: height × width × length (mm).",
+        "schema": list(_BASE),
+    },
+    {
+        "name": "strip",
+        "label": "Strip",
+        "description": "Rectangular wood strip / Leiste. bbox: height × width × length (mm).",
+        "schema": [*_BASE, _PACK_PROP],
+    },
+    {
+        "name": "triangular_strip",
+        "label": "Triangular Strip",
+        "description": "Triangular wood strip / Dreikantleiste. bbox: leg × leg × length (mm).",
+        "schema": [*_BASE, _PACK_PROP],
+    },
+    {
+        "name": "grooved_strip",
+        "label": "Grooved Strip",
+        "description": "Grooved wood strip / Nutleiste. bbox: height × width × length (mm).",
+        "schema": [*_BASE, _PACK_PROP, _GROOVE_PROP],
+    },
+]
+
+_ABACHI = {
+    "name": "Abachi",
+    "component_type": "material",
+    "manufacturer": None,
+    "description": "Abachi (Obeche) — light construction veneer/strip wood. Density ≈ 390 kg/m³.",
+    "mass_g": None,
+    "bbox_x_mm": None,
+    "bbox_y_mm": None,
+    "bbox_z_mm": None,
+    "model_ref": None,
+    "specs": {"density_kg_m3": 390.0},
+    "created_at": _NOW,
+    "updated_at": _NOW,
+}
+
+_component_types = sa.table(
+    "component_types",
+    sa.column("name", sa.String),
+    sa.column("label", sa.String),
+    sa.column("description", sa.String),
+    sa.column("schema", sa.JSON),
+    sa.column("deletable", sa.Boolean),
+    sa.column("created_at", sa.String),
+    sa.column("updated_at", sa.String),
+)
+
+_components = sa.table(
+    "components",
+    sa.column("name", sa.String),
+    sa.column("component_type", sa.String),
+    sa.column("manufacturer", sa.String),
+    sa.column("description", sa.String),
+    sa.column("mass_g", sa.Float),
+    sa.column("bbox_x_mm", sa.Float),
+    sa.column("bbox_y_mm", sa.Float),
+    sa.column("bbox_z_mm", sa.Float),
+    sa.column("model_ref", sa.String),
+    sa.column("specs", sa.JSON),
+    sa.column("created_at", sa.String),
+    sa.column("updated_at", sa.String),
+)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # 1. Seed wood component types (idempotent by name).
+    for t in _WOOD_TYPES:
+        existing = conn.execute(
+            sa.text("SELECT id FROM component_types WHERE name = :n"), {"n": t["name"]}
+        ).fetchone()
+        if existing is None:
+            conn.execute(
+                _component_types.insert().values(
+                    name=t["name"],
+                    label=t["label"],
+                    description=t["description"],
+                    schema=t["schema"],
+                    deletable=False,
+                    created_at=_NOW,
+                    updated_at=_NOW,
+                )
+            )
+
+    # 2. Seed the Abachi material component (idempotent by name + type).
+    existing = conn.execute(
+        sa.text("SELECT id FROM components WHERE name = 'Abachi' AND component_type = 'material'")
+    ).fetchone()
+    if existing is None:
+        conn.execute(_components.insert().values(**_ABACHI))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text("DELETE FROM components WHERE name = 'Abachi' AND component_type = 'material'")
+    )
+    for t in _WOOD_TYPES:
+        conn.execute(sa.text("DELETE FROM component_types WHERE name = :n"), {"n": t["name"]})

--- a/app/services/component_type_service.py
+++ b/app/services/component_type_service.py
@@ -284,6 +284,50 @@ def list_type_names(db: Session) -> list[str]:
 # replaying old migrations isn't tied to the current application code).
 # --------------------------------------------------------------------------- #
 
+
+def _wood_stock_schema(*, pack: bool = False, groove: bool = False) -> list[dict[str, Any]]:
+    """Schema shared by the Höllein wood construction-stock types (gh-1083).
+
+    ``material`` references a material component (e.g. ``Pine (structural)``)
+    that carries ``density_kg_m3`` — mass is derived downstream from the bbox
+    dimensions × that density, so it is not stored on the stock item itself.
+    """
+    schema: list[dict[str, Any]] = [
+        {
+            "name": "material",
+            "label": "Material",
+            "type": "enum",
+            "options": ["Pine (structural)", "Abachi"],
+            "required": True,
+            "description": "Referenced material component carrying the density for mass estimation.",
+        },
+        {"name": "price_eur", "label": "Price", "type": "number", "unit": "EUR", "min": 0.0},
+        {"name": "sku", "label": "SKU / Art.-No.", "type": "string"},
+        {"name": "source_url", "label": "Source URL", "type": "string"},
+    ]
+    if pack:
+        schema.append(
+            {
+                "name": "pack_qty",
+                "label": "Pack quantity",
+                "type": "number",
+                "min": 1,
+                "description": "Units per pack (VE).",
+            }
+        )
+    if groove:
+        schema.append(
+            {
+                "name": "groove_mm",
+                "label": "Groove size",
+                "type": "number",
+                "unit": "mm",
+                "min": 0.0,
+            }
+        )
+    return schema
+
+
 DEFAULT_SEED_TYPES: list[dict[str, Any]] = [
     {
         "name": "material",
@@ -605,6 +649,33 @@ DEFAULT_SEED_TYPES: list[dict[str, Any]] = [
         "description": "Free-form type with no structured schema",
         "schema": [],
     },
+    # gh-1083: Höllein wood construction stock. Cross-section + length live in
+    # the bbox_x/y/z_mm columns; `material` references a density-bearing
+    # material component so mass derives from dimensions × density.
+    {
+        "name": "veneer",
+        "label": "Veneer",
+        "description": "Sheet veneer stock (e.g. Abachi facing). bbox: height × width × length (mm).",
+        "schema": _wood_stock_schema(),
+    },
+    {
+        "name": "strip",
+        "label": "Strip",
+        "description": "Rectangular wood strip / Leiste. bbox: height × width × length (mm).",
+        "schema": _wood_stock_schema(pack=True),
+    },
+    {
+        "name": "triangular_strip",
+        "label": "Triangular Strip",
+        "description": "Triangular wood strip / Dreikantleiste. bbox: leg × leg × length (mm).",
+        "schema": _wood_stock_schema(pack=True),
+    },
+    {
+        "name": "grooved_strip",
+        "label": "Grooved Strip",
+        "description": "Grooved wood strip / Nutleiste. bbox: height × width × length (mm).",
+        "schema": _wood_stock_schema(pack=True, groove=True),
+    },
 ]
 
 
@@ -689,6 +760,14 @@ _STRUCTURAL_MATERIAL_SEEDS: list[dict[str, Any]] = [
             "density_kg_m3": 1600.0,
             "allowable_bending_stress_mpa": 500.0,
             "youngs_modulus_gpa": 120.0,
+        },
+    },
+    # gh-1083: light construction wood referenced by Höllein veneer/strip stock.
+    {
+        "name": "Abachi",
+        "description": "Abachi (Obeche) — light construction veneer/strip wood. Density ≈ 390 kg/m³.",
+        "specs": {
+            "density_kg_m3": 390.0,
         },
     },
 ]

--- a/app/services/cots_import.py
+++ b/app/services/cots_import.py
@@ -20,7 +20,19 @@ from app.models.component import ComponentModel
 logger = logging.getLogger(__name__)
 
 # Allowed component_type values
-_VALID_COMPONENT_TYPES = {"brushless_motor", "esc", "battery", "propeller", "servo", "receiver"}
+_VALID_COMPONENT_TYPES = {
+    "brushless_motor",
+    "esc",
+    "battery",
+    "propeller",
+    "servo",
+    "receiver",
+    # gh-1083: Höllein wood construction stock
+    "veneer",
+    "strip",
+    "triangular_strip",
+    "grooved_strip",
+}
 
 
 @dataclass

--- a/app/tests/test_component_type_delete_cascade_bug.py
+++ b/app/tests/test_component_type_delete_cascade_bug.py
@@ -17,10 +17,10 @@ class TestDeleteDoesNotCascade:
     def test_deleting_one_user_type_leaves_all_others_intact(self, client_and_db):
         client, _ = client_and_db
 
-        # Baseline: 9 seeded types
+        # Baseline: 14 seeded types (gh-1083 added 4 wood-stock types)
         before = client.get("/component-types").json()
         seeded_ids = {t["id"] for t in before}
-        assert len(seeded_ids) == 10
+        assert len(seeded_ids) == 14
 
         # Create two user types
         ut1 = client.post(
@@ -41,7 +41,7 @@ class TestDeleteDoesNotCascade:
         ).json()
 
         mid = client.get("/component-types").json()
-        assert len(mid) == 12
+        assert len(mid) == 16  # 14 seeded + 2 user
 
         # Delete the second user type
         res = client.delete(f"/component-types/{ut2['id']}")
@@ -51,8 +51,8 @@ class TestDeleteDoesNotCascade:
         after = client.get("/component-types").json()
         remaining_ids = {t["id"] for t in after}
 
-        assert len(after) == 11, (
-            f"Expected 11 types after deleting one, got {len(after)}. "
+        assert len(after) == 15, (
+            f"Expected 15 types after deleting one, got {len(after)}. "
             f"Remaining: {[t['name'] for t in after]}"
         )
         assert ut1["id"] in remaining_ids

--- a/app/tests/test_component_types_end_to_end.py
+++ b/app/tests/test_component_types_end_to_end.py
@@ -44,7 +44,7 @@ class TestRowCountInvariants:
 
     def test_seed_produces_exactly_9_rows(self, client_and_db):
         _, sf = client_and_db
-        assert _count_types_in_db(sf) == 10
+        assert _count_types_in_db(sf) == 14
 
     def test_create_adds_exactly_one_row(self, client_and_db):
         client, sf = client_and_db
@@ -182,8 +182,8 @@ class TestLifecycleRoundTrip:
         # GET after DELETE → 404
         assert client.get(f"/component-types/{created['id']}").status_code == 404
 
-        # DB state: 9 seeded types, user type gone
-        assert _count_types_in_db(sf) == 10
+        # DB state: 14 seeded types, user type gone
+        assert _count_types_in_db(sf) == 14
 
 
 # --------------------------------------------------------------------------- #
@@ -291,7 +291,7 @@ class TestMultipleMutations:
             created_ids.append(r.json()["id"])
 
         before = _count_types_in_db(sf)
-        assert before == 10 + 5
+        assert before == 14 + 5
 
         # Delete just one
         res = client.delete(f"/component-types/{created_ids[2]}")

--- a/app/tests/test_components_catalog.py
+++ b/app/tests/test_components_catalog.py
@@ -16,7 +16,7 @@ class TestComponentTypes:
         assert "material" in types
         assert "propeller" in types
         assert "generic" in types
-        assert len(types) == 10
+        assert len(types) == 14  # gh-1083: + veneer/strip/triangular_strip/grooved_strip
 
 
 class TestComponentCRUDExtended:

--- a/app/tests/test_hoellein_wood_import.py
+++ b/app/tests/test_hoellein_wood_import.py
@@ -1,0 +1,193 @@
+"""Tests for the Höllein wood construction-stock import (gh-1083).
+
+Covers:
+- The four new seeded component types (veneer / strip / triangular_strip /
+  grooved_strip) exist, are non-deletable, and expose a required ``material``
+  enum that references a density-bearing material component.
+- The Abachi material component is seeded with its density.
+- The COTS importer accepts the new wood component types.
+- The committed snapshot ``data/cots/hoellein_wood.json`` is well-formed:
+  52 records, valid types, every ``material`` resolves to a seeded material
+  component, dimensions carried in the bbox fields, and no baked-in mass
+  (mass derives downstream from the referenced material's density).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.db.base import Base
+from app.models.component import ComponentModel
+from app.models.component_type import ComponentTypeModel
+from app.services.component_type_service import (
+    seed_default_types,
+    seed_structural_materials,
+)
+from app.services.cots_import import _validate_record, import_snapshot
+
+pytestmark = pytest.mark.integration
+
+WOOD_TYPES = {"veneer", "strip", "triangular_strip", "grooved_strip"}
+MATERIAL_OPTIONS = {"Pine (structural)", "Abachi"}
+
+SNAPSHOT = Path(__file__).resolve().parents[2] / "data" / "cots" / "hoellein_wood.json"
+
+
+@pytest.fixture()
+def session() -> Session:
+    """Fresh in-memory SQLite session per test (no real DB required)."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    SM = sessionmaker(bind=engine, autocommit=False, autoflush=False, class_=Session)
+    db = SM()
+    yield db
+    db.close()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Seeded component types
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_wood_types_seeded_nondeletable(session):
+    seed_default_types(session)
+    session.commit()
+    rows = {r.name: r for r in session.query(ComponentTypeModel).all()}
+    for name in WOOD_TYPES:
+        assert name in rows, f"missing seeded type {name}"
+        assert rows[name].deletable is False
+
+
+def test_wood_types_have_material_reference(session):
+    seed_default_types(session)
+    session.commit()
+    for name in WOOD_TYPES:
+        row = session.query(ComponentTypeModel).filter(ComponentTypeModel.name == name).first()
+        props = {p["name"]: p for p in row.schema_def}
+        assert "material" in props, f"{name} missing material field"
+        mat = props["material"]
+        assert mat["type"] == "enum"
+        assert mat.get("required") is True
+        assert MATERIAL_OPTIONS.issubset(set(mat["options"]))
+
+
+def test_grooved_strip_has_groove_field(session):
+    seed_default_types(session)
+    session.commit()
+    row = (
+        session.query(ComponentTypeModel).filter(ComponentTypeModel.name == "grooved_strip").first()
+    )
+    names = {p["name"] for p in row.schema_def}
+    assert "groove_mm" in names
+
+
+def test_abachi_material_seeded_with_density(session):
+    seed_structural_materials(session)
+    session.commit()
+    abachi = (
+        session.query(ComponentModel)
+        .filter(ComponentModel.name == "Abachi", ComponentModel.component_type == "material")
+        .first()
+    )
+    assert abachi is not None
+    assert abachi.specs["density_kg_m3"] == 390.0
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Importer accepts the new wood types
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_importer_accepts_wood_record(session):
+    record = {
+        "manufacturer": "Höllein",
+        "name": "Kiefernleiste 10x10x1000mm",
+        "component_type": "strip",
+        "mass_g": None,
+        "bbox_x_mm": 10,
+        "bbox_y_mm": 10,
+        "bbox_z_mm": 1000,
+        "model_ref": "hoellein/kiefernleiste-10x10x1000",
+        "source_url": "https://hoelleinshop.com/x",
+        "source_version": "hoellein 2026-06-22",
+        "specs": {"material": "Pine (structural)", "price_eur": 1.8},
+    }
+    assert _validate_record(record) is None
+    result = import_snapshot(session, [record])
+    session.commit()
+    assert result.imported == 1
+    assert not result.errors
+    row = session.query(ComponentModel).filter_by(name=record["name"]).first()
+    assert row.component_type == "strip"
+    assert row.bbox_z_mm == 1000
+    assert row.specs["material"] == "Pine (structural)"
+    assert row.mass_g is None
+
+
+def test_importer_rejects_unknown_type(session):
+    bad = {"manufacturer": "x", "name": "y", "component_type": "frobnicator", "specs": {}}
+    assert _validate_record(bad) is not None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Committed snapshot integrity
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _load_snapshot() -> list[dict]:
+    return json.loads(SNAPSHOT.read_text(encoding="utf-8"))
+
+
+def test_snapshot_exists_and_has_52_records():
+    assert SNAPSHOT.exists(), f"snapshot not found: {SNAPSHOT}"
+    assert len(_load_snapshot()) == 52
+
+
+def test_snapshot_records_well_formed():
+    for rec in _load_snapshot():
+        assert rec["component_type"] in WOOD_TYPES
+        # The importer would accept every record.
+        assert _validate_record(rec) is None
+        # Dimensions live in the bbox fields, all positive.
+        for f in ("bbox_x_mm", "bbox_y_mm", "bbox_z_mm"):
+            assert isinstance(rec[f], (int, float)) and rec[f] > 0, f"{rec['name']}: bad {f}"
+        # Mass is not baked in — it derives from the referenced material density.
+        assert rec.get("mass_g") is None
+        # Material reference resolves to a known material component.
+        assert rec["specs"]["material"] in MATERIAL_OPTIONS
+
+
+def test_snapshot_imports_end_to_end(session):
+    seed_default_types(session)
+    seed_structural_materials(session)
+    session.commit()
+
+    result = import_snapshot(session, _load_snapshot())
+    session.commit()
+    assert result.imported == 52
+    assert not result.errors
+
+    mats = {
+        m.name
+        for m in session.query(ComponentModel)
+        .filter(ComponentModel.component_type == "material")
+        .all()
+    }
+    woods = (
+        session.query(ComponentModel)
+        .filter(ComponentModel.component_type.in_(tuple(WOOD_TYPES)))
+        .all()
+    )
+    assert len(woods) == 52
+    for w in woods:
+        assert w.specs["material"] in mats, f"{w.name}: dangling material {w.specs['material']}"

--- a/app/tests/test_migration_gh1000.py
+++ b/app/tests/test_migration_gh1000.py
@@ -18,6 +18,12 @@ from alembic.config import Config
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 ENRICH_COLS = {"weight_g", "inertia_kg_m2", "geometry"}
 
+# Pin to the gh-1000 revision under test rather than "head"/"-1": later
+# migrations stack on top, so a relative downgrade from head would no longer
+# undo gh-1000 (regression seen in gh-1083). Targeting the revision keeps these
+# tests exercising gh-1000's own up/down regardless of what follows it.
+GH1000_REV = "b7d4e2a91c33"
+
 
 @pytest.fixture()
 def alembic_cfg():
@@ -40,19 +46,19 @@ def _cols(db_path: str) -> set[str]:
 
 class TestMigrationGh1000:
     def test_upgrade_adds_enrichment_columns(self, alembic_cfg):
-        command.upgrade(alembic_cfg, "head")
+        command.upgrade(alembic_cfg, GH1000_REV)
         cols = _cols(alembic_cfg.attributes["db_path"])
         assert ENRICH_COLS <= cols
 
     def test_downgrade_removes_enrichment_columns(self, alembic_cfg):
-        command.upgrade(alembic_cfg, "head")
+        command.upgrade(alembic_cfg, GH1000_REV)
         command.downgrade(alembic_cfg, "-1")
         cols = _cols(alembic_cfg.attributes["db_path"])
         assert not (ENRICH_COLS & cols)
 
     def test_upgrade_downgrade_upgrade_roundtrip(self, alembic_cfg):
-        command.upgrade(alembic_cfg, "head")
+        command.upgrade(alembic_cfg, GH1000_REV)
         command.downgrade(alembic_cfg, "-1")
-        command.upgrade(alembic_cfg, "head")
+        command.upgrade(alembic_cfg, GH1000_REV)
         cols = _cols(alembic_cfg.attributes["db_path"])
         assert ENRICH_COLS <= cols

--- a/data/cots/hoellein_wood.json
+++ b/data/cots/hoellein_wood.json
@@ -1,0 +1,856 @@
+[
+  {
+    "manufacturer": "Aero-naut",
+    "name": "Abachifurnier 1000x100x0.6mm",
+    "component_type": "veneer",
+    "mass_g": null,
+    "bbox_x_mm": 0.6,
+    "bbox_y_mm": 100,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/7520-21",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Abachi",
+      "price_eur": 3.0,
+      "sku": "7520/21"
+    }
+  },
+  {
+    "manufacturer": "Aero-naut",
+    "name": "Abachifurnier 1000x100x1.0mm",
+    "component_type": "veneer",
+    "mass_g": null,
+    "bbox_x_mm": 1.0,
+    "bbox_y_mm": 100,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/7520-22",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Abachi",
+      "price_eur": 3.2,
+      "sku": "7520/22"
+    }
+  },
+  {
+    "manufacturer": "Aero-naut",
+    "name": "Abachifurnier 1000x100x1.5mm",
+    "component_type": "veneer",
+    "mass_g": null,
+    "bbox_x_mm": 1.5,
+    "bbox_y_mm": 100,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/7520-23",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Abachi",
+      "price_eur": 3.3,
+      "sku": "7520/23"
+    }
+  },
+  {
+    "manufacturer": "Aero-naut",
+    "name": "Abachifurnier 1000x250x1.0mm",
+    "component_type": "veneer",
+    "mass_g": null,
+    "bbox_x_mm": 1.0,
+    "bbox_y_mm": 250,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/752042",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Abachi",
+      "price_eur": 6.4,
+      "sku": "752042"
+    }
+  },
+  {
+    "manufacturer": "Aero-naut",
+    "name": "Abachifurnier 1000x250x1.5mm",
+    "component_type": "veneer",
+    "mass_g": null,
+    "bbox_x_mm": 1.5,
+    "bbox_y_mm": 250,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/752043",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Abachi",
+      "price_eur": 7.6,
+      "sku": "752043"
+    }
+  },
+  {
+    "manufacturer": "Aero-naut",
+    "name": "Abachileiste 3x10x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 3,
+    "bbox_y_mm": 10,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/755935",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Abachi",
+      "price_eur": 0.9,
+      "sku": "755935",
+      "pack_qty": 10
+    }
+  },
+  {
+    "manufacturer": "Modellbau Klein",
+    "name": "Kiefer-Dreikantleiste 6x6x1000mm",
+    "component_type": "triangular_strip",
+    "mass_g": null,
+    "bbox_x_mm": 6,
+    "bbox_y_mm": 6,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefer-dreikantleiste-6x6x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 0.9
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 10x10x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 10,
+    "bbox_y_mm": 10,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-10x10x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 1.8
+    }
+  },
+  {
+    "manufacturer": "Aero-naut",
+    "name": "Kiefernleiste 10x10x1500mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 10,
+    "bbox_y_mm": 10,
+    "bbox_z_mm": 1500,
+    "model_ref": "hoellein/755652",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 3.0,
+      "sku": "755652"
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 10x15x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 10,
+    "bbox_y_mm": 15,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-10x15x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 2.84
+    }
+  },
+  {
+    "manufacturer": "Aero-naut",
+    "name": "Kiefernleiste 10x15x1500mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 10,
+    "bbox_y_mm": 15,
+    "bbox_z_mm": 1500,
+    "model_ref": "hoellein/7556-54",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 3.9,
+      "sku": "7556/54"
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 10x20x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 10,
+    "bbox_y_mm": 20,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-10x20x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 3.4
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 12x12x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 12,
+    "bbox_y_mm": 12,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-12x12x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 2.65
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 15x15x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 15,
+    "bbox_y_mm": 15,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-15x15x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 4.0
+    }
+  },
+  {
+    "manufacturer": "Aero-naut",
+    "name": "Kiefernleiste 15x15x1500mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 15,
+    "bbox_y_mm": 15,
+    "bbox_z_mm": 1500,
+    "model_ref": "hoellein/7556-61",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 4.61,
+      "sku": "7556/61"
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 1x10x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 1,
+    "bbox_y_mm": 10,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-1x10x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 2.2
+    }
+  },
+  {
+    "manufacturer": "Aero-naut",
+    "name": "Kiefernleiste 1x1x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 1,
+    "bbox_y_mm": 1,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/755506",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 1.4,
+      "sku": "755506"
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 1x3x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 1,
+    "bbox_y_mm": 3,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-1x3x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 1.5
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 2x10x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 2,
+    "bbox_y_mm": 10,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-2x10x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 1.0
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 2x2x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 2,
+    "bbox_y_mm": 2,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-2x2x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 0.75
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 2x3x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 2,
+    "bbox_y_mm": 3,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-2x3x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 0.75
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 2x4x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 2,
+    "bbox_y_mm": 4,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-2x4x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 0.8
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 2x5x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 2,
+    "bbox_y_mm": 5,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-2x5x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 0.8
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 2x6x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 2,
+    "bbox_y_mm": 6,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-2x6x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 0.9
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 2x7x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 2,
+    "bbox_y_mm": 7,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-2x7x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 0.9
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 2x8x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 2,
+    "bbox_y_mm": 8,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-2x8x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 0.9
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 3x10x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 3,
+    "bbox_y_mm": 10,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-3x10x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 1.0
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 3x15x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 3,
+    "bbox_y_mm": 15,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-3x15x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 1.59
+    }
+  },
+  {
+    "manufacturer": "Aero-naut",
+    "name": "Kiefernleiste 3x15x1500mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 3,
+    "bbox_y_mm": 15,
+    "bbox_z_mm": 1500,
+    "model_ref": "hoellein/7556-36",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 2.4,
+      "sku": "7556/36"
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 3x20x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 3,
+    "bbox_y_mm": 20,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-3x20x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 1.9
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 3x3x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 3,
+    "bbox_y_mm": 3,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-3x3x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 0.8
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 3x5x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 3,
+    "bbox_y_mm": 5,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-3x5x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 0.8
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 3x7x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 3,
+    "bbox_y_mm": 7,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-3x7x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 0.9
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 3x8x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 3,
+    "bbox_y_mm": 8,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-3x8x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 0.95
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 4x10x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 4,
+    "bbox_y_mm": 10,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-4x10x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 1.2
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 4x12x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 4,
+    "bbox_y_mm": 12,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-4x12x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 1.25
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 4x4x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 4,
+    "bbox_y_mm": 4,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-4x4x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 0.8
+    }
+  },
+  {
+    "manufacturer": "Aero-naut",
+    "name": "Kiefernleiste 4x4x1500mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 4,
+    "bbox_y_mm": 4,
+    "bbox_z_mm": 1500,
+    "model_ref": "hoellein/7556-38",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 1.3,
+      "sku": "7556/38"
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 4x8x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 4,
+    "bbox_y_mm": 8,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-4x8x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 1.2
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 5x10x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 5,
+    "bbox_y_mm": 10,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-5x10x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 1.5
+    }
+  },
+  {
+    "manufacturer": "Aero-naut",
+    "name": "Kiefernleiste 5x10x1500mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 5,
+    "bbox_y_mm": 10,
+    "bbox_z_mm": 1500,
+    "model_ref": "hoellein/7556-43",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 2.09,
+      "sku": "7556/43"
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 5x15x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 5,
+    "bbox_y_mm": 15,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-5x15x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 1.55
+    }
+  },
+  {
+    "manufacturer": "Aero-naut",
+    "name": "Kiefernleiste 5x15x1500mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 5,
+    "bbox_y_mm": 15,
+    "bbox_z_mm": 1500,
+    "model_ref": "hoellein/7556-44",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 2.59,
+      "sku": "7556/44"
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 5x20x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 5,
+    "bbox_y_mm": 20,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-5x20x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 1.9
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 5x5x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 5,
+    "bbox_y_mm": 5,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-5x5x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 0.95
+    }
+  },
+  {
+    "manufacturer": "Aero-naut",
+    "name": "Kiefernleiste 5x5x1500mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 5,
+    "bbox_y_mm": 5,
+    "bbox_z_mm": 1500,
+    "model_ref": "hoellein/7556-40",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 1.5,
+      "sku": "7556/40"
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 5x8x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 5,
+    "bbox_y_mm": 8,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-5x8x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 1.09
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 6x6x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 6,
+    "bbox_y_mm": 6,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-6x6x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 1.09
+    }
+  },
+  {
+    "manufacturer": "Höllein",
+    "name": "Kiefernleiste 8x8x1000mm",
+    "component_type": "strip",
+    "mass_g": null,
+    "bbox_x_mm": 8,
+    "bbox_y_mm": 8,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/kiefernleiste-8x8x1000mm",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Pine (structural)",
+      "price_eur": 1.5
+    }
+  },
+  {
+    "manufacturer": "Aero-naut",
+    "name": "Nutleiste Abachi 10x25x1000mm - Nut 4x4mm",
+    "component_type": "grooved_strip",
+    "mass_g": null,
+    "bbox_x_mm": 10,
+    "bbox_y_mm": 25,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/7596-02",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Abachi",
+      "price_eur": 2.8,
+      "sku": "7596/02",
+      "groove_mm": 4.0
+    }
+  },
+  {
+    "manufacturer": "Aero-naut",
+    "name": "Nutleiste Abachi 10x25x1000mm - Nut 5x5mm",
+    "component_type": "grooved_strip",
+    "mass_g": null,
+    "bbox_x_mm": 10,
+    "bbox_y_mm": 25,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/7596-03",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Abachi",
+      "price_eur": 2.8,
+      "sku": "7596/03",
+      "groove_mm": 5.0
+    }
+  },
+  {
+    "manufacturer": "Aero-naut",
+    "name": "Nutleiste Abachi 8x20x1000mm - Nut 3x3mm",
+    "component_type": "grooved_strip",
+    "mass_g": null,
+    "bbox_x_mm": 8,
+    "bbox_y_mm": 20,
+    "bbox_z_mm": 1000,
+    "model_ref": "hoellein/7596-01",
+    "source_url": "https://hoelleinshop.com/collections/werkstoffe-holz-kiefer-abachileisten?sort_by=title-ascending",
+    "source_version": "hoellein 2026-06-22",
+    "specs": {
+      "material": "Abachi",
+      "price_eur": 2.2,
+      "sku": "7596/01",
+      "groove_mm": 3.0
+    }
+  }
+]


### PR DESCRIPTION
## What

Imports 52 Höllein (hoelleinshop.com) wood construction-stock items — Abachi veneers and Pine strips (plain, triangular, grooved) — into the component library as first-class COTS components, selectable in the BoM / build views. Closes #1083.

## Modeling decisions (agreed with maintainer)

- **Four new seeded, non-deletable component types** mirroring the source taxonomy: `veneer`, `strip`, `triangular_strip`, `grooved_strip`.
- **Mass is not baked in.** Each item carries a required `material` enum referencing a **material component** that holds `density_kg_m3`; weight derives downstream from the bbox dimensions × that density.
  - `Pine (structural)` (density 500, from gh-1008) reused.
  - **`Abachi`** material newly seeded (density ≈ 390 kg/m³).
- Cross-section + length live in `bbox_x/y/z_mm`; `price_eur`, `sku`, `pack_qty` (VE), `groove_mm`, and `source_url` live in `specs`.

## Changes

- `DEFAULT_SEED_TYPES` + Alembic migration `d8015f98814c` seed the 4 types and the Abachi material (idempotent; downgrade tested).
- `cots_import` whitelist extended to accept the wood types.
- `data/cots/hoellein_wood.json` — committed snapshot, the durable reimport source (`scripts/import_cots.py data/cots/hoellein_wood.json`).
- Tests: seeded types/material, importer acceptance, snapshot integrity + end-to-end import; updated seeded-type counts (10 → 14).

## Verification

- `pytest -k "component or cots or material or catalog or seed or type"` → **430 passed**.
- `ruff check` / `ruff format` clean.
- Migration applied to the local DB and snapshot imported: **52 imported, 0 errors**, no dangling material references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
