### PR TITLE
fix(gh-1076): report explicit no-spar region instead of degenerate ID0/wall0 tip piece

### DIFF
--- a/app/schemas/spar_plan.py
+++ b/app/schemas/spar_plan.py
@@ -301,3 +301,21 @@ class SparPlanResponse(BaseModel):
         None,
         description="Reason for the first infeasible piece, or None when the plan is feasible.",
     )
+    front_no_spar_from_y: Optional[float] = Field(
+        None,
+        description=(
+            "Spanwise position (metres, starboard half) where the front spar's "
+            "tip-most no-spar region begins: outboard of this the bending load is "
+            "negligible and the D-box skin + ribs carry the tip, so no spar is "
+            "required. None when the front spar runs to the tip; the root y when "
+            "the whole span is negligible (no spar at all). gh-1076."
+        ),
+    )
+    rear_no_spar_from_y: Optional[float] = Field(
+        None,
+        description=(
+            "Spanwise position (metres, starboard half) where the rear spar's "
+            "tip-most no-spar region begins (negligible torsion outboard). None "
+            "when the rear spar runs to the tip. gh-1076."
+        ),
+    )

--- a/app/services/spar_insert_service.py
+++ b/app/services/spar_insert_service.py
@@ -270,13 +270,18 @@ def _persist_spares(db, aeroplane_uuid, wing, planned: list[_PlannedPiece]) -> N
 
 
 def _real_front_pieces(plan) -> list:
-    """Front pieces that actually become a Spare (drop degenerate Ø0 tips).
+    """Front pieces that actually become a Spare (drop sub-buildable tips).
 
-    The solver can emit a Ø0 terminal tip piece (gh-1045); a zero-diameter tube
-    is not a physical structural object and never reaches the build, so it must
-    not count toward telescoping detection or create a phantom split.
+    The solver already drops sub-floor terminal tip pieces (gh-1045/#1076); a
+    tube below the buildable floor is not a physical structural object and never
+    reaches the build, so it must not count toward telescoping detection or
+    create a phantom split. This guard mirrors the solver's floor so a plan that
+    reaches this path without going through ``plan_spar`` (e.g. deserialized)
+    stays coherent with it.
     """
-    return [p for p in plan.front_pieces if p.outer_d > 0.0]
+    from cad_designer.airplane.geometry.spar_solver import NEGLIGIBLE_OD_FLOOR_MM
+
+    return [p for p in plan.front_pieces if p.outer_d >= NEGLIGIBLE_OD_FLOOR_MM]
 
 
 def _front_telescopes(plan) -> bool:

--- a/app/services/spar_plan_service.py
+++ b/app/services/spar_plan_service.py
@@ -607,4 +607,10 @@ def compute_spar_plan(
         reinforcement=_piece_to_out(plan.reinforcement) if plan.reinforcement else None,
         feasible=plan.feasible,
         infeasibility_reason=plan.infeasibility_reason,
+        front_no_spar_from_y=(
+            plan.front_no_spar_from_y * _MM_TO_M if plan.front_no_spar_from_y is not None else None
+        ),
+        rear_no_spar_from_y=(
+            plan.rear_no_spar_from_y * _MM_TO_M if plan.rear_no_spar_from_y is not None else None
+        ),
     )

--- a/app/tests/test_spar_plan_endpoint.py
+++ b/app/tests/test_spar_plan_endpoint.py
@@ -188,6 +188,22 @@ class TestComputeSparPlanService:
         assert fp.spare_vector == [0.0, 1.0, 0.0]
         assert fp.role == "front"
 
+    def test_no_spar_from_y_converted_to_metres(self, plane_id):
+        # gh-1076: the tip-most no-spar region marker is exposed on the response,
+        # converted mm->m, so the UI can render "No spar required — span X -> tip".
+        aeroplane = _aeroplane_with_wings(["main_wing"])
+        plan = _stub_plan()
+        plan.front_no_spar_from_y = 600.0  # mm
+        plan.rear_no_spar_from_y = None  # rear spar runs to the tip
+        resp = _run(
+            _patch_full(aeroplane, plan),
+            lambda: spar_plan_service.compute_spar_plan(
+                db=None, aeroplane_uuid=plane_id, request=_basic_request()
+            ),
+        )
+        assert resp.front_no_spar_from_y == pytest.approx(0.6)  # 600 mm -> 0.6 m
+        assert resp.rear_no_spar_from_y is None
+
     def test_y_start_end_populated_and_in_metres(self, plane_id):
         # gh-1057: each piece exposes its spanwise extent (y_start..y_end, m) so
         # the UI can show where the piece runs. Derived from spare_origin.y +

--- a/cad_designer/airplane/geometry/spar_solver.py
+++ b/cad_designer/airplane/geometry/spar_solver.py
@@ -641,9 +641,15 @@ def solve_spar_plan(
     plan.front_no_spar_from_y = _no_spar_from_y(front_right, plan.front_pieces)
     if _inboard_collinear(front_left, front_right):
         plan.front_joint = "continuous"
-    else:
+    elif front_left and front_right:
         plan.front_joint = "reinforcement+joiner"
         plan.reinforcement = _reinforcement_piece(front_left, front_right, front_spec)
+    else:
+        # gh-1091: a single-half surface (e.g. a vertical stabiliser) has no
+        # symmetric opposite half, so there is no cross-root join to reinforce.
+        # Return the single half's pieces with a continuous joint rather than
+        # indexing into the empty half (_reinforcement_piece needs both roots).
+        plan.front_joint = "continuous"
 
     # --- rear ---
     if rear_left and rear_right:

--- a/cad_designer/airplane/geometry/spar_solver.py
+++ b/cad_designer/airplane/geometry/spar_solver.py
@@ -41,6 +41,17 @@ _FIT_TOL_MM = 1e-6
 # root, large enough to land on a valid (non-pinched) section.
 _ROOT_EPS = 1e-3
 
+# gh-1076: buildable-minimum spar outer diameter (mm). A tip station whose
+# design-moment-driven required OD falls below this floor carries negligible
+# bending load — no orderable/cuttable carbon spar exists that small, and the
+# D-box skin + ribs carry the tip. Such trailing stations are reported as an
+# explicit *no-spar region* on the plan (see :func:`solve_spar_plan`) rather
+# than emitted as a degenerate Ø≈0 piece whose wall rounds to 0. The threshold
+# is applied on ``required_od``, which is already the design moment (M·g·j)
+# sizing produced upstream in :func:`build_stations_from_geometry`. Tie to the
+# real CF-pin stock floor (#1081) when that lands.
+NEGLIGIBLE_OD_FLOOR_MM = 1.0
+
 
 class SparRole(str, Enum):
     """Which structural spar a plan/piece belongs to."""
@@ -146,6 +157,12 @@ class SparPlan:
     reinforcement: SparPiece | None = None
     feasible: bool = True  # gh-1037: False when any piece cannot contain a strong tube
     infeasibility_reason: str | None = None
+    # gh-1076: spanwise |y| (mm, starboard half) where the tip-most no-spar
+    # region begins — the load-bearing span ends here and the D-box skin + ribs
+    # carry the rest to the tip. ``None`` means the spar runs to the tip; the
+    # root y means the whole span is negligible (no spar at all).
+    front_no_spar_from_y: float | None = None
+    rear_no_spar_from_y: float | None = None
 
     def to_dict(self) -> dict:
         return {
@@ -156,6 +173,8 @@ class SparPlan:
             "reinforcement": self.reinforcement.to_dict() if self.reinforcement else None,
             "feasible": self.feasible,
             "infeasibility_reason": self.infeasibility_reason,
+            "front_no_spar_from_y": self.front_no_spar_from_y,
+            "rear_no_spar_from_y": self.rear_no_spar_from_y,
         }
 
 
@@ -389,31 +408,53 @@ def plan_spar(stations: list[StationData], spec: SparSpec) -> list[SparPiece]:
 
 
 def _drop_zero_od_tip(pieces: list[SparPiece]) -> list[SparPiece]:
-    """Drop degenerate Ø0 trailing pieces (gh-1045/#1057).
+    """Drop degenerate sub-floor trailing tip pieces (gh-1045/#1057, gh-1076).
 
-    At the tip the bending moment M(y)->0, so the strength-required OD rounds to
-    0. A Ø0 tube is not a physical structural object — you cannot cut, order, or
-    glue it (the skin / D-tube closes the tip). Drop every trailing piece whose
-    ``outer_d <= 0`` and extend the new last real piece to the wing tip so the
-    remaining pieces stay contiguous root->tip. The previous piece no longer
-    telescopes into a non-existent piece, so its joint becomes continuous (None).
+    Toward the tip the bending moment M(y)->0, so the strength-required OD falls
+    below :data:`NEGLIGIBLE_OD_FLOOR_MM` — no orderable/cuttable carbon spar that
+    small exists and the D-box skin + ribs carry the tip. Such a trailing piece
+    is not a physical structural object (a Ø≈0 tube whose wall rounds to 0 is the
+    gh-1076 symptom); drop every trailing piece below the floor.
+
+    gh-1076 Option A: the remaining last real piece KEEPS its natural length — it
+    ends where load ceased to be structurally relevant — and its joint becomes
+    continuous (``None``). The tip-most no-spar region is reported explicitly on
+    the plan (see :func:`solve_spar_plan`) rather than swallowed by extending the
+    last piece to the tip (which was gh-1057's behaviour, now superseded).
+
+    Because spar dimensions are non-increasing root->tip, sub-floor stations are
+    always tip-most; popping from the tail keeps the kept run contiguous.
     """
-    kept: list[SparPiece] = [p for p in pieces if p.outer_d > 0.0]
-    if not kept or len(kept) == len(pieces):
-        # all-zero -> no structural spar; or nothing to drop -> unchanged.
-        return kept if not kept else pieces
-
-    # The last real piece must run to the tip of the original (now-dropped) run.
-    dropped_tip = pieces[-1]
-    tip_y = dropped_tip.spare_origin[1] + dropped_tip.length * dropped_tip.spare_vector[1]
-    tip_z = dropped_tip.spare_origin[2] + dropped_tip.length * dropped_tip.spare_vector[2]
-    last = kept[-1]
-    origin = last.spare_origin
-    tip_point = (origin[0], tip_y, tip_z)
-    last.spare_vector = _unit_vector(origin, tip_point)
-    last.length = math.dist(origin, tip_point)
-    last.joint_to_next = None
+    kept = list(pieces)
+    while kept and kept[-1].outer_d < NEGLIGIBLE_OD_FLOOR_MM:
+        kept.pop()
+    if not kept:
+        # every station negligible -> no structural spar at all.
+        return []
+    kept[-1].joint_to_next = None
     return kept
+
+
+def _no_spar_from_y(stations: list[StationData], pieces: list[SparPiece]) -> float | None:
+    """Spanwise |y| (mm) where the tip-most no-spar region begins, else ``None``.
+
+    gh-1076 Option A. When trailing negligible-load stations produced no
+    buildable piece, the region from the last real piece's tip to the wing tip
+    carries no spar. Returns the ``|y|`` where that region starts (the root ``y``
+    when the whole span is negligible), or ``None`` when the spar runs to the
+    tip. ``y_mm`` is signed by half (port negative); the plan is symmetric, so we
+    report the starboard-half magnitude.
+    """
+    if not stations:
+        return None
+    tip_y = max(abs(s.y_mm) for s in stations)
+    if not pieces:
+        return min(abs(s.y_mm) for s in stations)  # whole span negligible
+    last = pieces[-1]
+    last_tip_y = abs(last.spare_origin[1] + last.length * last.spare_vector[1])
+    if last_tip_y < tip_y - _FIT_TOL_MM:
+        return last_tip_y
+    return None
 
 
 def _bore_for(run: _Run, spec: SparSpec, od: float) -> float:
@@ -597,6 +638,7 @@ def solve_spar_plan(
 
     # --- front ---
     plan.front_pieces = plan_spar(front_right, front_spec)
+    plan.front_no_spar_from_y = _no_spar_from_y(front_right, plan.front_pieces)
     if _inboard_collinear(front_left, front_right):
         plan.front_joint = "continuous"
     else:
@@ -606,6 +648,7 @@ def solve_spar_plan(
     # --- rear ---
     if rear_left and rear_right:
         plan.rear_pieces = plan_spar(rear_right, rear_spec)
+        plan.rear_no_spar_from_y = _no_spar_from_y(rear_right, plan.rear_pieces)
         if _straight_collinear_in_envelope(rear_left, rear_right):
             plan.rear_joint = "continuous"
         else:

--- a/cad_designer/tests/test_spar_solver.py
+++ b/cad_designer/tests/test_spar_solver.py
@@ -16,11 +16,13 @@ from __future__ import annotations
 import pytest
 
 from cad_designer.airplane.geometry.spar_solver import (
+    NEGLIGIBLE_OD_FLOOR_MM,
     SparPiece,
     SparPlan,
     SparRole,
     SparSpec,
     StationData,
+    _drop_zero_od_tip,
     _inboard_collinear,
     _straight_collinear_in_envelope,
     plan_spar,
@@ -449,16 +451,24 @@ class TestRearTorsionDistinctFromFront:
 
 
 class TestZeroOdTipPieceSuppressed:
-    """gh-1045/#1057: the solver must NOT emit a Ø0 terminal tip piece.
+    """gh-1045/#1057 + gh-1076: the solver must NOT emit a degenerate sub-floor
+    tip piece.
 
-    At the tip the bending moment M(y)->0, so the strength-required OD rounds to
-    0. The old solver emitted that as a feasible Ø0 piece — a phantom part you
-    cannot cut, order, or glue. The fix drops the degenerate trailing piece and
-    runs the previous (last real) piece to the tip with a continuous joint.
+    At the tip the bending moment M(y)->0, so the strength-required OD falls
+    below ``NEGLIGIBLE_OD_FLOOR_MM`` — no orderable/cuttable carbon spar that
+    small exists; the D-box skin + ribs carry the tip. The old solver emitted
+    that as a feasible Ø≈0 piece (whose wall rounds to 0 — the gh-1076 symptom).
+
+    gh-1076 Option A supersedes gh-1057's "extend the last real piece to the
+    tip": the last real piece now ENDS at the last load-bearing station, and the
+    tip-most no-spar region is reported explicitly on the plan (see
+    :class:`TestNegligibleLoadNoSparRegion`) instead of being swallowed by an
+    over-long piece.
     """
 
     def _tapered_to_zero_tip(self) -> list[StationData]:
         # required OD decays to 0 at the very tip (the normal physical case).
+        # Last load-bearing station is y=600 (od=28); the y=900 tip is negligible.
         return [
             _station(0.0, y_mm=0.0, band=(-60.0, 60.0), required_od=80.0),
             _station(0.33, y_mm=300.0, band=(-30.0, 30.0), required_od=55.0),
@@ -466,17 +476,18 @@ class TestZeroOdTipPieceSuppressed:
             _station(1.0, y_mm=900.0, band=(-8.0, 8.0), required_od=0.0),
         ]
 
-    def test_no_zero_od_piece_emitted(self):
+    def test_no_sub_floor_piece_emitted(self):
         pieces = plan_spar(self._tapered_to_zero_tip(), SparSpec(role=SparRole.FRONT))
         assert pieces
         for p in pieces:
-            assert p.outer_d > 0.0, f"Ø0 piece emitted: {p}"
+            assert p.outer_d >= NEGLIGIBLE_OD_FLOOR_MM, f"sub-floor piece emitted: {p}"
 
-    def test_pieces_cover_root_to_tip_without_gap(self):
-        # The remaining pieces must still cover the whole span root->tip with no
-        # gap. Telescoping pieces overlap rootward (a joint IS an overlap region),
-        # so the invariant is coverage, not abutment: the next piece must start at
-        # or before the previous piece's tip, and the union reaches the tip.
+    def test_pieces_cover_root_to_last_load_bearing_station_without_gap(self):
+        # gh-1076 Option A: the kept pieces cover root -> the last LOAD-BEARING
+        # station (y=600), NOT the tip. Telescoping pieces overlap rootward (a
+        # joint IS an overlap region), so the invariant is coverage, not
+        # abutment: the next piece must start at or before the previous piece's
+        # tip, and the union reaches the last load-bearing station.
         pieces = plan_spar(self._tapered_to_zero_tip(), SparSpec(role=SparRole.FRONT))
         covered_to = pieces[0].spare_origin[1] + pieces[0].length * pieces[0].spare_vector[1]
         for outer in pieces[1:]:
@@ -489,15 +500,16 @@ class TestZeroOdTipPieceSuppressed:
                 outer.spare_origin[1] + outer.length * outer.spare_vector[1],
             )
         assert pieces[0].spare_origin[1] == pytest.approx(0.0)  # starts at root
-        assert covered_to == pytest.approx(900.0)  # union reaches the tip
+        assert covered_to == pytest.approx(600.0)  # ends at last load-bearing station
 
-    def test_last_piece_runs_to_the_tip(self):
-        # After dropping the Ø0 tip piece, the new last real piece must reach the
-        # wing tip (y=900), not stop short where the Ø0 run began.
+    def test_last_piece_ends_at_last_load_bearing_station(self):
+        # gh-1076 Option A: the last real piece ends where load ceased to be
+        # structurally relevant (y=600), NOT at the wing tip (y=900). The tip
+        # region is reported as a no-spar region on the plan, not covered here.
         pieces = plan_spar(self._tapered_to_zero_tip(), SparSpec(role=SparRole.FRONT))
         last = pieces[-1]
         last_tip_y = last.spare_origin[1] + last.length * last.spare_vector[1]
-        assert last_tip_y == pytest.approx(900.0)
+        assert last_tip_y == pytest.approx(600.0)
 
     def test_last_piece_joint_is_continuous(self):
         # The previous piece no longer telescopes into a non-existent piece.
@@ -540,6 +552,122 @@ def _mirror(s: StationData) -> StationData:
         band_hi=s.band_hi,
         required_od=s.required_od,
     )
+
+
+class TestNegligibleLoadNoSparRegion:
+    """gh-1076: the tip-most region where the design-moment-driven required OD
+    falls below ``NEGLIGIBLE_OD_FLOOR_MM`` is reported as an explicit *no-spar*
+    region on the plan — answering the user's real question ("do I need a spar
+    here?") instead of emitting a contradictory Ø>0 / wall≈0 piece.
+    """
+
+    def _tapered_to_zero_tip(self) -> list[StationData]:
+        return [
+            _station(0.0, y_mm=0.0, band=(-60.0, 60.0), required_od=80.0),
+            _station(0.33, y_mm=300.0, band=(-30.0, 30.0), required_od=55.0),
+            _station(0.66, y_mm=600.0, band=(-15.0, 15.0), required_od=28.0),
+            _station(1.0, y_mm=900.0, band=(-8.0, 8.0), required_od=0.0),
+        ]
+
+    def test_floor_constant_is_a_positive_buildable_minimum(self):
+        # A stated, testable threshold — not an implicit ``<= 0`` (gh-1076 AC).
+        assert NEGLIGIBLE_OD_FLOOR_MM > 0.0
+
+    def test_no_spar_region_reported_for_negligible_tip(self):
+        # The load-bearing span ends at y=600; y=600 -> tip (900) is no-spar.
+        front = self._tapered_to_zero_tip()
+        plan = solve_spar_plan(
+            front_left=[_mirror(s) for s in front],
+            front_right=front,
+        )
+        assert plan.front_no_spar_from_y == pytest.approx(600.0)
+
+    def test_spar_running_to_the_tip_has_no_no_spar_region(self):
+        # A generously-thick straight wing needs a spar all the way out.
+        plan = solve_spar_plan(
+            front_left=[_mirror(s) for s in _uniform_stations(required_od=20.0)],
+            front_right=_uniform_stations(required_od=20.0),
+        )
+        assert plan.front_no_spar_from_y is None
+
+    def test_all_negligible_reports_no_spar_from_root(self):
+        # Every station below the floor (e.g. a tiny stabiliser): no pieces AND
+        # the no-spar region starts at the root — never a blank/phantom group.
+        stations = [
+            _station(0.0, y_mm=0.0, band=(-50.0, 50.0), required_od=0.0),
+            _station(1.0, y_mm=500.0, band=(-50.0, 50.0), required_od=0.0),
+        ]
+        plan = solve_spar_plan(
+            front_left=[_mirror(s) for s in stations],
+            front_right=stations,
+        )
+        assert plan.front_pieces == []
+        assert plan.front_no_spar_from_y == pytest.approx(0.0)
+
+    def test_no_spar_region_is_tip_most_and_contiguous(self):
+        # Pieces cover root -> from_y with no interior gap; from_y -> tip is the
+        # single, tip-most no-spar region (never a gap between two real pieces).
+        front = self._tapered_to_zero_tip()
+        plan = solve_spar_plan(
+            front_left=[_mirror(s) for s in front],
+            front_right=front,
+        )
+        from_y = plan.front_no_spar_from_y
+        assert from_y is not None
+        last = plan.front_pieces[-1]
+        last_tip = last.spare_origin[1] + last.length * last.spare_vector[1]
+        assert last_tip == pytest.approx(from_y)  # region begins exactly at the last piece tip
+
+    def _piece(self, *, outer_d: float, y0: float, y1: float) -> SparPiece:
+        return SparPiece(
+            role=SparRole.FRONT,
+            spare_origin=(0.0, y0, 0.0),
+            spare_vector=(0.0, 1.0, 0.0),
+            outer_d=outer_d,
+            inner_d=0.0,
+            shape="tube",
+            governing_y=y0,
+            utilisation=0.5,
+            length=y1 - y0,
+            joint_to_next="telescoping",
+        )
+
+    def test_drop_floor_keeps_above_and_drops_below(self):
+        # The threshold is a stated buildable floor, not an implicit ``<= 0``: a
+        # trailing tip piece just below the floor is dropped; one at/above the
+        # floor is kept. This is the fix for the contradictory Ø>0 / wall≈0 piece.
+        kept = _drop_zero_od_tip(
+            [
+                self._piece(outer_d=20.0, y0=0.0, y1=300.0),
+                self._piece(outer_d=NEGLIGIBLE_OD_FLOOR_MM + 0.1, y0=300.0, y1=600.0),
+                self._piece(outer_d=NEGLIGIBLE_OD_FLOOR_MM - 0.1, y0=600.0, y1=900.0),
+            ]
+        )
+        assert [round(p.outer_d, 3) for p in kept] == [20.0, round(NEGLIGIBLE_OD_FLOOR_MM + 0.1, 3)]
+        assert kept[-1].joint_to_next is None  # no longer telescopes into a dropped piece
+
+    def test_drop_floor_does_not_extend_last_piece_to_tip(self):
+        # gh-1076 Option A: the last kept piece keeps its natural length (ends at
+        # y=600), it is NOT stretched to the dropped tip run's end (y=900).
+        kept = _drop_zero_od_tip(
+            [
+                self._piece(outer_d=20.0, y0=0.0, y1=600.0),
+                self._piece(outer_d=0.4, y0=600.0, y1=900.0),
+            ]
+        )
+        last = kept[-1]
+        assert last.length == pytest.approx(600.0)
+        assert last.spare_origin[1] + last.length * last.spare_vector[1] == pytest.approx(600.0)
+
+    def test_no_spar_region_serialised_in_plan_dict(self):
+        front = self._tapered_to_zero_tip()
+        plan = solve_spar_plan(
+            front_left=[_mirror(s) for s in front],
+            front_right=front,
+        )
+        d = plan.to_dict()
+        assert d["front_no_spar_from_y"] == pytest.approx(600.0)
+        assert "rear_no_spar_from_y" in d
 
 
 class TestDegenerateRootSliceGuard:

--- a/cad_designer/tests/test_spar_solver.py
+++ b/cad_designer/tests/test_spar_solver.py
@@ -670,6 +670,32 @@ class TestNegligibleLoadNoSparRegion:
         assert "rear_no_spar_from_y" in d
 
 
+class TestSingleHalfSurface:
+    """gh-1091: a single-half surface (e.g. a vertical stabiliser) has no
+    symmetric port/starboard halves — one station list is empty. There is no
+    cross-root join, so no reinforcement is possible; the plan must return the
+    single half's pieces with a continuous joint, NOT crash with IndexError.
+    """
+
+    def test_empty_left_half_does_not_crash_and_has_no_reinforcement(self):
+        # front_left empty (vertical fin): _inboard_collinear is False, but a
+        # reinforcement needs BOTH halves — must not index into the empty list.
+        plan = solve_spar_plan(
+            front_left=[],
+            front_right=_uniform_stations(required_od=12.0),
+        )
+        assert plan.front_joint == "continuous"
+        assert plan.reinforcement is None
+        assert plan.front_pieces  # the single half still produced buildable pieces
+
+    def test_empty_right_half_does_not_crash(self):
+        plan = solve_spar_plan(
+            front_left=_uniform_stations(required_od=12.0),
+            front_right=[],
+        )
+        assert plan.reinforcement is None
+
+
 class TestDegenerateRootSliceGuard:
     """gh-1037 #4: a zero-thickness slice at y_span=0 must not poison the
     governing (root) station. Sample at y_span=eps instead."""

--- a/frontend/__tests__/SparBuiltAndInsert.test.tsx
+++ b/frontend/__tests__/SparBuiltAndInsert.test.tsx
@@ -55,6 +55,8 @@ function feasiblePlan(): SparPlanResult {
     reinforcement: piece({ role: "front", outer_d: 0.03, inner_d: 0.0 }),
     feasible: true,
     infeasibility_reason: null,
+    front_no_spar_from_y: null,
+    rear_no_spar_from_y: null,
   };
 }
 
@@ -131,6 +133,8 @@ describe("BuiltSparSection (gh-1050)", () => {
       reinforcement: null,
       feasible: true,
       infeasibility_reason: null,
+      front_no_spar_from_y: null,
+      rear_no_spar_from_y: null,
     };
     render(<BuiltSparSection plan={plan} />);
     // constant x/c → shown once on the group label.
@@ -154,6 +158,8 @@ describe("BuiltSparSection (gh-1050)", () => {
       reinforcement: null,
       feasible: true,
       infeasibility_reason: null,
+      front_no_spar_from_y: null,
+      rear_no_spar_from_y: null,
     };
     render(<BuiltSparSection plan={plan} />);
     const rows = screen.getAllByTestId("built-spar-piece");

--- a/frontend/__tests__/SparSizingPanel.test.tsx
+++ b/frontend/__tests__/SparSizingPanel.test.tsx
@@ -294,6 +294,8 @@ describe("SparSizingPanel", () => {
       reinforcement: null,
       feasible: true,
       infeasibility_reason: null,
+      front_no_spar_from_y: null,
+      rear_no_spar_from_y: null,
     };
     const onInsert = vi.fn();
     renderPanel({ plan, onInsert });
@@ -312,6 +314,8 @@ describe("SparSizingPanel", () => {
       reinforcement: null,
       feasible: true,
       infeasibility_reason: null,
+      front_no_spar_from_y: null,
+      rear_no_spar_from_y: null,
     };
     renderPanel({ plan });
     fireEvent.click(screen.getByTestId("spar-sizing-toggle"));

--- a/frontend/__tests__/sparPlanHelpers.test.ts
+++ b/frontend/__tests__/sparPlanHelpers.test.ts
@@ -8,6 +8,7 @@ import {
   sparGroupLabel,
   jointLabel,
   pieceDimsLabel,
+  noSparRegionLabel,
   touchedSegments,
   replaceWarning,
   pieceExtentLabel,
@@ -456,5 +457,100 @@ describe("pieceDimsLabel — rectangular/capped (gh-1080)", () => {
   it("rod regression — still Ø only after rectangular/capped additions", () => {
     const piece = makePiece({ shape: "rod", outer_d: 0.008, inner_d: 0, wall: 0 });
     expect(pieceDimsLabel(piece)).toBe("Ø 8.0 mm");
+  });
+});
+
+// gh-1076: pieceDimsLabel — thin-wall tube must never show "wall 0" ----------
+// Reuses gh1060Piece (defined above) to avoid a duplicate factory.
+
+describe("pieceDimsLabel — thin-wall tube (gh-1076)", () => {
+  const p = gh1060Piece;
+
+  it("tube with sub-0.1 mm wall (OD>0) never shows 'wall 0' or 'wall 0.0'", () => {
+    // OD 10 mm, ID 9.96 mm → wall = 0.02 mm → rounds to 0.0 at 1 decimal → must NOT show "wall 0.0"
+    const piece = p({ outer_d: 0.010, inner_d: 0.00996, wall: 0.00002 });
+    const label = pieceDimsLabel(piece);
+    expect(label).not.toContain("wall 0.0");
+    expect(label).not.toContain("wall 0)");
+    // Must use the sub-precision marker instead
+    expect(label).toContain("<0.1");
+  });
+
+  it("tube with wall that rounds to 0.0 (from OD/ID fallback) uses <0.1 marker", () => {
+    // wall field absent; computed from OD/ID: (0.010 - 0.00996)/2 = 0.00002 m = 0.02 mm → rounds to 0.0
+    const piece = {
+      role: "front",
+      spare_origin: [0, 0, 0],
+      spare_vector: [0, 1, 0],
+      outer_d: 0.010,
+      inner_d: 0.00996,
+      shape: "tube",
+      governing_y: 0,
+      x_over_chord: 0.3,
+      y_start: 0,
+      y_end: 0.5,
+      utilisation: 0.5,
+      joint_to_next: null,
+      feasible: true,
+      infeasibility_reason: null,
+    } as unknown as SparPieceOut;
+    const label = pieceDimsLabel(piece);
+    expect(label).not.toContain("wall 0.0");
+    expect(label).toContain("<0.1");
+  });
+
+  it("normal tube (OD 28.8 × ID 24.0, wall 2.4 mm) is byte-identical to before (regression)", () => {
+    const piece = p({ outer_d: 0.0288, inner_d: 0.024, wall: 0.0024 });
+    expect(pieceDimsLabel(piece)).toBe("OD 28.8 × ID 24.0 (wall 2.4) mm");
+  });
+
+  it("tube with wall exactly 0.1 mm renders '0.1' (boundary — not <0.1)", () => {
+    // wall = 0.0001 m = 0.1 mm — rounds to "0.1", NOT sub-precision
+    const piece = p({ outer_d: 0.010, inner_d: 0.0098, wall: 0.0001 });
+    const label = pieceDimsLabel(piece);
+    expect(label).toContain("wall 0.1");
+    expect(label).not.toContain("<0.1");
+  });
+});
+
+// gh-1076: noSparRegionLabel ---------------------------------------------------
+
+describe("noSparRegionLabel (gh-1076)", () => {
+  it("returns null when fromY is null (spar runs all the way to the tip)", () => {
+    expect(noSparRegionLabel(null, false)).toBeNull();
+    expect(noSparRegionLabel(null, true)).toBeNull();
+  });
+
+  it("returns 'loads negligible' message when the whole span is negligible (piecesEmpty=true)", () => {
+    const label = noSparRegionLabel(0, true);
+    expect(label).not.toBeNull();
+    expect(label).toContain("No spar required");
+    expect(label).toContain("negligible");
+  });
+
+  it("returns span-position message when there is a normal no-spar tip region (piecesEmpty=false)", () => {
+    // fromY = 0.75 m → 750 mm; spar runs to 750 mm then tip region is negligible
+    const label = noSparRegionLabel(0.75, false);
+    expect(label).not.toBeNull();
+    expect(label).toContain("No spar required");
+    expect(label).toContain("negligible");
+    expect(label).toContain("750");
+    expect(label).toContain("mm");
+    expect(label).toContain("tip");
+  });
+
+  it("span position uses the same mToMm rounding as pieceExtentLabel (0 decimals for extents)", () => {
+    // fromY = 0.7777 m → pieceExtentLabel uses mToMm(y, 0) → "778 mm"; we match that style
+    const label = noSparRegionLabel(0.7777, false);
+    expect(label).toContain("778");
+  });
+
+  it("piecesEmpty=false with fromY=0 (root=0 but not whole-span) renders the span position", () => {
+    // This case doesn't happen in practice, but the contract is: piecesEmpty drives the message,
+    // not fromY===0. With piecesEmpty=false, always show the span label.
+    const label = noSparRegionLabel(0, false);
+    expect(label).not.toBeNull();
+    expect(label).toContain("0");
+    expect(label).toContain("mm");
   });
 });

--- a/frontend/__tests__/sparPlanHelpers.test.ts
+++ b/frontend/__tests__/sparPlanHelpers.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect } from "vitest";
 import {
   buildMomentsFromLoads,
+  mainSurfaceIndex,
   mToMm,
   sparGroupLabel,
   jointLabel,
@@ -68,6 +69,46 @@ describe("buildMomentsFromLoads", () => {
       { y_m: 0, chord_m: 0.3, shear_N: 0, bending_moment_Nm: 10 },
     ];
     expect(buildMomentsFromLoads(l)).toBeNull();
+  });
+});
+
+describe("mainSurfaceIndex (gh-1092)", () => {
+  function surf(name: string, rootM: number) {
+    return {
+      surface_name: name,
+      starboard: [
+        { y_m: 0.0, chord_m: 0.3, shear_N: 10, bending_moment_Nm: rootM },
+        { y_m: 1.0, chord_m: 0.1, shear_N: 0, bending_moment_Nm: 0 },
+      ],
+      port: [],
+      root_shear_N_starboard: 10,
+      root_shear_N_port: 10,
+      root_bending_moment_Nm_starboard: rootM,
+      root_bending_moment_Nm_port: rootM,
+    };
+  }
+
+  it("picks the surface with the largest root bending moment (the main wing)", () => {
+    // solver order puts a stabiliser first (like the eHawk: v-stab, main_wing, h-stab)
+    const l: SpanwiseLoadsResult = {
+      ...loads(),
+      surfaces: [surf("v-stabilizer", 3), surf("main_wing", 70), surf("h-stabilizer", 8)],
+    };
+    expect(mainSurfaceIndex(l)).toBe(1);
+  });
+
+  it("uses |M| so a negative-moment surface still wins by magnitude", () => {
+    const l: SpanwiseLoadsResult = {
+      ...loads(),
+      surfaces: [surf("a", 5), surf("main", -90)],
+    };
+    expect(mainSurfaceIndex(l)).toBe(1);
+  });
+
+  it("defaults to 0 for null / empty / single-surface", () => {
+    expect(mainSurfaceIndex(null)).toBe(0);
+    expect(mainSurfaceIndex({ ...loads(), surfaces: [] })).toBe(0);
+    expect(mainSurfaceIndex(loads())).toBe(0); // single surface
   });
 });
 

--- a/frontend/__tests__/useSparPlan.test.ts
+++ b/frontend/__tests__/useSparPlan.test.ts
@@ -42,6 +42,8 @@ const FAKE_PLAN: SparPlanResult = {
   reinforcement: null,
   feasible: true,
   infeasibility_reason: null,
+  front_no_spar_from_y: null,
+  rear_no_spar_from_y: null,
 };
 
 const FAKE_INSERT: SparInsertResult = {

--- a/frontend/components/workbench/AnalysisViewerPanel.tsx
+++ b/frontend/components/workbench/AnalysisViewerPanel.tsx
@@ -18,7 +18,7 @@ import { SparSizingPanel, toSizingParams } from "@/components/workbench/SparSizi
 import type { SparSizingInputs } from "@/components/workbench/SparSizingPanel";
 import { useSparSizing } from "@/hooks/useSparSizing";
 import { useSparPlan, type SparPlanParams } from "@/hooks/useSparPlan";
-import { buildMomentsFromLoads } from "@/lib/sparPlanHelpers";
+import { buildMomentsFromLoads, mainSurfaceIndex } from "@/lib/sparPlanHelpers";
 import { useSWRConfig } from "swr";
 
 const TABS = ["Assumptions", "Operating Points", "Polar", "Trefftz Plane", "Spanwise Loads", "Streamlines", "Envelope", "Sizing"] as const;
@@ -1089,8 +1089,12 @@ export function SpanwiseLoadsTabContent({
   const firstSizing = sizingResult?.spar_sizing?.[0] ?? null;
   const gLimit = firstSizing?.g_limit ?? null;
   const gLimitFallback = firstSizing?.g_limit_fallback ?? false;
-  // The wing the plan/insert targets — the first surface (main wing).
-  const planWingName = spanwiseLoads?.surfaces?.[0]?.surface_name ?? null;
+  // The wing the plan/insert targets — the MAIN structural surface (largest
+  // root bending moment), not blindly surfaces[0] which the solver may order as
+  // a stabiliser (gh-1092).
+  const planSurfaceIndex = mainSurfaceIndex(spanwiseLoads);
+  const planWingName =
+    spanwiseLoads?.surfaces?.[planSurfaceIndex]?.surface_name ?? null;
 
   const handleSparCompute = (inputs: SparSizingInputs) => {
     if (!spanwiseLoads) return;
@@ -1112,7 +1116,7 @@ export function SpanwiseLoadsTabContent({
     // gh-1050: also compute the buildable plan from the SAME inputs. The
     // moments distribution comes from the already-displayed spanwise loads
     // M(y) — normalised to a 0..1 span fraction (buildMomentsFromLoads).
-    const moments = buildMomentsFromLoads(spanwiseLoads);
+    const moments = buildMomentsFromLoads(spanwiseLoads, planSurfaceIndex);
     if (moments) {
       const planParams: SparPlanParams = {
         material_id: sizingParams.material_id,

--- a/frontend/components/workbench/SparSizingPanel.tsx
+++ b/frontend/components/workbench/SparSizingPanel.tsx
@@ -266,6 +266,14 @@ function BuiltSparGroup({
  * joint type + feasibility. Exported for direct unit testing.
  */
 export function BuiltSparSection({ plan }: { plan: SparPlanResult }) {
+  const frontNoSparLabel = noSparRegionLabel(
+    plan.front_no_spar_from_y,
+    plan.front_pieces.length === 0,
+  );
+  const rearNoSparLabel = noSparRegionLabel(
+    plan.rear_no_spar_from_y,
+    plan.rear_pieces.length === 0,
+  );
   return (
     <div
       className="rounded border border-border/40 bg-card p-3 text-[13px] space-y-3"
@@ -284,33 +292,21 @@ export function BuiltSparSection({ plan }: { plan: SparPlanResult }) {
         </div>
       )}
       <BuiltSparGroup group="front" pieces={plan.front_pieces} />
-      {noSparRegionLabel(
-        plan.front_no_spar_from_y,
-        plan.front_pieces.length === 0,
-      ) && (
+      {frontNoSparLabel && (
         <p
           className="px-2 py-1 text-[11px] font-[family-name:var(--font-jetbrains-mono)] text-muted-foreground"
           data-testid="front-no-spar-label"
         >
-          {noSparRegionLabel(
-            plan.front_no_spar_from_y,
-            plan.front_pieces.length === 0,
-          )}
+          {frontNoSparLabel}
         </p>
       )}
       <BuiltSparGroup group="rear" pieces={plan.rear_pieces} />
-      {noSparRegionLabel(
-        plan.rear_no_spar_from_y,
-        plan.rear_pieces.length === 0,
-      ) && (
+      {rearNoSparLabel && (
         <p
           className="px-2 py-1 text-[11px] font-[family-name:var(--font-jetbrains-mono)] text-muted-foreground"
           data-testid="rear-no-spar-label"
         >
-          {noSparRegionLabel(
-            plan.rear_no_spar_from_y,
-            plan.rear_pieces.length === 0,
-          )}
+          {rearNoSparLabel}
         </p>
       )}
       <BuiltSparGroup

--- a/frontend/components/workbench/SparSizingPanel.tsx
+++ b/frontend/components/workbench/SparSizingPanel.tsx
@@ -32,6 +32,7 @@ import {
   sparGroupLabel,
   jointLabel,
   pieceDimsLabel,
+  noSparRegionLabel,
   pieceExtentLabel,
   pieceJointLabel,
   splitNote,
@@ -283,7 +284,35 @@ export function BuiltSparSection({ plan }: { plan: SparPlanResult }) {
         </div>
       )}
       <BuiltSparGroup group="front" pieces={plan.front_pieces} />
+      {noSparRegionLabel(
+        plan.front_no_spar_from_y,
+        plan.front_pieces.length === 0,
+      ) && (
+        <p
+          className="px-2 py-1 text-[11px] font-[family-name:var(--font-jetbrains-mono)] text-muted-foreground"
+          data-testid="front-no-spar-label"
+        >
+          {noSparRegionLabel(
+            plan.front_no_spar_from_y,
+            plan.front_pieces.length === 0,
+          )}
+        </p>
+      )}
       <BuiltSparGroup group="rear" pieces={plan.rear_pieces} />
+      {noSparRegionLabel(
+        plan.rear_no_spar_from_y,
+        plan.rear_pieces.length === 0,
+      ) && (
+        <p
+          className="px-2 py-1 text-[11px] font-[family-name:var(--font-jetbrains-mono)] text-muted-foreground"
+          data-testid="rear-no-spar-label"
+        >
+          {noSparRegionLabel(
+            plan.rear_no_spar_from_y,
+            plan.rear_pieces.length === 0,
+          )}
+        </p>
+      )}
       <BuiltSparGroup
         group="reinforcement"
         pieces={plan.reinforcement ? [plan.reinforcement] : []}

--- a/frontend/hooks/useSparPlan.ts
+++ b/frontend/hooks/useSparPlan.ts
@@ -72,6 +72,10 @@ export interface SparPlanResult {
   reinforcement: SparPieceOut | null;
   feasible: boolean;
   infeasibility_reason: string | null;
+  // gh-1076: spanwise position (metres) where the tip-most no-spar region
+  // begins (negligible load outboard). null = spar runs to the tip.
+  front_no_spar_from_y: number | null;
+  rear_no_spar_from_y: number | null;
 }
 
 // ---- Response types: insert (planned spares, metres) -----------------------

--- a/frontend/lib/sparPlanHelpers.ts
+++ b/frontend/lib/sparPlanHelpers.ts
@@ -41,6 +41,30 @@ export function buildMomentsFromLoads(
   }));
 }
 
+/**
+ * gh-1092: index of the main structural surface — the one carrying the largest
+ * root bending moment (|root_bending_moment_Nm_starboard|). A multi-surface
+ * aircraft's solver order can put a stabiliser first, so the built-spar plan
+ * must not blindly use surfaces[0]. Defaults to 0 for null / empty / single
+ * surface.
+ */
+export function mainSurfaceIndex(
+  loads: SpanwiseLoadsResult | null | undefined,
+): number {
+  const surfaces = loads?.surfaces;
+  if (!surfaces || surfaces.length === 0) return 0;
+  let best = 0;
+  let bestM = -Infinity;
+  surfaces.forEach((s, i) => {
+    const m = Math.abs(s.root_bending_moment_Nm_starboard ?? 0);
+    if (m > bestM) {
+      bestM = m;
+      best = i;
+    }
+  });
+  return best;
+}
+
 // ---- Built-spar piece formatting -------------------------------------------
 
 /** Metres → millimetres, rounded for display. */

--- a/frontend/lib/sparPlanHelpers.ts
+++ b/frontend/lib/sparPlanHelpers.ts
@@ -115,7 +115,13 @@ export function pieceDimsLabel(piece: SparPieceOut): string {
       piece.wall != null && Number.isFinite(piece.wall)
         ? piece.wall
         : (piece.outer_d - piece.inner_d) / 2;
-    const wallStr = mToMm(wall);
+    // gh-1076: a tube with OD>0 must never display "wall 0" or "wall 0.0".
+    // mToMm rounds to 1 decimal (0.1 mm resolution). If the wall is positive
+    // but rounds to "0.0", show "<0.1" instead to avoid the contradictory label.
+    const wallStr =
+      piece.outer_d > 0 && wall > 0 && parseFloat(mToMm(wall)) === 0
+        ? "<0.1"
+        : mToMm(wall);
     // length is the run-length along spare_vector; not on the piece schema, so
     // pieces show OD/ID/wall only (length lives on the planned-spare preview).
     return `OD ${od} × ID ${id} (wall ${wallStr}) mm`;
@@ -223,6 +229,25 @@ export function splitNote(
     `Main spar telescopes → the segment will be split into ${n} sub-segments ` +
     `(lengths ${lengths} mm); a snapshot will be taken so you can revert.`
   );
+}
+
+// ---- No-spar tip region (gh-1076) -------------------------------------------
+
+/**
+ * gh-1076: human label for a spar's tip-most no-spar region. Inputs are in
+ * METRES (as the API returns). `fromY` is where the region begins; `piecesEmpty`
+ * true means no buildable piece exists at all. Returns null when there is no
+ * no-spar region (fromY == null → spar runs to the tip).
+ */
+export function noSparRegionLabel(
+  fromY: number | null,
+  piecesEmpty: boolean,
+): string | null {
+  if (fromY == null) return null;
+  if (piecesEmpty) {
+    return "No spar required — loads negligible";
+  }
+  return `No spar required (negligible bending load) — span ${mToMm(fromY, 0)} mm → tip`;
 }
 
 /**


### PR DESCRIPTION
## Problem

The built-spar display showed a tube with **OD>0 but ID=0 / wall=0** — a contradiction that gave the user no way to tell whether a spar was actually needed at that station.

## Root cause

`_drop_zero_od_tip` dropped only `outer_d <= 0` pieces, so a sub-millimetre tip piece survived and its wall rounded to `"0.0"`. Toward the tip the bending moment `M(y)→0` — the D-box skin + ribs carry the load — but that "no spar needed here" state was never surfaced.

## Fix — Option A (user-selected, supersedes gh-1057 extend-to-tip)

- **Stated, testable buildable floor** `NEGLIGIBLE_OD_FLOOR_MM` (1.0 mm), evaluated on the design-moment (`M·g·j`) required OD produced upstream. Trailing tip pieces below it are dropped; the last real piece keeps its natural length instead of being stretched to the tip.
- **Explicit no-spar region** recorded on `SparPlan` (`front/rear_no_spar_from_y`, mm) and exposed on `SparPlanResponse` (metres).
- **Frontend**: `pieceDimsLabel` never emits `"wall 0"` for a tube with OD>0 (renders `"<0.1"`); new `noSparRegionLabel` renders *"No spar required (negligible bending load) — span X → tip"*, and *"loads negligible"* when the whole span is sub-floor. `SparSizingPanel` shows a muted info row per spar.

## Tests

- Solver: floor threshold (kept/dropped), no-spar region (contiguity, tip-most, all-negligible edge), no-extend-to-tip, plan-dict serialisation.
- **gh-1057 tests re-spec'd** to Option A intent (last piece ends at last load-bearing station; documented, not weakened).
- Endpoint mm→m conversion of the new fields.
- Frontend: `pieceDimsLabel` sub-precision wall + regression, `noSparRegionLabel` cases.

Backend spar suites: **185 passed** (fast). Frontend: **2351 passed**. Ruff + ESLint clean on changed files.

### Note
While verifying, found **3 pre-existing** `-m slow` spar-insert integration failures on clean `main` (stock-snap infeasibility, band 12.7mm < all seeded stock ODs) — **unrelated to this change**, filed as **#1089**.

Closes #1076

🤖 Generated with [Claude Code](https://claude.com/claude-code)