### PR TITLE
chore: resolve 5 SonarCloud backend findings (S2583, S5863, S5779)

### DIFF
--- a/app/converters/openvsp_wing_handler.py
+++ b/app/converters/openvsp_wing_handler.py
@@ -329,9 +329,9 @@ def _anchor_u_position(vsp: ModuleType, gid: str, anchor_index: int, n_xsec: int
         return -1.0  # sentinel: caller falls back to empirical probe
     cap_min = 1 if max(raw_min, 0) > 0 else 0
     cap_max = 1 if max(raw_max, 0) > 0 else 0
+    # n_xsec >= 2 here (early return above) so (n_xsec - 1) >= 1, and
+    # cap_min/cap_max are each 0 or 1 → total_segments >= 1 always.
     total_segments = (n_xsec - 1) + cap_min + cap_max
-    if total_segments <= 0:
-        return 0.0
     return (anchor_index + cap_min) / total_segments
 
 

--- a/app/tests/test_copilot_tools.py
+++ b/app/tests/test_copilot_tools.py
@@ -7,6 +7,7 @@ aerosandbox/network call.  The hub is never reached.
 from __future__ import annotations
 
 import asyncio
+import math
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -268,7 +269,7 @@ class TestRunAnalysisPolarMocked:
 
         for key in ("cl_max", "cd_min", "cl_cd_max"):
             assert isinstance(result[key], float)
-            assert result[key] == result[key]  # not NaN
+            assert not math.isnan(result[key])
 
 
 # ---------------------------------------------------------------------------

--- a/app/tests/test_openvsp_airfoil_hash_morph.py
+++ b/app/tests/test_openvsp_airfoil_hash_morph.py
@@ -25,7 +25,10 @@ def _sym(thick: float) -> list[tuple[float, float]]:
 
 
 def test_coords_hash_deterministic_and_distinct():
-    assert oa._coords_hash(_sym(0.06)) == oa._coords_hash(_sym(0.06))
+    # Same geometry produced by two independent list instances must hash equal.
+    coords_a = _sym(0.06)
+    coords_b = _sym(0.06)
+    assert oa._coords_hash(coords_a) == oa._coords_hash(coords_b)
     assert oa._coords_hash(_sym(0.06)) != oa._coords_hash(_sym(0.09))
 
 

--- a/app/tests/test_session_dependency.py
+++ b/app/tests/test_session_dependency.py
@@ -53,8 +53,6 @@ class TestGetDbTransactionManagement:
         with pytest.raises(ValueError, match="boom"):
             gen.throw(ValueError("boom"))
         with _patched_session.connect() as conn:
-            try:
-                row = conn.execute(text("SELECT id FROM _txn_test2")).fetchone()
-                assert row is None
-            except Exception:
-                pass
+            # The rollback undid the INSERT, so the row must not be visible.
+            row = conn.execute(text("SELECT id FROM _txn_test2")).fetchone()
+            assert row is None

--- a/app/tests/test_vlm_strip_forces.py
+++ b/app/tests/test_vlm_strip_forces.py
@@ -11,6 +11,7 @@ own aggregate CL/CD.
 
 from __future__ import annotations
 
+import math
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -91,7 +92,7 @@ class TestComputeVlmStripForces:
                 # inviscid VLM → no viscous drag component
                 assert entry.cdv == 0.0
                 # induced angle and derived products are finite
-                assert entry.ai == entry.ai  # not NaN
+                assert not math.isnan(entry.ai)
                 assert entry.c_cl == pytest.approx(entry.chord * entry.cl, rel=1e-6)
 
     def test_reconstruction_matches_aggregate_cl(self):


### PR DESCRIPTION
Maintainer-authorized SonarCloud debt cleanup (no GH issue). Existing-code fixes only; behavior preserved.

## Findings resolved
| Rule | File:Line | Fix |
|------|-----------|-----|
| S2583 (always-false) | `app/converters/openvsp_wing_handler.py:333` | Removed provably-unreachable `if total_segments <= 0: return 0.0`. After the `n_xsec < 2` early return, `(n_xsec-1) >= 1` and `cap_min,cap_max ∈ {0,1}`, so `total_segments >= 1` always. Behavior-preserving. |
| S5863 (`x == x`) | `app/tests/test_copilot_tools.py:271` | NaN check rewritten as `not math.isnan(result[key])` (intent unchanged). |
| S5863 (`x == x`) | `app/tests/test_vlm_strip_forces.py:94` | NaN check rewritten as `not math.isnan(entry.ai)`. |
| S5863 (identical expr) | `app/tests/test_openvsp_airfoil_hash_morph.py:28` | Bind two independent list instances of the same geometry, then assert equal hashes — determinism intent preserved. |
| S5779 (assert in try/except) | `app/tests/test_session_dependency.py:58` | Removed the `except Exception: pass` that swallowed the `AssertionError`; post-rollback query returns `None` (verified), asserted directly. |

## Test plan
- [x] `ruff check` + `ruff format --check` clean on all 5 files
- [x] `pytest` green on the 4 touched test files (67 passed)
- [x] openvsp wing-handler test suite green (97 passed)
- [ ] SonarCloud PR analysis no longer lists the 5 findings
- [ ] fast CI green

## Notes
No test assertion was weakened — each was strengthened to its verified intent.
A pre-existing, unrelated test failure was observed on `main` (`test_openvsp_importer.py::...::test_wing_handler_is_invoked`, fake VSP namespace lacks `GetXSecSurf`) — out of scope for this cleanup, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)