### PR TITLE
chore: resolve 6 SonarCloud frontend findings (S7727, S1244, S1082, S4822)

### DIFF
--- a/frontend/__tests__/ArtifactBrowserDirRow.test.tsx
+++ b/frontend/__tests__/ArtifactBrowserDirRow.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * Coverage for ArtifactBrowserDialog's directory-row rendering, touched by
+ * the SonarCloud chore cleanup (S1082 + S6819 → directory rows render as a
+ * real <button type="button"> instead of a <div role="button">; file rows
+ * stay non-interactive <div>s).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import type { ArtifactDirectory, ArtifactFile } from "@/hooks/useConstructionPlans";
+
+const mockUsePlanArtifacts = vi.fn();
+const mockUseArtifactFiles = vi.fn();
+
+vi.mock("@/hooks/useConstructionPlans", () => ({
+  usePlanArtifacts: (...a: unknown[]) => mockUsePlanArtifacts(...a),
+  useArtifactFiles: (...a: unknown[]) => mockUseArtifactFiles(...a),
+  deleteArtifactFile: vi.fn(),
+  deleteExecution: vi.fn(),
+  artifactDownloadUrl: () => "http://x/download",
+}));
+
+vi.mock("@/hooks/useDialog", () => ({
+  useDialog: () => ({ dialogRef: { current: null }, handleClose: vi.fn() }),
+}));
+
+import { ArtifactBrowserDialog } from "@/components/workbench/construction-plans/ArtifactBrowserDialog";
+
+const EXEC: ArtifactDirectory = {
+  execution_id: "exec-1",
+  plan_id: 1,
+  aeroplane_id: "a1",
+  created: "2026-01-01T00:00:00Z",
+  file_count: 2,
+};
+
+function file(overrides: Partial<ArtifactFile>): ArtifactFile {
+  return { name: "x", is_dir: false, size_bytes: 10, modified: "2026-01-01T00:00:00Z", ...overrides };
+}
+
+beforeEach(() => {
+  mockUsePlanArtifacts.mockReturnValue({
+    executions: [EXEC],
+    error: undefined,
+    isLoading: false,
+    mutate: vi.fn(),
+  });
+  mockUseArtifactFiles.mockReturnValue({
+    files: [file({ name: "sub", is_dir: true }), file({ name: "part.step", is_dir: false })],
+    error: undefined,
+    isLoading: false,
+    mutate: vi.fn(),
+  });
+});
+
+describe("ArtifactBrowserDialog directory rows (S1082 / S6819)", () => {
+  it("renders directory rows as a real <button> and files as non-buttons", () => {
+    render(<ArtifactBrowserDialog open planId={1} planName="P" onClose={vi.fn()} />);
+
+    // Content lives inside a jsdom <dialog> that is never shown via
+    // showModal(), so its descendants are "hidden" for a11y queries.
+    const dirLabel = screen.getByText("sub");
+    const dirButton = dirLabel.closest("button");
+    expect(dirButton).not.toBeNull();
+    expect(dirButton).toHaveAttribute("type", "button");
+
+    // The file name is NOT rendered inside a button.
+    const fileLabel = screen.getByText("part.step");
+    expect(fileLabel.closest("button")).toBeNull();
+  });
+
+  it("navigates into a directory when its button is clicked", () => {
+    render(<ArtifactBrowserDialog open planId={1} planName="P" onClose={vi.fn()} />);
+    const dirButton = screen.getByText("sub").closest("button");
+    expect(dirButton).not.toBeNull();
+    fireEvent.click(dirButton as HTMLButtonElement);
+    // Navigation triggers a re-fetch of files at the new subpath: the hook is
+    // called again with the "sub" currentPath.
+    const calledPaths = mockUseArtifactFiles.mock.calls.map((c) => c[2]);
+    expect(calledPaths).toContain("sub");
+  });
+});

--- a/frontend/__tests__/MetricColumnInteractive.test.tsx
+++ b/frontend/__tests__/MetricColumnInteractive.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Coverage for MetricColumn's interactive rendering, touched by the
+ * SonarCloud chore cleanup (S1082 → real <button> instead of role="button").
+ *
+ * - "tile" / "tab" (collapsed, non-large) modes must render a real, keyboard-
+ *   accessible <button> whose activation calls onActivate.
+ * - "large" mode must NOT be a button (it wraps a nested collapse control).
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Gauge } from "lucide-react";
+
+import { MetricColumn } from "@/components/workbench/metrics-dashboard/MetricColumn";
+
+function renderColumn(mode: "tab" | "tile" | "large", onActivate = vi.fn()) {
+  render(
+    <MetricColumn
+      title="Speed"
+      icon={Gauge}
+      mode={mode}
+      onActivate={onActivate}
+      onCollapse={vi.fn()}
+      headline="v_stall 9 m/s"
+      tile={<div>tile-body</div>}
+      large={<div>large-body</div>}
+    />,
+  );
+  return onActivate;
+}
+
+describe("MetricColumn interactive element (S1082)", () => {
+  it("renders a real <button> in tile mode and fires onActivate on click", () => {
+    const onActivate = renderColumn("tile");
+    const col = screen.getByTestId("metric-col-speed");
+    expect(col.tagName).toBe("BUTTON");
+    expect(col).toHaveAttribute("type", "button");
+    expect(col).toHaveAttribute("aria-label", "Expand Speed");
+    fireEvent.click(col);
+    expect(onActivate).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a real <button> in tab mode and fires onActivate on click", () => {
+    const onActivate = renderColumn("tab");
+    // tab mode has no data-testid; it is the only button rendered here.
+    const btn = screen.getByRole("button", { name: /Speed/i });
+    expect(btn.tagName).toBe("BUTTON");
+    fireEvent.click(btn);
+    expect(onActivate).toHaveBeenCalledTimes(1);
+  });
+
+  it("is native-keyboard accessible in tile mode (Enter activates a button)", () => {
+    renderColumn("tile");
+    const col = screen.getByTestId("metric-col-speed");
+    // A native <button> is activated by the browser on Enter/Space via a
+    // synthetic click — assert the element is focusable and a button so the
+    // platform provides keyboard activation (no manual onKeyDown needed).
+    col.focus();
+    expect(col).toHaveFocus();
+    expect(col.tagName).toBe("BUTTON");
+  });
+
+  it("does not render the large section as a button", () => {
+    renderColumn("large");
+    const col = screen.getByTestId("metric-col-speed");
+    expect(col.tagName).toBe("SECTION");
+    expect(col).not.toHaveAttribute("role", "button");
+  });
+});

--- a/frontend/__tests__/sonarChoreHelpers.test.ts
+++ b/frontend/__tests__/sonarChoreHelpers.test.ts
@@ -63,7 +63,7 @@ describe("speedPolarTraces (S7727 map wrapper)", () => {
       curve({ mass_kg: 3.0 }),
     ]);
     // 2 line traces + 1 marker trace for the base curve.
-    expect(traces.length).toBe(3);
+    expect(traces).toHaveLength(3);
     // The forwarded index means the second (non-base) curve is not orange.
     expect((traces[1].line as { color: string }).color).not.toBe("#FF8400");
   });
@@ -73,7 +73,7 @@ describe("speedPolarTraces (S7727 map wrapper)", () => {
     // array), the trace builder would still only read c and i, so behaviour
     // is unchanged — this simply pins the one-trace-per-curve contract.
     const traces = speedPolarTraces([curve({ v_min_sink: null, v_best_glide: null })]);
-    expect(traces.length).toBe(1);
+    expect(traces).toHaveLength(1);
   });
 });
 

--- a/frontend/__tests__/sonarChoreHelpers.test.ts
+++ b/frontend/__tests__/sonarChoreHelpers.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Coverage for the pure helpers touched by the SonarCloud chore cleanup
+ * (PR "chore: resolve 6 SonarCloud frontend findings").
+ *
+ * - speedPolarLineTrace / speedPolarTraces (S7727): the map callback must
+ *   forward the color-cycling index and produce one line trace per curve
+ *   (plus a marker trace for the base curve when key points exist).
+ * - approxEq (S1244): tolerant float equality used for scale-factor buttons.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("plotly.js-gl3d-dist-min", () => ({
+  default: { react: vi.fn(), purge: vi.fn(), newPlot: vi.fn(), relayout: vi.fn() },
+  react: vi.fn(),
+  purge: vi.fn(),
+}));
+
+import {
+  speedPolarLineTrace,
+  speedPolarTraces,
+} from "@/components/workbench/AnalysisViewerPanel";
+import { approxEq } from "@/components/workbench/ImportFuselageDialog";
+import type { SpeedPolarCurve } from "@/hooks/useAnalysis";
+
+function curve(overrides: Partial<SpeedPolarCurve> = {}): SpeedPolarCurve {
+  return {
+    mass_kg: 2.5,
+    is_base: false,
+    V: [10, 15, 20],
+    w: [1.2, 0.9, 1.4],
+    cl: [0.8, 0.6, 0.4],
+    cd: [0.03, 0.025, 0.03],
+    v_stall: 9,
+    v_min_sink: 12,
+    w_min: 0.85,
+    v_best_glide: 16,
+    ld_max: 18,
+    ...overrides,
+  };
+}
+
+describe("speedPolarLineTrace (S7727)", () => {
+  it("uses the base colour for the base curve regardless of index", () => {
+    const t = speedPolarLineTrace(curve({ is_base: true }), 3);
+    expect((t.line as { color: string }).color).toBe("#FF8400");
+    expect((t.line as { width: number }).width).toBe(2.5);
+  });
+
+  it("cycles a palette colour for non-base curves by index", () => {
+    const t0 = speedPolarLineTrace(curve(), 0);
+    const t1 = speedPolarLineTrace(curve(), 1);
+    // Different indices pick (at least potentially) different palette slots;
+    // the important contract is that the index is honoured, not dropped.
+    expect((t0.line as { color: string }).color).not.toBe("#FF8400");
+    expect((t1.line as { color: string }).color).not.toBe("#FF8400");
+  });
+});
+
+describe("speedPolarTraces (S7727 map wrapper)", () => {
+  it("emits one line trace per curve plus a base marker trace", () => {
+    const traces = speedPolarTraces([
+      curve({ is_base: true, mass_kg: 2.0 }),
+      curve({ mass_kg: 3.0 }),
+    ]);
+    // 2 line traces + 1 marker trace for the base curve.
+    expect(traces.length).toBe(3);
+    // The forwarded index means the second (non-base) curve is not orange.
+    expect((traces[1].line as { color: string }).color).not.toBe("#FF8400");
+  });
+
+  it("does not leak the array argument into speedPolarLineTrace", () => {
+    // A single curve → a single line trace. If map leaked (element, index,
+    // array), the trace builder would still only read c and i, so behaviour
+    // is unchanged — this simply pins the one-trace-per-curve contract.
+    const traces = speedPolarTraces([curve({ v_min_sink: null, v_best_glide: null })]);
+    expect(traces.length).toBe(1);
+  });
+});
+
+describe("approxEq (S1244)", () => {
+  it("is true for exactly-equal floats", () => {
+    expect(approxEq(0.001, 0.001)).toBe(true);
+    expect(approxEq(0.01, 0.01)).toBe(true);
+  });
+
+  it("is true within the default epsilon", () => {
+    expect(approxEq(0.1 + 0.2, 0.3)).toBe(true); // classic 0.30000000000000004
+  });
+
+  it("is false for clearly-different values", () => {
+    expect(approxEq(0.001, 0.01)).toBe(false);
+    expect(approxEq(0.01, 1)).toBe(false);
+  });
+
+  it("honours a custom epsilon", () => {
+    expect(approxEq(1.0, 1.4, 0.5)).toBe(true);
+    expect(approxEq(1.0, 1.4, 0.1)).toBe(false);
+  });
+});

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -263,7 +263,7 @@ function negate(w: number): number {
 }
 
 /** Build the line trace for one mass curve. */
-function speedPolarLineTrace(c: SpeedPolarCurve, i: number): PlotlyTrace {
+export function speedPolarLineTrace(c: SpeedPolarCurve, i: number): PlotlyTrace {
   return {
     x: c.V,
     y: c.w.map(negate),
@@ -309,7 +309,7 @@ function speedPolarMarkerTrace(base: SpeedPolarCurve): PlotlyTrace | null {
   };
 }
 
-function speedPolarTraces(curves: SpeedPolarCurve[]): PlotlyTrace[] {
+export function speedPolarTraces(curves: SpeedPolarCurve[]): PlotlyTrace[] {
   const traces = curves.map((d, i) => speedPolarLineTrace(d, i));
   const base = curves.find((c) => c.is_base) ?? curves[0];
   const markers = speedPolarMarkerTrace(base);

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -310,7 +310,7 @@ function speedPolarMarkerTrace(base: SpeedPolarCurve): PlotlyTrace | null {
 }
 
 function speedPolarTraces(curves: SpeedPolarCurve[]): PlotlyTrace[] {
-  const traces = curves.map(speedPolarLineTrace);
+  const traces = curves.map((d, i) => speedPolarLineTrace(d, i));
   const base = curves.find((c) => c.is_base) ?? curves[0];
   const markers = speedPolarMarkerTrace(base);
   if (markers) traces.push(markers);

--- a/frontend/components/workbench/ImportFuselageDialog.tsx
+++ b/frontend/components/workbench/ImportFuselageDialog.tsx
@@ -5,6 +5,11 @@ import { Upload, X, Check, Loader2, Maximize2, Minimize2, Plus, Trash2, Play } f
 import { API_BASE } from "@/lib/fetcher";
 import { useDialog } from "@/hooks/useDialog";
 
+/** Tolerant float equality — avoids exact `===` on floating-point scale factors. */
+function approxEq(a: number, b: number, eps: number = 1e-9): boolean {
+  return Math.abs(a - b) < eps;
+}
+
 /** Build Plotly Surface3d traces for a fuselage from xsec dicts */
 function buildFuselageSurface(
   xsecs: XSec[],
@@ -607,13 +612,13 @@ function renderUploadPhase(p: UploadPhaseProps) {
             />
             <button
               onClick={() => { p.setScaleFactor(0.001); p.setScaleInput("0.001"); }}
-              className={`rounded-full px-2 py-1 text-[10px] ${p.scaleFactor === 0.001 ? "bg-primary text-primary-foreground" : "bg-card-muted text-muted-foreground hover:text-foreground"}`}
+              className={`rounded-full px-2 py-1 text-[10px] ${approxEq(p.scaleFactor, 0.001) ? "bg-primary text-primary-foreground" : "bg-card-muted text-muted-foreground hover:text-foreground"}`}
             >
               mm→m
             </button>
             <button
               onClick={() => { p.setScaleFactor(0.01); p.setScaleInput("0.01"); }}
-              className={`rounded-full px-2 py-1 text-[10px] ${p.scaleFactor === 0.01 ? "bg-primary text-primary-foreground" : "bg-card-muted text-muted-foreground hover:text-foreground"}`}
+              className={`rounded-full px-2 py-1 text-[10px] ${approxEq(p.scaleFactor, 0.01) ? "bg-primary text-primary-foreground" : "bg-card-muted text-muted-foreground hover:text-foreground"}`}
             >
               cm→m
             </button>

--- a/frontend/components/workbench/ImportFuselageDialog.tsx
+++ b/frontend/components/workbench/ImportFuselageDialog.tsx
@@ -6,7 +6,7 @@ import { API_BASE } from "@/lib/fetcher";
 import { useDialog } from "@/hooks/useDialog";
 
 /** Tolerant float equality — avoids exact `===` on floating-point scale factors. */
-function approxEq(a: number, b: number, eps: number = 1e-9): boolean {
+export function approxEq(a: number, b: number, eps: number = 1e-9): boolean {
   return Math.abs(a - b) < eps;
 }
 

--- a/frontend/components/workbench/WingOutlineViewer.tsx
+++ b/frontend/components/workbench/WingOutlineViewer.tsx
@@ -955,7 +955,7 @@ export function WingOutlineViewer({
 
       // Restore saved camera
       if (savedCamera.current) {
-        try { await Plotly.relayout(node, { "scene.camera": savedCamera.current }); } catch { /* ok */ }
+        try { Plotly.relayout(node, { "scene.camera": savedCamera.current }); } catch { /* ok */ }
       }
 
       // Track camera changes from user interaction

--- a/frontend/components/workbench/WingOutlineViewer.tsx
+++ b/frontend/components/workbench/WingOutlineViewer.tsx
@@ -955,7 +955,7 @@ export function WingOutlineViewer({
 
       // Restore saved camera
       if (savedCamera.current) {
-        try { Plotly.relayout(node, { "scene.camera": savedCamera.current }); } catch { /* ok */ }
+        try { await Plotly.relayout(node, { "scene.camera": savedCamera.current }); } catch { /* ok */ }
       }
 
       // Track camera changes from user interaction

--- a/frontend/components/workbench/construction-plans/ArtifactBrowserDialog.tsx
+++ b/frontend/components/workbench/construction-plans/ArtifactBrowserDialog.tsx
@@ -204,27 +204,22 @@ export function ArtifactBrowserDialog({
               {selectedExecution && files.length > 0 && (
                 <div className="flex flex-col gap-1">
                   {files.map((f) => {
-                    const enterDir = f.is_dir
-                      ? () => setCurrentPath(currentPath ? `${currentPath}/${f.name}` : f.name)
-                      : undefined;
+                    // Directory rows are navigable and contain no nested
+                    // interactive controls, so they render as a real <button>
+                    // (keyboard-accessible, no role="button" on a div). File
+                    // rows are non-interactive containers with their own
+                    // download/delete controls.
+                    const rowClass = `group flex items-center gap-3 rounded-lg px-3 py-2 text-left hover:bg-sidebar-accent ${f.is_dir ? "w-full cursor-pointer" : ""}`;
+                    const RowTag = f.is_dir ? "button" : "div";
+                    const rowProps = f.is_dir
+                      ? {
+                          type: "button" as const,
+                          onClick: () =>
+                            setCurrentPath(currentPath ? `${currentPath}/${f.name}` : f.name),
+                        }
+                      : {};
                     return (
-                    <div
-                      key={f.name}
-                      className={`group flex items-center gap-3 rounded-lg px-3 py-2 hover:bg-sidebar-accent ${f.is_dir ? "cursor-pointer" : ""}`}
-                      onClick={enterDir}
-                      role={f.is_dir ? "button" : undefined}
-                      tabIndex={f.is_dir ? 0 : undefined}
-                      onKeyDown={
-                        f.is_dir
-                          ? (e) => {
-                              if (e.key === "Enter" || e.key === " ") {
-                                e.preventDefault();
-                                enterDir?.();
-                              }
-                            }
-                          : undefined
-                      }
-                    >
+                    <RowTag key={f.name} className={rowClass} {...rowProps}>
                       {f.is_dir ? (
                         <FolderOpen size={12} className="text-primary" />
                       ) : (
@@ -258,7 +253,7 @@ export function ArtifactBrowserDialog({
                           <Trash2 size={12} />
                         </button>
                       )}
-                    </div>
+                    </RowTag>
                     );
                   })}
                 </div>

--- a/frontend/components/workbench/construction-plans/ArtifactBrowserDialog.tsx
+++ b/frontend/components/workbench/construction-plans/ArtifactBrowserDialog.tsx
@@ -203,11 +203,27 @@ export function ArtifactBrowserDialog({
               )}
               {selectedExecution && files.length > 0 && (
                 <div className="flex flex-col gap-1">
-                  {files.map((f) => (
+                  {files.map((f) => {
+                    const enterDir = f.is_dir
+                      ? () => setCurrentPath(currentPath ? `${currentPath}/${f.name}` : f.name)
+                      : undefined;
+                    return (
                     <div
                       key={f.name}
                       className={`group flex items-center gap-3 rounded-lg px-3 py-2 hover:bg-sidebar-accent ${f.is_dir ? "cursor-pointer" : ""}`}
-                      onClick={f.is_dir ? () => setCurrentPath(currentPath ? `${currentPath}/${f.name}` : f.name) : undefined}
+                      onClick={enterDir}
+                      role={f.is_dir ? "button" : undefined}
+                      tabIndex={f.is_dir ? 0 : undefined}
+                      onKeyDown={
+                        f.is_dir
+                          ? (e) => {
+                              if (e.key === "Enter" || e.key === " ") {
+                                e.preventDefault();
+                                enterDir?.();
+                              }
+                            }
+                          : undefined
+                      }
                     >
                       {f.is_dir ? (
                         <FolderOpen size={12} className="text-primary" />
@@ -243,7 +259,8 @@ export function ArtifactBrowserDialog({
                         </button>
                       )}
                     </div>
-                  ))}
+                    );
+                  })}
                 </div>
               )}
             </div>

--- a/frontend/components/workbench/metrics-dashboard/MetricColumn.tsx
+++ b/frontend/components/workbench/metrics-dashboard/MetricColumn.tsx
@@ -51,15 +51,17 @@ export function MetricColumn({
       data-testid={`metric-col-${title.toLowerCase()}`}
       data-mode={mode}
       onClick={isLarge ? undefined : onActivate}
-      {...(!isLarge && {
-        tabIndex: 0,
-        role: "button",
-        "aria-label": `Expand ${title}`,
-        onKeyDown: (e: KeyboardEvent<HTMLElement>) => {
-          if (e.key === "Enter") { onActivate(); }
-          if (e.key === " ") { e.preventDefault(); onActivate(); }
-        },
-      })}
+      onKeyDown={
+        isLarge
+          ? undefined
+          : (e: KeyboardEvent<HTMLElement>) => {
+              if (e.key === "Enter") { onActivate(); }
+              if (e.key === " ") { e.preventDefault(); onActivate(); }
+            }
+      }
+      tabIndex={isLarge ? undefined : 0}
+      role={isLarge ? undefined : "button"}
+      aria-label={isLarge ? undefined : `Expand ${title}`}
     >
       <header className="flex shrink-0 items-center gap-1.5 px-2.5 py-1.5">
         <Icon size={13} className="text-primary" />

--- a/frontend/components/workbench/metrics-dashboard/MetricColumn.tsx
+++ b/frontend/components/workbench/metrics-dashboard/MetricColumn.tsx
@@ -5,7 +5,6 @@
 // (compact, equal-width column) · "large" (full width). The band height stays
 // constant (~20vh) in every mode; content scrolls if it overflows.
 
-import type { KeyboardEvent } from "react";
 import { Maximize2, X } from "lucide-react";
 
 export type ColumnMode = "tab" | "tile" | "large";
@@ -45,23 +44,20 @@ export function MetricColumn({
   }
 
   const isLarge = mode === "large";
+  // When clickable (tile/collapsed) the column renders as a real <button>
+  // — native keyboard activation, no role="button" on a non-interactive
+  // element. In "large" mode it holds a nested collapse <button>, so it
+  // must stay a <section>.
+  const Tag = isLarge ? "section" : "button";
+  const interactiveProps = isLarge
+    ? {}
+    : { type: "button" as const, onClick: onActivate, "aria-label": `Expand ${title}` };
   return (
-    <section
-      className={`flex h-full min-w-0 flex-col rounded-b-lg border bg-card ${isLarge ? "flex-1 border-border-strong" : "flex-1 cursor-pointer hover:border-border-strong"} border-border transition-colors`}
+    <Tag
+      className={`flex h-full min-w-0 flex-col rounded-b-lg border bg-card text-left ${isLarge ? "flex-1 border-border-strong" : "flex-1 cursor-pointer hover:border-border-strong"} border-border transition-colors`}
       data-testid={`metric-col-${title.toLowerCase()}`}
       data-mode={mode}
-      onClick={isLarge ? undefined : onActivate}
-      onKeyDown={
-        isLarge
-          ? undefined
-          : (e: KeyboardEvent<HTMLElement>) => {
-              if (e.key === "Enter") { onActivate(); }
-              if (e.key === " ") { e.preventDefault(); onActivate(); }
-            }
-      }
-      tabIndex={isLarge ? undefined : 0}
-      role={isLarge ? undefined : "button"}
-      aria-label={isLarge ? undefined : `Expand ${title}`}
+      {...interactiveProps}
     >
       <header className="flex shrink-0 items-center gap-1.5 px-2.5 py-1.5">
         <Icon size={13} className="text-primary" />
@@ -84,6 +80,6 @@ export function MetricColumn({
       <div className="min-h-0 flex-1 overflow-visible px-2.5 pb-2">
         {isLarge ? large : tile}
       </div>
-    </section>
+    </Tag>
   );
 }


### PR DESCRIPTION
Maintainer-authorized SonarCloud debt cleanup (no GH issue). Existing-code fixes only; behavior/visuals preserved. **5 of 6 findings ship; WingOutlineViewer S4822 deferred (see below).**

## Findings resolved
| Rule | File:Line | Fix |
|------|-----------|-----|
| S7727 (map callback leaks args) | `AnalysisViewerPanel.tsx:313` | `curves.map((d, i) => speedPolarLineTrace(d, i))` — array arg no longer leaked; color-cycling index still forwarded. Exported + unit-tested. |
| S1244 (float `===`) | `ImportFuselageDialog.tsx:610` | `approxEq(p.scaleFactor, 0.001)` epsilon check. Exported + unit-tested. |
| S1244 (float `===`) | `ImportFuselageDialog.tsx:616` | `approxEq(p.scaleFactor, 0.01)` epsilon check. |
| S1082 + S6819 (a11y) | `ArtifactBrowserDialog.tsx:207` | Directory rows (no nested controls) render as a real `<button type="button">` instead of `<div role="button">`. File rows stay non-interactive. Unit-tested. |
| S1082 + S6819 (a11y) | `MetricColumn.tsx:49` | Clickable tile/tab column renders as a real `<button>`; large mode stays `<section>` (holds a nested collapse button). Native keyboard activation. Unit-tested. |

## Deferred
| Rule | File:Line | Reason |
|------|-----------|--------|
| S4822 (floating promise in try) | `WingOutlineViewer.tsx:958` | The `Plotly.relayout` line lives in the sensitive Plotly-GL viewer render path that jsdom cannot execute — its changed line can't reach the SonarCloud new_coverage gate without touching viewer init, which is out of bounds per project memory. **Reverted from this PR.** Should be fixed separately with a human browser smoke test. |

## Coverage
The initial push failed the `new_coverage` soft-gate (39.1% < 80%) because the touched `.tsx` lines weren't unit-covered. Added focused vitest tests:
- `sonarChoreHelpers.test.ts` — `approxEq` + `speedPolarTraces`/`speedPolarLineTrace`
- `MetricColumnInteractive.test.tsx` — button render + click activation
- `ArtifactBrowserDirRow.test.tsx` — directory rows are real buttons, files are not, click navigates

## Test plan
- [x] `npm run lint` clean
- [x] `tsc --noEmit` clean
- [x] `npm run test:unit` green (2342 tests, 180 files; Node 22 — +14 new)
- [ ] SonarCloud PR gate green (new findings resolved + coverage on new code)

## Browser smoke test (visual / a11y — jsdom can't verify)
1. **MetricColumn / ArtifactBrowserDialog a11y**: Tab to a collapsed metric column and an artifact directory row, press Enter/Space — confirm they activate/navigate like a click, visuals unchanged.
2. **ImportFuselageDialog**: mm→m / cm→m scale buttons still highlight when active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)